### PR TITLE
Add intrinsic for Array#uniq

### DIFF
--- a/compiler/IREmitter/Payload/codegen-payload.c
+++ b/compiler/IREmitter/Payload/codegen-payload.c
@@ -1307,8 +1307,7 @@ VALUE sorbet_rb_array_uniq_withBlock(VALUE recv, ID fun, int argc, const VALUE *
     if (RARRAY_LEN(ary) <= 1) {
         hash = 0;
         uniq = rb_ary_dup(ary);
-    }
-    else {
+    } else {
         // inline of ary_tmp_hash_new
         long size = RARRAY_LEN(ary);
         hash = rb_hash_new_with_size(size);

--- a/compiler/IREmitter/Payload/codegen-payload.c
+++ b/compiler/IREmitter/Payload/codegen-payload.c
@@ -113,6 +113,8 @@ SORBET_ALIVE(VALUE, sorbet_stringInterpolate,
 SORBET_ALIVE(VALUE, sorbet_rb_array_square_br_slowpath,
              (VALUE recv, ID fun, int argc, const VALUE *const restrict argv, BlockFFIType blk, VALUE closure));
 SORBET_ALIVE(VALUE, rb_ary_compact_bang_forwarder, (VALUE recv));
+SORBET_ALIVE(VALUE, sorbet_ary_make_hash, (VALUE ary));
+SORBET_ALIVE(void, sorbet_ary_recycle_hash, (VALUE hash));
 
 SORBET_ALIVE(void, sorbet_hashUpdate, (VALUE hash, VALUE other));
 
@@ -160,6 +162,8 @@ SORBET_ALIVE(void, sorbet_vm_define_method,
              (VALUE klass, const char *name, rb_sorbet_func_t methodPtr, void *paramp, rb_iseq_t *iseq, bool isSelf));
 SORBET_ALIVE(void, sorbet_vm_define_prop_getter,
              (VALUE klass, const char *name, rb_sorbet_func_t methodPtr, void *paramp, rb_iseq_t *iseq));
+
+SORBET_ALIVE(void, sorbet_rbasic_set_class, (VALUE obj, VALUE klass));
 
 SORBET_ALIVE(VALUE, sorbet_maybeAllocateObjectFastPath, (VALUE recv, struct FunctionInlineCache *newCache));
 SORBET_ALIVE(VALUE, sorbet_vm_instance_variable_get,
@@ -1286,6 +1290,80 @@ VALUE sorbet_rb_array_empty(VALUE recv, ID fun, int argc, const VALUE *const res
         return Qtrue;
     }
     return Qfalse;
+}
+
+// This is the no-block version of rb_ary_uniq: https://github.com/ruby/ruby/blob/ruby_2_7/array.c#L5018-L5041
+SORBET_INLINE
+VALUE sorbet_rb_array_uniq(VALUE recv, ID fun, int argc, const VALUE *const restrict argv, BlockFFIType blk,
+                           VALUE closure) {
+    rb_check_arity(argc, 0, 0);
+    VALUE ary = recv;
+
+    VALUE hash, uniq;
+
+    if (RARRAY_LEN(ary) <= 1) {
+        hash = 0;
+        uniq = rb_ary_dup(ary);
+    }
+    else {
+        hash = sorbet_ary_make_hash(ary);
+        uniq = rb_hash_values(hash);
+    }
+    sorbet_rbasic_set_class(uniq, rb_obj_class(ary));
+    if (hash) {
+        sorbet_ary_recycle_hash(hash);
+    }
+
+    return uniq;
+}
+
+// This is the block version of rb_ary_uniq: https://github.com/ruby/ruby/blob/ruby_2_7/array.c#L5018-L5041
+SORBET_INLINE
+VALUE sorbet_rb_array_uniq_withBlock(VALUE recv, ID fun, int argc, const VALUE *const restrict argv, BlockFFIType blk,
+                                     const struct rb_captured_block *captured, VALUE closure, int numPositionalArgs) {
+    rb_check_arity(argc, 0, 0);
+    VALUE ary = recv;
+
+    // must push a frame for the captured block
+    sorbet_pushBlockFrame(captured);
+
+    VALUE hash, uniq;
+
+    if (RARRAY_LEN(ary) <= 1) {
+        hash = 0;
+        uniq = rb_ary_dup(ary);
+    }
+    else {
+        // inline of ary_tmp_hash_new
+        long size = RARRAY_LEN(ary);
+        hash = rb_hash_new_with_size(size);
+
+        RBASIC_CLEAR_CLASS(hash);
+
+        // inline of ary_make_hash_by
+        for (int i = 0; i < RARRAY_LEN(ary); ++i) {
+            // inline of rb_ary_elt
+            VALUE v;
+            long len = RARRAY_LEN(ary);
+            if (len == 0) v = Qnil;
+            else if (i < 0 || len <= i) {
+                v = Qnil;
+            }
+            else v = RARRAY_AREF(ary, i);
+    
+            VALUE k = blk(v, closure, 1, &v, Qnil);
+            rb_hash_add_new_element(hash, k, v);
+        }
+        uniq = rb_hash_values(hash);
+    }
+    sorbet_rbasic_set_class(uniq, rb_obj_class(ary));
+    if (hash) {
+        sorbet_ary_recycle_hash(hash);
+    }
+
+    sorbet_popFrame();
+
+    return uniq;
 }
 
 SORBET_INLINE

--- a/compiler/IREmitter/Payload/codegen-payload.c
+++ b/compiler/IREmitter/Payload/codegen-payload.c
@@ -165,8 +165,6 @@ SORBET_ALIVE(void, sorbet_vm_define_method,
 SORBET_ALIVE(void, sorbet_vm_define_prop_getter,
              (VALUE klass, const char *name, rb_sorbet_func_t methodPtr, void *paramp, rb_iseq_t *iseq));
 
-SORBET_ALIVE(void, sorbet_rbasic_set_class, (VALUE obj, VALUE klass));
-
 SORBET_ALIVE(VALUE, sorbet_maybeAllocateObjectFastPath, (VALUE recv, struct FunctionInlineCache *newCache));
 SORBET_ALIVE(VALUE, sorbet_vm_instance_variable_get,
              (struct FunctionInlineCache * getCache, struct iseq_inline_iv_cache_entry *varCache,
@@ -1327,7 +1325,7 @@ VALUE sorbet_rb_array_uniq_withBlock(VALUE recv, ID fun, int argc, const VALUE *
         }
         uniq = rb_hash_values(hash);
     }
-    sorbet_rbasic_set_class(uniq, rb_obj_class(ary));
+    RBASIC_SET_CLASS(uniq, rb_obj_class(ary));
     if (hash) {
         sorbet_ary_recycle_hash(hash);
     }

--- a/compiler/IREmitter/Payload/codegen-payload.c
+++ b/compiler/IREmitter/Payload/codegen-payload.c
@@ -1345,11 +1345,15 @@ VALUE sorbet_rb_array_uniq_withBlock(VALUE recv, ID fun, int argc, const VALUE *
             // inline of rb_ary_elt
             VALUE v;
             long len = RARRAY_LEN(ary);
-            if (len == 0) v = Qnil;
+            if (len == 0) {
+                v = Qnil;
+            }
             else if (i < 0 || len <= i) {
                 v = Qnil;
             }
-            else v = RARRAY_AREF(ary, i);
+            else {
+                v = RARRAY_AREF(ary, i);
+            }
     
             VALUE k = blk(v, closure, 1, &v, Qnil);
             rb_hash_add_new_element(hash, k, v);

--- a/compiler/IREmitter/Payload/codegen-payload.c
+++ b/compiler/IREmitter/Payload/codegen-payload.c
@@ -1296,7 +1296,7 @@ VALUE sorbet_rb_array_empty(VALUE recv, ID fun, int argc, const VALUE *const res
 SORBET_INLINE
 VALUE sorbet_rb_array_uniq(VALUE recv, ID fun, int argc, const VALUE *const restrict argv, BlockFFIType blk,
                            VALUE closure) {
-    rb_check_arity(argc, 0, 0);
+    sorbet_ensure_arity(argc, 0);
     VALUE ary = recv;
 
     VALUE hash, uniq;
@@ -1321,7 +1321,7 @@ VALUE sorbet_rb_array_uniq(VALUE recv, ID fun, int argc, const VALUE *const rest
 SORBET_INLINE
 VALUE sorbet_rb_array_uniq_withBlock(VALUE recv, ID fun, int argc, const VALUE *const restrict argv, BlockFFIType blk,
                                      const struct rb_captured_block *captured, VALUE closure, int numPositionalArgs) {
-    rb_check_arity(argc, 0, 0);
+    sorbet_ensure_arity(argc, 0);
     VALUE ary = recv;
 
     // must push a frame for the captured block

--- a/compiler/IREmitter/Payload/patches/array.c
+++ b/compiler/IREmitter/Payload/patches/array.c
@@ -36,8 +36,7 @@ VALUE sorbet_rb_array_uniq(VALUE recv, ID fun, int argc, const VALUE *const rest
     if (RARRAY_LEN(ary) <= 1) {
         hash = 0;
         uniq = rb_ary_dup(ary);
-    }
-    else {
+    } else {
         hash = ary_make_hash(ary);
         uniq = rb_hash_values(hash);
     }

--- a/compiler/IREmitter/Payload/patches/array.c
+++ b/compiler/IREmitter/Payload/patches/array.c
@@ -16,3 +16,11 @@ VALUE sorbet_rb_array_square_br_slowpath(VALUE recv, ID fun, int argc, const VAL
 VALUE rb_ary_compact_bang_forwarder(VALUE ary) {
     return rb_ary_compact_bang(ary);
 }
+
+VALUE sorbet_ary_make_hash(VALUE ary) {
+    return ary_make_hash(ary);
+}
+
+void sorbet_ary_recycle_hash(VALUE hash) {
+    ary_recycle_hash(hash);
+}

--- a/compiler/IREmitter/Payload/patches/array.c
+++ b/compiler/IREmitter/Payload/patches/array.c
@@ -24,3 +24,27 @@ VALUE sorbet_ary_make_hash(VALUE ary) {
 void sorbet_ary_recycle_hash(VALUE hash) {
     ary_recycle_hash(hash);
 }
+
+// This is the no-block version of rb_ary_uniq: https://github.com/ruby/ruby/blob/ruby_2_7/array.c#L5018-L5041
+VALUE sorbet_rb_array_uniq(VALUE recv, ID fun, int argc, const VALUE *const restrict argv, BlockFFIType blk,
+                           VALUE closure) {
+    rb_check_arity(argc, 0, 0);
+    VALUE ary = recv;
+
+    VALUE hash, uniq;
+
+    if (RARRAY_LEN(ary) <= 1) {
+        hash = 0;
+        uniq = rb_ary_dup(ary);
+    }
+    else {
+        hash = ary_make_hash(ary);
+        uniq = rb_hash_values(hash);
+    }
+    RBASIC_SET_CLASS(uniq, rb_obj_class(ary));
+    if (hash) {
+        ary_recycle_hash(hash);
+    }
+
+    return uniq;
+}

--- a/compiler/IREmitter/Payload/patches/object.c
+++ b/compiler/IREmitter/Payload/patches/object.c
@@ -126,3 +126,7 @@ VALUE (*sorbet_vm_Kernel_instance_variable_get_func(void))(VALUE obj, VALUE iv) 
 VALUE (*sorbet_vm_Kernel_instance_variable_set_func(void))(VALUE obj, VALUE iv, VALUE value) {
     return rb_obj_ivar_set;
 }
+
+void sorbet_rbasic_set_class(VALUE obj, VALUE klass) {
+    RBASIC_SET_CLASS(obj, klass);
+}

--- a/compiler/IREmitter/Payload/patches/object.c
+++ b/compiler/IREmitter/Payload/patches/object.c
@@ -126,7 +126,3 @@ VALUE (*sorbet_vm_Kernel_instance_variable_get_func(void))(VALUE obj, VALUE iv) 
 VALUE (*sorbet_vm_Kernel_instance_variable_set_func(void))(VALUE obj, VALUE iv, VALUE value) {
     return rb_obj_ivar_set;
 }
-
-void sorbet_rbasic_set_class(VALUE obj, VALUE klass) {
-    RBASIC_SET_CLASS(obj, klass);
-}

--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -921,6 +921,8 @@ static const vector<CallCMethod> knownCMethodsInstance{
     {core::Symbols::Array(), "to_h", CMethod{"sorbet_rb_array_to_h", core::Symbols::Hash()}},
     {core::Symbols::Array(), "size", CMethod{"sorbet_rb_array_len", core::Symbols::Integer()}},
     {core::Symbols::Array(), "length", CMethod{"sorbet_rb_array_len", core::Symbols::Integer()}},
+    {core::Symbols::Array(), "uniq", CMethod("sorbet_rb_array_uniq", core::Symbols::Array()),
+     CMethod("sorbet_rb_array_uniq_withBlock", core::Symbols::Array())},
     {core::Symbols::Hash(), "[]", CMethod{"sorbet_rb_hash_square_br"}},
     {core::Symbols::Hash(), "[]=", CMethod{"sorbet_rb_hash_square_br_eq"}},
     {core::Symbols::Hash(), "each_pair", CMethod{"sorbet_rb_hash_each_pair", core::Symbols::Enumerator()},

--- a/test/testdata/compiler/intrinsics/array_uniq.rb
+++ b/test/testdata/compiler/intrinsics/array_uniq.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+# run_filecheck: INITIAL
+
+def no_block
+  p ["yo","yo","yah","ah","oh","yo","yah","oh","oh","eh"].uniq
+  p [1, 2, 3, 2, 3, 4, 1, 1, 5, 8, 6].uniq
+end
+
+# INITIAL-LABEL: define internal i64 @"func_Object#8no_block"
+# INITIAL: call i64 @sorbet_rb_array_uniq(
+# INITIAL: call i64 @sorbet_rb_array_uniq(
+# INITIAL{LITERAL}: }
+
+no_block
+
+def with_block
+  p ["yo","yo","yah","ah","oh","yo","yah","oh","oh","eh"].uniq { |x| x.reverse }
+  p ["yo","yo","yah","ah","oh","yo","yah","oh","oh","eh"].uniq { |x| x.length }
+  p [1, 2, 3, 2, 3, 4, 1, 1, 5, 8, 6].uniq { |x| x%2 }
+  p [1, 2, 3, 4].uniq { break "ope" }
+end
+
+# INITIAL-LABEL: define internal i64 @"func_Object#10with_block"
+# INITIAL: call i64 @sorbet_callIntrinsicInlineBlock_noBreak(i64 (i64)* @forward_sorbet_rb_array_uniq_withBlock
+# INITIAL: call i64 @sorbet_callIntrinsicInlineBlock_noBreak(i64 (i64)* @forward_sorbet_rb_array_uniq_withBlock
+# INITIAL: call i64 @sorbet_callIntrinsicInlineBlock_noBreak(i64 (i64)* @forward_sorbet_rb_array_uniq_withBlock
+# INITIAL: call i64 @sorbet_callIntrinsicInlineBlock(i64 (i64)* @forward_sorbet_rb_array_uniq_withBlock
+# INITIAL{LITERAL}: }
+
+with_block


### PR DESCRIPTION
This adds a compiler intrinsic for `Array#uniq`.

### Motivation
We're pushing on adding compiler intrinsics in general, and this one's on the list. :)


### Test plan
See included automated tests.
