### PR TITLE
Report a better error when type aliases are exported in --stripe-packages mode

### DIFF
--- a/test/cli/package-type-alias-export/__package.rb
+++ b/test/cli/package-type-alias-export/__package.rb
@@ -1,0 +1,6 @@
+# typed: strict
+# enable-packager: true
+
+class MyPackage < PackageSpec
+  export MyPackage::A
+end

--- a/test/cli/package-type-alias-export/a.rb
+++ b/test/cli/package-type-alias-export/a.rb
@@ -1,0 +1,7 @@
+# typed: strict
+
+module MyPackage
+  extend T::Helpers
+
+  A = T.type_alias {String}
+end

--- a/test/cli/package-type-alias-export/package-type-alias-export.out
+++ b/test/cli/package-type-alias-export/package-type-alias-export.out
@@ -1,0 +1,10 @@
+__package.rb: Exporting a type alias is not allowed in package specifications https://srb.help/5034
+    a.rb:6: Originally defined here
+     6 |  A = T.type_alias {String}
+          ^
+
+__package.rb: Exporting a type alias is not allowed in package specifications https://srb.help/5034
+    a.rb:6: Originally defined here
+     6 |  A = T.type_alias {String}
+          ^
+Errors: 2

--- a/test/cli/package-type-alias-export/package-type-alias-export.sh
+++ b/test/cli/package-type-alias-export/package-type-alias-export.sh
@@ -1,0 +1,3 @@
+cd test/cli/package-type-alias-export || exit 1
+
+../../../main/sorbet --silence-dev-message --stripe-packages . 2>&1


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
In `--stripe-packages` mode, when a constant exported by a package is a type alias, we get error [5034](https://sorbet.org/docs/error-reference#5028) due to the fact that the packager's inserted virtual AST node effectively becomes a reassignment of a type-alias. We have ratcheted against this behavior in the Stripe codebase for now, but when we launch `--stripe-packages`, we may remove this ratchet. In that situation, we want to throw a more user-friendly error.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
