### PR TITLE
check types on rest/splat args properly

### DIFF
--- a/compiler/IREmitter/IREmitter.cc
+++ b/compiler/IREmitter/IREmitter.cc
@@ -754,8 +754,13 @@ void emitUserBody(CompilerState &base, cfg::CFG &cfg, const IREmitterContext &ir
                     auto var = Payload::varGet(cs, local, builder, irctx, 0);
                     if (auto &expectedType = argInfo.type) {
                         auto description = fmt::format("Parameter '{}'", bind.bind.variable.toString(cs, cfg));
-                        ENFORCE(!argInfo.flags.isBlock);
-                        IREmitterHelpers::emitTypeTest(cs, builder, var, expectedType, description);
+                        if (argInfo.flags.isRepeated && !argInfo.flags.isKeyword) {
+                            // Signature types for rest arguments apply to each individual element of
+                            // the rest arg, not the actual argument itself.
+                            IREmitterHelpers::emitTypeTestForRestArg(cs, builder, var, expectedType, description);
+                        } else {
+                            IREmitterHelpers::emitTypeTest(cs, builder, var, expectedType, description);
+                        }
                     }
                 },
                 [&](cfg::LoadYieldParams &i) {

--- a/compiler/IREmitter/IREmitterHelpers.cc
+++ b/compiler/IREmitter/IREmitterHelpers.cc
@@ -279,7 +279,7 @@ void IREmitterHelpers::emitTypeTestForRestArg(CompilerState &cs, llvm::IRBuilder
     builder.CreateCondBr(moreToGo, bodyBlock, continuationBlock);
 
     builder.SetInsertPoint(bodyBlock);
-    auto *element = builder.CreateCall(cs.getFunction("sorbet_rubyArrayAref"), {value, indexPhi}, "element");
+    auto *element = builder.CreateCall(cs.getFunction("sorbet_rubyArrayArefUnchecked"), {value, indexPhi}, "element");
     auto *typeTest = Payload::typeTest(cs, builder, element, expectedType);
     buildTypeTestPassFailBlocks(cs, builder, element, typeTest, expectedType, description);
     auto *incrementedIndex = builder.CreateAdd(indexPhi, buildS4(cs, 1));

--- a/compiler/IREmitter/IREmitterHelpers.h
+++ b/compiler/IREmitter/IREmitterHelpers.h
@@ -124,6 +124,8 @@ public:
     // the block following a successful test.
     static void emitTypeTest(CompilerState &gs, llvm::IRBuilderBase &builder, llvm::Value *value,
                              const core::TypePtr &expectedType, std::string_view description);
+    static void emitTypeTestForRestArg(CompilerState &gs, llvm::IRBuilderBase &builder, llvm::Value *value,
+                                       const core::TypePtr &expectedType, std::string_view description);
 
     // Return a value representing the literalish thing, which is either a LiteralType
     // or a type representing nil, false, or true.

--- a/compiler/IREmitter/Payload/codegen-payload.c
+++ b/compiler/IREmitter/Payload/codegen-payload.c
@@ -623,6 +623,11 @@ int sorbet_rubyArrayLen(VALUE array) {
 }
 
 SORBET_INLINE
+VALUE sorbet_rubyArrayAref(VALUE array, int i) {
+    return RARRAY_AREF(array, i);
+}
+
+SORBET_INLINE
 const VALUE *sorbet_rubyArrayInnerPtr(VALUE array) {
     // there's also a transient version of this function if we ever decide to want more speed. transient stands for that
     // we _should not_ allow to execute any code between getting these pointers and reading elements from

--- a/compiler/IREmitter/Payload/codegen-payload.c
+++ b/compiler/IREmitter/Payload/codegen-payload.c
@@ -623,7 +623,7 @@ int sorbet_rubyArrayLen(VALUE array) {
 }
 
 SORBET_INLINE
-VALUE sorbet_rubyArrayAref(VALUE array, int i) {
+VALUE sorbet_rubyArrayArefUnchecked(VALUE array, int i) {
     return RARRAY_AREF(array, i);
 }
 

--- a/test/testdata/compiler/typed_rest_arg.rb
+++ b/test/testdata/compiler/typed_rest_arg.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+
+module X
+  extend T::Sig
+
+  sig {params(maps: T::Hash[T.untyped, T.untyped]).void}
+  def self.f(*maps)
+    p maps
+  end
+end
+
+X.f({}, {a: 5})
+begin
+  X.f(T.unsafe([]), {a: 6})
+rescue => e
+  p "got error"
+end
+


### PR DESCRIPTION
### Motivation

When we have something like:

```ruby
sig {params(x: T::Hash[T.untyped, T.untyped]).void}
def f(*x)
  ...
end
```

sorbet-runtime checks that each element of the rest arg is a hash.  The compiler was checking that the rest arg itself was a hash, which obviously didn't work all that well.  This PR type checks rest args properly.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
