### PR TITLE
don't call `super` in `initialize` for `T::Struct` subclasses

### DIFF
--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -535,7 +535,19 @@ vector<ast::ExpressionPtr> mkTypedInitialize(core::MutableContext ctx, core::Loc
         stats.emplace_back(ast::MK::Assign(prop.loc, ast::MK::Instance(prop.nameLoc, ivarName),
                                            ast::MK::Local(prop.nameLoc, prop.name)));
     }
-    auto body = ast::MK::InsSeq(klassLoc, std::move(stats), ast::MK::Nil(klassDeclLoc));
+    // Normally we wouldn't need to call super here: the compiler will use the types
+    // in the sig to typecheck everything, just like sorbet-runtime, and we've
+    // generated a body to set all the appropriate instance variables, just like
+    // sorbet-runtime.  (deprecated) enum props, however, are not typechecked
+    // properly by the compiler, so we need to use super to call into sorbet-runtime
+    // to get the correct handling.
+    ast::ExpressionPtr maybeSuper;
+    if (absl::c_any_of(props, [](const auto &prop) { return prop.enum_ != nullptr; })) {
+        maybeSuper = ast::MK::ZSuper(klassDeclLoc);
+    } else {
+        maybeSuper = ast::MK::Nil(klassDeclLoc);
+    }
+    auto body = ast::MK::InsSeq(klassLoc, std::move(stats), std::move(maybeSuper));
 
     vector<ast::ExpressionPtr> result;
     result.emplace_back(ast::MK::SigVoid(klassDeclLoc, std::move(sigArgs)));

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -535,7 +535,7 @@ vector<ast::ExpressionPtr> mkTypedInitialize(core::MutableContext ctx, core::Loc
         stats.emplace_back(ast::MK::Assign(prop.loc, ast::MK::Instance(prop.nameLoc, ivarName),
                                            ast::MK::Local(prop.nameLoc, prop.name)));
     }
-    auto body = ast::MK::InsSeq(klassLoc, std::move(stats), ast::MK::ZSuper(klassDeclLoc));
+    auto body = ast::MK::InsSeq(klassLoc, std::move(stats), ast::MK::Nil(klassDeclLoc));
 
     vector<ast::ExpressionPtr> result;
     result.emplace_back(ast::MK::SigVoid(klassDeclLoc, std::move(sigArgs)));

--- a/test/testdata/compiler/prop/t_struct.rb
+++ b/test/testdata/compiler/prop/t_struct.rb
@@ -40,3 +40,9 @@ verify_runtime_error{A.new(int: 5, str: "foo", optstr: T.unsafe(29))}
 # Verify extra keyword arguments are not accepted.
 verify_runtime_error{A.send(:new, int: 6, str: "foo", notarg: 19)}
 verify_runtime_error{A.send(:new, 13, int: 7, str: "bar")}
+
+class HasEnumMember < T::Struct
+  prop :lame_enum, String, enum: ["value1", "value2"]
+end
+
+verify_runtime_error {HasEnumMember.new(lame_enum: "bad_value")}

--- a/test/testdata/compiler/prop/t_struct.rb
+++ b/test/testdata/compiler/prop/t_struct.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+
+class A < T::Struct
+  prop :int, Integer
+  prop :str, String
+  prop :optint, Integer, default: 5
+  prop :optarray, T::Array[Integer], default: [6]
+  prop :optstr, String, default: "shared string"
+end
+
+# Verify default arguments don't share structure.
+x = A.new(int: 5, str: "foo")
+y = A.new(int: 6, str: "bar")
+p x.optarray.object_id != y.optarray.object_id
+# ...but it's OK if the strings do, given that we're using frozen_string_literal.
+p x.optstr.object_id == y.optstr.object_id
+
+def verify_runtime_error(&blk)
+  begin
+    yield
+  rescue => e
+    # We're not particularly concerned about the error message.
+    p e.class
+  else
+    p "not supposed to get here"
+  end
+end
+
+# Verify runtime type-checking is done on required args.
+verify_runtime_error {A.new(int: T.unsafe(:not_an_integer), str: "foo")}
+verify_runtime_error {A.new(int: 4, str: T.unsafe(:not_a_string))}
+
+# Verify runtime type-checking is done on optional args.
+verify_runtime_error{A.new(int: 5, str: "foo", optint: T.unsafe("something"))}
+verify_runtime_error{A.new(int: 5, str: "foo", optint: 18, optarray: T.unsafe(34))}
+verify_runtime_error{A.new(int: 5, str: "foo", optstr: T.unsafe(29))}
+
+# Verify extra keyword arguments are not accepted.
+verify_runtime_error{A.send(:new, int: 6, str: "foo", notarg: 19)}
+verify_runtime_error{A.send(:new, 13, int: 7, str: "bar")}

--- a/test/testdata/rewriter/attr_reader_method_kind.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/attr_reader_method_kind.rb.rewrite-tree.exp
@@ -48,7 +48,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       begin
         @using_t_struct_prop = ::T.let(using_t_struct_prop, <emptyTree>::<C Integer>)
         @using_t_struct_const = ::T.let(using_t_struct_const, <emptyTree>::<C Integer>)
-        <self>.<super>(ZSuperArgs)
+        nil
       end
     end
 

--- a/test/testdata/rewriter/t_struct/default.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/default.rb.rewrite-tree.exp
@@ -7,7 +7,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     def initialize<<todo method>>(foo: = 3, &<blk>)
       begin
         @foo = ::T.let(foo, <emptyTree>::<C Integer>)
-        <self>.<super>(ZSuperArgs)
+        nil
       end
     end
 
@@ -50,7 +50,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def initialize<<todo method>>(&<blk>)
-      <self>.<super>(ZSuperArgs)
+      nil
     end
 
     ::Sorbet::Private::Static.keep_def(<self>, :initialize, :normal)

--- a/test/testdata/rewriter/t_struct/nilable.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/nilable.rb.rewrite-tree.exp
@@ -7,7 +7,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     def initialize<<todo method>>(foo: = nil, &<blk>)
       begin
         @foo = ::T.let(foo, <emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>))
-        <self>.<super>(ZSuperArgs)
+        nil
       end
     end
 

--- a/test/testdata/rewriter/t_struct/none.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/none.rb.rewrite-tree.exp
@@ -5,7 +5,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def initialize<<todo method>>(&<blk>)
-      <self>.<super>(ZSuperArgs)
+      nil
     end
 
     ::Sorbet::Private::Static.keep_def(<self>, :initialize, :normal)

--- a/test/testdata/rewriter/t_struct/normal.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/normal.rb.rewrite-tree.exp
@@ -7,7 +7,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     def initialize<<todo method>>(foo:, &<blk>)
       begin
         @foo = ::T.let(foo, <emptyTree>::<C Integer>)
-        <self>.<super>(ZSuperArgs)
+        nil
       end
     end
 

--- a/test/testdata/rewriter/t_struct/override.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/override.rb.rewrite-tree.exp
@@ -7,7 +7,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     def initialize<<todo method>>(foo:, &<blk>)
       begin
         @foo = ::T.let(foo, <emptyTree>::<C String>)
-        <self>.<super>(ZSuperArgs)
+        nil
       end
     end
 

--- a/test/testdata/rewriter/t_struct/param_order.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/param_order.rb.rewrite-tree.exp
@@ -8,7 +8,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       begin
         @foo = ::T.let(foo, <emptyTree>::<C Integer>)
         @bar = ::T.let(bar, <emptyTree>::<C Integer>)
-        <self>.<super>(ZSuperArgs)
+        nil
       end
     end
 

--- a/test/testdata/rewriter/t_struct/root.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/root.rb.rewrite-tree.exp
@@ -7,7 +7,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     def initialize<<todo method>>(foo:, &<blk>)
       begin
         @foo = ::T.let(foo, <emptyTree>::<C Integer>)
-        <self>.<super>(ZSuperArgs)
+        nil
       end
     end
 

--- a/test/testdata/rewriter/t_struct/some_default.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/some_default.rb.rewrite-tree.exp
@@ -8,7 +8,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       begin
         @foo = ::T.let(foo, <emptyTree>::<C Integer>)
         @bar = ::T.let(bar, <emptyTree>::<C T>::<C Boolean>)
-        <self>.<super>(ZSuperArgs)
+        nil
       end
     end
 

--- a/test/testdata/ruby_benchmark/stripe/t_struct_creation.rb
+++ b/test/testdata/ruby_benchmark/stripe/t_struct_creation.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+
+class TestClass < T::Struct
+  prop :int, Integer
+  prop :str, String
+end
+
+i = 0
+while i < 10_000_000
+  TestClass.new(int: 5, str: "foo")
+
+  i += 1
+end
+
+puts i


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The title says it all.  The compiler's view of `initialize` is that we're going to:

1. typecheck the arguments
2. set all the instance variables
3. call `super` (currently requiring allocating a kwargs hash, which wouldn't be required after #4920)
4. run all the sorbet-runtime code associated with initializing `T::Struct` subclasses...but theoretically our `initialize` method *already did that*

So dropping step 3 (and consequently 4) should be safe, since we're typechecking the arguments (which sorbet-runtime would do) and setting the instance variables (which sorbet-runtime would also do).

It's worth noting that this shouldn't affect the actual static typechecking Sorbet does because a) `super` is currently considered to be essentially untyped and b) even if we more correctly computed what `super` was calling, Sorbet doesn't see the actual implementation anyway.

A benchmark is included.  Before this change:

```
source  interpreted     compiled
stripe/while_10_000_000.rb      .224    .101
stripe/t_struct_creation.rb     12.043  12.271
stripe/t_struct_creation.rb - baseline  11.819  12.170
```

These timings are somewhat noisy, given the allocations involved, but we can see that the compiler is no faster than the interpreter -- which makes sense, since it's basically doing all the work the interpreter would be doing, plus whatever work the rewriter's `initialize` method does.

After this change:

```
source  interpreted     compiled
stripe/while_10_000_000.rb      .222    .100
stripe/t_struct_creation.rb     11.731  .887
stripe/t_struct_creation.rb - baseline  11.509  .787
```

I will take order-of-magnitude speedups.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I attempted to add tests to verify the compiler's behavior is ~compatible with sorbet-runtime's; I didn't go so far as to check the actual text of the error messages, because I don't think that's necessary in this case.  I don't claim that I captured all the behavior: extra review for those tests welcome.