### PR TITLE
Remove SymbolRef::data* methods.

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -814,8 +814,9 @@ MethodRef GlobalState::lookupMethodSymbolWithHash(ClassOrModuleRef owner, NameRe
     return Symbols::noMethod();
 }
 
-// look up a symbol whose flags match the desired flags. This might look through mangled names to discover one whose
-// flags match. If no such symbol exists, then it will return defaultReturnValue.
+// look up a symbol whose flags match the desired kind (or ignores the kind filter if `ignoreKind` is `true`).
+// This might look through mangled names to discover one whose flags match.
+// If no such symbol exists, then it will return defaultReturnValue.
 SymbolRef GlobalState::lookupSymbolWithKind(ClassOrModuleRef owner, NameRef name, SymbolRef::Kind kind,
                                             SymbolRef defaultReturnValue, bool ignoreKind) const {
     ENFORCE(owner.exists(), "looking up symbol from non-existing owner");

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -196,140 +196,142 @@ void GlobalState::initEmpty() {
     UnfreezeSymbolTable symTableAccess(*this);
     Names::registerNames(*this);
 
-    SymbolRef id;
-    id = synthesizeClass(core::Names::Constants::NoSymbol(), 0);
-    ENFORCE(id == Symbols::noSymbol());
-    id = enterMethodSymbol(Loc::none(), Symbols::noClassOrModule(), Names::noMethod());
-    ENFORCE(id == Symbols::noMethod());
-    id = enterFieldSymbol(Loc::none(), Symbols::noClassOrModule(), Names::noFieldOrStaticField());
-    ENFORCE(id == Symbols::noField());
-    id = enterTypeArgument(Loc::none(), Symbols::noMethod(), Names::Constants::NoTypeArgument(), Variance::CoVariant);
-    ENFORCE(id == Symbols::noTypeArgument());
-    id =
+    ClassOrModuleRef klass;
+    klass = synthesizeClass(core::Names::Constants::NoSymbol(), 0);
+    ENFORCE(klass == Symbols::noClassOrModule());
+    MethodRef method = enterMethodSymbol(Loc::none(), Symbols::noClassOrModule(), Names::noMethod());
+    ENFORCE(method == Symbols::noMethod());
+    FieldRef field = enterFieldSymbol(Loc::none(), Symbols::noClassOrModule(), Names::noFieldOrStaticField());
+    ENFORCE(field == Symbols::noField());
+    TypeArgumentRef typeArgument =
+        enterTypeArgument(Loc::none(), Symbols::noMethod(), Names::Constants::NoTypeArgument(), Variance::CoVariant);
+    ENFORCE(typeArgument == Symbols::noTypeArgument());
+    TypeMemberRef typeMember =
         enterTypeMember(Loc::none(), Symbols::noClassOrModule(), Names::Constants::NoTypeMember(), Variance::CoVariant);
-    ENFORCE(id == Symbols::noTypeMember());
+    ENFORCE(typeMember == Symbols::noTypeMember());
 
-    id = synthesizeClass(core::Names::Constants::Top(), 0);
-    ENFORCE(id == Symbols::top());
-    id = synthesizeClass(core::Names::Constants::Bottom(), 0);
-    ENFORCE(id == Symbols::bottom());
-    id = synthesizeClass(core::Names::Constants::Root(), 0);
-    ENFORCE(id == Symbols::root());
+    klass = synthesizeClass(core::Names::Constants::Top(), 0);
+    ENFORCE(klass == Symbols::top());
+    klass = synthesizeClass(core::Names::Constants::Bottom(), 0);
+    ENFORCE(klass == Symbols::bottom());
+    klass = synthesizeClass(core::Names::Constants::Root(), 0);
+    ENFORCE(klass == Symbols::root());
 
-    id = core::Symbols::root().data(*this)->singletonClass(*this);
-    ENFORCE(id == Symbols::rootSingleton());
-    id = synthesizeClass(core::Names::Constants::Todo(), 0);
-    ENFORCE(id == Symbols::todo());
-    id = synthesizeClass(core::Names::Constants::Object(), Symbols::BasicObject().id());
-    ENFORCE(id == Symbols::Object());
-    id = synthesizeClass(core::Names::Constants::Integer());
-    ENFORCE(id == Symbols::Integer());
-    id = synthesizeClass(core::Names::Constants::Float());
-    ENFORCE(id == Symbols::Float());
-    id = synthesizeClass(core::Names::Constants::String());
-    ENFORCE(id == Symbols::String());
-    id = synthesizeClass(core::Names::Constants::Symbol());
-    ENFORCE(id == Symbols::Symbol());
-    id = synthesizeClass(core::Names::Constants::Array());
-    ENFORCE(id == Symbols::Array());
-    id = synthesizeClass(core::Names::Constants::Hash());
-    ENFORCE(id == Symbols::Hash());
-    id = synthesizeClass(core::Names::Constants::TrueClass());
-    ENFORCE(id == Symbols::TrueClass());
-    id = synthesizeClass(core::Names::Constants::FalseClass());
-    ENFORCE(id == Symbols::FalseClass());
-    id = synthesizeClass(core::Names::Constants::NilClass());
-    ENFORCE(id == Symbols::NilClass());
-    id = synthesizeClass(core::Names::Constants::Untyped(), 0);
-    ENFORCE(id == Symbols::untyped());
-    id = synthesizeClass(core::Names::Constants::Opus(), 0, true);
-    ENFORCE(id == Symbols::Opus());
-    id = synthesizeClass(core::Names::Constants::T(), Symbols::todo().id(), true);
-    ENFORCE(id == Symbols::T());
-    id = synthesizeClass(core::Names::Constants::Class(), 0);
-    ENFORCE(id == Symbols::Class());
-    id = synthesizeClass(core::Names::Constants::BasicObject(), 0);
-    ENFORCE(id == Symbols::BasicObject());
-    id = synthesizeClass(core::Names::Constants::Kernel(), 0, true);
-    ENFORCE(id == Symbols::Kernel());
-    id = synthesizeClass(core::Names::Constants::Range());
-    ENFORCE(id == Symbols::Range());
-    id = synthesizeClass(core::Names::Constants::Regexp());
-    ENFORCE(id == Symbols::Regexp());
-    id = synthesizeClass(core::Names::Constants::Magic());
-    ENFORCE(id == Symbols::Magic());
-    id = Symbols::Magic().data(*this)->singletonClass(*this);
-    ENFORCE(id == Symbols::MagicSingleton());
-    id = synthesizeClass(core::Names::Constants::Module());
-    ENFORCE(id == Symbols::Module());
-    id = synthesizeClass(core::Names::Constants::StandardError());
-    ENFORCE(id == Symbols::StandardError());
-    id = synthesizeClass(core::Names::Constants::Complex());
-    ENFORCE(id == Symbols::Complex());
-    id = synthesizeClass(core::Names::Constants::Rational());
-    ENFORCE(id == Symbols::Rational());
-    id = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Array());
-    ENFORCE(id == Symbols::T_Array());
-    id = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Hash());
-    ENFORCE(id == Symbols::T_Hash());
-    id = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Proc());
-    ENFORCE(id == Symbols::T_Proc());
-    id = synthesizeClass(core::Names::Constants::Proc());
-    ENFORCE(id == Symbols::Proc());
-    id = synthesizeClass(core::Names::Constants::Enumerable(), 0, true);
-    ENFORCE(id == Symbols::Enumerable());
-    id = synthesizeClass(core::Names::Constants::Set());
-    ENFORCE(id == Symbols::Set());
-    id = synthesizeClass(core::Names::Constants::Struct());
-    ENFORCE(id == Symbols::Struct());
-    id = synthesizeClass(core::Names::Constants::File());
-    ENFORCE(id == Symbols::File());
-    id = synthesizeClass(core::Names::Constants::Sorbet());
-    ENFORCE(id == Symbols::Sorbet());
-    id = enterClassSymbol(Loc::none(), Symbols::Sorbet(), core::Names::Constants::Private());
-    ENFORCE(id == Symbols::Sorbet_Private());
-    id = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private(), core::Names::Constants::Static());
-    ENFORCE(id == Symbols::Sorbet_Private_Static());
-    id = Symbols::Sorbet_Private_Static().data(*this)->singletonClass(*this);
-    ENFORCE(id == Symbols::Sorbet_Private_StaticSingleton());
-    id = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::StubModule());
-    ENFORCE(id == Symbols::StubModule());
-    id = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::StubMixin());
-    ENFORCE(id == Symbols::StubMixin());
-    id = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::PlaceholderMixin());
-    ENFORCE(id == Symbols::PlaceholderMixin());
-    id = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::StubSuperClass());
-    ENFORCE(id == Symbols::StubSuperClass());
-    id = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Enumerable());
-    ENFORCE(id == Symbols::T_Enumerable());
-    id = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Range());
-    ENFORCE(id == Symbols::T_Range());
-    id = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Set());
-    ENFORCE(id == Symbols::T_Set());
-    id = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::Void());
-    id.data(*this)->setIsModule(false);
-    ENFORCE(id == Symbols::void_());
-    id = synthesizeClass(core::Names::Constants::TypeAlias(), 0);
-    ENFORCE(id == Symbols::typeAliasTemp());
-    id = enterClassSymbol(Loc::none(), Symbols::T(), Names::Constants::Configuration());
-    ENFORCE(id == Symbols::T_Configuration());
-    id = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Generic());
-    ENFORCE(id == Symbols::T_Generic());
-    id = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::Tuple());
-    ENFORCE(id == Symbols::Tuple());
-    id = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::Shape());
-    ENFORCE(id == Symbols::Shape());
-    id = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::Subclasses());
-    ENFORCE(id == Symbols::Subclasses());
-    id = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(),
-                          core::Names::Constants::ImplicitModuleSuperclass());
-    ENFORCE(id == Symbols::Sorbet_Private_Static_ImplicitModuleSuperClass());
-    id = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::ReturnTypeInference());
-    ENFORCE(id == Symbols::Sorbet_Private_Static_ReturnTypeInference());
-    MethodRef method =
+    klass = core::Symbols::root().data(*this)->singletonClass(*this);
+    ENFORCE(klass == Symbols::rootSingleton());
+    klass = synthesizeClass(core::Names::Constants::Todo(), 0);
+    ENFORCE(klass == Symbols::todo());
+    klass = synthesizeClass(core::Names::Constants::Object(), Symbols::BasicObject().id());
+    ENFORCE(klass == Symbols::Object());
+    klass = synthesizeClass(core::Names::Constants::Integer());
+    ENFORCE(klass == Symbols::Integer());
+    klass = synthesizeClass(core::Names::Constants::Float());
+    ENFORCE(klass == Symbols::Float());
+    klass = synthesizeClass(core::Names::Constants::String());
+    ENFORCE(klass == Symbols::String());
+    klass = synthesizeClass(core::Names::Constants::Symbol());
+    ENFORCE(klass == Symbols::Symbol());
+    klass = synthesizeClass(core::Names::Constants::Array());
+    ENFORCE(klass == Symbols::Array());
+    klass = synthesizeClass(core::Names::Constants::Hash());
+    ENFORCE(klass == Symbols::Hash());
+    klass = synthesizeClass(core::Names::Constants::TrueClass());
+    ENFORCE(klass == Symbols::TrueClass());
+    klass = synthesizeClass(core::Names::Constants::FalseClass());
+    ENFORCE(klass == Symbols::FalseClass());
+    klass = synthesizeClass(core::Names::Constants::NilClass());
+    ENFORCE(klass == Symbols::NilClass());
+    klass = synthesizeClass(core::Names::Constants::Untyped(), 0);
+    ENFORCE(klass == Symbols::untyped());
+    klass = synthesizeClass(core::Names::Constants::Opus(), 0, true);
+    ENFORCE(klass == Symbols::Opus());
+    klass = synthesizeClass(core::Names::Constants::T(), Symbols::todo().id(), true);
+    ENFORCE(klass == Symbols::T());
+    klass = synthesizeClass(core::Names::Constants::Class(), 0);
+    ENFORCE(klass == Symbols::Class());
+    klass = synthesizeClass(core::Names::Constants::BasicObject(), 0);
+    ENFORCE(klass == Symbols::BasicObject());
+    klass = synthesizeClass(core::Names::Constants::Kernel(), 0, true);
+    ENFORCE(klass == Symbols::Kernel());
+    klass = synthesizeClass(core::Names::Constants::Range());
+    ENFORCE(klass == Symbols::Range());
+    klass = synthesizeClass(core::Names::Constants::Regexp());
+    ENFORCE(klass == Symbols::Regexp());
+    klass = synthesizeClass(core::Names::Constants::Magic());
+    ENFORCE(klass == Symbols::Magic());
+    klass = Symbols::Magic().data(*this)->singletonClass(*this);
+    ENFORCE(klass == Symbols::MagicSingleton());
+    klass = synthesizeClass(core::Names::Constants::Module());
+    ENFORCE(klass == Symbols::Module());
+    klass = synthesizeClass(core::Names::Constants::StandardError());
+    ENFORCE(klass == Symbols::StandardError());
+    klass = synthesizeClass(core::Names::Constants::Complex());
+    ENFORCE(klass == Symbols::Complex());
+    klass = synthesizeClass(core::Names::Constants::Rational());
+    ENFORCE(klass == Symbols::Rational());
+    klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Array());
+    ENFORCE(klass == Symbols::T_Array());
+    klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Hash());
+    ENFORCE(klass == Symbols::T_Hash());
+    klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Proc());
+    ENFORCE(klass == Symbols::T_Proc());
+    klass = synthesizeClass(core::Names::Constants::Proc());
+    ENFORCE(klass == Symbols::Proc());
+    klass = synthesizeClass(core::Names::Constants::Enumerable(), 0, true);
+    ENFORCE(klass == Symbols::Enumerable());
+    klass = synthesizeClass(core::Names::Constants::Set());
+    ENFORCE(klass == Symbols::Set());
+    klass = synthesizeClass(core::Names::Constants::Struct());
+    ENFORCE(klass == Symbols::Struct());
+    klass = synthesizeClass(core::Names::Constants::File());
+    ENFORCE(klass == Symbols::File());
+    klass = synthesizeClass(core::Names::Constants::Sorbet());
+    ENFORCE(klass == Symbols::Sorbet());
+    klass = enterClassSymbol(Loc::none(), Symbols::Sorbet(), core::Names::Constants::Private());
+    ENFORCE(klass == Symbols::Sorbet_Private());
+    klass = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private(), core::Names::Constants::Static());
+    ENFORCE(klass == Symbols::Sorbet_Private_Static());
+    klass = Symbols::Sorbet_Private_Static().data(*this)->singletonClass(*this);
+    ENFORCE(klass == Symbols::Sorbet_Private_StaticSingleton());
+    klass = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::StubModule());
+    ENFORCE(klass == Symbols::StubModule());
+    klass = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::StubMixin());
+    ENFORCE(klass == Symbols::StubMixin());
+    klass = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::PlaceholderMixin());
+    ENFORCE(klass == Symbols::PlaceholderMixin());
+    klass = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::StubSuperClass());
+    ENFORCE(klass == Symbols::StubSuperClass());
+    klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Enumerable());
+    ENFORCE(klass == Symbols::T_Enumerable());
+    klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Range());
+    ENFORCE(klass == Symbols::T_Range());
+    klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Set());
+    ENFORCE(klass == Symbols::T_Set());
+    klass = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::Void());
+    klass.data(*this)->setIsModule(false);
+    ENFORCE(klass == Symbols::void_());
+    klass = synthesizeClass(core::Names::Constants::TypeAlias(), 0);
+    ENFORCE(klass == Symbols::typeAliasTemp());
+    klass = enterClassSymbol(Loc::none(), Symbols::T(), Names::Constants::Configuration());
+    ENFORCE(klass == Symbols::T_Configuration());
+    klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Generic());
+    ENFORCE(klass == Symbols::T_Generic());
+    klass = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::Tuple());
+    ENFORCE(klass == Symbols::Tuple());
+    klass = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::Shape());
+    ENFORCE(klass == Symbols::Shape());
+    klass = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::Subclasses());
+    ENFORCE(klass == Symbols::Subclasses());
+    klass = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(),
+                             core::Names::Constants::ImplicitModuleSuperclass());
+    ENFORCE(klass == Symbols::Sorbet_Private_Static_ImplicitModuleSuperClass());
+    klass =
+        enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::ReturnTypeInference());
+    ENFORCE(klass == Symbols::Sorbet_Private_Static_ReturnTypeInference());
+    method =
         enterMethod(*this, Symbols::Sorbet_Private_Static(), core::Names::guessedTypeTypeParameterHolder()).build();
     ENFORCE(method == Symbols::Sorbet_Private_Static_ReturnTypeInference_guessed_type_type_parameter_holder());
-    auto typeArgument = enterTypeArgument(
+    typeArgument = enterTypeArgument(
         Loc::none(), Symbols::Sorbet_Private_Static_ReturnTypeInference_guessed_type_type_parameter_holder(),
         freshNameUnique(core::UniqueNameKind::TypeVarName, core::Names::Constants::InferredReturnType(), 1),
         core::Variance::ContraVariant);
@@ -344,12 +346,12 @@ void GlobalState::initEmpty() {
     typeArgument.data(*this)->resultType = make_type<core::TypeVar>(typeArgument);
     ENFORCE(typeArgument ==
             Symbols::Sorbet_Private_Static_ReturnTypeInference_guessed_type_type_parameter_holder_tparam_covariant());
-    id = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Sig());
-    ENFORCE(id == Symbols::T_Sig());
+    klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Sig());
+    ENFORCE(klass == Symbols::T_Sig());
 
     // A magic non user-creatable class with methods to keep state between passes
-    id = enterFieldSymbol(Loc::none(), Symbols::Magic(), core::Names::Constants::UndeclaredFieldStub());
-    ENFORCE(id == Symbols::Magic_undeclaredFieldStub());
+    field = enterFieldSymbol(Loc::none(), Symbols::Magic(), core::Names::Constants::UndeclaredFieldStub());
+    ENFORCE(field == Symbols::Magic_undeclaredFieldStub());
 
     // Sorbet::Private::Static#badAliasMethodStub(*arg0 : T.untyped) => T.untyped
     method = enterMethod(*this, Symbols::Sorbet_Private_Static(), core::Names::badAliasMethodStub())
@@ -358,74 +360,74 @@ void GlobalState::initEmpty() {
     ENFORCE(method == Symbols::Sorbet_Private_Static_badAliasMethodStub());
 
     // T::Helpers
-    id = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Helpers());
-    ENFORCE(id == Symbols::T_Helpers());
+    klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Helpers());
+    ENFORCE(klass == Symbols::T_Helpers());
 
     // SigBuilder magic class
-    id = synthesizeClass(core::Names::Constants::DeclBuilderForProcs());
-    ENFORCE(id == Symbols::DeclBuilderForProcs());
-    id = Symbols::DeclBuilderForProcs().data(*this)->singletonClass(*this);
-    ENFORCE(id == Symbols::DeclBuilderForProcsSingleton());
+    klass = synthesizeClass(core::Names::Constants::DeclBuilderForProcs());
+    ENFORCE(klass == Symbols::DeclBuilderForProcs());
+    klass = Symbols::DeclBuilderForProcs().data(*this)->singletonClass(*this);
+    ENFORCE(klass == Symbols::DeclBuilderForProcsSingleton());
 
     // Ruby 2.5 Hack
-    id = synthesizeClass(core::Names::Constants::Net(), 0, true);
-    ENFORCE(id == Symbols::Net());
-    id = enterClassSymbol(Loc::none(), Symbols::Net(), core::Names::Constants::IMAP());
+    klass = synthesizeClass(core::Names::Constants::Net(), 0, true);
+    ENFORCE(klass == Symbols::Net());
+    klass = enterClassSymbol(Loc::none(), Symbols::Net(), core::Names::Constants::IMAP());
     Symbols::Net_IMAP().data(*this)->setIsModule(false);
-    ENFORCE(id == Symbols::Net_IMAP());
-    id = enterClassSymbol(Loc::none(), Symbols::Net(), core::Names::Constants::Protocol());
-    ENFORCE(id == Symbols::Net_Protocol());
+    ENFORCE(klass == Symbols::Net_IMAP());
+    klass = enterClassSymbol(Loc::none(), Symbols::Net(), core::Names::Constants::Protocol());
+    ENFORCE(klass == Symbols::Net_Protocol());
     Symbols::Net_Protocol().data(*this)->setIsModule(false);
 
-    id = enterClassSymbol(Loc::none(), Symbols::T_Sig(), core::Names::Constants::WithoutRuntime());
-    ENFORCE(id == Symbols::T_Sig_WithoutRuntime());
+    klass = enterClassSymbol(Loc::none(), Symbols::T_Sig(), core::Names::Constants::WithoutRuntime());
+    ENFORCE(klass == Symbols::T_Sig_WithoutRuntime());
 
-    id = synthesizeClass(core::Names::Constants::Enumerator());
-    ENFORCE(id == Symbols::Enumerator());
-    id = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Enumerator());
-    ENFORCE(id == Symbols::T_Enumerator());
+    klass = synthesizeClass(core::Names::Constants::Enumerator());
+    ENFORCE(klass == Symbols::Enumerator());
+    klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Enumerator());
+    ENFORCE(klass == Symbols::T_Enumerator());
 
-    id = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Struct());
-    ENFORCE(id == Symbols::T_Struct());
+    klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Struct());
+    ENFORCE(klass == Symbols::T_Struct());
 
-    id = synthesizeClass(core::Names::Constants::Singleton(), 0, true);
-    ENFORCE(id == Symbols::Singleton());
+    klass = synthesizeClass(core::Names::Constants::Singleton(), 0, true);
+    ENFORCE(klass == Symbols::Singleton());
 
-    id = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Enum());
-    id.data(*this)->setIsModule(false);
-    ENFORCE(id == Symbols::T_Enum());
+    klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Enum());
+    klass.data(*this)->setIsModule(false);
+    ENFORCE(klass == Symbols::T_Enum());
 
     // T::Sig#sig
     method = enterMethod(*this, Symbols::T_Sig(), Names::sig()).defaultArg(Names::arg0()).build();
     ENFORCE(method == Symbols::sig());
 
     // Enumerable::Lazy
-    id = enterClassSymbol(Loc::none(), Symbols::Enumerator(), core::Names::Constants::Lazy());
-    ENFORCE(id == Symbols::Enumerator_Lazy());
+    klass = enterClassSymbol(Loc::none(), Symbols::Enumerator(), core::Names::Constants::Lazy());
+    ENFORCE(klass == Symbols::Enumerator_Lazy());
 
-    id = enterClassSymbol(Loc::none(), Symbols::T(), Names::Constants::Private());
-    ENFORCE(id == Symbols::T_Private());
-    id = enterClassSymbol(Loc::none(), Symbols::T_Private(), Names::Constants::Types());
-    ENFORCE(id == Symbols::T_Private_Types());
-    id = enterClassSymbol(Loc::none(), Symbols::T_Private_Types(), Names::Constants::Void());
-    id.data(*this)->setIsModule(false);
-    ENFORCE(id == Symbols::T_Private_Types_Void());
-    id = enterClassSymbol(Loc::none(), Symbols::T_Private_Types_Void(), Names::Constants::VOID());
-    ENFORCE(id == Symbols::T_Private_Types_Void_VOID());
-    id = id.data(*this)->singletonClass(*this);
-    ENFORCE(id == Symbols::T_Private_Types_Void_VOIDSingleton());
+    klass = enterClassSymbol(Loc::none(), Symbols::T(), Names::Constants::Private());
+    ENFORCE(klass == Symbols::T_Private());
+    klass = enterClassSymbol(Loc::none(), Symbols::T_Private(), Names::Constants::Types());
+    ENFORCE(klass == Symbols::T_Private_Types());
+    klass = enterClassSymbol(Loc::none(), Symbols::T_Private_Types(), Names::Constants::Void());
+    klass.data(*this)->setIsModule(false);
+    ENFORCE(klass == Symbols::T_Private_Types_Void());
+    klass = enterClassSymbol(Loc::none(), Symbols::T_Private_Types_Void(), Names::Constants::VOID());
+    ENFORCE(klass == Symbols::T_Private_Types_Void_VOID());
+    klass = klass.data(*this)->singletonClass(*this);
+    ENFORCE(klass == Symbols::T_Private_Types_Void_VOIDSingleton());
 
     // T.class_of(T::Sig::WithoutRuntime)
-    id = Symbols::T_Sig_WithoutRuntime().data(*this)->singletonClass(*this);
-    ENFORCE(id == Symbols::T_Sig_WithoutRuntimeSingleton());
+    klass = Symbols::T_Sig_WithoutRuntime().data(*this)->singletonClass(*this);
+    ENFORCE(klass == Symbols::T_Sig_WithoutRuntimeSingleton());
 
     // T::Sig::WithoutRuntime.sig
     method =
         enterMethod(*this, Symbols::T_Sig_WithoutRuntimeSingleton(), Names::sig()).defaultArg(Names::arg0()).build();
     ENFORCE(method == Symbols::sigWithoutRuntime());
 
-    id = enterClassSymbol(Loc::none(), Symbols::T(), Names::Constants::NonForcingConstants());
-    ENFORCE(id == Symbols::T_NonForcingConstants());
+    klass = enterClassSymbol(Loc::none(), Symbols::T(), Names::Constants::NonForcingConstants());
+    ENFORCE(klass == Symbols::T_NonForcingConstants());
 
     method = enterMethod(*this, Symbols::Sorbet_Private_StaticSingleton(), Names::sig())
                  .arg(Names::arg0())
@@ -433,18 +435,18 @@ void GlobalState::initEmpty() {
                  .build();
     ENFORCE(method == Symbols::SorbetPrivateStaticSingleton_sig());
 
-    id = enterClassSymbol(Loc::none(), Symbols::root(), Names::Constants::PackageRegistry());
-    ENFORCE(id == Symbols::PackageRegistry());
-    id = enterClassSymbol(Loc::none(), Symbols::root(), Names::Constants::PackageTests());
-    ENFORCE(id == Symbols::PackageTests());
+    klass = enterClassSymbol(Loc::none(), Symbols::root(), Names::Constants::PackageRegistry());
+    ENFORCE(klass == Symbols::PackageRegistry());
+    klass = enterClassSymbol(Loc::none(), Symbols::root(), Names::Constants::PackageTests());
+    ENFORCE(klass == Symbols::PackageTests());
 
     // PackageSpec is a class that can be subclassed.
-    id = enterClassSymbol(Loc::none(), Symbols::root(), Names::Constants::PackageSpec());
-    id.data(*this)->setIsModule(false);
-    ENFORCE(id == Symbols::PackageSpec());
+    klass = enterClassSymbol(Loc::none(), Symbols::root(), Names::Constants::PackageSpec());
+    klass.data(*this)->setIsModule(false);
+    ENFORCE(klass == Symbols::PackageSpec());
 
-    id = id.data(*this)->singletonClass(*this);
-    ENFORCE(id == Symbols::PackageSpecSingleton());
+    klass = klass.data(*this)->singletonClass(*this);
+    ENFORCE(klass == Symbols::PackageSpecSingleton());
 
     method = enterMethod(*this, Symbols::PackageSpecSingleton(), Names::import())
                  .typedArg(Names::arg0(), make_type<ClassType>(Symbols::PackageSpecSingleton()))
@@ -464,11 +466,11 @@ void GlobalState::initEmpty() {
         enterMethod(*this, Symbols::PackageSpecSingleton(), Names::restrict_to_service()).arg(Names::arg0()).build();
     ENFORCE(method == Symbols::PackageSpec_restrict_to_service());
 
-    id = synthesizeClass(core::Names::Constants::Encoding());
-    ENFORCE(id == Symbols::Encoding());
+    klass = synthesizeClass(core::Names::Constants::Encoding());
+    ENFORCE(klass == Symbols::Encoding());
 
-    id = synthesizeClass(core::Names::Constants::Thread());
-    ENFORCE(id == Symbols::Thread());
+    klass = synthesizeClass(core::Names::Constants::Thread());
+    ENFORCE(klass == Symbols::Thread());
 
     // Class#new
     method = enterMethod(*this, Symbols::Class(), Names::new_()).repeatedArg(Names::args()).build();
@@ -478,15 +480,15 @@ void GlobalState::initEmpty() {
     enterMethodArgumentSymbol(Loc::none(), method, Names::args());
     ENFORCE(method == Symbols::todoMethod());
 
-    id = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::ResolvedSig());
-    ENFORCE(id == Symbols::Sorbet_Private_Static_ResolvedSig());
-    id = Symbols::Sorbet_Private_Static_ResolvedSig().data(*this)->singletonClass(*this);
-    ENFORCE(id == Symbols::Sorbet_Private_Static_ResolvedSigSingleton());
+    klass = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::ResolvedSig());
+    ENFORCE(klass == Symbols::Sorbet_Private_Static_ResolvedSig());
+    klass = Symbols::Sorbet_Private_Static_ResolvedSig().data(*this)->singletonClass(*this);
+    ENFORCE(klass == Symbols::Sorbet_Private_Static_ResolvedSigSingleton());
 
-    id = enterClassSymbol(Loc::none(), Symbols::T_Private(), core::Names::Constants::Compiler());
-    ENFORCE(id == Symbols::T_Private_Compiler());
-    id = Symbols::T_Private_Compiler().data(*this)->singletonClass(*this);
-    ENFORCE(id == Symbols::T_Private_CompilerSingleton());
+    klass = enterClassSymbol(Loc::none(), Symbols::T_Private(), core::Names::Constants::Compiler());
+    ENFORCE(klass == Symbols::T_Private_Compiler());
+    klass = Symbols::T_Private_Compiler().data(*this)->singletonClass(*this);
+    ENFORCE(klass == Symbols::T_Private_CompilerSingleton());
 
     typeArgument =
         enterTypeArgument(Loc::none(), Symbols::noMethod(), Names::Constants::TodoTypeArgument(), Variance::CoVariant);
@@ -499,8 +501,9 @@ void GlobalState::initEmpty() {
     Symbols::root().data(*this)->members()[core::Names::Constants::Bottom()] = Symbols::bottom();
 
     // Sorbet::Private::Static::VERSION
-    id = enterStaticFieldSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), Names::Constants::VERSION());
-    id.data(*this)->resultType = make_type<LiteralType>(Symbols::String(), enterNameUTF8(sorbet_full_version_string));
+    field = enterStaticFieldSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), Names::Constants::VERSION());
+    field.data(*this)->resultType =
+        make_type<LiteralType>(Symbols::String(), enterNameUTF8(sorbet_full_version_string));
 
     // Synthesize <Magic>.<build-hash>(*vs : T.untyped) => Hash
     method = enterMethod(*this, Symbols::MagicSingleton(), Names::buildHash())
@@ -658,8 +661,8 @@ void GlobalState::initEmpty() {
     Symbols::StubSuperClass().data(*this)->setSuperClass(Symbols::Object());
 
     // Synthesize T::Utils
-    id = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Utils());
-    id.data(*this)->setIsModule(true);
+    klass = enterClassSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Utils());
+    klass.data(*this)->setIsModule(true);
 
     int reservedCount = 0;
 
@@ -793,11 +796,13 @@ MethodRef GlobalState::lookupMethodSymbolWithHash(ClassOrModuleRef owner, NameRe
     auto res = ownerScope->members().find(lookupName);
     while (res != ownerScope->members().end()) {
         ENFORCE(res->second.exists());
-        auto resData = res->second.data(*this);
-        if ((resData->flags & Symbol::Flags::METHOD) == Symbol::Flags::METHOD &&
-            (resData->methodArgumentHash(*this) == methodHash ||
-             (resData->intrinsic != nullptr && !resData->hasSig()))) {
-            return res->second.asMethodRef();
+        auto resSym = res->second;
+        if (resSym.isMethod()) {
+            auto resMethod = resSym.asMethodRef().data(*this);
+            if (resMethod->methodArgumentHash(*this) == methodHash ||
+                (resMethod->intrinsic != nullptr && !resMethod->hasSig())) {
+                return resSym.asMethodRef();
+            }
         }
         lookupName = lookupNameUnique(UniqueNameKind::MangleRename, name, unique);
         if (!lookupName.exists()) {
@@ -810,9 +815,9 @@ MethodRef GlobalState::lookupMethodSymbolWithHash(ClassOrModuleRef owner, NameRe
 }
 
 // look up a symbol whose flags match the desired flags. This might look through mangled names to discover one whose
-// flags match. If no sych symbol exists, then it will return defaultReturnValue.
-SymbolRef GlobalState::lookupSymbolWithFlags(SymbolRef owner, NameRef name, u4 flags,
-                                             SymbolRef defaultReturnValue) const {
+// flags match. If no such symbol exists, then it will return defaultReturnValue.
+SymbolRef GlobalState::lookupSymbolWithKind(ClassOrModuleRef owner, NameRef name, SymbolRef::Kind kind,
+                                            SymbolRef defaultReturnValue, bool ignoreKind) const {
     ENFORCE(owner.exists(), "looking up symbol from non-existing owner");
     ENFORCE(name.exists(), "looking up symbol with non-existing name");
     auto ownerScope = owner.dataAllowingNone(*this);
@@ -823,7 +828,7 @@ SymbolRef GlobalState::lookupSymbolWithFlags(SymbolRef owner, NameRef name, u4 f
     auto res = ownerScope->members().find(lookupName);
     while (res != ownerScope->members().end()) {
         ENFORCE(res->second.exists());
-        if ((res->second.data(*this)->flags & flags) == flags) {
+        if (ignoreKind || res->second.kind() == kind) {
             return res->second;
         }
         lookupName = lookupNameUnique(UniqueNameKind::MangleRename, name, unique);
@@ -836,7 +841,7 @@ SymbolRef GlobalState::lookupSymbolWithFlags(SymbolRef owner, NameRef name, u4 f
     return defaultReturnValue;
 }
 
-SymbolRef GlobalState::findRenamedSymbol(SymbolRef owner, SymbolRef sym) const {
+SymbolRef GlobalState::findRenamedSymbol(ClassOrModuleRef owner, SymbolRef sym) const {
     // This method works by knowing how to replicate the logic of renaming in order to find whatever
     // the previous name was: for `x$n` where `n` is larger than 2, it'll be `x$(n-1)`, for bare `x`,
     // it'll be whatever the largest `x$n` that exists is, if any; otherwise, there will be none.
@@ -884,10 +889,9 @@ ClassOrModuleRef GlobalState::enterClassSymbol(Loc loc, ClassOrModuleRef owner, 
     SymbolData ownerScope = owner.dataAllowingNone(*this);
     histogramInc("symbol_enter_by_name", ownerScope->members().size());
 
-    auto flags = Symbol::Flags::CLASS_OR_MODULE;
     auto &store = ownerScope->members()[name];
     if (store.exists()) {
-        ENFORCE_NO_TIMER((store.data(*this)->flags & flags) == flags, "existing symbol has wrong flags");
+        ENFORCE_NO_TIMER(store.isClassOrModule(), "existing symbol is not a class or module");
         counterInc("symbols.hit");
         return store.asClassOrModuleRef();
     }
@@ -898,7 +902,7 @@ ClassOrModuleRef GlobalState::enterClassSymbol(Loc loc, ClassOrModuleRef owner, 
     classAndModules.emplace_back();
     SymbolData data = ret.data(*this);
     data->name = name;
-    data->flags = flags;
+    data->flags = Symbol::Flags::CLASS_OR_MODULE;
     data->owner = owner;
     data->addLoc(*this, loc);
     DEBUG_ONLY(categoryCounterInc("symbols", "class"));
@@ -928,13 +932,14 @@ TypeMemberRef GlobalState::enterTypeMember(Loc loc, ClassOrModuleRef owner, Name
 
     auto &store = ownerScope->members()[name];
     if (store.exists()) {
-        ENFORCE((store.data(*this)->flags & flags) == flags, "existing symbol has wrong flags");
+        ENFORCE(store.isTypeMember() && (store.asTypeMemberRef().data(*this)->flags & flags) == flags,
+                "existing symbol has wrong flags");
         counterInc("symbols.hit");
         return store.asTypeMemberRef();
     }
 
     ENFORCE(!symbolTableFrozen);
-    auto result = SymbolRef(this, SymbolRef::Kind::TypeMember, typeMembers.size());
+    auto result = TypeMemberRef(*this, typeMembers.size());
     store = result; // DO NOT MOVE this assignment down. emplace_back on typeMembers invalidates `store`
     typeMembers.emplace_back();
 
@@ -950,7 +955,7 @@ TypeMemberRef GlobalState::enterTypeMember(Loc loc, ClassOrModuleRef owner, Name
     if (!absl::c_linear_search(members, result)) {
         members.emplace_back(result);
     }
-    return result.asTypeMemberRef();
+    return result;
 }
 
 TypeArgumentRef GlobalState::enterTypeArgument(Loc loc, MethodRef owner, NameRef name, Variance variance) {
@@ -970,18 +975,19 @@ TypeArgumentRef GlobalState::enterTypeArgument(Loc loc, MethodRef owner, NameRef
 
     flags = flags | Symbol::Flags::TYPE_ARGUMENT;
 
-    SymbolData ownerScope = core::SymbolRef(*this, core::SymbolRef::Kind::Method, owner.id()).dataAllowingNone(*this);
+    auto ownerScope = owner.dataAllowingNone(*this);
     histogramInc("symbol_enter_by_name", ownerScope->members().size());
 
     auto &store = ownerScope->members()[name];
     if (store.exists()) {
-        ENFORCE((store.data(*this)->flags & flags) == flags, "existing symbol has wrong flags");
+        ENFORCE(store.isTypeArgument() && (store.asTypeArgumentRef().data(*this)->flags & flags) == flags,
+                "existing symbol has wrong flags");
         counterInc("symbols.hit");
         return store.asTypeArgumentRef();
     }
 
     ENFORCE(!symbolTableFrozen);
-    auto result = SymbolRef(this, SymbolRef::Kind::TypeArgument, typeArguments.size());
+    auto result = TypeArgumentRef(*this, typeArguments.size());
     store = result; // DO NOT MOVE this assignment down. emplace_back on typeArguments invalidates `store`
     typeArguments.emplace_back();
 
@@ -993,19 +999,17 @@ TypeArgumentRef GlobalState::enterTypeArgument(Loc loc, MethodRef owner, NameRef
     DEBUG_ONLY(categoryCounterInc("symbols", "type_argument"));
     wasModified_ = true;
 
-    core::SymbolRef(owner).dataAllowingNone(*this)->typeArguments().emplace_back(result);
-    return result.asTypeArgumentRef();
+    owner.dataAllowingNone(*this)->typeArguments().emplace_back(result);
+    return result;
 }
 
 MethodRef GlobalState::enterMethodSymbol(Loc loc, ClassOrModuleRef owner, NameRef name) {
-    auto flags = Symbol::Flags::METHOD;
-
     SymbolData ownerScope = owner.dataAllowingNone(*this);
     histogramInc("symbol_enter_by_name", ownerScope->members().size());
 
     auto &store = ownerScope->members()[name];
     if (store.exists()) {
-        ENFORCE((store.data(*this)->flags & flags) == flags, "existing symbol has wrong flags");
+        ENFORCE(store.isMethod(), "existing symbol is not a method");
         counterInc("symbols.hit");
         return store.asMethodRef();
     }
@@ -1016,9 +1020,9 @@ MethodRef GlobalState::enterMethodSymbol(Loc loc, ClassOrModuleRef owner, NameRe
     store = result; // DO NOT MOVE this assignment down. emplace_back on methods invalidates `store`
     methods.emplace_back();
 
-    SymbolData data = SymbolRef(result).dataAllowingNone(*this);
+    SymbolData data = result.dataAllowingNone(*this);
     data->name = name;
-    data->flags = flags;
+    data->flags = Symbol::Flags::METHOD;
     data->owner = owner;
     data->addLoc(*this, loc);
     DEBUG_ONLY(categoryCounterInc("symbols", "method"));
@@ -1062,33 +1066,32 @@ MethodRef GlobalState::enterNewMethodOverload(Loc sigLoc, MethodRef original, co
 FieldRef GlobalState::enterFieldSymbol(Loc loc, ClassOrModuleRef owner, NameRef name) {
     ENFORCE(name.exists());
 
-    auto flags = Symbol::Flags::FIELD;
     SymbolData ownerScope = owner.dataAllowingNone(*this);
     histogramInc("symbol_enter_by_name", ownerScope->members().size());
 
     auto &store = ownerScope->members()[name];
     if (store.exists()) {
-        ENFORCE((store.data(*this)->flags & flags) == flags, "existing symbol has wrong flags");
+        ENFORCE(store.isField(*this), "existing symbol is not a field");
         counterInc("symbols.hit");
         return store.asFieldRef();
     }
 
     ENFORCE(!symbolTableFrozen);
 
-    auto result = SymbolRef(this, SymbolRef::Kind::FieldOrStaticField, fields.size());
+    auto result = FieldRef(*this, fields.size());
     store = result; // DO NOT MOVE this assignment down. emplace_back on fields invalidates `store`
     fields.emplace_back();
 
     SymbolData data = result.dataAllowingNone(*this);
     data->name = name;
-    data->flags = flags;
+    data->flags = Symbol::Flags::FIELD;
     data->owner = owner;
     data->addLoc(*this, loc);
 
     DEBUG_ONLY(categoryCounterInc("symbols", "field"));
     wasModified_ = true;
 
-    return result.asFieldRef();
+    return result;
 }
 
 FieldRef GlobalState::enterStaticFieldSymbol(Loc loc, ClassOrModuleRef owner, NameRef name) {
@@ -1097,30 +1100,30 @@ FieldRef GlobalState::enterStaticFieldSymbol(Loc loc, ClassOrModuleRef owner, Na
     SymbolData ownerScope = owner.dataAllowingNone(*this);
     histogramInc("symbol_enter_by_name", ownerScope->members().size());
 
-    auto flags = Symbol::Flags::STATIC_FIELD;
     auto &store = ownerScope->members()[name];
     if (store.exists()) {
-        ENFORCE((store.data(*this)->flags & flags) == flags, "existing symbol has wrong flags");
+        ENFORCE(store.isStaticField(*this), "existing symbol is not a static field");
         counterInc("symbols.hit");
         return store.asFieldRef();
     }
 
     ENFORCE(!symbolTableFrozen);
 
-    auto ret = SymbolRef(this, SymbolRef::Kind::FieldOrStaticField, fields.size());
+    auto ret = FieldRef(*this, fields.size());
     store = ret; // DO NOT MOVE this assignment down. emplace_back on fields invalidates `store`
     fields.emplace_back();
 
     SymbolData data = ret.dataAllowingNone(*this);
     data->name = name;
-    data->flags = flags;
+    data->flags = Symbol::Flags::STATIC_FIELD;
+    ;
     data->owner = owner;
     data->addLoc(*this, loc);
 
     DEBUG_ONLY(categoryCounterInc("symbols", "static_field"));
     wasModified_ = true;
 
-    return ret.asFieldRef();
+    return ret;
 }
 
 ArgInfo &GlobalState::enterMethodArgumentSymbol(Loc loc, MethodRef owner, NameRef name) {
@@ -1507,14 +1510,13 @@ FileRef GlobalState::reserveFileRef(string path) {
 }
 
 void GlobalState::mangleRenameSymbol(SymbolRef what, NameRef origName) {
-    auto whatData = what.data(*this);
-    auto owner = whatData->owner;
+    auto owner = what.owner(*this).asClassOrModuleRef();
     auto ownerData = owner.data(*this);
     auto &ownerMembers = ownerData->members();
     auto fnd = ownerMembers.find(origName);
     ENFORCE(fnd != ownerMembers.end());
     ENFORCE(fnd->second == what);
-    ENFORCE(whatData->name == origName);
+    ENFORCE(what.name(*this) == origName);
     u4 collisionCount = 1;
     NameRef name;
     do {
@@ -1522,12 +1524,28 @@ void GlobalState::mangleRenameSymbol(SymbolRef what, NameRef origName) {
     } while (ownerData->findMember(*this, name).exists());
     ownerMembers.erase(fnd);
     ownerMembers[name] = what;
-    whatData->name = name;
-    if (whatData->isClassOrModule()) {
-        auto singleton = whatData->lookupSingletonClass(*this);
-        if (singleton.exists()) {
-            mangleRenameSymbol(singleton, singleton.data(*this)->name);
+    switch (what.kind()) {
+        case SymbolRef::Kind::ClassOrModule: {
+            auto whatKlass = what.asClassOrModuleRef().data(*this);
+            whatKlass->name = name;
+            auto singleton = whatKlass->lookupSingletonClass(*this);
+            if (singleton.exists()) {
+                mangleRenameSymbol(singleton, singleton.data(*this)->name);
+            }
+            break;
         }
+        case SymbolRef::Kind::Method:
+            what.asMethodRef().data(*this)->name = name;
+            break;
+        case SymbolRef::Kind::FieldOrStaticField:
+            what.asFieldRef().data(*this)->name = name;
+            break;
+        case SymbolRef::Kind::TypeArgument:
+            what.asTypeArgumentRef().data(*this)->name = name;
+            break;
+        case SymbolRef::Kind::TypeMember:
+            what.asTypeMemberRef().data(*this)->name = name;
+            break;
     }
 }
 

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -103,28 +103,31 @@ public:
     FieldRef enterStaticFieldSymbol(Loc loc, ClassOrModuleRef owner, NameRef name);
     ArgInfo &enterMethodArgumentSymbol(Loc loc, MethodRef owner, NameRef name);
 
-    SymbolRef lookupSymbol(SymbolRef owner, NameRef name) const {
-        return lookupSymbolWithFlags(owner, name, 0, Symbols::noSymbol());
+    SymbolRef lookupSymbol(ClassOrModuleRef owner, NameRef name) const {
+        return lookupSymbolWithKind(owner, name, SymbolRef::Kind::ClassOrModule, Symbols::noSymbol(),
+                                    /* ignoreKind */ true);
     }
     TypeMemberRef lookupTypeMemberSymbol(ClassOrModuleRef owner, NameRef name) const {
-        return lookupSymbolWithFlags(owner, name, Symbol::Flags::TYPE_MEMBER, Symbols::noTypeMember())
+        return lookupSymbolWithKind(owner, name, SymbolRef::Kind::TypeMember, Symbols::noTypeMember())
             .asTypeMemberRef();
     }
     ClassOrModuleRef lookupClassSymbol(ClassOrModuleRef owner, NameRef name) const {
-        return lookupSymbolWithFlags(owner, name, Symbol::Flags::CLASS_OR_MODULE, Symbols::noClassOrModule())
+        return lookupSymbolWithKind(owner, name, SymbolRef::Kind::ClassOrModule, Symbols::noClassOrModule())
             .asClassOrModuleRef();
     }
     MethodRef lookupMethodSymbol(ClassOrModuleRef owner, NameRef name) const {
-        return lookupSymbolWithFlags(owner, name, Symbol::Flags::METHOD, Symbols::noMethod()).asMethodRef();
+        return lookupSymbolWithKind(owner, name, SymbolRef::Kind::Method, Symbols::noMethod()).asMethodRef();
     }
     MethodRef lookupMethodSymbolWithHash(ClassOrModuleRef owner, NameRef name, const std::vector<u4> &methodHash) const;
     FieldRef lookupStaticFieldSymbol(ClassOrModuleRef owner, NameRef name) const {
-        return lookupSymbolWithFlags(owner, name, Symbol::Flags::STATIC_FIELD, Symbols::noField()).asFieldRef();
+        // N.B.: Fields and static fields have entirely different types of names, so this should be unambiguous.
+        return lookupSymbolWithKind(owner, name, SymbolRef::Kind::FieldOrStaticField, Symbols::noField()).asFieldRef();
     }
     FieldRef lookupFieldSymbol(ClassOrModuleRef owner, NameRef name) const {
-        return lookupSymbolWithFlags(owner, name, Symbol::Flags::FIELD, Symbols::noField()).asFieldRef();
+        // N.B.: Fields and static fields have entirely different types of names, so this should be unambiguous.
+        return lookupSymbolWithKind(owner, name, SymbolRef::Kind::FieldOrStaticField, Symbols::noField()).asFieldRef();
     }
-    SymbolRef findRenamedSymbol(SymbolRef owner, SymbolRef name) const;
+    SymbolRef findRenamedSymbol(ClassOrModuleRef owner, SymbolRef name) const;
 
     MethodRef staticInitForFile(Loc loc);
     MethodRef staticInitForClass(ClassOrModuleRef klass, Loc loc);
@@ -320,7 +323,8 @@ private:
 
     ClassOrModuleRef synthesizeClass(NameRef nameID, u4 superclass = Symbols::todo().id(), bool isModule = false);
 
-    SymbolRef lookupSymbolWithFlags(SymbolRef owner, NameRef name, u4 flags, SymbolRef defaultReturnValue) const;
+    SymbolRef lookupSymbolWithKind(ClassOrModuleRef owner, NameRef name, SymbolRef::Kind kind,
+                                   SymbolRef defaultReturnValue, bool ignoreKind = false) const;
 
     std::string toStringWithOptions(bool showFull, bool showRaw) const;
 };

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -128,6 +128,7 @@ public:
 
     SymbolData data(GlobalState &gs) const;
     ConstSymbolData data(const GlobalState &gs) const;
+    SymbolData dataAllowingNone(GlobalState &gs) const;
 
     ClassOrModuleRef enclosingClass(const GlobalState &gs) const;
     std::string_view showKind(const GlobalState &gs) const;
@@ -171,6 +172,7 @@ public:
     SymbolData data(GlobalState &gs) const;
     ConstSymbolData data(const GlobalState &gs) const;
     ConstSymbolData dataAllowingNone(const GlobalState &gs) const;
+    SymbolData dataAllowingNone(GlobalState &gs) const;
     std::string_view showKind(const GlobalState &gs) const;
     std::string showFullName(const GlobalState &gs) const;
     std::string toStringFullName(const GlobalState &gs) const;
@@ -211,6 +213,7 @@ public:
 
     SymbolData data(GlobalState &gs) const;
     ConstSymbolData data(const GlobalState &gs) const;
+    SymbolData dataAllowingNone(GlobalState &gs) const;
     std::string_view showKind(const GlobalState &gs) const;
     std::string showFullName(const GlobalState &gs) const;
     std::string toStringFullName(const GlobalState &gs) const;
@@ -251,6 +254,7 @@ public:
 
     SymbolData data(GlobalState &gs) const;
     ConstSymbolData data(const GlobalState &gs) const;
+    SymbolData dataAllowingNone(GlobalState &gs) const;
     std::string_view showKind(const GlobalState &gs) const;
     std::string showFullName(const GlobalState &gs) const;
     std::string toStringFullName(const GlobalState &gs) const;
@@ -406,15 +410,6 @@ public:
         ENFORCE_NO_TIMER(kind() == Kind::TypeArgument);
         return TypeArgumentRef::fromRaw(unsafeTableIndex());
     }
-
-private:
-    // TODO(jvilk): Remove these methods so we can have separate classes per symbol type (e.g., Symbol ->
-    // {ClassOrModule, Method, ...}). These are currently used in methods on SymbolRef and friend classes -- but not for
-    // long.
-    SymbolData data(GlobalState &gs) const;
-    ConstSymbolData data(const GlobalState &gs) const;
-    SymbolData dataAllowingNone(GlobalState &gs) const;
-    ConstSymbolData dataAllowingNone(const GlobalState &gs) const;
 
 public:
     bool operator==(const SymbolRef &rhs) const;

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -580,6 +580,7 @@ SymbolRef Symbol::findConcreteMethodTransitive(const GlobalState &gs, NameRef na
 }
 
 namespace {
+// TODO(jvilk): Remove this when we remove flag filter in `findMemberTransitiveInternal`.
 u4 getFlags(const GlobalState &gs, SymbolRef symbol) {
     switch (symbol.kind()) {
         case SymbolRef::Kind::Method:
@@ -596,6 +597,7 @@ u4 getFlags(const GlobalState &gs, SymbolRef symbol) {
 }
 } // namespace
 
+// TODO(jvilk): Remove flag filter -- it's only used for `findConcreteMethodTransitive`.
 SymbolRef Symbol::findMemberTransitiveInternal(const GlobalState &gs, NameRef name, u4 mask, u4 flags,
                                                int maxDepth) const {
     ENFORCE(this->isClassOrModule());

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -225,56 +225,6 @@ bool SymbolRef::isStaticField(const GlobalState &gs) const {
     return isFieldOrStaticField() && asFieldRef().dataAllowingNone(gs)->isStaticField();
 }
 
-SymbolData SymbolRef::data(GlobalState &gs) const {
-    ENFORCE_NO_TIMER(this->exists());
-    return dataAllowingNone(gs);
-}
-
-SymbolData SymbolRef::dataAllowingNone(GlobalState &gs) const {
-    switch (kind()) {
-        case SymbolRef::Kind::ClassOrModule:
-            ENFORCE_NO_TIMER(classOrModuleIndex() < gs.classAndModules.size());
-            return SymbolData(gs.classAndModules[classOrModuleIndex()], gs);
-        case SymbolRef::Kind::Method:
-            ENFORCE_NO_TIMER(methodIndex() < gs.methods.size());
-            return SymbolData(gs.methods[methodIndex()], gs);
-        case SymbolRef::Kind::FieldOrStaticField:
-            ENFORCE_NO_TIMER(fieldIndex() < gs.fields.size());
-            return SymbolData(gs.fields[fieldIndex()], gs);
-        case SymbolRef::Kind::TypeArgument:
-            ENFORCE_NO_TIMER(typeArgumentIndex() < gs.typeArguments.size());
-            return SymbolData(gs.typeArguments[typeArgumentIndex()], gs);
-        case SymbolRef::Kind::TypeMember:
-            ENFORCE_NO_TIMER(typeMemberIndex() < gs.typeMembers.size());
-            return SymbolData(gs.typeMembers[typeMemberIndex()], gs);
-    }
-}
-
-ConstSymbolData SymbolRef::data(const GlobalState &gs) const {
-    ENFORCE_NO_TIMER(this->exists());
-    return dataAllowingNone(gs);
-}
-
-ConstSymbolData SymbolRef::dataAllowingNone(const GlobalState &gs) const {
-    switch (kind()) {
-        case SymbolRef::Kind::ClassOrModule:
-            ENFORCE_NO_TIMER(classOrModuleIndex() < gs.classAndModules.size());
-            return ConstSymbolData(gs.classAndModules[classOrModuleIndex()], gs);
-        case SymbolRef::Kind::Method:
-            ENFORCE_NO_TIMER(methodIndex() < gs.methods.size());
-            return ConstSymbolData(gs.methods[methodIndex()], gs);
-        case SymbolRef::Kind::FieldOrStaticField:
-            ENFORCE_NO_TIMER(fieldIndex() < gs.fields.size());
-            return ConstSymbolData(gs.fields[fieldIndex()], gs);
-        case SymbolRef::Kind::TypeArgument:
-            ENFORCE_NO_TIMER(typeArgumentIndex() < gs.typeArguments.size());
-            return ConstSymbolData(gs.typeArguments[typeArgumentIndex()], gs);
-        case SymbolRef::Kind::TypeMember:
-            ENFORCE_NO_TIMER(typeMemberIndex() < gs.typeMembers.size());
-            return ConstSymbolData(gs.typeMembers[typeMemberIndex()], gs);
-    }
-}
-
 SymbolData ClassOrModuleRef::dataAllowingNone(GlobalState &gs) const {
     ENFORCE_NO_TIMER(_id < gs.classAndModulesUsed());
     return SymbolData(gs.classAndModules[_id], gs);
@@ -307,6 +257,11 @@ ConstSymbolData MethodRef::data(const GlobalState &gs) const {
     return ConstSymbolData(gs.methods[_id], gs);
 }
 
+SymbolData MethodRef::dataAllowingNone(GlobalState &gs) const {
+    ENFORCE_NO_TIMER(_id < gs.methodsUsed());
+    return SymbolData(gs.methods[_id], gs);
+}
+
 SymbolData FieldRef::data(GlobalState &gs) const {
     ENFORCE_NO_TIMER(this->exists());
     ENFORCE_NO_TIMER(_id < gs.fieldsUsed());
@@ -323,6 +278,11 @@ ConstSymbolData FieldRef::data(const GlobalState &gs) const {
     return dataAllowingNone(gs);
 }
 
+SymbolData FieldRef::dataAllowingNone(GlobalState &gs) const {
+    ENFORCE_NO_TIMER(_id < gs.fieldsUsed());
+    return SymbolData(gs.fields[_id], gs);
+}
+
 SymbolData TypeMemberRef::data(GlobalState &gs) const {
     ENFORCE_NO_TIMER(this->exists());
     ENFORCE_NO_TIMER(_id < gs.typeMembersUsed());
@@ -335,6 +295,11 @@ ConstSymbolData TypeMemberRef::data(const GlobalState &gs) const {
     return ConstSymbolData(gs.typeMembers[_id], gs);
 }
 
+SymbolData TypeMemberRef::dataAllowingNone(GlobalState &gs) const {
+    ENFORCE_NO_TIMER(_id < gs.typeMembersUsed());
+    return SymbolData(gs.typeMembers[_id], gs);
+}
+
 SymbolData TypeArgumentRef::data(GlobalState &gs) const {
     ENFORCE_NO_TIMER(this->exists());
     ENFORCE_NO_TIMER(_id < gs.typeArgumentsUsed());
@@ -345,6 +310,11 @@ ConstSymbolData TypeArgumentRef::data(const GlobalState &gs) const {
     ENFORCE_NO_TIMER(this->exists());
     ENFORCE_NO_TIMER(_id < gs.typeArgumentsUsed());
     return ConstSymbolData(gs.typeArguments[_id], gs);
+}
+
+SymbolData TypeArgumentRef::dataAllowingNone(GlobalState &gs) const {
+    ENFORCE_NO_TIMER(_id < gs.typeArgumentsUsed());
+    return SymbolData(gs.typeArguments[_id], gs);
 }
 
 bool SymbolRef::isSynthetic() const {
@@ -457,7 +427,8 @@ string ClassOrModuleRef::show(const GlobalState &gs) const {
 string MethodRef::show(const GlobalState &gs) const {
     auto sym = data(gs);
     if (sym->owner.isClassOrModule() && sym->owner.isSingletonClass(gs)) {
-        return absl::StrCat(sym->owner.data(gs)->attachedClass(gs).show(gs), ".", sym->name.show(gs));
+        return absl::StrCat(sym->owner.asClassOrModuleRef().data(gs)->attachedClass(gs).show(gs), ".",
+                            sym->name.show(gs));
     }
     return showInternal(gs, sym->owner, sym->name, HASH_SEPARATOR);
 }
@@ -608,6 +579,23 @@ SymbolRef Symbol::findConcreteMethodTransitive(const GlobalState &gs, NameRef na
     return findMemberTransitiveInternal(gs, name, Flags::METHOD | Flags::METHOD_ABSTRACT, Flags::METHOD, 100);
 }
 
+namespace {
+u4 getFlags(const GlobalState &gs, SymbolRef symbol) {
+    switch (symbol.kind()) {
+        case SymbolRef::Kind::Method:
+            return symbol.asMethodRef().data(gs)->flags;
+        case SymbolRef::Kind::ClassOrModule:
+            return symbol.asClassOrModuleRef().data(gs)->flags;
+        case SymbolRef::Kind::FieldOrStaticField:
+            return symbol.asFieldRef().data(gs)->flags;
+        case SymbolRef::Kind::TypeArgument:
+            return symbol.asTypeArgumentRef().data(gs)->flags;
+        case SymbolRef::Kind::TypeMember:
+            return symbol.asTypeMemberRef().data(gs)->flags;
+    }
+}
+} // namespace
+
 SymbolRef Symbol::findMemberTransitiveInternal(const GlobalState &gs, NameRef name, u4 mask, u4 flags,
                                                int maxDepth) const {
     ENFORCE(this->isClassOrModule());
@@ -636,22 +624,20 @@ SymbolRef Symbol::findMemberTransitiveInternal(const GlobalState &gs, NameRef na
 
     SymbolRef result = findMember(gs, name);
     if (result.exists()) {
-        if (mask == 0 || (result.data(gs)->flags & mask) == flags) {
+        if (mask == 0 || (getFlags(gs, result) & mask) == flags) {
             return result;
         }
     }
     if (isClassOrModuleLinearizationComputed()) {
         for (auto it = this->mixins().begin(); it != this->mixins().end(); ++it) {
             ENFORCE(it->exists());
-            if (isClassOrModuleLinearizationComputed()) {
-                result = it->data(gs)->findMember(gs, name);
-                if (result.exists()) {
-                    if (mask == 0 || (result.data(gs)->flags & mask) == flags) {
-                        return result;
-                    }
+            result = it->data(gs)->findMember(gs, name);
+            if (result.exists()) {
+                if (mask == 0 || (getFlags(gs, result) & mask) == flags) {
+                    return result;
                 }
-                result = core::Symbols::noSymbol();
             }
+            result = core::Symbols::noSymbol();
         }
     } else {
         for (auto it = this->mixins().rbegin(); it != this->mixins().rend(); ++it) {
@@ -807,7 +793,7 @@ vector<Symbol::FuzzySearchResult> Symbol::findMemberFuzzyMatchConstant(const Glo
                 if (member.second.exists() && member.first.exists() && member.first.kind() == NameKind::CONSTANT &&
                     (member.first.dataCnst(gs)->original.kind() == NameKind::UTF8 || member.first.isPackagerName(gs))) {
                     if (member.second.isClassOrModule() &&
-                        member.second.data(gs)->derivesFrom(gs, core::Symbols::StubModule())) {
+                        member.second.asClassOrModuleRef().data(gs)->derivesFrom(gs, core::Symbols::StubModule())) {
                         continue;
                     }
                     // Mangled packager names are not matched, but we do descend into them to search
@@ -1058,7 +1044,7 @@ bool Symbol::isPrintable(const GlobalState &gs) const {
             continue;
         }
 
-        if (childPair.second.data(gs)->isPrintable(gs)) {
+        if (childPair.second.isPrintable(gs)) {
             return true;
         }
     }
@@ -1126,8 +1112,8 @@ string ClassOrModuleRef::toStringWithOptions(const GlobalState &gs, int tabs, bo
     fmt::format_to(std::back_inserter(buf), "{} {}", showKind(gs), showRaw ? toStringFullName(gs) : showFullName(gs));
 
     auto typeMembers = sym->typeMembers();
-    auto it =
-        remove_if(typeMembers.begin(), typeMembers.end(), [&gs](auto &sym) -> bool { return sym.data(gs)->isFixed(); });
+    auto it = remove_if(typeMembers.begin(), typeMembers.end(),
+                        [&gs](auto &sym) -> bool { return sym.asTypeMemberRef().data(gs)->isFixed(); });
     typeMembers.erase(it, typeMembers.end());
     if (!typeMembers.empty()) {
         fmt::format_to(std::back_inserter(buf), "[{}]", fmt::map_join(typeMembers, ", ", [&](auto symb) {
@@ -1169,7 +1155,7 @@ string ClassOrModuleRef::toStringWithOptions(const GlobalState &gs, int tabs, bo
             continue;
         }
 
-        if (!showFull && !pair.second.data(gs)->isPrintable(gs)) {
+        if (!showFull && !pair.second.isPrintable(gs)) {
             continue;
         }
 
@@ -1248,7 +1234,7 @@ string MethodRef::toStringWithOptions(const GlobalState &gs, int tabs, bool show
         ENFORCE_NO_TIMER(pair.first != Names::singleton() && pair.first != Names::attached() &&
                          pair.first != Names::mixedInClassMethods());
 
-        if (!showFull && !pair.second.data(gs)->isPrintable(gs)) {
+        if (!showFull && !pair.second.isPrintable(gs)) {
             continue;
         }
 
@@ -1605,7 +1591,7 @@ ClassOrModuleRef Symbol::singletonClass(GlobalState &gs) {
     if (singleton.exists()) {
         return singleton;
     }
-    SymbolRef selfRef = this->ref(gs);
+    ClassOrModuleRef selfRef = this->ref(gs).asClassOrModuleRef();
 
     // avoid using `this` after the call to gs.enterTypeMember
     auto selfLoc = this->loc();
@@ -1672,7 +1658,7 @@ void Symbol::recordSealedSubclass(MutableContext ctx, ClassOrModuleRef subclass)
     ENFORCE(subclass.exists(), "Can't record sealed subclass for {} when subclass doesn't exist", ref(ctx).show(ctx));
 
     // Avoid using a clobbered `this` pointer, as `singletonClass` can cause the symbol table to move.
-    auto selfRef = this->ref(ctx);
+    ClassOrModuleRef selfRef = this->ref(ctx).asClassOrModuleRef();
 
     // We record sealed subclasses on a magical method called core::Names::sealedSubclasses(). This is so we don't
     // bloat the `sizeof class Symbol` with an extra field that most class sybmols will never use.
@@ -1829,7 +1815,7 @@ vector<Symbol::RequiredAncestor> Symbol::readRequiredAncestorsInternal(const Glo
 
     vector<RequiredAncestor> res;
 
-    auto ancestors = this->findMember(gs, prop);
+    auto ancestors = this->findMethod(gs, prop);
     if (!ancestors.exists()) {
         // No ancestor was recorded for this class or module
         return res;
@@ -1914,20 +1900,34 @@ void Symbol::computeRequiredAncestorLinearization(GlobalState &gs) {
     requiredAncestorsTransitiveInternal(gs, seen);
 }
 
-SymbolRef Symbol::dealiasWithDefault(const GlobalState &gs, int depthLimit, SymbolRef def) const {
+namespace {
+SymbolRef dealiasWithDefault(const GlobalState &gs, core::SymbolRef symbol, int depthLimit, SymbolRef def) {
+    const auto &resultType = symbol.resultType(gs);
     if (isa_type<AliasType>(resultType)) {
         auto alias = cast_type_nonnull<AliasType>(resultType);
         if (depthLimit == 0) {
-            if (auto e = gs.beginError(loc(), errors::Internal::CyclicReferenceError)) {
+            if (auto e = gs.beginError(symbol.loc(gs), errors::Internal::CyclicReferenceError)) {
                 e.setHeader("Too many alias expansions for symbol {}, the alias is either too long or infinite. Next "
                             "expansion would have been to {}",
-                            ref(gs).showFullName(gs), alias.symbol.showFullName(gs));
+                            symbol.showFullName(gs), alias.symbol.showFullName(gs));
             }
             return def;
         }
-        return alias.symbol.data(gs)->dealiasWithDefault(gs, depthLimit - 1, def);
+        return dealiasWithDefault(gs, alias.symbol, depthLimit - 1, def);
     }
-    return this->ref(gs);
+    return symbol;
+}
+} // namespace
+
+// if dealiasing fails here, then we return Untyped instead
+SymbolRef Symbol::dealias(const GlobalState &gs, int depthLimit) const {
+    return dealiasWithDefault(gs, this->ref(gs), depthLimit, Symbols::untyped());
+}
+// if dealiasing fails here, then we return a bad alias method stub instead
+MethodRef Symbol::dealiasMethod(const GlobalState &gs, int depthLimit) const {
+    ENFORCE_NO_TIMER(isMethod());
+    return dealiasWithDefault(gs, this->ref(gs), depthLimit, core::Symbols::Sorbet_Private_Static_badAliasMethodStub())
+        .asMethodRef();
 }
 
 bool ArgInfo::isSyntheticBlockArgument() const {
@@ -2101,9 +2101,19 @@ u4 Symbol::hash(const GlobalState &gs) const {
         vector<core::SymbolRef> membersToHash;
         membersToHash.reserve(this->members().size());
         for (auto e : this->members()) {
-            if (e.second.exists() && !e.second.data(gs)->ignoreInHashing(gs)) {
-                membersToHash.emplace_back(e.second);
+            if (!e.second.exists()) {
+                continue;
             }
+
+            if (e.second.isMethod() && e.second.asMethodRef().data(gs)->ignoreInHashing(gs)) {
+                continue;
+            }
+
+            if (e.second.isClassOrModule() && e.second.asClassOrModuleRef().data(gs)->ignoreInHashing(gs)) {
+                continue;
+            }
+
+            membersToHash.emplace_back(e.second);
         }
         fast_sort(membersToHash, [](const auto &a, const auto &b) -> bool { return a.rawId() < b.rawId(); });
         for (auto member : membersToHash) {
@@ -2125,7 +2135,7 @@ u4 Symbol::hash(const GlobalState &gs) const {
         result = mix(result, _hash(arg.name.shortName(gs)));
     }
     for (const auto &e : typeParams) {
-        if (e.exists() && !e.data(gs)->ignoreInHashing(gs)) {
+        if (e.exists()) {
             result = mix(result, _hash(e.name(gs).shortName(gs)));
         }
     }
@@ -2242,8 +2252,8 @@ vector<std::pair<NameRef, SymbolRef>> Symbol::membersStableOrderSlow(const Globa
             return compareRaw < 0;
         }
         int i = -1;
-        const auto &rhsLocs = rhs.second.data(gs)->locs();
-        for (const auto lhsLoc : lhs.second.data(gs)->locs()) {
+        const auto &rhsLocs = rhs.second.locs(gs);
+        for (const auto lhsLoc : lhs.second.locs(gs)) {
             i++;
             if (i > rhsLocs.size()) {
                 // more locs in lhs, so `lhs < rhs` is `false`

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -601,17 +601,10 @@ public:
     std::vector<RequiredAncestor> requiredAncestorsTransitive(const GlobalState &gs) const;
 
     // if dealiasing fails here, then we return Untyped instead
-    SymbolRef dealias(const GlobalState &gs, int depthLimit = 42) const {
-        return dealiasWithDefault(gs, depthLimit, Symbols::untyped());
-    }
-    // if dealiasing fails here, then we return a bad alias method stub instead
-    MethodRef dealiasMethod(const GlobalState &gs, int depthLimit = 42) const {
-        ENFORCE_NO_TIMER(isMethod());
-        return dealiasWithDefault(gs, depthLimit, core::Symbols::Sorbet_Private_Static_badAliasMethodStub())
-            .asMethodRef();
-    }
+    SymbolRef dealias(const GlobalState &gs, int depthLimit = 42) const;
 
-    SymbolRef dealiasWithDefault(const GlobalState &gs, int depthLimit, SymbolRef def) const;
+    // if dealiasing fails here, then we return a bad alias method stub instead
+    MethodRef dealiasMethod(const GlobalState &gs, int depthLimit = 42) const;
 
     bool ignoreInHashing(const GlobalState &gs) const;
 

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -779,7 +779,8 @@ class SymbolDefiner {
         // Common case: Everything is fine, user is trying to define a symbol on a class or module.
         if (scope.isClassOrModule()) {
             // Check if original symbol was mangled away. If so, complain.
-            auto renamedSymbol = ctx.state.findRenamedSymbol(scope.owner(ctx), scope);
+            auto renamedSymbol =
+                ctx.state.findRenamedSymbol(scope.asClassOrModuleRef().data(ctx)->owner.asClassOrModuleRef(), scope);
             if (renamedSymbol.exists()) {
                 if (auto e = ctx.state.beginError(core::Loc(ctx.file, loc), core::errors::Namer::InvalidClassOwner)) {
                     auto constLitName = name.show(ctx);
@@ -1155,7 +1156,7 @@ class SymbolDefiner {
             }
         } else {
             klassSymbol.data(ctx)->setIsModule(isModule);
-            auto renamed = ctx.state.findRenamedSymbol(symbol.owner(ctx), symbol);
+            auto renamed = ctx.state.findRenamedSymbol(klassSymbol.data(ctx)->owner.asClassOrModuleRef(), symbol);
             if (renamed.exists()) {
                 emitRedefinedConstantError(ctx, core::Loc(ctx.file, klass.loc), symbol, renamed);
             }


### PR DESCRIPTION
Remove SymbolRef::data* methods.

Once this PR lands, we can define separate Symbol classes per symbol type!

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

See #4900 for motivation and more details.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
