### PR TITLE
Add intrinsic for Array#-

### DIFF
--- a/compiler/IREmitter/Intrinsics/intrinsic-report.md
+++ b/compiler/IREmitter/Intrinsics/intrinsic-report.md
@@ -70,7 +70,7 @@
 * [✔  ] `rb_ary_rassoc` (`Array#rassoc`)
 * [✔  ] `rb_ary_plus` (`Array#+`)
 * [   ] `rb_ary_times` (`Array#*`)
-* [   ] `rb_ary_diff` (`Array#-`)
+* [  ✔] `rb_ary_diff` (`Array#-`)
 * [   ] `rb_ary_and` (`Array#&`)
 * [   ] `rb_ary_or` (`Array#|`)
 * [   ] `rb_ary_max` (`Array#max`)
@@ -1564,4 +1564,4 @@
 
 ## Stats
 * Total:   1488
-* Visible: 237
+* Visible: 238

--- a/compiler/IREmitter/Intrinsics/wrap-intrinsics.rb
+++ b/compiler/IREmitter/Intrinsics/wrap-intrinsics.rb
@@ -218,6 +218,7 @@ module Intrinsics
 
     METHOD_WHITELIST = T.let(Set[
       "Array#+",
+      "Array#-",
       "Array#<<",
       "Array#<=>",
       "Array#[]",

--- a/compiler/IREmitter/Payload/PayloadIntrinsics.c
+++ b/compiler/IREmitter/Payload/PayloadIntrinsics.c
@@ -19,6 +19,17 @@ VALUE sorbet_int_rb_ary_plus(VALUE recv, ID fun, int argc, VALUE *const restrict
     return rb_ary_plus(recv, arg_0);
 }
 
+// Array#-
+// Calling convention: 1
+extern VALUE sorbet_rb_ary_diff(VALUE obj, VALUE arg_0);
+
+VALUE sorbet_int_rb_ary_diff(VALUE recv, ID fun, int argc, VALUE *const restrict args, BlockFFIType blk,
+                             VALUE closure) {
+    rb_check_arity(argc, 1, 1);
+    VALUE arg_0 = args[0];
+    return sorbet_rb_ary_diff(recv, arg_0);
+}
+
 // Array#<<
 // Calling convention: 1
 extern VALUE rb_ary_push(VALUE obj, VALUE arg_0);

--- a/compiler/IREmitter/WrappedIntrinsics.h
+++ b/compiler/IREmitter/WrappedIntrinsics.h
@@ -3,6 +3,7 @@
 
 // clang-format off
     {core::Symbols::Array(), "+", CMethod{"sorbet_int_rb_ary_plus"}},
+    {core::Symbols::Array(), "-", CMethod{"sorbet_int_rb_ary_diff"}},
     {core::Symbols::Array(), "<<", CMethod{"sorbet_int_rb_ary_push"}},
     {core::Symbols::Array(), "<=>", CMethod{"sorbet_int_rb_ary_cmp"}},
     {core::Symbols::Array(), "[]", CMethod{"sorbet_int_rb_ary_aref"}},

--- a/compiler/ruby-static-exports/array.c
+++ b/compiler/ruby-static-exports/array.c
@@ -1,3 +1,7 @@
 VALUE sorbet_rb_ary_join_m(int argc, const VALUE *args, VALUE obj) {
     return rb_ary_join_m(argc, args, obj);
 }
+
+VALUE sorbet_rb_ary_diff(VALUE obj, VALUE arg_0) {
+    return rb_ary_diff(obj, arg_0);
+}

--- a/test/testdata/compiler/intrinsics/array_diff.rb
+++ b/test/testdata/compiler/intrinsics/array_diff.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+# run_filecheck: INITIAL
+
+def test_array_diff
+  p ([] - [1,2,3])
+  p ([1,2,3] - [])
+  p ([1,2,3] - [1,2])
+  p ([1,2,3] - [2,2,3])
+  p ([1,2,3] - [1,2,3,4])
+  p ([1,"3",2,0] - [1,2,"3"])
+end
+
+test_array_diff
+
+# INITIAL-LABEL: define internal i64 @"func_Object#15test_array_diff"
+# INITIAL: call i64 @sorbet_int_rb_ary_diff(
+# INITIAL: call i64 @sorbet_int_rb_ary_diff(
+# INITIAL: call i64 @sorbet_int_rb_ary_diff(
+# INITIAL: call i64 @sorbet_int_rb_ary_diff(
+# INITIAL: call i64 @sorbet_int_rb_ary_diff(
+# INITIAL: call i64 @sorbet_int_rb_ary_diff(
+# INITIAL{LITERAL}: }


### PR DESCRIPTION
Adds a compiler intrinsic for `Array#-`.

### Motivation
General push for more compiler intrinsics.

### Test plan
See included automated tests.
