### PR TITLE
Typecheck: Destroy trees passed to it in parallel.

### DIFF
--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -538,6 +538,9 @@ void typecheckOne(core::Context ctx, ast::ParsedFile resolved, const options::Op
     core::FileRef f = resolved.file;
 
     if (opts.stopAfterPhase == options::Phase::NAMER) {
+        if (intentionallyLeakASTs) {
+            intentionallyLeakMemory(resolved.tree.release());
+        }
         return;
     }
 
@@ -553,9 +556,15 @@ void typecheckOne(core::Context ctx, ast::ParsedFile resolved, const options::Op
     }
 
     if (opts.stopAfterPhase == options::Phase::RESOLVER) {
+        if (intentionallyLeakASTs) {
+            intentionallyLeakMemory(resolved.tree.release());
+        }
         return;
     }
     if (f.data(ctx).isRBI()) {
+        if (intentionallyLeakASTs) {
+            intentionallyLeakMemory(resolved.tree.release());
+        }
         return;
     }
 

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -34,12 +34,15 @@ ast::ParsedFilesOrCancelled name(core::GlobalState &gs, std::vector<ast::ParsedF
                                  WorkerPool &workers);
 
 // Note: `cancelable` and `preemption task manager` are only applicable to LSP.
+// If `intentionallyLeakASTs` is `true`, typecheck will leak the ASTs rather than pay the cost of deleting them
+// properly, which is a significant speedup on large codebases.
 void typecheck(std::unique_ptr<core::GlobalState> &gs, std::vector<ast::ParsedFile> what, const options::Options &opts,
                WorkerPool &workers, bool cancelable = false,
                std::optional<std::shared_ptr<core::lsp::PreemptionTaskManager>> preemptionManager = std::nullopt,
-               bool presorted = false);
+               bool presorted = false, bool intentionallyLeakASTs = false);
 
-void typecheckOne(core::Context ctx, ast::ParsedFile resolved, const options::Options &opts);
+void typecheckOne(core::Context ctx, ast::ParsedFile resolved, const options::Options &opts,
+                  bool intentionallyLeakASTs = false);
 
 core::StrictLevel decideStrictLevel(const core::GlobalState &gs, const core::FileRef file,
                                     const options::Options &opts);

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -34,13 +34,12 @@ ast::ParsedFilesOrCancelled name(core::GlobalState &gs, std::vector<ast::ParsedF
                                  WorkerPool &workers);
 
 // Note: `cancelable` and `preemption task manager` are only applicable to LSP.
-ast::ParsedFilesOrCancelled
-typecheck(std::unique_ptr<core::GlobalState> &gs, std::vector<ast::ParsedFile> what, const options::Options &opts,
-          WorkerPool &workers, bool cancelable = false,
-          std::optional<std::shared_ptr<core::lsp::PreemptionTaskManager>> preemptionManager = std::nullopt,
-          bool presorted = false);
+void typecheck(std::unique_ptr<core::GlobalState> &gs, std::vector<ast::ParsedFile> what, const options::Options &opts,
+               WorkerPool &workers, bool cancelable = false,
+               std::optional<std::shared_ptr<core::lsp::PreemptionTaskManager>> preemptionManager = std::nullopt,
+               bool presorted = false);
 
-ast::ParsedFile typecheckOne(core::Context ctx, ast::ParsedFile resolved, const options::Options &opts);
+void typecheckOne(core::Context ctx, ast::ParsedFile resolved, const options::Options &opts);
 
 core::StrictLevel decideStrictLevel(const core::GlobalState &gs, const core::FileRef file,
                                     const options::Options &opts);

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -609,7 +609,7 @@ int realmain(int argc, char *argv[]) {
                 gs->errorQueue->flushAllErrors(*gs);
             }
             pipeline::typecheck(gs, move(indexed), opts, *workers, /* cancelable */ false, nullopt,
-                                /* presorted */ false, /* intentionallyLeakASTs */ true);
+                                /* presorted */ false, /* intentionallyLeakASTs */ !sorbet::emscripten_build);
             if (gs->hadCriticalError()) {
                 gs->errorQueue->flushAllErrors(*gs);
             }

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -608,7 +608,8 @@ int realmain(int argc, char *argv[]) {
             if (gs->hadCriticalError()) {
                 gs->errorQueue->flushAllErrors(*gs);
             }
-            pipeline::typecheck(gs, move(indexed), opts, *workers);
+            pipeline::typecheck(gs, move(indexed), opts, *workers, /* cancelable */ false, nullopt,
+                                /* presorted */ false, /* intentionallyLeakASTs */ true);
             if (gs->hadCriticalError()) {
                 gs->errorQueue->flushAllErrors(*gs);
             }

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -630,8 +630,12 @@ int realmain(int argc, char *argv[]) {
         }
 
         if (opts.suggestTyped) {
-            for (u4 i = 1; i < gs->filesUsed(); i++) {
-                core::FileRef file(i);
+            for (auto &filename : opts.inputFileNames) {
+                core::FileRef file = gs->findFileByPath(filename);
+                if (!file.exists()) {
+                    continue;
+                }
+
                 if (file.data(*gs).minErrorLevel() <= core::StrictLevel::Ignore) {
                     continue;
                 }

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -758,6 +758,7 @@ int realmain(int argc, char *argv[]) {
 
     if (!sorbet::emscripten_build) {
         // Let it go: leak memory so that we don't need to call destructors
+        // (Although typecheck leaks these, autogen goes thru a different codepath.)
         for (auto &e : indexed) {
             intentionallyLeakMemory(e.tree.release());
         }

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -608,7 +608,7 @@ int realmain(int argc, char *argv[]) {
             if (gs->hadCriticalError()) {
                 gs->errorQueue->flushAllErrors(*gs);
             }
-            indexed = move(pipeline::typecheck(gs, move(indexed), opts, *workers).result());
+            pipeline::typecheck(gs, move(indexed), opts, *workers);
             if (gs->hadCriticalError()) {
                 gs->errorQueue->flushAllErrors(*gs);
             }
@@ -630,8 +630,8 @@ int realmain(int argc, char *argv[]) {
         }
 
         if (opts.suggestTyped) {
-            for (auto &tree : indexed) {
-                auto file = tree.file;
+            for (u4 i = 1; i < gs->filesUsed(); i++) {
+                core::FileRef file(i);
                 if (file.data(*gs).minErrorLevel() <= core::StrictLevel::Ignore) {
                     continue;
                 }

--- a/test/fuzz/fuzz_dash_e.cc
+++ b/test/fuzz/fuzz_dash_e.cc
@@ -72,6 +72,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
     indexed = realmain::pipeline::index(gs, inputFiles, *opts, *workers, kvstore);
     indexed = move(realmain::pipeline::resolve(gs, move(indexed), *opts, *workers).result());
-    indexed = move(realmain::pipeline::typecheck(gs, move(indexed), *opts, *workers).result());
+    realmain::pipeline::typecheck(gs, move(indexed), *opts, *workers).result();
     return 0;
 }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Typecheck: Destroy trees passed to it in parallel.

There is no reason for typecheck to keep the trees around.

Avoids destructing all ASTs on a single thread.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Potentially speed. It also simplifies an optimization @ngroman is doing to remove package stuff from ASTs prior to CFG running.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

N/A
