### PR TITLE
Stop reporting inconsistent usage of bare type error

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1828,22 +1828,13 @@ public:
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
         vector<TypePtr> elems;
         elems.reserve(args.args.size());
-        bool isType = absl::c_any_of(args.args, [](auto ty) { return isa_type<MetaType>(ty->type); });
         int i = -1;
         for (auto &elem : args.args) {
             ++i;
-            if (isType) {
-                elems.emplace_back(unwrapType(gs, args.argLoc(i), elem->type));
-            } else {
-                elems.emplace_back(elem->type);
-            }
+            elems.emplace_back(elem->type);
         }
 
-        auto tuple = make_type<TupleType>(move(elems));
-        if (isType) {
-            tuple = make_type<MetaType>(move(tuple));
-        }
-        res.returnType = move(tuple);
+        res.returnType = make_type<TupleType>(move(elems));
     }
 } Magic_buildArray;
 

--- a/test/testdata/infer/call_on_metatype.rb
+++ b/test/testdata/infer/call_on_metatype.rb
@@ -41,4 +41,4 @@ T.reveal_type(y) # error: `T.untyped`
 y = T.nilable(Integer).validate!(x)
 T.reveal_type(y) # error: `T.untyped`
 
-[T::Array[Integer]].first.to_s # error: Call to method `first` on `[T::Array[Integer]]` mistakes a type for a value
+[T::Array[Integer]].first.to_s # error: Call to method `to_s` on `T::Array[Integer]` mistakes a type for a value

--- a/test/testdata/infer/call_on_metatype.rb
+++ b/test/testdata/infer/call_on_metatype.rb
@@ -40,3 +40,5 @@ y = T.nilable(Integer).error_message_for_obj_recursive(x)
 T.reveal_type(y) # error: `T.untyped`
 y = T.nilable(Integer).validate!(x)
 T.reveal_type(y) # error: `T.untyped`
+
+[T::Array[Integer]].first.to_s # error: Call to method `first` on `[T::Array[Integer]]` mistakes a type for a value

--- a/test/testdata/infer/tuple_bare_types.rb
+++ b/test/testdata/infer/tuple_bare_types.rb
@@ -1,0 +1,52 @@
+# typed: strict
+
+extend T::Sig
+
+class Parent; end
+class ChildA; end
+class ChildB; end
+
+ChildAorChildB = T.type_alias {T.any(ChildA, ChildB)}
+
+sig {returns([Parent])}
+def example1
+  [ChildAorChildB]
+# ^^^^^^^^^^^^^^^^ error: Expected `[Parent]` but found `<Type: [T.any(ChildA, ChildB)]>` for method result type
+end
+
+sig {returns([T.untyped])}
+def example2
+  [ChildAorChildB]
+# ^^^^^^^^^^^^^^^^ error: Expected `[T.untyped]` but found `<Type: [T.any(ChildA, ChildB)]>` for method result type
+end
+
+sig {returns([Parent, T::Boolean])}
+def example3
+  [ChildAorChildB, true]
+# ^^^^^^^^^^^^^^^^^^^^^^ error: Unsupported usage of bare type
+# ^^^^^^^^^^^^^^^^^^^^^^ error: Expected `[Parent, T::Boolean]` but found `<Type: [T.any(ChildA, ChildB), T.untyped]>` for method result type
+end
+
+sig {returns([T.untyped, T::Boolean])}
+def example4
+  [ChildAorChildB, true]
+# ^^^^^^^^^^^^^^^^^^^^^^ error: Unsupported usage of bare type
+# ^^^^^^^^^^^^^^^^^^^^^^ error: Expected `[T.untyped, T::Boolean]` but found `<Type: [T.any(ChildA, ChildB), T.untyped]>` for method result type
+end
+
+sig {returns([true, false])}
+#             ^^^^ error: Unsupported literal in type syntax
+#                   ^^^^^ error: Unsupported literal in type syntax
+def example5
+  [true, false]
+end
+
+sig {returns([TrueClass, FalseClass])}
+def example6
+  [true, false]
+end
+
+sig {returns([ChildAorChildB, FalseClass])}
+def example7
+  [ChildA.new, false]
+end

--- a/test/testdata/infer/tuple_bare_types.rb
+++ b/test/testdata/infer/tuple_bare_types.rb
@@ -11,27 +11,23 @@ ChildAorChildB = T.type_alias {T.any(ChildA, ChildB)}
 sig {returns([Parent])}
 def example1
   [ChildAorChildB]
-# ^^^^^^^^^^^^^^^^ error: Expected `[Parent]` but found `<Type: [T.any(ChildA, ChildB)]>` for method result type
+# ^^^^^^^^^^^^^^^^ error: Expected `[Parent]` but found `[<Type: T.any(ChildA, ChildB)>]` for method result type
 end
 
 sig {returns([T.untyped])}
 def example2
   [ChildAorChildB]
-# ^^^^^^^^^^^^^^^^ error: Expected `[T.untyped]` but found `<Type: [T.any(ChildA, ChildB)]>` for method result type
 end
 
 sig {returns([Parent, T::Boolean])}
 def example3
   [ChildAorChildB, true]
-# ^^^^^^^^^^^^^^^^^^^^^^ error: Unsupported usage of bare type
-# ^^^^^^^^^^^^^^^^^^^^^^ error: Expected `[Parent, T::Boolean]` but found `<Type: [T.any(ChildA, ChildB), T.untyped]>` for method result type
+# ^^^^^^^^^^^^^^^^^^^^^^ error: Expected `[Parent, T::Boolean]` but found `[<Type: T.any(ChildA, ChildB)>, TrueClass]` for method result type
 end
 
 sig {returns([T.untyped, T::Boolean])}
 def example4
   [ChildAorChildB, true]
-# ^^^^^^^^^^^^^^^^^^^^^^ error: Unsupported usage of bare type
-# ^^^^^^^^^^^^^^^^^^^^^^ error: Expected `[T.untyped, T::Boolean]` but found `<Type: [T.any(ChildA, ChildB), T.untyped]>` for method result type
 end
 
 sig {returns([true, false])}

--- a/test/testdata/infer/tuple_bare_types.rb
+++ b/test/testdata/infer/tuple_bare_types.rb
@@ -46,3 +46,25 @@ sig {returns([ChildAorChildB, FalseClass])}
 def example7
   [ChildA.new, false]
 end
+
+sig {returns([ChildA, FalseClass])}
+def example8
+  [ChildA, false] # error: Expected `[ChildA, FalseClass]` but found `[T.class_of(ChildA), FalseClass]` for method result type
+end
+
+sig {returns([ChildA, FalseClass])}
+def example9
+  [ChildA, false] # error: Expected `[ChildA, FalseClass]` but found `[T.class_of(ChildA), FalseClass]` for method result type
+end
+
+x1 = T.let(T.unsafe(nil), [true]) # error: Unsupported literal in type syntax
+T.reveal_type(x1) # error: Revealed type: `[TrueClass] (1-tuple)`
+
+x2 = T.let(T.unsafe(nil), [TrueClass])
+T.reveal_type(x2) # error: Revealed type: `[TrueClass] (1-tuple)`
+
+x3 = T.let(T.unsafe(nil), [ChildA])
+T.reveal_type(x3) # error: Revealed type: `[ChildA] (1-tuple)`
+
+x4 = T.let(T.unsafe(nil), [ChildAorChildB])
+T.reveal_type(x4) # error: Revealed type: `[T.any(ChildA, ChildB)] (1-tuple)`

--- a/test/testdata/infer/tuples.rb
+++ b/test/testdata/infer/tuples.rb
@@ -30,7 +30,7 @@ empty << 4
 # Arrays of literals decay
 ["foo"] + ["bar"]
 
-[T::Array[Integer], 0] # error: Unsupported usage of literal type
+T.let(T.unsafe(nil), [T::Array[Integer], 0]) # error: Unsupported usage of literal type)
 
 T.assert_type!([1].concat([:foo]), [Integer, Symbol])
 T.assert_type!([1].concat([:foo]).concat([3, 4]), [Integer, Symbol, Integer, Integer])

--- a/test/testdata/infer/tuples.rb
+++ b/test/testdata/infer/tuples.rb
@@ -30,7 +30,7 @@ empty << 4
 # Arrays of literals decay
 ["foo"] + ["bar"]
 
-T.let(T.unsafe(nil), [T::Array[Integer], 0]) # error: Unsupported usage of literal type)
+T.let(T.unsafe(nil), [T::Array[Integer], 0]) # error: Unsupported literal in type syntax
 
 T.assert_type!([1].concat([:foo]), [Integer, Symbol])
 T.assert_type!([1].concat([:foo]).concat([3, 4]), [Integer, Symbol, Integer, Integer])


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This came up when helping someone at Stripe yesterday. These `bare type` errors
almost always mean there's a bug in Sorbet, not in the programmer's code.

In this case, the problem was that in almost all other cases, you can use
`T.untyped` to silence an error arising from attempting to type check code that
uses runtime type representations (like type aliases or T.any), etc. except in
the case where those runtime types were being used inside tuples.

That was needlessly inconsistent, so I've deleted the relevant code.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.