### PR TITLE
Add autocorrect for exports

### DIFF
--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -40,6 +40,10 @@ public:
         return {};
     }
 
+    std::optional<core::AutocorrectSuggestion> addExport(const core::GlobalState &gs, const PackageInfo &pkg) const {
+        return {};
+    }
+
     ~NonePackage() {}
 
 private:

--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -40,7 +40,7 @@ public:
         return {};
     }
 
-    std::optional<core::AutocorrectSuggestion> addExport(const core::GlobalState &gs, const PackageInfo &pkg) const {
+    std::optional<core::AutocorrectSuggestion> addExport(const core::GlobalState &gs, const vector<core::NameRef> name, bool isPrivateTestExport) const {
         return {};
     }
 

--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -40,7 +40,8 @@ public:
         return {};
     }
 
-    std::optional<core::AutocorrectSuggestion> addExport(const core::GlobalState &gs, const vector<core::NameRef> name, bool isPrivateTestExport) const {
+    std::optional<core::AutocorrectSuggestion> addExport(const core::GlobalState &gs, const vector<core::NameRef> name,
+                                                         bool isPrivateTestExport) const {
         return {};
     }
 

--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -24,7 +24,8 @@ public:
     // autocorrects
     virtual std::optional<core::AutocorrectSuggestion> addImport(const core::GlobalState &gs, const PackageInfo &pkg,
                                                                  bool isTestImport) const = 0;
-    virtual std::optional<core::AutocorrectSuggestion> addExport(const core::GlobalState &gs, const std::vector<core::NameRef> name, bool isPrivateTestExport) const = 0;
+    virtual std::optional<core::AutocorrectSuggestion>
+    addExport(const core::GlobalState &gs, const std::vector<core::NameRef> name, bool isPrivateTestExport) const = 0;
 
     virtual ~PackageInfo() = 0;
     PackageInfo() = default;

--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -24,7 +24,7 @@ public:
     // autocorrects
     virtual std::optional<core::AutocorrectSuggestion> addImport(const core::GlobalState &gs, const PackageInfo &pkg,
                                                                  bool isTestImport) const = 0;
-    virtual std::optional<core::AutocorrectSuggestion> addExport(const core::GlobalState &gs, const PackageInfo &pkg) const = 0;
+    virtual std::optional<core::AutocorrectSuggestion> addExport(const core::GlobalState &gs, const std::vector<core::NameRef> name, bool isPrivateTestExport) const = 0;
 
     virtual ~PackageInfo() = 0;
     PackageInfo() = default;

--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -24,6 +24,7 @@ public:
     // autocorrects
     virtual std::optional<core::AutocorrectSuggestion> addImport(const core::GlobalState &gs, const PackageInfo &pkg,
                                                                  bool isTestImport) const = 0;
+    virtual std::optional<core::AutocorrectSuggestion> addExport(const core::GlobalState &gs, const PackageInfo &pkg) const = 0;
 
     virtual ~PackageInfo() = 0;
     PackageInfo() = default;

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -209,7 +209,7 @@ public:
         // first let's try adding it to the end of the imports.
         if (!importedPackageNames.empty()) {
             auto lastOffset = importedPackageNames.back().name.loc;
-            insertionLoc = {info.loc.file(), lastOffset.endPos(), lastOffset.endPos()};
+            insertionLoc = {loc.file(), lastOffset.endPos(), lastOffset.endPos()};
         } else {
             // if we don't have any imports, then we can try adding it
             // either before the first export, or if we have no
@@ -218,11 +218,11 @@ public:
             if (!exports.empty()) {
                 exportLoc = exports.front().fqn.loc.beginPos() - "export "sv.size() - 1;
             } else {
-                exportLoc = info.loc.endPos() - "end"sv.size() - 1;
+                exportLoc = loc.endPos() - "end"sv.size() - 1;
             }
             // we want to find the end of the last non-empty line, so
             // let's do something gross: walk backward until we find non-whitespace
-            const auto &file_source = info.loc.file().data(gs).source();
+            const auto &file_source = loc.file().data(gs).source();
             while (isspace(file_source[exportLoc])) {
                 exportLoc--;
                 // this shouldn't happen in a well-formatted
@@ -231,7 +231,7 @@ public:
                     return nullopt;
                 }
             }
-            insertionLoc = {info.loc.file(), exportLoc + 1, exportLoc + 1};
+            insertionLoc = {loc.file(), exportLoc + 1, exportLoc + 1};
         }
         ENFORCE(insertionLoc.exists());
 

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -244,7 +244,8 @@ public:
         return {suggestion};
     }
 
-    std::optional<core::AutocorrectSuggestion> addExport(const core::GlobalState &gs, const vector<core::NameRef> newExport, bool isPrivateTestExport) const {
+    std::optional<core::AutocorrectSuggestion>
+    addExport(const core::GlobalState &gs, const vector<core::NameRef> newExport, bool isPrivateTestExport) const {
         for (auto expt : exports) {
             // check if we already import this, and if so, don't
             // return an autocorrect
@@ -283,8 +284,7 @@ public:
         auto strName = absl::StrJoin(newExport, "::", NameFormatter(gs));
         core::AutocorrectSuggestion suggestion(
             fmt::format("Export `{}` in package `{}`", strName, name.toString(gs)),
-            {{insertionLoc,
-                 fmt::format("\n  {} {}", isPrivateTestExport ? "export_for_test" : "export", strName)}});
+            {{insertionLoc, fmt::format("\n  {} {}", isPrivateTestExport ? "export_for_test" : "export", strName)}});
         return {suggestion};
     }
 };

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -244,9 +244,8 @@ public:
         return {suggestion};
     }
 
-    std::optional<core::AutocorrectSuggestion> addExport(const core::GlobalState &gs, const PackageInfo &pkg) const {
-        auto &info = PackageInfoImpl::from(pkg);
-        for (auto import : importedPackageNames) {
+    std::optional<core::AutocorrectSuggestion> addExport(const core::GlobalState &gs, const vector<core::NameRef> newExport, bool isPrivateTestExport) const {
+        for (auto expt : exports) {
             // check if we already import this, and if so, don't
             // return an autocorrect
             if (import.name == info.name) {

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -244,8 +244,8 @@ public:
         return {suggestion};
     }
 
-   optional<core::AutocorrectSuggestion>
-    addExport(const core::GlobalState &gs, const vector<core::NameRef> newExport, bool isPrivateTestExport) const {
+    optional<core::AutocorrectSuggestion> addExport(const core::GlobalState &gs, const vector<core::NameRef> newExport,
+                                                    bool isPrivateTestExport) const {
         for (auto expt : exports) {
             // check if we already import this, and if so, don't
             // return an autocorrect

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -244,7 +244,7 @@ public:
         return {suggestion};
     }
 
-    std::optional<core::AutocorrectSuggestion>
+   optional<core::AutocorrectSuggestion>
     addExport(const core::GlobalState &gs, const vector<core::NameRef> newExport, bool isPrivateTestExport) const {
         for (auto expt : exports) {
             // check if we already import this, and if so, don't

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -254,7 +254,7 @@ public:
             }
         }
 
-        core::Loc insertionLoc = loc.adjust(gs, core::INVALID_POS_LOC, core::INVALID_POS_LOC);
+        auto insertionLoc = core::Loc::none(loc.file());
         // first let's try adding it to the end of the imports.
         if (!exports.empty()) {
             auto lastOffset = exports.back().fqn.loc;

--- a/test/pkg_autocorrects_test.cc
+++ b/test/pkg_autocorrects_test.cc
@@ -20,50 +20,71 @@ namespace spd = spdlog;
 auto logger = spd::stderr_color_mt("pkg-autocorrects-test");
 auto errorQueue = make_shared<sorbet::core::ErrorQueue>(*logger, *logger);
 
+string examplePackage = "class Opus::ExamplePackage < PackageSpec\nend\n";
+string examplePackagePath = "example/__package.rb";
+
 namespace sorbet {
 struct TestPackageFile {
-    core::FileRef fileRef;
-    ast::ParsedFile parsedFile;
+    // the `ParsedFile` corresponding to the package in which we want
+    // to make the edit
+    ast::ParsedFile targetParsedFile;
+    // the `ParsedFile` corresponding to the package that we want to
+    // add.
+    ast::ParsedFile newParsedFile;
 
-    TestPackageFile(core::FileRef fileRef, ast::ParsedFile parsedFile)
-        : fileRef(fileRef), parsedFile(move(parsedFile)) {}
+    TestPackageFile(ast::ParsedFile targetParsedFile, ast::ParsedFile newParsedFile)
+        : targetParsedFile(move(targetParsedFile)), newParsedFile(move(newParsedFile)) {}
 
     static TestPackageFile create(core::GlobalState &gs, string filename, string source) {
         // add the package file
-        core::FileRef pkg_file;
+        vector<core::FileRef> files;
         {
             core::UnfreezeFileTable fileTableAccess(gs);
-            pkg_file = gs.enterFile(filename, source);
+            files.emplace_back(gs.enterFile(filename, source));
+            files.emplace_back(gs.enterFile(examplePackagePath, examplePackage));
         }
 
         // run through the pipeline up through the packager
         // start by parsing and desugaring
-        ast::ParsedFile parsed_file;
+        vector<ast::ParsedFile> parsedFiles;
         {
             core::UnfreezeNameTable nameTableAccess(gs);
             // run parser
-            auto nodes = parser::Parser::run(gs, pkg_file);
-            // run desugarer
-            core::MutableContext ctx(gs, core::Symbols::root(), pkg_file);
-            parsed_file = ast::ParsedFile{ast::desugar::node2Tree(ctx, move(nodes)), pkg_file};
+            for (auto file : files) {
+                auto nodes = parser::Parser::run(gs, file);
 
-            // we can skip the rewriter because packages don't need it and
-            // go straight on to indexing
-            parsed_file = local_vars::LocalVars::run(ctx, move(parsed_file));
+                core::MutableContext ctx(gs, core::Symbols::root(), file);
+                auto parsedFile = ast::ParsedFile{ast::desugar::node2Tree(ctx, move(nodes)), file};
+                parsedFiles.emplace_back(local_vars::LocalVars::run(ctx, move(parsedFile)));
+            }
         }
 
         {
             // and then finally the packager!
             auto workers = WorkerPool::create(0, gs.tracer());
-            vector<ast::ParsedFile> trees;
-            trees.emplace_back(move(parsed_file));
-            trees = packager::Packager::run(gs, *workers, move(trees));
-            parsed_file = move(trees.front());
+            parsedFiles = packager::Packager::run(gs, *workers, move(parsedFiles));
         }
 
-        TestPackageFile pkgFile(pkg_file, move(parsed_file));
+        TestPackageFile pkgFile(move(parsedFiles.front()), move(parsedFiles[1]));
 
         return pkgFile;
+    }
+
+    const core::packages::PackageInfo& targetPackage(core::GlobalState& gs) const {
+        return gs.packageDB().getPackageForFile(gs, targetParsedFile.file);
+    }
+
+    const core::packages::PackageInfo& newPackage(core::GlobalState& gs) const {
+        return gs.packageDB().getPackageForFile(gs, newParsedFile.file);
+    }
+
+    const vector<core::NameRef> getName(core::GlobalState &gs, vector<string> rawName) const {
+        vector<core::NameRef> name;
+        core::UnfreezeNameTable nameTableAccess(gs);
+        for (auto &n : rawName) {
+            name.emplace_back(gs.enterNameUTF8(n));
+        }
+        return name;
     }
 };
 
@@ -77,14 +98,14 @@ TEST_CASE("Simple add import") {
 
     string expected = "class Opus::MyPackage < PackageSpec\n"
                       "  import Opus::SomethingElse\n"
-                      "  import Opus::MyPackage\n"
+                      "  import Opus::ExamplePackage\n"
                       "end\n";
 
     auto test = TestPackageFile::create(gs, "my_package/__package.rb", pkg_source);
 
-    auto &package = gs.packageDB().getPackageForFile(gs, test.fileRef);
+    auto &package = test.targetPackage(gs);
     ENFORCE(package.exists());
-    auto addImport = package.addImport(gs, package, false);
+    auto addImport = package.addImport(gs, test.newPackage(gs), false);
     ENFORCE(addImport, "Expected to get an autocorrect from `addImport`");
     auto replaced = addImport->applySingleEditForTesting(pkg_source);
     CHECK_EQ(expected, replaced);
@@ -100,14 +121,14 @@ TEST_CASE("Simple test import") {
 
     string expected = "class Opus::MyPackage < PackageSpec\n"
                       "  import Opus::SomethingElse\n"
-                      "  test_import Opus::MyPackage\n"
+                      "  test_import Opus::ExamplePackage\n"
                       "end\n";
 
     auto test = TestPackageFile::create(gs, "my_package/__package.rb", pkg_source);
 
-    auto &package = gs.packageDB().getPackageForFile(gs, test.fileRef);
+    auto &package = test.targetPackage(gs);
     ENFORCE(package.exists());
-    auto addImport = package.addImport(gs, package, true);
+    auto addImport = package.addImport(gs, test.newPackage(gs), true);
     ENFORCE(addImport, "Expected to get an autocorrect from `addImport`");
     auto replaced = addImport->applySingleEditForTesting(pkg_source);
     CHECK_EQ(expected, replaced);
@@ -122,15 +143,15 @@ TEST_CASE("Add import with only existing exports") {
                         "end\n";
 
     string expected = "class Opus::MyPackage < PackageSpec\n"
-                      "  import Opus::MyPackage\n"
+                      "  import Opus::ExamplePackage\n"
                       "  export Opus::SomethingElse\n"
                       "end\n";
 
     auto test = TestPackageFile::create(gs, "my_package/__package.rb", pkg_source);
 
-    auto &package = gs.packageDB().getPackageForFile(gs, test.fileRef);
+    auto &package = test.targetPackage(gs);
     ENFORCE(package.exists());
-    auto addImport = package.addImport(gs, package, false);
+    auto addImport = package.addImport(gs, test.newPackage(gs), false);
     ENFORCE(addImport, "Expected to get an autocorrect from `addImport`");
     auto replaced = addImport->applySingleEditForTesting(pkg_source);
     CHECK_EQ(expected, replaced);
@@ -145,15 +166,15 @@ TEST_CASE("Add test import with only existing exports") {
                         "end\n";
 
     string expected = "class Opus::MyPackage < PackageSpec\n"
-                      "  test_import Opus::MyPackage\n"
+                      "  test_import Opus::ExamplePackage\n"
                       "  export Opus::SomethingElse\n"
                       "end\n";
 
     auto test = TestPackageFile::create(gs, "my_package/__package.rb", pkg_source);
 
-    auto &package = gs.packageDB().getPackageForFile(gs, test.fileRef);
+    auto &package = test.targetPackage(gs);
     ENFORCE(package.exists());
-    auto addImport = package.addImport(gs, package, true);
+    auto addImport = package.addImport(gs, test.newPackage(gs), true);
     ENFORCE(addImport, "Expected to get an autocorrect from `addImport`");
     auto replaced = addImport->applySingleEditForTesting(pkg_source);
     CHECK_EQ(expected, replaced);
@@ -167,14 +188,14 @@ TEST_CASE("Add import to package with neither imports nor exports") {
                         "end\n";
 
     string expected = "class Opus::MyPackage < PackageSpec\n"
-                      "  import Opus::MyPackage\n"
+                      "  import Opus::ExamplePackage\n"
                       "end\n";
 
     auto test = TestPackageFile::create(gs, "my_package/__package.rb", pkg_source);
 
-    auto &package = gs.packageDB().getPackageForFile(gs, test.fileRef);
+    auto &package = test.targetPackage(gs);
     ENFORCE(package.exists());
-    auto addImport = package.addImport(gs, package, false);
+    auto addImport = package.addImport(gs, test.newPackage(gs), false);
     ENFORCE(addImport, "Expected to get an autocorrect from `addImport`");
     auto replaced = addImport->applySingleEditForTesting(pkg_source);
     CHECK_EQ(expected, replaced);
@@ -188,14 +209,14 @@ TEST_CASE("Add test import to package with neither imports nor exports") {
                         "end\n";
 
     string expected = "class Opus::MyPackage < PackageSpec\n"
-                      "  test_import Opus::MyPackage\n"
+                      "  test_import Opus::ExamplePackage\n"
                       "end\n";
 
     auto test = TestPackageFile::create(gs, "my_package/__package.rb", pkg_source);
 
-    auto &package = gs.packageDB().getPackageForFile(gs, test.fileRef);
+    auto &package = test.targetPackage(gs);
     ENFORCE(package.exists());
-    auto addImport = package.addImport(gs, package, true);
+    auto addImport = package.addImport(gs, test.newPackage(gs), true);
     ENFORCE(addImport, "Expected to get an autocorrect from `addImport`");
     auto replaced = addImport->applySingleEditForTesting(pkg_source);
     CHECK_EQ(expected, replaced);
@@ -214,17 +235,11 @@ TEST_CASE("Simple add export") {
                       "  export Opus::MyPackage::NewExport\n"
                       "end\n";
 
-    vector<core::NameRef> newExport;
-    {
-        core::UnfreezeNameTable nameTableAccess(gs);
-        newExport = {gs.enterNameUTF8("Opus"), gs.enterNameUTF8("MyPackage"), gs.enterNameUTF8("NewExport")};
-    }
-
     auto test = TestPackageFile::create(gs, "my_package/__package.rb", pkg_source);
 
-    auto &package = gs.packageDB().getPackageForFile(gs, test.fileRef);
+    auto &package = test.targetPackage(gs);
     ENFORCE(package.exists());
-    auto addExport = package.addExport(gs, newExport, false);
+    auto addExport = package.addExport(gs, test.getName(gs, {"Opus", "MyPackage", "NewExport"}), false);
     ENFORCE(addExport, "Expected to get an autocorrect from `addImport`");
     auto replaced = addExport->applySingleEditForTesting(pkg_source);
     CHECK_EQ(expected, replaced);
@@ -243,17 +258,11 @@ TEST_CASE("Simple add export_for_test") {
                       "  export_for_test Opus::MyPackage::NewExport\n"
                       "end\n";
 
-    vector<core::NameRef> newExport;
-    {
-        core::UnfreezeNameTable nameTableAccess(gs);
-        newExport = {gs.enterNameUTF8("Opus"), gs.enterNameUTF8("MyPackage"), gs.enterNameUTF8("NewExport")};
-    }
-
     auto test = TestPackageFile::create(gs, "my_package/__package.rb", pkg_source);
 
-    auto &package = gs.packageDB().getPackageForFile(gs, test.fileRef);
+    auto &package = test.targetPackage(gs);
     ENFORCE(package.exists());
-    auto addExport = package.addExport(gs, newExport, true);
+    auto addExport = package.addExport(gs, test.getName(gs, {"Opus", "MyPackage", "NewExport"}), true);
     ENFORCE(addExport, "Expected to get an autocorrect from `addImport`");
     auto replaced = addExport->applySingleEditForTesting(pkg_source);
     CHECK_EQ(expected, replaced);

--- a/test/pkg_autocorrects_test.cc
+++ b/test/pkg_autocorrects_test.cc
@@ -70,11 +70,11 @@ struct TestPackageFile {
         return pkgFile;
     }
 
-    const core::packages::PackageInfo& targetPackage(core::GlobalState& gs) const {
+    const core::packages::PackageInfo &targetPackage(core::GlobalState &gs) const {
         return gs.packageDB().getPackageForFile(gs, targetParsedFile.file);
     }
 
-    const core::packages::PackageInfo& newPackage(core::GlobalState& gs) const {
+    const core::packages::PackageInfo &newPackage(core::GlobalState &gs) const {
         return gs.packageDB().getPackageForFile(gs, newParsedFile.file);
     }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Add an autocorrect for `export` as well. This takes a `vector<NameRef>` for the exported name.

This also fixes some issues with the `import` autocorrect, and fixes the test suite so that it would have caught them.


### Test plan
See included automated tests. Added tests for both new functionality and fixed old functionality.
