### PR TITLE
Add intrinsic for Array#reject

### DIFF
--- a/compiler/IREmitter/Payload/codegen-payload.c
+++ b/compiler/IREmitter/Payload/codegen-payload.c
@@ -1023,6 +1023,41 @@ VALUE sorbet_rb_array_select_withBlock(VALUE recv, ID fun, int argc, const VALUE
     return result;
 }
 
+// This is the no-block version of rb_ary_reject: https://github.com/ruby/ruby/blob/ruby_2_7/array.c#L3609-L3618
+// In that version, the `RETURN_SIZED_ENUMERATOR` macro is what causes the early return when a block is not passed. In
+// this case, we know that the block wasn't passed, so we always return an enumerator
+SORBET_INLINE
+VALUE sorbet_rb_array_reject(VALUE recv, ID fun, int argc, const VALUE *const restrict argv, BlockFFIType blk,
+                             VALUE closure) {
+    sorbet_ensure_arity(argc, 0);
+    return rb_enumeratorize_with_size(recv, ID2SYM(fun), argc, argv, sorbet_array_enum_length);
+}
+
+// This is the block version of rb_ary_reject: https://github.com/ruby/ruby/blob/ruby_2_7/array.c#L3609-L3618
+// In that version the for loop uses `rb_yield`, whereas we call the block function pointer directly.
+SORBET_INLINE
+VALUE sorbet_rb_array_reject_withBlock(VALUE recv, ID fun, int argc, const VALUE *const restrict argv, BlockFFIType blk,
+                                       const struct rb_captured_block *captured, VALUE closure, int numPositionalArgs) {
+    sorbet_ensure_arity(argc, 0);
+    VALUE result = rb_ary_new2(RARRAY_LEN(recv));
+
+    // must push a frame for the captured block
+    sorbet_pushBlockFrame(captured);
+
+    // inlining ary_reject
+    for (long i = 0; i < RARRAY_LEN(recv); ++i) {
+        VALUE val = RARRAY_AREF(recv, i);
+        VALUE ret = blk(val, closure, 1, &val, Qnil);
+        if (!RTEST(ret)) {
+            rb_ary_push(result, val);
+        }
+    }
+
+    sorbet_popFrame();
+
+    return result;
+}
+
 // This is the non-block version of rb_enum_find: https://github.com/ruby/ruby/blob/ruby_2_7/enum.c#L292-L309
 // In that version, the `RETURN_ENUMERATOR` macro is what causes the early return when a block is not passed. In
 // this case, we know that the block wasn't passed, so we always return an enumerator

--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -1039,4 +1039,5 @@ vector<const SymbolBasedIntrinsicMethod *> &SymbolBasedIntrinsicMethod::definedI
 
     return ret;
 }
+
 }; // namespace sorbet::compiler

--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -902,6 +902,8 @@ static const vector<CallCMethod> knownCMethodsInstance{
     // filter is an alias for select, so we call the same intrinsic
     {core::Symbols::Array(), "filter", CMethod{"sorbet_rb_array_select", core::Symbols::Enumerator()},
      CMethod{"sorbet_rb_array_select_withBlock", core::Symbols::Array()}},
+    {core::Symbols::Array(), "reject", CMethod{"sorbet_rb_array_reject", core::Symbols::Enumerator()},
+     CMethod{"sorbet_rb_array_reject_withBlock", core::Symbols::Array()}},
     {core::Symbols::Array(), "find", CMethod{"sorbet_rb_array_find"}, CMethod{"sorbet_rb_array_find_withBlock"}},
     {core::Symbols::Array(), "collect", CMethod{"sorbet_rb_array_collect", core::Symbols::Enumerator()},
      CMethod{"sorbet_rb_array_collect_withBlock", core::Symbols::Array()}},
@@ -1037,5 +1039,4 @@ vector<const SymbolBasedIntrinsicMethod *> &SymbolBasedIntrinsicMethod::definedI
 
     return ret;
 }
-
 }; // namespace sorbet::compiler

--- a/test/testdata/compiler/intrinsics/array_reject_blk.rb
+++ b/test/testdata/compiler/intrinsics/array_reject_blk.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+# run_filecheck: INITIAL
+
+result = [1, 2, 3, 4, 5, 6].reject do |x|
+  x.even?
+end
+
+puts result
+
+puts ([1, 2, 3, 4, 5, 6].reject do |x|
+        break "ope"
+      end)
+
+# INITIAL-LABEL: define internal i64 @"func_<root>.17<static-init>
+# INITIAL: call i64 @sorbet_callIntrinsicInlineBlock_noBreak(i64 (i64)* @forward_sorbet_rb_array_reject_withBlock
+# INITIAL: call i64 @sorbet_callIntrinsicInlineBlock(i64 (i64)* @forward_sorbet_rb_array_reject_withBlock
+# INITIAL{LITERAL}: }
+
+def foo(&blk)
+  result = [1, 2, 3, 4, 5, 6].reject(&blk)
+  puts result
+end
+
+foo do |x|
+  x.even?
+end

--- a/test/testdata/compiler/intrinsics/array_reject_no_blk.rb
+++ b/test/testdata/compiler/intrinsics/array_reject_no_blk.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+# run_filecheck: INITIAL
+
+enumerator = ['zero', 'one', 'two'].reject
+
+# INITIAL-LABEL: define internal i64 @"func_<root>.17<static-init>
+# INITIAL: call i64 @sorbet_rb_array_reject(
+# INITIAL{LITERAL}: }
+
+puts enumerator.class
+
+result = enumerator.with_index do |x, i|
+  puts "#{i}: #{x}"
+end
+
+puts result.class
+
+puts "a"
+puts enumerator.each { |x| true }
+puts "b"
+puts enumerator.each { |x| false }
+puts "c"
+puts enumerator.each { |x| x.length > 3 }
+puts "d"
+puts enumerator.each { |x| x.length <= 3 }

--- a/test/testdata/compiler/intrinsics/array_select_no_blk.rb
+++ b/test/testdata/compiler/intrinsics/array_select_no_blk.rb
@@ -12,6 +12,15 @@ end
 
 puts result.class
 
+puts "a"
+puts enumerator.each { |x| true }
+puts "b"
+puts enumerator.each { |x| false }
+puts "c"
+puts enumerator.each { |x| x.length > 3 }
+puts "d"
+puts enumerator.each { |x| x.length <= 3 }
+
 enumerator = ['zero', 'one', 'two'].select
 
 puts enumerator.class
@@ -21,3 +30,12 @@ result = enumerator.with_index do |x, i|
 end
 
 puts result.class
+
+puts "a"
+puts enumerator.each { |x| true }
+puts "b"
+puts enumerator.each { |x| false }
+puts "c"
+puts enumerator.each { |x| x.length > 3 }
+puts "d"
+puts enumerator.each { |x| x.length <= 3 }


### PR DESCRIPTION
Adds a compiler intrinsic for `Array#reject`.


### Motivation
General push for more compiler intrinsics.


### Test plan
See included automated tests.
