### PR TITLE
always keep the original dsl_{required,optional} send

### DIFF
--- a/rewriter/DSLBuilder.cc
+++ b/rewriter/DSLBuilder.cc
@@ -82,10 +82,9 @@ vector<ast::ExpressionPtr> DSLBuilder::run(core::MutableContext ctx, ast::Send *
     ast::MethodDef::Flags flags;
     flags.discardDef = true;
 
-    if (!skipSetter && !skipGetter) {
-        stats.emplace_back(ast::MK::Send(loc, ast::MK::Unsafe(loc, move(send->recv)), sendFun, send->numPosArgs,
-                                         std::move(send->args), send->flags, move(send->block)));
-    }
+    // We need to keep around the original send for the compiler.
+    stats.emplace_back(ast::MK::Send(loc, ast::MK::Unsafe(loc, move(send->recv)), sendFun, send->numPosArgs,
+                                     std::move(send->args), send->flags, move(send->block)));
 
     // def self.<prop>
     if (!skipSetter) {

--- a/test/testdata/rewriter/dsl_builder.rb
+++ b/test/testdata/rewriter/dsl_builder.rb
@@ -6,7 +6,7 @@ class TestDSLBuilder
   dsl_required :implied_string, String, implied: "foo"
   dsl_optional :no_getter, String, skip_getter: true
   dsl_optional :no_setter, String, skip_setter: true
-  dsl_optional :no_getter_or_setter, String, skip_getter: true, skip_setter: true # error: does not exist
+  dsl_optional :no_getter_or_setter, String, skip_getter: true, skip_setter: true
   dsl_optional :class_of, T.class_of(Integer)
 
   dsl_optional :root_const, ::Integer

--- a/test/testdata/rewriter/dsl_builder.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/dsl_builder.rb.rewrite-tree.exp
@@ -176,7 +176,11 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     ::T.unsafe(<self>).dsl_required(:implied_string, <emptyTree>::<C String>, :implied, "foo")
 
-    <self>.dsl_optional(:no_getter_or_setter, <emptyTree>::<C String>, :skip_getter, true, :skip_setter, true)
+    ::T.unsafe(<self>).dsl_optional(:no_getter, <emptyTree>::<C String>, :skip_getter, true)
+
+    ::T.unsafe(<self>).dsl_optional(:no_setter, <emptyTree>::<C String>, :skip_setter, true)
+
+    ::T.unsafe(<self>).dsl_optional(:no_getter_or_setter, <emptyTree>::<C String>, :skip_getter, true, :skip_setter, true)
 
     ::T.unsafe(<self>).dsl_optional(:class_of, <emptyTree>::<C T>.class_of(<emptyTree>::<C Integer>))
 


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

#4639 kept around the original send when rewriting `DSLBuilder` methods, but it didn't go far enough: for the compiler's purposes, we always need to keep the original send around, even if the getter and setter are both skipped (!) because there might be other arguments to the send that need to take effect at runtime.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
