### PR TITLE
Add an intrinsic for Hash#dig

### DIFF
--- a/compiler/IREmitter/Intrinsics/intrinsic-report.md
+++ b/compiler/IREmitter/Intrinsics/intrinsic-report.md
@@ -545,7 +545,7 @@
 * [   ] `rb_hash_compare_by_id` (`Hash#compare_by_identity`)
 * [✔  ] `rb_hash_compare_by_id_p` (`Hash#compare_by_identity?`)
 * [   ] `rb_hash_any_p` (`Hash#any?`)
-* [   ] `rb_hash_dig` (`Hash#dig`)
+* [  ✔] `rb_hash_dig` (`Hash#dig`)
 * [   ] `rb_hash_le` (`Hash#<=`)
 * [   ] `rb_hash_lt` (`Hash#<`)
 * [   ] `rb_hash_ge` (`Hash#>=`)
@@ -1564,4 +1564,4 @@
 
 ## Stats
 * Total:   1488
-* Visible: 243
+* Visible: 244

--- a/compiler/IREmitter/Intrinsics/wrap-intrinsics.rb
+++ b/compiler/IREmitter/Intrinsics/wrap-intrinsics.rb
@@ -251,6 +251,7 @@ module Intrinsics
       "Float#finite?",
       "Float#infinite?",
       "Float#magnitude",
+      "Hash#dig",
       "Hash#has_key?",
       "Hash#include?",
       "Hash#key?",

--- a/compiler/IREmitter/Payload/PayloadIntrinsics.c
+++ b/compiler/IREmitter/Payload/PayloadIntrinsics.c
@@ -326,6 +326,15 @@ VALUE sorbet_int_rb_flo_is_infinite_p(VALUE recv, ID fun, int argc, VALUE *const
     return rb_flo_is_infinite_p(recv);
 }
 
+// Hash#dig
+// Calling convention: -1
+extern VALUE sorbet_rb_hash_dig(int argc, const VALUE *args, VALUE obj);
+
+VALUE sorbet_int_rb_hash_dig(VALUE recv, ID fun, int argc, VALUE *const restrict args, BlockFFIType blk,
+                             VALUE closure) {
+    return sorbet_rb_hash_dig(argc, args, recv);
+}
+
 // Hash#include?
 // Hash#member?
 // Hash#has_key?

--- a/compiler/IREmitter/WrappedIntrinsics.h
+++ b/compiler/IREmitter/WrappedIntrinsics.h
@@ -36,6 +36,7 @@
     {core::Symbols::Float(), "magnitude", CMethod{"sorbet_int_rb_float_abs"}},
     {core::Symbols::Float(), "finite?", CMethod{"sorbet_int_rb_flo_is_finite_p"}},
     {core::Symbols::Float(), "infinite?", CMethod{"sorbet_int_rb_flo_is_infinite_p"}},
+    {core::Symbols::Hash(), "dig", CMethod{"sorbet_int_rb_hash_dig"}},
     {core::Symbols::Hash(), "include?", CMethod{"sorbet_int_rb_hash_has_key"}},
     {core::Symbols::Hash(), "member?", CMethod{"sorbet_int_rb_hash_has_key"}},
     {core::Symbols::Hash(), "has_key?", CMethod{"sorbet_int_rb_hash_has_key"}},

--- a/compiler/ruby-static-exports/hash.c
+++ b/compiler/ruby-static-exports/hash.c
@@ -1,0 +1,3 @@
+VALUE sorbet_rb_hash_dig(int argc, const VALUE *args, VALUE obj) {
+    return rb_hash_dig(argc, args, obj);
+}

--- a/test/testdata/compiler/intrinsics/hash_dig.rb
+++ b/test/testdata/compiler/intrinsics/hash_dig.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+# run_filecheck: INITIAL
+
+
+module M
+  extend T::Sig
+
+  # INITIAL-LABEL: @func_M.7dig_x_y
+  # INITIAL: call i64 @sorbet_int_rb_hash_dig
+  # INITIAL-NOT: sorbet_i_send
+  # INITIAL{LITERAL}: }
+  sig {params(x: T::Hash[Symbol, T.untyped]).returns(T.untyped)}
+  def self.dig_x_y(x)
+    x.dig(:x, :y)
+  end
+end
+
+puts M.dig_x_y({x: {y: 10}})
+puts M.dig_x_y({x: {z: 10}})

--- a/test/testdata/ruby_benchmark/stripe/hash_dig.rb
+++ b/test/testdata/ruby_benchmark/stripe/hash_dig.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+
+hash = {x: {y: {z: "hi"}}}
+
+i = 0
+sum = 0
+
+while i < 10_000_000
+  i += 1
+
+  sum += hash.dig(:x, :y, :z).length
+end
+
+puts i
+puts sum


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Import an intrinsic for `Hash#dig` to avoid the vm overhead of setting up a call frame.

```
# master

source                                                         interpreted     compiled
stripe/while_10_000_000.rb                                      .269           .114
./test/testdata/ruby_benchmark/stripe/hash_dig.rb              1.008           .964
./test/testdata/ruby_benchmark/stripe/hash_dig.rb - baseline    .739           .850

# this branch

source                                                         interpreted     compiled
stripe/while_10_000_000.rb                                      .271           .115
./test/testdata/ruby_benchmark/stripe/hash_dig.rb              1.008           .816
./test/testdata/ruby_benchmark/stripe/hash_dig.rb - baseline    .737           .701
```

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Performance, the overhead seem surprisingly high for an interpreted call to `Hash#dig`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
