### PR TITLE
Do not hide package names in  ClassOrModuleRef::showFullName

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -933,23 +933,6 @@ string SymbolRef::showFullName(const GlobalState &gs) const {
 
 string ClassOrModuleRef::showFullName(const GlobalState &gs) const {
     auto sym = dataAllowingNone(gs);
-    if (sym->owner == core::Symbols::PackageRegistry()) {
-        // Pretty print package name (only happens when `--stripe-packages` is enabled)
-        if (sym->name.isPackagerName(gs)) {
-            auto nameStr = sym->name.shortName(gs);
-            if (sym->name.isPackagerPrivateName(gs)) {
-                // Foo_Bar_Package_Private => Foo::Bar
-                // Remove _Package_Private before de-munging
-                return absl::StrReplaceAll(nameStr.substr(0, nameStr.size() - core::PACKAGE_PRIVATE_SUFFIX.size()),
-                                           {{"_", "::"}});
-            } else {
-                // Foo_Bar_Package => Foo::Bar
-                // Remove _Package before de-munging
-                return absl::StrReplaceAll(nameStr.substr(0, nameStr.size() - core::PACKAGE_SUFFIX.size()),
-                                           {{"_", "::"}});
-            }
-        }
-    }
     return showFullNameInternal(gs, sym->owner, sym->name, COLON_SEPARATOR);
 }
 

--- a/test/testdata/packager/simple_package/pass.flatten-tree.exp
+++ b/test/testdata/packager/simple_package/pass.flatten-tree.exp
@@ -1,0 +1,426 @@
+begin
+  <emptyTree>
+  class <emptyTree><<C <root>>> < (::<todo sym>)
+    def self.<static-init><<static-init>$CENSORED>(<blk>)
+      begin
+        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Bar_Package_Private)
+        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Bar_Package_Private)
+        <emptyTree>
+      end
+    end
+  end
+  module ::<PackageRegistry>::Project_Bar_Package_Private<<C Project_Bar_Package_Private$1>> < ()
+    def self.<static-init>(<blk>)
+      begin
+        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::CallsFoo)
+        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::CallsFoo)
+        <emptyTree>
+      end
+    end
+  end
+  module ::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::CallsFoo<<C CallsFoo>> < ()
+    def self.build_foo(<blk>)
+      ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo.new(10)
+    end
+
+    def self.build_bar(<blk>)
+      ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::CallsBar.build_bar()
+    end
+
+    def self.<static-init>(<blk>)
+      begin
+        ::Sorbet::Private::Static::ResolvedSig.sig(<self>, true, :build_foo) do ||
+          <self>.returns(::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo)
+        end
+        ::Sorbet::Private::Static::ResolvedSig.sig(<self>, true, :build_bar) do ||
+          <self>.returns(::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar)
+        end
+        <self>.extend(::T::Sig)
+        ::Sorbet::Private::Static.keep_self_def(<self>, :build_foo, :normal)
+        ::Sorbet::Private::Static.keep_self_def(<self>, :build_bar, :normal)
+        <emptyTree>
+      end
+    end
+  end
+  <emptyTree>
+end
+begin
+  <emptyTree>
+  class <emptyTree><<C <root>>> < (::<todo sym>)
+    def self.<static-init><<static-init>$CENSORED>(<blk>)
+      begin
+        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Foo_Package_Private)
+        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Foo_Package_Private)
+        <emptyTree>
+      end
+    end
+  end
+  module ::<PackageRegistry>::Project_Foo_Package_Private<<C Project_Foo_Package_Private$1>> < ()
+    def self.<static-init>(<blk>)
+      begin
+        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::CallsBar)
+        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::CallsBar)
+        <emptyTree>
+      end
+    end
+  end
+  module ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::CallsBar<<C CallsBar>> < ()
+    def self.build_bar(<blk>)
+      ::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar.new(10)
+    end
+
+    def self.<static-init>(<blk>)
+      begin
+        ::Sorbet::Private::Static::ResolvedSig.sig(<self>, true, :build_bar) do ||
+          <self>.returns(::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar)
+        end
+        <self>.extend(::T::Sig)
+        ::Sorbet::Private::Static.keep_self_def(<self>, :build_bar, :normal)
+        <emptyTree>
+      end
+    end
+  end
+  <emptyTree>
+end
+begin
+  <emptyTree>
+  class <emptyTree><<C <root>>> < (::<todo sym>)
+    def self.<static-init><<static-init>$CENSORED>(<blk>)
+      begin
+        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Bar_Package_Private)
+        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Bar_Package_Private)
+        <emptyTree>
+      end
+    end
+  end
+  module ::<PackageRegistry>::Project_Bar_Package_Private<<C Project_Bar_Package_Private$1>> < ()
+    def self.<static-init>(<blk>)
+      begin
+        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar)
+        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar)
+        <emptyTree>
+      end
+    end
+  end
+  class ::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar<<C Bar>> < (::<todo sym>)
+    def initialize(value, <blk>)
+      @value = begin
+        ::Sorbet::Private::Static.keep_for_typechecking(::Integer)
+        T.let(value, Integer)
+      end
+    end
+
+    def self.<static-init>(<blk>)
+      begin
+        ::Sorbet::Private::Static::ResolvedSig.sig(<self>, false, :initialize) do ||
+          <self>.params(:value, ::Integer).void()
+        end
+        <self>.extend(::T::Sig)
+        ::Sorbet::Private::Static.keep_def(<self>, :initialize, :normal)
+        <emptyTree>
+      end
+    end
+  end
+  <emptyTree>
+end
+begin
+  <emptyTree>
+  class <emptyTree><<C <root>>> < (::<todo sym>)
+    def self.<static-init><<static-init>$CENSORED>(<blk>)
+      begin
+        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Foo_Package_Private)
+        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Foo_Package_Private)
+        <emptyTree>
+      end
+    end
+  end
+  module ::<PackageRegistry>::Project_Foo_Package_Private<<C Project_Foo_Package_Private$1>> < ()
+    def self.<static-init>(<blk>)
+      begin
+        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo)
+        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo)
+        <emptyTree>
+      end
+    end
+  end
+  class ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo<<C Foo>> < (::<todo sym>)
+    def initialize(value, <blk>)
+      @value = begin
+        ::Sorbet::Private::Static.keep_for_typechecking(::Integer)
+        T.let(value, Integer)
+      end
+    end
+
+    def self.<static-init>(<blk>)
+      begin
+        ::Sorbet::Private::Static::ResolvedSig.sig(<self>, false, :initialize) do ||
+          <self>.params(:value, ::Integer).void()
+        end
+        <self>.extend(::T::Sig)
+        ::Sorbet::Private::Static.keep_def(<self>, :initialize, :normal)
+        <emptyTree>
+      end
+    end
+  end
+  <emptyTree>
+end
+begin
+  <emptyTree>
+  class <emptyTree><<C <root>>> < (::<todo sym>)
+    def self.<static-init><<static-init>$CENSORED>(<blk>)
+      begin
+        begin
+          ::<Magic>.<define-top-class-or-module>(::Project::Bar)
+          ::Sorbet::Private::Static.keep_for_ide(::Project::Bar)
+          ::Sorbet::Private::Static.keep_for_ide(::PackageSpec)
+          <emptyTree>
+        end
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>)
+          <emptyTree>
+        end
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageTests>)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>)
+          <emptyTree>
+        end
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>)
+          <emptyTree>
+        end
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageTests>)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>)
+          <emptyTree>
+        end
+        <emptyTree>
+      end
+    end
+  end
+  class ::Project::Bar<<C Bar>> < (::PackageSpec)
+    def self.<static-init>(<blk>)
+      begin
+        <self>.import(::Project::Foo)
+        <self>.export(::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar)
+        <self>.export(::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::CallsFoo)
+        <emptyTree>
+      end
+    end
+  end
+  module ::<PackageRegistry><<C <PackageRegistry>>> < ()
+    def self.<static-init>(<blk>)
+      begin
+        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Bar_Package_Private::Project)
+        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Bar_Package_Private::Project)
+        <emptyTree>
+      end
+    end
+  end
+  module ::<PackageRegistry>::Project_Bar_Package_Private::Project<<C Project>> < ()
+    def self.<static-init>(<blk>)
+      ::<PackageRegistry>::Project_Bar_Package_Private::Project::Foo = ::<PackageRegistry>::Project_Foo_Package::Project::Foo
+    end
+  end
+  module ::<PackageTests><<C <PackageTests>>> < ()
+    def self.<static-init>(<blk>)
+      begin
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageTests>::Project_Bar_Package_Private::Project::Bar)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>::Project_Bar_Package_Private::Project::Bar)
+          <emptyTree>
+        end
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageTests>::Project_Bar_Package_Private::Project::Bar)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>::Project_Bar_Package_Private::Project::Bar)
+          <emptyTree>
+        end
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageTests>::Project_Bar_Package_Private::Project)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>::Project_Bar_Package_Private::Project)
+          <emptyTree>
+        end
+        <emptyTree>
+      end
+    end
+  end
+  module ::<PackageTests>::Project_Bar_Package_Private::Project::Bar<<C Bar>> < ()
+    def self.<static-init>(<blk>)
+      ::<PackageTests>::Project_Bar_Package_Private::Project::Bar::Bar = ::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar
+    end
+  end
+  module ::<PackageTests>::Project_Bar_Package_Private::Project::Bar<<C Bar>> < ()
+    def self.<static-init>(<blk>)
+      ::<PackageTests>::Project_Bar_Package_Private::Project::Bar::CallsFoo = ::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::CallsFoo
+    end
+  end
+  module ::<PackageTests>::Project_Bar_Package_Private::Project<<C Project>> < ()
+    def self.<static-init>(<blk>)
+      ::<PackageTests>::Project_Bar_Package_Private::Project::Foo = ::<PackageRegistry>::Project_Foo_Package::Project::Foo
+    end
+  end
+  module ::<PackageRegistry><<C <PackageRegistry>>> < ()
+    def self.<static-init>(<blk>)
+      begin
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Bar_Package::Project::Bar)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Bar_Package::Project::Bar)
+          <emptyTree>
+        end
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Bar_Package::Project::Bar)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Bar_Package::Project::Bar)
+          <emptyTree>
+        end
+        <emptyTree>
+      end
+    end
+  end
+  module ::<PackageRegistry>::Project_Bar_Package::Project::Bar<<C Bar>> < ()
+    def self.<static-init>(<blk>)
+      ::<PackageRegistry>::Project_Bar_Package::Project::Bar::Bar = ::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar
+    end
+  end
+  module ::<PackageRegistry>::Project_Bar_Package::Project::Bar<<C Bar>> < ()
+    def self.<static-init>(<blk>)
+      ::<PackageRegistry>::Project_Bar_Package::Project::Bar::CallsFoo = ::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::CallsFoo
+    end
+  end
+  module ::<PackageTests><<C <PackageTests>>> < ()
+    def self.<static-init>(<blk>)
+      <emptyTree>
+    end
+  end
+  <emptyTree>
+end
+begin
+  <emptyTree>
+  class <emptyTree><<C <root>>> < (::<todo sym>)
+    def self.<static-init><<static-init>$CENSORED>(<blk>)
+      begin
+        begin
+          ::<Magic>.<define-top-class-or-module>(::Project::Foo)
+          ::Sorbet::Private::Static.keep_for_ide(::Project::Foo)
+          ::Sorbet::Private::Static.keep_for_ide(::PackageSpec)
+          <emptyTree>
+        end
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>)
+          <emptyTree>
+        end
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageTests>)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>)
+          <emptyTree>
+        end
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>)
+          <emptyTree>
+        end
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageTests>)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>)
+          <emptyTree>
+        end
+        <emptyTree>
+      end
+    end
+  end
+  class ::Project::Foo<<C Foo>> < (::PackageSpec)
+    def self.<static-init>(<blk>)
+      begin
+        <self>.import(::Project::Bar)
+        <self>.export(::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo)
+        <self>.export(::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::CallsBar)
+        <emptyTree>
+      end
+    end
+  end
+  module ::<PackageRegistry><<C <PackageRegistry>>> < ()
+    def self.<static-init>(<blk>)
+      begin
+        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Foo_Package_Private::Project)
+        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Foo_Package_Private::Project)
+        <emptyTree>
+      end
+    end
+  end
+  module ::<PackageRegistry>::Project_Foo_Package_Private::Project<<C Project>> < ()
+    def self.<static-init>(<blk>)
+      ::<PackageRegistry>::Project_Foo_Package_Private::Project::Bar = ::<PackageRegistry>::Project_Bar_Package::Project::Bar
+    end
+  end
+  module ::<PackageTests><<C <PackageTests>>> < ()
+    def self.<static-init>(<blk>)
+      begin
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageTests>::Project_Foo_Package_Private::Project)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>::Project_Foo_Package_Private::Project)
+          <emptyTree>
+        end
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageTests>::Project_Foo_Package_Private::Project::Foo)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>::Project_Foo_Package_Private::Project::Foo)
+          <emptyTree>
+        end
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageTests>::Project_Foo_Package_Private::Project::Foo)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>::Project_Foo_Package_Private::Project::Foo)
+          <emptyTree>
+        end
+        <emptyTree>
+      end
+    end
+  end
+  module ::<PackageTests>::Project_Foo_Package_Private::Project<<C Project>> < ()
+    def self.<static-init>(<blk>)
+      ::<PackageTests>::Project_Foo_Package_Private::Project::Bar = ::<PackageRegistry>::Project_Bar_Package::Project::Bar
+    end
+  end
+  module ::<PackageTests>::Project_Foo_Package_Private::Project::Foo<<C Foo>> < ()
+    def self.<static-init>(<blk>)
+      ::<PackageTests>::Project_Foo_Package_Private::Project::Foo::CallsBar = ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::CallsBar
+    end
+  end
+  module ::<PackageTests>::Project_Foo_Package_Private::Project::Foo<<C Foo>> < ()
+    def self.<static-init>(<blk>)
+      ::<PackageTests>::Project_Foo_Package_Private::Project::Foo::Foo = ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo
+    end
+  end
+  module ::<PackageRegistry><<C <PackageRegistry>>> < ()
+    def self.<static-init>(<blk>)
+      begin
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Foo_Package::Project::Foo)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Foo_Package::Project::Foo)
+          <emptyTree>
+        end
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Foo_Package::Project::Foo)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Foo_Package::Project::Foo)
+          <emptyTree>
+        end
+        <emptyTree>
+      end
+    end
+  end
+  module ::<PackageRegistry>::Project_Foo_Package::Project::Foo<<C Foo>> < ()
+    def self.<static-init>(<blk>)
+      ::<PackageRegistry>::Project_Foo_Package::Project::Foo::CallsBar = ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::CallsBar
+    end
+  end
+  module ::<PackageRegistry>::Project_Foo_Package::Project::Foo<<C Foo>> < ()
+    def self.<static-init>(<blk>)
+      ::<PackageRegistry>::Project_Foo_Package::Project::Foo::Foo = ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo
+    end
+  end
+  module ::<PackageTests><<C <PackageTests>>> < ()
+    def self.<static-init>(<blk>)
+      <emptyTree>
+    end
+  end
+  <emptyTree>
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Remove special handling for package related modules in `showFullName`.  This code is also in `show`, but that should stay because it is in user-visible errors.


### Motivation
Easier debugging of symbols when viewing `ast-raw` and similar.
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See existing automated tests.
