### PR TITLE
propagate type assumptions for never-modified method arguments into blocks

### DIFF
--- a/compiler/IREmitter/Exceptions.cc
+++ b/compiler/IREmitter/Exceptions.cc
@@ -47,9 +47,10 @@ void IREmitterHelpers::emitExceptionHandlers(CompilerState &cs, llvm::IRBuilderB
     auto *cfp = Payload::getCFPForBlock(cs, builder, irctx, rubyBlockId);
 
     auto info = Payload::escapedVariableInfo(cs, exceptionValue, irctx, bodyRubyBlockId);
-    auto *v = builder.CreateCall(cs.getFunction("sorbet_run_exception_handling"),
-                                 {ec, irctx.rubyBlocks2Functions[bodyRubyBlockId], pc, closure, cfp, handlersFunc,
-                                  elseFunc, ensureFunc, Payload::retrySingleton(cs, builder, irctx), info.index, info.level});
+    auto *v =
+        builder.CreateCall(cs.getFunction("sorbet_run_exception_handling"),
+                           {ec, irctx.rubyBlocks2Functions[bodyRubyBlockId], pc, closure, cfp, handlersFunc, elseFunc,
+                            ensureFunc, Payload::retrySingleton(cs, builder, irctx), info.index, info.level});
 
     auto *exceptionContinue = llvm::BasicBlock::Create(cs, "exception-continue", currentFunc);
     auto *exceptionReturn = llvm::BasicBlock::Create(cs, "exception-return", currentFunc);

--- a/compiler/IREmitter/Exceptions.cc
+++ b/compiler/IREmitter/Exceptions.cc
@@ -46,10 +46,10 @@ void IREmitterHelpers::emitExceptionHandlers(CompilerState &cs, llvm::IRBuilderB
     auto *closure = Payload::buildLocalsOffset(cs);
     auto *cfp = Payload::getCFPForBlock(cs, builder, irctx, rubyBlockId);
 
-    auto [index, level] = Payload::escapedVariableIndexAndLevel(cs, exceptionValue, irctx, bodyRubyBlockId);
+    auto info = Payload::escapedVariableInfo(cs, exceptionValue, irctx, bodyRubyBlockId);
     auto *v = builder.CreateCall(cs.getFunction("sorbet_run_exception_handling"),
                                  {ec, irctx.rubyBlocks2Functions[bodyRubyBlockId], pc, closure, cfp, handlersFunc,
-                                  elseFunc, ensureFunc, Payload::retrySingleton(cs, builder, irctx), index, level});
+                                  elseFunc, ensureFunc, Payload::retrySingleton(cs, builder, irctx), info.index, info.level});
 
     auto *exceptionContinue = llvm::BasicBlock::Create(cs, "exception-continue", currentFunc);
     auto *exceptionReturn = llvm::BasicBlock::Create(cs, "exception-return", currentFunc);

--- a/compiler/IREmitter/IREmitterContext.cc
+++ b/compiler/IREmitter/IREmitterContext.cc
@@ -270,7 +270,8 @@ class TrackCaptures final {
         core::TypePtr type;
     };
 
-    void trackBlockUsage(cfg::BasicBlock *bb, cfg::LocalRef lv, const core::TypePtr &type, LocalUsedHow use, CaptureContext context) {
+    void trackBlockUsage(cfg::BasicBlock *bb, cfg::LocalRef lv, const core::TypePtr &type, LocalUsedHow use,
+                         CaptureContext context) {
         if (lv == cfg::LocalRef::selfVariable()) {
             return;
         }

--- a/compiler/IREmitter/IREmitterContext.h
+++ b/compiler/IREmitter/IREmitterContext.h
@@ -111,6 +111,9 @@ struct EscapedUse {
     // Index into the local variables array from the environment.
     int localIndex;
     LocalUsedHow used;
+    // If this escaped variable comes from a method argument, this is the declared
+    // type of that argument.  Otherwise, this is nullptr.
+    core::TypePtr type;
 };
 
 struct BlockArity {

--- a/compiler/IREmitter/IREmitterContext.h
+++ b/compiler/IREmitter/IREmitterContext.h
@@ -107,6 +107,12 @@ constexpr bool functionTypeNeedsPostprocessing(FunctionType ty) {
 
 struct Alias;
 
+struct EscapedUse {
+    // Index into the local variables array from the environment.
+    int localIndex;
+    LocalUsedHow used;
+};
+
 struct BlockArity {
     int min = 0;
     int max = 0;
@@ -192,8 +198,11 @@ struct IREmitterContext {
     // idx: cfg::BasicBlock::rubyBlockId;
     std::vector<llvm::AllocaInst *> sendArgArrayByBlock;
 
-    // TODO(jez) document escapedVariableIndices
-    UnorderedMap<cfg::LocalRef, int> escapedVariableIndices;
+    // Local variables that escape, i.e. are referenced from multiple Ruby blocks, are
+    // stored in the Ruby frame's environment.  That storage may live on the Ruby stack
+    // or in heap-allocated memory.  Either way, this maps from escaped local variables
+    // to details on their use.
+    UnorderedMap<cfg::LocalRef, EscapedUse> escapedVariableIndices;
 
     // When arguments have defaults, the use of the default is guarded by a call to ArgPresent. The ArgPresent variables
     // are initialized during setupArguments, but need to be available by argument index.

--- a/compiler/IREmitter/Payload.cc
+++ b/compiler/IREmitter/Payload.cc
@@ -550,7 +550,9 @@ void fillLocals(CompilerState &cs, llvm::IRBuilderBase &builder, const IREmitter
         escapedVariables.emplace_back(entry);
     }
 
-    fast_sort(escapedVariables, [](const auto &left, const auto &right) -> bool { return left.second.localIndex < right.second.localIndex; });
+    fast_sort(escapedVariables, [](const auto &left, const auto &right) -> bool {
+        return left.second.localIndex < right.second.localIndex;
+    });
 
     for (auto &entry : escapedVariables) {
         auto *id = Payload::idIntern(cs, builder, entry.first.data(irctx.cfg)._name.shortName(cs));
@@ -939,8 +941,8 @@ llvm::Value *Payload::getClassVariableStoreClass(CompilerState &cs, llvm::IRBuil
     return Payload::getRubyConstant(cs, sym.data(cs)->topAttachedClass(cs), builder);
 }
 
-EscapedVariableInfo Payload::escapedVariableInfo(CompilerState &cs, cfg::LocalRef local,
-                                                 const IREmitterContext &irctx, int rubyBlockId) {
+EscapedVariableInfo Payload::escapedVariableInfo(CompilerState &cs, cfg::LocalRef local, const IREmitterContext &irctx,
+                                                 int rubyBlockId) {
     auto &escapedUse = irctx.escapedVariableIndices.at(local);
     auto *index = indexForLocalVariable(cs, irctx, rubyBlockId, escapedUse.localIndex);
     auto level = irctx.rubyBlockLevel[rubyBlockId];
@@ -994,10 +996,9 @@ llvm::Value *Payload::varGet(CompilerState &cs, cfg::LocalRef local, llvm::IRBui
         }
 
         core::ClassOrModuleRef klass;
-        typecase(info.use.type,
-                 [&klass](const core::ClassType &ct) { klass = ct.symbol; },
-                 [&klass](const core::AppliedType &at) { klass = at.klass; },
-                 [](const core::TypePtr &def) {});
+        typecase(
+            info.use.type, [&klass](const core::ClassType &ct) { klass = ct.symbol; },
+            [&klass](const core::AppliedType &at) { klass = at.klass; }, [](const core::TypePtr &def) {});
         if (!klass.exists()) {
             return value;
         }

--- a/compiler/IREmitter/Payload.cc
+++ b/compiler/IREmitter/Payload.cc
@@ -285,8 +285,18 @@ bool hasOptimizedTest(core::ClassOrModuleRef sym) {
 core::ClassOrModuleRef hasOptimizedTest(const core::TypePtr &type) {
     core::ClassOrModuleRef res;
     typecase(
-             type, [&res](const core::ClassType &ct) { if (hasOptimizedTest(ct.symbol)) { res = ct.symbol; } },
-             [&res](const core::AppliedType &at) { if (hasOptimizedTest(at.klass)) { res = at.klass; } }, [](const core::TypePtr &def) {});
+        type,
+        [&res](const core::ClassType &ct) {
+            if (hasOptimizedTest(ct.symbol)) {
+                res = ct.symbol;
+            }
+        },
+        [&res](const core::AppliedType &at) {
+            if (hasOptimizedTest(at.klass)) {
+                res = at.klass;
+            }
+        },
+        [](const core::TypePtr &def) {});
 
     return res;
 }

--- a/compiler/IREmitter/Payload.h
+++ b/compiler/IREmitter/Payload.h
@@ -9,7 +9,16 @@ namespace sorbet::compiler {
 
 struct IREmitterContext;
 struct Alias;
+struct EscapedUse;
 class CompilerState;
+
+struct EscapedVariableInfo {
+    const EscapedUse &use;
+    // The index of the variable within the frame.
+    llvm::Value *index;
+    // The number of frames to traverse.
+    llvm::Value *level;
+};
 
 // This class serves as forwarder to payload.c, which are the c wrappers for
 // Ruby functions. These functions can (and do) use information known during
@@ -78,9 +87,8 @@ public:
     static void varSet(CompilerState &cs, cfg::LocalRef local, llvm::Value *var, llvm::IRBuilderBase &builder,
                        const IREmitterContext &irctx, int rubyBlockId);
 
-    static std::tuple<llvm::Value *, llvm::Value *> escapedVariableIndexAndLevel(CompilerState &cs, cfg::LocalRef local,
-                                                                                 const IREmitterContext &irctx,
-                                                                                 int rubyBlockId);
+    static EscapedVariableInfo escapedVariableInfo(CompilerState &cs, cfg::LocalRef local,
+                                                   const IREmitterContext &irctx, int rubyBlockId);
 
     static llvm::Value *retrySingleton(CompilerState &cs, llvm::IRBuilderBase &builder, const IREmitterContext &irctx);
     static llvm::Value *voidSingleton(CompilerState &cs, llvm::IRBuilderBase &builder, const IREmitterContext &irctx);

--- a/test/testdata/compiler/locals_type_info.rb
+++ b/test/testdata/compiler/locals_type_info.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+# run_filecheck: INITIAL
+# run_filecheck: OPT
+
+extend T::Sig
+
+sig {params(queue: T::Array[T.untyped], obj: T::Array[T.untyped]).void}
+def f(queue, obj)
+  obj.each do |x|
+    queue << x
+  end
+end
+
+q = []
+f(q, [1, 2, 3])
+f(q, [:z, :y, :x, :w])
+p q
+
+# Check that:
+#
+# * We read the local
+# * We applied an appropriate llvm.assume to it
+# * We did a normal type test + branch to intrinsic/VM implementations
+#
+# The last is not strictly necessary, but it helps ensure that the VM-based codepath
+# is there so that if it disappeared in some way, we have a warning besides just the
+# OPT-NOT test below succeeding.
+
+# INITIAL-LABEL: define internal i64 @"func_Object#1f$block_1"
+# INITIAL: [[QUEUE:%[0-9]+]] = call i64 @sorbet_readLocal{{.*}}
+# INITIAL-NEXT: [[ASSUMPTION:%[0-9]+]] = call i1 @sorbet_i_isa_Array(i64 [[QUEUE]]){{.*}}
+# INITIAL-NEXT: call void @llvm.assume(i1 [[ASSUMPTION]]){{.*}}
+# INITIAL: sendContinuation:
+# INITIAL-NEXT: [[TEST:%[0-9]+]] = call i1 @sorbet_i_isa_Array(i64 [[QUEUE]]){{.*}}
+# INITIAL-NEXT: [[COND:%[0-9]+]] = call i1 @llvm.expect.i1(i1 [[TEST]], i1 true){{.*}}
+# INITIAL-NEXT: br i1 [[COND]], label %"fastSymCallIntrinsic_Array_<<", label %"alternativeCallIntrinsic_Array_<<"{{.*}}
+# INITIAL: "alternativeCallIntrinsic_Array_<<":
+# INITIAL: call i64{{.*}}@sorbet_i_send
+# INITIAL: "fastSymCallIntrinsic_Array_<<":
+# INITIAL{LITERAL}: }
+
+# We should have optimized out the alternative VM-based call path based on type assumptions.
+# OPT-LABEL: define internal i64 @"func_Object#1f$block_1"
+# OPT-NOT: call i64 @sorbet_callFuncWithCache
+# OPT{LITERAL}: }


### PR DESCRIPTION
[This is an updated, rebased version of stripe/sorbet_llvm#490]

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

DeepFreeze has code like:

```ruby
    sig(:final) {params(todo: T::Array[T.untyped], obj: T.untyped).void.checked(:tests)}
    def self.freeze_one(todo, obj)
      case obj
      ...
      when Hash
        obj.freeze
        obj.each do |key, value|
          todo << key
          todo << value
        end
    ...
```

The block provided to each ought to be able to treat todo as an Array, just like todo would be at the "toplevel" of the method, outside of any blocks. Unfortunately, since blocks are compiled as separate functions, the information that todo has been type-checked to be an Array is lost and we need to continually re-check on each iteration.

This PR attempts to change that by recording very basic read/write information for locals that escape (and therefore get stuffed into the locals array) as well as type information for locals that correspond to method arguments. Once we have all that information, if an escaped variable is:

* a method argument
* never written to anywhere
* has a reasonable type that we can add llvm.assume for

we can "propagate" that information into the LLVM IR for the block. The included test shows the sort of thing that should happen.

Obviously there are a lot of caveats. I could see making the framework a little more flexible; it would be nice to catch something like:

```ruby
sig {params(other_hash: T::Hash[...]).returns(...)
def frob(other_hash)
  ...
  hash = {}
  other_hash.each do |k, v|
    modified_k = ...
    modified_v = ...
    hash[modified_k] = modified_v
  end
  ...
```

I think we can do this during `findCaptures` by having some analysis on `Send`s that ask whether we can "trust" the return type or not.  We can trust the return type from, e.g.:

* `<Magic>.<build-hash>`
* `<Magic>.<build-array>`
* `"constant-string".dup` (this one comes up in logging code)

and maybe a couple other cases.  Then we'd just say, on the first write to a variable (?) that the send type could be trusted and make it "read-only", trusting any later writes to make it actually `WrittenTo`.  But that is a followup PR in any event.  (The actual code for `frob` has `hash = other_hash.class.new` which is a different kind of wrinkle.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
