### PR TITLE
Switch copts for payload build from -std=c99 to -std=gnu99

### DIFF
--- a/compiler/IREmitter/Payload/BUILD
+++ b/compiler/IREmitter/Payload/BUILD
@@ -68,6 +68,9 @@ payload_files = [
     copts = [
         "-Wno-gcc-compat",
         "-fembed-bitcode",
+        # Note that we use -std=gnu99 here (instead of -std=c99) because we
+        # borrow a lot of code from Ruby (via, e.g., internal.h), and that code
+        # sometimes depends on GNU extensions (e.g. the "typeof" keyword).
         "-std=gnu99",
         "-O1",
         "-g",

--- a/compiler/IREmitter/Payload/BUILD
+++ b/compiler/IREmitter/Payload/BUILD
@@ -68,7 +68,7 @@ payload_files = [
     copts = [
         "-Wno-gcc-compat",
         "-fembed-bitcode",
-        "-std=c99",
+        "-std=gnu99",
         "-O1",
         "-g",
         "-fPIC",


### PR DESCRIPTION
PR title says it all.

### Motivation
https://github.com/sorbet/sorbet/pull/4873#discussion_r751799241 (tl;dr when compiling the payload we need some GNU-flavored extensions, like the `typeof` keyword, that are depended upon by Ruby)

### Test plan
See included automated tests.
