### PR TITLE
Add autofixes for exports

### DIFF
--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -46,7 +46,7 @@ public:
         return {};
     }
 
-    std::optional<core::AutocorrectSuggestion> addExport(const core::GlobalState &gs, const vector<core::NameRef> name,
+    std::optional<core::AutocorrectSuggestion> addExport(const core::GlobalState &gs, const core::SymbolRef name,
                                                          bool isPrivateTestExport) const {
         return {};
     }

--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -28,7 +28,7 @@ public:
     virtual std::optional<core::AutocorrectSuggestion> addImport(const core::GlobalState &gs, const PackageInfo &pkg,
                                                                  bool isTestImport) const = 0;
     virtual std::optional<core::AutocorrectSuggestion>
-    addExport(const core::GlobalState &gs, const std::vector<core::NameRef> name, bool isPrivateTestExport) const = 0;
+    addExport(const core::GlobalState &gs, const core::SymbolRef name, bool isPrivateTestExport) const = 0;
 
     bool operator==(const PackageInfo &rhs) const;
 

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -315,16 +315,8 @@ public:
         return {suggestion};
     }
 
-    optional<core::AutocorrectSuggestion> addExport(const core::GlobalState &gs, const vector<core::NameRef> newExport,
+    optional<core::AutocorrectSuggestion> addExport(const core::GlobalState &gs, const core::SymbolRef newExport,
                                                     bool isPrivateTestExport) const {
-        for (auto expt : exports) {
-            // check if we already import this, and if so, don't
-            // return an autocorrect
-            if (expt.fqn.parts == newExport) {
-                return nullopt;
-            }
-        }
-
         auto insertionLoc = core::Loc::none(loc.file());
         // first let's try adding it to the end of the imports.
         if (!exports.empty()) {
@@ -352,7 +344,7 @@ public:
 
         // now find the appropriate place for it, specifically by
         // finding the import that directly preceeds it, if any
-        auto strName = absl::StrJoin(newExport, "::", NameFormatter(gs));
+        auto strName = newExport.show(gs);
         core::AutocorrectSuggestion suggestion(
             fmt::format("Export `{}` in package `{}`", strName, name.toString(gs)),
             {{insertionLoc, fmt::format("\n  {} {}", isPrivateTestExport ? "export_for_test" : "export", strName)}});

--- a/resolver/SuggestPackage.cc
+++ b/resolver/SuggestPackage.cc
@@ -60,7 +60,7 @@ public:
         e.addErrorSection(core::ErrorSection(lines));
 
         if (auto autocorrect = srcPkg.addExport(ctx, match.symbol, false)) {
-            e.addAutocorrect(std::forward<core::AutocorrectSuggestion>(*autocorrect));
+            e.addAutocorrect(std::move(*autocorrect));
         }
     }
 
@@ -75,7 +75,7 @@ public:
             fmt::map_join(otherPkg.fullName(), "::", [&](auto nr) -> string { return nr.show(ctx); })));
         e.addErrorSection(core::ErrorSection(lines));
         if (auto autocorrect = currentPkg.addImport(ctx, otherPkg, isTestFile)) {
-            e.addAutocorrect(std::forward<core::AutocorrectSuggestion>(*autocorrect));
+            e.addAutocorrect(std::move(*autocorrect));
         }
     }
 

--- a/resolver/SuggestPackage.cc
+++ b/resolver/SuggestPackage.cc
@@ -57,18 +57,11 @@ public:
             fmt::map_join(srcPkg.fullName(), "::", [&](auto nr) -> string { return nr.show(ctx); })));
         lines.emplace_back(
             core::ErrorLine::from(match.symbol.loc(ctx), "Constant `{}` is defined here:", match.symbol.show(ctx)));
+        e.addErrorSection(core::ErrorSection(lines));
 
-        core::SymbolRef sym = match.symbol;
-        vector<core::NameRef> name;
-        do {
-            name.emplace_back(sym.name(ctx));
-            sym = sym.owner(ctx);
-        } while(sym.exists() && sym != core::Symbols::root());
-        if (auto autocorrect = srcPkg.addExport(ctx, name, false)) {
+        if (auto autocorrect = srcPkg.addExport(ctx, match.symbol, false)) {
             e.addAutocorrect(std::forward<core::AutocorrectSuggestion>(*autocorrect));
         }
-
-        e.addErrorSection(core::ErrorSection(lines));
     }
 
     void addMissingImportSuggestions(core::ErrorBuilder &e, PackageMatch &match) {

--- a/test/cli/package-error-missing-export/package-error-missing-export.out
+++ b/test/cli/package-error-missing-export/package-error-missing-export.out
@@ -8,6 +8,11 @@ foo_class.rb:10: Unable to resolve constant `NotExported` https://srb.help/5002
     other/other_class.rb:7: Constant `Foo::Bar::OtherPackage::NotExported` is defined here:
      7 |  class NotExported
           ^^^^^^^^^^^^^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    other/__package.rb:4: Insert `
+  export Foo::Bar::OtherPackage::NotExported`
+     4 |  export Foo::Bar::OtherPackage::OtherClass
+                                                   ^
 
 foo_class.rb:11: Unable to resolve constant `NotExported` https://srb.help/5002
     11 |      Bar::OtherPackage::NotExported
@@ -19,6 +24,11 @@ foo_class.rb:11: Unable to resolve constant `NotExported` https://srb.help/5002
     other/other_class.rb:7: Constant `Foo::Bar::OtherPackage::NotExported` is defined here:
      7 |  class NotExported
           ^^^^^^^^^^^^^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    other/__package.rb:4: Insert `
+  export Foo::Bar::OtherPackage::NotExported`
+     4 |  export Foo::Bar::OtherPackage::OtherClass
+                                                   ^
 
 foo_class.rb:12: Unable to resolve constant `Inner` https://srb.help/5002
     12 |      Foo::Bar::OtherPackage::Inner::AlsoNotExported
@@ -30,6 +40,11 @@ foo_class.rb:12: Unable to resolve constant `Inner` https://srb.help/5002
     other/other_class.rb:10: Constant `Foo::Bar::OtherPackage::Inner` is defined here:
     10 |  class Inner::AlsoNotExported
                 ^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    other/__package.rb:4: Insert `
+  export Foo::Bar::OtherPackage::Inner`
+     4 |  export Foo::Bar::OtherPackage::OtherClass
+                                                   ^
 
 foo_class.rb:13: Unable to resolve constant `Inner` https://srb.help/5002
     13 |      Bar::OtherPackage::Inner::AlsoNotExported
@@ -41,4 +56,9 @@ foo_class.rb:13: Unable to resolve constant `Inner` https://srb.help/5002
     other/other_class.rb:10: Constant `Foo::Bar::OtherPackage::Inner` is defined here:
     10 |  class Inner::AlsoNotExported
                 ^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    other/__package.rb:4: Insert `
+  export Foo::Bar::OtherPackage::Inner`
+     4 |  export Foo::Bar::OtherPackage::OtherClass
+                                                   ^
 Errors: 4

--- a/test/cli/package-test-simple/package-test-simple.out
+++ b/test/cli/package-test-simple/package-test-simple.out
@@ -8,4 +8,9 @@ main_lib/lib.rb:8: Unable to resolve constant `TestOnly` https://srb.help/5002
     test_only/some_helper.rb:4: Constant `Project::TestOnly` is defined here:
      4 |class Project::TestOnly::SomeHelper
               ^^^^^^^^^^^^^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    test_only/__package.rb:6: Insert `
+  export Project::TestOnly`
+     6 |  export Project::TestOnly::SomeHelper
+                                              ^
 Errors: 1

--- a/test/cli/simple-package/simple-package.out
+++ b/test/cli/simple-package/simple-package.out
@@ -20,4 +20,9 @@ foo/foo.rb:14: Unable to resolve constant `UnexportedClass` https://srb.help/500
     bar/bar.rb:14: Constant `Project::Bar::UnexportedClass` is defined here:
     14 |  class UnexportedClass; end
           ^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    bar/__package.rb:9: Insert `
+  export Project::Bar::UnexportedClass`
+     9 |  export Project::Bar::BarMethods
+                                         ^
 Errors: 2

--- a/test/pkg_autocorrects_test.cc
+++ b/test/pkg_autocorrects_test.cc
@@ -78,13 +78,15 @@ struct TestPackageFile {
         return gs.packageDB().getPackageForFile(gs, newParsedFile.file);
     }
 
-    const vector<core::NameRef> getName(core::GlobalState &gs, vector<string> rawName) const {
-        vector<core::NameRef> name;
+    const core::SymbolRef getConstantRef(core::GlobalState &gs, vector<string> rawName) const {
         core::UnfreezeNameTable nameTableAccess(gs);
+        core::UnfreezeSymbolTable symbolTableAccess(gs);
+        core::ClassOrModuleRef sym = core::Symbols::root();
+
         for (auto &n : rawName) {
-            name.emplace_back(gs.enterNameUTF8(n));
+            sym = gs.enterClassSymbol(core::Loc(), sym, gs.enterNameConstant(gs.enterNameUTF8(n)));
         }
-        return name;
+        return sym;
     }
 };
 
@@ -239,7 +241,7 @@ TEST_CASE("Simple add export") {
 
     auto &package = test.targetPackage(gs);
     ENFORCE(package.exists());
-    auto addExport = package.addExport(gs, test.getName(gs, {"Opus", "MyPackage", "NewExport"}), false);
+    auto addExport = package.addExport(gs, test.getConstantRef(gs, {"Opus", "MyPackage", "NewExport"}), false);
     ENFORCE(addExport, "Expected to get an autocorrect from `addImport`");
     auto replaced = addExport->applySingleEditForTesting(pkg_source);
     CHECK_EQ(expected, replaced);
@@ -262,7 +264,7 @@ TEST_CASE("Simple add export_for_test") {
 
     auto &package = test.targetPackage(gs);
     ENFORCE(package.exists());
-    auto addExport = package.addExport(gs, test.getName(gs, {"Opus", "MyPackage", "NewExport"}), true);
+    auto addExport = package.addExport(gs, test.getConstantRef(gs, {"Opus", "MyPackage", "NewExport"}), true);
     ENFORCE(addExport, "Expected to get an autocorrect from `addImport`");
     auto replaced = addExport->applySingleEditForTesting(pkg_source);
     CHECK_EQ(expected, replaced);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
This wires up the export autofix functionality with the existing export errors. To do so cleanly, it also tweaks the existing API for the autofix functionality: it now takes a `SymbolRef` instead of a `vector<NameRef>`, and updates the tests accordingly.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
