### PR TITLE
give `!` per-callsite caches

### DIFF
--- a/compiler/IREmitter/Payload/codegen-payload.c
+++ b/compiler/IREmitter/Payload/codegen-payload.c
@@ -176,6 +176,7 @@ SORBET_ALIVE(VALUE, sorbet_vm_instance_variable_set,
              (struct FunctionInlineCache * getCache, struct iseq_inline_iv_cache_entry *varCache,
               rb_control_frame_t *cfp, VALUE recv, ID var, VALUE value));
 SORBET_ALIVE(VALUE, sorbet_vm_class, (struct FunctionInlineCache * classCache, rb_control_frame_t *cfp, VALUE recv));
+SORBET_ALIVE(VALUE, sorbet_vm_bang, (struct FunctionInlineCache * bangCache, rb_control_frame_t *cfp, VALUE recv));
 SORBET_ALIVE(VALUE, sorbet_vm_isa_p,
              (struct FunctionInlineCache * classCache, rb_control_frame_t *cfp, VALUE recv, VALUE klass));
 
@@ -2097,21 +2098,6 @@ VALUE sorbet_int_bool_nand(VALUE recv, ID fun, int argc, const VALUE *const rest
         return Qfalse;
     }
     return Qtrue;
-}
-
-SORBET_INLINE
-VALUE sorbet_bang(VALUE recv, ID fun, int argc, const VALUE *const restrict argv, BlockFFIType blk, VALUE closure) {
-    // RTEST is false when the value is Qfalse or Qnil
-    if (RTEST(recv)) {
-        if (recv == Qtrue) {
-            return Qfalse;
-        } else {
-            // slow path - dispatch via the VM
-            return rb_funcallv(recv, fun, argc, argv);
-        }
-    } else {
-        return Qtrue;
-    }
 }
 
 SORBET_INLINE

--- a/test/testdata/compiler/boolean_ops.opt.ll.exp
+++ b/test/testdata/compiler/boolean_ops.opt.ll.exp
@@ -89,6 +89,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @iseqEncodedArray = internal global [6 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @"str_>" = private unnamed_addr constant [2 x i8] c">\00", align 1
+@"ic_!" = internal global %struct.FunctionInlineCache zeroinitializer
+@"rubyIdPrecomputed_!" = internal unnamed_addr global i64 0, align 8
 @"str_!" = private unnamed_addr constant [2 x i8] c"!\00", align 1
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
@@ -105,6 +107,8 @@ declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64,
 declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #0
 
 declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #0
+
+declare i64 @sorbet_vm_bang(%struct.FunctionInlineCache*, %struct.rb_control_frame_struct*, i64) local_unnamed_addr #0
 
 declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
 
@@ -143,6 +147,7 @@ entry:
   store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_>", i64 0, i64 0), i64 noundef 1) #6
   %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_!", i64 0, i64 0), i64 noundef 1) #6
+  store i64 %2, i64* @"rubyIdPrecomputed_!", align 8
   %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #6
   store i64 %3, i64* @rubyIdPrecomputed_puts, align 8
   %4 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #6
@@ -157,52 +162,54 @@ entry:
   %"rubyStr_test/testdata/compiler/boolean_ops.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/boolean_ops.rb", align 8
   %6 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/boolean_ops.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %6, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !10
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !10
-  %7 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !15
+  %"rubyId_!.i" = load i64, i64* @"rubyIdPrecomputed_!", align 8, !dbg !10
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_!", i64 %"rubyId_!.i", i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !10
+  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !15
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
+  %7 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !16
   %8 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %7, i64 0, i32 18
-  %9 = load i64, i64* %8, align 8, !tbaa !17
-  %10 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
+  %9 = load i64, i64* %8, align 8, !tbaa !18
+  %10 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !16
   %11 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %10, i64 0, i32 2
-  %12 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %11, align 8, !tbaa !27
+  %12 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %11, align 8, !tbaa !28
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   %13 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %13, align 8, !tbaa !30
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %13, align 8, !tbaa !31
   %14 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 4
-  %15 = load i64*, i64** %14, align 8, !tbaa !32
+  %15 = load i64*, i64** %14, align 8, !tbaa !33
   %16 = load i64, i64* %15, align 8, !tbaa !6
   %17 = and i64 %16, -33
   store i64 %17, i64* %15, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %10, %struct.rb_control_frame_struct* %12, %struct.rb_iseq_struct* %stackFrame.i) #6
   %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 0
-  store i64* getelementptr inbounds ([6 x i64], [6 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %18, align 8, !dbg !33, !tbaa !15
-  call void @llvm.experimental.noalias.scope.decl(metadata !34) #6, !dbg !37
-  %19 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !37, !tbaa !15
-  %20 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %19, i64 0, i32 5, !dbg !37
-  %21 = load i32, i32* %20, align 8, !dbg !37, !tbaa !38
-  %22 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %19, i64 0, i32 6, !dbg !37
-  %23 = load i32, i32* %22, align 4, !dbg !37, !tbaa !39
-  %24 = xor i32 %23, -1, !dbg !37
-  %25 = and i32 %24, %21, !dbg !37
-  %26 = icmp eq i32 %25, 0, !dbg !37
-  br i1 %26, label %"func_<root>.17<static-init>$152.exit", label %27, !dbg !37, !prof !40
+  store i64* getelementptr inbounds ([6 x i64], [6 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %18, align 8, !dbg !34, !tbaa !16
+  call void @llvm.experimental.noalias.scope.decl(metadata !35) #6, !dbg !38
+  %19 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !38, !tbaa !16
+  %20 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %19, i64 0, i32 5, !dbg !38
+  %21 = load i32, i32* %20, align 8, !dbg !38, !tbaa !39
+  %22 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %19, i64 0, i32 6, !dbg !38
+  %23 = load i32, i32* %22, align 4, !dbg !38, !tbaa !40
+  %24 = xor i32 %23, -1, !dbg !38
+  %25 = and i32 %24, %21, !dbg !38
+  %26 = icmp eq i32 %25, 0, !dbg !38
+  br i1 %26, label %"func_<root>.17<static-init>$152.exit", label %27, !dbg !38, !prof !41
 
 27:                                               ; preds = %entry
-  %28 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %19, i64 0, i32 8, !dbg !37
-  %29 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %28, align 8, !dbg !37, !tbaa !41
-  %30 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %29, i32 noundef 0) #6, !dbg !37
-  br label %"func_<root>.17<static-init>$152.exit", !dbg !37
+  %28 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %19, i64 0, i32 8, !dbg !38
+  %29 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %28, align 8, !dbg !38, !tbaa !42
+  %30 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %29, i32 noundef 0) #6, !dbg !38
+  br label %"func_<root>.17<static-init>$152.exit", !dbg !38
 
 "func_<root>.17<static-init>$152.exit":           ; preds = %entry, %27
-  call void @llvm.experimental.noalias.scope.decl(metadata !42) #6, !dbg !45
-  %31 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 1, !dbg !10
-  %32 = load i64*, i64** %31, align 8, !dbg !10
-  store i64 %9, i64* %32, align 8, !dbg !10, !tbaa !6
-  %33 = getelementptr inbounds i64, i64* %32, i64 1, !dbg !10
-  store i64 20, i64* %33, align 8, !dbg !10, !tbaa !6
-  %34 = getelementptr inbounds i64, i64* %33, i64 1, !dbg !10
-  store i64* %34, i64** %31, align 8, !dbg !10
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !10
+  %31 = call i64 @sorbet_vm_bang(%struct.FunctionInlineCache* noundef @"ic_!", %struct.rb_control_frame_struct* nonnull %12, i64 noundef 0) #6, !dbg !10
+  %32 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 1, !dbg !15
+  %33 = load i64*, i64** %32, align 8, !dbg !15
+  store i64 %9, i64* %33, align 8, !dbg !15, !tbaa !6
+  %34 = getelementptr inbounds i64, i64* %33, i64 1, !dbg !15
+  store i64 %31, i64* %34, align 8, !dbg !15, !tbaa !6
+  %35 = getelementptr inbounds i64, i64* %34, i64 1, !dbg !15
+  store i64* %35, i64** %32, align 8, !dbg !15
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !15
   ret void
 }
 
@@ -227,39 +234,36 @@ attributes #6 = { nounwind }
 !7 = !{!"long", !8, i64 0}
 !8 = !{!"omnipotent char", !9, i64 0}
 !9 = !{!"Simple C/C++ TBAA"}
-!10 = !DILocation(line: 5, column: 1, scope: !11)
+!10 = !DILocation(line: 5, column: 6, scope: !11)
 !11 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$152", scope: null, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
 !12 = !DISubroutineType(types: !13)
 !13 = !{!14}
 !14 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
-!15 = !{!16, !16, i64 0}
-!16 = !{!"any pointer", !8, i64 0}
-!17 = !{!18, !7, i64 400}
-!18 = !{!"rb_vm_struct", !7, i64 0, !19, i64 8, !16, i64 192, !16, i64 200, !16, i64 208, !23, i64 216, !8, i64 224, !20, i64 264, !20, i64 280, !20, i64 296, !20, i64 312, !7, i64 328, !22, i64 336, !22, i64 340, !22, i64 344, !22, i64 344, !22, i64 344, !22, i64 344, !22, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !16, i64 456, !16, i64 464, !24, i64 472, !25, i64 992, !16, i64 1016, !16, i64 1024, !22, i64 1032, !22, i64 1036, !20, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !22, i64 1136, !16, i64 1144, !16, i64 1152, !16, i64 1160, !16, i64 1168, !16, i64 1176, !16, i64 1184, !22, i64 1192, !26, i64 1200, !8, i64 1232}
-!19 = !{!"rb_global_vm_lock_struct", !16, i64 0, !8, i64 8, !20, i64 48, !16, i64 64, !22, i64 72, !8, i64 80, !8, i64 128, !22, i64 176, !22, i64 180}
-!20 = !{!"list_head", !21, i64 0}
-!21 = !{!"list_node", !16, i64 0, !16, i64 8}
-!22 = !{!"int", !8, i64 0}
-!23 = !{!"long long", !8, i64 0}
-!24 = !{!"", !8, i64 0}
-!25 = !{!"rb_hook_list_struct", !16, i64 0, !22, i64 8, !22, i64 12, !22, i64 16}
-!26 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
-!27 = !{!28, !16, i64 16}
-!28 = !{!"rb_execution_context_struct", !16, i64 0, !7, i64 8, !16, i64 16, !16, i64 24, !16, i64 32, !22, i64 40, !22, i64 44, !16, i64 48, !16, i64 56, !16, i64 64, !7, i64 72, !7, i64 80, !16, i64 88, !7, i64 96, !16, i64 104, !16, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !29, i64 152}
-!29 = !{!"", !16, i64 0, !16, i64 8, !7, i64 16, !8, i64 24}
-!30 = !{!31, !16, i64 16}
-!31 = !{!"rb_control_frame_struct", !16, i64 0, !16, i64 8, !16, i64 16, !7, i64 24, !16, i64 32, !16, i64 40, !16, i64 48}
-!32 = !{!31, !16, i64 32}
-!33 = !DILocation(line: 0, scope: !11)
-!34 = !{!35}
-!35 = distinct !{!35, !36, !"sorbet_rb_int_gt: argument 0"}
-!36 = distinct !{!36, !"sorbet_rb_int_gt"}
-!37 = !DILocation(line: 5, column: 8, scope: !11)
-!38 = !{!28, !22, i64 40}
-!39 = !{!28, !22, i64 44}
-!40 = !{!"branch_weights", i32 2000, i32 1}
-!41 = !{!28, !16, i64 56}
-!42 = !{!43}
-!43 = distinct !{!43, !44, !"sorbet_bang: argument 0"}
-!44 = distinct !{!44, !"sorbet_bang"}
-!45 = !DILocation(line: 5, column: 6, scope: !11)
+!15 = !DILocation(line: 5, column: 1, scope: !11)
+!16 = !{!17, !17, i64 0}
+!17 = !{!"any pointer", !8, i64 0}
+!18 = !{!19, !7, i64 400}
+!19 = !{!"rb_vm_struct", !7, i64 0, !20, i64 8, !17, i64 192, !17, i64 200, !17, i64 208, !24, i64 216, !8, i64 224, !21, i64 264, !21, i64 280, !21, i64 296, !21, i64 312, !7, i64 328, !23, i64 336, !23, i64 340, !23, i64 344, !23, i64 344, !23, i64 344, !23, i64 344, !23, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !17, i64 456, !17, i64 464, !25, i64 472, !26, i64 992, !17, i64 1016, !17, i64 1024, !23, i64 1032, !23, i64 1036, !21, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !23, i64 1136, !17, i64 1144, !17, i64 1152, !17, i64 1160, !17, i64 1168, !17, i64 1176, !17, i64 1184, !23, i64 1192, !27, i64 1200, !8, i64 1232}
+!20 = !{!"rb_global_vm_lock_struct", !17, i64 0, !8, i64 8, !21, i64 48, !17, i64 64, !23, i64 72, !8, i64 80, !8, i64 128, !23, i64 176, !23, i64 180}
+!21 = !{!"list_head", !22, i64 0}
+!22 = !{!"list_node", !17, i64 0, !17, i64 8}
+!23 = !{!"int", !8, i64 0}
+!24 = !{!"long long", !8, i64 0}
+!25 = !{!"", !8, i64 0}
+!26 = !{!"rb_hook_list_struct", !17, i64 0, !23, i64 8, !23, i64 12, !23, i64 16}
+!27 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!28 = !{!29, !17, i64 16}
+!29 = !{!"rb_execution_context_struct", !17, i64 0, !7, i64 8, !17, i64 16, !17, i64 24, !17, i64 32, !23, i64 40, !23, i64 44, !17, i64 48, !17, i64 56, !17, i64 64, !7, i64 72, !7, i64 80, !17, i64 88, !7, i64 96, !17, i64 104, !17, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !30, i64 152}
+!30 = !{!"", !17, i64 0, !17, i64 8, !7, i64 16, !8, i64 24}
+!31 = !{!32, !17, i64 16}
+!32 = !{!"rb_control_frame_struct", !17, i64 0, !17, i64 8, !17, i64 16, !7, i64 24, !17, i64 32, !17, i64 40, !17, i64 48}
+!33 = !{!32, !17, i64 32}
+!34 = !DILocation(line: 0, scope: !11)
+!35 = !{!36}
+!36 = distinct !{!36, !37, !"sorbet_rb_int_gt: argument 0"}
+!37 = distinct !{!37, !"sorbet_rb_int_gt"}
+!38 = !DILocation(line: 5, column: 8, scope: !11)
+!39 = !{!29, !23, i64 40}
+!40 = !{!29, !23, i64 44}
+!41 = !{!"branch_weights", i32 2000, i32 1}
+!42 = !{!29, !17, i64 56}

--- a/test/testdata/compiler/intrinsics/bang.opt.ll.exp
+++ b/test/testdata/compiler/intrinsics/bang.opt.ll.exp
@@ -77,7 +77,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 
 @ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @ruby_vm_global_constant_state = external local_unnamed_addr global i64, align 8
-@sorbet_bang.rb_funcallv_data = internal global %struct.rb_call_data zeroinitializer, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
 @.str.10 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.11 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
@@ -107,19 +106,24 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @"str_<class:Bad>" = private unnamed_addr constant [12 x i8] c"<class:Bad>\00", align 1
 @str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
 @stackFramePrecomputed_func_Main.4test = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
+@"ic_!" = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.1 = internal global %struct.FunctionInlineCache zeroinitializer
-@ic_puts.2 = internal global %struct.FunctionInlineCache zeroinitializer
+@"ic_!.2" = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.3 = internal global %struct.FunctionInlineCache zeroinitializer
+@"ic_!.4" = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_puts.5 = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyStrFrozen_hello = internal unnamed_addr global i64 0, align 8
 @str_hello = private unnamed_addr constant [6 x i8] c"hello\00", align 1
-@ic_puts.4 = internal global %struct.FunctionInlineCache zeroinitializer
+@"ic_!.6" = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_puts.7 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_new = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_new = internal unnamed_addr global i64 0, align 8
 @str_new = private unnamed_addr constant [4 x i8] c"new\00", align 1
 @ic_initialize = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_initialize = internal unnamed_addr global i64 0, align 8
 @str_initialize = private unnamed_addr constant [11 x i8] c"initialize\00", align 1
-@ic_puts.5 = internal global %struct.FunctionInlineCache zeroinitializer
+@"ic_!.8" = internal global %struct.FunctionInlineCache zeroinitializer
+@ic_puts.9 = internal global %struct.FunctionInlineCache zeroinitializer
 @"stackFramePrecomputed_func_Main.13<static-init>" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<module:Main>" = internal unnamed_addr global i64 0, align 8
 @"str_<module:Main>" = private unnamed_addr constant [14 x i8] c"<module:Main>\00", align 1
@@ -154,6 +158,8 @@ declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_
 
 declare i64 @sorbet_maybeAllocateObjectFastPath(i64, %struct.FunctionInlineCache*) local_unnamed_addr #1
 
+declare i64 @sorbet_vm_bang(%struct.FunctionInlineCache*, %struct.rb_control_frame_struct*, i64) local_unnamed_addr #1
+
 declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #1
 
 declare i64 @rb_define_module(i8*) local_unnamed_addr #1
@@ -167,59 +173,54 @@ declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #1
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #0
 
-declare i64 @rb_funcallv_with_cc(%struct.rb_call_data*, i64, i64, i32, i64*) local_unnamed_addr #1
-
-; Function Attrs: inaccessiblememonly nofree nosync nounwind willreturn
-declare void @llvm.experimental.noalias.scope.decl(metadata) #2
-
 ; Function Attrs: allocsize(0,1)
-declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #3
+declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #2
 
 ; Function Attrs: nounwind ssp uwtable
-define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #4 {
+define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #3 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.11, i64 0, i64 0)) #10
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.11, i64 0, i64 0)) #9
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
-define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #4 {
+define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #3 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.10, i64 0, i64 0)) #10
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.10, i64 0, i64 0)) #9
   unreachable
 }
 
 ; Function Attrs: sspreq
-define void @Init_bang() local_unnamed_addr #5 {
+define void @Init_bang() local_unnamed_addr #4 {
 entry:
-  %locals.i27.i = alloca i64, i32 0, align 8
-  %locals.i25.i = alloca i64, i32 0, align 8
-  %locals.i23.i = alloca i64, i32 0, align 8
-  %locals.i21.i = alloca i64, i32 0, align 8
+  %locals.i36.i = alloca i64, i32 0, align 8
+  %locals.i34.i = alloca i64, i32 0, align 8
+  %locals.i32.i = alloca i64, i32 0, align 8
+  %locals.i30.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
+  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #10
   store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_test, i64 0, i64 0), i64 noundef 4) #11
+  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_test, i64 0, i64 0), i64 noundef 4) #10
   store i64 %1, i64* @rubyIdPrecomputed_test, align 8
-  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_!", i64 0, i64 0), i64 noundef 1) #11
+  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_!", i64 0, i64 0), i64 noundef 1) #10
   store i64 %2, i64* @"rubyIdPrecomputed_!", align 8
-  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #11
+  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #10
   store i64 %3, i64* @rubyIdPrecomputed_puts, align 8
-  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([12 x i8], [12 x i8]* @"str_<class:Bad>", i64 0, i64 0), i64 noundef 11) #11
+  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([12 x i8], [12 x i8]* @"str_<class:Bad>", i64 0, i64 0), i64 noundef 11) #10
   store i64 %4, i64* @"rubyIdPrecomputed_<class:Bad>", align 8
-  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #11
-  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_new, i64 0, i64 0), i64 noundef 3) #11
+  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #10
+  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_new, i64 0, i64 0), i64 noundef 3) #10
   store i64 %6, i64* @rubyIdPrecomputed_new, align 8
-  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 noundef 10) #11
+  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 noundef 10) #10
   store i64 %7, i64* @rubyIdPrecomputed_initialize, align 8
-  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_<module:Main>", i64 0, i64 0), i64 noundef 13) #11
+  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_<module:Main>", i64 0, i64 0), i64 noundef 13) #10
   store i64 %8, i64* @"rubyIdPrecomputed_<module:Main>", align 8
-  %9 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
-  tail call void @rb_gc_register_mark_object(i64 %9) #11
+  %9 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #10
+  tail call void @rb_gc_register_mark_object(i64 %9) #10
   store i64 %9, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %10 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([42 x i8], [42 x i8]* @"str_test/testdata/compiler/intrinsics/bang.rb", i64 0, i64 0), i64 noundef 41) #11
-  tail call void @rb_gc_register_mark_object(i64 %10) #11
+  %10 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([42 x i8], [42 x i8]* @"str_test/testdata/compiler/intrinsics/bang.rb", i64 0, i64 0), i64 noundef 41) #10
+  tail call void @rb_gc_register_mark_object(i64 %10) #10
   store i64 %10, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 23)
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
@@ -229,151 +230,161 @@ entry:
   store %struct.rb_iseq_struct* %11, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   %rubyId_test.i = load i64, i64* @rubyIdPrecomputed_test, align 8, !dbg !10
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test, i64 %rubyId_test.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !10
-  %12 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_!", i64 0, i64 0), i64 noundef 1) #11
-  call void @rb_gc_register_mark_object(i64 %12) #11
+  %12 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_!", i64 0, i64 0), i64 noundef 1) #10
+  call void @rb_gc_register_mark_object(i64 %12) #10
   %"rubyId_!.i.i" = load i64, i64* @"rubyIdPrecomputed_!", align 8
-  %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i20.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
-  %13 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %12, i64 %"rubyId_!.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i20.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i21.i, i32 noundef 0, i32 noundef 2)
+  %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i29.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
+  %13 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %12, i64 %"rubyId_!.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i29.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i30.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %13, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad#1!", align 8
-  %14 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([18 x i8], [18 x i8]* @"str_bad bang overload", i64 0, i64 0), i64 noundef 17) #11
-  call void @rb_gc_register_mark_object(i64 %14) #11
+  %14 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([18 x i8], [18 x i8]* @"str_bad bang overload", i64 0, i64 0), i64 noundef 17) #10
+  call void @rb_gc_register_mark_object(i64 %14) #10
   store i64 %14, i64* @"rubyStrFrozen_bad bang overload", align 8
   %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !15
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
-  %15 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([12 x i8], [12 x i8]* @"str_<class:Bad>", i64 0, i64 0), i64 noundef 11) #11
-  call void @rb_gc_register_mark_object(i64 %15) #11
+  %15 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([12 x i8], [12 x i8]* @"str_<class:Bad>", i64 0, i64 0), i64 noundef 11) #10
+  call void @rb_gc_register_mark_object(i64 %15) #10
   %"rubyId_<class:Bad>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:Bad>", align 8
-  %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i22.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
-  %16 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %15, i64 %"rubyId_<class:Bad>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i22.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i23.i, i32 noundef 0, i32 noundef 4)
+  %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i31.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
+  %16 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %15, i64 %"rubyId_<class:Bad>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i31.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i32.i, i32 noundef 0, i32 noundef 4)
   store %struct.rb_iseq_struct* %16, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad.13<static-init>", align 8
-  %17 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_test, i64 0, i64 0), i64 noundef 4) #11
-  call void @rb_gc_register_mark_object(i64 %17) #11
+  %17 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_test, i64 0, i64 0), i64 noundef 4) #10
+  call void @rb_gc_register_mark_object(i64 %17) #10
   %rubyId_test.i.i = load i64, i64* @rubyIdPrecomputed_test, align 8
-  %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i24.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
-  %18 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %17, i64 %rubyId_test.i.i, i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i24.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 13, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i25.i, i32 noundef 0, i32 noundef 2)
+  %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i33.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
+  %18 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %17, i64 %rubyId_test.i.i, i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i33.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 13, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i34.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %18, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Main.4test, align 8
-  %rubyId_puts2.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !17
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts2.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !17
-  %rubyId_puts5.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !19
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts5.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
-  %rubyId_puts8.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !20
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts8.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !20
-  %19 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_hello, i64 0, i64 0), i64 noundef 5) #11
-  call void @rb_gc_register_mark_object(i64 %19) #11
+  %"rubyId_!.i" = load i64, i64* @"rubyIdPrecomputed_!", align 8, !dbg !17
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_!", i64 %"rubyId_!.i", i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !17
+  %rubyId_puts3.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !19
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts3.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
+  %"rubyId_!6.i" = load i64, i64* @"rubyIdPrecomputed_!", align 8, !dbg !20
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_!.2", i64 %"rubyId_!6.i", i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !20
+  %rubyId_puts8.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !21
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts8.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !21
+  %"rubyId_!11.i" = load i64, i64* @"rubyIdPrecomputed_!", align 8, !dbg !22
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_!.4", i64 %"rubyId_!11.i", i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !22
+  %rubyId_puts13.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !23
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.5, i64 %rubyId_puts13.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !23
+  %19 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_hello, i64 0, i64 0), i64 noundef 5) #10
+  call void @rb_gc_register_mark_object(i64 %19) #10
   store i64 %19, i64* @rubyStrFrozen_hello, align 8
-  %rubyId_puts11.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !21
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.4, i64 %rubyId_puts11.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !21
-  %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !22
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !22
-  %rubyId_initialize.i = load i64, i64* @rubyIdPrecomputed_initialize, align 8, !dbg !22
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 %rubyId_initialize.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !22
-  %rubyId_puts17.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !23
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.5, i64 %rubyId_puts17.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !23
-  %20 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_<module:Main>", i64 0, i64 0), i64 noundef 13) #11
-  call void @rb_gc_register_mark_object(i64 %20) #11
+  %"rubyId_!16.i" = load i64, i64* @"rubyIdPrecomputed_!", align 8, !dbg !24
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_!.6", i64 %"rubyId_!16.i", i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !24
+  %rubyId_puts18.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !25
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.7, i64 %rubyId_puts18.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !25
+  %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !26
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !26
+  %rubyId_initialize.i = load i64, i64* @rubyIdPrecomputed_initialize, align 8, !dbg !26
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 %rubyId_initialize.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !26
+  %"rubyId_!24.i" = load i64, i64* @"rubyIdPrecomputed_!", align 8, !dbg !27
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_!.8", i64 %"rubyId_!24.i", i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !27
+  %rubyId_puts26.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !28
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.9, i64 %rubyId_puts26.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !28
+  %20 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_<module:Main>", i64 0, i64 0), i64 noundef 13) #10
+  call void @rb_gc_register_mark_object(i64 %20) #10
   %"rubyId_<module:Main>.i.i" = load i64, i64* @"rubyIdPrecomputed_<module:Main>", align 8
-  %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i26.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
-  %21 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %20, i64 %"rubyId_<module:Main>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i26.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 12, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i27.i, i32 noundef 0, i32 noundef 4)
+  %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i35.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
+  %21 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %20, i64 %"rubyId_<module:Main>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i35.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 12, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i36.i, i32 noundef 0, i32 noundef 4)
   store %struct.rb_iseq_struct* %21, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Main.13<static-init>", align 8
-  %22 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !24
+  %22 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !29
   %23 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %22, i64 0, i32 2
-  %24 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %23, align 8, !tbaa !26
+  %24 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %23, align 8, !tbaa !31
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   %25 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %25, align 8, !tbaa !30
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %25, align 8, !tbaa !35
   %26 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 4
-  %27 = load i64*, i64** %26, align 8, !tbaa !32
+  %27 = load i64*, i64** %26, align 8, !tbaa !37
   %28 = load i64, i64* %27, align 8, !tbaa !6
   %29 = and i64 %28, -33
   store i64 %29, i64* %27, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %22, %struct.rb_control_frame_struct* %24, %struct.rb_iseq_struct* %stackFrame.i) #11
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %22, %struct.rb_control_frame_struct* %24, %struct.rb_iseq_struct* %stackFrame.i) #10
   %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 0
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %30, align 8, !dbg !33, !tbaa !24
-  %31 = load i64, i64* @rb_cObject, align 8, !dbg !34
-  %32 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_Bad, i64 0, i64 0), i64 %31) #11, !dbg !34
-  %33 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %32) #11, !dbg !34
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %30, align 8, !dbg !38, !tbaa !29
+  %31 = load i64, i64* @rb_cObject, align 8, !dbg !39
+  %32 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_Bad, i64 0, i64 0), i64 %31) #10, !dbg !39
+  %33 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %32) #10, !dbg !39
   %stackFrame.i1.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad.13<static-init>", align 8
-  %34 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !24
+  %34 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !29
   %35 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %34, i64 0, i32 2
-  %36 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %35, align 8, !tbaa !26
+  %36 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %35, align 8, !tbaa !31
   %37 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i1.i, %struct.rb_iseq_struct** %37, align 8, !tbaa !30
+  store %struct.rb_iseq_struct* %stackFrame.i1.i, %struct.rb_iseq_struct** %37, align 8, !tbaa !35
   %38 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 4
-  %39 = load i64*, i64** %38, align 8, !tbaa !32
+  %39 = load i64*, i64** %38, align 8, !tbaa !37
   %40 = load i64, i64* %39, align 8, !tbaa !6
   %41 = and i64 %40, -33
   store i64 %41, i64* %39, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %34, %struct.rb_control_frame_struct* %36, %struct.rb_iseq_struct* %stackFrame.i1.i) #11
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %34, %struct.rb_control_frame_struct* %36, %struct.rb_iseq_struct* %stackFrame.i1.i) #10
   %42 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 0
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %42, align 8, !dbg !35, !tbaa !24
-  %43 = load i64, i64* @guard_epoch_Bad, align 8, !dbg !38
-  %44 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !38, !tbaa !39
-  %needTakeSlowPath = icmp ne i64 %43, %44, !dbg !38
-  br i1 %needTakeSlowPath, label %45, label %46, !dbg !38, !prof !41
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %42, align 8, !dbg !40, !tbaa !29
+  %43 = load i64, i64* @guard_epoch_Bad, align 8, !dbg !43
+  %44 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !43, !tbaa !44
+  %needTakeSlowPath = icmp ne i64 %43, %44, !dbg !43
+  br i1 %needTakeSlowPath, label %45, label %46, !dbg !43, !prof !46
 
 45:                                               ; preds = %entry
-  call void @const_recompute_Bad(), !dbg !38
-  br label %46, !dbg !38
+  call void @const_recompute_Bad(), !dbg !43
+  br label %46, !dbg !43
 
 46:                                               ; preds = %entry, %45
-  %47 = load i64, i64* @guarded_const_Bad, align 8, !dbg !38
-  %48 = load i64, i64* @guard_epoch_Bad, align 8, !dbg !38
-  %49 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !38, !tbaa !39
-  %guardUpdated = icmp eq i64 %48, %49, !dbg !38
-  call void @llvm.assume(i1 %guardUpdated), !dbg !38
-  %stackFrame7.i2.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad#1!", align 8, !dbg !38
-  %50 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !38
-  %51 = bitcast i8* %50 to i16*, !dbg !38
-  %52 = load i16, i16* %51, align 8, !dbg !38
-  %53 = and i16 %52, -384, !dbg !38
-  store i16 %53, i16* %51, align 8, !dbg !38
-  %54 = getelementptr inbounds i8, i8* %50, i64 4, !dbg !38
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %54, i8 0, i64 28, i1 false) #11, !dbg !38
-  call void @sorbet_vm_define_method(i64 %47, i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_!", i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Bad#1!", i8* nonnull %50, %struct.rb_iseq_struct* %stackFrame7.i2.i, i1 noundef zeroext false) #11, !dbg !38
-  call void @sorbet_popFrame() #11, !dbg !34
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %30, align 8, !dbg !34, !tbaa !24
-  %55 = call i64 @rb_define_module(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_Main, i64 0, i64 0)) #11, !dbg !42
-  %56 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %55) #11, !dbg !42
+  %47 = load i64, i64* @guarded_const_Bad, align 8, !dbg !43
+  %48 = load i64, i64* @guard_epoch_Bad, align 8, !dbg !43
+  %49 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !43, !tbaa !44
+  %guardUpdated = icmp eq i64 %48, %49, !dbg !43
+  call void @llvm.assume(i1 %guardUpdated), !dbg !43
+  %stackFrame7.i2.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad#1!", align 8, !dbg !43
+  %50 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #11, !dbg !43
+  %51 = bitcast i8* %50 to i16*, !dbg !43
+  %52 = load i16, i16* %51, align 8, !dbg !43
+  %53 = and i16 %52, -384, !dbg !43
+  store i16 %53, i16* %51, align 8, !dbg !43
+  %54 = getelementptr inbounds i8, i8* %50, i64 4, !dbg !43
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %54, i8 0, i64 28, i1 false) #10, !dbg !43
+  call void @sorbet_vm_define_method(i64 %47, i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_!", i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Bad#1!", i8* nonnull %50, %struct.rb_iseq_struct* %stackFrame7.i2.i, i1 noundef zeroext false) #10, !dbg !43
+  call void @sorbet_popFrame() #10, !dbg !39
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %30, align 8, !dbg !39, !tbaa !29
+  %55 = call i64 @rb_define_module(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_Main, i64 0, i64 0)) #10, !dbg !47
+  %56 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %55) #10, !dbg !47
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Main.13<static-init>", align 8
-  %57 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !24
+  %57 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !29
   %58 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %57, i64 0, i32 2
-  %59 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %58, align 8, !tbaa !26
+  %59 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %58, align 8, !tbaa !31
   %60 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %59, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %60, align 8, !tbaa !30
+  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %60, align 8, !tbaa !35
   %61 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %59, i64 0, i32 4
-  %62 = load i64*, i64** %61, align 8, !tbaa !32
+  %62 = load i64*, i64** %61, align 8, !tbaa !37
   %63 = load i64, i64* %62, align 8, !tbaa !6
   %64 = and i64 %63, -33
   store i64 %64, i64* %62, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %57, %struct.rb_control_frame_struct* %59, %struct.rb_iseq_struct* %stackFrame.i.i) #11
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %57, %struct.rb_control_frame_struct* %59, %struct.rb_iseq_struct* %stackFrame.i.i) #10
   %65 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 0
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %65, align 8, !dbg !43, !tbaa !24
-  %66 = load i64, i64* @guard_epoch_Main, align 8, !dbg !46
-  %67 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !46, !tbaa !39
-  %needTakeSlowPath1 = icmp ne i64 %66, %67, !dbg !46
-  br i1 %needTakeSlowPath1, label %68, label %69, !dbg !46, !prof !41
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %65, align 8, !dbg !48, !tbaa !29
+  %66 = load i64, i64* @guard_epoch_Main, align 8, !dbg !51
+  %67 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !51, !tbaa !44
+  %needTakeSlowPath1 = icmp ne i64 %66, %67, !dbg !51
+  br i1 %needTakeSlowPath1, label %68, label %69, !dbg !51, !prof !46
 
 68:                                               ; preds = %46
-  call void @const_recompute_Main(), !dbg !46
-  br label %69, !dbg !46
+  call void @const_recompute_Main(), !dbg !51
+  br label %69, !dbg !51
 
 69:                                               ; preds = %46, %68
-  %70 = load i64, i64* @guarded_const_Main, align 8, !dbg !46
-  %71 = load i64, i64* @guard_epoch_Main, align 8, !dbg !46
-  %72 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !46, !tbaa !39
-  %guardUpdated2 = icmp eq i64 %71, %72, !dbg !46
-  call void @llvm.assume(i1 %guardUpdated2), !dbg !46
-  %stackFrame7.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Main.4test, align 8, !dbg !46
-  %73 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !46
-  %74 = bitcast i8* %73 to i16*, !dbg !46
-  %75 = load i16, i16* %74, align 8, !dbg !46
-  %76 = and i16 %75, -384, !dbg !46
-  store i16 %76, i16* %74, align 8, !dbg !46
-  %77 = getelementptr inbounds i8, i8* %73, i64 4, !dbg !46
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %77, i8 0, i64 28, i1 false) #11, !dbg !46
-  call void @sorbet_vm_define_method(i64 %70, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_test, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_Main.4test, i8* nonnull %73, %struct.rb_iseq_struct* %stackFrame7.i.i, i1 noundef zeroext true) #11, !dbg !46
-  call void @sorbet_popFrame() #11, !dbg !42
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %30, align 8, !dbg !42, !tbaa !24
+  %70 = load i64, i64* @guarded_const_Main, align 8, !dbg !51
+  %71 = load i64, i64* @guard_epoch_Main, align 8, !dbg !51
+  %72 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !51, !tbaa !44
+  %guardUpdated2 = icmp eq i64 %71, %72, !dbg !51
+  call void @llvm.assume(i1 %guardUpdated2), !dbg !51
+  %stackFrame7.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Main.4test, align 8, !dbg !51
+  %73 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #11, !dbg !51
+  %74 = bitcast i8* %73 to i16*, !dbg !51
+  %75 = load i16, i16* %74, align 8, !dbg !51
+  %76 = and i16 %75, -384, !dbg !51
+  store i16 %76, i16* %74, align 8, !dbg !51
+  %77 = getelementptr inbounds i8, i8* %73, i64 4, !dbg !51
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %77, i8 0, i64 28, i1 false) #10, !dbg !51
+  call void @sorbet_vm_define_method(i64 %70, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_test, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_Main.4test, i8* nonnull %73, %struct.rb_iseq_struct* %stackFrame7.i.i, i1 noundef zeroext true) #10, !dbg !51
+  call void @sorbet_popFrame() #10, !dbg !47
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %30, align 8, !dbg !47, !tbaa !29
   %78 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !10
   %79 = load i64*, i64** %78, align 8, !dbg !10
   store i64 %70, i64* %79, align 8, !dbg !10, !tbaa !6
@@ -384,20 +395,20 @@ entry:
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define internal noundef i64 @"func_Bad#1!"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #6 !dbg !16 {
+define internal noundef i64 @"func_Bad#1!"(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #5 !dbg !16 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %0, align 8, !tbaa !24
-  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !47
-  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !47, !prof !48
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %0, align 8, !tbaa !29
+  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !52
+  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !52, !prof !53
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #13, !dbg !47
-  unreachable, !dbg !47
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #12, !dbg !52
+  unreachable, !dbg !52
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %0, align 8, !dbg !49, !tbaa !24
-  %"rubyStr_bad bang overload" = load i64, i64* @"rubyStrFrozen_bad bang overload", align 8, !dbg !50
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %0, align 8, !dbg !54, !tbaa !29
+  %"rubyStr_bad bang overload" = load i64, i64* @"rubyStrFrozen_bad bang overload", align 8, !dbg !55
   %1 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !15
   %2 = load i64*, i64** %1, align 8, !dbg !15
   store i64 %selfRaw, i64* %2, align 8, !dbg !15, !tbaa !6
@@ -406,184 +417,153 @@ fillRequiredArgs:                                 ; preds = %functionEntryInitia
   %4 = getelementptr inbounds i64, i64* %3, i64 1, !dbg !15
   store i64* %4, i64** %1, align 8, !dbg !15
   %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !15
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !dbg !15, !tbaa !24
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !dbg !15, !tbaa !29
   ret i64 20
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define internal i64 @func_Main.4test(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #6 !dbg !18 {
+define internal i64 @func_Main.4test(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #5 !dbg !18 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %0, align 8, !tbaa !24
-  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !51
-  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !51, !prof !48
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %0, align 8, !tbaa !29
+  %tooManyArgs = icmp ugt i32 %argc, 0, !dbg !56
+  br i1 %tooManyArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !56, !prof !53
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #13, !dbg !51
-  unreachable, !dbg !51
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #12, !dbg !56
+  unreachable, !dbg !56
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %0, align 8, !dbg !52, !tbaa !24
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !53), !dbg !56
-  %1 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !17
-  %2 = load i64*, i64** %1, align 8, !dbg !17
-  store i64 %selfRaw, i64* %2, align 8, !dbg !17, !tbaa !6
-  %3 = getelementptr inbounds i64, i64* %2, i64 1, !dbg !17
-  store i64 0, i64* %3, align 8, !dbg !17, !tbaa !6
-  %4 = getelementptr inbounds i64, i64* %3, i64 1, !dbg !17
-  store i64* %4, i64** %1, align 8, !dbg !17
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.1, i64 0), !dbg !17
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 15), i64** %0, align 8, !dbg !17, !tbaa !24
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !57), !dbg !60
-  %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !19
-  %6 = load i64*, i64** %5, align 8, !dbg !19
-  store i64 %selfRaw, i64* %6, align 8, !dbg !19, !tbaa !6
-  %7 = getelementptr inbounds i64, i64* %6, i64 1, !dbg !19
-  store i64 20, i64* %7, align 8, !dbg !19, !tbaa !6
-  %8 = getelementptr inbounds i64, i64* %7, i64 1, !dbg !19
-  store i64* %8, i64** %5, align 8, !dbg !19
-  %send109 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.2, i64 0), !dbg !19
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %0, align 8, !dbg !19, !tbaa !24
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !61), !dbg !64
-  %9 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !20
-  %10 = load i64*, i64** %9, align 8, !dbg !20
-  store i64 %selfRaw, i64* %10, align 8, !dbg !20, !tbaa !6
-  %11 = getelementptr inbounds i64, i64* %10, i64 1, !dbg !20
-  store i64 20, i64* %11, align 8, !dbg !20, !tbaa !6
-  %12 = getelementptr inbounds i64, i64* %11, i64 1, !dbg !20
-  store i64* %12, i64** %9, align 8, !dbg !20
-  %send111 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.3, i64 0), !dbg !20
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %0, align 8, !dbg !20, !tbaa !24
-  %rubyStr_hello = load i64, i64* @rubyStrFrozen_hello, align 8, !dbg !65
-  %"rubyId_!68" = load i64, i64* @"rubyIdPrecomputed_!", align 8, !dbg !66
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !67), !dbg !66
-  %13 = and i64 %rubyStr_hello, -9, !dbg !66
-  %14 = icmp eq i64 %13, 0, !dbg !66
-  br i1 %14, label %sorbet_bang.exit105, label %15, !dbg !66
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %0, align 8, !dbg !57, !tbaa !29
+  %1 = tail call i64 @sorbet_vm_bang(%struct.FunctionInlineCache* noundef @"ic_!", %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp, i64 noundef 20), !dbg !17
+  %2 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !19
+  %3 = load i64*, i64** %2, align 8, !dbg !19
+  store i64 %selfRaw, i64* %3, align 8, !dbg !19, !tbaa !6
+  %4 = getelementptr inbounds i64, i64* %3, i64 1, !dbg !19
+  store i64 %1, i64* %4, align 8, !dbg !19, !tbaa !6
+  %5 = getelementptr inbounds i64, i64* %4, i64 1, !dbg !19
+  store i64* %5, i64** %2, align 8, !dbg !19
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.1, i64 0), !dbg !19
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 15), i64** %0, align 8, !dbg !19, !tbaa !29
+  %6 = tail call i64 @sorbet_vm_bang(%struct.FunctionInlineCache* noundef @"ic_!.2", %struct.rb_control_frame_struct* nonnull %cfp, i64 noundef 0), !dbg !20
+  %7 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !21
+  %8 = load i64*, i64** %7, align 8, !dbg !21
+  store i64 %selfRaw, i64* %8, align 8, !dbg !21, !tbaa !6
+  %9 = getelementptr inbounds i64, i64* %8, i64 1, !dbg !21
+  store i64 %6, i64* %9, align 8, !dbg !21, !tbaa !6
+  %10 = getelementptr inbounds i64, i64* %9, i64 1, !dbg !21
+  store i64* %10, i64** %7, align 8, !dbg !21
+  %send98 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.3, i64 0), !dbg !21
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %0, align 8, !dbg !21, !tbaa !29
+  %11 = tail call i64 @sorbet_vm_bang(%struct.FunctionInlineCache* noundef @"ic_!.4", %struct.rb_control_frame_struct* nonnull %cfp, i64 noundef 8), !dbg !22
+  %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !23
+  %13 = load i64*, i64** %12, align 8, !dbg !23
+  store i64 %selfRaw, i64* %13, align 8, !dbg !23, !tbaa !6
+  %14 = getelementptr inbounds i64, i64* %13, i64 1, !dbg !23
+  store i64 %11, i64* %14, align 8, !dbg !23, !tbaa !6
+  %15 = getelementptr inbounds i64, i64* %14, i64 1, !dbg !23
+  store i64* %15, i64** %12, align 8, !dbg !23
+  %send100 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.5, i64 0), !dbg !23
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %0, align 8, !dbg !23, !tbaa !29
+  %rubyStr_hello = load i64, i64* @rubyStrFrozen_hello, align 8, !dbg !58
+  %16 = tail call i64 @sorbet_vm_bang(%struct.FunctionInlineCache* noundef @"ic_!.6", %struct.rb_control_frame_struct* nonnull %cfp, i64 %rubyStr_hello), !dbg !24
+  %17 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !25
+  %18 = load i64*, i64** %17, align 8, !dbg !25
+  store i64 %selfRaw, i64* %18, align 8, !dbg !25, !tbaa !6
+  %19 = getelementptr inbounds i64, i64* %18, i64 1, !dbg !25
+  store i64 %16, i64* %19, align 8, !dbg !25, !tbaa !6
+  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !25
+  store i64* %20, i64** %17, align 8, !dbg !25
+  %send102 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.7, i64 0), !dbg !25
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %0, align 8, !dbg !25, !tbaa !29
+  %21 = load i64, i64* @guard_epoch_Bad, align 8, !dbg !26
+  %22 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !26, !tbaa !44
+  %needTakeSlowPath = icmp ne i64 %21, %22, !dbg !26
+  br i1 %needTakeSlowPath, label %23, label %24, !dbg !26, !prof !46
 
-15:                                               ; preds = %fillRequiredArgs
-  %16 = icmp eq i64 %rubyStr_hello, 20, !dbg !66
-  br i1 %16, label %sorbet_bang.exit105, label %17, !dbg !66
+23:                                               ; preds = %fillRequiredArgs
+  tail call void @const_recompute_Bad(), !dbg !26
+  br label %24, !dbg !26
 
-17:                                               ; preds = %15
-  %18 = tail call i64 @rb_funcallv_with_cc(%struct.rb_call_data* noundef nonnull @sorbet_bang.rb_funcallv_data, i64 %rubyStr_hello, i64 %"rubyId_!68", i32 noundef 0, i64* noundef null) #11, !dbg !66
-  br label %sorbet_bang.exit105, !dbg !66
+24:                                               ; preds = %fillRequiredArgs, %23
+  %25 = load i64, i64* @guarded_const_Bad, align 8, !dbg !26
+  %26 = load i64, i64* @guard_epoch_Bad, align 8, !dbg !26
+  %27 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !26, !tbaa !44
+  %guardUpdated = icmp eq i64 %26, %27, !dbg !26
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !26
+  %28 = tail call i64 @sorbet_maybeAllocateObjectFastPath(i64 %25, %struct.FunctionInlineCache* noundef @ic_new), !dbg !26
+  %29 = icmp eq i64 %28, 52, !dbg !26
+  br i1 %29, label %slowNew, label %fastNew, !dbg !26
 
-sorbet_bang.exit105:                              ; preds = %fillRequiredArgs, %15, %17
-  %19 = phi i64 [ %18, %17 ], [ 0, %15 ], [ 20, %fillRequiredArgs ], !dbg !66
-  %20 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !21
-  %21 = load i64*, i64** %20, align 8, !dbg !21
-  store i64 %selfRaw, i64* %21, align 8, !dbg !21, !tbaa !6
-  %22 = getelementptr inbounds i64, i64* %21, i64 1, !dbg !21
-  store i64 %19, i64* %22, align 8, !dbg !21, !tbaa !6
-  %23 = getelementptr inbounds i64, i64* %22, i64 1, !dbg !21
-  store i64* %23, i64** %20, align 8, !dbg !21
-  %send113 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.4, i64 0), !dbg !21
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %0, align 8, !dbg !21, !tbaa !24
-  %24 = load i64, i64* @guard_epoch_Bad, align 8, !dbg !22
-  %25 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !22, !tbaa !39
-  %needTakeSlowPath = icmp ne i64 %24, %25, !dbg !22
-  br i1 %needTakeSlowPath, label %26, label %27, !dbg !22, !prof !41
+slowNew:                                          ; preds = %24
+  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !26
+  %31 = load i64*, i64** %30, align 8, !dbg !26
+  store i64 %25, i64* %31, align 8, !dbg !26, !tbaa !6
+  %32 = getelementptr inbounds i64, i64* %31, i64 1, !dbg !26
+  store i64* %32, i64** %30, align 8, !dbg !26
+  %33 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_new, i64 noundef 0), !dbg !26
+  br label %afterNew, !dbg !26
 
-26:                                               ; preds = %sorbet_bang.exit105
-  tail call void @const_recompute_Bad(), !dbg !22
-  br label %27, !dbg !22
-
-27:                                               ; preds = %sorbet_bang.exit105, %26
-  %28 = load i64, i64* @guarded_const_Bad, align 8, !dbg !22
-  %29 = load i64, i64* @guard_epoch_Bad, align 8, !dbg !22
-  %30 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !22, !tbaa !39
-  %guardUpdated = icmp eq i64 %29, %30, !dbg !22
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !22
-  %31 = tail call i64 @sorbet_maybeAllocateObjectFastPath(i64 %28, %struct.FunctionInlineCache* noundef @ic_new), !dbg !22
-  %32 = icmp eq i64 %31, 52, !dbg !22
-  br i1 %32, label %slowNew, label %fastNew, !dbg !22
-
-slowNew:                                          ; preds = %27
-  %33 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !22
-  %34 = load i64*, i64** %33, align 8, !dbg !22
-  store i64 %28, i64* %34, align 8, !dbg !22, !tbaa !6
-  %35 = getelementptr inbounds i64, i64* %34, i64 1, !dbg !22
-  store i64* %35, i64** %33, align 8, !dbg !22
-  %36 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_new, i64 noundef 0), !dbg !22
-  br label %afterNew, !dbg !22
-
-fastNew:                                          ; preds = %27
-  %37 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !22
-  %38 = load i64*, i64** %37, align 8, !dbg !22
-  store i64 %31, i64* %38, align 8, !dbg !22, !tbaa !6
-  %39 = getelementptr inbounds i64, i64* %38, i64 1, !dbg !22
-  store i64* %39, i64** %37, align 8, !dbg !22
-  %40 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 noundef 0), !dbg !22
-  br label %afterNew, !dbg !22
+fastNew:                                          ; preds = %24
+  %34 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !26
+  %35 = load i64*, i64** %34, align 8, !dbg !26
+  store i64 %28, i64* %35, align 8, !dbg !26, !tbaa !6
+  %36 = getelementptr inbounds i64, i64* %35, i64 1, !dbg !26
+  store i64* %36, i64** %34, align 8, !dbg !26
+  %37 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 noundef 0), !dbg !26
+  br label %afterNew, !dbg !26
 
 afterNew:                                         ; preds = %fastNew, %slowNew
-  %initializedObject = phi i64 [ %36, %slowNew ], [ %31, %fastNew ], !dbg !22
-  %"rubyId_!85" = load i64, i64* @"rubyIdPrecomputed_!", align 8, !dbg !70
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !71), !dbg !70
-  %41 = and i64 %initializedObject, -9, !dbg !70
-  %42 = icmp eq i64 %41, 0, !dbg !70
-  br i1 %42, label %sorbet_bang.exit, label %43, !dbg !70
-
-43:                                               ; preds = %afterNew
-  %44 = icmp eq i64 %initializedObject, 20, !dbg !70
-  br i1 %44, label %sorbet_bang.exit, label %45, !dbg !70
-
-45:                                               ; preds = %43
-  %46 = tail call i64 @rb_funcallv_with_cc(%struct.rb_call_data* noundef nonnull @sorbet_bang.rb_funcallv_data, i64 %initializedObject, i64 %"rubyId_!85", i32 noundef 0, i64* noundef null) #11, !dbg !70
-  br label %sorbet_bang.exit, !dbg !70
-
-sorbet_bang.exit:                                 ; preds = %afterNew, %43, %45
-  %47 = phi i64 [ %46, %45 ], [ 0, %43 ], [ 20, %afterNew ], !dbg !70
-  %48 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !23
-  %49 = load i64*, i64** %48, align 8, !dbg !23
-  store i64 %selfRaw, i64* %49, align 8, !dbg !23, !tbaa !6
-  %50 = getelementptr inbounds i64, i64* %49, i64 1, !dbg !23
-  store i64 %47, i64* %50, align 8, !dbg !23, !tbaa !6
-  %51 = getelementptr inbounds i64, i64* %50, i64 1, !dbg !23
-  store i64* %51, i64** %48, align 8, !dbg !23
-  %send115 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.5, i64 0), !dbg !23
-  ret i64 %send115
+  %initializedObject = phi i64 [ %33, %slowNew ], [ %28, %fastNew ], !dbg !26
+  %38 = tail call i64 @sorbet_vm_bang(%struct.FunctionInlineCache* noundef @"ic_!.8", %struct.rb_control_frame_struct* nonnull %cfp, i64 %initializedObject), !dbg !27
+  %39 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !28
+  %40 = load i64*, i64** %39, align 8, !dbg !28
+  store i64 %selfRaw, i64* %40, align 8, !dbg !28, !tbaa !6
+  %41 = getelementptr inbounds i64, i64* %40, i64 1, !dbg !28
+  store i64 %38, i64* %41, align 8, !dbg !28, !tbaa !6
+  %42 = getelementptr inbounds i64, i64* %41, i64 1, !dbg !28
+  store i64* %42, i64** %39, align 8, !dbg !28
+  %send104 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.9, i64 0), !dbg !28
+  ret i64 %send104
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #7
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #6
 
 ; Function Attrs: nofree nosync nounwind willreturn
-declare void @llvm.assume(i1 noundef) #8
+declare void @llvm.assume(i1 noundef) #7
 
 ; Function Attrs: ssp
-define linkonce void @const_recompute_Bad() local_unnamed_addr #9 {
+define linkonce void @const_recompute_Bad() local_unnamed_addr #8 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @str_Bad, i64 0, i64 0), i64 3)
   store i64 %1, i64* @guarded_const_Bad, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !39
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !44
   store i64 %2, i64* @guard_epoch_Bad, align 8
   ret void
 }
 
 ; Function Attrs: ssp
-define linkonce void @const_recompute_Main() local_unnamed_addr #9 {
+define linkonce void @const_recompute_Main() local_unnamed_addr #8 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @str_Main, i64 0, i64 0), i64 4)
   store i64 %1, i64* @guarded_const_Main, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !39
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !44
   store i64 %2, i64* @guard_epoch_Main, align 8
   ret void
 }
 
 attributes #0 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #2 = { inaccessiblememonly nofree nosync nounwind willreturn }
-attributes #3 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #4 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #5 = { sspreq }
-attributes #6 = { nounwind sspreq uwtable }
-attributes #7 = { argmemonly nofree nosync nounwind willreturn writeonly }
-attributes #8 = { nofree nosync nounwind willreturn }
-attributes #9 = { ssp }
-attributes #10 = { noreturn nounwind }
-attributes #11 = { nounwind }
-attributes #12 = { nounwind allocsize(0,1) }
-attributes #13 = { noreturn }
+attributes #2 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #3 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #4 = { sspreq }
+attributes #5 = { nounwind sspreq uwtable }
+attributes #6 = { argmemonly nofree nosync nounwind willreturn writeonly }
+attributes #7 = { nofree nosync nounwind willreturn }
+attributes #8 = { ssp }
+attributes #9 = { noreturn nounwind }
+attributes #10 = { nounwind }
+attributes #11 = { nounwind allocsize(0,1) }
+attributes #12 = { noreturn }
 
 !llvm.module.flags = !{!0, !1, !2}
 !llvm.dbg.cu = !{!3}
@@ -605,60 +585,45 @@ attributes #13 = { noreturn }
 !14 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
 !15 = !DILocation(line: 7, column: 5, scope: !16)
 !16 = distinct !DISubprogram(name: "Bad#!", linkageName: "func_Bad#1!", scope: null, file: !4, line: 6, type: !12, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!17 = !DILocation(line: 14, column: 5, scope: !18)
+!17 = !DILocation(line: 14, column: 10, scope: !18)
 !18 = distinct !DISubprogram(name: "Main.test", linkageName: "func_Main.4test", scope: null, file: !4, line: 13, type: !12, scopeLine: 13, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!19 = !DILocation(line: 15, column: 5, scope: !18)
-!20 = !DILocation(line: 16, column: 5, scope: !18)
-!21 = !DILocation(line: 17, column: 5, scope: !18)
-!22 = !DILocation(line: 18, column: 11, scope: !18)
-!23 = !DILocation(line: 18, column: 5, scope: !18)
-!24 = !{!25, !25, i64 0}
-!25 = !{!"any pointer", !8, i64 0}
-!26 = !{!27, !25, i64 16}
-!27 = !{!"rb_execution_context_struct", !25, i64 0, !7, i64 8, !25, i64 16, !25, i64 24, !25, i64 32, !28, i64 40, !28, i64 44, !25, i64 48, !25, i64 56, !25, i64 64, !7, i64 72, !7, i64 80, !25, i64 88, !7, i64 96, !25, i64 104, !25, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !29, i64 152}
-!28 = !{!"int", !8, i64 0}
-!29 = !{!"", !25, i64 0, !25, i64 8, !7, i64 16, !8, i64 24}
-!30 = !{!31, !25, i64 16}
-!31 = !{!"rb_control_frame_struct", !25, i64 0, !25, i64 8, !25, i64 16, !7, i64 24, !25, i64 32, !25, i64 40, !25, i64 48}
-!32 = !{!31, !25, i64 32}
-!33 = !DILocation(line: 0, scope: !11)
-!34 = !DILocation(line: 5, column: 1, scope: !11)
-!35 = !DILocation(line: 0, scope: !36, inlinedAt: !37)
-!36 = distinct !DISubprogram(name: "Bad.<static-init>", linkageName: "func_Bad.13<static-init>L62", scope: null, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!37 = distinct !DILocation(line: 5, column: 1, scope: !11)
-!38 = !DILocation(line: 6, column: 3, scope: !36, inlinedAt: !37)
-!39 = !{!40, !40, i64 0}
-!40 = !{!"long long", !8, i64 0}
-!41 = !{!"branch_weights", i32 1, i32 10000}
-!42 = !DILocation(line: 12, column: 1, scope: !11)
-!43 = !DILocation(line: 0, scope: !44, inlinedAt: !45)
-!44 = distinct !DISubprogram(name: "Main.<static-init>", linkageName: "func_Main.13<static-init>L129", scope: null, file: !4, line: 12, type: !12, scopeLine: 12, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!45 = distinct !DILocation(line: 12, column: 1, scope: !11)
-!46 = !DILocation(line: 13, column: 3, scope: !44, inlinedAt: !45)
-!47 = !DILocation(line: 6, column: 3, scope: !16)
-!48 = !{!"branch_weights", i32 1, i32 2000}
-!49 = !DILocation(line: 0, scope: !16)
-!50 = !DILocation(line: 7, column: 10, scope: !16)
-!51 = !DILocation(line: 13, column: 3, scope: !18)
-!52 = !DILocation(line: 0, scope: !18)
-!53 = !{!54}
-!54 = distinct !{!54, !55, !"sorbet_bang: argument 0"}
-!55 = distinct !{!55, !"sorbet_bang"}
-!56 = !DILocation(line: 14, column: 10, scope: !18)
-!57 = !{!58}
-!58 = distinct !{!58, !59, !"sorbet_bang: argument 0"}
-!59 = distinct !{!59, !"sorbet_bang"}
-!60 = !DILocation(line: 15, column: 10, scope: !18)
-!61 = !{!62}
-!62 = distinct !{!62, !63, !"sorbet_bang: argument 0"}
-!63 = distinct !{!63, !"sorbet_bang"}
-!64 = !DILocation(line: 16, column: 10, scope: !18)
-!65 = !DILocation(line: 17, column: 11, scope: !18)
-!66 = !DILocation(line: 17, column: 10, scope: !18)
-!67 = !{!68}
-!68 = distinct !{!68, !69, !"sorbet_bang: argument 0"}
-!69 = distinct !{!69, !"sorbet_bang"}
-!70 = !DILocation(line: 18, column: 10, scope: !18)
-!71 = !{!72}
-!72 = distinct !{!72, !73, !"sorbet_bang: argument 0"}
-!73 = distinct !{!73, !"sorbet_bang"}
+!19 = !DILocation(line: 14, column: 5, scope: !18)
+!20 = !DILocation(line: 15, column: 10, scope: !18)
+!21 = !DILocation(line: 15, column: 5, scope: !18)
+!22 = !DILocation(line: 16, column: 10, scope: !18)
+!23 = !DILocation(line: 16, column: 5, scope: !18)
+!24 = !DILocation(line: 17, column: 10, scope: !18)
+!25 = !DILocation(line: 17, column: 5, scope: !18)
+!26 = !DILocation(line: 18, column: 11, scope: !18)
+!27 = !DILocation(line: 18, column: 10, scope: !18)
+!28 = !DILocation(line: 18, column: 5, scope: !18)
+!29 = !{!30, !30, i64 0}
+!30 = !{!"any pointer", !8, i64 0}
+!31 = !{!32, !30, i64 16}
+!32 = !{!"rb_execution_context_struct", !30, i64 0, !7, i64 8, !30, i64 16, !30, i64 24, !30, i64 32, !33, i64 40, !33, i64 44, !30, i64 48, !30, i64 56, !30, i64 64, !7, i64 72, !7, i64 80, !30, i64 88, !7, i64 96, !30, i64 104, !30, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !34, i64 152}
+!33 = !{!"int", !8, i64 0}
+!34 = !{!"", !30, i64 0, !30, i64 8, !7, i64 16, !8, i64 24}
+!35 = !{!36, !30, i64 16}
+!36 = !{!"rb_control_frame_struct", !30, i64 0, !30, i64 8, !30, i64 16, !7, i64 24, !30, i64 32, !30, i64 40, !30, i64 48}
+!37 = !{!36, !30, i64 32}
+!38 = !DILocation(line: 0, scope: !11)
+!39 = !DILocation(line: 5, column: 1, scope: !11)
+!40 = !DILocation(line: 0, scope: !41, inlinedAt: !42)
+!41 = distinct !DISubprogram(name: "Bad.<static-init>", linkageName: "func_Bad.13<static-init>L62", scope: null, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!42 = distinct !DILocation(line: 5, column: 1, scope: !11)
+!43 = !DILocation(line: 6, column: 3, scope: !41, inlinedAt: !42)
+!44 = !{!45, !45, i64 0}
+!45 = !{!"long long", !8, i64 0}
+!46 = !{!"branch_weights", i32 1, i32 10000}
+!47 = !DILocation(line: 12, column: 1, scope: !11)
+!48 = !DILocation(line: 0, scope: !49, inlinedAt: !50)
+!49 = distinct !DISubprogram(name: "Main.<static-init>", linkageName: "func_Main.13<static-init>L129", scope: null, file: !4, line: 12, type: !12, scopeLine: 12, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!50 = distinct !DILocation(line: 12, column: 1, scope: !11)
+!51 = !DILocation(line: 13, column: 3, scope: !49, inlinedAt: !50)
+!52 = !DILocation(line: 6, column: 3, scope: !16)
+!53 = !{!"branch_weights", i32 1, i32 2000}
+!54 = !DILocation(line: 0, scope: !16)
+!55 = !DILocation(line: 7, column: 10, scope: !16)
+!56 = !DILocation(line: 13, column: 3, scope: !18)
+!57 = !DILocation(line: 0, scope: !18)
+!58 = !DILocation(line: 17, column: 11, scope: !18)

--- a/test/testdata/ruby_benchmark/stripe/bang_intrinsic_dispatch.rb
+++ b/test/testdata/ruby_benchmark/stripe/bang_intrinsic_dispatch.rb
@@ -3,7 +3,7 @@
 # compiled: true
 
 i = 0
-while i < 100_000
+while i < 10_000_000
   !"foo"
   i += 1
 end

--- a/test/testdata/ruby_benchmark/stripe/bang_intrinsic_toggle.rb
+++ b/test/testdata/ruby_benchmark/stripe/bang_intrinsic_toggle.rb
@@ -4,7 +4,7 @@
 
 i = 0
 x = T.let(true, T::Boolean)
-while i < 1_000_000
+while i < 10_000_000
   x = !x
   i += 1
 end


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

`!` calls on non-boolean, non-nil values currently shares a single method call cache per module.  This seems suboptimal, especially compared to the VM.  Benchmark:

```
ruby vm startup time: .093
source  interpreted     compiled
stripe/while_10_000_000.rb      .247    .102
stripe/bang_intrinsic_dispatch.rb       .302    .232
stripe/bang_intrinsic_dispatch.rb - baseline    .055    .130
```

This PR changes that, and gives every `!` callsite a method call cache.  Same benchmark with changes:

```
source  interpreted     compiled
stripe/while_10_000_000.rb      .240    .101
stripe/bang_intrinsic_dispatch.rb       .290    .155
stripe/bang_intrinsic_dispatch.rb - baseline    .050    .054
```

So we are ~as fast as the VM now, instead of 2x slower.  (Presumably we're a little bit slower because of function call overhead and the special-casing of boolean values and `nil`.)

This change means that the boolean case gets somewhat slower, but I think that's OK, because it's still significantly faster than the VM:

Before this change:

```
source  interpreted     compiled
stripe/while_10_000_000.rb      .252    .109
stripe/bang_intrinsic_toggle.rb .401    .106
stripe/bang_intrinsic_toggle.rb - baseline      .149    -.003
```

I'm not entirely sure I believe those numbers, because I think the compiler might be constant-folding away some of the computation.  After:

```
source  interpreted     compiled
stripe/while_10_000_000.rb      .253    .097
stripe/bang_intrinsic_toggle.rb .395    .118
stripe/bang_intrinsic_toggle.rb - baseline      .142    .021
```

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
