### PR TITLE
Accept `T.self_type` and `T.attached_class` for proc binding

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -490,6 +490,13 @@ void GlobalState::initEmpty() {
     klass = Symbols::T_Private_Compiler().data(*this)->singletonClass(*this);
     ENFORCE(klass == Symbols::T_Private_CompilerSingleton());
 
+    // Magic classes for special proc bindings
+    klass = synthesizeClass(core::Names::Constants::BindToAttachedClass());
+    ENFORCE(klass == Symbols::BindToAttachedClass());
+
+    klass = synthesizeClass(core::Names::Constants::BindToSelfType());
+    ENFORCE(klass == Symbols::BindToSelfType());
+
     typeArgument =
         enterTypeArgument(Loc::none(), Symbols::noMethod(), Names::Constants::TodoTypeArgument(), Variance::CoVariant);
     ENFORCE(typeArgument == Symbols::todoTypeArgument());

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -970,6 +970,14 @@ public:
         return ClassOrModuleRef::fromRaw(88);
     }
 
+    static ClassOrModuleRef BindToAttachedClass() {
+        return ClassOrModuleRef::fromRaw(89);
+    }
+
+    static ClassOrModuleRef BindToSelfType() {
+        return ClassOrModuleRef::fromRaw(90);
+    }
+
     static constexpr int MAX_PROC_ARITY = 10;
     static ClassOrModuleRef Proc0() {
         return ClassOrModuleRef::fromRaw(MAX_SYNTHETIC_CLASS_SYMBOLS - MAX_PROC_ARITY * 2 - 2);
@@ -992,11 +1000,11 @@ public:
         return ClassOrModuleRef::fromRaw(MAX_SYNTHETIC_CLASS_SYMBOLS - 1);
     }
 
-    static constexpr int MAX_SYNTHETIC_CLASS_SYMBOLS = 203;
+    static constexpr int MAX_SYNTHETIC_CLASS_SYMBOLS = 205;
     static constexpr int MAX_SYNTHETIC_METHOD_SYMBOLS = 45;
     static constexpr int MAX_SYNTHETIC_FIELD_SYMBOLS = 4;
     static constexpr int MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 4;
-    static constexpr int MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 100;
+    static constexpr int MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 102;
 };
 
 template <typename H> H AbslHashValue(H h, const SymbolRef &m) {

--- a/core/errors/resolver.h
+++ b/core/errors/resolver.h
@@ -76,6 +76,7 @@ constexpr ErrorClass NonClassSuperclass{5067, StrictLevel::False};
 constexpr ErrorClass AmbiguousDefinitionError{5068, StrictLevel::False};
 constexpr ErrorClass MultipleStatementsInSig{5069, StrictLevel::False};
 constexpr ErrorClass NilableUntyped{5070, StrictLevel::False};
+constexpr ErrorClass BindNonBlockParameter{5071, StrictLevel::False};
 } // namespace sorbet::core::errors::Resolver
 
 #endif

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -477,6 +477,10 @@ NameDef names[] = {
     {"Rational", "Rational", true},
     // A magic non user-creatable class with methods to keep state between passes
     {"Magic", "<Magic>", true},
+    // A magic non user-creatable class for binding procs to attached_class
+    {"BindToAttachedClass", "<BindToAttachedClass>", true},
+    // A magic non user-creatable class for binding procs to self_type
+    {"BindToSelfType", "<BindToSelfType>", true},
     // A magic non user-creatable class for mimicing the decl builder during cfg
     // construction
     {"DeclBuilderForProcs", "<DeclBuilderForProcs>", true},

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1370,11 +1370,14 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                     if (rebind == core::Symbols::BindToSelfType()) {
                         tp.type = l.link->result->main.receiver;
                     } else if (rebind == core::Symbols::BindToAttachedClass()) {
-                        tp.type = core::cast_type<core::AppliedType>(l.link->result->main.receiver)
-                                      ->klass.data(ctx)
-                                      ->attachedClass(ctx)
-                                      .data(ctx)
-                                      ->externalType();
+                        auto appliedType = core::cast_type<core::AppliedType>(l.link->result->main.receiver);
+                        auto attachedClass =
+                            appliedType->klass.data(ctx)->findMember(ctx, core::Names::Constants::AttachedClass());
+
+                        auto lambdaParam =
+                            core::cast_type<core::LambdaParam>(attachedClass.asTypeMemberRef().data(ctx)->resultType);
+
+                        tp.type = lambdaParam->upperBound;
                     } else {
                         tp.type = rebind.data(ctx)->externalType();
                     }

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -290,6 +290,14 @@ ParsedSig parseSigWithSelfTypeParams(core::Context ctx, const ast::Send &sigSend
                         sig.bind = appType->klass;
                         validBind = true;
                     }
+                } else if (auto arg = ast::cast_tree<ast::Send>(send->getPosArg(0))) {
+                    if (arg->fun == core::Names::selfType()) {
+                        sig.bind = core::Symbols::BindToSelfType();
+                        validBind = true;
+                    } else if (arg->fun == core::Names::attachedClass()) {
+                        sig.bind = core::Symbols::BindToAttachedClass();
+                        validBind = true;
+                    }
                 }
 
                 if (!validBind) {
@@ -991,7 +999,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx,
         },
         [&](const ast::Send &s) {
             if (isTProc(ctx, &s)) {
-                auto sig = parseSigWithSelfTypeParams(ctx, s, &sigBeingParsed, args.withoutSelfType());
+                auto sig = parseSigWithSelfTypeParams(ctx, s, &sigBeingParsed, args);
                 if (sig.bind.exists()) {
                     if (!args.allowRebind) {
                         if (auto e = ctx.beginError(s.loc, core::errors::Resolver::InvalidTypeDeclaration)) {

--- a/test/testdata/resolver/bad_generic_bind.rb
+++ b/test/testdata/resolver/bad_generic_bind.rb
@@ -1,0 +1,23 @@
+# typed: true
+
+class TypeTemplate
+  extend T::Sig
+  extend T::Generic
+
+  Elem = type_template
+
+  sig { params(block: T.proc.bind(Elem).void).void }
+                    # ^^^^^^^^^^^^^^^^^ error: Malformed `bind`: Can only bind to simple class names
+  def self.before_create(&block); end
+end
+
+class TypeMember
+  extend T::Sig
+  extend T::Generic
+
+  Elem = type_member
+
+  sig { params(block: T.proc.bind(Elem).void).void }
+                    # ^^^^^^^^^^^^^^^^^ error: Malformed `bind`: Can only bind to simple class names
+  def before_create(&block); end
+end

--- a/test/testdata/resolver/bind.rb
+++ b/test/testdata/resolver/bind.rb
@@ -13,8 +13,22 @@ class Foo
   sig {bind(Bar).returns(Integer)}
   def bar; 1; end
 
+  sig {bind(T.attached_class).returns(Integer)}
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Using `bind` is not permitted here
+  def self.bar; 1; end
+
   sig {bind(T.any(Integer, String)).void} # error: Malformed `bind`: Can only bind to simple class names
   def too_complex; end
+
+  sig {params(blk: T.proc.params(x: T.proc.bind(T.attached_class).void).void).void}
+                                  # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Using `bind` is not permitted here
+  def self.lambda_argument(&blk); end
+
+  sig {returns(T.proc.returns(T.proc.bind(T.attached_class).void))}
+                            # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Using `bind` is not permitted here
+  def self.lambda_returns
+    T.unsafe(nil)
+  end
 end
 
 class Bar

--- a/test/testdata/resolver/bind_attached_class.rb
+++ b/test/testdata/resolver/bind_attached_class.rb
@@ -37,6 +37,10 @@ class BadBinds
   extend T::Sig
 
   sig {params(blk: T.proc.params(x: T.proc.bind(T.attached_class).void).void).void}
-                                              # ^^^^^^^^^^^^^^^^ error: `T.attached_class` may only be used in a singleton class method context
-  def foo(&blk); end
+                                  # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Using `bind` is not permitted here
+  def self.lambda_argument(&blk); end
+
+  sig {params(it: T.proc.bind(T.attached_class).void).void}
+            # ^^ error: Using `bind` is not permitted here
+  def self.non_block_argument(it); end
 end

--- a/test/testdata/resolver/bind_attached_class.rb
+++ b/test/testdata/resolver/bind_attached_class.rb
@@ -1,0 +1,34 @@
+# typed: true
+
+class Base
+  extend T::Sig
+
+  sig { params(block: T.proc.bind(T.attached_class).void).void }
+  def self.before_create(&block); end
+
+  before_create do
+    T.reveal_type(self) # error: Revealed type: `Base`
+  end
+end
+
+Base.before_create do
+  T.reveal_type(self) # error: Revealed type: `Base`
+end
+
+class Model < Base
+  before_create do
+    T.reveal_type(self) # error: Revealed type: `Model`
+
+    does_exist
+    does_not_exist # error: Method `does_not_exist` does not exist on `Model`
+  end
+
+  def does_exist; end
+end
+
+Model.before_create do
+  T.reveal_type(self) # error: Revealed type: `Model`
+
+  does_exist
+  does_not_exist # error: Method `does_not_exist` does not exist on `Model`
+end

--- a/test/testdata/resolver/bind_attached_class.rb
+++ b/test/testdata/resolver/bind_attached_class.rb
@@ -32,3 +32,11 @@ Model.before_create do
   does_exist
   does_not_exist # error: Method `does_not_exist` does not exist on `Model`
 end
+
+class BadBinds
+  extend T::Sig
+
+  sig {params(blk: T.proc.params(x: T.proc.bind(T.attached_class).void).void).void}
+                                              # ^^^^^^^^^^^^^^^^ error: `T.attached_class` may only be used in a singleton class method context
+  def foo(&blk); end
+end

--- a/test/testdata/resolver/bind_attached_class.rb
+++ b/test/testdata/resolver/bind_attached_class.rb
@@ -36,11 +36,13 @@ end
 class BadBinds
   extend T::Sig
 
-  sig {params(blk: T.proc.params(x: T.proc.bind(T.attached_class).void).void).void}
-                                  # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Using `bind` is not permitted here
-  def self.lambda_argument(&blk); end
-
   sig {params(it: T.proc.bind(T.attached_class).void).void}
             # ^^ error: Using `bind` is not permitted here
   def self.non_block_argument(it); end
+
+  sig {returns(T.proc.bind(T.attached_class).void)}
+             # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Using `bind` is not permitted here
+  def self.attached_class_return
+    T.unsafe(nil)
+  end
 end

--- a/test/testdata/resolver/bind_self_type.rb
+++ b/test/testdata/resolver/bind_self_type.rb
@@ -1,0 +1,75 @@
+# typed: true
+
+module Mixin
+  extend T::Sig
+
+  sig { params(block: T.proc.bind(T.self_type).void).void }
+  def foo(&block); end
+end
+
+class IncludesMixin
+  include Mixin
+
+  def does_exist; end
+
+  def bar
+    foo do
+      T.reveal_type(self) # error: Revealed type: `IncludesMixin`
+
+      does_exist
+      does_not_exist # error: Method `does_not_exist` does not exist on `IncludesMixin`
+    end
+  end
+end
+
+IncludesMixin.new.foo do
+  T.reveal_type(self) # error: Revealed type: `IncludesMixin`
+
+  does_exist
+  does_not_exist # error: Method `does_not_exist` does not exist on `IncludesMixin`
+end
+
+class Base
+  extend T::Sig
+
+  sig { params(block: T.proc.bind(T.self_type).void).void }
+  def self.foo(&block); end
+
+  sig { params(block: T.proc.bind(T.self_type).void).void }
+  def instance_foo(&block); end
+end
+
+class Model < Base
+  def self.does_exist; end
+  def does_exist; end
+
+  foo do
+    T.reveal_type(self) # error: Revealed type: `T.class_of(Model)`
+
+    does_exist
+    does_not_exist # error: Method `does_not_exist` does not exist on `T.class_of(Model)`
+  end
+
+  def bar
+    instance_foo do
+      T.reveal_type(self) # error: Revealed type: `Model`
+
+      does_exist
+      does_not_exist # error: Method `does_not_exist` does not exist on `Model`
+    end
+  end
+end
+
+Model.foo do
+  T.reveal_type(self) # error: Revealed type: `T.class_of(Model)`
+
+  does_exist
+  does_not_exist # error: Method `does_not_exist` does not exist on `T.class_of(Model)`
+end
+
+Model.new.instance_foo do
+  T.reveal_type(self) # error: Revealed type: `Model`
+
+  does_exist
+  does_not_exist # error: Method `does_not_exist` does not exist on `Model`
+end


### PR DESCRIPTION
### RFC

This RFC proposes allowing binding procs to `T.attached_class` and `T.self_type`, which are a very common occurrence in the Rails world.

### What the proposed changes do

We created two magic classes two indicate the two special types of binding. This is enough to propagate the information down to inference, which can then handle the cases appropriately when processing `LoadSelf`.

### Motivation

Being able to bind method block's to generic types is very useful, especially in the Rails world, where blocks are captured into variables and then executed in different contexts. Here are some common examples:
```ruby
class MyModel < ActiveRecord::Base
  before_create do
     # This block is captured and executed in the context of the instance
     do_something
  end

  def do_something; end
end

# The correct signature for this method would look like this
class ActiveRecord::Base
  sig { params(block: T.proc.bind(T.attached_class).void).void }
  def self.before_create(&block); end
end

# Similarly, ActiveSupport::TestCase methods do exactly the same thing

class MyTest < ActiveSupport::TestCase
  # The blocks for all of these methods are evaluated in an instance context
  setup do
  end

  test "something" do
  end

  teardown do
  end
end

# The correct signatures for them would look like this
class ActiveSupport::TestCase
  sig { params(block: T.proc.bind(T.attached_class).void).void }
  def self.setup(&block); end

  sig { params(block: T.proc.bind(T.attached_class).void).void }
  def self.teardown(&block); end

  sig { params(name: String, block: T.proc.bind(T.attached_class).void).void }
  def self.test(name, &block); end
end

# Similarly binding the block to T.self_type has benefits
class Foo
  sig { params(block: T.proc.bind(T.self_type).void).void }
  def self.run(&block); end
end

Foo.run do
  # If not for the bind to self_type, the context here would be <root> and not T.class_of(Foo)
end
```

**What continues to not be allowed**
```ruby
# Binding a method to anything but a simple type
# Not allowed
sig { bind(T.attached_class).returns(Integer) }
def foo; end

# Binding blocks to arbitrary generics
# Now allowed
Elem = type_member
sig { params(block: T.proc.bind(Elem).void).void }
def foo(&block); end

# Using self_type or attached_class inside other generics
# Not allowed
sig { returns(T::Array[T.self_type]) }
def method4; end
```

### Test plan

See included automated tests.