### PR TITLE
Improve LSP responsiveness by always destroying ASTs in parallel during cancelation

### DIFF
--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -1416,6 +1416,8 @@ ParsedFilesOrCancelled::ParsedFilesOrCancelled(std::vector<ParsedFile> &&trees) 
 
 ParsedFilesOrCancelled ParsedFilesOrCancelled::cancel(std::vector<ParsedFile> &&trees, WorkerPool &workers) {
     if (!trees.empty()) {
+        // N.B.: `workers.size()` can be `0` when threads are disabled, which would result in undefined behavior for
+        // `BlockingCounter`.
         absl::BlockingCounter threadBarrier(std::max(workers.size(), 1));
         auto fileq = make_shared<ConcurrentBoundedQueue<ast::ParsedFile>>(trees.size());
         for (auto &tree : trees) {

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -1426,7 +1426,7 @@ ParsedFilesOrCancelled ParsedFilesOrCancelled::cancel(std::vector<ParsedFile> &&
             {
                 ast::ParsedFile job;
                 for (auto result = fileq->try_pop(job); !result.done(); result = fileq->try_pop(job)) {
-                    // Do nothing; allow the destructor of `ast::ParsedFile` to run.
+                    // Do nothing; allow the destructor of `ast::ParsedFile` to run for `job`.
                 }
             }
             threadBarrier.DecrementCount();

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -1416,7 +1416,7 @@ ParsedFilesOrCancelled::ParsedFilesOrCancelled(std::vector<ParsedFile> &&trees) 
 
 ParsedFilesOrCancelled ParsedFilesOrCancelled::cancel(std::vector<ParsedFile> &&trees, WorkerPool &workers) {
     if (!trees.empty()) {
-        absl::BlockingCounter threadBarrier(workers.size());
+        absl::BlockingCounter threadBarrier(std::max(workers.size(), 1));
         auto fileq = make_shared<ConcurrentBoundedQueue<ast::ParsedFile>>(trees.size());
         for (auto &tree : trees) {
             fileq->push(move(tree), 1);

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -26,6 +26,10 @@
 // node type can likely have been created from multiple Ruby constructs.
 //
 
+namespace sorbet {
+class WorkerPool;
+}
+
 namespace sorbet::ast {
 
 enum class Tag {
@@ -235,10 +239,15 @@ struct ParsedFile {
 class ParsedFilesOrCancelled final {
 private:
     std::optional<std::vector<ParsedFile>> trees;
+    ParsedFilesOrCancelled();
 
 public:
-    ParsedFilesOrCancelled();
     ParsedFilesOrCancelled(std::vector<ParsedFile> &&trees);
+
+    // Produces a `ParsedFilesOrCancelled` in the cancelled state.
+    // Trees passed to this function will be destructed in parallel with `workers`, which improves LSP responsiveness on
+    // large projects.
+    static ParsedFilesOrCancelled cancel(std::vector<ParsedFile> &&trees, WorkerPool &workers);
 
     bool hasResult() const;
     std::vector<ParsedFile> &result();

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1885,7 +1885,8 @@ vector<SymbolFinderResult> findSymbols(const core::GlobalState &gs, vector<ast::
     return allFoundDefinitions;
 }
 
-ast::ParsedFilesOrCancelled defineSymbols(core::GlobalState &gs, vector<SymbolFinderResult> allFoundDefinitions) {
+ast::ParsedFilesOrCancelled defineSymbols(core::GlobalState &gs, vector<SymbolFinderResult> allFoundDefinitions,
+                                          WorkerPool &workers) {
     Timer timeit(gs.tracer(), "naming.defineSymbols");
     vector<ast::ParsedFile> output;
     output.reserve(allFoundDefinitions.size());
@@ -1895,7 +1896,10 @@ ast::ParsedFilesOrCancelled defineSymbols(core::GlobalState &gs, vector<SymbolFi
         count++;
         // defineSymbols is really fast. Avoid this mildly expensive check for most turns of the loop.
         if (count % 250 == 0 && epochManager.wasTypecheckingCanceled()) {
-            return ast::ParsedFilesOrCancelled();
+            while (count <= allFoundDefinitions.size()) {
+                output.emplace_back(move(allFoundDefinitions[count - 1].tree));
+            }
+            return ast::ParsedFilesOrCancelled::cancel(move(output), workers);
         }
         core::MutableContext ctx(gs, core::Symbols::root(), fileFoundDefinitions.tree.file);
         SymbolDefiner symbolDefiner(move(fileFoundDefinitions.names));
@@ -1953,9 +1957,13 @@ vector<ast::ParsedFile> symbolizeTrees(const core::GlobalState &gs, vector<ast::
 ast::ParsedFilesOrCancelled Namer::run(core::GlobalState &gs, vector<ast::ParsedFile> trees, WorkerPool &workers) {
     auto foundDefs = findSymbols(gs, move(trees), workers);
     if (gs.epochManager->wasTypecheckingCanceled()) {
-        return ast::ParsedFilesOrCancelled();
+        trees.reserve(foundDefs.size());
+        for (auto &def : foundDefs) {
+            trees.emplace_back(move(def.tree));
+        }
+        return ast::ParsedFilesOrCancelled::cancel(move(trees), workers);
     }
-    auto result = defineSymbols(gs, move(foundDefs));
+    auto result = defineSymbols(gs, move(foundDefs), workers);
     if (!result.hasResult()) {
         return result;
     }

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1896,7 +1896,7 @@ ast::ParsedFilesOrCancelled defineSymbols(core::GlobalState &gs, vector<SymbolFi
         count++;
         // defineSymbols is really fast. Avoid this mildly expensive check for most turns of the loop.
         if (count % 250 == 0 && epochManager.wasTypecheckingCanceled()) {
-            while (count <= allFoundDefinitions.size()) {
+            for (; count <= allFoundDefinitions.size(); count++) {
                 output.emplace_back(move(allFoundDefinitions[count - 1].tree));
             }
             return ast::ParsedFilesOrCancelled::cancel(move(output), workers);

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3073,19 +3073,19 @@ ast::ParsedFilesOrCancelled Resolver::run(core::GlobalState &gs, vector<ast::Par
     const auto &epochManager = *gs.epochManager;
     trees = ResolveConstantsWalk::resolveConstants(gs, std::move(trees), workers);
     if (epochManager.wasTypecheckingCanceled()) {
-        return ast::ParsedFilesOrCancelled();
+        return ast::ParsedFilesOrCancelled::cancel(move(trees), workers);
     }
     finalizeAncestors(gs);
     if (epochManager.wasTypecheckingCanceled()) {
-        return ast::ParsedFilesOrCancelled();
+        return ast::ParsedFilesOrCancelled::cancel(move(trees), workers);
     }
     finalizeSymbols(gs);
     if (epochManager.wasTypecheckingCanceled()) {
-        return ast::ParsedFilesOrCancelled();
+        return ast::ParsedFilesOrCancelled::cancel(move(trees), workers);
     }
     trees = ResolveTypeMembersAndFieldsWalk::run(gs, std::move(trees), workers);
     if (epochManager.wasTypecheckingCanceled()) {
-        return ast::ParsedFilesOrCancelled();
+        return ast::ParsedFilesOrCancelled::cancel(move(trees), workers);
     }
 
     auto result = resolveSigs(gs, std::move(trees), workers);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Improve LSP responsiveness by always destroying ASTs in parallel during cancelation.

When LSP is typechecking the world and a new edit comes in that causes LSP to cancel that typecheck, the code used to destroy all ASTs on a single thread, which is very slow on large projects and resulted in a noticeable pause.

This change enforces that cancelation always destroys trees in parallel by making the only way to construct a `ast::ParsedFilesOrCancelled` object in the "cancelled" state is to call a new static function that destroys the trees passed to it in parallel.

Note that `pipeline::typecheck` always destroys ASTs in parallel after #4952 landed, so this change only impacts `namer` and `resolver`.

One negative of the way that I implemented this is that `ast/Trees.cc` now contains WorkerPool-related code to implement `ast::ParsedFilesOrCancelled::cancel`. I'd be happy to entertain alternative code organization ideas.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Improve Sorbet LSP responsiveness.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Cancelation is tested by existing tests. I also manually tested it.
