### PR TITLE
Optimize the final method fast path

### DIFF
--- a/compiler/IREmitter/IREmitterHelpers.cc
+++ b/compiler/IREmitter/IREmitterHelpers.cc
@@ -291,6 +291,22 @@ void IREmitterHelpers::emitTypeTestForRestArg(CompilerState &cs, llvm::IRBuilder
     builder.SetInsertPoint(continuationBlock);
 }
 
+bool IREmitterHelpers::isAliasToSingleton(const core::GlobalState &gs, const IREmitterContext &irctx, cfg::LocalRef var,
+                                          core::ClassOrModuleRef klass) {
+    auto aliasit = irctx.aliases.find(var);
+    if (aliasit == irctx.aliases.end()) {
+        return false;
+    }
+
+    if (aliasit->second.kind != Alias::AliasKind::Constant) {
+        return false;
+    }
+
+    ENFORCE(klass.data(gs)->isSingletonClass(gs));
+    auto attachedClass = klass.data(gs)->attachedClass(gs);
+    return aliasit->second.constantSym == attachedClass;
+}
+
 llvm::Value *IREmitterHelpers::emitLiteralish(CompilerState &cs, llvm::IRBuilderBase &builder,
                                               const core::TypePtr &lit) {
     if (lit.derivesFrom(cs, core::Symbols::FalseClass())) {

--- a/compiler/IREmitter/IREmitterHelpers.h
+++ b/compiler/IREmitter/IREmitterHelpers.h
@@ -182,6 +182,9 @@ public:
                                                       const std::vector<KnownFunction> &expectedRubyCFuncs,
                                                       const std::string &methodNameForDebug);
 
+    static bool isAliasToSingleton(const core::GlobalState &gs, const IREmitterContext &irctx, cfg::LocalRef var,
+                                   core::ClassOrModuleRef klass);
+
     // Given a method call context representing a send, determine whether a variable
     // representing a block can be fetched out of the Ruby VM state.
     static bool canPassThroughBlockViaRubyVM(MethodCallContext &mcctx, cfg::LocalRef var);

--- a/compiler/IREmitter/Payload.cc
+++ b/compiler/IREmitter/Payload.cc
@@ -453,6 +453,12 @@ void Payload::assumeType(CompilerState &cs, llvm::IRBuilderBase &builder, llvm::
     return;
 }
 
+void Payload::assumeType(CompilerState &cs, llvm::IRBuilderBase &builder, llvm::Value *val, const core::TypePtr &type) {
+    auto *cond = Payload::typeTest(cs, builder, val, type);
+    builder.CreateIntrinsic(llvm::Intrinsic::IndependentIntrinsics::assume, {}, {cond});
+    return;
+}
+
 llvm::Value *Payload::boolToRuby(CompilerState &cs, llvm::IRBuilderBase &builder, llvm::Value *u1) {
     return builder.CreateCall(cs.getFunction("sorbet_boolToRuby"), {u1}, "rubyBool");
 }

--- a/compiler/IREmitter/Payload.h
+++ b/compiler/IREmitter/Payload.h
@@ -64,6 +64,9 @@ public:
 
     static void assumeType(CompilerState &cs, llvm::IRBuilderBase &builder, llvm::Value *val,
                            core::ClassOrModuleRef sym);
+    static void assumeType(CompilerState &cs, llvm::IRBuilderBase &builder, llvm::Value *val,
+                           const core::TypePtr &type);
+
     static llvm::Value *boolToRuby(CompilerState &cs, llvm::IRBuilderBase &builder, llvm::Value *u1);
     static llvm::Value *setRubyStackFrame(CompilerState &cs, llvm::IRBuilderBase &builder,
                                           const IREmitterContext &irctx, const ast::MethodDef &md, int rubyBlockId);

--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -893,18 +893,7 @@ public:
         auto &irctx = mcctx.irctx;
         auto &recv = mcctx.send->recv;
 
-        auto aliasit = irctx.aliases.find(recv.variable);
-        if (aliasit == irctx.aliases.end()) {
-            return false;
-        }
-
-        if (aliasit->second.kind != Alias::AliasKind::Constant) {
-            return false;
-        }
-
-        ENFORCE(potentialClass.data(cs)->isSingletonClass(cs));
-        auto attachedClass = potentialClass.data(cs)->attachedClass(cs);
-        return aliasit->second.constantSym == attachedClass;
+        return IREmitterHelpers::isAliasToSingleton(cs, irctx, recv.variable, potentialClass);
     }
     virtual InlinedVector<core::ClassOrModuleRef, 2> applicableClasses(const core::GlobalState &gs) const override {
         return {rubyClass.data(gs)->lookupSingletonClass(gs)};

--- a/test/testdata/compiler/final_method_assume_result_type__1.rb
+++ b/test/testdata/compiler/final_method_assume_result_type__1.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+# run_filecheck: LOWERED
+
+# NOTE: explicitly not testing the interaction with interpreted code here
+# because we only emit direct calls if the call would be compiled -> compiled.
+
+#
+
+require_relative './final_method_assume_result_type__2'
+
+# LOWERED-LABEL: @"func_Object#21test_singleton_method"
+# LOWERED: @direct_func_Compiled.21test_singleton_method
+# LOWERED-NOT: @sorbet_i_isa_Array
+# LOWERED{LITERAL}: }
+def test_singleton_method
+  Compiled.test_singleton_method.length
+end
+
+# LOWERED-LABEL: @"func_Object#20test_instance_method"
+# LOWERED: @"direct_func_Compiled#20test_instance_method"
+# LOWERED-NOT: @sorbet_i_isa_Array
+# LOWERED{LITERAL}: }
+def test_instance_method
+  compiled_inst = T.let(Compiled.new, Compiled)
+  compiled_inst.test_instance_method.length
+end
+
+puts test_singleton_method
+puts test_instance_method

--- a/test/testdata/compiler/final_method_assume_result_type__2.rb
+++ b/test/testdata/compiler/final_method_assume_result_type__2.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+# typed: true
+# compiled: true
+
+class Compiled
+  extend T::Sig
+
+  sig(:final) {returns(T::Array[Integer])}
+  def test_instance_method
+    [10,12]
+  end
+
+  sig(:final) {returns(T::Array[Integer])}
+  def self.test_singleton_method
+    [10,12]
+  end
+end


### PR DESCRIPTION
- Add a helper for testing if a variable is an alias to a singleton
- Allow type assumptions on arbitrary TypePtr values
- Optimize type tests for final methods, and assume their results are typed correctly on the fast path

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
