### PR TITLE
add a disabled test for types on kwsplat args

### DIFF
--- a/test/testdata/compiler/disabled/typed_kwsplat_arg.rb
+++ b/test/testdata/compiler/disabled/typed_kwsplat_arg.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+
+extend T::Sig
+
+# The runtime asserts that the values of the kwsplat hash are the declared type.
+# The compiler, at the time this testcase was written, doesn't do that.
+sig {params(msg: String, kwargs: Integer).void}
+def foo(msg, **kwargs)
+  p msg
+end
+
+begin
+  foo("shouldn't execute the body", a: 1, b: 2, c: T.unsafe('nope'))
+rescue
+  p "got exception as expected"
+else
+  p "we shouldn't be here"
+end
+
+foo("should execute the body", a: 1, b: 2, c: 3)


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Followup from review comments on #4848.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
