### PR TITLE
Add sig for blockless Hash#select

### DIFF
--- a/rbi/core/hash.rbi
+++ b/rbi/core/hash.rbi
@@ -1096,6 +1096,7 @@ class Hash < Object
     )
     .returns(T::Hash[K, V])
   end
+  sig {returns(T::Enumerator[[K, V]])}
   def select(&blk); end
 
   # Returns a hash containing only the given keys and their values.
@@ -1126,6 +1127,7 @@ class Hash < Object
     )
     .returns(T::Hash[K, V])
   end
+  sig {returns(T::Enumerator[[K, V]])}
   def filter(&blk); end
 
   # Equivalent to


### PR DESCRIPTION
Adds a sig for the blockless variant of `Hash#select` (the one that returns an `Enumerator`).

### Motivation
Was working on an intrinsic for `Hash#select` and noticed we don't have a sig for this.

### Test plan
See included automated tests.
