### PR TITLE
make Tuple#sum smarter when faced with a homogeneous tuple

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -384,6 +384,7 @@ NameDef names[] = {
     {"first"},
     {"min"},
     {"max"},
+    {"sum"},
 
     // Argument forwarding
     {"fwdArgs", "<fwd-args>"},

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2603,6 +2603,26 @@ public:
     }
 } Tuple_minMax;
 
+class Tuple_sum : public IntrinsicMethod {
+public:
+    void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
+        auto *tuple = cast_type<TupleType>(args.thisType);
+        ENFORCE(tuple);
+
+        if (!args.args.empty()) {
+            return;
+        }
+        if (args.block != nullptr) {
+            return;
+        }
+        if (tuple->elems.empty()) {
+            res.returnType = Types::Integer();
+        } else {
+            res.returnType = tuple->elementType(gs);
+        }
+    }
+} Tuple_sum;
+
 class Tuple_to_a : public IntrinsicMethod {
 public:
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
@@ -3461,6 +3481,7 @@ const vector<Intrinsic> intrinsicMethods{
     {Symbols::Tuple(), Intrinsic::Kind::Instance, Names::last(), &Tuple_last},
     {Symbols::Tuple(), Intrinsic::Kind::Instance, Names::min(), &Tuple_minMax},
     {Symbols::Tuple(), Intrinsic::Kind::Instance, Names::max(), &Tuple_minMax},
+    {Symbols::Tuple(), Intrinsic::Kind::Instance, Names::sum(), &Tuple_sum},
     {Symbols::Tuple(), Intrinsic::Kind::Instance, Names::toA(), &Tuple_to_a},
     {Symbols::Tuple(), Intrinsic::Kind::Instance, Names::concat(), &Tuple_concat},
 

--- a/test/testdata/infer/tuples.rb
+++ b/test/testdata/infer/tuples.rb
@@ -15,6 +15,8 @@ T.assert_type!([1, 2].min, Integer)
 T.assert_type!([1, 2].max, Integer)
 T.assert_type!([1, 2].first, Integer)
 T.assert_type!([1, 2].last, Integer)
+T.assert_type!([].sum, Integer)
+T.assert_type!([1.1, 2.2].sum, Float)
 
 
 # Empty arrays are T::Array[T.untyped]

--- a/test/testdata/rbi/array.rb
+++ b/test/testdata/rbi/array.rb
@@ -9,7 +9,7 @@ T.assert_type!(T::Array[String].new(3, 'a'), T::Array[String])
 
 # no arg, no block
 T.assert_type!(T::Array[Float].new.sum, T.any(Float, Integer))
-T.assert_type!([Rational(1, 2)].sum, T.any(Rational, Integer))
+T.assert_type!([Rational(1, 2)].sum, Rational)
 # block, no arg
 T.assert_type!([1.0].sum {|f| f.to_i}, Integer)
 T.assert_type!([].sum {|f| Rational(1, 2)}, T.any(Rational, Integer))


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This case came up internally: `[1.3, 2.4].sum` should be able to figure out that the return type is a `Float`, not a `T.any(Float, Integer)`, because we know that the tuple is non-empty.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
