### PR TITLE
Add a disabled test for def inside instance_eval from self.included

### DIFF
--- a/test/testdata/compiler/disabled/instance_eval_def.rb
+++ b/test/testdata/compiler/disabled/instance_eval_def.rb
@@ -6,7 +6,7 @@ module M
   include Kernel
 
   def self.included(klass)
-    puts "hello from C::M.included"
+    puts "hello from M.included"
 
     klass.instance_eval do
       puts "hello from the instance_eval block"

--- a/test/testdata/compiler/disabled/instance_eval_def.rb
+++ b/test/testdata/compiler/disabled/instance_eval_def.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+
+module M
+  include Kernel
+
+  def self.included(klass)
+    puts "hello from C::M.included"
+
+    klass.instance_eval do
+      puts "hello from the instance_eval block"
+      puts "self is: #{self}"
+      puts "let's def f"
+
+      def f
+        puts "hello from f"
+      end
+
+      puts "done deffing f"
+    end
+  end
+end
+
+module Z
+  include M
+end
+
+T.unsafe(Z).f


### PR DESCRIPTION
Adds a disabled compiler test case for defining a method inside `instance_eval` within `self.included`.


### Motivation
Encountered this pattern in the wild, and we don't seem to compile it correctly.


### Test plan
See included automated tests.
