### PR TITLE
Restructure the CallCMethod sanity checks to check for block handlers

### DIFF
--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -61,6 +61,9 @@ public:
         if (resultType.exists()) {
             auto intrinsicResultType = resultType.data(gs)->externalType();
 
+            // We can only reasonably add type assertions for methods that have signatures
+            ENFORCE(primaryMethod.data(gs)->hasSig());
+
             // test all overloads to see if we can find a sig that produces this type
             if (core::Types::isSubType(gs, intrinsicResultType, primaryMethod.data(gs)->resultType)) {
                 return;
@@ -237,7 +240,6 @@ protected:
         auto methodName = gs.lookupNameUTF8(call.rubyMethod);
         ENFORCE(methodName.exists());
 
-        // We can only reasonably add type assertions for methods that have signatures
         auto methodSym = klass.data(gs)->findMemberTransitive(gs, methodName);
         ENFORCE(methodSym.exists());
 
@@ -249,7 +251,7 @@ protected:
             call.cMethodWithBlock->sanityCheck(gs, primaryMethod);
         }
 
-        // when the intrinsic is defined without a block variant but the signature
+        // Determine if the primary, or any overload, accepts a block argument.
         int i = 0;
         bool acceptsBlock = false;
         auto current = primaryMethod;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
To help avoid adding intrinsics for methods that can accept blocks, without an explicit block handling variant.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Avoiding potential correctness issues.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I manually removed a block handler from one of the `CallCMethod` intrinsics to verify that the `ENFORCE` triggers.