### PR TITLE
Add a benchmark for Array#reject!

### DIFF
--- a/test/testdata/ruby_benchmark/stripe/array_reject_bang.rb
+++ b/test/testdata/ruby_benchmark/stripe/array_reject_bang.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+
+arr = (1..10_000_000).to_a
+
+arr.reject! do |x|
+  x%2 == 0
+end
+
+p arr.length

--- a/test/testdata/ruby_benchmark/stripe/array_reject_bang_baseline.rb
+++ b/test/testdata/ruby_benchmark/stripe/array_reject_bang_baseline.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+
+arr = (1..10_000_000).to_a


### PR DESCRIPTION
Adds a benchmark for `Array#reject!` intrinsic.

```
ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-linux]
ruby vm startup time: .071
source                                  interpreted  compiled
stripe/array_reject_bang_baseline.rb    .248         .244
stripe/array_reject_bang.rb             .671         .398
stripe/array_reject_bang.rb - baseline  .423         .154
```

### Motivation
The unexamined life is not worth living.

More seriously: Nathan pointed out at https://github.com/sorbet/sorbet/pull/4888#pullrequestreview-812978954 that the intrinsic implementation wouldn't be able to inline the block, due to `rb_ensure`, so a benchmark would be useful. I think the results here are explained by the fact that we're not pushing and popping Ruby stack frames at every iteration.

### Test plan
See included automated tests.
