### PR TITLE
shellcheck: Use Bazel, upgrade to 0.8.0

### DIFF
--- a/gems/sorbet/test/hidden-method-finder/hidden_methods_bazel.sh
+++ b/gems/sorbet/test/hidden-method-finder/hidden_methods_bazel.sh
@@ -42,7 +42,7 @@ test_name=$3
 test_dir="${repo_root}/gems/sorbet/test/hidden-method-finder/${test_name}"
 
 # NOTE: using rlocation here because this script gets run from a genrule
-# shellcheck disable=SC1090
+# shellcheck source=SCRIPTDIR/logging.sh
 source "$(rlocation com_stripe_ruby_typer/gems/sorbet/test/hidden-method-finder/logging.sh)"
 
 # ----- Environment setup and validation -----

--- a/gems/sorbet/test/snapshot/run_one.sh
+++ b/gems/sorbet/test/snapshot/run_one.sh
@@ -182,6 +182,7 @@ fi
   #
   # note: redirects stderr before the pipe
   info "├─ Running srb"
+  # shellcheck disable=SC2048
   if ! SRB_YES=1 ${test_cmd[*]} < /dev/null 2> "err.log" > "out.log"; then
     error "├─ srb failed."
     error "├─ stdout (out.log):"

--- a/gems/sorbet/test/snapshot/run_one.sh
+++ b/gems/sorbet/test/snapshot/run_one.sh
@@ -42,10 +42,10 @@ test_name=$3
 test_dir="${repo_root}/gems/sorbet/test/snapshot/${test_name}"
 
 # NOTE: using rlocation here because this script gets run from a genrule
-# shellcheck disable=SC1090
+# shellcheck source=SCRIPTDIR/logging.sh
 source "$(rlocation com_stripe_ruby_typer/gems/sorbet/test/snapshot/logging.sh)"
 
-# shellcheck disable=SC1090
+# shellcheck source=SCRIPTDIR/hermetic_tar.sh
 source "$(rlocation com_stripe_ruby_typer/gems/sorbet/test/snapshot/hermetic_tar.sh)"
 
 

--- a/gems/sorbet/test/snapshot/update_one.sh
+++ b/gems/sorbet/test/snapshot/update_one.sh
@@ -3,8 +3,9 @@
 set -euo pipefail
 shopt -s dotglob
 
-# shellcheck disable=SC1090
+# shellcheck source-path=SCRIPTDIR/../../../..
 source "gems/sorbet/test/snapshot/logging.sh"
+# shellcheck source-path=SCRIPTDIR/../../../..
 source "gems/sorbet/test/snapshot/validate_utils.sh"
 
 setup_validate_env "$@"

--- a/gems/sorbet/test/snapshot/update_one.sh
+++ b/gems/sorbet/test/snapshot/update_one.sh
@@ -32,7 +32,7 @@ diff_partial() {
     attn "├─ updating expected/sorbet (partial):"
 
     find "$test_dir/expected/sorbet" -print0 | while IFS= read -r -d '' expected_path; do
-      path_suffix="${expected_path#$test_dir/expected/sorbet}"
+      path_suffix="${expected_path#"$test_dir"/expected/sorbet}"
       actual_path="$actual/sorbet$path_suffix"
 
       # Only ever update existing files, never grow this partial snapshot.

--- a/test/build_extension.sh
+++ b/test/build_extension.sh
@@ -28,10 +28,10 @@ fi
 
 # Find logging and hermetic_tar with rlocation, as this script is run from a genrule
 
-# shellcheck disable=SC1090
+# shellcheck source=SCRIPTDIR/logging.sh
 source "$(rlocation com_stripe_ruby_typer/test/logging.sh)"
 
-# shellcheck disable=SC1090
+# shellcheck source=SCRIPTDIR/hermetic_tar.sh
 source "$(rlocation com_stripe_ruby_typer/test/hermetic_tar.sh)"
 
 # Argument Parsing #############################################################

--- a/test/cli/compiler/new_test.sh
+++ b/test/cli/compiler/new_test.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 test_dir="$(dirname "${BASH_SOURCE[0]}")"
 root_dir="${test_dir}/../.."
 
-# shellcheck disable=SC1090
+# shellcheck source=SCRIPTDIR/../../logging.sh
 source "${root_dir}/test/logging.sh"
 
 usage() {

--- a/test/cli/compiler/update_cli_exp_files.sh
+++ b/test/cli/compiler/update_cli_exp_files.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 test_dir="$(dirname "${BASH_SOURCE[0]}")"
 root_dir="${test_dir}/../../.."
 
-# shellcheck disable=SC1090
+# shellcheck source=SCRIPTDIR/../../logging.sh
 source "${root_dir}/test/logging.sh"
 
 info "Building the exp test outputs"

--- a/test/filecheck.sh
+++ b/test/filecheck.sh
@@ -2,9 +2,7 @@
 
 set -euo pipefail
 
-# This script is always run from the repo root, so `logging.sh` doesn't exist
-# where shellcheck thinks it does.
-# shellcheck disable=SC1091
+# shellcheck source-path=SCRIPTDIR/..
 source "test/logging.sh"
 
 # Argument Parsing #############################################################

--- a/test/generate_out_file.sh
+++ b/test/generate_out_file.sh
@@ -26,7 +26,7 @@ fi
 # --- end runfiles.bash initialization --- }}}
 
 # Find logging with rlocation, as this script is run from a genrule
-# shellcheck disable=SC1090
+# shellcheck source=SCRIPTDIR/logging.sh
 source "$(rlocation com_stripe_ruby_typer/test/logging.sh)"
 
 # Argument Parsing #############################################################

--- a/test/lsp/lsp_test_runner.sh
+++ b/test/lsp/lsp_test_runner.sh
@@ -52,7 +52,7 @@ while read -r line
 do
     if [[ "$line" == ${READ_PREFIX}* ]] ;
     then
-       payload=${line#$READ_PREFIX}
+       payload=${line#"$READ_PREFIX"}
        bytelen=${#payload}
         echo -e -n "Content-Length: ${bytelen}\r\n\r\n">&"$IN_FD"
         # Don't interpret escape characters in payload.
@@ -63,7 +63,7 @@ do
 
     elif [[ "$line" == ${WRITE_PREFIX}* ]] ;
     then
-        expected_payload=${line#$WRITE_PREFIX}
+        expected_payload=${line#"$WRITE_PREFIX"}
         read -r -u "$OUT_FD" header
         if [[ "$header" == "Content-Length: "* ]] ;
         then

--- a/test/test_corpus_runner.sh
+++ b/test/test_corpus_runner.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-# This script is always run from the repo root, so `logging.sh` doesn't exist
-# where shellcheck thinks it does.
-# shellcheck disable=SC1091
+# shellcheck source-path=SCRIPTDIR/..
 source "test/logging.sh"
 
 # Argument Parsing #############################################################

--- a/test/validate_exp.sh
+++ b/test/validate_exp.sh
@@ -26,9 +26,7 @@ else
 fi
 # --- end runfiles.bash initialization --- }}}
 
-# This script is always run from the repo root, so `logging.sh` doesn't exist
-# where shellcheck thinks it does.
-# shellcheck disable=SC1091
+# shellcheck source-path=SCRIPTDIR/..
 source "test/logging.sh"
 
 # Argument Parsing #############################################################

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -335,6 +335,22 @@ package(default_visibility = ["//visibility:public"])
         strip_prefix = "llvm-project-0cbbf06b625605fff83d89b17c2187c7ccfcecd5/llvm",
     )
 
+    shellcheck_version = "0.8.0"
+    http_archive(
+        name = "shellcheck_linux",
+        urls = _github_public_urls("koalaman/shellcheck/releases/download/v{0}/shellcheck-v{0}.linux.x86_64.tar.xz".format(shellcheck_version)),
+        build_file = "@com_stripe_ruby_typer//third_party:shellcheck.BUILD",
+        sha256 = "ab6ee1b178f014d1b86d1e24da20d1139656c8b0ed34d2867fbb834dad02bf0a",
+        strip_prefix = "shellcheck-v{}".format(shellcheck_version),
+    )
+    http_archive(
+        name = "shellcheck_darwin",
+        urls = _github_public_urls("koalaman/shellcheck/releases/download/v{0}/shellcheck-v{0}.darwin.x86_64.tar.xz".format(shellcheck_version)),
+        build_file = "@com_stripe_ruby_typer//third_party:shellcheck.BUILD",
+        sha256 = "e065d4afb2620cc8c1d420a9b3e6243c84ff1a693c1ff0e38f279c8f31e86634",
+        strip_prefix = "shellcheck-v{}".format(shellcheck_version),
+    )
+
     http_file(
         name = "bundler_stripe",
         urls = _rubygems_urls("bundler-1.17.3.gem"),

--- a/third_party/shellcheck.BUILD
+++ b/third_party/shellcheck.BUILD
@@ -1,0 +1,5 @@
+filegroup(
+    name = "shellcheck_exe",
+    srcs = ["shellcheck"],
+    visibility = ["//visibility:public"],
+)

--- a/tools/scripts/lint_sh.sh
+++ b/tools/scripts/lint_sh.sh
@@ -21,7 +21,7 @@ if ! bazel build "@shellcheck_$platform//:shellcheck_exe"; then
   echo "warning: Could not fetch shellcheck with Bazel. Falling back to system"
   shellcheck="shellcheck"
 else
-  shellcheck="bazel-sorbet/external/shellcheck/shellcheck"
+  shellcheck="bazel-sorbet/external/shellcheck_$platform/shellcheck"
 fi
 
 if [ "$1" = "-t" ]; then

--- a/tools/scripts/lint_sh.sh
+++ b/tools/scripts/lint_sh.sh
@@ -8,8 +8,24 @@ list_sh_src() {
     git ls-files -z -c -m -o --exclude-standard -- '*.sh' '*.bash'
 }
 
+
+unameOut="$(uname -s)"
+case "${unameOut}" in
+    Linux*)     platform="linux";;
+    Darwin*)    platform="mac";;
+    *)          exit 1
+esac
+
+# Fetches shellcheck binary
+if ! bazel build "@shellcheck_$platform//:shellcheck_exe"; then
+  echo "warning: Could not fetch shellcheck with Bazel. Falling back to system"
+  shellcheck="shellcheck"
+else
+  shellcheck="bazel-sorbet/external/shellcheck/shellcheck"
+fi
+
 if [ "$1" = "-t" ]; then
-  OUTPUT=$(list_sh_src | xargs -0 shellcheck -s bash || :)
+  OUTPUT=$(list_sh_src | xargs -0 "$shellcheck" -s bash || :)
   if [ -n "$OUTPUT" ]; then
     echo "Some shell files have lint errors!"
     echo ""
@@ -21,5 +37,5 @@ if [ "$1" = "-t" ]; then
     exit 1
   fi
 else
-    list_sh_src | xargs -0 shellcheck -s bash
+    list_sh_src | xargs -0 "$shellcheck" -s bash
 fi


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

- Everyone running lint_sh.sh is going to get the right version of shellcheck
- Don't have to bump the build image to get new shellcheck versions
- Upgrade to 0.8.0 for good measure

  Changelog: https://github.com/koalaman/shellcheck/blob/master/CHANGELOG.md#v080---2021-11-06


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.