### PR TITLE
switch codegen ordering of final methods and name-based intrinsics

### DIFF
--- a/test/testdata/compiler/final_method_square_brackets.rb
+++ b/test/testdata/compiler/final_method_square_brackets.rb
@@ -1,0 +1,29 @@
+# typed: true
+# compiled: true
+# frozen_string_literal: true
+# run_filecheck: INITIAL
+
+class Parent
+  extend T::Sig
+  extend T::Helpers
+
+  sig(:final) {void}
+  def []
+    puts "final method!"
+  end
+end
+
+Parent.new.[]
+
+# We used to have an ordering issue between codegen for name-based intrinsics
+# and codegen for final methods: name-based intrinsics were tried first, and the
+# name-based intrinsic for [] would bail to a Ruby VM call if there was type
+# information.  Which meant that the codegen for the final method would never
+# actually run, and therefore we would always call through the Ruby VM, which
+# is not what the user intended.
+#
+# This test is intended to ensure we don't run into that situation again.
+
+# INITIAL-LABEL: define internal i64 @"func_<root>.17<static-init>$152"
+# INITIAL: call i64 @"direct_func_Parent#2[]"
+# INITIAL{LITERAL}: }


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

When #4760 landed, it silently disabled final method codegen for `[]` methods: the name-based intrinsic for `[]` would fire, and, finding that there was actual type information associated with the receiver, the intrinsic would emit a method call through the Ruby VM for the reasons written in the comment:

https://github.com/sorbet/sorbet/blob/d6aefd59ae07dba98e0132cf8b0fff727a8344be/compiler/IREmitter/NameBasedIntrinsics.cc#L852-L857

I can say with some certainty that the author was only thinking about symbol-based intrinsics, and not thinking about final methods when they wrote that.

We didn't really notice because the gain on the lspace benchmark (which said PR was intended to speedup) was so significant, and we didn't have any tests.  But today I noticed that removing `sig(:final)` from the lspace benchmark wasn't having any effect, and so I went hunting.

This PR should restore the functionality of generating direct calls for `[]`-methods (and other similar methods that we have untyped specializations for).  Arguably we should maybe move final methods to attempt codegen before symbol-based intrinsics, but seeing as how none of the methods we'd write symbol-based intrinsics for could be final, I'm not too worried about this.

lspace benchmark before this PR:

```
ruby vm startup time: .092
source  interpreted     compiled
stripe/while_10_000_000.rb      .218    .099
stripe/lspace.rb        .892    .474
stripe/lspace.rb - baseline     .674    .375
```

lspace benchmark after this PR:

```
ruby vm startup time: .093
source  interpreted     compiled
stripe/while_10_000_000.rb      .223    .109
stripe/lspace.rb        .899    .417
stripe/lspace.rb - baseline     .676    .308
```

...and we are now officially more than 2x faster on this benchmark. :tada: 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
