### PR TITLE
Add docs for how `Array#sample` is surprising

### DIFF
--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -160,7 +160,7 @@ out-of-bounds. If you would rather raise an exception than handle `nil`, use the
 [0, 1, 2].fetch(3) # IndexError: index 3 outside of array bounds
 ```
 
-## Sigs are vague for std lib methods that accept keyword arguments & have multiple return types
+## Sigs are vague for stdlib methods that accept keyword arguments & have multiple return types
 
 You might notice this when calling `Array#sample`, `Pathname#find`, or other std
 lib methods that accept a keyword argument and can have different return types

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -170,7 +170,7 @@ based on arguments:
 T.reveal_type([1, 2, 3].sample) # Revealed type: T.nilable(T.any(Integer, T::Array[Integer]))
 ```
 
-The sig in Sorbet's std lib is quite wide, since it has to cover every possible
+The sig in Sorbet's stdlib is quite wide, since it has to cover every possible
 return type. Sorbet does not have good support for this for methods that accept
 keyword arguments. [#37](https://github.com/sorbet/sorbet/issues/37) is the
 original report of this.

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -222,7 +222,7 @@ class Array
 end
 ```
 
-> Overriding std lib RBIs can make type checking less safe, since Sorbet will
+> Overriding stdlib RBIs can make type checking less safe, since Sorbet will
 > now have an incorrect understanding of how the stdlib behaves.
 
 Another alternative is to define new methods that are stricter about arguments,

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -162,8 +162,8 @@ out-of-bounds. If you would rather raise an exception than handle `nil`, use the
 
 ## Sigs are vague for stdlib methods that accept keyword arguments & have multiple return types
 
-You might notice this when calling `Array#sample`, `Pathname#find`, or other std
-lib methods that accept a keyword argument and can have different return types
+You might notice this when calling `Array#sample`, `Pathname#find`, or other
+stdlib methods that accept a keyword argument and can have different return types
 based on arguments:
 
 ```ruby

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -226,7 +226,7 @@ end
 > now have an incorrect understanding of how the std lib behaves.
 
 Another alternative is to define new methods that are stricter about arguments,
-and use these in place of std lib methods:
+and use these in place of stdlib methods:
 
 ```ruby
 class Array

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -163,8 +163,8 @@ out-of-bounds. If you would rather raise an exception than handle `nil`, use the
 ## Sigs are vague for stdlib methods that accept keyword arguments & have multiple return types
 
 You might notice this when calling `Array#sample`, `Pathname#find`, or other
-stdlib methods that accept a keyword argument and can have different return types
-based on arguments:
+stdlib methods that accept a keyword argument and can have different return
+types based on arguments:
 
 ```ruby
 T.reveal_type([1, 2, 3].sample) # Revealed type: T.nilable(T.any(Integer, T::Array[Integer]))
@@ -222,8 +222,8 @@ class Array
 end
 ```
 
-> Overriding stdlib RBIs can make type checking less safe, since Sorbet will
-> now have an incorrect understanding of how the stdlib behaves.
+> Overriding stdlib RBIs can make type checking less safe, since Sorbet will now
+> have an incorrect understanding of how the stdlib behaves.
 
 Another alternative is to define new methods that are stricter about arguments,
 and use these in place of stdlib methods:

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -223,7 +223,7 @@ end
 ```
 
 > Overriding std lib RBIs can make type checking less safe, since Sorbet will
-> now have an incorrect understanding of how the std lib behaves.
+> now have an incorrect understanding of how the stdlib behaves.
 
 Another alternative is to define new methods that are stricter about arguments,
 and use these in place of stdlib methods:

--- a/website/docs/tenum.md
+++ b/website/docs/tenum.md
@@ -35,9 +35,12 @@ can be used:
 ```ruby
 sig {returns(Suit)}
 def random_suit
-  Suit.values.sample
+  T.cast(Suit.values.sample, Suit)
 end
 ```
+
+> The `T.cast` is necessary because of how
+> [Sorbet behaves with `Array#sample`](faq.md#the-types-for-arraysample-are-weird).
 
 ## Exhaustiveness
 

--- a/website/docs/tenum.md
+++ b/website/docs/tenum.md
@@ -40,7 +40,7 @@ end
 ```
 
 > The `T.cast` is necessary because of how
-> [Sorbet behaves with `Array#sample`](faq.md#the-types-for-arraysample-are-weird).
+> [Sorbet behaves with `Array#sample`](faq.md#sigs-are-vague-for-std-lib-methods-that-accept-keyword-arguments--have-multiple-return-types).
 
 ## Exhaustiveness
 

--- a/website/docs/tenum.md
+++ b/website/docs/tenum.md
@@ -40,7 +40,7 @@ end
 ```
 
 > The `T.cast` is necessary because of how
-> [Sorbet behaves with `Array#sample`](faq.md#sigs-are-vague-for-std-lib-methods-that-accept-keyword-arguments--have-multiple-return-types).
+> [Sorbet behaves with `Array#sample`](faq.md#sigs-are-vague-for-stdlib-methods-that-accept-keyword-arguments--have-multiple-return-types).
 
 ## Exhaustiveness
 


### PR DESCRIPTION
This has come up a few times (https://github.com/sorbet/sorbet/pull/3351 https://github.com/sorbet/sorbet/pull/2530 https://github.com/sorbet/sorbet/pull/2248), and anecdotally I get confused about it fairly often before remembering those PRs. Adding some docs to explain why `Array#sample` has a weird sig, and what you can do to decrease the annoyance if you are displined about it.
