### PR TITLE
Preserve mixin ordering in resolution

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -296,6 +296,8 @@ void GlobalState::initEmpty() {
     ENFORCE(id == Symbols::StubModule());
     id = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::StubMixin());
     ENFORCE(id == Symbols::StubMixin());
+    id = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::PlaceholderMixin());
+    ENFORCE(id == Symbols::PlaceholderMixin());
     id = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::StubSuperClass());
     ENFORCE(id == Symbols::StubSuperClass());
     id = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Enumerable());

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -616,59 +616,65 @@ public:
         return ClassOrModuleRef::fromRaw(43);
     }
 
-    // Used to mark the presence of a superclass that we were unable to
-    // statically resolve to a class
-    static ClassOrModuleRef StubSuperClass() {
+    // Used to mark the presence of a mixin that will be replaced with a real
+    // ClassOrModuleRef or StubMixin once resolution completes.
+    static ClassOrModuleRef PlaceholderMixin() {
         return ClassOrModuleRef::fromRaw(44);
     }
 
-    static ClassOrModuleRef T_Enumerable() {
+    // Used to mark the presence of a superclass that we were unable to
+    // statically resolve to a class
+    static ClassOrModuleRef StubSuperClass() {
         return ClassOrModuleRef::fromRaw(45);
     }
 
-    static ClassOrModuleRef T_Range() {
+    static ClassOrModuleRef T_Enumerable() {
         return ClassOrModuleRef::fromRaw(46);
     }
 
-    static ClassOrModuleRef T_Set() {
+    static ClassOrModuleRef T_Range() {
         return ClassOrModuleRef::fromRaw(47);
     }
 
-    static ClassOrModuleRef void_() {
+    static ClassOrModuleRef T_Set() {
         return ClassOrModuleRef::fromRaw(48);
+    }
+
+    static ClassOrModuleRef void_() {
+        return ClassOrModuleRef::fromRaw(49);
     }
 
     // Synthetic symbol used by resolver to mark type alias assignments.
     static ClassOrModuleRef typeAliasTemp() {
-        return ClassOrModuleRef::fromRaw(49);
-    }
-
-    static ClassOrModuleRef T_Configuration() {
         return ClassOrModuleRef::fromRaw(50);
     }
 
-    static ClassOrModuleRef T_Generic() {
+    static ClassOrModuleRef T_Configuration() {
         return ClassOrModuleRef::fromRaw(51);
     }
 
-    static ClassOrModuleRef Tuple() {
+    static ClassOrModuleRef T_Generic() {
         return ClassOrModuleRef::fromRaw(52);
     }
 
-    static ClassOrModuleRef Shape() {
+    static ClassOrModuleRef Tuple() {
         return ClassOrModuleRef::fromRaw(53);
     }
 
-    static ClassOrModuleRef Subclasses() {
+    static ClassOrModuleRef Shape() {
         return ClassOrModuleRef::fromRaw(54);
     }
 
-    static ClassOrModuleRef Sorbet_Private_Static_ImplicitModuleSuperClass() {
+    static ClassOrModuleRef Subclasses() {
         return ClassOrModuleRef::fromRaw(55);
     }
 
-    static ClassOrModuleRef Sorbet_Private_Static_ReturnTypeInference() {
+    static ClassOrModuleRef Sorbet_Private_Static_ImplicitModuleSuperClass() {
         return ClassOrModuleRef::fromRaw(56);
+    }
+
+    static ClassOrModuleRef Sorbet_Private_Static_ReturnTypeInference() {
+        return ClassOrModuleRef::fromRaw(57);
     }
 
     static MethodRef noMethod() {
@@ -706,7 +712,7 @@ public:
     }
 
     static ClassOrModuleRef T_Sig() {
-        return ClassOrModuleRef::fromRaw(57);
+        return ClassOrModuleRef::fromRaw(58);
     }
 
     static FieldRef Magic_undeclaredFieldStub() {
@@ -718,51 +724,51 @@ public:
     }
 
     static ClassOrModuleRef T_Helpers() {
-        return ClassOrModuleRef::fromRaw(58);
-    }
-
-    static ClassOrModuleRef DeclBuilderForProcs() {
         return ClassOrModuleRef::fromRaw(59);
     }
 
-    static ClassOrModuleRef DeclBuilderForProcsSingleton() {
+    static ClassOrModuleRef DeclBuilderForProcs() {
         return ClassOrModuleRef::fromRaw(60);
     }
 
-    static ClassOrModuleRef Net() {
+    static ClassOrModuleRef DeclBuilderForProcsSingleton() {
         return ClassOrModuleRef::fromRaw(61);
     }
 
-    static ClassOrModuleRef Net_IMAP() {
+    static ClassOrModuleRef Net() {
         return ClassOrModuleRef::fromRaw(62);
     }
 
-    static ClassOrModuleRef Net_Protocol() {
+    static ClassOrModuleRef Net_IMAP() {
         return ClassOrModuleRef::fromRaw(63);
     }
 
-    static ClassOrModuleRef T_Sig_WithoutRuntime() {
+    static ClassOrModuleRef Net_Protocol() {
         return ClassOrModuleRef::fromRaw(64);
     }
 
-    static ClassOrModuleRef Enumerator() {
+    static ClassOrModuleRef T_Sig_WithoutRuntime() {
         return ClassOrModuleRef::fromRaw(65);
     }
 
-    static ClassOrModuleRef T_Enumerator() {
+    static ClassOrModuleRef Enumerator() {
         return ClassOrModuleRef::fromRaw(66);
     }
 
-    static ClassOrModuleRef T_Struct() {
+    static ClassOrModuleRef T_Enumerator() {
         return ClassOrModuleRef::fromRaw(67);
     }
 
-    static ClassOrModuleRef Singleton() {
+    static ClassOrModuleRef T_Struct() {
         return ClassOrModuleRef::fromRaw(68);
     }
 
-    static ClassOrModuleRef T_Enum() {
+    static ClassOrModuleRef Singleton() {
         return ClassOrModuleRef::fromRaw(69);
+    }
+
+    static ClassOrModuleRef T_Enum() {
+        return ClassOrModuleRef::fromRaw(70);
     }
 
     static MethodRef sig() {
@@ -770,31 +776,31 @@ public:
     }
 
     static ClassOrModuleRef Enumerator_Lazy() {
-        return ClassOrModuleRef::fromRaw(70);
-    }
-
-    static ClassOrModuleRef T_Private() {
         return ClassOrModuleRef::fromRaw(71);
     }
 
-    static ClassOrModuleRef T_Private_Types() {
+    static ClassOrModuleRef T_Private() {
         return ClassOrModuleRef::fromRaw(72);
     }
 
-    static ClassOrModuleRef T_Private_Types_Void() {
+    static ClassOrModuleRef T_Private_Types() {
         return ClassOrModuleRef::fromRaw(73);
     }
 
-    static ClassOrModuleRef T_Private_Types_Void_VOID() {
+    static ClassOrModuleRef T_Private_Types_Void() {
         return ClassOrModuleRef::fromRaw(74);
     }
 
-    static ClassOrModuleRef T_Private_Types_Void_VOIDSingleton() {
+    static ClassOrModuleRef T_Private_Types_Void_VOID() {
         return ClassOrModuleRef::fromRaw(75);
     }
 
-    static ClassOrModuleRef T_Sig_WithoutRuntimeSingleton() {
+    static ClassOrModuleRef T_Private_Types_Void_VOIDSingleton() {
         return ClassOrModuleRef::fromRaw(76);
+    }
+
+    static ClassOrModuleRef T_Sig_WithoutRuntimeSingleton() {
+        return ClassOrModuleRef::fromRaw(77);
     }
 
     static MethodRef sigWithoutRuntime() {
@@ -802,7 +808,7 @@ public:
     }
 
     static ClassOrModuleRef T_NonForcingConstants() {
-        return ClassOrModuleRef::fromRaw(77);
+        return ClassOrModuleRef::fromRaw(78);
     }
 
     static MethodRef SorbetPrivateStaticSingleton_sig() {
@@ -810,19 +816,19 @@ public:
     }
 
     static ClassOrModuleRef PackageRegistry() {
-        return ClassOrModuleRef::fromRaw(78);
-    }
-
-    static ClassOrModuleRef PackageTests() {
         return ClassOrModuleRef::fromRaw(79);
     }
 
-    static ClassOrModuleRef PackageSpec() {
+    static ClassOrModuleRef PackageTests() {
         return ClassOrModuleRef::fromRaw(80);
     }
 
-    static ClassOrModuleRef PackageSpecSingleton() {
+    static ClassOrModuleRef PackageSpec() {
         return ClassOrModuleRef::fromRaw(81);
+    }
+
+    static ClassOrModuleRef PackageSpecSingleton() {
+        return ClassOrModuleRef::fromRaw(82);
     }
 
     static MethodRef PackageSpec_import() {
@@ -846,11 +852,11 @@ public:
     }
 
     static ClassOrModuleRef Encoding() {
-        return ClassOrModuleRef::fromRaw(82);
+        return ClassOrModuleRef::fromRaw(83);
     }
 
     static ClassOrModuleRef Thread() {
-        return ClassOrModuleRef::fromRaw(83);
+        return ClassOrModuleRef::fromRaw(84);
     }
 
     static MethodRef Class_new() {
@@ -862,19 +868,19 @@ public:
     }
 
     static ClassOrModuleRef Sorbet_Private_Static_ResolvedSig() {
-        return ClassOrModuleRef::fromRaw(84);
-    }
-
-    static ClassOrModuleRef Sorbet_Private_Static_ResolvedSigSingleton() {
         return ClassOrModuleRef::fromRaw(85);
     }
 
-    static ClassOrModuleRef T_Private_Compiler() {
+    static ClassOrModuleRef Sorbet_Private_Static_ResolvedSigSingleton() {
         return ClassOrModuleRef::fromRaw(86);
     }
 
-    static ClassOrModuleRef T_Private_CompilerSingleton() {
+    static ClassOrModuleRef T_Private_Compiler() {
         return ClassOrModuleRef::fromRaw(87);
+    }
+
+    static ClassOrModuleRef T_Private_CompilerSingleton() {
+        return ClassOrModuleRef::fromRaw(88);
     }
 
     static constexpr int MAX_PROC_ARITY = 10;
@@ -899,11 +905,11 @@ public:
         return ClassOrModuleRef::fromRaw(MAX_SYNTHETIC_CLASS_SYMBOLS - 1);
     }
 
-    static constexpr int MAX_SYNTHETIC_CLASS_SYMBOLS = 202;
+    static constexpr int MAX_SYNTHETIC_CLASS_SYMBOLS = 203;
     static constexpr int MAX_SYNTHETIC_METHOD_SYMBOLS = 44;
     static constexpr int MAX_SYNTHETIC_FIELD_SYMBOLS = 3;
     static constexpr int MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 4;
-    static constexpr int MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 99;
+    static constexpr int MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 100;
 };
 
 template <typename H> H AbslHashValue(H h, const SymbolRef &m) {

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -544,7 +544,7 @@ bool Symbol::addMixin(const GlobalState &gs, ClassOrModuleRef sym, std::optional
     return isValidMixin;
 }
 
-u2 Symbol::addStubMixin(const GlobalState &gs) {
+u2 Symbol::addMixinPlaceholder(const GlobalState &gs) {
     ENFORCE(isClassOrModule());
     ENFORCE(ref(gs) != core::Symbols::StubMixin(), "Created a cycle through StubMixin");
     mixins_.emplace_back(core::Symbols::StubMixin());

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -502,7 +502,7 @@ TypePtr ArgInfo::argumentTypeAsSeenByImplementation(Context ctx, core::TypeConst
     return Types::arrayOf(ctx, instantiated);
 }
 
-bool Symbol::addMixin(const GlobalState &gs, ClassOrModuleRef sym, std::optional<size_t> index) {
+bool Symbol::addMixin(const GlobalState &gs, ClassOrModuleRef sym, std::optional<u2> index) {
     ENFORCE(isClassOrModule());
     // Note: Symbols without an explicit declaration may not have class or module set. They default to modules in
     // GlobalPass.cc. We also do not complain if the mixin is BasicObject.
@@ -514,7 +514,7 @@ bool Symbol::addMixin(const GlobalState &gs, ClassOrModuleRef sym, std::optional
         // semantically important!)
         // This is the 99% common case.
         if (index.has_value()) {
-            size_t i = index.value();
+            auto i = index.value();
             ENFORCE(mixins_.size() > i);
             ENFORCE(!mixins_[i].exists());
             mixins_[i] = sym;
@@ -544,9 +544,10 @@ bool Symbol::addMixin(const GlobalState &gs, ClassOrModuleRef sym, std::optional
     return isValidMixin;
 }
 
-size_t Symbol::addStubMixin(const GlobalState &gs) {
+u2 Symbol::addStubMixin(const GlobalState &gs) {
     ENFORCE(isClassOrModule());
     mixins_.emplace_back(ClassOrModuleRef());
+    ENFORCE(mixins_.size() < numeric_limits<u2>::max());
     return mixins_.size() - 1;
 }
 

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -547,7 +547,6 @@ bool Symbol::addMixin(const GlobalState &gs, ClassOrModuleRef sym, std::optional
 size_t Symbol::addStubMixin(const GlobalState &gs) {
     ENFORCE(isClassOrModule());
     mixins_.emplace_back(ClassOrModuleRef());
-    fmt::print("STUB {}\n", mixins_.size() - 1);
     return mixins_.size() - 1;
 }
 

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -516,7 +516,7 @@ bool Symbol::addMixin(const GlobalState &gs, ClassOrModuleRef sym, std::optional
         if (index.has_value()) {
             auto i = index.value();
             ENFORCE(mixins_.size() > i);
-            ENFORCE(!mixins_[i].exists());
+            ENFORCE(mixins_[i] == core::Symbols::StubMixin());
             mixins_[i] = sym;
         } else {
             mixins_.emplace_back(sym);
@@ -546,7 +546,8 @@ bool Symbol::addMixin(const GlobalState &gs, ClassOrModuleRef sym, std::optional
 
 u2 Symbol::addStubMixin(const GlobalState &gs) {
     ENFORCE(isClassOrModule());
-    mixins_.emplace_back(ClassOrModuleRef());
+    ENFORCE(ref(gs) != core::Symbols::StubMixin(), "Created a cycle through StubMixin");
+    mixins_.emplace_back(core::Symbols::StubMixin());
     ENFORCE(mixins_.size() < numeric_limits<u2>::max());
     return mixins_.size() - 1;
 }

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -516,7 +516,7 @@ bool Symbol::addMixin(const GlobalState &gs, ClassOrModuleRef sym, std::optional
         if (index.has_value()) {
             auto i = index.value();
             ENFORCE(mixins_.size() > i);
-            ENFORCE(mixins_[i] == core::Symbols::StubMixin());
+            ENFORCE(mixins_[i] == core::Symbols::PlaceholderMixin());
             mixins_[i] = sym;
         } else {
             mixins_.emplace_back(sym);
@@ -546,8 +546,8 @@ bool Symbol::addMixin(const GlobalState &gs, ClassOrModuleRef sym, std::optional
 
 u2 Symbol::addMixinPlaceholder(const GlobalState &gs) {
     ENFORCE(isClassOrModule());
-    ENFORCE(ref(gs) != core::Symbols::StubMixin(), "Created a cycle through StubMixin");
-    mixins_.emplace_back(core::Symbols::StubMixin());
+    ENFORCE(ref(gs) != core::Symbols::PlaceholderMixin(), "Created a cycle through PlaceholderMixin");
+    mixins_.emplace_back(core::Symbols::PlaceholderMixin());
     ENFORCE(mixins_.size() < numeric_limits<u2>::max());
     return mixins_.size() - 1;
 }

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -142,9 +142,10 @@ public:
 
     // Attempts to add the given mixin to the symbol. If the mixin is invalid because it is not a module, it returns
     // `false` (but still adds the mixin for processing during linearization) and the caller should report an error.
-    [[nodiscard]] bool addMixin(const GlobalState &gs, ClassOrModuleRef sym, std::optional<size_t> index= std::nullopt);
+    [[nodiscard]] bool addMixin(const GlobalState &gs, ClassOrModuleRef sym, std::optional<u2> index= std::nullopt);
 
-    size_t addStubMixin(const GlobalState &gs);
+    // Add a placeholder for a mixin and return index in mixins()
+    u2 addStubMixin(const GlobalState &gs);
 
     inline InlinedVector<SymbolRef, 4> &typeMembers() {
         ENFORCE(isClassOrModule());

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -145,7 +145,7 @@ public:
     [[nodiscard]] bool addMixin(const GlobalState &gs, ClassOrModuleRef sym, std::optional<u2> index = std::nullopt);
 
     // Add a placeholder for a mixin and return index in mixins()
-    u2 addStubMixin(const GlobalState &gs);
+    u2 addMixinPlaceholder(const GlobalState &gs);
 
     inline InlinedVector<SymbolRef, 4> &typeMembers() {
         ENFORCE(isClassOrModule());

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -142,7 +142,7 @@ public:
 
     // Attempts to add the given mixin to the symbol. If the mixin is invalid because it is not a module, it returns
     // `false` (but still adds the mixin for processing during linearization) and the caller should report an error.
-    [[nodiscard]] bool addMixin(const GlobalState &gs, ClassOrModuleRef sym, std::optional<u2> index= std::nullopt);
+    [[nodiscard]] bool addMixin(const GlobalState &gs, ClassOrModuleRef sym, std::optional<u2> index = std::nullopt);
 
     // Add a placeholder for a mixin and return index in mixins()
     u2 addStubMixin(const GlobalState &gs);

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -142,7 +142,9 @@ public:
 
     // Attempts to add the given mixin to the symbol. If the mixin is invalid because it is not a module, it returns
     // `false` (but still adds the mixin for processing during linearization) and the caller should report an error.
-    [[nodiscard]] bool addMixin(const GlobalState &gs, ClassOrModuleRef sym);
+    [[nodiscard]] bool addMixin(const GlobalState &gs, ClassOrModuleRef sym, std::optional<size_t> index= std::nullopt);
+
+    size_t addStubMixin(const GlobalState &gs);
 
     inline InlinedVector<SymbolRef, 4> &typeMembers() {
         ENFORCE(isClassOrModule());

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -716,6 +716,8 @@ private:
         ENFORCE(isClassOrModule());
         flags &= ~Symbol::Flags::CLASS_OR_MODULE_LINEARIZATION_COMPUTED;
     }
+
+    void addMixinAt(ClassOrModuleRef sym, std::optional<u2> index);
 };
 // CheckSize(Symbol, 144, 8); // This is under too much churn to be worth checking
 

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -517,9 +517,6 @@ NameDef names[] = {
     {"Autogen", "Autogen", true},
     {"Tokens", "Tokens", true},
     {"AccountModelMerchantToken", "AccountModelMerchantToken", true},
-
-    // Debugging:
-    {"ClearingSubmissionRecord", "ClearingSubmissionRecord", true},
 };
 
 void emit_name_header(ostream &out, NameDef &name) {

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -517,6 +517,9 @@ NameDef names[] = {
     {"Autogen", "Autogen", true},
     {"Tokens", "Tokens", true},
     {"AccountModelMerchantToken", "AccountModelMerchantToken", true},
+
+    // Debugging:
+    {"ClearingSubmissionRecord", "ClearingSubmissionRecord", true},
 };
 
 void emit_name_header(ostream &out, NameDef &name) {

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -482,6 +482,7 @@ NameDef names[] = {
     {"StubModule", "StubModule", true},
     {"StubSuperClass", "StubSuperClass", true},
     {"StubMixin", "StubMixin", true},
+    {"PlaceholderMixin", "PlaceholderMixin", true},
     {"Base", "Base", true},
     {"Void", "Void", true},
     {"TypeAlias", "<TypeAlias>", true},

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -291,26 +291,12 @@ ParentLinearizationInformation computeClassLinearization(core::GlobalState &gs, 
     ENFORCE_NO_TIMER(ofClass.exists());
     auto data = ofClass.data(gs);
     if (!data->isClassOrModuleLinearizationComputed()) {
-        bool rp_debug = false;
-        if (data->name == core::Names::Constants::ClearingSubmissionRecord() && ofClass.show(gs) == "Opus::Ops::CartesBancaires::Model::ClearingSubmissionRecord") {
-            fmt::print(stderr, "LIN: {}\n", ofClass.showFullName(gs));
-            rp_debug = true;
-        }
-        if (rp_debug) {
-            int i = 0;
-            for (auto mixin : data->mixins()) {
-                fmt::print(stderr, "  ORIG_MIX {}: {}\n", i++, mixin.showFullName(gs));
-            }
-        }
         if (data->superClass().exists()) {
             computeClassLinearization(gs, data->superClass());
         }
         InlinedVector<core::ClassOrModuleRef, 4> currentMixins = data->mixins();
         InlinedVector<core::ClassOrModuleRef, 4> newMixins;
         for (auto mixin : currentMixins) {
-            if (rp_debug) {
-                fmt::print(stderr, "CUR MIX: {}\n", mixin.showFullName(gs));
-            }
             if (mixin == data->superClass()) {
                 continue;
             }
@@ -339,12 +325,6 @@ ParentLinearizationInformation computeClassLinearization(core::GlobalState &gs, 
             for (auto oldMixin : currentMixins) {
                 ENFORCE(ofClass.data(gs)->derivesFrom(gs, oldMixin), "{} no longer derives from {}",
                         ofClass.showFullName(gs), oldMixin.showFullName(gs));
-            }
-        }
-        if (rp_debug) {
-            int i = 0;
-            for (auto mixin : data->mixins()) {
-                fmt::print("  MIX {}: {}\n", i++, mixin.showFullName(gs));
             }
         }
     }

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -291,12 +291,26 @@ ParentLinearizationInformation computeClassLinearization(core::GlobalState &gs, 
     ENFORCE_NO_TIMER(ofClass.exists());
     auto data = ofClass.data(gs);
     if (!data->isClassOrModuleLinearizationComputed()) {
+        bool rp_debug = false;
+        if (data->name == core::Names::Constants::ClearingSubmissionRecord() && ofClass.show(gs) == "Opus::Ops::CartesBancaires::Model::ClearingSubmissionRecord") {
+            fmt::print(stderr, "LIN: {}\n", ofClass.showFullName(gs));
+            rp_debug = true;
+        }
+        if (rp_debug) {
+            int i = 0;
+            for (auto mixin : data->mixins()) {
+                fmt::print(stderr, "  ORIG_MIX {}: {}\n", i++, mixin.showFullName(gs));
+            }
+        }
         if (data->superClass().exists()) {
             computeClassLinearization(gs, data->superClass());
         }
         InlinedVector<core::ClassOrModuleRef, 4> currentMixins = data->mixins();
         InlinedVector<core::ClassOrModuleRef, 4> newMixins;
         for (auto mixin : currentMixins) {
+            if (rp_debug) {
+                fmt::print(stderr, "CUR MIX: {}\n", mixin.showFullName(gs));
+            }
             if (mixin == data->superClass()) {
                 continue;
             }
@@ -325,6 +339,12 @@ ParentLinearizationInformation computeClassLinearization(core::GlobalState &gs, 
             for (auto oldMixin : currentMixins) {
                 ENFORCE(ofClass.data(gs)->derivesFrom(gs, oldMixin), "{} no longer derives from {}",
                         ofClass.showFullName(gs), oldMixin.showFullName(gs));
+            }
+        }
+        if (rp_debug) {
+            int i = 0;
+            for (auto mixin : data->mixins()) {
+                fmt::print("  MIX {}: {}\n", i++, mixin.showFullName(gs));
             }
         }
     }

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -297,6 +297,7 @@ ParentLinearizationInformation computeClassLinearization(core::GlobalState &gs, 
         InlinedVector<core::ClassOrModuleRef, 4> currentMixins = data->mixins();
         InlinedVector<core::ClassOrModuleRef, 4> newMixins;
         for (auto mixin : currentMixins) {
+            ENFORCE(mixin != core::Symbols::PlaceholderMixin(), "Resolver failed to replace all placeholders");
             if (mixin == data->superClass()) {
                 continue;
             }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -528,7 +528,7 @@ private:
                 e.addErrorLine(resolvedClass.data(ctx)->loc(), "Class definition");
             }
             resolvedClass = stubSymbolForAncestor(job);
-        } else if (resolvedClass.data(ctx)->derivesFrom(ctx, job.klass)) { // TODO problem if already a stub
+        } else if (resolvedClass.data(ctx)->derivesFrom(ctx, job.klass)) {
             if (auto e = ctx.beginError(job.ancestor->loc, core::errors::Resolver::CircularDependency)) {
                 e.setHeader("Circular dependency: `{}` and `{}` are declared as parents of each other",
                             job.klass.show(ctx), resolvedClass.show(ctx));

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -508,9 +508,9 @@ private:
             if (!resolved.isClassOrModule()) {
                 if (!lastRun) {
                     if (!job.isSuperclass) {
-                        // This is an include or extend. Add a stub to fill in later to preserve
+                        // This is an include or extend. Add a placeholder to fill in later to preserve
                         // ordering of mixins.
-                        job.mixinIndex = job.klass.data(ctx)->addStubMixin(ctx);
+                        job.mixinIndex = job.klass.data(ctx)->addMixinPlaceholder(ctx);
                     }
                     return false;
                 }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -486,27 +486,15 @@ private:
 
     static bool resolveAncestorJob(core::MutableContext ctx, AncestorResolutionItem &job, bool lastRun) {
         auto ancestorSym = job.ancestor->symbol;
-        bool dbg = job.file.data(ctx).path() == "./example.rb" || job.file.data(ctx).path() == "./example_no_alias.rb";
-        if (dbg) {
-            fmt::print("RESOLVE {} {} {}\n", job.klass.show(ctx), ancestorSym.show(ctx), job.klass.data(ctx)->mixins().size());
-        }
-
         if (!ancestorSym.exists()) {
-            if (dbg) {
-                fmt::print("RET 0\n");
-            }
             return false;
         }
-        // fmt::print("false {}\n", ancestorSym.show(ctx));
 
         core::ClassOrModuleRef resolvedClass;
         {
             core::SymbolRef resolved;
             if (ancestorSym.data(ctx)->isTypeAlias()) {
                 if (!lastRun) {
-                    if (dbg) {
-                        fmt::print("RET 1\n");
-                    }
                     return false;
                 }
                 if (auto e = ctx.beginError(job.ancestor->loc, core::errors::Resolver::DynamicSuperclass)) {
@@ -519,9 +507,6 @@ private:
 
             if (!resolved.isClassOrModule()) {
                 if (!lastRun) {
-                    if (dbg) {
-                        fmt::print("RET 2 kind={} {}\n", resolved.kind(), resolved.showRaw(ctx));
-                    }
                     job.mixinInd = job.klass.data(ctx)->addStubMixin(ctx);
                     return false;
                 }
@@ -566,10 +551,6 @@ private:
             }
         } else {
             if (!job.klass.data(ctx)->addMixin(ctx, resolvedClass, job.mixinInd)) {
-                auto x = resolvedClass.data(ctx)->dealias(ctx);
-                if (x.rawId() != resolvedClass.id()) {
-                    fmt::print(stderr, "WEIRD: {} {} {}\n", ctx.file.data(ctx).path(), resolvedClass.show(ctx), x.show(ctx));
-                }
                 if (auto e = ctx.beginError(job.ancestor->loc, core::errors::Resolver::IncludesNonModule)) {
                     e.setHeader("Only modules can be `{}`d, but `{}` is a class", job.isInclude ? "include" : "extend",
                                 resolvedClass.show(ctx));
@@ -581,9 +562,6 @@ private:
 
         if (ancestorPresent) {
             saveAncestorTypeForHashing(ctx, job);
-        }
-        if (dbg) {
-            fmt::print("RET TRUE\n");
         }
         return true;
     }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -487,6 +487,11 @@ private:
     static bool resolveAncestorJob(core::MutableContext ctx, AncestorResolutionItem &job, bool lastRun) {
         auto ancestorSym = job.ancestor->symbol;
         if (!ancestorSym.exists()) {
+            if (!lastRun && !job.isSuperclass && !job.mixinIndex.has_value()) {
+                // This is an include or extend. Add a placeholder to fill in later to preserve
+                // ordering of mixins, unless an index is already set.
+                job.mixinIndex = job.klass.data(ctx)->addMixinPlaceholder(ctx);
+            }
             return false;
         }
 
@@ -507,7 +512,7 @@ private:
 
             if (!resolved.isClassOrModule()) {
                 if (!lastRun) {
-                    if (!job.isSuperclass) {
+                    if (!job.isSuperclass && !job.mixinIndex.has_value()) {
                         // This is an include or extend. Add a placeholder to fill in later to preserve
                         // ordering of mixins.
                         job.mixinIndex = job.klass.data(ctx)->addMixinPlaceholder(ctx);

--- a/test/testdata/resolver/aliased_mixin_ordering.rb
+++ b/test/testdata/resolver/aliased_mixin_ordering.rb
@@ -1,0 +1,46 @@
+# typed: strict
+
+module Stringy
+  extend T::Sig
+
+  sig {returns(String)}
+  def f
+    "1"
+  end
+end
+
+module Inty
+  extend T::Sig
+
+  sig {returns(Integer)}
+  def f
+    1
+  end
+end
+
+class MixesAlias
+  extend T::Sig
+
+  StringyAlias = Stringy
+
+  include StringyAlias
+  include Inty
+end
+
+class MixesDirect
+  extend T::Sig
+
+  include Stringy
+  include Inty
+end
+
+class MixesDirectSwapped
+  extend T::Sig
+
+  include Inty
+  include Stringy
+end
+
+T.reveal_type(MixesAlias.new.f) # error: Revealed type: `Integer`
+T.reveal_type(MixesDirect.new.f) # error: Revealed type: `Integer`
+T.reveal_type(MixesDirectSwapped.new.f) # error: Revealed type: `String`


### PR DESCRIPTION
The resolver attempts to resolve ancestors (superclass and mixins) early as possible as an optimization. If a mixin is referenced via an alias this is deferred until the alias itself has been resolved, and at that time it is pushed class's vector of mixins. In this case it results in re-ordering. (See test case on master)

Preserve the ordering by adding a placeholder value and updating the job to hold that index.

Note: that this is still best effort w.r.t. ordering. This change allows for Sorbet to more closely model what would occur at runtime if a class is defined in a single file. However, if a class's `include`s happen in multiple files it is impossible for Sorbet to know what order they'd be executed in.

### Motivation
`--stripe-packages` mode introduces encapsulation via constant aliases making this existing issue more prounced.
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
