### PR TITLE
Packages: improve invalid export handling

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1532,7 +1532,8 @@ class ResolveTypeMembersAndFieldsWalk {
         auto data = job.sym.data(ctx);
         if (data->resultType == nullptr) {
             auto resultType = resolveConstantType(ctx, asgn->rhs);
-            if (resultType == nullptr) {
+            // Do not attempt to suggest types for aliases that fail to resolve in package files.
+            if (resultType == nullptr && !ctx.file.data(ctx).isPackage()) {
                 // Instead of emitting an error now, emit an error in infer that has a proper type suggestion
                 auto rhs = move(job.asgn->rhs);
                 auto loc = rhs.loc();

--- a/test/testdata/packager/invalid-export/__package.rb
+++ b/test/testdata/packager/invalid-export/__package.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class Foo::Bar < PackageSpec
+
+  export Foo::Bar::Exists
+  export Foo::Bar::NotDefined
+#        ^^^^^^^^^^^^^^^^^^^^ error: Unable to resolve constant `NotDefined`
+end

--- a/test/testdata/packager/invalid-export/foo_bar.rb
+++ b/test/testdata/packager/invalid-export/foo_bar.rb
@@ -1,0 +1,10 @@
+# typed: strict
+
+module Foo::Bar
+  class Exists
+    extend T::Sig
+
+    sig {void}
+    def self.hello; end
+  end
+end

--- a/test/testdata/packager/invalid-export/foo_bar.test.rb
+++ b/test/testdata/packager/invalid-export/foo_bar.test.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# typed: strict
+
+module Test::Foo::Bar
+  # Ensure that bad exports don't cause errors in test namespace
+  Foo::Bar::Exists
+end

--- a/test/testdata/packager/invalid-export/other/__package.rb
+++ b/test/testdata/packager/invalid-export/other/__package.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Other < PackageSpec
+  # Ensure that the bad export in Foo::Bar don't create errors in a package that imports it.
+  import Foo::Bar
+end

--- a/test/testdata/packager/invalid-export/other/other.rb
+++ b/test/testdata/packager/invalid-export/other/other.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Other::OtherClass
+  Foo::Bar::Exists.hello # This ref still works
+  Foo::Bar::Exists.helloXX
+# ^^^^^^^^^^^^^^^^^^^^^^^^ error: Method `helloXX` does not exist on `T.class_of(Foo::Bar::Exists)`
+
+
+  # Note this is a weird quirk that in this package `NotDefined` exists as a stub. This is safe
+  # because an error exists for this in the `__package.rb` file itself.
+  Foo::Bar::NotDefined
+  Foo::Bar::NotDefined.xxx
+  Foo::Bar::NotDefined::Deeper
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Unable to resolve constant `Deeper`
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
* Suppress errors from non-resolved exports on the RHS of the assignments we create in packager
* Also skip attempting to suggest types for these.


### Motivation
Fix error handling when encountering invalid `export`s in package specs.
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
