### PR TITLE
add arm64 mac configuration bits

### DIFF
--- a/common/BUILD
+++ b/common/BUILD
@@ -12,6 +12,7 @@ cc_library(
         exclude = ["flycheck_*"],
     ) + select({
         "//tools/config:darwin": ["os/mac.cc"],
+        "//tools/config:darwin_arm64": ["os/mac.cc"],
         "//tools/config:webasm": ["os/emscripten.cc"],
         "//conditions:default": ["os/linux.cc"],
     }),

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -296,6 +296,13 @@ package(default_visibility = ["//visibility:public"])
         build_file = "@com_stripe_ruby_typer//third_party/openssl:darwin.BUILD",
     )
 
+    # The default location of Homebrew is slightly different on arm64 Mac.
+    native.new_local_repository(
+        name = "system_ssl_darwin_arm64",
+        path = "/opt/homebrew/opt/openssl",
+        build_file = "@com_stripe_ruby_typer//third_party/openssl:darwin.BUILD",
+    )
+
     native.new_local_repository(
         name = "system_ssl_linux",
         path = "/usr",

--- a/third_party/llvm/llvm.bzl
+++ b/third_party/llvm/llvm.bzl
@@ -311,6 +311,14 @@ llvm_all_cmake_vars = select({
             darwin_cmake_vars,
         ),
     ),
+    "@com_stripe_ruby_typer//tools/config:darwin_arm64": cmake_var_string(
+        _dict_add(
+            cmake_vars,
+            llvm_target_cmake_vars("AARCH64", "aarch64-apple-darwin"),
+            posix_cmake_vars,
+            darwin_cmake_vars,
+        ),
+    ),
     "@com_stripe_ruby_typer//tools/config:linux": cmake_var_string(
         _dict_add(
             cmake_vars,

--- a/third_party/ruby/ruby_patched.BUILD
+++ b/third_party/ruby/ruby_patched.BUILD
@@ -62,6 +62,10 @@ ruby(
             "@system_ssl_darwin//:ssl",
             "@system_ssl_darwin//:crypto",
         ],
+        "@com_stripe_ruby_typer//tools/config:darwin_arm64": [
+            "@system_ssl_darwin_arm64//:ssl",
+            "@system_ssl_darwin_arm64//:crypto",
+        ],
         "@com_stripe_ruby_typer//tools/config:linux": [
             "@system_ssl_linux//:ssl",
             "@system_ssl_linux//:crypto",

--- a/third_party/ruby/ruby_unpatched.BUILD
+++ b/third_party/ruby/ruby_unpatched.BUILD
@@ -56,6 +56,10 @@ ruby(
             "@system_ssl_darwin//:ssl",
             "@system_ssl_darwin//:crypto",
         ],
+        "@com_stripe_ruby_typer//tools/config:darwin_arm64": [
+            "@system_ssl_darwin_arm64//:ssl",
+            "@system_ssl_darwin_arm64//:crypto",
+        ],
         "@com_stripe_ruby_typer//tools/config:linux": [
             "@system_ssl_linux//:ssl",
             "@system_ssl_linux//:crypto",

--- a/tools/config/BUILD
+++ b/tools/config/BUILD
@@ -6,6 +6,11 @@ config_setting(
 )
 
 config_setting(
+    name = "darwin_arm64",
+    values = {"host_cpu": "darwin_arm64"},
+)
+
+config_setting(
     name = "linux",
     values = {"host_cpu": "k8"},
 )


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is all very cargo-culty, because I don't actually understand how one would go about building Sorbet natively on a arm64 mac.  I think @vinistock and/or @Morriar have been working on this, though?

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
