### PR TITLE
Implement an intrinsic for `Hash#transform_values`

### DIFF
--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -1000,6 +1000,8 @@ static const vector<CallCMethod> knownCMethodsInstance{
      CMethod{"sorbet_rb_hash_select_withBlock", core::Symbols::Hash()}},
     {core::Symbols::Hash(), "delete", CMethod{"sorbet_rb_hash_delete_m"}, CMethod{"sorbet_rb_hash_delete_m_withBlock"}},
     {core::Symbols::Hash(), "empty?", CMethod{"sorbet_rb_hash_empty_p"}},
+    {core::Symbols::Hash(), "transform_values", CMethod{"sorbet_rb_hash_transform_values", core::Symbols::Hash()},
+     CMethod{"sorbet_rb_hash_transform_values_withBlock", core::Symbols::Hash()}},
     {core::Symbols::TrueClass(), "|", CMethod{"sorbet_int_bool_true"}},
     {core::Symbols::FalseClass(), "|", CMethod{"sorbet_int_bool_and"}},
     {core::Symbols::TrueClass(), "&", CMethod{"sorbet_int_bool_and"}},

--- a/test/testdata/compiler/intrinsics/hash_transform_values.rb
+++ b/test/testdata/compiler/intrinsics/hash_transform_values.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+# run_filecheck: INITIAL
+
+module M
+
+  # INITIAL-LABEL: define internal i64 @func_M.10test_block(
+  # INITIAL: call i64 @sorbet_callIntrinsicInlineBlock_noBreak({{.*}}@forward_sorbet_rb_hash_transform_values_withBlock
+  # INITIAL-NOT: @sorbet_i_send
+  # INITIAL{LITERAL}: }
+  def self.test_block()
+    {a: 1, b: 2, c: 3}.transform_values do |a|
+      p " #{a}"
+      a + 1
+    end
+  end
+
+  # INITIAL-LABEL: define internal i64 @func_M.9test_enum(
+  # INITIAL: call i64 @sorbet_rb_hash_transform_values(
+  # INITIAL-NOT: @sorbet_i_send
+  # INITIAL{LITERAL}: }
+  def self.test_enum()
+    {a: 1, b: 2, c: 3}.transform_values
+  end
+
+end
+
+p(M.test_block)
+p(M.test_enum.each {|x| p "enum #{x}"})
+

--- a/test/testdata/ruby_benchmark/stripe/hash_transform_values.rb
+++ b/test/testdata/ruby_benchmark/stripe/hash_transform_values.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+
+i = 0
+
+# 8 is a tipping point on the performance of this benchmark. Initially the compiler is about 2x faster than the
+# interpreter, but anything above 8 starts to stretch out the interpreted time substantially, and really show the
+# benefit of having compiled blocks.
+xs = T.let((:a..).take(8).zip(1..).to_h.compact, T::Hash[Symbol, Integer])
+
+while i < 1_000_000
+  xs.transform_values{|a| a+1}.length
+
+  i += 1
+end
+
+puts i


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

```
# master

source                                                                          interpreted     compiled
stripe/while_1_000_000.rb                                                       .107            .091
./test/testdata/ruby_benchmark/stripe/hash_transform_values.rb                  .585            .357
./test/testdata/ruby_benchmark/stripe/hash_transform_values.rb - baseline       .478            .266

# this branch

source                                                                          interpreted     compiled
stripe/while_1_000_000.rb                                                       .106            .090
./test/testdata/ruby_benchmark/stripe/hash_transform_values.rb                  .587            .256
./test/testdata/ruby_benchmark/stripe/hash_transform_values.rb - baseline       .481            .166
```

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Performance

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
