### PR TITLE
Add `Pathname#glob` to stdlib. Fix second argument.

### DIFF
--- a/rbi/stdlib/pathname.rbi
+++ b/rbi/stdlib/pathname.rbi
@@ -245,19 +245,19 @@ class Pathname < Object
   sig do
     params(
         p1: T.any(String, Pathname),
-        p2: String,
+        p2: Integer,
     )
     .returns(T::Array[Pathname])
   end
   sig do
     params(
         p1: T.any(String, Pathname),
-        p2: String,
+        p2: Integer,
         blk: T.proc.params(arg0: Pathname).void,
     )
     .returns(NilClass)
   end
-  def self.glob(p1, p2=T.unsafe(nil), &blk); end
+  def self.glob(p1, p2=0, &blk); end
 
   def initialize(p); end
 
@@ -842,6 +842,23 @@ class Pathname < Object
   # [`File.ftype`](https://docs.ruby-lang.org/en/2.7.0/File.html#method-c-ftype).
   sig {returns(String)}
   def ftype(); end
+
+  sig do
+    params(
+        p1: T.any(String, Pathname),
+        p2: Integer,
+    )
+    .returns(T::Array[Pathname])
+  end
+  sig do
+    params(
+        p1: T.any(String, Pathname),
+        p2: Integer,
+        blk: T.proc.params(arg0: Pathname).void
+    )
+    .returns(NilClass)
+  end
+  def glob(p1, p2=0, &blk); end
 
   # See
   # [`FileTest.grpowned?`](https://docs.ruby-lang.org/en/2.7.0/FileTest.html#method-i-grpowned-3F).


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Previously, Sorbet knew only about `Pathname.glob` the class-method. This adds support for the instance-method version. It is nearly identical, but globs from PWD instead. 

The second argument to both (and to Dir.glob which is used underneath) is a logical-OR of flags
defined in File, e.g. File::FNM_DOTMATCH which makes `*` match filenames beginning with a dot.

### Motivation

Annoyed by sorbet pointing out that `Pathname#glob` is not a method.


### Test plan

See included automated tests.
