### PR TITLE
Add better error messaging for packages importing prefixes of themselves

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -797,13 +797,15 @@ public:
 
 class ImportTreeBuilder final {
     // PackageInfoImpl package; // The package we are building an import tree for.
+    const FullyQualifiedName *fullPkgName;
     core::NameRef pkgMangledName;
     core::NameRef privatePkgMangledName;
     ImportTree root;
 
 public:
     ImportTreeBuilder(const PackageInfoImpl &package)
-        : pkgMangledName(package.name.mangledName), privatePkgMangledName(package.privateMangledName) {}
+        : fullPkgName(&(package.name.fullName)), pkgMangledName(package.name.mangledName),
+          privatePkgMangledName(package.privateMangledName) {}
     ImportTreeBuilder(const ImportTreeBuilder &) = delete;
     ImportTreeBuilder(ImportTreeBuilder &&) = default;
     ImportTreeBuilder &operator=(const ImportTreeBuilder &) = delete;
@@ -934,11 +936,27 @@ private:
             node = child.get();
         }
 
-        // If the node already has an import source, this is a conflicting import.
-        // See test/cli/package-import-conflicts/ for an example.
-        if (node->source.exists() && importType != ImportType::Friend) {
-            addImportConflictError(ctx, loc, node->source.importLoc, exportFqn.parts);
+        if (importType != ImportType::Friend && node->source.exists()) {
+            // If the node already has an import source, this is a conflicting import.
+            // See test/cli/package-import-conflicts/ for an example.
+
+            addConflictingImportSourcesError(ctx, loc, node->source.importLoc, exportFqn.parts);
+
+            // Don't add source; import will not get re-mapped.
+            return;
         }
+
+        if (importType != ImportType::Friend && fullPkgName->isSuffix(exportFqn)) {
+            // If the import is a prefix of the current package, add an error, as this
+            // is by definition a conflicting import.
+            // See test/cli/package-import-parent-package-conflict/ for an example.
+            addPrefixImportError(ctx, loc, importedPackage.name.fullName.parts, exportFqn.parts);
+
+            // Don't add source; import will not get mapped. This prevents an additional
+            // redefinition error in the namer.
+            return;
+        }
+
         node->source = ImportTree::Source{importedPackage.name.mangledName, loc, importType, isEnumeratedImport};
     }
 
@@ -998,7 +1016,7 @@ private:
                 // A conflicting import exists. Only report errors while constructing the test output
                 // to avoid duplicate errors because test imports are a superset of normal imports.
                 if (moduleType == ModuleType::PrivateTest && !isFriendImport) {
-                    addImportConflictError(ctx, source.importLoc, parentSrc.importLoc, parts);
+                    addConflictingImportSourcesError(ctx, source.importLoc, parentSrc.importLoc, parts);
                 }
 
                 return;
@@ -1045,16 +1063,30 @@ private:
         }
     }
 
-    // Create an error that represents an import conflict; namely a package importing two names where one is a
-    // prefix of another. This is disallowed, as it would (rightly) cause a redefinition error in the namer pass.
-    void addImportConflictError(core::Context ctx, const core::LocOffsets &loc, const core::LocOffsets &otherLoc,
-                                const vector<core::NameRef> &nameParts) {
+    // Create an error that occurs if a package imports two names where one is a prefix of another. This is disallowed,
+    // as it would (rightly) cause a redefinition error in the namer pass.
+    void addConflictingImportSourcesError(core::Context ctx, const core::LocOffsets &loc,
+                                          const core::LocOffsets &otherLoc, const vector<core::NameRef> &nameParts) {
         if (auto e = ctx.beginError(loc, core::errors::Packager::ImportConflict)) {
             // TODO Fix flaky ordering of errors. This is strange...not being done in parallel,
             // and the file processing order is consistent.
             e.setHeader("Conflicting import sources for `{}`",
                         fmt::map_join(nameParts, "::", [&](const auto &nr) { return nr.show(ctx); }));
             e.addErrorLine(core::Loc(ctx.file, otherLoc), "Conflict from");
+        }
+    }
+
+    // Create an error that occurs if a package's import exports a prefix of the package's name. This is disallowed,
+    // as it would (rightly) cause a redefinition error in the namer pass.
+    void addPrefixImportError(core::Context ctx, const core::LocOffsets &loc,
+                              const vector<core::NameRef> &importedPackageNameParts,
+                              const vector<core::NameRef> &exportedPrefixNameParts) {
+        if (auto e = ctx.beginError(loc, core::errors::Packager::ImportConflict)) {
+            e.setHeader("Package {} cannot import {}. The latter exports the constant {}, which is a prefix of the "
+                        "importing package",
+                        fmt::map_join(fullPkgName->parts, "::", [&](const auto &nr) { return nr.show(ctx); }),
+                        fmt::map_join(importedPackageNameParts, "::", [&](const auto &nr) { return nr.show(ctx); }),
+                        fmt::map_join(exportedPrefixNameParts, "::", [&](const auto &nr) { return nr.show(ctx); }));
         }
     }
 

--- a/test/cli/package-import-parent-package-conflict/package-import-parent-package-conflict.out
+++ b/test/cli/package-import-parent-package-conflict/package-import-parent-package-conflict.out
@@ -1,0 +1,4 @@
+parent/child/__package.rb:4: Package Parent::Child cannot import Parent. The latter exports the constant Parent, which is a prefix of the importing package https://srb.help/3714
+     4 |  import Parent
+                 ^^^^^^
+Errors: 1

--- a/test/cli/package-import-parent-package-conflict/package-import-parent-package-conflict.sh
+++ b/test/cli/package-import-parent-package-conflict/package-import-parent-package-conflict.sh
@@ -1,0 +1,5 @@
+cd test/cli/package-import-parent-package-conflict || exit 1
+
+../../../main/sorbet --silence-dev-message --stripe-packages --max-threads=0 . 2>&1
+
+

--- a/test/cli/package-import-parent-package-conflict/parent/__package.rb
+++ b/test/cli/package-import-parent-package-conflict/parent/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class Parent < PackageSpec
+  export Parent
+end

--- a/test/cli/package-import-parent-package-conflict/parent/child/__package.rb
+++ b/test/cli/package-import-parent-package-conflict/parent/child/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class Parent::Child < PackageSpec
+  import Parent
+end

--- a/test/cli/package-import-parent-package-conflict/parent/child/child.rb
+++ b/test/cli/package-import-parent-package-conflict/parent/child/child.rb
@@ -1,0 +1,5 @@
+# typed: true
+
+module Parent::Child
+  def self.c; end
+end

--- a/test/cli/package-import-parent-package-conflict/parent/parent.rb
+++ b/test/cli/package-import-parent-package-conflict/parent/parent.rb
@@ -1,0 +1,5 @@
+# typed: true
+
+module Parent
+  def self.p; end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
In `--stripe-packages` mode, there are 3 classes of import conflict errors:
1. package `A::B` imports a prefix package `A`, which happens to export its whole namespace.
2. package `A` imports a suffix package `A::B`, but also defines constants inside the `A::B` namespace.
3. package `C` imports 2 packages `A` and `A::B`, where-in A exports its whole namespace.

Currently, we report a packager error for class 3, but not for 1 & 2, instead, relying on namer errors to inform the user. These namer errors can be difficult to understand. This change catches case 1 and reports a packager error. Case 2 might be a bit more complex to catch here (and is probably rarer), but it's something we can address later.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->
Added a CLI test.

See included automated tests.