### PR TITLE
clarify comment now that we reject Sorbet::Private::Static for full Ruby calls

### DIFF
--- a/compiler/IREmitter/sends.cc
+++ b/compiler/IREmitter/sends.cc
@@ -403,11 +403,8 @@ llvm::Value *IREmitterHelpers::emitMethodCallViaRubyVM(MethodCallContext &mcctx)
     auto &irctx = mcctx.irctx;
     auto *send = mcctx.send;
 
-    // If we get here with <Magic>, then something has gone wrong.
-    // TODO(froydnj): We want to do the same thing with Sorbet::Private::Static,
-    // but we'd need to do some surgery on either a) making those methods not
-    // be emitted via symbol-based intrinsics or b) making it possible for
-    // (some) symbol-based intrinsics to bypass typechecks completely.
+    // If we get here with <Magic> or Sorbet::Private::Static, then something has
+    // gone wrong.
     if (auto *at = core::cast_type<core::AppliedType>(send->recv.type)) {
         if (at->klass == core::Symbols::MagicSingleton()) {
             failCompilation(cs, core::Loc(irctx.cfg.file, send->receiverLoc),


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Apparently I forgot to fix this up when #4645 landed.  Better late than never!

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
