### PR TITLE
Add intrinsic for Array#concat

### DIFF
--- a/compiler/IREmitter/Intrinsics/intrinsic-report.md
+++ b/compiler/IREmitter/Intrinsics/intrinsic-report.md
@@ -16,7 +16,7 @@
 * [   ] `rb_ary_fetch` (`Array#fetch`)
 * [  ✔] `rb_ary_first` (`Array#first`)
 * [✔  ] `rb_ary_last` (`Array#last`)
-* [   ] `rb_ary_concat_multi` (`Array#concat`)
+* [  ✔] `rb_ary_concat_multi` (`Array#concat`)
 * [   ] `rb_ary_union_multi` (`Array#union`)
 * [   ] `rb_ary_difference_multi` (`Array#difference`)
 * [   ] `rb_ary_intersection_multi` (`Array#intersection`)
@@ -1564,4 +1564,4 @@
 
 ## Stats
 * Total:   1488
-* Visible: 238
+* Visible: 240

--- a/compiler/IREmitter/Intrinsics/wrap-intrinsics.rb
+++ b/compiler/IREmitter/Intrinsics/wrap-intrinsics.rb
@@ -225,6 +225,7 @@ module Intrinsics
       "Array#assoc",
       "Array#at",
       "Array#clear",
+      "Array#concat",
       "Array#delete",
       "Array#first",
       "Array#include?",

--- a/compiler/IREmitter/Payload/PayloadIntrinsics.c
+++ b/compiler/IREmitter/Payload/PayloadIntrinsics.c
@@ -92,6 +92,15 @@ VALUE sorbet_int_rb_ary_clear(VALUE recv, ID fun, int argc, VALUE *const restric
     return rb_ary_clear(recv);
 }
 
+// Array#concat
+// Calling convention: -1
+extern VALUE sorbet_rb_ary_concat_multi(int argc, const VALUE *args, VALUE obj);
+
+VALUE sorbet_int_rb_ary_concat_multi(VALUE recv, ID fun, int argc, VALUE *const restrict args, BlockFFIType blk,
+                                     VALUE closure) {
+    return sorbet_rb_ary_concat_multi(argc, args, recv);
+}
+
 // Array#delete
 // Calling convention: 1
 extern VALUE rb_ary_delete(VALUE obj, VALUE arg_0);

--- a/compiler/IREmitter/WrappedIntrinsics.h
+++ b/compiler/IREmitter/WrappedIntrinsics.h
@@ -11,6 +11,7 @@
     {core::Symbols::Array(), "assoc", CMethod{"sorbet_int_rb_ary_assoc"}},
     {core::Symbols::Array(), "at", CMethod{"sorbet_int_rb_ary_at"}},
     {core::Symbols::Array(), "clear", CMethod{"sorbet_int_rb_ary_clear"}},
+    {core::Symbols::Array(), "concat", CMethod{"sorbet_int_rb_ary_concat_multi"}},
     {core::Symbols::Array(), "delete", CMethod{"sorbet_int_rb_ary_delete"}},
     {core::Symbols::Array(), "first", CMethod{"sorbet_int_rb_ary_first"}},
     {core::Symbols::Array(), "include?", CMethod{"sorbet_int_rb_ary_includes"}},

--- a/compiler/ruby-static-exports/array.c
+++ b/compiler/ruby-static-exports/array.c
@@ -6,6 +6,10 @@ VALUE sorbet_rb_ary_join_m(int argc, const VALUE *args, VALUE obj) {
     return rb_ary_join_m(argc, args, obj);
 }
 
+VALUE sorbet_rb_ary_concat_multi(int argc, const VALUE *args, VALUE obj) {
+    return rb_ary_concat_multi(argc, args, obj);
+}
+
 VALUE sorbet_rb_ary_diff(VALUE obj, VALUE arg_0) {
     return rb_ary_diff(obj, arg_0);
 }

--- a/test/testdata/compiler/intrinsics/array_concat.rb
+++ b/test/testdata/compiler/intrinsics/array_concat.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+# run_filecheck: INITIAL
+
+def test_array_concat
+  p ([1, 2, 3].concat)
+  p ([1, 2, 3].concat([]))
+  p ([1, 2, 3].concat([],[]))
+  p ([1, 2, 3].concat([],[3,2,1]))
+  p ([1, 2, 3].concat([1,2,3],[4,5,6],[7,8,9,10],["greetings"]))
+  p ([].concat([1,2,3],[4,5,6],[7,8,9,10],["greetings"]))
+end
+
+test_array_concat
+
+# INITIAL-LABEL: define internal i64 @"func_Object#17test_array_concat"
+# INITIAL: call i64 @sorbet_int_rb_ary_concat_multi(
+# INITIAL: call i64 @sorbet_int_rb_ary_concat_multi(
+# INITIAL: call i64 @sorbet_int_rb_ary_concat_multi(
+# INITIAL: call i64 @sorbet_int_rb_ary_concat_multi(
+# INITIAL: call i64 @sorbet_int_rb_ary_concat_multi(
+# INITIAL: call i64 @sorbet_int_rb_ary_concat_multi(
+# INITIAL{LITERAL}: }


### PR DESCRIPTION
Adds a compiler intrinsic for `Array#concat`.


### Motivation
General push for more compiler intrinsics.


### Test plan
See included automated tests.
