### PR TITLE
fix to_s method in kernel.rbi to accept an Integer as an optional arg

### DIFF
--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -645,8 +645,8 @@ module Kernel
   end
   def to_enum(method=T.unsafe(nil), *args, &blk); end
 
-  sig {returns(String)}
-  def to_s(); end
+  sig {params(arg: Integer).returns(String)}
+  def to_s(*arg); end
 
   sig {returns(T.self_type)}
   def trust(); end

--- a/test/testdata/rbi/kernel.rb
+++ b/test/testdata/rbi/kernel.rb
@@ -19,6 +19,10 @@ T.assert_type!(Kernel.rand(1.0..1.0), Float)
 T.assert_type!(Kernel.rand(36**8), Numeric)
 T.assert_type!(Kernel.rand((36**8..36**9)), Numeric)
 
+# to_s
+T.assert_type!(10.to_s, String)
+T.assert_type!(10.to_s(36), String)
+
 # make sure we don't regress and mark `loop` as returning `nil`
 x = loop {break 1}
 T.assert_type!(x, Integer)


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The `to_s` method in the `kernel.rbi` was not aware of the fact that passing an Integer as an optional argument is valid https://apidock.com/ruby/v2_6_3/Integer/to_s. This results in code like [this example in the Sorbet Playground](https://sorbet.run/#%23%20typed%3A%20true%0A%0Arand%2810**100%29.to_s%2836%29) failing a type check. 

You can see this code is valid here:
```
irb(main):003:0> rand(10**100).to_s
=> "8235066421852743943633840297423609396022289043887726302077545134757967651325206712046158158536019151"
irb(main):004:0> rand(10**100).to_s(36)
=> "gaawupbkuv0xfpf33ztiiv7vsgg3186f83mewg3r274irs2dm00mnahsq2uz8mtf"
irb(main):005:0> 
```




### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
