### PR TITLE
reuse input trees vector in Resolver::resolveSigs

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3145,7 +3145,7 @@ ast::ParsedFilesOrCancelled Resolver::resolveSigs(core::GlobalState &gs, vector<
         }
     }
 
-    return move(trees);
+    return trees;
 }
 
 void Resolver::sanityCheck(core::GlobalState &gs, vector<ast::ParsedFile> &trees) {


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Per the PR title.  This saves some memory churn, since we can reuse the allocation of `trees`.  (We also weren't reserving space in `combinedTrees`, either.)  Notice that we already do the same thing in ResolveConstantsWalk.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
