### PR TITLE
Add elaborate error explanation for `T.attached_class`

### DIFF
--- a/core/TypeErrorDiagnostics.cc
+++ b/core/TypeErrorDiagnostics.cc
@@ -1,10 +1,10 @@
-#include "core/TypeDrivenAutocorrect.h"
+#include "core/TypeErrorDiagnostics.h"
 
 using namespace std;
 
 namespace sorbet::core {
 
-void TypeDrivenAutocorrect::maybeAutocorrect(const GlobalState &gs, ErrorBuilder &e, Loc loc, TypeConstraint &constr,
+void TypeErrorDiagnostics::maybeAutocorrect(const GlobalState &gs, ErrorBuilder &e, Loc loc, TypeConstraint &constr,
                                              TypePtr expectedType, TypePtr actualType) {
     if (!loc.exists()) {
         return;

--- a/core/TypeErrorDiagnostics.h
+++ b/core/TypeErrorDiagnostics.h
@@ -1,5 +1,5 @@
-#ifndef SORBET_TYPE_DRIVEN_AUTOCORRECT_H
-#define SORBET_TYPE_DRIVEN_AUTOCORRECT_H
+#ifndef SORBET_TYPE_ERROR_DIAGNOSTICS_H
+#define SORBET_TYPE_ERROR_DIAGNOSTICS_H
 
 #include "core/Error.h"
 #include "core/GlobalState.h"
@@ -18,6 +18,8 @@ public:
     // Statefully accumulates the autocorrect directly onto the provided `ErrorBuilder`.
     static void maybeAutocorrect(const GlobalState &gs, ErrorBuilder &e, Loc loc, TypeConstraint &constr,
                                  TypePtr expectedType, TypePtr actualType);
+
+    static void explainTypeMismatch(const GlobalState &gs, ErrorBuilder &e, const TypePtr expected, const TypePtr got);
 };
 
 } // namespace sorbet::core

--- a/core/TypeErrorDiagnostics.h
+++ b/core/TypeErrorDiagnostics.h
@@ -8,7 +8,7 @@
 
 namespace sorbet::core {
 
-class TypeDrivenAutocorrect final {
+class TypeErrorDiagnostics final {
 public:
     // Uses heuristics to insert an autocorrect that converts from `expectedType` to `actualType`.
     //

--- a/core/Types.h
+++ b/core/Types.h
@@ -784,8 +784,6 @@ public:
     ErrorSection explainExpected(const GlobalState &gs, const std::string &for_, Loc originForUninitialized) const;
     ErrorSection explainGot(const GlobalState &gs, Loc originForUninitialized) const;
 
-    static void elaborateOnExplanation(const GlobalState &gs, ErrorBuilder &e, TypePtr expected, TypePtr got);
-
     ~TypeAndOrigins() noexcept;
     TypeAndOrigins() = default;
     TypeAndOrigins(const TypeAndOrigins &) = default;

--- a/core/Types.h
+++ b/core/Types.h
@@ -784,6 +784,8 @@ public:
     ErrorSection explainExpected(const GlobalState &gs, const std::string &for_, Loc originForUninitialized) const;
     ErrorSection explainGot(const GlobalState &gs, Loc originForUninitialized) const;
 
+    static void elaborateOnExplanation(const GlobalState &gs, ErrorBuilder &e, TypePtr expected, TypePtr got);
+
     ~TypeAndOrigins() noexcept;
     TypeAndOrigins() = default;
     TypeAndOrigins(const TypeAndOrigins &) = default;

--- a/core/TypesAndOrigins.cc
+++ b/core/TypesAndOrigins.cc
@@ -100,8 +100,9 @@ namespace {
     auto gotStr = got.show(gs);
     auto expectedStr = expected.show(gs);
     e.addErrorNote(
-        "`{}` is incompatible with `{}` because when this method is called on a subclass, `{}` will represent a more "
-        "specific subclass, and `{}` will not be specific enough. See https://sorbet.org/docs/attached-class for more.",
+        "`{}` is incompatible with `{}` because when this method is called on a subclass `{}` will represent a more "
+        "specific subclass, meaning `{}` will not be specific enough. See https://sorbet.org/docs/attached-class for "
+        "more.",
         gotStr, expectedStr, expectedStr, gotStr);
     return true;
 }

--- a/core/TypesAndOrigins.cc
+++ b/core/TypesAndOrigins.cc
@@ -1,3 +1,4 @@
+#include "Symbols.h"
 #include "Types.h"
 #include "common/sort.h"
 
@@ -77,6 +78,47 @@ ErrorSection TypeAndOrigins::explainExpected(const GlobalState &gs, const string
 ErrorSection TypeAndOrigins::explainGot(const GlobalState &gs, Loc originForUninitialized) const {
     auto header = ErrorColors::format("Got `{}` originating from:", this->type.showWithMoreInfo(gs));
     return ErrorSection(header, this->origins2Explanations(gs, originForUninitialized));
+}
+
+namespace {
+
+[[nodiscard]] bool checkForAttachedClassHint(const GlobalState &gs, ErrorBuilder &e, const SelfTypeParam expected,
+                                             const ClassType got) {
+    if (expected.definition.data(gs)->name != Names::Constants::AttachedClass()) {
+        return false;
+    }
+
+    auto attachedClass = got.symbol.data(gs)->lookupSingletonClass(gs);
+    if (!attachedClass.exists()) {
+        return false;
+    }
+
+    if (attachedClass != expected.definition.data(gs)->owner.asClassOrModuleRef()) {
+        return false;
+    }
+
+    auto gotStr = got.show(gs);
+    auto expectedStr = expected.show(gs);
+    e.addErrorNote(
+        "`{}` is incompatible with `{}` because when this method is called on a subclass, `{}` will represent a more "
+        "specific subclass, and `{}` will not be specific enough. See https://sorbet.org/docs/attached-class for more.",
+        gotStr, expectedStr, expectedStr, gotStr);
+    return true;
+}
+} // namespace
+
+void TypeAndOrigins::elaborateOnExplanation(const GlobalState &gs, ErrorBuilder &e, const TypePtr expected,
+                                            const TypePtr got) {
+    auto selfTypeParamExpected = isa_type<SelfTypeParam>(expected);
+    auto classTypeGot = isa_type<ClassType>(got);
+    if (selfTypeParamExpected && classTypeGot) {
+        if (checkForAttachedClassHint(gs, e, cast_type_nonnull<SelfTypeParam>(expected),
+                                      cast_type_nonnull<ClassType>(got))) {
+            return;
+        }
+    }
+
+    // TODO(jez) More elaborate explanations
 }
 
 TypeAndOrigins::~TypeAndOrigins() noexcept {

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -196,7 +196,7 @@ unique_ptr<Error> matchArgType(const GlobalState &gs, TypeConstraint &constr, Lo
             e.addErrorSection(TypeAndOrigins::explainExpected(gs, expectedType, argSym.loc, for_));
         }
         e.addErrorSection(argTpe.explainGot(gs, originForUninitialized));
-        core::TypeAndOrigins::explainTypeMismatch(gs, e, expectedType, argTpe.type);
+        core::TypeErrorDiagnostics::explainTypeMismatch(gs, e, expectedType, argTpe.type);
         TypeErrorDiagnostics::maybeAutocorrect(gs, e, loc, constr, expectedType, argTpe.type);
         return e.build();
     }

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -196,6 +196,7 @@ unique_ptr<Error> matchArgType(const GlobalState &gs, TypeConstraint &constr, Lo
             e.addErrorSection(TypeAndOrigins::explainExpected(gs, expectedType, argSym.loc, for_));
         }
         e.addErrorSection(argTpe.explainGot(gs, originForUninitialized));
+        core::TypeAndOrigins::elaborateOnExplanation(gs, e, expectedType, argTpe.type);
         TypeDrivenAutocorrect::maybeAutocorrect(gs, e, loc, constr, expectedType, argTpe.type);
         return e.build();
     }

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -196,7 +196,7 @@ unique_ptr<Error> matchArgType(const GlobalState &gs, TypeConstraint &constr, Lo
             e.addErrorSection(TypeAndOrigins::explainExpected(gs, expectedType, argSym.loc, for_));
         }
         e.addErrorSection(argTpe.explainGot(gs, originForUninitialized));
-        core::TypeAndOrigins::elaborateOnExplanation(gs, e, expectedType, argTpe.type);
+        core::TypeAndOrigins::explainTypeMismatch(gs, e, expectedType, argTpe.type);
         TypeErrorDiagnostics::maybeAutocorrect(gs, e, loc, constr, expectedType, argTpe.type);
         return e.build();
     }

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -7,7 +7,7 @@
 #include "core/Names.h"
 #include "core/Symbols.h"
 #include "core/TypeConstraint.h"
-#include "core/TypeDrivenAutocorrect.h"
+#include "core/TypeErrorDiagnostics.h"
 #include "core/Types.h"
 #include "core/errors/infer.h"
 #include "core/errors/resolver.h"
@@ -197,7 +197,7 @@ unique_ptr<Error> matchArgType(const GlobalState &gs, TypeConstraint &constr, Lo
         }
         e.addErrorSection(argTpe.explainGot(gs, originForUninitialized));
         core::TypeAndOrigins::elaborateOnExplanation(gs, e, expectedType, argTpe.type);
-        TypeDrivenAutocorrect::maybeAutocorrect(gs, e, loc, constr, expectedType, argTpe.type);
+        TypeErrorDiagnostics::maybeAutocorrect(gs, e, loc, constr, expectedType, argTpe.type);
         return e.build();
     }
     return nullptr;

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1250,7 +1250,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                         if (i.whatLoc != inWhat.implicitReturnLoc) {
                             auto replaceLoc = core::Loc(ctx.file, i.whatLoc);
                             core::TypeErrorDiagnostics::maybeAutocorrect(ctx, e, replaceLoc, constr, methodReturnType,
-                                                                          typeAndOrigin.type);
+                                                                         typeAndOrigin.type);
                         }
                     }
                 }
@@ -1428,7 +1428,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                                 // We are not processing a method call, so there is no constraint.
                                 auto &constr = core::TypeConstraint::EmptyFrozenConstraint;
                                 core::TypeErrorDiagnostics::maybeAutocorrect(ctx, e, replaceLoc, constr, cur.type,
-                                                                              tp.type);
+                                                                             tp.type);
                             }
                             tp = cur;
                         }

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1246,7 +1246,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                         e.addErrorSection(
                             core::TypeAndOrigins::explainExpected(ctx, methodReturnType, ownerData->loc(), for_));
                         e.addErrorSection(typeAndOrigin.explainGot(ctx, ownerLoc));
-                        core::TypeAndOrigins::elaborateOnExplanation(ctx, e, methodReturnType, typeAndOrigin.type);
+                        core::TypeAndOrigins::explainTypeMismatch(ctx, e, methodReturnType, typeAndOrigin.type);
                         if (i.whatLoc != inWhat.implicitReturnLoc) {
                             auto replaceLoc = core::Loc(ctx.file, i.whatLoc);
                             core::TypeErrorDiagnostics::maybeAutocorrect(ctx, e, replaceLoc, constr, methodReturnType,
@@ -1283,7 +1283,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                             core::TypeAndOrigins::explainExpected(ctx, expectedType, bspec.loc, "block result type"));
 
                         e.addErrorSection(typeAndOrigin.explainGot(ctx, ownerLoc));
-                        core::TypeAndOrigins::elaborateOnExplanation(ctx, e, expectedType, typeAndOrigin.type);
+                        core::TypeAndOrigins::explainTypeMismatch(ctx, e, expectedType, typeAndOrigin.type);
                     }
                 }
 
@@ -1423,7 +1423,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                                 // message, but we don't have a convenient way to compute this at the moment.
                                 e.addErrorSection(cur.explainExpected(ctx, "field defined here", ownerLoc));
                                 e.addErrorSection(tp.explainGot(ctx, ownerLoc));
-                                core::TypeAndOrigins::elaborateOnExplanation(ctx, e, cur.type, tp.type);
+                                core::TypeAndOrigins::explainTypeMismatch(ctx, e, cur.type, tp.type);
                                 auto replaceLoc = core::Loc(ctx.file, bind.loc);
                                 // We are not processing a method call, so there is no constraint.
                                 auto &constr = core::TypeConstraint::EmptyFrozenConstraint;

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -3,7 +3,7 @@
 #include "common/typecase.h"
 #include "core/GlobalState.h"
 #include "core/TypeConstraint.h"
-#include "core/TypeDrivenAutocorrect.h"
+#include "core/TypeErrorDiagnostics.h"
 #include <algorithm> // find, remove_if
 
 template struct std::pair<sorbet::core::LocalVariable, std::shared_ptr<sorbet::core::Type>>;
@@ -1249,7 +1249,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                         core::TypeAndOrigins::elaborateOnExplanation(ctx, e, methodReturnType, typeAndOrigin.type);
                         if (i.whatLoc != inWhat.implicitReturnLoc) {
                             auto replaceLoc = core::Loc(ctx.file, i.whatLoc);
-                            core::TypeDrivenAutocorrect::maybeAutocorrect(ctx, e, replaceLoc, constr, methodReturnType,
+                            core::TypeErrorDiagnostics::maybeAutocorrect(ctx, e, replaceLoc, constr, methodReturnType,
                                                                           typeAndOrigin.type);
                         }
                     }
@@ -1427,7 +1427,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                                 auto replaceLoc = core::Loc(ctx.file, bind.loc);
                                 // We are not processing a method call, so there is no constraint.
                                 auto &constr = core::TypeConstraint::EmptyFrozenConstraint;
-                                core::TypeDrivenAutocorrect::maybeAutocorrect(ctx, e, replaceLoc, constr, cur.type,
+                                core::TypeErrorDiagnostics::maybeAutocorrect(ctx, e, replaceLoc, constr, cur.type,
                                                                               tp.type);
                             }
                             tp = cur;

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1246,7 +1246,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                         e.addErrorSection(
                             core::TypeAndOrigins::explainExpected(ctx, methodReturnType, ownerData->loc(), for_));
                         e.addErrorSection(typeAndOrigin.explainGot(ctx, ownerLoc));
-                        core::TypeAndOrigins::explainTypeMismatch(ctx, e, methodReturnType, typeAndOrigin.type);
+                        core::TypeErrorDiagnostics::explainTypeMismatch(ctx, e, methodReturnType, typeAndOrigin.type);
                         if (i.whatLoc != inWhat.implicitReturnLoc) {
                             auto replaceLoc = core::Loc(ctx.file, i.whatLoc);
                             core::TypeErrorDiagnostics::maybeAutocorrect(ctx, e, replaceLoc, constr, methodReturnType,
@@ -1283,7 +1283,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                             core::TypeAndOrigins::explainExpected(ctx, expectedType, bspec.loc, "block result type"));
 
                         e.addErrorSection(typeAndOrigin.explainGot(ctx, ownerLoc));
-                        core::TypeAndOrigins::explainTypeMismatch(ctx, e, expectedType, typeAndOrigin.type);
+                        core::TypeErrorDiagnostics::explainTypeMismatch(ctx, e, expectedType, typeAndOrigin.type);
                     }
                 }
 
@@ -1423,7 +1423,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                                 // message, but we don't have a convenient way to compute this at the moment.
                                 e.addErrorSection(cur.explainExpected(ctx, "field defined here", ownerLoc));
                                 e.addErrorSection(tp.explainGot(ctx, ownerLoc));
-                                core::TypeAndOrigins::explainTypeMismatch(ctx, e, cur.type, tp.type);
+                                core::TypeErrorDiagnostics::explainTypeMismatch(ctx, e, cur.type, tp.type);
                                 auto replaceLoc = core::Loc(ctx.file, bind.loc);
                                 // We are not processing a method call, so there is no constraint.
                                 auto &constr = core::TypeConstraint::EmptyFrozenConstraint;

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1283,6 +1283,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                             core::TypeAndOrigins::explainExpected(ctx, expectedType, bspec.loc, "block result type"));
 
                         e.addErrorSection(typeAndOrigin.explainGot(ctx, ownerLoc));
+                        core::TypeAndOrigins::elaborateOnExplanation(ctx, e, expectedType, typeAndOrigin.type);
                     }
                 }
 
@@ -1422,6 +1423,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                                 // message, but we don't have a convenient way to compute this at the moment.
                                 e.addErrorSection(cur.explainExpected(ctx, "field defined here", ownerLoc));
                                 e.addErrorSection(tp.explainGot(ctx, ownerLoc));
+                                core::TypeAndOrigins::elaborateOnExplanation(ctx, e, cur.type, tp.type);
                                 auto replaceLoc = core::Loc(ctx.file, bind.loc);
                                 // We are not processing a method call, so there is no constraint.
                                 auto &constr = core::TypeConstraint::EmptyFrozenConstraint;

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1246,6 +1246,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                         e.addErrorSection(
                             core::TypeAndOrigins::explainExpected(ctx, methodReturnType, ownerData->loc(), for_));
                         e.addErrorSection(typeAndOrigin.explainGot(ctx, ownerLoc));
+                        core::TypeAndOrigins::elaborateOnExplanation(ctx, e, methodReturnType, typeAndOrigin.type);
                         if (i.whatLoc != inWhat.implicitReturnLoc) {
                             auto replaceLoc = core::Loc(ctx.file, i.whatLoc);
                             core::TypeDrivenAutocorrect::maybeAutocorrect(ctx, e, replaceLoc, constr, methodReturnType,


### PR DESCRIPTION
First of many more elaborate explanations, hopefully.


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This should give us an extension point to give more targeted error messages for
type errors. This should be a good way to introduce people to feature of the
type system.


**In the future** we might want to figure out a way to combine this with this
issue:

<https://github.com/sorbet/sorbet/issues/4338>

which suggests that `isSubType` itself might want to be able to surface
explanations, because there are time when providing an error message can only be
done well deep inside recursive `isSubType` calls.

For the time being, I think this solution is fine, as it will allow us to start
collecting a list of explanations which will be easy enough to merge into
`isSubType` if we ever decide to work on the above issue.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

<img width="983" alt="Screen Shot 2021-11-15 at 4 54 55 PM" src="https://user-images.githubusercontent.com/5544532/141876173-60f36013-4ba6-4b23-9e49-456a4879a72e.png">
