### PR TITLE
Run props pass during autogen

### DIFF
--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -547,9 +547,6 @@ vector<ast::ExpressionPtr> mkTypedInitialize(core::MutableContext ctx, core::Loc
 } // namespace
 
 void Prop::run(core::MutableContext ctx, ast::ClassDef *klass) {
-    if (ctx.state.runningUnderAutogen) {
-        return;
-    }
     auto syntacticSuperClass = SyntacticSuperClass::Unknown;
     if (!klass->ancestors.empty()) {
         auto &superClass = klass->ancestors[0];

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -274,7 +274,8 @@ TEST_CASE("PerPhaseTest") { // NOLINT
                 gs->runningUnderAutogen = true;
                 core::UnfreezeNameTable nameTableAccess(*gs);
                 core::MutableContext ctx(*gs, core::Symbols::root(), desugared.file);
-                rewriten = testSerialize(*gs, ast::ParsedFile{rewriter::Rewriter::run(ctx, move(desugared.tree)), desugared.file});
+                rewriten = testSerialize(
+                    *gs, ast::ParsedFile{rewriter::Rewriter::run(ctx, move(desugared.tree)), desugared.file});
             }
             core::MutableContext ctx(*gs, core::Symbols::root(), desugared.file);
             localNamed = testSerialize(*gs, local_vars::LocalVars::run(ctx, move(rewriten)));

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -269,8 +269,15 @@ TEST_CASE("PerPhaseTest") { // NOLINT
             handler.addObserved(*gs, "index-tree", [&]() { return localNamed.tree.toString(*gs); });
             handler.addObserved(*gs, "index-tree-raw", [&]() { return localNamed.tree.showRaw(*gs); });
         } else {
+            ast::ParsedFile rewriten;
+            {
+                gs->runningUnderAutogen = true;
+                core::UnfreezeNameTable nameTableAccess(*gs);
+                core::MutableContext ctx(*gs, core::Symbols::root(), desugared.file);
+                rewriten = testSerialize(*gs, ast::ParsedFile{rewriter::Rewriter::run(ctx, move(desugared.tree)), desugared.file});
+            }
             core::MutableContext ctx(*gs, core::Symbols::root(), desugared.file);
-            localNamed = testSerialize(*gs, local_vars::LocalVars::run(ctx, move(desugared)));
+            localNamed = testSerialize(*gs, local_vars::LocalVars::run(ctx, move(rewriten)));
             if (test.expectations.contains("rewrite-tree-raw") || test.expectations.contains("rewrite-tree")) {
                 FAIL_CHECK("Running Rewriter passes with autogen isn't supported");
             }

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -269,16 +269,8 @@ TEST_CASE("PerPhaseTest") { // NOLINT
             handler.addObserved(*gs, "index-tree", [&]() { return localNamed.tree.toString(*gs); });
             handler.addObserved(*gs, "index-tree-raw", [&]() { return localNamed.tree.showRaw(*gs); });
         } else {
-            ast::ParsedFile rewriten;
-            {
-                gs->runningUnderAutogen = true;
-                core::UnfreezeNameTable nameTableAccess(*gs);
-                core::MutableContext ctx(*gs, core::Symbols::root(), desugared.file);
-                rewriten = testSerialize(
-                    *gs, ast::ParsedFile{rewriter::Rewriter::run(ctx, move(desugared.tree)), desugared.file});
-            }
             core::MutableContext ctx(*gs, core::Symbols::root(), desugared.file);
-            localNamed = testSerialize(*gs, local_vars::LocalVars::run(ctx, move(rewriten)));
+            localNamed = testSerialize(*gs, local_vars::LocalVars::run(ctx, move(desugared)));
             if (test.expectations.contains("rewrite-tree-raw") || test.expectations.contains("rewrite-tree")) {
                 FAIL_CHECK("Running Rewriter passes with autogen isn't supported");
             }


### PR DESCRIPTION
This allows the props DSL to run under autogen, something which was previously disallowed.

### Motivation
The props rewriter [introduces constant references](https://github.com/sorbet/sorbet/blob/master/rewriter/Prop.cc#L170-L179) which we want to include in the `DependencyDB`. We can see that testing this internally produces the constant references we want (for Stripe employees, c.f. the build failure [go/builds/bui_KZ710mMhNsXMgM](https://go/builds/bui_KZ710mMhNsXMgM): this is what we want to have happen, because that packaging failure indicates we're correctly seeing the result of this rewrite applying).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Also tested over Stripe and ensured that including this rewriter pass does not regress autogen times.