### PR TITLE
(wip) Try name based intrinsics in the tryFinalMethodCall slow path

### DIFF
--- a/compiler/IREmitter/sends.cc
+++ b/compiler/IREmitter/sends.cc
@@ -96,7 +96,7 @@ llvm::Value *tryFinalMethodCall(MethodCallContext &mcctx) {
 
     // slow path: emit a call via the ruby vm
     builder.SetInsertPoint(slowFinalCall);
-    auto *slowPathResult = IREmitterHelpers::emitMethodCallViaRubyVM(mcctx);
+    auto *slowPathResult = tryNameBasedIntrinsic(mcctx);
     auto *slowPathEnd = builder.GetInsertBlock();
     builder.CreateBr(afterFinalCall);
 


### PR DESCRIPTION
Changes the `IREmitterHelpers::emitMethodCallViaRubyVM` in the slow path of `tryFinalMethodCall` to `tryNameBasedIntrinsic`.


### Motivation
I actually don't know if this is right/wrong/necessary/unnecessary!

I just happened to notice while doing some edificatory code reading that prior to #4944 there were three `emitMethodCallViaRubyVM` calls from `tryFinalMethodCall`; two of them were replaced with `tryFinalMethodCall`, but the third one (in the slow path where `isFinalMethod` returns something but the type test fails) was not changed. I didn't see any indication in the discussion of #4944 that this was intentional (e.g., maybe we somehow know that name-based intrinsics can't apply here?) So I'm opening a draft PR I can point and grunt at.


### Test plan
TBD
