### PR TITLE
Fix `Tempfile#read` in tempfile.rbi

### DIFF
--- a/rbi/stdlib/tempfile.rbi
+++ b/rbi/stdlib/tempfile.rbi
@@ -286,7 +286,7 @@ class Tempfile
         length: Integer,
         outbuf: String,
     )
-    .returns(String)
+    .returns(T.nilable(String))
   end
   def read(length=T.unsafe(nil), outbuf=T.unsafe(nil)); end
 


### PR DESCRIPTION
### Motivation

Due to https://github.com/ruby/ruby/blob/master/io.c#L3320, the result of `Temfile#read` can be `nil`.

```
irb(main):008:0> require 'tempfile'; Tempfile.new.read(1)
=> nil
```

### Test plan

See included automated tests.
