### PR TITLE
Mark sorbet_i_objIsKindOf as const

### DIFF
--- a/compiler/IREmitter/Payload.cc
+++ b/compiler/IREmitter/Payload.cc
@@ -350,7 +350,8 @@ llvm::Value *Payload::typeTest(CompilerState &cs, llvm::IRBuilderBase &builder, 
                                   {val, Payload::getRubyConstant(cs, attachedClass, builder)});
     }
     sym = isProc(sym) ? core::Symbols::Proc() : sym;
-    return builder.CreateCall(cs.getFunction("sorbet_isa"), {val, Payload::getRubyConstant(cs, sym, builder)});
+    return builder.CreateCall(cs.getFunction("sorbet_i_objIsKindOf"),
+                              {val, Payload::getRubyConstant(cs, sym, builder)});
 }
 
 llvm::Value *Payload::typeTest(CompilerState &cs, llvm::IRBuilderBase &builder, llvm::Value *val,

--- a/compiler/IREmitter/Payload/codegen-payload.c
+++ b/compiler/IREmitter/Payload/codegen-payload.c
@@ -132,7 +132,7 @@ SORBET_ALIVE(VALUE, sorbet_rb_int_ge_slowpath, (VALUE, VALUE));
 
 SORBET_ALIVE(VALUE, sorbet_i_getRubyClass, (const char *const className, long classNameLen) __attribute__((const)));
 SORBET_ALIVE(VALUE, sorbet_i_getRubyConstant, (const char *const className, long classNameLen) __attribute__((const)));
-SORBET_ALIVE(VALUE, sorbet_i_objIsKindOf, (VALUE, VALUE));
+SORBET_ALIVE(VALUE, sorbet_i_objIsKindOf, (VALUE, VALUE) __attribute__((const)));
 SORBET_ALIVE(VALUE, sorbet_i_send,
              (struct FunctionInlineCache *, _Bool blkUsesBreak, struct vm_ifunc *, bool searchSuper,
               rb_control_frame_t *, ...));
@@ -395,11 +395,6 @@ _Bool sorbet_isa_RootSingleton(VALUE obj) {
 KEEP_ALIVE(sorbet_isa_RootSingleton);
 
 SORBET_ATTRIBUTE(const) VALUE rb_class_inherited_p(VALUE, VALUE);
-
-SORBET_ATTRIBUTE(const)
-_Bool sorbet_isa(VALUE obj, VALUE class) {
-    return sorbet_i_objIsKindOf(obj, class) == Qtrue;
-}
 
 SORBET_ATTRIBUTE(const)
 _Bool sorbet_isa_class_of(VALUE obj, VALUE class) {

--- a/compiler/IREmitter/Payload/codegen-payload.c
+++ b/compiler/IREmitter/Payload/codegen-payload.c
@@ -132,7 +132,6 @@ SORBET_ALIVE(VALUE, sorbet_rb_int_ge_slowpath, (VALUE, VALUE));
 
 SORBET_ALIVE(VALUE, sorbet_i_getRubyClass, (const char *const className, long classNameLen) __attribute__((const)));
 SORBET_ALIVE(VALUE, sorbet_i_getRubyConstant, (const char *const className, long classNameLen) __attribute__((const)));
-SORBET_ALIVE(VALUE, sorbet_i_objIsKindOf, (VALUE, VALUE) __attribute__((const)));
 SORBET_ALIVE(VALUE, sorbet_i_send,
              (struct FunctionInlineCache *, _Bool blkUsesBreak, struct vm_ifunc *, bool searchSuper,
               rb_control_frame_t *, ...));
@@ -152,6 +151,7 @@ SORBET_ALIVE(_Bool, sorbet_i_isa_String, (VALUE) __attribute__((const)));
 SORBET_ALIVE(_Bool, sorbet_i_isa_Proc, (VALUE) __attribute__((const)));
 SORBET_ALIVE(_Bool, sorbet_i_isa_Thread, (VALUE) __attribute__((const)));
 SORBET_ALIVE(_Bool, sorbet_i_isa_RootSingleton, (VALUE) __attribute__((const)));
+SORBET_ALIVE(_Bool, sorbet_i_objIsKindOf, (VALUE, VALUE) __attribute__((const)));
 
 SORBET_ALIVE(long, sorbet_globalConstRegister, (VALUE val));
 SORBET_ALIVE(VALUE, sorbet_globalConstDupHash, (long index));


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Remove `sorbet_isa` in favor of a direct call to `sorbet_i_objIsKindOf`, and mark `sorbet_i_objIsKindOf` as `const`. Also change the return type of `sorbet_i_objIsKindOf` to `_Bool`, matching the other type testing intrinsics.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Cleaning up generated code, coalescing calls to `sorbet_i_objIsKindOf` when possible.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.