### PR TITLE
Add intrinsic for Array#push

### DIFF
--- a/compiler/IREmitter/Intrinsics/intrinsic-report.md
+++ b/compiler/IREmitter/Intrinsics/intrinsic-report.md
@@ -21,7 +21,7 @@
 * [   ] `rb_ary_difference_multi` (`Array#difference`)
 * [   ] `rb_ary_intersection_multi` (`Array#intersection`)
 * [✔  ] `rb_ary_push` (`Array#<<`)
-* [   ] `rb_ary_push_m` (`Array#push`)
+* [  ✔] `rb_ary_push_m` (`Array#push`)
 * [   ] `rb_ary_pop_m` (`Array#pop`)
 * [   ] `rb_ary_shift_m` (`Array#shift`)
 * [   ] `rb_ary_unshift_m` (`Array#unshift`)
@@ -1564,4 +1564,4 @@
 
 ## Stats
 * Total:   1488
-* Visible: 240
+* Visible: 241

--- a/compiler/IREmitter/Intrinsics/wrap-intrinsics.rb
+++ b/compiler/IREmitter/Intrinsics/wrap-intrinsics.rb
@@ -232,6 +232,7 @@ module Intrinsics
       "Array#initialize_copy",
       "Array#join",
       "Array#last",
+      "Array#push",
       "Array#rassoc",
       "Array#replace",
       "Array#slice",

--- a/compiler/IREmitter/Payload/PayloadIntrinsics.c
+++ b/compiler/IREmitter/Payload/PayloadIntrinsics.c
@@ -162,6 +162,15 @@ VALUE sorbet_int_rb_ary_last(VALUE recv, ID fun, int argc, VALUE *const restrict
     return rb_ary_last(argc, args, recv);
 }
 
+// Array#push
+// Calling convention: -1
+extern VALUE sorbet_rb_ary_push_m(int argc, const VALUE *args, VALUE obj);
+
+VALUE sorbet_int_rb_ary_push_m(VALUE recv, ID fun, int argc, VALUE *const restrict args, BlockFFIType blk,
+                               VALUE closure) {
+    return sorbet_rb_ary_push_m(argc, args, recv);
+}
+
 // Array#rassoc
 // Calling convention: 1
 extern VALUE rb_ary_rassoc(VALUE obj, VALUE arg_0);

--- a/compiler/IREmitter/WrappedIntrinsics.h
+++ b/compiler/IREmitter/WrappedIntrinsics.h
@@ -19,6 +19,7 @@
     {core::Symbols::Array(), "replace", CMethod{"sorbet_int_rb_ary_replace"}},
     {core::Symbols::Array(), "join", CMethod{"sorbet_int_rb_ary_join_m"}},
     {core::Symbols::Array(), "last", CMethod{"sorbet_int_rb_ary_last"}},
+    {core::Symbols::Array(), "push", CMethod{"sorbet_int_rb_ary_push_m"}},
     {core::Symbols::Array(), "rassoc", CMethod{"sorbet_int_rb_ary_rassoc"}},
     {core::Symbols::Array(), "sort", CMethod{"sorbet_int_rb_ary_sort"}},
     {core::Symbols::Array(), "sort!", CMethod{"sorbet_int_rb_ary_sort_bang"}},

--- a/compiler/ruby-static-exports/array.c
+++ b/compiler/ruby-static-exports/array.c
@@ -1,3 +1,7 @@
+VALUE sorbet_rb_ary_push_m(int argc, const VALUE *args, VALUE obj) {
+    return rb_ary_push_m(argc, args, obj);
+}
+
 VALUE sorbet_rb_ary_first(int argc, const VALUE *args, VALUE obj) {
     return rb_ary_first(argc, args, obj);
 }

--- a/test/testdata/compiler/intrinsics/array_push.rb
+++ b/test/testdata/compiler/intrinsics/array_push.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+# run_filecheck: INITIAL
+
+def test_array_push
+  p ([1, 2, 3].push)
+  p ([1, 2, 3].push(4))
+  p ([1, 2, 3].push(3, 2, 1))
+  p ([1, 2, 3].push(1, 2, 3, T.unsafe("greetings")))
+  p ([].push(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, T.unsafe("greetings")))
+
+  x = [1, 2, 3]
+  x.push(99)
+
+  p x
+end
+
+test_array_push
+
+# INITIAL-LABEL: define internal i64 @"func_Object#15test_array_push"
+# INITIAL: call i64 @sorbet_int_rb_ary_push_m(
+# INITIAL: call i64 @sorbet_int_rb_ary_push_m(
+# INITIAL: call i64 @sorbet_int_rb_ary_push_m(
+# INITIAL: call i64 @sorbet_int_rb_ary_push_m(
+# INITIAL: call i64 @sorbet_int_rb_ary_push_m(
+# INITIAL: call i64 @sorbet_int_rb_ary_push_m(
+# INITIAL{LITERAL}: }


### PR DESCRIPTION
Implements a compiler intrinsic for `Array#push`.


### Motivation
General push for more compiler intrinsics.


### Test plan
See included automated tests.
