### PR TITLE
add an intrinsic for Thread.main

### DIFF
--- a/compiler/IREmitter/Payload/codegen-payload.c
+++ b/compiler/IREmitter/Payload/codegen-payload.c
@@ -826,6 +826,12 @@ VALUE sorbet_Thread_current(VALUE recv, ID fun, int argc, const VALUE *const res
     return rb_thread_current();
 }
 
+SORBET_INLINE
+VALUE sorbet_Thread_main(VALUE recv, ID fun, int argc, const VALUE *const restrict argv, BlockFFIType blk,
+                         VALUE closure) {
+    return rb_thread_main();
+}
+
 // https://github.com/ruby/ruby/blob/5445e0435260b449decf2ac16f9d09bae3cafe72/thread.c#L3281-L3287
 SORBET_INLINE
 VALUE sorbet_Thread_square_br(VALUE recv, ID fun, int argc, const VALUE *const restrict argv, BlockFFIType blk,

--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -958,6 +958,7 @@ static const vector<CallCMethodSingleton> knownCMethodsSingleton{
     {core::Symbols::T(), "unsafe", CMethod{"sorbet_T_unsafe"}},
     {core::Symbols::T(), "must", CMethod{"sorbet_T_must"}},
     {core::Symbols::Thread(), "current", CMethod{"sorbet_Thread_current", core::Symbols::Thread()}},
+    {core::Symbols::Thread(), "main", CMethod{"sorbet_Thread_main", core::Symbols::Thread()}},
 };
 
 vector<const SymbolBasedIntrinsicMethod *> getKnownCMethodPtrs(const core::GlobalState &gs) {

--- a/test/testdata/compiler/intrinsics/thread_aref_aset.rb
+++ b/test/testdata/compiler/intrinsics/thread_aref_aset.rb
@@ -22,6 +22,23 @@ end
 # OPT-NOT: call i64 @callFuncWithCache
 # OPT{LITERAL}: }
 
+sig {returns(Thread)}
+def thread_main
+  Thread.main
+end
+
+# INITIAL-LABEL: define internal i64 @"func_Object#11thread_main
+# INITIAL-NOT: call i64 @sorbet_i_send
+# INITIAL: call i64 @sorbet_Thread_main
+# INITIAL-NOT: call i64 @sorbet_i_send
+# INITIAL{LITERAL}: }
+
+# OPT-LABEL: define internal i64 @"func_Object#11thread_main
+# OPT-NOT: call i64 @callFuncWithCache
+# OPT: call i64 @rb_thread_main
+# OPT-NOT: call i64 @callFuncWithCache
+# OPT{LITERAL}: }
+
 sig {params(thread: Thread).returns(T.untyped)}
 def thread_aref_constant(thread)
   thread[:my_key]


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We have one for `Thread.current`, might as well have one for `Thread.main`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
