### PR TITLE
Migrate uses of --spawn_strategy=standalone to local

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -138,11 +138,6 @@ test:buildfarm --test_output=errors
 build:buildfarm-sanitized-linux --config=test-sanitized-linux --config=buildfarm
 build:buildfarm-sanitized-mac --config=test-sanitized-mac --config=buildfarm --config=shared-libs
 
-build:travis --config=test-sanitized-linux
-test:travis --ram_utilization_factor=10
-test:travis --test_strategy=standalone
-test:travis --test_output=errors
-
 ##
 ## Shared fragments of configuration
 ##

--- a/.bazelrc
+++ b/.bazelrc
@@ -61,7 +61,7 @@ build:rubydbg --copt=-DRUBY_DEBUG --copt=-DVM_CHECK_MODE=1 --copt=-DTRANSIENT_HE
 
 build:coverage --config=forcedebug
 build:coverage --cxxopt=-Wno-pass-failed # coverage build fails vectorization
-test:coverage --spawn_strategy=standalone
+test:coverage --spawn_strategy=local
 
 build --define=versioned=false
 build:versioned --workspace_status_command=tools/buildstamp/get_workspace_status --stamp --define=versioned=true
@@ -216,14 +216,14 @@ build:size --copt=-Os --config=lto
 # See https://github.com/bazelbuild/bazel/issues/2537
 build:debugsymbols --copt=-g3 --copt=-fstandalone-debug --copt=-DDEBUG_SYMBOLS --copt=-glldb
 build:debugsymbols --linkopt=-g3 --linkopt=-fstandalone-debug --linkopt=-DDEBUG_SYMBOLS --linkopt=-glldb
-build:debugsymbols --spawn_strategy=standalone
-build:debugsymbols --genrule_strategy=standalone
+build:debugsymbols --spawn_strategy=local
+build:debugsymbols --genrule_strategy=local
 
 # simpler & smaller debug symbols. Good enough for backtraces, but not for debugging.
 build:backtracesymbols --copt=-DDEBUG_SYMBOLS --copt=-gline-tables-only
 build:backtracesymbols --linkopt=-DDEBUG_SYMBOLS --linkopt=-gline-tables-only
-build:backtracesymbols --spawn_strategy=standalone
-build:backtracesymbols --genrule_strategy=standalone
+build:backtracesymbols --spawn_strategy=local
+build:backtracesymbols --genrule_strategy=local
 
 build --strip=never
 
@@ -242,7 +242,7 @@ build:webasm-darwin --crosstool_top=//tools/toolchain/webasm-darwin --config=web
 
 # common webasm config
 # Use --cpu as a differentiator.
-build:webasm --cpu=webasm --spawn_strategy=standalone --genrule_strategy=standalone --copt=-Oz --linkopt=-Oz --copt=-DMDB_USE_ROBUST=0
+build:webasm --cpu=webasm --spawn_strategy=local --genrule_strategy=local --copt=-Oz --linkopt=-Oz --copt=-DMDB_USE_ROBUST=0
 build:webasm --define release=true
 build:webasm --compilation_mode=opt
 build:webasm --copt=-DNDEBUG --linkopt=-DNDEBUG # for some reason emscripten doesn't pass those when -O2\-Oz are specified

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -680,7 +680,7 @@ See [core/Symbols.h] and [core/SymbolRef.h] for more information.
   - `toString` is "internal representation" (like Rust `Debug` trait)
 - `gems/sorbet/` (`srb init`)
 - `gems/sorbet-runtime/`
-- `bazel build //foo --copt=-ftime-trace --spawn_strategy=standalone`
+- `bazel build //foo --copt=-ftime-trace --spawn_strategy=local`
   - generates <chrome://tracing> profiles for clang
 
 <!-- -- Links -------------------------------------------------------------- -->


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
`standalone` is no longer a valid argument to `--spawn_strategy` or `--genrule_strategy`, but we missed this because bazel doesn't seem to emit an error when the flag is given an incorrect value.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Build performance -- we run builds with `--spawn_strategy=standalone` when using the `buildfarm-sanitized-*` configurations, wihch has been using the wrong argument to `--spawn_strategy` for a while now.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.