### PR TITLE
Add an overload of Payload::typeTest that accepts a symbol

### DIFF
--- a/compiler/IREmitter/Payload.cc
+++ b/compiler/IREmitter/Payload.cc
@@ -321,11 +321,8 @@ void flattenOrType(vector<core::TypePtr> &results, const core::OrType &type) {
         [&results](const core::TypePtr &def) { results.emplace_back(def); });
 }
 
-static bool isProc(core::SymbolRef sym) {
-    if (sym.kind() != core::SymbolRef::Kind::ClassOrModule) {
-        return false;
-    }
-    auto id = sym.classOrModuleIndex();
+static bool isProc(core::ClassOrModuleRef sym) {
+    auto id = sym.id();
     return id >= core::Symbols::Proc0().id() && id <= core::Symbols::last_proc().id();
 }
 

--- a/compiler/IREmitter/Payload.h
+++ b/compiler/IREmitter/Payload.h
@@ -56,8 +56,12 @@ public:
     static llvm::Value *testIsTruthy(CompilerState &cs, llvm::IRBuilderBase &builder, llvm::Value *val);
     static llvm::Value *getRubyConstant(CompilerState &cs, core::SymbolRef sym, llvm::IRBuilderBase &builder);
     static llvm::Value *toCString(CompilerState &cs, std::string_view str, llvm::IRBuilderBase &builder);
+
+    static llvm::Value *typeTest(CompilerState &cs, llvm::IRBuilderBase &builder, llvm::Value *val,
+                                 core::ClassOrModuleRef sym);
     static llvm::Value *typeTest(CompilerState &cs, llvm::IRBuilderBase &builder, llvm::Value *val,
                                  const core::TypePtr &type);
+
     static void assumeType(CompilerState &cs, llvm::IRBuilderBase &builder, llvm::Value *val,
                            core::ClassOrModuleRef sym);
     static llvm::Value *boolToRuby(CompilerState &cs, llvm::IRBuilderBase &builder, llvm::Value *u1);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Split out the behavior of `Payload::typeTest` for `AppliedType` and `ClassType` into a separate overload.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Simplify `Payload::assumeType` and the leaf cases of `Payload::typeTest`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.