### PR TITLE
Packager enumerates export trees selectively

### DIFF
--- a/compiler/IREmitter/IREmitterHelpers.cc
+++ b/compiler/IREmitter/IREmitterHelpers.cc
@@ -365,12 +365,12 @@ std::string IREmitterHelpers::showClassNameWithoutOwner(const core::GlobalState 
 
     if (name.isPackagerPrivateName(gs)) {
         // Remove _Package_Private before de-munging
-        return absl::StrReplaceAll(withoutOwnerStr.substr(0, withoutOwnerStr.size() - core::PACKAGE_PRIVATE_SUFFIX_LEN),
-                                   {{"_", "::"}});
+        return absl::StrReplaceAll(
+            withoutOwnerStr.substr(0, withoutOwnerStr.size() - core::PACKAGE_PRIVATE_SUFFIX.size()), {{"_", "::"}});
     }
 
     // Remove _Package before de-munging
-    return absl::StrReplaceAll(withoutOwnerStr.substr(0, withoutOwnerStr.size() - core::PACKAGE_SUFFIX_LEN),
+    return absl::StrReplaceAll(withoutOwnerStr.substr(0, withoutOwnerStr.size() - core::PACKAGE_SUFFIX.size()),
                                {{"_", "::"}});
 }
 

--- a/compiler/IREmitter/IREmitterHelpers.cc
+++ b/compiler/IREmitter/IREmitterHelpers.cc
@@ -359,16 +359,18 @@ std::string IREmitterHelpers::showClassNameWithoutOwner(const core::GlobalState 
     // the above calls are done inside NameRef, which doesn't have the necessary
     // symbol ownership information to do this sort of munging.  So we have to
     // duplicate the Symbol logic here.
-    if (sym.data(gs)->owner != core::Symbols::PackageRegistry()) {
+    if (sym.data(gs)->owner != core::Symbols::PackageRegistry() || !name.isPackagerName(gs)) {
         return withoutOwnerStr;
     }
 
-    constexpr string_view packageNameSuffix = "_Package"sv;
-    if (!absl::EndsWith(withoutOwnerStr, packageNameSuffix)) {
-        return withoutOwnerStr;
+    if (name.isPackagerPrivateName(gs)) {
+        // Remove _Package_Private before de-munging
+        return absl::StrReplaceAll(withoutOwnerStr.substr(0, withoutOwnerStr.size() - core::PACKAGE_PRIVATE_SUFFIX_LEN),
+                                   {{"_", "::"}});
     }
 
-    return absl::StrReplaceAll(withoutOwnerStr.substr(0, withoutOwnerStr.size() - packageNameSuffix.size()),
+    // Remove _Package before de-munging
+    return absl::StrReplaceAll(withoutOwnerStr.substr(0, withoutOwnerStr.size() - core::PACKAGE_SUFFIX_LEN),
                                {{"_", "::"}});
 }
 

--- a/core/NameRef.h
+++ b/core/NameRef.h
@@ -66,8 +66,8 @@ struct NameRefDebugCheck {
     void check(const GlobalSubstitution &subst) const;
 };
 
-constexpr int PACKAGE_SUFFIX_LEN = 8;          // Length of string "_Package"
-constexpr int PACKAGE_PRIVATE_SUFFIX_LEN = 16; // Length of string "_Package_Private"
+constexpr std::string_view PACKAGE_SUFFIX = "_Package";
+constexpr std::string_view PACKAGE_PRIVATE_SUFFIX = "_Package_Private";
 
 class NameRef final : private DebugOnlyCheck<NameRefDebugCheck> {
 private:

--- a/core/NameRef.h
+++ b/core/NameRef.h
@@ -66,6 +66,9 @@ struct NameRefDebugCheck {
     void check(const GlobalSubstitution &subst) const;
 };
 
+constexpr int PACKAGE_SUFFIX_LEN = 8;          // Length of string "_Package"
+constexpr int PACKAGE_PRIVATE_SUFFIX_LEN = 16; // Length of string "_Package_Private"
+
 class NameRef final : private DebugOnlyCheck<NameRefDebugCheck> {
 private:
     // NameKind takes up this many bits in _id.
@@ -172,7 +175,7 @@ public:
 
     NameRef prepend(GlobalState &gs, std::string_view s) const;
 
-    NameRef lookupMangledPackageName(const GlobalState &gs) const;
+    NameRef lookupMangledPrivatePackageName(const GlobalState &gs) const;
 
     bool isClassName(const GlobalState &gs) const;
 
@@ -184,6 +187,7 @@ public:
     // Convenience method to avoid forgeting to unwrap the first layer (NameKind::CONSTANT)
     // before checking for UniqueNameKind::Packager.
     bool isPackagerName(const GlobalState &gs) const;
+    bool isPackagerPrivateName(const GlobalState &gs) const;
 
     bool isValidConstantName(const GlobalState &gs) const;
 

--- a/core/Names.cc
+++ b/core/Names.cc
@@ -72,6 +72,9 @@ string NameRef::showRaw(const GlobalState &gs) const {
                 case UniqueNameKind::Packager:
                     kind = "G";
                     break;
+                case UniqueNameKind::PackagerPrivate:
+                    kind = "V";
+                    break;
             }
             if (gs.censorForSnapshotTests && unique->uniqueNameKind == UniqueNameKind::Namer &&
                 unique->original == core::Names::staticInit()) {
@@ -184,6 +187,7 @@ bool NameRef::isClassName(const GlobalState &gs) const {
                     return dataUnique(gs)->original.isClassName(gs);
                 case UniqueNameKind::ResolverMissingClass:
                 case UniqueNameKind::Packager:
+                case UniqueNameKind::PackagerPrivate:
                 case UniqueNameKind::Parser:
                 case UniqueNameKind::Desugar:
                 case UniqueNameKind::Namer:
@@ -212,7 +216,18 @@ bool NameRef::isPackagerName(const GlobalState &gs) const {
         return false;
     }
     auto original = dataCnst(gs)->original;
-    return original.kind() == NameKind::UNIQUE && original.dataUnique(gs)->uniqueNameKind == UniqueNameKind::Packager;
+    return original.kind() == NameKind::UNIQUE &&
+           (original.dataUnique(gs)->uniqueNameKind == UniqueNameKind::Packager ||
+            original.dataUnique(gs)->uniqueNameKind == UniqueNameKind::PackagerPrivate);
+}
+
+bool NameRef::isPackagerPrivateName(const GlobalState &gs) const {
+    if (kind() != NameKind::CONSTANT) {
+        return false;
+    }
+    auto original = dataCnst(gs)->original;
+    return original.kind() == NameKind::UNIQUE &&
+           original.dataUnique(gs)->uniqueNameKind == UniqueNameKind::PackagerPrivate;
 }
 
 bool NameRef::isValidConstantName(const GlobalState &gs) const {
@@ -224,6 +239,7 @@ bool NameRef::isValidConstantName(const GlobalState &gs) const {
                 case UniqueNameKind::ResolverMissingClass:
                 case UniqueNameKind::TEnum:
                 case UniqueNameKind::Packager:
+                case UniqueNameKind::PackagerPrivate:
                     return true;
                 case UniqueNameKind::Parser:
                 case UniqueNameKind::Desugar:
@@ -369,17 +385,17 @@ NameRef NameRef::prepend(GlobalState &gs, string_view s) const {
     return gs.enterNameUTF8(nameEq);
 }
 
-NameRef NameRef::lookupMangledPackageName(const GlobalState &gs) const {
+NameRef NameRef::lookupMangledPrivatePackageName(const GlobalState &gs) const {
     auto name = this->dataUtf8(gs);
     auto parts = absl::StrSplit(name->utf8, "::");
-    string mangledName = absl::StrCat(absl::StrJoin(parts, "_"), "_Package");
+    string mangledName = absl::StrCat(absl::StrJoin(parts, "_"), "_Package_Private");
 
     auto utf8Name = gs.lookupNameUTF8(mangledName);
     if (!utf8Name.exists()) {
         return utf8Name;
     }
 
-    auto packagerName = gs.lookupNameUnique(core::UniqueNameKind::Packager, utf8Name, 1);
+    auto packagerName = gs.lookupNameUnique(core::UniqueNameKind::PackagerPrivate, utf8Name, 1);
     if (!packagerName.exists()) {
         return packagerName;
     }

--- a/core/Names.cc
+++ b/core/Names.cc
@@ -388,7 +388,7 @@ NameRef NameRef::prepend(GlobalState &gs, string_view s) const {
 NameRef NameRef::lookupMangledPrivatePackageName(const GlobalState &gs) const {
     auto name = this->dataUtf8(gs);
     auto parts = absl::StrSplit(name->utf8, "::");
-    string mangledName = absl::StrCat(absl::StrJoin(parts, "_"), "_Package_Private");
+    string mangledName = absl::StrCat(absl::StrJoin(parts, "_"), core::PACKAGE_PRIVATE_SUFFIX);
 
     auto utf8Name = gs.lookupNameUTF8(mangledName);
     if (!utf8Name.exists()) {

--- a/core/Names.h
+++ b/core/Names.h
@@ -32,6 +32,7 @@ enum class UniqueNameKind : u1 {
                           // test/resolver/stub_missing_class_alias.rb
     TEnum,
     Packager,
+    PackagerPrivate,
 };
 
 struct UniqueName final {

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -430,12 +430,13 @@ string ClassOrModuleRef::show(const GlobalState &gs) const {
             if (sym->name.isPackagerPrivateName(gs)) {
                 // Foo_Bar_Package_Private => Foo::Bar
                 // Remove _Package_Private before de-munging
-                return absl::StrReplaceAll(nameStr.substr(0, nameStr.size() - core::PACKAGE_PRIVATE_SUFFIX_LEN),
+                return absl::StrReplaceAll(nameStr.substr(0, nameStr.size() - core::PACKAGE_PRIVATE_SUFFIX.size()),
                                            {{"_", "::"}});
             } else {
                 // Foo_Bar_Package => Foo::Bar
                 // Remove _Package before de-munging
-                return absl::StrReplaceAll(nameStr.substr(0, nameStr.size() - core::PACKAGE_SUFFIX_LEN), {{"_", "::"}});
+                return absl::StrReplaceAll(nameStr.substr(0, nameStr.size() - core::PACKAGE_SUFFIX.size()),
+                                           {{"_", "::"}});
             }
         }
     }
@@ -938,12 +939,13 @@ string ClassOrModuleRef::showFullName(const GlobalState &gs) const {
             if (sym->name.isPackagerPrivateName(gs)) {
                 // Foo_Bar_Package_Private => Foo::Bar
                 // Remove _Package_Private before de-munging
-                return absl::StrReplaceAll(nameStr.substr(0, nameStr.size() - core::PACKAGE_PRIVATE_SUFFIX_LEN),
+                return absl::StrReplaceAll(nameStr.substr(0, nameStr.size() - core::PACKAGE_PRIVATE_SUFFIX.size()),
                                            {{"_", "::"}});
             } else {
                 // Foo_Bar_Package => Foo::Bar
                 // Remove _Package before de-munging
-                return absl::StrReplaceAll(nameStr.substr(0, nameStr.size() - core::PACKAGE_SUFFIX_LEN), {{"_", "::"}});
+                return absl::StrReplaceAll(nameStr.substr(0, nameStr.size() - core::PACKAGE_SUFFIX.size()),
+                                           {{"_", "::"}});
             }
         }
     }

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -427,9 +427,16 @@ string ClassOrModuleRef::show(const GlobalState &gs) const {
         // Pretty print package name (only happens when `--stripe-packages` is enabled)
         if (sym->name.isPackagerName(gs)) {
             auto nameStr = sym->name.shortName(gs);
-            constexpr size_t packageSuffix = char_traits<char>::length("_Package");
-            // Foo_Bar_Package => Foo::Bar
-            return absl::StrReplaceAll(nameStr.substr(0, nameStr.size() - packageSuffix), {{"_", "::"}});
+            if (sym->name.isPackagerPrivateName(gs)) {
+                // Foo_Bar_Package_Private => Foo::Bar
+                // Remove _Package_Private before de-munging
+                return absl::StrReplaceAll(nameStr.substr(0, nameStr.size() - core::PACKAGE_PRIVATE_SUFFIX_LEN),
+                                           {{"_", "::"}});
+            } else {
+                // Foo_Bar_Package => Foo::Bar
+                // Remove _Package before de-munging
+                return absl::StrReplaceAll(nameStr.substr(0, nameStr.size() - core::PACKAGE_SUFFIX_LEN), {{"_", "::"}});
+            }
         }
     }
 
@@ -928,9 +935,16 @@ string ClassOrModuleRef::showFullName(const GlobalState &gs) const {
         // Pretty print package name (only happens when `--stripe-packages` is enabled)
         if (sym->name.isPackagerName(gs)) {
             auto nameStr = sym->name.shortName(gs);
-            constexpr size_t packageSuffix = char_traits<char>::length("_Package");
-            // Foo_Bar_Package => Foo::Bar
-            return absl::StrReplaceAll(nameStr.substr(0, nameStr.size() - packageSuffix), {{"_", "::"}});
+            if (sym->name.isPackagerPrivateName(gs)) {
+                // Foo_Bar_Package_Private => Foo::Bar
+                // Remove _Package_Private before de-munging
+                return absl::StrReplaceAll(nameStr.substr(0, nameStr.size() - core::PACKAGE_PRIVATE_SUFFIX_LEN),
+                                           {{"_", "::"}});
+            } else {
+                // Foo_Bar_Package => Foo::Bar
+                // Remove _Package before de-munging
+                return absl::StrReplaceAll(nameStr.substr(0, nameStr.size() - core::PACKAGE_SUFFIX_LEN), {{"_", "::"}});
+            }
         }
     }
     return showFullNameInternal(gs, sym->owner, sym->name, COLON_SEPARATOR);

--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -60,6 +60,9 @@ com::stripe::rubytyper::Name Proto::toProto(const GlobalState &gs, NameRef name)
                 case UniqueNameKind::Packager:
                     protoName.set_unique(com::stripe::rubytyper::Name::PACKAGER);
                     break;
+                case UniqueNameKind::PackagerPrivate:
+                    protoName.set_unique(com::stripe::rubytyper::Name::PACKAGER_PRIVATE);
+                    break;
             }
             break;
         case NameKind::CONSTANT:

--- a/main/autogen/autoloader.cc
+++ b/main/autogen/autoloader.cc
@@ -418,7 +418,10 @@ void populateAutoloadTasksAndCreateDirectories(const core::GlobalState &gs, vect
                 ENFORCE(child->qname.package);
                 auto namespaceName = child->qname.package->show(gs);
                 // this package name will include the suffix _Package on the end, and we want to remove that
-                constexpr int suffixLen = char_traits<char>::length("_Package");
+                constexpr int suffixLen = core::PACKAGE_SUFFIX.size();
+
+                // TODO (ngroman, aadi-stripe) Determine if we need to check _Package_Private here in this autoloader
+                // context.
                 ENFORCE(namespaceName.size() > suffixLen);
                 string packageName = namespaceName.substr(0, namespaceName.size() - suffixLen);
                 auto pkgSubdir = join(subdir, packageName);

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -158,6 +158,7 @@ const vector<StopAfterOptions> stop_after_options({
     {"rewriter", Phase::REWRITER},
     {"local-vars", Phase::LOCAL_VARS},
     {"namer", Phase::NAMER},
+    {"packager", Phase::PACKAGER},
     {"resolver", Phase::RESOLVER},
     {"cfg", Phase::CFG},
     {"inferencer", Phase::INFERENCER},

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -158,7 +158,6 @@ const vector<StopAfterOptions> stop_after_options({
     {"rewriter", Phase::REWRITER},
     {"local-vars", Phase::LOCAL_VARS},
     {"namer", Phase::NAMER},
-    {"packager", Phase::PACKAGER},
     {"resolver", Phase::RESOLVER},
     {"cfg", Phase::CFG},
     {"inferencer", Phase::INFERENCER},

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -96,6 +96,7 @@ enum class Phase {
     REWRITER,
     LOCAL_VARS,
     NAMER,
+    PACKAGER,
     RESOLVER,
     CFG,
     INFERENCER,

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -714,7 +714,7 @@ ast::ParsedFilesOrCancelled resolve(unique_ptr<core::GlobalState> &gs, vector<as
         if (opts.stopAfterPhase == options::Phase::PACKAGER) {
             return ast::ParsedFilesOrCancelled(move(what));
         }
- 
+
         auto result = name(*gs, move(what), opts, workers);
         if (!result.hasResult()) {
             return result;

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -226,6 +226,9 @@ vector<ast::ParsedFile> incrementalResolve(core::GlobalState &gs, vector<ast::Pa
         if (opts.stripePackages) {
             Timer timeit(gs.tracer(), "incremental_packager");
             what = packager::Packager::runIncremental(gs, move(what));
+            if (opts.stopAfterPhase == options::Phase::PACKAGER) {
+                return what;
+            }
         }
 #endif
         {
@@ -708,7 +711,10 @@ ast::ParsedFilesOrCancelled resolve(unique_ptr<core::GlobalState> &gs, vector<as
     try {
         // packager intentionally runs outside of rewriter so that its output does not get cached.
         what = package(*gs, move(what), opts, workers);
-
+        if (opts.stopAfterPhase == options::Phase::PACKAGER) {
+            return ast::ParsedFilesOrCancelled(move(what));
+        }
+ 
         auto result = name(*gs, move(what), opts, workers);
         if (!result.hasResult()) {
             return result;

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -226,9 +226,6 @@ vector<ast::ParsedFile> incrementalResolve(core::GlobalState &gs, vector<ast::Pa
         if (opts.stripePackages) {
             Timer timeit(gs.tracer(), "incremental_packager");
             what = packager::Packager::runIncremental(gs, move(what));
-            if (opts.stopAfterPhase == options::Phase::PACKAGER) {
-                return what;
-            }
         }
 #endif
         {
@@ -711,9 +708,6 @@ ast::ParsedFilesOrCancelled resolve(unique_ptr<core::GlobalState> &gs, vector<as
     try {
         // packager intentionally runs outside of rewriter so that its output does not get cached.
         what = package(*gs, move(what), opts, workers);
-        if (opts.stopAfterPhase == options::Phase::PACKAGER) {
-            return ast::ParsedFilesOrCancelled(move(what));
-        }
 
         auto result = name(*gs, move(what), opts, workers);
         if (!result.hasResult()) {

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -603,7 +603,7 @@ int realmain(int argc, char *argv[]) {
             if (opts.stopAfterPhase != options::Phase::PACKAGER) {
                 indexed = move(pipeline::typecheck(gs, move(indexed), opts, *workers).result());
                 if (gs->hadCriticalError()) {
-                  gs->errorQueue->flushAllErrors(*gs);
+                    gs->errorQueue->flushAllErrors(*gs);
                 }
             }
         }

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -600,11 +600,10 @@ int realmain(int argc, char *argv[]) {
             if (gs->hadCriticalError()) {
                 gs->errorQueue->flushAllErrors(*gs);
             }
-            if (opts.stopAfterPhase != options::Phase::PACKAGER) {
-                indexed = move(pipeline::typecheck(gs, move(indexed), opts, *workers).result());
-                if (gs->hadCriticalError()) {
-                    gs->errorQueue->flushAllErrors(*gs);
-                }
+
+            indexed = move(pipeline::typecheck(gs, move(indexed), opts, *workers).result());
+            if (gs->hadCriticalError()) {
+                gs->errorQueue->flushAllErrors(*gs);
             }
         }
 

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -600,7 +600,6 @@ int realmain(int argc, char *argv[]) {
             if (gs->hadCriticalError()) {
                 gs->errorQueue->flushAllErrors(*gs);
             }
-
             indexed = move(pipeline::typecheck(gs, move(indexed), opts, *workers).result());
             if (gs->hadCriticalError()) {
                 gs->errorQueue->flushAllErrors(*gs);

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -600,9 +600,11 @@ int realmain(int argc, char *argv[]) {
             if (gs->hadCriticalError()) {
                 gs->errorQueue->flushAllErrors(*gs);
             }
-            indexed = move(pipeline::typecheck(gs, move(indexed), opts, *workers).result());
-            if (gs->hadCriticalError()) {
-                gs->errorQueue->flushAllErrors(*gs);
+            if (opts.stopAfterPhase != options::Phase::PACKAGER) {
+                indexed = move(pipeline::typecheck(gs, move(indexed), opts, *workers).result());
+                if (gs->hadCriticalError()) {
+                  gs->errorQueue->flushAllErrors(*gs);
+                }
             }
         }
 

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -760,7 +760,7 @@ class ImportTree final {
             return importType == ImportType::Normal;
         }
 
-        bool isSelfOrTestImport() {
+        bool isFriendOrTestImport() {
             return importType == ImportType::Friend || importType == ImportType::Test;
         }
 
@@ -1033,8 +1033,8 @@ private:
                 //                               ^^^  jump to actual definition of `Baz` class
 
                 // Ensure import's do not add duplicate loc-s in the test_module
-                const bool useImportLoc =
-                    source.isEnumeratedImport && (moduleType != ModuleType::PrivateTest || source.isSelfOrTestImport());
+                const bool useImportLoc = source.isEnumeratedImport &&
+                                          (moduleType != ModuleType::PrivateTest || source.isFriendOrTestImport());
                 const auto &importLoc = useImportLoc ? source.importLoc : core::LocOffsets::none();
 
                 auto mod = ast::MK::Module(core::LocOffsets::none(), importLoc,

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -846,10 +846,9 @@ public:
             // suffix of the imported name. Based on this, we determine whether to enumerate and alias all exports
             // from an imported package or only alias the top-level export.
             //
-            // Essentially, to save on memory usage by reducing the number of nodes created in the AST, we
-            // individually alias exported constants from the imported package if & only if there would be an import
-            // conflict otherwise; i.e., when the given package is either a subpackage of the imported name or also
-            // imports a subpackage of the imported name.
+            // This approach saves memory by adding package aliases in the common case, falling back on naming a whole
+            // package tree only when a package and subpackage of it are both imported.
+
             const bool isOrImportsSubpackage =
                 absl::c_any_of(package.importedPackageNames,
                                [&](const auto &otherImport) -> bool {

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -60,6 +60,14 @@ struct FullyQualifiedName {
         ENFORCE(prefixed.size() == parts.size() + 1);
         return {move(prefixed), loc};
     }
+
+    bool isSuffix(const FullyQualifiedName &prefix) const {
+        if (prefix.parts.size() >= parts.size()) {
+            return false;
+        }
+
+        return std::equal(parts.begin(), parts.begin() + prefix.parts.size(), prefix.parts.begin());
+    }
 };
 
 class NameFormatter final {
@@ -88,7 +96,21 @@ struct PackageName {
 enum class ImportType {
     Normal,
     Test, // test_import
+
+    // "self-import": This represents code that is exported by a package, and is therefore "imported" (i.e. remapped)
+    // into its private test namespace and its public->private mapping.
+    Self,
 };
+
+// There are 4 kinds of virtual modules inserted into the AST.
+// Normal: suffixed with _Package_Private, it maps external imports of a package into its namespace.
+// Test: suffixed with _Package_Private, it maps external imports, exports and self-test exports of a package into its
+//   test namespace.
+// ExportMappingNormal: suffixed with _Package, it maps exports of a package into its publicly available namespace (this
+//   is used by other packages when they import this package).
+// ExportMappingTest: suffixed with _Package, it maps exports of a package that are in the "Test::" namespace into its
+//   publicly available test namespace (this is used by other packages when they import this package).
+enum class ModuleType { Normal, Test, ExportMappingNormal, ExportMappingTest };
 
 struct Import {
     PackageName name;
@@ -130,6 +152,14 @@ public:
     // The possible path prefixes associated with files in the package, including path separator at end.
     vector<std::string> packagePathPrefixes;
     PackageName name;
+
+    // Private namespace of the package. We do not put this in the PackageName struct above because the former
+    // is used to not only hold package name information as part of PackageInfoImpl, but also created for every imported
+    // package when a package is enumerating its imports. In that context, the private name is unnecessary and would
+    // take up an unnecessary extra reference, which would contribute O(packages * imports) in space. Putting
+    // it here ensures only O(packages) space complexity for the private name.
+    core::NameRef privateMangledName;
+
     // loc for the package definition. Used for error messages.
     core::Loc loc;
     // The names of each package imported by this package.
@@ -502,6 +532,14 @@ struct PackageInfoFinder {
             info = make_unique<PackageInfoImpl>();
             checkPackageName(ctx, nameTree);
             info->name = getPackageName(ctx, nameTree);
+
+            // Append _Private at the end of the mangled package name to get the name of its private namespace.
+            auto utf8PrivateName =
+                ctx.state.enterNameUTF8(absl::StrCat(info->name.mangledName.show(ctx.state), "_Private"));
+            auto packagerPrivateName =
+                ctx.state.freshNameUnique(core::UniqueNameKind::PackagerPrivate, utf8PrivateName, 1);
+            info->privateMangledName = ctx.state.enterNameConstant(packagerPrivateName);
+
             info->loc = core::Loc(ctx.file, classDef.loc);
         } else {
             if (auto e = ctx.beginError(classDef.loc, core::errors::Packager::MultiplePackagesInOneFile)) {
@@ -515,7 +553,7 @@ struct PackageInfoFinder {
 
     // Bar::Baz => <PackageRegistry>::Foo_Package::Bar::Baz
     ast::ExpressionPtr prependInternalPackageName(const core::GlobalState &gs, ast::ExpressionPtr scope) {
-        return prependPackageScope(gs, move(scope), this->info->name.mangledName);
+        return prependPackageScope(gs, move(scope), this->info->privateMangledName);
     }
 
     // Generate a list of FQNs exported by this package. No export may be a prefix of another.
@@ -702,8 +740,40 @@ class ImportTree final {
         core::NameRef packageMangledName;
         core::LocOffsets importLoc;
         ImportType importType;
+        bool isEnumeratedImport;
+
         bool exists() {
             return importLoc.exists();
+        }
+
+        bool isSelfImport() {
+            return importType == ImportType::Self;
+        }
+
+        bool isTestImport() {
+            return importType == ImportType::Test;
+        }
+
+        bool isNormalImport() {
+            return importType == ImportType::Normal;
+        }
+
+        bool isSelfOrTestImport() {
+            return importType == ImportType::Self || importType == ImportType::Test;
+        }
+
+        bool skipBuildMappingFor(ModuleType moduleType) {
+            // Don't build mappings in the export mapping modules for external imports.
+            if (!isSelfImport() &&
+                (moduleType == ModuleType::ExportMappingNormal || moduleType == ModuleType::ExportMappingTest)) {
+                return true;
+            }
+
+            // Don't build mappings in the main (normal) package module for internal imports.
+            if (isSelfImport() && moduleType == ModuleType::Normal)
+                return true;
+
+            return false;
         }
     };
 
@@ -725,37 +795,77 @@ public:
 class ImportTreeBuilder final {
     // PackageInfoImpl package; // The package we are building an import tree for.
     core::NameRef pkgMangledName;
+    core::NameRef privatePkgMangledName;
     ImportTree root;
 
 public:
-    ImportTreeBuilder(const PackageInfoImpl &package) : pkgMangledName(package.name.mangledName) {}
+    ImportTreeBuilder(const PackageInfoImpl &package)
+        : pkgMangledName(package.name.mangledName), privatePkgMangledName(package.privateMangledName) {}
     ImportTreeBuilder(const ImportTreeBuilder &) = delete;
     ImportTreeBuilder(ImportTreeBuilder &&) = default;
     ImportTreeBuilder &operator=(const ImportTreeBuilder &) = delete;
     ImportTreeBuilder &operator=(ImportTreeBuilder &&) = default;
 
-    void mergeImports(const PackageInfoImpl &importedPackage, const Import &import) {
-        for (const auto &exp : importedPackage.exports) {
-            if (exp.type == ExportType::Public) {
-                addImport(importedPackage, import.name.loc, exp.fqn, import.type);
+    void mergeImports(core::Context ctx, const PackageInfoImpl &package) {
+        const auto &packageDB = ctx.state.packageDB();
+        UnorderedMap<core::NameRef, core::LocOffsets> importedNames;
+        for (auto &import : package.importedPackageNames) {
+            auto &imported = import.name;
+            auto &importedPackage = packageDB.getPackageInfo(imported.mangledName);
+            if (!importedPackage.exists()) {
+                if (auto e = ctx.beginError(imported.loc, core::errors::Packager::PackageNotFound)) {
+                    e.setHeader("Cannot find package `{}`", imported.toString(ctx));
+                }
+                continue;
+            }
+
+            if (importedNames.contains(imported.mangledName)) {
+                if (auto e = ctx.beginError(imported.loc, core::errors::Packager::InvalidImportOrExport)) {
+                    e.setHeader("Duplicate package import `{}`", imported.toString(ctx));
+                    e.addErrorLine(core::Loc(ctx.file, importedNames[imported.mangledName]),
+                                   "Previous package import found here");
+                }
+            } else {
+                importedNames[imported.mangledName] = imported.loc;
+
+                // TODO (aadi-stripe): fix this so it's not quadratic (if it ends up causing runtime bloat). Currently
+                // (11/8/2021) timing analysis suggests that it doesn't.
+                //
+                // Determine whether the current package either imports a suffix of the imported name, or itself is a
+                // suffix of the imported name. This bit is passed into mergeImportsFromImportedPackage, specifically
+                // into the "enumerateExportsInFull" parameter.
+                //
+                // To save on memory usage by reducing the number of nodes created in the AST, we individually alias
+                // exported constants from the imported package only when there would be an import conflict otherwise -
+                // i.e., when this is either a subpackage of the imported name or imports a subpackage of the imported
+                // name.
+                const bool isOrImportsSubpackage =
+                    absl::c_any_of(package.importedPackageNames,
+                                   [&](const auto &otherImport) -> bool {
+                                       return otherImport.name.fullName.isSuffix(imported.fullName);
+                                   }) ||
+                    package.name.fullName.isSuffix(imported.fullName);
+                mergeImportsFromImportedPackage(ctx, PackageInfoImpl::from(importedPackage), import,
+                                                isOrImportsSubpackage);
             }
         }
     }
 
     // Make add imports for the test package for all normal code exported by its corresponding
     // "normal" package.
-    void mergeSelfExportsForTest(core::Context ctx, const PackageInfoImpl &pkg) {
+    void mergeSelfExports(core::Context ctx, const PackageInfoImpl &pkg, ExportType type) {
         for (const auto &exp : pkg.exports) {
+            if (exp.type != type)
+                continue;
+
             const auto &parts = exp.parts();
             ENFORCE(parts.size() > 0);
-            if (!isTestNamespace(ctx, parts[0])) { // Only add imports for non-test
-                auto loc = exp.fqn.loc.offsets();
-                addImport(pkg, loc, exp.fqn, ImportType::Test);
-            }
+            auto loc = exp.fqn.loc.offsets();
+            addImport(ctx, pkg, loc, exp.fqn, ImportType::Self, true);
         }
     }
 
-    ast::ClassDef::RHS_store makeModule(core::Context ctx, ImportType moduleType) {
+    ast::ClassDef::RHS_store makeModule(core::Context ctx, ModuleType moduleType) {
         vector<core::NameRef> parts;
         ast::ClassDef::RHS_store modRhs;
         makeModule(ctx, &root, parts, modRhs, moduleType, ImportTree::Source());
@@ -763,8 +873,44 @@ public:
     }
 
 private:
-    void addImport(const PackageInfoImpl &importedPackage, core::LocOffsets loc, const FullyQualifiedName &exportFqn,
-                   ImportType importType) {
+    const bool isNonTestModule(ModuleType moduleType) const {
+        return moduleType == ModuleType::ExportMappingNormal || moduleType == ModuleType::Normal;
+    }
+
+    const bool isExportMappingModule(ModuleType moduleType) const {
+        return moduleType == ModuleType::ExportMappingNormal || moduleType == ModuleType::ExportMappingTest;
+    }
+
+    void mergeImportsFromImportedPackage(core::Context ctx, const PackageInfoImpl &importedPackage,
+                                         const Import &import, bool enumerateExportsInFull) {
+        if (enumerateExportsInFull) {
+            // Enumerate and add all exported names from the imported package
+            for (const auto &exp : importedPackage.exports) {
+                if (exp.type == ExportType::Public) {
+                    addImport(ctx, importedPackage, import.name.loc, exp.fqn, import.type, true);
+                }
+            }
+        } else {
+            // Add only the top-level namespaces
+            const bool exportsTestConstant = absl::c_any_of(importedPackage.exports, [&](const auto &exp) -> bool {
+                return exp.type == ExportType::Public && isPrimaryTestNamespace(exp.fqn.parts[0]);
+            });
+            const bool exportsRealConstant = absl::c_any_of(importedPackage.exports, [&](const auto &exp) -> bool {
+                return exp.type == ExportType::Public && !isPrimaryTestNamespace(exp.fqn.parts[0]);
+            });
+
+            // If a Test:: constant is publicly exported, we add the top-level test package namespace.
+            if (exportsTestConstant)
+                addImport(ctx, importedPackage, import.name.loc, import.name.fullTestPkgName, import.type, false);
+
+            // If a non-test constant is publicly exported, we add the top-level package namespace.
+            if (exportsRealConstant)
+                addImport(ctx, importedPackage, import.name.loc, import.name.fullName, import.type, false);
+        }
+    }
+
+    void addImport(core::Context ctx, const PackageInfoImpl &importedPackage, core::LocOffsets loc,
+                   const FullyQualifiedName &exportFqn, ImportType importType, bool isEnumeratedImport) {
         ImportTree *node = &root;
         for (auto nameRef : exportFqn.parts) {
             auto &child = node->children[nameRef];
@@ -773,13 +919,20 @@ private:
             }
             node = child.get();
         }
-        node->source = {importedPackage.name.mangledName, loc, importType};
+
+        // If the node already has an import source, this is a conflicting import.
+        // See test/cli/package-import-conflicts/ for an example.
+        if (node->source.exists() && importType != ImportType::Self) {
+            addImportConflictError(ctx, loc, node->source.importLoc, exportFqn.parts);
+        }
+        node->source = {importedPackage.name.mangledName, loc, importType, isEnumeratedImport};
     }
 
     void makeModule(core::Context ctx, ImportTree *node, vector<core::NameRef> &parts, ast::ClassDef::RHS_store &modRhs,
-                    ImportType moduleType, ImportTree::Source parentSrc) {
+                    ModuleType moduleType, ImportTree::Source parentSrc) {
         auto newParentSrc = parentSrc;
-        if (node->source.exists() && !parentSrc.exists()) {
+        ImportTree::Source &source = node->source;
+        if (source.exists() && !parentSrc.exists()) {
             newParentSrc = node->source;
         }
 
@@ -791,60 +944,99 @@ private:
             return lhs.first.show(ctx) < rhs.first.show(ctx);
         });
         for (auto const &[nameRef, child] : childPairs) {
-            // Ignore the entire `Test::*` part of import tree if we are not in a test context.
-            if (moduleType != ImportType::Test && parts.empty() && isTestNamespace(ctx, nameRef)) {
-                continue;
+            if (parts.empty()) {
+                // Ignore the entire `Test::*` part of import tree if we are not in a test context.
+                if (isNonTestModule(moduleType) && isTestNamespace(ctx, nameRef))
+                    continue;
+
+                // Ignore non-test constants for the test export mapping module.
+                if (moduleType == ModuleType::ExportMappingTest && !isTestNamespace(ctx, nameRef))
+                    continue;
             }
+
             parts.emplace_back(nameRef);
             makeModule(ctx, child, parts, modRhs, moduleType, newParentSrc);
             parts.pop_back();
         }
 
-        if (node->source.exists()) {
+        if (source.exists()) {
+            // If we do not need to map the given import for the given module type, return
+            if (source.skipBuildMappingFor(moduleType))
+                return;
+
+            const bool isSelfImport = source.isSelfImport();
+            // For the test module, we do not need to map self-imports (i.e. exports from the current package) that
+            // begin with "Test::".
+            if (moduleType == ModuleType::Test && isSelfImport && isTestNamespace(ctx, parts[0]))
+                return;
+
             if (parentSrc.exists()) {
-                // A conflicting import exist. Only report errors while constructing the test output
+                // A conflicting import exists. Only report errors while constructing the test output
                 // to avoid duplicate errors because test imports are a superset of normal imports.
-                bool isSelfImport = node->source.packageMangledName == pkgMangledName;
-                if (moduleType == ImportType::Test && !isSelfImport) {
-                    if (auto e = ctx.beginError(node->source.importLoc, core::errors::Packager::ImportConflict)) {
-                        // TODO Fix flaky ordering of errors. This is strange...not being done in parallel,
-                        // and the file processing order is consistent.
-                        e.setHeader("Conflicting import sources for `{}`",
-                                    fmt::map_join(parts, "::", [&](const auto &nr) { return nr.show(ctx); }));
-                        e.addErrorLine(core::Loc(ctx.file, parentSrc.importLoc), "Conflict from");
-                    }
-                }
-            } else if (moduleType == ImportType::Test || node->source.importType == ImportType::Normal) {
+                if (moduleType == ModuleType::Test && !isSelfImport)
+                    addImportConflictError(ctx, source.importLoc, parentSrc.importLoc, parts);
+
+                return;
+            }
+
+            if (moduleType != ModuleType::Normal || source.isNormalImport()) {
                 // Construct a module containing an assignment for an imported name:
                 // For name `A::B::C::D` imported from package `A::B` construct:
                 // module A::B::C
                 //   D = <Mangled A::B>::A::B::C::D
                 // end
-                auto assignRhs = prependPackageScope(ctx, parts2literal(parts, core::LocOffsets::none()),
-                                                     node->source.packageMangledName);
+                const auto &sourceMangledName = isSelfImport ? privatePkgMangledName : source.packageMangledName;
+                auto assignRhs =
+                    prependPackageScope(ctx, parts2literal(parts, core::LocOffsets::none()), sourceMangledName);
+
                 auto assign = ast::MK::Assign(core::LocOffsets::none(), name2Expr(parts.back(), ast::MK::EmptyTree()),
                                               std::move(assignRhs));
 
-                // Ensure import's do not add duplicate loc's in the test_module
-                auto importLoc =
-                    moduleType == node->source.importType ? node->source.importLoc : core::LocOffsets::none();
-
                 ast::ClassDef::RHS_store rhs;
                 rhs.emplace_back(std::move(assign));
+
                 // Use the loc from the import in the module name and declaration to get the
-                // following jump to definition behavior:
+                // following jump to definition behavior in the case of enumerated imports:
                 // imported constant: `Foo::Bar::Baz` from package `Foo::Bar`
                 //                     ^^^^^^^^       jump to the import statement
                 //                               ^^^  jump to actual definition of `Baz` class
-                auto mod = ast::MK::Module(core::LocOffsets::none(), importLoc, importModuleName(parts, importLoc), {},
-                                           std::move(rhs));
+                //
+                // In the case of un-enumerated imports, we don't use the loc at the import site,
+                // but effectively use the one from the export site (due to the export mapping module).
+                // This results in the following behavior:
+                // imported constant: `Foo::Bar::Baz` from package `Foo::Bar`
+                //                     ^^^^^^^^       jump to package file of `Foo::Bar`
+                //                               ^^^  jump to actual definition of `Baz` class
+
+                // Ensure import's do not add duplicate loc-s in the test_module
+                const bool useImportLoc =
+                    source.isEnumeratedImport && (moduleType != ModuleType::Test || source.isSelfOrTestImport());
+                const auto &importLoc = useImportLoc ? source.importLoc : core::LocOffsets::none();
+
+                auto mod = ast::MK::Module(core::LocOffsets::none(), importLoc,
+                                           importModuleName(parts, importLoc, moduleType), {}, std::move(rhs));
                 modRhs.emplace_back(std::move(mod));
             }
         }
     }
 
-    ast::ExpressionPtr importModuleName(vector<core::NameRef> &parts, core::LocOffsets importLoc) const {
-        ast::ExpressionPtr name = name2Expr(pkgMangledName);
+    void addImportConflictError(core::Context ctx, const core::LocOffsets &loc, const core::LocOffsets &otherLoc,
+                                const vector<core::NameRef> &nameParts) {
+        if (auto e = ctx.beginError(loc, core::errors::Packager::ImportConflict)) {
+            // TODO Fix flaky ordering of errors. This is strange...not being done in parallel,
+            // and the file processing order is consistent.
+            e.setHeader("Conflicting import sources for `{}`",
+                        fmt::map_join(nameParts, "::", [&](const auto &nr) { return nr.show(ctx); }));
+            e.addErrorLine(core::Loc(ctx.file, otherLoc), "Conflict from");
+        }
+    }
+
+    ast::ExpressionPtr importModuleName(vector<core::NameRef> &parts, core::LocOffsets importLoc,
+                                        ModuleType moduleType) const {
+        // Export mapping modules are built in the public (_Package) namespace, whereas other modules are built in
+        // the private (_Package_Private) namespace.
+        ast::ExpressionPtr name =
+            isExportMappingModule(moduleType) ? name2Expr(pkgMangledName) : name2Expr(privatePkgMangledName);
         for (auto part = parts.begin(); part < parts.end() - 1; part++) {
             name = name2Expr(*part, move(name));
         }
@@ -906,6 +1098,8 @@ bool checkContainsAllPackages(const core::GlobalState &gs, const vector<ast::Par
 ast::ParsedFile rewritePackage(core::Context ctx, ast::ParsedFile file) {
     ast::ClassDef::RHS_store importedPackages;
     ast::ClassDef::RHS_store testImportedPackages;
+    ast::ClassDef::RHS_store exportMappingNormal;
+    ast::ClassDef::RHS_store exportMappingTest;
 
     const auto &packageDB = ctx.state.packageDB();
     auto &absPkg = packageDB.getPackageForFile(ctx, file.file);
@@ -924,46 +1118,46 @@ ast::ParsedFile rewritePackage(core::Context ctx, ast::ParsedFile file) {
     }
 
     {
-        UnorderedMap<core::NameRef, core::LocOffsets> importedNames;
         ImportTreeBuilder treeBuilder(package);
-        for (auto &import : package.importedPackageNames) {
-            auto &imported = import.name;
-            auto &importedPackage = packageDB.getPackageInfo(imported.mangledName);
-            if (!importedPackage.exists()) {
-                if (auto e = ctx.beginError(imported.loc, core::errors::Packager::PackageNotFound)) {
-                    e.setHeader("Cannot find package `{}`", imported.toString(ctx));
-                }
-                continue;
-            }
 
-            if (importedNames.contains(imported.mangledName)) {
-                if (auto e = ctx.beginError(imported.loc, core::errors::Packager::InvalidImportOrExport)) {
-                    e.setHeader("Duplicate package import `{}`", imported.toString(ctx));
-                    e.addErrorLine(core::Loc(ctx.file, importedNames[imported.mangledName]),
-                                   "Previous package import found here");
-                }
-            } else {
-                importedNames[imported.mangledName] = imported.loc;
-                treeBuilder.mergeImports(PackageInfoImpl::from(importedPackage), import);
-            }
-        }
+        // Merge public exports of this package into tree builder in order to "self-map" them
+        // from the package's private module to its public-facing module
+        treeBuilder.mergeSelfExports(ctx, package, ExportType::Public);
+        exportMappingNormal = treeBuilder.makeModule(ctx, ModuleType::ExportMappingNormal);
+        exportMappingTest = treeBuilder.makeModule(ctx, ModuleType::ExportMappingTest);
 
-        importedPackages = treeBuilder.makeModule(ctx, ImportType::Normal);
+        // Merge imports of package into tree builder in order to map external package modules
+        // into this package's private module
+        treeBuilder.mergeImports(ctx, package);
+        importedPackages = treeBuilder.makeModule(ctx, ModuleType::Normal);
 
-        treeBuilder.mergeSelfExportsForTest(ctx, package);
-        testImportedPackages = treeBuilder.makeModule(ctx, ImportType::Test);
+        // Merge self-test exports package into tree builder in order to "self-map" them (in addition
+        // to the public exports and imports of this package) into the package's private test module
+        treeBuilder.mergeSelfExports(ctx, package, ExportType::PrivateTest);
+        testImportedPackages = treeBuilder.makeModule(ctx, ModuleType::Test);
     }
 
+    // Create wrapper modules
     auto packageNamespace =
         ast::MK::Module(core::LocOffsets::none(), core::LocOffsets::none(),
                         name2Expr(core::Names::Constants::PackageRegistry()), {}, std::move(importedPackages));
     auto testPackageNamespace =
         ast::MK::Module(core::LocOffsets::none(), core::LocOffsets::none(),
                         name2Expr(core::Names::Constants::PackageTests()), {}, std::move(testImportedPackages));
+    auto exportMappingNormalNamespace =
+        ast::MK::Module(core::LocOffsets::none(), core::LocOffsets::none(),
+                        name2Expr(core::Names::Constants::PackageRegistry()), {}, std::move(exportMappingNormal));
+    auto exportMappingTestNamespace =
+        ast::MK::Module(core::LocOffsets::none(), core::LocOffsets::none(),
+                        name2Expr(core::Names::Constants::PackageTests()), {}, std::move(exportMappingTest));
 
+    // Add wrapper modules to root of the tree
     auto &rootKlass = ast::cast_tree_nonnull<ast::ClassDef>(file.tree);
     rootKlass.rhs.emplace_back(move(packageNamespace));
     rootKlass.rhs.emplace_back(move(testPackageNamespace));
+    rootKlass.rhs.emplace_back(move(exportMappingNormalNamespace));
+    rootKlass.rhs.emplace_back(move(exportMappingTestNamespace));
+
     return file;
 }
 
@@ -974,8 +1168,11 @@ ast::ParsedFile rewritePackagedFile(core::GlobalState &gs, ast::ParsedFile parse
     auto &pkg = gs.packageDB().getPackageForFile(ctx, ctx.file);
     if (pkg.exists()) {
         auto &pkgImpl = PackageInfoImpl::from(pkg);
+
+        // Wrap the file in a package module (ending with _Package_Private) to put it by default in the package's
+        // private namespace (private-by-default paradigm).
         parsedFile =
-            wrapFileInPackageModule(ctx, move(parsedFile), pkgImpl.name.mangledName, pkgImpl, isTestFile(gs, file));
+            wrapFileInPackageModule(ctx, move(parsedFile), pkgImpl.privateMangledName, pkgImpl, isTestFile(gs, file));
     } else {
         // Don't transform, but raise an error on the first line.
         if (auto e = ctx.beginError(core::LocOffsets{0, 0}, core::errors::Packager::UnpackagedFile)) {

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -154,10 +154,10 @@ public:
     PackageName name;
 
     // Private namespace of the package. We do not put this in the PackageName struct above because the former
-    // is used to not only hold package name information as part of PackageInfoImpl, but also created for every imported
-    // package when a package is enumerating its imports. In that context, the private name is unnecessary and would
-    // take up an unnecessary extra reference, which would contribute O(packages * imports) in space. Putting
-    // it here ensures only O(packages) space complexity for the private name.
+    // is used to not only hold package name information in PackageInfoImpl, but also created for every imported
+    // package during import enumeration. In that context, the private name is unnecessary and would
+    // take up an extra reference, which would contribute O(packages * imports) in space. Putting
+    // it here ensures only O(packages) space complexity.
     core::NameRef privateMangledName;
 
     // loc for the package definition. Used for error messages.
@@ -740,6 +740,9 @@ class ImportTree final {
         core::NameRef packageMangledName;
         core::LocOffsets importLoc;
         ImportType importType;
+
+        // This bit is set to true if the import is added as part of a fully-enumerated set
+        // of exports from a package.
         bool isEnumeratedImport;
 
         bool exists() {
@@ -806,6 +809,8 @@ public:
     ImportTreeBuilder &operator=(const ImportTreeBuilder &) = delete;
     ImportTreeBuilder &operator=(ImportTreeBuilder &&) = default;
 
+    // Add the imports of a package into the import tree. These are used for building the Normal and Test modules
+    // in the package's internal namespace.
     void mergeImports(core::Context ctx, const PackageInfoImpl &package) {
         const auto &packageDB = ctx.state.packageDB();
         UnorderedMap<core::NameRef, core::LocOffsets> importedNames;
@@ -832,27 +837,30 @@ public:
                 // (11/8/2021) timing analysis suggests that it doesn't.
                 //
                 // Determine whether the current package either imports a suffix of the imported name, or itself is a
-                // suffix of the imported name. This bit is passed into mergeImportsFromImportedPackage, specifically
-                // into the "enumerateExportsInFull" parameter.
+                // suffix of the imported name. Based on this, we determine whether to enumerate and alias all exports
+                // from an imported package or only alias the top-level export.
                 //
-                // To save on memory usage by reducing the number of nodes created in the AST, we individually alias
-                // exported constants from the imported package only when there would be an import conflict otherwise -
-                // i.e., when this is either a subpackage of the imported name or imports a subpackage of the imported
-                // name.
+                // Essentially, to save on memory usage by reducing the number of nodes created in the AST, we
+                // individually alias exported constants from the imported package if & only if there would be an import
+                // conflict otherwise; i.e., when the given package is either a subpackage of the imported name or also
+                // imports a subpackage of the imported name.
                 const bool isOrImportsSubpackage =
                     absl::c_any_of(package.importedPackageNames,
                                    [&](const auto &otherImport) -> bool {
                                        return otherImport.name.fullName.isSuffix(imported.fullName);
                                    }) ||
                     package.name.fullName.isSuffix(imported.fullName);
-                mergeImportsFromImportedPackage(ctx, PackageInfoImpl::from(importedPackage), import,
-                                                isOrImportsSubpackage);
+                if (isOrImportsSubpackage) {
+                    mergeAllExportsFromImportedPackage(ctx, PackageInfoImpl::from(importedPackage), import);
+                } else {
+                    mergeTopLevelExportFromImportedPackage(ctx, PackageInfoImpl::from(importedPackage), import);
+                }
             }
         }
     }
 
-    // Make add imports for the test package for all normal code exported by its corresponding
-    // "normal" package.
+    // Add the exports of a package as "self-imports" into the import tree. These are used for building the package's
+    // Test, ExportMappingNormal and ExportMappingTest modules.
     void mergeSelfExports(core::Context ctx, const PackageInfoImpl &pkg, ExportType type) {
         for (const auto &exp : pkg.exports) {
             if (exp.type != type)
@@ -881,34 +889,36 @@ private:
         return moduleType == ModuleType::ExportMappingNormal || moduleType == ModuleType::ExportMappingTest;
     }
 
-    void mergeImportsFromImportedPackage(core::Context ctx, const PackageInfoImpl &importedPackage,
-                                         const Import &import, bool enumerateExportsInFull) {
-        if (enumerateExportsInFull) {
-            // Enumerate and add all exported names from the imported package
-            for (const auto &exp : importedPackage.exports) {
-                if (exp.type == ExportType::Public) {
-                    addImport(ctx, importedPackage, import.name.loc, exp.fqn, import.type, true);
-                }
+    // Enumerate and add all exported names from an imported package into the import tree
+    void mergeAllExportsFromImportedPackage(core::Context ctx, const PackageInfoImpl &importedPackage,
+                                            const Import &import) {
+        for (const auto &exp : importedPackage.exports) {
+            if (exp.type == ExportType::Public) {
+                addImport(ctx, importedPackage, import.name.loc, exp.fqn, import.type, true);
             }
-        } else {
-            // Add only the top-level namespaces
-            const bool exportsTestConstant = absl::c_any_of(importedPackage.exports, [&](const auto &exp) -> bool {
-                return exp.type == ExportType::Public && isPrimaryTestNamespace(exp.fqn.parts[0]);
-            });
-            const bool exportsRealConstant = absl::c_any_of(importedPackage.exports, [&](const auto &exp) -> bool {
-                return exp.type == ExportType::Public && !isPrimaryTestNamespace(exp.fqn.parts[0]);
-            });
-
-            // If a Test:: constant is publicly exported, we add the top-level test package namespace.
-            if (exportsTestConstant)
-                addImport(ctx, importedPackage, import.name.loc, import.name.fullTestPkgName, import.type, false);
-
-            // If a non-test constant is publicly exported, we add the top-level package namespace.
-            if (exportsRealConstant)
-                addImport(ctx, importedPackage, import.name.loc, import.name.fullName, import.type, false);
         }
     }
 
+    // Add the entire top-level exported namespaces of an imported package into the import tree
+    void mergeTopLevelExportFromImportedPackage(core::Context ctx, const PackageInfoImpl &importedPackage,
+                                                const Import &import) {
+        const bool exportsTestConstant = absl::c_any_of(importedPackage.exports, [&](const auto &exp) -> bool {
+            return exp.type == ExportType::Public && isPrimaryTestNamespace(exp.fqn.parts[0]);
+        });
+        const bool exportsRealConstant = absl::c_any_of(importedPackage.exports, [&](const auto &exp) -> bool {
+            return exp.type == ExportType::Public && !isPrimaryTestNamespace(exp.fqn.parts[0]);
+        });
+
+        // If a Test:: constant is publicly exported, we add the top-level test package namespace.
+        if (exportsTestConstant)
+            addImport(ctx, importedPackage, import.name.loc, import.name.fullTestPkgName, import.type, false);
+
+        // If a non-test constant is publicly exported, we add the top-level package namespace.
+        if (exportsRealConstant)
+            addImport(ctx, importedPackage, import.name.loc, import.name.fullName, import.type, false);
+    }
+
+    // Add an individual imported name into the import tree.
     void addImport(core::Context ctx, const PackageInfoImpl &importedPackage, core::LocOffsets loc,
                    const FullyQualifiedName &exportFqn, ImportType importType, bool isEnumeratedImport) {
         ImportTree *node = &root;
@@ -928,6 +938,12 @@ private:
         node->source = {importedPackage.name.mangledName, loc, importType, isEnumeratedImport};
     }
 
+    // Method that makes a wrapper module for an import, of the form:
+    // module PkgMangledName::PkgName
+    //   Import = ImportedPkgMangledName::ImportedPkgName::Export
+    // end
+    //
+    // This method in fact creates a wrapper module recursively for the entire import tree of a package.
     void makeModule(core::Context ctx, ImportTree *node, vector<core::NameRef> &parts, ast::ClassDef::RHS_store &modRhs,
                     ModuleType moduleType, ImportTree::Source parentSrc) {
         auto newParentSrc = parentSrc;
@@ -1020,6 +1036,8 @@ private:
         }
     }
 
+    // Create an error that represents an import conflict; namely a package importing two names where one is a
+    // prefix of another. This is disallowed, as it would (rightly) cause a redefinition error in the namer pass.
     void addImportConflictError(core::Context ctx, const core::LocOffsets &loc, const core::LocOffsets &otherLoc,
                                 const vector<core::NameRef> &nameParts) {
         if (auto e = ctx.beginError(loc, core::errors::Packager::ImportConflict)) {
@@ -1031,6 +1049,7 @@ private:
         }
     }
 
+    // Name of the wrapper module for a given import, prefixed with the mangled name of the package.
     ast::ExpressionPtr importModuleName(vector<core::NameRef> &parts, core::LocOffsets importLoc,
                                         ModuleType moduleType) const {
         // Export mapping modules are built in the public (_Package) namespace, whereas other modules are built in
@@ -1046,6 +1065,7 @@ private:
     }
 };
 
+// Given a packaged file, wrap it in the _Package_Private mangled namespace of its package.
 ast::ParsedFile wrapFileInPackageModule(core::Context ctx, ast::ParsedFile file, core::NameRef packageMangledName,
                                         const PackageInfoImpl &pkg, bool isTestFile) {
     if (ast::isa_tree<ast::EmptyTree>(file.tree)) {

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -66,7 +66,7 @@ struct FullyQualifiedName {
             return false;
         }
 
-        return std::equal(parts.begin(), parts.begin() + prefix.parts.size(), prefix.parts.begin());
+        return std::equal(prefix.parts.begin(), prefix.parts.end(), parts.begin());
     }
 };
 
@@ -579,8 +579,7 @@ struct PackageInfoFinder {
         // TODO(nroman) If this is too slow could probably be sped up with lexigraphic sort.
         for (auto longer = exported.begin() + 1; longer != exported.end(); longer++) {
             for (auto shorter = exported.begin(); shorter != longer; shorter++) {
-                if (std::equal(longer->parts().begin(), longer->parts().begin() + shorter->parts().size(),
-                               shorter->parts().begin()) &&
+                if (std::equal(shorter->parts().begin(), shorter->parts().end(), longer->parts().begin()) &&
                     !allowedExportPrefix(ctx, *shorter, *longer)) {
                     if (auto e = ctx.beginError(longer->fqn.loc.offsets(), core::errors::Packager::ExportConflict)) {
                         e.setHeader(

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -839,8 +839,7 @@ public:
 
             importedNames[imported.mangledName] = imported.loc;
 
-            // TODO (aadi-stripe): fix this so it's not quadratic (if it ends up causing runtime bloat). Currently
-            // (11/8/2021) timing analysis suggests that it doesn't.
+            // TODO (aadi-stripe, 2022-02-01): re-run timing analysis to see if the quadratic implementation should be revisited.
             //
             // Determine whether the current package either imports a suffix of the imported name, or itself is a
             // suffix of the imported name. Based on this, we determine whether to enumerate and alias all exports

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -97,23 +97,24 @@ enum class ImportType {
     Normal,
     Test, // test_import
 
-    // "self-import": This represents code that is exported by a package, and is therefore "imported" (i.e. remapped)
-    // into its private test namespace and its public->private mapping.
-    Self,
+    // "friend-import": This represents code that is re-mapped into a package's own public->private mapping or
+    // its private test namespace.
+    Friend,
 };
 
 // There are 4 kinds of virtual modules inserted into the AST.
-// Normal: suffixed with _Package_Private, it maps external imports of a package into its namespace.
-// Test: suffixed with _Package_Private, it maps external imports, exports and self-test exports of a package into its
+// Private: suffixed with _Package_Private, it maps external imports of a package into its namespace.
+// PrivateTest: suffixed with _Package_Private, it maps external imports, exports and self-test exports of a package
+// into its
 //   test namespace.
-// ExportMappingNormal: suffixed with _Package, it maps exports of a package into its publicly available namespace (this
+// Public: suffixed with _Package, it maps exports of a package into its publicly available namespace (this
 //   is used by other packages when they import this package).
-// ExportMappingTest: suffixed with _Package, it maps exports of a package that are in the "Test::" namespace into its
+// PublicTest: suffixed with _Package, it maps exports of a package that are in the "Test::" namespace into its
 //   publicly available test namespace (this is used by other packages when they import this package).
 //
 // A package cannot access an external package's _Package_Private module, but a package's private module can access
 // an external package's public interface (which is the public _Package module).
-enum class ModuleType { Normal, Test, ExportMappingNormal, ExportMappingTest };
+enum class ModuleType { Private, PrivateTest, Public, PublicTest };
 
 struct Import {
     PackageName name;
@@ -751,8 +752,8 @@ class ImportTree final {
             return importLoc.exists();
         }
 
-        bool isSelfImport() {
-            return importType == ImportType::Self;
+        bool isFriendImport() {
+            return importType == ImportType::Friend;
         }
 
         bool isNormalImport() {
@@ -760,18 +761,17 @@ class ImportTree final {
         }
 
         bool isSelfOrTestImport() {
-            return importType == ImportType::Self || importType == ImportType::Test;
+            return importType == ImportType::Friend || importType == ImportType::Test;
         }
 
         bool skipBuildMappingFor(ModuleType moduleType) {
-            // Don't build mappings in the export mapping modules for external imports.
-            if (!isSelfImport() &&
-                (moduleType == ModuleType::ExportMappingNormal || moduleType == ModuleType::ExportMappingTest)) {
+            // Don't build mappings in the export-mapping/public modules for non-friend imports.
+            if (!isFriendImport() && (moduleType == ModuleType::Public || moduleType == ModuleType::PublicTest)) {
                 return true;
             }
 
             // Don't build mappings in the main (normal) package module for internal imports.
-            if (isSelfImport() && moduleType == ModuleType::Normal) {
+            if (isFriendImport() && moduleType == ModuleType::Private) {
                 return true;
             }
 
@@ -835,7 +835,8 @@ public:
 
             importedNames[imported.mangledName] = imported.loc;
 
-            // TODO (aadi-stripe, 2022-02-01): re-run timing analysis to see if the quadratic implementation should be revisited.
+            // TODO (aadi-stripe, 2022-02-01): re-run timing analysis to see if the quadratic implementation should be
+            // revisited.
             //
             // Determine whether the current package either imports a suffix of the imported name, or itself is a
             // suffix of the imported name. Based on this, we determine whether to enumerate and alias all exports
@@ -858,9 +859,9 @@ public:
         }
     }
 
-    // Add the exports of a package as "self-imports" into the import tree. These are used for building the package's
-    // Test, ExportMappingNormal and ExportMappingTest modules.
-    void mergeSelfExports(core::Context ctx, const PackageInfoImpl &pkg, ExportType type) {
+    // Add the exports of a package as "friend-imports" into the import tree. These are used for building the package's
+    // Test, Public and PublicTest modules.
+    void mergePublicInterface(core::Context ctx, const PackageInfoImpl &pkg, ExportType type) {
         for (const auto &exp : pkg.exports) {
             if (exp.type != type) {
                 continue;
@@ -869,7 +870,7 @@ public:
             const auto &parts = exp.parts();
             ENFORCE(parts.size() > 0);
             auto loc = exp.fqn.loc.offsets();
-            addImport(ctx, pkg, loc, exp.fqn, ImportType::Self, true);
+            addImport(ctx, pkg, loc, exp.fqn, ImportType::Friend, true);
         }
     }
 
@@ -882,11 +883,11 @@ public:
 
 private:
     const bool isNonTestModule(ModuleType moduleType) const {
-        return moduleType == ModuleType::ExportMappingNormal || moduleType == ModuleType::Normal;
+        return moduleType == ModuleType::Public || moduleType == ModuleType::Private;
     }
 
-    const bool isExportMappingModule(ModuleType moduleType) const {
-        return moduleType == ModuleType::ExportMappingNormal || moduleType == ModuleType::ExportMappingTest;
+    const bool isPublicModule(ModuleType moduleType) const {
+        return moduleType == ModuleType::Public || moduleType == ModuleType::PublicTest;
     }
 
     // Enumerate and add all exported names from an imported package into the import tree
@@ -934,7 +935,7 @@ private:
 
         // If the node already has an import source, this is a conflicting import.
         // See test/cli/package-import-conflicts/ for an example.
-        if (node->source.exists() && importType != ImportType::Self) {
+        if (node->source.exists() && importType != ImportType::Friend) {
             addImportConflictError(ctx, loc, node->source.importLoc, exportFqn.parts);
         }
         node->source = ImportTree::Source{importedPackage.name.mangledName, loc, importType, isEnumeratedImport};
@@ -968,8 +969,8 @@ private:
                     continue;
                 }
 
-                // Ignore non-test constants for the test export mapping module.
-                if (moduleType == ModuleType::ExportMappingTest && !isTestNamespace(ctx, nameRef)) {
+                // Ignore non-test constants for the public test module.
+                if (moduleType == ModuleType::PublicTest && !isTestNamespace(ctx, nameRef)) {
                     continue;
                 }
             }
@@ -985,30 +986,30 @@ private:
                 return;
             }
 
-            const bool isSelfImport = source.isSelfImport();
-            // For the test module, we do not need to map self-imports (i.e. exports from the current package) that
+            const bool isFriendImport = source.isFriendImport();
+            // For the test module, we do not need to map friend-imports (i.e. exports from the current package) that
             // begin with "Test::".
-            if (moduleType == ModuleType::Test && isSelfImport && isTestNamespace(ctx, parts[0])) {
+            if (moduleType == ModuleType::PrivateTest && isFriendImport && isTestNamespace(ctx, parts[0])) {
                 return;
             }
 
             if (parentSrc.exists()) {
                 // A conflicting import exists. Only report errors while constructing the test output
                 // to avoid duplicate errors because test imports are a superset of normal imports.
-                if (moduleType == ModuleType::Test && !isSelfImport) {
+                if (moduleType == ModuleType::PrivateTest && !isFriendImport) {
                     addImportConflictError(ctx, source.importLoc, parentSrc.importLoc, parts);
                 }
 
                 return;
             }
 
-            if (moduleType != ModuleType::Normal || source.isNormalImport()) {
+            if (moduleType != ModuleType::Private || source.isNormalImport()) {
                 // Construct a module containing an assignment for an imported name:
                 // For name `A::B::C::D` imported from package `A::B` construct:
                 // module A::B::C
                 //   D = <Mangled A::B>::A::B::C::D
                 // end
-                const auto &sourceMangledName = isSelfImport ? privatePkgMangledName : source.packageMangledName;
+                const auto &sourceMangledName = isFriendImport ? privatePkgMangledName : source.packageMangledName;
                 auto assignRhs =
                     prependPackageScope(ctx, parts2literal(parts, core::LocOffsets::none()), sourceMangledName);
 
@@ -1025,7 +1026,7 @@ private:
                 //                               ^^^  jump to actual definition of `Baz` class
                 //
                 // In the case of un-enumerated imports, we don't use the loc at the import site,
-                // but effectively use the one from the export site (due to the export mapping module).
+                // but effectively use the one from the export site (due to the export-mapping/public module).
                 // This results in the following behavior:
                 // imported constant: `Foo::Bar::Baz` from package `Foo::Bar`
                 //                     ^^^^^^^^       jump to package file of `Foo::Bar`
@@ -1033,7 +1034,7 @@ private:
 
                 // Ensure import's do not add duplicate loc-s in the test_module
                 const bool useImportLoc =
-                    source.isEnumeratedImport && (moduleType != ModuleType::Test || source.isSelfOrTestImport());
+                    source.isEnumeratedImport && (moduleType != ModuleType::PrivateTest || source.isSelfOrTestImport());
                 const auto &importLoc = useImportLoc ? source.importLoc : core::LocOffsets::none();
 
                 auto mod = ast::MK::Module(core::LocOffsets::none(), importLoc,
@@ -1062,7 +1063,7 @@ private:
         // Export mapping modules are built in the public (_Package) namespace, whereas other modules are built in
         // the private (_Package_Private) namespace.
         ast::ExpressionPtr name =
-            isExportMappingModule(moduleType) ? name2Expr(pkgMangledName) : name2Expr(privatePkgMangledName);
+            isPublicModule(moduleType) ? name2Expr(pkgMangledName) : name2Expr(privatePkgMangledName);
         for (auto part = parts.begin(); part < parts.end() - 1; part++) {
             name = name2Expr(*part, move(name));
         }
@@ -1135,8 +1136,8 @@ bool checkContainsAllPackages(const core::GlobalState &gs, const vector<ast::Par
 ast::ParsedFile rewritePackage(core::Context ctx, ast::ParsedFile file) {
     ast::ClassDef::RHS_store importedPackages;
     ast::ClassDef::RHS_store testImportedPackages;
-    ast::ClassDef::RHS_store exportMappingNormal;
-    ast::ClassDef::RHS_store exportMappingTest;
+    ast::ClassDef::RHS_store publicMapping;
+    ast::ClassDef::RHS_store publicTestMapping;
 
     const auto &packageDB = ctx.state.packageDB();
     auto &absPkg = packageDB.getPackageForFile(ctx, file.file);
@@ -1159,19 +1160,19 @@ ast::ParsedFile rewritePackage(core::Context ctx, ast::ParsedFile file) {
 
         // Merge public exports of this package into tree builder in order to "self-map" them
         // from the package's private module to its public-facing module
-        treeBuilder.mergeSelfExports(ctx, package, ExportType::Public);
-        exportMappingNormal = treeBuilder.makeModule(ctx, ModuleType::ExportMappingNormal);
-        exportMappingTest = treeBuilder.makeModule(ctx, ModuleType::ExportMappingTest);
+        treeBuilder.mergePublicInterface(ctx, package, ExportType::Public);
+        publicMapping = treeBuilder.makeModule(ctx, ModuleType::Public);
+        publicTestMapping = treeBuilder.makeModule(ctx, ModuleType::PublicTest);
 
         // Merge imports of package into tree builder in order to map external package modules
         // into this package's private module
         treeBuilder.mergeImports(ctx, package);
-        importedPackages = treeBuilder.makeModule(ctx, ModuleType::Normal);
+        importedPackages = treeBuilder.makeModule(ctx, ModuleType::Private);
 
         // Merge self-test exports package into tree builder in order to "self-map" them (in addition
         // to the public exports and imports of this package) into the package's private test module
-        treeBuilder.mergeSelfExports(ctx, package, ExportType::PrivateTest);
-        testImportedPackages = treeBuilder.makeModule(ctx, ModuleType::Test);
+        treeBuilder.mergePublicInterface(ctx, package, ExportType::PrivateTest);
+        testImportedPackages = treeBuilder.makeModule(ctx, ModuleType::PrivateTest);
     }
 
     // Create wrapper modules
@@ -1181,19 +1182,19 @@ ast::ParsedFile rewritePackage(core::Context ctx, ast::ParsedFile file) {
     auto testPackageNamespace =
         ast::MK::Module(core::LocOffsets::none(), core::LocOffsets::none(),
                         name2Expr(core::Names::Constants::PackageTests()), {}, std::move(testImportedPackages));
-    auto exportMappingNormalNamespace =
+    auto publicMappingNamespace =
         ast::MK::Module(core::LocOffsets::none(), core::LocOffsets::none(),
-                        name2Expr(core::Names::Constants::PackageRegistry()), {}, std::move(exportMappingNormal));
-    auto exportMappingTestNamespace =
+                        name2Expr(core::Names::Constants::PackageRegistry()), {}, std::move(publicMapping));
+    auto publicTestMappingNamespace =
         ast::MK::Module(core::LocOffsets::none(), core::LocOffsets::none(),
-                        name2Expr(core::Names::Constants::PackageTests()), {}, std::move(exportMappingTest));
+                        name2Expr(core::Names::Constants::PackageTests()), {}, std::move(publicTestMapping));
 
     // Add wrapper modules to root of the tree
     auto &rootKlass = ast::cast_tree_nonnull<ast::ClassDef>(file.tree);
     rootKlass.rhs.emplace_back(move(packageNamespace));
     rootKlass.rhs.emplace_back(move(testPackageNamespace));
-    rootKlass.rhs.emplace_back(move(exportMappingNormalNamespace));
-    rootKlass.rhs.emplace_back(move(exportMappingTestNamespace));
+    rootKlass.rhs.emplace_back(move(publicMappingNamespace));
+    rootKlass.rhs.emplace_back(move(publicTestMappingNamespace));
 
     return file;
 }

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -110,6 +110,9 @@ enum class ImportType {
 //   is used by other packages when they import this package).
 // ExportMappingTest: suffixed with _Package, it maps exports of a package that are in the "Test::" namespace into its
 //   publicly available test namespace (this is used by other packages when they import this package).
+//
+// A package cannot access an external package's _Package_Private module, but a package's private module can access
+// an external package's public interface (which is the public _Package module).
 enum class ModuleType { Normal, Test, ExportMappingNormal, ExportMappingTest };
 
 struct Import {
@@ -231,7 +234,7 @@ PackageName getPackageName(core::MutableContext ctx, ast::UnresolvedConstantLit 
     pName.fullTestPkgName = pName.fullName.withPrefix(TEST_NAME);
 
     // Foo::Bar => Foo_Bar_Package
-    auto mangledName = absl::StrCat(absl::StrJoin(pName.fullName.parts, "_", NameFormatter(ctx)), "_Package");
+    auto mangledName = absl::StrCat(absl::StrJoin(pName.fullName.parts, "_", NameFormatter(ctx)), core::PACKAGE_SUFFIX);
     auto utf8Name = ctx.state.enterNameUTF8(mangledName);
     auto packagerName = ctx.state.freshNameUnique(core::UniqueNameKind::Packager, utf8Name, 1);
     pName.mangledName = ctx.state.enterNameConstant(packagerName);
@@ -551,7 +554,7 @@ struct PackageInfoFinder {
         return tree;
     }
 
-    // Bar::Baz => <PackageRegistry>::Foo_Package::Bar::Baz
+    // Bar::Baz => <PackageRegistry>::Foo_Package_Private::Bar::Baz
     ast::ExpressionPtr prependInternalPackageName(const core::GlobalState &gs, ast::ExpressionPtr scope) {
         return prependPackageScope(gs, move(scope), this->info->privateMangledName);
     }
@@ -723,7 +726,7 @@ unique_ptr<PackageInfoImpl> getPackageInfo(core::MutableContext ctx, ast::Parsed
     if (finder.info) {
         finder.info->packagePathPrefixes.emplace_back(packageFilePath.substr(0, packageFilePath.find_last_of('/') + 1));
         const string_view shortName = finder.info->name.mangledName.shortName(ctx.state);
-        const string_view dirNameFromShortName = shortName.substr(0, shortName.find("_Package"));
+        const string_view dirNameFromShortName = shortName.substr(0, shortName.find(core::PACKAGE_SUFFIX));
 
         for (const string &prefix : extraPackageFilesDirectoryPrefixes) {
             string additionalDirPath = absl::StrCat(prefix, dirNameFromShortName, "/");
@@ -773,8 +776,9 @@ class ImportTree final {
             }
 
             // Don't build mappings in the main (normal) package module for internal imports.
-            if (isSelfImport() && moduleType == ModuleType::Normal)
+            if (isSelfImport() && moduleType == ModuleType::Normal) {
                 return true;
+            }
 
             return false;
         }
@@ -830,31 +834,33 @@ public:
                     e.addErrorLine(core::Loc(ctx.file, importedNames[imported.mangledName]),
                                    "Previous package import found here");
                 }
-            } else {
-                importedNames[imported.mangledName] = imported.loc;
 
-                // TODO (aadi-stripe): fix this so it's not quadratic (if it ends up causing runtime bloat). Currently
-                // (11/8/2021) timing analysis suggests that it doesn't.
-                //
-                // Determine whether the current package either imports a suffix of the imported name, or itself is a
-                // suffix of the imported name. Based on this, we determine whether to enumerate and alias all exports
-                // from an imported package or only alias the top-level export.
-                //
-                // Essentially, to save on memory usage by reducing the number of nodes created in the AST, we
-                // individually alias exported constants from the imported package if & only if there would be an import
-                // conflict otherwise; i.e., when the given package is either a subpackage of the imported name or also
-                // imports a subpackage of the imported name.
-                const bool isOrImportsSubpackage =
-                    absl::c_any_of(package.importedPackageNames,
-                                   [&](const auto &otherImport) -> bool {
-                                       return otherImport.name.fullName.isSuffix(imported.fullName);
-                                   }) ||
-                    package.name.fullName.isSuffix(imported.fullName);
-                if (isOrImportsSubpackage) {
-                    mergeAllExportsFromImportedPackage(ctx, PackageInfoImpl::from(importedPackage), import);
-                } else {
-                    mergeTopLevelExportFromImportedPackage(ctx, PackageInfoImpl::from(importedPackage), import);
-                }
+                continue;
+            }
+
+            importedNames[imported.mangledName] = imported.loc;
+
+            // TODO (aadi-stripe): fix this so it's not quadratic (if it ends up causing runtime bloat). Currently
+            // (11/8/2021) timing analysis suggests that it doesn't.
+            //
+            // Determine whether the current package either imports a suffix of the imported name, or itself is a
+            // suffix of the imported name. Based on this, we determine whether to enumerate and alias all exports
+            // from an imported package or only alias the top-level export.
+            //
+            // Essentially, to save on memory usage by reducing the number of nodes created in the AST, we
+            // individually alias exported constants from the imported package if & only if there would be an import
+            // conflict otherwise; i.e., when the given package is either a subpackage of the imported name or also
+            // imports a subpackage of the imported name.
+            const bool isOrImportsSubpackage =
+                absl::c_any_of(package.importedPackageNames,
+                               [&](const auto &otherImport) -> bool {
+                                   return otherImport.name.fullName.isSuffix(imported.fullName);
+                               }) ||
+                package.name.fullName.isSuffix(imported.fullName);
+            if (isOrImportsSubpackage) {
+                mergeAllExportsFromImportedPackage(ctx, PackageInfoImpl::from(importedPackage), import);
+            } else {
+                mergeTopLevelExportFromImportedPackage(ctx, PackageInfoImpl::from(importedPackage), import);
             }
         }
     }
@@ -863,8 +869,9 @@ public:
     // Test, ExportMappingNormal and ExportMappingTest modules.
     void mergeSelfExports(core::Context ctx, const PackageInfoImpl &pkg, ExportType type) {
         for (const auto &exp : pkg.exports) {
-            if (exp.type != type)
+            if (exp.type != type) {
                 continue;
+            }
 
             const auto &parts = exp.parts();
             ENFORCE(parts.size() > 0);
@@ -910,12 +917,14 @@ private:
         });
 
         // If a Test:: constant is publicly exported, we add the top-level test package namespace.
-        if (exportsTestConstant)
+        if (exportsTestConstant) {
             addImport(ctx, importedPackage, import.name.loc, import.name.fullTestPkgName, import.type, false);
+        }
 
         // If a non-test constant is publicly exported, we add the top-level package namespace.
-        if (exportsRealConstant)
+        if (exportsRealConstant) {
             addImport(ctx, importedPackage, import.name.loc, import.name.fullName, import.type, false);
+        }
     }
 
     // Add an individual imported name into the import tree.
@@ -935,7 +944,7 @@ private:
         if (node->source.exists() && importType != ImportType::Self) {
             addImportConflictError(ctx, loc, node->source.importLoc, exportFqn.parts);
         }
-        node->source = {importedPackage.name.mangledName, loc, importType, isEnumeratedImport};
+        node->source = ImportTree::Source{importedPackage.name.mangledName, loc, importType, isEnumeratedImport};
     }
 
     // Method that makes a wrapper module for an import, of the form:
@@ -947,7 +956,7 @@ private:
     void makeModule(core::Context ctx, ImportTree *node, vector<core::NameRef> &parts, ast::ClassDef::RHS_store &modRhs,
                     ModuleType moduleType, ImportTree::Source parentSrc) {
         auto newParentSrc = parentSrc;
-        ImportTree::Source &source = node->source;
+        auto &source = node->source;
         if (source.exists() && !parentSrc.exists()) {
             newParentSrc = node->source;
         }
@@ -962,12 +971,14 @@ private:
         for (auto const &[nameRef, child] : childPairs) {
             if (parts.empty()) {
                 // Ignore the entire `Test::*` part of import tree if we are not in a test context.
-                if (isNonTestModule(moduleType) && isTestNamespace(ctx, nameRef))
+                if (isNonTestModule(moduleType) && isTestNamespace(ctx, nameRef)) {
                     continue;
+                }
 
                 // Ignore non-test constants for the test export mapping module.
-                if (moduleType == ModuleType::ExportMappingTest && !isTestNamespace(ctx, nameRef))
+                if (moduleType == ModuleType::ExportMappingTest && !isTestNamespace(ctx, nameRef)) {
                     continue;
+                }
             }
 
             parts.emplace_back(nameRef);
@@ -977,20 +988,23 @@ private:
 
         if (source.exists()) {
             // If we do not need to map the given import for the given module type, return
-            if (source.skipBuildMappingFor(moduleType))
+            if (source.skipBuildMappingFor(moduleType)) {
                 return;
+            }
 
             const bool isSelfImport = source.isSelfImport();
             // For the test module, we do not need to map self-imports (i.e. exports from the current package) that
             // begin with "Test::".
-            if (moduleType == ModuleType::Test && isSelfImport && isTestNamespace(ctx, parts[0]))
+            if (moduleType == ModuleType::Test && isSelfImport && isTestNamespace(ctx, parts[0])) {
                 return;
+            }
 
             if (parentSrc.exists()) {
                 // A conflicting import exists. Only report errors while constructing the test output
                 // to avoid duplicate errors because test imports are a superset of normal imports.
-                if (moduleType == ModuleType::Test && !isSelfImport)
+                if (moduleType == ModuleType::Test && !isSelfImport) {
                     addImportConflictError(ctx, source.importLoc, parentSrc.importLoc, parts);
+                }
 
                 return;
             }
@@ -1108,13 +1122,23 @@ bool checkContainsAllPackages(const core::GlobalState &gs, const vector<ast::Par
 } // namespace
 
 // Add:
-//    module <PackageRegistry>::Mangled_Name_Package
+//    module <PackageRegistry>::Mangled_Name_Package_Private
 //      module A::B::C
 //        D = Mangled_Imported_Package::A::B::C::D
 //      end
 //      ...
 //    end
-// ...to __package.rb files to set up the package namespace.
+//
+//    for external imports, and
+//
+//    module <PackageRegistry>::Mangled_Name_Package
+//      module F
+//        G = Mangled_Name_Package_Private::G
+//      end
+//      ...
+//    end
+//
+// ...for self-mapping, to __package.rb files to set up the package namespace.
 ast::ParsedFile rewritePackage(core::Context ctx, ast::ParsedFile file) {
     ast::ClassDef::RHS_store importedPackages;
     ast::ClassDef::RHS_store testImportedPackages;

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -755,10 +755,6 @@ class ImportTree final {
             return importType == ImportType::Self;
         }
 
-        bool isTestImport() {
-            return importType == ImportType::Test;
-        }
-
         bool isNormalImport() {
             return importType == ImportType::Normal;
         }

--- a/proto/Name.proto
+++ b/proto/Name.proto
@@ -25,6 +25,7 @@ message Name {
          OPUS_ENUM = 11;
          DEFAULT_ARG = 12;
          PACKAGER = 13;
+         PACKAGER_PRIVATE = 14;
     };
 
     Kind kind = 1;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1931,7 +1931,7 @@ class ResolveTypeMembersAndFieldsWalk {
                 } else {
                     auto package = core::cast_type_nonnull<core::LiteralType>(packageType);
                     auto packageName = package.asName(ctx);
-                    auto mangledName = packageName.lookupMangledPackageName(ctx.state);
+                    auto mangledName = packageName.lookupMangledPrivatePackageName(ctx.state);
                     // if the mangled name doesn't exist, then this means probably there's no package named this
                     if (!mangledName.exists()) {
                         if (auto e = ctx.beginError(*packageLoc, core::errors::Resolver::LazyResolve)) {

--- a/test/BUILD
+++ b/test/BUILD
@@ -200,6 +200,18 @@ pipeline_tests(
 )
 
 pipeline_tests(
+    "test_corpus_packager",
+    glob(
+        [
+            "testdata/packager/**/*.rb",
+            "testdata/packager/**/*.exp",
+        ],
+    ),
+    "PackagerTests",
+    filter = "PackagerTests",
+)
+
+pipeline_tests(
     "whitequark_parser_corpus",
     glob([
         "whitequark/**/*.rb",
@@ -234,6 +246,11 @@ test_suite(
 test_suite(
     name = "whitequark_parser_tests",
     tests = ["whitequark_parser_corpus"],
+)
+
+test_suite(
+    name = "test_packager",
+    tests = ["test_corpus_packager"],
 )
 
 load(":compiler_tests.bzl", "compiler_tests")

--- a/test/BUILD
+++ b/test/BUILD
@@ -200,7 +200,7 @@ pipeline_tests(
 )
 
 pipeline_tests(
-    "test_corpus_packager",
+    "test_packager",
     glob(
         [
             "testdata/packager/**/*.rb",
@@ -246,11 +246,6 @@ test_suite(
 test_suite(
     name = "whitequark_parser_tests",
     tests = ["whitequark_parser_corpus"],
-)
-
-test_suite(
-    name = "test_packager",
-    tests = ["test_corpus_packager"],
 )
 
 load(":compiler_tests.bzl", "compiler_tests")

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -211,7 +211,7 @@ Usage:
                                 Like --ignore, but it only affects `-p
                                 autogen-subclasses`.
       --stop-after phase        Stop After: [init, parser, desugarer,
-                                rewriter, local-vars, namer, resolver, cfg,
+                                rewriter, local-vars, namer, packager, resolver, cfg,
                                 inferencer] (default: inferencer)
       --no-stdlib               Do not load included rbi files for stdlib
       --skip-rewriter-passes    Do not run Rewriter passess

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -211,7 +211,7 @@ Usage:
                                 Like --ignore, but it only affects `-p
                                 autogen-subclasses`.
       --stop-after phase        Stop After: [init, parser, desugarer,
-                                rewriter, local-vars, namer, packager, resolver, cfg,
+                                rewriter, local-vars, namer, resolver, cfg,
                                 inferencer] (default: inferencer)
       --no-stdlib               Do not load included rbi files for stdlib
       --skip-rewriter-passes    Do not run Rewriter passess

--- a/test/cli/package-export-nested-namespace-conflict/package-export-nested-namespace-conflict.out
+++ b/test/cli/package-export-nested-namespace-conflict/package-export-nested-namespace-conflict.out
@@ -1,0 +1,7 @@
+parent/__package.rb:4: Conflicting import sources for `Parent::Child` https://srb.help/3714
+     4 |  import Parent::Child
+                 ^^^^^^^^^^^^^
+    parent/__package.rb:6: Conflict from
+     6 |  export_for_test Parent
+                          ^^^^^^
+Errors: 1

--- a/test/cli/package-export-nested-namespace-conflict/package-export-nested-namespace-conflict.sh
+++ b/test/cli/package-export-nested-namespace-conflict/package-export-nested-namespace-conflict.sh
@@ -1,0 +1,4 @@
+cd test/cli/package-export-nested-namespace-conflict || exit 1
+
+../../../main/sorbet --silence-dev-message --stripe-packages --max-threads=0 . 2>&1
+

--- a/test/cli/package-export-nested-namespace-conflict/parent/__package.rb
+++ b/test/cli/package-export-nested-namespace-conflict/parent/__package.rb
@@ -1,0 +1,7 @@
+# typed: strict
+
+class Parent < PackageSpec
+  import Parent::Child
+
+  export_for_test Parent
+end

--- a/test/cli/package-export-nested-namespace-conflict/parent/b.rb
+++ b/test/cli/package-export-nested-namespace-conflict/parent/b.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+module Parent
+  class B; end
+end

--- a/test/cli/package-export-nested-namespace-conflict/parent/child/__package.rb
+++ b/test/cli/package-export-nested-namespace-conflict/parent/child/__package.rb
@@ -1,0 +1,6 @@
+# typed: strict
+
+class Parent::Child < PackageSpec
+  export Parent::Child::A
+end
+

--- a/test/cli/package-export-nested-namespace-conflict/parent/child/a.rb
+++ b/test/cli/package-export-nested-namespace-conflict/parent/child/a.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+module Parent::Child
+  class A; end
+end

--- a/test/cli/package-import-conflicts/package-import-conflicts.out
+++ b/test/cli/package-import-conflicts/package-import-conflicts.out
@@ -1,11 +1,11 @@
-imports_both_reversed/__package.rb:4: Conflicting import sources for `A::B::C` https://srb.help/3714
-     4 |  import A::B
-                 ^^^^
-    imports_both_reversed/__package.rb:5: Conflict from
+imports_both_reversed/__package.rb:5: Conflicting import sources for `A::B` https://srb.help/3714
      5 |  import A
                  ^
+    imports_both_reversed/__package.rb:4: Conflict from
+     4 |  import A::B
+                 ^^^^
 
-imports_both/__package.rb:5: Conflicting import sources for `A::B::C` https://srb.help/3714
+imports_both/__package.rb:5: Conflicting import sources for `A::B` https://srb.help/3714
      5 |  import A::B
                  ^^^^
     imports_both/__package.rb:4: Conflict from

--- a/test/cli/package-redefine-nested-namespace-error/package-redefine-nested-namespace-error.out
+++ b/test/cli/package-redefine-nested-namespace-error/package-redefine-nested-namespace-error.out
@@ -1,0 +1,11 @@
+parent/b.rb:4: Redefining constant `Parent::Child` https://srb.help/4012
+     4 |  module Child
+     5 |    class B; end
+     6 |  end
+    parent/__package.rb: Previous definition
+
+parent/b.rb:5: Can't nest `B` under `Parent::Child` because `Parent::Child` is not a class or module https://srb.help/4015
+     5 |    class B; end
+                  ^
+    parent/__package.rb: `Parent::Child` defined here
+Errors: 2

--- a/test/cli/package-redefine-nested-namespace-error/package-redefine-nested-namespace-error.sh
+++ b/test/cli/package-redefine-nested-namespace-error/package-redefine-nested-namespace-error.sh
@@ -1,0 +1,4 @@
+cd test/cli/package-redefine-nested-namespace-error || exit 1
+
+../../../main/sorbet --silence-dev-message --stripe-packages --max-threads=0 . 2>&1
+

--- a/test/cli/package-redefine-nested-namespace-error/parent/__package.rb
+++ b/test/cli/package-redefine-nested-namespace-error/parent/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class Parent < PackageSpec
+  import Parent::Child
+end

--- a/test/cli/package-redefine-nested-namespace-error/parent/b.rb
+++ b/test/cli/package-redefine-nested-namespace-error/parent/b.rb
@@ -1,0 +1,7 @@
+# typed: strict
+
+module Parent
+  module Child
+    class B; end
+  end
+end

--- a/test/cli/package-redefine-nested-namespace-error/parent/child/__package.rb
+++ b/test/cli/package-redefine-nested-namespace-error/parent/child/__package.rb
@@ -1,0 +1,6 @@
+# typed: strict
+
+class Parent::Child < PackageSpec
+  export Parent::Child::A
+end
+

--- a/test/cli/package-redefine-nested-namespace-error/parent/child/a.rb
+++ b/test/cli/package-redefine-nested-namespace-error/parent/child/a.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+module Parent::Child
+  class A; end
+end

--- a/test/cli/simple-package/bar/bar.rb
+++ b/test/cli/simple-package/bar/bar.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
+
 # typed: strict
 
 module Project::Bar
   class BarClass
     extend T::Sig
-    sig {params(value: Integer).void}
+    sig { params(value: Integer).void }
     def initialize(value)
       @value = T.let(value, Integer)
     end
   end
+
+  class UnexportedClass; end
 end

--- a/test/cli/simple-package/foo/foo.rb
+++ b/test/cli/simple-package/foo/foo.rb
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
+
 # typed: strict
 
 module Project::Foo
   class FooClass
     extend T::Sig
-    sig {params(value: Integer).void}
+    sig { params(value: Integer).void }
     def initialize(value)
       @value = T.let(value, Integer)
     end
 
     Project::Bar::BardClass
+    Project::Bar::UnexportedClass
   end
 end

--- a/test/cli/simple-package/simple-package.out
+++ b/test/cli/simple-package/simple-package.out
@@ -1,9 +1,20 @@
-foo/foo.rb:12: Unable to resolve constant `BardClass` https://srb.help/5002
-    12 |    Project::Bar::BardClass
+foo/foo.rb:13: Unable to resolve constant `BardClass` https://srb.help/5002
+    13 |    Project::Bar::BardClass
             ^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    foo/foo.rb:12: Replace with `Project::Bar::BarClass`
-    12 |    Project::Bar::BardClass
+    foo/foo.rb:13: Replace with `Project::Bar::BarClass`
+    13 |    Project::Bar::BardClass
             ^^^^^^^^^^^^^^^^^^^^^^^
-    foo/__package.rb: Did you mean: `Project::Bar::BarClass`?
-Errors: 1
+    bar/__package.rb: Did you mean: `Project::Bar::BarClass`?
+
+foo/foo.rb:14: Unable to resolve constant `UnexportedClass` https://srb.help/5002
+    14 |    Project::Bar::UnexportedClass
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    foo/foo.rb:14: Replace with `Gem::Package::TarReader::UnexpectedEOF`
+    14 |    Project::Bar::UnexportedClass
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/rubygems.rbi#L2901: Did you mean: `Gem::Package::TarReader::UnexpectedEOF`?
+    2901 |class Gem::Package::TarReader::UnexpectedEOF < StandardError
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Errors: 2

--- a/test/pipeline_test.bzl
+++ b/test/pipeline_test.bzl
@@ -52,6 +52,7 @@ _TEST_RUNNERS = {
     "PosTests": ":pipeline_test_runner",
     "LSPTests": ":lsp_test_runner",
     "WhitequarkParserTests": ":parser_test_runner",
+    "PackagerTests": ":pipeline_test_runner",
 }
 
 def pipeline_tests(suite_name, all_paths, test_name_prefix, filter = "*", extra_args = [], tags = []):

--- a/test/testdata/packager/deeply_nested_packages/pass.package-tree.exp
+++ b/test/testdata/packager/deeply_nested_packages/pass.package-tree.exp
@@ -3,34 +3,47 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C Package><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.import(<emptyTree>::<C Package>::<C Subpackage>)
 
-    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>::<C PackageClass>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Package_Package_Private$1>::<C Package>::<C PackageClass>)
 
-    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>::<C InnerClass>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Package_Package_Private$1>::<C Package>::<C InnerClass>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Package_Package$1>::<C Package>::<C Subpackage><<C <todo sym>>> < ()
-      <emptyTree>::<C SubpackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage>::<C SubpackageClass>
+    module <emptyTree>::<C Package_Package_Private$1>::<C Package><<C <todo sym>>> < ()
+      <emptyTree>::<C Subpackage> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage>
     end
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+    module <emptyTree>::<C Package_Package_Private$1>::<C Package><<C <todo sym>>> < ()
+      <emptyTree>::<C InnerClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package_Private$1>::<C Package>::<C InnerClass>
+    end
+
+    module <emptyTree>::<C Package_Package_Private$1>::<C Package><<C <todo sym>>> < ()
+      <emptyTree>::<C PackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package_Private$1>::<C Package>::<C PackageClass>
+    end
+
+    module <emptyTree>::<C Package_Package_Private$1>::<C Package><<C <todo sym>>> < ()
+      <emptyTree>::<C Subpackage> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage>
+    end
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
     module <emptyTree>::<C Package_Package$1>::<C Package><<C <todo sym>>> < ()
-      <emptyTree>::<C InnerClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>::<C InnerClass>
+      <emptyTree>::<C InnerClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package_Private$1>::<C Package>::<C InnerClass>
     end
 
     module <emptyTree>::<C Package_Package$1>::<C Package><<C <todo sym>>> < ()
-      <emptyTree>::<C PackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>::<C PackageClass>
+      <emptyTree>::<C PackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package_Private$1>::<C Package>::<C PackageClass>
     end
+  end
 
-    module <emptyTree>::<C Package_Package$1>::<C Package>::<C Subpackage><<C <todo sym>>> < ()
-      <emptyTree>::<C SubpackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage>::<C SubpackageClass>
-    end
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
   end
 end
 # -- test/testdata/packager/deeply_nested_packages/mainpackage.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<C Package_Package_Private$1><<C <todo sym>>> < ()
     class <emptyTree>::<C Package>::<C PackageClass><<C <todo sym>>> < (::<todo sym>)
       ::Sorbet::Private::Static.sig(<self>) do ||
         <self>.returns(<emptyTree>::<C Package>::<C Subpackage>::<C SubpackageClass>)
@@ -48,7 +61,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/deeply_nested_packages/subdirectory/inner_class.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<C Package_Package_Private$1><<C <todo sym>>> < ()
     class <emptyTree>::<C Package>::<C InnerClass><<C <todo sym>>> < (::<todo sym>)
     end
   end
@@ -58,36 +71,45 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C Package>::<C Subpackage><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.import(<emptyTree>::<C Package>)
 
-    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage>::<C SubpackageClass>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package_Private$1>::<C Package>::<C Subpackage>::<C SubpackageClass>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Package_Subpackage_Package$1>::<C Package><<C <todo sym>>> < ()
+    module <emptyTree>::<C Package_Subpackage_Package_Private$1>::<C Package><<C <todo sym>>> < ()
       <emptyTree>::<C InnerClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>::<C InnerClass>
     end
 
-    module <emptyTree>::<C Package_Subpackage_Package$1>::<C Package><<C <todo sym>>> < ()
+    module <emptyTree>::<C Package_Subpackage_Package_Private$1>::<C Package><<C <todo sym>>> < ()
       <emptyTree>::<C PackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>::<C PackageClass>
     end
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Package_Subpackage_Package$1>::<C Package><<C <todo sym>>> < ()
+    module <emptyTree>::<C Package_Subpackage_Package_Private$1>::<C Package><<C <todo sym>>> < ()
       <emptyTree>::<C InnerClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>::<C InnerClass>
     end
 
-    module <emptyTree>::<C Package_Subpackage_Package$1>::<C Package><<C <todo sym>>> < ()
+    module <emptyTree>::<C Package_Subpackage_Package_Private$1>::<C Package><<C <todo sym>>> < ()
       <emptyTree>::<C PackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>::<C PackageClass>
     end
 
-    module <emptyTree>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage><<C <todo sym>>> < ()
-      <emptyTree>::<C SubpackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage>::<C SubpackageClass>
+    module <emptyTree>::<C Package_Subpackage_Package_Private$1>::<C Package>::<C Subpackage><<C <todo sym>>> < ()
+      <emptyTree>::<C SubpackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package_Private$1>::<C Package>::<C Subpackage>::<C SubpackageClass>
     end
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
+    module <emptyTree>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage><<C <todo sym>>> < ()
+      <emptyTree>::<C SubpackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package_Private$1>::<C Package>::<C Subpackage>::<C SubpackageClass>
+    end
+  end
+
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
   end
 end
 # -- test/testdata/packager/deeply_nested_packages/subdirectory/subpackage/subpackage.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package$1><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package_Private$1><<C <todo sym>>> < ()
     class <emptyTree>::<C Package>::<C Subpackage>::<C SubpackageClass><<C <todo sym>>> < (::<todo sym>)
       ::Sorbet::Private::Static.sig(<self>) do ||
         <self>.returns(<emptyTree>::<C Package>::<C PackageClass>)

--- a/test/testdata/packager/export_for_test/pass.package-tree.exp
+++ b/test/testdata/packager/export_for_test/pass.package-tree.exp
@@ -8,6 +8,12 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
   end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
+  end
+
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+  end
 end
 # -- test/testdata/packager/export_for_test/foo/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
@@ -18,92 +24,105 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <self>.test_import(<emptyTree>::<C Opus>::<C TestImported>)
 
-    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Package$1>::<C Opus>::<C Foo>::<C FooClass>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Package_Private$1>::<C Opus>::<C Foo>::<C FooClass>)
 
-    <self>.export_for_test(<emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Package$1>::<C Opus>::<C Foo>::<C Private>::<C ImplDetail>)
+    <self>.export_for_test(<emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Package_Private$1>::<C Opus>::<C Foo>::<C Private>::<C ImplDetail>)
 
-    <self>.export_for_test(<emptyTree>::<C <PackageTests>>::<C Opus_Foo_Package$1>::<C Test>::<C Opus>::<C Foo>::<C FooTest>)
+    <self>.export_for_test(<emptyTree>::<C <PackageTests>>::<C Opus_Foo_Package_Private$1>::<C Test>::<C Opus>::<C Foo>::<C FooTest>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Opus_Foo_Package$1>::<C Opus>::<C Foo>::<C Bar><<C <todo sym>>> < ()
-      <emptyTree>::<C BarClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Bar_Package$1>::<C Opus>::<C Foo>::<C Bar>::<C BarClass>
+    module <emptyTree>::<C Opus_Foo_Package_Private$1>::<C Opus>::<C Foo><<C <todo sym>>> < ()
+      <emptyTree>::<C Bar> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Bar_Package$1>::<C Opus>::<C Foo>::<C Bar>
     end
 
-    module <emptyTree>::<C Opus_Foo_Package$1>::<C Opus>::<C Util>::<C Nesting><<C <todo sym>>> < ()
-      <emptyTree>::<C Public> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Util_Package$1>::<C Opus>::<C Util>::<C Nesting>::<C Public>
-    end
-
-    module <emptyTree>::<C Opus_Foo_Package$1>::<C Opus>::<C Util><<C <todo sym>>> < ()
-      <emptyTree>::<C UtilClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Util_Package$1>::<C Opus>::<C Util>::<C UtilClass>
+    module <emptyTree>::<C Opus_Foo_Package_Private$1>::<C Opus><<C <todo sym>>> < ()
+      <emptyTree>::<C Util> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Util_Package$1>::<C Opus>::<C Util>
     end
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Opus_Foo_Package$1>::<C Opus>::<C Foo>::<C Bar><<C <todo sym>>> < ()
-      <emptyTree>::<C BarClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Bar_Package$1>::<C Opus>::<C Foo>::<C Bar>::<C BarClass>
+    module <emptyTree>::<C Opus_Foo_Package_Private$1>::<C Opus>::<C Foo><<C <todo sym>>> < ()
+      <emptyTree>::<C Bar> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Bar_Package$1>::<C Opus>::<C Foo>::<C Bar>
     end
 
+    module <emptyTree>::<C Opus_Foo_Package_Private$1>::<C Opus>::<C Foo><<C <todo sym>>> < ()
+      <emptyTree>::<C FooClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Package_Private$1>::<C Opus>::<C Foo>::<C FooClass>
+    end
+
+    module <emptyTree>::<C Opus_Foo_Package_Private$1>::<C Opus>::<C Foo>::<C Private><<C <todo sym>>> < ()
+      <emptyTree>::<C ImplDetail> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Package_Private$1>::<C Opus>::<C Foo>::<C Private>::<C ImplDetail>
+    end
+
+    module <emptyTree>::<C Opus_Foo_Package_Private$1>::<C Opus><<C <todo sym>>> < ()
+      <emptyTree>::<C TestImported> = <emptyTree>::<C <PackageRegistry>>::<C Opus_TestImported_Package$1>::<C Opus>::<C TestImported>
+    end
+
+    module <emptyTree>::<C Opus_Foo_Package_Private$1>::<C Opus><<C <todo sym>>> < ()
+      <emptyTree>::<C Util> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Util_Package$1>::<C Opus>::<C Util>
+    end
+
+    module <emptyTree>::<C Opus_Foo_Package_Private$1>::<C Test>::<C Opus>::<C Foo><<C <todo sym>>> < ()
+      <emptyTree>::<C Bar> = <emptyTree>::<C <PackageTests>>::<C Opus_Foo_Bar_Package$1>::<C Test>::<C Opus>::<C Foo>::<C Bar>
+    end
+
+    module <emptyTree>::<C Opus_Foo_Package_Private$1>::<C Test>::<C Opus><<C <todo sym>>> < ()
+      <emptyTree>::<C TestImported> = <emptyTree>::<C <PackageTests>>::<C Opus_TestImported_Package$1>::<C Test>::<C Opus>::<C TestImported>
+    end
+
+    module <emptyTree>::<C Opus_Foo_Package_Private$1>::<C Test>::<C Opus><<C <todo sym>>> < ()
+      <emptyTree>::<C Util> = <emptyTree>::<C <PackageTests>>::<C Opus_Util_Package$1>::<C Test>::<C Opus>::<C Util>
+    end
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
     module <emptyTree>::<C Opus_Foo_Package$1>::<C Opus>::<C Foo><<C <todo sym>>> < ()
-      <emptyTree>::<C FooClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Package$1>::<C Opus>::<C Foo>::<C FooClass>
+      <emptyTree>::<C FooClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Package_Private$1>::<C Opus>::<C Foo>::<C FooClass>
     end
+  end
 
-    module <emptyTree>::<C Opus_Foo_Package$1>::<C Opus>::<C Foo>::<C Private><<C <todo sym>>> < ()
-      <emptyTree>::<C ImplDetail> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Package$1>::<C Opus>::<C Foo>::<C Private>::<C ImplDetail>
-    end
-
-    module <emptyTree>::<C Opus_Foo_Package$1>::<C Opus>::<C TestImported><<C <todo sym>>> < ()
-      <emptyTree>::<C TIClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_TestImported_Package$1>::<C Opus>::<C TestImported>::<C TIClass>
-    end
-
-    module <emptyTree>::<C Opus_Foo_Package$1>::<C Opus>::<C Util>::<C Nesting><<C <todo sym>>> < ()
-      <emptyTree>::<C Public> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Util_Package$1>::<C Opus>::<C Util>::<C Nesting>::<C Public>
-    end
-
-    module <emptyTree>::<C Opus_Foo_Package$1>::<C Opus>::<C Util><<C <todo sym>>> < ()
-      <emptyTree>::<C UtilClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Util_Package$1>::<C Opus>::<C Util>::<C UtilClass>
-    end
-
-    module <emptyTree>::<C Opus_Foo_Package$1>::<C Test>::<C Opus>::<C Foo>::<C Bar><<C <todo sym>>> < ()
-      <emptyTree>::<C BarClassTest> = <emptyTree>::<C <PackageTests>>::<C Opus_Foo_Bar_Package$1>::<C Test>::<C Opus>::<C Foo>::<C Bar>::<C BarClassTest>
-    end
-
-    module <emptyTree>::<C Opus_Foo_Package$1>::<C Test>::<C Opus>::<C TestImported><<C <todo sym>>> < ()
-      <emptyTree>::<C TITestClass> = <emptyTree>::<C <PackageTests>>::<C Opus_TestImported_Package$1>::<C Test>::<C Opus>::<C TestImported>::<C TITestClass>
-    end
-
-    module <emptyTree>::<C Opus_Foo_Package$1>::<C Test>::<C Opus>::<C Util><<C <todo sym>>> < ()
-      <emptyTree>::<C TestUtil> = <emptyTree>::<C <PackageTests>>::<C Opus_Util_Package$1>::<C Test>::<C Opus>::<C Util>::<C TestUtil>
-    end
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
   end
 end
 # -- test/testdata/packager/export_for_test/foo/bar/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C Opus>::<C Foo>::<C Bar><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
-    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Bar_Package$1>::<C Opus>::<C Foo>::<C Bar>::<C BarClass>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Bar_Package_Private$1>::<C Opus>::<C Foo>::<C Bar>::<C BarClass>)
 
-    <self>.export(<emptyTree>::<C <PackageTests>>::<C Opus_Foo_Bar_Package$1>::<C Test>::<C Opus>::<C Foo>::<C Bar>::<C BarClassTest>)
+    <self>.export(<emptyTree>::<C <PackageTests>>::<C Opus_Foo_Bar_Package_Private$1>::<C Test>::<C Opus>::<C Foo>::<C Bar>::<C BarClassTest>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+    module <emptyTree>::<C Opus_Foo_Bar_Package_Private$1>::<C Opus>::<C Foo>::<C Bar><<C <todo sym>>> < ()
+      <emptyTree>::<C BarClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Bar_Package_Private$1>::<C Opus>::<C Foo>::<C Bar>::<C BarClass>
+    end
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
     module <emptyTree>::<C Opus_Foo_Bar_Package$1>::<C Opus>::<C Foo>::<C Bar><<C <todo sym>>> < ()
-      <emptyTree>::<C BarClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Bar_Package$1>::<C Opus>::<C Foo>::<C Bar>::<C BarClass>
+      <emptyTree>::<C BarClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Bar_Package_Private$1>::<C Opus>::<C Foo>::<C Bar>::<C BarClass>
+    end
+  end
+
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+    module <emptyTree>::<C Opus_Foo_Bar_Package$1>::<C Test>::<C Opus>::<C Foo>::<C Bar><<C <todo sym>>> < ()
+      <emptyTree>::<C BarClassTest> = <emptyTree>::<C <PackageTests>>::<C Opus_Foo_Bar_Package_Private$1>::<C Test>::<C Opus>::<C Foo>::<C Bar>::<C BarClassTest>
     end
   end
 end
 # -- test/testdata/packager/export_for_test/foo/bar/bar.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Bar_Package$1><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Bar_Package_Private$1><<C <todo sym>>> < ()
     class <emptyTree>::<C Opus>::<C Foo>::<C Bar>::<C BarClass><<C <todo sym>>> < (::<todo sym>)
     end
   end
 end
 # -- test/testdata/packager/export_for_test/foo/bar/bar.test.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageTests>>::<C Opus_Foo_Bar_Package$1><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageTests>>::<C Opus_Foo_Bar_Package_Private$1><<C <todo sym>>> < ()
     module <emptyTree>::<C Test>::<C Opus>::<C Foo>::<C Bar><<C <todo sym>>> < ()
       class <emptyTree>::<C BarClassTest><<C <todo sym>>> < (::<todo sym>)
       end
@@ -112,7 +131,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/export_for_test/foo/foo.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Package$1><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Package_Private$1><<C <todo sym>>> < ()
     module <emptyTree>::<C Opus>::<C Foo><<C <todo sym>>> < ()
       class <emptyTree>::<C FooClass><<C <todo sym>>> < (::<todo sym>)
         <emptyTree>::<C Inner> = 1
@@ -159,7 +178,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/export_for_test/foo/foo.test.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageTests>>::<C Opus_Foo_Package$1><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageTests>>::<C Opus_Foo_Package_Private$1><<C <todo sym>>> < ()
     class <emptyTree>::<C Test>::<C Opus>::<C Foo>::<C FooTest><<C <todo sym>>> < (::<todo sym>)
       <emptyTree>::<C Opus>::<C Foo>::<C Bar>::<C BarClass>
 
@@ -190,23 +209,35 @@ end
 # -- test/testdata/packager/export_for_test/test_imported/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C Opus>::<C TestImported><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
-    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Opus_TestImported_Package$1>::<C Opus>::<C TestImported>::<C TIClass>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Opus_TestImported_Package_Private$1>::<C Opus>::<C TestImported>::<C TIClass>)
 
-    <self>.export(<emptyTree>::<C <PackageTests>>::<C Opus_TestImported_Package$1>::<C Test>::<C Opus>::<C TestImported>::<C TITestClass>)
+    <self>.export(<emptyTree>::<C <PackageTests>>::<C Opus_TestImported_Package_Private$1>::<C Test>::<C Opus>::<C TestImported>::<C TITestClass>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+    module <emptyTree>::<C Opus_TestImported_Package_Private$1>::<C Opus>::<C TestImported><<C <todo sym>>> < ()
+      <emptyTree>::<C TIClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_TestImported_Package_Private$1>::<C Opus>::<C TestImported>::<C TIClass>
+    end
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
     module <emptyTree>::<C Opus_TestImported_Package$1>::<C Opus>::<C TestImported><<C <todo sym>>> < ()
-      <emptyTree>::<C TIClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_TestImported_Package$1>::<C Opus>::<C TestImported>::<C TIClass>
+      <emptyTree>::<C TIClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_TestImported_Package_Private$1>::<C Opus>::<C TestImported>::<C TIClass>
+    end
+  end
+
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+    module <emptyTree>::<C Opus_TestImported_Package$1>::<C Test>::<C Opus>::<C TestImported><<C <todo sym>>> < ()
+      <emptyTree>::<C TITestClass> = <emptyTree>::<C <PackageTests>>::<C Opus_TestImported_Package_Private$1>::<C Test>::<C Opus>::<C TestImported>::<C TITestClass>
     end
   end
 end
 # -- test/testdata/packager/export_for_test/test_imported/test_imported.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageRegistry>>::<C Opus_TestImported_Package$1><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<C Opus_TestImported_Package_Private$1><<C <todo sym>>> < ()
     module <emptyTree>::<C Opus>::<C TestImported><<C <todo sym>>> < ()
       class <emptyTree>::<C TIClass><<C <todo sym>>> < (::<todo sym>)
       end
@@ -215,7 +246,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/export_for_test/test_imported/test_imported.test.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageTests>>::<C Opus_TestImported_Package$1><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageTests>>::<C Opus_TestImported_Package_Private$1><<C <todo sym>>> < ()
     module <emptyTree>::<C Test>::<C Opus>::<C TestImported><<C <todo sym>>> < ()
       class <emptyTree>::<C TITestClass><<C <todo sym>>> < (::<todo sym>)
       end
@@ -225,31 +256,47 @@ end
 # -- test/testdata/packager/export_for_test/util/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C Opus>::<C Util><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
-    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Opus_Util_Package$1>::<C Opus>::<C Util>::<C UtilClass>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Opus_Util_Package_Private$1>::<C Opus>::<C Util>::<C UtilClass>)
 
-    <self>.export(<emptyTree>::<C <PackageTests>>::<C Opus_Util_Package$1>::<C Test>::<C Opus>::<C Util>::<C TestUtil>)
+    <self>.export(<emptyTree>::<C <PackageTests>>::<C Opus_Util_Package_Private$1>::<C Test>::<C Opus>::<C Util>::<C TestUtil>)
 
-    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Opus_Util_Package$1>::<C Opus>::<C Util>::<C Nesting>::<C Public>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Opus_Util_Package_Private$1>::<C Opus>::<C Util>::<C Nesting>::<C Public>)
 
-    <self>.export_for_test(<emptyTree>::<C <PackageRegistry>>::<C Opus_Util_Package$1>::<C Opus>::<C Util>::<C Nesting>)
+    <self>.export_for_test(<emptyTree>::<C <PackageRegistry>>::<C Opus_Util_Package_Private$1>::<C Opus>::<C Util>::<C Nesting>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Opus_Util_Package$1>::<C Opus>::<C Util><<C <todo sym>>> < ()
-      <emptyTree>::<C Nesting> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Util_Package$1>::<C Opus>::<C Util>::<C Nesting>
+    module <emptyTree>::<C Opus_Util_Package_Private$1>::<C Opus>::<C Util><<C <todo sym>>> < ()
+      <emptyTree>::<C Nesting> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Util_Package_Private$1>::<C Opus>::<C Util>::<C Nesting>
+    end
+
+    module <emptyTree>::<C Opus_Util_Package_Private$1>::<C Opus>::<C Util><<C <todo sym>>> < ()
+      <emptyTree>::<C UtilClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Util_Package_Private$1>::<C Opus>::<C Util>::<C UtilClass>
+    end
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
+    module <emptyTree>::<C Opus_Util_Package$1>::<C Opus>::<C Util>::<C Nesting><<C <todo sym>>> < ()
+      <emptyTree>::<C Public> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Util_Package_Private$1>::<C Opus>::<C Util>::<C Nesting>::<C Public>
     end
 
     module <emptyTree>::<C Opus_Util_Package$1>::<C Opus>::<C Util><<C <todo sym>>> < ()
-      <emptyTree>::<C UtilClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Util_Package$1>::<C Opus>::<C Util>::<C UtilClass>
+      <emptyTree>::<C UtilClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Util_Package_Private$1>::<C Opus>::<C Util>::<C UtilClass>
+    end
+  end
+
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+    module <emptyTree>::<C Opus_Util_Package$1>::<C Test>::<C Opus>::<C Util><<C <todo sym>>> < ()
+      <emptyTree>::<C TestUtil> = <emptyTree>::<C <PackageTests>>::<C Opus_Util_Package_Private$1>::<C Test>::<C Opus>::<C Util>::<C TestUtil>
     end
   end
 end
 # -- test/testdata/packager/export_for_test/util/util.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageRegistry>>::<C Opus_Util_Package$1><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<C Opus_Util_Package_Private$1><<C <todo sym>>> < ()
     module <emptyTree>::<C Opus>::<C Util><<C <todo sym>>> < ()
       class <emptyTree>::<C UtilClass><<C <todo sym>>> < (::<todo sym>)
       end
@@ -289,7 +336,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/export_for_test/util/util.test.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageTests>>::<C Opus_Util_Package$1><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageTests>>::<C Opus_Util_Package_Private$1><<C <todo sym>>> < ()
     module <emptyTree>::<C Test>::<C Opus>::<C Util><<C <todo sym>>> < ()
       class <emptyTree>::<C TestUtil><<C <todo sym>>> < (::<todo sym>)
       end

--- a/test/testdata/packager/export_imported/pass.package-tree.exp
+++ b/test/testdata/packager/export_imported/pass.package-tree.exp
@@ -3,39 +3,57 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C A><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.import(<emptyTree>::<C B>)
 
-    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C A_Package$1>::<C B>::<C BClass>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C A_Package_Private$1>::<C B>::<C BClass>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C A_Package$1>::<C B><<C <todo sym>>> < ()
-      <emptyTree>::<C BClass> = <emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>::<C BClass>
+    module <emptyTree>::<C A_Package_Private$1><<C <todo sym>>> < ()
+      <emptyTree>::<C B> = <emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>
     end
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C A_Package$1>::<C B><<C <todo sym>>> < ()
-      <emptyTree>::<C BClass> = <emptyTree>::<C <PackageRegistry>>::<C A_Package$1>::<C B>::<C BClass>
+    module <emptyTree>::<C A_Package_Private$1><<C <todo sym>>> < ()
+      <emptyTree>::<C B> = <emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>
     end
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
+    module <emptyTree>::<C A_Package$1>::<C B><<C <todo sym>>> < ()
+      <emptyTree>::<C BClass> = <emptyTree>::<C <PackageRegistry>>::<C A_Package_Private$1>::<C B>::<C BClass>
+    end
+  end
+
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
   end
 end
 # -- test/testdata/packager/export_imported/b/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C B><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
-    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>::<C BClass>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C B_Package_Private$1>::<C B>::<C BClass>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C B_Package$1>::<C B><<C <todo sym>>> < ()
-      <emptyTree>::<C BClass> = <emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>::<C BClass>
+    module <emptyTree>::<C B_Package_Private$1>::<C B><<C <todo sym>>> < ()
+      <emptyTree>::<C BClass> = <emptyTree>::<C <PackageRegistry>>::<C B_Package_Private$1>::<C B>::<C BClass>
     end
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
+    module <emptyTree>::<C B_Package$1>::<C B><<C <todo sym>>> < ()
+      <emptyTree>::<C BClass> = <emptyTree>::<C <PackageRegistry>>::<C B_Package_Private$1>::<C B>::<C BClass>
+    end
+  end
+
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
   end
 end
 # -- test/testdata/packager/export_imported/b/b.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageRegistry>>::<C B_Package$1><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<C B_Package_Private$1><<C <todo sym>>> < ()
     class <emptyTree>::<C B>::<C BClass><<C <todo sym>>> < (::<todo sym>)
     end
   end

--- a/test/testdata/packager/extra_package_paths/pass.package-tree.exp
+++ b/test/testdata/packager/extra_package_paths/pass.package-tree.exp
@@ -7,28 +7,34 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Project_Bar_Package$1>::<C Project>::<C Baz><<C <todo sym>>> < ()
-      <emptyTree>::<C C> = <emptyTree>::<C <PackageRegistry>>::<C Project_Baz_Package$1>::<C Project>::<C Baz>::<C C>
+    module <emptyTree>::<C Project_Bar_Package_Private$1>::<C Project><<C <todo sym>>> < ()
+      <emptyTree>::<C Baz> = <emptyTree>::<C <PackageRegistry>>::<C Project_Baz_Package$1>::<C Project>::<C Baz>
     end
 
-    module <emptyTree>::<C Project_Bar_Package$1>::<C Project>::<C Foo><<C <todo sym>>> < ()
-      <emptyTree>::<C B> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>::<C B>
+    module <emptyTree>::<C Project_Bar_Package_Private$1>::<C Project><<C <todo sym>>> < ()
+      <emptyTree>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>
     end
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Project_Bar_Package$1>::<C Project>::<C Baz><<C <todo sym>>> < ()
-      <emptyTree>::<C C> = <emptyTree>::<C <PackageRegistry>>::<C Project_Baz_Package$1>::<C Project>::<C Baz>::<C C>
+    module <emptyTree>::<C Project_Bar_Package_Private$1>::<C Project><<C <todo sym>>> < ()
+      <emptyTree>::<C Baz> = <emptyTree>::<C <PackageRegistry>>::<C Project_Baz_Package$1>::<C Project>::<C Baz>
     end
 
-    module <emptyTree>::<C Project_Bar_Package$1>::<C Project>::<C Foo><<C <todo sym>>> < ()
-      <emptyTree>::<C B> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>::<C B>
+    module <emptyTree>::<C Project_Bar_Package_Private$1>::<C Project><<C <todo sym>>> < ()
+      <emptyTree>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>
     end
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
+  end
+
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
   end
 end
 # -- test/testdata/packager/extra_package_paths/bar/bar.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package$1><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package_Private$1><<C <todo sym>>> < ()
     class <emptyTree>::<C Project>::<C Bar>::<C Bar><<C <todo sym>>> < (::<todo sym>)
       ::Sorbet::Private::Static.sig(<self>) do ||
         <self>.void()
@@ -57,21 +63,30 @@ end
 # -- test/testdata/packager/extra_package_paths/baz/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C Project>::<C Baz><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
-    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Project_Baz_Package$1>::<C Project>::<C Baz>::<C C>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Project_Baz_Package_Private$1>::<C Project>::<C Baz>::<C C>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Project_Baz_Package$1>::<C Project>::<C Baz><<C <todo sym>>> < ()
-      <emptyTree>::<C C> = <emptyTree>::<C <PackageRegistry>>::<C Project_Baz_Package$1>::<C Project>::<C Baz>::<C C>
+    module <emptyTree>::<C Project_Baz_Package_Private$1>::<C Project>::<C Baz><<C <todo sym>>> < ()
+      <emptyTree>::<C C> = <emptyTree>::<C <PackageRegistry>>::<C Project_Baz_Package_Private$1>::<C Project>::<C Baz>::<C C>
     end
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
+    module <emptyTree>::<C Project_Baz_Package$1>::<C Project>::<C Baz><<C <todo sym>>> < ()
+      <emptyTree>::<C C> = <emptyTree>::<C <PackageRegistry>>::<C Project_Baz_Package_Private$1>::<C Project>::<C Baz>::<C C>
+    end
+  end
+
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
   end
 end
 # -- test/testdata/packager/extra_package_paths/extra/Project_Baz/c.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageRegistry>>::<C Project_Baz_Package$1><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<C Project_Baz_Package_Private$1><<C <todo sym>>> < ()
     class <emptyTree>::<C Project>::<C Baz>::<C C><<C <todo sym>>> < (::<todo sym>)
       ::Sorbet::Private::Static.sig(<self>) do ||
         <self>.void()
@@ -89,7 +104,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/extra_package_paths/extra/Project_Foo/b.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package_Private$1><<C <todo sym>>> < ()
     class <emptyTree>::<C Project>::<C Foo>::<C B><<C <todo sym>>> < (::<todo sym>)
       ::Sorbet::Private::Static.sig(<self>) do ||
         <self>.void()
@@ -108,15 +123,24 @@ end
 # -- test/testdata/packager/extra_package_paths/foo/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C Project>::<C Foo><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
-    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>::<C B>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package_Private$1>::<C Project>::<C Foo>::<C B>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Project_Foo_Package$1>::<C Project>::<C Foo><<C <todo sym>>> < ()
-      <emptyTree>::<C B> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>::<C B>
+    module <emptyTree>::<C Project_Foo_Package_Private$1>::<C Project>::<C Foo><<C <todo sym>>> < ()
+      <emptyTree>::<C B> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package_Private$1>::<C Project>::<C Foo>::<C B>
     end
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
+    module <emptyTree>::<C Project_Foo_Package$1>::<C Project>::<C Foo><<C <todo sym>>> < ()
+      <emptyTree>::<C B> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package_Private$1>::<C Project>::<C Foo>::<C B>
+    end
+  end
+
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
   end
 end

--- a/test/testdata/packager/import_subpackage/pass.package-tree.exp
+++ b/test/testdata/packager/import_subpackage/pass.package-tree.exp
@@ -5,35 +5,50 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Root_Package$1>::<C Root>::<C B><<C <todo sym>>> < ()
-      <emptyTree>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Root_B_Package$1>::<C Root>::<C B>::<C Foo>
+    module <emptyTree>::<C Root_Package_Private$1>::<C Root><<C <todo sym>>> < ()
+      <emptyTree>::<C B> = <emptyTree>::<C <PackageRegistry>>::<C Root_B_Package$1>::<C Root>::<C B>
     end
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Root_Package$1>::<C Root>::<C B><<C <todo sym>>> < ()
-      <emptyTree>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Root_B_Package$1>::<C Root>::<C B>::<C Foo>
+    module <emptyTree>::<C Root_Package_Private$1>::<C Root><<C <todo sym>>> < ()
+      <emptyTree>::<C B> = <emptyTree>::<C <PackageRegistry>>::<C Root_B_Package$1>::<C Root>::<C B>
     end
-  end
-end
-# -- test/testdata/packager/import_subpackage/a/b/__package.rb --
-class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C Root>::<C B><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
-    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Root_B_Package$1>::<C Root>::<C B>::<C Foo>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Root_B_Package$1>::<C Root>::<C B><<C <todo sym>>> < ()
-      <emptyTree>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Root_B_Package$1>::<C Root>::<C B>::<C Foo>
+  end
+end
+# -- test/testdata/packager/import_subpackage/a/b/__package.rb --
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C Root>::<C B><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Root_B_Package_Private$1>::<C Root>::<C B>::<C Foo>)
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
+  end
+
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+    module <emptyTree>::<C Root_B_Package_Private$1>::<C Root>::<C B><<C <todo sym>>> < ()
+      <emptyTree>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Root_B_Package_Private$1>::<C Root>::<C B>::<C Foo>
     end
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
+    module <emptyTree>::<C Root_B_Package$1>::<C Root>::<C B><<C <todo sym>>> < ()
+      <emptyTree>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Root_B_Package_Private$1>::<C Root>::<C B>::<C Foo>
+    end
+  end
+
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
   end
 end
 # -- test/testdata/packager/import_subpackage/a/b/foo.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageRegistry>>::<C Root_B_Package$1><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<C Root_B_Package_Private$1><<C <todo sym>>> < ()
     module <emptyTree>::<C Root>::<C B>::<C Foo><<C <todo sym>>> < ()
     end
   end

--- a/test/testdata/packager/invalid_imports_and_exports/pass.package-tree.exp
+++ b/test/testdata/packager/invalid_imports_and_exports/pass.package-tree.exp
@@ -19,48 +19,57 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <self>.export(<self>.method())
 
-    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C A_Package$1>::<C A>::<C REFERENCE>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C A_Package_Private$1>::<C A>::<C REFERENCE>)
 
-    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C A_Package$1>::<C A>::<C AClass>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C A_Package_Private$1>::<C A>::<C AClass>)
 
-    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C A_Package$1>::<C A>::<C AModule>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C A_Package_Private$1>::<C A>::<C AModule>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C A_Package$1>::<C B><<C <todo sym>>> < ()
-      <emptyTree>::<C BClass> = <emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>::<C BClass>
-    end
-
-    module <emptyTree>::<C A_Package$1>::<C B><<C <todo sym>>> < ()
-      <emptyTree>::<C BModule> = <emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>::<C BModule>
+    module <emptyTree>::<C A_Package_Private$1><<C <todo sym>>> < ()
+      <emptyTree>::<C B> = <emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>
     end
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+    module <emptyTree>::<C A_Package_Private$1>::<C A><<C <todo sym>>> < ()
+      <emptyTree>::<C AClass> = <emptyTree>::<C <PackageRegistry>>::<C A_Package_Private$1>::<C A>::<C AClass>
+    end
+
+    module <emptyTree>::<C A_Package_Private$1>::<C A><<C <todo sym>>> < ()
+      <emptyTree>::<C AModule> = <emptyTree>::<C <PackageRegistry>>::<C A_Package_Private$1>::<C A>::<C AModule>
+    end
+
+    module <emptyTree>::<C A_Package_Private$1>::<C A><<C <todo sym>>> < ()
+      <emptyTree>::<C REFERENCE> = <emptyTree>::<C <PackageRegistry>>::<C A_Package_Private$1>::<C A>::<C REFERENCE>
+    end
+
+    module <emptyTree>::<C A_Package_Private$1><<C <todo sym>>> < ()
+      <emptyTree>::<C B> = <emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>
+    end
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
     module <emptyTree>::<C A_Package$1>::<C A><<C <todo sym>>> < ()
-      <emptyTree>::<C AClass> = <emptyTree>::<C <PackageRegistry>>::<C A_Package$1>::<C A>::<C AClass>
+      <emptyTree>::<C AClass> = <emptyTree>::<C <PackageRegistry>>::<C A_Package_Private$1>::<C A>::<C AClass>
     end
 
     module <emptyTree>::<C A_Package$1>::<C A><<C <todo sym>>> < ()
-      <emptyTree>::<C AModule> = <emptyTree>::<C <PackageRegistry>>::<C A_Package$1>::<C A>::<C AModule>
+      <emptyTree>::<C AModule> = <emptyTree>::<C <PackageRegistry>>::<C A_Package_Private$1>::<C A>::<C AModule>
     end
 
     module <emptyTree>::<C A_Package$1>::<C A><<C <todo sym>>> < ()
-      <emptyTree>::<C REFERENCE> = <emptyTree>::<C <PackageRegistry>>::<C A_Package$1>::<C A>::<C REFERENCE>
+      <emptyTree>::<C REFERENCE> = <emptyTree>::<C <PackageRegistry>>::<C A_Package_Private$1>::<C A>::<C REFERENCE>
     end
+  end
 
-    module <emptyTree>::<C A_Package$1>::<C B><<C <todo sym>>> < ()
-      <emptyTree>::<C BClass> = <emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>::<C BClass>
-    end
-
-    module <emptyTree>::<C A_Package$1>::<C B><<C <todo sym>>> < ()
-      <emptyTree>::<C BModule> = <emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>::<C BModule>
-    end
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
   end
 end
 # -- test/testdata/packager/invalid_imports_and_exports/a.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageRegistry>>::<C A_Package$1><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<C A_Package_Private$1><<C <todo sym>>> < ()
     module <emptyTree>::<C A><<C <todo sym>>> < ()
       <emptyTree>::<C REFERENCE> = <emptyTree>::<C ASecondClass>
 
@@ -102,50 +111,47 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C B><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.import(<emptyTree>::<C A>)
 
-    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>::<C BClass>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C B_Package_Private$1>::<C B>::<C BClass>)
 
-    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>::<C BModule>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C B_Package_Private$1>::<C B>::<C BModule>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C B_Package$1>::<C A><<C <todo sym>>> < ()
-      <emptyTree>::<C AClass> = <emptyTree>::<C <PackageRegistry>>::<C A_Package$1>::<C A>::<C AClass>
-    end
-
-    module <emptyTree>::<C B_Package$1>::<C A><<C <todo sym>>> < ()
-      <emptyTree>::<C AModule> = <emptyTree>::<C <PackageRegistry>>::<C A_Package$1>::<C A>::<C AModule>
-    end
-
-    module <emptyTree>::<C B_Package$1>::<C A><<C <todo sym>>> < ()
-      <emptyTree>::<C REFERENCE> = <emptyTree>::<C <PackageRegistry>>::<C A_Package$1>::<C A>::<C REFERENCE>
+    module <emptyTree>::<C B_Package_Private$1><<C <todo sym>>> < ()
+      <emptyTree>::<C A> = <emptyTree>::<C <PackageRegistry>>::<C A_Package$1>::<C A>
     end
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C B_Package$1>::<C A><<C <todo sym>>> < ()
-      <emptyTree>::<C AClass> = <emptyTree>::<C <PackageRegistry>>::<C A_Package$1>::<C A>::<C AClass>
+    module <emptyTree>::<C B_Package_Private$1><<C <todo sym>>> < ()
+      <emptyTree>::<C A> = <emptyTree>::<C <PackageRegistry>>::<C A_Package$1>::<C A>
     end
 
-    module <emptyTree>::<C B_Package$1>::<C A><<C <todo sym>>> < ()
-      <emptyTree>::<C AModule> = <emptyTree>::<C <PackageRegistry>>::<C A_Package$1>::<C A>::<C AModule>
+    module <emptyTree>::<C B_Package_Private$1>::<C B><<C <todo sym>>> < ()
+      <emptyTree>::<C BClass> = <emptyTree>::<C <PackageRegistry>>::<C B_Package_Private$1>::<C B>::<C BClass>
     end
 
-    module <emptyTree>::<C B_Package$1>::<C A><<C <todo sym>>> < ()
-      <emptyTree>::<C REFERENCE> = <emptyTree>::<C <PackageRegistry>>::<C A_Package$1>::<C A>::<C REFERENCE>
+    module <emptyTree>::<C B_Package_Private$1>::<C B><<C <todo sym>>> < ()
+      <emptyTree>::<C BModule> = <emptyTree>::<C <PackageRegistry>>::<C B_Package_Private$1>::<C B>::<C BModule>
+    end
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
+    module <emptyTree>::<C B_Package$1>::<C B><<C <todo sym>>> < ()
+      <emptyTree>::<C BClass> = <emptyTree>::<C <PackageRegistry>>::<C B_Package_Private$1>::<C B>::<C BClass>
     end
 
     module <emptyTree>::<C B_Package$1>::<C B><<C <todo sym>>> < ()
-      <emptyTree>::<C BClass> = <emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>::<C BClass>
+      <emptyTree>::<C BModule> = <emptyTree>::<C <PackageRegistry>>::<C B_Package_Private$1>::<C B>::<C BModule>
     end
+  end
 
-    module <emptyTree>::<C B_Package$1>::<C B><<C <todo sym>>> < ()
-      <emptyTree>::<C BModule> = <emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>::<C BModule>
-    end
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
   end
 end
 # -- test/testdata/packager/invalid_imports_and_exports/b/b.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageRegistry>>::<C B_Package$1><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<C B_Package_Private$1><<C <todo sym>>> < ()
     module <emptyTree>::<C B><<C <todo sym>>> < ()
       class <emptyTree>::<C BClass><<C <todo sym>>> < (::<todo sym>)
         ::Sorbet::Private::Static.sig(<self>) do ||

--- a/test/testdata/packager/invalid_package_control_flow/pass.package-tree.exp
+++ b/test/testdata/packager/invalid_package_control_flow/pass.package-tree.exp
@@ -51,10 +51,16 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
   end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
+  end
+
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+  end
 end
 # -- test/testdata/packager/invalid_package_control_flow/package_spec_additions.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageRegistry>>::<C MyPackage_Package$1><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<C MyPackage_Package_Private$1><<C <todo sym>>> < ()
     class ::<root>::<C PackageSpec><<C <todo sym>>> < (::<todo sym>)
       def self.some_method<<todo method>>(x, &<blk>)
         <emptyTree>

--- a/test/testdata/packager/lsp_features/__package.rb
+++ b/test/testdata/packager/lsp_features/__package.rb
@@ -8,8 +8,6 @@ class Simpsons < PackageSpec
     # go-to-def on a reference to Bart within the package goes here, but go-to-def on Bart in `import Bart` goes to the
     # package.
     import Bart
-    #      ^^^^ symbol-search: "Bart", name = "Bart", container = "Simpsons"
-    #      ^^^^ def: bart 1 not-def-of-self
     #      ^^^^ usage: bartpkg
     #      ^^^^ hover: Bart package description
     #      ^    show-symbol: Bart
@@ -20,12 +18,13 @@ class Simpsons < PackageSpec
     #           ^         show-symbol: Krabappel
 
     export Simpsons::Family
+    #      ^^^^^^^^ symbol-search: "Simpsons", name = "Simpsons", container = "Simpsons"
     #                ^^^^^^ usage: family
     #                ^      show-symbol: Simpsons::Family
 
     export_for_test Simpsons::Private
     #                         ^^^^^^^ usage: s-private
-    #               ^^^^^^^^^^^^^^^^^ symbol-search: "Simpsons", name = "Simpsons", container = "<PackageTests>::Simpsons_Package"
+    #               ^^^^^^^^^^^^^^^^^ symbol-search: "Simpsons", name = "Simpsons", container = "<PackageTests>::Simpsons_Package_Private"
     #                         ^       show-symbol: Simpsons::Private
     #               ^                 show-symbol: Simpsons
 end

--- a/test/testdata/packager/lsp_features/bart/__package.rb
+++ b/test/testdata/packager/lsp_features/bart/__package.rb
@@ -7,12 +7,17 @@ class Bart < PackageSpec
     # ^^^^ symbol-search: "Bart", name = "Bart", container = "(nothing)"
     # ^ show-symbol: Bart
     export Bart::Character
+    #      ^^^^ symbol-search: "Bart", name = "Bart", container = "Bart"
+    #      ^^^^ def: bart 1 not-def-of-self
+    #      ^^^^ usage: bartmod
     #            ^^^^^^^^^ usage: character
     #            ^^^^^^^^^ hover: Character class description
-    #      ^^^^^^^^^^^^^^^ symbol-search: "Bart", name = "Bart", container = "<PackageTests>::Bart_Package"
+    #      ^^^^^^^^^^^^^^^ symbol-search: "Bart", name = "Bart", container = "<PackageTests>::Bart_Package_Private"
     #            ^ show-symbol: Bart::Character
     #      ^ show-symbol: Bart
     export Bart::CatchPhrase
+    #      ^^^^ def: bart 2 not-def-of-self
+    #      ^^^^ usage: bartmod
     #            ^^^^^^^^^^^ usage: catchphrase
     #            ^ show-symbol: Bart::CatchPhrase
 end

--- a/test/testdata/packager/lsp_features/bart/bart.rb
+++ b/test/testdata/packager/lsp_features/bart/bart.rb
@@ -2,6 +2,7 @@
 # typed: strict
 
 module Bart
+  #    ^^^^ def: bartmod
   #    ^^^^ symbol-search: "Bart", name = "Bart", container = "Bart"
       CatchPhrase = "Don't have a cow, man."
   #   ^^^^^^^^^^^ def: catchphrase

--- a/test/testdata/packager/nested_inner_namespaces/pass.package-tree.exp
+++ b/test/testdata/packager/nested_inner_namespaces/pass.package-tree.exp
@@ -5,36 +5,26 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C RootPackage_Package$1>::<C RootPackage>::<C Foo>::<C Bar><<C <todo sym>>> < ()
-      <emptyTree>::<C Baz> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo>::<C Bar>::<C Baz>
-    end
-
-    module <emptyTree>::<C RootPackage_Package$1>::<C RootPackage>::<C Foo>::<C Bar><<C <todo sym>>> < ()
-      <emptyTree>::<C Constant> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo>::<C Bar>::<C Constant>
-    end
-
-    module <emptyTree>::<C RootPackage_Package$1>::<C RootPackage>::<C Foo><<C <todo sym>>> < ()
-      <emptyTree>::<C Constant> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo>::<C Constant>
+    module <emptyTree>::<C RootPackage_Package_Private$1>::<C RootPackage><<C <todo sym>>> < ()
+      <emptyTree>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo>
     end
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C RootPackage_Package$1>::<C RootPackage>::<C Foo>::<C Bar><<C <todo sym>>> < ()
-      <emptyTree>::<C Baz> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo>::<C Bar>::<C Baz>
+    module <emptyTree>::<C RootPackage_Package_Private$1>::<C RootPackage><<C <todo sym>>> < ()
+      <emptyTree>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo>
     end
+  end
 
-    module <emptyTree>::<C RootPackage_Package$1>::<C RootPackage>::<C Foo>::<C Bar><<C <todo sym>>> < ()
-      <emptyTree>::<C Constant> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo>::<C Bar>::<C Constant>
-    end
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
+  end
 
-    module <emptyTree>::<C RootPackage_Package$1>::<C RootPackage>::<C Foo><<C <todo sym>>> < ()
-      <emptyTree>::<C Constant> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo>::<C Constant>
-    end
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
   end
 end
 # -- test/testdata/packager/nested_inner_namespaces/bar.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Package$1><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Package_Private$1><<C <todo sym>>> < ()
     module <emptyTree>::<C RootPackage>::<C Bar><<C <todo sym>>> < ()
       ::Sorbet::Private::Static.sig(<self>) do ||
         <self>.params(:a, <emptyTree>::<C Integer>).returns(<emptyTree>::<C String>)
@@ -61,33 +51,50 @@ end
 # -- test/testdata/packager/nested_inner_namespaces/foo/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C RootPackage>::<C Foo><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
-    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo>::<C Constant>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package_Private$1>::<C RootPackage>::<C Foo>::<C Constant>)
 
-    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo>::<C Bar>::<C Constant>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package_Private$1>::<C RootPackage>::<C Foo>::<C Bar>::<C Constant>)
 
-    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo>::<C Bar>::<C Baz>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package_Private$1>::<C RootPackage>::<C Foo>::<C Bar>::<C Baz>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+    module <emptyTree>::<C RootPackage_Foo_Package_Private$1>::<C RootPackage>::<C Foo>::<C Bar><<C <todo sym>>> < ()
+      <emptyTree>::<C Baz> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package_Private$1>::<C RootPackage>::<C Foo>::<C Bar>::<C Baz>
+    end
+
+    module <emptyTree>::<C RootPackage_Foo_Package_Private$1>::<C RootPackage>::<C Foo>::<C Bar><<C <todo sym>>> < ()
+      <emptyTree>::<C Constant> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package_Private$1>::<C RootPackage>::<C Foo>::<C Bar>::<C Constant>
+    end
+
+    module <emptyTree>::<C RootPackage_Foo_Package_Private$1>::<C RootPackage>::<C Foo><<C <todo sym>>> < ()
+      <emptyTree>::<C Constant> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package_Private$1>::<C RootPackage>::<C Foo>::<C Constant>
+    end
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
     module <emptyTree>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo>::<C Bar><<C <todo sym>>> < ()
-      <emptyTree>::<C Baz> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo>::<C Bar>::<C Baz>
+      <emptyTree>::<C Baz> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package_Private$1>::<C RootPackage>::<C Foo>::<C Bar>::<C Baz>
     end
 
     module <emptyTree>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo>::<C Bar><<C <todo sym>>> < ()
-      <emptyTree>::<C Constant> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo>::<C Bar>::<C Constant>
+      <emptyTree>::<C Constant> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package_Private$1>::<C RootPackage>::<C Foo>::<C Bar>::<C Constant>
     end
 
     module <emptyTree>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo><<C <todo sym>>> < ()
-      <emptyTree>::<C Constant> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo>::<C Constant>
+      <emptyTree>::<C Constant> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package_Private$1>::<C RootPackage>::<C Foo>::<C Constant>
     end
+  end
+
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
   end
 end
 # -- test/testdata/packager/nested_inner_namespaces/foo/foo.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package$1><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package_Private$1><<C <todo sym>>> < ()
     module <emptyTree>::<C RootPackage>::<C Foo><<C <todo sym>>> < ()
       <emptyTree>::<C Constant> = "Foo"
 

--- a/test/testdata/packager/nested_packages/pass.package-tree.exp
+++ b/test/testdata/packager/nested_packages/pass.package-tree.exp
@@ -3,28 +3,37 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C Package><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.import(<emptyTree>::<C Package>::<C Subpackage>)
 
-    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>::<C PackageClass>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Package_Package_Private$1>::<C Package>::<C PackageClass>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Package_Package$1>::<C Package>::<C Subpackage><<C <todo sym>>> < ()
-      <emptyTree>::<C SubpackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage>::<C SubpackageClass>
+    module <emptyTree>::<C Package_Package_Private$1>::<C Package><<C <todo sym>>> < ()
+      <emptyTree>::<C Subpackage> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage>
     end
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Package_Package$1>::<C Package><<C <todo sym>>> < ()
-      <emptyTree>::<C PackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>::<C PackageClass>
+    module <emptyTree>::<C Package_Package_Private$1>::<C Package><<C <todo sym>>> < ()
+      <emptyTree>::<C PackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package_Private$1>::<C Package>::<C PackageClass>
     end
 
-    module <emptyTree>::<C Package_Package$1>::<C Package>::<C Subpackage><<C <todo sym>>> < ()
-      <emptyTree>::<C SubpackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage>::<C SubpackageClass>
+    module <emptyTree>::<C Package_Package_Private$1>::<C Package><<C <todo sym>>> < ()
+      <emptyTree>::<C Subpackage> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage>
     end
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
+    module <emptyTree>::<C Package_Package$1>::<C Package><<C <todo sym>>> < ()
+      <emptyTree>::<C PackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package_Private$1>::<C Package>::<C PackageClass>
+    end
+  end
+
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
   end
 end
 # -- test/testdata/packager/nested_packages/mainpackage.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<C Package_Package_Private$1><<C <todo sym>>> < ()
     class <emptyTree>::<C Package>::<C PackageClass><<C <todo sym>>> < (::<todo sym>)
       ::Sorbet::Private::Static.sig(<self>) do ||
         <self>.returns(<emptyTree>::<C Package>::<C Subpackage>::<C SubpackageClass>)
@@ -45,28 +54,37 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C Package>::<C Subpackage><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.import(<emptyTree>::<C Package>)
 
-    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage>::<C SubpackageClass>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package_Private$1>::<C Package>::<C Subpackage>::<C SubpackageClass>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Package_Subpackage_Package$1>::<C Package><<C <todo sym>>> < ()
+    module <emptyTree>::<C Package_Subpackage_Package_Private$1>::<C Package><<C <todo sym>>> < ()
       <emptyTree>::<C PackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>::<C PackageClass>
     end
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Package_Subpackage_Package$1>::<C Package><<C <todo sym>>> < ()
+    module <emptyTree>::<C Package_Subpackage_Package_Private$1>::<C Package><<C <todo sym>>> < ()
       <emptyTree>::<C PackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>::<C PackageClass>
     end
 
-    module <emptyTree>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage><<C <todo sym>>> < ()
-      <emptyTree>::<C SubpackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage>::<C SubpackageClass>
+    module <emptyTree>::<C Package_Subpackage_Package_Private$1>::<C Package>::<C Subpackage><<C <todo sym>>> < ()
+      <emptyTree>::<C SubpackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package_Private$1>::<C Package>::<C Subpackage>::<C SubpackageClass>
     end
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
+    module <emptyTree>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage><<C <todo sym>>> < ()
+      <emptyTree>::<C SubpackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package_Private$1>::<C Package>::<C Subpackage>::<C SubpackageClass>
+    end
+  end
+
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
   end
 end
 # -- test/testdata/packager/nested_packages/subpackage/subpackage.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package$1><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package_Private$1><<C <todo sym>>> < ()
     class <emptyTree>::<C Package>::<C Subpackage>::<C SubpackageClass><<C <todo sym>>> < (::<todo sym>)
       ::Sorbet::Private::Static.sig(<self>) do ||
         <self>.returns(<emptyTree>::<C Package>::<C PackageClass>)

--- a/test/testdata/packager/simple_package/pass.package-tree.exp
+++ b/test/testdata/packager/simple_package/pass.package-tree.exp
@@ -3,42 +3,47 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C Project>::<C Bar><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.import(<emptyTree>::<C Project>::<C Foo>)
 
-    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package$1>::<C Project>::<C Bar>::<C Bar>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package_Private$1>::<C Project>::<C Bar>::<C Bar>)
 
-    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package$1>::<C Project>::<C Bar>::<C CallsFoo>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package_Private$1>::<C Project>::<C Bar>::<C CallsFoo>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Project_Bar_Package$1>::<C Project>::<C Foo><<C <todo sym>>> < ()
-      <emptyTree>::<C CallsBar> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>::<C CallsBar>
-    end
-
-    module <emptyTree>::<C Project_Bar_Package$1>::<C Project>::<C Foo><<C <todo sym>>> < ()
-      <emptyTree>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>::<C Foo>
+    module <emptyTree>::<C Project_Bar_Package_Private$1>::<C Project><<C <todo sym>>> < ()
+      <emptyTree>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>
     end
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+    module <emptyTree>::<C Project_Bar_Package_Private$1>::<C Project>::<C Bar><<C <todo sym>>> < ()
+      <emptyTree>::<C Bar> = <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package_Private$1>::<C Project>::<C Bar>::<C Bar>
+    end
+
+    module <emptyTree>::<C Project_Bar_Package_Private$1>::<C Project>::<C Bar><<C <todo sym>>> < ()
+      <emptyTree>::<C CallsFoo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package_Private$1>::<C Project>::<C Bar>::<C CallsFoo>
+    end
+
+    module <emptyTree>::<C Project_Bar_Package_Private$1>::<C Project><<C <todo sym>>> < ()
+      <emptyTree>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>
+    end
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
     module <emptyTree>::<C Project_Bar_Package$1>::<C Project>::<C Bar><<C <todo sym>>> < ()
-      <emptyTree>::<C Bar> = <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package$1>::<C Project>::<C Bar>::<C Bar>
+      <emptyTree>::<C Bar> = <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package_Private$1>::<C Project>::<C Bar>::<C Bar>
     end
 
     module <emptyTree>::<C Project_Bar_Package$1>::<C Project>::<C Bar><<C <todo sym>>> < ()
-      <emptyTree>::<C CallsFoo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package$1>::<C Project>::<C Bar>::<C CallsFoo>
+      <emptyTree>::<C CallsFoo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package_Private$1>::<C Project>::<C Bar>::<C CallsFoo>
     end
+  end
 
-    module <emptyTree>::<C Project_Bar_Package$1>::<C Project>::<C Foo><<C <todo sym>>> < ()
-      <emptyTree>::<C CallsBar> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>::<C CallsBar>
-    end
-
-    module <emptyTree>::<C Project_Bar_Package$1>::<C Project>::<C Foo><<C <todo sym>>> < ()
-      <emptyTree>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>::<C Foo>
-    end
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
   end
 end
 # -- test/testdata/packager/simple_package/bar/bar.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package$1><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package_Private$1><<C <todo sym>>> < ()
     class <emptyTree>::<C Project>::<C Bar>::<C Bar><<C <todo sym>>> < (::<todo sym>)
       ::Sorbet::Private::Static.sig(<self>) do ||
         <self>.params(:value, <emptyTree>::<C Integer>).void()
@@ -56,7 +61,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/simple_package/bar/calls_foo.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package$1><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package_Private$1><<C <todo sym>>> < ()
     module <emptyTree>::<C Project>::<C Bar>::<C CallsFoo><<C <todo sym>>> < ()
       ::Sorbet::Private::Static.sig(<self>) do ||
         <self>.returns(<emptyTree>::<C Project>::<C Foo>::<C Foo>)
@@ -87,42 +92,47 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C Project>::<C Foo><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.import(<emptyTree>::<C Project>::<C Bar>)
 
-    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>::<C Foo>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package_Private$1>::<C Project>::<C Foo>::<C Foo>)
 
-    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>::<C CallsBar>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package_Private$1>::<C Project>::<C Foo>::<C CallsBar>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Project_Foo_Package$1>::<C Project>::<C Bar><<C <todo sym>>> < ()
-      <emptyTree>::<C Bar> = <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package$1>::<C Project>::<C Bar>::<C Bar>
-    end
-
-    module <emptyTree>::<C Project_Foo_Package$1>::<C Project>::<C Bar><<C <todo sym>>> < ()
-      <emptyTree>::<C CallsFoo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package$1>::<C Project>::<C Bar>::<C CallsFoo>
+    module <emptyTree>::<C Project_Foo_Package_Private$1>::<C Project><<C <todo sym>>> < ()
+      <emptyTree>::<C Bar> = <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package$1>::<C Project>::<C Bar>
     end
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Project_Foo_Package$1>::<C Project>::<C Bar><<C <todo sym>>> < ()
-      <emptyTree>::<C Bar> = <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package$1>::<C Project>::<C Bar>::<C Bar>
+    module <emptyTree>::<C Project_Foo_Package_Private$1>::<C Project><<C <todo sym>>> < ()
+      <emptyTree>::<C Bar> = <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package$1>::<C Project>::<C Bar>
     end
 
-    module <emptyTree>::<C Project_Foo_Package$1>::<C Project>::<C Bar><<C <todo sym>>> < ()
-      <emptyTree>::<C CallsFoo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package$1>::<C Project>::<C Bar>::<C CallsFoo>
+    module <emptyTree>::<C Project_Foo_Package_Private$1>::<C Project>::<C Foo><<C <todo sym>>> < ()
+      <emptyTree>::<C CallsBar> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package_Private$1>::<C Project>::<C Foo>::<C CallsBar>
+    end
+
+    module <emptyTree>::<C Project_Foo_Package_Private$1>::<C Project>::<C Foo><<C <todo sym>>> < ()
+      <emptyTree>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package_Private$1>::<C Project>::<C Foo>::<C Foo>
+    end
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
+    module <emptyTree>::<C Project_Foo_Package$1>::<C Project>::<C Foo><<C <todo sym>>> < ()
+      <emptyTree>::<C CallsBar> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package_Private$1>::<C Project>::<C Foo>::<C CallsBar>
     end
 
     module <emptyTree>::<C Project_Foo_Package$1>::<C Project>::<C Foo><<C <todo sym>>> < ()
-      <emptyTree>::<C CallsBar> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>::<C CallsBar>
+      <emptyTree>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package_Private$1>::<C Project>::<C Foo>::<C Foo>
     end
+  end
 
-    module <emptyTree>::<C Project_Foo_Package$1>::<C Project>::<C Foo><<C <todo sym>>> < ()
-      <emptyTree>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>::<C Foo>
-    end
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
   end
 end
 # -- test/testdata/packager/simple_package/foo/calls_bar.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package_Private$1><<C <todo sym>>> < ()
     module <emptyTree>::<C Project>::<C Foo>::<C CallsBar><<C <todo sym>>> < ()
       ::Sorbet::Private::Static.sig(<self>) do ||
         <self>.returns(<emptyTree>::<C Project>::<C Bar>::<C Bar>)
@@ -140,7 +150,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/simple_package/foo/foo.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package_Private$1><<C <todo sym>>> < ()
     class <emptyTree>::<C Project>::<C Foo>::<C Foo><<C <todo sym>>> < (::<todo sym>)
       ::Sorbet::Private::Static.sig(<self>) do ||
         <self>.params(:value, <emptyTree>::<C Integer>).void()

--- a/test/testdata/packager/simple_test_import/pass.package-tree.exp
+++ b/test/testdata/packager/simple_test_import/pass.package-tree.exp
@@ -5,36 +5,42 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <self>.test_import(<emptyTree>::<C Project>::<C TestOnly>)
 
-    <self>.export_for_test(<emptyTree>::<C <PackageRegistry>>::<C Project_MainLib_Package$1>::<C Project>::<C MainLib>::<C Lib>)
+    <self>.export_for_test(<emptyTree>::<C <PackageRegistry>>::<C Project_MainLib_Package_Private$1>::<C Project>::<C MainLib>::<C Lib>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Project_MainLib_Package$1>::<C Project>::<C Util><<C <todo sym>>> < ()
-      <emptyTree>::<C MyUtil> = <emptyTree>::<C <PackageRegistry>>::<C Project_Util_Package$1>::<C Project>::<C Util>::<C MyUtil>
+    module <emptyTree>::<C Project_MainLib_Package_Private$1>::<C Project><<C <todo sym>>> < ()
+      <emptyTree>::<C Util> = <emptyTree>::<C <PackageRegistry>>::<C Project_Util_Package$1>::<C Project>::<C Util>
     end
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Project_MainLib_Package$1>::<C Project>::<C MainLib><<C <todo sym>>> < ()
-      <emptyTree>::<C Lib> = <emptyTree>::<C <PackageRegistry>>::<C Project_MainLib_Package$1>::<C Project>::<C MainLib>::<C Lib>
+    module <emptyTree>::<C Project_MainLib_Package_Private$1>::<C Project>::<C MainLib><<C <todo sym>>> < ()
+      <emptyTree>::<C Lib> = <emptyTree>::<C <PackageRegistry>>::<C Project_MainLib_Package_Private$1>::<C Project>::<C MainLib>::<C Lib>
     end
 
-    module <emptyTree>::<C Project_MainLib_Package$1>::<C Project>::<C TestOnly><<C <todo sym>>> < ()
-      <emptyTree>::<C SomeHelper> = <emptyTree>::<C <PackageRegistry>>::<C Project_TestOnly_Package$1>::<C Project>::<C TestOnly>::<C SomeHelper>
+    module <emptyTree>::<C Project_MainLib_Package_Private$1>::<C Project><<C <todo sym>>> < ()
+      <emptyTree>::<C TestOnly> = <emptyTree>::<C <PackageRegistry>>::<C Project_TestOnly_Package$1>::<C Project>::<C TestOnly>
     end
 
-    module <emptyTree>::<C Project_MainLib_Package$1>::<C Project>::<C Util><<C <todo sym>>> < ()
-      <emptyTree>::<C MyUtil> = <emptyTree>::<C <PackageRegistry>>::<C Project_Util_Package$1>::<C Project>::<C Util>::<C MyUtil>
+    module <emptyTree>::<C Project_MainLib_Package_Private$1>::<C Project><<C <todo sym>>> < ()
+      <emptyTree>::<C Util> = <emptyTree>::<C <PackageRegistry>>::<C Project_Util_Package$1>::<C Project>::<C Util>
     end
 
-    module <emptyTree>::<C Project_MainLib_Package$1>::<C Test>::<C Project>::<C Util><<C <todo sym>>> < ()
-      <emptyTree>::<C UtilHelper> = <emptyTree>::<C <PackageTests>>::<C Project_Util_Package$1>::<C Test>::<C Project>::<C Util>::<C UtilHelper>
+    module <emptyTree>::<C Project_MainLib_Package_Private$1>::<C Test>::<C Project><<C <todo sym>>> < ()
+      <emptyTree>::<C Util> = <emptyTree>::<C <PackageTests>>::<C Project_Util_Package$1>::<C Test>::<C Project>::<C Util>
     end
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
+  end
+
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
   end
 end
 # -- test/testdata/packager/simple_test_import/main_lib/lib.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageRegistry>>::<C Project_MainLib_Package$1><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<C Project_MainLib_Package_Private$1><<C <todo sym>>> < ()
     class <emptyTree>::<C Project>::<C MainLib>::<C Lib><<C <todo sym>>> < (::<todo sym>)
       <emptyTree>::<C Project>::<C Util>::<C MyUtil>.new()
 
@@ -48,7 +54,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/simple_test_import/main_lib/lib.test.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageTests>>::<C Project_MainLib_Package$1><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageTests>>::<C Project_MainLib_Package_Private$1><<C <todo sym>>> < ()
     class <emptyTree>::<C Test>::<C Project>::<C MainLib>::<C LibTest><<C <todo sym>>> < (::<todo sym>)
       <emptyTree>::<C Project>::<C MainLib>::<C Lib>.new()
 
@@ -65,21 +71,30 @@ end
 # -- test/testdata/packager/simple_test_import/test_only/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C Project>::<C TestOnly><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
-    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Project_TestOnly_Package$1>::<C Project>::<C TestOnly>::<C SomeHelper>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Project_TestOnly_Package_Private$1>::<C Project>::<C TestOnly>::<C SomeHelper>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Project_TestOnly_Package$1>::<C Project>::<C TestOnly><<C <todo sym>>> < ()
-      <emptyTree>::<C SomeHelper> = <emptyTree>::<C <PackageRegistry>>::<C Project_TestOnly_Package$1>::<C Project>::<C TestOnly>::<C SomeHelper>
+    module <emptyTree>::<C Project_TestOnly_Package_Private$1>::<C Project>::<C TestOnly><<C <todo sym>>> < ()
+      <emptyTree>::<C SomeHelper> = <emptyTree>::<C <PackageRegistry>>::<C Project_TestOnly_Package_Private$1>::<C Project>::<C TestOnly>::<C SomeHelper>
     end
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
+    module <emptyTree>::<C Project_TestOnly_Package$1>::<C Project>::<C TestOnly><<C <todo sym>>> < ()
+      <emptyTree>::<C SomeHelper> = <emptyTree>::<C <PackageRegistry>>::<C Project_TestOnly_Package_Private$1>::<C Project>::<C TestOnly>::<C SomeHelper>
+    end
+  end
+
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
   end
 end
 # -- test/testdata/packager/simple_test_import/test_only/some_helper.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageRegistry>>::<C Project_TestOnly_Package$1><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<C Project_TestOnly_Package_Private$1><<C <todo sym>>> < ()
     class <emptyTree>::<C Project>::<C TestOnly>::<C SomeHelper><<C <todo sym>>> < (::<todo sym>)
     end
   end
@@ -87,37 +102,49 @@ end
 # -- test/testdata/packager/simple_test_import/util/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C Project>::<C Util><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
-    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Project_Util_Package$1>::<C Project>::<C Util>::<C MyUtil>)
+    <self>.export(<emptyTree>::<C <PackageRegistry>>::<C Project_Util_Package_Private$1>::<C Project>::<C Util>::<C MyUtil>)
 
-    <self>.export(<emptyTree>::<C <PackageTests>>::<C Project_Util_Package$1>::<C Test>::<C Project>::<C Util>::<C UtilHelper>)
+    <self>.export(<emptyTree>::<C <PackageTests>>::<C Project_Util_Package_Private$1>::<C Test>::<C Project>::<C Util>::<C UtilHelper>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+    module <emptyTree>::<C Project_Util_Package_Private$1>::<C Project>::<C Util><<C <todo sym>>> < ()
+      <emptyTree>::<C MyUtil> = <emptyTree>::<C <PackageRegistry>>::<C Project_Util_Package_Private$1>::<C Project>::<C Util>::<C MyUtil>
+    end
+  end
+
+  module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
     module <emptyTree>::<C Project_Util_Package$1>::<C Project>::<C Util><<C <todo sym>>> < ()
-      <emptyTree>::<C MyUtil> = <emptyTree>::<C <PackageRegistry>>::<C Project_Util_Package$1>::<C Project>::<C Util>::<C MyUtil>
+      <emptyTree>::<C MyUtil> = <emptyTree>::<C <PackageRegistry>>::<C Project_Util_Package_Private$1>::<C Project>::<C Util>::<C MyUtil>
+    end
+  end
+
+  module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
+    module <emptyTree>::<C Project_Util_Package$1>::<C Test>::<C Project>::<C Util><<C <todo sym>>> < ()
+      <emptyTree>::<C UtilHelper> = <emptyTree>::<C <PackageTests>>::<C Project_Util_Package_Private$1>::<C Test>::<C Project>::<C Util>::<C UtilHelper>
     end
   end
 end
 # -- test/testdata/packager/simple_test_import/util/my_util.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageRegistry>>::<C Project_Util_Package$1><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageRegistry>>::<C Project_Util_Package_Private$1><<C <todo sym>>> < ()
     class <emptyTree>::<C Project>::<C Util>::<C MyUtil><<C <todo sym>>> < (::<todo sym>)
     end
   end
 end
 # -- test/testdata/packager/simple_test_import/util/unexported.test.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageTests>>::<C Project_Util_Package$1><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageTests>>::<C Project_Util_Package_Private$1><<C <todo sym>>> < ()
     class <emptyTree>::<C Test>::<C Project>::<C Util>::<C Unexported><<C <todo sym>>> < (::<todo sym>)
     end
   end
 end
 # -- test/testdata/packager/simple_test_import/util/util_helper.test.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  module <emptyTree>::<C <PackageTests>>::<C Project_Util_Package$1><<C <todo sym>>> < ()
+  module <emptyTree>::<C <PackageTests>>::<C Project_Util_Package_Private$1><<C <todo sym>>> < ()
     class <emptyTree>::<C Test>::<C Project>::<C Util>::<C UtilHelper><<C <todo sym>>> < (::<todo sym>)
     end
   end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
With this change, packager will only selectively enumerate a full export tree at an import site.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
We found that the current design of `--stripe-packages` introduces memory bloat. This is due to its inherently quadratic space complexity, where given a package `A`, every package that imports `A` has to enumerate and alias the full set of exports of `A` at the corresponding import site. Given that, the space impact of a package (proportional to the number of nodes created in the AST) is `O(number of exports * number of importing packages)`.

This change introduces an optimization, which is based on the lemma that full export enumeration at an import site is not strictly necessary, except in some cases. These are when the importing package is a nested namespace of the import, or imports a package which is a nested namespace of the import. Meaning, we only need to enumerate all the exports of a package when the import site also interacts with a nested namespace of it. In all other cases, we simply make a top-level alias to the entire package's exported namespace.

Due to the current state of the Stripe codebase, this optimization effectively has linear space complexity (`O(number of exports + number of importing packages)`) in the average case and quadratic space complexity in the highly worst case. This significantly reduces memory usage and is a stable solution that can last us for quite some time in the medium term.

Additionally, this change introduces the concept of a "public" and "private" mangled namespace for each package. This is to prevent un-exported constants from being exposed via the top-level alias described above.

For demonstrations of the concept in Sorbet playground, please see:
* [Link 1](https://sorbet.run/#%23%20Assume%0A%23%20class%20Opus%3A%3AA%20%3C%20PackageSpec%0A%23%20%20%20import%20Opus%3A%3AB%0A%23%20%20%20import%20Opus%3A%3AB%3A%3AC%0A%23%20end%0A%23%0A%23%20class%20Opus%3A%3AB%20%3C%20PackageSpec%0A%23%20%20%20export%20Opus%3A%3AB%3A%3AB1%0A%23%20%20%20export%20Opus%3A%3AB%3A%3AB2%20%0A%23%20end%0A%23%20%0A%23%20class%20Opus%3A%3AB%3A%3AC%20%3C%20PackageSpec%0A%23%20%20export%20Opus%3A%3AB%3A%3AC%3A%3AC1%0A%23%20end%0A%0Amodule%20PkgOpusB%0A%20%20class%20Opus%3A%3AB%3A%3AB1%0A%20%20end%0A%20%20class%20Opus%3A%3AB%3A%3AB2%0A%20%20end%0A%20%20class%20Opus%3A%3AB%3A%3AB3Unexported%0A%20%20end%0Aend%0A%0Amodule%20PkgOpusB_EXPORTED%0A%20%20Opus%3A%3AB%3A%3AB1%20%3D%20PkgOpusB%3A%3AOpus%3A%3AB%3A%3AB1%0A%20%20Opus%3A%3AB%3A%3AB2%20%3D%20PkgOpusB%3A%3AOpus%3A%3AB%3A%3AB2%0Aend%0A%0Amodule%20PkgOpusBC%0A%20%20class%20Opus%3A%3AB%3A%3AC%3A%3AC1%0A%20%20end%0A%20%20class%20Opus%3A%3AB%3A%3AC%3A%3AC2Unexported%0A%20%20end%0Aend%0A%0Amodule%20PkgOpusBC_EXPORTED%0A%20%20Opus%3A%3AB%3A%3AC%3A%3AC1%20%3D%20PkgOpusBC%3A%3AOpus%3A%3AB%3A%3AC%3A%3AC1%0Aend%0A%0Amodule%20PkgOpusA%0A%20%20%23%20Enumerate%20aliases%20for%20all%20Opus%3A%3AB%20exports%0A%20%20Opus%3A%3AB%3A%3AB1%20%3D%20PkgOpusB_EXPORTED%3A%3AOpus%3A%3AB%3A%3AB1%0A%20%20Opus%3A%3AB%3A%3AB2%20%3D%20PkgOpusB_EXPORTED%3A%3AOpus%3A%3AB%3A%3AB2%0A%0A%20%20Opus%3A%3AB%3A%3AC%20%3D%20PkgOpusBC_EXPORTED%3A%3AOpus%3A%3AB%3A%3AC%20%23%20Can%20import%20this%20successfully%0A%0A%20%20module%20Opus%3A%3AA%0A%20%20%20%20Opus%3A%3AB%3A%3AB1%0A%20%20%20%20Opus%3A%3AB%3A%3AB2%0A%20%20%20%20%0A%20%20%20%20Opus%3A%3AB%3A%3AC%3A%3AC1%0A%20%20end%0Aend)
* [Link 2](https://sorbet.run/#%23%20Assume%0A%23%20class%20Opus%3A%3AA%20%3C%20PackageSpec%0A%23%20%20%20import%20Opus%3A%3AB%0A%23%20%20%20import%20Opus%3A%3AB%3A%3AC%0A%23%20end%0A%23%0A%23%20class%20Opus%3A%3AB%20%3C%20PackageSpec%0A%23%20%20%20export%20Opus%3A%3AB%3A%3AB1%0A%23%20%20%20export%20Opus%3A%3AB%3A%3AB2%20%0A%23%20end%0A%23%20%0A%23%20class%20Opus%3A%3AB%3A%3AC%20%3C%20PackageSpec%0A%23%20%20export%20Opus%3A%3AB%3A%3AC%3A%3AC1%0A%23%20end%0A%0Amodule%20PkgOpusB%0A%20%20class%20Opus%3A%3AB%3A%3AB1%0A%20%20end%0A%20%20class%20Opus%3A%3AB%3A%3AB2%0A%20%20end%0A%20%20class%20Opus%3A%3AB%3A%3AB3Unexported%0A%20%20end%0Aend%0A%0Amodule%20PkgOpusB_EXPORTED%0A%20%20Opus%3A%3AB%3A%3AB1%20%3D%20PkgOpusB%3A%3AOpus%3A%3AB%3A%3AB1%0A%20%20Opus%3A%3AB%3A%3AB2%20%3D%20PkgOpusB%3A%3AOpus%3A%3AB%3A%3AB2%0Aend%0A%0Amodule%20PkgOpusBC%0A%20%20class%20Opus%3A%3AB%3A%3AC%3A%3AC1%0A%20%20end%0A%20%20class%20Opus%3A%3AB%3A%3AC%3A%3AC2Unexported%0A%20%20end%0Aend%0A%0Amodule%20PkgOpusBC_EXPORTED%0A%20%20Opus%3A%3AB%3A%3AC%3A%3AC1%20%3D%20PkgOpusBC%3A%3AOpus%3A%3AB%3A%3AC%3A%3AC1%0Aend%0A%0Amodule%20PkgOpusA%0A%20%20Opus%3A%3AB%20%3D%20PkgOpusB_EXPORTED%3A%3AOpus%3A%3AB%20%23%20Only%20alias%20root%20of%20export%20tree%0A%20%20Opus%3A%3AB%3A%3AC%20%3D%20PkgOpusBC_EXPORTED%3A%3AOpus%3A%3AB%3A%3AC%20%23%20Can't%20do%20this%2C%20import%20conflict!%0A%0A%20%20module%20Opus%3A%3AA%0A%20%20%20%20Opus%3A%3AB%3A%3AB1%0A%20%20%20%20Opus%3A%3AB%3A%3AB2%0A%20%20end%0Aend)
* [Link 3](https://sorbet.run/#%23%20Assume%0A%23%20class%20Opus%3A%3AA%20%3C%20PackageSpec%0A%23%20%20%20import%20Opus%3A%3AB%0A%23%20end%0A%23%0A%23%20class%20Opus%3A%3AB%20%3C%20PackageSpec%0A%23%20%20%20export%20Opus%3A%3AB%3A%3AB1%0A%23%20%20%20export%20Opus%3A%3AB%3A%3AB2%20%0A%23%20end%0A%23%20%0A%23%20class%20Opus%3A%3AB%3A%3AC%20%3C%20PackageSpec%0A%23%20%20export%20Opus%3A%3AB%3A%3AC%3A%3AC1%0A%23%20end%0A%0Amodule%20PkgOpusB%0A%20%20class%20Opus%3A%3AB%3A%3AB1%0A%20%20end%0A%20%20class%20Opus%3A%3AB%3A%3AB2%0A%20%20end%0A%20%20class%20Opus%3A%3AB%3A%3AB3Unexported%0A%20%20end%0Aend%0A%0Amodule%20PkgOpusB_EXPORTED%0A%20%20Opus%3A%3AB%3A%3AB1%20%3D%20PkgOpusB%3A%3AOpus%3A%3AB%3A%3AB1%0A%20%20Opus%3A%3AB%3A%3AB2%20%3D%20PkgOpusB%3A%3AOpus%3A%3AB%3A%3AB2%0Aend%0A%0Amodule%20PkgOpusBC%0A%20%20class%20Opus%3A%3AB%3A%3AC%3A%3AC1%0A%20%20end%0A%20%20class%20Opus%3A%3AB%3A%3AC%3A%3AC2Unexported%0A%20%20end%0Aend%0A%0Amodule%20PkgOpusBC_EXPORTED%0A%20%20Opus%3A%3AB%3A%3AC%3A%3AC1%20%3D%20PkgOpusBC%3A%3AOpus%3A%3AB%3A%3AC%3A%3AC1%0Aend%0A%0Amodule%20PkgOpusA%0A%20%20Opus%3A%3AB%20%3D%20PkgOpusB_EXPORTED%3A%3AOpus%3A%3AB%20%23%20Only%20alias%20root%20of%20export%20tree%0A%0A%20%20module%20Opus%3A%3AA%0A%20%20%20%20Opus%3A%3AB%3A%3AB1%0A%20%20%20%20Opus%3A%3AB%3A%3AB2%0A%20%20end%0Aend)


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Also verified on Stripe codebase.