### PR TITLE
Add helper for package autocorrect imports

### DIFF
--- a/core/AutocorrectSuggestion.cc
+++ b/core/AutocorrectSuggestion.cc
@@ -26,9 +26,16 @@ bool hasSeen(const UnorderedSet<Loc> &seen, Loc loc) {
     return false;
 }
 
-string AutocorrectSuggestion::apply(const std::string_view source) {
+string AutocorrectSuggestion::unsafeApplyToString(const std::string_view source) {
     UnorderedSet<Loc> seen;
     vector<AutocorrectSuggestion::Edit> edits = move(this->edits);
+
+    if (edits.size() > 1) {
+        auto file = edits.front().loc.file();
+        for (int i = 1; i < edits.size(); i++) {
+            ENFORCE(edits[i].loc.file() == file, "All edits in `unsafeApplyToString` need to apply to the same file");
+        }
+    }
 
     auto compare = [](const AutocorrectSuggestion::Edit &left, const AutocorrectSuggestion::Edit &right) {
         return left.loc.beginPos() > right.loc.beginPos();

--- a/core/AutocorrectSuggestion.cc
+++ b/core/AutocorrectSuggestion.cc
@@ -26,6 +26,27 @@ bool hasSeen(const UnorderedSet<Loc> &seen, Loc loc) {
     return false;
 }
 
+string AutocorrectSuggestion::apply(const std::string_view source) {
+    UnorderedSet<Loc> seen;
+    vector<AutocorrectSuggestion::Edit> edits = move(this->edits);
+
+    auto compare = [](const AutocorrectSuggestion::Edit &left, const AutocorrectSuggestion::Edit &right) {
+        return left.loc.beginPos() > right.loc.beginPos();
+    };
+    fast_sort(edits, compare);
+
+    string replaced{source};
+    for (auto &edit : edits) {
+        auto start = edit.loc.beginPos();
+        auto end = edit.loc.endPos();
+        fmt::print("check it out: replaced is {} and replacement is {}", replaced, edit.replacement);
+        fmt::print("start={}, end={}", start, end);
+        replaced = absl::StrCat(replaced.substr(0, start), edit.replacement, replaced.substr(end, -1));
+    }
+
+    return replaced;
+}
+
 UnorderedMap<FileRef, string> AutocorrectSuggestion::apply(const GlobalState &gs, FileSystem &fs,
                                                            const vector<AutocorrectSuggestion> &autocorrects) {
     UnorderedMap<FileRef, string> sources;

--- a/core/AutocorrectSuggestion.cc
+++ b/core/AutocorrectSuggestion.cc
@@ -46,8 +46,6 @@ string AutocorrectSuggestion::unsafeApplyToString(const std::string_view source)
     for (auto &edit : edits) {
         auto start = edit.loc.beginPos();
         auto end = edit.loc.endPos();
-        fmt::print("check it out: replaced is {} and replacement is {}", replaced, edit.replacement);
-        fmt::print("start={}, end={}", start, end);
         replaced = absl::StrCat(replaced.substr(0, start), edit.replacement, replaced.substr(end, -1));
     }
 

--- a/core/AutocorrectSuggestion.cc
+++ b/core/AutocorrectSuggestion.cc
@@ -26,29 +26,17 @@ bool hasSeen(const UnorderedSet<Loc> &seen, Loc loc) {
     return false;
 }
 
-string AutocorrectSuggestion::unsafeApplyToString(const std::string_view source) {
+string AutocorrectSuggestion::applySingleEditForTesting(const std::string_view source) {
     UnorderedSet<Loc> seen;
-    vector<AutocorrectSuggestion::Edit> edits = move(this->edits);
 
-    if (edits.size() > 1) {
-        auto file = edits.front().loc.file();
-        for (int i = 1; i < edits.size(); i++) {
-            ENFORCE(edits[i].loc.file() == file, "All edits in `unsafeApplyToString` need to apply to the same file");
-        }
-    }
-
-    auto compare = [](const AutocorrectSuggestion::Edit &left, const AutocorrectSuggestion::Edit &right) {
-        return left.loc.beginPos() > right.loc.beginPos();
-    };
-    fast_sort(edits, compare);
+    ENFORCE(edits.size() <= 1, "applySingleEditForTesting needs either 0 or 1 edits");
 
     string replaced{source};
-    for (auto &edit : edits) {
-        auto start = edit.loc.beginPos();
-        auto end = edit.loc.endPos();
-        replaced = absl::StrCat(replaced.substr(0, start), edit.replacement, replaced.substr(end, -1));
+    if (edits.size() == 1) {
+        auto start = edits.front().loc.beginPos();
+        auto end = edits.front().loc.endPos();
+        replaced = absl::StrCat(replaced.substr(0, start), edits.front().replacement, replaced.substr(end, -1));
     }
-
     return replaced;
 }
 

--- a/core/AutocorrectSuggestion.cc
+++ b/core/AutocorrectSuggestion.cc
@@ -26,7 +26,7 @@ bool hasSeen(const UnorderedSet<Loc> &seen, Loc loc) {
     return false;
 }
 
-string AutocorrectSuggestion::applySingleEditForTesting(const std::string_view source) {
+const string AutocorrectSuggestion::applySingleEditForTesting(const std::string_view source) const {
     UnorderedSet<Loc> seen;
 
     ENFORCE(edits.size() <= 1, "applySingleEditForTesting needs either 0 or 1 edits");

--- a/core/AutocorrectSuggestion.h
+++ b/core/AutocorrectSuggestion.h
@@ -18,8 +18,9 @@ struct AutocorrectSuggestion {
 
     AutocorrectSuggestion(std::string title, std::vector<Edit> edits) : title(title), edits(edits) {}
 
-    // Apply a single `AutocorrectSuggestion` to a string, yielding the autocorrected source
-    std::string apply(const std::string_view source);
+    // Apply a single `AutocorrectSuggestion` to a string, yielding the autocorrected source.
+    // This is useful for testing that an autocorrect does what we want.
+    std::string unsafeApplyToString(const std::string_view source);
 
     // Reads all the files to be edited, and then accumulates all the edits that need to be applied
     // to those files into a resulting string with all edits applied. Does not write those back out

--- a/core/AutocorrectSuggestion.h
+++ b/core/AutocorrectSuggestion.h
@@ -18,6 +18,9 @@ struct AutocorrectSuggestion {
 
     AutocorrectSuggestion(std::string title, std::vector<Edit> edits) : title(title), edits(edits) {}
 
+    // Apply a single `AutocorrectSuggestion` to a string, yielding the autocorrected source
+    std::string apply(const std::string_view source);
+
     // Reads all the files to be edited, and then accumulates all the edits that need to be applied
     // to those files into a resulting string with all edits applied. Does not write those back out
     // to disk.

--- a/core/AutocorrectSuggestion.h
+++ b/core/AutocorrectSuggestion.h
@@ -20,7 +20,7 @@ struct AutocorrectSuggestion {
 
     // Apply a single `AutocorrectSuggestion` that contains either zero or one edits to a string, yielding the
     // autocorrected source.  This is useful for testing that an autocorrect does what we want.
-    std::string applySingleEditForTesting(const std::string_view source);
+    const std::string applySingleEditForTesting(const std::string_view source) const;
 
     // Reads all the files to be edited, and then accumulates all the edits that need to be applied
     // to those files into a resulting string with all edits applied. Does not write those back out

--- a/core/AutocorrectSuggestion.h
+++ b/core/AutocorrectSuggestion.h
@@ -18,9 +18,9 @@ struct AutocorrectSuggestion {
 
     AutocorrectSuggestion(std::string title, std::vector<Edit> edits) : title(title), edits(edits) {}
 
-    // Apply a single `AutocorrectSuggestion` to a string, yielding the autocorrected source.
-    // This is useful for testing that an autocorrect does what we want.
-    std::string unsafeApplyToString(const std::string_view source);
+    // Apply a single `AutocorrectSuggestion` that contains either zero or one edits to a string, yielding the
+    // autocorrected source.  This is useful for testing that an autocorrect does what we want.
+    std::string applySingleEditForTesting(const std::string_view source);
 
     // Reads all the files to be edited, and then accumulates all the edits that need to be applied
     // to those files into a resulting string with all edits applied. Does not write those back out

--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -1,6 +1,6 @@
-#include "core/AutocorrectSuggestion.h"
 #include "core/packages/PackageDB.h"
 #include "absl/strings/match.h"
+#include "core/AutocorrectSuggestion.h"
 #include "core/GlobalState.h"
 #include "core/Loc.h"
 
@@ -35,7 +35,8 @@ public:
         return Loc::none();
     }
 
-    std::optional<core::AutocorrectSuggestion> addImport(const core::GlobalState& gs, const PackageInfo& pkg, bool isTestImport) const {
+    std::optional<core::AutocorrectSuggestion> addImport(const core::GlobalState &gs, const PackageInfo &pkg,
+                                                         bool isTestImport) const {
         return {};
     }
 

--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -1,3 +1,4 @@
+#include "core/AutocorrectSuggestion.h"
 #include "core/packages/PackageDB.h"
 #include "absl/strings/match.h"
 #include "core/GlobalState.h"
@@ -32,6 +33,10 @@ public:
     Loc definitionLoc() const {
         ENFORCE(false);
         return Loc::none();
+    }
+
+    std::optional<core::AutocorrectSuggestion> addImport(const core::GlobalState& gs, const PackageInfo& pkg, bool isTestImport) const {
+        return {};
     }
 
     ~NonePackage() {}

--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -1,11 +1,14 @@
 #ifndef SORBET_CORE_PACKAGES_PACKAGEINFO_H
 #define SORBET_CORE_PACKAGES_PACKAGEINFO_H
 
+#include <optional>
 #include <vector>
 
 namespace sorbet::core {
+class GlobalState;
 class NameRef;
 class Loc;
+struct AutocorrectSuggestion;
 } // namespace sorbet::core
 
 namespace sorbet::core::packages {
@@ -17,6 +20,9 @@ public:
     virtual std::unique_ptr<PackageInfo> deepCopy() const = 0;
     virtual core::Loc definitionLoc() const = 0;
     virtual bool exists() const final;
+
+    // autocorrects
+    virtual std::optional<core::AutocorrectSuggestion> addImport(const core::GlobalState& gs, const PackageInfo& pkg, bool isTestImport) const = 0;
 
     virtual ~PackageInfo() = 0;
     PackageInfo() = default;

--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -22,7 +22,8 @@ public:
     virtual bool exists() const final;
 
     // autocorrects
-    virtual std::optional<core::AutocorrectSuggestion> addImport(const core::GlobalState& gs, const PackageInfo& pkg, bool isTestImport) const = 0;
+    virtual std::optional<core::AutocorrectSuggestion> addImport(const core::GlobalState &gs, const PackageInfo &pkg,
+                                                                 bool isTestImport) const = 0;
 
     virtual ~PackageInfo() = 0;
     PackageInfo() = default;

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -209,7 +209,7 @@ public:
         // first let's try adding it to the end of the imports.
         if (!importedPackageNames.empty()) {
             auto lastOffset = importedPackageNames.back().name.loc;
-            insertionLoc = loc.adjust(gs, lastOffset.endPos(), lastOffset.endPos());
+            insertionLoc = {info.loc.file(), lastOffset.endPos(), lastOffset.endPos()};
         } else {
             // TODO: fix this case
             return nullopt;

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -9,6 +9,7 @@
 #include "common/concurrency/WorkerPool.h"
 #include "common/formatting.h"
 #include "common/sort.h"
+#include "core/AutocorrectSuggestion.h"
 #include "core/Unfreeze.h"
 #include "core/errors/packager.h"
 #include "core/packages/PackageInfo.h"
@@ -84,6 +85,10 @@ struct PackageName {
     // Pretty print the package's (user-observable) name (e.g. Foo::Bar)
     string toString(const core::GlobalState &gs) const {
         return absl::StrJoin(fullName.parts, "::", NameFormatter(gs));
+    }
+
+    bool operator==(const PackageName& rhs) const {
+        return mangledName == rhs.mangledName;
     }
 };
 
@@ -188,6 +193,35 @@ public:
     PackageInfoImpl() = default;
     explicit PackageInfoImpl(const PackageInfoImpl &) = default;
     PackageInfoImpl &operator=(const PackageInfoImpl &) = delete;
+
+    optional<core::AutocorrectSuggestion> addImport(const core::GlobalState &gs, const PackageInfo& pkg, bool isTestImport) const {
+        auto &info = PackageInfoImpl::from(pkg);
+        for (auto import : importedPackageNames) {
+            // check if we already import this, and if so, don't
+            // return an autocorrect
+            if (import.name == info.name) {
+                return nullopt;
+            }
+        }
+
+        core::Loc insertionLoc = loc.adjust(gs, core::INVALID_POS_LOC, core::INVALID_POS_LOC);
+        // first let's try adding it to the end of the imports.
+        if (!importedPackageNames.empty()) {
+            auto lastOffset = importedPackageNames.back().name.loc;
+            insertionLoc = loc.adjust(gs, lastOffset.endPos(), lastOffset.endPos());
+        } else {
+            // TODO: fix this case
+            return nullopt;
+        }
+
+        // now find the appropriate place for it, specifically by
+        // finding the import that directly preceeds it, if any
+        core::AutocorrectSuggestion suggestion(
+            fmt::format("Import `{}` in package `{}`", info.name.toString(gs), name.toString(gs)),
+            {{insertionLoc, fmt::format("\n  {} {}", isTestImport ? "test_import" : "import", info.name.toString(gs))}}
+            );
+        return {suggestion};
+    }
 };
 
 void checkPackageName(core::Context ctx, ast::UnresolvedConstantLit *constLit) {

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -87,7 +87,7 @@ struct PackageName {
         return absl::StrJoin(fullName.parts, "::", NameFormatter(gs));
     }
 
-    bool operator==(const PackageName& rhs) const {
+    bool operator==(const PackageName &rhs) const {
         return mangledName == rhs.mangledName;
     }
 };
@@ -194,7 +194,8 @@ public:
     explicit PackageInfoImpl(const PackageInfoImpl &) = default;
     PackageInfoImpl &operator=(const PackageInfoImpl &) = delete;
 
-    optional<core::AutocorrectSuggestion> addImport(const core::GlobalState &gs, const PackageInfo& pkg, bool isTestImport) const {
+    optional<core::AutocorrectSuggestion> addImport(const core::GlobalState &gs, const PackageInfo &pkg,
+                                                    bool isTestImport) const {
         auto &info = PackageInfoImpl::from(pkg);
         for (auto import : importedPackageNames) {
             // check if we already import this, and if so, don't
@@ -218,8 +219,8 @@ public:
         // finding the import that directly preceeds it, if any
         core::AutocorrectSuggestion suggestion(
             fmt::format("Import `{}` in package `{}`", info.name.toString(gs), name.toString(gs)),
-            {{insertionLoc, fmt::format("\n  {} {}", isTestImport ? "test_import" : "import", info.name.toString(gs))}}
-            );
+            {{insertionLoc,
+              fmt::format("\n  {} {}", isTestImport ? "test_import" : "import", info.name.toString(gs))}});
         return {suggestion};
     }
 };

--- a/test/BUILD
+++ b/test/BUILD
@@ -131,6 +131,29 @@ cc_test(
 )
 
 cc_test(
+    name = "pkg-autocorrects-test",
+    size = "small",
+    srcs = ["pkg_autocorrects_test.cc"],
+    linkstatic = select({
+        "//tools/config:linkshared": 0,
+        "//conditions:default": 1,
+    }),
+    visibility = ["//tools:__pkg__"],
+    deps = [
+        "//ast",
+        "//ast/desugar",
+        "//common",
+        "//common/concurrency",
+        "//core",
+        "//local_vars",
+        "//packager",
+        "//parser",
+        "@doctest",
+        "@doctest//:doctest_main",
+    ],
+)
+
+cc_test(
     name = "error-check-test",
     size = "small",
     srcs = ["error-check-test.cc"],

--- a/test/pkg_autocorrects_test.cc
+++ b/test/pkg_autocorrects_test.cc
@@ -112,4 +112,93 @@ TEST_CASE("Simple test import") {
     auto replaced = addImport->unsafeApplyToString(pkg_source);
     CHECK_EQ(expected, replaced);
 }
+
+TEST_CASE("Add import with only existing exports") {
+    core::GlobalState gs(errorQueue);
+    gs.initEmpty();
+
+    string pkg_source = "class Opus::MyPackage < PackageSpec\n"
+                        "  export Opus::SomethingElse\n"
+                        "end\n";
+
+    string expected = "class Opus::MyPackage < PackageSpec\n"
+                      "  import Opus::MyPackage\n"
+                      "  export Opus::SomethingElse\n"
+                      "end\n";
+
+    auto test = TestPackageFile::create(gs, "my_package/__package.rb", pkg_source);
+
+    auto &package = gs.packageDB().getPackageForFile(gs, test.fileRef);
+    ENFORCE(package.exists());
+    auto addImport = package.addImport(gs, package, false);
+    ENFORCE(addImport, "Expected to get an autocorrect from `addImport`");
+    auto replaced = addImport->unsafeApplyToString(pkg_source);
+    CHECK_EQ(expected, replaced);
+}
+
+TEST_CASE("Add test import with only existing exports") {
+    core::GlobalState gs(errorQueue);
+    gs.initEmpty();
+
+    string pkg_source = "class Opus::MyPackage < PackageSpec\n"
+                        "  export Opus::SomethingElse\n"
+                        "end\n";
+
+    string expected = "class Opus::MyPackage < PackageSpec\n"
+                      "  test_import Opus::MyPackage\n"
+                      "  export Opus::SomethingElse\n"
+                      "end\n";
+
+    auto test = TestPackageFile::create(gs, "my_package/__package.rb", pkg_source);
+
+    auto &package = gs.packageDB().getPackageForFile(gs, test.fileRef);
+    ENFORCE(package.exists());
+    auto addImport = package.addImport(gs, package, true);
+    ENFORCE(addImport, "Expected to get an autocorrect from `addImport`");
+    auto replaced = addImport->unsafeApplyToString(pkg_source);
+    CHECK_EQ(expected, replaced);
+}
+
+TEST_CASE("Add import to package with neither imports nor exports") {
+    core::GlobalState gs(errorQueue);
+    gs.initEmpty();
+
+    string pkg_source = "class Opus::MyPackage < PackageSpec\n"
+                        "end\n";
+
+    string expected = "class Opus::MyPackage < PackageSpec\n"
+                      "  import Opus::MyPackage\n"
+                      "end\n";
+
+    auto test = TestPackageFile::create(gs, "my_package/__package.rb", pkg_source);
+
+    auto &package = gs.packageDB().getPackageForFile(gs, test.fileRef);
+    ENFORCE(package.exists());
+    auto addImport = package.addImport(gs, package, false);
+    ENFORCE(addImport, "Expected to get an autocorrect from `addImport`");
+    auto replaced = addImport->unsafeApplyToString(pkg_source);
+    CHECK_EQ(expected, replaced);
+}
+
+TEST_CASE("Add test import to package with neither imports nor exports") {
+    core::GlobalState gs(errorQueue);
+    gs.initEmpty();
+
+    string pkg_source = "class Opus::MyPackage < PackageSpec\n"
+                        "end\n";
+
+    string expected = "class Opus::MyPackage < PackageSpec\n"
+                      "  test_import Opus::MyPackage\n"
+                      "end\n";
+
+    auto test = TestPackageFile::create(gs, "my_package/__package.rb", pkg_source);
+
+    auto &package = gs.packageDB().getPackageForFile(gs, test.fileRef);
+    ENFORCE(package.exists());
+    auto addImport = package.addImport(gs, package, true);
+    ENFORCE(addImport, "Expected to get an autocorrect from `addImport`");
+    auto replaced = addImport->unsafeApplyToString(pkg_source);
+    CHECK_EQ(expected, replaced);
+}
+
 } // namespace sorbet

--- a/test/pkg_autocorrects_test.cc
+++ b/test/pkg_autocorrects_test.cc
@@ -1,0 +1,92 @@
+#include "doctest.h"
+
+#include "ast/ast.h"
+#include "ast/desugar/Desugar.h"
+#include "common/common.h"
+#include "common/concurrency/WorkerPool.h"
+#include "core/Error.h"
+#include "core/ErrorQueue.h"
+#include "core/GlobalSubstitution.h"
+#include "core/Unfreeze.h"
+#include "local_vars/local_vars.h"
+#include "packager/packager.h"
+#include "parser/parser.h"
+#include "spdlog/sinks/stdout_color_sinks.h"
+#include "spdlog/spdlog.h"
+
+using namespace std;
+
+namespace spd = spdlog;
+auto logger = spd::stderr_color_mt("pkg-autocorrects-test");
+auto errorQueue = make_shared<sorbet::core::ErrorQueue>(*logger, *logger);
+
+namespace sorbet {
+struct TestPackageFile {
+    core::FileRef fileRef;
+    ast::ParsedFile parsedFile;
+
+    TestPackageFile(core::FileRef fileRef, ast::ParsedFile parsedFile)
+        : fileRef(fileRef), parsedFile(move(parsedFile)) {}
+
+    static TestPackageFile create(core::GlobalState &gs, string filename, string source) {
+        // add the package file
+        core::FileRef pkg_file;
+        {
+            core::UnfreezeFileTable fileTableAccess(gs);
+            pkg_file = gs.enterFile(filename, source);
+        }
+
+        // run through the pipeline up through the packager
+        // start by parsing and desugaring
+        ast::ParsedFile parsed_file;
+        {
+            core::UnfreezeNameTable nameTableAccess(gs);
+            // run parser
+            auto nodes = parser::Parser::run(gs, pkg_file);
+            // run desugarer
+            core::MutableContext ctx(gs, core::Symbols::root(), pkg_file);
+            parsed_file = ast::ParsedFile{ast::desugar::node2Tree(ctx, move(nodes)), pkg_file};
+
+            // we can skip the rewriter because packages don't need it and
+            // go straight on to indexing
+            parsed_file = local_vars::LocalVars::run(ctx, move(parsed_file));
+        }
+
+        {
+            // and then finally the packager!
+            auto workers = WorkerPool::create(0, gs.tracer());
+            vector<ast::ParsedFile> trees;
+            trees.emplace_back(move(parsed_file));
+            trees = packager::Packager::run(gs, *workers, move(trees));
+            parsed_file = move(trees.front());
+        }
+
+        TestPackageFile pkgFile(pkg_file, move(parsed_file));
+
+        return pkgFile;
+    }
+};
+
+TEST_CASE("Simple add import") {
+    sorbet::core::GlobalState gs(errorQueue);
+    gs.initEmpty();
+
+    auto test = TestPackageFile::create(
+        gs,
+        "my_package/__package.rb",
+        "class Opus::MyPackage < PackageSpec\n  import Opus::SomethingeElse\nend\n");
+
+    auto& package = gs.packageDB().getPackageForFile(gs, test.fileRef);
+    ENFORCE(package.exists());
+    gs.tracer().error("Got a package: {}", package.mangledName().show(gs));
+    auto addImport = package.addImport(gs, package, false);
+    if (addImport) {
+        gs.tracer().error("Got an autocorrect: {}", addImport->edits.front().replacement);
+    } else {
+        gs.tracer().error("No autocorrect");
+    }
+    gs.tracer().error(":: {}", test.parsedFile.tree.toString(gs));
+
+    CHECK_EQ("Yes", "Yes");
+}
+}

--- a/test/pkg_autocorrects_test.cc
+++ b/test/pkg_autocorrects_test.cc
@@ -71,12 +71,10 @@ TEST_CASE("Simple add import") {
     sorbet::core::GlobalState gs(errorQueue);
     gs.initEmpty();
 
-    auto test = TestPackageFile::create(
-        gs,
-        "my_package/__package.rb",
-        "class Opus::MyPackage < PackageSpec\n  import Opus::SomethingeElse\nend\n");
+    auto test = TestPackageFile::create(gs, "my_package/__package.rb",
+                                        "class Opus::MyPackage < PackageSpec\n  import Opus::SomethingeElse\nend\n");
 
-    auto& package = gs.packageDB().getPackageForFile(gs, test.fileRef);
+    auto &package = gs.packageDB().getPackageForFile(gs, test.fileRef);
     ENFORCE(package.exists());
     gs.tracer().error("Got a package: {}", package.mangledName().show(gs));
     auto addImport = package.addImport(gs, package, false);
@@ -89,4 +87,4 @@ TEST_CASE("Simple add import") {
 
     CHECK_EQ("Yes", "Yes");
 }
-}
+} // namespace sorbet

--- a/test/pkg_autocorrects_test.cc
+++ b/test/pkg_autocorrects_test.cc
@@ -86,7 +86,7 @@ TEST_CASE("Simple add import") {
     ENFORCE(package.exists());
     auto addImport = package.addImport(gs, package, false);
     ENFORCE(addImport, "Expected to get an autocorrect from `addImport`");
-    auto replaced = addImport->apply(pkg_source);
+    auto replaced = addImport->unsafeApplyToString(pkg_source);
     CHECK_EQ(expected, replaced);
 }
 
@@ -109,7 +109,7 @@ TEST_CASE("Simple test import") {
     ENFORCE(package.exists());
     auto addImport = package.addImport(gs, package, true);
     ENFORCE(addImport, "Expected to get an autocorrect from `addImport`");
-    auto replaced = addImport->apply(pkg_source);
+    auto replaced = addImport->unsafeApplyToString(pkg_source);
     CHECK_EQ(expected, replaced);
 }
 } // namespace sorbet

--- a/test/pkg_autocorrects_test.cc
+++ b/test/pkg_autocorrects_test.cc
@@ -86,7 +86,7 @@ TEST_CASE("Simple add import") {
     ENFORCE(package.exists());
     auto addImport = package.addImport(gs, package, false);
     ENFORCE(addImport, "Expected to get an autocorrect from `addImport`");
-    auto replaced = addImport->unsafeApplyToString(pkg_source);
+    auto replaced = addImport->applySingleEditForTesting(pkg_source);
     CHECK_EQ(expected, replaced);
 }
 
@@ -109,7 +109,7 @@ TEST_CASE("Simple test import") {
     ENFORCE(package.exists());
     auto addImport = package.addImport(gs, package, true);
     ENFORCE(addImport, "Expected to get an autocorrect from `addImport`");
-    auto replaced = addImport->unsafeApplyToString(pkg_source);
+    auto replaced = addImport->applySingleEditForTesting(pkg_source);
     CHECK_EQ(expected, replaced);
 }
 
@@ -132,7 +132,7 @@ TEST_CASE("Add import with only existing exports") {
     ENFORCE(package.exists());
     auto addImport = package.addImport(gs, package, false);
     ENFORCE(addImport, "Expected to get an autocorrect from `addImport`");
-    auto replaced = addImport->unsafeApplyToString(pkg_source);
+    auto replaced = addImport->applySingleEditForTesting(pkg_source);
     CHECK_EQ(expected, replaced);
 }
 
@@ -155,7 +155,7 @@ TEST_CASE("Add test import with only existing exports") {
     ENFORCE(package.exists());
     auto addImport = package.addImport(gs, package, true);
     ENFORCE(addImport, "Expected to get an autocorrect from `addImport`");
-    auto replaced = addImport->unsafeApplyToString(pkg_source);
+    auto replaced = addImport->applySingleEditForTesting(pkg_source);
     CHECK_EQ(expected, replaced);
 }
 
@@ -176,7 +176,7 @@ TEST_CASE("Add import to package with neither imports nor exports") {
     ENFORCE(package.exists());
     auto addImport = package.addImport(gs, package, false);
     ENFORCE(addImport, "Expected to get an autocorrect from `addImport`");
-    auto replaced = addImport->unsafeApplyToString(pkg_source);
+    auto replaced = addImport->applySingleEditForTesting(pkg_source);
     CHECK_EQ(expected, replaced);
 }
 
@@ -197,7 +197,7 @@ TEST_CASE("Add test import to package with neither imports nor exports") {
     ENFORCE(package.exists());
     auto addImport = package.addImport(gs, package, true);
     ENFORCE(addImport, "Expected to get an autocorrect from `addImport`");
-    auto replaced = addImport->unsafeApplyToString(pkg_source);
+    auto replaced = addImport->applySingleEditForTesting(pkg_source);
     CHECK_EQ(expected, replaced);
 }
 

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -24,6 +24,7 @@ compilation_database(
         "//test/fuzz:fuzz_dash_e",
         "//test/fuzz:fuzz_dash_e_impl",
         "//test:print_document_symbols",
+        "//test:pkg-autocorrects-test",
         "//test:pipeline_test_runner",
         "//test:parser_test_runner",
         "//test:lsp_test_runner",


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
This adds (but does not yet expose) an interface to `PackageInfo` that can be used to add imports via autocorrect. This right now adds the imports at the end—we can later try to position them "correctly", but this gives us a baseline to work from.

This also adds an extra method to `AutocorrectSuggestion` that's useful for testing, since the existing interface explicitly relies on re-reading the file in question, and the test suite included here uses inline string literals instead of on-disk files.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Adds a separate unit test suite that tests only these autocorrects.
