### PR TITLE
Move method symbols into a new Method class

### DIFF
--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -525,7 +525,7 @@ string MethodDef::toStringWithTabs(const core::GlobalState &gs, int tabs) const 
             fmt::format_to(std::back_inserter(buf), "{}", a.toStringWithTabs(gs, tabs + 1));
         }
     } else {
-        for (auto &a : data->arguments()) {
+        for (auto &a : data->arguments) {
             if (!first) {
                 fmt::format_to(std::back_inserter(buf), ", ");
             }

--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -218,7 +218,7 @@ string LoadArg::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) c
 }
 
 const core::ArgInfo &LoadArg::argument(const core::GlobalState &gs) const {
-    return this->method.data(gs)->arguments()[this->argId];
+    return this->method.data(gs)->arguments[this->argId];
 }
 
 string ArgPresent::toString(const core::GlobalState &gs, const CFG &cfg) const {
@@ -230,7 +230,7 @@ string ArgPresent::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs
 }
 
 const core::ArgInfo &ArgPresent::argument(const core::GlobalState &gs) const {
-    return this->method.data(gs)->arguments()[this->argId];
+    return this->method.data(gs)->arguments[this->argId];
 }
 
 string LoadYieldParams::toString(const core::GlobalState &gs, const CFG &cfg) const {

--- a/cfg/builder/builder_entry.cc
+++ b/cfg/builder/builder_entry.cc
@@ -10,7 +10,7 @@ namespace sorbet::cfg {
 unique_ptr<CFG> CFGBuilder::buildFor(core::Context ctx, ast::MethodDef &md) {
     Timer timeit(ctx.state.tracer(), "cfg");
     ENFORCE(md.symbol.exists());
-    ENFORCE(!md.symbol.data(ctx)->isOverloaded());
+    ENFORCE(!md.symbol.data(ctx)->flags.isOverloaded);
     unique_ptr<CFG> res(new CFG); // private constructor
     res->file = ctx.file;
     res->symbol = md.symbol.data(ctx)->dealiasMethod(ctx);
@@ -39,7 +39,7 @@ unique_ptr<CFG> CFGBuilder::buildFor(core::Context ctx, ast::MethodDef &md) {
         BasicBlock *defaultCont = nullptr;
 
         auto &argInfos = md.symbol.data(ctx)->arguments;
-        bool isAbstract = md.symbol.data(ctx)->isAbstract();
+        bool isAbstract = md.symbol.data(ctx)->flags.isAbstract;
         bool seenKeyword = false;
         int i = -1;
         for (auto &argExpr : md.args) {

--- a/cfg/builder/builder_entry.cc
+++ b/cfg/builder/builder_entry.cc
@@ -38,7 +38,7 @@ unique_ptr<CFG> CFGBuilder::buildFor(core::Context ctx, ast::MethodDef &md) {
         BasicBlock *presentCont = entry;
         BasicBlock *defaultCont = nullptr;
 
-        auto &argInfos = md.symbol.data(ctx)->arguments();
+        auto &argInfos = md.symbol.data(ctx)->arguments;
         bool isAbstract = md.symbol.data(ctx)->isAbstract();
         bool seenKeyword = false;
         int i = -1;

--- a/cfg/builder/builder_entry.cc
+++ b/cfg/builder/builder_entry.cc
@@ -27,7 +27,7 @@ unique_ptr<CFG> CFGBuilder::buildFor(core::Context ctx, ast::MethodDef &md) {
         CFG::UnfreezeCFGLocalVariables unfreezeVars(*res);
         retSym = cctx.newTemporary(core::Names::returnMethodTemp());
 
-        auto selfClaz = md.symbol.data(ctx)->rebind();
+        auto selfClaz = md.symbol.data(ctx)->rebind;
         if (!selfClaz.exists()) {
             selfClaz = md.symbol.enclosingClass(ctx);
         }

--- a/class_flatten/class_flatten.cc
+++ b/class_flatten/class_flatten.cc
@@ -96,9 +96,9 @@ public:
             // available to the containing static-init
             replacement = ast::MK::DefineTopClassOrModule(classDef->declLoc, classDef->symbol);
         }
-        ENFORCE(!sym.data(ctx)->arguments().empty(), "<static-init> method should already have a block arg symbol: {}",
+        ENFORCE(!sym.data(ctx)->arguments.empty(), "<static-init> method should already have a block arg symbol: {}",
                 sym.show(ctx));
-        ENFORCE(sym.data(ctx)->arguments().back().flags.isBlock, "Last argument symbol is not a block arg: {}",
+        ENFORCE(sym.data(ctx)->arguments.back().flags.isBlock, "Last argument symbol is not a block arg: {}",
                 sym.show(ctx));
 
         // Synthesize a block argument for this <static-init> block. This is rather fiddly,

--- a/compiler/IREmitter/IREmitter.cc
+++ b/compiler/IREmitter/IREmitter.cc
@@ -41,7 +41,7 @@ vector<core::ArgInfo::ArgFlags> getArgFlagsForBlockId(CompilerState &cs, int blo
     }
 
     vector<core::ArgInfo::ArgFlags> res;
-    for (auto &argInfo : method.data(cs)->arguments()) {
+    for (auto &argInfo : method.data(cs)->arguments) {
         res.emplace_back(argInfo.flags);
     }
 
@@ -637,7 +637,7 @@ llvm::BasicBlock *resolveJumpTarget(cfg::CFG &cfg, const IREmitterContext &irctx
 void emitUserBody(CompilerState &base, cfg::CFG &cfg, const IREmitterContext &irctx) {
     llvm::IRBuilder<> builder(base);
     auto startLoc = cfg.symbol.data(base)->loc();
-    auto &arguments = cfg.symbol.data(base)->arguments();
+    auto &arguments = cfg.symbol.data(base)->arguments;
     for (auto it = cfg.forwardsTopoSort.rbegin(); it != cfg.forwardsTopoSort.rend(); ++it) {
         cfg::BasicBlock *bb = *it;
         auto cs = base.withFunctionEntry(irctx.functionInitializersByFunction[bb->rubyRegionId]);

--- a/compiler/IREmitter/IREmitter.cc
+++ b/compiler/IREmitter/IREmitter.cc
@@ -957,7 +957,7 @@ void IREmitter::run(CompilerState &cs, cfg::CFG &cfg, const ast::MethodDef &md) 
     emitBlockExits(cs, cfg, irctx);
     emitPostProcess(cs, cfg, irctx);
 
-    if (md.symbol.data(cs)->isFinalMethod()) {
+    if (md.symbol.data(cs)->flags.isFinal) {
         emitDirectWrapper(cs, md, irctx);
     }
 

--- a/compiler/IREmitter/IREmitterContext.cc
+++ b/compiler/IREmitter/IREmitterContext.cc
@@ -499,9 +499,9 @@ llvm::DISubprogram *getDebugScope(CompilerState &cs, cfg::CFG &cfg, llvm::DIScop
     auto loc = cfg.symbol.data(cs)->loc();
 
     auto owner = cfg.symbol.data(cs)->owner;
-    std::string diName(owner.name(cs).shortName(cs));
+    std::string diName(owner.data(cs)->name.shortName(cs));
 
-    if (owner.isSingletonClass(cs)) {
+    if (owner.data(cs)->isSingletonClass(cs)) {
         diName += ".";
     } else {
         diName += "#";

--- a/compiler/IREmitter/IREmitterContext.cc
+++ b/compiler/IREmitter/IREmitterContext.cc
@@ -380,7 +380,7 @@ CapturedVariables findCaptures(CompilerState &cs, const ast::MethodDef &mdef, cf
     TrackCaptures usage(aliases, blockLevels);
 
     int argId = -1;
-    auto &methodArguments = cfg.symbol.data(cs)->arguments();
+    auto &methodArguments = cfg.symbol.data(cs)->arguments;
     for (auto &arg : mdef.args) {
         argId += 1;
         ast::Local const *local = nullptr;
@@ -392,7 +392,7 @@ CapturedVariables findCaptures(CompilerState &cs, const ast::MethodDef &mdef, cf
         ENFORCE(local);
         auto localRef = cfg.enterLocal(local->localVariable);
         auto &argInfo = methodArguments[argId];
-        if (cfg.symbol.data(cs)->arguments()[argId].flags.isBlock) {
+        if (cfg.symbol.data(cs)->arguments[argId].flags.isBlock) {
             usage.blkArg = localRef;
         }
         usage.trackBlockArgument(cfg.entry(), localRef, argInfo.type);
@@ -1032,7 +1032,7 @@ IREmitterContext IREmitterContext::getSorbetBlocks2LLVMBlockMapping(CompilerStat
 
     // The method arguments are initialized here, while the block arguments are initialized when the blockCall header is
     // encountered in the loop below.
-    int numArgs = md.symbol.data(cs)->arguments().size();
+    int numArgs = md.symbol.data(cs)->arguments.size();
     argPresentVariables[0].resize(numArgs, cfg::LocalRef::noVariable());
 
     for (auto &b : cfg.basicBlocks) {

--- a/compiler/IREmitter/IREmitterHelpers.cc
+++ b/compiler/IREmitter/IREmitterHelpers.cc
@@ -228,7 +228,7 @@ llvm::Value *IREmitterHelpers::maybeCheckReturnValue(CompilerState &cs, cfg::CFG
 
     // sorbet-runtime doesn't check this type for abstract methods, so we won't either.
     // TODO(froydnj): we should check this type.
-    if (!cfg.symbol.data(cs)->isAbstract()) {
+    if (!cfg.symbol.data(cs)->flags.isAbstract) {
         IREmitterHelpers::emitTypeTest(cs, builder, returnValue, expectedType, "Return value");
     }
 
@@ -447,7 +447,7 @@ IREmitterHelpers::isFinalMethod(const core::GlobalState &gs, core::TypePtr recvT
         return std::nullopt;
     }
 
-    if (!funSym.data(gs)->isFinalMethod()) {
+    if (!funSym.data(gs)->flags.isFinal) {
         return std::nullopt;
     }
 

--- a/compiler/IREmitter/IREmitterHelpers.cc
+++ b/compiler/IREmitter/IREmitterHelpers.cc
@@ -364,7 +364,7 @@ bool IREmitterHelpers::hasBlockArgument(CompilerState &cs, int blockId, core::Me
         return blockLink->argFlags.back().isBlock;
     }
 
-    auto &args = method.data(cs)->arguments();
+    auto &args = method.data(cs)->arguments;
     if (args.empty()) {
         return false;
     }

--- a/compiler/IREmitter/IREmitterHelpers.cc
+++ b/compiler/IREmitter/IREmitterHelpers.cc
@@ -43,7 +43,7 @@ string getFunctionNamePrefix(CompilerState &cs, core::ClassOrModuleRef sym) {
 } // namespace
 
 string IREmitterHelpers::getFunctionName(CompilerState &cs, core::MethodRef sym) {
-    auto owner = sym.data(cs)->owner.asClassOrModuleRef();
+    auto owner = sym.data(cs)->owner;
     auto maybeAttachedOwner = owner.data(cs)->attachedClass(cs);
     string prefix = "func_";
     if (maybeAttachedOwner.exists()) {

--- a/compiler/IREmitter/Payload.cc
+++ b/compiler/IREmitter/Payload.cc
@@ -945,7 +945,7 @@ llvm::Value *Payload::buildInstanceVariableCache(CompilerState &cs, std::string_
 
 llvm::Value *Payload::getClassVariableStoreClass(CompilerState &cs, llvm::IRBuilderBase &builder,
                                                  const IREmitterContext &irctx) {
-    auto sym = irctx.cfg.symbol.data(cs)->owner.asClassOrModuleRef();
+    auto sym = irctx.cfg.symbol.data(cs)->owner;
     return Payload::getRubyConstant(cs, sym.data(cs)->topAttachedClass(cs), builder);
 }
 

--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -75,8 +75,7 @@ public:
             while (current.data(gs)->isOverloaded()) {
                 i++;
                 auto overloadName = gs.lookupNameUnique(core::UniqueNameKind::Overload, methodName, i);
-                auto overload =
-                    primaryMethod.data(gs)->owner.asClassOrModuleRef().data(gs)->findMethod(gs, overloadName);
+                auto overload = primaryMethod.data(gs)->owner.data(gs)->findMethod(gs, overloadName);
                 ENFORCE(overload.exists());
                 if (core::Types::isSubType(gs, intrinsicResultType, overload.data(gs)->resultType)) {
                     return;
@@ -261,8 +260,7 @@ protected:
 
             i++;
             auto overloadName = gs.lookupNameUnique(core::UniqueNameKind::Overload, methodName, i);
-            auto overloadSym =
-                primaryMethod.data(gs)->owner.asClassOrModuleRef().data(gs)->findMember(gs, overloadName);
+            auto overloadSym = primaryMethod.data(gs)->owner.data(gs)->findMember(gs, overloadName);
             ENFORCE(overloadSym.exists());
 
             current = overloadSym.asMethodRef();

--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -72,7 +72,7 @@ public:
             int i = 0;
             auto methodName = primaryMethod.data(gs)->name;
             auto current = primaryMethod;
-            while (current.data(gs)->isOverloaded()) {
+            while (current.data(gs)->flags.isOverloaded) {
                 i++;
                 auto overloadName = gs.lookupNameUnique(core::UniqueNameKind::Overload, methodName, i);
                 auto overload = primaryMethod.data(gs)->owner.data(gs)->findMethod(gs, overloadName);
@@ -251,7 +251,7 @@ protected:
         int i = 0;
         bool acceptsBlock = false;
         auto current = primaryMethod;
-        while (current.data(gs)->isOverloaded()) {
+        while (current.data(gs)->flags.isOverloaded) {
             const auto &args = current.data(gs)->arguments;
             if (!args.empty() && !args.back().isSyntheticBlockArgument()) {
                 acceptsBlock = true;
@@ -496,7 +496,7 @@ public:
         ENFORCE(funcSym.exists());
 
         // We are going to rely on compiled final methods having their return values checked.
-        const bool needsTypechecking = funcSym.data(cs)->isFinalMethod();
+        const bool needsTypechecking = funcSym.data(cs)->flags.isFinal;
 
         if (methodKind == core::Names::attrReader() && !needsTypechecking) {
             const char *payloadFuncName = isSelf ? "sorbet_defineIvarMethodSingleton" : "sorbet_defineIvarMethod";

--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -252,7 +252,7 @@ protected:
         bool acceptsBlock = false;
         auto current = primaryMethod;
         while (current.data(gs)->isOverloaded()) {
-            const auto &args = current.data(gs)->arguments();
+            const auto &args = current.data(gs)->arguments;
             if (!args.empty() && !args.back().isSyntheticBlockArgument()) {
                 acceptsBlock = true;
                 break;
@@ -319,7 +319,7 @@ void emitParamInitialization(CompilerState &cs, llvm::IRBuilderBase &builder, co
     InlinedVector<const core::ArgInfo *, 4> keywordArgInfo;
 
     int i = -1;
-    for (auto &argInfo : funcSym.data(cs)->arguments()) {
+    for (auto &argInfo : funcSym.data(cs)->arguments) {
         ++i;
         auto &flags = argInfo.flags;
         if (flags.isBlock) {

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -978,19 +978,17 @@ TypeArgumentRef GlobalState::enterTypeArgument(Loc loc, MethodRef owner, NameRef
     flags = flags | Symbol::Flags::TYPE_ARGUMENT;
 
     auto ownerScope = owner.dataAllowingNone(*this);
-    histogramInc("symbol_enter_by_name", ownerScope->members().size());
+    histogramInc("symbol_enter_by_name", ownerScope->typeArguments().size());
 
-    auto &store = ownerScope->members()[name];
-    if (store.exists()) {
-        ENFORCE(store.isTypeArgument() && (store.asTypeArgumentRef().data(*this)->flags & flags) == flags,
-                "existing symbol has wrong flags");
+    auto existingTypeArgument = ownerScope->findMember(*this, name);
+    if (existingTypeArgument.exists()) {
+        ENFORCE((existingTypeArgument.data(*this)->flags & flags) == flags, "existing symbol has wrong flags");
         counterInc("symbols.hit");
-        return store.asTypeArgumentRef();
+        return existingTypeArgument;
     }
 
     ENFORCE(!symbolTableFrozen);
     auto result = TypeArgumentRef(*this, typeArguments.size());
-    store = result; // DO NOT MOVE this assignment down. emplace_back on typeArguments invalidates `store`
     typeArguments.emplace_back();
 
     SymbolData data = result.dataAllowingNone(*this);
@@ -1022,9 +1020,8 @@ MethodRef GlobalState::enterMethodSymbol(Loc loc, ClassOrModuleRef owner, NameRe
     store = result; // DO NOT MOVE this assignment down. emplace_back on methods invalidates `store`
     methods.emplace_back();
 
-    SymbolData data = result.dataAllowingNone(*this);
+    MethodData data = result.dataAllowingNone(*this);
     data->name = name;
-    data->flags = Symbol::Flags::METHOD;
     data->owner = owner;
     data->addLoc(*this, loc);
     DEBUG_ONLY(categoryCounterInc("symbols", "method"));
@@ -1038,7 +1035,7 @@ MethodRef GlobalState::enterNewMethodOverload(Loc sigLoc, MethodRef original, co
     NameRef name = num == 0 ? originalName : freshNameUnique(UniqueNameKind::Overload, originalName, num);
     core::Loc loc = num == 0 ? original.data(*this)->loc()
                              : sigLoc; // use original Loc for main overload so that we get right jump-to-def for it.
-    auto owner = original.data(*this)->owner.asClassOrModuleRef();
+    auto owner = original.data(*this)->owner;
     auto res = enterMethodSymbol(loc, owner, name);
     ENFORCE(res != original);
     if (res.data(*this)->arguments().size() != original.data(*this)->arguments().size()) {
@@ -1131,7 +1128,7 @@ FieldRef GlobalState::enterStaticFieldSymbol(Loc loc, ClassOrModuleRef owner, Na
 ArgInfo &GlobalState::enterMethodArgumentSymbol(Loc loc, MethodRef owner, NameRef name) {
     ENFORCE(owner.exists(), "entering symbol in to non-existing owner");
     ENFORCE(name.exists(), "entering symbol with non-existing name");
-    SymbolData ownerScope = owner.data(*this);
+    MethodData ownerScope = owner.data(*this);
 
     for (auto &arg : ownerScope->arguments()) {
         if (arg.name == name) {
@@ -1781,7 +1778,7 @@ unique_ptr<GlobalState> GlobalState::deepCopy(bool keepId) const {
     }
     result->methods.reserve(this->methods.capacity());
     for (auto &sym : this->methods) {
-        result->methods.emplace_back(sym.deepCopy(*result, keepId));
+        result->methods.emplace_back(sym.deepCopy(*result));
     }
     result->fields.reserve(this->fields.capacity());
     for (auto &sym : this->fields) {

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -978,9 +978,9 @@ TypeArgumentRef GlobalState::enterTypeArgument(Loc loc, MethodRef owner, NameRef
     flags = flags | Symbol::Flags::TYPE_ARGUMENT;
 
     auto ownerScope = owner.dataAllowingNone(*this);
-    histogramInc("symbol_enter_by_name", ownerScope->typeArguments().size());
+    histogramInc("symbol_enter_by_name", ownerScope->typeArguments.size());
 
-    for (auto typeArg : ownerScope->typeArguments()) {
+    for (auto typeArg : ownerScope->typeArguments) {
         if (typeArg.dataAllowingNone(*this)->name == name) {
             ENFORCE((typeArg.dataAllowingNone(*this)->flags & flags) == flags, "existing symbol has wrong flags");
             counterInc("symbols.hit");
@@ -1000,7 +1000,7 @@ TypeArgumentRef GlobalState::enterTypeArgument(Loc loc, MethodRef owner, NameRef
     DEBUG_ONLY(categoryCounterInc("symbols", "type_argument"));
     wasModified_ = true;
 
-    owner.dataAllowingNone(*this)->typeArguments().emplace_back(result);
+    owner.dataAllowingNone(*this)->typeArguments.emplace_back(result);
     return result;
 }
 

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -980,11 +980,12 @@ TypeArgumentRef GlobalState::enterTypeArgument(Loc loc, MethodRef owner, NameRef
     auto ownerScope = owner.dataAllowingNone(*this);
     histogramInc("symbol_enter_by_name", ownerScope->typeArguments().size());
 
-    auto existingTypeArgument = ownerScope->findMember(*this, name);
-    if (existingTypeArgument.exists()) {
-        ENFORCE((existingTypeArgument.data(*this)->flags & flags) == flags, "existing symbol has wrong flags");
-        counterInc("symbols.hit");
-        return existingTypeArgument;
+    for (auto typeArg : ownerScope->typeArguments()) {
+        if (typeArg.dataAllowingNone(*this)->name == name) {
+            ENFORCE((typeArg.dataAllowingNone(*this)->flags & flags) == flags, "existing symbol has wrong flags");
+            counterInc("symbols.hit");
+            return typeArg;
+        }
     }
 
     ENFORCE(!symbolTableFrozen);

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1039,10 +1039,10 @@ MethodRef GlobalState::enterNewMethodOverload(Loc sigLoc, MethodRef original, co
     auto owner = original.data(*this)->owner;
     auto res = enterMethodSymbol(loc, owner, name);
     ENFORCE(res != original);
-    if (res.data(*this)->arguments().size() != original.data(*this)->arguments().size()) {
-        ENFORCE(res.data(*this)->arguments().empty());
-        res.data(*this)->arguments().reserve(original.data(*this)->arguments().size());
-        const auto &originalArguments = original.data(*this)->arguments();
+    if (res.data(*this)->arguments.size() != original.data(*this)->arguments.size()) {
+        ENFORCE(res.data(*this)->arguments.empty());
+        res.data(*this)->arguments.reserve(original.data(*this)->arguments.size());
+        const auto &originalArguments = original.data(*this)->arguments;
         int i = -1;
         for (auto &arg : originalArguments) {
             i += 1;
@@ -1131,12 +1131,12 @@ ArgInfo &GlobalState::enterMethodArgumentSymbol(Loc loc, MethodRef owner, NameRe
     ENFORCE(name.exists(), "entering symbol with non-existing name");
     MethodData ownerScope = owner.data(*this);
 
-    for (auto &arg : ownerScope->arguments()) {
+    for (auto &arg : ownerScope->arguments) {
         if (arg.name == name) {
             return arg;
         }
     }
-    auto &store = ownerScope->arguments().emplace_back();
+    auto &store = ownerScope->arguments.emplace_back();
 
     ENFORCE(!symbolTableFrozen);
 

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -40,6 +40,7 @@ class SerializerImpl;
 class GlobalState final {
     friend NameRef;
     friend Symbol;
+    friend Method;
     friend SymbolRef;
     friend ClassOrModuleRef;
     friend MethodRef;
@@ -298,7 +299,7 @@ private:
     std::vector<UniqueName> uniqueNames;
     UnorderedMap<std::string, FileRef> fileRefByPath;
     std::vector<Symbol> classAndModules;
-    std::vector<Symbol> methods;
+    std::vector<Method> methods;
     std::vector<Symbol> fields;
     std::vector<Symbol> typeMembers;
     std::vector<Symbol> typeArguments;

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -453,7 +453,6 @@ public:
     const TypePtr &resultType(const GlobalState &gs) const;
     void setResultType(GlobalState &gs, const TypePtr &typePtr) const;
     SymbolRef dealias(const GlobalState &gs) const;
-    SymbolRef findMember(const GlobalState &gs, NameRef name) const;
     // End methods that should be removed.
 
     // Prints the fully qualified name of the symbol in a format that is suitable for showing to the user (e.g.

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -18,7 +18,7 @@ struct SymbolDataDebugCheck {
     void check() const;
 };
 
-/** This class is intended to be a safe way to pass `Symbol &` around.
+/** These classes are intended to be a safe way to pass symbol references around.
  *  Entering new symbols can invalidate `Symbol &`s and thus they are generally unsafe.
  *  This class ensures that all accesses are safe in debug builds and effectively is a `Symbol &` in optimized builds.
  */
@@ -43,7 +43,27 @@ public:
 };
 CheckSize(ConstSymbolData, 8, 8);
 
-class Symbol;
+class Method;
+class MethodData : private DebugOnlyCheck<SymbolDataDebugCheck> {
+    Method &method;
+
+public:
+    MethodData(Method &ref, GlobalState &gs);
+
+    Method *operator->();
+    const Method *operator->() const;
+};
+CheckSize(MethodData, 8, 8);
+
+class ConstMethodData : private DebugOnlyCheck<SymbolDataDebugCheck> {
+    const Method &method;
+
+public:
+    ConstMethodData(const Method &ref, const GlobalState &gs);
+
+    const Method *operator->() const;
+};
+CheckSize(ConstMethodData, 8, 8);
 
 class ClassOrModuleRef final {
     uint32_t _id;
@@ -126,9 +146,9 @@ public:
         return toStringWithOptions(gs, 0, showFull, showRaw);
     }
 
-    SymbolData data(GlobalState &gs) const;
-    ConstSymbolData data(const GlobalState &gs) const;
-    SymbolData dataAllowingNone(GlobalState &gs) const;
+    MethodData data(GlobalState &gs) const;
+    ConstMethodData data(const GlobalState &gs) const;
+    MethodData dataAllowingNone(GlobalState &gs) const;
 
     ClassOrModuleRef enclosingClass(const GlobalState &gs) const;
     std::string_view showKind(const GlobalState &gs) const;
@@ -229,6 +249,7 @@ class TypeArgumentRef final {
     uint32_t _id;
 
     friend class SymbolRef;
+    friend class MethodRef;
 
 private:
     std::string toStringWithOptions(const GlobalState &gs, int tabs = 0, bool showFull = false,
@@ -433,7 +454,6 @@ public:
     void setResultType(GlobalState &gs, const TypePtr &typePtr) const;
     SymbolRef dealias(const GlobalState &gs) const;
     SymbolRef findMember(const GlobalState &gs, NameRef name) const;
-    SymbolRef findMemberTransitive(const GlobalState &gs, NameRef name) const;
     // End methods that should be removed.
 
     // Prints the fully qualified name of the symbol in a format that is suitable for showing to the user (e.g.

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -447,7 +447,6 @@ public:
     core::SymbolRef owner(const GlobalState &gs) const;
     core::Loc loc(const GlobalState &gs) const;
     bool isSingletonClass(const GlobalState &gs) const;
-    std::vector<std::pair<NameRef, SymbolRef>> membersStableOrderSlow(const GlobalState &gs) const;
     bool isPrintable(const GlobalState &gs) const;
     const InlinedVector<Loc, 2> &locs(const GlobalState &gs) const;
     const TypePtr &resultType(const GlobalState &gs) const;

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -446,7 +446,6 @@ public:
     core::NameRef name(const GlobalState &gs) const;
     core::SymbolRef owner(const GlobalState &gs) const;
     core::Loc loc(const GlobalState &gs) const;
-    bool isSingletonClass(const GlobalState &gs) const;
     bool isPrintable(const GlobalState &gs) const;
     const InlinedVector<Loc, 2> &locs(const GlobalState &gs) const;
     const TypePtr &resultType(const GlobalState &gs) const;

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1095,7 +1095,7 @@ bool Method::isPrintable(const GlobalState &gs) const {
         return true;
     }
 
-    for (auto typeParam : this->typeParams) {
+    for (auto typeParam : this->typeArguments) {
         if (typeParam.data(gs)->isPrintable(gs)) {
             return true;
         }
@@ -1257,7 +1257,7 @@ string MethodRef::toStringWithOptions(const GlobalState &gs, int tabs, bool show
                        fmt::map_join(methodFlags, "|", [](const auto &flag) { return flag; }));
     }
 
-    auto typeMembers = sym->typeArguments();
+    auto typeMembers = sym->typeArguments;
     auto it =
         remove_if(typeMembers.begin(), typeMembers.end(), [&gs](auto &sym) -> bool { return sym.data(gs)->isFixed(); });
     typeMembers.erase(it, typeMembers.end());
@@ -1280,7 +1280,7 @@ string MethodRef::toStringWithOptions(const GlobalState &gs, int tabs, bool show
 
     ENFORCE(!absl::c_any_of(to_string(buf), [](char c) { return c == '\n'; }));
     fmt::format_to(std::back_inserter(buf), "\n");
-    for (auto ta : sym->typeArguments()) {
+    for (auto ta : sym->typeArguments) {
         ENFORCE_NO_TIMER(ta.exists());
 
         if (!showFull && !ta.data(gs)->isPrintable(gs)) {
@@ -2011,7 +2011,7 @@ Method Method::deepCopy(const GlobalState &to) const {
     result.resultType = this->resultType;
     result.name = NameRef(to, this->name);
     result.locs_ = this->locs_;
-    result.typeParams = this->typeParams;
+    result.typeArguments = this->typeArguments;
     result.arguments.reserve(this->arguments.size());
     for (auto &mem : this->arguments) {
         auto &store = result.arguments.emplace_back(mem.deepCopy());
@@ -2084,7 +2084,7 @@ void Method::sanityCheck(const GlobalState &gs) const {
     MethodRef current2 = const_cast<GlobalState &>(gs).enterMethodSymbol(this->loc(), this->owner, this->name);
 
     ENFORCE_NO_TIMER(current == current2);
-    for (auto &tp : typeParams) {
+    for (auto &tp : typeArguments) {
         ENFORCE_NO_TIMER(tp.data(gs)->name.exists(), name.toString(gs) + " has a member symbol without a name");
         ENFORCE_NO_TIMER(tp.exists(), name.toString(gs) + "." + tp.data(gs)->name.toString(gs) +
                                           " corresponds to a core::Symbols::noTypeArgument()");
@@ -2182,7 +2182,7 @@ uint32_t Method::hash(const GlobalState &gs) const {
         result = mix(result, type.hash(gs));
         result = mix(result, _hash(arg.name.shortName(gs)));
     }
-    for (const auto &e : typeParams) {
+    for (const auto &e : typeArguments) {
         if (e.exists()) {
             result = mix(result, _hash(e.data(gs)->name.shortName(gs)));
         }

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -2056,11 +2056,6 @@ Method Method::deepCopy(const GlobalState &to) const {
         store.name = NameRef(to, mem.name);
     }
     result.rebind_ = this->rebind_;
-    result.arguments_.reserve(this->arguments_.size());
-    for (auto &mem : this->arguments_) {
-        auto &store = result.arguments_.emplace_back(mem.deepCopy());
-        store.name = NameRef(to, mem.name);
-    }
     result.intrinsic = this->intrinsic;
     return result;
 }

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1281,9 +1281,9 @@ string MethodRef::toStringWithOptions(const GlobalState &gs, int tabs, bool show
     printResultType(gs, buf, sym->resultType, tabs, showRaw);
     printLocs(gs, buf, sym->locs(), showRaw);
 
-    if (sym->rebind().exists()) {
+    if (sym->rebind.exists()) {
         fmt::format_to(std::back_inserter(buf), " rebindTo {}",
-                       showRaw ? sym->rebind().toStringFullName(gs) : sym->rebind().showFullName(gs));
+                       showRaw ? sym->rebind.toStringFullName(gs) : sym->rebind.showFullName(gs));
     }
 
     ENFORCE(!absl::c_any_of(to_string(buf), [](char c) { return c == '\n'; }));
@@ -2055,7 +2055,7 @@ Method Method::deepCopy(const GlobalState &to) const {
         auto &store = result.arguments_.emplace_back(mem.deepCopy());
         store.name = NameRef(to, mem.name);
     }
-    result.rebind_ = this->rebind_;
+    result.rebind = this->rebind;
     result.intrinsic = this->intrinsic;
     return result;
 }
@@ -2210,7 +2210,7 @@ uint32_t Method::hash(const GlobalState &gs) const {
     result = mix(result, !this->resultType ? 0 : this->resultType.hash(gs));
     result = mix(result, this->flags);
     result = mix(result, this->owner.id());
-    result = mix(result, this->rebind_.id());
+    result = mix(result, this->rebind.id());
     for (const auto &arg : arguments_) {
         // If an argument's resultType changes, then the sig has changed.
         auto type = arg.type;
@@ -2233,7 +2233,7 @@ uint32_t Method::methodShapeHash(const GlobalState &gs) const {
     uint32_t result = _hash(name.shortName(gs));
     result = mix(result, this->flags);
     result = mix(result, this->owner.id());
-    result = mix(result, this->rebind_.id());
+    result = mix(result, this->rebind.id());
     result = mix(result, this->hasSig());
     for (auto &arg : this->methodArgumentHash(gs)) {
         result = mix(result, arg);

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1428,15 +1428,6 @@ Loc SymbolRef::loc(const GlobalState &gs) const {
     }
 }
 
-bool SymbolRef::isSingletonClass(const GlobalState &gs) const {
-    switch (kind()) {
-        case SymbolRef::Kind::ClassOrModule:
-            return asClassOrModuleRef().data(gs)->isSingletonClass(gs);
-        default:
-            return false;
-    }
-}
-
 bool SymbolRef::isPrintable(const GlobalState &gs) const {
     switch (kind()) {
         case SymbolRef::Kind::ClassOrModule:

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -2170,7 +2170,7 @@ uint32_t Symbol::hash(const GlobalState &gs) const {
 uint32_t Method::hash(const GlobalState &gs) const {
     uint32_t result = _hash(name.shortName(gs));
     result = mix(result, !this->resultType ? 0 : this->resultType.hash(gs));
-    result = mix(result, this->flags);
+    result = mix(result, this->flags.serialize());
     result = mix(result, this->owner.id());
     result = mix(result, this->rebind.id());
     for (const auto &arg : arguments) {
@@ -2193,7 +2193,7 @@ uint32_t Method::hash(const GlobalState &gs) const {
 
 uint32_t Method::methodShapeHash(const GlobalState &gs) const {
     uint32_t result = _hash(name.shortName(gs));
-    result = mix(result, this->flags);
+    result = mix(result, this->flags.serialize());
     result = mix(result, this->owner.id());
     result = mix(result, this->rebind.id());
     result = mix(result, this->hasSig());

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -540,15 +540,6 @@ SymbolRef Symbol::findMember(const GlobalState &gs, NameRef name) const {
     return ret;
 }
 
-TypeArgumentRef Method::findMember(const GlobalState &gs, NameRef name) const {
-    for (auto &typeParam : typeParams) {
-        if (typeParam.exists() && typeParam.data(gs)->name == name) {
-            return typeParam;
-        }
-    }
-    return Symbols::noTypeArgument();
-}
-
 MethodRef Symbol::findMethod(const GlobalState &gs, NameRef name) const {
     auto sym = findMember(gs, name);
     if (sym.exists() && sym.isMethod()) {
@@ -558,6 +549,7 @@ MethodRef Symbol::findMethod(const GlobalState &gs, NameRef name) const {
 }
 
 SymbolRef Symbol::findMemberNoDealias(const GlobalState &gs, NameRef name) const {
+    ENFORCE(this->isClassOrModule(), "Only classes and modules have members");
     histogramInc("find_member_scope_size", members().size());
     auto fnd = members().find(name);
     if (fnd == members().end()) {
@@ -1543,21 +1535,6 @@ SymbolRef SymbolRef::dealias(const GlobalState &gs) const {
             return asTypeArgumentRef().data(gs)->dealias(gs);
         case SymbolRef::Kind::TypeMember:
             return asTypeMemberRef().data(gs)->dealias(gs);
-    }
-}
-
-SymbolRef SymbolRef::findMember(const GlobalState &gs, NameRef name) const {
-    switch (kind()) {
-        case SymbolRef::Kind::ClassOrModule:
-            return asClassOrModuleRef().data(gs)->findMember(gs, name);
-        case SymbolRef::Kind::Method:
-            return asMethodRef().data(gs)->findMember(gs, name);
-        case SymbolRef::Kind::FieldOrStaticField:
-            return asFieldRef().data(gs)->findMember(gs, name);
-        case SymbolRef::Kind::TypeArgument:
-            return asTypeArgumentRef().data(gs)->findMember(gs, name);
-        case SymbolRef::Kind::TypeMember:
-            return asTypeMemberRef().data(gs)->findMember(gs, name);
     }
 }
 

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1497,14 +1497,8 @@ SymbolRef SymbolRef::dealias(const GlobalState &gs) const {
     switch (kind()) {
         case SymbolRef::Kind::ClassOrModule:
             return asClassOrModuleRef().data(gs)->dealias(gs);
-        case SymbolRef::Kind::Method: {
-            auto rv = asMethodRef().data(gs)->dealiasMethod(gs);
-            // dealiasMethod returns badAliasMethodStub but callers of dealias expect Symbols::untyped.
-            if (rv == Symbols::Sorbet_Private_Static_badAliasMethodStub()) {
-                return Symbols::untyped();
-            }
-            return rv;
-        }
+        case SymbolRef::Kind::Method:
+            return asMethodRef().data(gs)->dealiasMethod(gs);
         case SymbolRef::Kind::FieldOrStaticField:
             return asFieldRef().data(gs)->dealias(gs);
         case SymbolRef::Kind::TypeArgument:

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -86,13 +86,14 @@ vector<TypePtr> Symbol::selfTypeArgs(const GlobalState &gs) const {
     ENFORCE(isClassOrModule()); // should be removed when we have generic methods
     vector<TypePtr> targs;
     for (auto tm : typeMembers()) {
-        auto tmData = tm.asTypeMemberRef().data(gs);
+        auto tmData = tm.data(gs);
         if (tmData->isFixed()) {
             auto *lambdaParam = cast_type<LambdaParam>(tmData->resultType);
             ENFORCE(lambdaParam != nullptr);
             targs.emplace_back(lambdaParam->upperBound);
         } else {
-            targs.emplace_back(make_type<SelfTypeParam>(tm));
+            auto selfType = core::SymbolRef(tm);
+            targs.emplace_back(make_type<SelfTypeParam>(selfType));
         }
     }
     return targs;
@@ -140,7 +141,7 @@ TypePtr Symbol::unsafeComputeExternalType(GlobalState &gs) {
                                ref == core::Symbols::Enumerable() || ref == core::Symbols::Enumerator();
 
         for (auto &tm : typeMembers()) {
-            auto tmData = tm.asTypeMemberRef().data(gs);
+            auto tmData = tm.data(gs);
             auto *lambdaParam = cast_type<LambdaParam>(tmData->resultType);
             ENFORCE(lambdaParam != nullptr);
 
@@ -195,9 +196,6 @@ SymbolRef Symbol::ref(const GlobalState &gs) const {
     if (isClassOrModule()) {
         type = SymbolRef::Kind::ClassOrModule;
         distance = this - gs.classAndModules.data();
-    } else if (isMethod()) {
-        type = SymbolRef::Kind::Method;
-        distance = this - gs.methods.data();
     } else if (isField() || isStaticField()) {
         type = SymbolRef::Kind::FieldOrStaticField;
         distance = this - gs.fields.data();
@@ -212,6 +210,11 @@ SymbolRef Symbol::ref(const GlobalState &gs) const {
     }
 
     return SymbolRef(gs, type, distance);
+}
+
+MethodRef Method::ref(const GlobalState &gs) const {
+    uint32_t distance = this - gs.methods.data();
+    return MethodRef(gs, distance);
 }
 
 bool SymbolRef::isTypeAlias(const GlobalState &gs) const {
@@ -245,21 +248,21 @@ ConstSymbolData ClassOrModuleRef::dataAllowingNone(const GlobalState &gs) const 
     return ConstSymbolData(gs.classAndModules[_id], gs);
 }
 
-SymbolData MethodRef::data(GlobalState &gs) const {
+MethodData MethodRef::data(GlobalState &gs) const {
     ENFORCE_NO_TIMER(this->exists());
     ENFORCE_NO_TIMER(_id < gs.methodsUsed());
-    return SymbolData(gs.methods[_id], gs);
+    return MethodData(gs.methods[_id], gs);
 }
 
-ConstSymbolData MethodRef::data(const GlobalState &gs) const {
+ConstMethodData MethodRef::data(const GlobalState &gs) const {
     ENFORCE_NO_TIMER(this->exists());
     ENFORCE_NO_TIMER(_id < gs.methodsUsed());
-    return ConstSymbolData(gs.methods[_id], gs);
+    return ConstMethodData(gs.methods[_id], gs);
 }
 
-SymbolData MethodRef::dataAllowingNone(GlobalState &gs) const {
+MethodData MethodRef::dataAllowingNone(GlobalState &gs) const {
     ENFORCE_NO_TIMER(_id < gs.methodsUsed());
-    return SymbolData(gs.methods[_id], gs);
+    return MethodData(gs.methods[_id], gs);
 }
 
 SymbolData FieldRef::data(GlobalState &gs) const {
@@ -426,9 +429,8 @@ string ClassOrModuleRef::show(const GlobalState &gs) const {
 
 string MethodRef::show(const GlobalState &gs) const {
     auto sym = data(gs);
-    if (sym->owner.isClassOrModule() && sym->owner.isSingletonClass(gs)) {
-        return absl::StrCat(sym->owner.asClassOrModuleRef().data(gs)->attachedClass(gs).show(gs), ".",
-                            sym->name.show(gs));
+    if (sym->owner.data(gs)->isSingletonClass(gs)) {
+        return absl::StrCat(sym->owner.data(gs)->attachedClass(gs).show(gs), ".", sym->name.show(gs));
     }
     return showInternal(gs, sym->owner, sym->name, HASH_SEPARATOR);
 }
@@ -538,6 +540,15 @@ SymbolRef Symbol::findMember(const GlobalState &gs, NameRef name) const {
     return ret;
 }
 
+TypeArgumentRef Method::findMember(const GlobalState &gs, NameRef name) const {
+    for (auto &typeParam : typeParams) {
+        if (typeParam.exists() && typeParam.data(gs)->name == name) {
+            return typeParam;
+        }
+    }
+    return Symbols::noTypeArgument();
+}
+
 MethodRef Symbol::findMethod(const GlobalState &gs, NameRef name) const {
     auto sym = findMember(gs, name);
     if (sym.exists() && sym.isMethod()) {
@@ -564,7 +575,7 @@ MethodRef Symbol::findMethodNoDealias(const GlobalState &gs, NameRef name) const
 }
 
 SymbolRef Symbol::findMemberTransitive(const GlobalState &gs, NameRef name) const {
-    return findMemberTransitiveInternal(gs, name, Flags::NONE, Flags::NONE, 100);
+    return findMemberTransitiveInternal(gs, name, 100);
 }
 
 MethodRef Symbol::findMethodTransitive(const GlobalState &gs, NameRef name) const {
@@ -575,31 +586,62 @@ MethodRef Symbol::findMethodTransitive(const GlobalState &gs, NameRef name) cons
     return Symbols::noMethod();
 }
 
-SymbolRef Symbol::findConcreteMethodTransitive(const GlobalState &gs, NameRef name) const {
-    return findMemberTransitiveInternal(gs, name, Flags::METHOD | Flags::METHOD_ABSTRACT, Flags::METHOD, 100);
-}
-
 namespace {
-// TODO(jvilk): Remove this when we remove flag filter in `findMemberTransitiveInternal`.
-uint32_t getFlags(const GlobalState &gs, SymbolRef symbol) {
-    switch (symbol.kind()) {
-        case SymbolRef::Kind::Method:
-            return symbol.asMethodRef().data(gs)->flags;
-        case SymbolRef::Kind::ClassOrModule:
-            return symbol.asClassOrModuleRef().data(gs)->flags;
-        case SymbolRef::Kind::FieldOrStaticField:
-            return symbol.asFieldRef().data(gs)->flags;
-        case SymbolRef::Kind::TypeArgument:
-            return symbol.asTypeArgumentRef().data(gs)->flags;
-        case SymbolRef::Kind::TypeMember:
-            return symbol.asTypeMemberRef().data(gs)->flags;
+MethodRef findConcreteMethodTransitiveInternal(const GlobalState &gs, ClassOrModuleRef owner, NameRef name,
+                                               int maxDepth) {
+    // We can support it before linearization but it's more code to do so.
+    ENFORCE(owner.data(gs)->isClassOrModuleLinearizationComputed());
+
+    if (maxDepth == 0) {
+        if (auto e = gs.beginError(Loc::none(), errors::Internal::InternalError)) {
+            e.setHeader("findConcreteMethodTransitive hit a loop while resolving `{}` in `{}`. Parents are: ",
+                        name.show(gs), owner.showFullName(gs));
+        }
+        int i = -1;
+        for (auto it = owner.data(gs)->mixins().rbegin(); it != owner.data(gs)->mixins().rend(); ++it) {
+            i++;
+            if (auto e = gs.beginError(Loc::none(), errors::Internal::InternalError)) {
+                e.setHeader("`{}`:- `{}`", i, it->showFullName(gs));
+            }
+            int j = 0;
+            for (auto it2 = it->data(gs)->mixins().rbegin(); it2 != it->data(gs)->mixins().rend(); ++it2) {
+                if (auto e = gs.beginError(Loc::none(), errors::Internal::InternalError)) {
+                    e.setHeader("`{}`:`{}` `{}`", i, j, it2->showFullName(gs));
+                }
+                j++;
+            }
+        }
+
+        Exception::raise("findConcreteMethodTransitive hit a loop while resolving");
     }
+
+    MethodRef result = owner.data(gs)->findMethod(gs, name);
+    if (result.exists() && !result.data(gs)->isAbstract()) {
+        return result;
+    }
+
+    for (auto it = owner.data(gs)->mixins().begin(); it != owner.data(gs)->mixins().end(); ++it) {
+        ENFORCE(it->exists());
+        result = it->data(gs)->findMethod(gs, name);
+        if (result.exists() && !result.data(gs)->isAbstract()) {
+            return result;
+        }
+    }
+
+    if (owner.data(gs)->superClass().exists()) {
+        return findConcreteMethodTransitiveInternal(gs, owner.data(gs)->superClass(), name, maxDepth - 1);
+    }
+
+    return Symbols::noMethod();
 }
 } // namespace
 
-// TODO(jvilk): Remove flag filter -- it's only used for `findConcreteMethodTransitive`.
-SymbolRef Symbol::findMemberTransitiveInternal(const GlobalState &gs, NameRef name, uint32_t mask, uint32_t flags,
-                                               int maxDepth) const {
+MethodRef Symbol::findConcreteMethodTransitive(const GlobalState &gs, NameRef name) const {
+    ENFORCE(this->isClassOrModule());
+    return findConcreteMethodTransitiveInternal(gs, this->ref(gs).asClassOrModuleRef(), name, 100);
+}
+
+SymbolRef Symbol::findMemberTransitiveInternal(const GlobalState &gs, NameRef name, int maxDepth) const {
     ENFORCE(this->isClassOrModule());
     if (maxDepth == 0) {
         if (auto e = gs.beginError(Loc::none(), errors::Internal::InternalError)) {
@@ -626,32 +668,28 @@ SymbolRef Symbol::findMemberTransitiveInternal(const GlobalState &gs, NameRef na
 
     SymbolRef result = findMember(gs, name);
     if (result.exists()) {
-        if (mask == 0 || (getFlags(gs, result) & mask) == flags) {
-            return result;
-        }
+        return result;
     }
     if (isClassOrModuleLinearizationComputed()) {
         for (auto it = this->mixins().begin(); it != this->mixins().end(); ++it) {
             ENFORCE(it->exists());
             result = it->data(gs)->findMember(gs, name);
             if (result.exists()) {
-                if (mask == 0 || (getFlags(gs, result) & mask) == flags) {
-                    return result;
-                }
+                return result;
             }
             result = core::Symbols::noSymbol();
         }
     } else {
         for (auto it = this->mixins().rbegin(); it != this->mixins().rend(); ++it) {
             ENFORCE(it->exists());
-            result = it->data(gs)->findMemberTransitiveInternal(gs, name, mask, flags, maxDepth - 1);
+            result = it->data(gs)->findMemberTransitiveInternal(gs, name, maxDepth - 1);
             if (result.exists()) {
                 return result;
             }
         }
     }
     if (this->superClass().exists()) {
-        return this->superClass().data(gs)->findMemberTransitiveInternal(gs, name, mask, flags, maxDepth - 1);
+        return this->superClass().data(gs)->findMemberTransitiveInternal(gs, name, maxDepth - 1);
     }
     return Symbols::noSymbol();
 }
@@ -892,14 +930,14 @@ Symbol::FuzzySearchResult Symbol::findMemberFuzzyMatchUTF8(const GlobalState &gs
 }
 
 namespace {
-bool isHiddenFromPrinting(const GlobalState &gs, const Symbol &symbol) {
-    if (symbol.ref(gs).isSynthetic()) {
+bool isHiddenFromPrinting(const GlobalState &gs, SymbolRef symbol) {
+    if (symbol.isSynthetic()) {
         return true;
     }
-    if (symbol.locs().empty()) {
+    if (symbol.locs(gs).empty()) {
         return true;
     }
-    for (auto loc : symbol.locs()) {
+    for (auto loc : symbol.locs(gs)) {
         if (loc.file().data(gs).sourceType == File::Type::Payload) {
             return true;
         }
@@ -1042,7 +1080,7 @@ string TypeMemberRef::toStringFullName(const GlobalState &gs) const {
 }
 
 bool Symbol::isPrintable(const GlobalState &gs) const {
-    if (!isHiddenFromPrinting(gs, *this)) {
+    if (!isHiddenFromPrinting(gs, this->ref(gs))) {
         return true;
     }
 
@@ -1053,6 +1091,20 @@ bool Symbol::isPrintable(const GlobalState &gs) const {
         }
 
         if (childPair.second.isPrintable(gs)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool Method::isPrintable(const GlobalState &gs) const {
+    if (!isHiddenFromPrinting(gs, this->ref(gs))) {
+        return true;
+    }
+
+    for (auto typeParam : this->typeParams) {
+        if (typeParam.data(gs)->isPrintable(gs)) {
             return true;
         }
     }
@@ -1120,12 +1172,12 @@ string ClassOrModuleRef::toStringWithOptions(const GlobalState &gs, int tabs, bo
     fmt::format_to(std::back_inserter(buf), "{} {}", showKind(gs), showRaw ? toStringFullName(gs) : showFullName(gs));
 
     auto typeMembers = sym->typeMembers();
-    auto it = remove_if(typeMembers.begin(), typeMembers.end(),
-                        [&gs](auto &sym) -> bool { return sym.asTypeMemberRef().data(gs)->isFixed(); });
+    auto it =
+        remove_if(typeMembers.begin(), typeMembers.end(), [&gs](auto &sym) -> bool { return sym.data(gs)->isFixed(); });
     typeMembers.erase(it, typeMembers.end());
     if (!typeMembers.empty()) {
         fmt::format_to(std::back_inserter(buf), "[{}]", fmt::map_join(typeMembers, ", ", [&](auto symb) {
-                           auto name = symb.name(gs);
+                           auto name = symb.data(gs)->name;
                            return showRaw ? name.showRaw(gs) : name.show(gs);
                        }));
     }
@@ -1214,12 +1266,12 @@ string MethodRef::toStringWithOptions(const GlobalState &gs, int tabs, bool show
     }
 
     auto typeMembers = sym->typeArguments();
-    auto it = remove_if(typeMembers.begin(), typeMembers.end(),
-                        [&gs](auto &sym) -> bool { return sym.asTypeArgumentRef().data(gs)->isFixed(); });
+    auto it =
+        remove_if(typeMembers.begin(), typeMembers.end(), [&gs](auto &sym) -> bool { return sym.data(gs)->isFixed(); });
     typeMembers.erase(it, typeMembers.end());
     if (!typeMembers.empty()) {
         fmt::format_to(std::back_inserter(buf), "[{}]", fmt::map_join(typeMembers, ", ", [&](auto symb) {
-                           auto name = symb.name(gs);
+                           auto name = symb.data(gs)->name;
                            return showRaw ? name.showRaw(gs) : name.show(gs);
                        }));
     }
@@ -1236,17 +1288,14 @@ string MethodRef::toStringWithOptions(const GlobalState &gs, int tabs, bool show
 
     ENFORCE(!absl::c_any_of(to_string(buf), [](char c) { return c == '\n'; }));
     fmt::format_to(std::back_inserter(buf), "\n");
-    for (auto pair : sym->membersStableOrderSlow(gs)) {
-        ENFORCE_NO_TIMER(pair.second.exists());
-        // These should only show up in classes.
-        ENFORCE_NO_TIMER(pair.first != Names::singleton() && pair.first != Names::attached() &&
-                         pair.first != Names::mixedInClassMethods());
+    for (auto ta : sym->typeArguments()) {
+        ENFORCE_NO_TIMER(ta.exists());
 
-        if (!showFull && !pair.second.isPrintable(gs)) {
+        if (!showFull && !ta.data(gs)->isPrintable(gs)) {
             continue;
         }
 
-        auto str = pair.second.toStringWithOptions(gs, tabs + 1, showFull, showRaw);
+        auto str = ta.toStringWithOptions(gs, tabs + 1, showFull, showRaw);
         ENFORCE(!str.empty());
         fmt::format_to(std::back_inserter(buf), "{}", move(str));
     }
@@ -1480,8 +1529,14 @@ SymbolRef SymbolRef::dealias(const GlobalState &gs) const {
     switch (kind()) {
         case SymbolRef::Kind::ClassOrModule:
             return asClassOrModuleRef().data(gs)->dealias(gs);
-        case SymbolRef::Kind::Method:
-            return asMethodRef().data(gs)->dealias(gs);
+        case SymbolRef::Kind::Method: {
+            auto rv = asMethodRef().data(gs)->dealiasMethod(gs);
+            // dealiasMethod returns badAliasMethodStub but callers of dealias expect Symbols::untyped.
+            if (rv == Symbols::Sorbet_Private_Static_badAliasMethodStub()) {
+                return Symbols::untyped();
+            }
+            return rv;
+        }
         case SymbolRef::Kind::FieldOrStaticField:
             return asFieldRef().data(gs)->dealias(gs);
         case SymbolRef::Kind::TypeArgument:
@@ -1503,21 +1558,6 @@ SymbolRef SymbolRef::findMember(const GlobalState &gs, NameRef name) const {
             return asTypeArgumentRef().data(gs)->findMember(gs, name);
         case SymbolRef::Kind::TypeMember:
             return asTypeMemberRef().data(gs)->findMember(gs, name);
-    }
-}
-
-SymbolRef SymbolRef::findMemberTransitive(const GlobalState &gs, NameRef name) const {
-    switch (kind()) {
-        case SymbolRef::Kind::ClassOrModule:
-            return asClassOrModuleRef().data(gs)->findMemberTransitive(gs, name);
-        case SymbolRef::Kind::Method:
-            return asMethodRef().data(gs)->findMemberTransitive(gs, name);
-        case SymbolRef::Kind::FieldOrStaticField:
-            return asFieldRef().data(gs)->findMemberTransitive(gs, name);
-        case SymbolRef::Kind::TypeArgument:
-            return asTypeArgumentRef().data(gs)->findMemberTransitive(gs, name);
-        case SymbolRef::Kind::TypeMember:
-            return asTypeMemberRef().data(gs)->findMemberTransitive(gs, name);
     }
 }
 
@@ -1932,8 +1972,7 @@ SymbolRef Symbol::dealias(const GlobalState &gs, int depthLimit) const {
     return dealiasWithDefault(gs, this->ref(gs), depthLimit, Symbols::untyped());
 }
 // if dealiasing fails here, then we return a bad alias method stub instead
-MethodRef Symbol::dealiasMethod(const GlobalState &gs, int depthLimit) const {
-    ENFORCE_NO_TIMER(isMethod());
+MethodRef Method::dealiasMethod(const GlobalState &gs, int depthLimit) const {
     return dealiasWithDefault(gs, this->ref(gs), depthLimit, core::Symbols::Sorbet_Private_Static_badAliasMethodStub())
         .asMethodRef();
 }
@@ -1998,12 +2037,30 @@ Symbol Symbol::deepCopy(const GlobalState &to, bool keepGsId) const {
             result.members_[NameRef(to, mem.first)] = mem.second;
         }
     }
+
+    result.superClass_ = this->superClass_;
+    return result;
+}
+
+Method Method::deepCopy(const GlobalState &to) const {
+    Method result;
+    result.owner = this->owner;
+    result.flags = this->flags;
+    result.resultType = this->resultType;
+    result.name = NameRef(to, this->name);
+    result.locs_ = this->locs_;
+    result.typeParams = this->typeParams;
     result.arguments_.reserve(this->arguments_.size());
     for (auto &mem : this->arguments_) {
         auto &store = result.arguments_.emplace_back(mem.deepCopy());
         store.name = NameRef(to, mem.name);
     }
-    result.superClassOrRebind = this->superClassOrRebind;
+    result.rebind_ = this->rebind_;
+    result.arguments_.reserve(this->arguments_.size());
+    for (auto &mem : this->arguments_) {
+        auto &store = result.arguments_.emplace_back(mem.deepCopy());
+        store.name = NameRef(to, mem.name);
+    }
     result.intrinsic = this->intrinsic;
     return result;
 }
@@ -2011,8 +2068,7 @@ Symbol Symbol::deepCopy(const GlobalState &to, bool keepGsId) const {
 int Symbol::typeArity(const GlobalState &gs) const {
     ENFORCE(this->isClassOrModule());
     int arity = 0;
-    for (auto &ty : this->typeMembers()) {
-        auto tm = ty.asTypeMemberRef();
+    for (auto &tm : this->typeMembers()) {
         if (!tm.data(gs)->isFixed()) {
             ++arity;
         }
@@ -2033,8 +2089,7 @@ void Symbol::sanityCheck(const GlobalState &gs) const {
                                                                           this->name);
                 break;
             case SymbolRef::Kind::Method:
-                current2 = const_cast<GlobalState &>(gs).enterMethodSymbol(
-                    this->loc(), this->owner.asClassOrModuleRef(), this->name);
+                ENFORCE(false, "Methods cannot be stored in the Symbol class");
                 break;
             case SymbolRef::Kind::FieldOrStaticField:
                 if (isField()) {
@@ -2062,20 +2117,33 @@ void Symbol::sanityCheck(const GlobalState &gs) const {
                              e.first.toString(gs));
         }
     }
-    if (this->isMethod()) {
-        if (isa_type<AliasType>(this->resultType)) {
-            // If we have an alias method, we should never look at it's arguments;
-            // we should instead look at the arguments of whatever we're aliasing.
-            ENFORCE_NO_TIMER(this->arguments().empty(), "{}", ref(gs).show(gs));
-        } else {
-            ENFORCE_NO_TIMER(!this->arguments().empty(), "{}", ref(gs).show(gs));
-        }
+}
+
+void Method::sanityCheck(const GlobalState &gs) const {
+    if (!debug_mode) {
+        return;
+    }
+    MethodRef current = this->ref(gs);
+    MethodRef current2 = const_cast<GlobalState &>(gs).enterMethodSymbol(this->loc(), this->owner, this->name);
+
+    ENFORCE_NO_TIMER(current == current2);
+    for (auto &tp : typeParams) {
+        ENFORCE_NO_TIMER(tp.data(gs)->name.exists(), name.toString(gs) + " has a member symbol without a name");
+        ENFORCE_NO_TIMER(tp.exists(), name.toString(gs) + "." + tp.data(gs)->name.toString(gs) +
+                                          " corresponds to a core::Symbols::noTypeArgument()");
+    }
+    if (isa_type<AliasType>(this->resultType)) {
+        // If we have an alias method, we should never look at it's arguments;
+        // we should instead look at the arguments of whatever we're aliasing.
+        ENFORCE_NO_TIMER(this->arguments().empty(), ref(gs).show(gs));
+    } else {
+        ENFORCE_NO_TIMER(!this->arguments().empty(), ref(gs).show(gs));
     }
 }
 
 ClassOrModuleRef MethodRef::enclosingClass(const GlobalState &gs) const {
     // Methods can only be owned by classes or modules.
-    return data(gs)->owner.asClassOrModuleRef();
+    return data(gs)->owner;
 }
 
 ClassOrModuleRef SymbolRef::enclosingClass(const GlobalState &gs) const {
@@ -2101,7 +2169,7 @@ uint32_t Symbol::hash(const GlobalState &gs) const {
     result = mix(result, !this->resultType ? 0 : this->resultType.hash(gs));
     result = mix(result, this->flags);
     result = mix(result, this->owner._id);
-    result = mix(result, this->superClassOrRebind.id());
+    result = mix(result, this->superClass_.id());
     // argumentsOrMixins, typeParams, typeAliases
     if (!members().empty()) {
         // Rather than use membersStableOrderSlow, which is... slow..., use an order dictated by symbol ref ID.
@@ -2133,6 +2201,21 @@ uint32_t Symbol::hash(const GlobalState &gs) const {
             result = mix(result, _hash(e.data(gs)->name.shortName(gs)));
         }
     }
+    for (const auto &e : typeParams) {
+        if (e.exists()) {
+            result = mix(result, _hash(e.data(gs)->name.shortName(gs)));
+        }
+    }
+
+    return result;
+}
+
+uint32_t Method::hash(const GlobalState &gs) const {
+    uint32_t result = _hash(name.shortName(gs));
+    result = mix(result, !this->resultType ? 0 : this->resultType.hash(gs));
+    result = mix(result, this->flags);
+    result = mix(result, this->owner.id());
+    result = mix(result, this->rebind_.id());
     for (const auto &arg : arguments_) {
         // If an argument's resultType changes, then the sig has changed.
         auto type = arg.type;
@@ -2144,20 +2227,18 @@ uint32_t Symbol::hash(const GlobalState &gs) const {
     }
     for (const auto &e : typeParams) {
         if (e.exists()) {
-            result = mix(result, _hash(e.name(gs).shortName(gs)));
+            result = mix(result, _hash(e.data(gs)->name.shortName(gs)));
         }
     }
 
     return result;
 }
 
-uint32_t Symbol::methodShapeHash(const GlobalState &gs) const {
-    ENFORCE(isMethod());
-
+uint32_t Method::methodShapeHash(const GlobalState &gs) const {
     uint32_t result = _hash(name.shortName(gs));
     result = mix(result, this->flags);
-    result = mix(result, this->owner._id);
-    result = mix(result, this->superClassOrRebind.id());
+    result = mix(result, this->owner.id());
+    result = mix(result, this->rebind_.id());
     result = mix(result, this->hasSig());
     for (auto &arg : this->methodArgumentHash(gs)) {
         result = mix(result, arg);
@@ -2173,7 +2254,7 @@ uint32_t Symbol::methodShapeHash(const GlobalState &gs) const {
     return result;
 }
 
-vector<uint32_t> Symbol::methodArgumentHash(const GlobalState &gs) const {
+vector<uint32_t> Method::methodArgumentHash(const GlobalState &gs) const {
     vector<uint32_t> result;
     result.reserve(arguments().size());
     for (const auto &e : arguments()) {
@@ -2191,11 +2272,21 @@ vector<uint32_t> Symbol::methodArgumentHash(const GlobalState &gs) const {
 bool Symbol::ignoreInHashing(const GlobalState &gs) const {
     if (isClassOrModule()) {
         return superClass() == core::Symbols::StubModule();
-    } else if (isMethod()) {
-        return name.kind() == NameKind::UNIQUE && name.dataUnique(gs)->original == core::Names::staticInit();
     }
     return false;
 }
+
+bool Method::ignoreInHashing(const GlobalState &gs) const {
+    return name.kind() == NameKind::UNIQUE && name.dataUnique(gs)->original == core::Names::staticInit();
+}
+
+Loc Method::loc() const {
+    if (!locs_.empty()) {
+        return locs_.back();
+    }
+    return Loc::none();
+}
+
 Loc Symbol::loc() const {
     if (!locs_.empty()) {
         return locs_.back();
@@ -2203,8 +2294,44 @@ Loc Symbol::loc() const {
     return Loc::none();
 }
 
+const InlinedVector<Loc, 2> &Method::locs() const {
+    return locs_;
+}
+
 const InlinedVector<Loc, 2> &Symbol::locs() const {
     return locs_;
+}
+
+namespace {
+void addLocInternal(const core::GlobalState &gs, core::Loc loc, core::Loc mainLoc, InlinedVector<Loc, 2> &locs) {
+    for (auto &existing : locs) {
+        if (existing.file() == loc.file()) {
+            existing = loc;
+            return;
+        }
+    }
+
+    if (locs.empty() || (loc.file().data(gs).sourceType == core::File::Type::Normal && !loc.file().data(gs).isRBI())) {
+        if (mainLoc.exists() && loc.file().data(gs).strictLevel >= mainLoc.file().data(gs).strictLevel) {
+            // The new loc is stricter; make it the new canonical loc.
+            locs.emplace_back(loc);
+        } else {
+            locs.insert(locs.begin(), loc);
+        }
+    } else {
+        // This is an RBI file; continue to use existing loc as the canonical loc.
+        // Insert just before end.
+        locs.insert(locs.end() - 1, loc);
+    }
+}
+} // namespace
+
+void Method::addLoc(const core::GlobalState &gs, core::Loc loc) {
+    if (!loc.file().exists()) {
+        return;
+    }
+
+    addLocInternal(gs, loc, this->loc(), locs_);
 }
 
 void Symbol::addLoc(const core::GlobalState &gs, core::Loc loc) {
@@ -2219,25 +2346,55 @@ void Symbol::addLoc(const core::GlobalState &gs, core::Loc loc) {
     // We allow one loc (during class creation) for packages under package registry.
     ENFORCE(locs_.empty() || owner != Symbols::PackageRegistry());
 
-    for (auto &existing : locs_) {
-        if (existing.file() == loc.file()) {
-            existing = loc;
-            return;
-        }
-    }
+    addLocInternal(gs, loc, this->loc(), locs_);
+}
 
-    if (locs_.empty() || (loc.file().data(gs).sourceType == core::File::Type::Normal && !loc.file().data(gs).isRBI())) {
-        if (this->loc().exists() && loc.file().data(gs).strictLevel >= this->loc().file().data(gs).strictLevel) {
-            // The new loc is stricter; make it the new canonical loc.
-            locs_.emplace_back(loc);
-        } else {
-            locs_.insert(locs_.begin(), loc);
-        }
-    } else {
-        // This is an RBI file; continue to use existing loc as the canonical loc.
-        // Insert just before end.
-        locs_.insert(locs_.end() - 1, loc);
+namespace {
+bool stableOrder(const GlobalState &gs, const pair<NameRef, SymbolRef> &lhs, const pair<NameRef, SymbolRef> &rhs) {
+    auto lhsShort = lhs.first.shortName(gs);
+    auto rhsShort = rhs.first.shortName(gs);
+    auto compareShort = lhsShort.compare(rhsShort);
+    if (compareShort != 0) {
+        return compareShort < 0;
     }
+    auto lhsRaw = lhs.first.showRaw(gs);
+    auto rhsRaw = rhs.first.showRaw(gs);
+    auto compareRaw = lhsRaw.compare(rhsRaw);
+    if (compareRaw != 0) {
+        return compareRaw < 0;
+    }
+    int i = -1;
+    const auto &rhsLocs = rhs.second.locs(gs);
+    for (const auto lhsLoc : lhs.second.locs(gs)) {
+        i++;
+        if (i > rhsLocs.size()) {
+            // more locs in lhs, so `lhs < rhs` is `false`
+            return false;
+        }
+        auto rhsLoc = rhsLocs[i];
+        auto compareLoc = lhsLoc.filePosToString(gs).compare(rhsLoc.filePosToString(gs));
+        if (compareLoc != 0) {
+            return compareLoc < 0;
+        }
+    }
+    if (i < rhsLocs.size()) {
+        // more locs in rhs, so `lhs < rhs` is true
+        return true;
+    }
+    ENFORCE(false, "no stable sort");
+    return false;
+}
+} // namespace
+
+vector<pair<NameRef, SymbolRef>> Method::membersStableOrderSlow(const GlobalState &gs) const {
+    vector<pair<NameRef, SymbolRef>> result;
+    if (!typeParams.empty()) {
+        for (auto typeParam : typeParams) {
+            result.emplace_back(typeParam.data(gs)->name, typeParam);
+        }
+        fast_sort(result, [&](auto const &lhs, auto const &rhs) -> bool { return stableOrder(gs, lhs, rhs); });
+    }
+    return result;
 }
 
 vector<std::pair<NameRef, SymbolRef>> Symbol::membersStableOrderSlow(const GlobalState &gs) const {
@@ -2246,40 +2403,7 @@ vector<std::pair<NameRef, SymbolRef>> Symbol::membersStableOrderSlow(const Globa
     for (const auto &e : members()) {
         result.emplace_back(e);
     }
-    fast_sort(result, [&](auto const &lhs, auto const &rhs) -> bool {
-        auto lhsShort = lhs.first.shortName(gs);
-        auto rhsShort = rhs.first.shortName(gs);
-        auto compareShort = lhsShort.compare(rhsShort);
-        if (compareShort != 0) {
-            return compareShort < 0;
-        }
-        auto lhsRaw = lhs.first.showRaw(gs);
-        auto rhsRaw = rhs.first.showRaw(gs);
-        auto compareRaw = lhsRaw.compare(rhsRaw);
-        if (compareRaw != 0) {
-            return compareRaw < 0;
-        }
-        int i = -1;
-        const auto &rhsLocs = rhs.second.locs(gs);
-        for (const auto lhsLoc : lhs.second.locs(gs)) {
-            i++;
-            if (i > rhsLocs.size()) {
-                // more locs in lhs, so `lhs < rhs` is `false`
-                return false;
-            }
-            auto rhsLoc = rhsLocs[i];
-            auto compareLoc = lhsLoc.filePosToString(gs).compare(rhsLoc.filePosToString(gs));
-            if (compareLoc != 0) {
-                return compareLoc < 0;
-            }
-        }
-        if (i < rhsLocs.size()) {
-            // more locs in rhs, so `lhs < rhs` is true
-            return true;
-        }
-        ENFORCE(false, "no stable sort");
-        return 0;
-    });
+    fast_sort(result, [&](auto const &lhs, auto const &rhs) -> bool { return stableOrder(gs, lhs, rhs); });
     return result;
 }
 
@@ -2307,6 +2431,25 @@ const Symbol *SymbolData::operator->() const {
 const Symbol *ConstSymbolData::operator->() const {
     runDebugOnlyCheck();
     return &symbol;
+};
+
+MethodData::MethodData(Method &ref, GlobalState &gs) : DebugOnlyCheck(gs), method(ref) {}
+
+ConstMethodData::ConstMethodData(const Method &ref, const GlobalState &gs) : DebugOnlyCheck(gs), method(ref) {}
+
+Method *MethodData::operator->() {
+    runDebugOnlyCheck();
+    return &method;
+};
+
+const Method *MethodData::operator->() const {
+    runDebugOnlyCheck();
+    return &method;
+};
+
+const Method *ConstMethodData::operator->() const {
+    runDebugOnlyCheck();
+    return &method;
 };
 
 } // namespace sorbet::core

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -462,7 +462,7 @@ TypePtr ArgInfo::argumentTypeAsSeenByImplementation(Context ctx, core::TypeConst
     if (instantiated == nullptr) {
         instantiated = core::Types::untyped(ctx, owner);
     }
-    if (owner.data(ctx)->isGenericMethod()) {
+    if (owner.data(ctx)->flags.isGenericMethod) {
         instantiated = core::Types::instantiate(ctx, instantiated, constr);
     } else {
         // You might expect us to instantiate with the constr to be null for a non-generic method,
@@ -608,14 +608,14 @@ MethodRef findConcreteMethodTransitiveInternal(const GlobalState &gs, ClassOrMod
     }
 
     MethodRef result = owner.data(gs)->findMethod(gs, name);
-    if (result.exists() && !result.data(gs)->isAbstract()) {
+    if (result.exists() && !result.data(gs)->flags.isAbstract) {
         return result;
     }
 
     for (auto it = owner.data(gs)->mixins().begin(); it != owner.data(gs)->mixins().end(); ++it) {
         ENFORCE(it->exists());
         result = it->data(gs)->findMethod(gs, name);
-        if (result.exists() && !result.data(gs)->isAbstract()) {
+        if (result.exists() && !result.data(gs)->flags.isAbstract) {
             return result;
         }
     }
@@ -1230,25 +1230,25 @@ string MethodRef::toStringWithOptions(const GlobalState &gs, int tabs, bool show
 
     auto methodFlags = InlinedVector<string, 3>{};
 
-    if (sym->isMethodPrivate()) {
+    if (sym->flags.isPrivate) {
         methodFlags.emplace_back("private");
-    } else if (sym->isMethodProtected()) {
+    } else if (sym->flags.isProtected) {
         methodFlags.emplace_back("protected");
     }
 
-    if (sym->isAbstract()) {
+    if (sym->flags.isAbstract) {
         methodFlags.emplace_back("abstract");
     }
-    if (sym->isOverridable()) {
+    if (sym->flags.isOverridable) {
         methodFlags.emplace_back("overridable");
     }
-    if (sym->isOverride()) {
+    if (sym->flags.isOverride) {
         methodFlags.emplace_back("override");
     }
-    if (sym->isIncompatibleOverride()) {
+    if (sym->flags.isIncompatibleOverride) {
         methodFlags.emplace_back("allow_incompatible");
     }
-    if (sym->isFinalMethod()) {
+    if (sym->flags.isFinal) {
         methodFlags.emplace_back("final");
     }
 

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -199,8 +199,6 @@ public:
         return resultType != nullptr;
     }
 
-    std::vector<std::pair<NameRef, SymbolRef>> membersStableOrderSlow(const GlobalState &gs) const;
-
     using ArgumentsStore = InlinedVector<ArgInfo, core::SymbolRef::EXPECTED_METHOD_ARGS_COUNT>;
     ArgumentsStore &arguments() {
         return arguments_;

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -49,20 +49,20 @@ public:
     class Flags {
     public:
         // Synthesized by C++ code in a Rewriter pass
-        bool rewriterSynthesized : 1;
-        bool methodProtected : 1;
-        bool methodPrivate : 1;
-        bool methodOverloaded : 1;
-        bool methodAbstract : 1;
-        bool methodGeneric : 1;
-        bool methodOverridable : 1;
-        bool methodFinal : 1;
-        bool methodOverride : 1;
-        bool methodIncompatibleOverride : 1;
+        bool isRewriterSynthesized : 1;
+        bool isProtected : 1;
+        bool isPrivate : 1;
+        bool isOverloaded : 1;
+        bool isAbstract : 1;
+        bool isGenericMethod : 1;
+        bool isOverridable : 1;
+        bool isFinal : 1;
+        bool isOverride : 1;
+        bool isIncompatibleOverride : 1;
         Flags() noexcept
-            : rewriterSynthesized(false), methodProtected(false), methodPrivate(false), methodOverloaded(false),
-              methodAbstract(false), methodGeneric(false), methodOverridable(false), methodFinal(false),
-              methodOverride(false), methodIncompatibleOverride(false) {}
+            : isRewriterSynthesized(false), isProtected(false), isPrivate(false), isOverloaded(false),
+              isAbstract(false), isGenericMethod(false), isOverridable(false), isFinal(false), isOverride(false),
+              isIncompatibleOverride(false) {}
 
         uint16_t serialize() const {
             // Can replace this with std::bit_cast in C++20
@@ -79,72 +79,72 @@ public:
     std::vector<uint32_t> methodArgumentHash(const GlobalState &gs) const;
 
     inline bool isOverloaded() const {
-        return flags.methodOverloaded;
+        return flags.isOverloaded;
     }
 
     inline bool isAbstract() const {
-        return flags.methodAbstract;
+        return flags.isAbstract;
     }
 
     inline bool isIncompatibleOverride() const {
-        return flags.methodIncompatibleOverride;
+        return flags.isIncompatibleOverride;
     }
 
     inline bool isGenericMethod() const {
-        return flags.methodGeneric;
+        return flags.isGenericMethod;
     }
 
     inline bool isOverridable() const {
-        return flags.methodOverridable;
+        return flags.isOverridable;
     }
 
     inline bool isOverride() const {
-        return flags.methodOverride;
+        return flags.isOverride;
     }
 
     inline void setOverloaded() {
-        flags.methodOverloaded = true;
+        flags.isOverloaded = true;
     }
 
     inline void setAbstract() {
-        flags.methodAbstract = true;
+        flags.isAbstract = true;
     }
 
     inline void setIncompatibleOverride() {
-        flags.methodIncompatibleOverride = true;
+        flags.isIncompatibleOverride = true;
     }
 
     inline void setGenericMethod() {
-        flags.methodGeneric = true;
+        flags.isGenericMethod = true;
     }
 
     inline void setOverridable() {
-        flags.methodOverridable = true;
+        flags.isOverridable = true;
     }
 
     inline void setFinalMethod() {
-        flags.methodFinal = true;
+        flags.isFinal = true;
     }
 
     inline void setOverride() {
-        flags.methodOverride = true;
+        flags.isOverride = true;
     }
 
     inline bool isFinalMethod() const {
-        return flags.methodFinal;
+        return flags.isFinal;
     }
 
     inline void setMethodPublic() {
-        flags.methodPrivate = false;
-        flags.methodProtected = false;
+        flags.isPrivate = false;
+        flags.isProtected = false;
     }
 
     inline void setMethodProtected() {
-        flags.methodProtected = true;
+        flags.isProtected = true;
     }
 
     inline void setMethodPrivate() {
-        flags.methodPrivate = true;
+        flags.isPrivate = true;
     }
 
     void setMethodVisibility(Visibility visibility) {
@@ -166,18 +166,18 @@ public:
     }
 
     inline bool isMethodProtected() const {
-        return flags.methodProtected;
+        return flags.isProtected;
     }
 
     inline bool isMethodPrivate() const {
-        return flags.methodPrivate;
+        return flags.isPrivate;
     }
 
     inline void setRewriterSynthesized() {
-        flags.rewriterSynthesized = true;
+        flags.isRewriterSynthesized = true;
     }
     inline bool isRewriterSynthesized() const {
-        return flags.rewriterSynthesized;
+        return flags.isRewriterSynthesized;
     }
 
     Visibility methodVisibility() const {

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -199,7 +199,6 @@ public:
         return resultType != nullptr;
     }
 
-    TypeArgumentRef findMember(const GlobalState &gs, NameRef name) const;
     std::vector<std::pair<NameRef, SymbolRef>> membersStableOrderSlow(const GlobalState &gs) const;
 
     using ArgumentsStore = InlinedVector<ArgInfo, core::SymbolRef::EXPECTED_METHOD_ARGS_COUNT>;

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -195,14 +195,6 @@ public:
         }
     }
 
-    inline void setReBind(ClassOrModuleRef rebind) {
-        this->rebind_ = rebind;
-    }
-
-    ClassOrModuleRef rebind() const {
-        return rebind_;
-    }
-
     bool hasSig() const {
         return resultType != nullptr;
     }
@@ -232,18 +224,19 @@ public:
 
     ClassOrModuleRef owner;
     NameRef name;
+    ClassOrModuleRef rebind;
     TypePtr resultType;
     // All `IntrinsicMethod`s in sorbet should be statically-allocated, which is
     // why raw pointers are safe.
     const IntrinsicMethod *intrinsic = nullptr;
 
 private:
-    uint16_t flags = Flags::NONE;
-    ClassOrModuleRef rebind_;
     InlinedVector<TypeArgumentRef, 4> typeParams;
     InlinedVector<Loc, 2> locs_;
     ArgumentsStore arguments_;
+    uint16_t flags = Flags::NONE;
 };
+CheckSize(Method, 208, 8);
 
 class Symbol final {
 public:

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -78,73 +78,9 @@ public:
     uint32_t methodShapeHash(const GlobalState &gs) const;
     std::vector<uint32_t> methodArgumentHash(const GlobalState &gs) const;
 
-    inline bool isOverloaded() const {
-        return flags.isOverloaded;
-    }
-
-    inline bool isAbstract() const {
-        return flags.isAbstract;
-    }
-
-    inline bool isIncompatibleOverride() const {
-        return flags.isIncompatibleOverride;
-    }
-
-    inline bool isGenericMethod() const {
-        return flags.isGenericMethod;
-    }
-
-    inline bool isOverridable() const {
-        return flags.isOverridable;
-    }
-
-    inline bool isOverride() const {
-        return flags.isOverride;
-    }
-
-    inline void setOverloaded() {
-        flags.isOverloaded = true;
-    }
-
-    inline void setAbstract() {
-        flags.isAbstract = true;
-    }
-
-    inline void setIncompatibleOverride() {
-        flags.isIncompatibleOverride = true;
-    }
-
-    inline void setGenericMethod() {
-        flags.isGenericMethod = true;
-    }
-
-    inline void setOverridable() {
-        flags.isOverridable = true;
-    }
-
-    inline void setFinalMethod() {
-        flags.isFinal = true;
-    }
-
-    inline void setOverride() {
-        flags.isOverride = true;
-    }
-
-    inline bool isFinalMethod() const {
-        return flags.isFinal;
-    }
-
     inline void setMethodPublic() {
         flags.isPrivate = false;
         flags.isProtected = false;
-    }
-
-    inline void setMethodProtected() {
-        flags.isProtected = true;
-    }
-
-    inline void setMethodPrivate() {
-        flags.isPrivate = true;
     }
 
     void setMethodVisibility(Visibility visibility) {
@@ -153,39 +89,24 @@ public:
                 this->setMethodPublic();
                 break;
             case Visibility::Protected:
-                this->setMethodProtected();
+                this->flags.isProtected = true;
                 break;
             case Visibility::Private:
-                this->setMethodPrivate();
+                this->flags.isPrivate = true;
                 break;
         }
     }
 
     inline bool isMethodPublic() const {
-        return !isMethodProtected() && !isMethodPrivate();
-    }
-
-    inline bool isMethodProtected() const {
-        return flags.isProtected;
-    }
-
-    inline bool isMethodPrivate() const {
-        return flags.isPrivate;
-    }
-
-    inline void setRewriterSynthesized() {
-        flags.isRewriterSynthesized = true;
-    }
-    inline bool isRewriterSynthesized() const {
-        return flags.isRewriterSynthesized;
+        return !flags.isProtected && !flags.isPrivate;
     }
 
     Visibility methodVisibility() const {
         if (this->isMethodPublic()) {
             return Visibility::Public;
-        } else if (this->isMethodProtected()) {
+        } else if (this->flags.isProtected) {
             return Visibility::Protected;
-        } else if (this->isMethodPrivate()) {
+        } else if (this->flags.isPrivate) {
             return Visibility::Private;
         } else {
             Exception::raise("Expected method to have visibility");
@@ -221,6 +142,8 @@ public:
 
 private:
     InlinedVector<Loc, 2> locs_;
+
+public:
     Flags flags;
 };
 CheckSize(Method, 192, 8);
@@ -559,7 +482,7 @@ public:
     inline void setRewriterSynthesized() {
         flags |= Symbol::Flags::REWRITER_SYNTHESIZED;
     }
-    inline bool isRewriterSynthesized() const {
+    inline bool isRewriterSynthesized() {
         return (flags & Symbol::Flags::REWRITER_SYNTHESIZED) != 0;
     }
 

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -38,6 +38,213 @@ enum class Visibility : uint8_t {
     Private,
 };
 
+class Method final {
+public:
+    friend class Symbol;
+    friend class serialize::SerializerImpl;
+
+    Method(const Method &) = delete;
+    Method() = default;
+    Method(Method &&) noexcept = default;
+    class Flags {
+    public:
+        static constexpr uint16_t NONE = 0;
+
+        // Synthesized by C++ code in a Rewriter pass
+        static constexpr uint16_t REWRITER_SYNTHESIZED = 00001;
+
+        static constexpr uint16_t METHOD_PROTECTED = 0x0002;
+        static constexpr uint16_t METHOD_PRIVATE = 0x0004;
+        static constexpr uint16_t METHOD_OVERLOADED = 0x0008;
+        static constexpr uint16_t METHOD_ABSTRACT = 0x0010;
+        static constexpr uint16_t METHOD_GENERIC = 0x0020;
+        [[deprecated]] static constexpr uint16_t METHOD_GENERATED_SIG = 0x0040;
+        static constexpr uint16_t METHOD_OVERRIDABLE = 0x0080;
+        static constexpr uint16_t METHOD_FINAL = 0x0100;
+        static constexpr uint16_t METHOD_OVERRIDE = 0x0200;
+        [[deprecated]] static constexpr uint16_t METHOD_IMPLEMENTATION = 0x0400;
+        static constexpr uint16_t METHOD_INCOMPATIBLE_OVERRIDE = 0x0800;
+    };
+
+    Loc loc() const;
+    const InlinedVector<Loc, 2> &locs() const;
+    void addLoc(const core::GlobalState &gs, core::Loc loc);
+    uint32_t hash(const GlobalState &gs) const;
+    uint32_t methodShapeHash(const GlobalState &gs) const;
+    std::vector<uint32_t> methodArgumentHash(const GlobalState &gs) const;
+
+    inline InlinedVector<TypeArgumentRef, 4> &typeArguments() {
+        return typeParams;
+    }
+
+    inline const InlinedVector<TypeArgumentRef, 4> &typeArguments() const {
+        return typeParams;
+    }
+
+    inline bool isOverloaded() const {
+        return (flags & Method::Flags::METHOD_OVERLOADED) != 0;
+    }
+
+    inline bool isAbstract() const {
+        return (flags & Method::Flags::METHOD_ABSTRACT) != 0;
+    }
+
+    inline bool isIncompatibleOverride() const {
+        return (flags & Method::Flags::METHOD_INCOMPATIBLE_OVERRIDE) != 0;
+    }
+
+    inline bool isGenericMethod() const {
+        return (flags & Method::Flags::METHOD_GENERIC) != 0;
+    }
+
+    inline bool isOverridable() const {
+        return (flags & Method::Flags::METHOD_OVERRIDABLE) != 0;
+    }
+
+    inline bool isOverride() const {
+        return (flags & Method::Flags::METHOD_OVERRIDE) != 0;
+    }
+
+    inline void setOverloaded() {
+        flags |= Method::Flags::METHOD_OVERLOADED;
+    }
+
+    inline void setAbstract() {
+        flags |= Method::Flags::METHOD_ABSTRACT;
+    }
+
+    inline void setIncompatibleOverride() {
+        flags |= Method::Flags::METHOD_INCOMPATIBLE_OVERRIDE;
+    }
+
+    inline void setGenericMethod() {
+        flags |= Method::Flags::METHOD_GENERIC;
+    }
+
+    inline void setOverridable() {
+        flags |= Method::Flags::METHOD_OVERRIDABLE;
+    }
+
+    inline void setFinalMethod() {
+        flags |= Method::Flags::METHOD_FINAL;
+    }
+
+    inline void setOverride() {
+        flags |= Method::Flags::METHOD_OVERRIDE;
+    }
+
+    inline bool isFinalMethod() const {
+        return (flags & Method::Flags::METHOD_FINAL) != 0;
+    }
+
+    inline void setMethodPublic() {
+        flags &= ~Method::Flags::METHOD_PRIVATE;
+        flags &= ~Method::Flags::METHOD_PROTECTED;
+    }
+
+    inline void setMethodProtected() {
+        flags |= Method::Flags::METHOD_PROTECTED;
+    }
+
+    inline void setMethodPrivate() {
+        flags |= Method::Flags::METHOD_PRIVATE;
+    }
+
+    void setMethodVisibility(Visibility visibility) {
+        switch (visibility) {
+            case Visibility::Public:
+                this->setMethodPublic();
+                break;
+            case Visibility::Protected:
+                this->setMethodProtected();
+                break;
+            case Visibility::Private:
+                this->setMethodPrivate();
+                break;
+        }
+    }
+
+    inline bool isMethodPublic() const {
+        return !isMethodProtected() && !isMethodPrivate();
+    }
+
+    inline bool isMethodProtected() const {
+        return (flags & Method::Flags::METHOD_PROTECTED) != 0;
+    }
+
+    inline bool isMethodPrivate() const {
+        return (flags & Method::Flags::METHOD_PRIVATE) != 0;
+    }
+
+    inline void setRewriterSynthesized() {
+        flags |= Method::Flags::REWRITER_SYNTHESIZED;
+    }
+    inline bool isRewriterSynthesized() const {
+        return (flags & Method::Flags::REWRITER_SYNTHESIZED) != 0;
+    }
+
+    Visibility methodVisibility() const {
+        if (this->isMethodPublic()) {
+            return Visibility::Public;
+        } else if (this->isMethodProtected()) {
+            return Visibility::Protected;
+        } else if (this->isMethodPrivate()) {
+            return Visibility::Private;
+        } else {
+            Exception::raise("Expected method to have visibility");
+        }
+    }
+
+    inline void setReBind(ClassOrModuleRef rebind) {
+        this->rebind_ = rebind;
+    }
+
+    ClassOrModuleRef rebind() const {
+        return rebind_;
+    }
+
+    bool hasSig() const {
+        return resultType != nullptr;
+    }
+
+    TypeArgumentRef findMember(const GlobalState &gs, NameRef name) const;
+    std::vector<std::pair<NameRef, SymbolRef>> membersStableOrderSlow(const GlobalState &gs) const;
+
+    using ArgumentsStore = InlinedVector<ArgInfo, core::SymbolRef::EXPECTED_METHOD_ARGS_COUNT>;
+    ArgumentsStore &arguments() {
+        return arguments_;
+    }
+
+    const ArgumentsStore &arguments() const {
+        return arguments_;
+    }
+
+    // if dealiasing fails here, then we return a bad alias method stub instead
+    MethodRef dealiasMethod(const GlobalState &gs, int depthLimit = 42) const;
+
+    // TODO(dmitry) perf: most calls to this method could be eliminated as part of perf work.
+    MethodRef ref(const GlobalState &gs) const;
+
+    Method deepCopy(const GlobalState &to) const;
+    void sanityCheck(const GlobalState &gs) const;
+    bool ignoreInHashing(const GlobalState &gs) const;
+    bool isPrintable(const GlobalState &gs) const;
+
+    ClassOrModuleRef owner;
+    NameRef name;
+    TypePtr resultType;
+    // All `IntrinsicMethod`s in sorbet should be statically-allocated, which is
+    // why raw pointers are safe.
+    const IntrinsicMethod *intrinsic = nullptr;
+
+private:
+    uint16_t flags = Flags::NONE;
+    ClassOrModuleRef rebind_;
+    InlinedVector<TypeArgumentRef, 4> typeParams;
+    InlinedVector<Loc, 2> locs_;
+    ArgumentsStore arguments_;
+};
+
 class Symbol final {
 public:
     Symbol(const Symbol &) = delete;
@@ -62,7 +269,6 @@ public:
 
         // --- What type of symbol is this? ---
         static constexpr uint32_t CLASS_OR_MODULE = 0x8000'0000;
-        static constexpr uint32_t METHOD = 0x4000'0000;
         static constexpr uint32_t FIELD = 0x2000'0000;
         static constexpr uint32_t STATIC_FIELD = 0x1000'0000;
         static constexpr uint32_t TYPE_ARGUMENT = 0x0800'0000;
@@ -85,19 +291,6 @@ public:
         static constexpr uint32_t CLASS_OR_MODULE_SEALED = 0x0000'0400;
         static constexpr uint32_t CLASS_OR_MODULE_PRIVATE = 0x0000'0800;
 
-        // Method flags
-        static constexpr uint32_t METHOD_PROTECTED = 0x0000'0010;
-        static constexpr uint32_t METHOD_PRIVATE = 0x0000'0020;
-        static constexpr uint32_t METHOD_OVERLOADED = 0x0000'0040;
-        static constexpr uint32_t METHOD_ABSTRACT = 0x0000'0080;
-        static constexpr uint32_t METHOD_GENERIC = 0x0000'0100;
-        [[deprecated]] static constexpr uint32_t METHOD_GENERATED_SIG = 0x0000'0200;
-        static constexpr uint32_t METHOD_OVERRIDABLE = 0x0000'0400;
-        static constexpr uint32_t METHOD_FINAL = 0x0000'0800;
-        static constexpr uint32_t METHOD_OVERRIDE = 0x0000'1000;
-        [[deprecated]] static constexpr uint32_t METHOD_IMPLEMENTATION = 0x0000'2000;
-        static constexpr uint32_t METHOD_INCOMPATIBLE_OVERRIDE = 0x0000'4000;
-
         // Type flags
         static constexpr uint32_t TYPE_COVARIANT = 0x0000'0010;
         static constexpr uint32_t TYPE_INVARIANT = 0x0000'0020;
@@ -114,8 +307,6 @@ public:
     void addLoc(const core::GlobalState &gs, core::Loc loc);
 
     uint32_t hash(const GlobalState &gs) const;
-    uint32_t methodShapeHash(const GlobalState &gs) const;
-    std::vector<uint32_t> methodArgumentHash(const GlobalState &gs) const;
 
     std::vector<TypePtr> selfTypeArgs(const GlobalState &gs) const;
 
@@ -148,12 +339,12 @@ public:
     // Add a placeholder for a mixin and return index in mixins()
     uint16_t addMixinPlaceholder(const GlobalState &gs);
 
-    inline InlinedVector<SymbolRef, 4> &typeMembers() {
+    inline InlinedVector<TypeMemberRef, 4> &typeMembers() {
         ENFORCE(isClassOrModule());
         return typeParams;
     }
 
-    inline const InlinedVector<SymbolRef, 4> &typeMembers() const {
+    inline const InlinedVector<TypeMemberRef, 4> &typeMembers() const {
         ENFORCE(isClassOrModule());
         return typeParams;
     }
@@ -162,16 +353,6 @@ public:
     // this generic type. May differ from typeMembers.size() if some type
     // members have fixed values.
     int typeArity(const GlobalState &gs) const;
-
-    inline InlinedVector<SymbolRef, 4> &typeArguments() {
-        ENFORCE(isMethod());
-        return typeParams;
-    }
-
-    inline const InlinedVector<SymbolRef, 4> &typeArguments() const {
-        ENFORCE(isMethod());
-        return typeParams;
-    }
 
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef sym) const;
 
@@ -192,46 +373,12 @@ public:
         return (flags & Symbol::Flags::FIELD) != 0;
     }
 
-    inline bool isMethod() const {
-        return (flags & Symbol::Flags::METHOD) != 0;
-    }
-
     inline bool isTypeMember() const {
         return (flags & Symbol::Flags::TYPE_MEMBER) != 0;
     }
 
     inline bool isTypeArgument() const {
         return (flags & Symbol::Flags::TYPE_ARGUMENT) != 0;
-    }
-
-    inline bool isOverloaded() const {
-        ENFORCE_NO_TIMER(isMethod());
-        return (flags & Symbol::Flags::METHOD_OVERLOADED) != 0;
-    }
-
-    inline bool isAbstract() const {
-        ENFORCE_NO_TIMER(isMethod());
-        return (flags & Symbol::Flags::METHOD_ABSTRACT) != 0;
-    }
-
-    inline bool isIncompatibleOverride() const {
-        ENFORCE_NO_TIMER(isMethod());
-        return (flags & Symbol::Flags::METHOD_INCOMPATIBLE_OVERRIDE) != 0;
-    }
-
-    inline bool isGenericMethod() const {
-        ENFORCE_NO_TIMER(isMethod());
-        return (flags & Symbol::Flags::METHOD_GENERIC) != 0;
-    }
-
-    inline bool isOverridable() const {
-        ENFORCE_NO_TIMER(isMethod());
-        return (flags & Symbol::Flags::METHOD_OVERRIDABLE) != 0;
-    }
-
-    inline bool isOverride() const {
-        ENFORCE_NO_TIMER(isMethod());
-        return (flags & Symbol::Flags::METHOD_OVERRIDE) != 0;
     }
 
     inline bool isCovariant() const {
@@ -265,33 +412,6 @@ public:
             return Variance::ContraVariant;
         }
         Exception::raise("Should not happen");
-    }
-
-    inline bool isMethodPublic() const {
-        ENFORCE_NO_TIMER(isMethod());
-        return !isMethodProtected() && !isMethodPrivate();
-    }
-
-    inline bool isMethodProtected() const {
-        ENFORCE_NO_TIMER(isMethod());
-        return (flags & Symbol::Flags::METHOD_PROTECTED) != 0;
-    }
-
-    inline bool isMethodPrivate() const {
-        ENFORCE_NO_TIMER(isMethod());
-        return (flags & Symbol::Flags::METHOD_PRIVATE) != 0;
-    }
-
-    Visibility methodVisibility() const {
-        if (this->isMethodPublic()) {
-            return Visibility::Public;
-        } else if (this->isMethodProtected()) {
-            return Visibility::Protected;
-        } else if (this->isMethodPrivate()) {
-            return Visibility::Private;
-        } else {
-            Exception::raise("Expected method to have visibility");
-        }
     }
 
     inline bool isClassOrModuleModule() const {
@@ -350,32 +470,27 @@ public:
     }
 
     inline void setClassOrModule() {
-        ENFORCE(!isStaticField() && !isField() && !isMethod() && !isTypeArgument() && !isTypeMember());
+        ENFORCE(!isStaticField() && !isField() && !isTypeArgument() && !isTypeMember());
         flags |= Symbol::Flags::CLASS_OR_MODULE;
     }
 
     inline void setStaticField() {
-        ENFORCE(!isClassOrModule() && !isField() && !isMethod() && !isTypeArgument() && !isTypeMember());
+        ENFORCE(!isClassOrModule() && !isField() && !isTypeArgument() && !isTypeMember());
         flags |= Symbol::Flags::STATIC_FIELD;
     }
 
     inline void setField() {
-        ENFORCE(!isClassOrModule() && !isStaticField() && !isMethod() && !isTypeArgument() && !isTypeMember());
+        ENFORCE(!isClassOrModule() && !isStaticField() && !isTypeArgument() && !isTypeMember());
         flags |= Symbol::Flags::FIELD;
     }
 
-    inline void setMethod() {
-        ENFORCE(!isClassOrModule() && !isStaticField() && !isField() && !isTypeArgument() && !isTypeMember());
-        flags |= Symbol::Flags::METHOD;
-    }
-
     inline void setTypeArgument() {
-        ENFORCE(!isClassOrModule() && !isStaticField() && !isField() && !isMethod() && !isTypeMember());
+        ENFORCE(!isClassOrModule() && !isStaticField() && !isField() && !isTypeMember());
         flags |= Symbol::Flags::TYPE_ARGUMENT;
     }
 
     inline void setTypeMember() {
-        ENFORCE(!isClassOrModule() && !isStaticField() && !isField() && !isMethod() && !isTypeArgument());
+        ENFORCE(!isClassOrModule() && !isStaticField() && !isField() && !isTypeArgument());
         flags |= Symbol::Flags::TYPE_MEMBER;
     }
 
@@ -411,77 +526,6 @@ public:
     inline void setFixed() {
         ENFORCE(isTypeArgument() || isTypeMember());
         flags |= Symbol::Flags::TYPE_FIXED;
-    }
-
-    inline void setOverloaded() {
-        ENFORCE(isMethod());
-        flags |= Symbol::Flags::METHOD_OVERLOADED;
-    }
-
-    inline void setAbstract() {
-        ENFORCE(isMethod());
-        flags |= Symbol::Flags::METHOD_ABSTRACT;
-    }
-
-    inline void setIncompatibleOverride() {
-        ENFORCE(isMethod());
-        flags |= Symbol::Flags::METHOD_INCOMPATIBLE_OVERRIDE;
-    }
-
-    inline void setGenericMethod() {
-        ENFORCE(isMethod());
-        flags |= Symbol::Flags::METHOD_GENERIC;
-    }
-
-    inline void setOverridable() {
-        ENFORCE(isMethod());
-        flags |= Symbol::Flags::METHOD_OVERRIDABLE;
-    }
-
-    inline void setFinalMethod() {
-        ENFORCE(isMethod());
-        flags |= Symbol::Flags::METHOD_FINAL;
-    }
-
-    inline void setOverride() {
-        ENFORCE(isMethod());
-        flags |= Symbol::Flags::METHOD_OVERRIDE;
-    }
-
-    inline bool isFinalMethod() const {
-        ENFORCE(isMethod());
-        return (flags & Symbol::Flags::METHOD_FINAL) != 0;
-    }
-
-    inline void setMethodPublic() {
-        ENFORCE(isMethod());
-        flags &= ~Symbol::Flags::METHOD_PRIVATE;
-        flags &= ~Symbol::Flags::METHOD_PROTECTED;
-    }
-
-    inline void setMethodProtected() {
-        ENFORCE(isMethod());
-        flags |= Symbol::Flags::METHOD_PROTECTED;
-    }
-
-    inline void setMethodPrivate() {
-        ENFORCE(isMethod());
-        flags |= Symbol::Flags::METHOD_PRIVATE;
-    }
-
-    void setMethodVisibility(Visibility visibility) {
-        ENFORCE(isMethod());
-        switch (visibility) {
-            case Visibility::Public:
-                this->setMethodPublic();
-                break;
-            case Visibility::Protected:
-                this->setMethodProtected();
-                break;
-            case Visibility::Private:
-                this->setMethodPrivate();
-                break;
-        }
     }
 
     inline void setClassOrModuleAbstract() {
@@ -521,7 +565,8 @@ public:
     inline bool isTypeAlias() const {
         // We should only be able to set the type alias bit on static fields.
         // But it's rather unweidly to ask "isStaticField() && isTypeAlias()" just to satisfy the ENFORCE.
-        // To make things nicer, we relax the ENFORCE here to also allow asking whether "some constant" is a type alias.
+        // To make things nicer, we relax the ENFORCE here to also allow asking whether "some constant" is a type
+        // alias.
         ENFORCE(isClassOrModule() || isStaticField() || isTypeMember());
         return isStaticField() && (flags & Symbol::Flags::STATIC_FIELD_TYPE_ALIAS) != 0;
     }
@@ -544,7 +589,7 @@ public:
     MethodRef findMethodNoDealias(const GlobalState &gs, NameRef name) const;
     SymbolRef findMemberTransitive(const GlobalState &gs, NameRef name) const;
     MethodRef findMethodTransitive(const GlobalState &gs, NameRef name) const;
-    SymbolRef findConcreteMethodTransitive(const GlobalState &gs, NameRef name) const;
+    MethodRef findConcreteMethodTransitive(const GlobalState &gs, NameRef name) const;
 
     /* transitively finds a member with the most similar name */
 
@@ -604,47 +649,26 @@ public:
     // if dealiasing fails here, then we return Untyped instead
     SymbolRef dealias(const GlobalState &gs, int depthLimit = 42) const;
 
-    // if dealiasing fails here, then we return a bad alias method stub instead
-    MethodRef dealiasMethod(const GlobalState &gs, int depthLimit = 42) const;
-
     bool ignoreInHashing(const GlobalState &gs) const;
 
     SymbolRef owner;
-    ClassOrModuleRef superClassOrRebind; // method arguments store rebind here
+    ClassOrModuleRef superClass_;
 
     inline ClassOrModuleRef superClass() const {
         ENFORCE_NO_TIMER(isClassOrModule());
-        return superClassOrRebind;
+        return superClass_;
     }
 
     inline void setSuperClass(ClassOrModuleRef claz) {
         ENFORCE(isClassOrModule());
-        superClassOrRebind = claz;
-    }
-
-    inline void setReBind(ClassOrModuleRef rebind) {
-        ENFORCE(isMethod());
-        superClassOrRebind = rebind;
-    }
-
-    ClassOrModuleRef rebind() const {
-        ENFORCE_NO_TIMER(isMethod());
-        return superClassOrRebind;
+        superClass_ = claz;
     }
 
     uint32_t flags = Flags::NONE;
     NameRef name; // todo: move out? it should not matter but it's important for name resolution
     TypePtr resultType;
 
-    bool hasSig() const {
-        ENFORCE_NO_TIMER(isMethod());
-        return resultType != nullptr;
-    }
-
     UnorderedMap<NameRef, SymbolRef> members_;
-
-    using ArgumentsStore = InlinedVector<ArgInfo, core::SymbolRef::EXPECTED_METHOD_ARGS_COUNT>;
-    ArgumentsStore arguments_;
 
     UnorderedMap<NameRef, SymbolRef> &members() {
         return members_;
@@ -653,24 +677,10 @@ public:
         return members_;
     };
 
-    ArgumentsStore &arguments() {
-        ENFORCE_NO_TIMER(isMethod());
-        return arguments_;
-    }
-
-    const ArgumentsStore &arguments() const {
-        ENFORCE_NO_TIMER(isMethod());
-        return arguments_;
-    }
-
     std::vector<std::pair<NameRef, SymbolRef>> membersStableOrderSlow(const GlobalState &gs) const;
 
     Symbol deepCopy(const GlobalState &to, bool keepGsId = false) const;
     void sanityCheck(const GlobalState &gs) const;
-
-    // All `IntrinsicMethod`s in sorbet should be statically-allocated, which is
-    // why raw pointers are safe.
-    const IntrinsicMethod *intrinsic = nullptr;
 
 private:
     friend class serialize::SerializerImpl;
@@ -692,9 +702,8 @@ private:
     InlinedVector<ClassOrModuleRef, 4> mixins_;
 
     /** For Class or module - ordered type members of the class,
-     * for method - ordered type generic type arguments of the class
      */
-    InlinedVector<SymbolRef, 4> typeParams;
+    InlinedVector<TypeMemberRef, 4> typeParams;
     InlinedVector<Loc, 2> locs_;
 
     // Record a required ancestor for this class of module in a magic property
@@ -706,8 +715,7 @@ private:
     std::vector<RequiredAncestor> requiredAncestorsTransitiveInternal(GlobalState &gs,
                                                                       std::vector<ClassOrModuleRef> &seen);
 
-    SymbolRef findMemberTransitiveInternal(const GlobalState &gs, NameRef name, uint32_t mask, uint32_t flags,
-                                           int maxDepth = 100) const;
+    SymbolRef findMemberTransitiveInternal(const GlobalState &gs, NameRef name, int maxDepth = 100) const;
 
     inline void unsetClassOrModuleLinearizationComputed() {
         ENFORCE(isClassOrModule());

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -73,14 +73,6 @@ public:
     uint32_t methodShapeHash(const GlobalState &gs) const;
     std::vector<uint32_t> methodArgumentHash(const GlobalState &gs) const;
 
-    inline InlinedVector<TypeArgumentRef, 4> &typeArguments() {
-        return typeParams;
-    }
-
-    inline const InlinedVector<TypeArgumentRef, 4> &typeArguments() const {
-        return typeParams;
-    }
-
     inline bool isOverloaded() const {
         return (flags & Method::Flags::METHOD_OVERLOADED) != 0;
     }
@@ -220,9 +212,9 @@ public:
     // why raw pointers are safe.
     const IntrinsicMethod *intrinsic = nullptr;
     ArgumentsStore arguments;
+    InlinedVector<TypeArgumentRef, 4> typeArguments;
 
 private:
-    InlinedVector<TypeArgumentRef, 4> typeParams;
     InlinedVector<Loc, 2> locs_;
     uint16_t flags = Flags::NONE;
 };

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -200,13 +200,6 @@ public:
     }
 
     using ArgumentsStore = InlinedVector<ArgInfo, core::SymbolRef::EXPECTED_METHOD_ARGS_COUNT>;
-    ArgumentsStore &arguments() {
-        return arguments_;
-    }
-
-    const ArgumentsStore &arguments() const {
-        return arguments_;
-    }
 
     // if dealiasing fails here, then we return a bad alias method stub instead
     MethodRef dealiasMethod(const GlobalState &gs, int depthLimit = 42) const;
@@ -226,11 +219,11 @@ public:
     // All `IntrinsicMethod`s in sorbet should be statically-allocated, which is
     // why raw pointers are safe.
     const IntrinsicMethod *intrinsic = nullptr;
+    ArgumentsStore arguments;
 
 private:
     InlinedVector<TypeArgumentRef, 4> typeParams;
     InlinedVector<Loc, 2> locs_;
-    ArgumentsStore arguments_;
     uint16_t flags = Flags::NONE;
 };
 CheckSize(Method, 208, 8);

--- a/core/TypeConstraint.cc
+++ b/core/TypeConstraint.cc
@@ -11,12 +11,10 @@ bool TypeConstraint::isEmpty() const {
     return upperBounds.empty() && lowerBounds.empty();
 }
 
-void TypeConstraint::defineDomain(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &typeParams) {
+void TypeConstraint::defineDomain(const GlobalState &gs, const InlinedVector<TypeArgumentRef, 4> &typeParams) {
     // ENFORCE(isEmpty()); // unfortunately this is false. See
     // test/testdata/infer/generic_methods/countraints_crosstalk.rb
-    for (const auto &tp : typeParams) {
-        ENFORCE(tp.isTypeArgument());
-        auto ta = tp.asTypeArgumentRef();
+    for (const auto &ta : typeParams) {
         auto typ = cast_type<TypeVar>(ta.data(gs)->resultType);
         ENFORCE(typ != nullptr);
 

--- a/core/TypeConstraint.h
+++ b/core/TypeConstraint.h
@@ -23,7 +23,7 @@ public:
     TypeConstraint() = default;
     TypeConstraint(const TypeConstraint &) = delete;
     TypeConstraint(TypeConstraint &&) = default;
-    void defineDomain(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &typeParams);
+    void defineDomain(const GlobalState &gs, const InlinedVector<TypeArgumentRef, 4> &typeParams);
     bool hasUpperBound(TypeArgumentRef forWhat) const;
     bool hasLowerBound(TypeArgumentRef forWhat) const;
     TypePtr findSolution(TypeArgumentRef forWhat) const;

--- a/core/TypePtr.cc
+++ b/core/TypePtr.cc
@@ -274,7 +274,7 @@ TypePtr TypePtr::_instantiate(const GlobalState &gs, const TypeConstraint &tc) c
 #undef _INSTANTIATE
 }
 
-TypePtr TypePtr::_instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
+TypePtr TypePtr::_instantiate(const GlobalState &gs, const InlinedVector<TypeMemberRef, 4> &params,
                               const std::vector<TypePtr> &targs) const {
     switch (tag()) {
         case Tag::BlamedUntyped:

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -300,7 +300,7 @@ public:
 
     TypePtr _instantiate(const GlobalState &gs, const TypeConstraint &tc) const;
 
-    TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
+    TypePtr _instantiate(const GlobalState &gs, const InlinedVector<TypeMemberRef, 4> &params,
                          const std::vector<TypePtr> &targs) const;
 
     // If this TypePtr `is_proxy_type`, returns its underlying type.

--- a/core/Types.h
+++ b/core/Types.h
@@ -38,7 +38,7 @@ public:
         ArgFlags() : isKeyword(false), isRepeated(false), isDefault(false), isShadow(false), isBlock(false) {}
 
     private:
-        friend class Symbol;
+        friend class Method;
         friend class serialize::SerializerImpl;
 
         void setFromU1(uint8_t flags);
@@ -135,12 +135,12 @@ public:
     static TypePtr resultTypeAsSeenFrom(const GlobalState &gs, const TypePtr &what, ClassOrModuleRef fromWhat,
                                         ClassOrModuleRef inWhat, const std::vector<TypePtr> &targs);
 
-    static InlinedVector<SymbolRef, 4> alignBaseTypeArgs(const GlobalState &gs, ClassOrModuleRef what,
-                                                         const std::vector<TypePtr> &targs, ClassOrModuleRef asIf);
+    static InlinedVector<TypeMemberRef, 4> alignBaseTypeArgs(const GlobalState &gs, ClassOrModuleRef what,
+                                                             const std::vector<TypePtr> &targs, ClassOrModuleRef asIf);
     // Extract the return value type from a proc.
     static TypePtr getProcReturnType(const GlobalState &gs, const TypePtr &procType);
-    static TypePtr instantiate(const GlobalState &gs, const TypePtr &what, const InlinedVector<SymbolRef, 4> &params,
-                               const std::vector<TypePtr> &targs);
+    static TypePtr instantiate(const GlobalState &gs, const TypePtr &what,
+                               const InlinedVector<TypeMemberRef, 4> &params, const std::vector<TypePtr> &targs);
     /** Replace all type variables in `what` with their instantiations.
      * Requires that `tc` has already been solved.
      */
@@ -383,7 +383,7 @@ public:
 
     void _sanityCheck(const GlobalState &gs) const;
 
-    TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
+    TypePtr _instantiate(const GlobalState &gs, const InlinedVector<TypeMemberRef, 4> &params,
                          const std::vector<TypePtr> &targs) const;
 };
 CheckSize(LambdaParam, 40, 8);
@@ -583,7 +583,7 @@ public:
     TypePtr getCallArguments(const GlobalState &gs, NameRef name) const;
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const;
     void _sanityCheck(const GlobalState &gs) const;
-    TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
+    TypePtr _instantiate(const GlobalState &gs, const InlinedVector<TypeMemberRef, 4> &params,
                          const std::vector<TypePtr> &targs) const;
     TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc) const;
     TypePtr _instantiate(const GlobalState &gs, const TypeConstraint &tc) const;
@@ -635,7 +635,7 @@ public:
     TypePtr getCallArguments(const GlobalState &gs, NameRef name) const;
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const;
     void _sanityCheck(const GlobalState &gs) const;
-    TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
+    TypePtr _instantiate(const GlobalState &gs, const InlinedVector<TypeMemberRef, 4> &params,
                          const std::vector<TypePtr> &targs) const;
     TypePtr _replaceSelfType(const GlobalState &gs, const TypePtr &receiver) const;
     TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc) const;
@@ -676,7 +676,7 @@ public:
     std::string showWithMoreInfo(const GlobalState &gs) const;
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
     void _sanityCheck(const GlobalState &gs) const;
-    TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
+    TypePtr _instantiate(const GlobalState &gs, const InlinedVector<TypeMemberRef, 4> &params,
                          const std::vector<TypePtr> &targs) const;
     TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc) const;
     TypePtr _instantiate(const GlobalState &gs, const TypeConstraint &tc) const;
@@ -699,7 +699,7 @@ public:
     std::string showWithMoreInfo(const GlobalState &gs) const;
     uint32_t hash(const GlobalState &gs) const;
     void _sanityCheck(const GlobalState &gs) const;
-    TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
+    TypePtr _instantiate(const GlobalState &gs, const InlinedVector<TypeMemberRef, 4> &params,
                          const std::vector<TypePtr> &targs) const;
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
     TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc) const;
@@ -723,7 +723,7 @@ public:
     uint32_t hash(const GlobalState &gs) const;
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
     void _sanityCheck(const GlobalState &gs) const;
-    TypePtr _instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
+    TypePtr _instantiate(const GlobalState &gs, const InlinedVector<TypeMemberRef, 4> &params,
                          const std::vector<TypePtr> &targs) const;
 
     TypePtr getCallArguments(const GlobalState &gs, NameRef name) const;

--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -147,7 +147,7 @@ com::stripe::rubytyper::Symbol Proto::toProto(const GlobalState &gs, SymbolRef s
             *symbolProto.add_children() = toProto(gs, pair.second, showFull);
         }
     } else if (sym.isMethod()) {
-        for (auto typeArg : sym.asMethodRef().data(gs)->typeArguments()) {
+        for (auto typeArg : sym.asMethodRef().data(gs)->typeArguments) {
             if (!typeArg.exists()) {
                 continue;
             }

--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -115,7 +115,7 @@ com::stripe::rubytyper::Symbol Proto::toProto(const GlobalState &gs, SymbolRef s
             }
         } else {
             auto method = sym.asMethodRef();
-            for (auto &thing : method.data(gs)->arguments()) {
+            for (auto &thing : method.data(gs)->arguments) {
                 *symbolProto.add_arguments() = toProto(gs, thing);
             }
         }

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -539,8 +539,8 @@ void SerializerImpl::pickle(Pickler &p, const Method &what) {
     p.putU4(what.name.rawId());
     p.putU4(what.rebind.id());
     p.putU4(what.flags);
-    p.putU4(what.typeParams.size());
-    for (auto s : what.typeParams) {
+    p.putU4(what.typeArguments.size());
+    for (auto s : what.typeArguments) {
         p.putU4(s.id());
     }
     p.putU4(what.arguments.size());
@@ -562,9 +562,9 @@ Method SerializerImpl::unpickleMethod(UnPickler &p, const GlobalState *gs) {
     result.flags = static_cast<u2>(p.getU4());
 
     int typeParamsSize = p.getU4();
-    result.typeParams.reserve(typeParamsSize);
+    result.typeArguments.reserve(typeParamsSize);
     for (int i = 0; i < typeParamsSize; i++) {
-        result.typeParams.emplace_back(TypeArgumentRef::fromRaw(p.getU4()));
+        result.typeArguments.emplace_back(TypeArgumentRef::fromRaw(p.getU4()));
     }
 
     int argsSize = p.getU4();

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -537,7 +537,7 @@ ArgInfo SerializerImpl::unpickleArgInfo(UnPickler &p, const GlobalState *gs) {
 void SerializerImpl::pickle(Pickler &p, const Method &what) {
     p.putU4(what.owner.id());
     p.putU4(what.name.rawId());
-    p.putU4(what.rebind_.id());
+    p.putU4(what.rebind.id());
     p.putU4(what.flags);
     p.putU4(what.typeParams.size());
     for (auto s : what.typeParams) {
@@ -558,7 +558,7 @@ Method SerializerImpl::unpickleMethod(UnPickler &p, const GlobalState *gs) {
     Method result;
     result.owner = ClassOrModuleRef::fromRaw(p.getU4());
     result.name = NameRef::fromRaw(*gs, p.getU4());
-    result.rebind_ = ClassOrModuleRef::fromRaw(p.getU4());
+    result.rebind = ClassOrModuleRef::fromRaw(p.getU4());
     result.flags = static_cast<u2>(p.getU4());
 
     int typeParamsSize = p.getU4();

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -543,8 +543,8 @@ void SerializerImpl::pickle(Pickler &p, const Method &what) {
     for (auto s : what.typeParams) {
         p.putU4(s.id());
     }
-    p.putU4(what.arguments().size());
-    for (const auto &a : what.arguments()) {
+    p.putU4(what.arguments.size());
+    for (const auto &a : what.arguments) {
         pickle(p, a);
     }
     pickle(p, what.resultType);
@@ -569,7 +569,7 @@ Method SerializerImpl::unpickleMethod(UnPickler &p, const GlobalState *gs) {
 
     int argsSize = p.getU4();
     for (int i = 0; i < argsSize; i++) {
-        result.arguments().emplace_back(unpickleArgInfo(p, gs));
+        result.arguments.emplace_back(unpickleArgInfo(p, gs));
     }
 
     result.resultType = unpickleType(p, gs);

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -540,8 +540,8 @@ void SerializerImpl::pickle(Pickler &p, const Method &what) {
     p.putU4(what.rebind_.id());
     p.putU4(what.flags);
     p.putU4(what.typeParams.size());
-    for (SymbolRef s : what.typeParams) {
-        p.putU4(s.rawId());
+    for (auto s : what.typeParams) {
+        p.putU4(s.id());
     }
     p.putU4(what.arguments().size());
     for (const auto &a : what.arguments()) {
@@ -559,7 +559,7 @@ Method SerializerImpl::unpickleMethod(UnPickler &p, const GlobalState *gs) {
     result.owner = ClassOrModuleRef::fromRaw(p.getU4());
     result.name = NameRef::fromRaw(*gs, p.getU4());
     result.rebind_ = ClassOrModuleRef::fromRaw(p.getU4());
-    result.flags = p.getU4();
+    result.flags = static_cast<u2>(p.getU4());
 
     int typeParamsSize = p.getU4();
     result.typeParams.reserve(typeParamsSize);
@@ -591,8 +591,8 @@ void SerializerImpl::pickle(Pickler &p, const Symbol &what) {
     }
 
     p.putU4(what.typeParams.size());
-    for (SymbolRef s : what.typeParams) {
-        p.putU4(s.rawId());
+    for (auto s : what.typeParams) {
+        p.putU4(s.id());
     }
 
     p.putU4(what.members().size());

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -559,7 +559,7 @@ Method SerializerImpl::unpickleMethod(UnPickler &p, const GlobalState *gs) {
     result.owner = ClassOrModuleRef::fromRaw(p.getU4());
     result.name = NameRef::fromRaw(*gs, p.getU4());
     result.rebind = ClassOrModuleRef::fromRaw(p.getU4());
-    auto flagsU2 = static_cast<u2>(p.getU4());
+    auto flagsU2 = static_cast<uint16_t>(p.getU4());
     Method::Flags flags;
     static_assert(sizeof(flags) == sizeof(flagsU2));
     // Can replace this with std::bit_cast in C++20

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -714,7 +714,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
     }
 
     if (data->isGenericMethod()) {
-        constr->defineDomain(gs, data->typeArguments());
+        constr->defineDomain(gs, data->typeArguments);
     }
     auto posArgs = args.numPosArgs;
     bool hasKwargs = absl::c_any_of(data->arguments, [](const auto &arg) { return arg.flags.isKeyword; });

--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -339,7 +339,7 @@ string AppliedType::toStringWithTabs(const GlobalState &gs, int tabs) const {
         ++i;
         if (i < this->klass.data(gs)->typeMembers().size()) {
             auto tyMem = this->klass.data(gs)->typeMembers()[i];
-            fmt::format_to(std::back_inserter(buf), "{}{} = {}\n", twiceNestedTabs, tyMem.name(gs).showRaw(gs),
+            fmt::format_to(std::back_inserter(buf), "{}{} = {}\n", twiceNestedTabs, tyMem.data(gs)->name.showRaw(gs),
                            targ.toStringWithTabs(gs, tabs + 3));
         } else {
             // this happens if we try to print type before resolver has processed stdlib
@@ -408,10 +408,10 @@ string AppliedType::show(const GlobalState &gs) const {
     }
     auto it = targs.begin();
     for (auto typeMember : typeMembers) {
-        auto tm = typeMember.asTypeMemberRef();
+        auto tm = typeMember;
         if (tm.data(gs)->isFixed()) {
             it = targs.erase(it);
-        } else if (typeMember.name(gs) == core::Names::Constants::AttachedClass()) {
+        } else if (typeMember.data(gs)->name == core::Names::Constants::AttachedClass()) {
             it = targs.erase(it);
         } else if (this->klass == Symbols::Hash() && typeMember == typeMembers.back()) {
             it = targs.erase(it);

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -298,7 +298,7 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
         const TypePtr &t2s = ltr ? t1 : t2;
         // now a1 <: a2
 
-        InlinedVector<SymbolRef, 4> indexes = Types::alignBaseTypeArgs(gs, a1->klass, a1->targs, a2->klass);
+        InlinedVector<TypeMemberRef, 4> indexes = Types::alignBaseTypeArgs(gs, a1->klass, a1->targs, a2->klass);
         vector<TypePtr> newTargs;
         newTargs.reserve(indexes.size());
         // code below inverts permutation of type params
@@ -914,7 +914,7 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
         }
         // a1 <:< a2
 
-        InlinedVector<SymbolRef, 4> indexes = Types::alignBaseTypeArgs(gs, a2->klass, a2->targs, a1->klass);
+        InlinedVector<TypeMemberRef, 4> indexes = Types::alignBaseTypeArgs(gs, a2->klass, a2->targs, a1->klass);
 
         // code below inverts permutation of type params
 
@@ -1151,7 +1151,7 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
             result = classSymbolIsAsGoodAs(gs, a1->klass, a2->klass);
         }
         if (result) {
-            InlinedVector<SymbolRef, 4> indexes = Types::alignBaseTypeArgs(gs, a1->klass, a1->targs, a2->klass);
+            InlinedVector<TypeMemberRef, 4> indexes = Types::alignBaseTypeArgs(gs, a1->klass, a1->targs, a2->klass);
             // code below inverts permutation of type params
             int j = 0;
             for (SymbolRef idx : a2->klass.data(gs)->typeMembers()) {

--- a/core/types/typemaps.cc
+++ b/core/types/typemaps.cc
@@ -8,7 +8,7 @@
 using namespace std;
 namespace sorbet::core {
 
-TypePtr Types::instantiate(const GlobalState &gs, const TypePtr &what, const InlinedVector<SymbolRef, 4> &params,
+TypePtr Types::instantiate(const GlobalState &gs, const TypePtr &what, const InlinedVector<TypeMemberRef, 4> &params,
                            const vector<TypePtr> &targs) {
     ENFORCE(what != nullptr);
     auto t = what._instantiate(gs, params, targs);
@@ -119,7 +119,7 @@ optional<vector<TypePtr>> approximateElems(const vector<TypePtr> &elems, const G
 }
 } // anonymous namespace
 
-TypePtr TupleType::_instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
+TypePtr TupleType::_instantiate(const GlobalState &gs, const InlinedVector<TypeMemberRef, 4> &params,
                                 const vector<TypePtr> &targs) const {
     optional<vector<TypePtr>> newElems = instantiateElems(this->elems, gs, params, targs);
     if (!newElems) {
@@ -144,7 +144,7 @@ TypePtr TupleType::_approximate(const GlobalState &gs, const TypeConstraint &tc)
     return make_type<TupleType>(move(*newElems));
 };
 
-TypePtr ShapeType::_instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
+TypePtr ShapeType::_instantiate(const GlobalState &gs, const InlinedVector<TypeMemberRef, 4> &params,
                                 const vector<TypePtr> &targs) const {
     optional<vector<TypePtr>> newValues = instantiateElems(this->values, gs, params, targs);
     if (!newValues) {
@@ -169,7 +169,7 @@ TypePtr ShapeType::_approximate(const GlobalState &gs, const TypeConstraint &tc)
     return make_type<ShapeType>(this->keys, move(*newValues));
 }
 
-TypePtr OrType::_instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
+TypePtr OrType::_instantiate(const GlobalState &gs, const InlinedVector<TypeMemberRef, 4> &params,
                              const vector<TypePtr> &targs) const {
     auto left = this->left._instantiate(gs, params, targs);
     auto right = this->right._instantiate(gs, params, targs);
@@ -215,7 +215,7 @@ TypePtr OrType::_approximate(const GlobalState &gs, const TypeConstraint &tc) co
     return nullptr;
 }
 
-TypePtr AndType::_instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
+TypePtr AndType::_instantiate(const GlobalState &gs, const InlinedVector<TypeMemberRef, 4> &params,
                               const vector<TypePtr> &targs) const {
     auto left = this->left._instantiate(gs, params, targs);
     auto right = this->right._instantiate(gs, params, targs);
@@ -261,7 +261,7 @@ TypePtr AndType::_approximate(const GlobalState &gs, const TypeConstraint &tc) c
     return nullptr;
 }
 
-TypePtr AppliedType::_instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
+TypePtr AppliedType::_instantiate(const GlobalState &gs, const InlinedVector<TypeMemberRef, 4> &params,
                                   const vector<TypePtr> &targs) const {
     optional<vector<TypePtr>> newTargs = instantiateElems(this->targs, gs, params, targs);
     if (!newTargs) {
@@ -286,7 +286,7 @@ TypePtr AppliedType::_approximate(const GlobalState &gs, const TypeConstraint &t
     return make_type<AppliedType>(this->klass, move(*newTargs));
 }
 
-TypePtr LambdaParam::_instantiate(const GlobalState &gs, const InlinedVector<SymbolRef, 4> &params,
+TypePtr LambdaParam::_instantiate(const GlobalState &gs, const InlinedVector<TypeMemberRef, 4> &params,
                                   const vector<TypePtr> &targs) const {
     ENFORCE(params.size() == targs.size());
     for (auto &el : params) {

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -489,11 +489,11 @@ void ClassType::_sanityCheck(const GlobalState &gs) const {
 /** Returns type parameters of what reordered in the order of type parameters of asIf
  * If some typeArgs are not present, return NoSymbol
  * */
-InlinedVector<SymbolRef, 4> Types::alignBaseTypeArgs(const GlobalState &gs, ClassOrModuleRef what,
-                                                     const vector<TypePtr> &targs, ClassOrModuleRef asIf) {
+InlinedVector<TypeMemberRef, 4> Types::alignBaseTypeArgs(const GlobalState &gs, ClassOrModuleRef what,
+                                                         const vector<TypePtr> &targs, ClassOrModuleRef asIf) {
     ENFORCE(what == asIf || what.data(gs)->derivesFrom(gs, asIf) || asIf.data(gs)->derivesFrom(gs, what),
             "what={} asIf={}", what.data(gs)->name.showRaw(gs), asIf.data(gs)->name.showRaw(gs));
-    InlinedVector<SymbolRef, 4> currentAlignment;
+    InlinedVector<TypeMemberRef, 4> currentAlignment;
     if (targs.empty()) {
         return currentAlignment;
     }
@@ -504,11 +504,11 @@ InlinedVector<SymbolRef, 4> Types::alignBaseTypeArgs(const GlobalState &gs, Clas
     } else {
         currentAlignment.reserve(asIf.data(gs)->typeMembers().size());
         for (auto originalTp : asIf.data(gs)->typeMembers()) {
-            auto name = originalTp.name(gs);
+            auto name = originalTp.data(gs)->name;
             SymbolRef align;
             int i = 0;
             for (auto x : what.data(gs)->typeMembers()) {
-                if (x.name(gs) == name) {
+                if (x.data(gs)->name == name) {
                     align = x;
                     currentAlignment.emplace_back(x);
                     break;
@@ -516,7 +516,7 @@ InlinedVector<SymbolRef, 4> Types::alignBaseTypeArgs(const GlobalState &gs, Clas
                 i++;
             }
             if (!align.exists()) {
-                currentAlignment.emplace_back(Symbols::noSymbol());
+                currentAlignment.emplace_back(Symbols::noTypeMember());
             }
         }
     }

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -24,7 +24,7 @@ struct Signature {
 
 Signature decomposeSignature(const core::GlobalState &gs, core::MethodRef method) {
     Signature sig;
-    for (auto &arg : method.data(gs)->arguments()) {
+    for (auto &arg : method.data(gs)->arguments) {
         if (arg.flags.isBlock) {
             sig.syntheticBlk = arg.isSyntheticBlockArgument();
             continue;

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -264,7 +264,7 @@ void validateCompatibleOverride(const core::Context ctx, core::MethodRef superMe
 }
 
 void validateOverriding(const core::Context ctx, core::MethodRef method) {
-    auto klass = method.data(ctx)->owner.asClassOrModuleRef();
+    auto klass = method.data(ctx)->owner;
     auto name = method.data(ctx)->name;
     auto klassData = klass.data(ctx);
     InlinedVector<core::MethodRef, 4> overridenMethods;
@@ -751,7 +751,7 @@ public:
     ast::ExpressionPtr preTransformMethodDef(core::Context ctx, ast::ExpressionPtr tree) {
         auto &methodDef = ast::cast_tree_nonnull<ast::MethodDef>(tree);
         auto methodData = methodDef.symbol.data(ctx);
-        auto ownerData = methodData->owner.asClassOrModuleRef().data(ctx);
+        auto ownerData = methodData->owner.data(ctx);
 
         // Only perform this check if this isn't a module from the stdlib, and
         // if there are type members in the owning context.

--- a/definition_validator/variance.cc
+++ b/definition_validator/variance.cc
@@ -110,7 +110,7 @@ private:
                         params.size());
 
                 for (int i = 0; i < members.size(); ++i) {
-                    auto memberVariance = members[i].asTypeMemberRef().data(ctx)->variance();
+                    auto memberVariance = members[i].data(ctx)->variance();
                     auto typeArg = params[i];
 
                     // The polarity used to check the parameter is negated

--- a/definition_validator/variance.cc
+++ b/definition_validator/variance.cc
@@ -196,7 +196,7 @@ public:
         // context.
         const Polarity negated = negatePolarity(polarity);
 
-        for (auto &arg : methodData->arguments()) {
+        for (auto &arg : methodData->arguments) {
             if (arg.type != nullptr) {
                 validatePolarity(arg.loc, ctx, negated, arg.type);
             }

--- a/definition_validator/variance.cc
+++ b/definition_validator/variance.cc
@@ -148,7 +148,10 @@ private:
                         }
                     } else {
                         if (auto e = ctx.state.beginError(this->loc, core::errors::Resolver::InvalidVariance)) {
-                            auto flavor = paramData->owner.isSingletonClass(ctx) ? "type_template" : "type_member";
+                            auto flavor = paramData->owner.isClassOrModule() &&
+                                                  paramData->owner.asClassOrModuleRef().data(ctx)->isSingletonClass(ctx)
+                                              ? "type_template"
+                                              : "type_member";
 
                             auto paramName = paramData->name.show(ctx);
 

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -59,7 +59,7 @@ optional<core::AutocorrectSuggestion::Edit> maybeSuggestExtendTSig(core::Context
 core::TypePtr extractArgType(core::Context ctx, cfg::Send &send, core::DispatchComponent &component,
                              optional<core::NameRef> keyword, int argId) {
     ENFORCE(component.method.exists());
-    const auto &args = component.method.data(ctx)->arguments();
+    const auto &args = component.method.data(ctx)->arguments;
     if (argId >= args.size()) {
         return nullptr;
     }
@@ -389,7 +389,7 @@ optional<core::AutocorrectSuggestion> SigSuggestion::maybeSuggestSig(core::Conte
             // sometimes variable does not have a name e.g. `def initialize (*)`
             arg.name.shortName(ctx).empty();
     };
-    bool hasBadArg = absl::c_any_of(methodSymbol.data(ctx)->arguments(), isBadArg);
+    bool hasBadArg = absl::c_any_of(methodSymbol.data(ctx)->arguments, isBadArg);
     if (hasBadArg) {
         return nullopt;
     }
@@ -406,7 +406,7 @@ optional<core::AutocorrectSuggestion> SigSuggestion::maybeSuggestSig(core::Conte
             guessedReturnType = closestReturnType;
         }
 
-        for (const auto &arg : closestMethod.data(ctx)->arguments()) {
+        for (const auto &arg : closestMethod.data(ctx)->arguments) {
             if (arg.type && !arg.type.isUntyped()) {
                 guessedArgumentTypes[arg.name] = arg.type;
             }
@@ -426,9 +426,9 @@ optional<core::AutocorrectSuggestion> SigSuggestion::maybeSuggestSig(core::Conte
     }
     fmt::format_to(std::back_inserter(ss), " {{");
 
-    ENFORCE(!methodSymbol.data(ctx)->arguments().empty(), "There should always be at least one arg (the block arg).");
-    bool onlyArgumentIsBlkArg = methodSymbol.data(ctx)->arguments().size() == 1 &&
-                                methodSymbol.data(ctx)->arguments()[0].isSyntheticBlockArgument();
+    ENFORCE(!methodSymbol.data(ctx)->arguments.empty(), "There should always be at least one arg (the block arg).");
+    bool onlyArgumentIsBlkArg = methodSymbol.data(ctx)->arguments.size() == 1 &&
+                                methodSymbol.data(ctx)->arguments[0].isSyntheticBlockArgument();
 
     if (methodSymbol.data(ctx)->name != core::Names::initialize()) {
         // Only need override / implementation if the parent has a sig
@@ -443,7 +443,7 @@ optional<core::AutocorrectSuggestion> SigSuggestion::maybeSuggestSig(core::Conte
         fmt::format_to(std::back_inserter(ss), "params(");
 
         bool first = true;
-        for (auto &argSym : methodSymbol.data(ctx)->arguments()) {
+        for (auto &argSym : methodSymbol.data(ctx)->arguments) {
             // WARNING: This is doing raw string equality--don't cargo cult this!
             // You almost certainly want to compare NameRef's for equality instead.
             // We need to compare strings here because we're running with a frozen global state

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -340,13 +340,13 @@ bool childNeedsOverride(core::Context ctx, core::MethodRef childSymbol, core::Me
         // that isn't the constructor...
         childSymbol.data(ctx)->name != core::Names::initialize() &&
         // and wasn't Rewriter synthesized (beause we can't change DSL'd sigs).
-        !parentSymbol.data(ctx)->isRewriterSynthesized() &&
+        !parentSymbol.data(ctx)->flags.isRewriterSynthesized &&
         // It has a sig...
         parentSymbol.data(ctx)->resultType != nullptr &&
         //  that is either overridable...
-        (parentSymbol.data(ctx)->isOverridable() ||
+        (parentSymbol.data(ctx)->flags.isOverridable ||
          // or override...
-         parentSymbol.data(ctx)->isOverride());
+         parentSymbol.data(ctx)->flags.isOverride);
 }
 
 } // namespace
@@ -433,7 +433,7 @@ optional<core::AutocorrectSuggestion> SigSuggestion::maybeSuggestSig(core::Conte
     if (methodSymbol.data(ctx)->name != core::Names::initialize()) {
         // Only need override / implementation if the parent has a sig
         if (closestMethod.exists() && closestMethod.data(ctx)->resultType != nullptr) {
-            if (closestMethod.data(ctx)->isAbstract() || childNeedsOverride(ctx, methodSymbol, closestMethod)) {
+            if (closestMethod.data(ctx)->flags.isAbstract || childNeedsOverride(ctx, methodSymbol, closestMethod)) {
                 fmt::format_to(std::back_inserter(ss), "override.");
             }
         }

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -984,7 +984,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                     //  - When a method doesn't exist.
                     //
                     // In all of these cases, we bail out and skip the non-private checking.
-                    if (it->main.method.exists() && it->main.method.data(ctx)->isMethodPrivate() && !send.isPrivateOk) {
+                    if (it->main.method.exists() && it->main.method.data(ctx)->flags.isPrivate && !send.isPrivateOk) {
                         if (auto e = ctx.beginError(bind.loc, core::errors::Infer::PrivateMethod)) {
                             if (multipleComponents) {
                                 e.setHeader("Non-private call to private method `{}` on `{}` component of `{}`",

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1280,7 +1280,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                         e.setHeader("Expected `{}` but found `{}` for block result type", expectedType.show(ctx),
                                     typeAndOrigin.type.show(ctx));
 
-                        const auto &bspec = i.link->result->main.method.data(ctx)->arguments().back();
+                        const auto &bspec = i.link->result->main.method.data(ctx)->arguments.back();
                         ENFORCE(bspec.flags.isBlock, "The last symbol must be the block arg");
                         e.addErrorSection(
                             core::TypeAndOrigins::explainExpected(ctx, expectedType, bspec.loc, "block result type"));

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -25,7 +25,7 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
     if (cfg->symbol.data(ctx)->isGenericMethod()) {
         _constr = make_unique<core::TypeConstraint>();
         constr = _constr.get();
-        for (core::SymbolRef typeArgument : cfg->symbol.data(ctx)->typeArguments()) {
+        for (core::SymbolRef typeArgument : cfg->symbol.data(ctx)->typeArguments) {
             constr->rememberIsSubtype(ctx, typeArgument.asTypeArgumentRef().data(ctx)->resultType,
                                       core::make_type<core::SelfTypeParam>(typeArgument));
         }

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -22,7 +22,7 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
     auto guessTypes = true;
     unique_ptr<core::TypeConstraint> _constr;
     core::TypeConstraint *constr = &core::TypeConstraint::EmptyFrozenConstraint;
-    if (cfg->symbol.data(ctx)->isGenericMethod()) {
+    if (cfg->symbol.data(ctx)->flags.isGenericMethod) {
         _constr = make_unique<core::TypeConstraint>();
         constr = _constr.get();
         for (core::SymbolRef typeArgument : cfg->symbol.data(ctx)->typeArguments) {

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -50,7 +50,7 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
             constr = _constr.get();
             auto returnTypeVar = core::Symbols::
                 Sorbet_Private_Static_ReturnTypeInference_guessed_type_type_parameter_holder_tparam_contravariant();
-            InlinedVector<core::SymbolRef, 4> domainTemp;
+            InlinedVector<core::TypeArgumentRef, 4> domainTemp;
             domainTemp.emplace_back(returnTypeVar);
             methodReturnType = returnTypeVar.data(ctx)->resultType;
 
@@ -62,9 +62,8 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
         auto enclosingClass = cfg->symbol.enclosingClass(ctx);
         methodReturnType = core::Types::instantiate(
             ctx,
-            core::Types::resultTypeAsSeenFrom(ctx, cfg->symbol.data(ctx)->resultType,
-                                              cfg->symbol.data(ctx)->owner.asClassOrModuleRef(), enclosingClass,
-                                              enclosingClass.data(ctx)->selfTypeArgs(ctx)),
+            core::Types::resultTypeAsSeenFrom(ctx, cfg->symbol.data(ctx)->resultType, cfg->symbol.data(ctx)->owner,
+                                              enclosingClass, enclosingClass.data(ctx)->selfTypeArgs(ctx)),
             *constr);
         methodReturnType = core::Types::replaceSelfType(ctx, methodReturnType, enclosingClass.data(ctx)->selfType(ctx));
     }

--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -16,7 +16,7 @@ ast::ExpressionPtr DefLocSaver::postTransformMethodDef(core::Context ctx, ast::E
     if (lspQueryMatch) {
         // Query matches against the method definition as a whole.
         auto symbolData = methodDef.symbol.data(ctx);
-        auto &argTypes = symbolData->arguments();
+        auto &argTypes = symbolData->arguments;
         core::TypeAndOrigins tp;
 
         // Check if it matches against a specific argument. If it does, send that instead;

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -88,16 +88,16 @@ string prettySigForMethod(const core::GlobalState &gs, core::MethodRef method, c
     vector<string> flags;
     auto sym = method.data(gs);
     string sigCall = "sig";
-    if (sym->isFinalMethod()) {
+    if (sym->flags.isFinal) {
         sigCall = "sig(:final)";
     }
-    if (sym->isAbstract()) {
+    if (sym->flags.isAbstract) {
         flags.emplace_back("abstract");
     }
-    if (sym->isOverridable()) {
+    if (sym->flags.isOverridable) {
         flags.emplace_back("overridable");
     }
-    if (sym->isOverride()) {
+    if (sym->flags.isOverride) {
         flags.emplace_back("override");
     }
     for (auto &argSym : method.data(gs)->arguments) {
@@ -140,9 +140,9 @@ string prettyDefForMethod(const core::GlobalState &gs, core::MethodRef method) {
     auto methodData = method.data(gs);
 
     string visibility = "";
-    if (methodData->isMethodPrivate()) {
+    if (methodData->flags.isPrivate) {
         visibility = "private ";
-    } else if (methodData->isMethodProtected()) {
+    } else if (methodData->flags.isProtected) {
         visibility = "protected ";
     }
 

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -100,7 +100,7 @@ string prettySigForMethod(const core::GlobalState &gs, core::MethodRef method, c
     if (sym->isOverride()) {
         flags.emplace_back("override");
     }
-    for (auto &argSym : method.data(gs)->arguments()) {
+    for (auto &argSym : method.data(gs)->arguments) {
         // Don't display synthetic arguments (like blk).
         if (!argSym.isSyntheticBlockArgument()) {
             typeAndArgNames.emplace_back(absl::StrCat(
@@ -157,7 +157,7 @@ string prettyDefForMethod(const core::GlobalState &gs, core::MethodRef method) {
         methodNamePrefix = "self.";
     }
     vector<string> prettyArgs;
-    const auto &arguments = methodData->dealiasMethod(gs).data(gs)->arguments();
+    const auto &arguments = methodData->dealiasMethod(gs).data(gs)->arguments;
     ENFORCE(!arguments.empty(), "Should have at least a block arg");
     for (const auto &argSym : arguments) {
         // Don't display synthetic arguments (like blk).

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -72,7 +72,7 @@ constexpr int MAX_PRETTY_WIDTH = 80;
 string prettySigForMethod(const core::GlobalState &gs, core::MethodRef method, const core::TypePtr &receiver,
                           core::TypePtr retType, const core::TypeConstraint *constraint) {
     ENFORCE(method.exists());
-    ENFORCE(method.data(gs)->dealias(gs) == method);
+    ENFORCE(method.data(gs)->dealiasMethod(gs) == method);
     // handle this case anyways so that we don't crash in prod when this method is mis-used
     if (!method.exists()) {
         return "";
@@ -88,26 +88,23 @@ string prettySigForMethod(const core::GlobalState &gs, core::MethodRef method, c
     vector<string> flags;
     auto sym = method.data(gs);
     string sigCall = "sig";
-    if (sym->isMethod()) {
-        if (sym->isFinalMethod()) {
-            sigCall = "sig(:final)";
-        }
-        if (sym->isAbstract()) {
-            flags.emplace_back("abstract");
-        }
-        if (sym->isOverridable()) {
-            flags.emplace_back("overridable");
-        }
-        if (sym->isOverride()) {
-            flags.emplace_back("override");
-        }
-        for (auto &argSym : method.data(gs)->arguments()) {
-            // Don't display synthetic arguments (like blk).
-            if (!argSym.isSyntheticBlockArgument()) {
-                typeAndArgNames.emplace_back(
-                    absl::StrCat(argSym.argumentName(gs), ": ",
-                                 getResultType(gs, argSym.type, method, receiver, constraint).show(gs)));
-            }
+    if (sym->isFinalMethod()) {
+        sigCall = "sig(:final)";
+    }
+    if (sym->isAbstract()) {
+        flags.emplace_back("abstract");
+    }
+    if (sym->isOverridable()) {
+        flags.emplace_back("overridable");
+    }
+    if (sym->isOverride()) {
+        flags.emplace_back("override");
+    }
+    for (auto &argSym : method.data(gs)->arguments()) {
+        // Don't display synthetic arguments (like blk).
+        if (!argSym.isSyntheticBlockArgument()) {
+            typeAndArgNames.emplace_back(absl::StrCat(
+                argSym.argumentName(gs), ": ", getResultType(gs, argSym.type, method, receiver, constraint).show(gs)));
         }
     }
 
@@ -156,12 +153,11 @@ string prettyDefForMethod(const core::GlobalState &gs, core::MethodRef method) {
         methodName = methodNameRef.toString(gs);
     }
     string methodNamePrefix = "";
-    if (methodData->owner.exists() && methodData->owner.isClassOrModule() &&
-        methodData->owner.asClassOrModuleRef().data(gs)->attachedClass(gs).exists()) {
+    if (methodData->owner.exists() && methodData->owner.data(gs)->attachedClass(gs).exists()) {
         methodNamePrefix = "self.";
     }
     vector<string> prettyArgs;
-    const auto &arguments = methodData->dealias(gs).asMethodRef().data(gs)->arguments();
+    const auto &arguments = methodData->dealiasMethod(gs).data(gs)->arguments();
     ENFORCE(!arguments.empty(), "Should have at least a block arg");
     for (const auto &argSym : arguments) {
         // Don't display synthetic arguments (like blk).
@@ -213,9 +209,9 @@ string prettyDefForMethod(const core::GlobalState &gs, core::MethodRef method) {
 
 string prettyTypeForMethod(const core::GlobalState &gs, core::MethodRef method, const core::TypePtr &receiver,
                            const core::TypePtr &retType, const core::TypeConstraint *constraint) {
-    return fmt::format(
-        "{}\n{}", prettySigForMethod(gs, method.data(gs)->dealias(gs).asMethodRef(), receiver, retType, constraint),
-        prettyDefForMethod(gs, method));
+    return fmt::format("{}\n{}",
+                       prettySigForMethod(gs, method.data(gs)->dealiasMethod(gs), receiver, retType, constraint),
+                       prettyDefForMethod(gs, method));
 }
 
 string prettyTypeForConstant(const core::GlobalState &gs, core::SymbolRef constant) {

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -731,9 +731,13 @@ void CompletionTask::findSimilarConstants(const core::GlobalState &gs, const cor
     }
 
     for (auto scope : resp.scopes) {
+        if (!scope.isClassOrModule()) {
+            continue;
+        }
+
         // TODO(jez) This membersStableOrderSlow is the only ordering we have on constant items right now.
         // We should probably at least sort by whether the prefix of the suggested constant matches.
-        for (auto [_name, sym] : scope.membersStableOrderSlow(gs)) {
+        for (auto [_name, sym] : scope.asClassOrModuleRef().data(gs)->membersStableOrderSlow(gs)) {
             if (isSimilarConstant(gs, prefix, sym)) {
                 items.push_back(getCompletionItemForConstant(gs, config, sym, queryLoc, prefix, items.size()));
             }

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -258,7 +258,7 @@ string methodSnippet(const core::GlobalState &gs, core::DispatchResult &dispatch
     }
 
     vector<string> typeAndArgNames;
-    for (auto &argSym : method.data(gs)->arguments()) {
+    for (auto &argSym : method.data(gs)->arguments) {
         fmt::memory_buffer argBuf;
         if (argSym.flags.isBlock) {
             // Blocks are handled below
@@ -286,8 +286,8 @@ string methodSnippet(const core::GlobalState &gs, core::DispatchResult &dispatch
         fmt::format_to(std::back_inserter(result), "({})", fmt::join(typeAndArgNames, ", "));
     }
 
-    ENFORCE(!method.data(gs)->arguments().empty());
-    auto &blkArg = method.data(gs)->arguments().back();
+    ENFORCE(!method.data(gs)->arguments.empty());
+    auto &blkArg = method.data(gs)->arguments.back();
     ENFORCE(blkArg.flags.isBlock);
 
     auto hasBlockType = blkArg.type != nullptr && !blkArg.type.isUntyped();

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -670,7 +670,7 @@ CompletionTask::getCompletionItemForMethod(LSPTypecheckerDelegate &typechecker, 
 
     // Intuition for when to use maybeAlias vs what: if it needs to know the original name: maybeAlias.
     // If it needs to know the types / arity: what. Default to `what` if you don't know.
-    auto what = maybeAlias.data(gs)->dealias(gs).asMethodRef();
+    auto what = maybeAlias.data(gs)->dealiasMethod(gs);
 
     if (what == core::Symbols::sig()) {
         if (auto item = trySuggestSig(typechecker, clientConfig, what, receiverType, queryLoc, prefix, sortIdx)) {

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -837,7 +837,7 @@ unique_ptr<ResponseMessage> CompletionTask::runRequest(LSPTypecheckerDelegate &t
             // Since each list is sorted by depth, taking the first elem dedups by depth within each name.
             auto similarMethod = similarMethods[0];
 
-            if (similarMethod.method.data(gs)->isMethodPrivate() && !sendResp->isPrivateOk) {
+            if (similarMethod.method.data(gs)->flags.isPrivate && !sendResp->isPrivateOk) {
                 continue;
             }
 

--- a/main/lsp/requests/document_symbol.cc
+++ b/main/lsp/requests/document_symbol.cc
@@ -11,7 +11,11 @@ std::unique_ptr<DocumentSymbol> symbolRef2DocumentSymbol(const core::GlobalState
 
 void symbolRef2DocumentSymbolWalkMembers(const core::GlobalState &gs, core::SymbolRef sym, core::FileRef filter,
                                          vector<unique_ptr<DocumentSymbol>> &out) {
-    for (auto mem : sym.membersStableOrderSlow(gs)) {
+    if (!sym.isClassOrModule()) {
+        return;
+    }
+
+    for (auto mem : sym.asClassOrModuleRef().data(gs)->membersStableOrderSlow(gs)) {
         if (mem.first != core::Names::attached() && mem.first != core::Names::singleton()) {
             bool foundThisFile = false;
             for (auto loc : mem.second.locs(gs)) {

--- a/main/lsp/requests/implementation.cc
+++ b/main/lsp/requests/implementation.cc
@@ -26,7 +26,7 @@ unique_ptr<ResponseError> makeInvalidRequestError(core::SymbolRef symbol, const 
 
 const MethodImplementationResults findMethodImplementations(const core::GlobalState &gs, core::MethodRef method) {
     MethodImplementationResults res;
-    if (!method.data(gs)->isAbstract()) {
+    if (!method.data(gs)->flags.isAbstract) {
         res.error = makeInvalidRequestError(method, gs);
         return res;
     }
@@ -89,7 +89,7 @@ unique_ptr<ResponseMessage> ImplementationTask::runRequest(LSPTypecheckerDelegat
 
         auto method = maybeMethod.asMethodRef();
         core::MethodRef overridedMethod = method;
-        if (method.data(gs)->isOverride()) {
+        if (method.data(gs)->flags.isOverride) {
             overridedMethod = findOverridedMethod(gs, method);
         }
         auto locationsOrError = findMethodImplementations(gs, overridedMethod);
@@ -130,7 +130,7 @@ unique_ptr<ResponseMessage> ImplementationTask::runRequest(LSPTypecheckerDelegat
 
         auto calledMethod = mainResponse.method;
         auto overridedMethod = calledMethod;
-        if (calledMethod.data(gs)->isOverride()) {
+        if (calledMethod.data(gs)->flags.isOverride) {
             overridedMethod = findOverridedMethod(gs, overridedMethod);
         }
 

--- a/main/lsp/requests/implementation.cc
+++ b/main/lsp/requests/implementation.cc
@@ -26,22 +26,16 @@ unique_ptr<ResponseError> makeInvalidRequestError(core::SymbolRef symbol, const 
 
 const MethodImplementationResults findMethodImplementations(const core::GlobalState &gs, core::MethodRef method) {
     MethodImplementationResults res;
-    if (!method.data(gs)->isMethod() || !method.data(gs)->isAbstract()) {
+    if (!method.data(gs)->isAbstract()) {
         res.error = makeInvalidRequestError(method, gs);
         return res;
     }
 
     vector<core::Loc> locations;
     auto owner = method.data(gs)->owner;
-    if (!owner.isClassOrModule()) {
-        res.error = makeInvalidParamsError("Abstract method can only be inside a class or module");
-        return res;
-    }
-
-    auto owningClassSymbolRef = owner.asClassOrModuleRef();
     auto includeOwner = false;
     // Scans whole symbol table. This is slow, and we might need to make this faster eventually.
-    auto childClasses = getSubclassesSlow(gs, owningClassSymbolRef, includeOwner);
+    auto childClasses = getSubclassesSlow(gs, owner, includeOwner);
     auto methodName = method.data(gs)->name;
     for (const auto &childClass : childClasses) {
         auto methodImplementation = childClass.data(gs)->findMethod(gs, methodName);
@@ -53,12 +47,9 @@ const MethodImplementationResults findMethodImplementations(const core::GlobalSt
 }
 
 core::MethodRef findOverridedMethod(const core::GlobalState &gs, const core::MethodRef method) {
-    auto ownerClass = method.data(gs)->owner.asClassOrModuleRef();
+    auto ownerClass = method.data(gs)->owner;
 
     for (auto mixin : ownerClass.data(gs)->mixins()) {
-        if (!mixin.data(gs)->isClassOrModule() && !mixin.data(gs)->isAbstract()) {
-            continue;
-        }
         return mixin.data(gs)->findMethod(gs, method.data(gs)->name);
     }
     return core::Symbols::noMethod();

--- a/main/lsp/requests/signature_help.cc
+++ b/main/lsp/requests/signature_help.cc
@@ -20,7 +20,7 @@ void addSignatureHelpItem(const core::GlobalState &gs, core::MethodRef method,
     vector<unique_ptr<ParameterInformation>> parameters;
     // Documentation is set to be a markdown element that highlights which parameter you are currently typing in.
     string methodDocumentation = "(";
-    auto &args = method.data(gs)->arguments();
+    auto &args = method.data(gs)->arguments;
     int i = 0;
     for (const auto &arg : args) {
         // label field is populated with the name of the variable.

--- a/main/minimize/minimize.cc
+++ b/main/minimize/minimize.cc
@@ -184,7 +184,7 @@ void serializeMethods(const core::GlobalState &sourceGS, const core::GlobalState
             // Have to find the superMethod in sourceGS, because otherwise the `isAbstract` bit won't be set
             auto sourceSuperMethod = sourceClass.data(sourceGS)->findMethodTransitive(
                 sourceGS, rbiNameToSourceName(sourceGS, rbiGS, rbiEntryName));
-            if (sourceSuperMethod.exists() && !sourceSuperMethod.data(sourceGS)->isAbstract()) {
+            if (sourceSuperMethod.exists() && !sourceSuperMethod.data(sourceGS)->flags.isAbstract) {
                 // Sorbet will fall back to dispatching to the parent method, which might have a sig.
                 // But if the parent is abstract, and we don't serialize a method, Sorbet will
                 // complain about the method not being implemented when it was, just not visibly.

--- a/main/minimize/minimize.cc
+++ b/main/minimize/minimize.cc
@@ -222,7 +222,7 @@ void serializeMethods(const core::GlobalState &sourceGS, const core::GlobalState
         auto isSingleton = rbiClass.data(rbiGS)->isSingletonClass(rbiGS);
         outfile.fmt("  def {}{}(", isSingleton ? "self." : "", rbiEntryShortName);
 
-        auto &rbiParameters = rbiEntry.data(rbiGS)->arguments();
+        auto &rbiParameters = rbiEntry.data(rbiGS)->arguments;
         if (rbiParameters.size() == 3 && rbiParameters[1].name == core::Names::fwdKwargs()) {
             // The positional and block parameters get their names normalized to make overload
             // checking easier. The only reliable way to detect `...` syntax is by looking at the

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -55,7 +55,7 @@ public:
 
     ast::ExpressionPtr preTransformMethodDef(core::Context ctx, ast::ExpressionPtr tree) {
         auto &m = ast::cast_tree_nonnull<ast::MethodDef>(tree);
-        if (ctx.file.data(ctx).strictLevel < core::StrictLevel::True || m.symbol.data(ctx)->isOverloaded()) {
+        if (ctx.file.data(ctx).strictLevel < core::StrictLevel::True || m.symbol.data(ctx)->flags.isOverloaded) {
             return tree;
         }
         auto &print = opts.print;

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1051,7 +1051,7 @@ class SymbolDefiner {
         defineArgs(ctx.withOwner(sym), parsedArgs);
         sym.data(ctx)->addLoc(ctx, declLoc);
         if (method.flags.isRewriterSynthesized) {
-            sym.data(ctx)->setRewriterSynthesized();
+            sym.data(ctx)->flags.isRewriterSynthesized = true;
         }
         ENFORCE(ctx.state.lookupMethodSymbolWithHash(owner, method.name, method.argsHash).exists());
         return sym;
@@ -1062,7 +1062,7 @@ class SymbolDefiner {
         auto implicitlyPrivate = ctx.owner.enclosingClass(ctx) == core::Symbols::root();
         if (implicitlyPrivate) {
             // Methods defined at the top level default to private (on Object)
-            symbol.data(ctx)->setMethodPrivate();
+            symbol.data(ctx)->flags.isPrivate = true;
         } else {
             // All other methods default to public (their visibility might be changed later)
             symbol.data(ctx)->setMethodPublic();
@@ -1082,10 +1082,10 @@ class SymbolDefiner {
             switch (mod.name.rawId()) {
                 case core::Names::private_().rawId():
                 case core::Names::privateClassMethod().rawId():
-                    method.data(ctx)->setMethodPrivate();
+                    method.data(ctx)->flags.isPrivate = true;
                     break;
                 case core::Names::protected_().rawId():
-                    method.data(ctx)->setMethodProtected();
+                    method.data(ctx)->flags.isProtected = true;
                     break;
                 case core::Names::public_().rawId():
                     method.data(ctx)->setMethodPublic();

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -757,7 +757,7 @@ class SymbolDefiner {
 
     // Allow stub symbols created to hold intrinsics to be filled in
     // with real types from code
-    bool isIntrinsic(const core::SymbolData &data) {
+    bool isIntrinsic(const core::MethodData &data) {
         return data->intrinsic != nullptr && !data->hasSig();
     }
 
@@ -831,7 +831,7 @@ class SymbolDefiner {
         return existing;
     }
 
-    void defineArg(core::MutableContext ctx, core::SymbolData &methodData, int pos, const ast::ParsedArg &parsedArg) {
+    void defineArg(core::MutableContext ctx, core::MethodData &methodData, int pos, const ast::ParsedArg &parsedArg) {
         if (pos < methodData->arguments().size()) {
             // TODO: check that flags match;
             if (parsedArg.loc.exists()) {
@@ -903,7 +903,7 @@ class SymbolDefiner {
     }
 
     bool paramsMatch(core::MutableContext ctx, core::MethodRef method, const vector<ast::ParsedArg> &parsedArgs) {
-        auto sym = method.data(ctx)->dealias(ctx).asMethodRef();
+        auto sym = method.data(ctx)->dealiasMethod(ctx);
         if (sym.data(ctx)->arguments().size() != parsedArgs.size()) {
             return false;
         }
@@ -1333,7 +1333,7 @@ class SymbolDefiner {
             }
             // if we have more than one type member with the same name, then we have messed up somewhere
             ENFORCE(absl::c_find_if(onSymbol.data(ctx)->typeMembers(), [&](auto mem) {
-                        return mem.name(ctx) == existingTypeMember.data(ctx)->name;
+                        return mem.data(ctx)->name == existingTypeMember.data(ctx)->name;
                     }) != onSymbol.data(ctx)->typeMembers().end());
             sym = existingTypeMember;
         } else {

--- a/namer/test/namer_test.cc
+++ b/namer/test/namer_test.cc
@@ -70,7 +70,7 @@ TEST_CASE("namer tests") {
         REQUIRE_EQ(4, objectScope->members().size());
         auto methodSym = objectScope->members().at(gs.enterNameUTF8("hello_world")).asMethodRef();
         const auto &symbol = methodSym.data(gs);
-        REQUIRE_EQ(core::Symbols::Object(), symbol->owner.asClassOrModuleRef());
+        REQUIRE_EQ(core::Symbols::Object(), symbol->owner);
         REQUIRE_EQ(1, symbol->arguments().size());
     }
 

--- a/namer/test/namer_test.cc
+++ b/namer/test/namer_test.cc
@@ -71,7 +71,7 @@ TEST_CASE("namer tests") {
         auto methodSym = objectScope->members().at(gs.enterNameUTF8("hello_world")).asMethodRef();
         const auto &symbol = methodSym.data(gs);
         REQUIRE_EQ(core::Symbols::Object(), symbol->owner);
-        REQUIRE_EQ(1, symbol->arguments().size());
+        REQUIRE_EQ(1, symbol->arguments.size());
     }
 
     SUBCASE("Idempotent") { // NOLINT

--- a/plugin_injector/plugin_injector.cc
+++ b/plugin_injector/plugin_injector.cc
@@ -194,7 +194,7 @@ public:
         }
 
         if (md.symbol.data(gs)->name == core::Names::staticInit()) {
-            auto attachedClass = md.symbol.data(gs)->owner.asClassOrModuleRef().data(gs)->attachedClass(gs);
+            auto attachedClass = md.symbol.data(gs)->owner.data(gs)->attachedClass(gs);
             if (attachedClass.exists() && attachedClass.data(gs)->name.isTEnumName(gs)) {
                 return;
             }

--- a/plugin_injector/plugin_injector.cc
+++ b/plugin_injector/plugin_injector.cc
@@ -189,7 +189,7 @@ public:
 
         // This method will be handled as a VM_METHOD_TYPE_IVAR method by the
         // standard VM mechanisms, so we don't need to generate code for it.
-        if (md.flags.isAttrReader && !md.symbol.data(gs)->isFinalMethod()) {
+        if (md.flags.isAttrReader && !md.symbol.data(gs)->flags.isFinal) {
             return;
         }
 

--- a/rbi/stdlib/rubygems.rbi
+++ b/rbi/stdlib/rubygems.rbi
@@ -3512,7 +3512,7 @@ class Gem::Command
   #   "FILE          name of file to find"
   # end
   # ```
-  def arguments(); end
+  def arguments; end
 
   # True if `long` begins with the characters from `short`.
   def begins?(long, short); end

--- a/rbi/stdlib/rubygems.rbi
+++ b/rbi/stdlib/rubygems.rbi
@@ -3512,7 +3512,7 @@ class Gem::Command
   #   "FILE          name of file to find"
   # end
   # ```
-  def arguments; end
+  def arguments(); end
 
   # True if `long` begins with the characters from `short`.
   def begins?(long, short); end

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1526,7 +1526,8 @@ class ResolveTypeMembersAndFieldsWalk {
                 // Declaring a class instance variable
             } else if (job.atTopLevel && ctx.owner.name(ctx) == core::Names::initialize()) {
                 // Declaring a instance variable
-            } else if (ctx.owner.isMethod() && ctx.owner.owner(ctx).isSingletonClass(ctx) &&
+            } else if (ctx.owner.isMethod() &&
+                       ctx.owner.asMethodRef().data(ctx)->owner.data(ctx)->isSingletonClass(ctx) &&
                        !core::Types::isSubType(ctx, core::Types::nilClass(), cast->type)) {
                 // Declaring a class instance variable in a static method
                 if (auto e = ctx.beginError(uid->loc, core::errors::Resolver::InvalidDeclareVariables)) {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -221,7 +221,7 @@ private:
             }
             scope = scope->parent.get();
         }
-        return nesting->scope.findMemberTransitive(ctx, name);
+        return nesting->scope.asClassOrModuleRef().data(ctx)->findMemberTransitive(ctx, name);
     }
 
     static bool isAlreadyResolved(core::Context ctx, const ast::ConstantLit &original) {
@@ -501,7 +501,7 @@ private:
         while (enclosingClass != core::Symbols::root()) {
             auto typeMembers = enclosingClass.data(ctx)->typeMembers();
             if (!typeMembers.empty()) {
-                enclosingTypeMember = typeMembers[0].asTypeMemberRef();
+                enclosingTypeMember = typeMembers[0];
                 break;
             }
             enclosingClass = enclosingClass.data(ctx)->owner.enclosingClass(ctx);

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2780,7 +2780,7 @@ private:
             method.data(ctx)->setFinalMethod();
         }
         if (sig.seen.bind) {
-            method.data(ctx)->setReBind(sig.bind);
+            method.data(ctx)->rebind = sig.bind;
         }
 
         auto methodInfo = method.data(ctx);

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2679,10 +2679,10 @@ private:
             // we cannot rely on method and symbol arguments being aligned, as method could have more arguments.
             // we roundtrip through original symbol that is stored in mdef.
             auto internalNameToLookFor = argSym.name;
-            auto originalArgIt = absl::c_find_if(mdef.symbol.data(ctx)->arguments(),
+            auto originalArgIt = absl::c_find_if(mdef.symbol.data(ctx)->arguments,
                                                  [&](const auto &arg) { return arg.name == internalNameToLookFor; });
-            ENFORCE(originalArgIt != mdef.symbol.data(ctx)->arguments().end());
-            auto realPos = originalArgIt - mdef.symbol.data(ctx)->arguments().begin();
+            ENFORCE(originalArgIt != mdef.symbol.data(ctx)->arguments.end());
+            auto realPos = originalArgIt - mdef.symbol.data(ctx)->arguments.begin();
             return ast::MK::arg2Local(mdef.args[realPos]);
         }
     }
@@ -2720,7 +2720,7 @@ private:
                     local = ast::cast_tree<ast::Local>(arg);
                 }
 
-                auto &info = mdef.symbol.data(ctx)->arguments()[argIdx];
+                auto &info = mdef.symbol.data(ctx)->arguments[argIdx];
                 if (info.flags.isKeyword) {
                     args.emplace_back(ast::MK::Symbol(local->loc, info.name));
                     args.emplace_back(local->deepCopy());
@@ -2746,7 +2746,7 @@ private:
     static void fillInInfoFromSig(core::MutableContext ctx, core::MethodRef method, core::LocOffsets exprLoc,
                                   ParsedSig &sig, bool isOverloaded, const ast::MethodDef &mdef) {
         ENFORCE(isOverloaded || mdef.symbol == method);
-        ENFORCE(isOverloaded || method.data(ctx)->arguments().size() == mdef.args.size());
+        ENFORCE(isOverloaded || method.data(ctx)->arguments.size() == mdef.args.size());
 
         if (!sig.seen.returns && !sig.seen.void_) {
             if (auto e = ctx.beginError(exprLoc, core::errors::Resolver::InvalidMethodSignature)) {
@@ -2794,13 +2794,13 @@ private:
         auto methodInfo = method.data(ctx);
 
         // Is this a signature for a method defined with argument forwarding syntax?
-        if (methodInfo->arguments().size() >= 3) {
+        if (methodInfo->arguments.size() >= 3) {
             // To match, the definition must have been desugared with at least 3 parameters named
             // `<fwd-args>`, `<fwd-kwargs>` and `<fwd-block>`
-            auto len = methodInfo->arguments().size();
-            auto l1 = getArgLocal(ctx, methodInfo->arguments()[len - 3], mdef, len - 3, isOverloaded)->localVariable;
-            auto l2 = getArgLocal(ctx, methodInfo->arguments()[len - 2], mdef, len - 2, isOverloaded)->localVariable;
-            auto l3 = getArgLocal(ctx, methodInfo->arguments()[len - 1], mdef, len - 1, isOverloaded)->localVariable;
+            auto len = methodInfo->arguments.size();
+            auto l1 = getArgLocal(ctx, methodInfo->arguments[len - 3], mdef, len - 3, isOverloaded)->localVariable;
+            auto l2 = getArgLocal(ctx, methodInfo->arguments[len - 2], mdef, len - 2, isOverloaded)->localVariable;
+            auto l3 = getArgLocal(ctx, methodInfo->arguments[len - 1], mdef, len - 1, isOverloaded)->localVariable;
             if (l1._name == core::Names::fwdArgs() && l2._name == core::Names::fwdKwargs() &&
                 l3._name == core::Names::fwdBlock()) {
                 if (auto e = ctx.beginError(exprLoc, core::errors::Resolver::InvalidMethodSignature)) {
@@ -2821,7 +2821,7 @@ private:
 
         methodInfo->resultType = sig.returns;
         int i = -1;
-        for (auto &arg : methodInfo->arguments()) {
+        for (auto &arg : methodInfo->arguments) {
             ++i;
             auto local = getArgLocal(ctx, arg, mdef, i, isOverloaded);
             auto treeArgName = local->localVariable._name;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2688,7 +2688,7 @@ private:
     }
 
     static void handleAbstractMethod(core::Context ctx, ast::MethodDef &mdef) {
-        if (mdef.symbol.data(ctx)->isAbstract()) {
+        if (mdef.symbol.data(ctx)->flags.isAbstract) {
             if (!ast::isa_tree<ast::EmptyTree>(mdef.rhs)) {
                 if (auto e = ctx.beginError(mdef.rhs.loc(), core::errors::Resolver::AbstractMethodWithBody)) {
                     e.setHeader("Abstract methods must not contain any code in their body");
@@ -2760,13 +2760,13 @@ private:
         }
 
         if (sig.seen.abstract) {
-            method.data(ctx)->setAbstract();
+            method.data(ctx)->flags.isAbstract = true;
         }
         if (sig.seen.incompatibleOverride) {
-            method.data(ctx)->setIncompatibleOverride();
+            method.data(ctx)->flags.isIncompatibleOverride = true;
         }
         if (!sig.typeArgs.empty()) {
-            method.data(ctx)->setGenericMethod();
+            method.data(ctx)->flags.isGenericMethod = true;
             for (auto &typeSpec : sig.typeArgs) {
                 if (typeSpec.type) {
                     auto name = ctx.state.freshNameUnique(core::UniqueNameKind::TypeVarName, typeSpec.name, 1);
@@ -2779,13 +2779,13 @@ private:
             }
         }
         if (sig.seen.overridable) {
-            method.data(ctx)->setOverridable();
+            method.data(ctx)->flags.isOverridable = true;
         }
         if (sig.seen.override_) {
-            method.data(ctx)->setOverride();
+            method.data(ctx)->flags.isOverride = true;
         }
         if (sig.seen.final) {
-            method.data(ctx)->setFinalMethod();
+            method.data(ctx)->flags.isFinal = true;
         }
         if (sig.seen.bind) {
             method.data(ctx)->rebind = sig.bind;
@@ -3135,7 +3135,7 @@ public:
                                                                i, sig.argsToKeep);
                 overloadSym.data(ctx)->setMethodVisibility(mdef.symbol.data(ctx)->methodVisibility());
                 if (i != sigs.size() - 1) {
-                    overloadSym.data(ctx)->setOverloaded();
+                    overloadSym.data(ctx)->flags.isOverloaded = true;
                 }
             } else {
                 overloadSym = mdef.symbol;

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -673,7 +673,7 @@ TypeSyntax::ResultType interpretTCombinator(core::Context ctx, const ast::Send &
                 }
             }
 
-            if (!ctx.owner.isSingletonClass(ctx)) {
+            if (!ctx.owner.isClassOrModule() || !ctx.owner.asClassOrModuleRef().data(ctx)->isSingletonClass(ctx)) {
                 if (auto e = ctx.beginError(send.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                     e.setHeader("`{}` may only be used in a singleton class method context",
                                 "T." + core::Names::attachedClass().show(ctx));

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -62,7 +62,7 @@ public:
     ast::ExpressionPtr preTransformMethodDef(core::Context ctx, ast::ExpressionPtr tree) {
         auto &m = ast::cast_tree_nonnull<ast::MethodDef>(tree);
 
-        if (m.symbol.data(ctx)->isOverloaded()) {
+        if (m.symbol.data(ctx)->flags.isOverloaded) {
             return tree;
         }
         auto cfg = cfg::CFGBuilder::buildFor(ctx.withOwner(m.symbol), m);

--- a/test/testdata/namer/alias_method.rb
+++ b/test/testdata/namer/alias_method.rb
@@ -9,4 +9,12 @@ module Alias
   alias_method # error: Not enough arguments provided for method `Module#alias_method`. Expected: `2`, got: `0`
   alias_method :f # error: Not enough arguments provided for method `Module#alias_method`. Expected: `2`, got: `1`
   alias_method :f, 8 # error: Expected `Symbol` but found `Integer(8)` for argument `old_name`
+  alias_method :bad_alias, :nonexistant_method
+  #                        ^^^^^^^^^^^^^^^^^^^ error: Can't make method alias from `bad_alias` to non existing method `nonexistant_method`
+
+  def alias_user
+    f_alias_1
+    # Should work without error, even though the alias is bad.
+    bad_alias
+  end
 end

--- a/test/testdata/namer/alias_method.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/alias_method.rb.symbol-table-raw.exp
@@ -1,14 +1,17 @@
 class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
-    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/alias_method.rb start=2:1 end=12:4}
+    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/alias_method.rb start=2:1 end=20:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/alias_method.rb start=??? end=???}
   module <C <U Alias>> < <C <U Sorbet>>::<C <U Private>>::<C <U Static>>::<C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/namer/alias_method.rb start=2:1 end=2:13}
+    method <C <U Alias>>#<U alias_user> (<blk>) @ Loc {file=test/testdata/namer/alias_method.rb start=15:3 end=15:17}
+      argument <blk><block> @ Loc {file=test/testdata/namer/alias_method.rb start=??? end=???}
+    method <C <U Alias>>#<U bad_alias> () -> AliasType { symbol = <C <U Sorbet>>::<C <U Private>>::<C <U Static>>#<U <bad-method-alias-stub>> } @ Loc {file=test/testdata/namer/alias_method.rb start=12:3 end=12:47}
     method <C <U Alias>>#<U f> (<blk>) @ Loc {file=test/testdata/namer/alias_method.rb start=3:3 end=3:8}
       argument <blk><block> @ Loc {file=test/testdata/namer/alias_method.rb start=??? end=???}
     method <C <U Alias>>#<U f_alias> () -> AliasType { symbol = <C <U Alias>>#<U f> } @ Loc {file=test/testdata/namer/alias_method.rb start=6:3 end=6:18}
     method <C <U Alias>>#<U f_alias_1> () -> AliasType { symbol = <C <U Alias>>#<U f> } @ Loc {file=test/testdata/namer/alias_method.rb start=7:3 end=7:30}
   class <S <C <U Alias>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> () @ Loc {file=test/testdata/namer/alias_method.rb start=2:8 end=2:13}
     type-member(+) <S <C <U Alias>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U Alias>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=Alias) @ Loc {file=test/testdata/namer/alias_method.rb start=2:8 end=2:13}
-    method <S <C <U Alias>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/alias_method.rb start=2:1 end=12:4}
+    method <S <C <U Alias>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/alias_method.rb start=2:1 end=20:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/alias_method.rb start=??? end=???}
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Move method symbols into a new Method class.

* Speeds up Sorbet typechecking on large projects by reducing the cost of defining/allocating method symbols.
* Slightly reduces memory consumption due to smaller method symbol objects.
* Reduces `SymbolRef` casts due to more specifically-typed APIs (e.g., `Method::owner` is a `ClassOrModuleRef`, `Method::typeArguments` is a `vector` of `TypeArgumentRef`, and `Symbol::typeMembers()` is now a `vector` of `TypeMemberRef`).
* Removes some `SymbolRef` methods that are no longer required.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

In addition to the above, this change moves errors that previously occurred at runtime (calling a method-only method on Symbol) to ones that happen at compile time (method methods can only run on `Method` objects).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
