### PR TITLE
Add intrinsic for Array#join

### DIFF
--- a/compiler/IREmitter/Intrinsics/intrinsic-report.md
+++ b/compiler/IREmitter/Intrinsics/intrinsic-report.md
@@ -34,7 +34,7 @@
 * [   ] `rb_ary_index` (`Array#find_index`)
 * [   ] `rb_ary_index` (`Array#index`)
 * [   ] `rb_ary_rindex` (`Array#rindex`)
-* [   ] `rb_ary_join_m` (`Array#join`)
+* [  ✔] `rb_ary_join_m` (`Array#join`)
 * [   ] `rb_ary_reverse_m` (`Array#reverse`)
 * [   ] `rb_ary_reverse_bang` (`Array#reverse!`)
 * [   ] `rb_ary_rotate_m` (`Array#rotate`)
@@ -1564,4 +1564,4 @@
 
 ## Stats
 * Total:   1488
-* Visible: 236
+* Visible: 237

--- a/compiler/IREmitter/Intrinsics/wrap-intrinsics.rb
+++ b/compiler/IREmitter/Intrinsics/wrap-intrinsics.rb
@@ -227,6 +227,7 @@ module Intrinsics
       "Array#delete",
       "Array#include?",
       "Array#initialize_copy",
+      "Array#join",
       "Array#last",
       "Array#rassoc",
       "Array#replace",

--- a/compiler/IREmitter/Payload/PayloadIntrinsics.c
+++ b/compiler/IREmitter/Payload/PayloadIntrinsics.c
@@ -115,6 +115,15 @@ VALUE sorbet_int_rb_ary_replace(VALUE recv, ID fun, int argc, VALUE *const restr
     return rb_ary_replace(recv, arg_0);
 }
 
+// Array#join
+// Calling convention: -1
+extern VALUE sorbet_rb_ary_join_m(int argc, const VALUE *args, VALUE obj);
+
+VALUE sorbet_int_rb_ary_join_m(VALUE recv, ID fun, int argc, VALUE *const restrict args, BlockFFIType blk,
+                               VALUE closure) {
+    return sorbet_rb_ary_join_m(argc, args, recv);
+}
+
 // Array#last
 // Calling convention: -1
 extern VALUE rb_ary_last(int argc, const VALUE *args, VALUE obj);

--- a/compiler/IREmitter/WrappedIntrinsics.h
+++ b/compiler/IREmitter/WrappedIntrinsics.h
@@ -14,6 +14,7 @@
     {core::Symbols::Array(), "include?", CMethod{"sorbet_int_rb_ary_includes"}},
     {core::Symbols::Array(), "initialize_copy", CMethod{"sorbet_int_rb_ary_replace"}},
     {core::Symbols::Array(), "replace", CMethod{"sorbet_int_rb_ary_replace"}},
+    {core::Symbols::Array(), "join", CMethod{"sorbet_int_rb_ary_join_m"}},
     {core::Symbols::Array(), "last", CMethod{"sorbet_int_rb_ary_last"}},
     {core::Symbols::Array(), "rassoc", CMethod{"sorbet_int_rb_ary_rassoc"}},
     {core::Symbols::Array(), "sort", CMethod{"sorbet_int_rb_ary_sort"}},

--- a/compiler/ruby-static-exports/array.c
+++ b/compiler/ruby-static-exports/array.c
@@ -1,0 +1,3 @@
+VALUE sorbet_rb_ary_join_m(int argc, const VALUE *args, VALUE obj) {
+    return rb_ary_join_m(argc, args, obj);
+}

--- a/test/testdata/compiler/intrinsics/array_join.rb
+++ b/test/testdata/compiler/intrinsics/array_join.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+
+puts ["ha","ho","hey"].join("---")
+puts [1,2,"hey"].join(",")
+puts [1,2,3].join

--- a/test/testdata/compiler/intrinsics/array_join.rb
+++ b/test/testdata/compiler/intrinsics/array_join.rb
@@ -1,7 +1,14 @@
 # frozen_string_literal: true
 # typed: true
 # compiled: true
+# run_filecheck: INITIAL
 
 puts ["ha","ho","hey"].join("---")
 puts [1,2,"hey"].join(",")
 puts [1,2,3].join
+
+# INITIAL-LABEL: define internal i64 @"func_<root>.17<static-init>
+# INITIAL: call i64 @sorbet_int_rb_ary_join_m(
+# INITIAL: call i64 @sorbet_int_rb_ary_join_m(
+# INITIAL: call i64 @sorbet_int_rb_ary_join_m(
+# INITIAL{LITERAL}: }


### PR DESCRIPTION
Adds an intrinsic for `Array#join` (generated by `wrap-intrinsics.rb`) and a simple test.


### Motivation
More compiler intrinsics!


### Test plan
See included automated tests.
