### PR TITLE
Add a block intrinsic for Hash#fetch

### DIFF
--- a/compiler/IREmitter/Payload/codegen-payload.c
+++ b/compiler/IREmitter/Payload/codegen-payload.c
@@ -704,6 +704,25 @@ VALUE sorbet_int_hash_to_h(VALUE recv, ID fun, int argc, const VALUE *const rest
     return sorbet_rb_hash_to_h(recv);
 }
 
+SORBET_INLINE
+VALUE sorbet_rb_hash_fetch_m_withBlock(VALUE recv, ID fun, int argc, const VALUE *const restrict argv, BlockFFIType blk,
+                                       const struct rb_captured_block *captured, VALUE closure, int numPositionalArgs) {
+    extern VALUE sorbet_hash_stlike_lookup(VALUE hash, VALUE key, VALUE * val);
+
+    rb_check_arity(argc, 1, 2);
+    VALUE key = argv[0];
+    VALUE val;
+
+    if (sorbet_hash_stlike_lookup(recv, key, &val)) {
+        return (VALUE)val;
+    } else {
+        sorbet_pushBlockFrame(captured);
+        val = blk(key, closure, 1, &key, Qnil);
+        sorbet_popFrame();
+        return val;
+    }
+}
+
 struct sorbet_int_hash_to_h_closure {
     BlockFFIType fun;
     VALUE closure_for_block;

--- a/compiler/IREmitter/Payload/codegen-payload.c
+++ b/compiler/IREmitter/Payload/codegen-payload.c
@@ -704,6 +704,8 @@ VALUE sorbet_int_hash_to_h(VALUE recv, ID fun, int argc, const VALUE *const rest
     return sorbet_rb_hash_to_h(recv);
 }
 
+// This is the block variant of rb_hash_fetch_m:
+// https://github.com/sorbet/ruby/blob/12d8c43330278a744d6e45135d1a8735f23f5afe/hash.c#L2113-L2147
 SORBET_INLINE
 VALUE sorbet_rb_hash_fetch_m_withBlock(VALUE recv, ID fun, int argc, const VALUE *const restrict argv, BlockFFIType blk,
                                        const struct rb_captured_block *captured, VALUE closure, int numPositionalArgs) {
@@ -712,6 +714,9 @@ VALUE sorbet_rb_hash_fetch_m_withBlock(VALUE recv, ID fun, int argc, const VALUE
     rb_check_arity(argc, 1, 2);
     VALUE key = argv[0];
     VALUE val;
+
+    // NOTE: the vm will issue a warning when two arguments and a block are
+    // given, but we don't issue that warning here.
 
     if (sorbet_hash_stlike_lookup(recv, key, &val)) {
         return (VALUE)val;

--- a/compiler/IREmitter/Payload/patches/hash.c
+++ b/compiler/IREmitter/Payload/patches/hash.c
@@ -132,3 +132,7 @@ int sorbet_rb_hash_update_withBlock_i(VALUE key, VALUE value, VALUE argsv) {
     RHASH_UPDATE(hash, key, sorbet_rb_hash_update_withBlock_callback, (VALUE)&callback_args);
     return ST_CONTINUE;
 }
+
+int sorbet_hash_stlike_lookup(VALUE hash, VALUE key, VALUE *val) {
+    return hash_stlike_lookup(hash, key, val);
+}

--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -956,7 +956,7 @@ static const vector<CallCMethod> knownCMethodsInstance{
      CMethod{"sorbet_int_hash_to_h_withBlock", core::Symbols::Hash()},
      {KnownFunction::cached("sorbet_rb_hash_to_h_func")}},
     {core::Symbols::Hash(), "to_hash", CMethod{"sorbet_returnRecv", core::Symbols::Hash()}},
-    {core::Symbols::Hash(), "fetch", CMethod{"sorbet_rb_hash_fetch_m"}},
+    {core::Symbols::Hash(), "fetch", CMethod{"sorbet_rb_hash_fetch_m"}, CMethod{"sorbet_rb_hash_fetch_m_withBlock"}},
     {core::Symbols::Hash(), "merge", CMethod{"sorbet_rb_hash_merge", core::Symbols::Hash()},
      CMethod{"sorbet_rb_hash_merge_withBlock", core::Symbols::Hash()}},
     {core::Symbols::Hash(), "merge!", CMethod{"sorbet_rb_hash_update", core::Symbols::Hash()},

--- a/test/testdata/compiler/intrinsics/hash_fetch.rb
+++ b/test/testdata/compiler/intrinsics/hash_fetch.rb
@@ -31,6 +31,7 @@ def block_arg(hash, key, &blk)
 end
 
 # INITIAL-LABEL: define internal i64 @"func_Object#9block_arg"
+# INITIAL: call i64 @sorbet_callIntrinsicInlineBlock_noBreak({{.*sorbet_rb_hash_fetch_m_withBlock}}
 # INITIAL-NOT: call i64 @sorbet_rb_hash_fetch_m
 # INITIAL{LITERAL}: }
 

--- a/test/testdata/ruby_benchmark/stripe/hash_fetch_block.rb
+++ b/test/testdata/ruby_benchmark/stripe/hash_fetch_block.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+
+hash = {a: 10}
+
+i = 0
+misses = 0
+
+while i < 10_000_000 do
+  i += 1
+
+  hash.fetch(:x) {misses += 1}
+  hash.fetch(:a) {misses += 1}
+end
+
+p i
+p misses


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
```
# master
source                                                                  interpreted     compiled
stripe/while_10_000_000.rb                                               .276           .122
./test/testdata/ruby_benchmark/stripe/hash_fetch_block.rb               1.488          1.009
./test/testdata/ruby_benchmark/stripe/hash_fetch_block.rb - baseline    1.212           .887

# this branch
source                                                                  interpreted     compiled
stripe/while_10_000_000.rb                                               .274           .114
./test/testdata/ruby_benchmark/stripe/hash_fetch_block.rb               1.503           .497
./test/testdata/ruby_benchmark/stripe/hash_fetch_block.rb - baseline    1.229           .383
```


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Performance, avoiding a call through the VM when a block is given to `Hash#fetch`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.