### PR TITLE
Add intrinsic for Array#first

### DIFF
--- a/compiler/IREmitter/Intrinsics/intrinsic-report.md
+++ b/compiler/IREmitter/Intrinsics/intrinsic-report.md
@@ -14,7 +14,7 @@
 * [   ] `rb_ary_aset` (`Array#[]=`)
 * [✔  ] `rb_ary_at` (`Array#at`)
 * [   ] `rb_ary_fetch` (`Array#fetch`)
-* [   ] `rb_ary_first` (`Array#first`)
+* [  ✔] `rb_ary_first` (`Array#first`)
 * [✔  ] `rb_ary_last` (`Array#last`)
 * [   ] `rb_ary_concat_multi` (`Array#concat`)
 * [   ] `rb_ary_union_multi` (`Array#union`)
@@ -1564,4 +1564,4 @@
 
 ## Stats
 * Total:   1488
-* Visible: 237
+* Visible: 238

--- a/compiler/IREmitter/Intrinsics/wrap-intrinsics.rb
+++ b/compiler/IREmitter/Intrinsics/wrap-intrinsics.rb
@@ -225,6 +225,7 @@ module Intrinsics
       "Array#at",
       "Array#clear",
       "Array#delete",
+      "Array#first",
       "Array#include?",
       "Array#initialize_copy",
       "Array#join",

--- a/compiler/IREmitter/Payload/PayloadIntrinsics.c
+++ b/compiler/IREmitter/Payload/PayloadIntrinsics.c
@@ -92,6 +92,15 @@ VALUE sorbet_int_rb_ary_delete(VALUE recv, ID fun, int argc, VALUE *const restri
     return rb_ary_delete(recv, arg_0);
 }
 
+// Array#first
+// Calling convention: -1
+extern VALUE sorbet_rb_ary_first(int argc, const VALUE *args, VALUE obj);
+
+VALUE sorbet_int_rb_ary_first(VALUE recv, ID fun, int argc, VALUE *const restrict args, BlockFFIType blk,
+                              VALUE closure) {
+    return sorbet_rb_ary_first(argc, args, recv);
+}
+
 // Array#include?
 // Calling convention: 1
 extern VALUE rb_ary_includes(VALUE obj, VALUE arg_0);

--- a/compiler/IREmitter/WrappedIntrinsics.h
+++ b/compiler/IREmitter/WrappedIntrinsics.h
@@ -11,6 +11,7 @@
     {core::Symbols::Array(), "at", CMethod{"sorbet_int_rb_ary_at"}},
     {core::Symbols::Array(), "clear", CMethod{"sorbet_int_rb_ary_clear"}},
     {core::Symbols::Array(), "delete", CMethod{"sorbet_int_rb_ary_delete"}},
+    {core::Symbols::Array(), "first", CMethod{"sorbet_int_rb_ary_first"}},
     {core::Symbols::Array(), "include?", CMethod{"sorbet_int_rb_ary_includes"}},
     {core::Symbols::Array(), "initialize_copy", CMethod{"sorbet_int_rb_ary_replace"}},
     {core::Symbols::Array(), "replace", CMethod{"sorbet_int_rb_ary_replace"}},

--- a/compiler/ruby-static-exports/array.c
+++ b/compiler/ruby-static-exports/array.c
@@ -1,3 +1,7 @@
+VALUE sorbet_rb_ary_first(int argc, const VALUE *args, VALUE obj) {
+    return rb_ary_first(argc, args, obj);
+}
+
 VALUE sorbet_rb_ary_join_m(int argc, const VALUE *args, VALUE obj) {
     return rb_ary_join_m(argc, args, obj);
 }

--- a/test/testdata/compiler/intrinsics/array_first.rb
+++ b/test/testdata/compiler/intrinsics/array_first.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+# run_filecheck: INITIAL
+
+def test_array_first
+  p [].first
+  p [1, 2, 3].first
+  p [1, 2, 3].first(0)
+  p [1, 2, 3].first(1)
+  p [1, 2, 3].first(2)
+  p [1, 2, 3].first(3)
+  p [1, 2, 3].first(4)
+end
+
+test_array_first
+
+# INITIAL-LABEL: define internal i64 @"func_Object#16test_array_first"
+# INITIAL: call i64 @sorbet_int_rb_ary_first(
+# INITIAL: call i64 @sorbet_int_rb_ary_first(
+# INITIAL: call i64 @sorbet_int_rb_ary_first(
+# INITIAL: call i64 @sorbet_int_rb_ary_first(
+# INITIAL: call i64 @sorbet_int_rb_ary_first(
+# INITIAL: call i64 @sorbet_int_rb_ary_first(
+# INITIAL: call i64 @sorbet_int_rb_ary_first(
+# INITIAL{LITERAL}: }


### PR DESCRIPTION
Adds a compiler intrinsic for `Array#first`.


### Motivation
General push for more compiler intrinsics.


### Test plan
See included automated tests.
