### PR TITLE
Skip including abstract initialize in --minimize-to-rbi

### DIFF
--- a/main/minimize/minimize.cc
+++ b/main/minimize/minimize.cc
@@ -186,6 +186,13 @@ void serializeMethods(const core::GlobalState &sourceGS, const core::GlobalState
                 // complain about the method not being implemented when it was, just not visibly.
                 continue;
             }
+
+            if (sourceClass.data(sourceGS)->isClassOrModuleAbstract() && rbiEntryName == core::Names::initialize()) {
+                // `abstract!` will define `initialize` in the class to raise unconditionally
+                // https://github.com/sorbet/sorbet/blob/026c60bf719d/gems/sorbet-runtime/lib/types/private/abstract/declare.rb#L37-L42
+                // Which is not useful to include in the minimized output.
+                continue;
+            }
         }
 
         // TODO: The old Ruby-powered version used runtime reflection to record a comment like

--- a/test/testdata/minimize-rbi/abstract_initialize.rb
+++ b/test/testdata/minimize-rbi/abstract_initialize.rb
@@ -1,0 +1,6 @@
+# typed: true
+
+class AbstractFoo
+  extend T::Helpers
+  abstract!
+end

--- a/test/testdata/minimize-rbi/abstract_initialize.rb.minimize.rbi
+++ b/test/testdata/minimize-rbi/abstract_initialize.rb.minimize.rbi
@@ -1,0 +1,10 @@
+# typed: true
+
+class AbstractFoo
+  extend T::Helpers
+
+  # This method will actually be defined at runtime in files that use `abstract!`
+  # (The method is designed to `raise` unconditionally.)
+  def initialize(*args, &blk)
+  end
+end

--- a/test/testdata/minimize-rbi/abstract_initialize.rb.minimized-rbi.exp
+++ b/test/testdata/minimize-rbi/abstract_initialize.rb.minimized-rbi.exp
@@ -1,0 +1,6 @@
+# typed: true
+
+class ::AbstractFoo
+  def initialize(*args, &blk); end
+end
+

--- a/test/testdata/minimize-rbi/abstract_initialize.rb.minimized-rbi.exp
+++ b/test/testdata/minimize-rbi/abstract_initialize.rb.minimized-rbi.exp
@@ -1,6 +1,2 @@
 # typed: true
 
-class ::AbstractFoo
-  def initialize(*args, &blk); end
-end
-


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

When we generate an RBI file that shows all the methods that are actually
defined at runtime, one of those methods is this `initialize` method for
abstract classes (to prevent you from instantiating it).

That's noise, we shouldn't include it in the final output.

The Ruby-powered one didn't include this because it had more access to runtime
reflection to filter these out.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See commits for test before+after.