### PR TITLE
ClassOrModuleRef::showKind don't crash if module/class not set

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1048,7 +1048,10 @@ string_view SymbolRef::showKind(const GlobalState &gs) const {
 }
 
 string_view ClassOrModuleRef::showKind(const GlobalState &gs) const {
-    if (dataAllowingNone(gs)->isClassOrModuleClass()) {
+    auto sym = dataAllowingNone(gs);
+    if (!sym->isClassModuleSet()) {
+        return "class-or-module"sv;
+    } else if (sym->isClassOrModuleClass()) {
         return "class"sv;
     } else {
         return "module"sv;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
```
sorbet -e 'module Foo::Bar;  end' -p name-tree-raw
Exception::raise(): Should never happen

Backtrace:
  #3 0x27de07b sorbet::ast::ExpressionPtr::showRaw()
  #4 0x27df16a sorbet::ast::ExpressionPtr::showRaw()
  #5 0x27e4e34 sorbet::ast::ConstantLit::showRaw()
  #6 0x27de07b sorbet::ast::ExpressionPtr::showRaw()
  #7 0x27e0997 sorbet::ast::ClassDef::showRaw()
  #8 0x27ddbc4 sorbet::ast::ExpressionPtr::showRaw()
  #9 0x27e5b2e sorbet::ast::InsSeq::showRaw()
  #10 0x27dea48 sorbet::ast::ExpressionPtr::showRaw()
  #11 0x27e0ead sorbet::ast::ClassDef::showRaw()
  #12 0x27ddbc4 sorbet::ast::ExpressionPtr::showRaw()
  #13 0x27e5b2e sorbet::ast::InsSeq::showRaw()
  #14 0x27dea48 sorbet::ast::ExpressionPtr::showRaw()
  #15 0x23e54a7 sorbet::realmain::pipeline::resolve()
  #16 0x22ac036 sorbet::realmain::realmain()
  #17 0x22a883f main
  #18 0x7fe19e1dd0b3 __libc_start_main
  #19 0xe642be _start

Segmentation fault (core dumped)
```
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->
```
./bazel-bin/main/sorbet -e 'module Foo::Bar;  end' -p name-tree-raw
InsSeq{
  stats = [
    ClassDef{
      kind = class
      name = EmptyTree<<C <U <root>>>>
      ancestors = [ConstantLit{
          symbol = (class ::<todo sym>)
          orig = nullptr
        }]
      rhs = [
        InsSeq{
          stats = [
            ClassDef{
              kind = module
              name = ConstantLit{
                symbol = (module ::Foo::Bar)
                orig = UnresolvedConstantLit{
                  cnst = <C <U Bar>>
                  scope = ConstantLit{
                    symbol = (class-or-module ::Foo)
                    orig = UnresolvedConstantLit{
                      cnst = <C <U Foo>>
                      scope = EmptyTree
                    }
                  }
                }
              }<<C <U Bar>>>
              ancestors = []
              rhs = [
              ]
            }
            Send{
              recv = ConstantLit{
                symbol = (module ::Sorbet::Private::Static)
                orig = nullptr
              }
              fun = <U keep_for_ide>
              block = nullptr
              pos_args = 1
              args = [
                ConstantLit{
                  symbol = (module ::Foo::Bar)
                  orig = UnresolvedConstantLit{
                    cnst = <C <U Bar>>
                    scope = ConstantLit{
                      symbol = (class-or-module ::Foo)
                      orig = UnresolvedConstantLit{
                        cnst = <C <U Foo>>
                        scope = EmptyTree
                      }
                    }
                  }
                }
              ]
            }
          ],
          expr = EmptyTree
        }
      ]
    }
  ],
  expr = EmptyTree
}
No errors! Great job.
```