### PR TITLE
Add intrinsic for Integer#to_f

### DIFF
--- a/compiler/IREmitter/Intrinsics/intrinsic-report.md
+++ b/compiler/IREmitter/Intrinsics/intrinsic-report.md
@@ -750,7 +750,7 @@
 * [   ] `int_ord` (`Integer#ord`)
 * [   ] `int_to_i` (`Integer#to_i`)
 * [   ] `int_to_i` (`Integer#to_int`)
-* [   ] `int_to_f` (`Integer#to_f`)
+* [  ✔] `int_to_f` (`Integer#to_f`)
 * [   ] `int_floor` (`Integer#floor`)
 * [   ] `int_ceil` (`Integer#ceil`)
 * [   ] `int_truncate` (`Integer#truncate`)
@@ -1564,4 +1564,4 @@
 
 ## Stats
 * Total:   1488
-* Visible: 242
+* Visible: 243

--- a/compiler/IREmitter/Intrinsics/wrap-intrinsics.rb
+++ b/compiler/IREmitter/Intrinsics/wrap-intrinsics.rb
@@ -281,6 +281,7 @@ module Intrinsics
       "Integer#modulo",
       "Integer#odd?",
       "Integer#pow",
+      "Integer#to_f",
       "Regexp#encoding",
       "String#*",
       "String#+",

--- a/compiler/IREmitter/Payload/PayloadIntrinsics.c
+++ b/compiler/IREmitter/Payload/PayloadIntrinsics.c
@@ -578,6 +578,15 @@ VALUE sorbet_int_rb_int_powm(VALUE recv, ID fun, int argc, VALUE *const restrict
     return rb_int_powm(argc, args, recv);
 }
 
+// Integer#to_f
+// Calling convention: 0
+extern VALUE sorbet_int_to_f(VALUE obj);
+
+VALUE sorbet_int_int_to_f(VALUE recv, ID fun, int argc, VALUE *const restrict args, BlockFFIType blk, VALUE closure) {
+    rb_check_arity(argc, 0, 0);
+    return sorbet_int_to_f(recv);
+}
+
 // Regexp#encoding
 // String#encoding
 // Calling convention: 0

--- a/compiler/IREmitter/WrappedIntrinsics.h
+++ b/compiler/IREmitter/WrappedIntrinsics.h
@@ -66,6 +66,7 @@
     {core::Symbols::Integer(), "lcm", CMethod{"sorbet_int_rb_lcm"}},
     {core::Symbols::Integer(), "odd?", CMethod{"sorbet_int_rb_int_odd_p"}},
     {core::Symbols::Integer(), "pow", CMethod{"sorbet_int_rb_int_powm"}},
+    {core::Symbols::Integer(), "to_f", CMethod{"sorbet_int_int_to_f"}},
     {core::Symbols::Regexp(), "encoding", CMethod{"sorbet_int_rb_obj_encoding"}},
     {core::Symbols::String(), "encoding", CMethod{"sorbet_int_rb_obj_encoding"}},
     {core::Symbols::String(), "*", CMethod{"sorbet_int_rb_str_times"}},

--- a/compiler/ruby-static-exports/numeric.c
+++ b/compiler/ruby-static-exports/numeric.c
@@ -9,3 +9,7 @@ VALUE sorbet_flo_lt(VALUE obj, VALUE arg_0) {
 VALUE sorbet_flo_le(VALUE obj, VALUE arg_0) {
     return flo_le(obj, arg_0);
 }
+
+VALUE sorbet_int_to_f(VALUE obj) {
+    return int_to_f(obj);
+}

--- a/test/testdata/compiler/intrinsics/int_to_f.rb
+++ b/test/testdata/compiler/intrinsics/int_to_f.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+# run_filecheck: OPT
+
+def test_int_to_f
+  puts(-128.to_f)
+  puts(-1.to_f)
+  puts(0.to_f)
+  puts(1.to_f)
+  puts(127.to_f)
+
+  # https://stackoverflow.com/questions/3793838/which-is-the-first-integer-that-an-ieee-754-float-is-incapable-of-representing-e
+  puts(9_007_199_254_740_992.to_f.to_i)
+end
+
+# OPT-LABEL: define internal i64 @"func_Object#13test_int_to_f"
+# OPT: tail call i64 @sorbet_int_to_f(
+# OPT: tail call i64 @sorbet_int_to_f(
+# OPT: tail call i64 @sorbet_int_to_f(
+# OPT: tail call i64 @sorbet_int_to_f(
+# OPT: tail call i64 @sorbet_int_to_f(
+# OPT: tail call i64 @sorbet_int_to_f(
+# OPT{LITERAL}: }
+
+test_int_to_f


### PR DESCRIPTION
Adds a compiler intrinsic for `Integer#to_f`.

So I went with the easy route and did this through `wrap-intrinsics.rb` which I think should probably be an improvement, but I think it might actually make more sense to implement this in `SymbolBasedIntrinsics` so it inlines better. I think it probably makes sense to land this as-is and follow up later, so throwin' it out there for review.

### Motivation
General push for more compiler intrinsics.

### Test plan
See included automated tests.
