### PR TITLE
Add an intrinsic for `String#split`

### DIFF
--- a/compiler/IREmitter/Intrinsics/intrinsic-report.md
+++ b/compiler/IREmitter/Intrinsics/intrinsic-report.md
@@ -1235,7 +1235,7 @@
 * [   ] `rb_str_swapcase_bang` (`String#swapcase!`)
 * [   ] `rb_str_hex` (`String#hex`)
 * [   ] `rb_str_oct` (`String#oct`)
-* [   ] `rb_str_split_m` (`String#split`)
+* [  ✔] `rb_str_split_m` (`String#split`)
 * [   ] `rb_str_lines` (`String#lines`)
 * [   ] `rb_str_bytes` (`String#bytes`)
 * [   ] `rb_str_chars` (`String#chars`)
@@ -1564,4 +1564,4 @@
 
 ## Stats
 * Total:   1488
-* Visible: 243
+* Visible: 245

--- a/compiler/IREmitter/Intrinsics/wrap-intrinsics.rb
+++ b/compiler/IREmitter/Intrinsics/wrap-intrinsics.rb
@@ -304,6 +304,7 @@ module Intrinsics
       "String#slice",
       "String#start_with?",
       "String#succ",
+      "String#split",
       "String#to_sym",
     ], T::Set[String])
 

--- a/compiler/IREmitter/Payload/PayloadIntrinsics.c
+++ b/compiler/IREmitter/Payload/PayloadIntrinsics.c
@@ -736,6 +736,15 @@ VALUE sorbet_int_rb_str_ord(VALUE recv, ID fun, int argc, VALUE *const restrict 
     return rb_str_ord(recv);
 }
 
+// String#split
+// Calling convention: -1
+extern VALUE sorbet_rb_str_split_m(int argc, const VALUE *args, VALUE obj);
+
+VALUE sorbet_int_rb_str_split_m(VALUE recv, ID fun, int argc, VALUE *const restrict args, BlockFFIType blk,
+                                VALUE closure) {
+    return sorbet_rb_str_split_m(argc, args, recv);
+}
+
 // String#start_with?
 // Calling convention: -1
 extern VALUE sorbet_rb_str_start_with(int argc, const VALUE *args, VALUE obj);

--- a/compiler/IREmitter/WrappedIntrinsics.h
+++ b/compiler/IREmitter/WrappedIntrinsics.h
@@ -87,6 +87,7 @@
     {core::Symbols::String(), "length", CMethod{"sorbet_int_rb_str_length"}},
     {core::Symbols::String(), "size", CMethod{"sorbet_int_rb_str_length"}},
     {core::Symbols::String(), "ord", CMethod{"sorbet_int_rb_str_ord"}},
+    {core::Symbols::String(), "split", CMethod{"sorbet_int_rb_str_split_m"}},
     {core::Symbols::String(), "start_with?", CMethod{"sorbet_int_rb_str_start_with"}},
     {core::Symbols::String(), "succ", CMethod{"sorbet_int_rb_str_succ"}},
     {core::Symbols::String(), "next", CMethod{"sorbet_int_rb_str_succ"}},

--- a/compiler/ruby-static-exports/string.c
+++ b/compiler/ruby-static-exports/string.c
@@ -2,6 +2,10 @@ VALUE sorbet_rb_str_aref_m(int argc, const VALUE *args, VALUE obj) {
     return rb_str_aref_m(argc, args, obj);
 }
 
+VALUE sorbet_rb_str_split_m(int argc, const VALUE *args, VALUE obj) {
+    return rb_str_split_m(argc, args, obj);
+}
+
 VALUE sorbet_rb_str_start_with(int argc, const VALUE *args, VALUE obj) {
     return rb_str_start_with(argc, args, obj);
 }

--- a/test/testdata/compiler/intrinsics/string_split.rb
+++ b/test/testdata/compiler/intrinsics/string_split.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+# compiled: true
+# typed: true
+# run_filecheck: OPT
+
+module M
+  extend T::Sig
+
+  # OPT-LABEL: define internal i64 @func_M.10test_split(i32
+  sig {params(str: String).void}
+  def self.test_split(str)
+    # OPT: sorbet_rb_str_split_m
+    p str.split(' ')
+
+    # OPT: sorbet_rb_str_split_m
+    p str.split(/\s/)
+
+    # The current `String#split` intrinsic doesn't support blocks, so this case
+    # should fall back on vm dispatch
+    #
+    # OPT-NOT: sorbet_rb_str_split_m
+    p(str.split(/l/) {|x| puts "sub: #{x}"})
+  end
+  # OPT{LITERAL}: }
+end
+
+M.test_split("hello, welcome to compiled ruby")


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Though `String#split` can take a block argument, it looks like we'll get a pretty big win just by having an intrinsic for the non-block variant.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
More intrinsics for common methods

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.