### PR TITLE
lldbinit.py: Widen llvmsourcemap to bazelsourcemap

### DIFF
--- a/lldbinit.py
+++ b/lldbinit.py
@@ -44,14 +44,14 @@ def __lldb_init_module(debugger, internal_dict):
     result = lldb.SBCommandReturnObject()
     ci = debugger.GetCommandInterpreter()
     ci.HandleCommand("command script add -f lldbinit.cmd_rubysourcemap rubysourcemap", result)
-    ci.HandleCommand("command script add -f lldbinit.cmd_llvmsourcemap llvmsourcemap", result)
+    ci.HandleCommand("command script add -f lldbinit.cmd_bazelsourcemap bazelsourcemap", result)
     ci.HandleCommand("command script add -f lldbinit.cmd_dump_ruby_stack rubystack", result)
 
     cyan="\x1b[0;36m"
     cnone="\x1b[0m"
 
     print("(lldb) Run %srubysourcemap%s to set up Ruby source maps" % (cyan, cnone))
-    print("(lldb) Run %sllvmsourcemap%s to set up LLVM source maps" % (cyan, cnone))
+    print("(lldb) Run %sbazelsourcemap%s to set up LLVM source maps" % (cyan, cnone))
     print("(lldb) Run %srubystack%s to dump the ruby stack" % (cyan, cnone))
 
 
@@ -63,18 +63,18 @@ def cmd_rubysourcemap(debugger, command, result, dict):
     dir_search = re.search('^File: (.*)/main.c', output)
     if dir_search:
         dirname = dir_search.group(1)
-        ruby_path = ('%s/bazel-sorbet/external/sorbet_ruby_2_7' % project_root)
+        ruby_path = ('%s/bazel-sorbet/bazel/sorbet_ruby_2_7' % project_root)
         source_map_command = 'settings set -- target.source-map %s %s' % (dirname, ruby_path)
         print('(lldb) %s' % source_map_command)
         ci.HandleCommand(source_map_command, result)
 
-def cmd_llvmsourcemap(debugger, command, result, dict):
+def cmd_bazelsourcemap(debugger, command, result, dict):
     ci = debugger.GetCommandInterpreter()
 
-    llvm_path = ('%s/bazel-sorbet/external/llvm' % project_root)
+    external_path = ('%s/bazel-sorbet/external' % project_root)
     # TODO(jez) This hardcodes /proc/self/cwd to get it to work on the buildbox.
     # We should probably do something like the `list main` trick for rubysourcemap to make this more portable.
-    source_map_command = 'settings set -- target.source-map /proc/self/cwd/external/llvm %s' % llvm_path
+    source_map_command = 'settings set -- target.source-map /proc/self/cwd/external %s' % external_path
     print('(lldb) %s' % source_map_command)
     ci.HandleCommand(source_map_command, result)
 


### PR DESCRIPTION
It works out of the box to point lldb at the sources for all things in
`external`, not just llvm (e.g. absl, spdlog, etc.)


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.