### PR TITLE
Add some intrinsics for identity functions

### DIFF
--- a/compiler/IREmitter/Payload/codegen-payload.c
+++ b/compiler/IREmitter/Payload/codegen-payload.c
@@ -1811,6 +1811,12 @@ VALUE sorbet_selfNew(VALUE recv, ID fun, int argc, VALUE *argv, BlockFFIType blk
 }
 
 SORBET_INLINE
+VALUE sorbet_returnRecv(VALUE recv, ID fun, int argc, const VALUE *const restrict argv, BlockFFIType blk,
+                        VALUE closure) {
+    return recv;
+}
+
+SORBET_INLINE
 VALUE sorbet_int_str_uplus(VALUE recv, ID fun, int argc, VALUE *argv, BlockFFIType blk, VALUE closure) {
     rb_check_arity(argc, 0, 0);
     return sorbet_vm_str_uplus(recv);

--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -917,6 +917,7 @@ static const vector<CallCMethod> knownCMethodsInstance{
     {core::Symbols::Array(), "all?", CMethod{"sorbet_rb_array_all"}, CMethod{"sorbet_rb_array_all_withBlock"}},
     {core::Symbols::Array(), "compact", CMethod{"sorbet_rb_array_compact", core::Symbols::Array()}},
     {core::Symbols::Array(), "compact!", CMethod{"sorbet_rb_array_compact_bang"}},
+    {core::Symbols::Array(), "to_ary", CMethod{"sorbet_returnRecv", core::Symbols::Array()}},
     {core::Symbols::Array(), "to_h", CMethod{"sorbet_rb_array_to_h", core::Symbols::Hash()}},
     {core::Symbols::Array(), "size", CMethod{"sorbet_rb_array_len", core::Symbols::Integer()}},
     {core::Symbols::Array(), "length", CMethod{"sorbet_rb_array_len", core::Symbols::Integer()}},
@@ -929,6 +930,7 @@ static const vector<CallCMethod> knownCMethodsInstance{
     {core::Symbols::Hash(), "each_with_object", CMethod{"sorbet_rb_hash_each_with_object", core::Symbols::Enumerator()},
      CMethod{"sorbet_rb_hash_each_with_object_withBlock"}},
     {core::Symbols::Hash(), "any?", CMethod{"sorbet_rb_hash_any"}, CMethod{"sorbet_rb_hash_any_withBlock"}},
+    {core::Symbols::Hash(), "to_hash", CMethod{"sorbet_returnRecv", core::Symbols::Hash()}},
     {core::Symbols::TrueClass(), "|", CMethod{"sorbet_int_bool_true"}},
     {core::Symbols::FalseClass(), "|", CMethod{"sorbet_int_bool_and"}},
     {core::Symbols::TrueClass(), "&", CMethod{"sorbet_int_bool_and"}},
@@ -943,6 +945,8 @@ static const vector<CallCMethod> knownCMethodsInstance{
     {core::Symbols::Integer(), "<", CMethod{"sorbet_rb_int_lt"}},
     {core::Symbols::Integer(), ">=", CMethod{"sorbet_rb_int_ge"}},
     {core::Symbols::Integer(), "<=", CMethod{"sorbet_rb_int_le"}},
+    {core::Symbols::Integer(), "to_i", CMethod{"sorbet_returnRecv", core::Symbols::Integer()}},
+    {core::Symbols::Integer(), "to_int", CMethod{"sorbet_returnRecv", core::Symbols::Integer()}},
     {core::Symbols::Integer(), "to_s", CMethod{"sorbet_rb_int_to_s", core::Symbols::String()}},
     {core::Symbols::Integer(), "==", CMethod{"sorbet_rb_int_equal"}},
     {core::Symbols::Integer(), "!=", CMethod{"sorbet_rb_int_neq"}},
@@ -951,6 +955,7 @@ static const vector<CallCMethod> knownCMethodsInstance{
     {core::Symbols::String(), "+@", CMethod{"sorbet_int_str_uplus", core::Symbols::String()}},
     {core::Symbols::Symbol(), "==", CMethod{"sorbet_rb_sym_equal"}},
     {core::Symbols::Symbol(), "===", CMethod{"sorbet_rb_sym_equal"}},
+    {core::Symbols::Symbol(), "to_sym", CMethod{"sorbet_returnRecv"}},
 #include "WrappedIntrinsics.h"
 };
 

--- a/test/testdata/compiler/intrinsics/identities.rb
+++ b/test/testdata/compiler/intrinsics/identities.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+# run_filecheck: OPT
+
+module M
+  extend T::Sig
+
+  # OPT-LABEL: define internal i64 @func_M.12array_to_ary
+  # OPT-NOT: sorbet_callFuncWithCache
+  # OPT{LITERAL}: }
+  sig {params(x: T::Array[Integer]).returns(T::Array[Integer])}
+  def self.array_to_ary(x)
+    x.to_ary
+  end
+
+  # OPT-LABEL: define internal i64 @func_M.12hash_to_hash
+  # OPT-NOT: sorbet_callFuncWithCache
+  # OPT{LITERAL}: }
+  sig {params(x: T::Hash[T.untyped, T.untyped]).returns(T::Hash[T.untyped, T.untyped])}
+  def self.hash_to_hash(x)
+    x.to_hash
+  end
+
+  # OPT-LABEL: define internal i64 @func_M.12integer_to_i
+  # OPT-NOT: sorbet_callFuncWithCache
+  # OPT{LITERAL}: }
+  sig {params(x: Integer).returns(Integer)}
+  def self.integer_to_i(x)
+    x.to_i
+  end
+
+  # OPT-LABEL: define internal i64 @func_M.14integer_to_int
+  # OPT-NOT: sorbet_callFuncWithCache
+  # OPT{LITERAL}: }
+  sig {params(x: Integer).returns(Integer)}
+  def self.integer_to_int(x)
+    x.to_int
+  end
+
+  # OPT-LABEL: define internal i64 @func_M.13symbol_to_sym
+  # OPT-NOT: sorbet_callFuncWithCache
+  # OPT{LITERAL}: }
+  sig {params(x: Symbol).returns(Symbol)}
+  def self.symbol_to_sym(x)
+    x.to_sym
+  end
+end
+
+
+p M.array_to_ary([1,2,3])
+
+p M.hash_to_hash({x: 'hi', 10 => false})
+
+p M.integer_to_i(10)
+p M.integer_to_int(20)
+
+p M.symbol_to_sym(:foo)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
`to_ary`, `to_hash`, `to_i`, `to_int`, and `to_sym` all return their receiver when it's the target type. This PR adds intrinsics for them that return the receiver and adds the appropriate type annotation.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Performance.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
