### PR TITLE
StripePackages: helpful errors/fixes for unresolved export

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -798,6 +798,12 @@ vector<Symbol::FuzzySearchResult> Symbol::findMemberFuzzyMatchConstant(const Glo
                         member.second.asClassOrModuleRef().data(gs)->derivesFrom(gs, core::Symbols::StubModule())) {
                         continue;
                     }
+                    // A static-field inside a package file is an alias created by that packager.
+                    // Ignore these so that the search finds only actual definitions.
+                    if (member.second.isFieldOrStaticField() && member.second.loc(gs).file().exists() &&
+                        member.second.loc(gs).file().data(gs).isPackage()) {
+                        continue;
+                    }
                     // Mangled packager names are not matched, but we do descend into them to search
                     // deeper.
                     if (member.first.dataCnst(gs)->original.kind() == NameKind::UTF8) {

--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -16,33 +16,33 @@ public:
     }
 
     const vector<core::NameRef> &fullName() const {
-        ENFORCE(false);
+        notImplemented();
         return emptyName;
     }
 
     const vector<string> &pathPrefixes() const {
-        ENFORCE(false);
+        notImplemented();
         return prefixes;
     }
 
     unique_ptr<PackageInfo> deepCopy() const {
-        ENFORCE(false);
+        notImplemented();
         return make_unique<NonePackage>();
     }
 
     Loc definitionLoc() const {
-        ENFORCE(false);
+        notImplemented();
         return Loc::none();
     }
 
     std::optional<core::AutocorrectSuggestion> addImport(const core::GlobalState &gs, const PackageInfo &pkg,
                                                          bool isTestImport) const {
-        ENFORCE(false);
+        notImplemented();
         return nullopt;
     }
 
     vector<MissingExportMatch> findMissingExports(core::Context ctx, core::SymbolRef scope, core::NameRef name) const {
-        ENFORCE(false);
+        notImplemented();
         return {};
     }
 
@@ -52,7 +52,7 @@ public:
     }
 
     bool ownsSymbol(const core::GlobalState &gs, core::SymbolRef symbol) const {
-        ENFORCE(false);
+        notImplemented();
         return false;
     }
 
@@ -61,6 +61,10 @@ public:
 private:
     const vector<string> prefixes;
     const vector<core::NameRef> emptyName;
+
+    void notImplemented() const {
+        ENFORCE(false, "Not implemented for NonePackage");
+    }
 };
 static const NonePackage NONE_PKG;
 } // namespace

--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -51,6 +51,11 @@ public:
         return {};
     }
 
+    bool ownsSymbol(const core::GlobalState &gs, core::SymbolRef symbol) const {
+        ENFORCE(false);
+        return false;
+    }
+
     ~NonePackage() {}
 
 private:

--- a/core/packages/PackageInfo.cc
+++ b/core/packages/PackageInfo.cc
@@ -1,6 +1,7 @@
 #include "core/packages/PackageInfo.h"
 #include "core/Loc.h"
 #include "core/NameRef.h"
+#include "core/Symbols.h"
 
 using namespace std;
 
@@ -15,5 +16,15 @@ bool PackageInfo::operator==(const PackageInfo &rhs) const {
 
 PackageInfo::~PackageInfo() {
     // see https://eli.thegreenplace.net/2010/11/13/pure-virtual-destructors-in-c
+}
+
+bool PackageInfo::isPackageModule(const core::GlobalState &gs, core::ClassOrModuleRef klass) {
+    while (klass.exists() && klass != core::Symbols::root()) {
+        if (klass == core::Symbols::PackageRegistry() || klass == core::Symbols::PackageTests()) {
+            return true;
+        }
+        klass = klass.data(gs)->owner.asClassOrModuleRef();
+    }
+    return false;
 }
 } // namespace sorbet::core::packages

--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -45,6 +45,10 @@ public:
     };
     virtual std::vector<MissingExportMatch> findMissingExports(core::Context ctx, core::SymbolRef scope,
                                                                core::NameRef name) const = 0;
+
+    // Utilities:
+
+    static bool isPackageModule(const core::GlobalState &gs, core::ClassOrModuleRef klass);
 };
 } // namespace sorbet::core::packages
 #endif

--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -45,6 +45,7 @@ public:
     };
     virtual std::vector<MissingExportMatch> findMissingExports(core::Context ctx, core::SymbolRef scope,
                                                                core::NameRef name) const = 0;
+    virtual bool ownsSymbol(const core::GlobalState &gs, core::SymbolRef symbol) const = 0;
 
     // Utilities:
 

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -23,16 +23,6 @@ namespace {
 constexpr string_view PACKAGE_FILE_NAME = "__package.rb"sv;
 constexpr core::NameRef TEST_NAME = core::Names::Constants::Test();
 
-bool isPackageModule(const core::GlobalState &gs, core::ClassOrModuleRef modName) {
-    while (modName.exists() && modName != core::Symbols::root()) {
-        if (modName == core::Symbols::PackageRegistry() || modName == core::Symbols::PackageTests()) {
-            return true;
-        }
-        modName = modName.data(gs)->owner.asClassOrModuleRef();
-    }
-    return false;
-}
-
 class PrunePackageModules final {
     const bool intentionallyLeakASTs;
 
@@ -41,7 +31,7 @@ public:
 
     ast::ExpressionPtr postTransformClassDef(core::Context ctx, ast::ExpressionPtr tree) {
         auto &klass = ast::cast_tree_nonnull<ast::ClassDef>(tree);
-        if (isPackageModule(ctx, klass.symbol)) {
+        if (core::packages::PackageInfo::isPackageModule(ctx, klass.symbol)) {
             if (intentionallyLeakASTs) {
                 intentionallyLeakMemory(tree.release());
             }

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -251,6 +251,16 @@ public:
         return res;
     }
 
+    bool ownsSymbol(const core::GlobalState &gs, core::SymbolRef symbol) const {
+        while (symbol.exists() && symbol != core::Symbols::root()) {
+            if (symbol.isClassOrModule() && symbol.name(gs) == privateMangledName) {
+                return true;
+            }
+            symbol = symbol.owner(gs);
+        }
+        return false;
+    }
+
     PackageInfoImpl() = default;
     explicit PackageInfoImpl(const PackageInfoImpl &) = default;
     PackageInfoImpl &operator=(const PackageInfoImpl &) = delete;

--- a/resolver/SuggestPackage.cc
+++ b/resolver/SuggestPackage.cc
@@ -154,7 +154,7 @@ private:
                 matches.resize(4);
             }
         }
-        if (matches.size() > 0) {
+        if (!matches.empty()) {
             addReplacementSuggestions(e, unresolved, matches);
         } else {
             e.addErrorNote("To be exported it must be defined in package `{}`", formatPackageName(currentPkg));

--- a/test/cli/package-error-unresolved-export/__package.rb
+++ b/test/cli/package-error-unresolved-export/__package.rb
@@ -1,0 +1,9 @@
+# typed: strict
+
+class Foo::BasePkg < PackageSpec
+
+  export Foo::BasePkg::Exists
+
+  export Foo::BasePkg::WildlyMisspelled
+  export Foo::BasePkg::NameWithTipo
+end

--- a/test/cli/package-error-unresolved-export/base.rb
+++ b/test/cli/package-error-unresolved-export/base.rb
@@ -1,0 +1,8 @@
+# typed: strict
+
+module Foo::BasePkg
+
+  class Exists; end
+
+  class NameWithTypo; end
+end

--- a/test/cli/package-error-unresolved-export/other/__package.rb
+++ b/test/cli/package-error-unresolved-export/other/__package.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+class Foo::Other < PackageSpec
+end

--- a/test/cli/package-error-unresolved-export/other/other.rb
+++ b/test/cli/package-error-unresolved-export/other/other.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+module Foo::Other
+  class NameWithTipo; end
+end

--- a/test/cli/package-error-unresolved-export/package-error-unresolved-export.out
+++ b/test/cli/package-error-unresolved-export/package-error-unresolved-export.out
@@ -1,0 +1,17 @@
+__package.rb:7: Unable to resolve constant `WildlyMisspelled` https://srb.help/5002
+     7 |  export Foo::BasePkg::WildlyMisspelled
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Note:
+    To be exported it must be defined in package `Foo::BasePkg`
+
+__package.rb:8: Unable to resolve constant `NameWithTipo` https://srb.help/5002
+     8 |  export Foo::BasePkg::NameWithTipo
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    __package.rb:8: Replace with `Foo::BasePkg::NameWithTypo`
+     8 |  export Foo::BasePkg::NameWithTipo
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    base.rb:7: Did you mean: `Foo::BasePkg::NameWithTypo`?
+     7 |  class NameWithTypo; end
+          ^^^^^^^^^^^^^^^^^^
+Errors: 2

--- a/test/cli/package-error-unresolved-export/package-error-unresolved-export.sh
+++ b/test/cli/package-error-unresolved-export/package-error-unresolved-export.sh
@@ -1,0 +1,3 @@
+cd test/cli/package-error-unresolved-export || exit 1
+
+../../../main/sorbet --silence-dev-message --stripe-packages --max-threads=0 . 2>&1


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
If a user attempts to `export` a symbol and it does not resolved attempt to be more helpful.

In one scenario, this is a typo and is similar enough to something actually defined in this package. In that case we use the normal fuzzy logic and suggest replacements among candidates from _this_ package.

If no reasonable matches are found, instead add a note to the error:
```
__package.rb:7: Unable to resolve constant `WildlyMisspelled` https://srb.help/5002
     7 |  export Foo::BasePkg::WildlyMisspelled
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  Note:
    To be exported it must be defined in package `Foo::BasePkg`
```


### Motivation
UX
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
