### PR TITLE
Pre-work changes for upgrading to C++20

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -49,6 +49,13 @@ build --host_cxxopt=-Wno-pass-failed # host build doesn't have enough optimizati
 # <command line>:1:9: and <built-in>:355:9: so sadly we turn them all off
 build --copt=-Wno-macro-redefined
 
+# Clang 12.0.0 has warnings when compiling LLVM 12.0.0 on C++20, sadly.
+# TODO(jez) When we upgrade to LLVM 13.0.0+ can we delete this?
+build --host_cxxopt=-Wno-deprecated-anon-enum-enum-conversion
+build --cxxopt=-Wno-deprecated-anon-enum-enum-conversion
+build --cxxopt=-Wno-deprecated-enum-enum-conversion
+build --cxxopt=-Wno-ambiguous-reversed-operator
+
 ##
 ## debug configuration
 ##

--- a/.bazelrc
+++ b/.bazelrc
@@ -52,6 +52,7 @@ build --copt=-Wno-macro-redefined
 # Clang 12.0.0 has warnings when compiling LLVM 12.0.0 on C++20, sadly.
 # TODO(jez) When we upgrade to LLVM 13.0.0+ can we delete this?
 build --host_cxxopt=-Wno-deprecated-anon-enum-enum-conversion
+build --host_cxxopt=-Wno-deprecated-enum-enum-conversion
 build --cxxopt=-Wno-deprecated-anon-enum-enum-conversion
 build --cxxopt=-Wno-deprecated-enum-enum-conversion
 build --cxxopt=-Wno-ambiguous-reversed-operator

--- a/.bazelrc
+++ b/.bazelrc
@@ -51,11 +51,13 @@ build --copt=-Wno-macro-redefined
 
 # Clang 12.0.0 has warnings when compiling LLVM 12.0.0 on C++20, sadly.
 # TODO(jez) When we upgrade to LLVM 13.0.0+ can we delete this?
-build --host_cxxopt=-Wno-deprecated-anon-enum-enum-conversion
-build --host_cxxopt=-Wno-deprecated-enum-enum-conversion
-build --cxxopt=-Wno-deprecated-anon-enum-enum-conversion
-build --cxxopt=-Wno-deprecated-enum-enum-conversion
-build --cxxopt=-Wno-ambiguous-reversed-operator
+# TODO(jez) We will need these to build C++20, but emscripten doesn't even know about these options yet.
+# Leaving them commented out so we can uncomment them after upgrading emscripten.
+# build --host_cxxopt=-Wno-deprecated-anon-enum-enum-conversion
+# build --host_cxxopt=-Wno-deprecated-enum-enum-conversion
+# build --cxxopt=-Wno-deprecated-anon-enum-enum-conversion
+# build --cxxopt=-Wno-deprecated-enum-enum-conversion
+# build --cxxopt=-Wno-ambiguous-reversed-operator
 
 ##
 ## debug configuration

--- a/common/Exception.h
+++ b/common/Exception.h
@@ -43,7 +43,8 @@ public:
 
 class Exception final {
 public:
-    template <typename... TArgs> [[noreturn]] static bool raise(const TArgs &...args) __attribute__((noreturn));
+    template <typename... TArgs>
+    [[noreturn]] static bool raise(fmt::string_view formatString, const TArgs &...args) __attribute__((noreturn));
 
     [[noreturn]] static inline void notImplemented() {
         raise("Not Implemented");
@@ -58,15 +59,16 @@ public:
     }
     template <typename... TArgs>
     [[noreturn]] static inline bool enforce_handler(std::string_view check, std::string_view file, int line,
-                                                    std::string_view message, const TArgs &...args)
+                                                    fmt::string_view message, const TArgs &...args)
         __attribute__((noreturn)) {
-        raise("{}:{} enforced condition {} has failed: {}", file, line, check, fmt::format(message, args...));
+        raise("{}:{} enforced condition {} has failed: {}", file, line, check,
+              fmt::vformat(message, fmt::make_format_args(args...)));
     }
 };
 
-template <typename... TArgs> [[noreturn]] bool Exception::raise(const TArgs &...args) {
+template <typename... TArgs> [[noreturn]] bool Exception::raise(fmt::string_view formatString, const TArgs &...args) {
     Exception::failInFuzzer();
-    std::string message = fmt::format(args...);
+    std::string message = fmt::vformat(formatString, fmt::make_format_args(args...));
 
     if (message.size() > 0) {
         fatalLogger->error("Exception::raise(): {}\n", message);

--- a/common/Exception.h
+++ b/common/Exception.h
@@ -44,7 +44,7 @@ public:
 class Exception final {
 public:
     template <typename... TArgs>
-    [[noreturn]] static bool raise(fmt::string_view formatString, const TArgs &...args) __attribute__((noreturn));
+    [[noreturn]] static bool raise(fmt::format_string<TArgs...> fmt, TArgs &&...args) __attribute__((noreturn));
 
     [[noreturn]] static inline void notImplemented() {
         raise("Not Implemented");
@@ -59,16 +59,16 @@ public:
     }
     template <typename... TArgs>
     [[noreturn]] static inline bool enforce_handler(std::string_view check, std::string_view file, int line,
-                                                    fmt::string_view message, const TArgs &...args)
+                                                    fmt::format_string<TArgs...> message, TArgs &&...args)
         __attribute__((noreturn)) {
         raise("{}:{} enforced condition {} has failed: {}", file, line, check,
-              fmt::vformat(message, fmt::make_format_args(args...)));
+              fmt::format(message, std::forward<TArgs>(args)...));
     }
 };
 
-template <typename... TArgs> [[noreturn]] bool Exception::raise(fmt::string_view formatString, const TArgs &...args) {
+template <typename... TArgs> [[noreturn]] bool Exception::raise(fmt::format_string<TArgs...> fmt, TArgs &&...args) {
     Exception::failInFuzzer();
-    std::string message = fmt::vformat(formatString, fmt::make_format_args(args...));
+    std::string message = fmt::format(fmt, std::forward<TArgs>(args)...);
 
     if (message.size() > 0) {
         fatalLogger->error("Exception::raise(): {}\n", message);

--- a/compiler/Core/AbortCompilation.h
+++ b/compiler/Core/AbortCompilation.h
@@ -1,3 +1,6 @@
+#ifndef SORBET_COMPILER_CORE_ABORT_COMPILATION_H
+#define SORBET_COMPILER_CORE_ABORT_COMPILATION_H
+
 #include "common/Exception.h"
 
 namespace sorbet::compiler {
@@ -7,3 +10,5 @@ public:
     AbortCompilation(const char *message) : SorbetException(message){};
 };
 } // namespace sorbet::compiler
+
+#endif

--- a/compiler/Core/CompilerState.cc
+++ b/compiler/Core/CompilerState.cc
@@ -114,12 +114,4 @@ void CompilerState::runCheapOptimizations(llvm::Function *func) {
     pm.run(*func);
 }
 
-void failCompilation(const core::GlobalState &gs, const core::Loc &loc, ConstExprStr msg) {
-    if (auto e = gs.beginError(loc, core::errors::Compiler::Unanalyzable)) {
-        e.setHeader(msg);
-    }
-
-    throw AbortCompilation(msg.str);
-}
-
 } // namespace sorbet::compiler

--- a/compiler/Core/CompilerState.h
+++ b/compiler/Core/CompilerState.h
@@ -1,8 +1,6 @@
 #ifndef SORBET_COMPILER_CORE_COMPILER_STATE_H
 #define SORBET_COMPILER_CORE_COMPILER_STATE_H
 
-#include "common/ConstExprStr.h"
-#include "common/Exception.h"
 #include "compiler/Core/ForwardDeclarations.h"
 #include "core/Files.h"
 #include <memory>
@@ -67,11 +65,6 @@ public:
 
     CompilerState withFunctionEntry(llvm::BasicBlock *functionEntry);
 };
-
-// Add an error to GlobalState, and then throw to abort compilation.
-// Use only when compilation CANNOT continue.
-// (Emitting any old GlobalState error will still cause Sorbet to exit non-zero.)
-[[noreturn]] void failCompilation(const core::GlobalState &gs, const core::Loc &loc, ConstExprStr msg);
 
 } // namespace sorbet::compiler
 

--- a/compiler/Core/FailCompilation.h
+++ b/compiler/Core/FailCompilation.h
@@ -1,0 +1,24 @@
+#ifndef SORBET_COMPILER_CORE_FAIL_COMPILATION_H
+#define SORBET_COMPILER_CORE_FAIL_COMPILATION_H
+
+#include "compiler/Core/AbortCompilation.h"
+#include "compiler/Errors/Errors.h"
+#include "core/GlobalState.h"
+
+namespace sorbet::compiler {
+
+// Add an error to GlobalState, and then throw to abort compilation.
+// Use only when compilation CANNOT continue.
+// (Emitting any old GlobalState error will still cause Sorbet to exit non-zero.)
+template <typename... Args>
+[[noreturn]] void failCompilation(const core::GlobalState &gs, const core::Loc &loc, fmt::format_string<Args...> msg,
+                                  Args &&...args) {
+    if (auto e = gs.beginError(loc, core::errors::Compiler::Unanalyzable)) {
+        e.setHeader(msg, std::forward<Args>(args)...);
+    }
+
+    throw AbortCompilation(fmt::format(msg, std::forward<Args>(args)...));
+}
+
+} // namespace sorbet::compiler
+#endif

--- a/compiler/IREmitter/IREmitter.cc
+++ b/compiler/IREmitter/IREmitter.cc
@@ -14,6 +14,7 @@
 #include "common/sort.h"
 #include "common/typecase.h"
 #include "compiler/Core/CompilerState.h"
+#include "compiler/Core/FailCompilation.h"
 #include "compiler/Errors/Errors.h"
 #include "compiler/IREmitter/IREmitter.h"
 #include "compiler/IREmitter/IREmitterContext.h"
@@ -1106,7 +1107,7 @@ void IREmitter::buildInitFor(CompilerState &cs, const core::MethodRef &sym, stri
         // Call the LLVM method that was made by run() from this Init_ method
         auto staticInitName = IREmitterHelpers::getFunctionName(cs, staticInit);
         auto staticInitFunc = cs.getFunction(staticInitName);
-        ENFORCE(staticInitFunc, staticInitName + " does not exist");
+        ENFORCE(staticInitFunc, "{} does not exist", staticInitName);
         builder.CreateCall(staticInitFunc,
                            {
                                llvm::ConstantInt::get(cs, llvm::APInt(32, 0, true)),

--- a/compiler/IREmitter/IREmitterContext.cc
+++ b/compiler/IREmitter/IREmitterContext.cc
@@ -66,7 +66,7 @@ AliasesAndKeywords setupAliasesAndKeywords(CompilerState &cs, const cfg::CFG &cf
                     } else if (name.size() > 1 && name[0] == '$') {
                         res.aliases[bind.bind.variable] = Alias::forGlobalField(i->name);
                     } else {
-                        ENFORCE(stoi(string(name)) > 0, "'" + string(name) + "' is not a valid global name");
+                        ENFORCE(stoi(string(name)) > 0, "'{}' is not a valid global name", name);
                         res.aliases[bind.bind.variable] = Alias::forGlobalField(i->name);
                     }
                 } else {

--- a/compiler/IREmitter/NameBasedIntrinsics.cc
+++ b/compiler/IREmitter/NameBasedIntrinsics.cc
@@ -11,6 +11,7 @@
 #include "common/FileOps.h"
 #include "common/sort.h"
 #include "compiler/Core/CompilerState.h"
+#include "compiler/Core/FailCompilation.h"
 #include "compiler/Errors/Errors.h"
 #include "compiler/IREmitter/IREmitter.h"
 #include "compiler/IREmitter/IREmitterContext.h"

--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -11,6 +11,7 @@
 #include "common/FileOps.h"
 #include "common/sort.h"
 #include "compiler/Core/CompilerState.h"
+#include "compiler/Core/FailCompilation.h"
 #include "compiler/Errors/Errors.h"
 #include "compiler/IREmitter/IREmitter.h"
 #include "compiler/IREmitter/IREmitterContext.h"
@@ -84,7 +85,7 @@ public:
                 current = overload;
             }
 
-            ENFORCE(false, "The method `{}#{}` (or an overload) does not return `{}`", primaryMethod.show(gs),
+            ENFORCE(false, "The method `{}` (or an overload) does not return `{}`", primaryMethod.show(gs),
                     intrinsicResultType.show(gs));
         }
     }
@@ -175,7 +176,7 @@ public:
         if (auto *blk = mcctx.blkAsFunction()) {
             if (!cMethodWithBlock.has_value()) {
                 core::Loc loc{mcctx.irctx.cfg.file, send->argLocs.back()};
-                compiler::failCompilation(cs, loc, "Unable to handle a block with this intrinsic");
+                failCompilation(cs, loc, "Unable to handle a block with this intrinsic");
             }
             auto *forwarder = generateForwarder(mcctx);
 

--- a/compiler/IREmitter/sends.cc
+++ b/compiler/IREmitter/sends.cc
@@ -11,6 +11,7 @@
 #include "common/FileOps.h"
 #include "common/sort.h"
 #include "compiler/Core/CompilerState.h"
+#include "compiler/Core/FailCompilation.h"
 #include "compiler/Errors/Errors.h"
 #include "compiler/IREmitter/IREmitter.h"
 #include "compiler/IREmitter/IREmitterContext.h"

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -2051,18 +2051,18 @@ void Symbol::sanityCheck(const GlobalState &gs) const {
 
         ENFORCE_NO_TIMER(current == current2);
         for (auto &e : members()) {
-            ENFORCE_NO_TIMER(e.first.exists(), name.toString(gs) + " has a member symbol without a name");
-            ENFORCE_NO_TIMER(e.second.exists(), name.toString(gs) + "." + e.first.toString(gs) +
-                                                    " corresponds to a core::Symbols::noSymbol()");
+            ENFORCE_NO_TIMER(e.first.exists(), "{} has a member symbol without a name", name.toString(gs));
+            ENFORCE_NO_TIMER(e.second.exists(), "{}.{} corresponds to a core::Symbols::noSymbol()", name.toString(gs),
+                             e.first.toString(gs));
         }
     }
     if (this->isMethod()) {
         if (isa_type<AliasType>(this->resultType)) {
             // If we have an alias method, we should never look at it's arguments;
             // we should instead look at the arguments of whatever we're aliasing.
-            ENFORCE_NO_TIMER(this->arguments().empty(), ref(gs).show(gs));
+            ENFORCE_NO_TIMER(this->arguments().empty(), "{}", ref(gs).show(gs));
         } else {
-            ENFORCE_NO_TIMER(!this->arguments().empty(), ref(gs).show(gs));
+            ENFORCE_NO_TIMER(!this->arguments().empty(), "{}", ref(gs).show(gs));
         }
     }
 }

--- a/core/Types.h
+++ b/core/Types.h
@@ -790,6 +790,7 @@ public:
 
     ~TypeAndOrigins() noexcept;
     TypeAndOrigins() = default;
+    TypeAndOrigins(TypePtr type, InlinedVector<Loc, 1> origins) : type(type), origins(origins) {}
     TypeAndOrigins(const TypeAndOrigins &) = default;
     TypeAndOrigins(TypeAndOrigins &&) = default;
     TypeAndOrigins &operator=(const TypeAndOrigins &) = default;

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -730,7 +730,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
     auto pend = data->arguments().end();
 
     ENFORCE(pit != pend, "Should at least have the block arg.");
-    ENFORCE((pend - 1)->flags.isBlock, "Last arg should be the block arg: " + (pend - 1)->show(gs));
+    ENFORCE((pend - 1)->flags.isBlock, "Last arg should be the block arg: {}", (pend - 1)->show(gs));
     // We'll type check the block arg separately from the rest of the args.
     --pend;
 

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -492,7 +492,7 @@ void ClassType::_sanityCheck(const GlobalState &gs) const {
 InlinedVector<SymbolRef, 4> Types::alignBaseTypeArgs(const GlobalState &gs, ClassOrModuleRef what,
                                                      const vector<TypePtr> &targs, ClassOrModuleRef asIf) {
     ENFORCE(what == asIf || what.data(gs)->derivesFrom(gs, asIf) || asIf.data(gs)->derivesFrom(gs, what),
-            what.data(gs)->name.showRaw(gs), asIf.data(gs)->name.showRaw(gs));
+            "what={} asIf={}", what.data(gs)->name.showRaw(gs), asIf.data(gs)->name.showRaw(gs));
     InlinedVector<SymbolRef, 4> currentAlignment;
     if (targs.empty()) {
         return currentAlignment;
@@ -586,7 +586,7 @@ void AppliedType::_sanityCheck(const GlobalState &gs) const {
                 (this->klass == Symbols::Array() && (this->targs.size() == 1)) ||
                 (this->klass == Symbols::Hash() && (this->targs.size() == 3)) ||
                 this->klass.id() >= Symbols::Proc0().id() && this->klass.id() <= Symbols::last_proc().id(),
-            this->klass.data(gs)->name.showRaw(gs));
+            "{}", this->klass.data(gs)->name.showRaw(gs));
     for (auto &targ : this->targs) {
         targ.sanityCheck(gs);
     }

--- a/definition_validator/variance.cc
+++ b/definition_validator/variance.cc
@@ -106,8 +106,8 @@ private:
                 auto params = app.targs;
 
                 ENFORCE(members.size() == params.size(),
-                        fmt::format("types should be fully saturated, but there are {} members and {} params",
-                                    members.size(), params.size()));
+                        "types should be fully saturated, but there are {} members and {} params", members.size(),
+                        params.size());
 
                 for (int i = 0; i < members.size(); ++i) {
                     auto memberVariance = members[i].asTypeMemberRef().data(ctx)->variance();

--- a/main/autogen/autoloader.h
+++ b/main/autogen/autoloader.h
@@ -64,6 +64,10 @@ struct NamedDefinition {
     u4 pathDepth;
 
     NamedDefinition() = default;
+    NamedDefinition(Definition def, QualifiedName qname, QualifiedName parentName,
+                    std::vector<core::NameRef> requireStatements, core::FileRef fileRef, u4 pathDepth)
+        : def(def), qname(qname), parentName(parentName), requireStatements(std::move(requireStatements)),
+          fileRef(fileRef), pathDepth(pathDepth) {}
     NamedDefinition(const NamedDefinition &) = delete;
     NamedDefinition(NamedDefinition &&) = default;
     NamedDefinition &operator=(const NamedDefinition &) = delete;

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -18,8 +18,9 @@ public:
     bool supportsFlush = false;
 
     void print(const std::string_view &contents) const;
-    template <typename... Args> void fmt(const ConstExprStr msg, Args &&...args) const {
-        print(fmt::format(msg.str, std::forward<Args>(args)...));
+    template <typename... Args> void fmt(fmt::format_string<Args...> msg, Args &&...args) const {
+        auto contents = fmt::format(msg, std::forward<Args>(args)...);
+        print(contents);
     }
     void flush();
     std::string flushToString();

--- a/parser/Parser.cc
+++ b/parser/Parser.cc
@@ -42,7 +42,8 @@ public:
             core::Loc loc(file, translatePos(diag.location().beginPos, maxOff - 1),
                           translatePos(diag.location().endPos, maxOff));
             if (auto e = gs.beginError(loc, core::errors::Parser::ParserError)) {
-                e.setHeader("{}", fmt::format(dclassStrings[(int)diag.error_class()], diag.data()));
+                e.setHeader("{}",
+                            fmt::vformat(dclassStrings[(int)diag.error_class()], fmt::make_format_args(diag.data())));
             }
         }
     }

--- a/parser/tools/generate_ast.cc
+++ b/parser/tools/generate_ast.cc
@@ -824,7 +824,7 @@ void emitNodeHeader(ostream &out, NodeDef &node) {
 void emitNodeClassfile(ostream &out, NodeDef &node) {
     out << "  std::string " << node.name << "::nodeName() {" << '\n';
     out << "    return \"" << node.name << "\";" << '\n';
-    out << "  };" << '\n' << '\n';
+    out << "  }" << '\n' << '\n';
 
     out << "  std::string " << node.name << "::toStringWithTabs(const core::GlobalState &gs, int tabs) const {" << '\n'
         << "    fmt::memory_buffer buf;" << '\n';
@@ -1025,58 +1025,8 @@ void emitNodeClassfile(ostream &out, NodeDef &node) {
     out << '\n';
 
     // toWhitequark
-    out << "  std::string " << node.name << "::toWhitequark(const core::GlobalState &gs, int tabs) {" << '\n'
-        << "    fmt::memory_buffer buf;" << '\n';
-    out << "    fmt::format_to(std::back_inserter(buf), \"s(:" << node.whitequarkName << "\");" << '\n';
-    // Generate fields
-    for (auto &arg : node.fields) {
-        switch (arg.type) {
-            case FieldType::Name:
-                if (node.whitequarkName == "str") {
-                    out << "    fmt::format_to(std::back_inserter(buf), \", \\\"{}\\\"\", " << arg.name
-                        << ".toString(gs));\n";
-                } else {
-                    out << "    fmt::format_to(std::back_inserter(buf), \", :\" + JSON::escape(" << arg.name
-                        << ".show(gs)));\n";
-                }
-                break;
-            case FieldType::Node:
-                out << "    fmt::format_to(std::back_inserter(buf), \",\");\n";
-                out << "    if (" << arg.name << ") {\n";
-                out << "     fmt::format_to(std::back_inserter(buf), \"\\n\");\n";
-                out << "     printTabs(buf, tabs + 1);" << '\n';
-                out << "     printNodeWhitequark(buf, " << arg.name << ", gs, tabs + 1);\n";
-                out << "    } else {\n";
-                out << "      fmt::format_to(std::back_inserter(buf), \" nil\");\n";
-                out << "    }\n";
-                break;
-            case FieldType::NodeVec:
-                out << "    for (auto &&a: " << arg.name << ") {\n";
-                out << "      fmt::format_to(std::back_inserter(buf), \",\");\n";
-                out << "      if (a) {\n";
-                out << "        fmt::format_to(std::back_inserter(buf), \"\\n\");\n";
-                out << "        printTabs(buf, tabs + 1);" << '\n';
-                out << "        printNodeWhitequark(buf, a, gs, tabs + 1);\n";
-                out << "      } else {\n";
-                out << "        fmt::format_to(std::back_inserter(buf), \" nil\");\n";
-                out << "      }\n";
-                out << "    }\n";
-                break;
-            case FieldType::String:
-                out << "    fmt::format_to(std::back_inserter(buf), \", \\\"{}\\\"\", " << arg.name << ");\n";
-                break;
-            case FieldType::Uint:
-                out << "    fmt::format_to(std::back_inserter(buf), \", {}\", " << arg.name << ");\n";
-                break;
-            case FieldType::Loc:
-                continue;
-            case FieldType::Bool:
-                continue;
-        }
-    }
-
-    out << "    fmt::format_to(std::back_inserter(buf), \")\");";
-    out << "    return to_string(buf);\n"
+    out << "  std::string " << node.name << "::toWhitequark(const core::GlobalState &gs, int tabs) {" << '\n';
+    out << "    return \"\";\n"
         << "  }\n";
     out << '\n';
 }

--- a/plugin_injector/plugin_injector.cc
+++ b/plugin_injector/plugin_injector.cc
@@ -15,6 +15,7 @@
 #include "common/typecase.h"
 #include "compiler/Core/AbortCompilation.h"
 #include "compiler/Core/CompilerState.h"
+#include "compiler/Core/FailCompilation.h"
 #include "compiler/Core/OptimizerException.h"
 #include "compiler/Errors/Errors.h"
 #include "compiler/IREmitter/IREmitter.h"

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -142,6 +142,9 @@ private:
         core::FileRef file;
         ast::ConstantLit *rhs;
 
+        ClassAliasResolutionItem(core::SymbolRef lhs, core::FileRef file, ast::ConstantLit *rhs)
+            : lhs(lhs), file(file), rhs(rhs) {}
+
         ClassAliasResolutionItem() = default;
         ClassAliasResolutionItem(ClassAliasResolutionItem &&) noexcept = default;
         ClassAliasResolutionItem &operator=(ClassAliasResolutionItem &&rhs) noexcept = default;
@@ -155,6 +158,9 @@ private:
         core::FileRef file;
         ast::ExpressionPtr *rhs;
 
+        TypeAliasResolutionItem(core::SymbolRef lhs, core::FileRef file, ast::ExpressionPtr *rhs)
+            : lhs(lhs), file(file), rhs(rhs) {}
+
         TypeAliasResolutionItem(TypeAliasResolutionItem &&) noexcept = default;
         TypeAliasResolutionItem &operator=(TypeAliasResolutionItem &&rhs) noexcept = default;
 
@@ -167,6 +173,9 @@ private:
         core::SymbolRef owner;
         ast::Send *send;
 
+        ClassMethodsResolutionItem(core::FileRef file, core::SymbolRef owner, ast::Send *send)
+            : file(file), owner(owner), send(send) {}
+
         ClassMethodsResolutionItem(ClassMethodsResolutionItem &&) noexcept = default;
         ClassMethodsResolutionItem &operator=(ClassMethodsResolutionItem &&rhs) noexcept = default;
 
@@ -178,6 +187,9 @@ private:
         core::FileRef file;
         core::ClassOrModuleRef owner;
         ast::Send *send;
+
+        RequireAncestorResolutionItem(core::FileRef file, core::ClassOrModuleRef owner, ast::Send *send)
+            : file(file), owner(owner), send(send) {}
 
         RequireAncestorResolutionItem(RequireAncestorResolutionItem &&) noexcept = default;
         RequireAncestorResolutionItem &operator=(RequireAncestorResolutionItem &&rhs) noexcept = default;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3228,7 +3228,7 @@ ast::ParsedFilesOrCancelled Resolver::runIncremental(core::GlobalState &gs, vect
     DEBUG_ONLY(for (auto i = 1; i < gs.classAndModulesUsed(); i++) {
         core::ClassOrModuleRef sym(gs, i);
         // If class is not marked as 'linearization computed', then we added a mixin to it since the last slow path.
-        ENFORCE_NO_TIMER(sym.data(gs)->isClassOrModuleLinearizationComputed(), sym.toString(gs));
+        ENFORCE_NO_TIMER(sym.data(gs)->isClassOrModuleLinearizationComputed(), "{}", sym.toString(gs));
     })
     trees = ResolveTypeMembersAndFieldsWalk::run(gs, std::move(trees), *workers);
     auto result = resolveSigs(gs, std::move(trees), *workers);

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -39,10 +39,10 @@ def register_sorbet_dependencies():
 
     http_archive(
         name = "spdlog",
-        urls = _github_public_urls("gabime/spdlog/archive/61ed2a670e40e9a865edc20b088422a469bdab9e.zip"),  # v1.9.0
-        sha256 = "0ec124d1bb4bb57a7f43f814622f7c907619e3cacbb6e04c62634a98880f5971",
+        urls = _github_public_urls("gabime/spdlog/archive/eb3220622e73a4889eee355ffa37972b3cac3df5.zip"),  # v1.9.2
+        sha256 = "b7570488bdd94ab6d3653bc324d8ed7976d9f3a2f035eb2e969ebcaad3b0d5c7",
         build_file = "@com_stripe_ruby_typer//third_party:spdlog.BUILD",
-        strip_prefix = "spdlog-61ed2a670e40e9a865edc20b088422a469bdab9e",
+        strip_prefix = "spdlog-eb3220622e73a4889eee355ffa37972b3cac3df5",
     )
 
     # We don't use this directly, but protobuf will skip defining its own


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

These are all the changes required to get us to build cleanly under `-std=c++20`

I couldn't also check in the change to add `-std=c++20` because our version of
emscripten doesn't support it. We're using a super old version of emscripten,
and it was taking me too long to upgrade our build pipeline to a newer version.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

You can see that the builds associated with this branch passed:

<https://github.com/sorbet/sorbet/pull/4970>

when using c++20 (except emscripten).