### PR TITLE
Make SymbolRef::data private

### DIFF
--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -186,9 +186,9 @@ string Ident::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) con
 
 string Alias::toString(const core::GlobalState &gs, const CFG &cfg) const {
     if (name.exists()) {
-        return fmt::format("alias {} ({})", this->what.data(gs)->name.toString(gs), name.toString(gs));
+        return fmt::format("alias {} ({})", this->what.name(gs).toString(gs), name.toString(gs));
     } else {
-        return fmt::format("alias {}", this->what.data(gs)->name.toString(gs));
+        return fmt::format("alias {}", this->what.name(gs).toString(gs));
     }
 }
 

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -64,7 +64,7 @@ LocalRef unresolvedIdent2Local(CFGContext cctx, const ast::UnresolvedIdent &id) 
             break;
         case ast::UnresolvedIdent::Kind::Instance:
             ENFORCE(cctx.ctx.owner.data(cctx.ctx)->isMethod());
-            klass = cctx.ctx.owner.data(cctx.ctx)->owner.asClassOrModuleRef();
+            klass = cctx.ctx.owner.owner(cctx.ctx).asClassOrModuleRef();
             break;
         case ast::UnresolvedIdent::Kind::Global:
             klass = core::Symbols::root();

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -63,7 +63,7 @@ LocalRef unresolvedIdent2Local(CFGContext cctx, const ast::UnresolvedIdent &id) 
             }
             break;
         case ast::UnresolvedIdent::Kind::Instance:
-            ENFORCE(cctx.ctx.owner.data(cctx.ctx)->isMethod());
+            ENFORCE(cctx.ctx.owner.isMethod());
             klass = cctx.ctx.owner.owner(cctx.ctx).asClassOrModuleRef();
             break;
         case ast::UnresolvedIdent::Kind::Global:

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -47,8 +47,7 @@ LocalRef global2Local(CFGContext cctx, core::SymbolRef what) {
     // Note: this will add an empty local to aliases if 'what' is not there
     LocalRef &alias = cctx.aliases[what];
     if (!alias.exists()) {
-        auto data = what.data(cctx.ctx);
-        alias = cctx.newTemporary(data->name);
+        alias = cctx.newTemporary(what.name(cctx.ctx));
     }
     return alias;
 }

--- a/compiler/Core/ForwardDeclarations.h
+++ b/compiler/Core/ForwardDeclarations.h
@@ -21,6 +21,7 @@ class GlobalState;
 class Loc;
 class MutableContext;
 class SymbolRef;
+class MethodRef;
 class NameRef;
 } // namespace sorbet::core
 

--- a/compiler/IREmitter/IREmitter.cc
+++ b/compiler/IREmitter/IREmitter.cc
@@ -28,7 +28,7 @@ namespace sorbet::compiler {
 
 namespace {
 
-vector<core::ArgInfo::ArgFlags> getArgFlagsForBlockId(CompilerState &cs, int blockId, core::SymbolRef method,
+vector<core::ArgInfo::ArgFlags> getArgFlagsForBlockId(CompilerState &cs, int blockId, core::MethodRef method,
                                                       const IREmitterContext &irctx) {
     auto ty = irctx.rubyBlockType[blockId];
     ENFORCE(ty == FunctionType::Block || ty == FunctionType::Method || ty == FunctionType::StaticInitFile ||

--- a/compiler/IREmitter/IREmitter.cc
+++ b/compiler/IREmitter/IREmitter.cc
@@ -1054,10 +1054,10 @@ void IREmitter::run(CompilerState &cs, cfg::CFG &cfg, const ast::MethodDef &md) 
     cs.runCheapOptimizations(func);
 }
 
-void IREmitter::buildInitFor(CompilerState &cs, const core::SymbolRef &sym, string_view objectName) {
+void IREmitter::buildInitFor(CompilerState &cs, const core::MethodRef &sym, string_view objectName) {
     llvm::IRBuilder<> builder(cs);
 
-    auto owner = sym.owner(cs);
+    auto owner = sym.data(cs)->owner;
     auto isRoot = IREmitterHelpers::isRootishSymbol(cs, owner);
     llvm::Function *entryFunc;
 
@@ -1101,7 +1101,7 @@ void IREmitter::buildInitFor(CompilerState &cs, const core::SymbolRef &sym, stri
 
         builder.CreateCall(cs.getFunction("sorbet_globalConstructors"), {realpath});
 
-        core::SymbolRef staticInit = cs.gs.lookupStaticInitForFile(sym.loc(cs));
+        core::MethodRef staticInit = cs.gs.lookupStaticInitForFile(sym.data(cs)->loc());
 
         // Call the LLVM method that was made by run() from this Init_ method
         auto staticInitName = IREmitterHelpers::getFunctionName(cs, staticInit);

--- a/compiler/IREmitter/IREmitter.cc
+++ b/compiler/IREmitter/IREmitter.cc
@@ -1057,7 +1057,7 @@ void IREmitter::run(CompilerState &cs, cfg::CFG &cfg, const ast::MethodDef &md) 
 void IREmitter::buildInitFor(CompilerState &cs, const core::SymbolRef &sym, string_view objectName) {
     llvm::IRBuilder<> builder(cs);
 
-    auto owner = sym.data(cs)->owner;
+    auto owner = sym.owner(cs);
     auto isRoot = IREmitterHelpers::isRootishSymbol(cs, owner);
     llvm::Function *entryFunc;
 
@@ -1101,7 +1101,7 @@ void IREmitter::buildInitFor(CompilerState &cs, const core::SymbolRef &sym, stri
 
         builder.CreateCall(cs.getFunction("sorbet_globalConstructors"), {realpath});
 
-        core::SymbolRef staticInit = cs.gs.lookupStaticInitForFile(sym.data(cs)->loc());
+        core::SymbolRef staticInit = cs.gs.lookupStaticInitForFile(sym.loc(cs));
 
         // Call the LLVM method that was made by run() from this Init_ method
         auto staticInitName = IREmitterHelpers::getFunctionName(cs, staticInit);

--- a/compiler/IREmitter/IREmitter.h
+++ b/compiler/IREmitter/IREmitter.h
@@ -8,7 +8,7 @@ class CompilerState;
 class IREmitter {
 public:
     static void run(CompilerState &, cfg::CFG &cfg, const ast::MethodDef &md);
-    static void buildInitFor(CompilerState &gs, const core::SymbolRef &sym, std::string_view objectName);
+    static void buildInitFor(CompilerState &gs, const core::MethodRef &sym, std::string_view objectName);
 };
 } // namespace sorbet::compiler
 #endif

--- a/compiler/IREmitter/IREmitterContext.cc
+++ b/compiler/IREmitter/IREmitterContext.cc
@@ -76,9 +76,9 @@ AliasesAndKeywords setupAliasesAndKeywords(CompilerState &cs, const cfg::CFG &cf
                     auto shortName = name.shortName(cs);
                     ENFORCE(!(shortName.size() > 0 && shortName[0] == '$'));
 
-                    if (i->what.data(cs)->isField()) {
+                    if (i->what.isField(cs)) {
                         res.aliases[bind.bind.variable] = Alias::forInstanceField(name);
-                    } else if (i->what.data(cs)->isStaticField()) {
+                    } else if (i->what.isStaticField(cs)) {
                         if (shortName.size() > 2 && shortName[0] == '@' && shortName[1] == '@') {
                             res.aliases[bind.bind.variable] = Alias::forClassField(name);
                         } else {

--- a/compiler/IREmitter/IREmitterContext.cc
+++ b/compiler/IREmitter/IREmitterContext.cc
@@ -72,7 +72,7 @@ AliasesAndKeywords setupAliasesAndKeywords(CompilerState &cs, const cfg::CFG &cf
                 } else {
                     // It's currently impossible in Sorbet to declare a global field with a T.let
                     // (they will all be Magic_undeclaredFieldStub)
-                    auto name = i->what.data(cs)->name;
+                    auto name = i->what.name(cs);
                     auto shortName = name.shortName(cs);
                     ENFORCE(!(shortName.size() > 0 && shortName[0] == '$'));
 
@@ -499,7 +499,7 @@ llvm::DISubprogram *getDebugScope(CompilerState &cs, cfg::CFG &cfg, llvm::DIScop
     auto loc = cfg.symbol.data(cs)->loc();
 
     auto owner = cfg.symbol.data(cs)->owner;
-    std::string diName(owner.data(cs)->name.shortName(cs));
+    std::string diName(owner.name(cs).shortName(cs));
 
     if (owner.data(cs)->isSingletonClass(cs)) {
         diName += ".";

--- a/compiler/IREmitter/IREmitterContext.cc
+++ b/compiler/IREmitter/IREmitterContext.cc
@@ -501,7 +501,7 @@ llvm::DISubprogram *getDebugScope(CompilerState &cs, cfg::CFG &cfg, llvm::DIScop
     auto owner = cfg.symbol.data(cs)->owner;
     std::string diName(owner.name(cs).shortName(cs));
 
-    if (owner.data(cs)->isSingletonClass(cs)) {
+    if (owner.isSingletonClass(cs)) {
         diName += ".";
     } else {
         diName += "#";

--- a/compiler/IREmitter/IREmitterHelpers.cc
+++ b/compiler/IREmitter/IREmitterHelpers.cc
@@ -43,12 +43,13 @@ string getFunctionNamePrefix(CompilerState &cs, core::ClassOrModuleRef sym) {
 } // namespace
 
 string IREmitterHelpers::getFunctionName(CompilerState &cs, core::SymbolRef sym) {
-    auto maybeAttachedOwner = sym.owner(cs).data(cs)->attachedClass(cs);
+    auto owner = sym.owner(cs).asClassOrModuleRef();
+    auto maybeAttachedOwner = owner.data(cs)->attachedClass(cs);
     string prefix = "func_";
     if (maybeAttachedOwner.exists()) {
         prefix = prefix + getFunctionNamePrefix(cs, maybeAttachedOwner) + ".";
     } else {
-        prefix = prefix + getFunctionNamePrefix(cs, sym.owner(cs).asClassOrModuleRef()) + "#";
+        prefix = prefix + getFunctionNamePrefix(cs, owner) + "#";
     }
 
     auto name = sym.name(cs);

--- a/compiler/IREmitter/IREmitterHelpers.cc
+++ b/compiler/IREmitter/IREmitterHelpers.cc
@@ -28,7 +28,7 @@ string getFunctionNamePrefix(CompilerState &cs, core::SymbolRef sym) {
         return getFunctionNamePrefix(cs, maybeAttached) + ".singleton_class";
     }
     string suffix;
-    auto name = sym.data(cs)->name;
+    auto name = sym.name(cs);
     if (name.kind() == core::NameKind::CONSTANT && name.dataCnst(cs)->original.kind() == core::NameKind::UTF8) {
         suffix = string(name.shortName(cs));
     } else {
@@ -51,7 +51,7 @@ string IREmitterHelpers::getFunctionName(CompilerState &cs, core::SymbolRef sym)
         prefix = prefix + getFunctionNamePrefix(cs, sym.data(cs)->owner) + "#";
     }
 
-    auto name = sym.data(cs)->name;
+    auto name = sym.name(cs);
     string suffix;
     if (name.kind() == core::NameKind::UTF8) {
         suffix = string(name.shortName(cs));
@@ -78,7 +78,7 @@ string IREmitterHelpers::getFunctionName(CompilerState &cs, core::SymbolRef sym)
 }
 
 bool IREmitterHelpers::isFileStaticInit(const core::GlobalState &gs, core::SymbolRef sym) {
-    auto name = sym.data(gs)->name;
+    auto name = sym.name(gs);
     if (name.kind() != core::NameKind::UNIQUE) {
         return false;
     }
@@ -86,7 +86,7 @@ bool IREmitterHelpers::isFileStaticInit(const core::GlobalState &gs, core::Symbo
 }
 
 bool IREmitterHelpers::isClassStaticInit(const core::GlobalState &gs, core::SymbolRef sym) {
-    return sym.data(gs)->name == core::Names::staticInit();
+    return sym.name(gs) == core::Names::staticInit();
 }
 
 bool IREmitterHelpers::isFileOrClassStaticInit(const core::GlobalState &gs, core::SymbolRef sym) {
@@ -367,7 +367,7 @@ core::SymbolRef IREmitterHelpers::fixupOwningSymbol(const core::GlobalState &gs,
 std::string IREmitterHelpers::showClassNameWithoutOwner(const core::GlobalState &gs, core::SymbolRef sym) {
     std::string withoutOwnerStr;
 
-    auto name = sym.data(gs)->name;
+    auto name = sym.name(gs);
     if (name.kind() == core::NameKind::UNIQUE) {
         withoutOwnerStr = name.dataUnique(gs)->original.show(gs);
     } else {
@@ -405,7 +405,7 @@ bool IREmitterHelpers::isRootishSymbol(const core::GlobalState &gs, core::Symbol
 
     // --stripe-packages interposes its own set of symbols at the toplevel.
     // Absent any runtime support, we need to consider these as rootish.
-    if (sym == core::Symbols::PackageRegistry() || sym.data(gs)->name.isPackagerName(gs)) {
+    if (sym == core::Symbols::PackageRegistry() || sym.name(gs).isPackagerName(gs)) {
         return true;
     }
 

--- a/compiler/IREmitter/IREmitterHelpers.cc
+++ b/compiler/IREmitter/IREmitterHelpers.cc
@@ -34,21 +34,20 @@ string getFunctionNamePrefix(CompilerState &cs, core::SymbolRef sym) {
     } else {
         suffix = name.toString(cs);
     }
-    string prefix = IREmitterHelpers::isRootishSymbol(cs, sym.data(cs)->owner)
-                        ? ""
-                        : getFunctionNamePrefix(cs, sym.data(cs)->owner) + "::";
+    string prefix =
+        IREmitterHelpers::isRootishSymbol(cs, sym.owner(cs)) ? "" : getFunctionNamePrefix(cs, sym.owner(cs)) + "::";
 
     return prefix + suffix;
 }
 } // namespace
 
 string IREmitterHelpers::getFunctionName(CompilerState &cs, core::SymbolRef sym) {
-    auto maybeAttachedOwner = sym.data(cs)->owner.data(cs)->attachedClass(cs);
+    auto maybeAttachedOwner = sym.owner(cs).data(cs)->attachedClass(cs);
     string prefix = "func_";
     if (maybeAttachedOwner.exists()) {
         prefix = prefix + getFunctionNamePrefix(cs, maybeAttachedOwner) + ".";
     } else {
-        prefix = prefix + getFunctionNamePrefix(cs, sym.data(cs)->owner) + "#";
+        prefix = prefix + getFunctionNamePrefix(cs, sym.owner(cs)) + "#";
     }
 
     auto name = sym.name(cs);
@@ -378,7 +377,7 @@ std::string IREmitterHelpers::showClassNameWithoutOwner(const core::GlobalState 
     // the above calls are done inside NameRef, which doesn't have the necessary
     // symbol ownership information to do this sort of munging.  So we have to
     // duplicate the Symbol logic here.
-    if (sym.data(gs)->owner != core::Symbols::PackageRegistry() || !name.isPackagerName(gs)) {
+    if (sym.owner(gs) != core::Symbols::PackageRegistry() || !name.isPackagerName(gs)) {
         return withoutOwnerStr;
     }
 
@@ -434,7 +433,7 @@ IREmitterHelpers::isFinalMethod(const core::GlobalState &gs, core::TypePtr recvT
         return std::nullopt;
     }
 
-    auto file = funSym.data(gs)->loc().file();
+    auto file = funSym.loc(gs).file();
     if (file.data(gs).compiledLevel != core::CompiledLevel::True) {
         return std::nullopt;
     }

--- a/compiler/IREmitter/IREmitterHelpers.cc
+++ b/compiler/IREmitter/IREmitterHelpers.cc
@@ -431,7 +431,7 @@ IREmitterHelpers::isFinalMethod(const core::GlobalState &gs, core::TypePtr recvT
         return std::nullopt;
     }
 
-    if (!funSym.data(gs)->isFinalMethod()) {
+    if (!funSym.asMethodRef().data(gs)->isFinalMethod()) {
         return std::nullopt;
     }
 

--- a/compiler/IREmitter/IREmitterHelpers.cc
+++ b/compiler/IREmitter/IREmitterHelpers.cc
@@ -426,21 +426,21 @@ IREmitterHelpers::isFinalMethod(const core::GlobalState &gs, core::TypePtr recvT
         return std::nullopt;
     }
 
-    auto funSym = recvSym.data(gs)->findMember(gs, fun);
+    auto funSym = recvSym.data(gs)->findMethod(gs, fun);
     if (!funSym.exists()) {
         return std::nullopt;
     }
 
-    if (!funSym.asMethodRef().data(gs)->isFinalMethod()) {
+    if (!funSym.data(gs)->isFinalMethod()) {
         return std::nullopt;
     }
 
-    auto file = funSym.loc(gs).file();
+    auto file = funSym.data(gs)->loc().file();
     if (file.data(gs).compiledLevel != core::CompiledLevel::True) {
         return std::nullopt;
     }
 
-    return IREmitterHelpers::FinalMethodInfo{recvSym, funSym.asMethodRef(), file};
+    return IREmitterHelpers::FinalMethodInfo{recvSym, funSym, file};
 }
 
 llvm::Value *KnownFunction::getFunction(CompilerState &cs, llvm::IRBuilderBase &builder) const {

--- a/compiler/IREmitter/IREmitterHelpers.h
+++ b/compiler/IREmitter/IREmitterHelpers.h
@@ -86,18 +86,18 @@ private:
 
 class IREmitterHelpers {
 public:
-    static bool isClassStaticInit(const core::GlobalState &gs, core::SymbolRef sym);
-    static bool isFileStaticInit(const core::GlobalState &gs, core::SymbolRef sym);
-    static bool isFileOrClassStaticInit(const core::GlobalState &gs, core::SymbolRef sym);
+    static bool isClassStaticInit(const core::GlobalState &gs, core::MethodRef sym);
+    static bool isFileStaticInit(const core::GlobalState &gs, core::MethodRef sym);
+    static bool isFileOrClassStaticInit(const core::GlobalState &gs, core::MethodRef sym);
 
-    static std::string getFunctionName(CompilerState &cs, core::SymbolRef sym);
-    static llvm::Function *lookupFunction(CompilerState &cs, core::SymbolRef sym);
+    static std::string getFunctionName(CompilerState &cs, core::MethodRef sym);
+    static llvm::Function *lookupFunction(CompilerState &cs, core::MethodRef sym);
     static llvm::Function *cleanFunctionBody(CompilerState &cs, llvm::Function *func);
-    static llvm::Function *getOrCreateStaticInit(CompilerState &cs, core::SymbolRef sym, core::LocOffsets loc);
-    static llvm::Function *getOrCreateFunction(CompilerState &cs, core::SymbolRef sym);
-    static llvm::Function *getOrCreateDirectWrapper(CompilerState &cs, core::SymbolRef sym);
+    static llvm::Function *getOrCreateStaticInit(CompilerState &cs, core::MethodRef sym, core::LocOffsets loc);
+    static llvm::Function *getOrCreateFunction(CompilerState &cs, core::MethodRef sym);
+    static llvm::Function *getOrCreateDirectWrapper(CompilerState &cs, core::MethodRef sym);
 
-    static llvm::Function *getInitFunction(CompilerState &cs, core::SymbolRef sym);
+    static llvm::Function *getInitFunction(CompilerState &cs, core::MethodRef sym);
 
     static std::size_t sendArgCount(cfg::Send *send);
 
@@ -157,7 +157,7 @@ public:
                                        const core::TypePtr &literalish);
 
     // Return true if the given blockId has a block argument.
-    static bool hasBlockArgument(CompilerState &gs, int blockId, core::SymbolRef method, const IREmitterContext &irctx);
+    static bool hasBlockArgument(CompilerState &gs, int blockId, core::MethodRef method, const IREmitterContext &irctx);
 
     // Given an owner as the Sorbet-visible symbol, return the parent symbol
     // as seen by the Ruby VM.
@@ -170,7 +170,7 @@ public:
 
     struct FinalMethodInfo {
         core::ClassOrModuleRef recv;
-        core::SymbolRef method;
+        core::MethodRef method;
         core::FileRef file;
     };
 

--- a/compiler/IREmitter/NameBasedIntrinsics.cc
+++ b/compiler/IREmitter/NameBasedIntrinsics.cc
@@ -24,7 +24,7 @@
 using namespace std;
 namespace sorbet::compiler {
 namespace {
-core::SymbolRef typeToSym(const core::GlobalState &gs, core::TypePtr typ) {
+core::ClassOrModuleRef typeToSym(const core::GlobalState &gs, core::TypePtr typ) {
     core::SymbolRef sym;
     if (core::isa_type<core::ClassType>(typ)) {
         sym = core::cast_type_nonnull<core::ClassType>(typ).symbol;
@@ -34,8 +34,7 @@ core::SymbolRef typeToSym(const core::GlobalState &gs, core::TypePtr typ) {
         ENFORCE(false);
     }
     sym = IREmitterHelpers::fixupOwningSymbol(gs, sym);
-    ENFORCE(sym.isClassOrModule());
-    return sym;
+    return sym.asClassOrModuleRef();
 }
 
 class DoNothingIntrinsic : public NameBasedIntrinsicMethod {
@@ -85,8 +84,8 @@ public:
             auto classNameCStr = Payload::toCString(cs, IREmitterHelpers::showClassNameWithoutOwner(cs, sym), builder);
             auto isModule = sym.data(cs)->superClass() == core::Symbols::Module();
 
-            if (!IREmitterHelpers::isRootishSymbol(cs, sym.owner(cs))) {
-                auto getOwner = Payload::getRubyConstant(cs, sym.owner(cs), builder);
+            if (!IREmitterHelpers::isRootishSymbol(cs, sym.data(cs)->owner)) {
+                auto getOwner = Payload::getRubyConstant(cs, sym.data(cs)->owner, builder);
                 if (isModule) {
                     module = builder.CreateCall(cs.getFunction("sorbet_defineNestedModule"), {getOwner, classNameCStr});
                 } else {

--- a/compiler/IREmitter/NameBasedIntrinsics.cc
+++ b/compiler/IREmitter/NameBasedIntrinsics.cc
@@ -85,8 +85,8 @@ public:
             auto classNameCStr = Payload::toCString(cs, IREmitterHelpers::showClassNameWithoutOwner(cs, sym), builder);
             auto isModule = sym.data(cs)->superClass() == core::Symbols::Module();
 
-            if (!IREmitterHelpers::isRootishSymbol(cs, sym.data(cs)->owner)) {
-                auto getOwner = Payload::getRubyConstant(cs, sym.data(cs)->owner, builder);
+            if (!IREmitterHelpers::isRootishSymbol(cs, sym.owner(cs))) {
+                auto getOwner = Payload::getRubyConstant(cs, sym.owner(cs), builder);
                 if (isModule) {
                     module = builder.CreateCall(cs.getFunction("sorbet_defineNestedModule"), {getOwner, classNameCStr});
                 } else {

--- a/compiler/IREmitter/NameBasedIntrinsics.cc
+++ b/compiler/IREmitter/NameBasedIntrinsics.cc
@@ -34,7 +34,7 @@ core::SymbolRef typeToSym(const core::GlobalState &gs, core::TypePtr typ) {
         ENFORCE(false);
     }
     sym = IREmitterHelpers::fixupOwningSymbol(gs, sym);
-    ENFORCE(sym.data(gs)->isClassOrModule());
+    ENFORCE(sym.isClassOrModule());
     return sym;
 }
 

--- a/compiler/IREmitter/NameBasedIntrinsics.cc
+++ b/compiler/IREmitter/NameBasedIntrinsics.cc
@@ -25,7 +25,7 @@ using namespace std;
 namespace sorbet::compiler {
 namespace {
 core::ClassOrModuleRef typeToSym(const core::GlobalState &gs, core::TypePtr typ) {
-    core::SymbolRef sym;
+    core::ClassOrModuleRef sym;
     if (core::isa_type<core::ClassType>(typ)) {
         sym = core::cast_type_nonnull<core::ClassType>(typ).symbol;
     } else if (auto appliedType = core::cast_type<core::AppliedType>(typ)) {
@@ -33,8 +33,8 @@ core::ClassOrModuleRef typeToSym(const core::GlobalState &gs, core::TypePtr typ)
     } else {
         ENFORCE(false);
     }
-    sym = IREmitterHelpers::fixupOwningSymbol(gs, sym);
-    return sym.asClassOrModuleRef();
+    sym = IREmitterHelpers::fixupOwningSymbol(gs, sym).asClassOrModuleRef();
+    return sym;
 }
 
 class DoNothingIntrinsic : public NameBasedIntrinsicMethod {

--- a/compiler/IREmitter/Payload.cc
+++ b/compiler/IREmitter/Payload.cc
@@ -227,7 +227,7 @@ std::string showClassName(const core::GlobalState &gs, core::SymbolRef sym) {
 } // namespace
 
 llvm::Value *Payload::getRubyConstant(CompilerState &cs, core::SymbolRef sym, llvm::IRBuilderBase &builder) {
-    ENFORCE(sym.isClassOrModule() || sym.isStaticField(cs) || sym.data(cs)->isTypeMember());
+    ENFORCE(sym.isClassOrModule() || sym.isStaticField(cs) || sym.isTypeMember());
     sym = IREmitterHelpers::fixupOwningSymbol(cs, sym);
     auto str = showClassName(cs, sym);
     ENFORCE(str.length() < 2 || (str[0] != ':'), "implementation assumes that strings dont start with ::");

--- a/compiler/IREmitter/Payload.cc
+++ b/compiler/IREmitter/Payload.cc
@@ -227,7 +227,7 @@ std::string showClassName(const core::GlobalState &gs, core::SymbolRef sym) {
 } // namespace
 
 llvm::Value *Payload::getRubyConstant(CompilerState &cs, core::SymbolRef sym, llvm::IRBuilderBase &builder) {
-    ENFORCE(sym.isClassOrModule() || sym.data(cs)->isStaticField() || sym.data(cs)->isTypeMember());
+    ENFORCE(sym.isClassOrModule() || sym.isStaticField(cs) || sym.data(cs)->isTypeMember());
     sym = IREmitterHelpers::fixupOwningSymbol(cs, sym);
     auto str = showClassName(cs, sym);
     ENFORCE(str.length() < 2 || (str[0] != ':'), "implementation assumes that strings dont start with ::");

--- a/compiler/IREmitter/Payload.cc
+++ b/compiler/IREmitter/Payload.cc
@@ -227,11 +227,11 @@ std::string showClassName(const core::GlobalState &gs, core::SymbolRef sym) {
 } // namespace
 
 llvm::Value *Payload::getRubyConstant(CompilerState &cs, core::SymbolRef sym, llvm::IRBuilderBase &builder) {
-    ENFORCE(sym.data(cs)->isClassOrModule() || sym.data(cs)->isStaticField() || sym.data(cs)->isTypeMember());
+    ENFORCE(sym.isClassOrModule() || sym.data(cs)->isStaticField() || sym.data(cs)->isTypeMember());
     sym = IREmitterHelpers::fixupOwningSymbol(cs, sym);
     auto str = showClassName(cs, sym);
     ENFORCE(str.length() < 2 || (str[0] != ':'), "implementation assumes that strings dont start with ::");
-    auto functionName = sym.data(cs)->isClassOrModule() ? "sorbet_i_getRubyClass" : "sorbet_i_getRubyConstant";
+    auto functionName = sym.isClassOrModule() ? "sorbet_i_getRubyClass" : "sorbet_i_getRubyConstant";
     return builder.CreateCall(
         cs.getFunction(functionName),
         {Payload::toCString(cs, str, builder), llvm::ConstantInt::get(cs, llvm::APInt(64, str.length()))});

--- a/compiler/IREmitter/Payload.cc
+++ b/compiler/IREmitter/Payload.cc
@@ -1024,7 +1024,7 @@ void Payload::varSet(CompilerState &cs, cfg::LocalRef local, llvm::Value *var, l
         switch (alias.kind) {
             case Alias::AliasKind::Constant: {
                 auto sym = alias.constantSym;
-                auto name = sym.data(cs.gs)->name.show(cs.gs);
+                auto name = sym.name(cs.gs).show(cs.gs);
                 auto owner = sym.data(cs.gs)->owner;
                 builder.CreateCall(cs.getFunction("sorbet_setConstant"),
                                    {Payload::getRubyConstant(cs, owner, builder), Payload::toCString(cs, name, builder),

--- a/compiler/IREmitter/Payload.cc
+++ b/compiler/IREmitter/Payload.cc
@@ -218,7 +218,7 @@ llvm::Value *Payload::idIntern(CompilerState &cs, llvm::IRBuilderBase &builder, 
 
 namespace {
 std::string showClassName(const core::GlobalState &gs, core::SymbolRef sym) {
-    auto owner = sym.data(gs)->owner;
+    auto owner = sym.owner(gs);
     bool includeOwner = !IREmitterHelpers::isRootishSymbol(gs, owner);
     string ownerStr = includeOwner ? showClassName(gs, owner) + "::" : "";
     return ownerStr + IREmitterHelpers::showClassNameWithoutOwner(gs, sym);
@@ -1025,7 +1025,7 @@ void Payload::varSet(CompilerState &cs, cfg::LocalRef local, llvm::Value *var, l
             case Alias::AliasKind::Constant: {
                 auto sym = alias.constantSym;
                 auto name = sym.name(cs.gs).show(cs.gs);
-                auto owner = sym.data(cs.gs)->owner;
+                auto owner = sym.owner(cs.gs);
                 builder.CreateCall(cs.getFunction("sorbet_setConstant"),
                                    {Payload::getRubyConstant(cs, owner, builder), Payload::toCString(cs, name, builder),
                                     llvm::ConstantInt::get(cs, llvm::APInt(64, name.length())), var});

--- a/compiler/IREmitter/Payload.cc
+++ b/compiler/IREmitter/Payload.cc
@@ -939,9 +939,7 @@ llvm::Value *Payload::buildInstanceVariableCache(CompilerState &cs, std::string_
 
 llvm::Value *Payload::getClassVariableStoreClass(CompilerState &cs, llvm::IRBuilderBase &builder,
                                                  const IREmitterContext &irctx) {
-    auto sym = irctx.cfg.symbol.data(cs)->owner;
-    ENFORCE(sym.data(cs)->isClassOrModule());
-
+    auto sym = irctx.cfg.symbol.data(cs)->owner.asClassOrModuleRef();
     return Payload::getRubyConstant(cs, sym.data(cs)->topAttachedClass(cs), builder);
 }
 

--- a/compiler/IREmitter/Payload.cc
+++ b/compiler/IREmitter/Payload.cc
@@ -674,7 +674,7 @@ llvm::Function *allocateRubyStackFramesImpl(CompilerState &cs, const IREmitterCo
 }
 
 // The common suffix for stack frame related global names.
-string getStackFrameGlobalName(CompilerState &cs, const IREmitterContext &irctx, core::SymbolRef methodSym,
+string getStackFrameGlobalName(CompilerState &cs, const IREmitterContext &irctx, core::MethodRef methodSym,
                                int rubyBlockId) {
     auto name = IREmitterHelpers::getFunctionName(cs, methodSym);
 
@@ -694,7 +694,7 @@ string getStackFrameGlobalName(CompilerState &cs, const IREmitterContext &irctx,
 }
 
 llvm::GlobalVariable *rubyStackFrameVar(CompilerState &cs, llvm::IRBuilderBase &builder, const IREmitterContext &irctx,
-                                        core::SymbolRef methodSym, int rubyBlockId) {
+                                        core::MethodRef methodSym, int rubyBlockId) {
     auto tp = iseqType(cs);
     auto name = getStackFrameGlobalName(cs, irctx, methodSym, rubyBlockId);
     string rawName = "stackFramePrecomputed_" + name;
@@ -742,7 +742,7 @@ llvm::Value *allocateRubyStackFrames(CompilerState &cs, llvm::IRBuilderBase &bui
 } // namespace
 
 llvm::Value *Payload::rubyStackFrameVar(CompilerState &cs, llvm::IRBuilderBase &builder, const IREmitterContext &irctx,
-                                        core::SymbolRef methodSym) {
+                                        core::MethodRef methodSym) {
     return ::sorbet::compiler::rubyStackFrameVar(cs, builder, irctx, methodSym, 0);
 }
 

--- a/compiler/IREmitter/Payload.h
+++ b/compiler/IREmitter/Payload.h
@@ -118,7 +118,7 @@ public:
     static void afterIntrinsic(CompilerState &cs, llvm::IRBuilderBase &builder);
 
     static llvm::Value *rubyStackFrameVar(CompilerState &cs, llvm::IRBuilderBase &builder,
-                                          const IREmitterContext &irctx, core::SymbolRef methodSym);
+                                          const IREmitterContext &irctx, core::MethodRef methodSym);
 
     static llvm::Value *getFileLineNumberInfo(CompilerState &gs, llvm::IRBuilderBase &builder, core::FileRef file);
     static llvm::Value *getIseqEncodedPointer(CompilerState &gs, llvm::IRBuilderBase &builder, core::FileRef file);

--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -465,7 +465,7 @@ public:
         // If we're defining the method on `T.class_of(T.class_of(X))`, we need to
         // programatically access the class, rather than letting getRubyConstant do
         // that work for us.
-        if (ownerSym.data(cs)->isSingletonClass(cs)) {
+        if (ownerSym.isSingletonClass(cs)) {
             auto attachedClass = ownerSym.data(cs)->attachedClass(cs);
             ENFORCE(attachedClass.exists());
             if (attachedClass.data(cs)->isSingletonClass(cs)) {

--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -25,7 +25,7 @@
 using namespace std;
 namespace sorbet::compiler {
 namespace {
-core::SymbolRef typeToSym(const core::GlobalState &gs, core::TypePtr typ) {
+core::ClassOrModuleRef typeToSym(const core::GlobalState &gs, core::TypePtr typ) {
     core::SymbolRef sym;
     if (core::isa_type<core::ClassType>(typ)) {
         sym = core::cast_type_nonnull<core::ClassType>(typ).symbol;
@@ -36,7 +36,7 @@ core::SymbolRef typeToSym(const core::GlobalState &gs, core::TypePtr typ) {
     }
     sym = IREmitterHelpers::fixupOwningSymbol(gs, sym);
     ENFORCE(sym.isClassOrModule());
-    return sym;
+    return sym.asClassOrModuleRef();
 }
 
 class CMethod final {
@@ -465,7 +465,7 @@ public:
         // If we're defining the method on `T.class_of(T.class_of(X))`, we need to
         // programatically access the class, rather than letting getRubyConstant do
         // that work for us.
-        if (ownerSym.isSingletonClass(cs)) {
+        if (ownerSym.data(cs)->isSingletonClass(cs)) {
             auto attachedClass = ownerSym.data(cs)->attachedClass(cs);
             ENFORCE(attachedClass.exists());
             if (attachedClass.data(cs)->isSingletonClass(cs)) {

--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -75,12 +75,10 @@ public:
             while (current.data(gs)->isOverloaded()) {
                 i++;
                 auto overloadName = gs.lookupNameUnique(core::UniqueNameKind::Overload, methodName, i);
-                auto overloadSym = primaryMethod.data(gs)->owner.data(gs)->findMember(gs, overloadName);
+                auto overloadSym = primaryMethod.owner(gs).data(gs)->findMember(gs, overloadName);
                 ENFORCE(overloadSym.exists());
 
                 auto overload = overloadSym.asMethodRef();
-                ENFORCE(overload.exists());
-
                 if (core::Types::isSubType(gs, intrinsicResultType, overload.data(gs)->resultType)) {
                     return;
                 }

--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -74,9 +74,8 @@ public:
             while (current.data(gs)->isOverloaded()) {
                 i++;
                 auto overloadName = gs.lookupNameUnique(core::UniqueNameKind::Overload, methodName, i);
-                auto overloadSym = primaryMethod.data(gs)->owner.data(gs)->findMember(gs, overloadName);
-                ENFORCE(overloadSym.exists());
-                auto overload = overloadSym.asMethodRef();
+                auto overload = primaryMethod.data(gs)->owner.data(gs)->findMethod(gs, overloadName);
+                ENFORCE(overload.exists());
                 if (core::Types::isSubType(gs, intrinsicResultType, overload.data(gs)->resultType)) {
                     return;
                 }
@@ -492,7 +491,7 @@ public:
             // TODO Figure out if this speicial case is right
             lookupSym = core::Symbols::Object();
         }
-        auto funcSym = lookupSym.data(cs)->findMember(cs, funcNameRef).asMethodRef();
+        auto funcSym = lookupSym.data(cs)->findMethod(cs, funcNameRef);
         ENFORCE(funcSym.exists());
 
         // We are going to rely on compiled final methods having their return values checked.

--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -494,9 +494,8 @@ public:
             // TODO Figure out if this speicial case is right
             lookupSym = core::Symbols::Object();
         }
-        auto funcSym = lookupSym.data(cs)->findMember(cs, funcNameRef);
+        auto funcSym = lookupSym.data(cs)->findMember(cs, funcNameRef).asMethodRef();
         ENFORCE(funcSym.exists());
-        ENFORCE(funcSym.isMethod());
 
         // We are going to rely on compiled final methods having their return values checked.
         const bool needsTypechecking = funcSym.data(cs)->isFinalMethod();

--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -26,7 +26,7 @@ using namespace std;
 namespace sorbet::compiler {
 namespace {
 core::ClassOrModuleRef typeToSym(const core::GlobalState &gs, core::TypePtr typ) {
-    core::SymbolRef sym;
+    core::ClassOrModuleRef sym;
     if (core::isa_type<core::ClassType>(typ)) {
         sym = core::cast_type_nonnull<core::ClassType>(typ).symbol;
     } else if (auto appliedType = core::cast_type<core::AppliedType>(typ)) {
@@ -34,9 +34,8 @@ core::ClassOrModuleRef typeToSym(const core::GlobalState &gs, core::TypePtr typ)
     } else {
         ENFORCE(false);
     }
-    sym = IREmitterHelpers::fixupOwningSymbol(gs, sym);
-    ENFORCE(sym.isClassOrModule());
-    return sym.asClassOrModuleRef();
+    sym = IREmitterHelpers::fixupOwningSymbol(gs, sym).asClassOrModuleRef();
+    return sym;
 }
 
 class CMethod final {
@@ -75,9 +74,8 @@ public:
             while (current.data(gs)->isOverloaded()) {
                 i++;
                 auto overloadName = gs.lookupNameUnique(core::UniqueNameKind::Overload, methodName, i);
-                auto overloadSym = primaryMethod.owner(gs).data(gs)->findMember(gs, overloadName);
+                auto overloadSym = primaryMethod.data(gs)->owner.data(gs)->findMember(gs, overloadName);
                 ENFORCE(overloadSym.exists());
-
                 auto overload = overloadSym.asMethodRef();
                 if (core::Types::isSubType(gs, intrinsicResultType, overload.data(gs)->resultType)) {
                     return;

--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -260,7 +260,8 @@ protected:
 
             i++;
             auto overloadName = gs.lookupNameUnique(core::UniqueNameKind::Overload, methodName, i);
-            auto overloadSym = primaryMethod.data(gs)->owner.data(gs)->findMember(gs, overloadName);
+            auto overloadSym =
+                primaryMethod.data(gs)->owner.asClassOrModuleRef().data(gs)->findMember(gs, overloadName);
             ENFORCE(overloadSym.exists());
 
             current = overloadSym.asMethodRef();

--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -35,7 +35,7 @@ core::SymbolRef typeToSym(const core::GlobalState &gs, core::TypePtr typ) {
         ENFORCE(false);
     }
     sym = IREmitterHelpers::fixupOwningSymbol(gs, sym);
-    ENFORCE(sym.data(gs)->isClassOrModule());
+    ENFORCE(sym.isClassOrModule());
     return sym;
 }
 
@@ -496,7 +496,7 @@ public:
         }
         auto funcSym = lookupSym.data(cs)->findMember(cs, funcNameRef);
         ENFORCE(funcSym.exists());
-        ENFORCE(funcSym.data(cs)->isMethod());
+        ENFORCE(funcSym.isMethod());
 
         // We are going to rely on compiled final methods having their return values checked.
         const bool needsTypechecking = funcSym.data(cs)->isFinalMethod();

--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -275,7 +275,7 @@ protected:
 };
 
 void emitParamInitialization(CompilerState &cs, llvm::IRBuilderBase &builder, const IREmitterContext &irctx,
-                             core::SymbolRef funcSym, int rubyBlockId, llvm::Value *param) {
+                             core::MethodRef funcSym, int rubyBlockId, llvm::Value *param) {
     // Following the comment in vm_core.h:
     // https://github.com/ruby/ruby/blob/344a824ef9d4b6152703d02d7ffa042abd4252c1/vm_core.h#L321-L342
     // Comment reproduced here to make things somewhat easier to follow.
@@ -439,7 +439,7 @@ void emitParamInitialization(CompilerState &cs, llvm::IRBuilderBase &builder, co
 
 // TODO(froydnj): we need to do something like this for blocks as well.
 llvm::Value *buildParamInfo(CompilerState &cs, llvm::IRBuilderBase &builder, const IREmitterContext &irctx,
-                            core::SymbolRef funcSym, int rubyBlockId) {
+                            core::MethodRef funcSym, int rubyBlockId) {
     auto *paramInfo = builder.CreateCall(cs.getFunction("sorbet_allocateParamInfo"), {}, "parameterInfo");
 
     emitParamInitialization(cs, builder, irctx, funcSym, rubyBlockId, paramInfo);

--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -74,7 +74,8 @@ public:
             while (current.data(gs)->isOverloaded()) {
                 i++;
                 auto overloadName = gs.lookupNameUnique(core::UniqueNameKind::Overload, methodName, i);
-                auto overload = primaryMethod.data(gs)->owner.data(gs)->findMethod(gs, overloadName);
+                auto overload =
+                    primaryMethod.data(gs)->owner.asClassOrModuleRef().data(gs)->findMethod(gs, overloadName);
                 ENFORCE(overload.exists());
                 if (core::Types::isSubType(gs, intrinsicResultType, overload.data(gs)->resultType)) {
                     return;

--- a/core/Context.cc
+++ b/core/Context.cc
@@ -28,7 +28,7 @@ bool Context::permitOverloadDefinitions(const core::GlobalState &gs, FileRef sig
     if (!owner.exists()) {
         return false;
     }
-    for (auto loc : owner.data(gs)->locs()) {
+    for (auto loc : owner.locs(gs)) {
         auto &file = loc.file().data(gs);
         if ((file.isPayload() || file.isStdlib()) && owner != Symbols::root() &&
             (owner != Symbols::Object() || sigLoc.data(gs).isStdlib())) {

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -841,7 +841,7 @@ SymbolRef GlobalState::findRenamedSymbol(SymbolRef owner, SymbolRef sym) const {
     // the previous name was: for `x$n` where `n` is larger than 2, it'll be `x$(n-1)`, for bare `x`,
     // it'll be whatever the largest `x$n` that exists is, if any; otherwise, there will be none.
     ENFORCE(sym.exists(), "lookup up previous name of non-existing symbol");
-    NameRef name = sym.data(*this)->name;
+    NameRef name = sym.name(*this);
     auto ownerScope = owner.dataAllowingNone(*this);
 
     if (name.kind() == NameKind::UNIQUE) {

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2011,9 +2011,9 @@ MethodRef GlobalState::staticInitForClass(ClassOrModuleRef klass, Loc loc) {
 
 MethodRef GlobalState::lookupStaticInitForClass(ClassOrModuleRef klass) const {
     auto classData = klass.data(*this);
-    auto ref = classData->lookupSingletonClass(*this).data(*this)->findMember(*this, core::Names::staticInit());
+    auto ref = classData->lookupSingletonClass(*this).data(*this)->findMethod(*this, core::Names::staticInit());
     ENFORCE(ref.exists(), "looking up non-existent <static-init> for {}", klass.toString(*this));
-    return ref.asMethodRef();
+    return ref;
 }
 
 MethodRef GlobalState::staticInitForFile(Loc loc) {

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -428,6 +428,8 @@ public:
     const TypePtr &resultType(const GlobalState &gs) const;
     void setResultType(GlobalState &gs, const TypePtr &typePtr) const;
     SymbolRef dealias(const GlobalState &gs) const;
+    SymbolRef findMember(const GlobalState &gs, NameRef name) const;
+    SymbolRef findMemberTransitive(const GlobalState &gs, NameRef name) const;
     // Prints the fully qualified name of the symbol in a format that is suitable for showing to the user (e.g.
     // "Owner::SymbolName")
     std::string showFullName(const GlobalState &gs) const;

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -423,6 +423,7 @@ public:
     bool isSingletonClass(const GlobalState &gs) const;
     std::vector<std::pair<NameRef, SymbolRef>> membersStableOrderSlow(const GlobalState &gs) const;
     bool isPrintable(const GlobalState &gs) const;
+    const InlinedVector<Loc, 2> &locs(const GlobalState &gs) const;
     // Prints the fully qualified name of the symbol in a format that is suitable for showing to the user (e.g.
     // "Owner::SymbolName")
     std::string showFullName(const GlobalState &gs) const;

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -119,6 +119,12 @@ public:
         return ref;
     }
 
+    std::string toString(const GlobalState &gs) const {
+        bool showFull = false;
+        bool showRaw = false;
+        return toStringWithOptions(gs, 0, showFull, showRaw);
+    }
+
     SymbolData data(GlobalState &gs) const;
     ConstSymbolData data(const GlobalState &gs) const;
 

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -407,15 +407,23 @@ public:
         return TypeArgumentRef::fromRaw(unsafeTableIndex());
     }
 
+private:
+    // TODO(jvilk): Remove these methods so we can have separate classes per symbol type (e.g., Symbol ->
+    // {ClassOrModule, Method, ...}). These are currently used in methods on SymbolRef and friend classes -- but not for
+    // long.
     SymbolData data(GlobalState &gs) const;
     ConstSymbolData data(const GlobalState &gs) const;
     SymbolData dataAllowingNone(GlobalState &gs) const;
     ConstSymbolData dataAllowingNone(const GlobalState &gs) const;
 
+public:
     bool operator==(const SymbolRef &rhs) const;
 
     bool operator!=(const SymbolRef &rhs) const;
 
+    // TODO(jvilk): Remove as many of these methods as possible in favor of callsites using .data on the more specific
+    // symbol *Ref classes (e.g., ClassOrModuleRef). These were introduced to wean the codebase from calling
+    // SymbolRef::data.
     ClassOrModuleRef enclosingClass(const GlobalState &gs) const;
     std::string_view showKind(const GlobalState &gs) const;
     core::NameRef name(const GlobalState &gs) const;
@@ -430,6 +438,8 @@ public:
     SymbolRef dealias(const GlobalState &gs) const;
     SymbolRef findMember(const GlobalState &gs, NameRef name) const;
     SymbolRef findMemberTransitive(const GlobalState &gs, NameRef name) const;
+    // End methods that should be removed.
+
     // Prints the fully qualified name of the symbol in a format that is suitable for showing to the user (e.g.
     // "Owner::SymbolName")
     std::string showFullName(const GlobalState &gs) const;

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -7,6 +7,7 @@
 namespace sorbet::core {
 class Symbol;
 class GlobalState;
+class NameRef;
 struct SymbolDataDebugCheck {
     const GlobalState &gs;
     const unsigned int symbolCountAtCreation;
@@ -408,6 +409,7 @@ public:
 
     ClassOrModuleRef enclosingClass(const GlobalState &gs) const;
     std::string_view showKind(const GlobalState &gs) const;
+    core::NameRef name(const GlobalState &gs) const;
     // Prints the fully qualified name of the symbol in a format that is suitable for showing to the user (e.g.
     // "Owner::SymbolName")
     std::string showFullName(const GlobalState &gs) const;

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -421,6 +421,8 @@ public:
     core::SymbolRef owner(const GlobalState &gs) const;
     core::Loc loc(const GlobalState &gs) const;
     bool isSingletonClass(const GlobalState &gs) const;
+    std::vector<std::pair<NameRef, SymbolRef>> membersStableOrderSlow(const GlobalState &gs) const;
+    bool isPrintable(const GlobalState &gs) const;
     // Prints the fully qualified name of the symbol in a format that is suitable for showing to the user (e.g.
     // "Owner::SymbolName")
     std::string showFullName(const GlobalState &gs) const;

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -426,6 +426,7 @@ public:
     bool isPrintable(const GlobalState &gs) const;
     const InlinedVector<Loc, 2> &locs(const GlobalState &gs) const;
     const TypePtr &resultType(const GlobalState &gs) const;
+    void setResultType(GlobalState &gs, const TypePtr &typePtr) const;
     // Prints the fully qualified name of the symbol in a format that is suitable for showing to the user (e.g.
     // "Owner::SymbolName")
     std::string showFullName(const GlobalState &gs) const;

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -316,6 +316,7 @@ public:
         return kind() == Kind::TypeMember;
     }
 
+    bool isTypeAlias(const GlobalState &gs) const;
     bool isField(const GlobalState &gs) const;
     bool isStaticField(const GlobalState &gs) const;
 

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -8,6 +8,7 @@ namespace sorbet::core {
 class Symbol;
 class GlobalState;
 class NameRef;
+class Loc;
 struct SymbolDataDebugCheck {
     const GlobalState &gs;
     const unsigned int symbolCountAtCreation;
@@ -410,6 +411,8 @@ public:
     ClassOrModuleRef enclosingClass(const GlobalState &gs) const;
     std::string_view showKind(const GlobalState &gs) const;
     core::NameRef name(const GlobalState &gs) const;
+    core::SymbolRef owner(const GlobalState &gs) const;
+    core::Loc loc(const GlobalState &gs) const;
     // Prints the fully qualified name of the symbol in a format that is suitable for showing to the user (e.g.
     // "Owner::SymbolName")
     std::string showFullName(const GlobalState &gs) const;

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -413,6 +413,7 @@ public:
     core::NameRef name(const GlobalState &gs) const;
     core::SymbolRef owner(const GlobalState &gs) const;
     core::Loc loc(const GlobalState &gs) const;
+    bool isSingletonClass(const GlobalState &gs) const;
     // Prints the fully qualified name of the symbol in a format that is suitable for showing to the user (e.g.
     // "Owner::SymbolName")
     std::string showFullName(const GlobalState &gs) const;

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -427,6 +427,7 @@ public:
     const InlinedVector<Loc, 2> &locs(const GlobalState &gs) const;
     const TypePtr &resultType(const GlobalState &gs) const;
     void setResultType(GlobalState &gs, const TypePtr &typePtr) const;
+    SymbolRef dealias(const GlobalState &gs) const;
     // Prints the fully qualified name of the symbol in a format that is suitable for showing to the user (e.g.
     // "Owner::SymbolName")
     std::string showFullName(const GlobalState &gs) const;

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -9,6 +9,7 @@ class Symbol;
 class GlobalState;
 class NameRef;
 class Loc;
+class TypePtr;
 struct SymbolDataDebugCheck {
     const GlobalState &gs;
     const unsigned int symbolCountAtCreation;
@@ -424,6 +425,7 @@ public:
     std::vector<std::pair<NameRef, SymbolRef>> membersStableOrderSlow(const GlobalState &gs) const;
     bool isPrintable(const GlobalState &gs) const;
     const InlinedVector<Loc, 2> &locs(const GlobalState &gs) const;
+    const TypePtr &resultType(const GlobalState &gs) const;
     // Prints the fully qualified name of the symbol in a format that is suitable for showing to the user (e.g.
     // "Owner::SymbolName")
     std::string showFullName(const GlobalState &gs) const;

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -424,6 +424,7 @@ public:
     // TODO(jvilk): Remove as many of these methods as possible in favor of callsites using .data on the more specific
     // symbol *Ref classes (e.g., ClassOrModuleRef). These were introduced to wean the codebase from calling
     // SymbolRef::data.
+    // Please do not add methods to this list.
     ClassOrModuleRef enclosingClass(const GlobalState &gs) const;
     std::string_view showKind(const GlobalState &gs) const;
     core::NameRef name(const GlobalState &gs) const;

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -214,6 +214,10 @@ SymbolRef Symbol::ref(const GlobalState &gs) const {
     return SymbolRef(gs, type, distance);
 }
 
+bool SymbolRef::isTypeAlias(const GlobalState &gs) const {
+    return isFieldOrStaticField() && asFieldRef().data(gs)->isTypeAlias();
+}
+
 bool SymbolRef::isField(const GlobalState &gs) const {
     return isFieldOrStaticField() && asFieldRef().data(gs)->isField();
 }

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1879,7 +1879,8 @@ int Symbol::typeArity(const GlobalState &gs) const {
     ENFORCE(this->isClassOrModule());
     int arity = 0;
     for (auto &ty : this->typeMembers()) {
-        if (!ty.data(gs)->isFixed()) {
+        auto tm = ty.asTypeMemberRef();
+        if (!tm.data(gs)->isFixed()) {
             ++arity;
         }
     }

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1447,6 +1447,21 @@ const InlinedVector<Loc, 2> &SymbolRef::locs(const GlobalState &gs) const {
     }
 }
 
+const TypePtr &SymbolRef::resultType(const GlobalState &gs) const {
+    switch (kind()) {
+        case SymbolRef::Kind::ClassOrModule:
+            return asClassOrModuleRef().data(gs)->resultType;
+        case SymbolRef::Kind::Method:
+            return asMethodRef().data(gs)->resultType;
+        case SymbolRef::Kind::FieldOrStaticField:
+            return asFieldRef().data(gs)->resultType;
+        case SymbolRef::Kind::TypeArgument:
+            return asTypeArgumentRef().data(gs)->resultType;
+        case SymbolRef::Kind::TypeMember:
+            return asTypeMemberRef().data(gs)->resultType;
+    }
+}
+
 string ArgInfo::show(const GlobalState &gs) const {
     return fmt::format("{}", this->argumentName(gs));
 }

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -442,7 +442,7 @@ string ClassOrModuleRef::show(const GlobalState &gs) const {
     }
 
     if (sym->name == core::Names::Constants::AttachedClass()) {
-        auto attached = sym->owner.data(gs)->attachedClass(gs);
+        auto attached = sym->owner.asClassOrModuleRef().data(gs)->attachedClass(gs);
         ENFORCE(attached.exists());
         return fmt::format("T.attached_class (of {})", attached.show(gs));
     }
@@ -471,7 +471,7 @@ string TypeArgumentRef::show(const GlobalState &gs) const {
 string TypeMemberRef::show(const GlobalState &gs) const {
     auto sym = data(gs);
     if (sym->name == core::Names::Constants::AttachedClass()) {
-        auto attached = sym->owner.data(gs)->attachedClass(gs);
+        auto attached = sym->owner.asClassOrModuleRef().data(gs)->attachedClass(gs);
         ENFORCE(attached.exists());
         return fmt::format("T.attached_class (of {})", attached.show(gs));
     }

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1402,6 +1402,36 @@ bool SymbolRef::isSingletonClass(const GlobalState &gs) const {
     }
 }
 
+std::vector<std::pair<NameRef, SymbolRef>> SymbolRef::membersStableOrderSlow(const GlobalState &gs) const {
+    switch (kind()) {
+        case SymbolRef::Kind::ClassOrModule:
+            return asClassOrModuleRef().data(gs)->membersStableOrderSlow(gs);
+        case SymbolRef::Kind::Method:
+            return asMethodRef().data(gs)->membersStableOrderSlow(gs);
+        case SymbolRef::Kind::FieldOrStaticField:
+            return asFieldRef().data(gs)->membersStableOrderSlow(gs);
+        case SymbolRef::Kind::TypeArgument:
+            return asTypeArgumentRef().data(gs)->membersStableOrderSlow(gs);
+        case SymbolRef::Kind::TypeMember:
+            return asTypeMemberRef().data(gs)->membersStableOrderSlow(gs);
+    }
+}
+
+bool SymbolRef::isPrintable(const GlobalState &gs) const {
+    switch (kind()) {
+        case SymbolRef::Kind::ClassOrModule:
+            return asClassOrModuleRef().data(gs)->isPrintable(gs);
+        case SymbolRef::Kind::Method:
+            return asMethodRef().data(gs)->isPrintable(gs);
+        case SymbolRef::Kind::FieldOrStaticField:
+            return asFieldRef().data(gs)->isPrintable(gs);
+        case SymbolRef::Kind::TypeArgument:
+            return asTypeArgumentRef().data(gs)->isPrintable(gs);
+        case SymbolRef::Kind::TypeMember:
+            return asTypeMemberRef().data(gs)->isPrintable(gs);
+    }
+}
+
 string ArgInfo::show(const GlobalState &gs) const {
     return fmt::format("{}", this->argumentName(gs));
 }

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -452,7 +452,7 @@ string ClassOrModuleRef::show(const GlobalState &gs) const {
 
 string MethodRef::show(const GlobalState &gs) const {
     auto sym = data(gs);
-    if (sym->owner.isClassOrModule() && sym->owner.data(gs)->isSingletonClass(gs)) {
+    if (sym->owner.isClassOrModule() && sym->owner.isSingletonClass(gs)) {
         return absl::StrCat(sym->owner.data(gs)->attachedClass(gs).show(gs), ".", sym->name.show(gs));
     }
     return showInternal(gs, sym->owner, sym->name, HASH_SEPARATOR);
@@ -1362,6 +1362,15 @@ Loc SymbolRef::loc(const GlobalState &gs) const {
             return asTypeArgumentRef().data(gs)->loc();
         case SymbolRef::Kind::TypeMember:
             return asTypeMemberRef().data(gs)->loc();
+    }
+}
+
+bool SymbolRef::isSingletonClass(const GlobalState &gs) const {
+    switch (kind()) {
+        case SymbolRef::Kind::ClassOrModule:
+            return asClassOrModuleRef().data(gs)->isSingletonClass(gs);
+        default:
+            return false;
     }
 }
 

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1220,8 +1220,8 @@ string MethodRef::toStringWithOptions(const GlobalState &gs, int tabs, bool show
     }
 
     auto typeMembers = sym->typeArguments();
-    auto it =
-        remove_if(typeMembers.begin(), typeMembers.end(), [&gs](auto &sym) -> bool { return sym.data(gs)->isFixed(); });
+    auto it = remove_if(typeMembers.begin(), typeMembers.end(),
+                        [&gs](auto &sym) -> bool { return sym.asTypeArgumentRef().data(gs)->isFixed(); });
     typeMembers.erase(it, typeMembers.end());
     if (!typeMembers.empty()) {
         fmt::format_to(std::back_inserter(buf), "[{}]", fmt::map_join(typeMembers, ", ", [&](auto symb) {

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -584,6 +584,14 @@ SymbolRef Symbol::findMemberNoDealias(const GlobalState &gs, NameRef name) const
     return fnd->second;
 }
 
+MethodRef Symbol::findMethodNoDealias(const GlobalState &gs, NameRef name) const {
+    auto sym = findMemberNoDealias(gs, name);
+    if (!sym.isMethod()) {
+        return Symbols::noMethod();
+    }
+    return sym.asMethodRef();
+}
+
 SymbolRef Symbol::findMemberTransitive(const GlobalState &gs, NameRef name) const {
     return findMemberTransitiveInternal(gs, name, Flags::NONE, Flags::NONE, 100);
 }

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1432,6 +1432,21 @@ bool SymbolRef::isPrintable(const GlobalState &gs) const {
     }
 }
 
+const InlinedVector<Loc, 2> &SymbolRef::locs(const GlobalState &gs) const {
+    switch (kind()) {
+        case SymbolRef::Kind::ClassOrModule:
+            return asClassOrModuleRef().data(gs)->locs();
+        case SymbolRef::Kind::Method:
+            return asMethodRef().data(gs)->locs();
+        case SymbolRef::Kind::FieldOrStaticField:
+            return asFieldRef().data(gs)->locs();
+        case SymbolRef::Kind::TypeArgument:
+            return asTypeArgumentRef().data(gs)->locs();
+        case SymbolRef::Kind::TypeMember:
+            return asTypeMemberRef().data(gs)->locs();
+    }
+}
+
 string ArgInfo::show(const GlobalState &gs) const {
     return fmt::format("{}", this->argumentName(gs));
 }

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -760,8 +760,8 @@ vector<Symbol::FuzzySearchResult> Symbol::findMemberFuzzyMatchConstant(const Glo
                 }
             }
 
-            base = base.data(gs)->owner;
-        } while (best.distance > 0 && base.data(gs)->owner.exists() && base != Symbols::root());
+            base = base.owner(gs);
+        } while (best.distance > 0 && base.owner(gs).exists() && base != Symbols::root());
     }
 
     // At this point, `result` is in a deterministic order, and is ordered with _decreasing_ edit distance
@@ -1320,7 +1320,7 @@ string SymbolRef::toStringWithOptions(const GlobalState &gs, int tabs, bool show
     }
 }
 
-core::NameRef SymbolRef::name(const GlobalState &gs) const {
+NameRef SymbolRef::name(const GlobalState &gs) const {
     switch (kind()) {
         case SymbolRef::Kind::ClassOrModule:
             return asClassOrModuleRef().data(gs)->name;
@@ -1332,6 +1332,36 @@ core::NameRef SymbolRef::name(const GlobalState &gs) const {
             return asTypeArgumentRef().data(gs)->name;
         case SymbolRef::Kind::TypeMember:
             return asTypeMemberRef().data(gs)->name;
+    }
+}
+
+SymbolRef SymbolRef::owner(const GlobalState &gs) const {
+    switch (kind()) {
+        case SymbolRef::Kind::ClassOrModule:
+            return asClassOrModuleRef().data(gs)->owner;
+        case SymbolRef::Kind::Method:
+            return asMethodRef().data(gs)->owner;
+        case SymbolRef::Kind::FieldOrStaticField:
+            return asFieldRef().data(gs)->owner;
+        case SymbolRef::Kind::TypeArgument:
+            return asTypeArgumentRef().data(gs)->owner;
+        case SymbolRef::Kind::TypeMember:
+            return asTypeMemberRef().data(gs)->owner;
+    }
+}
+
+Loc SymbolRef::loc(const GlobalState &gs) const {
+    switch (kind()) {
+        case SymbolRef::Kind::ClassOrModule:
+            return asClassOrModuleRef().data(gs)->loc();
+        case SymbolRef::Kind::Method:
+            return asMethodRef().data(gs)->loc();
+        case SymbolRef::Kind::FieldOrStaticField:
+            return asFieldRef().data(gs)->loc();
+        case SymbolRef::Kind::TypeArgument:
+            return asTypeArgumentRef().data(gs)->loc();
+        case SymbolRef::Kind::TypeMember:
+            return asTypeMemberRef().data(gs)->loc();
     }
 }
 

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -215,14 +215,14 @@ SymbolRef Symbol::ref(const GlobalState &gs) const {
 }
 
 bool SymbolRef::isTypeAlias(const GlobalState &gs) const {
-    return isFieldOrStaticField() && asFieldRef().data(gs)->isTypeAlias();
+    return isFieldOrStaticField() && asFieldRef().dataAllowingNone(gs)->isTypeAlias();
 }
 
 bool SymbolRef::isField(const GlobalState &gs) const {
-    return isFieldOrStaticField() && asFieldRef().data(gs)->isField();
+    return isFieldOrStaticField() && asFieldRef().dataAllowingNone(gs)->isField();
 }
 bool SymbolRef::isStaticField(const GlobalState &gs) const {
-    return isFieldOrStaticField() && asFieldRef().data(gs)->isStaticField();
+    return isFieldOrStaticField() && asFieldRef().dataAllowingNone(gs)->isStaticField();
 }
 
 SymbolData SymbolRef::data(GlobalState &gs) const {
@@ -1494,6 +1494,36 @@ SymbolRef SymbolRef::dealias(const GlobalState &gs) const {
             return asTypeArgumentRef().data(gs)->dealias(gs);
         case SymbolRef::Kind::TypeMember:
             return asTypeMemberRef().data(gs)->dealias(gs);
+    }
+}
+
+SymbolRef SymbolRef::findMember(const GlobalState &gs, NameRef name) const {
+    switch (kind()) {
+        case SymbolRef::Kind::ClassOrModule:
+            return asClassOrModuleRef().data(gs)->findMember(gs, name);
+        case SymbolRef::Kind::Method:
+            return asMethodRef().data(gs)->findMember(gs, name);
+        case SymbolRef::Kind::FieldOrStaticField:
+            return asFieldRef().data(gs)->findMember(gs, name);
+        case SymbolRef::Kind::TypeArgument:
+            return asTypeArgumentRef().data(gs)->findMember(gs, name);
+        case SymbolRef::Kind::TypeMember:
+            return asTypeMemberRef().data(gs)->findMember(gs, name);
+    }
+}
+
+SymbolRef SymbolRef::findMemberTransitive(const GlobalState &gs, NameRef name) const {
+    switch (kind()) {
+        case SymbolRef::Kind::ClassOrModule:
+            return asClassOrModuleRef().data(gs)->findMemberTransitive(gs, name);
+        case SymbolRef::Kind::Method:
+            return asMethodRef().data(gs)->findMemberTransitive(gs, name);
+        case SymbolRef::Kind::FieldOrStaticField:
+            return asFieldRef().data(gs)->findMemberTransitive(gs, name);
+        case SymbolRef::Kind::TypeArgument:
+            return asTypeArgumentRef().data(gs)->findMemberTransitive(gs, name);
+        case SymbolRef::Kind::TypeMember:
+            return asTypeMemberRef().data(gs)->findMemberTransitive(gs, name);
     }
 }
 

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -562,7 +562,7 @@ u2 Symbol::addMixinPlaceholder(const GlobalState &gs) {
 SymbolRef Symbol::findMember(const GlobalState &gs, NameRef name) const {
     auto ret = findMemberNoDealias(gs, name);
     if (ret.exists()) {
-        return ret.data(gs)->dealias(gs);
+        return ret.dealias(gs);
     }
     return ret;
 }
@@ -1479,6 +1479,21 @@ void SymbolRef::setResultType(GlobalState &gs, const TypePtr &typePtr) const {
         case SymbolRef::Kind::TypeMember:
             asTypeMemberRef().data(gs)->resultType = typePtr;
             return;
+    }
+}
+
+SymbolRef SymbolRef::dealias(const GlobalState &gs) const {
+    switch (kind()) {
+        case SymbolRef::Kind::ClassOrModule:
+            return asClassOrModuleRef().data(gs)->dealias(gs);
+        case SymbolRef::Kind::Method:
+            return asMethodRef().data(gs)->dealias(gs);
+        case SymbolRef::Kind::FieldOrStaticField:
+            return asFieldRef().data(gs)->dealias(gs);
+        case SymbolRef::Kind::TypeArgument:
+            return asTypeArgumentRef().data(gs)->dealias(gs);
+        case SymbolRef::Kind::TypeMember:
+            return asTypeMemberRef().data(gs)->dealias(gs);
     }
 }
 

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -540,6 +540,7 @@ public:
     SymbolRef findMember(const GlobalState &gs, NameRef name) const;
     MethodRef findMethod(const GlobalState &gs, NameRef name) const;
     SymbolRef findMemberNoDealias(const GlobalState &gs, NameRef name) const;
+    MethodRef findMethodNoDealias(const GlobalState &gs, NameRef name) const;
     SymbolRef findMemberTransitive(const GlobalState &gs, NameRef name) const;
     MethodRef findMethodTransitive(const GlobalState &gs, NameRef name) const;
     SymbolRef findConcreteMethodTransitive(const GlobalState &gs, NameRef name) const;

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -538,8 +538,10 @@ public:
     }
 
     SymbolRef findMember(const GlobalState &gs, NameRef name) const;
+    MethodRef findMethod(const GlobalState &gs, NameRef name) const;
     SymbolRef findMemberNoDealias(const GlobalState &gs, NameRef name) const;
     SymbolRef findMemberTransitive(const GlobalState &gs, NameRef name) const;
+    MethodRef findMethodTransitive(const GlobalState &gs, NameRef name) const;
     SymbolRef findConcreteMethodTransitive(const GlobalState &gs, NameRef name) const;
 
     /* transitively finds a member with the most similar name */

--- a/core/TypeConstraint.cc
+++ b/core/TypeConstraint.cc
@@ -16,10 +16,11 @@ void TypeConstraint::defineDomain(const GlobalState &gs, const InlinedVector<Sym
     // test/testdata/infer/generic_methods/countraints_crosstalk.rb
     for (const auto &tp : typeParams) {
         ENFORCE(tp.isTypeArgument());
-        auto typ = cast_type<TypeVar>(tp.asTypeArgumentRef().data(gs)->resultType);
+        auto ta = tp.asTypeArgumentRef();
+        auto typ = cast_type<TypeVar>(ta.data(gs)->resultType);
         ENFORCE(typ != nullptr);
 
-        if (tp.data(gs)->isCovariant()) {
+        if (ta.data(gs)->isCovariant()) {
             findLowerBound(typ->sym) = Types::bottom();
         } else {
             findUpperBound(typ->sym) = Types::top();

--- a/core/TypeConstraint.cc
+++ b/core/TypeConstraint.cc
@@ -16,7 +16,7 @@ void TypeConstraint::defineDomain(const GlobalState &gs, const InlinedVector<Sym
     // test/testdata/infer/generic_methods/countraints_crosstalk.rb
     for (const auto &tp : typeParams) {
         ENFORCE(tp.isTypeArgument());
-        auto typ = cast_type<TypeVar>(tp.data(gs)->resultType);
+        auto typ = cast_type<TypeVar>(tp.asTypeArgumentRef().data(gs)->resultType);
         ENFORCE(typ != nullptr);
 
         if (tp.data(gs)->isCovariant()) {

--- a/core/TypeErrorDiagnostics.cc
+++ b/core/TypeErrorDiagnostics.cc
@@ -8,7 +8,7 @@ namespace {
 
 [[nodiscard]] bool checkForAttachedClassHint(const GlobalState &gs, ErrorBuilder &e, const SelfTypeParam expected,
                                              const ClassType got) {
-    if (expected.definition.data(gs)->name != Names::Constants::AttachedClass()) {
+    if (expected.definition.name(gs) != Names::Constants::AttachedClass()) {
         return false;
     }
 
@@ -17,7 +17,7 @@ namespace {
         return false;
     }
 
-    if (attachedClass != expected.definition.data(gs)->owner.asClassOrModuleRef()) {
+    if (attachedClass != expected.definition.owner(gs).asClassOrModuleRef()) {
         return false;
     }
 

--- a/core/test/core_test.cc
+++ b/core/test/core_test.cc
@@ -70,7 +70,7 @@ TEST_CASE("SymbolRef") {
     GlobalState gs(errorQueue);
     gs.initEmpty();
     auto ref = Symbols::Object();
-    CHECK_EQ(ref, ref.data(gs)->ref(gs));
+    CHECK_EQ(SymbolRef(ref), ref.data(gs)->ref(gs));
 }
 
 struct FileIsTypedCase {

--- a/core/test/core_test.cc
+++ b/core/test/core_test.cc
@@ -69,7 +69,7 @@ TEST_CASE("Errors") {
 TEST_CASE("SymbolRef") {
     GlobalState gs(errorQueue);
     gs.initEmpty();
-    SymbolRef ref = Symbols::Object();
+    auto ref = Symbols::Object();
     CHECK_EQ(ref, ref.data(gs)->ref(gs));
 }
 

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1695,7 +1695,7 @@ public:
         for (auto mem : attachedClass.data(gs)->typeMembers()) {
             ++i;
 
-            auto memData = mem.data(gs);
+            auto memData = mem.asTypeMemberRef().data(gs);
 
             auto *memType = cast_type<LambdaParam>(memData->resultType);
             ENFORCE(memType != nullptr);

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -629,7 +629,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                     auto objMeth = core::Symbols::Object().data(gs)->findMemberTransitive(gs, args.name);
                     if (objMeth.exists() && objMeth.data(gs)->owner.data(gs)->isClassOrModuleModule()) {
                         e.addErrorNote("Did you mean to `{}` in this module?",
-                                       fmt::format("include {}", objMeth.data(gs)->owner.data(gs)->name.show(gs)));
+                                       fmt::format("include {}", objMeth.data(gs)->owner.name(gs).show(gs)));
                     }
                 }
                 auto alternatives = symbol.data(gs)->findMemberFuzzyMatch(gs, args.name);
@@ -650,7 +650,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                         bool addedAutocorrect = false;
                         if (possibleSymbol.isClassOrModule()) {
                             // TODO(jez) Use Loc::adjust here?
-                            const auto replacement = possibleSymbol.data(gs)->name.show(gs);
+                            const auto replacement = possibleSymbol.name(gs).show(gs);
                             const auto loc = args.callLoc();
                             const auto toReplace = args.name.toString(gs);
                             // This is a bit hacky but the loc corresponding to the send isn't available here and until
@@ -663,7 +663,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                                 addedAutocorrect = true;
                             }
                         } else {
-                            const auto replacement = possibleSymbol.data(gs)->name.toString(gs);
+                            const auto replacement = possibleSymbol.name(gs).toString(gs);
                             const auto toReplace = args.name.toString(gs);
                             if (replacement != toReplace) {
                                 const auto recvLoc = args.receiverLoc();

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -627,9 +627,9 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
             } else {
                 if (symbol.data(gs)->isClassOrModuleModule()) {
                     auto objMeth = core::Symbols::Object().data(gs)->findMemberTransitive(gs, args.name);
-                    if (objMeth.exists() && objMeth.data(gs)->owner.data(gs)->isClassOrModuleModule()) {
+                    if (objMeth.exists() && objMeth.owner(gs).data(gs)->isClassOrModuleModule()) {
                         e.addErrorNote("Did you mean to `{}` in this module?",
-                                       fmt::format("include {}", objMeth.data(gs)->owner.name(gs).show(gs)));
+                                       fmt::format("include {}", objMeth.owner(gs).name(gs).show(gs)));
                     }
                 }
                 auto alternatives = symbol.data(gs)->findMemberFuzzyMatch(gs, args.name);
@@ -683,8 +683,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                         }
 
                         if (!addedAutocorrect) {
-                            lines.emplace_back(
-                                ErrorLine::from(alternative.symbol.data(gs)->loc(), "`{}`", suggestedName));
+                            lines.emplace_back(ErrorLine::from(alternative.symbol.loc(gs), "`{}`", suggestedName));
                         }
                     }
                     if (!lines.empty()) {

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -237,7 +237,7 @@ MethodRef guessOverload(const GlobalState &gs, ClassOrModuleRef inClass, MethodR
         while (current.data(gs)->isOverloaded()) {
             i++;
             NameRef overloadName = gs.lookupNameUnique(UniqueNameKind::Overload, primary.data(gs)->name, i);
-            MethodRef overload = primary.data(gs)->owner.data(gs)->findMethod(gs, overloadName);
+            MethodRef overload = primary.data(gs)->owner.asClassOrModuleRef().data(gs)->findMethod(gs, overloadName);
             if (!overload.exists()) {
                 Exception::raise("Corruption of overloads?");
             } else {
@@ -627,7 +627,8 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
             } else {
                 if (symbol.data(gs)->isClassOrModuleModule()) {
                     auto objMeth = core::Symbols::Object().data(gs)->findMethodTransitive(gs, args.name);
-                    if (objMeth.exists() && objMeth.data(gs)->owner.data(gs)->isClassOrModuleModule()) {
+                    if (objMeth.exists() &&
+                        objMeth.data(gs)->owner.asClassOrModuleRef().data(gs)->isClassOrModuleModule()) {
                         e.addErrorNote("Did you mean to `{}` in this module?",
                                        fmt::format("include {}", objMeth.data(gs)->owner.name(gs).show(gs)));
                     }
@@ -640,7 +641,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                         auto possibleSymbol = alternative.symbol;
                         if (!possibleSymbol.isClassOrModule() &&
                             (!possibleSymbol.isMethod() ||
-                             (possibleSymbol.data(gs)->isMethodPrivate() && !args.isPrivateOk))) {
+                             (possibleSymbol.asMethodRef().data(gs)->isMethodPrivate() && !args.isPrivateOk))) {
                             continue;
                         }
 

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -626,10 +626,10 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                 }
             } else {
                 if (symbol.data(gs)->isClassOrModuleModule()) {
-                    auto objMeth = core::Symbols::Object().data(gs)->findMemberTransitive(gs, args.name);
-                    if (objMeth.exists() && objMeth.owner(gs).data(gs)->isClassOrModuleModule()) {
+                    auto objMeth = core::Symbols::Object().data(gs)->findMethodTransitive(gs, args.name);
+                    if (objMeth.exists() && objMeth.data(gs)->owner.data(gs)->isClassOrModuleModule()) {
                         e.addErrorNote("Did you mean to `{}` in this module?",
-                                       fmt::format("include {}", objMeth.owner(gs).name(gs).show(gs)));
+                                       fmt::format("include {}", objMeth.data(gs)->owner.name(gs).show(gs)));
                     }
                 }
                 auto alternatives = symbol.data(gs)->findMemberFuzzyMatch(gs, args.name);

--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -408,7 +408,8 @@ string AppliedType::show(const GlobalState &gs) const {
     }
     auto it = targs.begin();
     for (auto typeMember : typeMembers) {
-        if (typeMember.data(gs)->isFixed()) {
+        auto tm = typeMember.asTypeMemberRef();
+        if (tm.data(gs)->isFixed()) {
             it = targs.erase(it);
         } else if (typeMember.name(gs) == core::Names::Constants::AttachedClass()) {
             it = targs.erase(it);

--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -339,7 +339,7 @@ string AppliedType::toStringWithTabs(const GlobalState &gs, int tabs) const {
         ++i;
         if (i < this->klass.data(gs)->typeMembers().size()) {
             auto tyMem = this->klass.data(gs)->typeMembers()[i];
-            fmt::format_to(std::back_inserter(buf), "{}{} = {}\n", twiceNestedTabs, tyMem.data(gs)->name.showRaw(gs),
+            fmt::format_to(std::back_inserter(buf), "{}{} = {}\n", twiceNestedTabs, tyMem.name(gs).showRaw(gs),
                            targ.toStringWithTabs(gs, tabs + 3));
         } else {
             // this happens if we try to print type before resolver has processed stdlib
@@ -410,7 +410,7 @@ string AppliedType::show(const GlobalState &gs) const {
     for (auto typeMember : typeMembers) {
         if (typeMember.data(gs)->isFixed()) {
             it = targs.erase(it);
-        } else if (typeMember.data(gs)->name == core::Names::Constants::AttachedClass()) {
+        } else if (typeMember.name(gs) == core::Names::Constants::AttachedClass()) {
             it = targs.erase(it);
         } else if (this->klass == Symbols::Hash() && typeMember == typeMembers.back()) {
             it = targs.erase(it);

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -1101,14 +1101,14 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
             // we can only check bounds when a LambdaParam is present.
             if (!isSelfTypeT1) {
                 auto self2 = cast_type_nonnull<SelfTypeParam>(t2);
-                if (auto *lambdaParam = cast_type<LambdaParam>(self2.definition.data(gs)->resultType)) {
+                if (auto *lambdaParam = cast_type<LambdaParam>(self2.definition.resultType(gs))) {
                     return Types::isSubTypeUnderConstraint(gs, constr, t1, lambdaParam->lowerBound, mode);
                 } else {
                     return false;
                 }
             } else if (!isSelfTypeT2) {
                 auto self1 = cast_type_nonnull<SelfTypeParam>(t1);
-                if (auto *lambdaParam = cast_type<LambdaParam>(self1.definition.data(gs)->resultType)) {
+                if (auto *lambdaParam = cast_type<LambdaParam>(self1.definition.resultType(gs))) {
                     return Types::isSubTypeUnderConstraint(gs, constr, lambdaParam->upperBound, t2, mode);
                 } else {
                     return false;
@@ -1120,8 +1120,8 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
                     return true;
                 }
 
-                auto *lambda1 = cast_type<LambdaParam>(self1.definition.data(gs)->resultType);
-                auto *lambda2 = cast_type<LambdaParam>(self2.definition.data(gs)->resultType);
+                auto *lambda1 = cast_type<LambdaParam>(self1.definition.resultType(gs));
+                auto *lambda2 = cast_type<LambdaParam>(self2.definition.resultType(gs));
                 return lambda1 && lambda2 &&
                        Types::isSubTypeUnderConstraint(gs, constr, lambda1->upperBound, lambda2->lowerBound, mode);
             }

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -307,14 +307,15 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
         // If klasses are equal, then it's possible that t1s <: t2s.
         bool changedFromT1 = a1->klass != a2->klass;
         for (SymbolRef idx : a2->klass.data(gs)->typeMembers()) {
+            TypeMemberRef idxTypeMember = idx.asTypeMemberRef();
             int i = 0;
             while (indexes[j] != a1->klass.data(gs)->typeMembers()[i]) {
                 i++;
             }
             ENFORCE(i < a1->klass.data(gs)->typeMembers().size());
-            if (idx.data(gs)->isCovariant()) {
+            if (idxTypeMember.data(gs)->isCovariant()) {
                 newTargs.emplace_back(Types::any(gs, a1->targs[i], a2->targs[j]));
-            } else if (idx.data(gs)->isInvariant()) {
+            } else if (idxTypeMember.data(gs)->isInvariant()) {
                 if (!Types::equiv(gs, a1->targs[i], a2->targs[j])) {
                     return OrType::make_shared(t1s, t2s);
                 }
@@ -324,7 +325,7 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                     newTargs.emplace_back(a2->targs[j]);
                 }
 
-            } else if (idx.data(gs)->isContravariant()) {
+            } else if (idxTypeMember.data(gs)->isContravariant()) {
                 newTargs.emplace_back(Types::all(gs, a1->targs[i], a2->targs[j]));
             }
             changedFromT2 = changedFromT2 || newTargs.back() != a2->targs[j];
@@ -921,6 +922,7 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
         newTargs.reserve(a1->klass.data(gs)->typeMembers().size());
         int j = 0;
         for (SymbolRef idx : a1->klass.data(gs)->typeMembers()) {
+            TypeMemberRef idxTypeMember = idx.asTypeMemberRef();
             int i = 0;
             if (j >= indexes.size()) {
                 i = INT_MAX;
@@ -931,9 +933,9 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
             if (i >= a2->klass.data(gs)->typeMembers().size()) { // a1 has more tparams, this is fine, it's a child
                 newTargs.emplace_back(a1->targs[j]);
             } else {
-                if (idx.data(gs)->isCovariant()) {
+                if (idxTypeMember.data(gs)->isCovariant()) {
                     newTargs.emplace_back(Types::all(gs, a1->targs[j], a2->targs[i]));
-                } else if (idx.data(gs)->isInvariant()) {
+                } else if (idxTypeMember.data(gs)->isInvariant()) {
                     if (!Types::equiv(gs, a1->targs[j], a2->targs[i])) {
                         return AndType::make_shared(t1, t2);
                     }
@@ -942,7 +944,7 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                     } else {
                         newTargs.emplace_back(a1->targs[j]);
                     }
-                } else if (idx.data(gs)->isContravariant()) {
+                } else if (idxTypeMember.data(gs)->isContravariant()) {
                     newTargs.emplace_back(Types::any(gs, a1->targs[j], a2->targs[i]));
                 }
             }
@@ -1153,6 +1155,7 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
             // code below inverts permutation of type params
             int j = 0;
             for (SymbolRef idx : a2->klass.data(gs)->typeMembers()) {
+                TypeMemberRef idxTypeMember = idx.asTypeMemberRef();
                 int i = 0;
                 while (indexes[j] != a1->klass.data(gs)->typeMembers()[i]) {
                     i++;
@@ -1163,9 +1166,9 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
 
                 ENFORCE(i < a1->klass.data(gs)->typeMembers().size());
 
-                if (idx.data(gs)->isCovariant()) {
+                if (idxTypeMember.data(gs)->isCovariant()) {
                     result = Types::isSubTypeUnderConstraint(gs, constr, a1->targs[i], a2->targs[j], mode);
-                } else if (idx.data(gs)->isInvariant()) {
+                } else if (idxTypeMember.data(gs)->isInvariant()) {
                     auto &a = a1->targs[i];
                     auto &b = a2->targs[j];
                     if (mode == UntypedMode::AlwaysCompatible) {
@@ -1173,7 +1176,7 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
                     } else {
                         result = Types::equivNoUntyped(gs, a, b);
                     }
-                } else if (idx.data(gs)->isContravariant()) {
+                } else if (idxTypeMember.data(gs)->isContravariant()) {
                     result = Types::isSubTypeUnderConstraint(gs, constr, a2->targs[j], a1->targs[i], mode);
                 }
                 if (!result) {

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -733,7 +733,7 @@ TypePtr Types::unwrapSelfTypeParam(Context ctx, const TypePtr &type) {
         },
         [&](const SelfTypeParam &param) {
             auto sym = param.definition;
-            if (sym.data(ctx)->owner == ctx.owner) {
+            if (sym.owner(ctx) == ctx.owner) {
                 ENFORCE(isa_type<LambdaParam>(sym.data(ctx)->resultType));
                 ret = sym.data(ctx)->resultType;
             } else {

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -504,11 +504,11 @@ InlinedVector<SymbolRef, 4> Types::alignBaseTypeArgs(const GlobalState &gs, Clas
     } else {
         currentAlignment.reserve(asIf.data(gs)->typeMembers().size());
         for (auto originalTp : asIf.data(gs)->typeMembers()) {
-            auto name = originalTp.data(gs)->name;
+            auto name = originalTp.name(gs);
             SymbolRef align;
             int i = 0;
             for (auto x : what.data(gs)->typeMembers()) {
-                if (x.data(gs)->name == name) {
+                if (x.name(gs) == name) {
                     align = x;
                     currentAlignment.emplace_back(x);
                     break;

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -734,8 +734,8 @@ TypePtr Types::unwrapSelfTypeParam(Context ctx, const TypePtr &type) {
         [&](const SelfTypeParam &param) {
             auto sym = param.definition;
             if (sym.owner(ctx) == ctx.owner) {
-                ENFORCE(isa_type<LambdaParam>(sym.data(ctx)->resultType));
-                ret = sym.data(ctx)->resultType;
+                ENFORCE(isa_type<LambdaParam>(sym.resultType(ctx)));
+                ret = sym.resultType(ctx);
             } else {
                 ret = type;
             }

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -400,7 +400,7 @@ void validateFinalMethodHelper(const core::GlobalState &gs, const core::ClassOrM
             sym.name(gs) == core::Names::unresolvedAncestors()) {
             continue;
         }
-        if (auto e = gs.beginError(sym.data(gs)->loc(), core::errors::Resolver::FinalModuleNonFinalMethod)) {
+        if (auto e = gs.beginError(sym.loc(gs), core::errors::Resolver::FinalModuleNonFinalMethod)) {
             e.setHeader("`{}` was declared as final but its method `{}` was not declared as final",
                         errMsgClass.show(gs), sym.name(gs).show(gs));
         }

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -394,15 +394,15 @@ void validateFinalMethodHelper(const core::GlobalState &gs, const core::ClassOrM
             // Method is 'final', and passes the check.
             sym.data(gs)->isFinalMethod() ||
             // <static-init> is a fake method Sorbet synthesizes for typechecking.
-            sym.data(gs)->name == core::Names::staticInit() ||
+            sym.name(gs) == core::Names::staticInit() ||
             // <unresolved-ancestors> is a fake method Sorbet synthesizes to ensure class hierarchy changes in IDE take
             // slow path.
-            sym.data(gs)->name == core::Names::unresolvedAncestors()) {
+            sym.name(gs) == core::Names::unresolvedAncestors()) {
             continue;
         }
         if (auto e = gs.beginError(sym.data(gs)->loc(), core::errors::Resolver::FinalModuleNonFinalMethod)) {
             e.setHeader("`{}` was declared as final but its method `{}` was not declared as final",
-                        errMsgClass.show(gs), sym.data(gs)->name.show(gs));
+                        errMsgClass.show(gs), sym.name(gs).show(gs));
         }
     }
 }

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -264,9 +264,8 @@ void validateCompatibleOverride(const core::Context ctx, core::MethodRef superMe
 }
 
 void validateOverriding(const core::Context ctx, core::MethodRef method) {
-    auto klass = method.data(ctx)->owner;
+    auto klass = method.data(ctx)->owner.asClassOrModuleRef();
     auto name = method.data(ctx)->name;
-    ENFORCE(klass.isClassOrModule());
     auto klassData = klass.data(ctx);
     InlinedVector<core::MethodRef, 4> overridenMethods;
 

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -294,15 +294,15 @@ void validateOverriding(const core::Context ctx, core::MethodRef method) {
     }
 
     if (klassData->superClass().exists()) {
-        auto superMethod = klassData->superClass().data(ctx)->findMemberTransitive(ctx, name);
+        auto superMethod = klassData->superClass().data(ctx)->findMethodTransitive(ctx, name);
         if (superMethod.exists()) {
-            overridenMethods.emplace_back(superMethod.asMethodRef());
+            overridenMethods.emplace_back(superMethod);
         }
     }
     for (const auto &mixin : klassData->mixins()) {
-        auto superMethod = mixin.data(ctx)->findMember(ctx, name);
+        auto superMethod = mixin.data(ctx)->findMethod(ctx, name);
         if (superMethod.exists()) {
-            overridenMethods.emplace_back(superMethod.asMethodRef());
+            overridenMethods.emplace_back(superMethod);
         }
     }
 

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -392,7 +392,7 @@ void validateFinalMethodHelper(const core::GlobalState &gs, const core::ClassOrM
         // We only care about method symbols that exist.
         if (!sym.exists() || !sym.isMethod() ||
             // Method is 'final', and passes the check.
-            sym.data(gs)->isFinalMethod() ||
+            sym.asMethodRef().data(gs)->isFinalMethod() ||
             // <static-init> is a fake method Sorbet synthesizes for typechecking.
             sym.name(gs) == core::Names::staticInit() ||
             // <unresolved-ancestors> is a fake method Sorbet synthesizes to ensure class hierarchy changes in IDE take

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -354,13 +354,13 @@ core::LocOffsets getAncestorLoc(const core::GlobalState &gs, const ast::ClassDef
                                 const core::ClassOrModuleRef ancestor) {
     for (const auto &anc : classDef.ancestors) {
         const auto ancConst = ast::cast_tree<ast::ConstantLit>(anc);
-        if (ancConst != nullptr && ancConst->symbol.data(gs)->dealias(gs) == ancestor) {
+        if (ancConst != nullptr && ancConst->symbol.dealias(gs) == ancestor) {
             return anc.loc();
         }
     }
     for (const auto &anc : classDef.singletonAncestors) {
         const auto ancConst = ast::cast_tree<ast::ConstantLit>(anc);
-        if (ancConst != nullptr && ancConst->symbol.data(gs)->dealias(gs) == ancestor) {
+        if (ancConst != nullptr && ancConst->symbol.dealias(gs) == ancestor) {
             return anc.loc();
         }
     }

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -663,7 +663,7 @@ private:
         auto isAbstract = klass.data(gs)->isClassOrModuleAbstract();
         if (isAbstract) {
             for (auto [name, sym] : klass.data(gs)->members()) {
-                if (sym.exists() && sym.isMethod() && sym.data(gs)->isAbstract()) {
+                if (sym.exists() && sym.isMethod() && sym.asMethodRef().data(gs)->isAbstract()) {
                     abstract.emplace_back(sym.asMethodRef());
                 }
             }
@@ -751,7 +751,7 @@ public:
     ast::ExpressionPtr preTransformMethodDef(core::Context ctx, ast::ExpressionPtr tree) {
         auto &methodDef = ast::cast_tree_nonnull<ast::MethodDef>(tree);
         auto methodData = methodDef.symbol.data(ctx);
-        auto ownerData = methodData->owner.data(ctx);
+        auto ownerData = methodData->owner.asClassOrModuleRef().data(ctx);
 
         // Only perform this check if this isn't a module from the stdlib, and
         // if there are type members in the owning context.

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -390,7 +390,7 @@ void validateFinalMethodHelper(const core::GlobalState &gs, const core::ClassOrM
     }
     for (const auto [name, sym] : klass.data(gs)->members()) {
         // We only care about method symbols that exist.
-        if (!sym.exists() || !sym.data(gs)->isMethod() ||
+        if (!sym.exists() || !sym.isMethod() ||
             // Method is 'final', and passes the check.
             sym.data(gs)->isFinalMethod() ||
             // <static-init> is a fake method Sorbet synthesizes for typechecking.
@@ -664,7 +664,7 @@ private:
         auto isAbstract = klass.data(gs)->isClassOrModuleAbstract();
         if (isAbstract) {
             for (auto [name, sym] : klass.data(gs)->members()) {
-                if (sym.exists() && sym.data(gs)->isMethod() && sym.data(gs)->isAbstract()) {
+                if (sym.exists() && sym.isMethod() && sym.data(gs)->isAbstract()) {
                     abstract.emplace_back(sym.asMethodRef());
                 }
             }

--- a/definition_validator/variance.cc
+++ b/definition_validator/variance.cc
@@ -169,7 +169,7 @@ private:
                 // This can be introduced by `module_function`, which in its
                 // current implementation will alias an instance method as a
                 // class method.
-                if (aliasSym.data(ctx)->isMethod()) {
+                if (aliasSym.isMethod()) {
                     validateMethod(ctx, polarity, aliasSym.asMethodRef());
                 } else {
                     Exception::raise("Unexpected type alias: {}", type.toString(ctx));

--- a/definition_validator/variance.cc
+++ b/definition_validator/variance.cc
@@ -110,7 +110,7 @@ private:
                                     members.size(), params.size()));
 
                 for (int i = 0; i < members.size(); ++i) {
-                    auto memberVariance = members[i].data(ctx)->variance();
+                    auto memberVariance = members[i].asTypeMemberRef().data(ctx)->variance();
                     auto typeArg = params[i];
 
                     // The polarity used to check the parameter is negated

--- a/definition_validator/variance.cc
+++ b/definition_validator/variance.cc
@@ -148,8 +148,7 @@ private:
                         }
                     } else {
                         if (auto e = ctx.state.beginError(this->loc, core::errors::Resolver::InvalidVariance)) {
-                            auto flavor =
-                                paramData->owner.data(ctx)->isSingletonClass(ctx) ? "type_template" : "type_member";
+                            auto flavor = paramData->owner.isSingletonClass(ctx) ? "type_template" : "type_member";
 
                             auto paramName = paramData->name.show(ctx);
 

--- a/definition_validator/variance.cc
+++ b/definition_validator/variance.cc
@@ -163,7 +163,7 @@ private:
             },
 
             [&](const core::AliasType &alias) {
-                auto aliasSym = alias.symbol.data(ctx)->dealias(ctx);
+                auto aliasSym = alias.symbol.dealias(ctx);
 
                 // This can be introduced by `module_function`, which in its
                 // current implementation will alias an instance method as a

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -310,9 +310,9 @@ core::MethodRef closestOverridenMethod(core::Context ctx, core::ClassOrModuleRef
     ENFORCE(enclosingClass->isClassOrModuleLinearizationComputed(), "Should have been linearized by resolver");
 
     for (const auto &mixin : enclosingClass->mixins()) {
-        auto mixinMethod = mixin.data(ctx)->findMember(ctx, name);
+        auto mixinMethod = mixin.data(ctx)->findMethod(ctx, name);
         if (mixinMethod.exists()) {
-            return mixinMethod.asMethodRef();
+            return mixinMethod;
         }
     }
 
@@ -321,9 +321,9 @@ core::MethodRef closestOverridenMethod(core::Context ctx, core::ClassOrModuleRef
         return core::Symbols::noMethod();
     }
 
-    auto superMethod = superClass.data(ctx)->findMember(ctx, name);
+    auto superMethod = superClass.data(ctx)->findMethod(ctx, name);
     if (superMethod.exists()) {
-        return superMethod.asMethodRef();
+        return superMethod;
     } else {
         return closestOverridenMethod(ctx, superClass, name);
     }

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1046,7 +1046,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                 ENFORCE(ctx.file.data(ctx).hasParseErrors || !tp.origins.empty(), "Inferencer did not assign location");
             },
             [&](cfg::Alias &a) {
-                core::SymbolRef symbol = a.what.data(ctx)->dealias(ctx);
+                core::SymbolRef symbol = a.what.dealias(ctx);
                 const auto &data = symbol.data(ctx);
                 if (data->isClassOrModule()) {
                     auto singletonClass = data->lookupSingletonClass(ctx);

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1067,7 +1067,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                             }
                         } else if (data->isField()) {
                             tp.type = core::Types::resultTypeAsSeenFrom(
-                                ctx, symbol.data(ctx)->resultType, symbol.data(ctx)->owner.asClassOrModuleRef(),
+                                ctx, symbol.data(ctx)->resultType, symbol.owner(ctx).asClassOrModuleRef(),
                                 ctx.owner.enclosingClass(ctx),
                                 ctx.owner.enclosingClass(ctx).data(ctx)->selfTypeArgs(ctx));
                         } else {

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1068,8 +1068,9 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                                 tp.type = core::make_type<core::MetaType>(core::make_type<core::SelfTypeParam>(symbol));
                             }
                         } else if (symbol.isField(ctx)) {
+                            auto field = symbol.asFieldRef();
                             tp.type = core::Types::resultTypeAsSeenFrom(
-                                ctx, symbol.data(ctx)->resultType, symbol.owner(ctx).asClassOrModuleRef(),
+                                ctx, field.data(ctx)->resultType, symbol.owner(ctx).asClassOrModuleRef(),
                                 ctx.owner.enclosingClass(ctx),
                                 ctx.owner.enclosingClass(ctx).data(ctx)->selfTypeArgs(ctx));
                         } else {
@@ -1241,12 +1242,12 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                 if (!core::Types::isSubTypeUnderConstraint(ctx, constr, typeAndOrigin.type, methodReturnType,
                                                            core::UntypedMode::AlwaysCompatible)) {
                     if (auto e = ctx.beginError(bind.loc, core::errors::Infer::ReturnTypeMismatch)) {
-                        auto ownerData = ctx.owner.data(ctx);
+                        auto owner = ctx.owner;
                         e.setHeader("Expected `{}` but found `{}` for method result type", methodReturnType.show(ctx),
                                     typeAndOrigin.type.show(ctx));
-                        auto for_ = core::ErrorColors::format("result type of method `{}`", ownerData->name.show(ctx));
+                        auto for_ = core::ErrorColors::format("result type of method `{}`", owner.name(ctx).show(ctx));
                         e.addErrorSection(
-                            core::TypeAndOrigins::explainExpected(ctx, methodReturnType, ownerData->loc(), for_));
+                            core::TypeAndOrigins::explainExpected(ctx, methodReturnType, owner.loc(ctx), for_));
                         e.addErrorSection(typeAndOrigin.explainGot(ctx, ownerLoc));
                         core::TypeErrorDiagnostics::explainTypeMismatch(ctx, e, methodReturnType, typeAndOrigin.type);
                         if (i.whatLoc != inWhat.implicitReturnLoc) {

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -26,7 +26,7 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
         _constr = make_unique<core::TypeConstraint>();
         constr = _constr.get();
         for (core::SymbolRef typeArgument : cfg->symbol.data(ctx)->typeArguments()) {
-            constr->rememberIsSubtype(ctx, typeArgument.data(ctx)->resultType,
+            constr->rememberIsSubtype(ctx, typeArgument.asTypeArgumentRef().data(ctx)->resultType,
                                       core::make_type<core::SelfTypeParam>(typeArgument));
         }
         if (!constr->solve(ctx)) {

--- a/infer/test/infer_test.cc
+++ b/infer/test/infer_test.cc
@@ -82,8 +82,8 @@ TEST_CASE("Infer") {
 
         auto barSymbol = rootScope->findMember(gs, gs.enterNameConstant("Bar"));
         auto fooSymbol = rootScope->findMember(gs, gs.enterNameConstant("Foo"));
-        REQUIRE_EQ("<C <U Bar>>", barSymbol.data(gs)->name.showRaw(gs));
-        REQUIRE_EQ("<C <U Foo>>", fooSymbol.data(gs)->name.showRaw(gs));
+        REQUIRE_EQ("<C <U Bar>>", barSymbol.name(gs).showRaw(gs));
+        REQUIRE_EQ("<C <U Foo>>", fooSymbol.name(gs).showRaw(gs));
 
         auto barType = core::make_type<core::ClassType>(barSymbol.asClassOrModuleRef());
         auto fooType = core::make_type<core::ClassType>(fooSymbol.asClassOrModuleRef());
@@ -101,9 +101,9 @@ TEST_CASE("Infer") {
         auto barSymbol = rootScope->findMember(gs, gs.enterNameConstant("Bar"));
         auto foo1Symbol = rootScope->findMember(gs, gs.enterNameConstant("Foo1"));
         auto foo2Symbol = rootScope->findMember(gs, gs.enterNameConstant("Foo2"));
-        REQUIRE_EQ("<C <U Bar>>", barSymbol.data(gs)->name.showRaw(gs));
-        REQUIRE_EQ("<C <U Foo1>>", foo1Symbol.data(gs)->name.showRaw(gs));
-        REQUIRE_EQ("<C <U Foo2>>", foo2Symbol.data(gs)->name.showRaw(gs));
+        REQUIRE_EQ("<C <U Bar>>", barSymbol.name(gs).showRaw(gs));
+        REQUIRE_EQ("<C <U Foo1>>", foo1Symbol.name(gs).showRaw(gs));
+        REQUIRE_EQ("<C <U Foo2>>", foo2Symbol.name(gs).showRaw(gs));
 
         auto barType = core::make_type<core::ClassType>(barSymbol.asClassOrModuleRef());
         auto foo1Type = core::make_type<core::ClassType>(foo1Symbol.asClassOrModuleRef());
@@ -150,9 +150,9 @@ TEST_CASE("Infer") {
         auto barSymbol = rootScope->findMember(gs, gs.enterNameConstant("Bar"));
         auto foo1Symbol = rootScope->findMember(gs, gs.enterNameConstant("Foo1"));
         auto foo2Symbol = rootScope->findMember(gs, gs.enterNameConstant("Foo2"));
-        REQUIRE_EQ("<C <U Bar>>", barSymbol.data(gs)->name.showRaw(gs));
-        REQUIRE_EQ("<C <U Foo1>>", foo1Symbol.data(gs)->name.showRaw(gs));
-        REQUIRE_EQ("<C <U Foo2>>", foo2Symbol.data(gs)->name.showRaw(gs));
+        REQUIRE_EQ("<C <U Bar>>", barSymbol.name(gs).showRaw(gs));
+        REQUIRE_EQ("<C <U Foo1>>", foo1Symbol.name(gs).showRaw(gs));
+        REQUIRE_EQ("<C <U Foo2>>", foo2Symbol.name(gs).showRaw(gs));
 
         auto barType = core::make_type<core::ClassType>(barSymbol.asClassOrModuleRef());
         auto foo1Type = core::make_type<core::ClassType>(foo1Symbol.asClassOrModuleRef());

--- a/main/autogen/autogen.cc
+++ b/main/autogen/autogen.cc
@@ -263,13 +263,13 @@ public:
 
         // if the RHS is _also_ a constant, then this is an alias
         auto *rhs = ast::cast_tree<ast::ConstantLit>(original.rhs);
-        if (rhs && rhs->symbol.exists() && !rhs->symbol.data(ctx)->isTypeAlias()) {
+        if (rhs && rhs->symbol.exists() && !rhs->symbol.isTypeAlias(ctx)) {
             def.type = Definition::Type::Alias;
             // since this is a `post`- method, then we've already created a `Reference` for the constant on the
             // RHS. Mark this `Definition` as an alias for it.
             ENFORCE(refMap.count(original.rhs.get()));
             def.aliased_ref = refMap[original.rhs.get()];
-        } else if (lhs->symbol.exists() && lhs->symbol.data(ctx)->isTypeAlias()) {
+        } else if (lhs->symbol.exists() && lhs->symbol.isTypeAlias(ctx)) {
             // if the LHS has already been annotated as a type alias by the namer, the definition is (by definition,
             // hah) a type alias.
             def.type = Definition::Type::TypeAlias;

--- a/main/autogen/autogen.cc
+++ b/main/autogen/autogen.cc
@@ -28,7 +28,7 @@ class AutogenWalk {
     vector<core::NameRef> symbolName(core::Context ctx, core::SymbolRef sym) {
         vector<core::NameRef> out;
         while (sym.exists() && sym != core::Symbols::root()) {
-            out.emplace_back(sym.data(ctx)->name);
+            out.emplace_back(sym.name(ctx));
             sym = sym.data(ctx)->owner;
         }
         reverse(out.begin(), out.end());

--- a/main/autogen/autogen.cc
+++ b/main/autogen/autogen.cc
@@ -29,7 +29,7 @@ class AutogenWalk {
         vector<core::NameRef> out;
         while (sym.exists() && sym != core::Symbols::root()) {
             out.emplace_back(sym.name(ctx));
-            sym = sym.data(ctx)->owner;
+            sym = sym.owner(ctx);
         }
         reverse(out.begin(), out.end());
         return out;

--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -56,7 +56,7 @@ ast::ExpressionPtr DefLocSaver::postTransformUnresolvedIdent(core::Context ctx, 
         // Logic cargo culted from `global2Local` in `walker_build.cc`.
         if (id.kind == ast::UnresolvedIdent::Kind::Instance) {
             ENFORCE(ctx.owner.data(ctx)->isMethod());
-            klass = ctx.owner.data(ctx)->owner.asClassOrModuleRef();
+            klass = ctx.owner.owner(ctx).asClassOrModuleRef();
         } else {
             // Class var.
             klass = ctx.owner.enclosingClass(ctx);
@@ -71,7 +71,7 @@ ast::ExpressionPtr DefLocSaver::postTransformUnresolvedIdent(core::Context ctx, 
             (lspQuery.matchesSymbol(sym) || lspQuery.matchesLoc(core::Loc(ctx.file, id.loc)))) {
             core::TypeAndOrigins tp;
             tp.type = sym.data(ctx)->resultType;
-            tp.origins.emplace_back(sym.data(ctx)->loc());
+            tp.origins.emplace_back(sym.loc(ctx));
             core::lsp::QueryResponse::pushQueryResponse(
                 ctx, core::lsp::FieldResponse(sym.asFieldRef(), core::Loc(ctx.file, id.loc), id.name, tp));
         }
@@ -90,7 +90,7 @@ void matchesQuery(core::Context ctx, ast::ConstantLit *lit, const core::lsp::Que
         if (lspQuery.matchesLoc(core::Loc(ctx.file, lit->loc)) || lspQuery.matchesSymbol(symbol)) {
             // This basically approximates the cfg::Alias case from Environment::processBinding.
             core::TypeAndOrigins tp;
-            tp.origins.emplace_back(symbol.data(ctx)->loc());
+            tp.origins.emplace_back(symbol.loc(ctx));
 
             if (symbol.isClassOrModule()) {
                 tp.type = symbol.data(ctx)->lookupSingletonClass(ctx).data(ctx)->externalType();

--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -96,7 +96,7 @@ void matchesQuery(core::Context ctx, ast::ConstantLit *lit, const core::lsp::Que
             if (symbol.isClassOrModule()) {
                 tp.type = symbol.data(ctx)->lookupSingletonClass(ctx).data(ctx)->externalType();
             } else {
-                auto resultType = symbol.data(ctx)->resultType;
+                auto resultType = symbol.resultType(ctx);
                 tp.type = resultType == nullptr ? core::Types::untyped(ctx, symbol) : resultType;
             }
 

--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -55,7 +55,7 @@ ast::ExpressionPtr DefLocSaver::postTransformUnresolvedIdent(core::Context ctx, 
         core::ClassOrModuleRef klass;
         // Logic cargo culted from `global2Local` in `walker_build.cc`.
         if (id.kind == ast::UnresolvedIdent::Kind::Instance) {
-            ENFORCE(ctx.owner.data(ctx)->isMethod());
+            ENFORCE(ctx.owner.isMethod());
             klass = ctx.owner.owner(ctx).asClassOrModuleRef();
         } else {
             // Class var.

--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -69,11 +69,12 @@ ast::ExpressionPtr DefLocSaver::postTransformUnresolvedIdent(core::Context ctx, 
         const core::lsp::Query &lspQuery = ctx.state.lspQuery;
         if (sym.exists() && sym.isFieldOrStaticField() &&
             (lspQuery.matchesSymbol(sym) || lspQuery.matchesLoc(core::Loc(ctx.file, id.loc)))) {
+            auto field = sym.asFieldRef();
             core::TypeAndOrigins tp;
-            tp.type = sym.data(ctx)->resultType;
-            tp.origins.emplace_back(sym.loc(ctx));
+            tp.type = field.data(ctx)->resultType;
+            tp.origins.emplace_back(field.data(ctx)->loc());
             core::lsp::QueryResponse::pushQueryResponse(
-                ctx, core::lsp::FieldResponse(sym.asFieldRef(), core::Loc(ctx.file, id.loc), id.name, tp));
+                ctx, core::lsp::FieldResponse(field, core::Loc(ctx.file, id.loc), id.name, tp));
         }
     }
     return tree;

--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -85,7 +85,7 @@ namespace {
 void matchesQuery(core::Context ctx, ast::ConstantLit *lit, const core::lsp::Query &lspQuery,
                   core::SymbolRef symbolBeforeDealias) {
     // Iterate. Ensures that we match "Foo" in "Foo::Bar" references.
-    auto symbol = symbolBeforeDealias.data(ctx)->dealias(ctx);
+    auto symbol = symbolBeforeDealias.dealias(ctx);
     while (lit && symbol.exists() && lit->original) {
         auto &unresolved = ast::cast_tree_nonnull<ast::UnresolvedConstantLit>(lit->original);
         if (lspQuery.matchesLoc(core::Loc(ctx.file, lit->loc)) || lspQuery.matchesSymbol(symbol)) {
@@ -94,7 +94,7 @@ void matchesQuery(core::Context ctx, ast::ConstantLit *lit, const core::lsp::Que
             tp.origins.emplace_back(symbol.loc(ctx));
 
             if (symbol.isClassOrModule()) {
-                tp.type = symbol.data(ctx)->lookupSingletonClass(ctx).data(ctx)->externalType();
+                tp.type = symbol.asClassOrModuleRef().data(ctx)->lookupSingletonClass(ctx).data(ctx)->externalType();
             } else {
                 auto resultType = symbol.resultType(ctx);
                 tp.type = resultType == nullptr ? core::Types::untyped(ctx, symbol) : resultType;
@@ -104,7 +104,7 @@ void matchesQuery(core::Context ctx, ast::ConstantLit *lit, const core::lsp::Que
             if (symbol == core::Symbols::StubModule()) {
                 scopes = *lit->resolutionScopes;
             } else {
-                scopes = {symbol.data(ctx)->owner};
+                scopes = {symbol.owner(ctx)};
             }
 
             auto resp = core::lsp::ConstantResponse(symbol, symbolBeforeDealias, core::Loc(ctx.file, lit->loc), scopes,
@@ -114,7 +114,7 @@ void matchesQuery(core::Context ctx, ast::ConstantLit *lit, const core::lsp::Que
         lit = ast::cast_tree<ast::ConstantLit>(unresolved.scope);
         if (lit) {
             symbolBeforeDealias = lit->symbol;
-            symbol = symbolBeforeDealias.data(ctx)->dealias(ctx);
+            symbol = symbolBeforeDealias.dealias(ctx);
         }
     }
 }

--- a/main/lsp/LSPTask.cc
+++ b/main/lsp/LSPTask.cc
@@ -160,7 +160,7 @@ LSPQueryResult LSPTask::queryBySymbol(LSPTypecheckerDelegate &typechecker, core:
     ENFORCE(sym.exists());
     vector<core::FileRef> frefs;
     const core::GlobalState &gs = typechecker.state();
-    const core::NameHash symNameHash(gs, sym.data(gs)->name);
+    const core::NameHash symNameHash(gs, sym.name(gs));
     // Locate files that contain the same Name as the symbol. Is an overapproximation, but a good first filter.
     int i = -1;
     for (auto &file : typechecker.state().getFiles()) {
@@ -381,7 +381,7 @@ AccessorInfo LSPTask::getAccessorInfo(const core::GlobalState &gs, core::SymbolR
 
     string_view baseName;
 
-    string symbolName = symbol.data(gs)->name.toString(gs);
+    string symbolName = symbol.name(gs).toString(gs);
     // Extract the base name from `symbol`.
     if (absl::StartsWith(symbolName, "@")) {
         if (!symbol.isField(gs)) {

--- a/main/lsp/LSPTask.cc
+++ b/main/lsp/LSPTask.cc
@@ -317,7 +317,7 @@ static const vector<core::NameRef> readerNames = {
 void populateFieldAccessorType(const core::GlobalState &gs, AccessorInfo &info) {
     auto method = info.readerSymbol.exists() ? info.readerSymbol : info.writerSymbol;
     ENFORCE(method.exists());
-    ENFORCE(method.data(gs)->isMethod());
+
     // Check definition site of method for `prop`, `const`, etc. The loc for the method should begin with
     // `def|prop|const|...`.
     auto methodSource = method.data(gs)->loc().source(gs);
@@ -390,13 +390,13 @@ AccessorInfo LSPTask::getAccessorInfo(const core::GlobalState &gs, core::SymbolR
         info.fieldSymbol = symbol.asFieldRef();
         baseName = string_view(symbolName).substr(1);
     } else if (absl::EndsWith(symbolName, "=")) {
-        if (!symbol.data(gs)->isMethod()) {
+        if (!symbol.isMethod()) {
             return info;
         }
         info.writerSymbol = symbol.asMethodRef();
         baseName = string_view(symbolName).substr(0, symbolName.length() - 1);
     } else {
-        if (!symbol.data(gs)->isMethod()) {
+        if (!symbol.isMethod()) {
             return info;
         }
         info.readerSymbol = symbol.asMethodRef();

--- a/main/lsp/LSPTask.cc
+++ b/main/lsp/LSPTask.cc
@@ -373,7 +373,7 @@ LSPTask::getReferencesToAccessor(LSPTypecheckerDelegate &typechecker, const Acce
 AccessorInfo LSPTask::getAccessorInfo(const core::GlobalState &gs, core::SymbolRef symbol) const {
     AccessorInfo info;
 
-    core::SymbolRef owner = symbol.data(gs)->owner;
+    core::SymbolRef owner = symbol.owner(gs);
     if (!owner.exists() || !owner.isClassOrModule()) {
         return info;
     }

--- a/main/lsp/LocalVarSaver.cc
+++ b/main/lsp/LocalVarSaver.cc
@@ -9,7 +9,7 @@ ast::ExpressionPtr LocalVarSaver::postTransformLocal(core::Context ctx, ast::Exp
     auto &local = ast::cast_tree_nonnull<ast::Local>(tree);
 
     core::MethodRef enclosingMethod;
-    if (ctx.owner.data(ctx)->isMethod()) {
+    if (ctx.owner.isMethod()) {
         enclosingMethod = ctx.owner.asMethodRef();
     } else if (ctx.owner == core::Symbols::root()) {
         enclosingMethod = ctx.state.lookupStaticInitForFile(core::Loc(ctx.file, local.loc));

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -223,7 +223,7 @@ string prettyTypeForMethod(const core::GlobalState &gs, core::MethodRef method, 
 string prettyTypeForConstant(const core::GlobalState &gs, core::SymbolRef constant) {
     // Request that the constant already be dealiased, rather than dealias here to avoid defensively dealiasing.
     // We should understand where dealias calls go.
-    ENFORCE(constant == constant.data(gs)->dealias(gs));
+    ENFORCE(constant == constant.dealias(gs));
 
     core::TypePtr result;
     if (constant.isClassOrModule()) {

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -159,7 +159,7 @@ string prettyDefForMethod(const core::GlobalState &gs, core::MethodRef method) {
     }
     string methodNamePrefix = "";
     if (methodData->owner.exists() && methodData->owner.isClassOrModule() &&
-        methodData->owner.data(gs)->attachedClass(gs).exists()) {
+        methodData->owner.asClassOrModuleRef().data(gs)->attachedClass(gs).exists()) {
         methodNamePrefix = "self.";
     }
     vector<string> prettyArgs;

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -233,7 +233,7 @@ string prettyTypeForConstant(const core::GlobalState &gs, core::SymbolRef consta
         }
         result = targetClass.data(gs)->externalType();
     } else {
-        auto resultType = constant.data(gs)->resultType;
+        auto resultType = constant.resultType(gs);
         result = resultType == nullptr ? core::Types::untyped(gs, constant) : resultType;
     }
 

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -237,7 +237,7 @@ string prettyTypeForConstant(const core::GlobalState &gs, core::SymbolRef consta
         result = resultType == nullptr ? core::Types::untyped(gs, constant) : resultType;
     }
 
-    if (constant.data(gs)->isTypeAlias()) {
+    if (constant.isTypeAlias(gs)) {
         // By wrapping the type in `MetaType`, it displays as `<Type: Foo>` rather than `Foo`.
         result = core::make_type<core::MetaType>(result);
     }

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -426,9 +426,9 @@ unique_ptr<CompletionItem> getCompletionItemForConstant(const core::GlobalState 
     }
 
     optional<string> documentation = nullopt;
-    auto whatFile = what.data(gs)->loc().file();
+    auto whatFile = what.loc(gs).file();
     if (whatFile.exists()) {
-        documentation = findDocumentation(whatFile.data(gs).source(), what.data(gs)->loc().beginPos());
+        documentation = findDocumentation(whatFile.data(gs).source(), what.loc(gs).beginPos());
     }
 
     auto prettyType = prettyTypeForConstant(gs, what);
@@ -702,9 +702,9 @@ CompletionTask::getCompletionItemForMethod(LSPTypecheckerDelegate &typechecker, 
     }
 
     optional<string> documentation = nullopt;
-    auto whatFile = what.data(gs)->loc().file();
+    auto whatFile = what.loc(gs).file();
     if (whatFile.exists()) {
-        documentation = findDocumentation(whatFile.data(gs).source(), what.data(gs)->loc().beginPos());
+        documentation = findDocumentation(whatFile.data(gs).source(), what.loc(gs).beginPos());
     }
 
     auto prettyType = prettyTypeForMethod(gs, maybeAlias, receiverType, nullptr, constraint);

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -245,7 +245,7 @@ vector<core::LocalVariable> allSimilarLocals(const core::GlobalState &gs, const 
 string methodSnippet(const core::GlobalState &gs, core::DispatchResult &dispatchResult, core::SymbolRef method,
                      const core::TypePtr &receiverType, const core::TypeConstraint *constraint, u2 totalArgs) {
     fmt::memory_buffer result;
-    fmt::format_to(std::back_inserter(result), "{}", method.data(gs)->name.shortName(gs));
+    fmt::format_to(std::back_inserter(result), "{}", method.name(gs).shortName(gs));
     auto nextTabstop = 1;
 
     /* If we are completing an existing send that either has some arguments
@@ -376,7 +376,7 @@ unique_ptr<CompletionItem> getCompletionItemForConstant(const core::GlobalState 
     auto supportsSnippets = clientConfig.clientCompletionItemSnippetSupport;
     auto markupKind = clientConfig.clientCompletionItemMarkupKind;
 
-    auto label = string(maybeAlias.data(gs)->name.shortName(gs));
+    auto label = string(maybeAlias.name(gs).shortName(gs));
 
     // Intuition for when to use maybeAlias vs what: if it needs to know the original name: maybeAlias.
     // If it needs to know the types / arity: what. Default to `what` if you don't know.
@@ -630,7 +630,7 @@ bool isSimilarConstant(const core::GlobalState &gs, string_view prefix, core::Sy
         return false;
     }
 
-    auto name = sym.data(gs)->name;
+    auto name = sym.name(gs);
     if (name.kind() != core::NameKind::CONSTANT) {
         return false;
     }

--- a/main/lsp/requests/definition.cc
+++ b/main/lsp/requests/definition.cc
@@ -28,7 +28,7 @@ unique_ptr<ResponseMessage> DefinitionTask::runRequest(LSPTypecheckerDelegate &t
             // Only support go-to-definition on constants and fields in untyped files.
             if (auto c = resp->isConstant()) {
                 auto sym = c->symbol;
-                for (auto loc : sym.data(gs)->locs()) {
+                for (auto loc : sym.locs(gs)) {
                     addLocIfExists(gs, result, loc);
                 }
             } else if (resp->isField() || (fileIsTyped && (resp->isIdent() || resp->isLiteral()))) {
@@ -38,7 +38,7 @@ unique_ptr<ResponseMessage> DefinitionTask::runRequest(LSPTypecheckerDelegate &t
                 }
             } else if (fileIsTyped && resp->isDefinition()) {
                 auto sym = resp->isDefinition()->symbol;
-                for (auto loc : sym.data(gs)->locs()) {
+                for (auto loc : sym.locs(gs)) {
                     addLocIfExists(gs, result, loc);
                 }
             } else if (fileIsTyped && resp->isSend()) {

--- a/main/lsp/requests/document_symbol.cc
+++ b/main/lsp/requests/document_symbol.cc
@@ -46,7 +46,8 @@ std::unique_ptr<DocumentSymbol> symbolRef2DocumentSymbol(const core::GlobalState
     }
 
     string prefix;
-    if (sym->owner.exists() && sym->owner.isClassOrModule() && sym->owner.data(gs)->attachedClass(gs).exists()) {
+    if (sym->owner.exists() && sym->owner.isClassOrModule() &&
+        sym->owner.asClassOrModuleRef().data(gs)->attachedClass(gs).exists()) {
         prefix = "self.";
     }
     auto result = make_unique<DocumentSymbol>(prefix + sym->name.show(gs), kind, move(range), move(selectionRange));

--- a/main/lsp/requests/document_symbol.cc
+++ b/main/lsp/requests/document_symbol.cc
@@ -102,7 +102,7 @@ unique_ptr<ResponseMessage> DocumentSymbolTask::runRequest(LSPTypecheckerDelegat
             core::SymbolRef ref(gs, kind, idx);
             if (!hideSymbol(gs, ref) &&
                 // a bit counter-intuitive, but this actually should be `!= fref`, as it prevents duplicates.
-                (ref.data(gs)->owner.data(gs)->loc().file() != fref || ref.data(gs)->owner == core::Symbols::root())) {
+                (ref.owner(gs).loc(gs).file() != fref || ref.data(gs)->owner == core::Symbols::root())) {
                 for (auto definitionLocation : ref.data(gs)->locs()) {
                     if (definitionLocation.file() == fref) {
                         auto data = symbolRef2DocumentSymbol(gs, ref, fref);

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -56,13 +56,13 @@ unique_ptr<ResponseMessage> HoverTask::runRequest(LSPTypecheckerDelegate &typech
         string typeString;
 
         if (auto c = resp->isConstant()) {
-            for (auto loc : c->symbol.data(gs)->locs()) {
+            for (auto loc : c->symbol.locs(gs)) {
                 if (loc.exists()) {
                     documentationLocations.emplace_back(loc);
                 }
             }
         } else if (auto d = resp->isDefinition()) {
-            for (auto loc : d->symbol.data(gs)->locs()) {
+            for (auto loc : d->symbol.locs(gs)) {
                 if (loc.exists()) {
                     documentationLocations.emplace_back(loc);
                 }

--- a/main/lsp/requests/implementation.cc
+++ b/main/lsp/requests/implementation.cc
@@ -44,7 +44,7 @@ const MethodImplementationResults findMethodImplementations(const core::GlobalSt
     auto childClasses = getSubclassesSlow(gs, owningClassSymbolRef, includeOwner);
     auto methodName = method.data(gs)->name;
     for (const auto &childClass : childClasses) {
-        auto methodImplementation = childClass.data(gs)->findMember(gs, methodName);
+        auto methodImplementation = childClass.data(gs)->findMethod(gs, methodName);
         locations.push_back(methodImplementation.data(gs)->loc());
     }
 
@@ -59,7 +59,7 @@ core::SymbolRef findOverridedMethod(const core::GlobalState &gs, const core::Sym
         if (!mixin.data(gs)->isClassOrModule() && !mixin.data(gs)->isAbstract()) {
             continue;
         }
-        return mixin.data(gs)->findMember(gs, method.data(gs)->name);
+        return mixin.data(gs)->findMethod(gs, method.data(gs)->name);
     }
     return core::Symbols::noSymbol();
 }

--- a/main/lsp/requests/prepare_rename.cc
+++ b/main/lsp/requests/prepare_rename.cc
@@ -16,7 +16,7 @@ variant<JSONNullObject, unique_ptr<PrepareRenameResult>> getPrepareRenameResult(
     }
 
     auto result = make_unique<PrepareRenameResult>(move(range));
-    auto name = symbol.data(gs)->name.show(gs);
+    auto name = symbol.name(gs).show(gs);
     result->placeholder = name;
     return result;
 }

--- a/main/lsp/requests/prepare_rename.cc
+++ b/main/lsp/requests/prepare_rename.cc
@@ -10,7 +10,7 @@ namespace sorbet::realmain::lsp {
 namespace {
 variant<JSONNullObject, unique_ptr<PrepareRenameResult>> getPrepareRenameResult(const core::GlobalState &gs,
                                                                                 core::SymbolRef symbol) {
-    auto range = Range::fromLoc(gs, symbol.data(gs)->loc());
+    auto range = Range::fromLoc(gs, symbol.loc(gs));
     if (range == nullptr) {
         return JSONNullObject();
     }

--- a/main/lsp/requests/prepare_rename.cc
+++ b/main/lsp/requests/prepare_rename.cc
@@ -76,7 +76,7 @@ unique_ptr<ResponseMessage> PrepareRenameTask::runRequest(LSPTypecheckerDelegate
     } else if (auto defResp = resp->isDefinition()) {
         if (defResp->symbol.isClassOrModule()) {
             response->result = getPrepareRenameResult(gs, defResp->symbol);
-        } else if (defResp->symbol.data(gs)->isMethod()) {
+        } else if (defResp->symbol.isMethod()) {
             response->result = getPrepareRenameResult(gs, defResp->symbol);
         }
     } else if (auto sendResp = resp->isSend()) {

--- a/main/lsp/requests/rename.cc
+++ b/main/lsp/requests/rename.cc
@@ -27,7 +27,7 @@ bool isValidRenameLocation(const core::SymbolRef &symbol, const core::GlobalStat
         if (!filetype.empty()) {
             auto error =
                 fmt::format("Renaming constants defined in {} files is not supported; symbol {} is defined at {}",
-                            filetype, symbol.data(gs)->name.show(gs), loc.filePosToString(gs));
+                            filetype, symbol.name(gs).show(gs), loc.filePosToString(gs));
             response->error = make_unique<ResponseError>((int)LSPErrorCodes::InvalidRequest, error);
             return false;
         }

--- a/main/lsp/requests/rename.cc
+++ b/main/lsp/requests/rename.cc
@@ -404,13 +404,13 @@ unique_ptr<ResponseMessage> RenameTask::runRequest(LSPTypecheckerDelegate &typec
             return response;
         }
 
-        if (defResp->symbol.data(gs)->isMethod() && isupper(params->newName[0])) {
+        if (defResp->symbol.isMethod() && isupper(params->newName[0])) {
             response->error = make_unique<ResponseError>((int)LSPErrorCodes::InvalidRequest,
                                                          "Method names must begin with an lowercase letter.");
             return response;
         }
 
-        if (defResp->symbol.isClassOrModule() || defResp->symbol.data(gs)->isMethod()) {
+        if (defResp->symbol.isClassOrModule() || defResp->symbol.isMethod()) {
             if (isValidRenameLocation(defResp->symbol, gs, response)) {
                 getRenameEdits(typechecker, defResp->symbol, params->newName, response);
             }

--- a/main/lsp/requests/rename.cc
+++ b/main/lsp/requests/rename.cc
@@ -99,11 +99,11 @@ void addSubclassRelatedMethods(const core::GlobalState &gs, core::MethodRef symb
     // find the target method definition in each subclass
     for (auto c : subclasses) {
         auto classSymbol = c.data(gs);
-        auto member = classSymbol->findMember(gs, symbolData->name);
+        auto member = classSymbol->findMethod(gs, symbolData->name);
         if (!member.exists()) {
             continue;
         }
-        methods.tryEnqueue(member.asMethodRef());
+        methods.tryEnqueue(member);
     }
 }
 

--- a/main/lsp/requests/rename.cc
+++ b/main/lsp/requests/rename.cc
@@ -15,7 +15,7 @@ namespace sorbet::realmain::lsp {
 namespace {
 bool isValidRenameLocation(const core::SymbolRef &symbol, const core::GlobalState &gs,
                            unique_ptr<ResponseMessage> &response) {
-    auto locs = symbol.data(gs)->locs();
+    auto locs = symbol.locs(gs);
     string filetype;
     for (auto loc : locs) {
         if (loc.file().data(gs).isRBI()) {
@@ -311,12 +311,11 @@ public:
 void RenameTask::getRenameEdits(LSPTypecheckerDelegate &typechecker, core::SymbolRef symbol, string newName,
                                 unique_ptr<ResponseMessage> &responseMsg) {
     const core::GlobalState &gs = typechecker.state();
-    auto symbolData = symbol.data(gs);
-    auto originalName = symbolData->name.show(gs);
+    auto originalName = symbol.name(gs).show(gs);
     unique_ptr<Renamer> renamer;
 
     UniqueSymbolQueue symbolQueue;
-    if (symbolData->isMethod()) {
+    if (symbol.isMethod()) {
         renamer = make_unique<MethodRenamer>(gs, config, symbolQueue, originalName, newName);
         addSubclassRelatedMethods(gs, symbol.asMethodRef(), symbolQueue);
     } else {

--- a/main/lsp/requests/signature_help.cc
+++ b/main/lsp/requests/signature_help.cc
@@ -10,7 +10,7 @@ void addSignatureHelpItem(const core::GlobalState &gs, core::MethodRef method,
                           vector<unique_ptr<SignatureInformation>> &sigs, const core::lsp::SendResponse &resp,
                           int activeParameter) {
     // signature helps only exist for methods.
-    if (!method.exists() || !method.data(gs)->isMethod() || hideSymbol(gs, method)) {
+    if (!method.exists() || hideSymbol(gs, method)) {
         return;
     }
     // Label is mandatory, so method name (i.e B#add) is shown for now. Might want to add markup highlighting

--- a/main/lsp/requests/sorbet_show_symbol.cc
+++ b/main/lsp/requests/sorbet_show_symbol.cc
@@ -53,9 +53,9 @@ unique_ptr<ResponseMessage> SorbetShowSymbolTask::runRequest(LSPTypecheckerDeleg
         }
 
         auto result = make_unique<SymbolInformation>(sym.show(gs), symbolRef2SymbolKind(gs, sym),
-                                                     config.loc2Location(gs, sym.data(gs)->loc()));
+                                                     config.loc2Location(gs, sym.loc(gs)));
 
-        auto container = sym.data(gs)->owner;
+        auto container = sym.owner(gs);
         if (container != core::Symbols::root()) {
             result->containerName = container.show(gs);
         }

--- a/main/lsp/requests/workspace_symbols.cc
+++ b/main/lsp/requests/workspace_symbols.cc
@@ -195,7 +195,7 @@ void SymbolMatcher::updatePartialMatch(core::SymbolRef symbolRef, string_view::c
     partialMatch = partialMatchSymbol(shortName, queryBegin, queryEnd, true, ceilingScore);
     for (auto previousAncestorRef = symbolRef, ancestorRef = symbolData->owner;
          previousAncestorRef != ancestorRef && ancestorRef.exists();
-         previousAncestorRef = ancestorRef, ancestorRef = ancestorRef.data(gs)->owner) {
+         previousAncestorRef = ancestorRef, ancestorRef = ancestorRef.owner(gs)) {
         auto &ancestorMatch = getPartialMatch(ancestorRef);
         auto ancestorEnd = ancestorMatch.matchEnd;
         if (ancestorEnd == queryBegin || ancestorEnd == nullptr) {
@@ -277,7 +277,7 @@ vector<unique_ptr<SymbolInformation>> SymbolMatcher::doQuery(string_view query_v
                 }
                 for (auto previousAncestorRef = symbolRef, ancestorRef = symbolData->owner;
                      previousAncestorRef != ancestorRef && ancestorRef.exists();
-                     previousAncestorRef = ancestorRef, ancestorRef = ancestorRef.data(gs)->owner) {
+                     previousAncestorRef = ancestorRef, ancestorRef = ancestorRef.owner(gs)) {
                     auto [ancestorScore, ancestorEnd] = getPartialMatch(ancestorRef);
                     if (ancestorEnd == queryBegin || ancestorEnd == nullptr) {
                         break; // no further ancestor will be of any help

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -679,9 +679,8 @@ private:
     const int prohibitedLinesEnd;
 
     bool isAllowListed(core::Context ctx, core::SymbolRef sym) {
-        return sym.data(ctx)->name == core::Names::staticInit() ||
-               sym.data(ctx)->name == core::Names::Constants::Root() ||
-               sym.data(ctx)->name == core::Names::unresolvedAncestors();
+        return sym.name(ctx) == core::Names::staticInit() || sym.name(ctx) == core::Names::Constants::Root() ||
+               sym.name(ctx) == core::Names::unresolvedAncestors();
     }
 
     void checkLoc(core::Context ctx, core::Loc loc) {

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -693,7 +693,7 @@ private:
         if (isAllowListed(ctx, sym)) {
             return;
         }
-        checkLoc(ctx, sym.data(ctx)->loc());
+        checkLoc(ctx, sym.loc(ctx));
     }
 
 public:

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -320,15 +320,13 @@ core::ClassOrModuleRef contextClass(const core::GlobalState &gs, core::SymbolRef
     core::SymbolRef owner = ofWhat;
     while (true) {
         ENFORCE(owner.exists(), "non-existing owner in contextClass");
-        const auto &data = owner.data(gs);
-
-        if (data->isClassOrModule()) {
+        if (owner.isClassOrModule()) {
             return owner.asClassOrModuleRef();
         }
-        if (data->name == core::Names::staticInit()) {
-            owner = data->owner.data(gs)->attachedClass(gs);
+        if (owner.name(gs) == core::Names::staticInit()) {
+            owner = owner.owner(gs).asClassOrModuleRef().data(gs)->attachedClass(gs);
         } else {
-            owner = data->owner;
+            owner = owner.owner(gs);
         }
     }
 }

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -824,7 +824,7 @@ class SymbolDefiner {
         core::SymbolRef existing = scope.data(ctx)->findMember(ctx, name);
         if (!existing.exists()) {
             existing = ctx.state.enterClassSymbol(core::Loc(ctx.file, loc), scope, name);
-            existing.data(ctx)->singletonClass(ctx); // force singleton class into existance
+            existing.asClassOrModuleRef().data(ctx)->singletonClass(ctx); // force singleton class into existance
         }
 
         return existing;

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1336,7 +1336,7 @@ class SymbolDefiner {
             if (oldSym.exists()) {
                 emitRedefinedConstantError(ctx, core::Loc(ctx.file, typeMember.nameLoc), oldSym.show(ctx),
                                            oldSym.loc(ctx));
-                ctx.state.mangleRenameSymbol(oldSym, oldSym.data(ctx)->name);
+                ctx.state.mangleRenameSymbol(oldSym, oldSym.name(ctx));
             }
             sym =
                 ctx.state.enterTypeMember(core::Loc(ctx.file, typeMember.asgnLoc), onSymbol, typeMember.name, variance);

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1039,8 +1039,8 @@ class SymbolDefiner {
             } else {
                 // if the symbol does exist, then we're running in incremental mode, and we need to compare it to
                 // the previously defined equivalent to re-report any errors
-                auto replacedSym = ctx.state.findRenamedSymbol(owner, matchingSym).asMethodRef();
-                if (replacedSym.exists() && !paramsMatch(ctx, replacedSym, parsedArgs) &&
+                auto replacedSym = ctx.state.findRenamedSymbol(owner, matchingSym);
+                if (replacedSym.exists() && !paramsMatch(ctx, replacedSym.asMethodRef(), parsedArgs) &&
                     !isIntrinsic(replacedSym.data(ctx))) {
                     paramMismatchErrors(ctx.withOwner(replacedSym), declLoc, parsedArgs);
                 }

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -383,7 +383,7 @@ class SymbolFinder {
     FoundDefinitionRef squashNames(core::Context ctx, const ast::ExpressionPtr &node) {
         if (auto *id = ast::cast_tree<ast::ConstantLit>(node)) {
             // Already defined. Insert a foundname so we can reference it.
-            auto sym = id->symbol.data(ctx)->dealias(ctx);
+            auto sym = id->symbol.dealias(ctx);
             ENFORCE(sym.exists());
             return foundDefs->addSymbol(sym);
         } else if (auto constLit = ast::cast_tree<ast::UnresolvedConstantLit>(node)) {
@@ -924,7 +924,7 @@ class SymbolDefiner {
     }
 
     void paramMismatchErrors(core::MutableContext ctx, core::Loc loc, const vector<ast::ParsedArg> &parsedArgs) {
-        auto sym = ctx.owner.data(ctx)->dealias(ctx);
+        auto sym = ctx.owner.dealias(ctx);
         if (!sym.isMethod()) {
             return;
         }
@@ -1433,7 +1433,7 @@ class TreeSymbolizer {
         auto constLit = ast::cast_tree<ast::UnresolvedConstantLit>(node);
         if (constLit == nullptr) {
             if (auto *id = ast::cast_tree<ast::ConstantLit>(node)) {
-                return id->symbol.data(ctx)->dealias(ctx);
+                return id->symbol.dealias(ctx);
             }
             if (auto *uid = ast::cast_tree<ast::UnresolvedIdent>(node)) {
                 if (uid->kind != ast::UnresolvedIdent::Kind::Class || uid->name != core::Names::singleton()) {
@@ -1461,7 +1461,7 @@ class TreeSymbolizer {
         if (firstName && !existing.exists() && newOwner.isClassOrModule()) {
             existing = ctx.state.lookupStaticFieldSymbol(newOwner.asClassOrModuleRef(), constLit->cnst);
             if (existing.exists()) {
-                existing = existing.data(ctx.state)->dealias(ctx.state);
+                existing = existing.dealias(ctx.state);
             }
         }
         // NameInserter should have created this symbol.

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1041,7 +1041,7 @@ class SymbolDefiner {
                 // the previously defined equivalent to re-report any errors
                 auto replacedSym = ctx.state.findRenamedSymbol(owner, matchingSym);
                 if (replacedSym.exists() && !paramsMatch(ctx, replacedSym.asMethodRef(), parsedArgs) &&
-                    !isIntrinsic(replacedSym.data(ctx))) {
+                    !isIntrinsic(replacedSym.asMethodRef().data(ctx))) {
                     paramMismatchErrors(ctx.withOwner(replacedSym), declLoc, parsedArgs);
                 }
                 sym = matchingSym;

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -925,7 +925,7 @@ class SymbolDefiner {
 
     void paramMismatchErrors(core::MutableContext ctx, core::Loc loc, const vector<ast::ParsedArg> &parsedArgs) {
         auto sym = ctx.owner.data(ctx)->dealias(ctx);
-        if (!sym.data(ctx)->isMethod()) {
+        if (!sym.isMethod()) {
             return;
         }
         if (sym.data(ctx)->arguments().size() != parsedArgs.size()) {

--- a/namer/test/namer_test.cc
+++ b/namer/test/namer_test.cc
@@ -68,7 +68,7 @@ TEST_CASE("namer tests") {
         REQUIRE_EQ(core::Symbols::root(), objectScope->owner.asClassOrModuleRef());
 
         REQUIRE_EQ(4, objectScope->members().size());
-        auto methodSym = objectScope->members().at(gs.enterNameUTF8("hello_world"));
+        auto methodSym = objectScope->members().at(gs.enterNameUTF8("hello_world")).asMethodRef();
         const auto &symbol = methodSym.data(gs);
         REQUIRE_EQ(core::Symbols::Object(), symbol->owner.asClassOrModuleRef());
         REQUIRE_EQ(1, symbol->arguments().size());
@@ -120,7 +120,7 @@ TEST_CASE("namer tests") {
                                     .data(gs);
 
         REQUIRE_EQ(3, rootScope->members().size());
-        auto fooSym = rootScope->members().at(gs.enterNameConstant("Foo"));
+        auto fooSym = rootScope->members().at(gs.enterNameConstant("Foo")).asClassOrModuleRef();
         const auto &fooInfo = fooSym.data(gs);
         REQUIRE_EQ(1, fooInfo->members().size());
     }
@@ -140,7 +140,7 @@ TEST_CASE("namer tests") {
                                     .data(gs);
 
         REQUIRE_EQ(3, rootScope->members().size());
-        auto fooSym = rootScope->members().at(gs.enterNameConstant("Foo"));
+        auto fooSym = rootScope->members().at(gs.enterNameConstant("Foo")).asClassOrModuleRef();
         const auto &fooInfo = fooSym.data(gs);
         REQUIRE_EQ(2, fooInfo->members().size());
 

--- a/namer/test/namer_test.cc
+++ b/namer/test/namer_test.cc
@@ -139,7 +139,7 @@ TEST_CASE("namer tests") {
         REQUIRE_EQ(2, fooInfo->members().size());
 
         auto barSym = fooInfo->members().at(gs.enterNameUTF8("bar"));
-        REQUIRE_EQ(fooSym, barSym.data(gs)->owner);
+        REQUIRE_EQ(fooSym, barSym.owner(gs));
     }
 }
 

--- a/namer/test/namer_test.cc
+++ b/namer/test/namer_test.cc
@@ -113,8 +113,11 @@ TEST_CASE("namer tests") {
             sorbet::core::UnfreezeSymbolTable symbolTableAccess(gs); // enters symbols
             runNamer(gs, move(localTree));
         }
-        const auto &rootScope =
-            core::Symbols::root().data(gs)->findMember(gs, gs.enterNameConstant(testClass_str)).data(gs);
+        const auto &rootScope = core::Symbols::root()
+                                    .data(gs)
+                                    ->findMember(gs, gs.enterNameConstant(testClass_str))
+                                    .asClassOrModuleRef()
+                                    .data(gs);
 
         REQUIRE_EQ(3, rootScope->members().size());
         auto fooSym = rootScope->members().at(gs.enterNameConstant("Foo"));
@@ -130,8 +133,11 @@ TEST_CASE("namer tests") {
             sorbet::core::UnfreezeSymbolTable symbolTableAccess(gs); // enters symbols
             runNamer(gs, move(localTree));
         }
-        const auto &rootScope =
-            core::Symbols::root().data(gs)->findMember(gs, gs.enterNameConstant(testClass_str)).data(gs);
+        const auto &rootScope = core::Symbols::root()
+                                    .data(gs)
+                                    ->findMember(gs, gs.enterNameConstant(testClass_str))
+                                    .asClassOrModuleRef()
+                                    .data(gs);
 
         REQUIRE_EQ(3, rootScope->members().size());
         auto fooSym = rootScope->members().at(gs.enterNameConstant("Foo"));

--- a/namer/test/namer_test.cc
+++ b/namer/test/namer_test.cc
@@ -145,7 +145,7 @@ TEST_CASE("namer tests") {
         REQUIRE_EQ(2, fooInfo->members().size());
 
         auto barSym = fooInfo->members().at(gs.enterNameUTF8("bar"));
-        REQUIRE_EQ(fooSym, barSym.owner(gs));
+        REQUIRE_EQ(core::SymbolRef(fooSym), barSym.owner(gs));
     }
 }
 

--- a/plugin_injector/plugin_injector.cc
+++ b/plugin_injector/plugin_injector.cc
@@ -193,7 +193,7 @@ public:
         }
 
         if (md.symbol.data(gs)->name == core::Names::staticInit()) {
-            auto attachedClass = md.symbol.data(gs)->owner.data(gs)->attachedClass(gs);
+            auto attachedClass = md.symbol.data(gs)->owner.asClassOrModuleRef().data(gs)->attachedClass(gs);
             if (attachedClass.exists() && attachedClass.data(gs)->name.isTEnumName(gs)) {
                 return;
             }

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -62,7 +62,7 @@ bool resolveTypeMember(core::GlobalState &gs, core::ClassOrModuleRef parent, cor
         return false;
     }
     if (!my.isTypeMember()) {
-        if (auto e = gs.beginError(my.data(gs)->loc(), core::errors::Resolver::NotATypeVariable)) {
+        if (auto e = gs.beginError(my.loc(gs), core::errors::Resolver::NotATypeVariable)) {
             e.setHeader("Type variable `{}` needs to be declared as `= type_member(SOMETHING)`", name.show(gs));
         }
         auto synthesizedName = gs.freshNameUnique(core::UniqueNameKind::TypeVarName, name, 1);
@@ -112,11 +112,10 @@ void resolveTypeMembers(core::GlobalState &gs, core::ClassOrModuleRef sym,
                 core::SymbolRef my = dealiasAt(gs, tp.asTypeMemberRef(), sym, typeAliases);
                 ENFORCE(my.exists(), "resolver failed to register type member aliases");
                 if (sym.data(gs)->typeMembers()[i] != my) {
-                    if (auto e = gs.beginError(my.data(gs)->loc(), core::errors::Resolver::TypeMembersInWrongOrder)) {
+                    if (auto e = gs.beginError(my.loc(gs), core::errors::Resolver::TypeMembersInWrongOrder)) {
                         e.setHeader("Type members for `{}` repeated in wrong order", sym.show(gs));
-                        e.addErrorLine(my.data(gs)->loc(), "Found type member with name `{}`", my.name(gs).show(gs));
-                        e.addErrorLine(sym.data(gs)->typeMembers()[i].data(gs)->loc(),
-                                       "Expected type member with name `{}`",
+                        e.addErrorLine(my.loc(gs), "Found type member with name `{}`", my.name(gs).show(gs));
+                        e.addErrorLine(sym.data(gs)->typeMembers()[i].loc(gs), "Expected type member with name `{}`",
                                        sym.data(gs)->typeMembers()[i].name(gs).show(gs));
                         e.addErrorLine(tp.data(gs)->loc(), "`{}` defined in parent here:", tp.name(gs).show(gs));
                     }
@@ -151,7 +150,7 @@ void resolveTypeMembers(core::GlobalState &gs, core::ClassOrModuleRef sym,
 
             auto myVariance = tp.data(gs)->variance();
             if (myVariance != core::Variance::Invariant) {
-                auto loc = tp.data(gs)->loc();
+                auto loc = tp.loc(gs);
                 if (!loc.file().data(gs).isPayload()) {
                     if (auto e = gs.beginError(loc, core::errors::Resolver::VariantTypeMemberInClass)) {
                         e.setHeader("Classes can only have invariant type members");

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -20,7 +20,7 @@ core::SymbolRef dealiasAt(const core::GlobalState &gs, core::TypeMemberRef tpara
         return tparam;
     } else {
         core::ClassOrModuleRef cursor;
-        if (tparam.data(gs)->owner.data(gs)->derivesFrom(gs, klass)) {
+        if (tparam.data(gs)->owner.asClassOrModuleRef().data(gs)->derivesFrom(gs, klass)) {
             cursor = tparam.data(gs)->owner.asClassOrModuleRef();
         } else if (klass.data(gs)->derivesFrom(gs, tparam.data(gs)->owner.asClassOrModuleRef())) {
             cursor = klass;
@@ -117,7 +117,7 @@ void resolveTypeMembers(core::GlobalState &gs, core::ClassOrModuleRef sym,
                         e.addErrorLine(my.loc(gs), "Found type member with name `{}`", my.name(gs).show(gs));
                         e.addErrorLine(sym.data(gs)->typeMembers()[i].loc(gs), "Expected type member with name `{}`",
                                        sym.data(gs)->typeMembers()[i].name(gs).show(gs));
-                        e.addErrorLine(tp.data(gs)->loc(), "`{}` defined in parent here:", tp.name(gs).show(gs));
+                        e.addErrorLine(tp.loc(gs), "`{}` defined in parent here:", tp.name(gs).show(gs));
                     }
                     int foundIdx = 0;
                     while (foundIdx < sym.data(gs)->typeMembers().size() &&

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -170,7 +170,8 @@ void resolveTypeMembers(core::GlobalState &gs, core::ClassOrModuleRef sym,
             // with RuntimeProfiled.
             auto attachedClass = singleton.data(gs)->findMember(gs, core::Names::Constants::AttachedClass());
             if (attachedClass.exists()) {
-                auto *lambdaParam = core::cast_type<core::LambdaParam>(attachedClass.data(gs)->resultType);
+                auto *lambdaParam =
+                    core::cast_type<core::LambdaParam>(attachedClass.asTypeMemberRef().data(gs)->resultType);
                 ENFORCE(lambdaParam != nullptr);
 
                 lambdaParam->lowerBound = core::Types::bottom();

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -114,12 +114,11 @@ void resolveTypeMembers(core::GlobalState &gs, core::ClassOrModuleRef sym,
                 if (sym.data(gs)->typeMembers()[i] != my) {
                     if (auto e = gs.beginError(my.data(gs)->loc(), core::errors::Resolver::TypeMembersInWrongOrder)) {
                         e.setHeader("Type members for `{}` repeated in wrong order", sym.show(gs));
-                        e.addErrorLine(my.data(gs)->loc(), "Found type member with name `{}`",
-                                       my.data(gs)->name.show(gs));
+                        e.addErrorLine(my.data(gs)->loc(), "Found type member with name `{}`", my.name(gs).show(gs));
                         e.addErrorLine(sym.data(gs)->typeMembers()[i].data(gs)->loc(),
                                        "Expected type member with name `{}`",
-                                       sym.data(gs)->typeMembers()[i].data(gs)->name.show(gs));
-                        e.addErrorLine(tp.data(gs)->loc(), "`{}` defined in parent here:", tp.data(gs)->name.show(gs));
+                                       sym.data(gs)->typeMembers()[i].name(gs).show(gs));
+                        e.addErrorLine(tp.data(gs)->loc(), "`{}` defined in parent here:", tp.name(gs).show(gs));
                     }
                     int foundIdx = 0;
                     while (foundIdx < sym.data(gs)->typeMembers().size() &&
@@ -146,7 +145,7 @@ void resolveTypeMembers(core::GlobalState &gs, core::ClassOrModuleRef sym,
     if (sym.data(gs)->isClassOrModuleClass()) {
         for (core::SymbolRef tp : sym.data(gs)->typeMembers()) {
             // AttachedClass is covariant, but not controlled by the user.
-            if (tp.data(gs)->name == core::Names::Constants::AttachedClass()) {
+            if (tp.name(gs) == core::Names::Constants::AttachedClass()) {
                 continue;
             }
 

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -143,14 +143,15 @@ void resolveTypeMembers(core::GlobalState &gs, core::ClassOrModuleRef sym,
 
     if (sym.data(gs)->isClassOrModuleClass()) {
         for (core::SymbolRef tp : sym.data(gs)->typeMembers()) {
+            auto tm = tp.asTypeMemberRef();
             // AttachedClass is covariant, but not controlled by the user.
-            if (tp.name(gs) == core::Names::Constants::AttachedClass()) {
+            if (tm.data(gs)->name == core::Names::Constants::AttachedClass()) {
                 continue;
             }
 
-            auto myVariance = tp.data(gs)->variance();
+            auto myVariance = tm.data(gs)->variance();
             if (myVariance != core::Variance::Invariant) {
-                auto loc = tp.loc(gs);
+                auto loc = tm.data(gs)->loc();
                 if (!loc.file().data(gs).isPayload()) {
                     if (auto e = gs.beginError(loc, core::errors::Resolver::VariantTypeMemberInClass)) {
                         e.setHeader("Classes can only have invariant type members");

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -379,7 +379,7 @@ void Resolver::finalizeSymbols(core::GlobalState &gs) {
         core::ClassOrModuleRef singleton;
         for (auto ancst : sym.data(gs)->mixins()) {
             // Reading the fake property created in resolver#resolveClassMethodsJob(){}
-            auto mixedInClassMethods = ancst.data(gs)->findMember(gs, core::Names::mixedInClassMethods());
+            auto mixedInClassMethods = ancst.data(gs)->findMethod(gs, core::Names::mixedInClassMethods());
             if (!mixedInClassMethods.exists()) {
                 continue;
             }

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -189,7 +189,6 @@ void Resolver::finalizeAncestors(core::GlobalState &gs) {
     int moduleCount = 0;
     for (size_t i = 1; i < gs.methodsUsed(); ++i) {
         auto ref = core::MethodRef(gs, i);
-        ENFORCE(ref.data(gs)->isMethod());
         auto loc = ref.data(gs)->loc();
         if (loc.file().exists() && loc.file().data(gs).sourceType == core::File::Type::Normal) {
             methodCount++;
@@ -379,7 +378,6 @@ void Resolver::finalizeSymbols(core::GlobalState &gs) {
 
         core::ClassOrModuleRef singleton;
         for (auto ancst : sym.data(gs)->mixins()) {
-            ENFORCE(ancst.data(gs)->isClassOrModule());
             // Reading the fake property created in resolver#resolveClassMethodsJob(){}
             auto mixedInClassMethods = ancst.data(gs)->findMember(gs, core::Names::mixedInClassMethods());
             if (!mixedInClassMethods.exists()) {

--- a/resolver/SuggestPackage.cc
+++ b/resolver/SuggestPackage.cc
@@ -55,8 +55,8 @@ public:
             srcPkg.definitionLoc(), "Do you need to `{} {}` in package `{}`?", core::Names::export_().show(ctx),
             match.symbol.show(ctx),
             fmt::map_join(srcPkg.fullName(), "::", [&](auto nr) -> string { return nr.show(ctx); })));
-        lines.emplace_back(core::ErrorLine::from(match.symbol.data(ctx)->loc(),
-                                                 "Constant `{}` is defined here:", match.symbol.show(ctx)));
+        lines.emplace_back(
+            core::ErrorLine::from(match.symbol.loc(ctx), "Constant `{}` is defined here:", match.symbol.show(ctx)));
         // TODO(nroman-stripe) Add automatic fixers
         e.addErrorSection(core::ErrorSection(lines));
     }

--- a/resolver/SuggestPackage.cc
+++ b/resolver/SuggestPackage.cc
@@ -10,9 +10,9 @@ namespace {
 // Add all name parts for a symbol to a vector, exclude internal names used by packager.
 void symbol2NameParts(core::Context ctx, core::SymbolRef symbol, vector<core::NameRef> &out) {
     ENFORCE(out.empty());
-    while (symbol.exists() && symbol != core::Symbols::root() && !symbol.data(ctx)->name.isPackagerName(ctx)) {
-        out.emplace_back(symbol.data(ctx)->name);
-        symbol = symbol.data(ctx)->owner;
+    while (symbol.exists() && symbol != core::Symbols::root() && !symbol.name(ctx).isPackagerName(ctx)) {
+        out.emplace_back(symbol.name(ctx));
+        symbol = symbol.owner(ctx);
     }
     std::reverse(out.begin(), out.end());
 }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1419,15 +1419,16 @@ class ResolveTypeMembersAndFieldsWalk {
         }
 
         auto prior = scope.data(ctx)->findMember(ctx, uid->name);
-        if (prior.exists()) {
-            if (core::Types::equiv(ctx, prior.data(ctx)->resultType, cast->type)) {
+        if (prior.exists() && prior.isFieldOrStaticField()) {
+            auto priorField = prior.asFieldRef();
+            if (core::Types::equiv(ctx, priorField.data(ctx)->resultType, cast->type)) {
                 // We already have a symbol for this field, and it matches what we already saw, so we can short
                 // circuit.
                 return;
             } else {
                 // We do some normalization here to ensure that the file / line we report the error on doesn't
                 // depend on the order that we traverse files nor the order we traverse within a file.
-                auto priorLoc = prior.loc(ctx);
+                auto priorLoc = priorField.data(ctx)->loc();
                 core::Loc reportOn;
                 core::Loc errorLine;
                 core::Loc thisLoc = core::Loc(job.file, uid->loc);

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1402,7 +1402,7 @@ class ResolveTypeMembersAndFieldsWalk {
             // class or body, rather then nested in some block
             if (job.atTopLevel && ctx.owner.data(ctx)->isClassOrModule()) {
                 // Declaring a class instance variable
-            } else if (job.atTopLevel && ctx.owner.data(ctx)->name == core::Names::initialize()) {
+            } else if (job.atTopLevel && ctx.owner.name(ctx) == core::Names::initialize()) {
                 // Declaring a instance variable
             } else if (ctx.owner.data(ctx)->isMethod() && ctx.owner.data(ctx)->owner.data(ctx)->isSingletonClass(ctx) &&
                        !core::Types::isSubType(ctx, core::Types::nilClass(), cast->type)) {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1403,7 +1403,7 @@ class ResolveTypeMembersAndFieldsWalk {
                 // Declaring a class instance variable
             } else if (job.atTopLevel && ctx.owner.name(ctx) == core::Names::initialize()) {
                 // Declaring a instance variable
-            } else if (ctx.owner.isMethod() && ctx.owner.owner(ctx).data(ctx)->isSingletonClass(ctx) &&
+            } else if (ctx.owner.isMethod() && ctx.owner.owner(ctx).isSingletonClass(ctx) &&
                        !core::Types::isSubType(ctx, core::Types::nilClass(), cast->type)) {
                 // Declaring a class instance variable in a static method
                 if (auto e = ctx.beginError(uid->loc, core::errors::Resolver::InvalidDeclareVariables)) {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1389,7 +1389,7 @@ class ResolveTypeMembersAndFieldsWalk {
         core::ClassOrModuleRef scope;
         auto uid = job.ident;
         if (uid->kind == ast::UnresolvedIdent::Kind::Class) {
-            if (!ctx.owner.data(ctx)->isClassOrModule()) {
+            if (!ctx.owner.isClassOrModule()) {
                 if (auto e = ctx.beginError(uid->loc, core::errors::Resolver::InvalidDeclareVariables)) {
                     e.setHeader("The class variable `{}` must be declared at class scope", uid->name.show(ctx));
                 }
@@ -1399,11 +1399,11 @@ class ResolveTypeMembersAndFieldsWalk {
         } else {
             // we need to check nested block counts because we want all fields to be declared on top level of either
             // class or body, rather then nested in some block
-            if (job.atTopLevel && ctx.owner.data(ctx)->isClassOrModule()) {
+            if (job.atTopLevel && ctx.owner.isClassOrModule()) {
                 // Declaring a class instance variable
             } else if (job.atTopLevel && ctx.owner.name(ctx) == core::Names::initialize()) {
                 // Declaring a instance variable
-            } else if (ctx.owner.data(ctx)->isMethod() && ctx.owner.owner(ctx).data(ctx)->isSingletonClass(ctx) &&
+            } else if (ctx.owner.isMethod() && ctx.owner.owner(ctx).data(ctx)->isSingletonClass(ctx) &&
                        !core::Types::isSubType(ctx, core::Types::nilClass(), cast->type)) {
                 // Declaring a class instance variable in a static method
                 if (auto e = ctx.beginError(uid->loc, core::errors::Resolver::InvalidDeclareVariables)) {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -286,14 +286,15 @@ private:
 
         auto resolved = resolveConstant(ctx.withOwner(job.scope->scope), job.scope, original, job.resolutionFailed);
         if (resolved.exists() && resolved.isTypeAlias(ctx)) {
-            if (resolved.data(ctx)->resultType == nullptr) {
+            auto resolvedField = resolved.asFieldRef();
+            if (resolvedField.data(ctx)->resultType == nullptr) {
                 // This is actually a use-site error, but we limit ourselves to emitting it once by checking resultType
-                auto loc = resolved.loc(ctx);
+                auto loc = resolvedField.data(ctx)->loc();
                 if (auto e = ctx.state.beginError(loc, core::errors::Resolver::RecursiveTypeAlias)) {
                     e.setHeader("Unable to resolve right hand side of type alias `{}`", resolved.show(ctx));
                     e.addErrorLine(core::Loc(ctx.file, job.out->original.loc()), "Type alias used here");
                 }
-                resolved.data(ctx)->resultType =
+                resolvedField.data(ctx)->resultType =
                     core::Types::untyped(ctx, resolved); // <<-- This is the reason this takes a MutableContext
             }
             job.out->symbol = resolved;
@@ -386,7 +387,8 @@ private:
             return false;
         }
         if (resolved.isTypeAlias(ctx)) {
-            if (resolved.data(ctx)->resultType != nullptr) {
+            auto resolvedField = resolved.asFieldRef();
+            if (resolvedField.data(ctx)->resultType != nullptr) {
                 job.out->symbol = resolved;
                 return true;
             }
@@ -1326,14 +1328,14 @@ class ResolveTypeMembersAndFieldsWalk {
 
     static bool isLHSResolved(core::Context ctx, core::SymbolRef sym) {
         if (sym.isTypeMember()) {
-            auto *lambdaParam = core::cast_type<core::LambdaParam>(sym.data(ctx)->resultType);
+            auto *lambdaParam = core::cast_type<core::LambdaParam>(sym.resultType(ctx));
             ENFORCE(lambdaParam != nullptr);
 
             // both bounds are set to todo in the namer, so it's sufficient to
             // just check one here.
             return !isTodo(lambdaParam->lowerBound);
         } else {
-            return !isTodo(sym.data(ctx)->resultType);
+            return !isTodo(sym.resultType(ctx));
         }
     }
 
@@ -1542,7 +1544,7 @@ class ResolveTypeMembersAndFieldsWalk {
         auto data = lhs.data(ctx);
         auto owner = data->owner;
 
-        core::LambdaParam *parentType = nullptr;
+        const core::LambdaParam *parentType = nullptr;
         core::SymbolRef parentMember = core::Symbols::noSymbol();
         parentMember = owner.data(ctx)->superClass().data(ctx)->findMember(ctx, data->name);
 
@@ -1558,7 +1560,7 @@ class ResolveTypeMembersAndFieldsWalk {
 
         if (parentMember.exists()) {
             if (parentMember.isTypeMember()) {
-                parentType = core::cast_type<core::LambdaParam>(parentMember.data(ctx)->resultType);
+                parentType = core::cast_type<core::LambdaParam>(parentMember.resultType(ctx));
                 ENFORCE(parentType != nullptr);
             } else if (auto e = ctx.beginError(rhs->loc, core::errors::Resolver::ParentTypeBoundsMismatch)) {
                 const auto parentShow = parentMember.show(ctx);
@@ -1666,8 +1668,8 @@ class ResolveTypeMembersAndFieldsWalk {
         if (!attachedClass.exists()) {
             return;
         }
-
-        auto *lambdaParam = core::cast_type<core::LambdaParam>(attachedClass.data(ctx)->resultType);
+        auto attachedClassTypeMember = attachedClass.asTypeMemberRef();
+        auto *lambdaParam = core::cast_type<core::LambdaParam>(attachedClassTypeMember.data(ctx)->resultType);
         ENFORCE(lambdaParam != nullptr);
 
         if (isTodo(lambdaParam->lowerBound)) {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -255,7 +255,7 @@ private:
             if (!sym.exists()) {
                 return core::Symbols::noSymbol();
             }
-            core::SymbolRef resolved = id->symbol.data(ctx)->dealias(ctx);
+            core::SymbolRef resolved = id->symbol.dealias(ctx);
             core::SymbolRef result = resolved.data(ctx)->findMember(ctx, c.cnst);
 
             // Private constants are allowed to be resolved, when there is no scope set (the scope is checked above),
@@ -314,7 +314,7 @@ private:
         bool alreadyReported = false;
         job.out->resolutionScopes = make_unique<ast::ConstantLit::ResolutionScopes>();
         if (auto *id = ast::cast_tree<ast::ConstantLit>(original.scope)) {
-            auto originalScope = id->symbol.data(ctx)->dealias(ctx);
+            auto originalScope = id->symbol.dealias(ctx);
             if (originalScope == core::Symbols::StubModule()) {
                 // If we were trying to resolve some literal like C::D but `C` itself was already stubbed,
                 // no need to also report that `D` is missing.
@@ -453,7 +453,7 @@ private:
             it.lhs.setResultType(ctx, core::Types::untypedUntracked());
             return true;
         } else {
-            if (rhsSym.data(ctx)->dealias(ctx) != it.lhs) {
+            if (rhsSym.dealias(ctx) != it.lhs) {
                 it.lhs.setResultType(ctx, core::make_type<core::AliasType>(rhsSym));
             } else {
                 if (auto e = ctx.state.beginError(it.lhs.loc(ctx), core::errors::Resolver::RecursiveClassAlias)) {
@@ -519,7 +519,7 @@ private:
                 }
                 resolved = stubSymbolForAncestor(job);
             } else {
-                resolved = ancestorSym.data(ctx)->dealias(ctx);
+                resolved = ancestorSym.dealias(ctx);
             }
 
             if (!resolved.isClassOrModule()) {
@@ -744,7 +744,7 @@ private:
 
     static void tryRegisterSealedSubclass(core::MutableContext ctx, AncestorResolutionItem &job) {
         ENFORCE(job.ancestor->symbol.exists(), "Ancestor must exist, or we can't check whether it's sealed.");
-        auto ancestorSym = job.ancestor->symbol.data(ctx)->dealias(ctx);
+        auto ancestorSym = job.ancestor->symbol.dealias(ctx);
 
         if (!ancestorSym.data(ctx)->isClassOrModuleSealed()) {
             return;
@@ -2096,7 +2096,7 @@ public:
         auto &lit = ast::cast_tree_nonnull<ast::ConstantLit>(tree);
 
         if (trackDependencies_) {
-            core::SymbolRef symbol = lit.symbol.data(ctx)->dealias(ctx);
+            core::SymbolRef symbol = lit.symbol.dealias(ctx);
             if (symbol == core::Symbols::T()) {
                 return tree;
             }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -648,7 +648,7 @@ private:
             }
 
             // Get the fake property holding the mixes
-            auto mixMethod = owner.data(gs)->findMember(gs, core::Names::mixedInClassMethods());
+            auto mixMethod = owner.data(gs)->findMethod(gs, core::Names::mixedInClassMethods());
             auto loc = core::Loc(owner.loc(gs).file(), send->loc);
             if (!mixMethod.exists()) {
                 // We never stored a mixin in this symbol
@@ -658,8 +658,7 @@ private:
                 mixMethod.data(gs)->resultType = core::make_type<core::TupleType>(move(targs));
 
                 // Create a dummy block argument to satisfy sanitycheck during GlobalState::expandNames
-                auto &arg =
-                    gs.enterMethodArgumentSymbol(core::Loc::none(), mixMethod.asMethodRef(), core::Names::blkArg());
+                auto &arg = gs.enterMethodArgumentSymbol(core::Loc::none(), mixMethod, core::Names::blkArg());
                 arg.flags.isBlock = true;
             }
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1733,11 +1733,9 @@ class ResolveTypeMembersAndFieldsWalk {
     }
 
     static void resolveMethodAlias(core::MutableContext ctx, const ResolveMethodAliasItem &job) {
-        core::SymbolRef member = ctx.owner.data(ctx)->findMemberNoDealias(ctx, job.toName);
-        // TODO(jvilk): Would be nice to have findMember that returned MethodRef.
-        core::MethodRef toMethod = core::Symbols::noMethod();
-        if (member.exists()) {
-            toMethod = member.data(ctx)->dealiasMethod(ctx);
+        core::MethodRef toMethod = ctx.owner.data(ctx)->findMethodNoDealias(ctx, job.toName);
+        if (toMethod.exists()) {
+            toMethod = toMethod.data(ctx)->dealiasMethod(ctx);
         }
 
         if (!toMethod.exists()) {
@@ -1748,7 +1746,7 @@ class ResolveTypeMembersAndFieldsWalk {
             toMethod = core::Symbols::Sorbet_Private_Static_badAliasMethodStub();
         }
 
-        core::SymbolRef fromMethod = ctx.owner.data(ctx)->findMemberNoDealias(ctx, job.fromName);
+        core::MethodRef fromMethod = ctx.owner.data(ctx)->findMethodNoDealias(ctx, job.fromName);
         if (fromMethod.exists() && fromMethod.data(ctx)->dealiasMethod(ctx) != toMethod) {
             if (auto e = ctx.beginError(job.loc, core::errors::Resolver::BadAliasMethod)) {
                 auto dealiased = fromMethod.data(ctx)->dealiasMethod(ctx);

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -289,7 +289,7 @@ private:
         if (resolved.exists() && resolved.data(ctx)->isTypeAlias()) {
             if (resolved.data(ctx)->resultType == nullptr) {
                 // This is actually a use-site error, but we limit ourselves to emitting it once by checking resultType
-                auto loc = resolved.data(ctx)->loc();
+                auto loc = resolved.loc(ctx);
                 if (auto e = ctx.state.beginError(loc, core::errors::Resolver::RecursiveTypeAlias)) {
                     e.setHeader("Unable to resolve right hand side of type alias `{}`", resolved.show(ctx));
                     e.addErrorLine(core::Loc(ctx.file, job.out->original.loc()), "Type alias used here");
@@ -365,8 +365,8 @@ private:
                         vector<core::ErrorLine> lines;
                         for (auto suggestion : suggested) {
                             const auto replacement = suggestion.symbol.show(ctx);
-                            lines.emplace_back(core::ErrorLine::from(suggestion.symbol.data(ctx)->loc(),
-                                                                     "Did you mean: `{}`?", replacement));
+                            lines.emplace_back(
+                                core::ErrorLine::from(suggestion.symbol.loc(ctx), "Did you mean: `{}`?", replacement));
                             e.replaceWith(fmt::format("Replace with `{}`", replacement),
                                           core::Loc(ctx.file, job.out->loc), "{}", replacement);
                         }
@@ -456,8 +456,7 @@ private:
             if (rhsData->dealias(ctx) != it.lhs) {
                 it.lhs.data(ctx)->resultType = core::make_type<core::AliasType>(rhsSym);
             } else {
-                if (auto e =
-                        ctx.state.beginError(it.lhs.data(ctx)->loc(), core::errors::Resolver::RecursiveClassAlias)) {
+                if (auto e = ctx.state.beginError(it.lhs.loc(ctx), core::errors::Resolver::RecursiveClassAlias)) {
                     e.setHeader("Class alias aliases to itself");
                 }
                 it.lhs.data(ctx)->resultType = core::Types::untypedUntracked();
@@ -652,7 +651,7 @@ private:
 
             // Get the fake property holding the mixes
             auto mixMethod = owner.data(gs)->findMember(gs, core::Names::mixedInClassMethods());
-            auto loc = core::Loc(owner.data(gs)->loc().file(), send->loc);
+            auto loc = core::Loc(owner.loc(gs).file(), send->loc);
             if (!mixMethod.exists()) {
                 // We never stored a mixin in this symbol
                 // Create a the fake property that will hold the mixed in modules
@@ -1404,7 +1403,7 @@ class ResolveTypeMembersAndFieldsWalk {
                 // Declaring a class instance variable
             } else if (job.atTopLevel && ctx.owner.name(ctx) == core::Names::initialize()) {
                 // Declaring a instance variable
-            } else if (ctx.owner.data(ctx)->isMethod() && ctx.owner.data(ctx)->owner.data(ctx)->isSingletonClass(ctx) &&
+            } else if (ctx.owner.data(ctx)->isMethod() && ctx.owner.owner(ctx).data(ctx)->isSingletonClass(ctx) &&
                        !core::Types::isSubType(ctx, core::Types::nilClass(), cast->type)) {
                 // Declaring a class instance variable in a static method
                 if (auto e = ctx.beginError(uid->loc, core::errors::Resolver::InvalidDeclareVariables)) {
@@ -1431,7 +1430,7 @@ class ResolveTypeMembersAndFieldsWalk {
             } else {
                 // We do some normalization here to ensure that the file / line we report the error on doesn't
                 // depend on the order that we traverse files nor the order we traverse within a file.
-                auto priorLoc = prior.data(ctx)->loc();
+                auto priorLoc = prior.loc(ctx);
                 core::Loc reportOn;
                 core::Loc errorLine;
                 core::Loc thisLoc = core::Loc(job.file, uid->loc);
@@ -1566,7 +1565,7 @@ class ResolveTypeMembersAndFieldsWalk {
             } else if (auto e = ctx.beginError(rhs->loc, core::errors::Resolver::ParentTypeBoundsMismatch)) {
                 const auto parentShow = parentMember.show(ctx);
                 e.setHeader("`{}` is a type member but `{}` is not a type member", lhs.show(ctx), parentShow);
-                e.addErrorLine(parentMember.data(ctx)->loc(), "`{}` definition", parentShow);
+                e.addErrorLine(parentMember.loc(ctx), "`{}` definition", parentShow);
             }
         }
 
@@ -2005,7 +2004,7 @@ class ResolveTypeMembersAndFieldsWalk {
         if (!current.isClassOrModule()) {
             if (auto e = ctx.beginError(stringLoc, core::errors::Resolver::LazyResolve)) {
                 e.setHeader("The string given to `{}` must resolve to a class or module", method);
-                e.addErrorLine(current.data(ctx)->loc(), "Resolved to this constant");
+                e.addErrorLine(current.loc(ctx), "Resolved to this constant");
             }
             return;
         }
@@ -2302,7 +2301,7 @@ public:
             ENFORCE(send->fun == core::Names::typeAlias() || send->fun == core::Names::typeMember() ||
                     send->fun == core::Names::typeTemplate());
 
-            auto owner = sym.data(ctx)->owner;
+            auto owner = sym.owner(ctx);
 
             dependencies_.emplace_back(owner.data(ctx)->superClass());
 

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -635,7 +635,7 @@ TypeSyntax::ResultType interpretTCombinator(core::Context ctx, const ast::Send &
                 }
                 return TypeSyntax::ResultType{core::Types::untypedUntracked(), core::Symbols::noClassOrModule()};
             }
-            auto sym = maybeAliased.data(ctx)->dealias(ctx);
+            auto sym = maybeAliased.dealias(ctx);
             if (sym.isStaticField(ctx)) {
                 if (auto e = ctx.beginError(send.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                     e.setHeader("T.class_of can't be used with a constant field");
@@ -771,7 +771,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx,
                 }
             }
 
-            auto sym = maybeAliased.data(ctx)->dealias(ctx);
+            auto sym = maybeAliased.dealias(ctx);
             if (sym.isClassOrModule()) {
                 // the T::Type generics internally have a typeArity of 0, so this allows us to check against them in the
                 // same way that we check against types like `Array`
@@ -1057,7 +1057,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx,
             } else {
                 corrected = recvi->symbol;
             }
-            corrected = corrected.data(ctx)->dealias(ctx);
+            corrected = corrected.dealias(ctx);
 
             if (!corrected.isClassOrModule()) {
                 if (auto e = ctx.beginError(s.loc, core::errors::Resolver::InvalidTypeDeclaration)) {

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -750,7 +750,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx,
             ENFORCE(maybeAliased.exists());
 
             if (maybeAliased.isTypeAlias(ctx)) {
-                result.type = maybeAliased.data(ctx)->resultType;
+                result.type = maybeAliased.resultType(ctx);
                 return;
             }
 
@@ -763,10 +763,10 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx,
             // times as wanted, and assigned into different constants each time. As much as possible, we
             // want there to be one name for every type; making an alias for a type should always be
             // syntactically declared with T.type_alias.
-            if (core::isa_type<core::ClassType>(maybeAliased.data(ctx)->resultType)) {
-                auto resultType = core::cast_type_nonnull<core::ClassType>(maybeAliased.data(ctx)->resultType);
+            if (core::isa_type<core::ClassType>(maybeAliased.resultType(ctx))) {
+                auto resultType = core::cast_type_nonnull<core::ClassType>(maybeAliased.resultType(ctx));
                 if (resultType.symbol.data(ctx)->derivesFrom(ctx, core::Symbols::T_Enum())) {
-                    result.type = maybeAliased.data(ctx)->resultType;
+                    result.type = maybeAliased.resultType(ctx);
                     return;
                 }
             }

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -682,7 +682,8 @@ TypeSyntax::ResultType interpretTCombinator(core::Context ctx, const ast::Send &
             } else {
                 // All singletons have an AttachedClass type member, created by
                 // `singletonClass`
-                auto attachedClass = ctx.owner.data(ctx)->findMember(ctx, core::Names::Constants::AttachedClass());
+                auto attachedClass =
+                    ctx.owner.data(ctx)->findMember(ctx, core::Names::Constants::AttachedClass()).asTypeMemberRef();
                 return TypeSyntax::ResultType{attachedClass.data(ctx)->resultType, core::Symbols::noClassOrModule()};
             }
         case core::Names::noreturn().rawId():

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -643,7 +643,7 @@ TypeSyntax::ResultType interpretTCombinator(core::Context ctx, const ast::Send &
                 return TypeSyntax::ResultType{core::Types::untypedUntracked(), core::Symbols::noClassOrModule()};
             }
 
-            auto singleton = sym.data(ctx)->lookupSingletonClass(ctx);
+            auto singleton = sym.asClassOrModuleRef().data(ctx)->lookupSingletonClass(ctx);
             if (!singleton.exists()) {
                 if (auto e = ctx.beginError(send.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                     e.setHeader("Unknown class");
@@ -682,8 +682,10 @@ TypeSyntax::ResultType interpretTCombinator(core::Context ctx, const ast::Send &
             } else {
                 // All singletons have an AttachedClass type member, created by
                 // `singletonClass`
-                auto attachedClass =
-                    ctx.owner.data(ctx)->findMember(ctx, core::Names::Constants::AttachedClass()).asTypeMemberRef();
+                auto attachedClass = ctx.owner.asClassOrModuleRef()
+                                         .data(ctx)
+                                         ->findMember(ctx, core::Names::Constants::AttachedClass())
+                                         .asTypeMemberRef();
                 return TypeSyntax::ResultType{attachedClass.data(ctx)->resultType, core::Symbols::noClassOrModule()};
             }
         case core::Names::noreturn().rawId():
@@ -712,8 +714,8 @@ unique_ptr<core::TypeAndOrigins> makeTypeAndOrigins(core::Context ctx, core::Loc
 TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx, const ast::ExpressionPtr &expr,
                                                               const ParsedSig &sigBeingParsed, TypeSyntaxArgs args) {
     // Ensure that we only check types from a class context
-    auto ctxOwnerData = ctx.owner.data(ctx);
-    ENFORCE(ctxOwnerData->isClassOrModule(), "getResultTypeAndBind wasn't called with a class owner");
+    ENFORCE(ctx.owner.isClassOrModule(), "getResultTypeAndBind wasn't called with a class owner");
+    auto ctxOwnerData = ctx.owner.asClassOrModuleRef().data(ctx);
 
     TypeSyntax::ResultType result;
     typecase(
@@ -773,36 +775,39 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx,
 
             auto sym = maybeAliased.dealias(ctx);
             if (sym.isClassOrModule()) {
+                auto klass = sym.asClassOrModuleRef();
                 // the T::Type generics internally have a typeArity of 0, so this allows us to check against them in the
                 // same way that we check against types like `Array`
-                bool isBuiltinGeneric = sym == core::Symbols::T_Hash() || sym == core::Symbols::T_Array() ||
-                                        sym == core::Symbols::T_Set() || sym == core::Symbols::T_Range() ||
-                                        sym == core::Symbols::T_Enumerable() || sym == core::Symbols::T_Enumerator();
+                bool isBuiltinGeneric = klass == core::Symbols::T_Hash() || klass == core::Symbols::T_Array() ||
+                                        klass == core::Symbols::T_Set() || klass == core::Symbols::T_Range() ||
+                                        klass == core::Symbols::T_Enumerable() ||
+                                        klass == core::Symbols::T_Enumerator();
 
-                if (isBuiltinGeneric || sym.data(ctx)->typeArity(ctx) > 0) {
+                if (isBuiltinGeneric || klass.data(ctx)->typeArity(ctx) > 0) {
                     // This set **should not** grow over time.
-                    bool isStdlibWhitelisted = sym == core::Symbols::Hash() || sym == core::Symbols::Array() ||
-                                               sym == core::Symbols::Set() || sym == core::Symbols::Range() ||
-                                               sym == core::Symbols::Enumerable() || sym == core::Symbols::Enumerator();
+                    bool isStdlibWhitelisted = klass == core::Symbols::Hash() || klass == core::Symbols::Array() ||
+                                               klass == core::Symbols::Set() || klass == core::Symbols::Range() ||
+                                               klass == core::Symbols::Enumerable() ||
+                                               klass == core::Symbols::Enumerator();
                     auto level = isStdlibWhitelisted ? core::errors::Resolver::GenericClassWithoutTypeArgsStdlib
                                                      : core::errors::Resolver::GenericClassWithoutTypeArgs;
                     if (auto e = ctx.beginError(i.loc, level)) {
                         e.setHeader("Malformed type declaration. Generic class without type arguments `{}`",
-                                    sym.show(ctx));
+                                    klass.show(ctx));
                         // if we're looking at `Array`, we want the autocorrect to include `T::`, but we don't need to
                         // if we're already looking at `T::Array` instead.
                         auto typePrefix = isBuiltinGeneric ? "" : "T::";
 
                         auto loc = core::Loc{ctx.file, i.loc};
                         if (auto locSource = loc.source(ctx)) {
-                            if (sym == core::Symbols::Hash() || sym == core::Symbols::T_Hash()) {
+                            if (klass == core::Symbols::Hash() || klass == core::Symbols::T_Hash()) {
                                 // Hash is special because it has arity 3 but you're only supposed to write the first 2
                                 e.replaceWith("Add type arguments", loc, "{}{}[T.untyped, T.untyped]", typePrefix,
                                               locSource.value());
                             } else if (isStdlibWhitelisted || isBuiltinGeneric) {
                                 // the default provided here for builtin generic types is 1, and that might need to
                                 // change if we add other builtin generics (but ideally we should never need to do so!)
-                                auto numTypeArgs = isBuiltinGeneric ? 1 : sym.data(ctx)->typeArity(ctx);
+                                auto numTypeArgs = isBuiltinGeneric ? 1 : klass.data(ctx)->typeArity(ctx);
                                 vector<string> untypeds;
                                 for (int i = 0; i < numTypeArgs; i++) {
                                     untypeds.emplace_back("T.untyped");
@@ -813,7 +818,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx,
                         }
                     }
                 }
-                if (sym == core::Symbols::StubModule()) {
+                if (klass == core::Symbols::StubModule()) {
                     // Though for normal types _and_ stub types `infer` should use `externalType`,
                     // using `externalType` for stub types here will lead to incorrect handling of global state hashing,
                     // where we won't see difference between two different unresolved stubs(or a mistyped stub). thus,
@@ -824,11 +829,12 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx,
                     result.type =
                         core::make_type<core::UnresolvedClassType>(unresolvedPath->first, move(unresolvedPath->second));
                 } else {
-                    result.type = sym.data(ctx)->externalType();
+                    result.type = klass.data(ctx)->externalType();
                 }
             } else if (sym.isTypeMember()) {
-                auto symData = sym.data(ctx);
-                auto symOwner = symData->owner.data(ctx);
+                auto tm = sym.asTypeMemberRef();
+                auto symData = tm.data(ctx);
+                auto symOwner = symData->owner.asClassOrModuleRef().data(ctx);
 
                 bool isTypeTemplate = symOwner->isSingletonClass(ctx);
 
@@ -1067,7 +1073,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx,
                 return;
             }
 
-            auto correctedSingleton = corrected.data(ctx)->lookupSingletonClass(ctx);
+            auto correctedSingleton = corrected.asClassOrModuleRef().data(ctx)->lookupSingletonClass(ctx);
             ENFORCE_NO_TIMER(correctedSingleton.exists());
             auto ctype = core::make_type<core::ClassType>(correctedSingleton);
             auto ctypeAndOrigins = core::TypeAndOrigins{ctype, {core::Loc(ctx.file, s.loc)}};

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -899,8 +899,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx,
             } else if (sym.isStaticField(ctx)) {
                 if (auto e = ctx.beginError(i.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                     e.setHeader("Constant `{}` is not a class or type alias", maybeAliased.show(ctx));
-                    e.addErrorLine(sym.data(ctx)->loc(),
-                                   "If you are trying to define a type alias, you should use `{}` here",
+                    e.addErrorLine(sym.loc(ctx), "If you are trying to define a type alias, you should use `{}` here",
                                    "T.type_alias");
                 }
                 result.type = core::Types::untypedUntracked();

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -673,7 +673,7 @@ TypeSyntax::ResultType interpretTCombinator(core::Context ctx, const ast::Send &
                 }
             }
 
-            if (!ctx.owner.data(ctx)->isSingletonClass(ctx)) {
+            if (!ctx.owner.isSingletonClass(ctx)) {
                 if (auto e = ctx.beginError(send.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                     e.setHeader("`{}` may only be used in a singleton class method context",
                                 "T." + core::Names::attachedClass().show(ctx));

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -623,7 +623,7 @@ TypeSyntax::ResultType interpretTCombinator(core::Context ctx, const ast::Send &
                 return TypeSyntax::ResultType{core::Types::untypedUntracked(), core::Symbols::noClassOrModule()};
             }
             auto maybeAliased = obj->symbol;
-            if (maybeAliased.data(ctx)->isTypeAlias()) {
+            if (maybeAliased.isTypeAlias(ctx)) {
                 if (auto e = ctx.beginError(send.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                     e.setHeader("T.class_of can't be used with a T.type_alias");
                 }
@@ -748,7 +748,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx,
             auto maybeAliased = i.symbol;
             ENFORCE(maybeAliased.exists());
 
-            if (maybeAliased.data(ctx)->isTypeAlias()) {
+            if (maybeAliased.isTypeAlias(ctx)) {
                 result.type = maybeAliased.data(ctx)->resultType;
                 return;
             }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Make SymbolRef::data private. The next step is to completely remove this method. This step prevents most new occurrences from SymbolRef::data from appearing in the codebase.

I have intentionally structured this PR so that we can break it up into multiple PRs or have it be reviewed commit-by-commit. I am opening this PR to open the discussion concerning how to break this up and land it. After discussing with @trevor-stripe , we believe that this PR is best to land all at once and would be harder to review piecemeal.

For convenience, I have introduced several methods onto `SymbolRef` that dispatch to the proper symbol-type `*Ref` class. I intend to remove as many of these methods as feasible. Fixing some of the callsites will involve reworking some code paths to switch on symbol type earlier. I did not want to introduce those changes into this PR, as it is already a bit big.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Currently, all symbol types (class or module, method, field, ...) share a common class: `Symbol`. This class contains a superset of the fields needed by any given symbol, which means that every method allocates a `members_` map that it doesn't need[0].

By removing `SymbolRef::data`, we can implement separate data structures per symbol type, which will have the following downstream effects:

* **More precise types for cleaner code.** This is the biggest motivator for this change in my book. For example, we can specify that a `Method` can only have a `ClassOrModuleRef` `owner`. This removes a lot of "casting" of `SymbolRef` with `isMethod()`/`asMethodRef()` and should make it more obvious what symbol type to expect[1]. We can also define symbol-specific methods, like `setIsModule()`, on the individual symbol types that it applies to. Currently, we ENFORCE that these methods are not called on the wrong symbol type at runtime in debug builds only.
* **Smaller Symbol types.** We can remove `UnorderedMap` from every non-class or module symbol, which saves a little bit of memory. The savings will not be super large since ASTs dominate Sorbet's memory footprint. However, shrinking symbol size has a more promising second impact... (see next bullet)
* **Faster namer.** Methods make up the majority of entries in the symbol table at Stripe. Creating method symbols will become faster because they will be smaller and will have fewer fields to allocate. It looks like the namer pass could become up to 8% faster[2]. 

[0] OK, it's currently used for type arguments -- but it _really_ doesn't have to be. Methods don't have enough to justify an UnorderedMap over a vector (and it already has a vector of type arguments we could use!).

[1] `typeArguments()` / `typeMembers()` can also return vectors of `TypeArgumentRef`/`TypeMemberRef`. There are a lot of small API improvements here that add up to big improvements at callsites that currently have to "cast" the SymbolRef to the proper type.

[2] I estimated this value by introducing a _second_ `UnorderedMap` into the `Symbol` class and measuring Sorbet performance on the Stripe codebase. It introduced an 8% slowdown to namer, which estimates the impact of allocating/constructing this data type for every symbol in the symbol table. Since methods make up over half of the entries in the symbol table, we could conservatively estimate a 5% speedup. There are other fields in Symbol that will be removed from the `Method` class, but `UnorderedMap` is the biggest 'win'.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
