### PR TITLE
more correctly dedent strings

### DIFF
--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -33,7 +33,14 @@ namespace sorbet::parser {
 string Dedenter::dedent(string_view str) {
     string out;
 
-    auto lines = absl::StrSplit(str, "\\\n");
+    vector<string_view> lines = absl::StrSplit(str, "\\\n");
+    if (!at_line_begin && !lines.empty()) {
+        out.append(lines[0]);
+        if (lines.size() > 1) {
+            out.push_back('\n');
+        }
+        lines.erase(lines.begin());
+    }
 
     for (auto line : lines) {
         spacesToRemove = dedentLevel;
@@ -672,6 +679,7 @@ public:
                         unique_ptr<Node> newstr = make_unique<String>(s->loc, gs_.enterNameUTF8(dedented));
                         parts.emplace_back(std::move(newstr));
                     } else {
+                        dedenter.interrupt();
                         parts.emplace_back(std::move(p));
                     }
                 }
@@ -689,6 +697,7 @@ public:
                         unique_ptr<Node> newstr = make_unique<String>(s->loc, gs_.enterNameUTF8(dedented));
                         parts.emplace_back(std::move(newstr));
                     } else {
+                        dedenter.interrupt();
                         parts.emplace_back(std::move(p));
                     }
                 }

--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -76,7 +76,10 @@ string Dedenter::dedent(string_view str) {
     }
 
     if (!out.empty() && out.back() == '\n') {
+        at_line_begin = true;
         spacesToRemove = dedentLevel;
+    } else {
+        at_line_begin = false;
     }
     return out;
 }

--- a/parser/Dedenter.h
+++ b/parser/Dedenter.h
@@ -14,7 +14,7 @@ public:
     }
 
 private:
-    unsigned int dedentLevel;
+    const unsigned int dedentLevel;
     bool at_line_begin = true;
     unsigned int spacesToRemove;
 };

--- a/parser/Dedenter.h
+++ b/parser/Dedenter.h
@@ -9,8 +9,13 @@ public:
 
     std::string dedent(std::string_view str);
 
+    void interrupt() {
+        at_line_begin = false;
+    }
+
 private:
     unsigned int dedentLevel;
+    bool at_line_begin = true;
     unsigned int spacesToRemove;
 };
 

--- a/test/testdata/compiler/string_interpolate_space.rb
+++ b/test/testdata/compiler/string_interpolate_space.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+
+class Session
+  MAX_OBJS = 849201
+  MAX_OBJS_MSG = <<~MSG
+    There are more than #{MAX_OBJS} objects!  Fire the missiles!
+  MSG
+end
+
+p Session::MAX_OBJS_MSG

--- a/test/testdata/compiler/string_interpolate_space.rb
+++ b/test/testdata/compiler/string_interpolate_space.rb
@@ -7,6 +7,12 @@ class Session
   MAX_OBJS_MSG = <<~MSG
     There are more than #{MAX_OBJS} objects!  Fire the missiles!
   MSG
+
+  SUPPORT = <<~MSG
+    Someone handed us #{MAX_OBJS}, but this
+    is not supported.  Please fix this!
+  MSG
 end
 
 p Session::MAX_OBJS_MSG
+p Session::SUPPORT


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

For the included testcase in this PR, Sorbet was parsing things as:

```
s(:begin,
  s(:class,
    s(:const, nil, :Session), nil,
    s(:begin,
      s(:assign,
        s(:casgn, nil, :MAX_OBJS),
        s(:int, "849201")),
      s(:assign,
        s(:casgn, nil, :MAX_OBJS_MSG),
        s(:dstr,
          s(:str, "There are more than "),
          s(:begin,
            s(:const, nil, :MAX_OBJS)),
          # BUG: we dropped a space here
          s(:str, "objects!  Fire the missiles!
"))))),
  s(:send, nil, :p,
    s(:const,
      s(:const, nil, :Session), :MAX_OBJS_MSG)))
```

This not-quite-correct parsing of heredocs is fine for the static checker, but not so much for the compiler.

This PR cargo-cults the dedent logic from whitequark's parser:

https://github.com/whitequark/parser/blob/b87613d2b99733e1400f076675daf501c19ede93/lib/parser/builders/default.rb#L358-L380
https://github.com/whitequark/parser/blob/b87613d2b99733e1400f076675daf501c19ede93/lib/parser/lexer/dedenter.rb#L36-L79

into our parser.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

There's a compiler testcase, which is fine, but every other testcase we have passes, which was surprising to me -- I would have expected some whitequark tests to transition from disabled to enabled.  Or do I have to reimport the upstream parser to add any necessary testcases?  Not really sure what to do here.

cc @vinistock who has worked on this stuff in the past.