### PR TITLE
make MethodDef's isRewriterSynthesized clearer in the raw dump output

### DIFF
--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -546,7 +546,7 @@ string MethodDef::showRaw(const core::GlobalState &gs, int tabs) {
         stringifiedFlags.emplace_back("self");
     }
     if (this->flags.isRewriterSynthesized) {
-        stringifiedFlags.emplace_back("rewriter");
+        stringifiedFlags.emplace_back("rewriterSynthesized");
     }
     fmt::format_to(std::back_inserter(buf), "flags = {{{}}}\n", fmt::join(stringifiedFlags, ", "));
 

--- a/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
@@ -1395,7 +1395,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U foo><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -1509,7 +1509,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U foo=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
@@ -1928,7 +1928,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U default><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -2042,7 +2042,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U default=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
@@ -2145,7 +2145,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U t_nilable><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -2283,7 +2283,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U t_nilable=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
@@ -2374,7 +2374,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U array><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -2488,7 +2488,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U array=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
@@ -2594,7 +2594,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U t_array><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -2738,7 +2738,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U t_array=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
@@ -2848,7 +2848,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U hash_of><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -3000,7 +3000,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U hash_of=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
@@ -3091,7 +3091,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U const_explicit><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -3192,7 +3192,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U const><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -3293,7 +3293,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U enum_prop><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -3407,7 +3407,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U enum_prop=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
@@ -3479,7 +3479,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U foreign><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -3593,7 +3593,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U foreign=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
@@ -3717,7 +3717,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U foreign_><<U <todo method>>>
           args = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
               kind = Local
@@ -3810,7 +3810,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U foreign_!><<U <todo method>>>
           args = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
               kind = Local
@@ -3882,7 +3882,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U foreign_lazy><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -3996,7 +3996,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U foreign_lazy=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
@@ -4120,7 +4120,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U foreign_lazy_><<U <todo method>>>
           args = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
               kind = Local
@@ -4213,7 +4213,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U foreign_lazy_!><<U <todo method>>>
           args = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
               kind = Local
@@ -4285,7 +4285,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U foreign_proc><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -4399,7 +4399,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U foreign_proc=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
@@ -4523,7 +4523,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U foreign_proc_><<U <todo method>>>
           args = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
               kind = Local
@@ -4616,7 +4616,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U foreign_proc_!><<U <todo method>>>
           args = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
               kind = Local
@@ -4688,7 +4688,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U foreign_invalid><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -4802,7 +4802,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U foreign_invalid=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
@@ -4922,7 +4922,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U foreign_invalid_><<U <todo method>>>
           args = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
               kind = Local
@@ -5023,7 +5023,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U foreign_invalid_!><<U <todo method>>>
           args = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
               kind = Local
@@ -5095,7 +5095,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U ifunset><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -5177,7 +5177,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U ifunset=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
@@ -5280,7 +5280,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U ifunset_nilable><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -5386,7 +5386,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U ifunset_nilable=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
@@ -5477,7 +5477,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U empty_hash_rules><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -5591,7 +5591,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U empty_hash_rules=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
@@ -5682,7 +5682,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U hash_rules><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -5796,7 +5796,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U hash_rules=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
@@ -6936,7 +6936,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U token><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -7050,7 +7050,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U token=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
@@ -7141,7 +7141,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U created><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -7255,7 +7255,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U created=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
@@ -7552,7 +7552,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U token><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -7666,7 +7666,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U token=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
@@ -7757,7 +7757,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U created><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -8096,7 +8096,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U foo><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -8192,7 +8192,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U encrypted_foo><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -8298,7 +8298,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U foo=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
@@ -8437,7 +8437,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U encrypted_foo=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
@@ -8521,7 +8521,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U bar><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -8617,7 +8617,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriter}
+          flags = {rewriterSynthesized}
           name = <U encrypted_bar><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Review comments in #4926 said that `rewriterSynthesized` would be better dump output for the relevant flag on `Send`.  Seeing as how I cargo-culted those bits from `MethodDef`'s flags, it seemed like a good idea to make the equivalent change to `MethodDef`'s dump output.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
