### PR TITLE
Add compiler intrinsic for Hash#empty?

### DIFF
--- a/compiler/IREmitter/Payload/codegen-payload.c
+++ b/compiler/IREmitter/Payload/codegen-payload.c
@@ -1612,6 +1612,14 @@ VALUE sorbet_rb_hash_delete_m_withBlock(VALUE recv, ID fun, int argc, const VALU
     }
 }
 
+// From rb_hash_empty_p: https://github.com/ruby/ruby/blob/ruby_2_7/hash.c#L2976-L2980
+SORBET_INLINE
+VALUE sorbet_rb_hash_empty_p(VALUE recv, ID fun, int argc, const VALUE *const restrict argv, BlockFFIType blk,
+                             VALUE closure) {
+    sorbet_ensure_arity(argc, 0);
+    return RHASH_EMPTY_P(recv) ? Qtrue : Qfalse;
+}
+
 SORBET_INLINE
 VALUE sorbet_rb_int_plus(VALUE recv, ID fun, int argc, const VALUE *const restrict argv, BlockFFIType blk,
                          VALUE closure) {

--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -999,6 +999,7 @@ static const vector<CallCMethod> knownCMethodsInstance{
     {core::Symbols::Hash(), "select", CMethod{"sorbet_rb_hash_select", core::Symbols::Enumerator()},
      CMethod{"sorbet_rb_hash_select_withBlock", core::Symbols::Hash()}},
     {core::Symbols::Hash(), "delete", CMethod{"sorbet_rb_hash_delete_m"}, CMethod{"sorbet_rb_hash_delete_m_withBlock"}},
+    {core::Symbols::Hash(), "empty?", CMethod{"sorbet_rb_hash_empty_p"}},
     {core::Symbols::TrueClass(), "|", CMethod{"sorbet_int_bool_true"}},
     {core::Symbols::FalseClass(), "|", CMethod{"sorbet_int_bool_and"}},
     {core::Symbols::TrueClass(), "&", CMethod{"sorbet_int_bool_and"}},

--- a/test/testdata/compiler/intrinsics/hash_empty_p.rb
+++ b/test/testdata/compiler/intrinsics/hash_empty_p.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+# run_filecheck: INITIAL
+
+def test_empty_p
+  h = {}
+  p (h.empty?)
+
+  h = {x: 33}
+  p (h.empty?)
+end
+
+# INITIAL-LABEL: define internal i64 @"func_Object#12test_empty_p"
+# INITIAL: call i64 @sorbet_rb_hash_empty_p(
+# INITIAL: call i64 @sorbet_rb_hash_empty_p(
+# INITIAL{LITERAL}: }

--- a/test/testdata/ruby_benchmark/stripe/hash_empty_p.rb
+++ b/test/testdata/ruby_benchmark/stripe/hash_empty_p.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+
+hash = {x: 33, y: 27}
+
+i = 0
+while i < 100_000_000 do
+  i += (hash.empty? ? 0 : 1)
+end
+
+p i

--- a/test/testdata/ruby_benchmark/stripe/while_100_000_000.rb
+++ b/test/testdata/ruby_benchmark/stripe/while_100_000_000.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+
+# Many of our benchmarks use a while loop with `+=` over 100M items.
+#
+# Use this benchmark as a baseline to check how much time is spent in an
+# operation vs spent in the while loop & loop counter.
+
+i = 0
+while i < 100_000_000
+
+  # ... potential extra stuff ...
+
+  i += 1
+end
+
+puts i


### PR DESCRIPTION
Adds a compiler intrinsic for `Hash#empty?`

**Benchmarks**

`master`:

|source | interpreted   |  compiled|
|-|-|-|
|stripe/while_100_000_000.rb |    2.063   |.189|
|stripe/hash_empty_p.rb | 2.895   |1.574|
|stripe/hash_empty_p.rb - baseline  |     .832   | 1.385|

PR branch:
|source|interpreted|compiled|
|-|-|-|
|stripe/while_100_000_000.rb|2.064|.188|
|stripe/hash_empty_p.rb|2.897|.285|
|stripe/hash_empty_p.rb - baseline|.833|.097|


### Motivation
General push for more compiler intrinsics.


### Test plan
See included automated tests.
