### PR TITLE
Fix publish-ruby-gems.sh after ruby-version upgrade

### DIFF
--- a/.buildkite/publish-ruby-gems.sh
+++ b/.buildkite/publish-ruby-gems.sh
@@ -46,6 +46,8 @@ with_backoff() {
   done
 }
 
+rbenv install --skip-existing
+
 # Push the sorbet-static gems first, in case they fail. We don't want to end
 # up in a weird state where 'sorbet' requires a pinned version of
 # sorbet-static, but the sorbet-static gem push failed.


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I broke this in #4908 when I upgraded the `.ruby-version` from 2.6 to
2.7. It was failing every night, but then made to look like a "flaky"
failure because the clean (not publish) job would run after it and pass.
So the publish job was consistently failing with messages like these:

    [2021-11-30T06:29:41Z] Attempting to publish _out_/gems/sorbet-static-0.5.9379-java.gem
    [2021-11-30T06:29:41Z] rbenv: version `2.7.2' is not installed (set by /app/.ruby-version)
    [2021-11-30T06:29:41Z] Attempt 1
    [2021-11-30T06:29:41Z] rbenv: version `2.7.2' is not installed (set by /app/.ruby-version)
    [2021-11-30T06:29:41Z] 'gem' failed. Retrying in 1s...
    [2021-11-30T06:29:42Z] Attempt 2
    [2021-11-30T06:29:42Z] rbenv: version `2.7.2' is not installed (set by /app/.ruby-version)
    [2021-11-30T06:29:42Z] 'gem' failed. Retrying in 2s...
    [2021-11-30T06:29:44Z] Attempt 3
    [2021-11-30T06:29:44Z] rbenv: version `2.7.2' is not installed (set by /app/.ruby-version)
    [2021-11-30T06:29:44Z] 'gem' failed. Retrying in 4s...
    [2021-11-30T06:29:48Z] Attempt 4
    [2021-11-30T06:29:48Z] rbenv: version `2.7.2' is not installed (set by /app/.ruby-version)
    [2021-11-30T06:29:48Z] 'gem' failed. Retrying in 8s...
    [2021-11-30T06:29:56Z] Attempt 5
    [2021-11-30T06:29:56Z] rbenv: version `2.7.2' is not installed (set by /app/.ruby-version)
    [2021-11-30T06:29:56Z] 'gem' failed 5 times. Quitting.
    [2021-11-30T06:29:57Z] 🚨 Error: The command exited with status 1

But it was not obvious that it was a publish-specific failure.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

We can either wait to see if this goes away tonight, or we can manually kick off
a publish job (out of schedule) to try it after it lands.