### PR TITLE
--stripe-packages: stop re-processing all packages in fast-path

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -175,7 +175,6 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
     vector<core::NameHash> changedHashes;
     // Replace error queue with one that is owned by this thread.
     gs->errorQueue = make_shared<core::ErrorQueue>(gs->errorQueue->logger, gs->errorQueue->tracer, errorFlusher);
-    fmt::print(stderr, "BEGIN loop run fast path\n");
     {
         vector<pair<core::NameHash, u4>> changedMethodHashes;
         for (auto &f : updates.updatedFiles) {
@@ -184,7 +183,6 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
             // path logic in LSPPreprocessor.
             ENFORCE(fref.exists());
             ENFORCE(f->getFileHash() != nullptr);
-            fmt::print(stderr, " - {} {}\n", f->path(), fref.exists());
             if (f->sourceType == core::File::Type::Package) {
                 // Only relevant in --stripe-packages mode. Package declarations do not have method
                 // hashes. Instead we rely on recomputing packages if any __package.rb source
@@ -214,14 +212,12 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
             }
         }
 
-
         changedHashes.reserve(changedMethodHashes.size());
         for (auto &changedMethodHash : changedMethodHashes) {
             changedHashes.push_back(changedMethodHash.first);
         }
         core::NameHash::sortAndDedupe(changedHashes);
     }
-    fmt::print(stderr, "END loop run fast path\n");
 
     int i = -1;
     // N.B.: We'll iterate over the changed files, too, but it's benign if we re-add them since we dedupe `subset`.
@@ -249,11 +245,6 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
     }
     // Remove any duplicate files.
     fast_sort(subset);
-    fmt::print(stderr, "START\n");
-    for (auto fr : subset) {
-        fmt::print(stderr, " xx{}\n", fr.data(*gs).path());
-    }
-    fmt::print(stderr, "END\n");
     subset.resize(std::distance(subset.begin(), std::unique(subset.begin(), subset.end())));
 
     config->logger->debug("Taking fast path");

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -175,6 +175,7 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
     vector<core::NameHash> changedHashes;
     // Replace error queue with one that is owned by this thread.
     gs->errorQueue = make_shared<core::ErrorQueue>(gs->errorQueue->logger, gs->errorQueue->tracer, errorFlusher);
+    fmt::print(stderr, "BEGIN loop run fast path\n");
     {
         vector<pair<core::NameHash, u4>> changedMethodHashes;
         for (auto &f : updates.updatedFiles) {
@@ -183,6 +184,13 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
             // path logic in LSPPreprocessor.
             ENFORCE(fref.exists());
             ENFORCE(f->getFileHash() != nullptr);
+            fmt::print(stderr, " - {} {}\n", f->path(), fref.exists());
+            if (f->sourceType == core::File::Type::Package) {
+                // Only relevant in --stripe-packages mode. Package declarations do not have method
+                // hashes. Instead we rely on recomputing packages if any __package.rb source
+                // changes.
+                continue;
+            }
             if (fref.exists()) {
                 // Update to existing file on fast path
                 ENFORCE(fref.data(*gs).getFileHash() != nullptr);
@@ -206,12 +214,14 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
             }
         }
 
+
         changedHashes.reserve(changedMethodHashes.size());
         for (auto &changedMethodHash : changedMethodHashes) {
             changedHashes.push_back(changedMethodHash.first);
         }
         core::NameHash::sortAndDedupe(changedHashes);
     }
+    fmt::print(stderr, "END loop run fast path\n");
 
     int i = -1;
     // N.B.: We'll iterate over the changed files, too, but it's benign if we re-add them since we dedupe `subset`.
@@ -222,8 +232,7 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
         }
 
         if (oldFile->sourceType == core::File::Type::Package) {
-            subset.emplace_back(core::FileRef(i));
-            continue;
+            continue; // See note above about --stripe-packages.
         }
 
         ENFORCE(oldFile->getFileHash() != nullptr);
@@ -240,6 +249,11 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
     }
     // Remove any duplicate files.
     fast_sort(subset);
+    fmt::print(stderr, "START\n");
+    for (auto fr : subset) {
+        fmt::print(stderr, " xx{}\n", fr.data(*gs).path());
+    }
+    fmt::print(stderr, "END\n");
     subset.resize(std::distance(subset.begin(), std::unique(subset.begin(), subset.end())));
 
     config->logger->debug("Taking fast path");

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1237,7 +1237,6 @@ vector<ast::ParsedFile> Packager::run(core::GlobalState &gs, WorkerPool &workers
     Timer timeit(gs.tracer(), "packager");
     // Ensure files are in canonical order.
     fast_sort(files, [](const auto &a, const auto &b) -> bool { return a.file < b.file; });
-    fmt::print(stderr, "RUN PACKAGER\n");
 
     // Step 1: Find packages and determine their imports/exports.
     {

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1237,6 +1237,7 @@ vector<ast::ParsedFile> Packager::run(core::GlobalState &gs, WorkerPool &workers
     Timer timeit(gs.tracer(), "packager");
     // Ensure files are in canonical order.
     fast_sort(files, [](const auto &a, const auto &b) -> bool { return a.file < b.file; });
+    fmt::print(stderr, "RUN PACKAGER\n");
 
     // Step 1: Find packages and determine their imports/exports.
     {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
As of https://github.com/sorbet/sorbet/pull/4631 we no longer need to reprocess every package file in the fastPath if no packages change. We do not need to add them to the edit if they were not changed. At a higher-up level we add all package files to the set if any have changed. 

This is already validated here: https://github.com/sorbet/sorbet/blob/8ba327976e58390c5fbc8259abfe3eeee08fd78c/packager/packager.cc#L1340


### Motivation
This was an oversight while working on https://github.com/sorbet/sorbet/pull/4631
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

### Test plan
Ran in vscode with `--lsp --stripe-package --sleep-in-slow-path` manually verified that local edits to non-package files did not force a slow-path.
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

cc @jvilk @jvilk-stripe 
