### PR TITLE
Add an intrinsic for Hash#delete

### DIFF
--- a/compiler/IREmitter/Payload/codegen-payload.c
+++ b/compiler/IREmitter/Payload/codegen-payload.c
@@ -1540,6 +1540,54 @@ VALUE sorbet_rb_hash_square_br_eq(VALUE recv, ID fun, int argc, const VALUE *con
     return rb_hash_aset(recv, argv[0], argv[1]);
 }
 
+// This is the no-block version of rb_hash_delete_m https://github.com/ruby/ruby/blob/ruby_2_7/hash.c#L2390-L2409
+SORBET_INLINE
+VALUE sorbet_rb_hash_delete_m(VALUE recv, ID fun, int argc, const VALUE *const restrict argv, BlockFFIType blk,
+                              VALUE closure) {
+    sorbet_ensure_arity(argc, 1);
+
+    VALUE val;
+    VALUE key = argv[0];
+
+    // begin inline of rb_hash_modify_check
+    rb_check_frozen(recv);
+    // end inline of rb_hash_modify_check
+
+    val = rb_hash_delete_entry(recv, key);
+
+    if (val != Qundef) {
+        return val;
+    } else {
+        return Qnil;
+    }
+}
+
+// This is the block version of rb_hash_delete_m https://github.com/ruby/ruby/blob/ruby_2_7/hash.c#L2390-L2409
+SORBET_INLINE
+VALUE sorbet_rb_hash_delete_m_withBlock(VALUE recv, ID fun, int argc, const VALUE *const restrict argv,
+                                        BlockFFIType blk, const struct rb_captured_block *captured, VALUE closure,
+                                        int numPositionalArgs) {
+    sorbet_ensure_arity(argc, 1);
+
+    VALUE val;
+    VALUE key = argv[0];
+
+    // begin inline of rb_hash_modify_check
+    rb_check_frozen(recv);
+    // end inline of rb_hash_modify_check
+
+    val = rb_hash_delete_entry(recv, key);
+
+    if (val != Qundef) {
+        return val;
+    } else {
+        sorbet_pushBlockFrame(captured);
+        VALUE ret = blk(key, closure, 1, &key, Qnil);
+        sorbet_popFrame();
+        return ret;
+    }
+}
+
 SORBET_INLINE
 VALUE sorbet_rb_int_plus(VALUE recv, ID fun, int argc, const VALUE *const restrict argv, BlockFFIType blk,
                          VALUE closure) {

--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -965,6 +965,7 @@ static const vector<CallCMethod> knownCMethodsInstance{
      CMethod{"sorbet_rb_hash_update_withBlock", core::Symbols::Hash()}},
     {core::Symbols::Hash(), "select", CMethod{"sorbet_rb_hash_select", core::Symbols::Enumerator()},
      CMethod{"sorbet_rb_hash_select_withBlock", core::Symbols::Hash()}},
+    {core::Symbols::Hash(), "delete", CMethod{"sorbet_rb_hash_delete_m"}, CMethod{"sorbet_rb_hash_delete_m_withBlock"}},
     {core::Symbols::TrueClass(), "|", CMethod{"sorbet_int_bool_true"}},
     {core::Symbols::FalseClass(), "|", CMethod{"sorbet_int_bool_and"}},
     {core::Symbols::TrueClass(), "&", CMethod{"sorbet_int_bool_and"}},

--- a/test/testdata/compiler/intrinsics/hash_delete.rb
+++ b/test/testdata/compiler/intrinsics/hash_delete.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+# run_filecheck: INITIAL
+
+extend T::Sig
+
+sig {params(hash: T::Hash[T.untyped, T.untyped], key: T.untyped).returns(T.untyped)}
+def one_arg(hash, key)
+  hash.delete(key)
+end
+
+# INITIAL-LABEL: define internal i64 @"func_Object#7one_arg"
+# INITIAL: call i64 @sorbet_rb_hash_delete_m
+# INITIAL{LITERAL}: }
+
+sig {params(hash: T::Hash[T.untyped, T.untyped], key: T.untyped, blk: T.untyped).returns(T.untyped)}
+def block_arg(hash, key, &blk)
+  hash.delete(key) do |x|
+    yield
+  end
+end
+
+# INITIAL-LABEL: define internal i64 @"func_Object#9block_arg"
+# INITIAL-NOT: call i64 @sorbet_rb_hash_delete_m
+# INITIAL: call i64 @sorbet_callIntrinsicInlineBlock_noBreak(i64 (i64)* @forward_sorbet_rb_hash_delete_m_withBlock
+# INITIAL{LITERAL}: }
+
+h = {key: 5, otherkey: 99}
+p one_arg(h, :key)
+p h
+
+h = {key: 6, otherkey: 100}
+x = block_arg(h, :key) do |x|
+  p "don't call"
+end
+p x
+p h
+
+h = {key: 7}
+y = block_arg(h, :otherkey) do |x|
+  p "called block"
+end
+p y
+p h

--- a/test/testdata/ruby_benchmark/stripe/hash_delete.rb
+++ b/test/testdata/ruby_benchmark/stripe/hash_delete.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+
+h = {}
+
+i = 0
+while i < 10_000_000
+  h[i] = i
+  i += 2
+end
+
+i = 0
+z = 0
+while i < 10_000_000
+  z += (h.delete(i) || 0)
+
+  i += 1
+end
+
+puts i
+puts z

--- a/test/testdata/ruby_benchmark/stripe/hash_delete_baseline.rb
+++ b/test/testdata/ruby_benchmark/stripe/hash_delete_baseline.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+
+h = {}
+
+i = 0
+while i < 10_000_000
+  h[i] = i
+  i += 2
+end
+
+i = 0
+z = 0
+while i < 10_000_000
+  z += i
+
+  i += 1
+end
+
+puts i
+puts z

--- a/test/testdata/ruby_benchmark/stripe/hash_delete_blk.rb
+++ b/test/testdata/ruby_benchmark/stripe/hash_delete_blk.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+
+h = {}
+
+i = 0
+while i < 10_000_000
+  h[i] = i
+  i += 2
+end
+
+i = 0
+z = 0
+while i < 10_000_000
+  z += h.delete(i) {0}
+
+  i += 1
+end
+
+puts i
+puts z


### PR DESCRIPTION
Adds a compiler intrinsic for `Hash#delete`.

**Benchmarks**

`master`:

| source | interpreted  |   compiled |
|-|-|-|
| stripe/hash_delete_baseline.rb | 1.413 |  1.032 |
| stripe/hash_delete.rb  | 2.728 |  2.331 |
| stripe/hash_delete.rb - baseline    |    1.315  | 1.299 |
| stripe/hash_delete_blk.rb     |  2.941 |  2.422 |
| stripe/hash_delete_blk.rb - baseline  |  1.528  | 1.390 |

PR branch:

| source | interpreted   |  compiled |
|-|-|-|
| stripe/hash_delete_baseline.rb | 1.413  | 1.036 |
| stripe/hash_delete.rb |  2.741 | 1.888 |
| stripe/hash_delete.rb - baseline      |  1.328 |   .852 |
| stripe/hash_delete_blk.rb  |     2.954 |  2.261 |
| stripe/hash_delete_blk.rb - baseline  |  1.541 |  1.225 |

The relatively small delta from `master` for `hash_delete_blk` doesn't seem too disappointing when you consider that we're still pushing frames for the block (so all the potential savings are from inlining the block function) and the block is just `do ; 0 ; end`.

### Motivation
General push for more compiler intrinsics.

### Test plan
See included automated tests.
