### PR TITLE
Fix link typo

### DIFF
--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -697,7 +697,7 @@ T.let([], T::Array[Integer])  # ok
 ```
 
 Many classes in the standard library are generic classes
-([see here](stdlib.md)), and must be passed type arguments, including `Array`
+([see here](stdlib-generics.md)), and must be passed type arguments, including `Array`
 and `Hash`. Any user-defined generic classes must similarly be provided type
 arguments when used.
 

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -697,9 +697,9 @@ T.let([], T::Array[Integer])  # ok
 ```
 
 Many classes in the standard library are generic classes
-([see here](stdlib-generics.md)), and must be passed type arguments, including `Array`
-and `Hash`. Any user-defined generic classes must similarly be provided type
-arguments when used.
+([see here](stdlib-generics.md)), and must be passed type arguments, including
+`Array` and `Hash`. Any user-defined generic classes must similarly be provided
+type arguments when used.
 
 For legacy reasons relating to the intial rollout of Sorbet, this error is only
 reported at `# typed: strict` for standard library generic classes and


### PR DESCRIPTION
### Motivation

Found a broken link, which appears to be the only of its kind. I'm not sure if the site builder will remove ".md" extensions though.

### Test plan

n/a