### PR TITLE
add a disabled test for `T.deprecated_enum` in sigs

### DIFF
--- a/test/testdata/compiler/disabled/deprecated_enum_in_sig.rb
+++ b/test/testdata/compiler/disabled/deprecated_enum_in_sig.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+
+extend T::Sig
+
+ENUM_VALUES = ["value1", "value2"]
+
+sig {params(e: T.deprecated_enum(ENUM_VALUES)).void}
+def f(e)
+  p e
+end
+
+begin
+  f("bad value")
+rescue => e
+  p e.class
+else
+  p "should have gotten an error"
+end


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Realized we don't handle this when working on #4921.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
