### PR TITLE
Symbol::findMemberFuzzyMatchConstant descend into stripe-packages

### DIFF
--- a/test/cli/package-test-simple/package-test-simple.out
+++ b/test/cli/package-test-simple/package-test-simple.out
@@ -5,7 +5,19 @@ main_lib/lib.rb:8: Unable to resolve constant `TestOnly` https://srb.help/5002
     main_lib/lib.rb:8: Replace with `Project::TestOnly`
      8 |  Project::TestOnly::SomeHelper.new
           ^^^^^^^^^^^^^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    main_lib/lib.rb:8: Replace with `Project::TestOnly`
+     8 |  Project::TestOnly::SomeHelper.new
+          ^^^^^^^^^^^^^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    main_lib/lib.rb:8: Replace with `Project::TestOnly`
+     8 |  Project::TestOnly::SomeHelper.new
+          ^^^^^^^^^^^^^^^^^
+    main_lib/__package.rb: Did you mean: `Project::TestOnly`?
     test_only/__package.rb:5: Did you mean: `Project::TestOnly`?
      5 |class Project::TestOnly < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    test_only/__package.rb:6: Did you mean: `Project::TestOnly`?
+     6 |  export Project::TestOnly::SomeHelper
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Errors: 1

--- a/test/cli/simple-package/simple-package.out
+++ b/test/cli/simple-package/simple-package.out
@@ -11,10 +11,10 @@ foo/foo.rb:14: Unable to resolve constant `UnexportedClass` https://srb.help/500
     14 |    Project::Bar::UnexportedClass
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    foo/foo.rb:14: Replace with `Gem::Package::TarReader::UnexpectedEOF`
+    foo/foo.rb:14: Replace with `Project::Bar::UnexportedClass`
     14 |    Project::Bar::UnexportedClass
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/rubygems.rbi#L2901: Did you mean: `Gem::Package::TarReader::UnexpectedEOF`?
-    2901 |class Gem::Package::TarReader::UnexpectedEOF < StandardError
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    bar/bar.rb:14: Did you mean: `Project::Bar::UnexportedClass`?
+    14 |  class UnexportedClass; end
+          ^^^^^^^^^^^^^^^^^^^^^
 Errors: 2


### PR DESCRIPTION
This allows the fuzzy constant search to descend into the symbols created by the packager pass when used with `--stripe-packages`.  We will leverage the fuzzy search to deal with typos, allowing `--stripe-packages` specific logic for errors/auto-corrects to operate only on exact matches. This makes the package code simpler and more robust. (See https://github.com/sorbet/sorbet/pull/4886 for an example)

Note: hide whitespace diff for easier review.

### Motivation
Error handling with `--stripe-packages`
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
