### PR TITLE
Add intrinsics for Hash#merge and Hash#merge!

### DIFF
--- a/compiler/IREmitter/Payload/codegen-payload.c
+++ b/compiler/IREmitter/Payload/codegen-payload.c
@@ -181,6 +181,8 @@ SORBET_ALIVE(VALUE, rb_hash_keys, (VALUE recv));
 SORBET_ALIVE(VALUE, rb_hash_values, (VALUE recv));
 SORBET_ALIVE(VALUE, sorbet_rb_hash_fetch_m,
              (VALUE recv, ID fun, int argc, const VALUE *const restrict argv, BlockFFIType blk, VALUE closure));
+SORBET_ALIVE(VALUE, sorbet_rb_hash_update, (VALUE recv, ID fun, int argc, const VALUE *const restrict argv, BlockFFIType blk, VALUE closure));
+SORBET_ALIVE(int, sorbet_rb_hash_update_withBlock_i, (VALUE key, VALUE value, VALUE argsv));
 
 SORBET_ALIVE(VALUE, sorbet_vm_fstring_new, (const char *ptr, long len));
 SORBET_ALIVE(VALUE, sorbet_vm_str_uplus, (VALUE str));
@@ -1924,6 +1926,48 @@ VALUE sorbet_rb_hash_values(VALUE recv, ID fun, int argc, const VALUE *const res
                             VALUE closure) {
     sorbet_ensure_arity(argc, 0);
     return rb_hash_values(recv);
+}
+
+struct sorbet_rb_hash_update_withBlock_i_args {
+    VALUE hash;
+    VALUE closure;
+    BlockFFIType blk;
+};
+
+// Block version of Hash#update: https://github.com/ruby/ruby/blob/ruby_2_7/hash.c#L3869-L3886
+SORBET_INLINE
+VALUE sorbet_rb_hash_update_withBlock(VALUE recv, ID fun, int argc, const VALUE *const restrict argv, BlockFFIType blk,
+                                      const struct rb_captured_block *captured, VALUE closure, int numPositionalArgs) {
+    int i;
+
+    // This line inlined from rb_hash_modify:
+    rb_check_frozen(recv);
+
+    // must push a frame for the captured block
+    sorbet_pushBlockFrame(captured);
+
+    for (i = 0; i < argc; i++){
+       VALUE hash = rb_to_hash_type(argv[i]);
+       struct sorbet_rb_hash_update_withBlock_i_args args = {recv, closure, blk};
+       rb_hash_foreach(hash, sorbet_rb_hash_update_withBlock_i, (VALUE)&args);
+    }
+
+    sorbet_popFrame();
+
+    return recv;
+}
+
+// No-block version of Hash#merge: https://github.com/ruby/ruby/blob/ac7c2754c004cdb3618738e315d2e2cb5f68a3a8/hash.c#L3973-L3977
+SORBET_INLINE
+VALUE sorbet_rb_hash_merge(VALUE recv, ID fun, int argc, const VALUE *const restrict argv, BlockFFIType blk, VALUE closure) {
+    return sorbet_rb_hash_update(rb_hash_dup(recv), fun, argc, argv, blk, closure);
+}
+
+// Block version of Hash#merge: https://github.com/ruby/ruby/blob/ac7c2754c004cdb3618738e315d2e2cb5f68a3a8/hash.c#L3973-L3977
+SORBET_INLINE
+VALUE sorbet_rb_hash_merge_withBlock(VALUE recv, ID fun, int argc, const VALUE *const restrict argv, BlockFFIType blk,
+                                     const struct rb_captured_block *captured, VALUE closure, int numPositionalArgs) {
+    return sorbet_rb_hash_update_withBlock(rb_hash_dup(recv), fun, argc, argv, blk, captured, closure, numPositionalArgs);
 }
 
 // ****

--- a/compiler/IREmitter/Payload/codegen-payload.c
+++ b/compiler/IREmitter/Payload/codegen-payload.c
@@ -181,7 +181,8 @@ SORBET_ALIVE(VALUE, rb_hash_keys, (VALUE recv));
 SORBET_ALIVE(VALUE, rb_hash_values, (VALUE recv));
 SORBET_ALIVE(VALUE, sorbet_rb_hash_fetch_m,
              (VALUE recv, ID fun, int argc, const VALUE *const restrict argv, BlockFFIType blk, VALUE closure));
-SORBET_ALIVE(VALUE, sorbet_rb_hash_update, (VALUE recv, ID fun, int argc, const VALUE *const restrict argv, BlockFFIType blk, VALUE closure));
+SORBET_ALIVE(VALUE, sorbet_rb_hash_update,
+             (VALUE recv, ID fun, int argc, const VALUE *const restrict argv, BlockFFIType blk, VALUE closure));
 SORBET_ALIVE(int, sorbet_rb_hash_update_withBlock_i, (VALUE key, VALUE value, VALUE argsv));
 
 SORBET_ALIVE(VALUE, sorbet_vm_fstring_new, (const char *ptr, long len));
@@ -1946,10 +1947,10 @@ VALUE sorbet_rb_hash_update_withBlock(VALUE recv, ID fun, int argc, const VALUE 
     // must push a frame for the captured block
     sorbet_pushBlockFrame(captured);
 
-    for (i = 0; i < argc; i++){
-       VALUE hash = rb_to_hash_type(argv[i]);
-       struct sorbet_rb_hash_update_withBlock_i_args args = {recv, closure, blk};
-       rb_hash_foreach(hash, sorbet_rb_hash_update_withBlock_i, (VALUE)&args);
+    for (i = 0; i < argc; i++) {
+        VALUE hash = rb_to_hash_type(argv[i]);
+        struct sorbet_rb_hash_update_withBlock_i_args args = {recv, closure, blk};
+        rb_hash_foreach(hash, sorbet_rb_hash_update_withBlock_i, (VALUE)&args);
     }
 
     sorbet_popFrame();
@@ -1957,17 +1958,21 @@ VALUE sorbet_rb_hash_update_withBlock(VALUE recv, ID fun, int argc, const VALUE 
     return recv;
 }
 
-// No-block version of Hash#merge: https://github.com/ruby/ruby/blob/ac7c2754c004cdb3618738e315d2e2cb5f68a3a8/hash.c#L3973-L3977
+// No-block version of Hash#merge:
+// https://github.com/ruby/ruby/blob/ac7c2754c004cdb3618738e315d2e2cb5f68a3a8/hash.c#L3973-L3977
 SORBET_INLINE
-VALUE sorbet_rb_hash_merge(VALUE recv, ID fun, int argc, const VALUE *const restrict argv, BlockFFIType blk, VALUE closure) {
+VALUE sorbet_rb_hash_merge(VALUE recv, ID fun, int argc, const VALUE *const restrict argv, BlockFFIType blk,
+                           VALUE closure) {
     return sorbet_rb_hash_update(rb_hash_dup(recv), fun, argc, argv, blk, closure);
 }
 
-// Block version of Hash#merge: https://github.com/ruby/ruby/blob/ac7c2754c004cdb3618738e315d2e2cb5f68a3a8/hash.c#L3973-L3977
+// Block version of Hash#merge:
+// https://github.com/ruby/ruby/blob/ac7c2754c004cdb3618738e315d2e2cb5f68a3a8/hash.c#L3973-L3977
 SORBET_INLINE
 VALUE sorbet_rb_hash_merge_withBlock(VALUE recv, ID fun, int argc, const VALUE *const restrict argv, BlockFFIType blk,
                                      const struct rb_captured_block *captured, VALUE closure, int numPositionalArgs) {
-    return sorbet_rb_hash_update_withBlock(rb_hash_dup(recv), fun, argc, argv, blk, captured, closure, numPositionalArgs);
+    return sorbet_rb_hash_update_withBlock(rb_hash_dup(recv), fun, argc, argv, blk, captured, closure,
+                                           numPositionalArgs);
 }
 
 // ****

--- a/compiler/IREmitter/Payload/patches/hash.c
+++ b/compiler/IREmitter/Payload/patches/hash.c
@@ -75,3 +75,60 @@ VALUE sorbet_rb_hash_fetch_m(VALUE recv, ID fun, int argc, const VALUE *const re
         }
     }
 }
+
+// No-block version of Hash#update: https://github.com/ruby/ruby/blob/ruby_2_7/hash.c#L3869-L3886
+VALUE sorbet_rb_hash_update(VALUE recv, ID fun, int argc, const VALUE *const restrict argv, BlockFFIType blk, VALUE closure) {
+    int i;
+
+    rb_hash_modify(recv);
+    for (i = 0; i < argc; i++){
+       VALUE hash = to_hash(argv[i]);
+       rb_hash_foreach(hash, rb_hash_update_i, recv);
+    }
+    return recv;
+}
+
+struct sorbet_rb_hash_update_withBlock_callback_args {
+    VALUE value;
+    VALUE closure;
+    BlockFFIType blk;
+};
+
+// Adapted from rb_hash_update_block_callback: https://github.com/ruby/ruby/blob/ruby_2_7/hash.c#L3800-L3817
+static int
+sorbet_rb_hash_update_withBlock_callback(st_data_t *key, st_data_t *value, struct update_arg *arg, int existing) {
+    struct sorbet_rb_hash_update_withBlock_callback_args *callback_args = (struct sorbet_rb_hash_update_withBlock_callback_args *)arg->arg;
+    VALUE newvalue = (VALUE)callback_args->value;
+
+    if (existing) {
+        VALUE closure = callback_args->closure;
+        BlockFFIType blk = callback_args->blk;
+        VALUE block_argv[3] = {(VALUE)*key, (VALUE)*value, newvalue};
+        newvalue = blk((VALUE)*key, closure, 3, &block_argv[0], Qnil);
+        arg->old_value = *value;
+    }
+    else {
+        arg->new_key = *key;
+    }
+    arg->new_value = newvalue;
+    *value = newvalue;
+    return ST_CONTINUE;
+}
+
+NOINSERT_UPDATE_CALLBACK(sorbet_rb_hash_update_withBlock_callback)
+
+struct sorbet_rb_hash_update_withBlock_i_args {
+    VALUE hash;
+    VALUE closure;
+    BlockFFIType blk;
+};
+
+// Adapted from rb_hash_update_block_i: https://github.com/ruby/ruby/blob/ruby_2_7/hash.c#L3819-L3824
+int
+sorbet_rb_hash_update_withBlock_i(VALUE key, VALUE value, VALUE argsv) {
+    struct sorbet_rb_hash_update_withBlock_i_args *args = (struct sorbet_rb_hash_update_withBlock_i_args *)argsv;
+    VALUE hash = args->hash;
+    struct sorbet_rb_hash_update_withBlock_callback_args callback_args = {value, args->closure, args->blk};
+    RHASH_UPDATE(hash, key, sorbet_rb_hash_update_withBlock_callback, (VALUE)&callback_args);
+    return ST_CONTINUE;
+}

--- a/compiler/IREmitter/Payload/patches/hash.c
+++ b/compiler/IREmitter/Payload/patches/hash.c
@@ -77,13 +77,14 @@ VALUE sorbet_rb_hash_fetch_m(VALUE recv, ID fun, int argc, const VALUE *const re
 }
 
 // No-block version of Hash#update: https://github.com/ruby/ruby/blob/ruby_2_7/hash.c#L3869-L3886
-VALUE sorbet_rb_hash_update(VALUE recv, ID fun, int argc, const VALUE *const restrict argv, BlockFFIType blk, VALUE closure) {
+VALUE sorbet_rb_hash_update(VALUE recv, ID fun, int argc, const VALUE *const restrict argv, BlockFFIType blk,
+                            VALUE closure) {
     int i;
 
     rb_hash_modify(recv);
-    for (i = 0; i < argc; i++){
-       VALUE hash = to_hash(argv[i]);
-       rb_hash_foreach(hash, rb_hash_update_i, recv);
+    for (i = 0; i < argc; i++) {
+        VALUE hash = to_hash(argv[i]);
+        rb_hash_foreach(hash, rb_hash_update_i, recv);
     }
     return recv;
 }
@@ -95,9 +96,10 @@ struct sorbet_rb_hash_update_withBlock_callback_args {
 };
 
 // Adapted from rb_hash_update_block_callback: https://github.com/ruby/ruby/blob/ruby_2_7/hash.c#L3800-L3817
-static int
-sorbet_rb_hash_update_withBlock_callback(st_data_t *key, st_data_t *value, struct update_arg *arg, int existing) {
-    struct sorbet_rb_hash_update_withBlock_callback_args *callback_args = (struct sorbet_rb_hash_update_withBlock_callback_args *)arg->arg;
+static int sorbet_rb_hash_update_withBlock_callback(st_data_t *key, st_data_t *value, struct update_arg *arg,
+                                                    int existing) {
+    struct sorbet_rb_hash_update_withBlock_callback_args *callback_args =
+        (struct sorbet_rb_hash_update_withBlock_callback_args *)arg->arg;
     VALUE newvalue = (VALUE)callback_args->value;
 
     if (existing) {
@@ -106,8 +108,7 @@ sorbet_rb_hash_update_withBlock_callback(st_data_t *key, st_data_t *value, struc
         VALUE block_argv[3] = {(VALUE)*key, (VALUE)*value, newvalue};
         newvalue = blk((VALUE)*key, closure, 3, &block_argv[0], Qnil);
         arg->old_value = *value;
-    }
-    else {
+    } else {
         arg->new_key = *key;
     }
     arg->new_value = newvalue;
@@ -124,8 +125,7 @@ struct sorbet_rb_hash_update_withBlock_i_args {
 };
 
 // Adapted from rb_hash_update_block_i: https://github.com/ruby/ruby/blob/ruby_2_7/hash.c#L3819-L3824
-int
-sorbet_rb_hash_update_withBlock_i(VALUE key, VALUE value, VALUE argsv) {
+int sorbet_rb_hash_update_withBlock_i(VALUE key, VALUE value, VALUE argsv) {
     struct sorbet_rb_hash_update_withBlock_i_args *args = (struct sorbet_rb_hash_update_withBlock_i_args *)argsv;
     VALUE hash = args->hash;
     struct sorbet_rb_hash_update_withBlock_callback_args callback_args = {value, args->closure, args->blk};

--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -958,6 +958,12 @@ static const vector<CallCMethod> knownCMethodsInstance{
      {KnownFunction::cached("sorbet_rb_hash_to_h_func")}},
     {core::Symbols::Hash(), "to_hash", CMethod{"sorbet_returnRecv", core::Symbols::Hash()}},
     {core::Symbols::Hash(), "fetch", CMethod{"sorbet_rb_hash_fetch_m"}},
+    {core::Symbols::Hash(), "merge", CMethod{"sorbet_rb_hash_merge", core::Symbols::Hash()},
+     CMethod{"sorbet_rb_hash_merge_withBlock", core::Symbols::Hash()}},
+    {core::Symbols::Hash(), "merge!", CMethod{"sorbet_rb_hash_update", core::Symbols::Hash()},
+     CMethod{"sorbet_rb_hash_update_withBlock", core::Symbols::Hash()}},
+    // TODO(aprocter): `update` needs a sig before we can declare a return type here
+    {core::Symbols::Hash(), "update", CMethod{"sorbet_rb_hash_update"}, CMethod{"sorbet_rb_hash_update_withBlock"}},
     {core::Symbols::TrueClass(), "|", CMethod{"sorbet_int_bool_true"}},
     {core::Symbols::FalseClass(), "|", CMethod{"sorbet_int_bool_and"}},
     {core::Symbols::TrueClass(), "&", CMethod{"sorbet_int_bool_and"}},

--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -962,8 +962,8 @@ static const vector<CallCMethod> knownCMethodsInstance{
      CMethod{"sorbet_rb_hash_merge_withBlock", core::Symbols::Hash()}},
     {core::Symbols::Hash(), "merge!", CMethod{"sorbet_rb_hash_update", core::Symbols::Hash()},
      CMethod{"sorbet_rb_hash_update_withBlock", core::Symbols::Hash()}},
-    // TODO(aprocter): `update` needs a sig before we can declare a return type here
-    {core::Symbols::Hash(), "update", CMethod{"sorbet_rb_hash_update"}, CMethod{"sorbet_rb_hash_update_withBlock"}},
+    {core::Symbols::Hash(), "update", CMethod{"sorbet_rb_hash_update", core::Symbols::Hash()},
+     CMethod{"sorbet_rb_hash_update_withBlock", core::Symbols::Hash()}},
     {core::Symbols::TrueClass(), "|", CMethod{"sorbet_int_bool_true"}},
     {core::Symbols::FalseClass(), "|", CMethod{"sorbet_int_bool_and"}},
     {core::Symbols::TrueClass(), "&", CMethod{"sorbet_int_bool_and"}},

--- a/test/testdata/compiler/intrinsics/hash_merge.rb
+++ b/test/testdata/compiler/intrinsics/hash_merge.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+# run_filecheck: INITIAL
+
+def no_block
+  h1 = {x: "foo", q: "bar", z: 33}
+
+  p (h1.merge({x: "bar", z: 33, j: 96}))
+
+  p h1
+end
+
+# INITIAL-LABEL: define internal i64 @"func_Object#8no_block"(
+# INITIAL: call i64 @sorbet_rb_hash_merge(
+# INITIAL{LITERAL}: }
+
+def with_block
+  h1 = {x: "foo", q: "bar", z: 33}
+
+  p (h1.merge({x: "bar", z: 33, j: 96}) do |key, oldval, newval|
+       "key: #{key}, oldval: #{oldval}, newval: #{oldval}"
+     end)
+
+  p h1
+end
+
+# INITIAL-LABEL: define internal i64 @"func_Object#10with_block"(
+# INITIAL: call i64 @sorbet_callIntrinsicInlineBlock_noBreak(i64 (i64)* @forward_sorbet_rb_hash_merge_withBlock
+# INITIAL{LITERAL}: }
+
+with_block
+
+def with_block_raise
+  h1 = {x: "foo", q: "bar", z: 33}
+
+  begin
+    h1.merge({x: "bar", z: 33, j: 96}) do |key, oldval, newval|
+      if key == :z
+        raise "boom"
+      end
+      newval
+    end
+  rescue => e
+    puts e
+  end
+
+  p h1
+end
+
+# INITIAL-LABEL: define internal i64 @"func_Object#16with_block_raise"(
+# INITIAL: call i64 @sorbet_callIntrinsicInlineBlock_noBreak(i64 (i64)* @forward_sorbet_rb_hash_merge_withBlock
+# INITIAL{LITERAL}: }
+
+with_block_raise

--- a/test/testdata/compiler/intrinsics/hash_merge_bang.rb
+++ b/test/testdata/compiler/intrinsics/hash_merge_bang.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+# run_filecheck: INITIAL
+
+def no_block
+  h1 = {x: "foo", q: "bar", z: 33}
+
+  p (h1.merge!({x: "bar", z: 33, j: 96}))
+
+  p h1
+end
+
+# INITIAL-LABEL: define internal i64 @"func_Object#8no_block"(
+# INITIAL: call i64 @sorbet_rb_hash_update(
+# INITIAL{LITERAL}: }
+
+no_block
+
+def with_block
+  h1 = {x: "foo", q: "bar", z: 33}
+
+  p (h1.merge!({x: "bar", z: 33, j: 96}) do |key, oldval, newval|
+       "key: #{key}, oldval: #{oldval}, newval: #{oldval}"
+     end)
+
+  p h1
+end
+
+# INITIAL-LABEL: define internal i64 @"func_Object#10with_block"(
+# INITIAL: call i64 @sorbet_callIntrinsicInlineBlock_noBreak(i64 (i64)* @forward_sorbet_rb_hash_update_withBlock
+# INITIAL{LITERAL}: }
+
+with_block
+
+def with_block_raise
+  h1 = {x: "foo", q: "bar", z: 33}
+
+  begin
+    h1.merge!({x: "bar", z: 33, j: 96}) do |key, oldval, newval|
+      if key == :z
+        raise "boom"
+      end
+      newval
+    end
+  rescue => e
+    puts e
+  end
+
+  p h1
+end
+
+# INITIAL-LABEL: define internal i64 @"func_Object#16with_block_raise"(
+# INITIAL: call i64 @sorbet_callIntrinsicInlineBlock_noBreak(i64 (i64)* @forward_sorbet_rb_hash_update_withBlock
+# INITIAL{LITERAL}: }
+
+with_block_raise

--- a/test/testdata/ruby_benchmark/stripe/hash_merge.rb
+++ b/test/testdata/ruby_benchmark/stripe/hash_merge.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+
+i = 0
+z = 0
+
+h1 = {x: 1, y: 2, z: 3, w: 4}
+h2 = {x: 3, z: 9, j: 22}
+
+while i < 10_000_000
+  h3 = h1.merge(h2)
+  z += h3.length
+
+  i += 1
+end
+
+puts z

--- a/test/testdata/ruby_benchmark/stripe/hash_merge_baseline.rb
+++ b/test/testdata/ruby_benchmark/stripe/hash_merge_baseline.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+
+i = 0
+z = 0
+
+h1 = {x: 1, y: 2, z: 3, w: 4}
+h2 = {x: 3, z: 9, j: 22}
+
+while i < 10_000_000
+  z += h1.length
+
+  i += 1
+end
+
+puts z

--- a/test/testdata/ruby_benchmark/stripe/hash_merge_block.rb
+++ b/test/testdata/ruby_benchmark/stripe/hash_merge_block.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+
+i = 0
+z = 0
+
+h1 = {x: 1, y: 2, z: 3, w: 4}
+h2 = {x: 3, z: 9, j: 22}
+
+while i < 10_000_000
+  h3 = h1.merge(h2) {|k, o, n| o+n}
+  z += h3.length
+
+  i += 1
+end
+
+puts z


### PR DESCRIPTION
Adds compiler intrinsics for `Hash#merge` and `Hash#merge!`.

**Benchmarks**

`merge` without a block:

| source |  interpreted | compiled |
|-|-|-|
| stripe/hash_merge_baseline.rb | .346 | .231 |
| stripe/hash_merge.rb | 1.838 | 1.361 |
| stripe/hash_merge.rb - baseline | 1.492 | 1.130

`merge` with a block:

| source | interpreted | compiled
|-|-|-|
| stripe/hash_merge_baseline.rb | .345 | .227 |
| stripe/hash_merge_block.rb | 2.694 | 1.746 |
| stripe/hash_merge_block.rb - baseline | 2.349 | 1.519 |

### Motivation
General push for more compiler intrinsics.

### Test plan
See included automated tests.
