### PR TITLE
Move `block` field from `ast::Send` into `args` vector

### DIFF
--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -135,7 +135,6 @@ public:
         if (auto *s = cast_tree<ast::Send>(lhs)) {
             // the LHS might be a send of the form x.y=(), in which case we add the RHS to the arguments list and get
             // x.y=(rhs)
-            ENFORCE(!s->hasBlock() && !s->hasKwArgs());
             s->addPosArg(std::move(rhs));
             return lhs;
         } else if (auto *seq = cast_tree<ast::InsSeq>(lhs)) {
@@ -145,7 +144,6 @@ public:
             //   { $t = x; if $t == nil then nil else $t.y=(rhs)
             if (auto *cond = cast_tree<ast::If>(seq->expr)) {
                 if (auto *s = cast_tree<ast::Send>(cond->elsep)) {
-                    ENFORCE(!s->hasBlock() && !s->hasKwArgs());
                     s->addPosArg(std::move(rhs));
                     return lhs;
                 }

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -136,8 +136,7 @@ public:
             // the LHS might be a send of the form x.y=(), in which case we add the RHS to the arguments list and get
             // x.y=(rhs)
             ENFORCE(!s->hasBlock() && !s->hasKwArgs());
-            s->args.emplace_back(std::move(rhs));
-            s->numPosArgs++;
+            s->addPosArg(std::move(rhs));
             return lhs;
         } else if (auto *seq = cast_tree<ast::InsSeq>(lhs)) {
             // the LHS might be a sequence, which means that it's the result of a safe navigation operator, like
@@ -147,7 +146,7 @@ public:
             if (auto *cond = cast_tree<ast::If>(seq->expr)) {
                 if (auto *s = cast_tree<ast::Send>(cond->elsep)) {
                     ENFORCE(!s->hasBlock() && !s->hasKwArgs());
-                    s->args.emplace_back(std::move(rhs));
+                    s->addPosArg(std::move(rhs));
                     return lhs;
                 }
             }

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -35,9 +35,8 @@ public:
     }
 
     static ExpressionPtr Send(core::LocOffsets loc, ExpressionPtr recv, core::NameRef fun, u2 numPosArgs,
-                              Send::ARGS_store args, Send::Flags flags = {}, ExpressionPtr blk = nullptr) {
-        auto send =
-            make_expression<ast::Send>(loc, std::move(recv), fun, numPosArgs, std::move(args), std::move(blk), flags);
+                              Send::ARGS_store args, Send::Flags flags = {}) {
+        auto send = make_expression<ast::Send>(loc, std::move(recv), fun, numPosArgs, std::move(args), flags);
         return send;
     }
 
@@ -48,7 +47,12 @@ public:
 
     static ExpressionPtr Send0Block(core::LocOffsets loc, ExpressionPtr recv, core::NameRef fun, ExpressionPtr blk) {
         Send::ARGS_store nargs;
-        return Send(loc, std::move(recv), fun, 0, std::move(nargs), {}, std::move(blk));
+        Send::Flags flags;
+        if (blk != nullptr) {
+            flags.hasBlock = true;
+            nargs.emplace_back(std::move(blk));
+        }
+        return Send(loc, std::move(recv), fun, 0, std::move(nargs), flags);
     }
 
     static ExpressionPtr Send1(core::LocOffsets loc, ExpressionPtr recv, core::NameRef fun, ExpressionPtr arg1) {
@@ -131,6 +135,7 @@ public:
         if (auto *s = cast_tree<ast::Send>(lhs)) {
             // the LHS might be a send of the form x.y=(), in which case we add the RHS to the arguments list and get
             // x.y=(rhs)
+            ENFORCE(!s->hasBlock() && !s->hasKwArgs());
             s->args.emplace_back(std::move(rhs));
             s->numPosArgs++;
             return lhs;
@@ -141,6 +146,7 @@ public:
             //   { $t = x; if $t == nil then nil else $t.y=(rhs)
             if (auto *cond = cast_tree<ast::If>(seq->expr)) {
                 if (auto *s = cast_tree<ast::Send>(cond->elsep)) {
+                    ENFORCE(!s->hasBlock() && !s->hasKwArgs());
                     s->args.emplace_back(std::move(rhs));
                     return lhs;
                 }
@@ -318,7 +324,7 @@ public:
         auto sig = Send1(loc, Constant(loc, core::Symbols::Sorbet_Private_Static()), core::Names::sig(),
                          Constant(loc, core::Symbols::T_Sig_WithoutRuntime()));
         auto sigSend = ast::cast_tree<ast::Send>(sig);
-        sigSend->block = Block0(loc, std::move(returns));
+        sigSend->setBlock(Block0(loc, std::move(returns)));
         sigSend->flags.isRewriterSynthesized = true;
         return sig;
     }
@@ -329,7 +335,7 @@ public:
         auto sig = Send1(loc, Constant(loc, core::Symbols::Sorbet_Private_Static()), core::Names::sig(),
                          Constant(loc, core::Symbols::T_Sig_WithoutRuntime()));
         auto sigSend = ast::cast_tree<ast::Send>(sig);
-        sigSend->block = Block0(loc, std::move(void_));
+        sigSend->setBlock(Block0(loc, std::move(void_)));
         sigSend->flags.isRewriterSynthesized = true;
         return sig;
     }
@@ -339,7 +345,7 @@ public:
         auto sig = Send1(loc, Constant(loc, core::Symbols::Sorbet_Private_Static()), core::Names::sig(),
                          Constant(loc, core::Symbols::T_Sig_WithoutRuntime()));
         auto sigSend = ast::cast_tree<ast::Send>(sig);
-        sigSend->block = Block0(loc, std::move(returns));
+        sigSend->setBlock(Block0(loc, std::move(returns)));
         sigSend->flags.isRewriterSynthesized = true;
         return sig;
     }
@@ -392,10 +398,9 @@ public:
     }
 
     static ExpressionPtr SelfNew(core::LocOffsets loc, int numPosArgs, ast::Send::ARGS_store args,
-                                 Send::Flags flags = {}, ExpressionPtr block = nullptr) {
+                                 Send::Flags flags = {}) {
         auto magic = Constant(loc, core::Symbols::Magic());
-        return Send(loc, std::move(magic), core::Names::selfNew(), numPosArgs, std::move(args), flags,
-                    std::move(block));
+        return Send(loc, std::move(magic), core::Names::selfNew(), numPosArgs, std::move(args), flags);
     }
 
     static ExpressionPtr DefineTopClassOrModule(core::LocOffsets loc, core::ClassOrModuleRef klass) {

--- a/ast/TreeCopying.cc
+++ b/ast/TreeCopying.cc
@@ -31,8 +31,8 @@ ExpressionPtr deepCopy(const void *avoid, const Tag tag, const void *tree, bool 
 
         case Tag::Send: {
             auto *exp = reinterpret_cast<const Send *>(tree);
-            return make_expression<Send>(exp->loc, deepCopy(avoid, exp->recv), exp->fun, exp->numPosArgs,
-                                         deepCopyVec(avoid, exp->args), exp->flags);
+            return make_expression<Send>(exp->loc, deepCopy(avoid, exp->recv), exp->fun, exp->numPosArgs(),
+                                         deepCopyVec(avoid, exp->rawArgs()), exp->flags);
         }
 
         case Tag::ClassDef: {

--- a/ast/TreeCopying.cc
+++ b/ast/TreeCopying.cc
@@ -32,8 +32,7 @@ ExpressionPtr deepCopy(const void *avoid, const Tag tag, const void *tree, bool 
         case Tag::Send: {
             auto *exp = reinterpret_cast<const Send *>(tree);
             return make_expression<Send>(exp->loc, deepCopy(avoid, exp->recv), exp->fun, exp->numPosArgs,
-                                         deepCopyVec(avoid, exp->args),
-                                         exp->block == nullptr ? nullptr : deepCopy(avoid, exp->block), exp->flags);
+                                         deepCopyVec(avoid, exp->args), exp->flags);
         }
 
         case Tag::ClassDef: {

--- a/ast/TreeCopying.cc
+++ b/ast/TreeCopying.cc
@@ -32,7 +32,7 @@ ExpressionPtr deepCopy(const void *avoid, const Tag tag, const void *tree, bool 
         case Tag::Send: {
             auto *exp = reinterpret_cast<const Send *>(tree);
             return make_expression<Send>(exp->loc, deepCopy(avoid, exp->recv), exp->fun, exp->numPosArgs(),
-                                         deepCopyVec(avoid, exp->rawArgs()), exp->flags);
+                                         deepCopyVec(avoid, exp->rawArgsDoNotUse()), exp->flags);
         }
 
         case Tag::ClassDef: {

--- a/ast/TreeSanityChecks.cc
+++ b/ast/TreeSanityChecks.cc
@@ -192,6 +192,19 @@ void Send::_sanityCheck() {
     ENFORCE(numPosArgs <= args.size(), "Expected {} positional arguments, but only have {} args", numPosArgs,
             args.size());
 
+    if (hasBlock() || hasKwSplat() || hasKwArgs()) {
+        ENFORCE(args.size() > numPosArgs);
+    }
+
+    if (hasBlock()) {
+        ENFORCE(block() != nullptr);
+    }
+
+    const int end = args.size() - (hasBlock() ? 1 : 0);
+    for (int i = 0; i < end; i++) {
+        ENFORCE(args[i].tag() != ast::Tag::Block);
+    }
+
     for (auto &node : args) {
         ENFORCE(node);
     }

--- a/ast/TreeSanityChecks.cc
+++ b/ast/TreeSanityChecks.cc
@@ -189,11 +189,11 @@ void Retry::_sanityCheck() {}
 void Send::_sanityCheck() {
     ENFORCE(recv);
     ENFORCE(fun.exists());
-    ENFORCE(numPosArgs <= args.size(), "Expected {} positional arguments, but only have {} args", numPosArgs,
+    ENFORCE(numPosArgs_ <= args.size(), "Expected {} positional arguments, but only have {} args", numPosArgs_,
             args.size());
 
     if (hasBlock() || hasKwSplat() || hasKwArgs()) {
-        ENFORCE(args.size() > numPosArgs);
+        ENFORCE(args.size() > numPosArgs_);
     }
 
     if (hasBlock()) {

--- a/ast/TreeSanityChecks.cc
+++ b/ast/TreeSanityChecks.cc
@@ -192,7 +192,7 @@ void Send::_sanityCheck() {
     ENFORCE(numPosArgs_ <= args.size(), "Expected {} positional arguments, but only have {} args", numPosArgs_,
             args.size());
 
-    if (hasBlock() || hasKwSplat() || hasKwArgs()) {
+    if (hasBlock() || hasKwArgs()) {
         ENFORCE(args.size() > numPosArgs_);
     }
 

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -1034,6 +1034,16 @@ void Send::addKwArg(ExpressionPtr key, ExpressionPtr value) {
     this->args.emplace(it + 1, move(value));
 }
 
+ExpressionPtr Send::withNewBody(core::LocOffsets loc, ExpressionPtr recv, core::NameRef fun) {
+    auto rv = make_expression<Send>(loc, move(recv), fun, numPosArgs_, std::move(args), flags);
+
+    // Reset important metadata on this function.
+    this->numPosArgs_ = 0;
+    this->flags.hasBlock = false;
+
+    return rv;
+}
+
 string Cast::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     fmt::memory_buffer buf;
     fmt::format_to(std::back_inserter(buf), "T.{}", this->cast.toString(gs));

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -229,11 +229,10 @@ Assign::Assign(core::LocOffsets loc, ExpressionPtr lhs, ExpressionPtr rhs)
 }
 
 Send::Send(core::LocOffsets loc, ExpressionPtr recv, core::NameRef fun, u2 numPosArgs, Send::ARGS_store args,
-           ExpressionPtr block, Flags flags)
-    : loc(loc), fun(fun), flags(flags), numPosArgs(numPosArgs), recv(std::move(recv)), args(std::move(args)),
-      block(std::move(block)) {
+           Flags flags)
+    : loc(loc), fun(fun), flags(flags), numPosArgs(numPosArgs), recv(std::move(recv)), args(std::move(args)) {
     categoryCounterInc("trees", "send");
-    if (block) {
+    if (hasBlock()) {
         counterInc("trees.send.with_block");
     }
     histogramInc("trees.send.args", this->args.size());
@@ -378,6 +377,9 @@ template <class T> void printElems(const core::GlobalState &gs, fmt::memory_buff
     bool first = true;
     bool didshadow = false;
     for (auto &a : args) {
+        if (isa_tree<Block>(a)) {
+            continue;
+        }
         if (!first) {
             if (isa_tree<ShadowArg>(a) && !didshadow) {
                 fmt::format_to(std::back_inserter(buf), "; ");
@@ -897,8 +899,8 @@ string Send::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     fmt::memory_buffer buf;
     fmt::format_to(std::back_inserter(buf), "{}.{}", this->recv.toStringWithTabs(gs, tabs), this->fun.toString(gs));
     printArgs(gs, buf, this->args, tabs);
-    if (this->block != nullptr) {
-        fmt::format_to(std::back_inserter(buf), "{}", this->block.toStringWithTabs(gs, tabs));
+    if (this->hasBlock()) {
+        fmt::format_to(std::back_inserter(buf), "{}", this->block()->toStringWithTabs(gs, tabs));
     }
 
     return fmt::to_string(buf);
@@ -913,8 +915,8 @@ string Send::showRaw(const core::GlobalState &gs, int tabs) {
     fmt::format_to(std::back_inserter(buf), "fun = {}\n", this->fun.showRaw(gs));
     printTabs(buf, tabs + 1);
     fmt::format_to(std::back_inserter(buf), "block = ");
-    if (this->block) {
-        fmt::format_to(std::back_inserter(buf), "{}\n", this->block.showRaw(gs, tabs + 1));
+    if (this->hasBlock()) {
+        fmt::format_to(std::back_inserter(buf), "{}\n", this->block()->showRaw(gs, tabs + 1));
     } else {
         fmt::format_to(std::back_inserter(buf), "nullptr\n");
     }
@@ -923,6 +925,9 @@ string Send::showRaw(const core::GlobalState &gs, int tabs) {
     printTabs(buf, tabs + 1);
     fmt::format_to(std::back_inserter(buf), "args = [\n");
     for (auto &a : args) {
+        if (this->hasBlock() && a == args.back()) {
+            continue;
+        }
         printTabs(buf, tabs + 2);
         fmt::format_to(std::back_inserter(buf), "{}\n", a.showRaw(gs, tabs + 2));
     }
@@ -932,6 +937,67 @@ string Send::showRaw(const core::GlobalState &gs, int tabs) {
     fmt::format_to(std::back_inserter(buf), "}}");
 
     return fmt::to_string(buf);
+}
+
+const ast::Block *Send::block() const {
+    if (hasBlock()) {
+        auto block = ast::cast_tree<ast::Block>(this->args.back());
+        ENFORCE(block);
+        return block;
+    } else {
+        return nullptr;
+    }
+}
+
+ast::Block *Send::block() {
+    if (hasBlock()) {
+        auto block = ast::cast_tree<ast::Block>(this->args.back());
+        // ENFORCE(block, "{} tag {} size {} posArgs {} fun", this->args.back().tag(), this->args.size(), numPosArgs,
+        //        this->fun.rawId());
+        return block;
+    } else {
+        return nullptr;
+    }
+}
+
+const ExpressionPtr *Send::kwSplat() const {
+    if (hasKwSplat()) {
+        auto index = this->args.size() - 1;
+        if (hasBlock()) {
+            index = index - 1;
+        }
+        return &this->args[index];
+    }
+    return nullptr;
+}
+
+ExpressionPtr *Send::kwSplat() {
+    if (hasKwSplat()) {
+        auto index = this->args.size() - 1;
+        if (hasBlock()) {
+            index = index - 1;
+        }
+        return &this->args[index];
+    }
+    return nullptr;
+}
+
+void Send::addPosArg(ExpressionPtr ptr) {
+    this->args.emplace(this->args.begin() + numPosArgs, move(ptr));
+    this->numPosArgs++;
+}
+
+void Send::setBlock(ExpressionPtr block) {
+    if (hasBlock()) {
+        this->args.pop_back();
+        flags.hasBlock = false;
+    }
+
+    if (block != nullptr) {
+        this->args.emplace_back(move(block));
+        flags.hasBlock = true;
+        ENFORCE(this->block() != nullptr);
+    }
 }
 
 string Cast::toStringWithTabs(const core::GlobalState &gs, int tabs) const {

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -984,6 +984,18 @@ const ExpressionPtr *Send::kwSplat() const {
     return nullptr;
 }
 
+core::LocOffsets Send::argsLoc() const {
+    if (!this->hasPosArgs() && !this->hasKwArgs()) {
+        return core::LocOffsets();
+    }
+    auto begin = this->args.begin();
+    auto end = this->args.end() - 1;
+    if (this->hasBlock()) {
+        end = end - 1;
+    }
+    return begin->loc().join(end->loc());
+}
+
 ExpressionPtr *Send::kwSplat() {
     if (hasKwSplat()) {
         auto index = this->args.size() - 1;

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -1012,6 +1012,12 @@ void Send::insertPosArg(u2 index, ExpressionPtr arg) {
     this->numPosArgs_++;
 }
 
+void Send::removePosArg(u2 index) {
+    ENFORCE(index < numPosArgs_);
+    this->args.erase(this->args.begin() + index);
+    this->numPosArgs_--;
+}
+
 void Send::setBlock(ExpressionPtr block) {
     if (hasBlock()) {
         this->args.pop_back();

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -952,8 +952,7 @@ const ast::Block *Send::block() const {
 ast::Block *Send::block() {
     if (hasBlock()) {
         auto block = ast::cast_tree<ast::Block>(this->args.back());
-        // ENFORCE(block, "{} tag {} size {} posArgs {} fun", this->args.back().tag(), this->args.size(), numPosArgs,
-        //        this->fun.rawId());
+        ENFORCE(block);
         return block;
     } else {
         return nullptr;

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -793,8 +793,8 @@ public:
     }
 
     // Returns the raw arguments vector. Please avoid using unless absolutely necessary; it is easier to query
-    // arguments via methods on Send.
-    const ARGS_store &rawArgs() const {
+    // arguments via methods on Send. It is a footgun.
+    const ARGS_store &rawArgsDoNotUse() const {
         return args;
     }
 

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -792,17 +792,14 @@ public:
         this->args.reserve(posArgs + (kwArgs * 2) + (hasSplat ? 1 : 0) + (hasBlock ? 1 : 0));
     }
 
-    // Returns the raw arguments vector. Please avoid using unless absolutely necessary; it is easier to manipulate the
-    // arguments via the Send.
-    ARGS_store &rawArgs() {
-        return args;
-    }
-
-    // Returns the raw arguments vector. Please avoid using unless absolutely necessary; it is easier to manipulate the
-    // arguments via the Send.
+    // Returns the raw arguments vector. Please avoid using unless absolutely necessary; it is easier to query
+    // arguments via methods on Send.
     const ARGS_store &rawArgs() const {
         return args;
     }
+
+    // Returns a loc covering the arguments in the send. Does not cover the block argument.
+    core::LocOffsets argsLoc() const;
 
     u2 numPosArgs() const {
         return numPosArgs_;

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -861,7 +861,7 @@ public:
 
     void _sanityCheck();
 };
-CheckSize(Send, 56, 8);
+CheckSize(Send, 48, 8);
 
 EXPRESSION(Cast) {
 public:

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -823,6 +823,22 @@ public:
         return args[idx];
     }
 
+    absl::Span<const ExpressionPtr> posArgs() const {
+        return absl::MakeSpan(args.begin(), numPosArgs_);
+    }
+
+    absl::Span<ExpressionPtr> posArgs() {
+        return absl::MakeSpan(args.begin(), numPosArgs_);
+    }
+
+    absl::Span<const ExpressionPtr> nonBlockArgs() const {
+        return absl::MakeSpan(args.begin(), numNonBlockArgs());
+    }
+
+    absl::Span<ExpressionPtr> nonBlockArgs() {
+        return absl::MakeSpan(args.begin(), numNonBlockArgs());
+    }
+
     // Remove all arguments to the function, including the block argument.
     void clearArgs();
 

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -880,6 +880,22 @@ public:
         return hasPosArgs() || hasKwArgs();
     }
 
+    // Returns the number of non-block arguments. Keyword arguments are represented as two separate arguments (key and
+    // value).
+    u2 numNonBlockArgs() const {
+        return numPosArgs_ + (numKwArgs() * 2) + (hasKwSplat() ? 1 : 0);
+    }
+
+    const ExpressionPtr &getNonBlockArg(u2 idx) const {
+        ENFORCE(idx < args.size() - (hasBlock() ? 1 : 0));
+        return args[idx];
+    }
+
+    ExpressionPtr &getNonBlockArg(u2 idx) {
+        ENFORCE(idx < args.size() - (hasBlock() ? 1 : 0));
+        return args[idx];
+    }
+
     // Returns a new ast::Send with a different loc, receiver, and function.
     // _Moves_ the arguments from this Send into the new Send.
     // The original send turns into a Send with 0 arguments.

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -880,6 +880,11 @@ public:
         return hasPosArgs() || hasKwArgs();
     }
 
+    // Returns a new ast::Send with a different loc, receiver, and function.
+    // _Moves_ the arguments from this Send into the new Send.
+    // The original send turns into a Send with 0 arguments.
+    ExpressionPtr withNewBody(core::LocOffsets loc, ExpressionPtr recv, core::NameRef fun);
+
     void _sanityCheck();
 };
 CheckSize(Send, 48, 8);

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -784,6 +784,9 @@ public:
     // Insert the given positional argument at the given position, shifting existing arguments over.
     void insertPosArg(u2 index, ExpressionPtr arg);
 
+    // Removes the position argument at the given index.
+    void removePosArg(u2 index);
+
     // Reserve space for the given number of arguments.
     void reserveArguments(size_t posArgs, size_t kwArgs, bool hasSplat, bool hasBlock) {
         this->args.reserve(posArgs + (kwArgs * 2) + (hasSplat ? 1 : 0) + (hasBlock ? 1 : 0));

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -530,8 +530,7 @@ OpAsgnScaffolding copyArgsForOpAsgn(DesugarContext dctx, Send *s) {
     // here: to accomodate the call to field= instead of just field.
     assgnArgs.reserve(numPosArgs + 1);
 
-    for (auto i = 0; i < numPosArgs; ++i) {
-        auto &arg = s->getPosArg(i);
+    for (auto &arg : s->posArgs()) {
         auto argLoc = arg.loc();
         core::NameRef name = dctx.freshNameUnique(s->fun);
         stats.emplace_back(MK::Assign(argLoc, name, std::move(arg)));

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -515,7 +515,7 @@ OpAsgnScaffolding copyArgsForOpAsgn(DesugarContext dctx, Send *s) {
     //
     // This means we'll always need statements for as many arguments as the send has, plus two more: one for the
     // temporary assignment and the last for the actual update we're desugaring.
-    ENFORCE(!s->hasKwSplat() && !s->hasKwArgs() && !s->hasBlock());
+    ENFORCE(!s->hasKwArgs() && !s->hasBlock());
     const auto numPosArgs = s->numPosArgs();
     InsSeq::STATS_store stats;
     stats.reserve(numPosArgs + 2);
@@ -779,10 +779,10 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                         auto convertedBlock = node2TreeImpl(dctx, std::move(block));
                         Literal *lit;
                         if ((lit = cast_tree<Literal>(convertedBlock)) && lit->isSymbol(dctx.ctx)) {
-                            sendargs.emplace_back(symbol2Proc(dctx, std::move(convertedBlock)));
-                            flags.hasBlock = true;
                             res = MK::Send(loc, MK::Constant(loc, core::Symbols::Magic()), core::Names::callWithSplat(),
                                            4, std::move(sendargs), flags);
+                            ast::cast_tree_nonnull<ast::Send>(res).setBlock(
+                                symbol2Proc(dctx, std::move(convertedBlock)));
                         } else {
                             sendargs.emplace_back(std::move(convertedBlock));
                             res = MK::Send(loc, MK::Constant(loc, core::Symbols::Magic()),
@@ -851,9 +851,9 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                         auto convertedBlock = node2TreeImpl(dctx, std::move(block));
                         Literal *lit;
                         if ((lit = cast_tree<Literal>(convertedBlock)) && lit->isSymbol(dctx.ctx)) {
-                            flags.hasBlock = true;
-                            args.emplace_back(symbol2Proc(dctx, std::move(convertedBlock)));
                             res = MK::Send(loc, std::move(rec), send->method, numPosArgs, std::move(args), flags);
+                            ast::cast_tree_nonnull<ast::Send>(res).setBlock(
+                                symbol2Proc(dctx, std::move(convertedBlock)));
                         } else {
                             Send::ARGS_store sendargs;
                             sendargs.emplace_back(std::move(rec));

--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -341,27 +341,11 @@ private:
 
         cast_tree_nonnull<Send>(v).recv = mapIt(std::move(cast_tree_nonnull<Send>(v).recv), ctx);
 
-        const auto numPosArgs = cast_tree_nonnull<Send>(v).numPosArgs();
-        for (auto i = 0; i < numPosArgs; ++i) {
-            auto &arg = cast_tree_nonnull<Send>(v).getPosArg(i);
+        const auto numNonBlockArgs = cast_tree_nonnull<Send>(v).numNonBlockArgs();
+        for (auto i = 0; i < numNonBlockArgs; ++i) {
+            auto &arg = cast_tree_nonnull<Send>(v).getNonBlockArg(i);
             arg = mapIt(std::move(arg), ctx);
             ENFORCE(arg != nullptr);
-        }
-
-        const auto numKwArgs = cast_tree_nonnull<Send>(v).numKwArgs();
-        for (auto i = 0; i < numKwArgs; ++i) {
-            auto &key = cast_tree_nonnull<Send>(v).getKwKey(i);
-            key = mapIt(std::move(key), ctx);
-            ENFORCE(key != nullptr);
-
-            auto &val = cast_tree_nonnull<Send>(v).getKwValue(i);
-            val = mapIt(std::move(val), ctx);
-            ENFORCE(val != nullptr);
-        }
-
-        if (auto kwSplat = cast_tree_nonnull<Send>(v).kwSplat()) {
-            *kwSplat = mapIt(std::move(*kwSplat), ctx);
-            ENFORCE(kwSplat != nullptr);
         }
 
         if (auto block = cast_tree_nonnull<Send>(v).rawBlock()) {
@@ -817,27 +801,11 @@ private:
 
         cast_tree_nonnull<Send>(v).recv = mapIt(std::move(cast_tree_nonnull<Send>(v).recv), ctx);
 
-        const auto numPosArgs = cast_tree_nonnull<Send>(v).numPosArgs();
-        for (auto i = 0; i < numPosArgs; ++i) {
-            auto &arg = cast_tree_nonnull<Send>(v).getPosArg(i);
+        const auto numNonBlockArgs = cast_tree_nonnull<Send>(v).numNonBlockArgs();
+        for (auto i = 0; i < numNonBlockArgs; ++i) {
+            auto &arg = cast_tree_nonnull<Send>(v).getNonBlockArg(i);
             arg = mapIt(std::move(arg), ctx);
             ENFORCE(arg != nullptr);
-        }
-
-        const auto numKwArgs = cast_tree_nonnull<Send>(v).numKwArgs();
-        for (auto i = 0; i < numKwArgs; ++i) {
-            auto &key = cast_tree_nonnull<Send>(v).getKwKey(i);
-            key = mapIt(std::move(key), ctx);
-            ENFORCE(key != nullptr);
-
-            auto &val = cast_tree_nonnull<Send>(v).getKwValue(i);
-            val = mapIt(std::move(val), ctx);
-            ENFORCE(val != nullptr);
-        }
-
-        if (auto kwSplat = cast_tree_nonnull<Send>(v).kwSplat()) {
-            *kwSplat = mapIt(std::move(*kwSplat), ctx);
-            ENFORCE(kwSplat != nullptr);
         }
 
         if (auto block = cast_tree_nonnull<Send>(v).rawBlock()) {

--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -335,23 +335,31 @@ private:
     }
 
     ExpressionPtr mapSend(ExpressionPtr v, CTX ctx) {
+        ENFORCE(cast_tree_nonnull<Send>(v).hasBlock() ? cast_tree_nonnull<Send>(v).block() != nullptr : true,
+                "block was mapped into not-a block {}", cast_tree_nonnull<Send>(v).fun.toString(ctx));
+
         if constexpr (HAS_MEMBER_preTransformSend<FUNC>()) {
             v = CALL_MEMBER_preTransformSend<FUNC>::call(func, ctx, std::move(v));
         }
+        ENFORCE(cast_tree_nonnull<Send>(v).hasBlock() ? cast_tree_nonnull<Send>(v).block() != nullptr : true,
+                "block was mapped into not-a block");
+
         cast_tree_nonnull<Send>(v).recv = mapIt(std::move(cast_tree_nonnull<Send>(v).recv), ctx);
         for (auto &arg : cast_tree_nonnull<Send>(v).args) {
             arg = mapIt(std::move(arg), ctx);
             ENFORCE(arg != nullptr);
         }
 
-        if (cast_tree_nonnull<Send>(v).block) {
-            auto nblock = mapBlock(std::move(cast_tree_nonnull<Send>(v).block), ctx);
-            ENFORCE(isa_tree<Block>(nblock), "block was mapped into not-a block");
-            cast_tree_nonnull<Send>(v).block = std::move(nblock);
-        }
+        ENFORCE(cast_tree_nonnull<Send>(v).hasBlock() ? cast_tree_nonnull<Send>(v).block() != nullptr : true,
+                "block was mapped into not-a block");
 
         if constexpr (HAS_MEMBER_postTransformSend<FUNC>()) {
-            return CALL_MEMBER_postTransformSend<FUNC>::call(func, ctx, std::move(v));
+            v = CALL_MEMBER_postTransformSend<FUNC>::call(func, ctx, std::move(v));
+        }
+
+        if (isa_tree<Send>(v)) {
+            ENFORCE(cast_tree_nonnull<Send>(v).hasBlock() ? cast_tree_nonnull<Send>(v).block() != nullptr : true,
+                    "block was mapped into not-a block");
         }
 
         return v;
@@ -568,8 +576,7 @@ private:
                     return what;
 
                 case Tag::Block:
-                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what.nodeName());
-                    break;
+                    return mapBlock(std::move(what), ctx);
 
                 case Tag::InsSeq:
                     return mapInsSeq(std::move(what), ctx);
@@ -793,23 +800,32 @@ private:
     }
 
     ExpressionPtr mapSend(ExpressionPtr v, CTX ctx) {
+        ENFORCE(cast_tree_nonnull<Send>(v).hasBlock() ? cast_tree_nonnull<Send>(v).block() != nullptr : true,
+                "block was mapped into not-a block");
+
         if constexpr (HAS_MEMBER_preTransformSend<FUNC>()) {
             v = CALL_MEMBER_preTransformSend<FUNC>::call(func, ctx, std::move(v));
         }
+
+        ENFORCE(cast_tree_nonnull<Send>(v).hasBlock() ? cast_tree_nonnull<Send>(v).block() != nullptr : true,
+                "block was mapped into not-a block");
+
         cast_tree_nonnull<Send>(v).recv = mapIt(std::move(cast_tree_nonnull<Send>(v).recv), ctx);
         for (auto &arg : cast_tree_nonnull<Send>(v).args) {
             arg = mapIt(std::move(arg), ctx);
             ENFORCE(arg != nullptr);
         }
 
-        if (cast_tree_nonnull<Send>(v).block) {
-            auto nblock = mapBlock(std::move(cast_tree_nonnull<Send>(v).block), ctx);
-            ENFORCE(isa_tree<Block>(nblock), "block was mapped into not-a block");
-            cast_tree_nonnull<Send>(v).block = std::move(nblock);
-        }
+        ENFORCE(cast_tree_nonnull<Send>(v).hasBlock() ? cast_tree_nonnull<Send>(v).block() != nullptr : true,
+                "block was mapped into not-a block");
 
         if constexpr (HAS_MEMBER_postTransformSend<FUNC>()) {
-            return CALL_MEMBER_postTransformSend<FUNC>::call(func, ctx, std::move(v));
+            v = CALL_MEMBER_postTransformSend<FUNC>::call(func, ctx, std::move(v));
+        }
+
+        if (isa_tree<Send>(v)) {
+            ENFORCE(cast_tree_nonnull<Send>(v).hasBlock() ? cast_tree_nonnull<Send>(v).block() != nullptr : true,
+                    "block was mapped into not-a block");
         }
 
         return v;
@@ -1026,8 +1042,7 @@ private:
                     return what;
 
                 case Tag::Block:
-                    Exception::raise("should never happen. Forgot to add new tree kind? {}", what.nodeName());
-                    break;
+                    return mapBlock(std::move(what), ctx);
 
                 case Tag::InsSeq:
                     return mapInsSeq(std::move(what), ctx);

--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -340,13 +340,34 @@ private:
         }
 
         cast_tree_nonnull<Send>(v).recv = mapIt(std::move(cast_tree_nonnull<Send>(v).recv), ctx);
-        for (auto &arg : cast_tree_nonnull<Send>(v).rawArgs()) {
+
+        const auto numPosArgs = cast_tree_nonnull<Send>(v).numPosArgs();
+        for (auto i = 0; i < numPosArgs; ++i) {
+            auto &arg = cast_tree_nonnull<Send>(v).getPosArg(i);
             arg = mapIt(std::move(arg), ctx);
             ENFORCE(arg != nullptr);
         }
 
-        ENFORCE(cast_tree_nonnull<Send>(v).hasBlock() ? cast_tree_nonnull<Send>(v).block() != nullptr : true,
-                "block was mapped into not-a block");
+        const auto numKwArgs = cast_tree_nonnull<Send>(v).numKwArgs();
+        for (auto i = 0; i < numKwArgs; ++i) {
+            auto &key = cast_tree_nonnull<Send>(v).getKwKey(i);
+            key = mapIt(std::move(key), ctx);
+            ENFORCE(key != nullptr);
+
+            auto &val = cast_tree_nonnull<Send>(v).getKwValue(i);
+            val = mapIt(std::move(val), ctx);
+            ENFORCE(val != nullptr);
+        }
+
+        if (auto kwSplat = cast_tree_nonnull<Send>(v).kwSplat()) {
+            *kwSplat = mapIt(std::move(*kwSplat), ctx);
+            ENFORCE(kwSplat != nullptr);
+        }
+
+        if (auto block = cast_tree_nonnull<Send>(v).rawBlock()) {
+            *block = mapIt(std::move(*block), ctx);
+            ENFORCE(cast_tree_nonnull<Send>(v).block() != nullptr, "block was mapped into not-a block");
+        }
 
         if constexpr (HAS_MEMBER_postTransformSend<FUNC>()) {
             return CALL_MEMBER_postTransformSend<FUNC>::call(func, ctx, std::move(v));
@@ -795,13 +816,34 @@ private:
         }
 
         cast_tree_nonnull<Send>(v).recv = mapIt(std::move(cast_tree_nonnull<Send>(v).recv), ctx);
-        for (auto &arg : cast_tree_nonnull<Send>(v).rawArgs()) {
+
+        const auto numPosArgs = cast_tree_nonnull<Send>(v).numPosArgs();
+        for (auto i = 0; i < numPosArgs; ++i) {
+            auto &arg = cast_tree_nonnull<Send>(v).getPosArg(i);
             arg = mapIt(std::move(arg), ctx);
             ENFORCE(arg != nullptr);
         }
 
-        ENFORCE(cast_tree_nonnull<Send>(v).hasBlock() ? cast_tree_nonnull<Send>(v).block() != nullptr : true,
-                "block was mapped into not-a block");
+        const auto numKwArgs = cast_tree_nonnull<Send>(v).numKwArgs();
+        for (auto i = 0; i < numKwArgs; ++i) {
+            auto &key = cast_tree_nonnull<Send>(v).getKwKey(i);
+            key = mapIt(std::move(key), ctx);
+            ENFORCE(key != nullptr);
+
+            auto &val = cast_tree_nonnull<Send>(v).getKwValue(i);
+            val = mapIt(std::move(val), ctx);
+            ENFORCE(val != nullptr);
+        }
+
+        if (auto kwSplat = cast_tree_nonnull<Send>(v).kwSplat()) {
+            *kwSplat = mapIt(std::move(*kwSplat), ctx);
+            ENFORCE(kwSplat != nullptr);
+        }
+
+        if (auto block = cast_tree_nonnull<Send>(v).rawBlock()) {
+            *block = mapIt(std::move(*block), ctx);
+            ENFORCE(cast_tree_nonnull<Send>(v).block() != nullptr, "block was mapped into not-a block");
+        }
 
         if constexpr (HAS_MEMBER_postTransformSend<FUNC>()) {
             return CALL_MEMBER_postTransformSend<FUNC>::call(func, ctx, std::move(v));

--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -345,7 +345,7 @@ private:
                 "block was mapped into not-a block");
 
         cast_tree_nonnull<Send>(v).recv = mapIt(std::move(cast_tree_nonnull<Send>(v).recv), ctx);
-        for (auto &arg : cast_tree_nonnull<Send>(v).args) {
+        for (auto &arg : cast_tree_nonnull<Send>(v).rawArgs()) {
             arg = mapIt(std::move(arg), ctx);
             ENFORCE(arg != nullptr);
         }
@@ -811,7 +811,7 @@ private:
                 "block was mapped into not-a block");
 
         cast_tree_nonnull<Send>(v).recv = mapIt(std::move(cast_tree_nonnull<Send>(v).recv), ctx);
-        for (auto &arg : cast_tree_nonnull<Send>(v).args) {
+        for (auto &arg : cast_tree_nonnull<Send>(v).rawArgs()) {
             arg = mapIt(std::move(arg), ctx);
             ENFORCE(arg != nullptr);
         }

--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -335,14 +335,9 @@ private:
     }
 
     ExpressionPtr mapSend(ExpressionPtr v, CTX ctx) {
-        ENFORCE(cast_tree_nonnull<Send>(v).hasBlock() ? cast_tree_nonnull<Send>(v).block() != nullptr : true,
-                "block was mapped into not-a block {}", cast_tree_nonnull<Send>(v).fun.toString(ctx));
-
         if constexpr (HAS_MEMBER_preTransformSend<FUNC>()) {
             v = CALL_MEMBER_preTransformSend<FUNC>::call(func, ctx, std::move(v));
         }
-        ENFORCE(cast_tree_nonnull<Send>(v).hasBlock() ? cast_tree_nonnull<Send>(v).block() != nullptr : true,
-                "block was mapped into not-a block");
 
         cast_tree_nonnull<Send>(v).recv = mapIt(std::move(cast_tree_nonnull<Send>(v).recv), ctx);
         for (auto &arg : cast_tree_nonnull<Send>(v).rawArgs()) {
@@ -354,12 +349,7 @@ private:
                 "block was mapped into not-a block");
 
         if constexpr (HAS_MEMBER_postTransformSend<FUNC>()) {
-            v = CALL_MEMBER_postTransformSend<FUNC>::call(func, ctx, std::move(v));
-        }
-
-        if (isa_tree<Send>(v)) {
-            ENFORCE(cast_tree_nonnull<Send>(v).hasBlock() ? cast_tree_nonnull<Send>(v).block() != nullptr : true,
-                    "block was mapped into not-a block");
+            return CALL_MEMBER_postTransformSend<FUNC>::call(func, ctx, std::move(v));
         }
 
         return v;
@@ -800,15 +790,9 @@ private:
     }
 
     ExpressionPtr mapSend(ExpressionPtr v, CTX ctx) {
-        ENFORCE(cast_tree_nonnull<Send>(v).hasBlock() ? cast_tree_nonnull<Send>(v).block() != nullptr : true,
-                "block was mapped into not-a block");
-
         if constexpr (HAS_MEMBER_preTransformSend<FUNC>()) {
             v = CALL_MEMBER_preTransformSend<FUNC>::call(func, ctx, std::move(v));
         }
-
-        ENFORCE(cast_tree_nonnull<Send>(v).hasBlock() ? cast_tree_nonnull<Send>(v).block() != nullptr : true,
-                "block was mapped into not-a block");
 
         cast_tree_nonnull<Send>(v).recv = mapIt(std::move(cast_tree_nonnull<Send>(v).recv), ctx);
         for (auto &arg : cast_tree_nonnull<Send>(v).rawArgs()) {
@@ -820,12 +804,7 @@ private:
                 "block was mapped into not-a block");
 
         if constexpr (HAS_MEMBER_postTransformSend<FUNC>()) {
-            v = CALL_MEMBER_postTransformSend<FUNC>::call(func, ctx, std::move(v));
-        }
-
-        if (isa_tree<Send>(v)) {
-            ENFORCE(cast_tree_nonnull<Send>(v).hasBlock() ? cast_tree_nonnull<Send>(v).block() != nullptr : true,
-                    "block was mapped into not-a block");
+            return CALL_MEMBER_postTransformSend<FUNC>::call(func, ctx, std::move(v));
         }
 
         return v;

--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -341,14 +341,12 @@ private:
 
         cast_tree_nonnull<Send>(v).recv = mapIt(std::move(cast_tree_nonnull<Send>(v).recv), ctx);
 
-        const auto numNonBlockArgs = cast_tree_nonnull<Send>(v).numNonBlockArgs();
-        for (auto i = 0; i < numNonBlockArgs; ++i) {
-            auto &arg = cast_tree_nonnull<Send>(v).getNonBlockArg(i);
+        for (auto &arg : cast_tree_nonnull<Send>(v).nonBlockArgs()) {
             arg = mapIt(std::move(arg), ctx);
             ENFORCE(arg != nullptr);
         }
 
-        if (auto block = cast_tree_nonnull<Send>(v).rawBlock()) {
+        if (auto *block = cast_tree_nonnull<Send>(v).rawBlock()) {
             *block = mapIt(std::move(*block), ctx);
             ENFORCE(cast_tree_nonnull<Send>(v).block() != nullptr, "block was mapped into not-a block");
         }
@@ -801,14 +799,12 @@ private:
 
         cast_tree_nonnull<Send>(v).recv = mapIt(std::move(cast_tree_nonnull<Send>(v).recv), ctx);
 
-        const auto numNonBlockArgs = cast_tree_nonnull<Send>(v).numNonBlockArgs();
-        for (auto i = 0; i < numNonBlockArgs; ++i) {
-            auto &arg = cast_tree_nonnull<Send>(v).getNonBlockArg(i);
+        for (auto &arg : cast_tree_nonnull<Send>(v).nonBlockArgs()) {
             arg = mapIt(std::move(arg), ctx);
             ENFORCE(arg != nullptr);
         }
 
-        if (auto block = cast_tree_nonnull<Send>(v).rawBlock()) {
+        if (auto *block = cast_tree_nonnull<Send>(v).rawBlock()) {
             *block = mapIt(std::move(*block), ctx);
             ENFORCE(cast_tree_nonnull<Send>(v).block() != nullptr, "block was mapped into not-a block");
         }

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -406,17 +406,16 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                     argLocs.emplace_back(val.loc());
                 }
 
-                if (s.hasKwSplat()) {
-                    auto &exp = *s.kwSplat();
+                if (auto *exp = s.kwSplat()) {
                     LocalRef temp = cctx.newTemporary(core::Names::statTemp());
-                    current = walk(cctx.withTarget(temp), exp, current);
+                    current = walk(cctx.withTarget(temp), *exp, current);
                     args.emplace_back(temp);
-                    argLocs.emplace_back(exp.loc());
+                    argLocs.emplace_back(exp->loc());
                 }
 
-                if (s.hasBlock()) {
+                if (auto *block = s.block()) {
                     auto newRubyBlockId = ++cctx.inWhat.maxRubyBlockId;
-                    auto &blockArgs = s.block()->args;
+                    auto &blockArgs = block->args;
                     vector<ast::ParsedArg> blockArgFlags = ast::ArgParsing::parseArgs(blockArgs);
                     vector<core::ArgInfo::ArgFlags> argFlags;
                     for (auto &e : blockArgFlags) {

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -928,24 +928,15 @@ void SerializerImpl::pickle(Pickler &p, const ast::ExpressionPtr &what) {
             p.putU1(flags);
             p.putU4(s.numPosArgs());
 
-            const auto numPosArgs = s.numPosArgs();
-            const auto numKwArgs = s.numKwArgs();
-            const auto hasSplat = s.hasKwSplat();
+            const auto numNonBlockArgs = s.numNonBlockArgs();
             const auto hasBlock = s.hasBlock();
 
-            u4 size = numPosArgs + (2 * numKwArgs) + (hasSplat ? 1 : 0) + (hasBlock ? 1 : 0);
+            u4 size = numNonBlockArgs + (hasBlock ? 1 : 0);
             p.putU4(size);
             pickle(p, s.recv);
 
-            for (auto i = 0; i < numPosArgs; ++i) {
-                pickle(p, s.getPosArg(i));
-            }
-            for (auto i = 0; i < numKwArgs; ++i) {
-                pickle(p, s.getKwKey(i));
-                pickle(p, s.getKwValue(i));
-            }
-            if (hasSplat) {
-                pickle(p, *s.kwSplat());
+            for (auto i = 0; i < numNonBlockArgs; ++i) {
+                pickle(p, s.getNonBlockArg(i));
             }
             if (hasBlock) {
                 pickle(p, *s.rawBlock());

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -929,7 +929,6 @@ void SerializerImpl::pickle(Pickler &p, const ast::ExpressionPtr &what) {
             p.putU4(s.numPosArgs);
             p.putU4(s.args.size());
             pickle(p, s.recv);
-            pickle(p, s.block);
             for (auto &arg : s.args) {
                 pickle(p, arg);
             }
@@ -1217,12 +1216,11 @@ ast::ExpressionPtr SerializerImpl::unpickleExpr(serialize::UnPickler &p, const G
             auto numPosArgs = static_cast<u2>(p.getU4());
             auto argsSize = p.getU4();
             auto recv = unpickleExpr(p, gs);
-            ast::ExpressionPtr blk = unpickleExpr(p, gs);
             ast::Send::ARGS_store store(argsSize);
             for (auto &expr : store) {
                 expr = unpickleExpr(p, gs);
             }
-            return ast::MK::Send(loc, std::move(recv), fun, numPosArgs, std::move(store), flags, std::move(blk));
+            return ast::MK::Send(loc, std::move(recv), fun, numPosArgs, std::move(store), flags);
         }
         case ast::Tag::Block: {
             auto loc = unpickleLocOffsets(p);

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -928,15 +928,14 @@ void SerializerImpl::pickle(Pickler &p, const ast::ExpressionPtr &what) {
             p.putU1(flags);
             p.putU4(s.numPosArgs());
 
-            const auto numNonBlockArgs = s.numNonBlockArgs();
             const auto hasBlock = s.hasBlock();
 
-            u4 size = numNonBlockArgs + (hasBlock ? 1 : 0);
+            u4 size = s.numNonBlockArgs() + (hasBlock ? 1 : 0);
             p.putU4(size);
             pickle(p, s.recv);
 
-            for (auto i = 0; i < numNonBlockArgs; ++i) {
-                pickle(p, s.getNonBlockArg(i));
+            for (auto &arg : s.nonBlockArgs()) {
+                pickle(p, arg);
             }
             if (hasBlock) {
                 pickle(p, *s.rawBlock());

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -926,10 +926,10 @@ void SerializerImpl::pickle(Pickler &p, const ast::ExpressionPtr &what) {
             // Can replace this with std::bit_cast in C++20
             memcpy(&flags, &s.flags, sizeof(flags));
             p.putU1(flags);
-            p.putU4(s.numPosArgs);
-            p.putU4(s.args.size());
+            p.putU4(s.numPosArgs());
+            p.putU4(s.rawArgs().size());
             pickle(p, s.recv);
-            for (auto &arg : s.args) {
+            for (auto &arg : s.rawArgs()) {
                 pickle(p, arg);
             }
             break;

--- a/local_vars/local_vars.cc
+++ b/local_vars/local_vars.cc
@@ -215,8 +215,8 @@ class LocalNameInserter {
         ENFORCE(original.numPosArgs() == 1 && ast::isa_tree<ast::ZSuperArgs>(original.getPosArg(0)));
 
         ast::ExpressionPtr originalBlock;
-        if (original.hasBlock()) {
-            originalBlock = move(*original.rawBlock());
+        if (auto *rawBlock = original.rawBlock()) {
+            originalBlock = move(*rawBlock);
         }
 
         // Clear out the args (which are just [ZSuperArgs]) in the original send. (Note that we want this cleared even

--- a/local_vars/local_vars.cc
+++ b/local_vars/local_vars.cc
@@ -386,7 +386,8 @@ class LocalNameInserter {
             }
         } else if (originalBlock == nullptr) {
             // No positional splat and no "do", so we need to forward &<blkvar> with <call-with-block>.
-            original.reserveArguments(3 + posArgsEntries.size() + std::max({1UL, 2 * kwArgKeyEntries.size()}));
+            original.reserveArguments(3 + posArgsEntries.size(), kwArgKeyEntries.size(),
+                                      /* hasKwSplat */ kwArgsHash != nullptr, /* hasBlock */ false);
             original.addPosArg(std::move(original.recv));
             original.addPosArg(std::move(method));
             original.addPosArg(std::move(blockArg));
@@ -411,7 +412,8 @@ class LocalNameInserter {
             original.fun = core::Names::callWithBlock();
         } else {
             // No positional splat and we have a "do", so we can synthesize an ordinary send.
-            original.reserveArguments(posArgsEntries.size() + std::max({1UL, 2 * kwArgKeyEntries.size()}));
+            original.reserveArguments(posArgsEntries.size(), kwArgKeyEntries.size(),
+                                      /* hasKwSplat */ kwArgsHash != nullptr, /* hasBlock */ false);
 
             for (auto &arg : posArgsEntries) {
                 original.addPosArg(std::move(arg));

--- a/main/autogen/autogen.cc
+++ b/main/autogen/autogen.cc
@@ -307,8 +307,8 @@ public:
             ignoring.emplace_back(original);
         }
         // This means it's a `require`; mark it as such
-        if (original->flags.isPrivateOk && original->fun == core::Names::require() && original->args.size() == 1) {
-            auto *lit = ast::cast_tree<ast::Literal>(original->args.front());
+        if (original->flags.isPrivateOk && original->fun == core::Names::require() && original->numPosArgs() == 1) {
+            auto *lit = ast::cast_tree<ast::Literal>(original->getPosArg(0));
             if (lit && lit->isString(ctx)) {
                 requires.emplace_back(lit->asString(ctx));
             }

--- a/main/autogen/packages.cc
+++ b/main/autogen/packages.cc
@@ -45,14 +45,14 @@ public:
         auto &send = ast::cast_tree_nonnull<ast::Send>(tree);
         // we're not going to report errors about ill-formed things here: those errors should get reported elsewhere,
         // and instead we'll bail if things don't look like we expect
-        if (send.args.size() != 1) {
+        if (send.numPosArgs() != 1) {
             return tree;
         }
         if (send.fun != core::Names::export_() && send.fun != core::Names::import()) {
             return tree;
         }
 
-        auto cnst = ast::cast_tree<ast::ConstantLit>(send.args.front());
+        auto cnst = ast::cast_tree<ast::ConstantLit>(send.getPosArg(0));
         if (!cnst) {
             return tree;
         }

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -499,7 +499,7 @@ public:
             case core::Names::private_().rawId():
             case core::Names::protected_().rawId():
             case core::Names::public_().rawId():
-                if (original.numPosArgs() == 0) {
+                if (!original.hasPosArgs()) {
                     ENFORCE(!methodVisiStack.empty());
                     methodVisiStack.back() = optional<Modifier>{Modifier{
                         Modifier::Kind::Method,

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -657,13 +657,10 @@ public:
                 }
             }
 
-            auto end = send->args.size();
-            if (send->hasKwSplat()) {
-                end -= 1;
-            }
+            auto kwArgsRange = send->kwArgsRange();
 
             // Walk over the keyword args to find bounds annotations
-            for (auto i = send->numPosArgs; i < end; i += 2) {
+            for (auto i = kwArgsRange.first; i < kwArgsRange.second; i += 2) {
                 auto *key = ast::cast_tree<ast::Literal>(send->args[i]);
                 if (key != nullptr && key->isSymbol(ctx)) {
                     switch (key->asSymbol(ctx).rawId()) {
@@ -1516,7 +1513,7 @@ class TreeSymbolizer {
             return;
         }
 
-        if (send->block != nullptr) {
+        if (send->hasBlock()) {
             if (auto e = ctx.beginError(send->loc, core::errors::Namer::IncludePassedBlock)) {
                 e.setHeader("`{}` can not be passed a block", send->fun.show(ctx));
             }

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -490,9 +490,8 @@ public:
 
         switch (original.fun.rawId()) {
             case core::Names::privateClassMethod().rawId(): {
-                const auto numPosArgs = original.numPosArgs();
-                for (auto i = 0; i < numPosArgs; ++i) {
-                    addMethodModifier(ctx, original.fun, original.getPosArg(i));
+                for (auto &arg : original.posArgs()) {
+                    addMethodModifier(ctx, original.fun, arg);
                 }
                 break;
             }
@@ -509,17 +508,14 @@ public:
                         core::NameRef::noName(),
                     }};
                 } else {
-                    const auto numPosArgs = original.numPosArgs();
-                    for (auto i = 0; i < numPosArgs; ++i) {
-                        auto &arg = original.getPosArg(i);
+                    for (auto &arg : original.posArgs()) {
                         addMethodModifier(ctx, original.fun, arg);
                     }
                 }
                 break;
             case core::Names::privateConstant().rawId(): {
-                const auto numPosArgs = original.numPosArgs();
-                for (auto i = 0; i < numPosArgs; ++i) {
-                    addConstantModifier(ctx, original.fun, original.getPosArg(i));
+                for (auto &arg : original.posArgs()) {
+                    addConstantModifier(ctx, original.fun, arg);
                 }
                 break;
             }

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -653,7 +653,7 @@ public:
             return foundDefs->addStaticField(move(staticField));
         }
 
-        if (send->numPosArgs() + send->numKwArgs() > 0) {
+        if (send->hasPosArgs() || send->hasKwArgs()) {
             // If there are positional arguments, there might be a variance annotation
             if (send->numPosArgs() > 0) {
                 auto *lit = ast::cast_tree<ast::Literal>(send->getPosArg(0));
@@ -1740,7 +1740,7 @@ public:
                                     ast::make_expression<ast::Assign>(asgn.loc, std::move(asgn.lhs), std::move(send)));
         }
 
-        if (send->numPosArgs() + send->numKwArgs() > 0) {
+        if (send->hasPosArgs() || send->hasKwArgs()) {
             if (send->numPosArgs() > 1) {
                 if (auto e = ctx.state.beginError(core::Loc(ctx.file, send->loc),
                                                   core::errors::Namer::InvalidTypeDefinition)) {

--- a/resolver/CorrectTypeAlias.cc
+++ b/resolver/CorrectTypeAlias.cc
@@ -21,18 +21,18 @@ void CorrectTypeAlias::eagerToLazy(core::Context ctx, core::ErrorBuilder &e, ast
     bool wrapHash = false;
 
     if (send->hasKwArgs()) {
-        if (send->numPosArgs != 0) {
+        if (send->numPosArgs() != 0) {
             return;
         }
         wrapHash = true;
     } else {
-        if (send->numPosArgs != 1) {
+        if (send->numPosArgs() != 1) {
             return;
         }
     }
 
-    auto &front = send->args.front();
-    auto &back = send->args.back();
+    auto &front = send->rawArgs().front();
+    auto &back = send->rawArgs().back();
     core::Loc argsLoc{ctx.file, front.loc().join(back.loc())};
 
     if (!argsLoc.exists()) {

--- a/resolver/CorrectTypeAlias.cc
+++ b/resolver/CorrectTypeAlias.cc
@@ -31,9 +31,7 @@ void CorrectTypeAlias::eagerToLazy(core::Context ctx, core::ErrorBuilder &e, ast
         }
     }
 
-    auto &front = send->rawArgs().front();
-    auto &back = send->rawArgs().back();
-    core::Loc argsLoc{ctx.file, front.loc().join(back.loc())};
+    core::Loc argsLoc{ctx.file, send->argsLoc()};
 
     if (!argsLoc.exists()) {
         return;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -854,7 +854,7 @@ public:
                     CorrectTypeAlias::eagerToLazy(ctx, e, send);
                 }
             }
-            auto block = send->block();
+            auto *block = send->block();
             auto typeAliasItem = TypeAliasResolutionItem{id->symbol, ctx.file, &block->body};
             this->todoTypeAliases_.emplace_back(std::move(typeAliasItem));
 

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -117,7 +117,7 @@ ParsedSig parseSigWithSelfTypeParams(core::Context ctx, const ast::Send &sigSend
     } else {
         sig.seen.sig = true;
         ENFORCE(sigSend.fun == core::Names::sig());
-        auto block = sigSend.block();
+        auto *block = sigSend.block();
         ENFORCE(block);
         auto send = ast::cast_tree<ast::Send>(block->body);
         if (send) {

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -1025,12 +1025,11 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx,
                 argLocs.emplace_back(val.loc());
             }
 
-            if (s.hasKwSplat()) {
-                auto &splat = *s.kwSplat();
-                auto ty = makeTypeAndOrigins(ctx, splat.loc(), core::Types::untypedUntracked());
+            if (auto *splat = s.kwSplat()) {
+                auto ty = makeTypeAndOrigins(ctx, splat->loc(), core::Types::untypedUntracked());
                 holders.emplace_back(move(ty));
                 targs.emplace_back(holders.back().get());
-                argLocs.emplace_back(splat.loc());
+                argLocs.emplace_back(splat->loc());
             }
 
             core::SymbolRef corrected;

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -162,9 +162,7 @@ ParsedSig parseSigWithSelfTypeParams(core::Context ctx, const ast::Send &sigSend
                     }
                     break;
                 }
-                const auto numPosArgs = tsend->numPosArgs();
-                for (auto i = 0; i < numPosArgs; ++i) {
-                    auto &arg = tsend->getPosArg(i);
+                for (auto &arg : tsend->posArgs()) {
                     if (auto c = ast::cast_tree<ast::Literal>(arg)) {
                         if (c->isSymbol(ctx)) {
                             auto name = c->asSymbol(ctx);
@@ -993,9 +991,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx,
             argLocs.reserve(argSize);
             holders.reserve(argSize);
 
-            const auto numPosArgs = s.numPosArgs();
-            for (auto i = 0; i < numPosArgs; ++i) {
-                auto &arg = s.getPosArg(i);
+            for (auto &arg : s.posArgs()) {
                 auto ty = makeTypeAndOrigins(ctx, arg.loc(),
                                              core::make_type<core::MetaType>(getResultTypeWithSelfTypeParams(
                                                  ctx, arg, sigBeingParsed, args.withoutSelfType())));

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -162,7 +162,9 @@ ParsedSig parseSigWithSelfTypeParams(core::Context ctx, const ast::Send &sigSend
                     }
                     break;
                 }
-                for (auto &arg : tsend->rawArgs()) {
+                const auto numPosArgs = tsend->numPosArgs();
+                for (auto i = 0; i < numPosArgs; ++i) {
+                    auto &arg = tsend->getPosArg(i);
                     if (auto c = ast::cast_tree<ast::Literal>(arg)) {
                         if (c->isSymbol(ctx)) {
                             auto name = c->asSymbol(ctx);
@@ -185,6 +187,21 @@ ParsedSig parseSigWithSelfTypeParams(core::Context ctx, const ast::Send &sigSend
                         if (auto e = ctx.beginError(arg.loc(), core::errors::Resolver::InvalidMethodSignature)) {
                             e.setHeader("Malformed signature; Type parameters are specified with symbols");
                         }
+                    }
+                }
+
+                const auto numKwArgs = tsend->numKwArgs();
+                for (auto i = 0; i < numKwArgs; ++i) {
+                    auto &kwkey = tsend->getKwKey(i);
+                    if (auto e = ctx.beginError(kwkey.loc(), core::errors::Resolver::InvalidMethodSignature)) {
+                        e.setHeader("Malformed signature; Type parameters are specified with symbols");
+                    }
+                }
+
+                if (tsend->kwSplat()) {
+                    if (auto e =
+                            ctx.beginError(tsend->kwSplat()->loc(), core::errors::Resolver::InvalidMethodSignature)) {
+                        e.setHeader("Malformed signature; Type parameters are specified with symbols");
                     }
                 }
             }

--- a/rewriter/AttrReader.cc
+++ b/rewriter/AttrReader.cc
@@ -70,7 +70,7 @@ bool isTNilableOrUntyped(const ast::ExpressionPtr &expr) {
 ast::Send *findSendReturns(ast::Send *sharedSig) {
     ENFORCE(ASTUtil::castSig(sharedSig), "We weren't given a send node that's a valid signature");
 
-    auto block = sharedSig->block();
+    auto *block = sharedSig->block();
     auto body = ast::cast_tree<ast::Send>(block->body);
 
     while (body->fun != core::Names::returns() && body->fun != core::Names::void_()) {
@@ -125,7 +125,7 @@ void ensureSafeSig(core::MutableContext ctx, const core::NameRef attrFun, ast::S
 ast::Send *findSendChecked(ast::Send *sharedSig) {
     ENFORCE(ASTUtil::castSig(sharedSig), "We weren't given a send node that's a valid signature");
 
-    auto block = sharedSig->block();
+    auto *block = sharedSig->block();
     auto body = ast::cast_tree<ast::Send>(block->body);
 
     while (body != nullptr && body->fun != core::Names::checked()) {

--- a/rewriter/AttrReader.cc
+++ b/rewriter/AttrReader.cc
@@ -70,7 +70,7 @@ bool isTNilableOrUntyped(const ast::ExpressionPtr &expr) {
 ast::Send *findSendReturns(ast::Send *sharedSig) {
     ENFORCE(ASTUtil::castSig(sharedSig), "We weren't given a send node that's a valid signature");
 
-    auto block = ast::cast_tree<ast::Block>(sharedSig->block);
+    auto block = sharedSig->block();
     auto body = ast::cast_tree<ast::Send>(block->body);
 
     while (body->fun != core::Names::returns() && body->fun != core::Names::void_()) {
@@ -107,7 +107,7 @@ ast::ExpressionPtr dupReturnsType(ast::Send *sharedSig) {
 // This will raise an error if we've given a type that's not what we want
 void ensureSafeSig(core::MutableContext ctx, const core::NameRef attrFun, ast::Send *sig) {
     // Loop down the chain of recv's until we get to the inner 'sig' node.
-    auto *block = ast::cast_tree<ast::Block>(sig->block);
+    auto *block = sig->block();
     auto *body = ast::cast_tree<ast::Send>(block->body);
     auto *cur = body;
     while (cur != nullptr) {
@@ -124,7 +124,7 @@ void ensureSafeSig(core::MutableContext ctx, const core::NameRef attrFun, ast::S
 ast::Send *findSendChecked(ast::Send *sharedSig) {
     ENFORCE(ASTUtil::castSig(sharedSig), "We weren't given a send node that's a valid signature");
 
-    auto block = ast::cast_tree<ast::Block>(sharedSig->block);
+    auto block = sharedSig->block();
     auto body = ast::cast_tree<ast::Send>(block->body);
 
     while (body != nullptr && body->fun != core::Names::checked()) {

--- a/rewriter/ClassNew.cc
+++ b/rewriter/ClassNew.cc
@@ -41,8 +41,8 @@ vector<ast::ExpressionPtr> ClassNew::run(core::MutableContext ctx, ast::Assign *
         return empty;
     }
 
-    auto argc = send->args.size();
-    if (argc > 1) {
+    auto argc = send->numPosArgs;
+    if (argc > 1 || send->hasKwArgs()) {
         return empty;
     }
 
@@ -52,13 +52,13 @@ vector<ast::ExpressionPtr> ClassNew::run(core::MutableContext ctx, ast::Assign *
 
     ast::ClassDef::RHS_store body;
 
-    auto *block = ast::cast_tree<ast::Block>(send->block);
+    auto *block = send->block();
     if (block != nullptr && block->args.size() == 1) {
         auto blockArg = move(block->args[0]);
         body.emplace_back(ast::MK::Assign(blockArg.loc(), move(blockArg), asgn->lhs.deepCopy()));
     }
 
-    if (send->block != nullptr) {
+    if (send->hasBlock()) {
         // Steal the trees, because the run is going to remove the original send node from the tree anyway.
         if (auto insSeq = ast::cast_tree<ast::InsSeq>(block->body)) {
             for (auto &&stat : insSeq->stats) {

--- a/rewriter/ClassNew.cc
+++ b/rewriter/ClassNew.cc
@@ -41,12 +41,12 @@ vector<ast::ExpressionPtr> ClassNew::run(core::MutableContext ctx, ast::Assign *
         return empty;
     }
 
-    auto argc = send->numPosArgs;
+    auto argc = send->numPosArgs();
     if (argc > 1 || send->hasKwArgs()) {
         return empty;
     }
 
-    if (argc == 1 && !ast::isa_tree<ast::UnresolvedConstantLit>(send->args[0])) {
+    if (argc == 1 && !ast::isa_tree<ast::UnresolvedConstantLit>(send->getPosArg(0))) {
         return empty;
     }
 
@@ -72,7 +72,7 @@ vector<ast::ExpressionPtr> ClassNew::run(core::MutableContext ctx, ast::Assign *
 
     ast::ClassDef::ANCESTORS_store ancestors;
     if (argc == 1) {
-        ancestors.emplace_back(move(send->args[0]));
+        ancestors.emplace_back(move(send->getPosArg(0)));
     } else {
         ancestors.emplace_back(ast::MK::Constant(send->loc, core::Symbols::todo()));
     }

--- a/rewriter/ClassNew.cc
+++ b/rewriter/ClassNew.cc
@@ -58,7 +58,7 @@ vector<ast::ExpressionPtr> ClassNew::run(core::MutableContext ctx, ast::Assign *
         body.emplace_back(ast::MK::Assign(blockArg.loc(), move(blockArg), asgn->lhs.deepCopy()));
     }
 
-    if (send->hasBlock()) {
+    if (block != nullptr) {
         // Steal the trees, because the run is going to remove the original send node from the tree anyway.
         if (auto insSeq = ast::cast_tree<ast::InsSeq>(block->body)) {
             for (auto &&stat : insSeq->stats) {

--- a/rewriter/Concern.cc
+++ b/rewriter/Concern.cc
@@ -72,7 +72,7 @@ void Concern::run(core::MutableContext ctx, ast::ClassDef *klass) {
     for (auto &stat : klass->rhs) {
         if (auto *send = ast::cast_tree<ast::Send>(stat)) {
             if (send->fun == core::Names::classMethods()) { // class_methods do ... end
-                if (send->block == nullptr) {
+                if (!send->hasBlock()) {
                     continue;
                 }
                 if (!send->recv.isSelfReference()) {
@@ -80,7 +80,7 @@ void Concern::run(core::MutableContext ctx, ast::ClassDef *klass) {
                 }
                 if (classMethodsNode) {
                     // ClassMethods module already exists. Let's add the block as one of its members
-                    auto *block = ast::cast_tree<ast::Block>(send->block);
+                    auto *block = send->block();
                     auto *classDef = ast::cast_tree<ast::ClassDef>(classMethodsNode);
 
                     if (auto insSeq = ast::cast_tree<ast::InsSeq>(block->body)) {
@@ -96,7 +96,7 @@ void Concern::run(core::MutableContext ctx, ast::ClassDef *klass) {
                     // members
                     auto loc = send->loc;
                     ast::ClassDef::RHS_store rhs;
-                    auto *block = ast::cast_tree<ast::Block>(send->block);
+                    auto *block = send->block();
                     if (auto insSeq = ast::cast_tree<ast::InsSeq>(block->body)) {
                         for (auto &stat : insSeq->stats) {
                             rhs.emplace_back(std::move(stat));

--- a/rewriter/Concern.cc
+++ b/rewriter/Concern.cc
@@ -19,7 +19,7 @@ bool doesExtendConcern(core::MutableContext ctx, ast::ClassDef *klass) {
                 if (send.fun != core::Names::extend()) {
                     return;
                 }
-                if (send.numPosArgs() == 0) {
+                if (!send.hasPosArgs()) {
                     return;
                 }
                 auto *firstArg = ast::cast_tree<ast::UnresolvedConstantLit>(send.getPosArg(0));

--- a/rewriter/Concern.cc
+++ b/rewriter/Concern.cc
@@ -19,11 +19,10 @@ bool doesExtendConcern(core::MutableContext ctx, ast::ClassDef *klass) {
                 if (send.fun != core::Names::extend()) {
                     return;
                 }
-                auto &args = send.args;
-                if (args.empty()) {
+                if (send.numPosArgs() == 0) {
                     return;
                 }
-                auto *firstArg = ast::cast_tree<ast::UnresolvedConstantLit>(args.at(0));
+                auto *firstArg = ast::cast_tree<ast::UnresolvedConstantLit>(send.getPosArg(0));
                 if (firstArg == nullptr) {
                     return;
                 }

--- a/rewriter/DSLBuilder.cc
+++ b/rewriter/DSLBuilder.cc
@@ -83,8 +83,7 @@ vector<ast::ExpressionPtr> DSLBuilder::run(core::MutableContext ctx, ast::Send *
     flags.discardDef = true;
 
     // We need to keep around the original send for the compiler.
-    stats.emplace_back(ast::MK::Send(loc, ast::MK::Unsafe(loc, move(send->recv)), sendFun, send->numPosArgs(),
-                                     std::move(send->rawArgs()), send->flags));
+    stats.emplace_back(send->withNewBody(loc, ast::MK::Unsafe(loc, move(send->recv)), sendFun));
 
     // def self.<prop>
     if (!skipSetter) {

--- a/rewriter/DSLBuilder.cc
+++ b/rewriter/DSLBuilder.cc
@@ -84,7 +84,7 @@ vector<ast::ExpressionPtr> DSLBuilder::run(core::MutableContext ctx, ast::Send *
 
     // We need to keep around the original send for the compiler.
     stats.emplace_back(ast::MK::Send(loc, ast::MK::Unsafe(loc, move(send->recv)), sendFun, send->numPosArgs,
-                                     std::move(send->args), send->flags, move(send->block)));
+                                     std::move(send->args), send->flags));
 
     // def self.<prop>
     if (!skipSetter) {

--- a/rewriter/DSLBuilder.cc
+++ b/rewriter/DSLBuilder.cc
@@ -40,10 +40,10 @@ vector<ast::ExpressionPtr> DSLBuilder::run(core::MutableContext ctx, ast::Send *
         return empty;
     }
 
-    if (send->args.size() < 2) {
+    if (send->numPosArgs() < 2) {
         return empty;
     }
-    auto *sym = ast::cast_tree<ast::Literal>(send->args[0]);
+    auto *sym = ast::cast_tree<ast::Literal>(send->getPosArg(0));
     if (sym == nullptr || !sym->isSymbol(ctx)) {
         return empty;
     }
@@ -54,7 +54,7 @@ vector<ast::ExpressionPtr> DSLBuilder::run(core::MutableContext ctx, ast::Send *
             core::Loc(ctx.file, sym->loc).source(ctx).value()[0] == ':');
     auto nameLoc = core::LocOffsets{sym->loc.beginPos() + 1, sym->loc.endPos()};
 
-    type = ASTUtil::dupType(send->args[1]);
+    type = ASTUtil::dupType(send->getPosArg(1));
     if (!type) {
         return empty;
     }
@@ -83,8 +83,8 @@ vector<ast::ExpressionPtr> DSLBuilder::run(core::MutableContext ctx, ast::Send *
     flags.discardDef = true;
 
     // We need to keep around the original send for the compiler.
-    stats.emplace_back(ast::MK::Send(loc, ast::MK::Unsafe(loc, move(send->recv)), sendFun, send->numPosArgs,
-                                     std::move(send->args), send->flags));
+    stats.emplace_back(ast::MK::Send(loc, ast::MK::Unsafe(loc, move(send->recv)), sendFun, send->numPosArgs(),
+                                     std::move(send->rawArgs()), send->flags));
 
     // def self.<prop>
     if (!skipSetter) {

--- a/rewriter/DefDelegator.cc
+++ b/rewriter/DefDelegator.cc
@@ -92,7 +92,7 @@ vector<ast::ExpressionPtr> runDefDelegators(core::MutableContext ctx, const ast:
         return methodStubs;
     }
 
-    for (int i = 0, numPosArgs = send->numPosArgs(); i < numPosArgs; ++i) {
+    for (int i = 1, numPosArgs = send->numPosArgs(); i < numPosArgs; ++i) {
         auto *method = ast::cast_tree<ast::Literal>(send->getPosArg(i));
         // Skip method names that we don't understand, but continue to emit
         // desugared calls for the ones we do.

--- a/rewriter/DefDelegator.cc
+++ b/rewriter/DefDelegator.cc
@@ -34,7 +34,7 @@ vector<ast::ExpressionPtr> runDefDelegator(core::MutableContext ctx, const ast::
 
     // This method takes 2..3 positional arguments and no keyword args:
     // `def_delegator(accessor, method, ali = method)`
-    if (!(send->numPosArgs == 2 || send->numPosArgs == 3)) {
+    if (!(send->numPosArgs() == 2 || send->numPosArgs() == 3)) {
         return methodStubs;
     }
 
@@ -42,20 +42,20 @@ vector<ast::ExpressionPtr> runDefDelegator(core::MutableContext ctx, const ast::
         return methodStubs;
     }
 
-    auto *accessor = ast::cast_tree<ast::Literal>(send->args[0]);
+    auto *accessor = ast::cast_tree<ast::Literal>(send->getPosArg(0));
     if (!accessor || !(accessor->isSymbol(ctx) || accessor->isString(ctx))) {
         return methodStubs;
     }
 
-    auto *method = ast::cast_tree<ast::Literal>(send->args[1]);
+    auto *method = ast::cast_tree<ast::Literal>(send->getPosArg(1));
     if (!method || !method->isSymbol(ctx)) {
         return methodStubs;
     }
 
     core::NameRef methodName = method->asSymbol(ctx);
 
-    if (send->numPosArgs == 3) {
-        auto *alias = ast::cast_tree<ast::Literal>(send->args[2]);
+    if (send->numPosArgs() == 3) {
+        auto *alias = ast::cast_tree<ast::Literal>(send->getPosArg(2));
         if (!alias || !alias->isSymbol(ctx)) {
             return methodStubs;
         }
@@ -79,7 +79,7 @@ vector<ast::ExpressionPtr> runDefDelegators(core::MutableContext ctx, const ast:
 
     // This method takes 1.. positional arguments and no keyword args:
     // `def_delegators(accessor, methods*)`
-    if (send->numPosArgs == 0) {
+    if (send->numPosArgs() == 0) {
         return methodStubs;
     }
 
@@ -87,13 +87,13 @@ vector<ast::ExpressionPtr> runDefDelegators(core::MutableContext ctx, const ast:
         return methodStubs;
     }
 
-    auto *accessor = ast::cast_tree<ast::Literal>(send->args[0]);
+    auto *accessor = ast::cast_tree<ast::Literal>(send->getPosArg(0));
     if (!accessor || !(accessor->isSymbol(ctx) || accessor->isString(ctx))) {
         return methodStubs;
     }
 
-    for (auto arg = send->args.begin() + 1, end = send->args.end(); arg != end; ++arg) {
-        auto *method = ast::cast_tree<ast::Literal>(*arg);
+    for (int i = 0, numPosArgs = send->numPosArgs(); i < numPosArgs; ++i) {
+        auto *method = ast::cast_tree<ast::Literal>(send->getPosArg(i));
         // Skip method names that we don't understand, but continue to emit
         // desugared calls for the ones we do.
         if (!method || !method->isSymbol(ctx)) {

--- a/rewriter/Delegate.cc
+++ b/rewriter/Delegate.cc
@@ -44,18 +44,14 @@ vector<ast::ExpressionPtr> Delegate::run(core::MutableContext ctx, const ast::Se
         return empty;
     }
 
-    if (send->args.empty()) {
+    if (send->numPosArgs() == 0) {
+        // there has to be at least one positional argument
         return empty;
     }
 
     auto optionsTree = ASTUtil::mkKwArgsHash(send);
     auto options = ast::cast_tree<ast::Hash>(optionsTree);
     if (!options) {
-        return empty;
-    }
-
-    if (send->numPosArgs == 0) {
-        // there has to be at least one positional argument
         return empty;
     }
 
@@ -93,8 +89,8 @@ vector<ast::ExpressionPtr> Delegate::run(core::MutableContext ctx, const ast::Se
     }
 
     vector<ast::ExpressionPtr> methodStubs;
-    for (int i = 0; i < send->numPosArgs; i++) {
-        auto *lit = ast::cast_tree<ast::Literal>(send->args[i]);
+    for (int i = 0; i < send->numPosArgs(); i++) {
+        auto *lit = ast::cast_tree<ast::Literal>(send->getPosArg(i));
         if (!lit || !lit->isSymbol(ctx)) {
             return empty;
         }

--- a/rewriter/Delegate.cc
+++ b/rewriter/Delegate.cc
@@ -44,7 +44,7 @@ vector<ast::ExpressionPtr> Delegate::run(core::MutableContext ctx, const ast::Se
         return empty;
     }
 
-    if (send->numPosArgs() == 0) {
+    if (!send->hasPosArgs()) {
         // there has to be at least one positional argument
         return empty;
     }

--- a/rewriter/Flatfiles.cc
+++ b/rewriter/Flatfiles.cc
@@ -11,13 +11,13 @@ using namespace std;
 
 namespace sorbet::rewriter {
 optional<core::NameRef> getFieldName(core::MutableContext ctx, ast::Send &send) {
-    if (auto propLit = ast::cast_tree<ast::Literal>(send.args.front())) {
+    if (auto propLit = ast::cast_tree<ast::Literal>(send.getPosArg(0))) {
         if (propLit->isSymbol(ctx)) {
             return propLit->asSymbol(ctx);
         }
     }
-    if (send.args.size() >= 2) {
-        if (auto propLit = ast::cast_tree<ast::Literal>(send.args[1])) {
+    if (send.numPosArgs() >= 2) {
+        if (auto propLit = ast::cast_tree<ast::Literal>(send.getPosArg(1))) {
             if (propLit->isSymbol(ctx)) {
                 return propLit->asSymbol(ctx);
             }
@@ -39,7 +39,7 @@ void handleFieldDefinition(core::MutableContext ctx, ast::ExpressionPtr &stat, v
     if (auto send = ast::cast_tree<ast::Send>(stat)) {
         if ((send->fun != core::Names::from() && send->fun != core::Names::field() &&
              send->fun != core::Names::pattern()) ||
-            !send->recv.isSelfReference() || send->args.size() < 1) {
+            !send->recv.isSelfReference() || send->numPosArgs() < 1) {
             return;
         }
         auto name = getFieldName(ctx, *send);

--- a/rewriter/Flatfiles.cc
+++ b/rewriter/Flatfiles.cc
@@ -28,7 +28,7 @@ optional<core::NameRef> getFieldName(core::MutableContext ctx, ast::Send &send) 
 
 ast::Send *asFlatfileDo(ast::ExpressionPtr &stat) {
     auto *send = ast::cast_tree<ast::Send>(stat);
-    if (send != nullptr && send->block != nullptr && send->fun == core::Names::flatfile()) {
+    if (send != nullptr && send->hasBlock() && send->fun == core::Names::flatfile()) {
         return send;
     } else {
         return nullptr;
@@ -66,14 +66,14 @@ void Flatfiles::run(core::MutableContext ctx, ast::ClassDef *klass) {
     vector<ast::ExpressionPtr> methods;
     for (auto &stat : klass->rhs) {
         if (auto flatfileBlock = asFlatfileDo(stat)) {
-            auto &block = ast::cast_tree_nonnull<ast::Block>(flatfileBlock->block);
-            if (auto *insSeq = ast::cast_tree<ast::InsSeq>(block.body)) {
+            auto block = flatfileBlock->block();
+            if (auto *insSeq = ast::cast_tree<ast::InsSeq>(block->body)) {
                 for (auto &stat : insSeq->stats) {
                     handleFieldDefinition(ctx, stat, methods);
                 }
                 handleFieldDefinition(ctx, insSeq->expr, methods);
             } else {
-                handleFieldDefinition(ctx, block.body, methods);
+                handleFieldDefinition(ctx, block->body, methods);
             }
         }
     }

--- a/rewriter/Flatfiles.cc
+++ b/rewriter/Flatfiles.cc
@@ -66,7 +66,7 @@ void Flatfiles::run(core::MutableContext ctx, ast::ClassDef *klass) {
     vector<ast::ExpressionPtr> methods;
     for (auto &stat : klass->rhs) {
         if (auto flatfileBlock = asFlatfileDo(stat)) {
-            auto block = flatfileBlock->block();
+            auto *block = flatfileBlock->block();
             if (auto *insSeq = ast::cast_tree<ast::InsSeq>(block->body)) {
                 for (auto &stat : insSeq->stats) {
                     handleFieldDefinition(ctx, stat, methods);

--- a/rewriter/Initializer.cc
+++ b/rewriter/Initializer.cc
@@ -130,7 +130,8 @@ void Initializer::run(core::MutableContext ctx, ast::MethodDef *methodDef, ast::
     if (sig == nullptr) {
         return;
     }
-    auto *block = ast::cast_tree<ast::Block>(sig->block);
+
+    auto *block = sig->block();
     if (block == nullptr) {
         return;
     }

--- a/rewriter/Initializer.cc
+++ b/rewriter/Initializer.cc
@@ -150,7 +150,7 @@ void Initializer::run(core::MutableContext ctx, ast::MethodDef *methodDef, ast::
     UnorderedMap<core::NameRef, const ast::ExpressionPtr *> argTypeMap;
     for (int i = 0; i < numKwArgs; ++i) {
         auto *argName = ast::cast_tree<ast::Literal>(params->getKwKey(i));
-        auto *argVal = &params->getKwKey(i);
+        auto *argVal = &params->getKwValue(i);
         if (argName->isSymbol(ctx)) {
             argTypeMap[argName->asSymbol(ctx)] = argVal;
         }

--- a/rewriter/Initializer.cc
+++ b/rewriter/Initializer.cc
@@ -146,11 +146,11 @@ void Initializer::run(core::MutableContext ctx, ast::MethodDef *methodDef, ast::
     }
 
     // build a lookup table that maps from names to the types they have
-    auto [kwStart, kwEnd] = params->kwArgsRange();
+    auto numKwArgs = params->numKwArgs();
     UnorderedMap<core::NameRef, const ast::ExpressionPtr *> argTypeMap;
-    for (int i = kwStart; i < kwEnd; i += 2) {
-        auto *argName = ast::cast_tree<ast::Literal>(params->args[i]);
-        auto *argVal = &params->args[i + 1];
+    for (int i = 0; i < numKwArgs; ++i) {
+        auto *argName = ast::cast_tree<ast::Literal>(params->getKwKey(i));
+        auto *argVal = &params->getKwKey(i);
         if (argName->isSymbol(ctx)) {
             argTypeMap[argName->asSymbol(ctx)] = argVal;
         }

--- a/rewriter/InterfaceWrapper.cc
+++ b/rewriter/InterfaceWrapper.cc
@@ -27,14 +27,14 @@ ast::ExpressionPtr InterfaceWrapper::run(core::MutableContext ctx, ast::Send *se
         return nullptr;
     }
 
-    if (send->args.size() != 1) {
+    if (send->numPosArgs() != 1) {
         if (auto e = ctx.beginError(send->loc, core::errors::Rewriter::BadWrapInstance)) {
             e.setHeader("Wrong number of arguments to `{}`. Expected: `{}`, got: `{}`", "wrap_instance", 0,
-                        send->args.size());
+                        send->numPosArgs());
         }
         return nullptr;
     }
 
-    return ast::MK::Let(send->loc, move(send->args.front()), move(send->recv));
+    return ast::MK::Let(send->loc, move(send->getPosArg(0)), move(send->recv));
 }
 } // namespace sorbet::rewriter

--- a/rewriter/Mattr.cc
+++ b/rewriter/Mattr.cc
@@ -57,7 +57,7 @@ vector<ast::ExpressionPtr> Mattr::run(core::MutableContext ctx, const ast::Send 
     bool instancePredicate = true;
     auto symbolArgsBound = send->numPosArgs();
 
-    if (send->rawArgs().empty()) {
+    if (!send->hasPosArgs() && !send->hasKwArgs()) {
         return empty;
     }
 

--- a/rewriter/Mattr.cc
+++ b/rewriter/Mattr.cc
@@ -55,9 +55,9 @@ vector<ast::ExpressionPtr> Mattr::run(core::MutableContext ctx, const ast::Send 
     bool instanceReader = true;
     bool instanceWriter = true;
     bool instancePredicate = true;
-    auto symbolArgsBound = send->numPosArgs;
+    auto symbolArgsBound = send->numPosArgs();
 
-    if (send->args.empty()) {
+    if (send->rawArgs().empty()) {
         return empty;
     }
 
@@ -88,7 +88,7 @@ vector<ast::ExpressionPtr> Mattr::run(core::MutableContext ctx, const ast::Send 
 
     vector<ast::ExpressionPtr> result;
     for (int i = 0; i < symbolArgsBound; i++) {
-        auto *lit = ast::cast_tree<ast::Literal>(send->args[i]);
+        auto *lit = ast::cast_tree<ast::Literal>(send->getPosArg(i));
         if (!lit || !lit->isSymbol(ctx)) {
             return empty;
         }

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -161,9 +161,8 @@ bool canMoveIntoMethodDef(const ast::ExpressionPtr &exp) {
         if (!canMoveIntoMethodDef(send->recv)) {
             return false;
         }
-        const auto numNonBlockArgs = send->numNonBlockArgs();
-        for (auto i = 0; i < numNonBlockArgs; ++i) {
-            if (!canMoveIntoMethodDef(send->getNonBlockArg(i))) {
+        for (auto &arg : send->nonBlockArgs()) {
+            if (!canMoveIntoMethodDef(arg)) {
                 return false;
             }
         }

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -161,23 +161,11 @@ bool canMoveIntoMethodDef(const ast::ExpressionPtr &exp) {
         if (!canMoveIntoMethodDef(send->recv)) {
             return false;
         }
-        const auto numPosArgs = send->numPosArgs();
-        for (auto i = 0; i < numPosArgs; ++i) {
-            if (!canMoveIntoMethodDef(send->getPosArg(i))) {
+        const auto numNonBlockArgs = send->numNonBlockArgs();
+        for (auto i = 0; i < numNonBlockArgs; ++i) {
+            if (!canMoveIntoMethodDef(send->getNonBlockArg(i))) {
                 return false;
             }
-        }
-
-        const auto numKwArgs = send->numKwArgs();
-        for (auto i = 0; i < numKwArgs; ++i) {
-            // Keys are always symbol literals.
-            if (!canMoveIntoMethodDef(send->getKwValue(i))) {
-                return false;
-            }
-        }
-
-        if (send->hasKwSplat() && !canMoveIntoMethodDef(*send->kwSplat())) {
-            return false;
         }
 
         return true;

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -22,7 +22,7 @@ public:
         auto loc = asgn.loc;
         auto raiseUnimplemented = ast::MK::RaiseUnimplemented(loc);
         if (auto send = ast::cast_tree<ast::Send>(asgn.rhs)) {
-            if (send->fun == core::Names::let() && send->args.size() == 2) {
+            if (send->fun == core::Names::let() && send->numPosArgs == 2) {
                 auto rhs = ast::MK::Let(loc, move(raiseUnimplemented), send->args[1].deepCopy());
                 return ast::MK::Assign(asgn.loc, move(asgn.lhs), move(rhs));
             }
@@ -70,7 +70,7 @@ public:
     // we treat those the same way we treat classes
     ast::ExpressionPtr preTransformSend(core::MutableContext ctx, ast::ExpressionPtr tree) {
         auto *send = ast::cast_tree<ast::Send>(tree);
-        if (send->recv.isSelfReference() && send->args.size() == 1 && send->fun == core::Names::describe()) {
+        if (send->recv.isSelfReference() && send->numPosArgs == 1 && send->fun == core::Names::describe()) {
             classDepth++;
         }
         return tree;
@@ -78,7 +78,7 @@ public:
 
     ast::ExpressionPtr postTransformSend(core::MutableContext ctx, ast::ExpressionPtr tree) {
         auto *send = ast::cast_tree<ast::Send>(tree);
-        if (send->recv.isSelfReference() && send->args.size() == 1 && send->fun == core::Names::describe()) {
+        if (send->recv.isSelfReference() && send->numPosArgs == 1 && send->fun == core::Names::describe()) {
             classDepth--;
             if (classDepth == 0) {
                 movedConstants.emplace_back(move(tree));
@@ -184,15 +184,15 @@ ast::ExpressionPtr runUnderEach(core::MutableContext ctx, core::NameRef eachName
     // this statement must be a send
     if (auto *send = ast::cast_tree<ast::Send>(stmt)) {
         // the send must be a call to `it` with a single argument (the test name) and a block with no arguments
-        if (send->fun == core::Names::it() && send->args.size() == 1 && send->block != nullptr &&
-            ast::cast_tree<ast::Block>(send->block)->args.size() == 0) {
+        if (send->fun == core::Names::it() && send->numPosArgs == 1 && send->hasBlock() &&
+            send->block()->args.size() == 0) {
             // we use this for the name of our test
             auto argString = to_s(ctx, send->args.front());
             auto name = ctx.state.enterNameUTF8("<it '" + argString + "'>");
 
             // pull constants out of the block
             ConstantMover constantMover;
-            ast::ExpressionPtr body = move(ast::cast_tree<ast::Block>(send->block)->body);
+            ast::ExpressionPtr body = move(send->block()->body);
             body = ast::TreeMap::apply(ctx, constantMover, move(body));
 
             // pull the arg and the iteratee in and synthesize `iterate.each { |arg| body }`
@@ -301,20 +301,20 @@ ast::ExpressionPtr prepareTestEachBody(core::MutableContext ctx, core::NameRef e
 }
 
 ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, ast::Send *send) {
-    if (send->block == nullptr) {
+    if (!send->hasBlock()) {
         return nullptr;
     }
 
-    auto *block = ast::cast_tree<ast::Block>(send->block);
+    auto *block = send->block();
 
     if (!send->recv.isSelfReference()) {
         return nullptr;
     }
 
-    if ((send->fun == core::Names::testEach() || send->fun == core::Names::testEachHash()) && send->args.size() == 1) {
+    if ((send->fun == core::Names::testEach() || send->fun == core::Names::testEachHash()) && send->numPosArgs == 1) {
         if ((send->fun == core::Names::testEach() && block->args.size() < 1) ||
             (send->fun == core::Names::testEachHash() && block->args.size() != 2)) {
-            if (auto e = ctx.beginError(send->block.loc(), core::errors::Rewriter::BadTestEach)) {
+            if (auto e = ctx.beginError(block->loc, core::errors::Rewriter::BadTestEach)) {
                 e.setHeader("Wrong number of parameters for `{}` block: expected `{}`, got `{}`", send->fun.show(ctx),
                             send->fun == core::Names::testEach() ? "at least 1" : "2", block->args.size());
             }
@@ -325,13 +325,16 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, ast::Send *
         auto iteratee = getIteratee(send->args.front());
         // and then reconstruct the send but with a modified body
         return ast::MK::Send(
-            send->loc, ast::MK::Self(send->loc), send->fun, 1, ast::MK::SendArgs(move(send->args.front())), send->flags,
-            ast::MK::Block(send->block.loc(),
-                           prepareTestEachBody(ctx, send->fun, std::move(block->body), block->args, {}, iteratee),
-                           std::move(block->args)));
+            send->loc, ast::MK::Self(send->loc), send->fun, 1,
+            ast::MK::SendArgs(
+                move(send->args.front()),
+                ast::MK::Block(block->loc,
+                               prepareTestEachBody(ctx, send->fun, std::move(block->body), block->args, {}, iteratee),
+                               std::move(block->args))),
+            send->flags);
     }
 
-    if (send->args.empty() && (send->fun == core::Names::before() || send->fun == core::Names::after())) {
+    if (send->numPosArgs == 0 && (send->fun == core::Names::before() || send->fun == core::Names::after())) {
         auto name = send->fun == core::Names::after() ? core::Names::afterAngles() : core::Names::initialize();
         ConstantMover constantMover;
         block->body = ast::TreeMap::apply(ctx, constantMover, move(block->body));
@@ -340,7 +343,7 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, ast::Send *
         return constantMover.addConstantsToExpression(send->loc, move(method));
     }
 
-    if (send->args.size() != 1) {
+    if (send->numPosArgs != 1) {
         return nullptr;
     }
     auto &arg = send->args[0];

--- a/rewriter/MixinEncryptedProp.cc
+++ b/rewriter/MixinEncryptedProp.cc
@@ -41,12 +41,12 @@ vector<ast::ExpressionPtr> MixinEncryptedProp::run(core::MutableContext ctx, ast
     if (send->fun != core::Names::encryptedProp()) {
         return empty;
     }
-    if (send->args.empty()) {
+    if (send->numPosArgs() == 0) {
         return empty;
     }
 
     auto loc = send->loc;
-    auto *sym = ast::cast_tree<ast::Literal>(send->args[0]);
+    auto *sym = ast::cast_tree<ast::Literal>(send->getPosArg(0));
     if (!sym || !sym->isSymbol(ctx)) {
         return empty;
     }
@@ -58,9 +58,7 @@ vector<ast::ExpressionPtr> MixinEncryptedProp::run(core::MutableContext ctx, ast
     enc_name = name.prepend(ctx, "encrypted_");
 
     ast::ExpressionPtr rules;
-    if (!send->args.empty()) {
-        rules = ASTUtil::mkKwArgsHash(send);
-    }
+    rules = ASTUtil::mkKwArgsHash(send);
 
     if (auto *hash = ast::cast_tree<ast::Hash>(rules)) {
         if (ASTUtil::hasTruthyHashValue(ctx, *hash, core::Names::immutable())) {

--- a/rewriter/ModuleFunction.cc
+++ b/rewriter/ModuleFunction.cc
@@ -21,7 +21,7 @@ void ModuleFunction::run(core::MutableContext ctx, ast::ClassDef *cdef) {
         if (auto send = ast::cast_tree<ast::Send>(stat)) {
             // we only care about sends if they're `module_function`
             if (send->fun == core::Names::moduleFunction() && send->recv.isSelfReference()) {
-                if (send->args.size() == 0) {
+                if (send->rawArgs().size() == 0) {
                     // a `module_function` with no args changes the way that every subsequent method definition works so
                     // we set this flag so we know that the rest of the defns should be rewritten
                     moduleFunctionActive = true;
@@ -110,7 +110,7 @@ vector<ast::ExpressionPtr> ModuleFunction::run(core::MutableContext ctx, ast::Se
         return stats;
     }
 
-    for (auto &arg : send->args) {
+    for (auto &arg : send->rawArgs()) {
         if (ast::isa_tree<ast::MethodDef>(arg)) {
             return ModuleFunction::rewriteDefn(ctx, arg, prevStat);
         } else if (auto lit = ast::cast_tree<ast::Literal>(arg)) {

--- a/rewriter/ModuleFunction.cc
+++ b/rewriter/ModuleFunction.cc
@@ -21,7 +21,7 @@ void ModuleFunction::run(core::MutableContext ctx, ast::ClassDef *cdef) {
         if (auto send = ast::cast_tree<ast::Send>(stat)) {
             // we only care about sends if they're `module_function`
             if (send->fun == core::Names::moduleFunction() && send->recv.isSelfReference()) {
-                if (send->rawArgs().size() == 0) {
+                if (!send->hasPosArgs() && !send->hasKwArgs()) {
                     // a `module_function` with no args changes the way that every subsequent method definition works so
                     // we set this flag so we know that the rest of the defns should be rewritten
                     moduleFunctionActive = true;

--- a/rewriter/ModuleFunction.cc
+++ b/rewriter/ModuleFunction.cc
@@ -158,8 +158,8 @@ vector<ast::ExpressionPtr> ModuleFunction::run(core::MutableContext ctx, ast::Se
         }
     }
 
-    if (send->hasKwSplat()) {
-        if (auto e = ctx.beginError(send->kwSplat()->loc(), core::errors::Rewriter::BadModuleFunction)) {
+    if (auto *kwSplat = send->kwSplat()) {
+        if (auto e = ctx.beginError(kwSplat->loc(), core::errors::Rewriter::BadModuleFunction)) {
             e.setHeader("Bad argument to `{}`: must be a symbol, string, method definition, or nothing",
                         "module_function");
         }

--- a/rewriter/ModuleFunction.cc
+++ b/rewriter/ModuleFunction.cc
@@ -110,9 +110,7 @@ vector<ast::ExpressionPtr> ModuleFunction::run(core::MutableContext ctx, ast::Se
         return stats;
     }
 
-    const auto numPosArgs = send->numPosArgs();
-    for (auto i = 0; i < numPosArgs; ++i) {
-        auto &arg = send->getPosArg(i);
+    for (auto &arg : send->posArgs()) {
         if (ast::isa_tree<ast::MethodDef>(arg)) {
             return ModuleFunction::rewriteDefn(ctx, arg, prevStat);
         } else if (auto lit = ast::cast_tree<ast::Literal>(arg)) {

--- a/rewriter/ModuleFunction.h
+++ b/rewriter/ModuleFunction.h
@@ -25,7 +25,7 @@ namespace sorbet::rewriter {
  *   private def foo(*args, **kwargs); end
  *   def self.foo(*args, **kwargs); end
  *
- * finally, you can use module_function on its on, in which case it will do the above-described rewrite to every
+ * finally, you can use module_function on its own, in which case it will do the above-described rewrite to every
  * subsequent method definition in the class
  */
 class ModuleFunction final {

--- a/rewriter/Private.cc
+++ b/rewriter/Private.cc
@@ -14,11 +14,11 @@ namespace sorbet::rewriter {
 vector<ast::ExpressionPtr> Private::run(core::MutableContext ctx, ast::Send *send) {
     vector<ast::ExpressionPtr> empty;
 
-    if (send->args.size() != 1) {
+    if (send->numPosArgs() != 1) {
         return empty;
     }
 
-    auto mdef = ast::cast_tree<ast::MethodDef>(send->args[0]);
+    auto mdef = ast::cast_tree<ast::MethodDef>(send->getPosArg(0));
     if (mdef == nullptr) {
         return empty;
     }

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -188,17 +188,17 @@ optional<PropInfo> parseProp(core::MutableContext ctx, const ast::Send *send) {
         expectedPosArgs = 2;
     }
 
-    if (send->numPosArgs > expectedPosArgs) {
+    if (send->numPosArgs() > expectedPosArgs) {
         // Too many args, even if all optional args were provided.
         return nullopt;
     }
 
     // ----- What's the prop's name? -----
     if (!ret.name.exists()) {
-        if (send->numPosArgs == 0) {
+        if (send->numPosArgs() == 0) {
             return nullopt;
         }
-        auto *sym = ast::cast_tree<ast::Literal>(send->args[0]);
+        auto *sym = ast::cast_tree<ast::Literal>(send->getPosArg(0));
         if (!sym || !sym->isSymbol(ctx)) {
             return nullopt;
         }
@@ -211,13 +211,13 @@ optional<PropInfo> parseProp(core::MutableContext ctx, const ast::Send *send) {
 
     // ----- What's the prop's type? -----
     if (ret.type == nullptr) {
-        if (send->numPosArgs == 1) {
+        if (send->numPosArgs() == 1) {
             // Type must have been inferred from prop method (like created_prop) or
             // been given in second argument.
             return nullopt;
         }
 
-        ret.type = ASTUtil::dupType(send->args[1]);
+        ret.type = ASTUtil::dupType(send->getPosArg(1));
         if (ret.type == nullptr) {
             return nullopt;
         }
@@ -230,7 +230,7 @@ optional<PropInfo> parseProp(core::MutableContext ctx, const ast::Send *send) {
     // Deep copy the rules hash so that we can destruct it at will to parse things,
     // without having to worry about whether we stole things from the tree.
     ast::ExpressionPtr rulesTree = ASTUtil::mkKwArgsHash(send);
-    if (rulesTree == nullptr && send->numPosArgs >= expectedPosArgs) {
+    if (rulesTree == nullptr && send->numPosArgs() >= expectedPosArgs) {
         // No rules, but 3 args including name and type. Also not a T::Props
         return std::nullopt;
     }
@@ -474,31 +474,15 @@ ast::ExpressionPtr ensureWithoutAccessors(const PropInfo &prop, const ast::Send 
     auto true_ = ast::MK::True(send->loc);
 
     auto *copy = ast::cast_tree<ast::Send>(result);
-    if (copy->hasKwArgs() || copy->numPosArgs == 0) {
+    if (copy->hasKwArgs() || copy->numPosArgs() == 0) {
         // append to the inline keyword arguments of the send
-        auto pos = copy->args.end();
-        if (copy->hasKwSplat()) {
-            pos--;
-        }
-        if (copy->hasBlock()) {
-            pos--;
-        }
-
-        pos = copy->args.insert(pos, move(withoutAccessors));
-        pos++;
-        copy->args.insert(pos, move(true_));
+        copy->addKwArg(move(withoutAccessors), move(true_));
     } else {
-        if (auto *hash = ast::cast_tree<ast::Hash>(copy->args[copy->numPosArgs - 1])) {
+        if (auto *hash = ast::cast_tree<ast::Hash>(*copy->kwSplat())) {
             hash->keys.emplace_back(move(withoutAccessors));
             hash->values.emplace_back(move(true_));
         } else {
-            auto pos = copy->args.end();
-            if (copy->hasBlock()) {
-                pos--;
-            }
-            pos = copy->args.insert(pos, move(withoutAccessors));
-            pos++;
-            copy->args.insert(pos, move(true_));
+            copy->addKwArg(move(withoutAccessors), move(true_));
         }
     }
 

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -195,7 +195,7 @@ optional<PropInfo> parseProp(core::MutableContext ctx, const ast::Send *send) {
 
     // ----- What's the prop's name? -----
     if (!ret.name.exists()) {
-        if (send->numPosArgs() == 0) {
+        if (!send->hasPosArgs()) {
             return nullopt;
         }
         auto *sym = ast::cast_tree<ast::Literal>(send->getPosArg(0));
@@ -474,7 +474,7 @@ ast::ExpressionPtr ensureWithoutAccessors(const PropInfo &prop, const ast::Send 
     auto true_ = ast::MK::True(send->loc);
 
     auto *copy = ast::cast_tree<ast::Send>(result);
-    if (copy->hasKwArgs() || copy->numPosArgs() == 0) {
+    if (copy->hasKwArgs() || !copy->hasPosArgs()) {
         // append to the inline keyword arguments of the send
         copy->addKwArg(move(withoutAccessors), move(true_));
     } else {

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -478,7 +478,7 @@ ast::ExpressionPtr ensureWithoutAccessors(const PropInfo &prop, const ast::Send 
         // append to the inline keyword arguments of the send
         copy->addKwArg(move(withoutAccessors), move(true_));
     } else {
-        if (auto *hash = ast::cast_tree<ast::Hash>(*copy->kwSplat())) {
+        if (auto *hash = ast::cast_tree<ast::Hash>(copy->getPosArg(copy->numPosArgs() - 1))) {
             hash->keys.emplace_back(move(withoutAccessors));
             hash->values.emplace_back(move(true_));
         } else {

--- a/rewriter/Rails.cc
+++ b/rewriter/Rails.cc
@@ -36,10 +36,10 @@ void Rails::run(core::MutableContext ctx, ast::ClassDef *cdef) {
     if (name2->cnst != core::Names::Constants::ActiveRecord()) {
         return;
     }
-    if (send->args.size() != 1 && !send->hasKwArgs()) {
+    if (send->numPosArgs() != 1 && !send->hasKwArgs()) {
         return;
     }
-    auto arg = ast::cast_tree<ast::Literal>(send->args[0]);
+    auto arg = ast::cast_tree<ast::Literal>(send->getPosArg(0));
     if (!arg) {
         return;
     }

--- a/rewriter/SelfNew.cc
+++ b/rewriter/SelfNew.cc
@@ -7,13 +7,12 @@ namespace sorbet::rewriter {
 
 namespace {
 ast::ExpressionPtr convertSelfNew(core::MutableContext ctx, ast::Send *send) {
-    auto numNonBlockArgs = send->numNonBlockArgs();
     ast::Send::ARGS_store args;
 
     args.emplace_back(std::move(send->recv));
 
-    for (auto i = 0; i < numNonBlockArgs; ++i) {
-        args.emplace_back(std::move(send->getNonBlockArg(i)));
+    for (auto &arg : send->nonBlockArgs()) {
+        args.emplace_back(std::move(arg));
     }
 
     if (auto *block = send->rawBlock()) {

--- a/rewriter/SelfNew.cc
+++ b/rewriter/SelfNew.cc
@@ -16,7 +16,7 @@ ast::ExpressionPtr convertSelfNew(core::MutableContext ctx, ast::Send *send) {
     }
 
     auto numPosArgs = send->numPosArgs + 1;
-    return ast::MK::SelfNew(send->loc, numPosArgs, std::move(args), send->flags, std::move(send->block));
+    return ast::MK::SelfNew(send->loc, numPosArgs, std::move(args), send->flags);
 }
 
 bool isSelfNewCallWithSplat(core::MutableContext ctx, ast::Send *send) {
@@ -60,8 +60,7 @@ ast::ExpressionPtr convertSelfNewCallWithSplat(core::MutableContext ctx, ast::Se
     args[0] = std::move(magic);
     args[1] = ast::MK::Symbol(send->loc, core::Names::selfNew());
 
-    return ast::MK::Send(send->loc, std::move(send->recv), send->fun, send->numPosArgs, std::move(args), send->flags,
-                         std::move(send->block));
+    return ast::MK::Send(send->loc, std::move(send->recv), send->fun, send->numPosArgs, std::move(args), send->flags);
 }
 } // namespace
 

--- a/rewriter/SelfNew.cc
+++ b/rewriter/SelfNew.cc
@@ -64,13 +64,15 @@ bool isSelfNewCallWithSplat(core::MutableContext ctx, ast::Send *send) {
 }
 
 ast::ExpressionPtr convertSelfNewCallWithSplat(core::MutableContext ctx, ast::Send *send) {
-    auto flags = send->flags;
-    ast::Send::ARGS_store args = std::move(send->rawArgs());
     auto magic = ast::MK::Constant(send->loc, core::Symbols::Magic());
-    args[0] = std::move(magic);
-    args[1] = ast::MK::Symbol(send->loc, core::Names::selfNew());
+    auto &arg0 = send->getPosArg(0);
+    arg0 = std::move(magic);
 
-    return ast::MK::Send(send->loc, std::move(send->recv), send->fun, send->numPosArgs(), std::move(args), flags);
+    auto &arg1 = send->getPosArg(1);
+    arg1 = ast::MK::Symbol(send->loc, core::Names::selfNew());
+
+    // The original expression is now properly mutated, but we need to return an expression not a Send.
+    return send->withNewBody(send->loc, std::move(send->recv), send->fun);
 }
 } // namespace
 

--- a/rewriter/SigRewriter.cc
+++ b/rewriter/SigRewriter.cc
@@ -44,7 +44,7 @@ bool SigRewriter::run(core::MutableContext &ctx, ast::Send *send) {
         return false;
     }
 
-    if (send->hasKwArgs()) {
+    if (send->hasKwSplat()) {
         return false;
     }
 

--- a/rewriter/SigRewriter.cc
+++ b/rewriter/SigRewriter.cc
@@ -36,11 +36,15 @@ bool SigRewriter::run(core::MutableContext &ctx, ast::Send *send) {
         return false;
     }
 
-    if (!(send->args.size() == 0 || send->args.size() == 1)) {
+    if (!(send->numPosArgs == 0 || send->numPosArgs == 1)) {
         return false;
     }
 
-    if (send->block == nullptr) {
+    if (!send->hasBlock()) {
+        return false;
+    }
+
+    if (send->hasKwArgs()) {
         return false;
     }
 

--- a/rewriter/SigRewriter.cc
+++ b/rewriter/SigRewriter.cc
@@ -36,7 +36,7 @@ bool SigRewriter::run(core::MutableContext &ctx, ast::Send *send) {
         return false;
     }
 
-    if (!(send->numPosArgs == 0 || send->numPosArgs == 1)) {
+    if (!(send->numPosArgs() == 0 || send->numPosArgs() == 1)) {
         return false;
     }
 
@@ -51,9 +51,8 @@ bool SigRewriter::run(core::MutableContext &ctx, ast::Send *send) {
     // Keep track of old receiver at this point so that we can report whether a method called
     // sig with the right arity even existed at this point.
     auto oldRecv = std::move(send->recv);
-    send->numPosArgs += 1;
     send->recv = ast::MK::Constant(send->loc, core::Symbols::Sorbet_Private_Static());
-    send->args.emplace(send->args.begin(), std::move(oldRecv));
+    send->insertPosArg(0, std::move(oldRecv));
     return true;
 }
 

--- a/rewriter/Singleton.cc
+++ b/rewriter/Singleton.cc
@@ -21,7 +21,7 @@ bool isFinal(const ast::ExpressionPtr &stmt) {
         return false;
     }
 
-    if (!send->args.empty()) {
+    if (!send->rawArgs().empty()) {
         return false;
     }
 
@@ -46,11 +46,11 @@ bool isIncludeSingleton(const ast::ExpressionPtr &stmt) {
         return false;
     }
 
-    if (send->args.size() != 1 || send->hasKwArgs()) {
+    if (send->numPosArgs() != 1 || send->hasKwArgs()) {
         return false;
     }
 
-    auto *sym = ast::cast_tree<ast::UnresolvedConstantLit>(send->args.front());
+    auto *sym = ast::cast_tree<ast::UnresolvedConstantLit>(send->getPosArg(0));
     if (sym == nullptr || sym->cnst != core::Names::Constants::Singleton()) {
         return false;
     }
@@ -77,7 +77,7 @@ void Singleton::run(core::MutableContext ctx, ast::ClassDef *cdef) {
     {
         auto sig = ast::MK::Sig0(loc, ast::MK::Send0(loc, ast::MK::T(loc), core::Names::attachedClass()));
         if (finalKlass) {
-            ast::cast_tree_nonnull<ast::Send>(sig).args.emplace_back(ast::MK::Symbol(loc, core::Names::final_()));
+            ast::cast_tree_nonnull<ast::Send>(sig).addPosArg(ast::MK::Symbol(loc, core::Names::final_()));
         }
         newRHS.emplace_back(std::move(sig));
     }

--- a/rewriter/Singleton.cc
+++ b/rewriter/Singleton.cc
@@ -21,7 +21,7 @@ bool isFinal(const ast::ExpressionPtr &stmt) {
         return false;
     }
 
-    if (!send->rawArgs().empty()) {
+    if (send->hasPosArgs() || send->hasKwArgs()) {
         return false;
     }
 

--- a/rewriter/Struct.cc
+++ b/rewriter/Struct.cc
@@ -85,7 +85,7 @@ vector<ast::ExpressionPtr> Struct::run(core::MutableContext ctx, ast::Assign *as
 
     bool keywordInit = false;
     if (send->hasKwArgs()) {
-        if (send->numPosArgs() == 0) {
+        if (!send->hasPosArgs()) {
             // leave bad usages like `Struct.new(keyword_init: true)` untouched so we error later
             return empty;
         }
@@ -160,8 +160,7 @@ vector<ast::ExpressionPtr> Struct::run(core::MutableContext ctx, ast::Assign *as
                                                    ast::MK::RaiseUnimplemented(loc)));
     }
 
-    if (send->hasBlock()) {
-        auto block = send->block();
+    if (auto *block = send->block()) {
 
         // Steal the trees, because the run is going to remove the original send node from the tree anyway.
         if (auto *insSeq = ast::cast_tree<ast::InsSeq>(block->body)) {

--- a/rewriter/Struct.cc
+++ b/rewriter/Struct.cc
@@ -23,13 +23,13 @@ bool isKeywordInitKey(const core::GlobalState &gs, const ast::ExpressionPtr &nod
 }
 
 bool isMissingInitialize(const core::GlobalState &gs, const ast::Send *send) {
-    if (send->block == nullptr) {
+    if (!send->hasBlock()) {
         return true;
     }
 
-    auto &block = ast::cast_tree_nonnull<ast::Block>(send->block);
+    auto block = send->block();
 
-    if (auto *insSeq = ast::cast_tree<ast::InsSeq>(block.body)) {
+    if (auto *insSeq = ast::cast_tree<ast::InsSeq>(block->body)) {
         auto methodDef = ast::cast_tree<ast::MethodDef>(insSeq->expr);
 
         if (methodDef && methodDef->name == core::Names::initialize()) {
@@ -162,17 +162,17 @@ vector<ast::ExpressionPtr> Struct::run(core::MutableContext ctx, ast::Assign *as
                                                    ast::MK::RaiseUnimplemented(loc)));
     }
 
-    if (send->block != nullptr) {
-        auto &block = ast::cast_tree_nonnull<ast::Block>(send->block);
+    if (send->hasBlock()) {
+        auto block = send->block();
 
         // Steal the trees, because the run is going to remove the original send node from the tree anyway.
-        if (auto *insSeq = ast::cast_tree<ast::InsSeq>(block.body)) {
+        if (auto *insSeq = ast::cast_tree<ast::InsSeq>(block->body)) {
             for (auto &&stat : insSeq->stats) {
                 body.emplace_back(move(stat));
             }
             body.emplace_back(move(insSeq->expr));
         } else {
-            body.emplace_back(move(block.body));
+            body.emplace_back(move(block->body));
         }
 
         // NOTE: the code in this block _STEALS_ trees. No _return empty_'s should go after it

--- a/rewriter/Struct.cc
+++ b/rewriter/Struct.cc
@@ -73,7 +73,7 @@ vector<ast::ExpressionPtr> Struct::run(core::MutableContext ctx, ast::Assign *as
     }
 
     if (!ast::MK::isRootScope(recv->scope) || recv->cnst != core::Symbols::Struct().data(ctx)->name ||
-        send->fun != core::Names::new_() || (send->numPosArgs() == 0 && !send->hasKwArgs())) {
+        send->fun != core::Names::new_() || (!send->hasPosArgs() && !send->hasKwArgs())) {
         return empty;
     }
 

--- a/rewriter/Struct.cc
+++ b/rewriter/Struct.cc
@@ -161,7 +161,6 @@ vector<ast::ExpressionPtr> Struct::run(core::MutableContext ctx, ast::Assign *as
     }
 
     if (auto *block = send->block()) {
-
         // Steal the trees, because the run is going to remove the original send node from the tree anyway.
         if (auto *insSeq = ast::cast_tree<ast::InsSeq>(block->body)) {
             for (auto &&stat : insSeq->stats) {

--- a/rewriter/TEnum.cc
+++ b/rewriter/TEnum.cc
@@ -88,11 +88,11 @@ vector<ast::ExpressionPtr> processStat(core::MutableContext ctx, ast::ClassDef *
             return badConst(ctx, stat.loc(), klass->loc);
         }
 
-        if (rhs->args.size() != 2) {
+        if (rhs->numPosArgs() != 2) {
             return badConst(ctx, stat.loc(), klass->loc);
         }
 
-        auto arg0 = ast::cast_tree<ast::Send>(rhs->args[0]);
+        auto arg0 = ast::cast_tree<ast::Send>(rhs->getPosArg(0));
         if (arg0 == nullptr) {
             return badConst(ctx, stat.loc(), klass->loc);
         }
@@ -126,7 +126,7 @@ vector<ast::ExpressionPtr> processStat(core::MutableContext ctx, ast::ClassDef *
 
     ast::Send::ARGS_store args;
     auto first = true;
-    for (auto &&arg : rhs->args) {
+    for (auto &&arg : rhs->rawArgs()) {
         if (first) {
             // This is a call to <Magic>.<self-new>, so we need to skip the first arg.
             first = false;
@@ -137,7 +137,7 @@ vector<ast::ExpressionPtr> processStat(core::MutableContext ctx, ast::ClassDef *
     }
 
     // Remove one from the number of positional arguments to account for the self param to <Magic>.<self-new>
-    auto numPosArgs = rhs->numPosArgs - 1;
+    auto numPosArgs = rhs->numPosArgs() - 1;
 
     ast::Send::Flags flags = {};
     flags.isPrivateOk = true;

--- a/rewriter/TEnum.cc
+++ b/rewriter/TEnum.cc
@@ -172,7 +172,7 @@ void TEnum::run(core::MutableContext ctx, ast::ClassDef *klass) {
     klass->rhs.emplace_back(ast::MK::Send0(loc, ast::MK::Self(loc), core::Names::declareSealed()));
     for (auto &stat : oldRHS) {
         if (auto enumsDo = asEnumsDo(stat)) {
-            auto block = enumsDo->block();
+            auto *block = enumsDo->block();
             vector<ast::ExpressionPtr> newStats;
             if (auto insSeq = ast::cast_tree<ast::InsSeq>(block->body)) {
                 for (auto &stat : insSeq->stats) {

--- a/rewriter/TestCase.cc
+++ b/rewriter/TestCase.cc
@@ -21,7 +21,7 @@ void TestCase::run(core::MutableContext ctx, ast::ClassDef *klass) {
                     }
                 }
             } else if (send->fun == core::Names::setup() || send->fun == core::Names::teardown()) {
-                if (send->hasBlock() && send->numPosArgs() == 0 && !send->hasKwArgs()) {
+                if (send->hasBlock() && !send->hasPosArgs() && !send->hasKwArgs()) {
                     // send->args only contains block.
                     setupAndTeardownSends.push_back(std::move(stat));
                     continue;

--- a/rewriter/TestCase.cc
+++ b/rewriter/TestCase.cc
@@ -12,7 +12,7 @@ void TestCase::run(core::MutableContext ctx, ast::ClassDef *klass) {
     for (auto &stat : klass->rhs) {
         if (auto *send = ast::cast_tree<ast::Send>(stat)) {
             if (send->fun == core::Names::test()) {
-                if (send->args.size() == 1 && send->numPosArgs == 1 && send->block) {
+                if (send->numPosArgs == 1 && !send->hasKwArgs() && send->hasBlock()) {
                     auto *arg0 = ast::cast_tree<ast::Literal>(send->args[0]);
 
                     if (arg0 && arg0->isString(ctx)) {
@@ -21,7 +21,8 @@ void TestCase::run(core::MutableContext ctx, ast::ClassDef *klass) {
                     }
                 }
             } else if (send->fun == core::Names::setup() || send->fun == core::Names::teardown()) {
-                if (send->args.empty() && send->block) {
+                if (send->hasBlock() && send->numPosArgs == 0 && !send->hasKwArgs()) {
+                    // send->args only contains block.
                     setupAndTeardownSends.push_back(std::move(stat));
                     continue;
                 }
@@ -35,7 +36,7 @@ void TestCase::run(core::MutableContext ctx, ast::ClassDef *klass) {
         auto *send = ast::cast_tree<ast::Send>(stat);
         auto loc = send->loc;
         auto *arg0 = ast::cast_tree<ast::Literal>(send->args[0]);
-        auto block = ast::cast_tree<ast::Block>(send->block);
+        auto block = send->block();
 
         auto snake_case_name = absl::StrReplaceAll(arg0->asString(ctx).toString(ctx), {{" ", "_"}});
         auto name = ctx.state.enterNameUTF8("test_" + snake_case_name);
@@ -51,7 +52,7 @@ void TestCase::run(core::MutableContext ctx, ast::ClassDef *klass) {
         for (auto &stat : setupAndTeardownSends) {
             auto *send = ast::cast_tree<ast::Send>(stat);
             auto loc = send->loc;
-            auto block = ast::cast_tree<ast::Block>(send->block);
+            auto block = send->block();
             auto method_name = send->fun == core::Names::setup() ? core::Names::initialize() : core::Names::teardown();
 
             auto method = ast::MK::SyntheticMethod0(loc, loc, method_name, std::move(block->body));

--- a/rewriter/TestCase.cc
+++ b/rewriter/TestCase.cc
@@ -36,7 +36,7 @@ void TestCase::run(core::MutableContext ctx, ast::ClassDef *klass) {
         auto *send = ast::cast_tree<ast::Send>(stat);
         auto loc = send->loc;
         auto *arg0 = ast::cast_tree<ast::Literal>(send->getPosArg(0));
-        auto block = send->block();
+        auto *block = send->block();
 
         auto snake_case_name = absl::StrReplaceAll(arg0->asString(ctx).toString(ctx), {{" ", "_"}});
         auto name = ctx.state.enterNameUTF8("test_" + snake_case_name);

--- a/rewriter/TestCase.cc
+++ b/rewriter/TestCase.cc
@@ -12,8 +12,8 @@ void TestCase::run(core::MutableContext ctx, ast::ClassDef *klass) {
     for (auto &stat : klass->rhs) {
         if (auto *send = ast::cast_tree<ast::Send>(stat)) {
             if (send->fun == core::Names::test()) {
-                if (send->numPosArgs == 1 && !send->hasKwArgs() && send->hasBlock()) {
-                    auto *arg0 = ast::cast_tree<ast::Literal>(send->args[0]);
+                if (send->numPosArgs() == 1 && !send->hasKwArgs() && send->hasBlock()) {
+                    auto *arg0 = ast::cast_tree<ast::Literal>(send->getPosArg(0));
 
                     if (arg0 && arg0->isString(ctx)) {
                         testSends.push_back(std::move(stat));
@@ -21,7 +21,7 @@ void TestCase::run(core::MutableContext ctx, ast::ClassDef *klass) {
                     }
                 }
             } else if (send->fun == core::Names::setup() || send->fun == core::Names::teardown()) {
-                if (send->hasBlock() && send->numPosArgs == 0 && !send->hasKwArgs()) {
+                if (send->hasBlock() && send->numPosArgs() == 0 && !send->hasKwArgs()) {
                     // send->args only contains block.
                     setupAndTeardownSends.push_back(std::move(stat));
                     continue;
@@ -35,7 +35,7 @@ void TestCase::run(core::MutableContext ctx, ast::ClassDef *klass) {
     for (auto &stat : testSends) {
         auto *send = ast::cast_tree<ast::Send>(stat);
         auto loc = send->loc;
-        auto *arg0 = ast::cast_tree<ast::Literal>(send->args[0]);
+        auto *arg0 = ast::cast_tree<ast::Literal>(send->getPosArg(0));
         auto block = send->block();
 
         auto snake_case_name = absl::StrReplaceAll(arg0->asString(ctx).toString(ctx), {{" ", "_"}});

--- a/rewriter/Util.cc
+++ b/rewriter/Util.cc
@@ -22,9 +22,7 @@ ast::ExpressionPtr ASTUtil::dupType(const ast::ExpressionPtr &orig) {
             return send->deepCopy();
         }
 
-        ENFORCE(!send->hasBlock());
-
-        if (send->fun == core::Names::params() && send->numPosArgs() == 0 && !send->hasKwSplat()) {
+        if (send->fun == core::Names::params() && !send->hasPosArgs() && !send->hasKwSplat()) {
             // T.proc.params takes inlined keyword argument pairs, and can't handle kwsplat
             ast::Send::ARGS_store args;
 
@@ -44,6 +42,7 @@ ast::ExpressionPtr ASTUtil::dupType(const ast::ExpressionPtr &orig) {
             return ast::MK::Send(send->loc, std::move(dupRecv), send->fun, 0, std::move(args));
         }
 
+        ENFORCE(!send->hasBlock());
         for (auto &arg : send->rawArgs()) {
             auto dupArg = dupType(arg);
             if (!dupArg) {
@@ -216,7 +215,7 @@ ast::Send *ASTUtil::castSig(ast::Send *send) {
 }
 
 ast::ExpressionPtr ASTUtil::mkKwArgsHash(const ast::Send *send) {
-    if (!send->hasKwArgs() && send->numPosArgs() == 0) {
+    if (!send->hasKwArgs() && !send->hasPosArgs()) {
         return nullptr;
     }
 

--- a/rewriter/Util.cc
+++ b/rewriter/Util.cc
@@ -199,7 +199,7 @@ ast::Send *ASTUtil::castSig(ast::Send *send) {
     // 0 args is common case
     // 1 arg  is `sig(:final)`
     // 2 args is `Sorbet::Private::Static.sig(self, :final)`
-    if (send->numPosArgs() + send->numKwArgs() > 2 || send->hasKwSplat()) {
+    if (send->numPosArgs() > 2) {
         return nullptr;
     }
     auto *block = send->block();
@@ -216,7 +216,7 @@ ast::Send *ASTUtil::castSig(ast::Send *send) {
 }
 
 ast::ExpressionPtr ASTUtil::mkKwArgsHash(const ast::Send *send) {
-    if (!send->hasKwArgs()) {
+    if (!send->hasKwArgs() && send->numPosArgs() == 0) {
         return nullptr;
     }
 

--- a/rewriter/Util.cc
+++ b/rewriter/Util.cc
@@ -42,9 +42,8 @@ ast::ExpressionPtr ASTUtil::dupType(const ast::ExpressionPtr &orig) {
             return ast::MK::Send(send->loc, std::move(dupRecv), send->fun, 0, std::move(args));
         }
 
-        const auto numNonBlockArgs = send->numNonBlockArgs();
-        for (auto i = 0; i < numNonBlockArgs; ++i) {
-            auto dupArg = dupType(send->getNonBlockArg(i));
+        for (auto &arg : send->nonBlockArgs()) {
+            auto dupArg = dupType(arg);
             if (!dupArg) {
                 // This isn't a Type signature, bail out
                 return nullptr;

--- a/rewriter/Util.cc
+++ b/rewriter/Util.cc
@@ -42,33 +42,14 @@ ast::ExpressionPtr ASTUtil::dupType(const ast::ExpressionPtr &orig) {
             return ast::MK::Send(send->loc, std::move(dupRecv), send->fun, 0, std::move(args));
         }
 
-        const auto numPosArgs = send->numPosArgs();
-        for (auto i = 0; i < numPosArgs; ++i) {
-            auto dupArg = dupType(send->getPosArg(i));
+        const auto numNonBlockArgs = send->numNonBlockArgs();
+        for (auto i = 0; i < numNonBlockArgs; ++i) {
+            auto dupArg = dupType(send->getNonBlockArg(i));
             if (!dupArg) {
                 // This isn't a Type signature, bail out
                 return nullptr;
             }
             args.emplace_back(std::move(dupArg));
-        }
-
-        const auto numKwArgs = send->numKwArgs();
-        for (auto i = 0; i < numKwArgs; ++i) {
-            auto dupKey = dupType(send->getKwKey(i));
-            auto dupVal = dupType(send->getKwValue(i));
-            if (!dupKey || !dupVal) {
-                return nullptr;
-            }
-            args.emplace_back(std::move(dupKey));
-            args.emplace_back(std::move(dupVal));
-        }
-
-        if (send->hasKwSplat()) {
-            auto dupSplat = dupType(*send->kwSplat());
-            if (!dupSplat) {
-                return nullptr;
-            }
-            args.emplace_back(std::move(dupSplat));
         }
 
         return ast::MK::Send(send->loc, std::move(dupRecv), send->fun, send->numPosArgs(), std::move(args));

--- a/rewriter/Util.cc
+++ b/rewriter/Util.cc
@@ -233,7 +233,7 @@ ast::ExpressionPtr ASTUtil::mkKwArgsHash(const ast::Send *send) {
     bool explicitEmptyHash = false;
     if (send->hasKwSplat() || !send->hasKwArgs()) {
         if (auto *hash = ast::cast_tree<ast::Hash>(send->hasKwSplat() ? *send->kwSplat()
-                                                                      : send->getKwValue(send->numKwArgs() - 1))) {
+                                                                      : send->getPosArg(send->numPosArgs() - 1))) {
             explicitEmptyHash = hash->keys.empty();
             for (auto i = 0; i < hash->keys.size(); ++i) {
                 keys.emplace_back(hash->keys[i].deepCopy());


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Move the `block` field on `ast::Send` into `args` vector; only Sends that contain blocks will 'pay' for its storage.

Also introduces a new flag that indicates if a Send has a block, and APIs to manipulate/query `args` without raw access to `args`. Raw access to `args` is a footgun, and using the APIs makes the intent of the code clearer. There is only one place that still has raw access to args: `deepCopy()`. Since that is a hot path, I was fearful that adding a layer of indirection there might slow things down. Thus, there is a `rawArgsDoNotUse` method on `Send` still.

Reduces Sorbet's memory consumption (max RSS) on the Stripe codebase by ~4%, and I think cleans up the code in some places that made assumptions about `args`'s layout.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Reduce Sorbet's memory consumption.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
