### PR TITLE
Tempfile is not actually a File

### DIFF
--- a/rbi/core/io.rbi
+++ b/rbi/core/io.rbi
@@ -1886,8 +1886,8 @@ class IO < Object
   # doesn't move the current file offset.
   sig do
     params(
-        src: T.any(String, IO),
-        dst: T.any(String, IO),
+        src: T.any(String, IO, Tempfile),
+        dst: T.any(String, IO, Tempfile),
         copy_length: Integer,
         src_offset: Integer,
     )

--- a/rbi/stdlib/tempfile.rbi
+++ b/rbi/stdlib/tempfile.rbi
@@ -274,4 +274,21 @@ class Tempfile
   # [`delete`](https://docs.ruby-lang.org/en/2.7.0/Tempfile.html#method-i-delete)
   sig {returns(T::Boolean)}
   def unlink; end
+
+  sig do
+    params(
+        length: Integer,
+        outbuf: String,
+    )
+    .returns(String)
+  end
+  def read(length=T.unsafe(nil), outbuf=T.unsafe(nil)); end
+
+  sig do
+    params(
+        arg0: Object,
+    )
+    .returns(Integer)
+  end
+  def write(arg0); end
 end

--- a/rbi/stdlib/tempfile.rbi
+++ b/rbi/stdlib/tempfile.rbi
@@ -277,6 +277,15 @@ class Tempfile
 
   sig do
     params(
+        amount: Integer,
+        whence: Integer,
+    )
+    .returns(Integer)
+  end
+  def seek(amount, whence=T.unsafe(nil)); end
+
+  sig do
+    params(
         length: Integer,
         outbuf: String,
     )

--- a/rbi/stdlib/tempfile.rbi
+++ b/rbi/stdlib/tempfile.rbi
@@ -85,7 +85,7 @@
 # may not be entirely thread-safe. If you access the same
 # [`Tempfile`](https://docs.ruby-lang.org/en/2.7.0/Tempfile.html) object from
 # multiple threads then you should protect it with a mutex.
-class Tempfile < File
+class Tempfile
   extend T::Sig
 
   extend T::Generic


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is currently hiding bugs, because `my_tempfile.is_a?(File)` will return `false`, but Sorbet thinks it returns `true`.

I've ported over enough methods that used to be inherited from `IO` and `File` to get Stripe's codebase passing. As people find more, we can add them to `tempfile.rbi`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.