### PR TITLE
Packages: nice errors for missing imports

### DIFF
--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -12,6 +12,11 @@ public:
         return NameRef::noName();
     }
 
+    const vector<core::NameRef> &fullName() const {
+        ENFORCE(false);
+        return emptyName;
+    }
+
     const vector<string> &pathPrefixes() const {
         ENFORCE(false);
         return prefixes;
@@ -31,6 +36,7 @@ public:
 
 private:
     const vector<string> prefixes;
+    const vector<core::NameRef> emptyName;
 };
 static const NonePackage NONE_PKG;
 } // namespace
@@ -53,11 +59,12 @@ NameRef PackageDB::enterPackage(unique_ptr<PackageInfo> pkg) {
     ENFORCE(!frozen);
     ENFORCE(writerThread == this_thread::get_id(), "PackageDB writes are not thread safe");
     auto nr = pkg->mangledName();
-    auto prev = packages.find(nr);
-    if (prev == packages.end()) {
+    auto prev = packages_.find(nr);
+    if (prev == packages_.end()) {
         for (const auto &prefix : pkg->pathPrefixes()) {
             packagesByPathPrefix[prefix] = nr;
         }
+        mangledNames.emplace_back(nr);
     } else {
         // Package files do not have full featured content hashing. If the contents of one changes
         // we always run slow-path and fully rebuild the set of packages. In some cases, the LSP
@@ -66,14 +73,15 @@ NameRef PackageDB::enterPackage(unique_ptr<PackageInfo> pkg) {
         ENFORCE(prev->second->definitionLoc() == pkg->definitionLoc());
         ENFORCE(prev->second->pathPrefixes() == pkg->pathPrefixes());
     }
-    packages[nr] = move(pkg);
+    packages_[nr] = move(pkg);
+    ENFORCE(mangledNames.size() == packages_.size());
     return nr;
 }
 
 NameRef PackageDB::lookupPackage(NameRef pkgMangledName) const {
     ENFORCE(pkgMangledName.exists());
-    auto it = packages.find(pkgMangledName);
-    if (it == packages.end()) {
+    auto it = packages_.find(pkgMangledName);
+    if (it == packages_.end()) {
         return NameRef::noName();
     }
     return it->first;
@@ -102,15 +110,19 @@ const PackageInfo &PackageDB::getPackageForFile(const core::GlobalState &gs, cor
 }
 
 const PackageInfo &PackageDB::getPackageInfo(core::NameRef mangledName) const {
-    auto it = packages.find(mangledName);
-    if (it == packages.end()) {
+    auto it = packages_.find(mangledName);
+    if (it == packages_.end()) {
         return NONE_PKG;
     }
     return *it->second;
 }
 
 bool PackageDB::empty() const {
-    return packages.empty();
+    return packages_.empty();
+}
+
+const vector<core::NameRef> &PackageDB::packages() const {
+    return mangledNames;
 }
 
 const std::vector<core::NameRef> &PackageDB::secondaryTestPackageNamespaceRefs() const {
@@ -124,13 +136,14 @@ const std::vector<std::string> &PackageDB::extraPackageFilesDirectoryPrefixes() 
 PackageDB PackageDB::deepCopy() const {
     ENFORCE(frozen);
     PackageDB result;
-    result.packages.reserve(this->packages.size());
-    for (auto const &[nr, pkgInfo] : this->packages) {
-        result.packages[nr] = pkgInfo->deepCopy();
+    result.packages_.reserve(this->packages_.size());
+    for (auto const &[nr, pkgInfo] : this->packages_) {
+        result.packages_[nr] = pkgInfo->deepCopy();
     }
     result.secondaryTestPackageNamespaceRefs_ = this->secondaryTestPackageNamespaceRefs_;
     result.extraPackageFilesDirectoryPrefixes_ = this->extraPackageFilesDirectoryPrefixes_;
     result.packagesByPathPrefix = this->packagesByPathPrefix;
+    result.mangledNames = this->mangledNames;
     return result;
 }
 

--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -1,4 +1,6 @@
 #include "core/packages/PackageDB.h"
+#include "absl/strings/match.h"
+#include "core/GlobalState.h"
 #include "core/Loc.h"
 
 using namespace std;
@@ -131,6 +133,12 @@ const std::vector<core::NameRef> &PackageDB::secondaryTestPackageNamespaceRefs()
 
 const std::vector<std::string> &PackageDB::extraPackageFilesDirectoryPrefixes() const {
     return extraPackageFilesDirectoryPrefixes_;
+}
+
+bool PackageDB::isTestFile(const core::GlobalState &gs, const core::File &file) {
+    // TODO: (aadi-stripe, 11/26/2021) see if these can all be changed to use getPrintablePath
+    return absl::EndsWith(file.path(), ".test.rb") || absl::StartsWith(file.path(), "./test/") ||
+           absl::StrContains(gs.getPrintablePath(file.path()), "/test/");
 }
 
 PackageDB PackageDB::deepCopy() const {

--- a/core/packages/PackageDB.h
+++ b/core/packages/PackageDB.h
@@ -45,6 +45,9 @@ public:
     const std::vector<core::NameRef> &secondaryTestPackageNamespaceRefs() const;
     const std::vector<std::string> &extraPackageFilesDirectoryPrefixes() const;
 
+    // NB: Do not call in hot path, this is SLOW due to string comparison!
+    static bool isTestFile(const core::GlobalState &gs, const core::File &file);
+
 private:
     std::vector<NameRef> secondaryTestPackageNamespaceRefs_;
     std::vector<std::string> extraPackageFilesDirectoryPrefixes_;

--- a/core/packages/PackageDB.h
+++ b/core/packages/PackageDB.h
@@ -29,6 +29,8 @@ public:
     const PackageInfo &getPackageInfo(core::NameRef mangledName) const;
 
     bool empty() const;
+    // Get mangled names for all packages
+    const std::vector<core::NameRef> &packages() const;
 
     PackageDB deepCopy() const;
 
@@ -47,8 +49,10 @@ private:
     std::vector<NameRef> secondaryTestPackageNamespaceRefs_;
     std::vector<std::string> extraPackageFilesDirectoryPrefixes_;
 
-    UnorderedMap<core::NameRef, std::unique_ptr<packages::PackageInfo>> packages;
+    UnorderedMap<core::NameRef, std::unique_ptr<packages::PackageInfo>> packages_;
     UnorderedMap<std::string, core::NameRef> packagesByPathPrefix;
+    std::vector<NameRef> mangledNames;
+
     bool frozen = true;
     std::thread::id writerThread;
 

--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -12,6 +12,7 @@ namespace sorbet::core::packages {
 class PackageInfo {
 public:
     virtual core::NameRef mangledName() const = 0;
+    virtual const std::vector<core::NameRef> &fullName() const = 0;
     virtual const std::vector<std::string> &pathPrefixes() const = 0;
     virtual std::unique_ptr<PackageInfo> deepCopy() const = 0;
     virtual core::Loc definitionLoc() const = 0;

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -22,12 +22,6 @@ namespace {
 constexpr string_view PACKAGE_FILE_NAME = "__package.rb"sv;
 constexpr core::NameRef TEST_NAME = core::Names::Constants::Test();
 
-bool isTestFile(const core::GlobalState &gs, core::File &file) {
-    // TODO: (aadi-stripe, 11/26/2021) see if these can all be changed to use getPrintablePath
-    return absl::EndsWith(file.path(), ".test.rb") || absl::StartsWith(file.path(), "./test/") ||
-           absl::StrContains(gs.getPrintablePath(file.path()), "/test/");
-}
-
 bool isPrimaryTestNamespace(const core::NameRef ns) {
     return ns == TEST_NAME;
 }
@@ -1214,8 +1208,8 @@ ast::ParsedFile rewritePackagedFile(core::GlobalState &gs, ast::ParsedFile parse
 
         // Wrap the file in a package module (ending with _Package_Private) to put it by default in the package's
         // private namespace (private-by-default paradigm).
-        parsedFile =
-            wrapFileInPackageModule(ctx, move(parsedFile), pkgImpl.privateMangledName, pkgImpl, isTestFile(gs, file));
+        parsedFile = wrapFileInPackageModule(ctx, move(parsedFile), pkgImpl.privateMangledName, pkgImpl,
+                                             core::packages::PackageDB::isTestFile(gs, file));
     } else {
         // Don't transform, but raise an error on the first line.
         if (auto e = ctx.beginError(core::LocOffsets{0, 0}, core::errors::Packager::UnpackagedFile)) {

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -145,6 +145,10 @@ public:
         return name.mangledName;
     }
 
+    const vector<core::NameRef> &fullName() const {
+        return name.fullName.parts;
+    }
+
     const std::vector<std::string> &pathPrefixes() const {
         return packagePathPrefixes;
     }

--- a/resolver/SuggestPackage.cc
+++ b/resolver/SuggestPackage.cc
@@ -1,0 +1,121 @@
+#include "resolver/SuggestPackage.h"
+
+#include "common/formatting.h"
+#include "core/core.h"
+
+using namespace std;
+
+namespace sorbet::resolver {
+namespace {
+// Count the number of name parts in a symbol. Length should be same as `symbol2NameParts`.
+size_t nameLen(core::Context ctx, core::SymbolRef symbol) {
+    auto len = 0;
+    while (symbol != core::Symbols::root() && !symbol.data(ctx)->name.isPackagerName(ctx)) {
+        ++len;
+        symbol = symbol.data(ctx)->owner;
+    }
+    return len;
+}
+
+// Add all name parts for a symbol to a vector, exclude internal names used by packager.
+void symbol2NameParts(core::Context ctx, core::SymbolRef symbol, vector<core::NameRef> &out) {
+    ENFORCE(out.empty());
+    while (symbol != core::Symbols::root() && !symbol.data(ctx)->name.isPackagerName(ctx)) {
+        out.emplace_back(symbol.data(ctx)->name);
+        symbol = symbol.data(ctx)->owner;
+    }
+    std::reverse(out.begin(), out.end());
+}
+
+struct PackageMatch {
+    core::NameRef mangledName;
+};
+
+class PackageContext final {
+public:
+    core::Context ctx;
+    const core::packages::PackageInfo &currentPkg;
+
+    PackageContext(core::Context ctx) : ctx(ctx), currentPkg(ctx.state.packageDB().getPackageForFile(ctx, ctx.file)) {}
+
+    const core::packages::PackageDB &db() const {
+        return ctx.state.packageDB();
+    }
+
+    vector<PackageMatch> findPossibleMissingImports(const ast::ConstantLit::ResolutionScopes &scopes,
+                                                    core::NameRef name) const {
+        vector<PackageMatch> matches;
+        vector<core::NameRef> prefix;
+        // Resolution scopes are always longest to shortest. Reserve additional space for the name we're
+        // looking for.
+        prefix.reserve(nameLen(ctx, scopes.front()) + 1);
+        for (auto scope : scopes) {
+            prefix.clear();
+            symbol2NameParts(ctx, scope, prefix);
+            prefix.emplace_back(name);
+
+            findPackagesWithPrefix(prefix, matches);
+        }
+        return matches;
+    }
+
+    void addMissingImportSuggestions(core::ErrorBuilder &e, PackageMatch &match) {
+        vector<core::ErrorLine> lines;
+        auto &otherPkg = db().getPackageInfo(match.mangledName);
+        lines.emplace_back(core::ErrorLine::from(
+            otherPkg.definitionLoc(), "Do you need to `{}` package `{}`?", "import",
+            fmt::map_join(otherPkg.fullName(), "::", [&](auto nr) -> string { return nr.show(ctx); })));
+        // TODO(nroman-stripe) Add automatic fixers
+        e.addErrorSection(core::ErrorSection(lines));
+    }
+
+private:
+    // Search all packages finding those that match a specific prefix. These are candidates for
+    // includes. See following example for why prefixes and not exact matches are used:
+    //
+    // Consider the package `Foo::Bar::Baz` that exports the name `Foo::Bar::Baz::Thing`.
+    // The following reference to that name from code in the package `Foo::Quuz`:
+    //   Foo::Bar::Baz::Thing
+    //        ^^^  The resolution error will be for `Bar` not resolving with a resolution scope
+    //             `Foo`
+    // In this case all we search with the prefix `Foo::Bar` and find that the `Foo::Bar::Baz`
+    // package matches.
+    void findPackagesWithPrefix(const vector<core::NameRef> &prefix, vector<PackageMatch> &matches) const {
+        ENFORCE(prefix.size() > 0);
+        for (auto name : db().packages()) {
+            auto &other = db().getPackageInfo(name);
+            auto &fullName = other.fullName();
+            if (fullName.size() >= prefix.size() && canImport(other) &&
+                std::equal(fullName.begin(), fullName.begin() + prefix.size(), prefix.begin())) {
+                matches.emplace_back(PackageMatch{name});
+            }
+        }
+    }
+
+    bool canImport(const core::packages::PackageInfo &other) const {
+        return currentPkg.mangledName() != other.mangledName(); // Don't import yourself
+    }
+};
+} // namespace
+
+bool SuggestPackage::tryPackageCorrections(core::Context ctx, core::ErrorBuilder &e,
+                                           const ast::ConstantLit::ResolutionScopes &scopes, core::NameRef name) {
+    ENFORCE(!scopes.empty());
+    PackageContext pkgCtx(ctx);
+    if (!pkgCtx.currentPkg.exists()) {
+        return false; // This error is not in packaged code. Nothing to do here.
+    }
+
+    // TODO(nroman-stripe) First search for missing exports.
+
+    vector<PackageMatch> missingImports = pkgCtx.findPossibleMissingImports(scopes, name);
+    if (missingImports.empty()) {
+        return false;
+    }
+
+    for (auto match : missingImports) {
+        pkgCtx.addMissingImportSuggestions(e, match);
+    }
+    return true;
+}
+} // namespace sorbet::resolver

--- a/resolver/SuggestPackage.cc
+++ b/resolver/SuggestPackage.cc
@@ -7,16 +7,6 @@ using namespace std;
 
 namespace sorbet::resolver {
 namespace {
-// Count the number of name parts in a symbol. Length should be same as `symbol2NameParts`.
-size_t nameLen(core::Context ctx, core::SymbolRef symbol) {
-    auto len = 0;
-    while (symbol.exists() && symbol != core::Symbols::root() && !symbol.data(ctx)->name.isPackagerName(ctx)) {
-        ++len;
-        symbol = symbol.data(ctx)->owner;
-    }
-    return len;
-}
-
 // Add all name parts for a symbol to a vector, exclude internal names used by packager.
 void symbol2NameParts(core::Context ctx, core::SymbolRef symbol, vector<core::NameRef> &out) {
     ENFORCE(out.empty());
@@ -48,7 +38,6 @@ public:
         vector<core::NameRef> prefix;
         // Resolution scopes are always longest to shortest. Reserve additional space for the name we're
         // looking for.
-        prefix.reserve(nameLen(ctx, scopes.front()) + 1);
         for (auto scope : scopes) {
             prefix.clear();
             symbol2NameParts(ctx, scope, prefix);
@@ -83,7 +72,7 @@ private:
     // In this case all we search with the prefix `Foo::Bar` and find that the `Foo::Bar::Baz`
     // package matches.
     void findPackagesWithPrefix(const vector<core::NameRef> &prefix, vector<PackageMatch> &matches) const {
-        ENFORCE(prefix.size() > 0);
+        ENFORCE(!prefix.empty());
         // If the search prefix starts with `Test` ignore it while searching matching package names.
         auto prefixBegin = prefix.begin();
         if (*prefixBegin == core::Names::Constants::Test() && prefix.size() > 1) {

--- a/resolver/SuggestPackage.cc
+++ b/resolver/SuggestPackage.cc
@@ -62,8 +62,10 @@ public:
     void addMissingImportSuggestions(core::ErrorBuilder &e, PackageMatch &match) {
         vector<core::ErrorLine> lines;
         auto &otherPkg = db().getPackageInfo(match.mangledName);
+        auto importName = core::packages::PackageDB::isTestFile(ctx, ctx.file.data(ctx)) ? core::Names::test_import()
+                                                                                         : core::Names::import();
         lines.emplace_back(core::ErrorLine::from(
-            otherPkg.definitionLoc(), "Do you need to `{}` package `{}`?", "import",
+            otherPkg.definitionLoc(), "Do you need to `{}` package `{}`?", importName.show(ctx),
             fmt::map_join(otherPkg.fullName(), "::", [&](auto nr) -> string { return nr.show(ctx); })));
         // TODO(nroman-stripe) Add automatic fixers
         e.addErrorSection(core::ErrorSection(lines));

--- a/resolver/SuggestPackage.cc
+++ b/resolver/SuggestPackage.cc
@@ -10,7 +10,7 @@ namespace {
 // Count the number of name parts in a symbol. Length should be same as `symbol2NameParts`.
 size_t nameLen(core::Context ctx, core::SymbolRef symbol) {
     auto len = 0;
-    while (symbol != core::Symbols::root() && !symbol.data(ctx)->name.isPackagerName(ctx)) {
+    while (symbol.exists() && symbol != core::Symbols::root() && !symbol.data(ctx)->name.isPackagerName(ctx)) {
         ++len;
         symbol = symbol.data(ctx)->owner;
     }
@@ -20,7 +20,7 @@ size_t nameLen(core::Context ctx, core::SymbolRef symbol) {
 // Add all name parts for a symbol to a vector, exclude internal names used by packager.
 void symbol2NameParts(core::Context ctx, core::SymbolRef symbol, vector<core::NameRef> &out) {
     ENFORCE(out.empty());
-    while (symbol != core::Symbols::root() && !symbol.data(ctx)->name.isPackagerName(ctx)) {
+    while (symbol.exists() && symbol != core::Symbols::root() && !symbol.data(ctx)->name.isPackagerName(ctx)) {
         out.emplace_back(symbol.data(ctx)->name);
         symbol = symbol.data(ctx)->owner;
     }
@@ -102,6 +102,9 @@ private:
 
 bool SuggestPackage::tryPackageCorrections(core::Context ctx, core::ErrorBuilder &e,
                                            const ast::ConstantLit::ResolutionScopes &scopes, core::NameRef name) {
+    if (ctx.state.packageDB().empty()) {
+        return false;
+    }
     ENFORCE(!scopes.empty());
     PackageContext pkgCtx(ctx);
     if (!pkgCtx.currentPkg.exists()) {

--- a/resolver/SuggestPackage.h
+++ b/resolver/SuggestPackage.h
@@ -1,0 +1,18 @@
+#ifndef SORBET_RESOLVER_SUGGEST_PACKAGE_H
+#define SORBET_RESOLVER_SUGGEST_PACKAGE_H
+
+#include "ast/ast.h"
+
+namespace sorbet::resolver {
+
+class SuggestPackage final {
+public:
+    static bool tryPackageCorrections(core::Context ctx, core::ErrorBuilder &e,
+                                      const ast::ConstantLit::ResolutionScopes &scopes, core::NameRef name);
+
+    SuggestPackage() = delete;
+};
+
+} // namespace sorbet::resolver
+
+#endif

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -10,6 +10,7 @@
 #include "core/core.h"
 #include "core/lsp/TypecheckEpochManager.h"
 #include "resolver/CorrectTypeAlias.h"
+#include "resolver/SuggestPackage.h"
 #include "resolver/resolver.h"
 #include "resolver/type_syntax.h"
 
@@ -351,6 +352,11 @@ private:
                                    "may need to re-generate the .rbi. Try running:\n"
                                    "  scripts/bin/remote-script sorbet/shim_generation/autogen.rb");
                 } else if (suggestDidYouMean && suggestScope.exists() && suggestScope.isClassOrModule()) {
+                    bool madePackageSuggestions =
+                        SuggestPackage::tryPackageCorrections(ctx, e, job.out->resolutionScopes, original.cnst);
+                    if (madePackageSuggestions) {
+                        return;
+                    }
                     auto suggested = suggestScope.data(ctx)->findMemberFuzzyMatch(ctx, original.cnst);
                     if (suggested.size() > 3) {
                         suggested.resize(3);

--- a/test/cli/package-error-missing-import/__package.rb
+++ b/test/cli/package-error-missing-import/__package.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class Foo::MyPackage < PackageSpec
+  # import Foo::Bar::OtherPackage ## MISSING!
+end

--- a/test/cli/package-error-missing-import/foo.test.rb
+++ b/test/cli/package-error-missing-import/foo.test.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+module Test::Foo::MyPackage
+  Test::Foo::Bar::OtherPackage::TestUtil
+end

--- a/test/cli/package-error-missing-import/foo_class.rb
+++ b/test/cli/package-error-missing-import/foo_class.rb
@@ -1,0 +1,15 @@
+# typed: strict
+
+module Foo
+  # This package is missing `import Foo::Bar::OtherPackage`
+  module MyPackage
+    class FooClass
+      Foo::Bar::OtherPackage::OtherClass # resolves via root
+      Bar::OtherPackage::OtherClass # resolves via `module Foo`
+    end
+  end
+end
+
+module Foo::MyPackage
+  Foo::Bar::OtherPackage::OtherClass # resolves via root
+end

--- a/test/cli/package-error-missing-import/other/__package.rb
+++ b/test/cli/package-error-missing-import/other/__package.rb
@@ -1,0 +1,6 @@
+# typed: strict
+
+class Foo::Bar::OtherPackage < PackageSpec
+  export Foo::Bar::OtherPackage::OtherClass
+  export Test::Foo::Bar::OtherPackage::TestUtil
+end

--- a/test/cli/package-error-missing-import/other/other.test.rb
+++ b/test/cli/package-error-missing-import/other/other.test.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+module Test::Foo::Bar::OtherPackage
+  class TestUtil; end
+end

--- a/test/cli/package-error-missing-import/other/other_class.rb
+++ b/test/cli/package-error-missing-import/other/other_class.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+class Foo::Bar::OtherPackage::OtherClass
+end

--- a/test/cli/package-error-missing-import/package-error-missing-import.out
+++ b/test/cli/package-error-missing-import/package-error-missing-import.out
@@ -1,0 +1,30 @@
+foo_class.rb:7: Unable to resolve constant `Bar` https://srb.help/5002
+     7 |      Foo::Bar::OtherPackage::OtherClass # resolves via root
+              ^^^^^^^^
+    other/__package.rb:3: Do you need to `import` package `Foo::Bar::OtherPackage`?
+     3 |class Foo::Bar::OtherPackage < PackageSpec
+     4 |  export Foo::Bar::OtherPackage::OtherClass
+     5 |  export Test::Foo::Bar::OtherPackage::TestUtil
+     6 |end
+
+foo_class.rb:8: Unable to resolve constant `Bar` https://srb.help/5002
+     8 |      Bar::OtherPackage::OtherClass # resolves via `module Foo`
+              ^^^
+    other/__package.rb:3: Do you need to `import` package `Foo::Bar::OtherPackage`?
+     3 |class Foo::Bar::OtherPackage < PackageSpec
+     4 |  export Foo::Bar::OtherPackage::OtherClass
+     5 |  export Test::Foo::Bar::OtherPackage::TestUtil
+     6 |end
+
+foo_class.rb:14: Unable to resolve constant `Bar` https://srb.help/5002
+    14 |  Foo::Bar::OtherPackage::OtherClass # resolves via root
+          ^^^^^^^^
+    other/__package.rb:3: Do you need to `import` package `Foo::Bar::OtherPackage`?
+     3 |class Foo::Bar::OtherPackage < PackageSpec
+     4 |  export Foo::Bar::OtherPackage::OtherClass
+     5 |  export Test::Foo::Bar::OtherPackage::TestUtil
+     6 |end
+
+foo.test.rb:4: Unable to resolve constant `Bar` https://srb.help/5002
+     4 |  Test::Foo::Bar::OtherPackage::TestUtil
+Errors: 4

--- a/test/cli/package-error-missing-import/package-error-missing-import.out
+++ b/test/cli/package-error-missing-import/package-error-missing-import.out
@@ -27,4 +27,10 @@ foo_class.rb:14: Unable to resolve constant `Bar` https://srb.help/5002
 
 foo.test.rb:4: Unable to resolve constant `Bar` https://srb.help/5002
      4 |  Test::Foo::Bar::OtherPackage::TestUtil
+          ^^^^^^^^^^^^^^
+    other/__package.rb:3: Do you need to `test_import` package `Foo::Bar::OtherPackage`?
+     3 |class Foo::Bar::OtherPackage < PackageSpec
+     4 |  export Foo::Bar::OtherPackage::OtherClass
+     5 |  export Test::Foo::Bar::OtherPackage::TestUtil
+     6 |end
 Errors: 4

--- a/test/cli/package-error-missing-import/package-error-missing-import.sh
+++ b/test/cli/package-error-missing-import/package-error-missing-import.sh
@@ -1,3 +1,3 @@
 cd test/cli/package-error-missing-import || exit 1
 
-../../../main/sorbet --silence-dev-message --stripe-packages . 2>&1
+../../../main/sorbet --silence-dev-message --stripe-packages --max-threads=0 . 2>&1

--- a/test/cli/package-error-missing-import/package-error-missing-import.sh
+++ b/test/cli/package-error-missing-import/package-error-missing-import.sh
@@ -1,0 +1,3 @@
+cd test/cli/package-error-missing-import || exit 1
+
+../../../main/sorbet --silence-dev-message --stripe-packages . 2>&1

--- a/test/cli/package-test-simple/package-test-simple.out
+++ b/test/cli/package-test-simple/package-test-simple.out
@@ -1,23 +1,8 @@
 main_lib/lib.rb:8: Unable to resolve constant `TestOnly` https://srb.help/5002
      8 |  Project::TestOnly::SomeHelper.new
           ^^^^^^^^^^^^^^^^^
-  Autocorrect: Use `-a` to autocorrect
-    main_lib/lib.rb:8: Replace with `Project::TestOnly`
-     8 |  Project::TestOnly::SomeHelper.new
-          ^^^^^^^^^^^^^^^^^
-  Autocorrect: Use `-a` to autocorrect
-    main_lib/lib.rb:8: Replace with `Project::TestOnly`
-     8 |  Project::TestOnly::SomeHelper.new
-          ^^^^^^^^^^^^^^^^^
-  Autocorrect: Use `-a` to autocorrect
-    main_lib/lib.rb:8: Replace with `Project::TestOnly`
-     8 |  Project::TestOnly::SomeHelper.new
-          ^^^^^^^^^^^^^^^^^
-    main_lib/__package.rb: Did you mean: `Project::TestOnly`?
-    test_only/__package.rb:5: Did you mean: `Project::TestOnly`?
+    test_only/__package.rb:5: Do you need to `import` package `Project::TestOnly`?
      5 |class Project::TestOnly < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    test_only/__package.rb:6: Did you mean: `Project::TestOnly`?
      6 |  export Project::TestOnly::SomeHelper
-                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     7 |end
 Errors: 1


### PR DESCRIPTION
When constant resolution fails and in packaged mode, search the possible resolution scopes for the prefix+name and find packages that start with that name. Suggest importing them. If no matches are found fall back to fuzzy name matching.

This is the first of other error handling changes to make improve UX of `--stripe-packages` mode. We also plan to add auto-correctors for these errors in future PRs.

Few other things this does:
* Expose `vector<NameRef> &fullName()` on `PackageInfo`
* Keep and expose a list of all mangled package names on `PackageDB` to make it easy to iterate over all packages

### Motivation
UX
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

cc @jvilk-stripe @aisamanra 