### PR TITLE
don't type check blocks in the compiler

### DIFF
--- a/compiler/IREmitter/IREmitter.cc
+++ b/compiler/IREmitter/IREmitter.cc
@@ -745,15 +745,17 @@ void emitUserBody(CompilerState &base, cfg::CFG &cfg, const IREmitterContext &ir
 
                     // Argument values are loaded by `setupArguments`, we just need to check their type here
                     auto &argInfo = arguments[i.argId];
+                    // The runtime doesn't check types for blocks, so we don't either.
+                    if (argInfo.flags.isBlock) {
+                        return;
+                    }
+
                     auto local = irctx.rubyBlockArgs[0][i.argId];
                     auto var = Payload::varGet(cs, local, builder, irctx, 0);
                     if (auto &expectedType = argInfo.type) {
                         auto description = fmt::format("Parameter '{}'", bind.bind.variable.toString(cs, cfg));
-                        if (argInfo.flags.isBlock) {
-                            IREmitterHelpers::emitTypeTestForBlock(cs, builder, var, expectedType, description);
-                        } else {
-                            IREmitterHelpers::emitTypeTest(cs, builder, var, expectedType, description);
-                        }
+                        ENFORCE(!argInfo.flags.isBlock);
+                        IREmitterHelpers::emitTypeTest(cs, builder, var, expectedType, description);
                     }
                 },
                 [&](cfg::LoadYieldParams &i) {

--- a/compiler/IREmitter/IREmitterHelpers.cc
+++ b/compiler/IREmitter/IREmitterHelpers.cc
@@ -259,18 +259,6 @@ void IREmitterHelpers::emitTypeTest(CompilerState &cs, llvm::IRBuilderBase &buil
     buildTypeTestPassFailBlocks(cs, builder, value, typeTest, expectedType, description);
 }
 
-void IREmitterHelpers::emitTypeTestForBlock(CompilerState &cs, llvm::IRBuilderBase &builder, llvm::Value *value,
-                                            const core::TypePtr &expectedType, std::string_view description) {
-    // Checking for blocks is special.  We don't want to materialize the block (`value`)
-    // unless we absolutely have to, so we check the type of blocks by poking at the
-    // RubyVM.  (We obviously have materialized the block at this point since we have
-    // `value` to inspect, but we have an LLVM optimization pass that will delete the
-    // materialization if the result of the materialization is unused.  So we don't
-    // want to add any more uses than we have to.)
-    auto *typeTest = Payload::typeTestForBlock(cs, builder, value, expectedType);
-    buildTypeTestPassFailBlocks(cs, builder, value, typeTest, expectedType, description);
-}
-
 llvm::Value *IREmitterHelpers::emitLiteralish(CompilerState &cs, llvm::IRBuilderBase &builder,
                                               const core::TypePtr &lit) {
     if (lit.derivesFrom(cs, core::Symbols::FalseClass())) {

--- a/compiler/IREmitter/IREmitterHelpers.h
+++ b/compiler/IREmitter/IREmitterHelpers.h
@@ -124,8 +124,6 @@ public:
     // the block following a successful test.
     static void emitTypeTest(CompilerState &gs, llvm::IRBuilderBase &builder, llvm::Value *value,
                              const core::TypePtr &expectedType, std::string_view description);
-    static void emitTypeTestForBlock(CompilerState &gs, llvm::IRBuilderBase &builder, llvm::Value *value,
-                                     const core::TypePtr &expectedType, std::string_view description);
 
     // Return a value representing the literalish thing, which is either a LiteralType
     // or a type representing nil, false, or true.

--- a/compiler/IREmitter/Payload.cc
+++ b/compiler/IREmitter/Payload.cc
@@ -435,28 +435,6 @@ llvm::Value *Payload::typeTest(CompilerState &cs, llvm::IRBuilderBase &builder, 
     return ret;
 }
 
-llvm::Value *Payload::typeTestForBlock(CompilerState &cs, llvm::IRBuilderBase &builder, llvm::Value *val,
-                                       const core::TypePtr &type) {
-    core::SymbolRef procSym;
-
-    // We are deliberately not being exhaustive here and only handling the "easy"
-    // Proc-like types.  T.any(proc-ish, proc-ish) and similar does not seem like
-    // they are worth the trouble.
-    if (core::isa_type<core::ClassType>(type)) {
-        auto ct = core::cast_type_nonnull<core::ClassType>(type);
-        procSym = ct.symbol;
-    } else if (core::isa_type<core::AppliedType>(type)) {
-        auto at = core::cast_type_nonnull<core::AppliedType>(type);
-        procSym = at.klass;
-    }
-
-    if (procSym.exists() && (procSym == core::Symbols::Proc() || isProc(procSym))) {
-        return builder.CreateCall(cs.getFunction("sorbet_block_isa_proc"), {});
-    }
-
-    return typeTest(cs, builder, val, type);
-}
-
 // Emit an `llvm.assume` intrinsic with the result of a `Payload::typeTest` with the given symbol. For example, this can
 // be used assert that a value will be an array.
 //

--- a/compiler/IREmitter/Payload.h
+++ b/compiler/IREmitter/Payload.h
@@ -49,8 +49,6 @@ public:
     static llvm::Value *toCString(CompilerState &cs, std::string_view str, llvm::IRBuilderBase &builder);
     static llvm::Value *typeTest(CompilerState &cs, llvm::IRBuilderBase &builder, llvm::Value *val,
                                  const core::TypePtr &type);
-    static llvm::Value *typeTestForBlock(CompilerState &cs, llvm::IRBuilderBase &builder, llvm::Value *val,
-                                         const core::TypePtr &type);
     static void assumeType(CompilerState &cs, llvm::IRBuilderBase &builder, llvm::Value *val,
                            core::ClassOrModuleRef sym);
     static llvm::Value *boolToRuby(CompilerState &cs, llvm::IRBuilderBase &builder, llvm::Value *u1);

--- a/test/testdata/compiler/all_arguments.opt.ll.exp
+++ b/test/testdata/compiler/all_arguments.opt.ll.exp
@@ -229,7 +229,7 @@ functionEntryInitializers:
   %9 = and i64 %6, -9, !dbg !16
   %10 = icmp eq i64 %9, 0, !dbg !16
   %11 = or i1 %8, %10, !dbg !16
-  br i1 %11, label %sorbet_determineKwSplatArg.exit.thread81, label %sorbet_isa_Hash.exit, !dbg !16
+  br i1 %11, label %sorbet_determineKwSplatArg.exit.thread79, label %sorbet_isa_Hash.exit, !dbg !16
 
 sorbet_isa_Hash.exit:                             ; preds = %2
   %12 = inttoptr i64 %6 to %struct.iseq_inline_iv_cache_entry*, !dbg !16
@@ -237,9 +237,9 @@ sorbet_isa_Hash.exit:                             ; preds = %2
   %14 = load i64, i64* %13, align 8, !dbg !16, !tbaa !17
   %15 = and i64 %14, 31, !dbg !16
   %16 = icmp eq i64 %15, 8, !dbg !16
-  br i1 %16, label %fillRequiredArgs, label %sorbet_determineKwSplatArg.exit.thread81, !dbg !16
+  br i1 %16, label %fillRequiredArgs, label %sorbet_determineKwSplatArg.exit.thread79, !dbg !16
 
-sorbet_determineKwSplatArg.exit.thread81:         ; preds = %sorbet_isa_Hash.exit, %2
+sorbet_determineKwSplatArg.exit.thread79:         ; preds = %sorbet_isa_Hash.exit, %2
   br label %fillRequiredArgs, !dbg !16
 
 sorbet_determineKwSplatArg.exit:                  ; preds = %functionEntryInitializers
@@ -257,8 +257,8 @@ fillFromDefaultBlockDone1:                        ; preds = %sorbet_getMethodBlo
   br i1 %18, label %20, label %fillFromDefaultBlockDone1.thread, !dbg !16
 
 fillFromDefaultBlockDone1.thread:                 ; preds = %sorbet_getMethodBlockAsProc.exit, %fillFromDefaultBlockDone1
-  %"<argPresent>.sroa.0.088" = phi i64 [ 20, %fillFromDefaultBlockDone1 ], [ 0, %sorbet_getMethodBlockAsProc.exit ]
-  %b.sroa.0.186 = phi i64 [ %rawArg_b, %fillFromDefaultBlockDone1 ], [ 8, %sorbet_getMethodBlockAsProc.exit ]
+  %"<argPresent>.sroa.0.086" = phi i64 [ 20, %fillFromDefaultBlockDone1 ], [ 0, %sorbet_getMethodBlockAsProc.exit ]
+  %b.sroa.0.184 = phi i64 [ %rawArg_b, %fillFromDefaultBlockDone1 ], [ 8, %sorbet_getMethodBlockAsProc.exit ]
   %19 = tail call i64 @rb_ary_new() #11, !dbg !16
   br label %sorbet_readRestArgs.exit, !dbg !16
 
@@ -270,27 +270,27 @@ fillFromDefaultBlockDone1.thread:                 ; preds = %sorbet_getMethodBlo
   br label %sorbet_readRestArgs.exit, !dbg !16
 
 sorbet_readRestArgs.exit:                         ; preds = %fillFromDefaultBlockDone1.thread, %20
-  %"<argPresent>.sroa.0.087" = phi i64 [ %"<argPresent>.sroa.0.088", %fillFromDefaultBlockDone1.thread ], [ 20, %20 ]
-  %b.sroa.0.185 = phi i64 [ %b.sroa.0.186, %fillFromDefaultBlockDone1.thread ], [ %rawArg_b, %20 ]
+  %"<argPresent>.sroa.0.085" = phi i64 [ %"<argPresent>.sroa.0.086", %fillFromDefaultBlockDone1.thread ], [ 20, %20 ]
+  %b.sroa.0.183 = phi i64 [ %b.sroa.0.184, %fillFromDefaultBlockDone1.thread ], [ %rawArg_b, %20 ]
   %25 = phi i64 [ %19, %fillFromDefaultBlockDone1.thread ], [ %24, %20 ], !dbg !16
   %rubyId_d = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !16
   %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_d), !dbg !16
   %26 = icmp eq i64 %29, 52, !dbg !16
-  br i1 %26, label %kwArgContinue, label %sorbet_removeKWArg.exit78, !dbg !16
+  br i1 %26, label %kwArgContinue, label %sorbet_removeKWArg.exit76, !dbg !16
 
-sorbet_removeKWArg.exit78:                        ; preds = %sorbet_readRestArgs.exit
+sorbet_removeKWArg.exit76:                        ; preds = %sorbet_readRestArgs.exit
   %27 = tail call i64 @rb_hash_delete_entry(i64 %29, i64 %rawSym) #11, !dbg !16
   %28 = icmp eq i64 %27, 52, !dbg !16
   br i1 %28, label %kwArgContinue, label %kwArgContinue.thread, !dbg !16
 
-kwArgContinue.thread:                             ; preds = %sorbet_removeKWArg.exit78
-  %rubyId_e91 = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !16
-  %rawSym2192 = tail call i64 @rb_id2sym(i64 %rubyId_e91), !dbg !16
+kwArgContinue.thread:                             ; preds = %sorbet_removeKWArg.exit76
+  %rubyId_e89 = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !16
+  %rawSym2190 = tail call i64 @rb_id2sym(i64 %rubyId_e89), !dbg !16
   br label %sorbet_removeKWArg.exit.thread, !dbg !16
 
-fillRequiredArgs:                                 ; preds = %sorbet_isa_Hash.exit, %sorbet_determineKwSplatArg.exit.thread81, %sorbet_determineKwSplatArg.exit
-  %29 = phi i64 [ 52, %sorbet_determineKwSplatArg.exit ], [ 52, %sorbet_determineKwSplatArg.exit.thread81 ], [ %6, %sorbet_isa_Hash.exit ]
-  %30 = phi i32 [ %argc, %sorbet_determineKwSplatArg.exit ], [ %argc, %sorbet_determineKwSplatArg.exit.thread81 ], [ %3, %sorbet_isa_Hash.exit ]
+fillRequiredArgs:                                 ; preds = %sorbet_isa_Hash.exit, %sorbet_determineKwSplatArg.exit.thread79, %sorbet_determineKwSplatArg.exit
+  %29 = phi i64 [ 52, %sorbet_determineKwSplatArg.exit ], [ 52, %sorbet_determineKwSplatArg.exit.thread79 ], [ %6, %sorbet_isa_Hash.exit ]
+  %30 = phi i32 [ %argc, %sorbet_determineKwSplatArg.exit ], [ %argc, %sorbet_determineKwSplatArg.exit.thread79 ], [ %3, %sorbet_isa_Hash.exit ]
   %rawArg_a = load i64, i64* %argArray, align 8, !dbg !16
   %31 = tail call i32 @rb_block_given_p() #11, !dbg !16
   %32 = icmp eq i32 %31, 0, !dbg !16
@@ -305,7 +305,7 @@ sorbet_getMethodBlockAsProc.exit:                 ; preds = %fillRequiredArgs, %
   %default0 = icmp eq i32 %30, 1, !dbg !16
   br i1 %default0, label %fillFromDefaultBlockDone1.thread, label %fillFromDefaultBlockDone1, !dbg !16, !prof !19
 
-kwArgContinue:                                    ; preds = %sorbet_readRestArgs.exit, %sorbet_removeKWArg.exit78
+kwArgContinue:                                    ; preds = %sorbet_readRestArgs.exit, %sorbet_removeKWArg.exit76
   %36 = tail call i64 @sorbet_addMissingKWArg(i64 noundef 52, i64 %rawSym), !dbg !16
   %rubyId_e = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !16
   %rawSym21 = tail call i64 @rb_id2sym(i64 %rubyId_e), !dbg !16
@@ -316,53 +316,53 @@ sorbet_removeKWArg.exit:                          ; preds = %kwArgContinue
   br i1 %37, label %sorbet_readKWRestArgs.exit.thread, label %41, !dbg !16, !prof !20
 
 sorbet_removeKWArg.exit.thread:                   ; preds = %kwArgContinue, %kwArgContinue.thread
-  %rawSym2197 = phi i64 [ %rawSym2192, %kwArgContinue.thread ], [ %rawSym21, %kwArgContinue ]
-  %missingArgsPhi95 = phi i64 [ 52, %kwArgContinue.thread ], [ %36, %kwArgContinue ]
-  %d.sroa.0.093 = phi i64 [ %27, %kwArgContinue.thread ], [ 8, %kwArgContinue ]
-  %38 = tail call i64 @rb_hash_delete_entry(i64 %29, i64 %rawSym2197) #11, !dbg !16
+  %rawSym2195 = phi i64 [ %rawSym2190, %kwArgContinue.thread ], [ %rawSym21, %kwArgContinue ]
+  %missingArgsPhi93 = phi i64 [ 52, %kwArgContinue.thread ], [ %36, %kwArgContinue ]
+  %d.sroa.0.091 = phi i64 [ %27, %kwArgContinue.thread ], [ 8, %kwArgContinue ]
+  %38 = tail call i64 @rb_hash_delete_entry(i64 %29, i64 %rawSym2195) #11, !dbg !16
   %39 = icmp eq i64 %38, 52, !dbg !16
-  %e.sroa.0.1100 = select i1 %39, i64 8, i64 %38, !dbg !16
-  %"<argPresent>9.sroa.0.0101" = select i1 %39, i64 0, i64 20, !dbg !16
-  %40 = icmp eq i64 %missingArgsPhi95, 52, !dbg !16
+  %e.sroa.0.198 = select i1 %39, i64 8, i64 %38, !dbg !16
+  %"<argPresent>9.sroa.0.099" = select i1 %39, i64 0, i64 20, !dbg !16
+  %40 = icmp eq i64 %missingArgsPhi93, 52, !dbg !16
   br i1 %40, label %sorbet_readKWRestArgs.exit, label %41, !dbg !16, !prof !20
 
 41:                                               ; preds = %sorbet_removeKWArg.exit.thread, %sorbet_removeKWArg.exit
-  %missingArgsPhi96102 = phi i64 [ %missingArgsPhi95, %sorbet_removeKWArg.exit.thread ], [ %36, %sorbet_removeKWArg.exit ]
-  tail call void @sorbet_raiseMissingKeywords(i64 %missingArgsPhi96102) #9, !dbg !16
+  %missingArgsPhi94100 = phi i64 [ %missingArgsPhi93, %sorbet_removeKWArg.exit.thread ], [ %36, %sorbet_removeKWArg.exit ]
+  tail call void @sorbet_raiseMissingKeywords(i64 %missingArgsPhi94100) #9, !dbg !16
   unreachable, !dbg !16
 
 sorbet_readKWRestArgs.exit.thread:                ; preds = %sorbet_removeKWArg.exit
   %42 = tail call i64 @rb_hash_new() #11, !dbg !16
-  %43 = and i64 %"<argPresent>.sroa.0.087", -9, !dbg !21
+  %43 = and i64 %"<argPresent>.sroa.0.085", -9, !dbg !21
   %44 = icmp ne i64 %43, 0, !dbg !21
-  %b.sroa.0.0129 = select i1 %44, i64 %b.sroa.0.185, i64 3, !dbg !21
+  %b.sroa.0.0127 = select i1 %44, i64 %b.sroa.0.183, i64 3, !dbg !21
   br label %50, !dbg !22
 
 sorbet_readKWRestArgs.exit:                       ; preds = %sorbet_removeKWArg.exit.thread
   %45 = tail call i64 @rb_hash_dup(i64 %29) #11, !dbg !16
-  %46 = and i64 %"<argPresent>.sroa.0.087", -9, !dbg !21
+  %46 = and i64 %"<argPresent>.sroa.0.085", -9, !dbg !21
   %47 = icmp ne i64 %46, 0, !dbg !21
-  %b.sroa.0.0 = select i1 %47, i64 %b.sroa.0.185, i64 3, !dbg !21
-  %48 = icmp ne i64 %"<argPresent>9.sroa.0.0101", 0, !dbg !22
+  %b.sroa.0.0 = select i1 %47, i64 %b.sroa.0.183, i64 3, !dbg !21
+  %48 = icmp ne i64 %"<argPresent>9.sroa.0.099", 0, !dbg !22
   br i1 %48, label %49, label %50, !dbg !22
 
 49:                                               ; preds = %sorbet_readKWRestArgs.exit
   br label %50, !dbg !22
 
 50:                                               ; preds = %sorbet_readKWRestArgs.exit.thread, %sorbet_readKWRestArgs.exit, %49
-  %b.sroa.0.0131 = phi i64 [ %b.sroa.0.0, %49 ], [ %b.sroa.0.0, %sorbet_readKWRestArgs.exit ], [ %b.sroa.0.0129, %sorbet_readKWRestArgs.exit.thread ]
+  %b.sroa.0.0129 = phi i64 [ %b.sroa.0.0, %49 ], [ %b.sroa.0.0, %sorbet_readKWRestArgs.exit ], [ %b.sroa.0.0127, %sorbet_readKWRestArgs.exit.thread ]
   %51 = phi i64 [ %45, %49 ], [ %45, %sorbet_readKWRestArgs.exit ], [ %42, %sorbet_readKWRestArgs.exit.thread ]
-  %d.sroa.0.094103113130 = phi i64 [ %d.sroa.0.093, %49 ], [ %d.sroa.0.093, %sorbet_readKWRestArgs.exit ], [ 8, %sorbet_readKWRestArgs.exit.thread ]
-  %52 = phi i64 [ %e.sroa.0.1100, %49 ], [ 5, %sorbet_readKWRestArgs.exit ], [ 5, %sorbet_readKWRestArgs.exit.thread ]
+  %d.sroa.0.092101111128 = phi i64 [ %d.sroa.0.091, %49 ], [ %d.sroa.0.091, %sorbet_readKWRestArgs.exit ], [ 8, %sorbet_readKWRestArgs.exit.thread ]
+  %52 = phi i64 [ %e.sroa.0.198, %49 ], [ 5, %sorbet_readKWRestArgs.exit ], [ 5, %sorbet_readKWRestArgs.exit.thread ]
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %0, align 8, !dbg !23, !tbaa !14
   %callArgs0Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 0, !dbg !24
   store i64 %rawArg_a, i64* %callArgs0Addr, align 8, !dbg !24
   %callArgs1Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 1, !dbg !24
-  store i64 %b.sroa.0.0131, i64* %callArgs1Addr, align 8, !dbg !24
+  store i64 %b.sroa.0.0129, i64* %callArgs1Addr, align 8, !dbg !24
   %callArgs2Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 2, !dbg !24
   store i64 %25, i64* %callArgs2Addr, align 8, !dbg !24
   %callArgs3Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 3, !dbg !24
-  store i64 %d.sroa.0.094103113130, i64* %callArgs3Addr, align 8, !dbg !24
+  store i64 %d.sroa.0.092101111128, i64* %callArgs3Addr, align 8, !dbg !24
   %callArgs4Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 4, !dbg !24
   store i64 %52, i64* %callArgs4Addr, align 8, !dbg !24
   %callArgs5Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 5, !dbg !24
@@ -385,8 +385,8 @@ sorbet_readKWRestArgs.exit:                       ; preds = %sorbet_removeKWArg.
   store i64 %send, i64* %60, align 8, !dbg !28, !tbaa !6
   %61 = getelementptr inbounds i64, i64* %60, i64 1, !dbg !28
   store i64* %61, i64** %58, align 8, !dbg !28
-  %send125 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !28
-  ret i64 %send125
+  %send123 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !28
+  ret i64 %send123
 }
 
 ; Function Attrs: sspreq

--- a/test/testdata/compiler/block_type_checking.opt.ll.exp
+++ b/test/testdata/compiler/block_type_checking.opt.ll.exp
@@ -112,8 +112,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @"stackFramePrecomputed_func_Foo#3bar" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"str_Parameter 'x'" = private unnamed_addr constant [14 x i8] c"Parameter 'x'\00", align 1
 @str_Integer = private unnamed_addr constant [8 x i8] c"Integer\00", align 1
-@"str_Parameter 'blk'" = private unnamed_addr constant [16 x i8] c"Parameter 'blk'\00", align 1
-@"str_T.proc.returns(Integer)" = private unnamed_addr constant [24 x i8] c"T.proc.returns(Integer)\00", align 1
 @"str_+" = private unnamed_addr constant [2 x i8] c"+\00", align 1
 @"str_Return value" = private unnamed_addr constant [13 x i8] c"Return value\00", align 1
 @"stackFramePrecomputed_func_Foo.13<static-init>" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
@@ -189,10 +187,6 @@ declare i64 @sorbet_maybeAllocateObjectFastPath(i64, %struct.FunctionInlineCache
 declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #3
 
 declare i64 @sorbet_vm_callBlock(%struct.rb_control_frame_struct*, i32, i64* nocapture, i32) local_unnamed_addr #3
-
-declare i32 @rb_block_given_p() local_unnamed_addr #3
-
-declare i64 @rb_block_proc() local_unnamed_addr #3
 
 declare i64 @rb_define_class(i8*, i64) local_unnamed_addr #3
 
@@ -550,121 +544,101 @@ argCountFailBlock:                                ; preds = %functionEntryInitia
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
   %rawArg_x = load i64, i64* %argArray, align 8, !dbg !63
-  %1 = tail call i32 @rb_block_given_p() #17, !dbg !63
-  %2 = icmp eq i32 %1, 0, !dbg !63
-  br i1 %2, label %sorbet_getMethodBlockAsProc.exit, label %3, !dbg !63
+  %1 = and i64 %rawArg_x, 1, !dbg !65
+  %2 = icmp eq i64 %1, 0, !dbg !65
+  br i1 %2, label %3, label %typeTestSuccess, !dbg !65, !prof !66
 
 3:                                                ; preds = %fillRequiredArgs
-  %4 = tail call i64 @rb_block_proc() #17, !dbg !63
-  br label %sorbet_getMethodBlockAsProc.exit, !dbg !63
+  %4 = and i64 %rawArg_x, 7, !dbg !65
+  %5 = icmp ne i64 %4, 0, !dbg !65
+  %6 = and i64 %rawArg_x, -9, !dbg !65
+  %7 = icmp eq i64 %6, 0, !dbg !65
+  %8 = or i1 %5, %7, !dbg !65
+  br i1 %8, label %codeRepl21, label %sorbet_isa_Integer.exit, !dbg !65
 
-sorbet_getMethodBlockAsProc.exit:                 ; preds = %fillRequiredArgs, %3
-  %5 = phi i64 [ %4, %3 ], [ 8, %fillRequiredArgs ], !dbg !63
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %0, align 8, !dbg !65, !tbaa !15
-  %6 = and i64 %rawArg_x, 1, !dbg !66
-  %7 = icmp eq i64 %6, 0, !dbg !66
-  br i1 %7, label %8, label %typeTestSuccess, !dbg !66, !prof !67
+sorbet_isa_Integer.exit:                          ; preds = %3
+  %9 = inttoptr i64 %rawArg_x to %struct.iseq_inline_iv_cache_entry*, !dbg !65
+  %10 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %9, i64 0, i32 0, !dbg !65
+  %11 = load i64, i64* %10, align 8, !dbg !65, !tbaa !67
+  %12 = and i64 %11, 31, !dbg !65
+  %13 = icmp eq i64 %12, 10, !dbg !65
+  br i1 %13, label %typeTestSuccess, label %codeRepl21, !dbg !65, !prof !69
 
-8:                                                ; preds = %sorbet_getMethodBlockAsProc.exit
-  %9 = and i64 %rawArg_x, 7, !dbg !66
-  %10 = icmp ne i64 %9, 0, !dbg !66
-  %11 = and i64 %rawArg_x, -9, !dbg !66
-  %12 = icmp eq i64 %11, 0, !dbg !66
-  %13 = or i1 %10, %12, !dbg !66
-  br i1 %13, label %codeRepl25, label %sorbet_isa_Integer.exit, !dbg !66
+typeTestSuccess:                                  ; preds = %fillRequiredArgs, %sorbet_isa_Integer.exit
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %0, align 8, !dbg !70, !tbaa !15
+  %rawBlockSendResult = tail call i64 @sorbet_vm_callBlock(%struct.rb_control_frame_struct* nonnull %cfp, i32 noundef 0, i64* noundef null, i32 noundef 0), !dbg !71
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %0, align 8, !dbg !71, !tbaa !15
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !72), !dbg !75
+  %14 = and i64 %rawArg_x, 1, !dbg !75
+  %15 = and i64 %14, %rawBlockSendResult, !dbg !75
+  %16 = icmp eq i64 %15, 0, !dbg !75
+  br i1 %16, label %26, label %17, !dbg !75, !prof !64
 
-sorbet_isa_Integer.exit:                          ; preds = %8
-  %14 = inttoptr i64 %rawArg_x to %struct.iseq_inline_iv_cache_entry*, !dbg !66
-  %15 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %14, i64 0, i32 0, !dbg !66
-  %16 = load i64, i64* %15, align 8, !dbg !66, !tbaa !68
-  %17 = and i64 %16, 31, !dbg !66
-  %18 = icmp eq i64 %17, 10, !dbg !66
-  br i1 %18, label %typeTestSuccess, label %codeRepl25, !dbg !66, !prof !70
+17:                                               ; preds = %typeTestSuccess
+  %18 = add nsw i64 %rawBlockSendResult, -1, !dbg !75
+  %19 = tail call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %rawArg_x, i64 %18) #21, !dbg !75
+  %20 = extractvalue { i64, i1 } %19, 1, !dbg !75
+  %21 = extractvalue { i64, i1 } %19, 0, !dbg !75
+  br i1 %20, label %22, label %sorbet_rb_int_plus.exit, !dbg !75
 
-typeTestSuccess:                                  ; preds = %sorbet_getMethodBlockAsProc.exit, %sorbet_isa_Integer.exit
-  %19 = tail call i32 @rb_block_given_p() #17, !dbg !71
-  %20 = icmp ne i32 %19, 0, !dbg !71
-  br i1 %20, label %typeTestSuccess7, label %codeRepl24, !dbg !71, !prof !70
+22:                                               ; preds = %17
+  %23 = ashr i64 %21, 1, !dbg !75
+  %24 = xor i64 %23, -9223372036854775808, !dbg !75
+  %25 = tail call i64 @rb_int2big(i64 %24) #17, !dbg !75, !noalias !72
+  br label %sorbet_rb_int_plus.exit, !dbg !75
 
-codeRepl25:                                       ; preds = %8, %sorbet_isa_Integer.exit
-  tail call fastcc void @"func_Foo#3bar.cold.3"(i64 %rawArg_x) #21, !dbg !66
+26:                                               ; preds = %typeTestSuccess
+  %27 = tail call i64 @sorbet_rb_int_plus_slowpath(i64 %rawArg_x, i64 %rawBlockSendResult) #17, !dbg !75, !noalias !72
+  br label %sorbet_rb_int_plus.exit, !dbg !75
+
+sorbet_rb_int_plus.exit:                          ; preds = %22, %17, %26
+  %28 = phi i64 [ %27, %26 ], [ %25, %22 ], [ %21, %17 ], !dbg !75
+  %29 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !75, !tbaa !15
+  %30 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %29, i64 0, i32 5, !dbg !75
+  %31 = load i32, i32* %30, align 8, !dbg !75, !tbaa !76
+  %32 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %29, i64 0, i32 6, !dbg !75
+  %33 = load i32, i32* %32, align 4, !dbg !75, !tbaa !77
+  %34 = xor i32 %33, -1, !dbg !75
+  %35 = and i32 %34, %31, !dbg !75
+  %36 = icmp eq i32 %35, 0, !dbg !75
+  br i1 %36, label %rb_vm_check_ints.exit, label %37, !dbg !75, !prof !69
+
+37:                                               ; preds = %sorbet_rb_int_plus.exit
+  %38 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %29, i64 0, i32 8, !dbg !75
+  %39 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %38, align 8, !dbg !75, !tbaa !78
+  %40 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %39, i32 noundef 0) #17, !dbg !75
+  br label %rb_vm_check_ints.exit, !dbg !75
+
+rb_vm_check_ints.exit:                            ; preds = %sorbet_rb_int_plus.exit, %37
+  %41 = and i64 %28, 1
+  %42 = icmp eq i64 %41, 0
+  br i1 %42, label %43, label %typeTestSuccess14, !prof !66
+
+43:                                               ; preds = %rb_vm_check_ints.exit
+  %44 = and i64 %28, 7
+  %45 = icmp ne i64 %44, 0
+  %46 = and i64 %28, -9
+  %47 = icmp eq i64 %46, 0
+  %48 = or i1 %45, %47
+  br i1 %48, label %codeRepl, label %sorbet_isa_Integer.exit22
+
+sorbet_isa_Integer.exit22:                        ; preds = %43
+  %49 = inttoptr i64 %28 to %struct.iseq_inline_iv_cache_entry*
+  %50 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %49, i64 0, i32 0
+  %51 = load i64, i64* %50, align 8, !tbaa !67
+  %52 = and i64 %51, 31
+  %53 = icmp eq i64 %52, 10
+  br i1 %53, label %typeTestSuccess14, label %codeRepl, !prof !69
+
+codeRepl21:                                       ; preds = %3, %sorbet_isa_Integer.exit
+  tail call fastcc void @"func_Foo#3bar.cold.2"(i64 %rawArg_x) #22, !dbg !65
   unreachable
 
-typeTestSuccess7:                                 ; preds = %typeTestSuccess
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %0, align 8, !dbg !71, !tbaa !15
-  %rawBlockSendResult = tail call i64 @sorbet_vm_callBlock(%struct.rb_control_frame_struct* nonnull %cfp, i32 noundef 0, i64* noundef null, i32 noundef 0), !dbg !72
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %0, align 8, !dbg !72, !tbaa !15
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !73), !dbg !76
-  %21 = and i64 %rawArg_x, 1, !dbg !76
-  %22 = and i64 %21, %rawBlockSendResult, !dbg !76
-  %23 = icmp eq i64 %22, 0, !dbg !76
-  br i1 %23, label %33, label %24, !dbg !76, !prof !64
+typeTestSuccess14:                                ; preds = %rb_vm_check_ints.exit, %sorbet_isa_Integer.exit22
+  ret i64 %28
 
-24:                                               ; preds = %typeTestSuccess7
-  %25 = add nsw i64 %rawBlockSendResult, -1, !dbg !76
-  %26 = tail call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %rawArg_x, i64 %25) #22, !dbg !76
-  %27 = extractvalue { i64, i1 } %26, 1, !dbg !76
-  %28 = extractvalue { i64, i1 } %26, 0, !dbg !76
-  br i1 %27, label %29, label %sorbet_rb_int_plus.exit, !dbg !76
-
-29:                                               ; preds = %24
-  %30 = ashr i64 %28, 1, !dbg !76
-  %31 = xor i64 %30, -9223372036854775808, !dbg !76
-  %32 = tail call i64 @rb_int2big(i64 %31) #17, !dbg !76, !noalias !73
-  br label %sorbet_rb_int_plus.exit, !dbg !76
-
-33:                                               ; preds = %typeTestSuccess7
-  %34 = tail call i64 @sorbet_rb_int_plus_slowpath(i64 %rawArg_x, i64 %rawBlockSendResult) #17, !dbg !76, !noalias !73
-  br label %sorbet_rb_int_plus.exit, !dbg !76
-
-sorbet_rb_int_plus.exit:                          ; preds = %29, %24, %33
-  %35 = phi i64 [ %34, %33 ], [ %32, %29 ], [ %28, %24 ], !dbg !76
-  %36 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !76, !tbaa !15
-  %37 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %36, i64 0, i32 5, !dbg !76
-  %38 = load i32, i32* %37, align 8, !dbg !76, !tbaa !77
-  %39 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %36, i64 0, i32 6, !dbg !76
-  %40 = load i32, i32* %39, align 4, !dbg !76, !tbaa !78
-  %41 = xor i32 %40, -1, !dbg !76
-  %42 = and i32 %41, %38, !dbg !76
-  %43 = icmp eq i32 %42, 0, !dbg !76
-  br i1 %43, label %rb_vm_check_ints.exit, label %44, !dbg !76, !prof !70
-
-44:                                               ; preds = %sorbet_rb_int_plus.exit
-  %45 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %36, i64 0, i32 8, !dbg !76
-  %46 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %45, align 8, !dbg !76, !tbaa !79
-  %47 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %46, i32 noundef 0) #17, !dbg !76
-  br label %rb_vm_check_ints.exit, !dbg !76
-
-rb_vm_check_ints.exit:                            ; preds = %sorbet_rb_int_plus.exit, %44
-  %48 = and i64 %35, 1
-  %49 = icmp eq i64 %48, 0
-  br i1 %49, label %50, label %typeTestSuccess17, !prof !67
-
-50:                                               ; preds = %rb_vm_check_ints.exit
-  %51 = and i64 %35, 7
-  %52 = icmp ne i64 %51, 0
-  %53 = and i64 %35, -9
-  %54 = icmp eq i64 %53, 0
-  %55 = or i1 %52, %54
-  br i1 %55, label %codeRepl, label %sorbet_isa_Integer.exit26
-
-sorbet_isa_Integer.exit26:                        ; preds = %50
-  %56 = inttoptr i64 %35 to %struct.iseq_inline_iv_cache_entry*
-  %57 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %56, i64 0, i32 0
-  %58 = load i64, i64* %57, align 8, !tbaa !68
-  %59 = and i64 %58, 31
-  %60 = icmp eq i64 %59, 10
-  br i1 %60, label %typeTestSuccess17, label %codeRepl, !prof !70
-
-codeRepl24:                                       ; preds = %typeTestSuccess
-  tail call fastcc void @"func_Foo#3bar.cold.2"(i64 %5) #21, !dbg !71
-  unreachable
-
-typeTestSuccess17:                                ; preds = %rb_vm_check_ints.exit, %sorbet_isa_Integer.exit26
-  ret i64 %35
-
-codeRepl:                                         ; preds = %50, %sorbet_isa_Integer.exit26
-  tail call fastcc void @"func_Foo#3bar.cold.1"(i64 %35) #21, !dbg !65
+codeRepl:                                         ; preds = %43, %sorbet_isa_Integer.exit22
+  tail call fastcc void @"func_Foo#3bar.cold.1"(i64 %28) #22, !dbg !79
   unreachable
 }
 
@@ -751,17 +725,10 @@ newFuncRoot:
 }
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
-define internal fastcc void @"func_Foo#3bar.cold.2"(i64 %0) unnamed_addr #14 !dbg !84 {
+define internal fastcc void @"func_Foo#3bar.cold.2"(i64 %rawArg_x) unnamed_addr #14 !dbg !84 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %0, i8* noundef getelementptr inbounds ([16 x i8], [16 x i8]* @"str_Parameter 'blk'", i64 0, i64 0), i8* noundef getelementptr inbounds ([24 x i8], [24 x i8]* @"str_T.proc.returns(Integer)", i64 0, i64 0)) #20, !dbg !85
+  tail call void @sorbet_cast_failure(i64 %rawArg_x, i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_Parameter 'x'", i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #20, !dbg !85
   unreachable, !dbg !85
-}
-
-; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
-define internal fastcc void @"func_Foo#3bar.cold.3"(i64 %rawArg_x) unnamed_addr #14 !dbg !86 {
-newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %rawArg_x, i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_Parameter 'x'", i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #20, !dbg !87
-  unreachable, !dbg !87
 }
 
 ; Function Attrs: nofree nosync nounwind willreturn
@@ -815,8 +782,8 @@ attributes #17 = { nounwind }
 attributes #18 = { nounwind readnone willreturn }
 attributes #19 = { nounwind allocsize(0,1) }
 attributes #20 = { noreturn }
-attributes #21 = { noinline }
-attributes #22 = { nounwind willreturn }
+attributes #21 = { nounwind willreturn }
+attributes #22 = { noinline }
 
 !llvm.module.flags = !{!0, !1, !2}
 !llvm.dbg.cu = !{!3}
@@ -886,26 +853,24 @@ attributes #22 = { nounwind willreturn }
 !62 = distinct !DISubprogram(name: "Foo#bar", linkageName: "func_Foo#3bar", scope: null, file: !4, line: 9, type: !12, scopeLine: 9, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
 !63 = !DILocation(line: 9, column: 3, scope: !62)
 !64 = !{!"branch_weights", i32 4001, i32 4000000}
-!65 = !DILocation(line: 0, scope: !62)
-!66 = !DILocation(line: 9, column: 11, scope: !62)
-!67 = !{!"branch_weights", i32 1, i32 2000}
-!68 = !{!69, !7, i64 0}
-!69 = !{!"RBasic", !7, i64 0, !7, i64 8}
-!70 = !{!"branch_weights", i32 2000, i32 1}
-!71 = !DILocation(line: 9, column: 15, scope: !62)
-!72 = !DILocation(line: 10, column: 9, scope: !62)
-!73 = !{!74}
-!74 = distinct !{!74, !75, !"sorbet_rb_int_plus: argument 0"}
-!75 = distinct !{!75, !"sorbet_rb_int_plus"}
-!76 = !DILocation(line: 11, column: 5, scope: !62)
-!77 = !{!18, !19, i64 40}
-!78 = !{!18, !19, i64 44}
-!79 = !{!18, !16, i64 56}
+!65 = !DILocation(line: 9, column: 11, scope: !62)
+!66 = !{!"branch_weights", i32 1, i32 2000}
+!67 = !{!68, !7, i64 0}
+!68 = !{!"RBasic", !7, i64 0, !7, i64 8}
+!69 = !{!"branch_weights", i32 2000, i32 1}
+!70 = !DILocation(line: 9, column: 15, scope: !62)
+!71 = !DILocation(line: 10, column: 9, scope: !62)
+!72 = !{!73}
+!73 = distinct !{!73, !74, !"sorbet_rb_int_plus: argument 0"}
+!74 = distinct !{!74, !"sorbet_rb_int_plus"}
+!75 = !DILocation(line: 11, column: 5, scope: !62)
+!76 = !{!18, !19, i64 40}
+!77 = !{!18, !19, i64 44}
+!78 = !{!18, !16, i64 56}
+!79 = !DILocation(line: 0, scope: !62)
 !80 = !{!22, !7, i64 24}
 !81 = !DILocation(line: 8, column: 3, scope: !30)
 !82 = distinct !DISubprogram(name: "func_Foo#3bar.cold.1", linkageName: "func_Foo#3bar.cold.1", scope: null, file: !4, type: !83, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
 !83 = !DISubroutineType(types: !5)
 !84 = distinct !DISubprogram(name: "func_Foo#3bar.cold.2", linkageName: "func_Foo#3bar.cold.2", scope: null, file: !4, type: !83, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
-!85 = !DILocation(line: 9, column: 15, scope: !84)
-!86 = distinct !DISubprogram(name: "func_Foo#3bar.cold.3", linkageName: "func_Foo#3bar.cold.3", scope: null, file: !4, type: !83, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
-!87 = !DILocation(line: 9, column: 11, scope: !86)
+!85 = !DILocation(line: 9, column: 11, scope: !84)


### PR DESCRIPTION
### Motivation

I had a FIXME in #4783 where I skipped typechecking blocks to make my life easier, but I knew I needed to put it back.

...then I read that we don't type check procs at runtime: https://sorbet.org/docs/procs

(see also the code driving type-checking for signatures:

https://github.com/sorbet/sorbet/blob/4725eb7442dd348470d11d164913ed51982b1831/gems/sorbet-runtime/lib/types/private/methods/signature.rb#L159-L204

which doesn't yield types or names for block parameters)

So we should stop doing this in the compiler because a) it's extra work compared to the interpreter runtime and b) converting blocks into procs just for type-checking purposes is unnecessary work.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
