### PR TITLE
Add intrinsic for Array#flatten

### DIFF
--- a/compiler/IREmitter/Intrinsics/intrinsic-report.md
+++ b/compiler/IREmitter/Intrinsics/intrinsic-report.md
@@ -80,7 +80,7 @@
 * [   ] `rb_ary_uniq_bang` (`Array#uniq!`)
 * [   ] `rb_ary_compact` (`Array#compact`)
 * [   ] `rb_ary_compact_bang` (`Array#compact!`)
-* [   ] `rb_ary_flatten` (`Array#flatten`)
+* [  ✔] `rb_ary_flatten` (`Array#flatten`)
 * [   ] `rb_ary_flatten_bang` (`Array#flatten!`)
 * [   ] `rb_ary_count` (`Array#count`)
 * [   ] `rb_ary_shuffle_bang` (`Array#shuffle!`)
@@ -1564,4 +1564,4 @@
 
 ## Stats
 * Total:   1488
-* Visible: 241
+* Visible: 242

--- a/compiler/IREmitter/Intrinsics/wrap-intrinsics.rb
+++ b/compiler/IREmitter/Intrinsics/wrap-intrinsics.rb
@@ -228,6 +228,7 @@ module Intrinsics
       "Array#concat",
       "Array#delete",
       "Array#first",
+      "Array#flatten",
       "Array#include?",
       "Array#initialize_copy",
       "Array#join",

--- a/compiler/IREmitter/Payload/PayloadIntrinsics.c
+++ b/compiler/IREmitter/Payload/PayloadIntrinsics.c
@@ -121,6 +121,15 @@ VALUE sorbet_int_rb_ary_first(VALUE recv, ID fun, int argc, VALUE *const restric
     return sorbet_rb_ary_first(argc, args, recv);
 }
 
+// Array#flatten
+// Calling convention: -1
+extern VALUE sorbet_rb_ary_flatten(int argc, const VALUE *args, VALUE obj);
+
+VALUE sorbet_int_rb_ary_flatten(VALUE recv, ID fun, int argc, VALUE *const restrict args, BlockFFIType blk,
+                                VALUE closure) {
+    return sorbet_rb_ary_flatten(argc, args, recv);
+}
+
 // Array#include?
 // Calling convention: 1
 extern VALUE rb_ary_includes(VALUE obj, VALUE arg_0);

--- a/compiler/IREmitter/WrappedIntrinsics.h
+++ b/compiler/IREmitter/WrappedIntrinsics.h
@@ -14,6 +14,7 @@
     {core::Symbols::Array(), "concat", CMethod{"sorbet_int_rb_ary_concat_multi"}},
     {core::Symbols::Array(), "delete", CMethod{"sorbet_int_rb_ary_delete"}},
     {core::Symbols::Array(), "first", CMethod{"sorbet_int_rb_ary_first"}},
+    {core::Symbols::Array(), "flatten", CMethod{"sorbet_int_rb_ary_flatten"}},
     {core::Symbols::Array(), "include?", CMethod{"sorbet_int_rb_ary_includes"}},
     {core::Symbols::Array(), "initialize_copy", CMethod{"sorbet_int_rb_ary_replace"}},
     {core::Symbols::Array(), "replace", CMethod{"sorbet_int_rb_ary_replace"}},

--- a/compiler/ruby-static-exports/array.c
+++ b/compiler/ruby-static-exports/array.c
@@ -17,3 +17,7 @@ VALUE sorbet_rb_ary_concat_multi(int argc, const VALUE *args, VALUE obj) {
 VALUE sorbet_rb_ary_diff(VALUE obj, VALUE arg_0) {
     return rb_ary_diff(obj, arg_0);
 }
+
+VALUE sorbet_rb_ary_flatten(int argc, const VALUE *args, VALUE obj) {
+    return rb_ary_flatten(argc, args, obj);
+}

--- a/test/testdata/compiler/intrinsics/array_flatten.rb
+++ b/test/testdata/compiler/intrinsics/array_flatten.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+# run_filecheck: INITIAL
+
+def test_array_flatten
+  p ([].flatten)
+  p ([1, 2, 3].flatten)
+  p ([1, [2, 3]].flatten)
+  p ([1, [2, [3, 4]]].flatten)
+  p ([1, [2, [3, 4]]].flatten(0))
+  p ([1, [2, [3, 4]]].flatten(1))
+  p ([1, [2, [3, 4]]].flatten(2))
+  p ([1, [2, [3, 4]]].flatten(3))
+  p ([1, [2, [3, 4]]].flatten(4))
+end
+
+test_array_flatten
+
+# INITIAL-LABEL: define internal i64 @"func_Object#18test_array_flatten"
+# INITIAL: call i64 @sorbet_int_rb_ary_flatten(
+# INITIAL: call i64 @sorbet_int_rb_ary_flatten(
+# INITIAL: call i64 @sorbet_int_rb_ary_flatten(
+# INITIAL: call i64 @sorbet_int_rb_ary_flatten(
+# INITIAL: call i64 @sorbet_int_rb_ary_flatten(
+# INITIAL: call i64 @sorbet_int_rb_ary_flatten(
+# INITIAL: call i64 @sorbet_int_rb_ary_flatten(
+# INITIAL: call i64 @sorbet_int_rb_ary_flatten(
+# INITIAL: call i64 @sorbet_int_rb_ary_flatten(
+# INITIAL{LITERAL}: }


### PR DESCRIPTION
Add a compiler intrinsic for `Array#flatten`.


### Motivation
General push for more compiler intrinsics.


### Test plan
See included automated tests.
