### PR TITLE
print send flags in raw tree output

### DIFF
--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -913,7 +913,7 @@ string Send::showRaw(const core::GlobalState &gs, int tabs) {
         stringifiedFlags.emplace_back("privateOk");
     }
     if (this->flags.isRewriterSynthesized) {
-        stringifiedFlags.emplace_back("rewriter");
+        stringifiedFlags.emplace_back("rewriterSynthesized");
     }
 
     printTabs(buf, tabs + 1);

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -908,7 +908,7 @@ string Send::showRaw(const core::GlobalState &gs, int tabs) {
     fmt::memory_buffer buf;
     fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
 
-    auto stringifiedFlags = vector<string>{};
+    vector<string> stringifiedFlags;
     if (this->flags.isPrivateOk) {
         stringifiedFlags.emplace_back("privateOk");
     }

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -907,6 +907,17 @@ string Send::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
 string Send::showRaw(const core::GlobalState &gs, int tabs) {
     fmt::memory_buffer buf;
     fmt::format_to(std::back_inserter(buf), "{}{{\n", nodeName());
+
+    auto stringifiedFlags = vector<string>{};
+    if (this->flags.isPrivateOk) {
+        stringifiedFlags.emplace_back("privateOk");
+    }
+    if (this->flags.isRewriterSynthesized) {
+        stringifiedFlags.emplace_back("rewriter");
+    }
+
+    printTabs(buf, tabs + 1);
+    fmt::format_to(std::back_inserter(buf), "flags = {{{}}}\n", fmt::join(stringifiedFlags, ", "));
     printTabs(buf, tabs + 1);
     fmt::format_to(std::back_inserter(buf), "recv = {}\n", this->recv.showRaw(gs, tabs + 1));
     printTabs(buf, tabs + 1);

--- a/test/testdata/cfg/rescue.rb.desugar-tree-raw.exp
+++ b/test/testdata/cfg/rescue.rb.desugar-tree-raw.exp
@@ -15,6 +15,7 @@ ClassDef{
         } }]
       rhs = Rescue{
         body = Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }
@@ -33,6 +34,7 @@ ClassDef{
               name = <D <U <rescueTemp>> $2>
             }
             body = Send{
+              flags = {privateOk}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -45,6 +47,7 @@ ClassDef{
           }
         ]
         else = Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }
@@ -55,6 +58,7 @@ ClassDef{
           ]
         }
         ensure = Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }
@@ -108,6 +112,7 @@ ClassDef{
     }
 
     Send{
+      flags = {privateOk}
       recv = Local{
         localVariable = <U <self>>
       }
@@ -116,6 +121,7 @@ ClassDef{
       pos_args = 1
       args = [
         Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }

--- a/test/testdata/cfg/retry.rb.desugar-tree-raw.exp
+++ b/test/testdata/cfg/retry.rb.desugar-tree-raw.exp
@@ -26,6 +26,7 @@ ClassDef{
         expr = Rescue{
           body = If{
             cond = Send{
+              flags = {}
               recv = UnresolvedIdent{
                 kind = Local
                 name = <U try>
@@ -45,6 +46,7 @@ ClassDef{
                     name = <U try>
                   }
                   rhs = Send{
+                    flags = {}
                     recv = UnresolvedIdent{
                       kind = Local
                       name = <U try>
@@ -59,6 +61,7 @@ ClassDef{
                 }
               ],
               expr = Send{
+                flags = {privateOk}
                 recv = Local{
                   localVariable = <U <self>>
                 }
@@ -83,6 +86,7 @@ ClassDef{
               body = InsSeq{
                 stats = [
                   Send{
+                    flags = {privateOk}
                     recv = Local{
                       localVariable = <U <self>>
                     }
@@ -106,6 +110,7 @@ ClassDef{
     }
 
     Send{
+      flags = {privateOk}
       recv = Local{
         localVariable = <U <self>>
       }

--- a/test/testdata/desugar/numbered_parameters.rb.desugar-tree-raw.exp
+++ b/test/testdata/desugar/numbered_parameters.rb.desugar-tree-raw.exp
@@ -17,6 +17,7 @@ ClassDef{
     }
 
     Send{
+      flags = {privateOk}
       recv = Local{
         localVariable = <U <self>>
       }
@@ -39,6 +40,7 @@ ClassDef{
     }
 
     Send{
+      flags = {privateOk}
       recv = Local{
         localVariable = <U <self>>
       }
@@ -93,6 +95,7 @@ ClassDef{
     }
 
     Send{
+      flags = {privateOk}
       recv = Local{
         localVariable = <U <self>>
       }
@@ -109,6 +112,7 @@ ClassDef{
           }
         ]
         body = Send{
+          flags = {}
           recv = UnresolvedIdent{
             kind = Local
             name = <U _2>
@@ -130,6 +134,7 @@ ClassDef{
     }
 
     Send{
+      flags = {privateOk}
       recv = Local{
         localVariable = <U <self>>
       }
@@ -152,6 +157,7 @@ ClassDef{
     }
 
     Send{
+      flags = {privateOk}
       recv = Local{
         localVariable = <U <self>>
       }
@@ -206,6 +212,7 @@ ClassDef{
     }
 
     Send{
+      flags = {privateOk}
       recv = Local{
         localVariable = <U <self>>
       }
@@ -222,6 +229,7 @@ ClassDef{
           }
         ]
         body = Send{
+          flags = {}
           recv = UnresolvedIdent{
             kind = Local
             name = <U _2>
@@ -243,6 +251,7 @@ ClassDef{
     }
 
     Send{
+      flags = {}
       recv = UnresolvedConstantLit{
         cnst = <C <U Kernel>>
         scope = EmptyTree
@@ -266,6 +275,7 @@ ClassDef{
     }
 
     Send{
+      flags = {}
       recv = UnresolvedConstantLit{
         cnst = <C <U Kernel>>
         scope = EmptyTree
@@ -321,6 +331,7 @@ ClassDef{
     }
 
     Send{
+      flags = {}
       recv = UnresolvedConstantLit{
         cnst = <C <U Kernel>>
         scope = EmptyTree
@@ -338,6 +349,7 @@ ClassDef{
           }
         ]
         body = Send{
+          flags = {}
           recv = UnresolvedIdent{
             kind = Local
             name = <U _2>
@@ -359,6 +371,7 @@ ClassDef{
     }
 
     Send{
+      flags = {privateOk}
       recv = Local{
         localVariable = <U <self>>
       }

--- a/test/testdata/desugar/opasgn_accessor.rb.desugar-tree-raw.exp
+++ b/test/testdata/desugar/opasgn_accessor.rb.desugar-tree-raw.exp
@@ -18,6 +18,7 @@ ClassDef{
         }]
       rhs = [
         Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }
@@ -36,6 +37,7 @@ ClassDef{
         }
 
         Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }
@@ -44,6 +46,7 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {privateOk}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -52,6 +55,7 @@ ClassDef{
               pos_args = 1
               args = [
                 Send{
+                  flags = {}
                   recv = UnresolvedConstantLit{
                     cnst = <C <U T>>
                     scope = EmptyTree
@@ -75,6 +79,7 @@ ClassDef{
         }
 
         Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }
@@ -94,6 +99,7 @@ ClassDef{
         name = <U a>
       }
       rhs = Send{
+        flags = {}
         recv = UnresolvedConstantLit{
           cnst = <C <U A>>
           scope = EmptyTree
@@ -124,6 +130,7 @@ ClassDef{
             name = <D <U value> $3>
           }
           rhs = Send{
+            flags = {}
             recv = UnresolvedIdent{
               kind = Local
               name = <D <U value> $2>
@@ -142,6 +149,7 @@ ClassDef{
           name = <D <U value> $3>
         }
         thenp = Send{
+          flags = {}
           recv = UnresolvedIdent{
             kind = Local
             name = <D <U value> $2>
@@ -178,6 +186,7 @@ ClassDef{
             name = <D <U value> $5>
           }
           rhs = Send{
+            flags = {}
             recv = UnresolvedIdent{
               kind = Local
               name = <D <U value> $4>
@@ -200,6 +209,7 @@ ClassDef{
           name = <D <U value> $5>
         }
         elsep = Send{
+          flags = {}
           recv = UnresolvedIdent{
             kind = Local
             name = <D <U value> $4>

--- a/test/testdata/desugar/range.rb.desugar-tree-raw.exp
+++ b/test/testdata/desugar/range.rb.desugar-tree-raw.exp
@@ -21,6 +21,7 @@ ClassDef{
               name = <U untyped>
             }
             rhs = Send{
+              flags = {}
               recv = UnresolvedConstantLit{
                 cnst = <C <U T>>
                 scope = EmptyTree
@@ -31,6 +32,7 @@ ClassDef{
               args = [
                 Literal{ value = 42 }
                 Send{
+                  flags = {}
                   recv = UnresolvedConstantLit{
                     cnst = <C <U T>>
                     scope = EmptyTree
@@ -50,6 +52,7 @@ ClassDef{
               name = <U nilable>
             }
             rhs = Send{
+              flags = {}
               recv = UnresolvedConstantLit{
                 cnst = <C <U T>>
                 scope = EmptyTree
@@ -60,6 +63,7 @@ ClassDef{
               args = [
                 Literal{ value = 42 }
                 Send{
+                  flags = {}
                   recv = UnresolvedConstantLit{
                     cnst = <C <U T>>
                     scope = EmptyTree
@@ -83,6 +87,7 @@ ClassDef{
               name = <U lr1>
             }
             rhs = Send{
+              flags = {}
               recv = ConstantLit{
                 symbol = (class ::<Magic>)
                 orig = nullptr
@@ -98,6 +103,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -118,6 +124,7 @@ ClassDef{
               name = <U lr2>
             }
             rhs = Send{
+              flags = {}
               recv = ConstantLit{
                 symbol = (class ::<Magic>)
                 orig = nullptr
@@ -133,6 +140,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -153,6 +161,7 @@ ClassDef{
               name = <U lr3>
             }
             rhs = Send{
+              flags = {}
               recv = ConstantLit{
                 symbol = (class ::<Magic>)
                 orig = nullptr
@@ -168,6 +177,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -188,6 +198,7 @@ ClassDef{
               name = <U lr4>
             }
             rhs = Send{
+              flags = {}
               recv = ConstantLit{
                 symbol = (class ::<Magic>)
                 orig = nullptr
@@ -203,6 +214,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -223,6 +235,7 @@ ClassDef{
               name = <U lr5>
             }
             rhs = Send{
+              flags = {}
               recv = ConstantLit{
                 symbol = (class ::<Magic>)
                 orig = nullptr
@@ -238,6 +251,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -258,6 +272,7 @@ ClassDef{
               name = <U lr6>
             }
             rhs = Send{
+              flags = {}
               recv = ConstantLit{
                 symbol = (class ::<Magic>)
                 orig = nullptr
@@ -273,6 +288,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -293,6 +309,7 @@ ClassDef{
               name = <U lr7>
             }
             rhs = Send{
+              flags = {}
               recv = ConstantLit{
                 symbol = (class ::<Magic>)
                 orig = nullptr
@@ -308,6 +325,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -328,6 +346,7 @@ ClassDef{
               name = <U lr8>
             }
             rhs = Send{
+              flags = {}
               recv = ConstantLit{
                 symbol = (class ::<Magic>)
                 orig = nullptr
@@ -343,6 +362,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -363,6 +383,7 @@ ClassDef{
               name = <U lr9>
             }
             rhs = Send{
+              flags = {}
               recv = ConstantLit{
                 symbol = (class ::<Magic>)
                 orig = nullptr
@@ -378,6 +399,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -398,6 +420,7 @@ ClassDef{
               name = <U lr10>
             }
             rhs = Send{
+              flags = {}
               recv = ConstantLit{
                 symbol = (class ::<Magic>)
                 orig = nullptr
@@ -413,6 +436,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -433,6 +457,7 @@ ClassDef{
               name = <U lr11>
             }
             rhs = Send{
+              flags = {}
               recv = ConstantLit{
                 symbol = (class ::<Magic>)
                 orig = nullptr
@@ -448,6 +473,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -468,6 +494,7 @@ ClassDef{
               name = <U lr12>
             }
             rhs = Send{
+              flags = {}
               recv = ConstantLit{
                 symbol = (class ::<Magic>)
                 orig = nullptr
@@ -483,6 +510,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -503,6 +531,7 @@ ClassDef{
               name = <U lr13>
             }
             rhs = Send{
+              flags = {}
               recv = ConstantLit{
                 symbol = (class ::<Magic>)
                 orig = nullptr
@@ -518,6 +547,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -538,6 +568,7 @@ ClassDef{
               name = <U lr14>
             }
             rhs = Send{
+              flags = {}
               recv = ConstantLit{
                 symbol = (class ::<Magic>)
                 orig = nullptr
@@ -556,6 +587,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -576,6 +608,7 @@ ClassDef{
               name = <U lr15>
             }
             rhs = Send{
+              flags = {}
               recv = ConstantLit{
                 symbol = (class ::<Magic>)
                 orig = nullptr
@@ -594,6 +627,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -614,6 +648,7 @@ ClassDef{
               name = <U lr16>
             }
             rhs = Send{
+              flags = {}
               recv = ConstantLit{
                 symbol = (class ::<Magic>)
                 orig = nullptr
@@ -635,6 +670,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -655,6 +691,7 @@ ClassDef{
               name = <U lr17>
             }
             rhs = Send{
+              flags = {}
               recv = ConstantLit{
                 symbol = (class ::<Magic>)
                 orig = nullptr
@@ -673,6 +710,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -693,6 +731,7 @@ ClassDef{
               name = <U lr18>
             }
             rhs = Send{
+              flags = {}
               recv = ConstantLit{
                 symbol = (class ::<Magic>)
                 orig = nullptr
@@ -711,6 +750,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -731,6 +771,7 @@ ClassDef{
               name = <U lr19>
             }
             rhs = Send{
+              flags = {}
               recv = ConstantLit{
                 symbol = (class ::<Magic>)
                 orig = nullptr
@@ -752,6 +793,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -772,6 +814,7 @@ ClassDef{
               name = <U lr20>
             }
             rhs = Send{
+              flags = {}
               recv = ConstantLit{
                 symbol = (class ::<Magic>)
                 orig = nullptr
@@ -787,6 +830,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -807,6 +851,7 @@ ClassDef{
               name = <U lr21>
             }
             rhs = Send{
+              flags = {}
               recv = ConstantLit{
                 symbol = (class ::<Magic>)
                 orig = nullptr
@@ -822,6 +867,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -842,6 +888,7 @@ ClassDef{
               name = <U lr22>
             }
             rhs = Send{
+              flags = {}
               recv = ConstantLit{
                 symbol = (class ::<Magic>)
                 orig = nullptr
@@ -860,6 +907,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -880,6 +928,7 @@ ClassDef{
               name = <U lr23>
             }
             rhs = Send{
+              flags = {}
               recv = ConstantLit{
                 symbol = (class ::<Magic>)
                 orig = nullptr
@@ -898,6 +947,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -918,7 +968,9 @@ ClassDef{
               name = <U lr_first>
             }
             rhs = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = ConstantLit{
                   symbol = (class ::<Magic>)
                   orig = nullptr
@@ -940,6 +992,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -960,7 +1013,9 @@ ClassDef{
               name = <U lr_last>
             }
             rhs = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = ConstantLit{
                   symbol = (class ::<Magic>)
                   orig = nullptr
@@ -982,6 +1037,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -1002,6 +1058,7 @@ ClassDef{
               name = <U rn1>
             }
             rhs = Send{
+              flags = {}
               recv = UnresolvedConstantLit{
                 cnst = <C <U Range>>
                 scope = EmptyTree
@@ -1014,6 +1071,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -1034,6 +1092,7 @@ ClassDef{
               name = <U rn2>
             }
             rhs = Send{
+              flags = {}
               recv = UnresolvedConstantLit{
                 cnst = <C <U Range>>
                 scope = EmptyTree
@@ -1047,6 +1106,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -1067,6 +1127,7 @@ ClassDef{
               name = <U rn3>
             }
             rhs = Send{
+              flags = {}
               recv = UnresolvedConstantLit{
                 cnst = <C <U Range>>
                 scope = EmptyTree
@@ -1081,6 +1142,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -1101,6 +1163,7 @@ ClassDef{
               name = <U rn4>
             }
             rhs = Send{
+              flags = {}
               recv = UnresolvedConstantLit{
                 cnst = <C <U Range>>
                 scope = EmptyTree
@@ -1116,6 +1179,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -1136,6 +1200,7 @@ ClassDef{
               name = <U rn5>
             }
             rhs = Send{
+              flags = {}
               recv = UnresolvedConstantLit{
                 cnst = <C <U Range>>
                 scope = EmptyTree
@@ -1150,6 +1215,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -1170,6 +1236,7 @@ ClassDef{
               name = <U rn6>
             }
             rhs = Send{
+              flags = {}
               recv = UnresolvedConstantLit{
                 cnst = <C <U Range>>
                 scope = EmptyTree
@@ -1184,6 +1251,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -1204,6 +1272,7 @@ ClassDef{
               name = <U rn7>
             }
             rhs = Send{
+              flags = {}
               recv = UnresolvedConstantLit{
                 cnst = <C <U Range>>
                 scope = EmptyTree
@@ -1218,6 +1287,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -1238,6 +1308,7 @@ ClassDef{
               name = <U rn8>
             }
             rhs = Send{
+              flags = {}
               recv = UnresolvedConstantLit{
                 cnst = <C <U Range>>
                 scope = EmptyTree
@@ -1252,6 +1323,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -1272,6 +1344,7 @@ ClassDef{
               name = <U rn9>
             }
             rhs = Send{
+              flags = {}
               recv = UnresolvedConstantLit{
                 cnst = <C <U Range>>
                 scope = EmptyTree
@@ -1286,6 +1359,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -1306,6 +1380,7 @@ ClassDef{
               name = <U rn10>
             }
             rhs = Send{
+              flags = {}
               recv = UnresolvedConstantLit{
                 cnst = <C <U Range>>
                 scope = EmptyTree
@@ -1323,6 +1398,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -1343,6 +1419,7 @@ ClassDef{
               name = <U rn11>
             }
             rhs = Send{
+              flags = {}
               recv = UnresolvedConstantLit{
                 cnst = <C <U Range>>
                 scope = EmptyTree
@@ -1360,6 +1437,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -1380,6 +1458,7 @@ ClassDef{
               name = <U rn12>
             }
             rhs = Send{
+              flags = {}
               recv = UnresolvedConstantLit{
                 cnst = <C <U Range>>
                 scope = EmptyTree
@@ -1400,6 +1479,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -1420,7 +1500,9 @@ ClassDef{
               name = <U rn_first>
             }
             rhs = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = UnresolvedConstantLit{
                   cnst = <C <U Range>>
                   scope = EmptyTree
@@ -1441,6 +1523,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -1461,7 +1544,9 @@ ClassDef{
               name = <U rn_last>
             }
             rhs = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = UnresolvedConstantLit{
                   cnst = <C <U Range>>
                   scope = EmptyTree
@@ -1482,6 +1567,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -1502,6 +1588,7 @@ ClassDef{
               name = <U tr1>
             }
             rhs = Send{
+              flags = {}
               recv = UnresolvedConstantLit{
                 cnst = <C <U Range>>
                 scope = UnresolvedConstantLit{
@@ -1517,6 +1604,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -1537,7 +1625,9 @@ ClassDef{
               name = <U tr2>
             }
             rhs = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = UnresolvedConstantLit{
                   cnst = <C <U Range>>
                   scope = UnresolvedConstantLit{
@@ -1563,6 +1653,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -1583,7 +1674,9 @@ ClassDef{
               name = <U tr3>
             }
             rhs = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = UnresolvedConstantLit{
                   cnst = <C <U Range>>
                   scope = UnresolvedConstantLit{
@@ -1611,6 +1704,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -1631,7 +1725,9 @@ ClassDef{
               name = <U tr4>
             }
             rhs = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = UnresolvedConstantLit{
                   cnst = <C <U Range>>
                   scope = UnresolvedConstantLit{
@@ -1660,6 +1756,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -1680,7 +1777,9 @@ ClassDef{
               name = <U tr5>
             }
             rhs = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = UnresolvedConstantLit{
                   cnst = <C <U Range>>
                   scope = UnresolvedConstantLit{
@@ -1708,6 +1807,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -1728,7 +1828,9 @@ ClassDef{
               name = <U tr6>
             }
             rhs = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = UnresolvedConstantLit{
                   cnst = <C <U Range>>
                   scope = UnresolvedConstantLit{
@@ -1756,6 +1858,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -1776,7 +1879,9 @@ ClassDef{
               name = <U tr7>
             }
             rhs = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = UnresolvedConstantLit{
                   cnst = <C <U Range>>
                   scope = UnresolvedConstantLit{
@@ -1804,6 +1909,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -1824,7 +1930,9 @@ ClassDef{
               name = <U tr8>
             }
             rhs = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = UnresolvedConstantLit{
                   cnst = <C <U Range>>
                   scope = UnresolvedConstantLit{
@@ -1852,6 +1960,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -1872,7 +1981,9 @@ ClassDef{
               name = <U tr9>
             }
             rhs = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = UnresolvedConstantLit{
                   cnst = <C <U Range>>
                   scope = UnresolvedConstantLit{
@@ -1885,6 +1996,7 @@ ClassDef{
                 pos_args = 1
                 args = [
                   Send{
+                    flags = {}
                     recv = UnresolvedConstantLit{
                       cnst = <C <U T>>
                       scope = EmptyTree
@@ -1907,6 +2019,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -1927,7 +2040,9 @@ ClassDef{
               name = <U tr10>
             }
             rhs = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = UnresolvedConstantLit{
                   cnst = <C <U Range>>
                   scope = UnresolvedConstantLit{
@@ -1958,6 +2073,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -1978,7 +2094,9 @@ ClassDef{
               name = <U tr11>
             }
             rhs = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = UnresolvedConstantLit{
                   cnst = <C <U Range>>
                   scope = UnresolvedConstantLit{
@@ -2009,6 +2127,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -2029,7 +2148,9 @@ ClassDef{
               name = <U tr12>
             }
             rhs = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = UnresolvedConstantLit{
                   cnst = <C <U Range>>
                   scope = UnresolvedConstantLit{
@@ -2063,6 +2184,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -2083,8 +2205,11 @@ ClassDef{
               name = <U tr_first>
             }
             rhs = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = UnresolvedConstantLit{
                     cnst = <C <U Range>>
                     scope = UnresolvedConstantLit{
@@ -2118,6 +2243,7 @@ ClassDef{
             }
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -2138,8 +2264,11 @@ ClassDef{
               name = <U tr_last>
             }
             rhs = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = UnresolvedConstantLit{
                     cnst = <C <U Range>>
                     scope = UnresolvedConstantLit{
@@ -2174,6 +2303,7 @@ ClassDef{
           }
         ],
         expr = Send{
+          flags = {}
           recv = UnresolvedConstantLit{
             cnst = <C <U T>>
             scope = EmptyTree

--- a/test/testdata/infer/yield_multiple.rb.desugar-tree-raw.exp
+++ b/test/testdata/infer/yield_multiple.rb.desugar-tree-raw.exp
@@ -7,6 +7,7 @@ ClassDef{
     }]
   rhs = [
     Send{
+      flags = {privateOk}
       recv = Local{
         localVariable = <U <self>>
       }
@@ -25,6 +26,7 @@ ClassDef{
     }
 
     Send{
+      flags = {privateOk}
       recv = Local{
         localVariable = <U <self>>
       }
@@ -33,7 +35,9 @@ ClassDef{
         args = [
         ]
         body = Send{
+          flags = {}
           recv = Send{
+            flags = {privateOk}
             recv = Local{
               localVariable = <U <self>>
             }
@@ -43,8 +47,11 @@ ClassDef{
             args = [
               Literal{ value = :blk }
               Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = Send{
+                    flags = {}
                     recv = UnresolvedConstantLit{
                       cnst = <C <U T>>
                       scope = EmptyTree
@@ -105,6 +112,7 @@ ClassDef{
       rhs = InsSeq{
         stats = [
           Send{
+            flags = {}
             recv = UnresolvedIdent{
               kind = Local
               name = <U blk>
@@ -119,6 +127,7 @@ ClassDef{
           }
         ],
         expr = Send{
+          flags = {}
           recv = UnresolvedIdent{
             kind = Local
             name = <U blk>

--- a/test/testdata/namer/arguments.rb.desugar-tree-raw.exp
+++ b/test/testdata/namer/arguments.rb.desugar-tree-raw.exp
@@ -91,6 +91,7 @@ ClassDef{
               }
             ],
             expr = Send{
+              flags = {privateOk}
               recv = Local{
                 localVariable = <U <self>>
               }

--- a/test/testdata/namer/arguments.rb.flatten-tree-raw.exp
+++ b/test/testdata/namer/arguments.rb.flatten-tree-raw.exp
@@ -18,7 +18,7 @@ InsSeq{
           rhs = InsSeq{
             stats = [
               Send{
-                flags = {rewriter}
+                flags = {rewriterSynthesized}
                 recv = ConstantLit{
                   symbol = (class ::<Magic>)
                   orig = nullptr

--- a/test/testdata/namer/arguments.rb.flatten-tree-raw.exp
+++ b/test/testdata/namer/arguments.rb.flatten-tree-raw.exp
@@ -18,6 +18,7 @@ InsSeq{
           rhs = InsSeq{
             stats = [
               Send{
+                flags = {rewriter}
                 recv = ConstantLit{
                   symbol = (class ::<Magic>)
                   orig = nullptr
@@ -33,6 +34,7 @@ InsSeq{
                 ]
               }
               Send{
+                flags = {}
                 recv = ConstantLit{
                   symbol = (module ::Sorbet::Private::Static)
                   orig = nullptr
@@ -129,6 +131,7 @@ InsSeq{
               }
             ],
             expr = Send{
+              flags = {privateOk}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -209,6 +212,7 @@ InsSeq{
               localVariable = <U <blk>>
             }]
           rhs = Send{
+            flags = {}
             recv = ConstantLit{
               symbol = (module ::Sorbet::Private::Static)
               orig = nullptr

--- a/test/testdata/packager/simple_package/pass.flatten-tree.exp
+++ b/test/testdata/packager/simple_package/pass.flatten-tree.exp
@@ -3,37 +3,28 @@ begin
   class <emptyTree><<C <root>>> < (::<todo sym>)
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
-        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Bar_Package_Private)
-        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Bar_Package_Private)
+        ::<Magic>.<define-top-class-or-module>(::Project::Bar::CallsFoo)
+        ::Sorbet::Private::Static.keep_for_ide(::Project::Bar::CallsFoo)
         <emptyTree>
       end
     end
   end
-  module ::<PackageRegistry>::Project_Bar_Package_Private<<C Project_Bar_Package_Private$1>> < ()
-    def self.<static-init>(<blk>)
-      begin
-        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::CallsFoo)
-        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::CallsFoo)
-        <emptyTree>
-      end
-    end
-  end
-  module ::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::CallsFoo<<C CallsFoo>> < ()
+  module ::Project::Bar::CallsFoo<<C CallsFoo>> < ()
     def self.build_foo(<blk>)
-      ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo.new(10)
+      ::Project::Foo::Foo.new(10)
     end
 
     def self.build_bar(<blk>)
-      ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::CallsBar.build_bar()
+      ::Project::Foo::CallsBar.build_bar()
     end
 
     def self.<static-init>(<blk>)
       begin
         ::Sorbet::Private::Static::ResolvedSig.sig(<self>, true, :build_foo) do ||
-          <self>.returns(::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo)
+          <self>.returns(::Project::Foo::Foo)
         end
         ::Sorbet::Private::Static::ResolvedSig.sig(<self>, true, :build_bar) do ||
-          <self>.returns(::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar)
+          <self>.returns(::Project::Bar::Bar)
         end
         <self>.extend(::T::Sig)
         ::Sorbet::Private::Static.keep_self_def(<self>, :build_foo, :normal)
@@ -49,30 +40,21 @@ begin
   class <emptyTree><<C <root>>> < (::<todo sym>)
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
-        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Foo_Package_Private)
-        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Foo_Package_Private)
+        ::<Magic>.<define-top-class-or-module>(::Project::Foo::CallsBar)
+        ::Sorbet::Private::Static.keep_for_ide(::Project::Foo::CallsBar)
         <emptyTree>
       end
     end
   end
-  module ::<PackageRegistry>::Project_Foo_Package_Private<<C Project_Foo_Package_Private$1>> < ()
-    def self.<static-init>(<blk>)
-      begin
-        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::CallsBar)
-        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::CallsBar)
-        <emptyTree>
-      end
-    end
-  end
-  module ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::CallsBar<<C CallsBar>> < ()
+  module ::Project::Foo::CallsBar<<C CallsBar>> < ()
     def self.build_bar(<blk>)
-      ::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar.new(10)
+      ::Project::Bar::Bar.new(10)
     end
 
     def self.<static-init>(<blk>)
       begin
         ::Sorbet::Private::Static::ResolvedSig.sig(<self>, true, :build_bar) do ||
-          <self>.returns(::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar)
+          <self>.returns(::Project::Bar::Bar)
         end
         <self>.extend(::T::Sig)
         ::Sorbet::Private::Static.keep_self_def(<self>, :build_bar, :normal)
@@ -87,22 +69,13 @@ begin
   class <emptyTree><<C <root>>> < (::<todo sym>)
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
-        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Bar_Package_Private)
-        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Bar_Package_Private)
+        ::<Magic>.<define-top-class-or-module>(::Project::Bar::Bar)
+        ::Sorbet::Private::Static.keep_for_ide(::Project::Bar::Bar)
         <emptyTree>
       end
     end
   end
-  module ::<PackageRegistry>::Project_Bar_Package_Private<<C Project_Bar_Package_Private$1>> < ()
-    def self.<static-init>(<blk>)
-      begin
-        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar)
-        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar)
-        <emptyTree>
-      end
-    end
-  end
-  class ::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar<<C Bar>> < (::<todo sym>)
+  class ::Project::Bar::Bar<<C Bar>> < (::<todo sym>)
     def initialize(value, <blk>)
       @value = begin
         ::Sorbet::Private::Static.keep_for_typechecking(::Integer)
@@ -128,22 +101,13 @@ begin
   class <emptyTree><<C <root>>> < (::<todo sym>)
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
-        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Foo_Package_Private)
-        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Foo_Package_Private)
+        ::<Magic>.<define-top-class-or-module>(::Project::Foo::Foo)
+        ::Sorbet::Private::Static.keep_for_ide(::Project::Foo::Foo)
         <emptyTree>
       end
     end
   end
-  module ::<PackageRegistry>::Project_Foo_Package_Private<<C Project_Foo_Package_Private$1>> < ()
-    def self.<static-init>(<blk>)
-      begin
-        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo)
-        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo)
-        <emptyTree>
-      end
-    end
-  end
-  class ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo<<C Foo>> < (::<todo sym>)
+  class ::Project::Foo::Foo<<C Foo>> < (::<todo sym>)
     def initialize(value, <blk>)
       @value = begin
         ::Sorbet::Private::Static.keep_for_typechecking(::Integer)
@@ -169,32 +133,9 @@ begin
   class <emptyTree><<C <root>>> < (::<todo sym>)
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
-        begin
-          ::<Magic>.<define-top-class-or-module>(::Project::Bar)
-          ::Sorbet::Private::Static.keep_for_ide(::Project::Bar)
-          ::Sorbet::Private::Static.keep_for_ide(::PackageSpec)
-          <emptyTree>
-        end
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>)
-          <emptyTree>
-        end
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageTests>)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>)
-          <emptyTree>
-        end
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>)
-          <emptyTree>
-        end
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageTests>)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>)
-          <emptyTree>
-        end
+        ::<Magic>.<define-top-class-or-module>(::Project::Bar)
+        ::Sorbet::Private::Static.keep_for_ide(::Project::Bar)
+        ::Sorbet::Private::Static.keep_for_ide(::PackageSpec)
         <emptyTree>
       end
     end
@@ -203,93 +144,10 @@ begin
     def self.<static-init>(<blk>)
       begin
         <self>.import(::Project::Foo)
-        <self>.export(::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar)
-        <self>.export(::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::CallsFoo)
+        <self>.export(::Project::Bar::Bar)
+        <self>.export(::Project::Bar::CallsFoo)
         <emptyTree>
       end
-    end
-  end
-  module ::<PackageRegistry><<C <PackageRegistry>>> < ()
-    def self.<static-init>(<blk>)
-      begin
-        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Bar_Package_Private::Project)
-        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Bar_Package_Private::Project)
-        <emptyTree>
-      end
-    end
-  end
-  module ::<PackageRegistry>::Project_Bar_Package_Private::Project<<C Project>> < ()
-    def self.<static-init>(<blk>)
-      ::<PackageRegistry>::Project_Bar_Package_Private::Project::Foo = ::<PackageRegistry>::Project_Foo_Package::Project::Foo
-    end
-  end
-  module ::<PackageTests><<C <PackageTests>>> < ()
-    def self.<static-init>(<blk>)
-      begin
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageTests>::Project_Bar_Package_Private::Project::Bar)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>::Project_Bar_Package_Private::Project::Bar)
-          <emptyTree>
-        end
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageTests>::Project_Bar_Package_Private::Project::Bar)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>::Project_Bar_Package_Private::Project::Bar)
-          <emptyTree>
-        end
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageTests>::Project_Bar_Package_Private::Project)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>::Project_Bar_Package_Private::Project)
-          <emptyTree>
-        end
-        <emptyTree>
-      end
-    end
-  end
-  module ::<PackageTests>::Project_Bar_Package_Private::Project::Bar<<C Bar>> < ()
-    def self.<static-init>(<blk>)
-      ::<PackageTests>::Project_Bar_Package_Private::Project::Bar::Bar = ::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar
-    end
-  end
-  module ::<PackageTests>::Project_Bar_Package_Private::Project::Bar<<C Bar>> < ()
-    def self.<static-init>(<blk>)
-      ::<PackageTests>::Project_Bar_Package_Private::Project::Bar::CallsFoo = ::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::CallsFoo
-    end
-  end
-  module ::<PackageTests>::Project_Bar_Package_Private::Project<<C Project>> < ()
-    def self.<static-init>(<blk>)
-      ::<PackageTests>::Project_Bar_Package_Private::Project::Foo = ::<PackageRegistry>::Project_Foo_Package::Project::Foo
-    end
-  end
-  module ::<PackageRegistry><<C <PackageRegistry>>> < ()
-    def self.<static-init>(<blk>)
-      begin
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Bar_Package::Project::Bar)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Bar_Package::Project::Bar)
-          <emptyTree>
-        end
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Bar_Package::Project::Bar)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Bar_Package::Project::Bar)
-          <emptyTree>
-        end
-        <emptyTree>
-      end
-    end
-  end
-  module ::<PackageRegistry>::Project_Bar_Package::Project::Bar<<C Bar>> < ()
-    def self.<static-init>(<blk>)
-      ::<PackageRegistry>::Project_Bar_Package::Project::Bar::Bar = ::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar
-    end
-  end
-  module ::<PackageRegistry>::Project_Bar_Package::Project::Bar<<C Bar>> < ()
-    def self.<static-init>(<blk>)
-      ::<PackageRegistry>::Project_Bar_Package::Project::Bar::CallsFoo = ::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::CallsFoo
-    end
-  end
-  module ::<PackageTests><<C <PackageTests>>> < ()
-    def self.<static-init>(<blk>)
-      <emptyTree>
     end
   end
   <emptyTree>
@@ -299,32 +157,9 @@ begin
   class <emptyTree><<C <root>>> < (::<todo sym>)
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
-        begin
-          ::<Magic>.<define-top-class-or-module>(::Project::Foo)
-          ::Sorbet::Private::Static.keep_for_ide(::Project::Foo)
-          ::Sorbet::Private::Static.keep_for_ide(::PackageSpec)
-          <emptyTree>
-        end
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>)
-          <emptyTree>
-        end
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageTests>)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>)
-          <emptyTree>
-        end
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>)
-          <emptyTree>
-        end
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageTests>)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>)
-          <emptyTree>
-        end
+        ::<Magic>.<define-top-class-or-module>(::Project::Foo)
+        ::Sorbet::Private::Static.keep_for_ide(::Project::Foo)
+        ::Sorbet::Private::Static.keep_for_ide(::PackageSpec)
         <emptyTree>
       end
     end
@@ -333,93 +168,10 @@ begin
     def self.<static-init>(<blk>)
       begin
         <self>.import(::Project::Bar)
-        <self>.export(::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo)
-        <self>.export(::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::CallsBar)
+        <self>.export(::Project::Foo::Foo)
+        <self>.export(::Project::Foo::CallsBar)
         <emptyTree>
       end
-    end
-  end
-  module ::<PackageRegistry><<C <PackageRegistry>>> < ()
-    def self.<static-init>(<blk>)
-      begin
-        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Foo_Package_Private::Project)
-        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Foo_Package_Private::Project)
-        <emptyTree>
-      end
-    end
-  end
-  module ::<PackageRegistry>::Project_Foo_Package_Private::Project<<C Project>> < ()
-    def self.<static-init>(<blk>)
-      ::<PackageRegistry>::Project_Foo_Package_Private::Project::Bar = ::<PackageRegistry>::Project_Bar_Package::Project::Bar
-    end
-  end
-  module ::<PackageTests><<C <PackageTests>>> < ()
-    def self.<static-init>(<blk>)
-      begin
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageTests>::Project_Foo_Package_Private::Project)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>::Project_Foo_Package_Private::Project)
-          <emptyTree>
-        end
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageTests>::Project_Foo_Package_Private::Project::Foo)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>::Project_Foo_Package_Private::Project::Foo)
-          <emptyTree>
-        end
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageTests>::Project_Foo_Package_Private::Project::Foo)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>::Project_Foo_Package_Private::Project::Foo)
-          <emptyTree>
-        end
-        <emptyTree>
-      end
-    end
-  end
-  module ::<PackageTests>::Project_Foo_Package_Private::Project<<C Project>> < ()
-    def self.<static-init>(<blk>)
-      ::<PackageTests>::Project_Foo_Package_Private::Project::Bar = ::<PackageRegistry>::Project_Bar_Package::Project::Bar
-    end
-  end
-  module ::<PackageTests>::Project_Foo_Package_Private::Project::Foo<<C Foo>> < ()
-    def self.<static-init>(<blk>)
-      ::<PackageTests>::Project_Foo_Package_Private::Project::Foo::CallsBar = ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::CallsBar
-    end
-  end
-  module ::<PackageTests>::Project_Foo_Package_Private::Project::Foo<<C Foo>> < ()
-    def self.<static-init>(<blk>)
-      ::<PackageTests>::Project_Foo_Package_Private::Project::Foo::Foo = ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo
-    end
-  end
-  module ::<PackageRegistry><<C <PackageRegistry>>> < ()
-    def self.<static-init>(<blk>)
-      begin
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Foo_Package::Project::Foo)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Foo_Package::Project::Foo)
-          <emptyTree>
-        end
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Foo_Package::Project::Foo)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Foo_Package::Project::Foo)
-          <emptyTree>
-        end
-        <emptyTree>
-      end
-    end
-  end
-  module ::<PackageRegistry>::Project_Foo_Package::Project::Foo<<C Foo>> < ()
-    def self.<static-init>(<blk>)
-      ::<PackageRegistry>::Project_Foo_Package::Project::Foo::CallsBar = ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::CallsBar
-    end
-  end
-  module ::<PackageRegistry>::Project_Foo_Package::Project::Foo<<C Foo>> < ()
-    def self.<static-init>(<blk>)
-      ::<PackageRegistry>::Project_Foo_Package::Project::Foo::Foo = ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo
-    end
-  end
-  module ::<PackageTests><<C <PackageTests>>> < ()
-    def self.<static-init>(<blk>)
-      <emptyTree>
     end
   end
   <emptyTree>

--- a/test/testdata/packager/simple_package/pass.flatten-tree.exp
+++ b/test/testdata/packager/simple_package/pass.flatten-tree.exp
@@ -3,28 +3,37 @@ begin
   class <emptyTree><<C <root>>> < (::<todo sym>)
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
-        ::<Magic>.<define-top-class-or-module>(::Project::Bar::CallsFoo)
-        ::Sorbet::Private::Static.keep_for_ide(::Project::Bar::CallsFoo)
+        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Bar_Package_Private)
+        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Bar_Package_Private)
         <emptyTree>
       end
     end
   end
-  module ::Project::Bar::CallsFoo<<C CallsFoo>> < ()
+  module ::<PackageRegistry>::Project_Bar_Package_Private<<C Project_Bar_Package_Private$1>> < ()
+    def self.<static-init>(<blk>)
+      begin
+        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::CallsFoo)
+        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::CallsFoo)
+        <emptyTree>
+      end
+    end
+  end
+  module ::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::CallsFoo<<C CallsFoo>> < ()
     def self.build_foo(<blk>)
-      ::Project::Foo::Foo.new(10)
+      ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo.new(10)
     end
 
     def self.build_bar(<blk>)
-      ::Project::Foo::CallsBar.build_bar()
+      ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::CallsBar.build_bar()
     end
 
     def self.<static-init>(<blk>)
       begin
         ::Sorbet::Private::Static::ResolvedSig.sig(<self>, true, :build_foo) do ||
-          <self>.returns(::Project::Foo::Foo)
+          <self>.returns(::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo)
         end
         ::Sorbet::Private::Static::ResolvedSig.sig(<self>, true, :build_bar) do ||
-          <self>.returns(::Project::Bar::Bar)
+          <self>.returns(::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar)
         end
         <self>.extend(::T::Sig)
         ::Sorbet::Private::Static.keep_self_def(<self>, :build_foo, :normal)
@@ -40,21 +49,30 @@ begin
   class <emptyTree><<C <root>>> < (::<todo sym>)
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
-        ::<Magic>.<define-top-class-or-module>(::Project::Foo::CallsBar)
-        ::Sorbet::Private::Static.keep_for_ide(::Project::Foo::CallsBar)
+        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Foo_Package_Private)
+        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Foo_Package_Private)
         <emptyTree>
       end
     end
   end
-  module ::Project::Foo::CallsBar<<C CallsBar>> < ()
+  module ::<PackageRegistry>::Project_Foo_Package_Private<<C Project_Foo_Package_Private$1>> < ()
+    def self.<static-init>(<blk>)
+      begin
+        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::CallsBar)
+        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::CallsBar)
+        <emptyTree>
+      end
+    end
+  end
+  module ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::CallsBar<<C CallsBar>> < ()
     def self.build_bar(<blk>)
-      ::Project::Bar::Bar.new(10)
+      ::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar.new(10)
     end
 
     def self.<static-init>(<blk>)
       begin
         ::Sorbet::Private::Static::ResolvedSig.sig(<self>, true, :build_bar) do ||
-          <self>.returns(::Project::Bar::Bar)
+          <self>.returns(::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar)
         end
         <self>.extend(::T::Sig)
         ::Sorbet::Private::Static.keep_self_def(<self>, :build_bar, :normal)
@@ -69,13 +87,22 @@ begin
   class <emptyTree><<C <root>>> < (::<todo sym>)
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
-        ::<Magic>.<define-top-class-or-module>(::Project::Bar::Bar)
-        ::Sorbet::Private::Static.keep_for_ide(::Project::Bar::Bar)
+        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Bar_Package_Private)
+        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Bar_Package_Private)
         <emptyTree>
       end
     end
   end
-  class ::Project::Bar::Bar<<C Bar>> < (::<todo sym>)
+  module ::<PackageRegistry>::Project_Bar_Package_Private<<C Project_Bar_Package_Private$1>> < ()
+    def self.<static-init>(<blk>)
+      begin
+        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar)
+        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar)
+        <emptyTree>
+      end
+    end
+  end
+  class ::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar<<C Bar>> < (::<todo sym>)
     def initialize(value, <blk>)
       @value = begin
         ::Sorbet::Private::Static.keep_for_typechecking(::Integer)
@@ -101,13 +128,22 @@ begin
   class <emptyTree><<C <root>>> < (::<todo sym>)
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
-        ::<Magic>.<define-top-class-or-module>(::Project::Foo::Foo)
-        ::Sorbet::Private::Static.keep_for_ide(::Project::Foo::Foo)
+        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Foo_Package_Private)
+        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Foo_Package_Private)
         <emptyTree>
       end
     end
   end
-  class ::Project::Foo::Foo<<C Foo>> < (::<todo sym>)
+  module ::<PackageRegistry>::Project_Foo_Package_Private<<C Project_Foo_Package_Private$1>> < ()
+    def self.<static-init>(<blk>)
+      begin
+        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo)
+        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo)
+        <emptyTree>
+      end
+    end
+  end
+  class ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo<<C Foo>> < (::<todo sym>)
     def initialize(value, <blk>)
       @value = begin
         ::Sorbet::Private::Static.keep_for_typechecking(::Integer)
@@ -133,9 +169,32 @@ begin
   class <emptyTree><<C <root>>> < (::<todo sym>)
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
-        ::<Magic>.<define-top-class-or-module>(::Project::Bar)
-        ::Sorbet::Private::Static.keep_for_ide(::Project::Bar)
-        ::Sorbet::Private::Static.keep_for_ide(::PackageSpec)
+        begin
+          ::<Magic>.<define-top-class-or-module>(::Project::Bar)
+          ::Sorbet::Private::Static.keep_for_ide(::Project::Bar)
+          ::Sorbet::Private::Static.keep_for_ide(::PackageSpec)
+          <emptyTree>
+        end
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>)
+          <emptyTree>
+        end
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageTests>)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>)
+          <emptyTree>
+        end
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>)
+          <emptyTree>
+        end
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageTests>)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>)
+          <emptyTree>
+        end
         <emptyTree>
       end
     end
@@ -144,10 +203,93 @@ begin
     def self.<static-init>(<blk>)
       begin
         <self>.import(::Project::Foo)
-        <self>.export(::Project::Bar::Bar)
-        <self>.export(::Project::Bar::CallsFoo)
+        <self>.export(::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar)
+        <self>.export(::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::CallsFoo)
         <emptyTree>
       end
+    end
+  end
+  module ::<PackageRegistry><<C <PackageRegistry>>> < ()
+    def self.<static-init>(<blk>)
+      begin
+        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Bar_Package_Private::Project)
+        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Bar_Package_Private::Project)
+        <emptyTree>
+      end
+    end
+  end
+  module ::<PackageRegistry>::Project_Bar_Package_Private::Project<<C Project>> < ()
+    def self.<static-init>(<blk>)
+      ::<PackageRegistry>::Project_Bar_Package_Private::Project::Foo = ::<PackageRegistry>::Project_Foo_Package::Project::Foo
+    end
+  end
+  module ::<PackageTests><<C <PackageTests>>> < ()
+    def self.<static-init>(<blk>)
+      begin
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageTests>::Project_Bar_Package_Private::Project::Bar)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>::Project_Bar_Package_Private::Project::Bar)
+          <emptyTree>
+        end
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageTests>::Project_Bar_Package_Private::Project::Bar)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>::Project_Bar_Package_Private::Project::Bar)
+          <emptyTree>
+        end
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageTests>::Project_Bar_Package_Private::Project)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>::Project_Bar_Package_Private::Project)
+          <emptyTree>
+        end
+        <emptyTree>
+      end
+    end
+  end
+  module ::<PackageTests>::Project_Bar_Package_Private::Project::Bar<<C Bar>> < ()
+    def self.<static-init>(<blk>)
+      ::<PackageTests>::Project_Bar_Package_Private::Project::Bar::Bar = ::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar
+    end
+  end
+  module ::<PackageTests>::Project_Bar_Package_Private::Project::Bar<<C Bar>> < ()
+    def self.<static-init>(<blk>)
+      ::<PackageTests>::Project_Bar_Package_Private::Project::Bar::CallsFoo = ::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::CallsFoo
+    end
+  end
+  module ::<PackageTests>::Project_Bar_Package_Private::Project<<C Project>> < ()
+    def self.<static-init>(<blk>)
+      ::<PackageTests>::Project_Bar_Package_Private::Project::Foo = ::<PackageRegistry>::Project_Foo_Package::Project::Foo
+    end
+  end
+  module ::<PackageRegistry><<C <PackageRegistry>>> < ()
+    def self.<static-init>(<blk>)
+      begin
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Bar_Package::Project::Bar)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Bar_Package::Project::Bar)
+          <emptyTree>
+        end
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Bar_Package::Project::Bar)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Bar_Package::Project::Bar)
+          <emptyTree>
+        end
+        <emptyTree>
+      end
+    end
+  end
+  module ::<PackageRegistry>::Project_Bar_Package::Project::Bar<<C Bar>> < ()
+    def self.<static-init>(<blk>)
+      ::<PackageRegistry>::Project_Bar_Package::Project::Bar::Bar = ::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar
+    end
+  end
+  module ::<PackageRegistry>::Project_Bar_Package::Project::Bar<<C Bar>> < ()
+    def self.<static-init>(<blk>)
+      ::<PackageRegistry>::Project_Bar_Package::Project::Bar::CallsFoo = ::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::CallsFoo
+    end
+  end
+  module ::<PackageTests><<C <PackageTests>>> < ()
+    def self.<static-init>(<blk>)
+      <emptyTree>
     end
   end
   <emptyTree>
@@ -157,9 +299,32 @@ begin
   class <emptyTree><<C <root>>> < (::<todo sym>)
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
-        ::<Magic>.<define-top-class-or-module>(::Project::Foo)
-        ::Sorbet::Private::Static.keep_for_ide(::Project::Foo)
-        ::Sorbet::Private::Static.keep_for_ide(::PackageSpec)
+        begin
+          ::<Magic>.<define-top-class-or-module>(::Project::Foo)
+          ::Sorbet::Private::Static.keep_for_ide(::Project::Foo)
+          ::Sorbet::Private::Static.keep_for_ide(::PackageSpec)
+          <emptyTree>
+        end
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>)
+          <emptyTree>
+        end
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageTests>)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>)
+          <emptyTree>
+        end
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>)
+          <emptyTree>
+        end
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageTests>)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>)
+          <emptyTree>
+        end
         <emptyTree>
       end
     end
@@ -168,10 +333,93 @@ begin
     def self.<static-init>(<blk>)
       begin
         <self>.import(::Project::Bar)
-        <self>.export(::Project::Foo::Foo)
-        <self>.export(::Project::Foo::CallsBar)
+        <self>.export(::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo)
+        <self>.export(::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::CallsBar)
         <emptyTree>
       end
+    end
+  end
+  module ::<PackageRegistry><<C <PackageRegistry>>> < ()
+    def self.<static-init>(<blk>)
+      begin
+        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Foo_Package_Private::Project)
+        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Foo_Package_Private::Project)
+        <emptyTree>
+      end
+    end
+  end
+  module ::<PackageRegistry>::Project_Foo_Package_Private::Project<<C Project>> < ()
+    def self.<static-init>(<blk>)
+      ::<PackageRegistry>::Project_Foo_Package_Private::Project::Bar = ::<PackageRegistry>::Project_Bar_Package::Project::Bar
+    end
+  end
+  module ::<PackageTests><<C <PackageTests>>> < ()
+    def self.<static-init>(<blk>)
+      begin
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageTests>::Project_Foo_Package_Private::Project)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>::Project_Foo_Package_Private::Project)
+          <emptyTree>
+        end
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageTests>::Project_Foo_Package_Private::Project::Foo)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>::Project_Foo_Package_Private::Project::Foo)
+          <emptyTree>
+        end
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageTests>::Project_Foo_Package_Private::Project::Foo)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>::Project_Foo_Package_Private::Project::Foo)
+          <emptyTree>
+        end
+        <emptyTree>
+      end
+    end
+  end
+  module ::<PackageTests>::Project_Foo_Package_Private::Project<<C Project>> < ()
+    def self.<static-init>(<blk>)
+      ::<PackageTests>::Project_Foo_Package_Private::Project::Bar = ::<PackageRegistry>::Project_Bar_Package::Project::Bar
+    end
+  end
+  module ::<PackageTests>::Project_Foo_Package_Private::Project::Foo<<C Foo>> < ()
+    def self.<static-init>(<blk>)
+      ::<PackageTests>::Project_Foo_Package_Private::Project::Foo::CallsBar = ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::CallsBar
+    end
+  end
+  module ::<PackageTests>::Project_Foo_Package_Private::Project::Foo<<C Foo>> < ()
+    def self.<static-init>(<blk>)
+      ::<PackageTests>::Project_Foo_Package_Private::Project::Foo::Foo = ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo
+    end
+  end
+  module ::<PackageRegistry><<C <PackageRegistry>>> < ()
+    def self.<static-init>(<blk>)
+      begin
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Foo_Package::Project::Foo)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Foo_Package::Project::Foo)
+          <emptyTree>
+        end
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Foo_Package::Project::Foo)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Foo_Package::Project::Foo)
+          <emptyTree>
+        end
+        <emptyTree>
+      end
+    end
+  end
+  module ::<PackageRegistry>::Project_Foo_Package::Project::Foo<<C Foo>> < ()
+    def self.<static-init>(<blk>)
+      ::<PackageRegistry>::Project_Foo_Package::Project::Foo::CallsBar = ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::CallsBar
+    end
+  end
+  module ::<PackageRegistry>::Project_Foo_Package::Project::Foo<<C Foo>> < ()
+    def self.<static-init>(<blk>)
+      ::<PackageRegistry>::Project_Foo_Package::Project::Foo::Foo = ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo
+    end
+  end
+  module ::<PackageTests><<C <PackageTests>>> < ()
+    def self.<static-init>(<blk>)
+      <emptyTree>
     end
   end
   <emptyTree>

--- a/test/testdata/resolver/field.rb.flatten-tree-raw.exp
+++ b/test/testdata/resolver/field.rb.flatten-tree-raw.exp
@@ -35,6 +35,7 @@ InsSeq{
               localVariable = <U <blk>>
             }]
           rhs = Send{
+            flags = {}
             recv = ConstantLit{
               symbol = (module ::Sorbet::Private::Static)
               orig = nullptr

--- a/test/testdata/resolver/resolve_tree_printing.rb.flatten-tree-raw.exp
+++ b/test/testdata/resolver/resolve_tree_printing.rb.flatten-tree-raw.exp
@@ -18,6 +18,7 @@ InsSeq{
           rhs = InsSeq{
             stats = [
               Send{
+                flags = {rewriter}
                 recv = ConstantLit{
                   symbol = (class ::<Magic>)
                   orig = nullptr
@@ -33,6 +34,7 @@ InsSeq{
                 ]
               }
               Send{
+                flags = {}
                 recv = ConstantLit{
                   symbol = (module ::Sorbet::Private::Static)
                   orig = nullptr
@@ -79,6 +81,7 @@ InsSeq{
           rhs = While{
             cond = Literal{ value = 1 }
             body = Send{
+              flags = {privateOk}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -138,6 +141,7 @@ InsSeq{
               localVariable = <U <blk>>
             }]
           rhs = Send{
+            flags = {privateOk}
             recv = Local{
               localVariable = <U <self>>
             }
@@ -160,6 +164,7 @@ InsSeq{
               localVariable = <U <blk>>
             }]
           rhs = Send{
+            flags = {privateOk}
             recv = Local{
               localVariable = <U <self>>
             }
@@ -193,6 +198,7 @@ InsSeq{
           rhs = InsSeq{
             stats = [
               Send{
+                flags = {}
                 recv = ConstantLit{
                   symbol = (module ::Sorbet::Private::Static)
                   orig = nullptr
@@ -202,6 +208,7 @@ InsSeq{
                 pos_args = 1
                 args = [
                   Send{
+                    flags = {}
                     recv = ConstantLit{
                       symbol = (module ::T)
                       orig = UnresolvedConstantLit{
@@ -243,6 +250,7 @@ InsSeq{
           rhs = InsSeq{
             stats = [
               Send{
+                flags = {}
                 recv = ConstantLit{
                   symbol = (module ::Sorbet::Private::Static)
                   orig = nullptr
@@ -259,6 +267,7 @@ InsSeq{
                 ]
               }
               Send{
+                flags = {}
                 recv = ConstantLit{
                   symbol = (module ::Sorbet::Private::Static)
                   orig = nullptr
@@ -275,6 +284,7 @@ InsSeq{
                 ]
               }
               Send{
+                flags = {}
                 recv = ConstantLit{
                   symbol = (module ::Sorbet::Private::Static)
                   orig = nullptr
@@ -291,6 +301,7 @@ InsSeq{
                 ]
               }
               Send{
+                flags = {}
                 recv = ConstantLit{
                   symbol = (module ::Sorbet::Private::Static)
                   orig = nullptr
@@ -307,6 +318,7 @@ InsSeq{
                 ]
               }
               Send{
+                flags = {}
                 recv = ConstantLit{
                   symbol = (module ::Sorbet::Private::Static)
                   orig = nullptr
@@ -323,6 +335,7 @@ InsSeq{
                 ]
               }
               Send{
+                flags = {}
                 recv = ConstantLit{
                   symbol = (module ::Sorbet::Private::Static)
                   orig = nullptr
@@ -339,6 +352,7 @@ InsSeq{
                 ]
               }
               Send{
+                flags = {}
                 recv = ConstantLit{
                   symbol = (module ::Sorbet::Private::Static)
                   orig = nullptr
@@ -355,6 +369,7 @@ InsSeq{
                 ]
               }
               Send{
+                flags = {}
                 recv = ConstantLit{
                   symbol = (module ::Sorbet::Private::Static)
                   orig = nullptr

--- a/test/testdata/resolver/resolve_tree_printing.rb.flatten-tree-raw.exp
+++ b/test/testdata/resolver/resolve_tree_printing.rb.flatten-tree-raw.exp
@@ -18,7 +18,7 @@ InsSeq{
           rhs = InsSeq{
             stats = [
               Send{
-                flags = {rewriter}
+                flags = {rewriterSynthesized}
                 recv = ConstantLit{
                   symbol = (class ::<Magic>)
                   orig = nullptr

--- a/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
@@ -1360,7 +1360,7 @@ ClassDef{
         }]
       rhs = [
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -1461,7 +1461,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -1893,7 +1893,7 @@ ClassDef{
         }]
       rhs = [
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -1994,7 +1994,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -2098,7 +2098,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -2211,7 +2211,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -2339,7 +2339,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -2440,7 +2440,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -2544,7 +2544,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -2660,7 +2660,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -2794,7 +2794,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -2914,7 +2914,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -3056,7 +3056,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -3157,7 +3157,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -3258,7 +3258,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -3359,7 +3359,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -3417,7 +3417,7 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
-            flags = {rewriter}
+            flags = {rewriterSynthesized}
             recv = Send{
               flags = {}
               recv = ConstantLit{
@@ -3444,7 +3444,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -3545,7 +3545,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -3649,7 +3649,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -3727,7 +3727,7 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
-            flags = {rewriter}
+            flags = {rewriterSynthesized}
             recv = Send{
               flags = {}
               recv = ConstantLit{
@@ -3754,7 +3754,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -3820,7 +3820,7 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
-            flags = {rewriter}
+            flags = {rewriterSynthesized}
             recv = Send{
               flags = {}
               recv = ConstantLit{
@@ -3847,7 +3847,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -3948,7 +3948,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -4052,7 +4052,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -4130,7 +4130,7 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
-            flags = {rewriter}
+            flags = {rewriterSynthesized}
             recv = Send{
               flags = {}
               recv = ConstantLit{
@@ -4157,7 +4157,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -4223,7 +4223,7 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
-            flags = {rewriter}
+            flags = {rewriterSynthesized}
             recv = Send{
               flags = {}
               recv = ConstantLit{
@@ -4250,7 +4250,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -4351,7 +4351,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -4455,7 +4455,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -4533,7 +4533,7 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
-            flags = {rewriter}
+            flags = {rewriterSynthesized}
             recv = Send{
               flags = {}
               recv = ConstantLit{
@@ -4560,7 +4560,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -4626,7 +4626,7 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
-            flags = {rewriter}
+            flags = {rewriterSynthesized}
             recv = Send{
               flags = {}
               recv = ConstantLit{
@@ -4653,7 +4653,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -4754,7 +4754,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -4858,7 +4858,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -4932,7 +4932,7 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
-            flags = {rewriter}
+            flags = {rewriterSynthesized}
             recv = Send{
               flags = {}
               recv = ConstantLit{
@@ -4959,7 +4959,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -5033,7 +5033,7 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
-            flags = {rewriter}
+            flags = {rewriterSynthesized}
             recv = Send{
               flags = {}
               recv = ConstantLit{
@@ -5060,7 +5060,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -5102,7 +5102,7 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
-            flags = {rewriter}
+            flags = {rewriterSynthesized}
             recv = Send{
               flags = {}
               recv = ConstantLit{
@@ -5129,7 +5129,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -5233,7 +5233,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -5287,7 +5287,7 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
-            flags = {rewriter}
+            flags = {rewriterSynthesized}
             recv = Send{
               flags = {}
               recv = ConstantLit{
@@ -5314,7 +5314,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -5442,7 +5442,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -5543,7 +5543,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -5647,7 +5647,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -5748,7 +5748,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -5806,7 +5806,7 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
-            flags = {rewriter}
+            flags = {rewriterSynthesized}
             recv = Send{
               flags = {}
               recv = ConstantLit{
@@ -6901,7 +6901,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -7002,7 +7002,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -7106,7 +7106,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -7207,7 +7207,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -7517,7 +7517,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -7618,7 +7618,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -7722,7 +7722,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -8049,7 +8049,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -8103,7 +8103,7 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
-            flags = {rewriter}
+            flags = {rewriterSynthesized}
             recv = Send{
               flags = {}
               recv = ConstantLit{
@@ -8130,7 +8130,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -8199,7 +8199,7 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
-            flags = {rewriter}
+            flags = {rewriterSynthesized}
             recv = Send{
               flags = {}
               recv = ConstantLit{
@@ -8226,7 +8226,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -8308,7 +8308,7 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
-            flags = {rewriter}
+            flags = {rewriterSynthesized}
             recv = Send{
               flags = {}
               recv = ConstantLit{
@@ -8335,7 +8335,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -8447,7 +8447,7 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
-            flags = {rewriter}
+            flags = {rewriterSynthesized}
             recv = Send{
               flags = {}
               recv = ConstantLit{
@@ -8474,7 +8474,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -8528,7 +8528,7 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
-            flags = {rewriter}
+            flags = {rewriterSynthesized}
             recv = Send{
               flags = {}
               recv = ConstantLit{
@@ -8555,7 +8555,7 @@ ClassDef{
         }
 
         Send{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -8624,7 +8624,7 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
-            flags = {rewriter}
+            flags = {rewriterSynthesized}
             recv = Send{
               flags = {}
               recv = ConstantLit{

--- a/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
@@ -16,6 +16,7 @@ ClassDef{
       rhs = InsSeq{
         stats = [
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -25,7 +26,9 @@ ClassDef{
             pos_args = 1
             args = [
               Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = UnresolvedConstantLit{
                     cnst = <C <U SomeODM>>
                     scope = EmptyTree
@@ -45,6 +48,7 @@ ClassDef{
             ]
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -54,7 +58,9 @@ ClassDef{
             pos_args = 1
             args = [
               Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = UnresolvedConstantLit{
                     cnst = <C <U SomeODM>>
                     scope = EmptyTree
@@ -75,6 +81,7 @@ ClassDef{
             ]
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -84,7 +91,9 @@ ClassDef{
             pos_args = 1
             args = [
               Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = UnresolvedConstantLit{
                     cnst = <C <U SomeODM>>
                     scope = EmptyTree
@@ -104,6 +113,7 @@ ClassDef{
             ]
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -113,7 +123,9 @@ ClassDef{
             pos_args = 1
             args = [
               Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = UnresolvedConstantLit{
                     cnst = <C <U SomeODM>>
                     scope = EmptyTree
@@ -134,6 +146,7 @@ ClassDef{
             ]
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -143,7 +156,9 @@ ClassDef{
             pos_args = 1
             args = [
               Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = UnresolvedConstantLit{
                     cnst = <C <U AdvancedODM>>
                     scope = EmptyTree
@@ -163,6 +178,7 @@ ClassDef{
             ]
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -172,7 +188,9 @@ ClassDef{
             pos_args = 1
             args = [
               Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = UnresolvedConstantLit{
                     cnst = <C <U AdvancedODM>>
                     scope = EmptyTree
@@ -192,6 +210,7 @@ ClassDef{
             ]
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -201,7 +220,9 @@ ClassDef{
             pos_args = 1
             args = [
               Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = UnresolvedConstantLit{
                     cnst = <C <U AdvancedODM>>
                     scope = EmptyTree
@@ -221,6 +242,7 @@ ClassDef{
             ]
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -230,7 +252,9 @@ ClassDef{
             pos_args = 1
             args = [
               Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = UnresolvedConstantLit{
                     cnst = <C <U AdvancedODM>>
                     scope = EmptyTree
@@ -250,6 +274,7 @@ ClassDef{
             ]
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -259,7 +284,9 @@ ClassDef{
             pos_args = 1
             args = [
               Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = UnresolvedConstantLit{
                     cnst = <C <U AdvancedODM>>
                     scope = EmptyTree
@@ -279,7 +306,9 @@ ClassDef{
             ]
           }
           Send{
+            flags = {}
             recv = Send{
+              flags = {}
               recv = UnresolvedConstantLit{
                 cnst = <C <U AdvancedODM>>
                 scope = EmptyTree
@@ -298,6 +327,7 @@ ClassDef{
             ]
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -307,7 +337,9 @@ ClassDef{
             pos_args = 1
             args = [
               Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = UnresolvedConstantLit{
                     cnst = <C <U AdvancedODM>>
                     scope = EmptyTree
@@ -327,7 +359,9 @@ ClassDef{
             ]
           }
           Send{
+            flags = {}
             recv = Send{
+              flags = {}
               recv = UnresolvedConstantLit{
                 cnst = <C <U AdvancedODM>>
                 scope = EmptyTree
@@ -346,6 +380,7 @@ ClassDef{
             ]
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -355,7 +390,9 @@ ClassDef{
             pos_args = 1
             args = [
               Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = UnresolvedConstantLit{
                     cnst = <C <U AdvancedODM>>
                     scope = EmptyTree
@@ -375,7 +412,9 @@ ClassDef{
             ]
           }
           Send{
+            flags = {}
             recv = Send{
+              flags = {}
               recv = UnresolvedConstantLit{
                 cnst = <C <U AdvancedODM>>
                 scope = EmptyTree
@@ -394,6 +433,7 @@ ClassDef{
             ]
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -403,7 +443,9 @@ ClassDef{
             pos_args = 1
             args = [
               Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = UnresolvedConstantLit{
                     cnst = <C <U AdvancedODM>>
                     scope = EmptyTree
@@ -423,6 +465,7 @@ ClassDef{
             ]
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -432,7 +475,9 @@ ClassDef{
             pos_args = 1
             args = [
               Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = UnresolvedConstantLit{
                     cnst = <C <U AdvancedODM>>
                     scope = EmptyTree
@@ -452,6 +497,7 @@ ClassDef{
             ]
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -461,7 +507,9 @@ ClassDef{
             pos_args = 1
             args = [
               Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = UnresolvedConstantLit{
                     cnst = <C <U AdvancedODM>>
                     scope = EmptyTree
@@ -481,7 +529,9 @@ ClassDef{
             ]
           }
           Send{
+            flags = {}
             recv = Send{
+              flags = {}
               recv = UnresolvedConstantLit{
                 cnst = <C <U AdvancedODM>>
                 scope = EmptyTree
@@ -499,6 +549,7 @@ ClassDef{
             ]
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -508,7 +559,9 @@ ClassDef{
             pos_args = 1
             args = [
               Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = UnresolvedConstantLit{
                     cnst = <C <U PropHelpers>>
                     scope = EmptyTree
@@ -528,7 +581,9 @@ ClassDef{
             ]
           }
           Send{
+            flags = {}
             recv = Send{
+              flags = {}
               recv = UnresolvedConstantLit{
                 cnst = <C <U PropHelpers>>
                 scope = EmptyTree
@@ -547,7 +602,9 @@ ClassDef{
             ]
           }
           Send{
+            flags = {}
             recv = Send{
+              flags = {}
               recv = UnresolvedConstantLit{
                 cnst = <C <U PropHelpers>>
                 scope = EmptyTree
@@ -566,6 +623,7 @@ ClassDef{
             ]
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -575,7 +633,9 @@ ClassDef{
             pos_args = 1
             args = [
               Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = UnresolvedConstantLit{
                     cnst = <C <U PropHelpers>>
                     scope = EmptyTree
@@ -595,7 +655,9 @@ ClassDef{
             ]
           }
           Send{
+            flags = {}
             recv = Send{
+              flags = {}
               recv = UnresolvedConstantLit{
                 cnst = <C <U PropHelpers>>
                 scope = EmptyTree
@@ -614,7 +676,9 @@ ClassDef{
             ]
           }
           Send{
+            flags = {}
             recv = Send{
+              flags = {}
               recv = UnresolvedConstantLit{
                 cnst = <C <U PropHelpers>>
                 scope = EmptyTree
@@ -633,6 +697,7 @@ ClassDef{
             ]
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -642,7 +707,9 @@ ClassDef{
             pos_args = 1
             args = [
               Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = UnresolvedConstantLit{
                     cnst = <C <U PropHelpers2>>
                     scope = EmptyTree
@@ -662,7 +729,9 @@ ClassDef{
             ]
           }
           Send{
+            flags = {}
             recv = Send{
+              flags = {}
               recv = UnresolvedConstantLit{
                 cnst = <C <U PropHelpers2>>
                 scope = EmptyTree
@@ -681,7 +750,9 @@ ClassDef{
             ]
           }
           Send{
+            flags = {}
             recv = Send{
+              flags = {}
               recv = UnresolvedConstantLit{
                 cnst = <C <U PropHelpers2>>
                 scope = EmptyTree
@@ -700,6 +771,7 @@ ClassDef{
             ]
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -709,7 +781,9 @@ ClassDef{
             pos_args = 1
             args = [
               Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = UnresolvedConstantLit{
                     cnst = <C <U PropHelpers2>>
                     scope = EmptyTree
@@ -729,7 +803,9 @@ ClassDef{
             ]
           }
           Send{
+            flags = {}
             recv = Send{
+              flags = {}
               recv = UnresolvedConstantLit{
                 cnst = <C <U PropHelpers2>>
                 scope = EmptyTree
@@ -748,6 +824,7 @@ ClassDef{
             ]
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -757,7 +834,9 @@ ClassDef{
             pos_args = 1
             args = [
               Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = UnresolvedConstantLit{
                     cnst = <C <U EncryptedProp>>
                     scope = EmptyTree
@@ -777,6 +856,7 @@ ClassDef{
             ]
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -786,7 +866,9 @@ ClassDef{
             pos_args = 1
             args = [
               Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = UnresolvedConstantLit{
                     cnst = <C <U EncryptedProp>>
                     scope = EmptyTree
@@ -806,7 +888,9 @@ ClassDef{
             ]
           }
           Send{
+            flags = {}
             recv = Send{
+              flags = {}
               recv = UnresolvedConstantLit{
                 cnst = <C <U EncryptedProp>>
                 scope = EmptyTree
@@ -825,7 +909,9 @@ ClassDef{
             ]
           }
           Send{
+            flags = {}
             recv = Send{
+              flags = {}
               recv = UnresolvedConstantLit{
                 cnst = <C <U EncryptedProp>>
                 scope = EmptyTree
@@ -844,7 +930,9 @@ ClassDef{
             ]
           }
           Send{
+            flags = {}
             recv = Send{
+              flags = {}
               recv = UnresolvedConstantLit{
                 cnst = <C <U EncryptedProp>>
                 scope = EmptyTree
@@ -863,6 +951,7 @@ ClassDef{
             ]
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -872,7 +961,9 @@ ClassDef{
             pos_args = 1
             args = [
               Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = UnresolvedConstantLit{
                     cnst = <C <U AdvancedODM>>
                     scope = EmptyTree
@@ -892,6 +983,7 @@ ClassDef{
             ]
           }
           Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -901,7 +993,9 @@ ClassDef{
             pos_args = 1
             args = [
               Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = UnresolvedConstantLit{
                     cnst = <C <U AdvancedODM>>
                     scope = EmptyTree
@@ -921,7 +1015,9 @@ ClassDef{
             ]
           }
           Send{
+            flags = {}
             recv = Send{
+              flags = {}
               recv = UnresolvedConstantLit{
                 cnst = <C <U AdvancedODM>>
                 scope = EmptyTree
@@ -941,7 +1037,9 @@ ClassDef{
           }
         ],
         expr = Send{
+          flags = {}
           recv = Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U AdvancedODM>>
               scope = EmptyTree
@@ -987,6 +1085,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -1004,6 +1103,7 @@ ClassDef{
         }
 
         Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }
@@ -1015,6 +1115,7 @@ ClassDef{
         }
 
         Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }
@@ -1028,6 +1129,7 @@ ClassDef{
         }
 
         Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }
@@ -1044,6 +1146,7 @@ ClassDef{
         }
 
         Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }
@@ -1061,6 +1164,7 @@ ClassDef{
         }
 
         Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }
@@ -1082,6 +1186,7 @@ ClassDef{
         }
 
         Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }
@@ -1099,6 +1204,7 @@ ClassDef{
         }
 
         Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }
@@ -1108,6 +1214,7 @@ ClassDef{
           args = [
             Literal{ value = :day }
             Send{
+              flags = {}
               recv = UnresolvedConstantLit{
                 cnst = <C <U IntegerParam>>
                 scope = EmptyTree
@@ -1126,6 +1233,7 @@ ClassDef{
         }
 
         Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }
@@ -1135,6 +1243,7 @@ ClassDef{
           args = [
             Literal{ value = :name }
             Send{
+              flags = {}
               recv = UnresolvedConstantLit{
                 cnst = <C <U StringParam>>
                 scope = EmptyTree
@@ -1149,6 +1258,7 @@ ClassDef{
         }
 
         Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }
@@ -1158,6 +1268,7 @@ ClassDef{
           args = [
             Literal{ value = :how_many }
             Send{
+              flags = {}
               recv = UnresolvedConstantLit{
                 cnst = <C <U CaseParam>>
                 scope = UnresolvedConstantLit{
@@ -1173,6 +1284,7 @@ ClassDef{
               pos_args = 2
               args = [
                 Send{
+                  flags = {privateOk}
                   recv = Local{
                     localVariable = <U <self>>
                   }
@@ -1183,6 +1295,7 @@ ClassDef{
                   ]
                 }
                 Send{
+                  flags = {}
                   recv = UnresolvedConstantLit{
                     cnst = <C <U ParamSpecsParam>>
                     scope = UnresolvedConstantLit{
@@ -1209,6 +1322,7 @@ ClassDef{
         }
 
         Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }
@@ -1218,6 +1332,7 @@ ClassDef{
           args = [
             Literal{ value = :optional_param }
             Send{
+              flags = {}
               recv = UnresolvedConstantLit{
                 cnst = <C <U IntegerParam>>
                 scope = EmptyTree
@@ -1245,6 +1360,7 @@ ClassDef{
         }]
       rhs = [
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -1254,6 +1370,7 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -1292,6 +1409,7 @@ ClassDef{
                   name = <U arg2>
                 }
                 rhs = Send{
+                  flags = {}
                   recv = Local{
                     localVariable = <U <self>>
                   }
@@ -1305,8 +1423,11 @@ ClassDef{
               }
             ],
             expr = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = Local{
                     localVariable = <U <self>>
                   }
@@ -1340,6 +1461,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -1349,7 +1471,9 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Local{
                   localVariable = <U <self>>
                 }
@@ -1397,7 +1521,9 @@ ClassDef{
           rhs = InsSeq{
             stats = [
               Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = ConstantLit{
                     symbol = (module ::T::Configuration)
                     orig = nullptr
@@ -1420,6 +1546,7 @@ ClassDef{
               }
             ],
             expr = Send{
+              flags = {}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -1438,6 +1565,7 @@ ClassDef{
         }
 
         Send{
+          flags = {privateOk}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -1447,6 +1575,7 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {privateOk}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -1455,6 +1584,7 @@ ClassDef{
               pos_args = 1
               args = [
                 Send{
+                  flags = {}
                   recv = UnresolvedConstantLit{
                     cnst = <C <U T>>
                     scope = EmptyTree
@@ -1488,6 +1618,7 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -1497,6 +1628,7 @@ ClassDef{
             pos_args = 2
             args = [
               Send{
+                flags = {}
                 recv = UnresolvedConstantLit{
                   cnst = <C <U T>>
                   scope = EmptyTree
@@ -1509,6 +1641,7 @@ ClassDef{
                 ]
               }
               Send{
+                flags = {}
                 recv = UnresolvedConstantLit{
                   cnst = <C <U T>>
                   scope = EmptyTree
@@ -1528,6 +1661,7 @@ ClassDef{
         }
 
         Send{
+          flags = {privateOk}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -1537,7 +1671,9 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Send{
+                flags = {privateOk}
                 recv = Local{
                   localVariable = <U <self>>
                 }
@@ -1582,6 +1718,7 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
+            flags = {}
             recv = UnresolvedConstantLit{
               cnst = <C <U T>>
               scope = EmptyTree
@@ -1600,6 +1737,7 @@ ClassDef{
         }
 
         Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }
@@ -1618,6 +1756,7 @@ ClassDef{
         }
 
         Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }
@@ -1636,6 +1775,7 @@ ClassDef{
         }
 
         Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }
@@ -1654,6 +1794,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -1671,6 +1812,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -1688,6 +1830,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -1705,6 +1848,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -1749,6 +1893,7 @@ ClassDef{
         }]
       rhs = [
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -1758,6 +1903,7 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -1796,6 +1942,7 @@ ClassDef{
                   name = <U arg2>
                 }
                 rhs = Send{
+                  flags = {}
                   recv = Local{
                     localVariable = <U <self>>
                   }
@@ -1809,8 +1956,11 @@ ClassDef{
               }
             ],
             expr = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = Local{
                     localVariable = <U <self>>
                   }
@@ -1844,6 +1994,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -1853,7 +2004,9 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Local{
                   localVariable = <U <self>>
                 }
@@ -1901,7 +2054,9 @@ ClassDef{
           rhs = InsSeq{
             stats = [
               Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = ConstantLit{
                     symbol = (module ::T::Configuration)
                     orig = nullptr
@@ -1924,6 +2079,7 @@ ClassDef{
               }
             ],
             expr = Send{
+              flags = {}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -1942,6 +2098,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -1951,6 +2108,7 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -1959,6 +2117,7 @@ ClassDef{
               pos_args = 1
               args = [
                 Send{
+                  flags = {}
                   recv = UnresolvedConstantLit{
                     cnst = <C <U T>>
                     scope = EmptyTree
@@ -2000,6 +2159,7 @@ ClassDef{
                   name = <U arg2>
                 }
                 rhs = Send{
+                  flags = {}
                   recv = Local{
                     localVariable = <U <self>>
                   }
@@ -2013,8 +2173,11 @@ ClassDef{
               }
             ],
             expr = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = Local{
                     localVariable = <U <self>>
                   }
@@ -2048,6 +2211,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -2057,7 +2221,9 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Local{
                   localVariable = <U <self>>
                 }
@@ -2067,6 +2233,7 @@ ClassDef{
                 args = [
                   Literal{ value = :arg0 }
                   Send{
+                    flags = {}
                     recv = UnresolvedConstantLit{
                       cnst = <C <U T>>
                       scope = EmptyTree
@@ -2088,6 +2255,7 @@ ClassDef{
               pos_args = 1
               args = [
                 Send{
+                  flags = {}
                   recv = UnresolvedConstantLit{
                     cnst = <C <U T>>
                     scope = EmptyTree
@@ -2127,7 +2295,9 @@ ClassDef{
           rhs = InsSeq{
             stats = [
               Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = ConstantLit{
                     symbol = (module ::T::Configuration)
                     orig = nullptr
@@ -2150,6 +2320,7 @@ ClassDef{
               }
             ],
             expr = Send{
+              flags = {}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -2168,6 +2339,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -2177,6 +2349,7 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -2215,6 +2388,7 @@ ClassDef{
                   name = <U arg2>
                 }
                 rhs = Send{
+                  flags = {}
                   recv = Local{
                     localVariable = <U <self>>
                   }
@@ -2228,8 +2402,11 @@ ClassDef{
               }
             ],
             expr = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = Local{
                     localVariable = <U <self>>
                   }
@@ -2263,6 +2440,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -2272,7 +2450,9 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Local{
                   localVariable = <U <self>>
                 }
@@ -2320,7 +2500,9 @@ ClassDef{
           rhs = InsSeq{
             stats = [
               Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = ConstantLit{
                     symbol = (module ::T::Configuration)
                     orig = nullptr
@@ -2343,6 +2525,7 @@ ClassDef{
               }
             ],
             expr = Send{
+              flags = {}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -2361,6 +2544,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -2370,6 +2554,7 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -2378,6 +2563,7 @@ ClassDef{
               pos_args = 1
               args = [
                 Send{
+                  flags = {}
                   recv = UnresolvedConstantLit{
                     cnst = <C <U Array>>
                     scope = UnresolvedConstantLit{
@@ -2422,6 +2608,7 @@ ClassDef{
                   name = <U arg2>
                 }
                 rhs = Send{
+                  flags = {}
                   recv = Local{
                     localVariable = <U <self>>
                   }
@@ -2435,8 +2622,11 @@ ClassDef{
               }
             ],
             expr = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = Local{
                     localVariable = <U <self>>
                   }
@@ -2470,6 +2660,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -2479,7 +2670,9 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Local{
                   localVariable = <U <self>>
                 }
@@ -2489,6 +2682,7 @@ ClassDef{
                 args = [
                   Literal{ value = :arg0 }
                   Send{
+                    flags = {}
                     recv = UnresolvedConstantLit{
                       cnst = <C <U Array>>
                       scope = UnresolvedConstantLit{
@@ -2513,6 +2707,7 @@ ClassDef{
               pos_args = 1
               args = [
                 Send{
+                  flags = {}
                   recv = UnresolvedConstantLit{
                     cnst = <C <U Array>>
                     scope = UnresolvedConstantLit{
@@ -2555,7 +2750,9 @@ ClassDef{
           rhs = InsSeq{
             stats = [
               Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = ConstantLit{
                     symbol = (module ::T::Configuration)
                     orig = nullptr
@@ -2578,6 +2775,7 @@ ClassDef{
               }
             ],
             expr = Send{
+              flags = {}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -2596,6 +2794,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -2605,6 +2804,7 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -2613,6 +2813,7 @@ ClassDef{
               pos_args = 1
               args = [
                 Send{
+                  flags = {}
                   recv = UnresolvedConstantLit{
                     cnst = <C <U Hash>>
                     scope = UnresolvedConstantLit{
@@ -2661,6 +2862,7 @@ ClassDef{
                   name = <U arg2>
                 }
                 rhs = Send{
+                  flags = {}
                   recv = Local{
                     localVariable = <U <self>>
                   }
@@ -2674,8 +2876,11 @@ ClassDef{
               }
             ],
             expr = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = Local{
                     localVariable = <U <self>>
                   }
@@ -2709,6 +2914,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -2718,7 +2924,9 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Local{
                   localVariable = <U <self>>
                 }
@@ -2728,6 +2936,7 @@ ClassDef{
                 args = [
                   Literal{ value = :arg0 }
                   Send{
+                    flags = {}
                     recv = UnresolvedConstantLit{
                       cnst = <C <U Hash>>
                       scope = UnresolvedConstantLit{
@@ -2756,6 +2965,7 @@ ClassDef{
               pos_args = 1
               args = [
                 Send{
+                  flags = {}
                   recv = UnresolvedConstantLit{
                     cnst = <C <U Hash>>
                     scope = UnresolvedConstantLit{
@@ -2802,7 +3012,9 @@ ClassDef{
           rhs = InsSeq{
             stats = [
               Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = ConstantLit{
                     symbol = (module ::T::Configuration)
                     orig = nullptr
@@ -2825,6 +3037,7 @@ ClassDef{
               }
             ],
             expr = Send{
+              flags = {}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -2843,6 +3056,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -2852,6 +3066,7 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -2890,6 +3105,7 @@ ClassDef{
                   name = <U arg2>
                 }
                 rhs = Send{
+                  flags = {}
                   recv = Local{
                     localVariable = <U <self>>
                   }
@@ -2903,8 +3119,11 @@ ClassDef{
               }
             ],
             expr = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = Local{
                     localVariable = <U <self>>
                   }
@@ -2938,6 +3157,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -2947,6 +3167,7 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -2985,6 +3206,7 @@ ClassDef{
                   name = <U arg2>
                 }
                 rhs = Send{
+                  flags = {}
                   recv = Local{
                     localVariable = <U <self>>
                   }
@@ -2998,8 +3220,11 @@ ClassDef{
               }
             ],
             expr = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = Local{
                     localVariable = <U <self>>
                   }
@@ -3033,6 +3258,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -3042,6 +3268,7 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -3080,6 +3307,7 @@ ClassDef{
                   name = <U arg2>
                 }
                 rhs = Send{
+                  flags = {}
                   recv = Local{
                     localVariable = <U <self>>
                   }
@@ -3093,8 +3321,11 @@ ClassDef{
               }
             ],
             expr = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = Local{
                     localVariable = <U <self>>
                   }
@@ -3128,6 +3359,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -3137,7 +3369,9 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Local{
                   localVariable = <U <self>>
                 }
@@ -3183,7 +3417,9 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
+            flags = {rewriter}
             recv = Send{
+              flags = {}
               recv = ConstantLit{
                 symbol = (module ::T)
                 orig = nullptr
@@ -3208,6 +3444,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -3217,6 +3454,7 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -3255,6 +3493,7 @@ ClassDef{
                   name = <U arg2>
                 }
                 rhs = Send{
+                  flags = {}
                   recv = Local{
                     localVariable = <U <self>>
                   }
@@ -3268,8 +3507,11 @@ ClassDef{
               }
             ],
             expr = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = Local{
                     localVariable = <U <self>>
                   }
@@ -3303,6 +3545,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -3312,7 +3555,9 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Local{
                   localVariable = <U <self>>
                 }
@@ -3360,7 +3605,9 @@ ClassDef{
           rhs = InsSeq{
             stats = [
               Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = ConstantLit{
                     symbol = (module ::T::Configuration)
                     orig = nullptr
@@ -3383,6 +3630,7 @@ ClassDef{
               }
             ],
             expr = Send{
+              flags = {}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -3401,6 +3649,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -3410,7 +3659,9 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Local{
                   localVariable = <U <self>>
                 }
@@ -3420,6 +3671,7 @@ ClassDef{
                 args = [
                   Literal{ value = :opts }
                   Send{
+                    flags = {}
                     recv = ConstantLit{
                       symbol = (module ::T)
                       orig = nullptr
@@ -3437,6 +3689,7 @@ ClassDef{
               pos_args = 1
               args = [
                 Send{
+                  flags = {}
                   recv = ConstantLit{
                     symbol = (module ::T)
                     orig = nullptr
@@ -3474,7 +3727,9 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
+            flags = {rewriter}
             recv = Send{
+              flags = {}
               recv = ConstantLit{
                 symbol = (module ::T)
                 orig = nullptr
@@ -3499,6 +3754,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -3508,7 +3764,9 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Local{
                   localVariable = <U <self>>
                 }
@@ -3518,6 +3776,7 @@ ClassDef{
                 args = [
                   Literal{ value = :opts }
                   Send{
+                    flags = {}
                     recv = ConstantLit{
                       symbol = (module ::T)
                       orig = nullptr
@@ -3561,7 +3820,9 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
+            flags = {rewriter}
             recv = Send{
+              flags = {}
               recv = ConstantLit{
                 symbol = (module ::T)
                 orig = nullptr
@@ -3586,6 +3847,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -3595,6 +3857,7 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -3633,6 +3896,7 @@ ClassDef{
                   name = <U arg2>
                 }
                 rhs = Send{
+                  flags = {}
                   recv = Local{
                     localVariable = <U <self>>
                   }
@@ -3646,8 +3910,11 @@ ClassDef{
               }
             ],
             expr = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = Local{
                     localVariable = <U <self>>
                   }
@@ -3681,6 +3948,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -3690,7 +3958,9 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Local{
                   localVariable = <U <self>>
                 }
@@ -3738,7 +4008,9 @@ ClassDef{
           rhs = InsSeq{
             stats = [
               Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = ConstantLit{
                     symbol = (module ::T::Configuration)
                     orig = nullptr
@@ -3761,6 +4033,7 @@ ClassDef{
               }
             ],
             expr = Send{
+              flags = {}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -3779,6 +4052,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -3788,7 +4062,9 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Local{
                   localVariable = <U <self>>
                 }
@@ -3798,6 +4074,7 @@ ClassDef{
                 args = [
                   Literal{ value = :opts }
                   Send{
+                    flags = {}
                     recv = ConstantLit{
                       symbol = (module ::T)
                       orig = nullptr
@@ -3815,6 +4092,7 @@ ClassDef{
               pos_args = 1
               args = [
                 Send{
+                  flags = {}
                   recv = ConstantLit{
                     symbol = (module ::T)
                     orig = nullptr
@@ -3852,7 +4130,9 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
+            flags = {rewriter}
             recv = Send{
+              flags = {}
               recv = ConstantLit{
                 symbol = (module ::T)
                 orig = nullptr
@@ -3877,6 +4157,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -3886,7 +4167,9 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Local{
                   localVariable = <U <self>>
                 }
@@ -3896,6 +4179,7 @@ ClassDef{
                 args = [
                   Literal{ value = :opts }
                   Send{
+                    flags = {}
                     recv = ConstantLit{
                       symbol = (module ::T)
                       orig = nullptr
@@ -3939,7 +4223,9 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
+            flags = {rewriter}
             recv = Send{
+              flags = {}
               recv = ConstantLit{
                 symbol = (module ::T)
                 orig = nullptr
@@ -3964,6 +4250,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -3973,6 +4260,7 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -4011,6 +4299,7 @@ ClassDef{
                   name = <U arg2>
                 }
                 rhs = Send{
+                  flags = {}
                   recv = Local{
                     localVariable = <U <self>>
                   }
@@ -4024,8 +4313,11 @@ ClassDef{
               }
             ],
             expr = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = Local{
                     localVariable = <U <self>>
                   }
@@ -4059,6 +4351,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -4068,7 +4361,9 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Local{
                   localVariable = <U <self>>
                 }
@@ -4116,7 +4411,9 @@ ClassDef{
           rhs = InsSeq{
             stats = [
               Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = ConstantLit{
                     symbol = (module ::T::Configuration)
                     orig = nullptr
@@ -4139,6 +4436,7 @@ ClassDef{
               }
             ],
             expr = Send{
+              flags = {}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -4157,6 +4455,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -4166,7 +4465,9 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Local{
                   localVariable = <U <self>>
                 }
@@ -4176,6 +4477,7 @@ ClassDef{
                 args = [
                   Literal{ value = :opts }
                   Send{
+                    flags = {}
                     recv = ConstantLit{
                       symbol = (module ::T)
                       orig = nullptr
@@ -4193,6 +4495,7 @@ ClassDef{
               pos_args = 1
               args = [
                 Send{
+                  flags = {}
                   recv = ConstantLit{
                     symbol = (module ::T)
                     orig = nullptr
@@ -4230,7 +4533,9 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
+            flags = {rewriter}
             recv = Send{
+              flags = {}
               recv = ConstantLit{
                 symbol = (module ::T)
                 orig = nullptr
@@ -4255,6 +4560,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -4264,7 +4570,9 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Local{
                   localVariable = <U <self>>
                 }
@@ -4274,6 +4582,7 @@ ClassDef{
                 args = [
                   Literal{ value = :opts }
                   Send{
+                    flags = {}
                     recv = ConstantLit{
                       symbol = (module ::T)
                       orig = nullptr
@@ -4317,7 +4626,9 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
+            flags = {rewriter}
             recv = Send{
+              flags = {}
               recv = ConstantLit{
                 symbol = (module ::T)
                 orig = nullptr
@@ -4342,6 +4653,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -4351,6 +4663,7 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -4389,6 +4702,7 @@ ClassDef{
                   name = <U arg2>
                 }
                 rhs = Send{
+                  flags = {}
                   recv = Local{
                     localVariable = <U <self>>
                   }
@@ -4402,8 +4716,11 @@ ClassDef{
               }
             ],
             expr = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = Local{
                     localVariable = <U <self>>
                   }
@@ -4437,6 +4754,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -4446,7 +4764,9 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Local{
                   localVariable = <U <self>>
                 }
@@ -4494,7 +4814,9 @@ ClassDef{
           rhs = InsSeq{
             stats = [
               Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = ConstantLit{
                     symbol = (module ::T::Configuration)
                     orig = nullptr
@@ -4517,6 +4839,7 @@ ClassDef{
               }
             ],
             expr = Send{
+              flags = {}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -4535,6 +4858,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -4544,7 +4868,9 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Local{
                   localVariable = <U <self>>
                 }
@@ -4554,6 +4880,7 @@ ClassDef{
                 args = [
                   Literal{ value = :opts }
                   Send{
+                    flags = {}
                     recv = ConstantLit{
                       symbol = (module ::T)
                       orig = nullptr
@@ -4571,6 +4898,7 @@ ClassDef{
               pos_args = 1
               args = [
                 Send{
+                  flags = {}
                   recv = ConstantLit{
                     symbol = (module ::T)
                     orig = nullptr
@@ -4604,7 +4932,9 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
+            flags = {rewriter}
             recv = Send{
+              flags = {}
               recv = ConstantLit{
                 symbol = (module ::T)
                 orig = nullptr
@@ -4629,6 +4959,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -4638,7 +4969,9 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Local{
                   localVariable = <U <self>>
                 }
@@ -4648,6 +4981,7 @@ ClassDef{
                 args = [
                   Literal{ value = :opts }
                   Send{
+                    flags = {}
                     recv = ConstantLit{
                       symbol = (module ::T)
                       orig = nullptr
@@ -4665,6 +4999,7 @@ ClassDef{
               pos_args = 1
               args = [
                 Send{
+                  flags = {}
                   recv = ConstantLit{
                     symbol = (module ::T)
                     orig = nullptr
@@ -4698,7 +5033,9 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
+            flags = {rewriter}
             recv = Send{
+              flags = {}
               recv = ConstantLit{
                 symbol = (module ::T)
                 orig = nullptr
@@ -4723,6 +5060,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -4732,6 +5070,7 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -4763,7 +5102,9 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
+            flags = {rewriter}
             recv = Send{
+              flags = {}
               recv = ConstantLit{
                 symbol = (module ::T)
                 orig = nullptr
@@ -4788,6 +5129,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -4797,7 +5139,9 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Local{
                   localVariable = <U <self>>
                 }
@@ -4845,7 +5189,9 @@ ClassDef{
           rhs = InsSeq{
             stats = [
               Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = ConstantLit{
                     symbol = (module ::T::Configuration)
                     orig = nullptr
@@ -4868,6 +5214,7 @@ ClassDef{
               }
             ],
             expr = Send{
+              flags = {}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -4886,6 +5233,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -4895,6 +5243,7 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -4903,6 +5252,7 @@ ClassDef{
               pos_args = 1
               args = [
                 Send{
+                  flags = {}
                   recv = UnresolvedConstantLit{
                     cnst = <C <U T>>
                     scope = EmptyTree
@@ -4937,7 +5287,9 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
+            flags = {rewriter}
             recv = Send{
+              flags = {}
               recv = ConstantLit{
                 symbol = (module ::T)
                 orig = nullptr
@@ -4962,6 +5314,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -4971,7 +5324,9 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Local{
                   localVariable = <U <self>>
                 }
@@ -4981,6 +5336,7 @@ ClassDef{
                 args = [
                   Literal{ value = :arg0 }
                   Send{
+                    flags = {}
                     recv = UnresolvedConstantLit{
                       cnst = <C <U T>>
                       scope = EmptyTree
@@ -5002,6 +5358,7 @@ ClassDef{
               pos_args = 1
               args = [
                 Send{
+                  flags = {}
                   recv = UnresolvedConstantLit{
                     cnst = <C <U T>>
                     scope = EmptyTree
@@ -5041,7 +5398,9 @@ ClassDef{
           rhs = InsSeq{
             stats = [
               Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = ConstantLit{
                     symbol = (module ::T::Configuration)
                     orig = nullptr
@@ -5064,6 +5423,7 @@ ClassDef{
               }
             ],
             expr = Send{
+              flags = {}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -5082,6 +5442,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -5091,6 +5452,7 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -5129,6 +5491,7 @@ ClassDef{
                   name = <U arg2>
                 }
                 rhs = Send{
+                  flags = {}
                   recv = Local{
                     localVariable = <U <self>>
                   }
@@ -5142,8 +5505,11 @@ ClassDef{
               }
             ],
             expr = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = Local{
                     localVariable = <U <self>>
                   }
@@ -5177,6 +5543,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -5186,7 +5553,9 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Local{
                   localVariable = <U <self>>
                 }
@@ -5234,7 +5603,9 @@ ClassDef{
           rhs = InsSeq{
             stats = [
               Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = ConstantLit{
                     symbol = (module ::T::Configuration)
                     orig = nullptr
@@ -5257,6 +5628,7 @@ ClassDef{
               }
             ],
             expr = Send{
+              flags = {}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -5275,6 +5647,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -5284,6 +5657,7 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -5322,6 +5696,7 @@ ClassDef{
                   name = <U arg2>
                 }
                 rhs = Send{
+                  flags = {}
                   recv = Local{
                     localVariable = <U <self>>
                   }
@@ -5335,8 +5710,11 @@ ClassDef{
               }
             ],
             expr = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = Local{
                     localVariable = <U <self>>
                   }
@@ -5370,6 +5748,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -5379,7 +5758,9 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Local{
                   localVariable = <U <self>>
                 }
@@ -5425,7 +5806,9 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
+            flags = {rewriter}
             recv = Send{
+              flags = {}
               recv = ConstantLit{
                 symbol = (module ::T)
                 orig = nullptr
@@ -5450,6 +5833,7 @@ ClassDef{
         }
 
         Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }
@@ -5468,6 +5852,7 @@ ClassDef{
         }
 
         Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }
@@ -5488,6 +5873,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -5505,6 +5891,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -5522,6 +5909,7 @@ ClassDef{
         }
 
         Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }
@@ -5531,6 +5919,7 @@ ClassDef{
           args = [
             Literal{ value = :t_nilable }
             Send{
+              flags = {}
               recv = UnresolvedConstantLit{
                 cnst = <C <U T>>
                 scope = EmptyTree
@@ -5551,6 +5940,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -5568,6 +5958,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -5585,6 +5976,7 @@ ClassDef{
         }
 
         Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }
@@ -5603,6 +5995,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -5620,6 +6013,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -5637,6 +6031,7 @@ ClassDef{
         }
 
         Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }
@@ -5646,6 +6041,7 @@ ClassDef{
           args = [
             Literal{ value = :t_array }
             Send{
+              flags = {}
               recv = UnresolvedConstantLit{
                 cnst = <C <U Array>>
                 scope = UnresolvedConstantLit{
@@ -5669,6 +6065,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -5686,6 +6083,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -5703,6 +6101,7 @@ ClassDef{
         }
 
         Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }
@@ -5712,6 +6111,7 @@ ClassDef{
           args = [
             Literal{ value = :hash_of }
             Send{
+              flags = {}
               recv = UnresolvedConstantLit{
                 cnst = <C <U Hash>>
                 scope = UnresolvedConstantLit{
@@ -5739,6 +6139,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -5756,6 +6157,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -5773,6 +6175,7 @@ ClassDef{
         }
 
         Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }
@@ -5793,6 +6196,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -5810,6 +6214,7 @@ ClassDef{
         }
 
         Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }
@@ -5828,6 +6233,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -5845,6 +6251,7 @@ ClassDef{
         }
 
         Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }
@@ -5870,6 +6277,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -5887,6 +6295,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -5904,6 +6313,7 @@ ClassDef{
         }
 
         Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }
@@ -5927,6 +6337,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -5944,6 +6355,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -5961,6 +6373,7 @@ ClassDef{
         }
 
         Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }
@@ -5975,6 +6388,7 @@ ClassDef{
             }
             Literal{ value = :foreign }
             Send{
+              flags = {}
               recv = UnresolvedConstantLit{
                 cnst = <C <U Kernel>>
                 scope = EmptyTree
@@ -5998,6 +6412,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -6015,6 +6430,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -6032,6 +6448,7 @@ ClassDef{
         }
 
         Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }
@@ -6046,6 +6463,7 @@ ClassDef{
             }
             Literal{ value = :foreign }
             Send{
+              flags = {privateOk}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -6068,6 +6486,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -6085,6 +6504,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -6102,6 +6522,7 @@ ClassDef{
         }
 
         Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }
@@ -6116,6 +6537,7 @@ ClassDef{
             }
             Literal{ value = :foreign }
             Send{
+              flags = {privateOk}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -6135,6 +6557,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -6152,6 +6575,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -6169,6 +6593,7 @@ ClassDef{
         }
 
         Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }
@@ -6189,6 +6614,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -6206,6 +6632,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -6223,6 +6650,7 @@ ClassDef{
         }
 
         Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }
@@ -6232,6 +6660,7 @@ ClassDef{
           args = [
             Literal{ value = :ifunset_nilable }
             Send{
+              flags = {}
               recv = UnresolvedConstantLit{
                 cnst = <C <U T>>
                 scope = EmptyTree
@@ -6254,6 +6683,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -6271,6 +6701,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -6288,6 +6719,7 @@ ClassDef{
         }
 
         Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }
@@ -6312,6 +6744,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -6329,6 +6762,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -6346,6 +6780,7 @@ ClassDef{
         }
 
         Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }
@@ -6379,6 +6814,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -6396,6 +6832,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -6464,6 +6901,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -6473,6 +6911,7 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -6511,6 +6950,7 @@ ClassDef{
                   name = <U arg2>
                 }
                 rhs = Send{
+                  flags = {}
                   recv = Local{
                     localVariable = <U <self>>
                   }
@@ -6524,8 +6964,11 @@ ClassDef{
               }
             ],
             expr = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = Local{
                     localVariable = <U <self>>
                   }
@@ -6559,6 +7002,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -6568,7 +7012,9 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Local{
                   localVariable = <U <self>>
                 }
@@ -6616,7 +7062,9 @@ ClassDef{
           rhs = InsSeq{
             stats = [
               Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = ConstantLit{
                     symbol = (module ::T::Configuration)
                     orig = nullptr
@@ -6639,6 +7087,7 @@ ClassDef{
               }
             ],
             expr = Send{
+              flags = {}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -6657,6 +7106,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -6666,6 +7116,7 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -6704,6 +7155,7 @@ ClassDef{
                   name = <U arg2>
                 }
                 rhs = Send{
+                  flags = {}
                   recv = Local{
                     localVariable = <U <self>>
                   }
@@ -6717,8 +7169,11 @@ ClassDef{
               }
             ],
             expr = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = Local{
                     localVariable = <U <self>>
                   }
@@ -6752,6 +7207,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -6761,7 +7217,9 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Local{
                   localVariable = <U <self>>
                 }
@@ -6809,7 +7267,9 @@ ClassDef{
           rhs = InsSeq{
             stats = [
               Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = ConstantLit{
                     symbol = (module ::T::Configuration)
                     orig = nullptr
@@ -6832,6 +7292,7 @@ ClassDef{
               }
             ],
             expr = Send{
+              flags = {}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -6850,6 +7311,7 @@ ClassDef{
         }
 
         Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }
@@ -6868,6 +7330,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -6885,6 +7348,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -6902,6 +7366,7 @@ ClassDef{
         }
 
         Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }
@@ -6915,6 +7380,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -6932,6 +7398,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -6949,6 +7416,7 @@ ClassDef{
         }
 
         Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }
@@ -6962,6 +7430,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -6979,6 +7448,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -7047,6 +7517,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -7056,6 +7527,7 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -7094,6 +7566,7 @@ ClassDef{
                   name = <U arg2>
                 }
                 rhs = Send{
+                  flags = {}
                   recv = Local{
                     localVariable = <U <self>>
                   }
@@ -7107,8 +7580,11 @@ ClassDef{
               }
             ],
             expr = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = Local{
                     localVariable = <U <self>>
                   }
@@ -7142,6 +7618,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -7151,7 +7628,9 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Local{
                   localVariable = <U <self>>
                 }
@@ -7199,7 +7678,9 @@ ClassDef{
           rhs = InsSeq{
             stats = [
               Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = ConstantLit{
                     symbol = (module ::T::Configuration)
                     orig = nullptr
@@ -7222,6 +7703,7 @@ ClassDef{
               }
             ],
             expr = Send{
+              flags = {}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -7240,6 +7722,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -7249,6 +7732,7 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -7287,6 +7771,7 @@ ClassDef{
                   name = <U arg2>
                 }
                 rhs = Send{
+                  flags = {}
                   recv = Local{
                     localVariable = <U <self>>
                   }
@@ -7300,8 +7785,11 @@ ClassDef{
               }
             ],
             expr = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Send{
+                  flags = {}
                   recv = Local{
                     localVariable = <U <self>>
                   }
@@ -7335,6 +7823,7 @@ ClassDef{
         }
 
         Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }
@@ -7353,6 +7842,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -7370,6 +7860,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -7387,6 +7878,7 @@ ClassDef{
         }
 
         Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }
@@ -7400,6 +7892,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -7417,6 +7910,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -7434,6 +7928,7 @@ ClassDef{
         }
 
         Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }
@@ -7449,6 +7944,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -7553,6 +8049,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -7562,6 +8059,7 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -7570,6 +8068,7 @@ ClassDef{
               pos_args = 1
               args = [
                 Send{
+                  flags = {}
                   recv = ConstantLit{
                     symbol = (module ::T)
                     orig = nullptr
@@ -7604,7 +8103,9 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
+            flags = {rewriter}
             recv = Send{
+              flags = {}
               recv = ConstantLit{
                 symbol = (module ::T)
                 orig = nullptr
@@ -7629,6 +8130,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -7638,6 +8140,7 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -7646,6 +8149,7 @@ ClassDef{
               pos_args = 1
               args = [
                 Send{
+                  flags = {}
                   recv = ConstantLit{
                     symbol = (module ::T)
                     orig = nullptr
@@ -7695,7 +8199,9 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
+            flags = {rewriter}
             recv = Send{
+              flags = {}
               recv = ConstantLit{
                 symbol = (module ::T)
                 orig = nullptr
@@ -7720,6 +8226,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -7729,7 +8236,9 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Local{
                   localVariable = <U <self>>
                 }
@@ -7739,6 +8248,7 @@ ClassDef{
                 args = [
                   Literal{ value = :arg0 }
                   Send{
+                    flags = {}
                     recv = ConstantLit{
                       symbol = (module ::T)
                       orig = nullptr
@@ -7760,6 +8270,7 @@ ClassDef{
               pos_args = 1
               args = [
                 Send{
+                  flags = {}
                   recv = ConstantLit{
                     symbol = (module ::T)
                     orig = nullptr
@@ -7797,7 +8308,9 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
+            flags = {rewriter}
             recv = Send{
+              flags = {}
               recv = ConstantLit{
                 symbol = (module ::T)
                 orig = nullptr
@@ -7822,6 +8335,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -7831,7 +8345,9 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Send{
+                flags = {}
                 recv = Local{
                   localVariable = <U <self>>
                 }
@@ -7841,6 +8357,7 @@ ClassDef{
                 args = [
                   Literal{ value = :arg0 }
                   Send{
+                    flags = {}
                     recv = ConstantLit{
                       symbol = (module ::T)
                       orig = nullptr
@@ -7877,6 +8394,7 @@ ClassDef{
               pos_args = 1
               args = [
                 Send{
+                  flags = {}
                   recv = ConstantLit{
                     symbol = (module ::T)
                     orig = nullptr
@@ -7929,7 +8447,9 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
+            flags = {rewriter}
             recv = Send{
+              flags = {}
               recv = ConstantLit{
                 symbol = (module ::T)
                 orig = nullptr
@@ -7954,6 +8474,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -7963,6 +8484,7 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -7971,6 +8493,7 @@ ClassDef{
               pos_args = 1
               args = [
                 Send{
+                  flags = {}
                   recv = ConstantLit{
                     symbol = (module ::T)
                     orig = nullptr
@@ -8005,7 +8528,9 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
+            flags = {rewriter}
             recv = Send{
+              flags = {}
               recv = ConstantLit{
                 symbol = (module ::T)
                 orig = nullptr
@@ -8030,6 +8555,7 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriter}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -8039,6 +8565,7 @@ ClassDef{
             args = [
             ]
             body = Send{
+              flags = {}
               recv = Local{
                 localVariable = <U <self>>
               }
@@ -8047,6 +8574,7 @@ ClassDef{
               pos_args = 1
               args = [
                 Send{
+                  flags = {}
                   recv = ConstantLit{
                     symbol = (module ::T)
                     orig = nullptr
@@ -8096,7 +8624,9 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
+            flags = {rewriter}
             recv = Send{
+              flags = {}
               recv = ConstantLit{
                 symbol = (module ::T)
                 orig = nullptr
@@ -8121,6 +8651,7 @@ ClassDef{
         }
 
         Send{
+          flags = {privateOk}
           recv = Local{
             localVariable = <U <self>>
           }
@@ -8139,6 +8670,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -8156,6 +8688,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -8173,6 +8706,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -8190,6 +8724,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -8207,6 +8742,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -8224,6 +8760,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -8241,6 +8778,7 @@ ClassDef{
         }
 
         Send{
+          flags = {}
           recv = ConstantLit{
             symbol = (module ::Sorbet::Private::Static)
             orig = nullptr
@@ -8260,6 +8798,7 @@ ClassDef{
     }
 
     Send{
+      flags = {}
       recv = ConstantLit{
         symbol = (module ::Sorbet::Private::Static)
         orig = nullptr


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I was making some changes on a different branch that dealt with send flags, and I noticed that there were no exp file changes as a result of my change, which seemed surprising.  Then I discovered that we don't print the flags in the raw output, and it seems like we should.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
