### PR TITLE
Add autocorrects to package suggestion code

### DIFF
--- a/test/cli/package-autocorrect-missing-import/__package.rb
+++ b/test/cli/package-autocorrect-missing-import/__package.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class Foo::MyPackage < PackageSpec
+  # import Foo::Bar::OtherPackage ## MISSING!
+end

--- a/test/cli/package-autocorrect-missing-import/foo.test.rb
+++ b/test/cli/package-autocorrect-missing-import/foo.test.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+module Test::Foo::MyPackage
+  Test::Foo::Bar::OtherPackage::TestUtil
+end

--- a/test/cli/package-autocorrect-missing-import/foo_class.rb
+++ b/test/cli/package-autocorrect-missing-import/foo_class.rb
@@ -1,0 +1,15 @@
+# typed: strict
+
+module Foo
+  # This package is missing `import Foo::Bar::OtherPackage`
+  module MyPackage
+    class FooClass
+      Foo::Bar::OtherPackage::OtherClass # resolves via root
+      Bar::OtherPackage::OtherClass # resolves via `module Foo`
+    end
+  end
+end
+
+module Foo::MyPackage
+  Foo::Bar::OtherPackage::OtherClass # resolves via root
+end

--- a/test/cli/package-autocorrect-missing-import/other/__package.rb
+++ b/test/cli/package-autocorrect-missing-import/other/__package.rb
@@ -1,0 +1,6 @@
+# typed: strict
+
+class Foo::Bar::OtherPackage < PackageSpec
+  export Foo::Bar::OtherPackage::OtherClass
+  export Test::Foo::Bar::OtherPackage::TestUtil
+end

--- a/test/cli/package-autocorrect-missing-import/other/other.test.rb
+++ b/test/cli/package-autocorrect-missing-import/other/other.test.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+module Test::Foo::Bar::OtherPackage
+  class TestUtil; end
+end

--- a/test/cli/package-autocorrect-missing-import/other/other_class.rb
+++ b/test/cli/package-autocorrect-missing-import/other/other_class.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+class Foo::Bar::OtherPackage::OtherClass
+end

--- a/test/cli/package-autocorrect-missing-import/package-autocorrect-missing-import.out
+++ b/test/cli/package-autocorrect-missing-import/package-autocorrect-missing-import.out
@@ -1,0 +1,1 @@
+nothing

--- a/test/cli/package-autocorrect-missing-import/package-autocorrect-missing-import.out
+++ b/test/cli/package-autocorrect-missing-import/package-autocorrect-missing-import.out
@@ -1,1 +1,67 @@
-nothing
+foo_class.rb:7: Unable to resolve constant `Bar` https://srb.help/5002
+     7 |      Foo::Bar::OtherPackage::OtherClass # resolves via root
+              ^^^^^^^^
+    other/__package.rb:3: Do you need to `import` package `Foo::Bar::OtherPackage`?
+     3 |class Foo::Bar::OtherPackage < PackageSpec
+     4 |  export Foo::Bar::OtherPackage::OtherClass
+     5 |  export Test::Foo::Bar::OtherPackage::TestUtil
+     6 |end
+  Autocorrect: Done
+    __package.rb:6: Inserted `
+  import Foo::Bar::OtherPackage`
+     6 |  # import Foo::Bar::OtherPackage ## MISSING!
+                                                     ^
+
+foo_class.rb:8: Unable to resolve constant `Bar` https://srb.help/5002
+     8 |      Bar::OtherPackage::OtherClass # resolves via `module Foo`
+              ^^^
+    other/__package.rb:3: Do you need to `import` package `Foo::Bar::OtherPackage`?
+     3 |class Foo::Bar::OtherPackage < PackageSpec
+     4 |  export Foo::Bar::OtherPackage::OtherClass
+     5 |  export Test::Foo::Bar::OtherPackage::TestUtil
+     6 |end
+  Autocorrect: Done
+    __package.rb:6: Inserted `
+  import Foo::Bar::OtherPackage`
+     6 |  # import Foo::Bar::OtherPackage ## MISSING!
+                                                     ^
+
+foo_class.rb:14: Unable to resolve constant `Bar` https://srb.help/5002
+    14 |  Foo::Bar::OtherPackage::OtherClass # resolves via root
+          ^^^^^^^^
+    other/__package.rb:3: Do you need to `import` package `Foo::Bar::OtherPackage`?
+     3 |class Foo::Bar::OtherPackage < PackageSpec
+     4 |  export Foo::Bar::OtherPackage::OtherClass
+     5 |  export Test::Foo::Bar::OtherPackage::TestUtil
+     6 |end
+  Autocorrect: Done
+    __package.rb:6: Inserted `
+  import Foo::Bar::OtherPackage`
+     6 |  # import Foo::Bar::OtherPackage ## MISSING!
+                                                     ^
+
+foo.test.rb:4: Unable to resolve constant `Bar` https://srb.help/5002
+     4 |  Test::Foo::Bar::OtherPackage::TestUtil
+          ^^^^^^^^^^^^^^
+    other/__package.rb:3: Do you need to `test_import` package `Foo::Bar::OtherPackage`?
+     3 |class Foo::Bar::OtherPackage < PackageSpec
+     4 |  export Foo::Bar::OtherPackage::OtherClass
+     5 |  export Test::Foo::Bar::OtherPackage::TestUtil
+     6 |end
+  Autocorrect: Done
+    __package.rb:6: Inserted `
+  test_import Foo::Bar::OtherPackage`
+     6 |  # import Foo::Bar::OtherPackage ## MISSING!
+                                                     ^
+Errors: 4
+
+--------------------------------------------------------------------------
+
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class Foo::MyPackage < PackageSpec
+  # import Foo::Bar::OtherPackage ## MISSING!
+  import Foo::Bar::OtherPackage
+end

--- a/test/cli/package-autocorrect-missing-import/package-autocorrect-missing-import.sh
+++ b/test/cli/package-autocorrect-missing-import/package-autocorrect-missing-import.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+cwd="$(pwd)"
+tmp="$(mktemp -d)"
+cd test/cli/package-autocorrect-missing-import || exit 1
+for file in $(find . -name '*.rb'); do
+    mkdir -p "$tmp/$(dirname $file)"
+    cp "$file" "$tmp/$file"
+done
+cd "$tmp" || exit 1
+
+"$cwd/main/sorbet" -a --silence-dev-message --stripe-packages --max-threads=0 . 2>&1
+
+echo
+echo --------------------------------------------------------------------------
+echo
+
+cat __package.rb
+
+rm -rf "$tmp"
+
+exit 1

--- a/test/cli/package-autocorrect-missing-import/package-autocorrect-missing-import.sh
+++ b/test/cli/package-autocorrect-missing-import/package-autocorrect-missing-import.sh
@@ -3,8 +3,8 @@
 cwd="$(pwd)"
 tmp="$(mktemp -d)"
 cd test/cli/package-autocorrect-missing-import || exit 1
-for file in $(find . -name '*.rb'); do
-    mkdir -p "$tmp/$(dirname $file)"
+for file in $(find . -name '*.rb' | sort); do
+    mkdir -p "$tmp/$(dirname "$file")"
     cp "$file" "$tmp/$file"
 done
 cd "$tmp" || exit 1

--- a/test/cli/package-error-missing-import/package-error-missing-import.out
+++ b/test/cli/package-error-missing-import/package-error-missing-import.out
@@ -6,6 +6,11 @@ foo_class.rb:7: Unable to resolve constant `Bar` https://srb.help/5002
      4 |  export Foo::Bar::OtherPackage::OtherClass
      5 |  export Test::Foo::Bar::OtherPackage::TestUtil
      6 |end
+  Autocorrect: Use `-a` to autocorrect
+    __package.rb:6: Insert `
+  import Foo::Bar::OtherPackage`
+     6 |  # import Foo::Bar::OtherPackage ## MISSING!
+                                                     ^
 
 foo_class.rb:8: Unable to resolve constant `Bar` https://srb.help/5002
      8 |      Bar::OtherPackage::OtherClass # resolves via `module Foo`
@@ -15,6 +20,11 @@ foo_class.rb:8: Unable to resolve constant `Bar` https://srb.help/5002
      4 |  export Foo::Bar::OtherPackage::OtherClass
      5 |  export Test::Foo::Bar::OtherPackage::TestUtil
      6 |end
+  Autocorrect: Use `-a` to autocorrect
+    __package.rb:6: Insert `
+  import Foo::Bar::OtherPackage`
+     6 |  # import Foo::Bar::OtherPackage ## MISSING!
+                                                     ^
 
 foo_class.rb:14: Unable to resolve constant `Bar` https://srb.help/5002
     14 |  Foo::Bar::OtherPackage::OtherClass # resolves via root
@@ -24,6 +34,11 @@ foo_class.rb:14: Unable to resolve constant `Bar` https://srb.help/5002
      4 |  export Foo::Bar::OtherPackage::OtherClass
      5 |  export Test::Foo::Bar::OtherPackage::TestUtil
      6 |end
+  Autocorrect: Use `-a` to autocorrect
+    __package.rb:6: Insert `
+  import Foo::Bar::OtherPackage`
+     6 |  # import Foo::Bar::OtherPackage ## MISSING!
+                                                     ^
 
 foo.test.rb:4: Unable to resolve constant `Bar` https://srb.help/5002
      4 |  Test::Foo::Bar::OtherPackage::TestUtil
@@ -33,4 +48,9 @@ foo.test.rb:4: Unable to resolve constant `Bar` https://srb.help/5002
      4 |  export Foo::Bar::OtherPackage::OtherClass
      5 |  export Test::Foo::Bar::OtherPackage::TestUtil
      6 |end
+  Autocorrect: Use `-a` to autocorrect
+    __package.rb:6: Insert `
+  test_import Foo::Bar::OtherPackage`
+     6 |  # import Foo::Bar::OtherPackage ## MISSING!
+                                                     ^
 Errors: 4


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
We've previously added functionality to add `import` autocorrects, and logic to determine when they're needed. This joins them together, actually invoking the autocorrects as part of the packaging process.

### Test plan
See included automated tests. Added a CLI test that shows the autocorrects in action.
