### PR TITLE
Fix Hash#fetch intrinsic

### DIFF
--- a/compiler/IREmitter/Intrinsics/intrinsic-report.md
+++ b/compiler/IREmitter/Intrinsics/intrinsic-report.md
@@ -490,7 +490,7 @@
 * [✔  ] `rb_hash_aref` (`Hash#[]`)
 * [   ] `rb_hash_hash` (`Hash#hash`)
 * [   ] `rb_hash_eql` (`Hash#eql?`)
-* [  ✔] `rb_hash_fetch_m` (`Hash#fetch`)
+* [   ] `rb_hash_fetch_m` (`Hash#fetch`)
 * [✔  ] `rb_hash_aset` (`Hash#[]=`)
 * [✔  ] `rb_hash_aset` (`Hash#store`)
 * [   ] `rb_hash_default` (`Hash#default`)

--- a/compiler/IREmitter/Intrinsics/wrap-intrinsics.rb
+++ b/compiler/IREmitter/Intrinsics/wrap-intrinsics.rb
@@ -251,7 +251,6 @@ module Intrinsics
       "Float#finite?",
       "Float#infinite?",
       "Float#magnitude",
-      "Hash#fetch",
       "Hash#has_key?",
       "Hash#include?",
       "Hash#key?",

--- a/compiler/IREmitter/Payload/PayloadIntrinsics.c
+++ b/compiler/IREmitter/Payload/PayloadIntrinsics.c
@@ -326,15 +326,6 @@ VALUE sorbet_int_rb_flo_is_infinite_p(VALUE recv, ID fun, int argc, VALUE *const
     return rb_flo_is_infinite_p(recv);
 }
 
-// Hash#fetch
-// Calling convention: -1
-extern VALUE sorbet_rb_hash_fetch_m(int argc, const VALUE *args, VALUE obj);
-
-VALUE sorbet_int_rb_hash_fetch_m(VALUE recv, ID fun, int argc, VALUE *const restrict args, BlockFFIType blk,
-                                 VALUE closure) {
-    return sorbet_rb_hash_fetch_m(argc, args, recv);
-}
-
 // Hash#include?
 // Hash#member?
 // Hash#has_key?

--- a/compiler/IREmitter/Payload/codegen-payload.c
+++ b/compiler/IREmitter/Payload/codegen-payload.c
@@ -178,6 +178,8 @@ SORBET_ALIVE(VALUE, sorbet_vm_isa_p,
 
 SORBET_ALIVE(VALUE, rb_hash_keys, (VALUE recv));
 SORBET_ALIVE(VALUE, rb_hash_values, (VALUE recv));
+SORBET_ALIVE(VALUE, sorbet_rb_hash_fetch_m,
+             (VALUE recv, ID fun, int argc, const VALUE *const restrict argv, BlockFFIType blk, VALUE closure));
 
 SORBET_ALIVE(VALUE, sorbet_vm_fstring_new, (const char *ptr, long len));
 SORBET_ALIVE(VALUE, sorbet_vm_str_uplus, (VALUE str));

--- a/compiler/IREmitter/Payload/patches/hash.c
+++ b/compiler/IREmitter/Payload/patches/hash.c
@@ -49,17 +49,15 @@ VALUE sorbet_rb_hash_fetch_m(VALUE recv, ID fun, int argc, const VALUE *const re
 
     if (hash_stlike_lookup(recv, key, &val)) {
         return (VALUE)val;
-    }
-    else {
+    } else {
         if (argc == 1) {
             VALUE desc = rb_protect(rb_inspect, key, 0);
             if (NIL_P(desc)) {
                 desc = rb_any_to_s(key);
             }
             desc = rb_str_ellipsize(desc, 65);
-            rb_key_err_raise(rb_sprintf("key not found: %"PRIsVALUE, desc), recv, key);
-        }
-        else {
+            rb_key_err_raise(rb_sprintf("key not found: %" PRIsVALUE, desc), recv, key);
+        } else {
             return argv[1];
         }
     }

--- a/compiler/IREmitter/Payload/patches/hash.c
+++ b/compiler/IREmitter/Payload/patches/hash.c
@@ -1,3 +1,4 @@
+typedef VALUE (*BlockFFIType)(VALUE firstYieldedArg, VALUE closure, int argCount, const VALUE *args, VALUE blockArg);
 
 // A faster version of merge!, under the assumption that we don't pass blocks, and only pass a single arg.
 VALUE sorbet_magic_mergeHashHelper(VALUE self, VALUE hash) {
@@ -35,4 +36,31 @@ VALUE sorbet_rb_hash_to_h(VALUE hash) {
         hash = hash_dup(hash, rb_cHash, flags & RHASH_PROC_DEFAULT);
     }
     return hash;
+}
+
+// no-block rb_hash_fetch_m: https://github.com/ruby/ruby/blob/ruby_2_7/hash.c#L2113-L2147
+VALUE sorbet_rb_hash_fetch_m(VALUE recv, ID fun, int argc, const VALUE *const restrict argv, BlockFFIType blk,
+                             VALUE closure) {
+    VALUE key;
+    st_data_t val;
+
+    rb_check_arity(argc, 1, 2);
+    key = argv[0];
+
+    if (hash_stlike_lookup(recv, key, &val)) {
+        return (VALUE)val;
+    }
+    else {
+        if (argc == 1) {
+            VALUE desc = rb_protect(rb_inspect, key, 0);
+            if (NIL_P(desc)) {
+                desc = rb_any_to_s(key);
+            }
+            desc = rb_str_ellipsize(desc, 65);
+            rb_key_err_raise(rb_sprintf("key not found: %"PRIsVALUE, desc), recv, key);
+        }
+        else {
+            return argv[1];
+        }
+    }
 }

--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -955,6 +955,7 @@ static const vector<CallCMethod> knownCMethodsInstance{
      CMethod{"sorbet_int_hash_to_h_withBlock", core::Symbols::Hash()},
      {KnownFunction::cached("sorbet_rb_hash_to_h_func")}},
     {core::Symbols::Hash(), "to_hash", CMethod{"sorbet_returnRecv", core::Symbols::Hash()}},
+    {core::Symbols::Hash(), "fetch", CMethod{"sorbet_rb_hash_fetch_m"}},
     {core::Symbols::TrueClass(), "|", CMethod{"sorbet_int_bool_true"}},
     {core::Symbols::FalseClass(), "|", CMethod{"sorbet_int_bool_and"}},
     {core::Symbols::TrueClass(), "&", CMethod{"sorbet_int_bool_and"}},

--- a/compiler/IREmitter/WrappedIntrinsics.h
+++ b/compiler/IREmitter/WrappedIntrinsics.h
@@ -36,7 +36,6 @@
     {core::Symbols::Float(), "magnitude", CMethod{"sorbet_int_rb_float_abs"}},
     {core::Symbols::Float(), "finite?", CMethod{"sorbet_int_rb_flo_is_finite_p"}},
     {core::Symbols::Float(), "infinite?", CMethod{"sorbet_int_rb_flo_is_infinite_p"}},
-    {core::Symbols::Hash(), "fetch", CMethod{"sorbet_int_rb_hash_fetch_m"}},
     {core::Symbols::Hash(), "include?", CMethod{"sorbet_int_rb_hash_has_key"}},
     {core::Symbols::Hash(), "member?", CMethod{"sorbet_int_rb_hash_has_key"}},
     {core::Symbols::Hash(), "has_key?", CMethod{"sorbet_int_rb_hash_has_key"}},

--- a/compiler/ruby-static-exports/hash.c
+++ b/compiler/ruby-static-exports/hash.c
@@ -1,3 +1,0 @@
-VALUE sorbet_rb_hash_fetch_m(int argc, const VALUE *args, VALUE obj) {
-    return rb_hash_fetch_m(argc, args, obj);
-}

--- a/test/testdata/compiler/intrinsics/hash_fetch.rb
+++ b/test/testdata/compiler/intrinsics/hash_fetch.rb
@@ -11,7 +11,7 @@ def one_arg(hash, key)
 end
 
 # INITIAL-LABEL: define internal i64 @"func_Object#7one_arg"
-# INITIAL: call i64 @sorbet_int_rb_hash_fetch_m
+# INITIAL: call i64 @sorbet_rb_hash_fetch_m
 # INITIAL{LITERAL}: }
 
 sig {params(hash: T::Hash[T.untyped, T.untyped], key: T.untyped, default: T.untyped).returns(T.untyped)}
@@ -20,7 +20,7 @@ def two_arg(hash, key, default)
 end
 
 # INITIAL-LABEL: define internal i64 @"func_Object#7two_arg"
-# INITIAL: call i64 @sorbet_int_rb_hash_fetch_m
+# INITIAL: call i64 @sorbet_rb_hash_fetch_m
 # INITIAL{LITERAL}: }
 
 sig {params(hash: T::Hash[T.untyped, T.untyped], key: T.untyped, blk: T.untyped).returns(T.untyped)}
@@ -31,7 +31,7 @@ def block_arg(hash, key, &blk)
 end
 
 # INITIAL-LABEL: define internal i64 @"func_Object#9block_arg"
-# INITIAL-NOT: call i64 @sorbet_int_rb_hash_fetch_m
+# INITIAL-NOT: call i64 @sorbet_rb_hash_fetch_m
 # INITIAL{LITERAL}: }
 
 p one_arg({key: 5}, :key)

--- a/test/testdata/compiler/regression/hash_fetch_noblk.rb
+++ b/test/testdata/compiler/regression/hash_fetch_noblk.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+# compiled: true
+# typed: true
+
+# This checks that the Hash#fetch intrinsic isn't inheriting the block from the
+# context of the call_fetch method that it's called from. The failure mode here
+# is that Hash#fetch picks up that there was a block passed in, and uses it as
+# its own.
+
+module M
+  def self.call_fetch(&blk)
+    {}.fetch(:x)
+  end
+end
+
+begin
+  puts M.call_fetch { puts "block called" }
+rescue KeyError
+  puts "got KeyError so block wasn't called"
+end


### PR DESCRIPTION
This switches the Hash#fetch intrinsic to an implementation that won't accidentally steal the block from the calling context.

See also #4893.


### Motivation
Bugfix.


### Test plan
See included automated tests.
