### PR TITLE
Fix typecheck call in fuzz_dash_e.cc

### DIFF
--- a/test/fuzz/fuzz_dash_e.cc
+++ b/test/fuzz/fuzz_dash_e.cc
@@ -72,6 +72,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
     indexed = realmain::pipeline::index(gs, inputFiles, *opts, *workers, kvstore);
     indexed = move(realmain::pipeline::resolve(gs, move(indexed), *opts, *workers).result());
-    realmain::pipeline::typecheck(gs, move(indexed), *opts, *workers).result();
+    realmain::pipeline::typecheck(gs, move(indexed), *opts, *workers);
     return 0;
 }


### PR DESCRIPTION
Fixes a call to `typecheck` in `fuzz_dash_e.cc` (this function returns `void` since #4952).

### Motivation
Fix compile failure that shows up with `./bazel test //... --config=dbg`

### Test plan
Verified offline that compilation no longer fails with `./bazel test //... --config=dbg`