### PR TITLE
Add Hash#select intrinsic

### DIFF
--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -964,6 +964,8 @@ static const vector<CallCMethod> knownCMethodsInstance{
      CMethod{"sorbet_rb_hash_update_withBlock", core::Symbols::Hash()}},
     {core::Symbols::Hash(), "update", CMethod{"sorbet_rb_hash_update", core::Symbols::Hash()},
      CMethod{"sorbet_rb_hash_update_withBlock", core::Symbols::Hash()}},
+    {core::Symbols::Hash(), "select", CMethod{"sorbet_rb_hash_select", core::Symbols::Enumerator()},
+     CMethod{"sorbet_rb_hash_select_withBlock", core::Symbols::Hash()}},
     {core::Symbols::TrueClass(), "|", CMethod{"sorbet_int_bool_true"}},
     {core::Symbols::FalseClass(), "|", CMethod{"sorbet_int_bool_and"}},
     {core::Symbols::TrueClass(), "&", CMethod{"sorbet_int_bool_and"}},

--- a/test/testdata/compiler/intrinsics/hash_select.rb
+++ b/test/testdata/compiler/intrinsics/hash_select.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+# run_filecheck: INITIAL
+
+def no_block
+  h1 = {q: 99, z: 48, t: 97, p: 100}
+  e = h1.select
+  puts (e.each do |k, v|
+          puts "#{k} => #{v}"
+          v%2==0 || k==:q
+        end)
+end
+
+no_block
+
+# INITIAL-LABEL: define internal i64 @"func_Object#8no_block"(
+# INITIAL: call i64 @sorbet_rb_hash_select(
+# INITIAL{LITERAL}: }
+
+def with_block
+  h1 = {q: 99, z: 48, t: 97, p: 100}
+  puts (h1.select do |k, v|
+          puts "#{k} => #{v}"
+          v%2==0 || k==:q
+        end)
+end
+
+with_block
+
+# INITIAL-LABEL: define internal i64 @"func_Object#10with_block"(
+# INITIAL: call i64 @sorbet_callIntrinsicInlineBlock_noBreak(i64 (i64)* @forward_sorbet_rb_hash_select_withBlock
+# INITIAL{LITERAL}: }

--- a/test/testdata/ruby_benchmark/stripe/hash_select.rb
+++ b/test/testdata/ruby_benchmark/stripe/hash_select.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+
+i = 0
+z = 0
+
+while i < 1_000_000
+  xs = {x: 99, q: 48, j: 21, e: 18}.select { |k, v| k==:x || v%2==0 }
+  z += xs.length
+
+  i += 1
+end
+
+puts z

--- a/test/testdata/ruby_benchmark/stripe/hash_select_baseline.rb
+++ b/test/testdata/ruby_benchmark/stripe/hash_select_baseline.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+
+i = 0
+z = 0
+
+while i < 1_000_000
+  xs = {x: 99, q: 48, j: 21, e: 18}
+  z += xs.length
+
+  i += 1
+end
+
+puts z

--- a/test/testdata/ruby_benchmark/stripe/hash_select_enum.rb
+++ b/test/testdata/ruby_benchmark/stripe/hash_select_enum.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+
+i = 0
+z = 0
+
+while i < 1_000_000
+  xs = {x: 99, q: 48, j: 21, e: 18}
+  e = xs.select
+  ys = e.each { |k, v| k==:x || v%2==0 }
+  z += ys.length
+
+  i += 1
+end
+
+puts z


### PR DESCRIPTION
Adds a compiler intrinsic for `Hash#select`.

**Benchmarks**

`Hash#select` with block:

| source | interpreted | compiled |
|-|-|-|
| stripe/hash_select_baseline.rb | .140 | .118 |
| stripe/hash_select.rb | .495 | .405 |
| stripe/hash_select.rb - baseline | .355 | .287 |

`Hash#select` without block (returns an enumerator):

| source | interpreted | compiled |
|-|-|-|
| stripe/hash_select_baseline.rb | .139 | .120 |
| stripe/hash_select_enum.rb | .799 | .625 |
| stripe/hash_select_enum.rb - baseline | .660 | .505 |

### Motivation
General push for more compiler intrinsics.

### Test plan
See included automated tests.
