### PR TITLE
[LSP] Fix crash in DocumentHighlightTask

### DIFF
--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -55,8 +55,12 @@ ast::ExpressionPtr DefLocSaver::postTransformUnresolvedIdent(core::Context ctx, 
         core::ClassOrModuleRef klass;
         // Logic cargo culted from `global2Local` in `walker_build.cc`.
         if (id.kind == ast::UnresolvedIdent::Kind::Instance) {
-            ENFORCE(ctx.owner.isMethod());
-            klass = ctx.owner.owner(ctx).asClassOrModuleRef();
+            ENFORCE(ctx.owner.isMethod() || ctx.owner.isClassOrModule());
+            if (ctx.owner.isMethod()) {
+              klass = ctx.owner.owner(ctx).asClassOrModuleRef();
+            } else if (ctx.owner.isClassOrModule()) {
+              klass = ctx.owner.asClassOrModuleRef();
+            }
         } else {
             // Class var.
             klass = ctx.owner.enclosingClass(ctx);

--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -53,7 +53,6 @@ ast::ExpressionPtr DefLocSaver::postTransformUnresolvedIdent(core::Context ctx, 
     auto &id = ast::cast_tree_nonnull<ast::UnresolvedIdent>(tree);
     if (id.kind == ast::UnresolvedIdent::Kind::Instance || id.kind == ast::UnresolvedIdent::Kind::Class) {
         core::ClassOrModuleRef klass;
-        // Logic cargo culted from `global2Local` in `walker_build.cc`.
         if (id.kind == ast::UnresolvedIdent::Kind::Instance) {
             ENFORCE(ctx.owner.isMethod() || ctx.owner.isClassOrModule());
             if (ctx.owner.isMethod()) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

This PR is a part of work to get a document symbols feature to a usable state. 
I took a look into the `/test/testdata/lsp/document_symbols_crash.rb` test:
https://github.com/sorbet/sorbet/blob/3bd289b6e8b6477864a83aeab06b07fb76eb93d6/test/testdata/lsp/document_symbols_crash.rb#L1-L4

What the test says if you add or delete a character in a property declaration, sorbet will crash. 
I assume it will work the same way for method declarations too.

The crash happens, because the `DocumentHighlightTask` tries to re-highlight the document 
and hits the `ENFORCE`, which is too tight.  I've tried disabling the document highlight feature, 
but the issue still occurred, because some other task called `queryByLoc`, 
which boils down to the same too tight `ENFORCE`

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Crash

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I'm not sure how to cover this kind of crash in a test, if you have any ideas, please, let me know!
