### PR TITLE
Add a pass to redirect the fast path over unnecessary type tests

### DIFF
--- a/compiler/ObjectFileEmitter/ObjectFileEmitter.cc
+++ b/compiler/ObjectFileEmitter/ObjectFileEmitter.cc
@@ -401,6 +401,7 @@ void ObjectFileEmitter::init() {
     // still exist in some fashion.
     pm.add(Passes::createDeleteUnusedSorbetIntrinsticsPass());
     pm.add(Passes::createDeleteUnusedInlineCachesPass());
+    pm.add(Passes::createReorganizeTypeTestFastPathsPass());
     pm.add(llvm::createAlwaysInlinerLegacyPass(false)); // Force inline functions early
     pm.add(llvm::createGlobalDCEPass());                // Remove dead fns and globals. We benefit from this a lot
     // Module passes

--- a/compiler/Passes/Passes.h
+++ b/compiler/Passes/Passes.h
@@ -12,6 +12,7 @@ public:
     static llvm::ModulePass *createDeleteUnusedSorbetIntrinsticsPass();
     static llvm::ModulePass *createDeleteUnusedInlineCachesPass();
     static llvm::ModulePass *createRemoveUnnecessaryHashDupsPass();
+    static llvm::ModulePass *createReorganizeTypeTestFastPathsPass();
     static const std::vector<llvm::ModulePass *> standardLowerings();
 };
 } // namespace sorbet::compiler


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Our intrinsics add both a fast and a slow path, and when their result is chained with another method send we get diamond-shaped control flow. This PR attempts to fix this by finding fast paths that assert the result of the type test being performed where the two diamonds join together, and redirecting it to the fast path on the exit. This makes a slow path that can re-join the fast path, and one long fast path that avoids re-checking types.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Better performance on the fast path by avoiding unnecessary type tests.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.