### PR TITLE
Use --spawn_strategy=local to avoid sandbox overhead in ci

### DIFF
--- a/.buildkite/test-compiler.sh
+++ b/.buildkite/test-compiler.sh
@@ -40,6 +40,7 @@ mkdir -p _out_
   -c opt \
   --config=forcedebug \
   --test_summary=terse \
+  --spawn_strategy=local \
   --test_output=errors || err=$?
 
 echo "--- uploading test results"


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Builds have gotten much slower, and it looks like sandbox overhead is to blame. This change pretty aggressively reduced tests times in a test, getting a complete compiler test run in less than 10 minutes.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Faster compiler builds.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
