### PR TITLE
Allow restrict_to_service DSL in packager

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -458,6 +458,9 @@ void GlobalState::initEmpty() {
     ENFORCE(method == Symbols::PackageSpec_export());
     method = enterMethod(*this, Symbols::PackageSpecSingleton(), Names::export_for_test()).arg(Names::arg0()).build();
     ENFORCE(method == Symbols::PackageSpec_export_for_test());
+    method =
+        enterMethod(*this, Symbols::PackageSpecSingleton(), Names::restrict_to_service()).arg(Names::arg0()).build();
+    ENFORCE(method == Symbols::PackageSpec_restrict_to_service());
 
     id = synthesizeClass(core::Names::Constants::Encoding());
     ENFORCE(id == Symbols::Encoding());

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -841,6 +841,10 @@ public:
         return MethodRef::fromRaw(9);
     }
 
+    static MethodRef PackageSpec_restrict_to_service() {
+        return MethodRef::fromRaw(10);
+    }
+
     static ClassOrModuleRef Encoding() {
         return ClassOrModuleRef::fromRaw(82);
     }
@@ -850,11 +854,11 @@ public:
     }
 
     static MethodRef Class_new() {
-        return MethodRef::fromRaw(10);
+        return MethodRef::fromRaw(11);
     }
 
     static MethodRef todoMethod() {
-        return MethodRef::fromRaw(11);
+        return MethodRef::fromRaw(12);
     }
 
     static ClassOrModuleRef Sorbet_Private_Static_ResolvedSig() {
@@ -896,7 +900,7 @@ public:
     }
 
     static constexpr int MAX_SYNTHETIC_CLASS_SYMBOLS = 202;
-    static constexpr int MAX_SYNTHETIC_METHOD_SYMBOLS = 43;
+    static constexpr int MAX_SYNTHETIC_METHOD_SYMBOLS = 44;
     static constexpr int MAX_SYNTHETIC_FIELD_SYMBOLS = 3;
     static constexpr int MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 4;
     static constexpr int MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 99;

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -420,6 +420,7 @@ NameDef names[] = {
     {"test_import"},
     {"export_", "export"},
     {"export_for_test"},
+    {"restrict_to_service"},
     {"PackageSpec", "PackageSpec", true},
     {"PackageRegistry", "<PackageRegistry>", true},
     {"PackageTests", "<PackageTests>", true},

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -571,6 +571,7 @@ struct PackageInfoFinder {
             case core::Names::test_import().rawId():
             case core::Names::export_().rawId():
             case core::Names::export_for_test().rawId():
+            case core::Names::restrict_to_service().rawId():
                 return true;
             default:
                 return false;

--- a/test/cli/package-special-allowed-dsls/bar/__package.rb
+++ b/test/cli/package-special-allowed-dsls/bar/__package.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+class Project::Bar < PackageSpec
+end

--- a/test/cli/package-special-allowed-dsls/foo/__package.rb
+++ b/test/cli/package-special-allowed-dsls/foo/__package.rb
@@ -1,0 +1,6 @@
+# typed: strict
+
+class Project::Foo < PackageSpec
+  restrict_to_service Project::Foo
+  restrict_to_service Project::Bar
+end

--- a/test/cli/package-special-allowed-dsls/foo/foo.rb
+++ b/test/cli/package-special-allowed-dsls/foo/foo.rb
@@ -1,0 +1,5 @@
+# typed: true
+
+class Project::Foo
+  def self.run; end
+end

--- a/test/cli/package-special-allowed-dsls/package-special-allowed-dsls.out
+++ b/test/cli/package-special-allowed-dsls/package-special-allowed-dsls.out
@@ -1,0 +1,1 @@
+No errors! Great job.

--- a/test/cli/package-special-allowed-dsls/package-special-allowed-dsls.sh
+++ b/test/cli/package-special-allowed-dsls/package-special-allowed-dsls.sh
@@ -1,0 +1,4 @@
+cd test/cli/package-special-allowed-dsls || exit 0
+
+../../../main/sorbet --silence-dev-message --stripe-packages . 2>&1
+


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

We are introducing a new DSL method in `__package.rb` files in the Stripe codebase, known as `restrict_to_service`. This change allows the method to take in a constant as a parameter.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.