### PR TITLE
Remove showRaw from membersStableOrderSlow

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -2027,6 +2027,24 @@ vector<std::pair<NameRef, SymbolRef>> Symbol::membersStableOrderSlow(const Globa
         if (compareRaw != 0) {
             return compareRaw < 0;
         }
+        int i = -1;
+        const auto &rhsLocs = rhs.second.data(gs)->locs();
+        for (const auto lhsLoc : lhs.second.data(gs)->locs()) {
+            i++;
+            if (i > rhsLocs.size()) {
+                // more locs in lhs, so `lhs < rhs` is `false`
+                return false;
+            }
+            auto rhsLoc = rhsLocs[i];
+            auto compareLoc = lhsLoc.filePosToString(gs).compare(rhsLoc.filePosToString(gs));
+            if (compareLoc != 0) {
+                return compareLoc < 0;
+            }
+        }
+        if (i < rhsLocs.size()) {
+            // more locs in rhs, so `lhs < rhs` is true
+            return true;
+        }
         ENFORCE(false, "no stable sort");
         return 0;
     });

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -2027,12 +2027,6 @@ vector<std::pair<NameRef, SymbolRef>> Symbol::membersStableOrderSlow(const Globa
         if (compareRaw != 0) {
             return compareRaw < 0;
         }
-        auto lhsSym = lhs.second.showRaw(gs);
-        auto rhsSym = rhs.second.showRaw(gs);
-        auto compareSym = lhsSym.compare(rhsSym);
-        if (compareSym != 0) {
-            return compareSym < 0;
-        }
         ENFORCE(false, "no stable sort");
         return 0;
     });


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This revives #3536, fixing the bug that I was too lazy to debug last time.

It should substantially speed up operations that need to use
`membersStableOrderSlow`, which includes LSP requests like document symbol and
completion, as well as tasks that dump Sorbet's symbol table (in any plain text
or binary format).

On the step in Stripe's codebase that uses Sorbet to generate missing method RBIs, this drops the time spent computing `symbol-table-full-messagepack` from 127.9s to 73.2.s (savings of 54.7s)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.

I confirmed that missing_methods.rb still works on Stripe's codebase.