### PR TITLE
Remove minimize dependency from sorbet-orig.

### DIFF
--- a/main/BUILD
+++ b/main/BUILD
@@ -97,7 +97,6 @@ cc_library(
         "//core",
         "//hashing:hashing-orig",
         "//main/cache:cache-orig",
-        "//main/minimize",
         "//main/options",
         "//main/pipeline:pipeline-orig",
         "//payload:interface",

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -15,6 +15,7 @@
 #include "main/lsp/LSPInput.h"
 #include "main/lsp/LSPOutput.h"
 #include "main/lsp/lsp.h"
+#include "main/minimize/minimize.h"
 #endif
 
 #include "absl/strings/str_cat.h"
@@ -31,7 +32,6 @@
 #include "core/serialize/serialize.h"
 #include "hashing/hashing.h"
 #include "main/cache/cache.h"
-#include "main/minimize/minimize.h"
 #include "main/pipeline/pipeline.h"
 #include "main/realmain.h"
 #include "payload/payload.h"
@@ -615,6 +615,10 @@ int realmain(int argc, char *argv[]) {
         }
 
         if (!opts.minimizeRBI.empty()) {
+#ifdef SORBET_REALMAIN_MIN
+            logger->warn("--minimize-rbi is disabled in sorbet-orig for faster builds");
+            return 1;
+#else
             // In the future, we might consider making minimizeRBI be a repeatable option, and run
             // this block once for each input file.
             // The trick there is that they would all currently output to the same file, even for
@@ -622,6 +626,7 @@ int realmain(int argc, char *argv[]) {
             // API we want to expose.
             Minimize::indexAndResolveForMinimize(gs, gsForMinimize, opts, *workers, opts.minimizeRBI);
             Minimize::writeDiff(*gs, *gsForMinimize, opts.print.MinimizeRBI);
+#endif
         }
 
         if (opts.suggestTyped) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Remove minimize dependency from sorbet-orig.

cc @nroman-stripe 

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

mimimize pulls in `pipeline`, not `pipeline-orig`, which leads to problems. Also, `sorbet-orig` doesn't need this dependency.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
