### PR TITLE
--stripe-packages: typecheck performance skip modules in package files

### DIFF
--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -544,6 +544,12 @@ void typecheckOne(core::Context ctx, ast::ParsedFile resolved, const options::Op
         return;
     }
 
+#ifndef SORBET_REALMAIN_MIN
+    if (f.data(ctx).isPackage()) {
+        resolved = packager::Packager::removePackageModules(ctx, move(resolved));
+    }
+#endif
+
     resolved = definition_validator::runOne(ctx, std::move(resolved));
 
     resolved = class_flatten::runOne(ctx, move(resolved));
@@ -567,12 +573,6 @@ void typecheckOne(core::Context ctx, ast::ParsedFile resolved, const options::Op
         }
         return;
     }
-#ifndef SORBET_REALMAIN_MIN
-    if (f.data(ctx).isPackage()) {
-        // Must be after `class_flatten`
-        resolved = packager::Packager::removePackageModules(ctx, move(resolved));
-    }
-#endif
 
     Timer timeit(ctx.state.tracer(), "typecheckOne", {{"file", string(f.data(ctx).path())}});
     try {

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -546,7 +546,7 @@ void typecheckOne(core::Context ctx, ast::ParsedFile resolved, const options::Op
 
 #ifndef SORBET_REALMAIN_MIN
     if (f.data(ctx).isPackage()) {
-        resolved = packager::Packager::removePackageModules(ctx, move(resolved));
+        resolved = packager::Packager::removePackageModules(ctx, move(resolved), intentionallyLeakASTs);
     }
 #endif
 

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -587,7 +587,7 @@ void typecheckOne(core::Context ctx, ast::ParsedFile resolved, const options::Op
         }
         CFGCollectorAndTyper collector(opts);
         {
-            result.tree = ast::TreeMap::apply(ctx, collector, move(resolved.tree));
+            ast::ShallowMap::apply(ctx, collector, move(resolved.tree));
             for (auto &extension : ctx.state.semanticExtensions) {
                 extension->finishTypecheckFile(ctx, f);
             }

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1471,4 +1471,34 @@ vector<ast::ParsedFile> Packager::runIncremental(core::GlobalState &gs, vector<a
     return files;
 }
 
+vector<ast::ExpressionPtr> Packager::removePackageModules(const core::GlobalState &gs, ast::ParsedFile &pf) {
+    ENFORCE(pf.file.data(gs).isPackage());
+    vector<ast::ExpressionPtr> removed;
+    removed.reserve(4);
+
+    auto &root = ast::cast_tree_nonnull<ast::InsSeq>(pf.tree);
+    auto it = remove_if(root.stats.begin(), root.stats.end(), [&removed](auto &exp) -> bool {
+        auto def = ast::cast_tree<ast::ClassDef>(exp);
+        if (def != nullptr &&
+            (def->symbol == core::Symbols::PackageRegistry() || def->symbol == core::Symbols::PackageTests())) {
+            ast::ExpressionPtr tmp;
+            swap(tmp, exp);
+            removed.emplace_back(move(tmp));
+            return true;
+        }
+        return false;
+    });
+    root.stats.erase(it, root.stats.end());
+
+    return removed;
+}
+
+ast::ParsedFile Packager::replacePackageModules(const core::GlobalState &gs, ast::ParsedFile pf,
+                                                std::vector<ast::ExpressionPtr> removed) {
+    ENFORCE(pf.file.data(gs).isPackage());
+    auto &root = ast::cast_tree_nonnull<ast::InsSeq>(pf.tree);
+    move(removed.begin(), removed.end(), root.stats.end());
+    return pf;
+}
+
 } // namespace sorbet::packager

--- a/packager/packager.h
+++ b/packager/packager.h
@@ -85,7 +85,7 @@ public:
     // The structures created for `__package.rb` files from their imports are large and deep. This causes
     // performance problems with typechecking. Use to remove these modules while retaining the PackageSpec
     // class itself during typecheck.
-    static ast::ParsedFile removePackageModules(const core::GlobalState &gs, ast::ParsedFile pf);
+    static ast::ParsedFile removePackageModules(core::Context ctx, ast::ParsedFile pf);
 
     Packager() = delete;
 };

--- a/packager/packager.h
+++ b/packager/packager.h
@@ -83,11 +83,9 @@ public:
     static std::vector<ast::ParsedFile> runIncremental(core::GlobalState &gs, std::vector<ast::ParsedFile> files);
 
     // The structures created for `__package.rb` files from their imports are large and deep. This causes
-    // performance problems with typechecking. Use  to remove these modules while retaining the PackageSpec
-    // class itself during typecheck. Pair with `replacePackageModules`.
-    static std::vector<ast::ExpressionPtr> removePackageModules(const core::GlobalState &gs, ast::ParsedFile &pf);
-    static ast::ParsedFile replacePackageModules(const core::GlobalState &gs, ast::ParsedFile pf,
-                                                 std::vector<ast::ExpressionPtr> removed);
+    // performance problems with typechecking. Use to remove these modules while retaining the PackageSpec
+    // class itself during typecheck.
+    static ast::ParsedFile removePackageModules(const core::GlobalState &gs, ast::ParsedFile pf);
 
     Packager() = delete;
 };

--- a/packager/packager.h
+++ b/packager/packager.h
@@ -82,6 +82,13 @@ public:
     // Run packager incrementally. Note: `files` must contain all packages files. Does not support package changes.
     static std::vector<ast::ParsedFile> runIncremental(core::GlobalState &gs, std::vector<ast::ParsedFile> files);
 
+    // The structures created for `__package.rb` files from their imports are large and deep. This causes
+    // performance problems with typechecking. Use  to remove these modules while retaining the PackageSpec
+    // class itself during typecheck. Pair with `replacePackageModules`.
+    static std::vector<ast::ExpressionPtr> removePackageModules(const core::GlobalState &gs, ast::ParsedFile &pf);
+    static ast::ParsedFile replacePackageModules(const core::GlobalState &gs, ast::ParsedFile pf,
+                                                 std::vector<ast::ExpressionPtr> removed);
+
     Packager() = delete;
 };
 } // namespace sorbet::packager

--- a/packager/packager.h
+++ b/packager/packager.h
@@ -85,7 +85,8 @@ public:
     // The structures created for `__package.rb` files from their imports are large and deep. This causes
     // performance problems with typechecking. Use to remove these modules while retaining the PackageSpec
     // class itself during typecheck.
-    static ast::ParsedFile removePackageModules(core::Context ctx, ast::ParsedFile pf);
+    static ast::ParsedFile removePackageModules(core::Context ctx, ast::ParsedFile pf,
+                                                bool intentionallyLeakASTs = false);
 
     Packager() = delete;
 };

--- a/test/testdata/packager/packagespec_methods/__package.rb
+++ b/test/testdata/packager/packagespec_methods/__package.rb
@@ -1,0 +1,10 @@
+# typed: strict
+
+class MyPkg < PackageSpec
+  custom_method 'abc'
+  custom_method 'abc', 'too_many_args'
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Too many arguments provided for method `PackageSpec.custom_method`. Expected: `1`, got: `2`
+
+  bad_method 'def'
+# ^^^^^^^^^^^^^^^^ error: Method `bad_method` does not exist on `T.class_of(MyPkg)`
+end

--- a/test/testdata/packager/packagespec_methods/packagespec.rbi
+++ b/test/testdata/packager/packagespec_methods/packagespec.rbi
@@ -1,0 +1,6 @@
+# typed: strict
+
+class ::PackageSpec
+  sig {params(x: String).void}
+  def self.custom_method(x); end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Typechecking degraded significantly (%50) when `--stripe-packages` was enabled on the Stripe codebase. The materialized modules we create do not actually have send's in the that need type-checking so these can be skipped (AFAIK).

Note: I tried simply skipping typechecking of `__package.rb` files completely but that ran into issues with some of the method validation we do specifically `test/test_LSPTests/testdata/packager/invalid_imports_and_exports `.
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

- [x] Re-do timing on stripe codebase.

See included automated tests.
