### PR TITLE
rename `rubyBlockId` to `rubyRegionId`

### DIFF
--- a/cfg/CFG.cc
+++ b/cfg/CFG.cc
@@ -31,12 +31,12 @@ int CFG::numLocalVariables() const {
     return this->localVariables.size();
 }
 
-BasicBlock *CFG::freshBlock(int outerLoops, int rubyBlockId) {
+BasicBlock *CFG::freshBlock(int outerLoops, int rubyRegionId) {
     int id = this->maxBasicBlockId++;
     auto &r = this->basicBlocks.emplace_back(make_unique<BasicBlock>());
     r->id = id;
     r->outerLoops = outerLoops;
-    r->rubyBlockId = rubyBlockId;
+    r->rubyRegionId = rubyRegionId;
     return r.get();
 }
 
@@ -247,8 +247,8 @@ string CFG::toTextualString(const core::GlobalState &gs) const {
         if (!basicBlock->backEdges.empty()) {
             fmt::format_to(std::back_inserter(buf), "# backedges\n");
             for (auto *backEdge : basicBlock->backEdges) {
-                fmt::format_to(std::back_inserter(buf), "# - bb{}(rubyBlockId={})\n", backEdge->id,
-                               backEdge->rubyBlockId);
+                fmt::format_to(std::back_inserter(buf), "# - bb{}(rubyRegionId={})\n", backEdge->id,
+                               backEdge->rubyRegionId);
             }
         }
 
@@ -296,7 +296,7 @@ string CFG::showRaw(core::Context ctx) const {
 
 string BasicBlock::toString(const core::GlobalState &gs, const CFG &cfg) const {
     fmt::memory_buffer buf;
-    fmt::format_to(std::back_inserter(buf), "block[id={}, rubyBlockId={}]({})\n", this->id, this->rubyBlockId,
+    fmt::format_to(std::back_inserter(buf), "block[id={}, rubyRegionId={}]({})\n", this->id, this->rubyRegionId,
                    fmt::map_join(
                        this->args.begin(), this->args.end(),
                        ", ", [&](const auto &arg) -> auto { return arg.toString(gs, cfg); }));
@@ -313,7 +313,7 @@ string BasicBlock::toString(const core::GlobalState &gs, const CFG &cfg) const {
 
 string BasicBlock::toTextualString(const core::GlobalState &gs, const CFG &cfg) const {
     fmt::memory_buffer buf;
-    fmt::format_to(std::back_inserter(buf), "bb{}[rubyBlockId={}, firstDead={}]({}):\n", this->id, this->rubyBlockId,
+    fmt::format_to(std::back_inserter(buf), "bb{}[rubyRegionId={}, firstDead={}]({}):\n", this->id, this->rubyRegionId,
                    this->firstDeadInstructionIdx,
                    fmt::map_join(
                        this->args.begin(), this->args.end(),

--- a/cfg/CFG.h
+++ b/cfg/CFG.h
@@ -100,7 +100,7 @@ public:
      */
     core::MethodRef symbol;
     int maxBasicBlockId = 0;
-    int maxRubyBlockId = 0;
+    int maxRubyRegionId = 0;
 
     /**
      * Get the number of unique local variables in the CFG. Used to size vectors that contain an entry per LocalRef.

--- a/cfg/CFG.h
+++ b/cfg/CFG.h
@@ -144,10 +144,10 @@ public:
     static constexpr int MIN_LOOP_GLOBAL = -2;
     static constexpr int MIN_LOOP_LET = -3;
 
-    // special ruby block id offsets for exception handling
-    static constexpr int HANDLERS_BLOCK_OFFSET = 1;
-    static constexpr int ENSURE_BLOCK_OFFSET = 2;
-    static constexpr int ELSE_BLOCK_OFFSET = 3;
+    // special ruby region id offsets for exception handling
+    static constexpr int HANDLERS_REGION_OFFSET = 1;
+    static constexpr int ENSURE_REGION_OFFSET = 2;
+    static constexpr int ELSE_REGION_OFFSET = 3;
 
     void sanityCheck(core::Context ctx);
 

--- a/cfg/CFG.h
+++ b/cfg/CFG.h
@@ -59,8 +59,8 @@ public:
     int outerLoops = 0;
     // Tracks which Ruby block (do ... end) this BasicBlock was generated from.
     // Incremented every time builder_walk sees a new Ruby block while traversing a Ruby method.
-    // rubyBlockId == 0 means code at the top-level of this method (outside any Ruby block).
-    int rubyBlockId = 0;
+    // rubyRegionId == 0 means code at the top-level of this method (outside any Ruby block).
+    int rubyRegionId = 0;
     int firstDeadInstructionIdx = -1;
     std::vector<Binding> exprs;
     BlockExit bexit;

--- a/cfg/CFG.h
+++ b/cfg/CFG.h
@@ -57,7 +57,11 @@ public:
     int bwdId = -1;
     int flags = 0;
     int outerLoops = 0;
-    // Tracks which Ruby block (do ... end) this BasicBlock was generated from.
+    // Tracks which Ruby block (do ... end) or Ruby exception-handling region
+    // (in begin ... rescue ... else ... ensure ... end, each `...` is its own
+    // region) this BasicBlock was generated from.  We call it a "region" to
+    // avoid confusion between BasicBlocks and Ruby blocks.
+    //
     // Incremented every time builder_walk sees a new Ruby block while traversing a Ruby method.
     // rubyRegionId == 0 means code at the top-level of this method (outside any Ruby block).
     int rubyRegionId = 0;

--- a/cfg/builder/builder_finalize.cc
+++ b/cfg/builder/builder_finalize.cc
@@ -50,7 +50,7 @@ void CFGBuilder::simplify(core::Context ctx, CFG &cfg) {
                 bb->bexit.cond = LocalRef::unconditional();
             }
             if (thenb == elseb && thenb != cfg.deadBlock() && thenb != bb &&
-                bb->rubyBlockId == thenb->rubyBlockId) { // can be squashed togather
+                bb->rubyRegionId == thenb->rubyRegionId) { // can be squashed togather
                 if (thenb->backEdges.size() == 1 && thenb->outerLoops == bb->outerLoops) {
                     bb->exprs.insert(bb->exprs.end(), make_move_iterator(thenb->exprs.begin()),
                                      make_move_iterator(thenb->exprs.end()));
@@ -83,7 +83,7 @@ void CFGBuilder::simplify(core::Context ctx, CFG &cfg) {
                     continue;
                 }
             }
-            if (thenb != cfg.deadBlock() && bb->rubyBlockId == thenb->rubyBlockId && thenb->exprs.empty() &&
+            if (thenb != cfg.deadBlock() && bb->rubyRegionId == thenb->rubyRegionId && thenb->exprs.empty() &&
                 thenb->bexit.thenb == thenb->bexit.elseb && bb->bexit.thenb != thenb->bexit.thenb) {
                 // shortcut then
                 bb->bexit.thenb = thenb->bexit.thenb;
@@ -94,7 +94,7 @@ void CFGBuilder::simplify(core::Context ctx, CFG &cfg) {
                 sanityCheck(ctx, cfg);
                 continue;
             }
-            if (elseb != cfg.deadBlock() && bb->rubyBlockId == thenb->rubyBlockId && elseb->exprs.empty() &&
+            if (elseb != cfg.deadBlock() && bb->rubyRegionId == thenb->rubyRegionId && elseb->exprs.empty() &&
                 elseb->bexit.thenb == elseb->bexit.elseb && bb->bexit.elseb != elseb->bexit.elseb) {
                 // shortcut else
                 sanityCheck(ctx, cfg);

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -137,7 +137,7 @@ BasicBlock *CFGBuilder::walkHash(CFGContext cctx, ast::Hash &h, BasicBlock *curr
 }
 
 BasicBlock *CFGBuilder::joinBlocks(CFGContext cctx, BasicBlock *a, BasicBlock *b) {
-    auto *join = cctx.inWhat.freshBlock(cctx.loops, a->rubyBlockId);
+    auto *join = cctx.inWhat.freshBlock(cctx.loops, a->rubyRegionId);
     unconditionalJump(a, join, cctx.inWhat, core::LocOffsets::none());
     unconditionalJump(b, join, cctx.inWhat, core::LocOffsets::none());
     return join;
@@ -149,8 +149,8 @@ tuple<LocalRef, BasicBlock *, BasicBlock *> CFGBuilder::walkDefault(CFGContext c
                                                                     BasicBlock *presentCont, BasicBlock *defaultCont) {
     auto defLoc = def.loc();
 
-    auto *presentNext = cctx.inWhat.freshBlock(cctx.loops, presentCont->rubyBlockId);
-    auto *defaultNext = cctx.inWhat.freshBlock(cctx.loops, presentCont->rubyBlockId);
+    auto *presentNext = cctx.inWhat.freshBlock(cctx.loops, presentCont->rubyRegionId);
+    auto *defaultNext = cctx.inWhat.freshBlock(cctx.loops, presentCont->rubyRegionId);
 
     auto present = cctx.newTemporary(core::Names::argPresent());
     auto methodSymbol = cctx.inWhat.symbol;
@@ -191,17 +191,17 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
         typecase(
             what,
             [&](ast::While &a) {
-                auto headerBlock = cctx.inWhat.freshBlock(cctx.loops + 1, current->rubyBlockId);
+                auto headerBlock = cctx.inWhat.freshBlock(cctx.loops + 1, current->rubyRegionId);
                 // breakNotCalledBlock is only entered if break is not called in
                 // the loop body
-                auto breakNotCalledBlock = cctx.inWhat.freshBlock(cctx.loops, current->rubyBlockId);
-                auto continueBlock = cctx.inWhat.freshBlock(cctx.loops, current->rubyBlockId);
+                auto breakNotCalledBlock = cctx.inWhat.freshBlock(cctx.loops, current->rubyRegionId);
+                auto continueBlock = cctx.inWhat.freshBlock(cctx.loops, current->rubyRegionId);
                 unconditionalJump(current, headerBlock, cctx.inWhat, a.loc);
 
                 LocalRef condSym = cctx.newTemporary(core::Names::whileTemp());
                 auto headerEnd =
                     walk(cctx.withTarget(condSym).withLoopScope(headerBlock, continueBlock), a.cond, headerBlock);
-                auto bodyBlock = cctx.inWhat.freshBlock(cctx.loops + 1, current->rubyBlockId);
+                auto bodyBlock = cctx.inWhat.freshBlock(cctx.loops + 1, current->rubyRegionId);
                 conditionalJump(headerEnd, condSym, bodyBlock, breakNotCalledBlock, cctx.inWhat, a.cond.loc());
                 // finishHeader
                 LocalRef bodySym = cctx.newTemporary(core::Names::statTemp());
@@ -246,8 +246,8 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                 LocalRef ifSym = cctx.newTemporary(core::Names::ifTemp());
                 ENFORCE(ifSym.exists(), "ifSym does not exist");
                 auto cont = walk(cctx.withTarget(ifSym), a.cond, current);
-                auto thenBlock = cctx.inWhat.freshBlock(cctx.loops, current->rubyBlockId);
-                auto elseBlock = cctx.inWhat.freshBlock(cctx.loops, current->rubyBlockId);
+                auto thenBlock = cctx.inWhat.freshBlock(cctx.loops, current->rubyRegionId);
+                auto elseBlock = cctx.inWhat.freshBlock(cctx.loops, current->rubyRegionId);
                 conditionalJump(cont, ifSym, thenBlock, elseBlock, cctx.inWhat, a.cond.loc());
 
                 auto thenEnd = walk(cctx, a.thenp, thenBlock);
@@ -258,7 +258,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                     } else if (elseEnd == cctx.inWhat.deadBlock()) {
                         ret = thenEnd;
                     } else {
-                        ret = cctx.inWhat.freshBlock(cctx.loops, current->rubyBlockId);
+                        ret = cctx.inWhat.freshBlock(cctx.loops, current->rubyRegionId);
                         unconditionalJump(thenEnd, ret, cctx.inWhat, a.loc);
                         unconditionalJump(elseEnd, ret, cctx.inWhat, a.loc);
                     }
@@ -433,8 +433,8 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                     auto headerBlock = cctx.inWhat.freshBlock(cctx.loops + 1, newRubyBlockId);
                     // solveConstraintBlock is only entered if break is not called
                     // in the block body.
-                    auto solveConstraintBlock = cctx.inWhat.freshBlock(cctx.loops, current->rubyBlockId);
-                    auto postBlock = cctx.inWhat.freshBlock(cctx.loops, current->rubyBlockId);
+                    auto solveConstraintBlock = cctx.inWhat.freshBlock(cctx.loops, current->rubyRegionId);
+                    auto postBlock = cctx.inWhat.freshBlock(cctx.loops, current->rubyRegionId);
                     auto bodyLoops = cctx.loops + 1;
                     auto bodyBlock = cctx.inWhat.freshBlock(bodyLoops, newRubyBlockId);
 
@@ -641,7 +641,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                 auto elseRubyBlockId = bodyRubyBlockId + CFG::ELSE_BLOCK_OFFSET;
                 cctx.inWhat.maxRubyBlockId = elseRubyBlockId;
 
-                auto rescueHeaderBlock = cctx.inWhat.freshBlock(cctx.loops, current->rubyBlockId);
+                auto rescueHeaderBlock = cctx.inWhat.freshBlock(cctx.loops, current->rubyRegionId);
                 unconditionalJump(current, rescueHeaderBlock, cctx.inWhat, a.loc);
                 cctx.rescueScope = rescueHeaderBlock;
 
@@ -741,7 +741,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
 
                 auto throwAway = cctx.newTemporary(core::Names::throwAwayTemp());
                 ensureBody = walk(cctx.withTarget(throwAway), a.ensure, ensureBody);
-                ret = cctx.inWhat.freshBlock(cctx.loops, current->rubyBlockId);
+                ret = cctx.inWhat.freshBlock(cctx.loops, current->rubyRegionId);
                 conditionalJump(ensureBody, gotoDeadTemp, cctx.inWhat.deadBlock(), ret, cctx.inWhat, a.loc);
             },
 

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -413,7 +413,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                 }
 
                 if (auto *block = s.block()) {
-                    auto newRubyBlockId = ++cctx.inWhat.maxRubyBlockId;
+                    auto newRubyBlockId = ++cctx.inWhat.maxRubyRegionId;
                     auto &blockArgs = block->args;
                     vector<ast::ParsedArg> blockArgFlags = ast::ArgParsing::parseArgs(blockArgs);
                     vector<core::ArgInfo::ArgFlags> argFlags;
@@ -635,11 +635,11 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
             },
 
             [&](ast::Rescue &a) {
-                auto bodyRubyBlockId = ++cctx.inWhat.maxRubyBlockId;
+                auto bodyRubyBlockId = ++cctx.inWhat.maxRubyRegionId;
                 auto handlersRubyBlockId = bodyRubyBlockId + CFG::HANDLERS_REGION_OFFSET;
                 auto ensureRubyBlockId = bodyRubyBlockId + CFG::ENSURE_REGION_OFFSET;
                 auto elseRubyBlockId = bodyRubyBlockId + CFG::ELSE_REGION_OFFSET;
-                cctx.inWhat.maxRubyBlockId = elseRubyBlockId;
+                cctx.inWhat.maxRubyRegionId = elseRubyBlockId;
 
                 auto rescueHeaderBlock = cctx.inWhat.freshBlock(cctx.loops, current->rubyRegionId);
                 unconditionalJump(current, rescueHeaderBlock, cctx.inWhat, a.loc);

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -636,9 +636,9 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
 
             [&](ast::Rescue &a) {
                 auto bodyRubyBlockId = ++cctx.inWhat.maxRubyBlockId;
-                auto handlersRubyBlockId = bodyRubyBlockId + CFG::HANDLERS_BLOCK_OFFSET;
-                auto ensureRubyBlockId = bodyRubyBlockId + CFG::ENSURE_BLOCK_OFFSET;
-                auto elseRubyBlockId = bodyRubyBlockId + CFG::ELSE_BLOCK_OFFSET;
+                auto handlersRubyBlockId = bodyRubyBlockId + CFG::HANDLERS_REGION_OFFSET;
+                auto ensureRubyBlockId = bodyRubyBlockId + CFG::ENSURE_REGION_OFFSET;
+                auto elseRubyBlockId = bodyRubyBlockId + CFG::ELSE_REGION_OFFSET;
                 cctx.inWhat.maxRubyBlockId = elseRubyBlockId;
 
                 auto rescueHeaderBlock = cctx.inWhat.freshBlock(cctx.loops, current->rubyRegionId);

--- a/compiler/IREmitter/CFGHelpers.cc
+++ b/compiler/IREmitter/CFGHelpers.cc
@@ -9,9 +9,9 @@ namespace sorbet::compiler {
 
 namespace {
 
-bool validExit(cfg::CFG &cfg, int targetRegionId, int rubyBlockId, vector<cfg::BasicBlock *> &exits,
+bool validExit(cfg::CFG &cfg, int targetRegionId, int rubyRegionId, vector<cfg::BasicBlock *> &exits,
                cfg::BasicBlock *candidate) {
-    if (candidate->rubyBlockId == rubyBlockId) {
+    if (candidate->rubyRegionId == rubyRegionId) {
         return false;
     }
 
@@ -23,7 +23,7 @@ bool validExit(cfg::CFG &cfg, int targetRegionId, int rubyBlockId, vector<cfg::B
         return false;
     }
 
-    return candidate->rubyBlockId == targetRegionId;
+    return candidate->rubyRegionId == targetRegionId;
 }
 
 } // namespace
@@ -32,7 +32,7 @@ vector<cfg::BasicBlock *> CFGHelpers::findRegionExits(cfg::CFG &cfg, int targetR
     vector<cfg::BasicBlock *> exits;
 
     for (auto &node : cfg.basicBlocks) {
-        if (node->rubyBlockId != sourceRegionId) {
+        if (node->rubyRegionId != sourceRegionId) {
             continue;
         }
 
@@ -51,9 +51,9 @@ vector<cfg::BasicBlock *> CFGHelpers::findRegionExits(cfg::CFG &cfg, int targetR
     return exits;
 }
 
-cfg::BasicBlock *CFGHelpers::findRegionEntry(cfg::CFG &cfg, int rubyBlockId) {
+cfg::BasicBlock *CFGHelpers::findRegionEntry(cfg::CFG &cfg, int rubyRegionId) {
     for (auto &bb : cfg.basicBlocks) {
-        if (bb->rubyBlockId == rubyBlockId) {
+        if (bb->rubyRegionId == rubyRegionId) {
             return bb.get();
         }
     }

--- a/compiler/IREmitter/Exceptions.cc
+++ b/compiler/IREmitter/Exceptions.cc
@@ -25,9 +25,9 @@ llvm::Function *getExceptionFunc(CompilerState &cs, const IREmitterContext &irct
 void IREmitterHelpers::emitExceptionHandlers(CompilerState &cs, llvm::IRBuilderBase &builder,
                                              const IREmitterContext &irctx, int rubyRegionId, int bodyRubyBlockId,
                                              cfg::LocalRef exceptionValue) {
-    const int handlersRubyBlockId = bodyRubyBlockId + cfg::CFG::HANDLERS_BLOCK_OFFSET;
-    const int ensureRubyBlockId = bodyRubyBlockId + cfg::CFG::ENSURE_BLOCK_OFFSET;
-    const int elseRubyBlockId = bodyRubyBlockId + cfg::CFG::ELSE_BLOCK_OFFSET;
+    const int handlersRubyBlockId = bodyRubyBlockId + cfg::CFG::HANDLERS_REGION_OFFSET;
+    const int ensureRubyBlockId = bodyRubyBlockId + cfg::CFG::ENSURE_REGION_OFFSET;
+    const int elseRubyBlockId = bodyRubyBlockId + cfg::CFG::ELSE_REGION_OFFSET;
 
     auto *currentFunc = irctx.rubyBlocks2Functions[rubyRegionId];
     // TODO: it would be nice if we could detect some of these functions

--- a/compiler/IREmitter/IREmitter.cc
+++ b/compiler/IREmitter/IREmitter.cc
@@ -847,7 +847,7 @@ void emitDeadBlocks(CompilerState &cs, cfg::CFG &cfg, const IREmitterContext &ir
 
     // Emit the dead block body for each ruby block. It should be an error to transition to the dead block, so
     // we mark its body as unreachable.
-    for (auto rubyRegionId = 0; rubyRegionId <= cfg.maxRubyBlockId; ++rubyRegionId) {
+    for (auto rubyRegionId = 0; rubyRegionId <= cfg.maxRubyRegionId; ++rubyRegionId) {
         auto *dead = irctx.deadBlockMapping[rubyRegionId];
         builder.SetInsertPoint(dead);
         builder.CreateUnreachable();
@@ -857,7 +857,7 @@ void emitDeadBlocks(CompilerState &cs, cfg::CFG &cfg, const IREmitterContext &ir
 void emitBlockExits(CompilerState &base, cfg::CFG &cfg, const IREmitterContext &irctx) {
     llvm::IRBuilder<> builder(base);
 
-    for (auto rubyRegionId = 0; rubyRegionId <= cfg.maxRubyBlockId; ++rubyRegionId) {
+    for (auto rubyRegionId = 0; rubyRegionId <= cfg.maxRubyRegionId; ++rubyRegionId) {
         auto cs = base.withFunctionEntry(irctx.functionInitializersByFunction[rubyRegionId]);
 
         builder.SetInsertPoint(irctx.blockExitMapping[rubyRegionId]);

--- a/compiler/IREmitter/IREmitter.cc
+++ b/compiler/IREmitter/IREmitter.cc
@@ -728,12 +728,12 @@ void emitUserBody(CompilerState &base, cfg::CFG &cfg, const IREmitterContext &ir
                 },
                 [&](cfg::GetCurrentException &i) {
                     // if this block isn't an exception block header, there's nothing to do here.
-                    auto bodyRubyBlockId = irctx.exceptionBlockHeader[bb->id];
-                    if (bodyRubyBlockId == 0) {
+                    auto bodyRubyRegionId = irctx.exceptionBlockHeader[bb->id];
+                    if (bodyRubyRegionId == 0) {
                         return;
                     }
 
-                    IREmitterHelpers::emitExceptionHandlers(cs, builder, irctx, bb->rubyRegionId, bodyRubyBlockId,
+                    IREmitterHelpers::emitExceptionHandlers(cs, builder, irctx, bb->rubyRegionId, bodyRubyRegionId,
                                                             bind.bind.variable);
                 },
                 [&](cfg::ArgPresent &i) {

--- a/compiler/IREmitter/IREmitter.cc
+++ b/compiler/IREmitter/IREmitter.cc
@@ -49,8 +49,8 @@ vector<core::ArgInfo::ArgFlags> getArgFlagsForBlockId(CompilerState &cs, int blo
 }
 
 void setupStackFrame(CompilerState &cs, const ast::MethodDef &md, const IREmitterContext &irctx,
-                     llvm::IRBuilderBase &builder, int rubyBlockId) {
-    switch (irctx.rubyBlockType[rubyBlockId]) {
+                     llvm::IRBuilderBase &builder, int rubyRegionId) {
+    switch (irctx.rubyBlockType[rubyRegionId]) {
         case FunctionType::Method:
         case FunctionType::StaticInitFile:
         case FunctionType::StaticInitModule:
@@ -58,16 +58,16 @@ void setupStackFrame(CompilerState &cs, const ast::MethodDef &md, const IREmitte
         case FunctionType::Rescue:
         case FunctionType::Ensure: {
             // Switch the current control frame from a C frame to a Ruby-esque one
-            auto pc = Payload::setRubyStackFrame(cs, builder, irctx, md, rubyBlockId);
-            builder.CreateStore(pc, irctx.lineNumberPtrsByFunction[rubyBlockId]);
+            auto pc = Payload::setRubyStackFrame(cs, builder, irctx, md, rubyRegionId);
+            builder.CreateStore(pc, irctx.lineNumberPtrsByFunction[rubyRegionId]);
             break;
         }
 
         case FunctionType::ExceptionBegin: {
             // Exception functions get their pc and iseq_encoded values as arguments
-            auto func = irctx.rubyBlocks2Functions[rubyBlockId];
+            auto func = irctx.rubyBlocks2Functions[rubyRegionId];
             auto *pc = func->arg_begin();
-            builder.CreateStore(pc, irctx.lineNumberPtrsByFunction[rubyBlockId]);
+            builder.CreateStore(pc, irctx.lineNumberPtrsByFunction[rubyRegionId]);
             break;
         }
 
@@ -80,19 +80,19 @@ void setupStackFrame(CompilerState &cs, const ast::MethodDef &md, const IREmitte
 
 void setupStackFrames(CompilerState &base, const ast::MethodDef &md, const IREmitterContext &irctx) {
     llvm::IRBuilder<> builder(base);
-    for (auto rubyBlockId = 0; rubyBlockId < irctx.rubyBlocks2Functions.size(); rubyBlockId++) {
-        auto cs = base.withFunctionEntry(irctx.functionInitializersByFunction[rubyBlockId]);
+    for (auto rubyRegionId = 0; rubyRegionId < irctx.rubyBlocks2Functions.size(); rubyRegionId++) {
+        auto cs = base.withFunctionEntry(irctx.functionInitializersByFunction[rubyRegionId]);
 
-        builder.SetInsertPoint(irctx.functionInitializersByFunction[rubyBlockId]);
+        builder.SetInsertPoint(irctx.functionInitializersByFunction[rubyRegionId]);
 
-        switch (irctx.rubyBlockType[rubyBlockId]) {
+        switch (irctx.rubyBlockType[rubyRegionId]) {
             case FunctionType::Method:
             case FunctionType::StaticInitFile:
             case FunctionType::StaticInitModule: {
                 // We could get this from the frame, as below, but it is slightly more
                 // efficient to get it from the function arguments.
-                auto selfArgRaw = irctx.rubyBlocks2Functions[rubyBlockId]->arg_begin() + 2;
-                Payload::varSet(cs, cfg::LocalRef::selfVariable(), selfArgRaw, builder, irctx, rubyBlockId);
+                auto selfArgRaw = irctx.rubyBlocks2Functions[rubyRegionId]->arg_begin() + 2;
+                Payload::varSet(cs, cfg::LocalRef::selfVariable(), selfArgRaw, builder, irctx, rubyRegionId);
                 break;
             }
             case FunctionType::Block:
@@ -100,33 +100,33 @@ void setupStackFrames(CompilerState &base, const ast::MethodDef &md, const IREmi
             case FunctionType::Ensure:
             case FunctionType::ExceptionBegin: {
                 auto selfArgRaw = builder.CreateCall(cs.getFunction("sorbet_getSelfFromFrame"), {}, "self");
-                Payload::varSet(cs, cfg::LocalRef::selfVariable(), selfArgRaw, builder, irctx, rubyBlockId);
+                Payload::varSet(cs, cfg::LocalRef::selfVariable(), selfArgRaw, builder, irctx, rubyRegionId);
                 break;
             }
             default:
                 break;
         }
 
-        if (irctx.rubyBlockType[rubyBlockId] == FunctionType::Block) {
+        if (irctx.rubyBlockType[rubyRegionId] == FunctionType::Block) {
             auto *cfp = builder.CreateCall(cs.getFunction("sorbet_getCFP"), {}, "cfp");
-            builder.CreateStore(cfp, irctx.blockControlFramePtrs.at(rubyBlockId));
+            builder.CreateStore(cfp, irctx.blockControlFramePtrs.at(rubyRegionId));
         }
 
-        setupStackFrame(cs, md, irctx, builder, rubyBlockId);
+        setupStackFrame(cs, md, irctx, builder, rubyRegionId);
         auto lastLoc = core::Loc::none();
         auto startLoc = md.symbol.data(base)->loc();
         Payload::setLineNumber(cs, builder, core::Loc(cs.file, md.loc), startLoc, lastLoc,
-                               irctx.lineNumberPtrsByFunction[rubyBlockId]);
+                               irctx.lineNumberPtrsByFunction[rubyRegionId]);
     }
 }
 
 void parseKeywordArgsFromCallData(CompilerState &cs, llvm::IRBuilderBase &builder, const IREmitterContext &irctx,
                                   cfg::LocalRef kwRestArgName, llvm::Value *argCountRaw, llvm::Value *argArrayRaw,
                                   llvm::Value *hashArgs, int maxPositionalArgCount,
-                                  const vector<core::ArgInfo::ArgFlags> &argsFlags, int rubyBlockId) {
-    ENFORCE(rubyBlockId == 0);
-    auto *func = irctx.rubyBlocks2Functions[rubyBlockId];
-    auto &argPresentVariables = irctx.argPresentVariables[rubyBlockId];
+                                  const vector<core::ArgInfo::ArgFlags> &argsFlags, int rubyRegionId) {
+    ENFORCE(rubyRegionId == 0);
+    auto *func = irctx.rubyBlocks2Functions[rubyRegionId];
+    auto &argPresentVariables = irctx.argPresentVariables[rubyRegionId];
     // required arguments remaining to be parsed
     auto numRequiredKwArgs = absl::c_count_if(
         argsFlags, [](auto &argFlag) { return argFlag.isKeyword && !argFlag.isDefault && !argFlag.isRepeated; });
@@ -149,7 +149,7 @@ void parseKeywordArgsFromCallData(CompilerState &cs, llvm::IRBuilderBase &builde
         if (!argsFlags[argId].isKeyword || argsFlags[argId].isRepeated) {
             continue;
         }
-        auto name = irctx.rubyBlockArgs[rubyBlockId][argId];
+        auto name = irctx.rubyBlockArgs[rubyRegionId][argId];
         auto strviewName = name.data(irctx.cfg)._name.shortName(cs);
         auto rawId = Payload::idIntern(cs, builder, strviewName);
 
@@ -174,7 +174,7 @@ void parseKeywordArgsFromCallData(CompilerState &cs, llvm::IRBuilderBase &builde
         // Write a default value out, and mark the variable as missing
         builder.SetInsertPoint(kwArgDefault);
         if (argPresent.exists()) {
-            Payload::varSet(cs, argPresent, Payload::rubyFalse(cs, builder), builder, irctx, rubyBlockId);
+            Payload::varSet(cs, argPresent, Payload::rubyFalse(cs, builder), builder, irctx, rubyRegionId);
         }
 
         auto *updatedMissingKwargs = missingKwargs;
@@ -196,9 +196,9 @@ void parseKeywordArgsFromCallData(CompilerState &cs, llvm::IRBuilderBase &builde
                                         fmt::format("updatedOptional_{}", strviewName));
             }
 
-            Payload::varSet(cs, argPresent, Payload::rubyTrue(cs, builder), builder, irctx, rubyBlockId);
+            Payload::varSet(cs, argPresent, Payload::rubyTrue(cs, builder), builder, irctx, rubyRegionId);
         }
-        Payload::varSet(cs, name, passedValue, builder, irctx, rubyBlockId);
+        Payload::varSet(cs, name, passedValue, builder, irctx, rubyRegionId);
 
         optionalPhi->addIncoming(updatedOptionalKwargs, builder.GetInsertBlock());
         missingPhi->addIncoming(missingKwargs, builder.GetInsertBlock());
@@ -218,9 +218,9 @@ void parseKeywordArgsFromCallData(CompilerState &cs, llvm::IRBuilderBase &builde
 
 void parseKeywordArgsFromKwSplat(CompilerState &cs, llvm::IRBuilderBase &builder, const IREmitterContext &irctx,
                                  cfg::LocalRef kwRestArgName, llvm::Value *hashArgs, int maxPositionalArgCount,
-                                 const vector<core::ArgInfo::ArgFlags> &argsFlags, int rubyBlockId) {
-    auto *func = irctx.rubyBlocks2Functions[rubyBlockId];
-    auto &argPresentVariables = irctx.argPresentVariables[rubyBlockId];
+                                 const vector<core::ArgInfo::ArgFlags> &argsFlags, int rubyRegionId) {
+    auto *func = irctx.rubyBlocks2Functions[rubyRegionId];
+    auto &argPresentVariables = irctx.argPresentVariables[rubyRegionId];
     // required arguments remaining to be parsed
     auto numRequiredKwArgs = absl::c_count_if(
         argsFlags, [](auto &argFlag) { return argFlag.isKeyword && !argFlag.isDefault && !argFlag.isRepeated; });
@@ -233,7 +233,7 @@ void parseKeywordArgsFromKwSplat(CompilerState &cs, llvm::IRBuilderBase &builder
         if (!argsFlags[argId].isKeyword || argsFlags[argId].isRepeated) {
             continue;
         }
-        auto name = irctx.rubyBlockArgs[rubyBlockId][argId];
+        auto name = irctx.rubyBlockArgs[rubyRegionId][argId];
         auto rawId = Payload::idIntern(cs, builder, name.data(irctx.cfg)._name.shortName(cs));
         auto rawRubySym = builder.CreateCall(cs.getFunction("rb_id2sym"), {rawId}, "rawSym");
 
@@ -260,7 +260,7 @@ void parseKeywordArgsFromKwSplat(CompilerState &cs, llvm::IRBuilderBase &builder
         // Write a default value out, and mark the variable as missing
         builder.SetInsertPoint(kwArgDefault);
         if (argPresent.exists()) {
-            Payload::varSet(cs, argPresent, Payload::rubyFalse(cs, builder), builder, irctx, rubyBlockId);
+            Payload::varSet(cs, argPresent, Payload::rubyFalse(cs, builder), builder, irctx, rubyRegionId);
         }
 
         auto *updatedMissingKwargs = missingKwargs;
@@ -280,9 +280,9 @@ void parseKeywordArgsFromKwSplat(CompilerState &cs, llvm::IRBuilderBase &builder
                     builder.CreateBinOp(llvm::Instruction::Add, optionalKwargs, IREmitterHelpers::buildS4(cs, 1));
             }
 
-            Payload::varSet(cs, argPresent, Payload::rubyTrue(cs, builder), builder, irctx, rubyBlockId);
+            Payload::varSet(cs, argPresent, Payload::rubyTrue(cs, builder), builder, irctx, rubyRegionId);
         }
-        Payload::varSet(cs, name, passedValue, builder, irctx, rubyBlockId);
+        Payload::varSet(cs, name, passedValue, builder, irctx, rubyRegionId);
         optionalPhi->addIncoming(updatedOptionalKwargs, builder.GetInsertBlock());
         missingPhi->addIncoming(missingKwargs, builder.GetInsertBlock());
         builder.CreateBr(kwArgContinue);
@@ -293,7 +293,7 @@ void parseKeywordArgsFromKwSplat(CompilerState &cs, llvm::IRBuilderBase &builder
     }
     Payload::assertAllRequiredKWArgs(cs, builder, missingKwargs);
     if (kwRestArgName.exists()) {
-        Payload::varSet(cs, kwRestArgName, Payload::readKWRestArg(cs, builder, hashArgs), builder, irctx, rubyBlockId);
+        Payload::varSet(cs, kwRestArgName, Payload::readKWRestArg(cs, builder, hashArgs), builder, irctx, rubyRegionId);
     } else {
         Payload::assertNoExtraKWArg(cs, builder, hashArgs, IREmitterHelpers::buildS4(cs, numRequiredKwArgs),
                                     optionalKwargs);
@@ -304,20 +304,20 @@ void setupArguments(CompilerState &base, cfg::CFG &cfg, const ast::MethodDef &md
     // this function effectively generate an optimized build of
     // https://github.com/ruby/ruby/blob/59c3b1c9c843fcd2d30393791fe224e5789d1677/include/ruby/ruby.h#L2522-L2675
     llvm::IRBuilder<> builder(base);
-    for (auto rubyBlockId = 0; rubyBlockId < irctx.rubyBlocks2Functions.size(); rubyBlockId++) {
-        auto cs = base.withFunctionEntry(irctx.functionInitializersByFunction[rubyBlockId]);
+    for (auto rubyRegionId = 0; rubyRegionId < irctx.rubyBlocks2Functions.size(); rubyRegionId++) {
+        auto cs = base.withFunctionEntry(irctx.functionInitializersByFunction[rubyRegionId]);
 
-        builder.SetInsertPoint(irctx.argumentSetupBlocksByFunction[rubyBlockId]);
+        builder.SetInsertPoint(irctx.argumentSetupBlocksByFunction[rubyRegionId]);
 
         // emit a location that corresponds to the function entry
         auto loc = md.symbol.data(cs)->loc();
-        IREmitterHelpers::emitDebugLoc(cs, builder, irctx, rubyBlockId, loc);
+        IREmitterHelpers::emitDebugLoc(cs, builder, irctx, rubyRegionId, loc);
 
-        auto blockType = irctx.rubyBlockType[rubyBlockId];
+        auto blockType = irctx.rubyBlockType[rubyRegionId];
         if (blockType == FunctionType::Method || blockType == FunctionType::StaticInitFile ||
             blockType == FunctionType::StaticInitModule || blockType == FunctionType::Block) {
-            auto func = irctx.rubyBlocks2Functions[rubyBlockId];
-            auto &argPresentVariables = irctx.argPresentVariables[rubyBlockId];
+            auto func = irctx.rubyBlocks2Functions[rubyRegionId];
+            auto &argPresentVariables = irctx.argPresentVariables[rubyRegionId];
             auto maxPositionalArgCount = 0;
             auto minPositionalArgCount = 0;
             auto isBlock = blockType == FunctionType::Block;
@@ -332,22 +332,22 @@ void setupArguments(CompilerState &base, cfg::CFG &cfg, const ast::MethodDef &md
             cfg::LocalRef restArgName;
             cfg::LocalRef kwRestArgName;
 
-            auto argsFlags = getArgFlagsForBlockId(cs, rubyBlockId, cfg.symbol, irctx);
+            auto argsFlags = getArgFlagsForBlockId(cs, rubyRegionId, cfg.symbol, irctx);
             {
                 auto argId = -1;
-                ENFORCE(argsFlags.size() == irctx.rubyBlockArgs[rubyBlockId].size());
+                ENFORCE(argsFlags.size() == irctx.rubyBlockArgs[rubyRegionId].size());
                 for (auto &argFlags : argsFlags) {
                     argId += 1;
                     if (argFlags.isKeyword) {
                         hasKWArgs = true;
                         if (argFlags.isRepeated) {
-                            kwRestArgName = irctx.rubyBlockArgs[rubyBlockId][argId];
+                            kwRestArgName = irctx.rubyBlockArgs[rubyRegionId][argId];
                             hasKWRestArgs = true;
                         }
                         continue;
                     }
                     if (argFlags.isRepeated) {
-                        restArgName = irctx.rubyBlockArgs[rubyBlockId][argId];
+                        restArgName = irctx.rubyBlockArgs[rubyRegionId][argId];
                         hasRestArgs = true;
                         continue;
                     }
@@ -356,7 +356,7 @@ void setupArguments(CompilerState &base, cfg::CFG &cfg, const ast::MethodDef &md
                         continue;
                     }
                     if (argFlags.isBlock) {
-                        blkArgName = irctx.rubyBlockArgs[rubyBlockId][argId];
+                        blkArgName = irctx.rubyBlockArgs[rubyRegionId][argId];
                         continue;
                     }
                     maxPositionalArgCount += 1;
@@ -480,7 +480,7 @@ void setupArguments(CompilerState &base, cfg::CFG &cfg, const ast::MethodDef &md
                         auto &block = fillFromArgBlocks[i - minPositionalArgCount];
                         builder.SetInsertPoint(block);
                     }
-                    const auto a = irctx.rubyBlockArgs[rubyBlockId][i];
+                    const auto a = irctx.rubyBlockArgs[rubyRegionId][i];
                     if (!a.data(cfg)._name.exists()) {
                         failCompilation(cs, core::Loc(cfg.file, md.declLoc),
                                         "this method has a block argument construct that's not supported");
@@ -489,14 +489,14 @@ void setupArguments(CompilerState &base, cfg::CFG &cfg, const ast::MethodDef &md
                     // mark the arg as present
                     auto &argPresent = argPresentVariables[i];
                     if (argPresent.exists()) {
-                        Payload::varSet(cs, argPresent, Payload::rubyTrue(cs, builder), builder, irctx, rubyBlockId);
+                        Payload::varSet(cs, argPresent, Payload::rubyTrue(cs, builder), builder, irctx, rubyRegionId);
                     }
 
                     llvm::Value *indices[] = {llvm::ConstantInt::get(cs, llvm::APInt(32, i, true))};
                     auto name = a.data(cfg)._name.shortName(cs);
                     llvm::StringRef nameRef(name.data(), name.length());
                     auto rawValue = builder.CreateLoad(builder.CreateGEP(argArrayRaw, indices), {"rawArg_", nameRef});
-                    Payload::varSet(cs, a, rawValue, builder, irctx, rubyBlockId);
+                    Payload::varSet(cs, a, rawValue, builder, irctx, rubyRegionId);
                     if (i >= minPositionalArgCount) {
                         // check if we need to fill in the next variable from the arg
                         builder.CreateBr(checkBlocks[i - minPositionalArgCount + 1]);
@@ -534,12 +534,12 @@ void setupArguments(CompilerState &base, cfg::CFG &cfg, const ast::MethodDef &md
                     auto argIndex = i + minPositionalArgCount;
                     auto argPresent = argPresentVariables[argIndex];
                     if (argPresent.exists()) {
-                        Payload::varSet(cs, argPresent, Payload::rubyFalse(cs, builder), builder, irctx, rubyBlockId);
+                        Payload::varSet(cs, argPresent, Payload::rubyFalse(cs, builder), builder, irctx, rubyRegionId);
                     }
 
                     if (isBlock) {
-                        auto a = irctx.rubyBlockArgs[rubyBlockId][argIndex];
-                        Payload::varSet(cs, a, Payload::rubyNil(cs, builder), builder, irctx, rubyBlockId);
+                        auto a = irctx.rubyBlockArgs[rubyRegionId][argIndex];
+                        Payload::varSet(cs, a, Payload::rubyNil(cs, builder), builder, irctx, rubyRegionId);
                     }
 
                     // fall through to the next default arg init block
@@ -555,7 +555,7 @@ void setupArguments(CompilerState &base, cfg::CFG &cfg, const ast::MethodDef &md
                 if (hasRestArgs) {
                     Payload::varSet(cs, restArgName,
                                     Payload::readRestArgs(cs, builder, maxPositionalArgCount, argCountRaw, argArrayRaw),
-                                    builder, irctx, rubyBlockId);
+                                    builder, irctx, rubyRegionId);
                 }
                 if (hasKWArgs) {
                     // If we have a kwsplat arg, the caller/VM will always make sure that
@@ -563,9 +563,9 @@ void setupArguments(CompilerState &base, cfg::CFG &cfg, const ast::MethodDef &md
                     // in attempting to take the efficient parsing route.
                     //
                     // Blocks also take the splat route always.
-                    if (hasKWRestArgs || rubyBlockId != 0) {
+                    if (hasKWRestArgs || rubyRegionId != 0) {
                         parseKeywordArgsFromKwSplat(cs, builder, irctx, kwRestArgName, hashArgs, maxPositionalArgCount,
-                                                    argsFlags, rubyBlockId);
+                                                    argsFlags, rubyRegionId);
                     } else {
                         // Due to the wonders of Ruby, we can't always be assured that
                         // our kwargs are passed directly on the stack.  They might
@@ -582,12 +582,12 @@ void setupArguments(CompilerState &base, cfg::CFG &cfg, const ast::MethodDef &md
 
                         builder.SetInsertPoint(efficientBlock);
                         parseKeywordArgsFromCallData(cs, builder, irctx, kwRestArgName, argCountRaw, argArrayRaw,
-                                                     hashArgs, maxPositionalArgCount, argsFlags, rubyBlockId);
+                                                     hashArgs, maxPositionalArgCount, argsFlags, rubyRegionId);
                         builder.CreateBr(continuationBlock);
 
                         builder.SetInsertPoint(hashBlock);
                         parseKeywordArgsFromKwSplat(cs, builder, irctx, kwRestArgName, hashArgs, maxPositionalArgCount,
-                                                    argsFlags, rubyBlockId);
+                                                    argsFlags, rubyRegionId);
                         builder.CreateBr(continuationBlock);
 
                         builder.SetInsertPoint(continuationBlock);
@@ -605,7 +605,7 @@ void setupArguments(CompilerState &base, cfg::CFG &cfg, const ast::MethodDef &md
             case FunctionType::Rescue:
             case FunctionType::Ensure:
                 // jump dirrectly to user body
-                builder.CreateBr(irctx.userEntryBlockByFunction[rubyBlockId]);
+                builder.CreateBr(irctx.userEntryBlockByFunction[rubyRegionId]);
                 break;
 
             case FunctionType::Unused:
@@ -623,12 +623,12 @@ cfg::LocalRef returnValue(cfg::CFG &cfg, CompilerState &cs) {
 llvm::BasicBlock *resolveJumpTarget(cfg::CFG &cfg, const IREmitterContext &irctx, const cfg::BasicBlock *from,
                                     const cfg::BasicBlock *to) {
     if (to == cfg.deadBlock()) {
-        return irctx.deadBlockMapping[from->rubyBlockId];
+        return irctx.deadBlockMapping[from->rubyRegionId];
     }
 
     auto remapped = irctx.basicBlockJumpOverrides[to->id];
-    if (from->rubyBlockId != irctx.basicBlockRubyBlockId[remapped]) {
-        return irctx.blockExitMapping[from->rubyBlockId];
+    if (from->rubyRegionId != irctx.basicBlockRubyBlockId[remapped]) {
+        return irctx.blockExitMapping[from->rubyRegionId];
     } else {
         return irctx.llvmBlocksBySorbetBlocks[remapped];
     }
@@ -640,7 +640,7 @@ void emitUserBody(CompilerState &base, cfg::CFG &cfg, const IREmitterContext &ir
     auto &arguments = cfg.symbol.data(base)->arguments();
     for (auto it = cfg.forwardsTopoSort.rbegin(); it != cfg.forwardsTopoSort.rend(); ++it) {
         cfg::BasicBlock *bb = *it;
-        auto cs = base.withFunctionEntry(irctx.functionInitializersByFunction[bb->rubyBlockId]);
+        auto cs = base.withFunctionEntry(irctx.functionInitializersByFunction[bb->rubyRegionId]);
 
         auto block = irctx.llvmBlocksBySorbetBlocks[bb->id];
         bool isTerminated = false;
@@ -660,15 +660,15 @@ void emitUserBody(CompilerState &base, cfg::CFG &cfg, const IREmitterContext &ir
             auto loc = core::Loc(cs.file, bind.loc);
 
             lastLoc = Payload::setLineNumber(cs, builder, loc, startLoc, lastLoc,
-                                             irctx.lineNumberPtrsByFunction[bb->rubyBlockId]);
+                                             irctx.lineNumberPtrsByFunction[bb->rubyRegionId]);
 
-            IREmitterHelpers::emitDebugLoc(cs, builder, irctx, bb->rubyBlockId, loc);
+            IREmitterHelpers::emitDebugLoc(cs, builder, irctx, bb->rubyRegionId, loc);
 
             typecase(
                 bind.value,
                 [&](cfg::Ident &i) {
-                    auto var = Payload::varGet(cs, i.what, builder, irctx, bb->rubyBlockId);
-                    Payload::varSet(cs, bind.bind.variable, var, builder, irctx, bb->rubyBlockId);
+                    auto var = Payload::varGet(cs, i.what, builder, irctx, bb->rubyRegionId);
+                    Payload::varSet(cs, bind.bind.variable, var, builder, irctx, bb->rubyRegionId);
                 },
                 [&](cfg::Alias &i) {
                     // We compute the alias map when IREmitterContext is first created, so if an entry is missing,
@@ -677,54 +677,54 @@ void emitUserBody(CompilerState &base, cfg::CFG &cfg, const IREmitterContext &ir
                             "Alias is missing from the alias map");
                 },
                 [&](cfg::SolveConstraint &i) {
-                    auto var = Payload::varGet(cs, i.send, builder, irctx, bb->rubyBlockId);
-                    Payload::varSet(cs, bind.bind.variable, var, builder, irctx, bb->rubyBlockId);
+                    auto var = Payload::varGet(cs, i.send, builder, irctx, bb->rubyRegionId);
+                    Payload::varSet(cs, bind.bind.variable, var, builder, irctx, bb->rubyRegionId);
                 },
                 [&](cfg::Send &i) {
                     std::optional<int> blk;
                     if (i.link != nullptr) {
-                        blk.emplace(i.link->rubyBlockId);
+                        blk.emplace(i.link->rubyRegionId);
                     }
-                    auto mcctx = MethodCallContext::create(cs, builder, irctx, bb->rubyBlockId, &i, blk);
+                    auto mcctx = MethodCallContext::create(cs, builder, irctx, bb->rubyRegionId, &i, blk);
                     auto rawCall = IREmitterHelpers::emitMethodCall(mcctx);
                     mcctx.finalize();
-                    Payload::varSet(cs, bind.bind.variable, rawCall, builder, irctx, bb->rubyBlockId);
+                    Payload::varSet(cs, bind.bind.variable, rawCall, builder, irctx, bb->rubyRegionId);
                 },
                 [&](cfg::Return &i) {
                     isTerminated = true;
 
-                    auto *var = Payload::varGet(cs, i.what.variable, builder, irctx, bb->rubyBlockId);
+                    auto *var = Payload::varGet(cs, i.what.variable, builder, irctx, bb->rubyRegionId);
                     bool hasBlockAncestor = false;
-                    int rubyBlockId = bb->rubyBlockId;
+                    int rubyRegionId = bb->rubyRegionId;
 
-                    while (rubyBlockId != 0) {
+                    while (rubyRegionId != 0) {
                         // We iterate over the entire ancestor chain instead of breaking out early
                         // when we hit a Ruby block.  We do this so we can check this ENFORCE and
                         // ensure that we're not throwing over something that would require postprocessing.
-                        ENFORCE(!functionTypeNeedsPostprocessing(irctx.rubyBlockType[rubyBlockId]));
-                        hasBlockAncestor = hasBlockAncestor || irctx.rubyBlockType[rubyBlockId] == FunctionType::Block;
-                        rubyBlockId = irctx.rubyBlockParent[rubyBlockId];
+                        ENFORCE(!functionTypeNeedsPostprocessing(irctx.rubyBlockType[rubyRegionId]));
+                        hasBlockAncestor = hasBlockAncestor || irctx.rubyBlockType[rubyRegionId] == FunctionType::Block;
+                        rubyRegionId = irctx.rubyBlockParent[rubyRegionId];
                     }
 
                     if (hasBlockAncestor) {
                         ENFORCE(irctx.hasReturnAcrossBlock);
-                        IREmitterHelpers::emitReturnAcrossBlock(cs, cfg, builder, irctx, bb->rubyBlockId, var);
+                        IREmitterHelpers::emitReturnAcrossBlock(cs, cfg, builder, irctx, bb->rubyRegionId, var);
                     } else {
-                        IREmitterHelpers::emitReturn(cs, builder, irctx, bb->rubyBlockId, var);
+                        IREmitterHelpers::emitReturn(cs, builder, irctx, bb->rubyRegionId, var);
                     }
                 },
                 [&](cfg::BlockReturn &i) {
-                    ENFORCE(bb->rubyBlockId != 0, "should never happen");
+                    ENFORCE(bb->rubyRegionId != 0, "should never happen");
                     isTerminated = true;
-                    auto var = Payload::varGet(cs, i.what.variable, builder, irctx, bb->rubyBlockId);
-                    IREmitterHelpers::emitReturn(cs, builder, irctx, bb->rubyBlockId, var);
+                    auto var = Payload::varGet(cs, i.what.variable, builder, irctx, bb->rubyRegionId);
+                    IREmitterHelpers::emitReturn(cs, builder, irctx, bb->rubyRegionId, var);
                 },
                 [&](cfg::LoadSelf &i) {
                     // it's done in function setup, no need to do anything here
                 },
                 [&](cfg::Literal &i) {
                     auto rawValue = IREmitterHelpers::emitLiteralish(cs, builder, i.value);
-                    Payload::varSet(cs, bind.bind.variable, rawValue, builder, irctx, bb->rubyBlockId);
+                    Payload::varSet(cs, bind.bind.variable, rawValue, builder, irctx, bb->rubyRegionId);
                 },
                 [&](cfg::GetCurrentException &i) {
                     // if this block isn't an exception block header, there's nothing to do here.
@@ -733,15 +733,15 @@ void emitUserBody(CompilerState &base, cfg::CFG &cfg, const IREmitterContext &ir
                         return;
                     }
 
-                    IREmitterHelpers::emitExceptionHandlers(cs, builder, irctx, bb->rubyBlockId, bodyRubyBlockId,
+                    IREmitterHelpers::emitExceptionHandlers(cs, builder, irctx, bb->rubyRegionId, bodyRubyBlockId,
                                                             bind.bind.variable);
                 },
                 [&](cfg::ArgPresent &i) {
-                    ENFORCE(bb->rubyBlockId == 0, "ArgPresent found outside of entry-method");
+                    ENFORCE(bb->rubyRegionId == 0, "ArgPresent found outside of entry-method");
                     // Intentionally omitted: the result of the ArgPresent call is filled out in `setupArguments`
                 },
                 [&](cfg::LoadArg &i) {
-                    ENFORCE(bb->rubyBlockId == 0, "LoadArg found outside of entry-method");
+                    ENFORCE(bb->rubyRegionId == 0, "LoadArg found outside of entry-method");
 
                     // Argument values are loaded by `setupArguments`, we just need to check their type here
                     auto &argInfo = arguments[i.argId];
@@ -764,19 +764,19 @@ void emitUserBody(CompilerState &base, cfg::CFG &cfg, const IREmitterContext &ir
                     }
                 },
                 [&](cfg::LoadYieldParams &i) {
-                    ENFORCE(bb->rubyBlockId != 0, "LoadYieldParams found outside of ruby block");
+                    ENFORCE(bb->rubyRegionId != 0, "LoadYieldParams found outside of ruby block");
                     /* intentionally omitted, it's part of method preambula */
                 },
                 [&](cfg::YieldParamPresent &i) {
-                    ENFORCE(bb->rubyBlockId != 0, "YieldParamPresent found outside of ruby block");
+                    ENFORCE(bb->rubyRegionId != 0, "YieldParamPresent found outside of ruby block");
                     // Intentionally omitted: the result of the YieldParamPresent call is filled out in `setupArguments`
                 },
                 [&](cfg::YieldLoadArg &i) {
-                    ENFORCE(bb->rubyBlockId != 0, "YieldLoadArg found outside of ruby block");
+                    ENFORCE(bb->rubyRegionId != 0, "YieldLoadArg found outside of ruby block");
                     // Filled out as part of the method preamble.
                 },
                 [&](cfg::Cast &i) {
-                    auto val = Payload::varGet(cs, i.value.variable, builder, irctx, bb->rubyBlockId);
+                    auto val = Payload::varGet(cs, i.value.variable, builder, irctx, bb->rubyRegionId);
 
                     // We skip the type test for Cast instructions that assign into <self>.
                     // These instructions only exist in the CFG for the purpose of type checking.
@@ -790,14 +790,14 @@ void emitUserBody(CompilerState &base, cfg::CFG &cfg, const IREmitterContext &ir
                     }
 
                     if (i.cast == core::Names::let() || i.cast == core::Names::cast()) {
-                        Payload::varSet(cs, bind.bind.variable, val, builder, irctx, bb->rubyBlockId);
+                        Payload::varSet(cs, bind.bind.variable, val, builder, irctx, bb->rubyRegionId);
                     } else if (i.cast == core::Names::assertType()) {
                         Payload::varSet(cs, bind.bind.variable, Payload::rubyFalse(cs, builder), builder, irctx,
-                                        bb->rubyBlockId);
+                                        bb->rubyRegionId);
                     }
                 },
                 [&](cfg::TAbsurd &i) {
-                    auto val = Payload::varGet(cs, i.what.variable, builder, irctx, bb->rubyBlockId);
+                    auto val = Payload::varGet(cs, i.what.variable, builder, irctx, bb->rubyRegionId);
                     builder.CreateCall(cs.getFunction("sorbet_t_absurd"), {val});
                 });
             if (isTerminated) {
@@ -830,7 +830,7 @@ void emitUserBody(CompilerState &base, cfg::CFG &cfg, const IREmitterContext &ir
                     auto id = Payload::idIntern(cs, builder, aliasEntry->second.classField.shortName(cs));
                     condValue = builder.CreateCall(cs.getFunction("sorbet_classVariableDefinedAndTruthy"), {klass, id});
                 } else {
-                    auto var = Payload::varGet(cs, testref, builder, irctx, bb->rubyBlockId);
+                    auto var = Payload::varGet(cs, testref, builder, irctx, bb->rubyRegionId);
                     condValue = Payload::testIsTruthy(cs, builder, var);
                 }
 
@@ -847,8 +847,8 @@ void emitDeadBlocks(CompilerState &cs, cfg::CFG &cfg, const IREmitterContext &ir
 
     // Emit the dead block body for each ruby block. It should be an error to transition to the dead block, so
     // we mark its body as unreachable.
-    for (auto rubyBlockId = 0; rubyBlockId <= cfg.maxRubyBlockId; ++rubyBlockId) {
-        auto *dead = irctx.deadBlockMapping[rubyBlockId];
+    for (auto rubyRegionId = 0; rubyRegionId <= cfg.maxRubyBlockId; ++rubyRegionId) {
+        auto *dead = irctx.deadBlockMapping[rubyRegionId];
         builder.SetInsertPoint(dead);
         builder.CreateUnreachable();
     }
@@ -857,12 +857,12 @@ void emitDeadBlocks(CompilerState &cs, cfg::CFG &cfg, const IREmitterContext &ir
 void emitBlockExits(CompilerState &base, cfg::CFG &cfg, const IREmitterContext &irctx) {
     llvm::IRBuilder<> builder(base);
 
-    for (auto rubyBlockId = 0; rubyBlockId <= cfg.maxRubyBlockId; ++rubyBlockId) {
-        auto cs = base.withFunctionEntry(irctx.functionInitializersByFunction[rubyBlockId]);
+    for (auto rubyRegionId = 0; rubyRegionId <= cfg.maxRubyBlockId; ++rubyRegionId) {
+        auto cs = base.withFunctionEntry(irctx.functionInitializersByFunction[rubyRegionId]);
 
-        builder.SetInsertPoint(irctx.blockExitMapping[rubyBlockId]);
+        builder.SetInsertPoint(irctx.blockExitMapping[rubyRegionId]);
 
-        switch (irctx.rubyBlockType[rubyBlockId]) {
+        switch (irctx.rubyBlockType[rubyRegionId]) {
             case FunctionType::Method:
             case FunctionType::StaticInitFile:
             case FunctionType::StaticInitModule:
@@ -875,7 +875,7 @@ void emitBlockExits(CompilerState &base, cfg::CFG &cfg, const IREmitterContext &
             case FunctionType::Ensure:
             case FunctionType::Unused:
                 // for non-top-level functions, we return `Qundef` to indicate that this value isn't used for anything.
-                IREmitterHelpers::emitReturn(cs, builder, irctx, rubyBlockId, Payload::rubyUndef(cs, builder));
+                IREmitterHelpers::emitReturn(cs, builder, irctx, rubyRegionId, Payload::rubyUndef(cs, builder));
                 break;
         }
     }
@@ -886,12 +886,12 @@ void emitPostProcess(CompilerState &cs, cfg::CFG &cfg, const IREmitterContext &i
     builder.SetInsertPoint(irctx.postProcessBlock);
 
     // we're only using the top-level ruby block at this point
-    auto rubyBlockId = 0;
+    auto rubyRegionId = 0;
 
-    auto var = Payload::varGet(cs, returnValue(cfg, cs), builder, irctx, rubyBlockId);
+    auto var = Payload::varGet(cs, returnValue(cfg, cs), builder, irctx, rubyRegionId);
     auto *maybeChecked = IREmitterHelpers::maybeCheckReturnValue(cs, cfg, builder, irctx, var);
 
-    IREmitterHelpers::emitUncheckedReturn(cs, builder, irctx, rubyBlockId, maybeChecked);
+    IREmitterHelpers::emitUncheckedReturn(cs, builder, irctx, rubyRegionId, maybeChecked);
 }
 
 // Direct wrappers call the wrapped function without checking the receiver's type; the caller is responsible for

--- a/compiler/IREmitter/IREmitterContext.cc
+++ b/compiler/IREmitter/IREmitterContext.cc
@@ -607,9 +607,9 @@ void determineBlockTypes(CompilerState &cs, cfg::CFG &cfg, vector<FunctionType> 
 
             // the relative block ids of blocks that are involved in the translation of an exception handling block.
             auto bodyBlockId = bodyBlock->rubyRegionId;
-            auto handlersBlockId = bodyBlockId + cfg::CFG::HANDLERS_BLOCK_OFFSET;
-            auto ensureBlockId = bodyBlockId + cfg::CFG::ENSURE_BLOCK_OFFSET;
-            auto elseBlockId = bodyBlockId + cfg::CFG::ELSE_BLOCK_OFFSET;
+            auto handlersBlockId = bodyBlockId + cfg::CFG::HANDLERS_REGION_OFFSET;
+            auto ensureBlockId = bodyBlockId + cfg::CFG::ENSURE_REGION_OFFSET;
+            auto elseBlockId = bodyBlockId + cfg::CFG::ELSE_REGION_OFFSET;
 
             // `b` is the exception handling header block if the two branches from it have the sequential ids we would
             // expect for the handler and body blocks. The reason we bail out here if this isn't the case is because
@@ -1083,9 +1083,9 @@ IREmitterContext IREmitterContext::getSorbetBlocks2LLVMBlockMapping(CompilerStat
 
             // the relative block ids of blocks that are involved in the translation of an exception handling block.
             auto bodyBlockId = bodyBlock->rubyRegionId;
-            auto handlersBlockId = bodyBlockId + cfg::CFG::HANDLERS_BLOCK_OFFSET;
-            auto ensureBlockId = bodyBlockId + cfg::CFG::ENSURE_BLOCK_OFFSET;
-            auto elseBlockId = bodyBlockId + cfg::CFG::ELSE_BLOCK_OFFSET;
+            auto handlersBlockId = bodyBlockId + cfg::CFG::HANDLERS_REGION_OFFSET;
+            auto ensureBlockId = bodyBlockId + cfg::CFG::ENSURE_REGION_OFFSET;
+            auto elseBlockId = bodyBlockId + cfg::CFG::ELSE_REGION_OFFSET;
 
             userEntryBlockByFunction[bodyBlockId] = llvmBlocks[bodyBlock->id];
             userEntryBlockByFunction[handlersBlockId] = llvmBlocks[handlersBlock->id];

--- a/compiler/IREmitter/IREmitterContext.h
+++ b/compiler/IREmitter/IREmitterContext.h
@@ -285,8 +285,8 @@ struct IREmitterContext {
     std::vector<llvm::BasicBlock *> deadBlockMapping;
 
     // Mapping from ruby region id to llvm block exit blocks. These blocks are used for the case where a transition
-    // between a basic block in a ruby region exists, and transitions to a node in a different ruby region (that isn't the
-    // dead block).
+    // between a basic block in a ruby region exists, and transitions to a node in a different ruby region (that isn't
+    // the dead block).
     std::vector<llvm::BasicBlock *> blockExitMapping;
 
     // Mappinf from ruby region id to debug info scope.

--- a/compiler/IREmitter/IREmitterContext.h
+++ b/compiler/IREmitter/IREmitterContext.h
@@ -43,8 +43,8 @@ enum class BlockArgUsage {
     None,
 
     // The block argument to the function is only used directly within the
-    // top-level ruby block (rubyRegionId == 0) or in ruby blocks that have the
-    // same frame as the top-level ruby block (e.g. ExceptionBegin blocks).
+    // top-level ruby region (rubyRegionId == 0) or in ruby regions that have the
+    // same frame as the top-level ruby region (e.g. ExceptionBegin regions).
     //
     // "used" here means that either it is only ever the receiver of .call
     // (i.e. it is yield'd to) or it is passed along as a block argument itself.
@@ -196,7 +196,7 @@ struct IREmitterContext {
     // hold the argv of the Ruby method call taking the most arguments within this Ruby method or
     // Ruby block, and reuse that stack space when making each Ruby method call.
     //
-    // This is a mapping from each Ruby method or block to that AllocaInst.
+    // This is a mapping from each Ruby method or region to that AllocaInst.
     //
     // idx: cfg::BasicBlock::rubyRegionId;
     std::vector<llvm::AllocaInst *> sendArgArrayByBlock;
@@ -210,7 +210,7 @@ struct IREmitterContext {
     // When arguments have defaults, the use of the default is guarded by a call to ArgPresent. The ArgPresent variables
     // are initialized during setupArguments, but need to be available by argument index.
     //
-    // outer idx: the ruby block id that defines these arguments
+    // outer idx: the ruby region id that defines these arguments
     // idx: Argument index into the method arguments
     // val: The local ref that holds the result of the ArgPresent instruction, or cfg::LocalRef::noVariable if the
     //      argument does not have a default value.
@@ -233,14 +233,14 @@ struct IREmitterContext {
     llvm::BasicBlock *postProcessBlock;
 
     // idx: cfg::BasicBlock::rubyRegionId
-    // val: The SendAndBlockLink for that block (each Ruby block correspondes to one cfg::Send)
+    // val: The SendAndBlockLink for that region (each Ruby block correspondes to one cfg::Send)
     std::vector<std::shared_ptr<core::SendAndBlockLink>> blockLinks;
 
     // idx: cfg::BasicBlock::rubyRegionId
-    // val: The arguments for that Ruby method or block.
+    // val: The arguments for that Ruby method or region.
     std::vector<std::vector<cfg::LocalRef>> rubyBlockArgs;
 
-    // Each Ruby method and Ruby block gets compiled to an llvm::Function so that it can be called
+    // Each Ruby method and Ruby region gets compiled to an llvm::Function so that it can be called
     // directly like any other C function.
     //
     // idx: cfg::BasicBlock::rubyRegionId
@@ -251,15 +251,15 @@ struct IREmitterContext {
     // idx: cfg::BasicBlock::rubyRegionId
     std::vector<FunctionType> rubyBlockType;
 
-    // The parent block id of each function being generated. Used for constructing the parent relationship when
+    // The parent region id of each function being generated. Used for constructing the parent relationship when
     // allocating iseq values for block/exception functions.
     //
     // idx: cfg::BasicBlock::rubyRegionId
     // val: cfg::BasicBlock::rubyRegionId
     std::vector<int> rubyBlockParent;
 
-    // The level of a ruby block corresponds to the nesting depth of non-method stack frames when it's called. So for a
-    // block at the top-level of the method, the value would be 1.
+    // The level of a ruby region corresponds to the nesting depth of non-method stack frames when it's called. So for a
+    // region at the top-level of the method, the value would be 1.
     //
     // idx: cfg::BasicBlock::rubyRegionId
     // val: the number of scopes traversed to get back to the top-level method frame at runtime
@@ -276,38 +276,38 @@ struct IREmitterContext {
     // How this function uses its block arg, if any.
     BlockArgUsage blockArgUsage;
 
-    // Non-zero for basic-blocks that originally jumped to exception-handling code.
+    // Non-zero for regions that originally jumped to exception-handling code.
     // idx: block id
     // val: the rubyRegionId for the body of the exception block
     std::vector<int> exceptionBlockHeader;
 
-    // Mapping from ruby block id to llvm dead block.
+    // Mapping from ruby region id to llvm dead block.
     std::vector<llvm::BasicBlock *> deadBlockMapping;
 
-    // Mapping from ruby block id to llvm block exit blocks. These blocks are used for the case where a transition
-    // between a basic block in a ruby block exists, and transitions to a node in a different ruby block (that isn't the
+    // Mapping from ruby region id to llvm block exit blocks. These blocks are used for the case where a transition
+    // between a basic block in a ruby region exists, and transitions to a node in a different ruby region (that isn't the
     // dead block).
     std::vector<llvm::BasicBlock *> blockExitMapping;
 
-    // Mappinf from ruby block id to debug info scope.
+    // Mappinf from ruby region id to debug info scope.
     std::vector<llvm::DISubprogram *> blockScopes;
 
-    // Records which ruby blocks use `break`, as that will forbid us from emitting type assertions on intrinsics that
+    // Records which ruby regions use `break`, as that will forbid us from emitting type assertions on intrinsics that
     // they are used with.
     //
     // idx: cfg::BasicBlock::rubyRegionId
-    // val: true when the block uses `break`
+    // val: true when the region uses `break`
     std::vector<bool> blockUsesBreak;
 
     // Whether an explicit return statement ever appears in a context that has a
     // Ruby block as an ancestor.
     bool hasReturnAcrossBlock;
 
-    // Mapping from ruby block id to the name for the block's iseq.
+    // Mapping from ruby region id to the name for the block's iseq.
     std::vector<std::optional<std::string>> rubyBlockLocationNames;
 
-    // Mapping from ruby block id to min/max arguments that block takes. As this is only used for block allocations,
-    // it's {0, 0} for every ruby block id that is not a FunctionType::Block.
+    // Mapping from ruby region id to min/max arguments that region takes. As this is only used for block allocations,
+    // it's {0, 0} for every ruby region id that is not a FunctionType::Block.
     std::vector<BlockArity> rubyBlockArity;
 
     static IREmitterContext getSorbetBlocks2LLVMBlockMapping(CompilerState &cs, cfg::CFG &cfg, const ast::MethodDef &md,

--- a/compiler/IREmitter/IREmitterContext.h
+++ b/compiler/IREmitter/IREmitterContext.h
@@ -43,7 +43,7 @@ enum class BlockArgUsage {
     None,
 
     // The block argument to the function is only used directly within the
-    // top-level ruby block (rubyBlockId == 0) or in ruby blocks that have the
+    // top-level ruby block (rubyRegionId == 0) or in ruby blocks that have the
     // same frame as the top-level ruby block (e.g. ExceptionBegin blocks).
     //
     // "used" here means that either it is only ever the receiver of .call
@@ -123,7 +123,7 @@ struct BlockArity {
 
 // Contains a bunch of state that gets populated and accessed while emitting IR for a single Ruby method.
 //
-// Nearly every vector here behaves as a lookup map keyed on cfg::BasicBlock::rubyBlockId (i.e., an ID
+// Nearly every vector here behaves as a lookup map keyed on cfg::BasicBlock::rubyRegionId (i.e., an ID
 // for each Ruby block like `do ...  end` inside a Ruby method, with 0 meaning "outside a Ruby block").
 // It might make sense to newtype this someday.
 struct IREmitterContext {
@@ -145,7 +145,7 @@ struct IREmitterContext {
     // Contains llvm::BasicBlocks (insertion points) to hold code for a Ruby method or block that runs first,
     // before starting to execute the user-written body.
     //
-    // idx: cfg::BasicBlock::rubyBlockId
+    // idx: cfg::BasicBlock::rubyRegionId
     std::vector<llvm::BasicBlock *> functionInitializersByFunction;
 
     // The insertion points for code that loads and validates arguments, one for each Ruby method or Ruby block.
@@ -157,12 +157,12 @@ struct IREmitterContext {
     // the original Ruby method had a fixed arity, so there ends up being a fair deal of argument checking logic.
     // In particular, there are many llvm::BasicBlocks involved in arguments--this map holds just the starting point.
     //
-    // idx: cfg::BasicBlock::rubyBlockId
+    // idx: cfg::BasicBlock::rubyRegionId
     std::vector<llvm::BasicBlock *> argumentSetupBlocksByFunction;
 
     // The insertion points for the body code a user wrote inside a Ruby method or Ruby block.
     //
-    // idx: cfg::BasicBlock::rubyBlockId
+    // idx: cfg::BasicBlock::rubyRegionId
     std::vector<llvm::BasicBlock *> userEntryBlockByFunction;
 
     // A mapping from cfg::BasicBlock -> llvm::BasicBlock
@@ -183,7 +183,7 @@ struct IREmitterContext {
     // that a jump override corresponds to, so this data can just exist along-side the jump overrides.
     //
     // idx: cfg::BasicBlock::id
-    // val: cfg::BasicBlock::rubyBlockId
+    // val: cfg::BasicBlock::rubyRegionId
     std::vector<int> basicBlockRubyBlockId;
 
     // This is the maximum number of argument seen in a given ruby method.
@@ -198,7 +198,7 @@ struct IREmitterContext {
     //
     // This is a mapping from each Ruby method or block to that AllocaInst.
     //
-    // idx: cfg::BasicBlock::rubyBlockId;
+    // idx: cfg::BasicBlock::rubyRegionId;
     std::vector<llvm::AllocaInst *> sendArgArrayByBlock;
 
     // Local variables that escape, i.e. are referenced from multiple Ruby blocks, are
@@ -224,7 +224,7 @@ struct IREmitterContext {
 
     // `self` is retrieved at the entry point of each Ruby block and stashed here.
     //
-    // idx: cfg::BasicBlock::rubyBlockId
+    // idx: cfg::BasicBlock::rubyRegionId
     // val: alloca for `self`
     UnorderedMap<int, llvm::AllocaInst *> selfVariables;
 
@@ -232,36 +232,36 @@ struct IREmitterContext {
     // This handles return type checking, among other things.
     llvm::BasicBlock *postProcessBlock;
 
-    // idx: cfg::BasicBlock::rubyBlockId
+    // idx: cfg::BasicBlock::rubyRegionId
     // val: The SendAndBlockLink for that block (each Ruby block correspondes to one cfg::Send)
     std::vector<std::shared_ptr<core::SendAndBlockLink>> blockLinks;
 
-    // idx: cfg::BasicBlock::rubyBlockId
+    // idx: cfg::BasicBlock::rubyRegionId
     // val: The arguments for that Ruby method or block.
     std::vector<std::vector<cfg::LocalRef>> rubyBlockArgs;
 
     // Each Ruby method and Ruby block gets compiled to an llvm::Function so that it can be called
     // directly like any other C function.
     //
-    // idx: cfg::BasicBlock::rubyBlockId
+    // idx: cfg::BasicBlock::rubyRegionId
     std::vector<llvm::Function *> rubyBlocks2Functions;
 
     // The type of each function that we're going to generate.
     //
-    // idx: cfg::BasicBlock::rubyBlockId
+    // idx: cfg::BasicBlock::rubyRegionId
     std::vector<FunctionType> rubyBlockType;
 
     // The parent block id of each function being generated. Used for constructing the parent relationship when
     // allocating iseq values for block/exception functions.
     //
-    // idx: cfg::BasicBlock::rubyBlockId
-    // val: cfg::BasicBlock::rubyBlockId
+    // idx: cfg::BasicBlock::rubyRegionId
+    // val: cfg::BasicBlock::rubyRegionId
     std::vector<int> rubyBlockParent;
 
     // The level of a ruby block corresponds to the nesting depth of non-method stack frames when it's called. So for a
     // block at the top-level of the method, the value would be 1.
     //
-    // idx: cfg::BasicBlock::rubyBlockId
+    // idx: cfg::BasicBlock::rubyRegionId
     // val: the number of scopes traversed to get back to the top-level method frame at runtime
     std::vector<int> rubyBlockLevel;
 
@@ -270,7 +270,7 @@ struct IREmitterContext {
 
     // Stores the control frame (GET_EC()->cfp) for ordinary ruby blocks.
     //
-    // idx: cfg::BasicBlock::rubyBlockId
+    // idx: cfg::BasicBlock::rubyRegionId
     UnorderedMap<int, llvm::AllocaInst *> blockControlFramePtrs;
 
     // How this function uses its block arg, if any.
@@ -278,7 +278,7 @@ struct IREmitterContext {
 
     // Non-zero for basic-blocks that originally jumped to exception-handling code.
     // idx: block id
-    // val: the rubyBlockId for the body of the exception block
+    // val: the rubyRegionId for the body of the exception block
     std::vector<int> exceptionBlockHeader;
 
     // Mapping from ruby block id to llvm dead block.
@@ -295,7 +295,7 @@ struct IREmitterContext {
     // Records which ruby blocks use `break`, as that will forbid us from emitting type assertions on intrinsics that
     // they are used with.
     //
-    // idx: cfg::BasicBlock::rubyBlockId
+    // idx: cfg::BasicBlock::rubyRegionId
     // val: true when the block uses `break`
     std::vector<bool> blockUsesBreak;
 

--- a/compiler/IREmitter/IREmitterHelpers.h
+++ b/compiler/IREmitter/IREmitterHelpers.h
@@ -127,7 +127,7 @@ public:
     static llvm::Value *emitMethodCallViaRubyVM(MethodCallContext &mcctx);
 
     static void emitExceptionHandlers(CompilerState &gs, llvm::IRBuilderBase &builder, const IREmitterContext &irctx,
-                                      int rubyRegionId, int bodyRubyBlockId, cfg::LocalRef exceptionValue);
+                                      int rubyRegionId, int bodyRubyRegionId, cfg::LocalRef exceptionValue);
 
     static void emitDebugLoc(CompilerState &gs, llvm::IRBuilderBase &builder, const IREmitterContext &irctx,
                              int rubyRegionId, core::Loc loc);

--- a/compiler/IREmitter/IREmitterHelpers.h
+++ b/compiler/IREmitter/IREmitterHelpers.h
@@ -127,17 +127,17 @@ public:
     static llvm::Value *emitMethodCallViaRubyVM(MethodCallContext &mcctx);
 
     static void emitExceptionHandlers(CompilerState &gs, llvm::IRBuilderBase &builder, const IREmitterContext &irctx,
-                                      int rubyBlockId, int bodyRubyBlockId, cfg::LocalRef exceptionValue);
+                                      int rubyRegionId, int bodyRubyBlockId, cfg::LocalRef exceptionValue);
 
     static void emitDebugLoc(CompilerState &gs, llvm::IRBuilderBase &builder, const IREmitterContext &irctx,
-                             int rubyBlockId, core::Loc loc);
+                             int rubyRegionId, core::Loc loc);
 
     static void emitUncheckedReturn(CompilerState &gs, llvm::IRBuilderBase &builder, const IREmitterContext &irctx,
-                                    int rubyBlockId, llvm::Value *retVal);
+                                    int rubyRegionId, llvm::Value *retVal);
     static void emitReturn(CompilerState &gs, llvm::IRBuilderBase &builder, const IREmitterContext &irctx,
-                           int rubyBlockId, llvm::Value *retVal);
+                           int rubyRegionId, llvm::Value *retVal);
     static void emitReturnAcrossBlock(CompilerState &gs, cfg::CFG &cfg, llvm::IRBuilderBase &builder,
-                                      const IREmitterContext &irctx, int rubyBlockId, llvm::Value *retVal);
+                                      const IREmitterContext &irctx, int rubyRegionId, llvm::Value *retVal);
     // Typecheck returnValue as the return value of cfg, if necessary.  Returns the actual
     // value to be returned, which may be different than returnValue e.g. in the case of a
     // void-returning method.

--- a/compiler/IREmitter/MethodCallContext.cc
+++ b/compiler/IREmitter/MethodCallContext.cc
@@ -12,9 +12,9 @@
 namespace sorbet::compiler {
 
 MethodCallContext MethodCallContext::create(CompilerState &cs, llvm::IRBuilderBase &builder,
-                                            const IREmitterContext &irctx, int rubyBlockId, cfg::Send *send,
+                                            const IREmitterContext &irctx, int rubyRegionId, cfg::Send *send,
                                             std::optional<int> blk) {
-    MethodCallContext ret{cs, builder, irctx, rubyBlockId, send, blk};
+    MethodCallContext ret{cs, builder, irctx, rubyRegionId, send, blk};
 
     auto *func = builder.GetInsertBlock()->getParent();
     ret.sendEntry = llvm::BasicBlock::Create(cs, "sendEntry", func);
@@ -63,7 +63,7 @@ llvm::Value *MethodCallContext::varGetRecv() {
         auto saved = builder.saveIP();
         this->builder.SetInsertPoint(this->sendEntry);
         this->recv =
-            Payload::varGet(this->cs, this->send->recv.variable, this->builder, this->irctx, this->rubyBlockId);
+            Payload::varGet(this->cs, this->send->recv.variable, this->builder, this->irctx, this->rubyRegionId);
         this->builder.restoreIP(saved);
     }
 

--- a/compiler/IREmitter/MethodCallContext.h
+++ b/compiler/IREmitter/MethodCallContext.h
@@ -31,9 +31,9 @@ class MethodCallContext {
 
     void initArgsAndCache();
 
-    MethodCallContext(CompilerState &cs, llvm::IRBuilderBase &builder, const IREmitterContext &irctx, int rubyBlockId,
+    MethodCallContext(CompilerState &cs, llvm::IRBuilderBase &builder, const IREmitterContext &irctx, int rubyRegionId,
                       cfg::Send *send, std::optional<int> blk)
-        : cs(cs), builder(builder), irctx(irctx), rubyBlockId(rubyBlockId), send(send), blk(blk){};
+        : cs(cs), builder(builder), irctx(irctx), rubyRegionId(rubyRegionId), send(send), blk(blk){};
 
 public:
     CompilerState &cs;
@@ -42,9 +42,9 @@ public:
 
     const IREmitterContext &irctx;
 
-    // See IREmitterContext for a description of rubyBlockId. Primarily used to index into the
+    // See IREmitterContext for a description of rubyRegionId. Primarily used to index into the
     // various vectors in `irctx`.
-    int rubyBlockId;
+    int rubyRegionId;
 
     // The method call being emitted right now.
     cfg::Send *send;
@@ -78,7 +78,7 @@ public:
     llvm::Function *blkAsFunction() const;
 
     static MethodCallContext create(CompilerState &cs, llvm::IRBuilderBase &build, const IREmitterContext &irctx,
-                                    int rubyBlockId, cfg::Send *send, std::optional<int> blk);
+                                    int rubyRegionId, cfg::Send *send, std::optional<int> blk);
 
     // connect the send entry and the continuation
     void finalize();

--- a/compiler/IREmitter/Payload.h
+++ b/compiler/IREmitter/Payload.h
@@ -69,7 +69,7 @@ public:
 
     static llvm::Value *boolToRuby(CompilerState &cs, llvm::IRBuilderBase &builder, llvm::Value *u1);
     static llvm::Value *setRubyStackFrame(CompilerState &cs, llvm::IRBuilderBase &builder,
-                                          const IREmitterContext &irctx, const ast::MethodDef &md, int rubyBlockId);
+                                          const IREmitterContext &irctx, const ast::MethodDef &md, int rubyRegionId);
 
     static llvm::Value *readKWRestArg(CompilerState &cs, llvm::IRBuilderBase &builder, llvm::Value *maybeHash);
     static llvm::Value *assertNoExtraKWArg(CompilerState &cs, llvm::IRBuilderBase &builder, llvm::Value *maybeHash,
@@ -90,12 +90,12 @@ public:
     static llvm::Value *getClassVariableStoreClass(CompilerState &cs, llvm::IRBuilderBase &builder,
                                                    const IREmitterContext &irctx);
     static llvm::Value *varGet(CompilerState &cs, cfg::LocalRef local, llvm::IRBuilderBase &builder,
-                               const IREmitterContext &irctx, int rubyBlockId);
+                               const IREmitterContext &irctx, int rubyRegionId);
     static void varSet(CompilerState &cs, cfg::LocalRef local, llvm::Value *var, llvm::IRBuilderBase &builder,
-                       const IREmitterContext &irctx, int rubyBlockId);
+                       const IREmitterContext &irctx, int rubyRegionId);
 
     static EscapedVariableInfo escapedVariableInfo(CompilerState &cs, cfg::LocalRef local,
-                                                   const IREmitterContext &irctx, int rubyBlockId);
+                                                   const IREmitterContext &irctx, int rubyRegionId);
 
     static llvm::Value *retrySingleton(CompilerState &cs, llvm::IRBuilderBase &builder, const IREmitterContext &irctx);
     static llvm::Value *voidSingleton(CompilerState &cs, llvm::IRBuilderBase &builder, const IREmitterContext &irctx);
@@ -127,7 +127,7 @@ public:
     static llvm::Value *getIseqEncodedPointer(CompilerState &gs, llvm::IRBuilderBase &builder, core::FileRef file);
 
     static llvm::Value *getCFPForBlock(CompilerState &cs, llvm::IRBuilderBase &builder, const IREmitterContext &irctx,
-                                       int rubyBlockId);
+                                       int rubyRegionId);
 
     static llvm::Value *buildLocalsOffset(CompilerState &cs);
 

--- a/core/Types.h
+++ b/core/Types.h
@@ -769,10 +769,10 @@ public:
     SendAndBlockLink(SendAndBlockLink &&) = default;
     std::vector<ArgInfo::ArgFlags> argFlags;
     core::NameRef fun;
-    int rubyBlockId;
+    int rubyRegionId;
     std::shared_ptr<DispatchResult> result;
 
-    SendAndBlockLink(NameRef fun, std::vector<ArgInfo::ArgFlags> &&argFlags, int rubyBlockId);
+    SendAndBlockLink(NameRef fun, std::vector<ArgInfo::ArgFlags> &&argFlags, int rubyRegionId);
     std::optional<int> fixedArity() const;
     std::shared_ptr<SendAndBlockLink> duplicate();
 };

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -633,8 +633,8 @@ TypePtr AndType::make_shared(const TypePtr &left, const TypePtr &right) {
     return res;
 }
 
-SendAndBlockLink::SendAndBlockLink(NameRef fun, vector<ArgInfo::ArgFlags> &&argFlags, int rubyBlockId)
-    : argFlags(move(argFlags)), fun(fun), rubyBlockId(rubyBlockId) {}
+SendAndBlockLink::SendAndBlockLink(NameRef fun, vector<ArgInfo::ArgFlags> &&argFlags, int rubyRegionId)
+    : argFlags(move(argFlags)), fun(fun), rubyRegionId(rubyRegionId) {}
 
 shared_ptr<SendAndBlockLink> SendAndBlockLink::duplicate() {
     auto copy = *this;

--- a/test/cli/phases/phases.out
+++ b/test/cli/phases/phases.out
@@ -198,14 +198,14 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
     "bb::<Class:<root>>#<static-init>_0" [
         shape = invhouse;
         color = black;
-        label = "block[id=0, rubyBlockId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));\l<returnMethodTemp>$2: Integer(1) = 1\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(1)\l<unconditional>\l"
+        label = "block[id=0, rubyRegionId=0]()\l<self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));\l<returnMethodTemp>$2: Integer(1) = 1\l<finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(1)\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_0" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
     "bb::<Class:<root>>#<static-init>_1" [
         shape = parallelogram;
         color = black;
-        label = "block[id=1, rubyBlockId=0]()\l<unconditional>\l"
+        label = "block[id=1, rubyRegionId=0]()\l<unconditional>\l"
     ];
 
     "bb::<Class:<root>>#<static-init>_1" -> "bb::<Class:<root>>#<static-init>_1" [style="bold"];
@@ -245,15 +245,15 @@ subgraph "cluster_::<Class:<root>>#<static-init>" {
 --- cfg-text start ---
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=3]():
+bb0[rubyRegionId=0, firstDead=3]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <returnMethodTemp>$2: Integer(1) = 1
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(1)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
@@ -315,11 +315,11 @@ class <C <U <root>>> < <C <U Object>> ()
 <   end
 <   expr = EmptyTree
 <   stats = [
-< # - bb0(rubyBlockId=0)
+< # - bb0(rubyRegionId=0)
 < # backedges
 < InsSeq{
-< bb0[rubyBlockId=0, firstDead=3]():
-< bb1[rubyBlockId=0, firstDead=-1]():
+< bb0[rubyRegionId=0, firstDead=3]():
+< bb1[rubyRegionId=0, firstDead=-1]():
 < begin
 < end
 < method ::<Class:<root>>#<static-init> {

--- a/test/testdata/cfg/array.rb.cfg-text.exp
+++ b/test/testdata/cfg/array.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=8]():
+bb0[rubyRegionId=0, firstDead=8]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <cfgAlias>$7: T.class_of(TestArray) = alias <C TestArray>
@@ -12,45 +12,45 @@ bb0[rubyBlockId=0, firstDead=8]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::TestArray#an_int {
 
-bb0[rubyBlockId=0, firstDead=3]():
+bb0[rubyRegionId=0, firstDead=3]():
     <self>: TestArray = cast(<self>: NilClass, TestArray);
     <returnMethodTemp>$2: Integer(0) = 0
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(0)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::TestArray#a_string {
 
-bb0[rubyBlockId=0, firstDead=3]():
+bb0[rubyRegionId=0, firstDead=3]():
     <self>: TestArray = cast(<self>: NilClass, TestArray);
     <returnMethodTemp>$2: String("str") = "str"
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: String("str")
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::TestArray#test_arrays {
 
-bb0[rubyBlockId=0, firstDead=14]():
+bb0[rubyRegionId=0, firstDead=14]():
     <self>: TestArray = cast(<self>: NilClass, TestArray);
     <magic>$4: T.class_of(<Magic>) = alias <C <Magic>>
     <statTemp>$3: [] = <magic>$4: T.class_of(<Magic>).<build-array>()
@@ -68,15 +68,15 @@ bb0[rubyBlockId=0, firstDead=14]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:TestArray>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(TestArray) = cast(<self>: NilClass, T.class_of(TestArray));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
     <statTemp>$7: FalseClass = false
@@ -86,20 +86,20 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb7(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb7(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb5(rubyBlockId=1)
-bb2[rubyBlockId=1, firstDead=-1](<self>: T.class_of(TestArray), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(TestArray)):
+# - bb0(rubyRegionId=0)
+# - bb5(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(TestArray), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(TestArray)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb3[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(TestArray)):
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(TestArray)):
     <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$9, sig>
     <self>: T.class_of(TestArray) = <selfRestore>$10
     <cfgAlias>$19: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
@@ -110,8 +110,8 @@ bb3[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$9: Sorbet::Private::Stati
     <unconditional> -> bb6
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb5[rubyBlockId=1, firstDead=4](<self>: T.class_of(TestArray), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(TestArray)):
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=4](<self>: T.class_of(TestArray), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(TestArray)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf
     <cfgAlias>$15: T.class_of(Integer) = alias <C Integer>
@@ -120,15 +120,15 @@ bb5[rubyBlockId=1, firstDead=4](<self>: T.class_of(TestArray), <block-pre-call-t
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-# - bb9(rubyBlockId=2)
-bb6[rubyBlockId=2, firstDead=-1](<self>: T.class_of(TestArray), <block-pre-call-temp>$23: Sorbet::Private::Static::Void, <selfRestore>$24: T.class_of(TestArray)):
+# - bb3(rubyRegionId=0)
+# - bb9(rubyRegionId=2)
+bb6[rubyRegionId=2, firstDead=-1](<self>: T.class_of(TestArray), <block-pre-call-temp>$23: Sorbet::Private::Static::Void, <selfRestore>$24: T.class_of(TestArray)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
-# - bb6(rubyBlockId=2)
-bb7[rubyBlockId=0, firstDead=18](<block-pre-call-temp>$23: Sorbet::Private::Static::Void, <selfRestore>$24: T.class_of(TestArray)):
+# - bb6(rubyRegionId=2)
+bb7[rubyRegionId=0, firstDead=18](<block-pre-call-temp>$23: Sorbet::Private::Static::Void, <selfRestore>$24: T.class_of(TestArray)):
     <statTemp>$17: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$23, sig>
     <self>: T.class_of(TestArray) = <selfRestore>$24
     <cfgAlias>$34: T.class_of(T::Sig) = alias <C Sig>
@@ -150,8 +150,8 @@ bb7[rubyBlockId=0, firstDead=18](<block-pre-call-temp>$23: Sorbet::Private::Stat
     <unconditional> -> bb1
 
 # backedges
-# - bb6(rubyBlockId=2)
-bb9[rubyBlockId=2, firstDead=4](<self>: T.class_of(TestArray), <block-pre-call-temp>$23: Sorbet::Private::Static::Void, <selfRestore>$24: T.class_of(TestArray)):
+# - bb6(rubyRegionId=2)
+bb9[rubyRegionId=2, firstDead=4](<self>: T.class_of(TestArray), <block-pre-call-temp>$23: Sorbet::Private::Static::Void, <selfRestore>$24: T.class_of(TestArray)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf
     <cfgAlias>$29: T.class_of(String) = alias <C String>

--- a/test/testdata/cfg/block_in_deadcode.rb.cfg-text.exp
+++ b/test/testdata/cfg/block_in_deadcode.rb.cfg-text.exp
@@ -1,35 +1,35 @@
 method ::Object#foo {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <block-pre-call-temp>$4: Sorbet::Private::Static::Void = <self>: Object.outer()
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-# - bb5(rubyBlockId=1)
-bb1[rubyBlockId=0, firstDead=-1](<self>):
+# - bb3(rubyRegionId=0)
+# - bb5(rubyRegionId=1)
+bb1[rubyRegionId=0, firstDead=-1](<self>):
     <statTemp>$10 = <self>
     <block-pre-call-temp>$11 = <statTemp>$10.inner()
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb2[rubyBlockId=1, firstDead=-1](<self>: Object, <block-pre-call-temp>$4: Sorbet::Private::Static::Void):
+# - bb0(rubyRegionId=0)
+bb2[rubyRegionId=1, firstDead=-1](<self>: Object, <block-pre-call-temp>$4: Sorbet::Private::Static::Void):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb3[rubyBlockId=0, firstDead=3](<self>: Object, <block-pre-call-temp>$4: Sorbet::Private::Static::Void):
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=3](<self>: Object, <block-pre-call-temp>$4: Sorbet::Private::Static::Void):
     <returnMethodTemp>$2: T.untyped = Solve<<block-pre-call-temp>$4, outer>
     <self>: Object = <self>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb5[rubyBlockId=1, firstDead=2](<self>: Object):
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=2](<self>: Object):
     # outerLoops: 1
     <self>: Object = loadSelf
     <statTemp>$8: T.noreturn = return <returnTemp>$9: NilClass
@@ -39,7 +39,7 @@ bb5[rubyBlockId=1, firstDead=2](<self>: Object):
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=6]():
+bb0[rubyRegionId=0, firstDead=6]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$6: Symbol(:foo) = :foo
@@ -49,8 +49,8 @@ bb0[rubyBlockId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/blocks.rb.cfg-text.exp
+++ b/test/testdata/cfg/blocks.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=8]():
+bb0[rubyRegionId=0, firstDead=8]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <cfgAlias>$7: T.class_of(BlockTest) = alias <C BlockTest>
@@ -12,15 +12,15 @@ bb0[rubyBlockId=0, firstDead=8]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::BlockTest#blockPass {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: BlockTest = cast(<self>: NilClass, BlockTest);
     <statTemp>$4: Integer(1) = 1
     <statTemp>$5: Integer(2) = 2
@@ -30,27 +30,27 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb5(rubyBlockId=1)
-bb2[rubyBlockId=1, firstDead=-1](<self>: BlockTest, <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: BlockTest):
+# - bb0(rubyRegionId=0)
+# - bb5(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: BlockTest, <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: BlockTest):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb3[rubyBlockId=0, firstDead=2](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: BlockTest):
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=2](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: BlockTest):
     <returnMethodTemp>$2: T.untyped = Solve<<block-pre-call-temp>$7, foo>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb5[rubyBlockId=1, firstDead=6](<self>: BlockTest, <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: BlockTest):
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=6](<self>: BlockTest, <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: BlockTest):
     # outerLoops: 1
     <self>: BlockTest = loadSelf
     <blk>$9: T.untyped = load_yield_params(foo)
@@ -64,7 +64,7 @@ bb5[rubyBlockId=1, firstDead=6](<self>: BlockTest, <block-pre-call-temp>$7: Sorb
 
 method ::<Class:BlockTest>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=6]():
+bb0[rubyRegionId=0, firstDead=6]():
     <self>: T.class_of(BlockTest) = cast(<self>: NilClass, T.class_of(BlockTest));
     <cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$6: Symbol(:blockPass) = :blockPass
@@ -74,8 +74,8 @@ bb0[rubyBlockId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/break.rb.cfg-text.exp
+++ b/test/testdata/cfg/break.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::Object#foo {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <arrayTemp>$5: Integer(1) = 1
     <arrayTemp>$6: Integer(2) = 2
@@ -11,34 +11,34 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb4(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb4(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb2[rubyBlockId=1, firstDead=-1](<self>: Object, <block-pre-call-temp>$8: Sorbet::Private::Static::Void, <selfRestore>$9: Object):
+# - bb0(rubyRegionId=0)
+bb2[rubyRegionId=1, firstDead=-1](<self>: Object, <block-pre-call-temp>$8: Sorbet::Private::Static::Void, <selfRestore>$9: Object):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb3[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$8: Sorbet::Private::Static::Void, <selfRestore>$9: Object):
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$8: Sorbet::Private::Static::Void, <selfRestore>$9: Object):
     target: T::Array[T.noreturn] = Solve<<block-pre-call-temp>$8, map>
     <unconditional> -> bb4
 
 # backedges
-# - bb3(rubyBlockId=0)
-# - bb5(rubyBlockId=1)
-bb4[rubyBlockId=0, firstDead=3](target: T.any(T::Array[T.noreturn], Integer), <selfRestore>$9: Object):
+# - bb3(rubyRegionId=0)
+# - bb5(rubyRegionId=1)
+bb4[rubyRegionId=0, firstDead=3](target: T.any(T::Array[T.noreturn], Integer), <selfRestore>$9: Object):
     <cfgAlias>$19: T.class_of(T) = alias <C T>
     <returnMethodTemp>$2: T.any(T::Array[T.noreturn], Integer) = <cfgAlias>$19: T.class_of(T).reveal_type(target: T.any(T::Array[T.noreturn], Integer))
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.any(T::Array[T.noreturn], Integer)
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb5[rubyBlockId=1, firstDead=-1](<self>: Object, <selfRestore>$9: Object):
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=-1](<self>: Object, <selfRestore>$9: Object):
     # outerLoops: 1
     <self>: Object = loadSelf
     <blk>$10: [Integer] = load_yield_params(map)
@@ -54,22 +54,22 @@ bb5[rubyBlockId=1, firstDead=-1](<self>: Object, <selfRestore>$9: Object):
 
 method ::Object#bar {
 
-bb0[rubyBlockId=0, firstDead=3]():
+bb0[rubyRegionId=0, firstDead=3]():
     <self>: Object = cast(<self>: NilClass, Object);
     <returnMethodTemp>$2: String("foo bar") = "foo bar"
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: String("foo bar")
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
     <statTemp>$7: FalseClass = false
@@ -79,20 +79,20 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb20(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb20(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb5(rubyBlockId=1)
-bb2[rubyBlockId=1, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(<root>)):
+# - bb0(rubyRegionId=0)
+# - bb5(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(<root>)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb3[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(<root>)):
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(<root>)):
     <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$9, sig>
     <self>: T.class_of(<root>) = <selfRestore>$10
     <cfgAlias>$32: T.class_of(T::Sig) = alias <C Sig>
@@ -113,8 +113,8 @@ bb3[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$9: Sorbet::Private::Stati
     <unconditional> -> bb6
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb5[rubyBlockId=1, firstDead=13](<self>: T.class_of(<root>), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(<root>)):
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=13](<self>: T.class_of(<root>), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(<root>)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf
     <hashTemp>$15: Symbol(:blk) = :blk
@@ -132,22 +132,22 @@ bb5[rubyBlockId=1, firstDead=13](<self>: T.class_of(<root>), <block-pre-call-tem
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-# - bb11(rubyBlockId=2)
-bb6[rubyBlockId=2, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$53: Sorbet::Private::Static::Void, <selfRestore>$54: T.class_of(<root>)):
+# - bb3(rubyRegionId=0)
+# - bb11(rubyRegionId=2)
+bb6[rubyRegionId=2, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$53: Sorbet::Private::Static::Void, <selfRestore>$54: T.class_of(<root>)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
-# - bb6(rubyBlockId=2)
-bb7[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$53: Sorbet::Private::Static::Void, <selfRestore>$54: T.class_of(<root>)):
+# - bb6(rubyRegionId=2)
+bb7[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$53: Sorbet::Private::Static::Void, <selfRestore>$54: T.class_of(<root>)):
     a: String = Solve<<block-pre-call-temp>$53, bar>
     <unconditional> -> bb8
 
 # backedges
-# - bb7(rubyBlockId=0)
-# - bb10(rubyBlockId=2)
-bb8[rubyBlockId=0, firstDead=-1](a: T.any(String, Integer), <selfRestore>$54: T.class_of(<root>)):
+# - bb7(rubyRegionId=0)
+# - bb10(rubyRegionId=2)
+bb8[rubyRegionId=0, firstDead=-1](a: T.any(String, Integer), <selfRestore>$54: T.class_of(<root>)):
     <self>: T.class_of(<root>) = <selfRestore>$54
     <cfgAlias>$68: T.class_of(T) = alias <C T>
     <statTemp>$66: T.any(String, Integer) = <cfgAlias>$68: T.class_of(T).reveal_type(a: T.any(String, Integer))
@@ -156,8 +156,8 @@ bb8[rubyBlockId=0, firstDead=-1](a: T.any(String, Integer), <selfRestore>$54: T.
     <unconditional> -> bb12
 
 # backedges
-# - bb6(rubyBlockId=2)
-bb9[rubyBlockId=2, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$53: Sorbet::Private::Static::Void, <selfRestore>$54: T.class_of(<root>)):
+# - bb6(rubyRegionId=2)
+bb9[rubyRegionId=2, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$53: Sorbet::Private::Static::Void, <selfRestore>$54: T.class_of(<root>)):
     # outerLoops: 1
     <self>: T.class_of(<root>) = loadSelf
     <blk>$55: [Integer] = load_yield_params(bar)
@@ -167,8 +167,8 @@ bb9[rubyBlockId=2, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-tem
     <ifTemp>$58 -> (T::Boolean ? bb10 : bb11)
 
 # backedges
-# - bb9(rubyBlockId=2)
-bb10[rubyBlockId=2, firstDead=-1](<selfRestore>$54: T.class_of(<root>)):
+# - bb9(rubyRegionId=2)
+bb10[rubyRegionId=2, firstDead=-1](<selfRestore>$54: T.class_of(<root>)):
     # outerLoops: 1
     <returnTemp>$61: Integer(10) = 10
     <block-break-assign>$62: Integer(10) = <returnTemp>$61
@@ -178,37 +178,37 @@ bb10[rubyBlockId=2, firstDead=-1](<selfRestore>$54: T.class_of(<root>)):
     <unconditional> -> bb8
 
 # backedges
-# - bb9(rubyBlockId=2)
-bb11[rubyBlockId=2, firstDead=2](<self>: T.class_of(<root>), <block-pre-call-temp>$53: Sorbet::Private::Static::Void, <selfRestore>$54: T.class_of(<root>)):
+# - bb9(rubyRegionId=2)
+bb11[rubyRegionId=2, firstDead=2](<self>: T.class_of(<root>), <block-pre-call-temp>$53: Sorbet::Private::Static::Void, <selfRestore>$54: T.class_of(<root>)):
     # outerLoops: 1
     <blockReturnTemp>$56: String("test") = "test"
     <blockReturnTemp>$65: T.noreturn = blockreturn<bar> <blockReturnTemp>$56: String("test")
     <unconditional> -> bb6
 
 # backedges
-# - bb8(rubyBlockId=0)
-# - bb17(rubyBlockId=3)
-bb12[rubyBlockId=3, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$72: Sorbet::Private::Static::Void, <selfRestore>$73: T.class_of(<root>)):
+# - bb8(rubyRegionId=0)
+# - bb17(rubyRegionId=3)
+bb12[rubyRegionId=3, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$72: Sorbet::Private::Static::Void, <selfRestore>$73: T.class_of(<root>)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb15 : bb13)
 
 # backedges
-# - bb12(rubyBlockId=3)
-bb13[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$72: Sorbet::Private::Static::Void, <selfRestore>$73: T.class_of(<root>)):
+# - bb12(rubyRegionId=3)
+bb13[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$72: Sorbet::Private::Static::Void, <selfRestore>$73: T.class_of(<root>)):
     b: String = Solve<<block-pre-call-temp>$72, bar>
     <unconditional> -> bb14
 
 # backedges
-# - bb13(rubyBlockId=0)
-# - bb16(rubyBlockId=3)
-bb14[rubyBlockId=0, firstDead=-1](b: T.nilable(String), <selfRestore>$73: T.class_of(<root>)):
+# - bb13(rubyRegionId=0)
+# - bb16(rubyRegionId=3)
+bb14[rubyRegionId=0, firstDead=-1](b: T.nilable(String), <selfRestore>$73: T.class_of(<root>)):
     <cfgAlias>$87: T.class_of(T) = alias <C T>
     <statTemp>$85: T.nilable(String) = <cfgAlias>$87: T.class_of(T).reveal_type(b: T.nilable(String))
     <unconditional> -> bb18
 
 # backedges
-# - bb12(rubyBlockId=3)
-bb15[rubyBlockId=3, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$72: Sorbet::Private::Static::Void, <selfRestore>$73: T.class_of(<root>)):
+# - bb12(rubyRegionId=3)
+bb15[rubyRegionId=3, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$72: Sorbet::Private::Static::Void, <selfRestore>$73: T.class_of(<root>)):
     # outerLoops: 1
     <self>: T.class_of(<root>) = loadSelf
     <blk>$74: [Integer] = load_yield_params(bar)
@@ -218,8 +218,8 @@ bb15[rubyBlockId=3, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-te
     <ifTemp>$77 -> (T::Boolean ? bb16 : bb17)
 
 # backedges
-# - bb15(rubyBlockId=3)
-bb16[rubyBlockId=3, firstDead=-1](<selfRestore>$73: T.class_of(<root>)):
+# - bb15(rubyRegionId=3)
+bb16[rubyRegionId=3, firstDead=-1](<selfRestore>$73: T.class_of(<root>)):
     # outerLoops: 1
     <block-break-assign>$81: NilClass = <returnTemp>$80
     <magic>$82: T.class_of(<Magic>) = alias <C <Magic>>
@@ -228,17 +228,17 @@ bb16[rubyBlockId=3, firstDead=-1](<selfRestore>$73: T.class_of(<root>)):
     <unconditional> -> bb14
 
 # backedges
-# - bb15(rubyBlockId=3)
-bb17[rubyBlockId=3, firstDead=2](<self>: T.class_of(<root>), <block-pre-call-temp>$72: Sorbet::Private::Static::Void, <selfRestore>$73: T.class_of(<root>)):
+# - bb15(rubyRegionId=3)
+bb17[rubyRegionId=3, firstDead=2](<self>: T.class_of(<root>), <block-pre-call-temp>$72: Sorbet::Private::Static::Void, <selfRestore>$73: T.class_of(<root>)):
     # outerLoops: 1
     <blockReturnTemp>$75: String("test") = "test"
     <blockReturnTemp>$84: T.noreturn = blockreturn<bar> <blockReturnTemp>$75: String("test")
     <unconditional> -> bb12
 
 # backedges
-# - bb14(rubyBlockId=0)
-# - bb21(rubyBlockId=0)
-bb18[rubyBlockId=0, firstDead=-1]():
+# - bb14(rubyRegionId=0)
+# - bb21(rubyRegionId=0)
+bb18[rubyRegionId=0, firstDead=-1]():
     # outerLoops: 1
     <statTemp>$92: Integer(1) = 1
     <statTemp>$91: String = <statTemp>$92: Integer(1).to_s()
@@ -247,23 +247,23 @@ bb18[rubyBlockId=0, firstDead=-1]():
     <whileTemp>$90 -> (T::Boolean ? bb21 : bb19)
 
 # backedges
-# - bb18(rubyBlockId=0)
-bb19[rubyBlockId=0, firstDead=-1]():
+# - bb18(rubyRegionId=0)
+bb19[rubyRegionId=0, firstDead=-1]():
     c: NilClass = nil
     <unconditional> -> bb20
 
 # backedges
-# - bb19(rubyBlockId=0)
-# - bb22(rubyBlockId=0)
-bb20[rubyBlockId=0, firstDead=3](c: T.nilable(Symbol)):
+# - bb19(rubyRegionId=0)
+# - bb22(rubyRegionId=0)
+bb20[rubyRegionId=0, firstDead=3](c: T.nilable(Symbol)):
     <cfgAlias>$103: T.class_of(T) = alias <C T>
     <statTemp>$101: T.nilable(Symbol) = <cfgAlias>$103: T.class_of(T).reveal_type(c: T.nilable(Symbol))
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb18(rubyBlockId=0)
-bb21[rubyBlockId=0, firstDead=-1]():
+# - bb18(rubyRegionId=0)
+bb21[rubyRegionId=0, firstDead=-1]():
     # outerLoops: 1
     <statTemp>$97: Integer(1) = 1
     <statTemp>$96: String = <statTemp>$97: Integer(1).to_s()
@@ -272,8 +272,8 @@ bb21[rubyBlockId=0, firstDead=-1]():
     <ifTemp>$95 -> (T::Boolean ? bb22 : bb18)
 
 # backedges
-# - bb21(rubyBlockId=0)
-bb22[rubyBlockId=0, firstDead=-1]():
+# - bb21(rubyRegionId=0)
+bb22[rubyRegionId=0, firstDead=-1]():
     # outerLoops: 1
     <returnTemp>$99: Symbol(:abc) = :abc
     <block-break-assign>$100: Symbol(:abc) = <returnTemp>$99

--- a/test/testdata/cfg/break_in_junk.rb.cfg-text.exp
+++ b/test/testdata/cfg/break_in_junk.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::Object#foo {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <returnTemp>$3: Integer(5) = 5
     <block-break-assign>$4: Integer(5) = <returnTemp>$3
@@ -9,8 +9,8 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
 
@@ -18,7 +18,7 @@ bb1[rubyBlockId=0, firstDead=-1]():
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=6]():
+bb0[rubyRegionId=0, firstDead=6]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$6: Symbol(:foo) = :foo
@@ -28,8 +28,8 @@ bb0[rubyBlockId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/break_in_while.rb.cfg-text.exp
+++ b/test/testdata/cfg/break_in_while.rb.cfg-text.exp
@@ -1,39 +1,39 @@
 method ::Object#foo {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <unconditional> -> bb2
 
 # backedges
-# - bb4(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1](<self>):
+# - bb4(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1](<self>):
     <statTemp>$9 = <self>
     <statTemp>$4 = <statTemp>$9.dead()
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb2[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb2[rubyRegionId=0, firstDead=-1]():
     # outerLoops: 1
     <whileTemp>$3: TrueClass = true
     <whileTemp>$3 -> (TrueClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=0)
-bb3[rubyBlockId=0, firstDead=0]():
+# - bb2(rubyRegionId=0)
+bb3[rubyRegionId=0, firstDead=0]():
     <returnMethodTemp>$2 = nil
     <unconditional> -> bb4
 
 # backedges
-# - bb3(rubyBlockId=0)
-# - bb5(rubyBlockId=0)
-bb4[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: Integer(2)):
+# - bb3(rubyRegionId=0)
+# - bb5(rubyRegionId=0)
+bb4[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: Integer(2)):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(2)
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=0)
-bb5[rubyBlockId=0, firstDead=-1]():
+# - bb2(rubyRegionId=0)
+bb5[rubyRegionId=0, firstDead=-1]():
     # outerLoops: 1
     <returnTemp>$7: Integer(2) = 2
     <block-break-assign>$8: Integer(2) = <returnTemp>$7
@@ -44,7 +44,7 @@ bb5[rubyBlockId=0, firstDead=-1]():
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=8]():
+bb0[rubyRegionId=0, firstDead=8]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$7: Symbol(:foo) = :foo
@@ -56,8 +56,8 @@ bb0[rubyBlockId=0, firstDead=8]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/dealias_with_return.rb.cfg-text.exp
+++ b/test/testdata/cfg/dealias_with_return.rb.cfg-text.exp
@@ -1,56 +1,56 @@
 method ::Object#a {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <magic>$6: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$4: T.untyped = <get-current-exception>
     <exceptionValue>$4 -> (T.untyped ? bb3 : bb4)
 
 # backedges
-# - bb4(rubyBlockId=1)
-# - bb6(rubyBlockId=3)
-# - bb9(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb4(rubyRegionId=1)
+# - bb6(rubyRegionId=3)
+# - bb9(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <exceptionValue>$4 = <get-current-exception>
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb3[rubyBlockId=2, firstDead=-1](<exceptionValue>$4: T.untyped, <magic>$6: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+bb3[rubyRegionId=2, firstDead=-1](<exceptionValue>$4: T.untyped, <magic>$6: T.class_of(<Magic>)):
     <cfgAlias>$9: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$10: T.untyped = <exceptionValue>$4: T.untyped.is_a?(<cfgAlias>$9: T.class_of(StandardError))
     <isaCheckTemp>$10 -> (T.untyped ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb4[rubyBlockId=1, firstDead=2]():
+# - bb0(rubyRegionId=0)
+bb4[rubyRegionId=1, firstDead=2]():
     <returnTemp>$5: Integer(1) = 1
     <statTemp>$3: T.noreturn = return <returnTemp>$5: Integer(1)
     <unconditional> -> bb1
 
 # backedges
-# - bb7(rubyBlockId=2)
-# - bb8(rubyBlockId=2)
-bb6[rubyBlockId=3, firstDead=-1](a: T.nilable(Integer), <gotoDeadTemp>$11: T.nilable(TrueClass)):
+# - bb7(rubyRegionId=2)
+# - bb8(rubyRegionId=2)
+bb6[rubyRegionId=3, firstDead=-1](a: T.nilable(Integer), <gotoDeadTemp>$11: T.nilable(TrueClass)):
     <gotoDeadTemp>$11 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb7[rubyBlockId=2, firstDead=-1](<magic>$6: T.class_of(<Magic>)):
+# - bb3(rubyRegionId=2)
+bb7[rubyRegionId=2, firstDead=-1](<magic>$6: T.class_of(<Magic>)):
     <exceptionValue>$4: NilClass = nil
     <keepForCfgTemp>$7: Sorbet::Private::Static::Void = <magic>$6: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)
     a: Integer(2) = 2
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb8[rubyBlockId=2, firstDead=-1]():
+# - bb3(rubyRegionId=2)
+bb8[rubyRegionId=2, firstDead=-1]():
     <gotoDeadTemp>$11: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyBlockId=3)
-bb9[rubyBlockId=0, firstDead=3](a: Integer(2)):
+# - bb6(rubyRegionId=3)
+bb9[rubyRegionId=0, firstDead=3](a: Integer(2)):
     <statTemp>$14: Integer(3) = 3
     <returnMethodTemp>$2: Integer = a: Integer(2).+(<statTemp>$14: Integer(3))
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer
@@ -60,7 +60,7 @@ bb9[rubyBlockId=0, firstDead=3](a: Integer(2)):
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=6]():
+bb0[rubyRegionId=0, firstDead=6]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$6: Symbol(:a) = :a
@@ -70,8 +70,8 @@ bb0[rubyBlockId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/default_args_cases.rb.cfg-text.exp
+++ b/test/testdata/cfg/default_args_cases.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=8]():
+bb0[rubyRegionId=0, firstDead=8]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <cfgAlias>$7: T.class_of(Test) = alias <C Test>
@@ -12,15 +12,15 @@ bb0[rubyBlockId=0, firstDead=8]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Test#test1 {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Test = cast(<self>: NilClass, Test);
     a: Integer = load_arg(a)
     b: Integer = load_arg(b)
@@ -28,35 +28,35 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <argPresent>$3 -> (T::Boolean ? bb2 : bb3)
 
 # backedges
-# - bb9(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb9(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb2[rubyBlockId=0, firstDead=-1](a: Integer, b: Integer):
+# - bb0(rubyRegionId=0)
+bb2[rubyRegionId=0, firstDead=-1](a: Integer, b: Integer):
     c: Integer = load_arg(c)
     <argPresent>$6: T::Boolean = arg_present(d)
     <argPresent>$6 -> (T::Boolean ? bb4 : bb5)
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb3[rubyBlockId=0, firstDead=-1](a: Integer, b: Integer):
+# - bb0(rubyRegionId=0)
+bb3[rubyRegionId=0, firstDead=-1](a: Integer, b: Integer):
     <statTemp>$4: Integer(10) = 10
     <castTemp>$5: Integer = cast(<statTemp>$4: Integer(10), Integer);
     c: Integer(10) = <statTemp>$4
     <unconditional> -> bb5
 
 # backedges
-# - bb2(rubyBlockId=0)
-bb4[rubyBlockId=0, firstDead=-1](a: Integer, b: Integer, c: Integer):
+# - bb2(rubyRegionId=0)
+bb4[rubyRegionId=0, firstDead=-1](a: Integer, b: Integer, c: Integer):
     d: Integer = load_arg(d)
     <unconditional> -> bb6
 
 # backedges
-# - bb2(rubyBlockId=0)
-# - bb3(rubyBlockId=0)
-bb5[rubyBlockId=0, firstDead=-1](a: Integer, b: Integer, c: Integer):
+# - bb2(rubyRegionId=0)
+# - bb3(rubyRegionId=0)
+bb5[rubyRegionId=0, firstDead=-1](a: Integer, b: Integer, c: Integer):
     x: Integer(20) = 20
     <statTemp>$7: Integer(20) = x
     <castTemp>$8: Integer = cast(<statTemp>$7: Integer(20), Integer);
@@ -64,31 +64,31 @@ bb5[rubyBlockId=0, firstDead=-1](a: Integer, b: Integer, c: Integer):
     <unconditional> -> bb6
 
 # backedges
-# - bb4(rubyBlockId=0)
-# - bb5(rubyBlockId=0)
-bb6[rubyBlockId=0, firstDead=-1](a: Integer, b: Integer, c: Integer, d: Integer, x: T.nilable(Integer)):
+# - bb4(rubyRegionId=0)
+# - bb5(rubyRegionId=0)
+bb6[rubyRegionId=0, firstDead=-1](a: Integer, b: Integer, c: Integer, d: Integer, x: T.nilable(Integer)):
     e: Integer = load_arg(e)
     <argPresent>$9: T::Boolean = arg_present(f)
     <argPresent>$9 -> (T::Boolean ? bb7 : bb8)
 
 # backedges
-# - bb6(rubyBlockId=0)
-bb7[rubyBlockId=0, firstDead=-1](a: Integer, b: Integer, c: Integer, d: Integer, x: T.nilable(Integer), e: Integer):
+# - bb6(rubyRegionId=0)
+bb7[rubyRegionId=0, firstDead=-1](a: Integer, b: Integer, c: Integer, d: Integer, x: T.nilable(Integer), e: Integer):
     f: String = load_arg(f)
     <unconditional> -> bb9
 
 # backedges
-# - bb6(rubyBlockId=0)
-bb8[rubyBlockId=0, firstDead=-1](a: Integer, b: Integer, c: Integer, d: Integer, x: T.nilable(Integer), e: Integer):
+# - bb6(rubyRegionId=0)
+bb8[rubyRegionId=0, firstDead=-1](a: Integer, b: Integer, c: Integer, d: Integer, x: T.nilable(Integer), e: Integer):
     <statTemp>$10: String("foo") = "foo"
     <castTemp>$11: String = cast(<statTemp>$10: String("foo"), String);
     f: String("foo") = <statTemp>$10
     <unconditional> -> bb9
 
 # backedges
-# - bb7(rubyBlockId=0)
-# - bb8(rubyBlockId=0)
-bb9[rubyBlockId=0, firstDead=19](a: Integer, b: Integer, c: Integer, d: Integer, x: T.nilable(Integer), e: Integer, f: String):
+# - bb7(rubyRegionId=0)
+# - bb8(rubyRegionId=0)
+bb9[rubyRegionId=0, firstDead=19](a: Integer, b: Integer, c: Integer, d: Integer, x: T.nilable(Integer), e: Integer, f: String):
     blk: T.proc.void = load_arg(blk)
     <cfgAlias>$14: T.class_of(T) = alias <C T>
     <statTemp>$12: Integer = <cfgAlias>$14: T.class_of(T).reveal_type(a: Integer)
@@ -114,34 +114,34 @@ bb9[rubyBlockId=0, firstDead=19](a: Integer, b: Integer, c: Integer, d: Integer,
 
 method ::Test#test2 {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Test = cast(<self>: NilClass, Test);
     <argPresent>$3: T::Boolean = arg_present(x)
     <argPresent>$3 -> (T::Boolean ? bb2 : bb3)
 
 # backedges
-# - bb4(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb4(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb2[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb2[rubyRegionId=0, firstDead=-1]():
     x: Integer = load_arg(x)
     <unconditional> -> bb4
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb3[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb3[rubyRegionId=0, firstDead=-1]():
     <statTemp>$4: Integer(10) = 10
     <castTemp>$5: Integer = cast(<statTemp>$4: Integer(10), Integer);
     x: Integer(10) = <statTemp>$4
     <unconditional> -> bb4
 
 # backedges
-# - bb2(rubyBlockId=0)
-# - bb3(rubyBlockId=0)
-bb4[rubyBlockId=0, firstDead=9](x: Integer):
+# - bb2(rubyRegionId=0)
+# - bb3(rubyRegionId=0)
+bb4[rubyRegionId=0, firstDead=9](x: Integer):
     rest: T::Array[Integer] = load_arg(rest)
     blk: T.proc.void = load_arg(blk)
     <cfgAlias>$8: T.class_of(T) = alias <C T>
@@ -157,34 +157,34 @@ bb4[rubyBlockId=0, firstDead=9](x: Integer):
 
 method ::Test#test3 {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Test = cast(<self>: NilClass, Test);
     <argPresent>$3: T::Boolean = arg_present(x)
     <argPresent>$3 -> (T::Boolean ? bb2 : bb3)
 
 # backedges
-# - bb4(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb4(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb2[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb2[rubyRegionId=0, firstDead=-1]():
     x: Integer = load_arg(x)
     <unconditional> -> bb4
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb3[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb3[rubyRegionId=0, firstDead=-1]():
     <statTemp>$4: Integer(10) = 10
     <castTemp>$5: Integer = cast(<statTemp>$4: Integer(10), Integer);
     x: Integer(10) = <statTemp>$4
     <unconditional> -> bb4
 
 # backedges
-# - bb2(rubyBlockId=0)
-# - bb3(rubyBlockId=0)
-bb4[rubyBlockId=0, firstDead=9](x: Integer):
+# - bb2(rubyRegionId=0)
+# - bb3(rubyRegionId=0)
+bb4[rubyRegionId=0, firstDead=9](x: Integer):
     rest: T::Hash[Symbol, Integer] = load_arg(rest)
     blk: T.proc.void = load_arg(blk)
     <cfgAlias>$8: T.class_of(T) = alias <C T>
@@ -200,7 +200,7 @@ bb4[rubyBlockId=0, firstDead=9](x: Integer):
 
 method ::<Class:Test>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(Test) = cast(<self>: NilClass, T.class_of(Test));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
     <statTemp>$7: FalseClass = false
@@ -210,20 +210,20 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb11(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb11(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb5(rubyBlockId=1)
-bb2[rubyBlockId=1, firstDead=-1](<self>: T.class_of(Test), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Test)):
+# - bb0(rubyRegionId=0)
+# - bb5(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Test), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Test)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb3[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Test)):
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Test)):
     <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$9, sig>
     <self>: T.class_of(Test) = <selfRestore>$10
     <cfgAlias>$41: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
@@ -234,8 +234,8 @@ bb3[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$9: Sorbet::Private::Stati
     <unconditional> -> bb6
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb5[rubyBlockId=1, firstDead=20](<self>: T.class_of(Test), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Test)):
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=20](<self>: T.class_of(Test), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Test)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf
     <hashTemp>$15: Symbol(:a) = :a
@@ -260,15 +260,15 @@ bb5[rubyBlockId=1, firstDead=20](<self>: T.class_of(Test), <block-pre-call-temp>
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-# - bb9(rubyBlockId=2)
-bb6[rubyBlockId=2, firstDead=-1](<self>: T.class_of(Test), <block-pre-call-temp>$45: Sorbet::Private::Static::Void, <selfRestore>$46: T.class_of(Test)):
+# - bb3(rubyRegionId=0)
+# - bb9(rubyRegionId=2)
+bb6[rubyRegionId=2, firstDead=-1](<self>: T.class_of(Test), <block-pre-call-temp>$45: Sorbet::Private::Static::Void, <selfRestore>$46: T.class_of(Test)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
-# - bb6(rubyBlockId=2)
-bb7[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$45: Sorbet::Private::Static::Void, <selfRestore>$46: T.class_of(Test)):
+# - bb6(rubyRegionId=2)
+bb7[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$45: Sorbet::Private::Static::Void, <selfRestore>$46: T.class_of(Test)):
     <statTemp>$39: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$45, sig>
     <self>: T.class_of(Test) = <selfRestore>$46
     <cfgAlias>$65: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
@@ -279,8 +279,8 @@ bb7[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$45: Sorbet::Private::Stat
     <unconditional> -> bb10
 
 # backedges
-# - bb6(rubyBlockId=2)
-bb9[rubyBlockId=2, firstDead=12](<self>: T.class_of(Test), <block-pre-call-temp>$45: Sorbet::Private::Static::Void, <selfRestore>$46: T.class_of(Test)):
+# - bb6(rubyRegionId=2)
+bb9[rubyRegionId=2, firstDead=12](<self>: T.class_of(Test), <block-pre-call-temp>$45: Sorbet::Private::Static::Void, <selfRestore>$46: T.class_of(Test)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf
     <hashTemp>$51: Symbol(:x) = :x
@@ -297,15 +297,15 @@ bb9[rubyBlockId=2, firstDead=12](<self>: T.class_of(Test), <block-pre-call-temp>
     <unconditional> -> bb6
 
 # backedges
-# - bb7(rubyBlockId=0)
-# - bb13(rubyBlockId=3)
-bb10[rubyBlockId=3, firstDead=-1](<self>: T.class_of(Test), <block-pre-call-temp>$69: Sorbet::Private::Static::Void, <selfRestore>$70: T.class_of(Test)):
+# - bb7(rubyRegionId=0)
+# - bb13(rubyRegionId=3)
+bb10[rubyRegionId=3, firstDead=-1](<self>: T.class_of(Test), <block-pre-call-temp>$69: Sorbet::Private::Static::Void, <selfRestore>$70: T.class_of(Test)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb13 : bb11)
 
 # backedges
-# - bb10(rubyBlockId=3)
-bb11[rubyBlockId=0, firstDead=18](<block-pre-call-temp>$69: Sorbet::Private::Static::Void, <selfRestore>$70: T.class_of(Test)):
+# - bb10(rubyRegionId=3)
+bb11[rubyRegionId=0, firstDead=18](<block-pre-call-temp>$69: Sorbet::Private::Static::Void, <selfRestore>$70: T.class_of(Test)):
     <statTemp>$63: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$69, sig>
     <self>: T.class_of(Test) = <selfRestore>$70
     <cfgAlias>$90: T.class_of(T::Sig) = alias <C Sig>
@@ -327,8 +327,8 @@ bb11[rubyBlockId=0, firstDead=18](<block-pre-call-temp>$69: Sorbet::Private::Sta
     <unconditional> -> bb1
 
 # backedges
-# - bb10(rubyBlockId=3)
-bb13[rubyBlockId=3, firstDead=12](<self>: T.class_of(Test), <block-pre-call-temp>$69: Sorbet::Private::Static::Void, <selfRestore>$70: T.class_of(Test)):
+# - bb10(rubyRegionId=3)
+bb13[rubyRegionId=3, firstDead=12](<self>: T.class_of(Test), <block-pre-call-temp>$69: Sorbet::Private::Static::Void, <selfRestore>$70: T.class_of(Test)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf
     <hashTemp>$75: Symbol(:x) = :x

--- a/test/testdata/cfg/do_while.rb.cfg-text.exp
+++ b/test/testdata/cfg/do_while.rb.cfg-text.exp
@@ -1,25 +1,25 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <unconditional> -> bb2
 
 # backedges
-# - bb20(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb20(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb5(rubyBlockId=0)
-bb2[rubyBlockId=0, firstDead=-1](<self>: T.class_of(<root>)):
+# - bb0(rubyRegionId=0)
+# - bb5(rubyRegionId=0)
+bb2[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>)):
     # outerLoops: 1
     <whileTemp>$4: TrueClass = true
     <whileTemp>$4 -> (TrueClass ? bb5 : bb8)
 
 # backedges
-# - bb2(rubyBlockId=0)
-bb5[rubyBlockId=0, firstDead=-1](<self>: T.class_of(<root>)):
+# - bb2(rubyRegionId=0)
+bb5[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>)):
     # outerLoops: 1
     <statTemp>$8: Integer(2) = 2
     <statTemp>$6: NilClass = <self>: T.class_of(<root>).puts(<statTemp>$8: Integer(2))
@@ -28,31 +28,31 @@ bb5[rubyBlockId=0, firstDead=-1](<self>: T.class_of(<root>)):
     <ifTemp>$9 -> (TrueClass ? bb6 : bb2)
 
 # backedges
-# - bb5(rubyBlockId=0)
-bb6[rubyBlockId=0, firstDead=-1](<self>: T.class_of(<root>)):
+# - bb5(rubyRegionId=0)
+bb6[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>)):
     # outerLoops: 1
     <block-break-assign>$12: NilClass = <returnTemp>$11
     <unconditional> -> bb8
 
 # backedges
-# - bb2(rubyBlockId=0)
-# - bb6(rubyBlockId=0)
-# - bb11(rubyBlockId=0)
-bb8[rubyBlockId=0, firstDead=-1](<self>: T.class_of(<root>)):
+# - bb2(rubyRegionId=0)
+# - bb6(rubyRegionId=0)
+# - bb11(rubyRegionId=0)
+bb8[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>)):
     # outerLoops: 1
     <whileTemp>$14: TrueClass = true
     <whileTemp>$14 -> (TrueClass ? bb11 : bb10)
 
 # backedges
-# - bb8(rubyBlockId=0)
-# - bb12(rubyBlockId=0)
-bb10[rubyBlockId=0, firstDead=-1](<self>: T.class_of(<root>)):
+# - bb8(rubyRegionId=0)
+# - bb12(rubyRegionId=0)
+bb10[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>)):
     x: Integer(0) = 0
     <unconditional> -> bb14
 
 # backedges
-# - bb8(rubyBlockId=0)
-bb11[rubyBlockId=0, firstDead=-1](<self>: T.class_of(<root>)):
+# - bb8(rubyRegionId=0)
+bb11[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>)):
     # outerLoops: 1
     <statTemp>$18: Integer(2) = 2
     <statTemp>$16: NilClass = <self>: T.class_of(<root>).puts(<statTemp>$18: Integer(2))
@@ -60,29 +60,29 @@ bb11[rubyBlockId=0, firstDead=-1](<self>: T.class_of(<root>)):
     <ifTemp>$19 -> (TrueClass ? bb12 : bb8)
 
 # backedges
-# - bb11(rubyBlockId=0)
-bb12[rubyBlockId=0, firstDead=-1](<self>: T.class_of(<root>)):
+# - bb11(rubyRegionId=0)
+bb12[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>)):
     # outerLoops: 1
     <block-break-assign>$21: NilClass = <returnTemp>$20
     <unconditional> -> bb10
 
 # backedges
-# - bb10(rubyBlockId=0)
-# - bb17(rubyBlockId=0)
-bb14[rubyBlockId=0, firstDead=-1](<self>: T.class_of(<root>), x: Integer(0)):
+# - bb10(rubyRegionId=0)
+# - bb17(rubyRegionId=0)
+bb14[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>), x: Integer(0)):
     # outerLoops: 1
     <whileTemp>$24: FalseClass = false
     <whileTemp>$24 -> (FalseClass ? bb17 : bb16)
 
 # backedges
-# - bb14(rubyBlockId=0)
-bb16[rubyBlockId=0, firstDead=-1](<self>: T.class_of(<root>), x: Integer(0)):
+# - bb14(rubyRegionId=0)
+bb16[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>), x: Integer(0)):
     y: Integer(0) = 0
     <unconditional> -> bb18
 
 # backedges
-# - bb14(rubyBlockId=0)
-bb17[rubyBlockId=0, firstDead=0](<self>: T.class_of(<root>), x: Integer(0)):
+# - bb14(rubyRegionId=0)
+bb17[rubyRegionId=0, firstDead=0](<self>: T.class_of(<root>), x: Integer(0)):
     # outerLoops: 1
     <statTemp>$28 = 2
     <statTemp>$26 = <self>.puts(<statTemp>$28)
@@ -90,24 +90,24 @@ bb17[rubyBlockId=0, firstDead=0](<self>: T.class_of(<root>), x: Integer(0)):
     <unconditional> -> bb14
 
 # backedges
-# - bb16(rubyBlockId=0)
-# - bb21(rubyBlockId=0)
-bb18[rubyBlockId=0, firstDead=-1](<self>: T.class_of(<root>), x: Integer(0), y: Integer(0)):
+# - bb16(rubyRegionId=0)
+# - bb21(rubyRegionId=0)
+bb18[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>), x: Integer(0), y: Integer(0)):
     # outerLoops: 1
     <statTemp>$32: TrueClass = true
     <whileTemp>$31: FalseClass = <statTemp>$32: TrueClass.!()
     <whileTemp>$31 -> (FalseClass ? bb21 : bb20)
 
 # backedges
-# - bb18(rubyBlockId=0)
-bb20[rubyBlockId=0, firstDead=2](<self>: T.class_of(<root>), x: Integer(0), y: Integer(0)):
+# - bb18(rubyRegionId=0)
+bb20[rubyRegionId=0, firstDead=2](<self>: T.class_of(<root>), x: Integer(0), y: Integer(0)):
     <statTemp>$37: NilClass = <self>: T.class_of(<root>).puts(x: Integer(0), y: Integer(0))
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb18(rubyBlockId=0)
-bb21[rubyBlockId=0, firstDead=0](<self>: T.class_of(<root>), x: Integer(0), y: Integer(0)):
+# - bb18(rubyRegionId=0)
+bb21[rubyRegionId=0, firstDead=0](<self>: T.class_of(<root>), x: Integer(0), y: Integer(0)):
     # outerLoops: 1
     <statTemp>$36 = 2
     <statTemp>$34 = <self>.puts(<statTemp>$36)

--- a/test/testdata/cfg/examples.rb.cfg-text.exp
+++ b/test/testdata/cfg/examples.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=8]():
+bb0[rubyRegionId=0, firstDead=8]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <cfgAlias>$7: T.class_of(Examples) = alias <C Examples>
@@ -12,36 +12,36 @@ bb0[rubyBlockId=0, firstDead=8]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Examples#i_like_ifs {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Examples = cast(<self>: NilClass, Examples);
     <ifTemp>$3: TrueClass = true
     <ifTemp>$3 -> (TrueClass ? bb2 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=0)
-# - bb3(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1](<returnMethodTemp>$2):
+# - bb2(rubyRegionId=0)
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1](<returnMethodTemp>$2):
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb2[rubyBlockId=0, firstDead=2]():
+# - bb0(rubyRegionId=0)
+bb2[rubyRegionId=0, firstDead=2]():
     <returnTemp>$4: Integer(1) = 1
     <returnMethodTemp>$2: T.noreturn = return <returnTemp>$4: Integer(1)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb3[rubyBlockId=0, firstDead=0]():
+# - bb0(rubyRegionId=0)
+bb3[rubyRegionId=0, firstDead=0]():
     <returnTemp>$5 = 2
     <returnMethodTemp>$2 = return <returnTemp>$5
     <unconditional> -> bb1
@@ -50,32 +50,32 @@ bb3[rubyBlockId=0, firstDead=0]():
 
 method ::Examples#i_like_exps {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Examples = cast(<self>: NilClass, Examples);
     <ifTemp>$3: TrueClass = true
     <ifTemp>$3 -> (TrueClass ? bb2 : bb3)
 
 # backedges
-# - bb4(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb4(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb2[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb2[rubyRegionId=0, firstDead=-1]():
     <returnMethodTemp>$2: Integer(1) = 1
     <unconditional> -> bb4
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb3[rubyBlockId=0, firstDead=0]():
+# - bb0(rubyRegionId=0)
+bb3[rubyRegionId=0, firstDead=0]():
     <returnMethodTemp>$2 = 2
     <unconditional> -> bb4
 
 # backedges
-# - bb2(rubyBlockId=0)
-# - bb3(rubyBlockId=0)
-bb4[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: Integer(1)):
+# - bb2(rubyRegionId=0)
+# - bb3(rubyRegionId=0)
+bb4[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: Integer(1)):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(1)
     <unconditional> -> bb1
 
@@ -83,27 +83,27 @@ bb4[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: Integer(1)):
 
 method ::Examples#return_in_one_branch1 {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Examples = cast(<self>: NilClass, Examples);
     <ifTemp>$3: TrueClass = true
     <ifTemp>$3 -> (TrueClass ? bb2 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=0)
-# - bb3(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb2(rubyRegionId=0)
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb2[rubyBlockId=0, firstDead=2]():
+# - bb0(rubyRegionId=0)
+bb2[rubyRegionId=0, firstDead=2]():
     <returnTemp>$4: Integer(1) = 1
     <returnMethodTemp>$2: T.noreturn = return <returnTemp>$4: Integer(1)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb3[rubyBlockId=0, firstDead=0]():
+# - bb0(rubyRegionId=0)
+bb3[rubyRegionId=0, firstDead=0]():
     <returnMethodTemp>$2 = 2
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
@@ -112,27 +112,27 @@ bb3[rubyBlockId=0, firstDead=0]():
 
 method ::Examples#return_in_one_branch2 {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Examples = cast(<self>: NilClass, Examples);
     <ifTemp>$3: TrueClass = true
     <ifTemp>$3 -> (TrueClass ? bb2 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=0)
-# - bb3(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb2(rubyRegionId=0)
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb2[rubyBlockId=0, firstDead=2]():
+# - bb0(rubyRegionId=0)
+bb2[rubyRegionId=0, firstDead=2]():
     <returnMethodTemp>$2: Integer(1) = 1
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(1)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb3[rubyBlockId=0, firstDead=0]():
+# - bb0(rubyRegionId=0)
+bb3[rubyRegionId=0, firstDead=0]():
     <returnTemp>$4 = 2
     <returnMethodTemp>$2 = return <returnTemp>$4
     <unconditional> -> bb1
@@ -141,51 +141,51 @@ bb3[rubyBlockId=0, firstDead=0]():
 
 method ::Examples#variables {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Examples = cast(<self>: NilClass, Examples);
     <ifTemp>$4: TrueClass = true
     <ifTemp>$4 -> (TrueClass ? bb2 : bb3)
 
 # backedges
-# - bb7(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb7(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb2[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb2[rubyRegionId=0, firstDead=-1]():
     a: Integer(1) = 1
     <unconditional> -> bb4
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb3[rubyBlockId=0, firstDead=0]():
+# - bb0(rubyRegionId=0)
+bb3[rubyRegionId=0, firstDead=0]():
     a = 2
     <unconditional> -> bb4
 
 # backedges
-# - bb2(rubyBlockId=0)
-# - bb3(rubyBlockId=0)
-bb4[rubyBlockId=0, firstDead=-1](a: Integer(1)):
+# - bb2(rubyRegionId=0)
+# - bb3(rubyRegionId=0)
+bb4[rubyRegionId=0, firstDead=-1](a: Integer(1)):
     <ifTemp>$6: FalseClass = false
     <ifTemp>$6 -> (FalseClass ? bb5 : bb6)
 
 # backedges
-# - bb4(rubyBlockId=0)
-bb5[rubyBlockId=0, firstDead=0](a: Integer(1)):
+# - bb4(rubyRegionId=0)
+bb5[rubyRegionId=0, firstDead=0](a: Integer(1)):
     b = 1
     <unconditional> -> bb7
 
 # backedges
-# - bb4(rubyBlockId=0)
-bb6[rubyBlockId=0, firstDead=-1](a: Integer(1)):
+# - bb4(rubyRegionId=0)
+bb6[rubyRegionId=0, firstDead=-1](a: Integer(1)):
     b: Integer(2) = 2
     <unconditional> -> bb7
 
 # backedges
-# - bb5(rubyBlockId=0)
-# - bb6(rubyBlockId=0)
-bb7[rubyBlockId=0, firstDead=2](a: Integer(1), b: Integer(2)):
+# - bb5(rubyRegionId=0)
+# - bb6(rubyRegionId=0)
+bb7[rubyRegionId=0, firstDead=2](a: Integer(1), b: Integer(2)):
     <returnMethodTemp>$2: Integer = a: Integer(1).+(b: Integer(2))
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer
     <unconditional> -> bb1
@@ -194,62 +194,62 @@ bb7[rubyBlockId=0, firstDead=2](a: Integer(1), b: Integer(2)):
 
 method ::Examples#variables_and_loop {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Examples = cast(<self>: NilClass, Examples);
     cond: T.untyped = load_arg(cond)
     <ifTemp>$4: TrueClass = true
     <ifTemp>$4 -> (TrueClass ? bb2 : bb3)
 
 # backedges
-# - bb7(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb7(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb2[rubyBlockId=0, firstDead=-1](cond: T.untyped):
+# - bb0(rubyRegionId=0)
+bb2[rubyRegionId=0, firstDead=-1](cond: T.untyped):
     a: Integer(1) = 1
     <unconditional> -> bb5
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb3[rubyBlockId=0, firstDead=0](cond: T.untyped):
+# - bb0(rubyRegionId=0)
+bb3[rubyRegionId=0, firstDead=0](cond: T.untyped):
     a = 2
     <unconditional> -> bb5
 
 # backedges
-# - bb2(rubyBlockId=0)
-# - bb3(rubyBlockId=0)
-# - bb9(rubyBlockId=0)
-# - bb10(rubyBlockId=0)
-bb5[rubyBlockId=0, firstDead=-1](cond: T.untyped, b: NilClass):
+# - bb2(rubyRegionId=0)
+# - bb3(rubyRegionId=0)
+# - bb9(rubyRegionId=0)
+# - bb10(rubyRegionId=0)
+bb5[rubyRegionId=0, firstDead=-1](cond: T.untyped, b: NilClass):
     # outerLoops: 1
     <whileTemp>$6: TrueClass = true
     <whileTemp>$6 -> (TrueClass ? bb8 : bb7)
 
 # backedges
-# - bb5(rubyBlockId=0)
-bb7[rubyBlockId=0, firstDead=0](b: NilClass):
+# - bb5(rubyRegionId=0)
+bb7[rubyRegionId=0, firstDead=0](b: NilClass):
     <returnMethodTemp>$2 = b
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
 
 # backedges
-# - bb5(rubyBlockId=0)
-bb8[rubyBlockId=0, firstDead=-1](cond: T.untyped, b: NilClass):
+# - bb5(rubyRegionId=0)
+bb8[rubyRegionId=0, firstDead=-1](cond: T.untyped, b: NilClass):
     # outerLoops: 1
     cond -> (T.untyped ? bb9 : bb10)
 
 # backedges
-# - bb8(rubyBlockId=0)
-bb9[rubyBlockId=0, firstDead=-1](cond: T.untyped, b: NilClass):
+# - bb8(rubyRegionId=0)
+bb9[rubyRegionId=0, firstDead=-1](cond: T.untyped, b: NilClass):
     # outerLoops: 1
     b: T.untyped = 1
     <unconditional> -> bb5
 
 # backedges
-# - bb8(rubyBlockId=0)
-bb10[rubyBlockId=0, firstDead=-1](cond: T.nilable(FalseClass), b: NilClass):
+# - bb8(rubyRegionId=0)
+bb10[rubyRegionId=0, firstDead=-1](cond: T.nilable(FalseClass), b: NilClass):
     # outerLoops: 1
     b: T.untyped = 2
     <unconditional> -> bb5
@@ -258,48 +258,48 @@ bb10[rubyBlockId=0, firstDead=-1](cond: T.nilable(FalseClass), b: NilClass):
 
 method ::Examples#variables_loop_if {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Examples = cast(<self>: NilClass, Examples);
     cond: T.untyped = load_arg(cond)
     <unconditional> -> bb2
 
 # backedges
-# - bb4(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb4(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb6(rubyBlockId=0)
-# - bb7(rubyBlockId=0)
-bb2[rubyBlockId=0, firstDead=-1](cond: T.untyped, b: NilClass):
+# - bb0(rubyRegionId=0)
+# - bb6(rubyRegionId=0)
+# - bb7(rubyRegionId=0)
+bb2[rubyRegionId=0, firstDead=-1](cond: T.untyped, b: NilClass):
     # outerLoops: 1
     <whileTemp>$4: TrueClass = true
     <whileTemp>$4 -> (TrueClass ? bb5 : bb4)
 
 # backedges
-# - bb2(rubyBlockId=0)
-bb4[rubyBlockId=0, firstDead=0](b: NilClass):
+# - bb2(rubyRegionId=0)
+bb4[rubyRegionId=0, firstDead=0](b: NilClass):
     <returnMethodTemp>$2 = b
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=0)
-bb5[rubyBlockId=0, firstDead=-1](cond: T.untyped, b: NilClass):
+# - bb2(rubyRegionId=0)
+bb5[rubyRegionId=0, firstDead=-1](cond: T.untyped, b: NilClass):
     # outerLoops: 1
     cond -> (T.untyped ? bb6 : bb7)
 
 # backedges
-# - bb5(rubyBlockId=0)
-bb6[rubyBlockId=0, firstDead=-1](cond: T.untyped, b: NilClass):
+# - bb5(rubyRegionId=0)
+bb6[rubyRegionId=0, firstDead=-1](cond: T.untyped, b: NilClass):
     # outerLoops: 1
     b: T.untyped = 1
     <unconditional> -> bb2
 
 # backedges
-# - bb5(rubyBlockId=0)
-bb7[rubyBlockId=0, firstDead=-1](cond: T.nilable(FalseClass), b: NilClass):
+# - bb5(rubyRegionId=0)
+bb7[rubyRegionId=0, firstDead=-1](cond: T.nilable(FalseClass), b: NilClass):
     # outerLoops: 1
     b: T.untyped = 2
     <unconditional> -> bb2
@@ -308,33 +308,33 @@ bb7[rubyBlockId=0, firstDead=-1](cond: T.nilable(FalseClass), b: NilClass):
 
 method ::Examples#take_arguments {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Examples = cast(<self>: NilClass, Examples);
     i: T.untyped = load_arg(i)
     <ifTemp>$3: FalseClass = false
     <ifTemp>$3 -> (FalseClass ? bb2 : bb3)
 
 # backedges
-# - bb4(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb4(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb2[rubyBlockId=0, firstDead=0]():
+# - bb0(rubyRegionId=0)
+bb2[rubyRegionId=0, firstDead=0]():
     <returnMethodTemp>$2 = 2
     <unconditional> -> bb4
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb3[rubyBlockId=0, firstDead=-1](i: T.untyped):
+# - bb0(rubyRegionId=0)
+bb3[rubyRegionId=0, firstDead=-1](i: T.untyped):
     <returnMethodTemp>$2: T.untyped = i
     <unconditional> -> bb4
 
 # backedges
-# - bb2(rubyBlockId=0)
-# - bb3(rubyBlockId=0)
-bb4[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
+# - bb2(rubyRegionId=0)
+# - bb3(rubyRegionId=0)
+bb4[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
@@ -342,7 +342,7 @@ bb4[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
 
 method ::<Class:Examples>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=34]():
+bb0[rubyRegionId=0, firstDead=34]():
     <self>: T.class_of(Examples) = cast(<self>: NilClass, T.class_of(Examples));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$7: Symbol(:i_like_ifs) = :i_like_ifs
@@ -380,8 +380,8 @@ bb0[rubyBlockId=0, firstDead=34]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/extra_bb_args.rb.cfg-text.exp
+++ b/test/testdata/cfg/extra_bb_args.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::Object#main {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <cfgAlias>$6: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <cfgAlias>$9: T.class_of(T) = alias <C T>
@@ -13,21 +13,21 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <ifTemp>$14 -> (T::Boolean ? bb2 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=0)
-# - bb3(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb2(rubyRegionId=0)
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb2[rubyBlockId=0, firstDead=2]():
+# - bb0(rubyRegionId=0)
+bb2[rubyRegionId=0, firstDead=2]():
     <returnTemp>$16: String("missing name") = "missing name"
     <statTemp>$13: T.noreturn = return <returnTemp>$16: String("missing name")
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb3[rubyBlockId=0, firstDead=3](name: String):
+# - bb0(rubyRegionId=0)
+bb3[rubyRegionId=0, firstDead=3](name: String):
     <statTemp>$18: String("foo") = "foo"
     <returnMethodTemp>$2: T::Boolean = name: String.include?(<statTemp>$18: String("foo"))
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T::Boolean
@@ -37,7 +37,7 @@ bb3[rubyBlockId=0, firstDead=3](name: String):
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=6]():
+bb0[rubyRegionId=0, firstDead=6]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$6: Symbol(:main) = :main
@@ -47,8 +47,8 @@ bb0[rubyBlockId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/floats.rb.cfg-text.exp
+++ b/test/testdata/cfg/floats.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::Object#test_large_float {
 
-bb0[rubyBlockId=0, firstDead=15]():
+bb0[rubyRegionId=0, firstDead=15]():
     <self>: Object = cast(<self>: NilClass, Object);
     a: Float(3.141593) = 3.141593
     a: Float(0.000001) = 0.000001
@@ -19,15 +19,15 @@ bb0[rubyBlockId=0, firstDead=15]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=6]():
+bb0[rubyRegionId=0, firstDead=6]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$6: Symbol(:test_large_float) = :test_large_float
@@ -37,8 +37,8 @@ bb0[rubyBlockId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/hash.rb.cfg-text.exp
+++ b/test/testdata/cfg/hash.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=8]():
+bb0[rubyRegionId=0, firstDead=8]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <cfgAlias>$7: T.class_of(TestHash) = alias <C TestHash>
@@ -12,30 +12,30 @@ bb0[rubyBlockId=0, firstDead=8]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::TestHash#something {
 
-bb0[rubyBlockId=0, firstDead=3]():
+bb0[rubyRegionId=0, firstDead=3]():
     <self>: TestHash = cast(<self>: NilClass, TestHash);
     <returnMethodTemp>$2: Integer(17) = 17
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(17)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::TestHash#test {
 
-bb0[rubyBlockId=0, firstDead=10]():
+bb0[rubyRegionId=0, firstDead=10]():
     <self>: TestHash = cast(<self>: NilClass, TestHash);
     <hashTemp>$3: T.untyped = <self>: TestHash.something()
     <hashTemp>$4: Symbol(:bar) = :bar
@@ -49,15 +49,15 @@ bb0[rubyBlockId=0, firstDead=10]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::TestHash#test_shaped {
 
-bb0[rubyBlockId=0, firstDead=12]():
+bb0[rubyRegionId=0, firstDead=12]():
     <self>: TestHash = cast(<self>: NilClass, TestHash);
     <hashTemp>$3: Integer(1) = 1
     <hashTemp>$4: Integer(2) = 2
@@ -73,15 +73,15 @@ bb0[rubyBlockId=0, firstDead=12]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:TestHash>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=14]():
+bb0[rubyRegionId=0, firstDead=14]():
     <self>: T.class_of(TestHash) = cast(<self>: NilClass, T.class_of(TestHash));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$7: Symbol(:something) = :something
@@ -99,8 +99,8 @@ bb0[rubyBlockId=0, firstDead=14]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/ivar_assign.rb.cfg-text.exp
+++ b/test/testdata/cfg/ivar_assign.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=8]():
+bb0[rubyRegionId=0, firstDead=8]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <cfgAlias>$7: T.class_of(TestIVar) = alias <C TestIVar>
@@ -12,15 +12,15 @@ bb0[rubyBlockId=0, firstDead=8]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::TestIVar#initialize {
 
-bb0[rubyBlockId=0, firstDead=9]():
+bb0[rubyRegionId=0, firstDead=9]():
     @foo$3: Integer = alias @foo
     <self>: TestIVar = cast(<self>: NilClass, TestIVar);
     <cfgAlias>$6: T.class_of(Sorbet::Private::Static) = alias <C Static>
@@ -33,15 +33,15 @@ bb0[rubyBlockId=0, firstDead=9]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::TestIVar#test {
 
-bb0[rubyBlockId=0, firstDead=5]():
+bb0[rubyRegionId=0, firstDead=5]():
     @foo$3: Integer = alias @foo
     <self>: TestIVar = cast(<self>: NilClass, TestIVar);
     @foo$3: Integer = nil
@@ -50,15 +50,15 @@ bb0[rubyBlockId=0, firstDead=5]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:TestIVar>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=10]():
+bb0[rubyRegionId=0, firstDead=10]():
     <self>: T.class_of(TestIVar) = cast(<self>: NilClass, T.class_of(TestIVar));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$7: Symbol(:initialize) = :initialize
@@ -72,8 +72,8 @@ bb0[rubyBlockId=0, firstDead=10]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/next.rb.cfg-text.exp
+++ b/test/testdata/cfg/next.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::Object#foo {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <arrayTemp>$4: Integer(1) = 1
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
@@ -10,30 +10,30 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1](<self>):
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1](<self>):
     <statTemp>$15 = <self>
     <blockReturnTemp>$9 = <statTemp>$15.bad()
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb5(rubyBlockId=1)
-bb2[rubyBlockId=1, firstDead=-1](<self>: Object, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: Object):
+# - bb0(rubyRegionId=0)
+# - bb5(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: Object, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: Object):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb3[rubyBlockId=0, firstDead=3](<block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: Object):
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=3](<block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: Object):
     <returnMethodTemp>$2: T::Array[Integer] = Solve<<block-pre-call-temp>$6, map>
     <self>: Object = <selfRestore>$7
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T::Array[Integer]
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb5[rubyBlockId=1, firstDead=6](<self>: Object, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: Object):
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=6](<self>: Object, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: Object):
     # outerLoops: 1
     <self>: Object = loadSelf
     <blk>$8: [Integer] = load_yield_params(map)
@@ -47,7 +47,7 @@ bb5[rubyBlockId=1, firstDead=6](<self>: Object, <block-pre-call-temp>$6: Sorbet:
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=6]():
+bb0[rubyRegionId=0, firstDead=6]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$6: Symbol(:foo) = :foo
@@ -57,8 +57,8 @@ bb0[rubyBlockId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/next_in_junk.rb.cfg-text.exp
+++ b/test/testdata/cfg/next_in_junk.rb.cfg-text.exp
@@ -1,12 +1,12 @@
 method ::Object#foo {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
 
@@ -14,7 +14,7 @@ bb1[rubyBlockId=0, firstDead=-1]():
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=6]():
+bb0[rubyRegionId=0, firstDead=6]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$6: Symbol(:foo) = :foo
@@ -24,8 +24,8 @@ bb0[rubyBlockId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/next_in_while.rb.cfg-text.exp
+++ b/test/testdata/cfg/next_in_while.rb.cfg-text.exp
@@ -1,34 +1,34 @@
 method ::Object#foo {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1](<self>):
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1](<self>):
     <statTemp>$10 = <self>
     <statTemp>$4 = <statTemp>$10.bad()
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb5(rubyBlockId=0)
-bb2[rubyBlockId=0, firstDead=-1](<self>: Object):
+# - bb0(rubyRegionId=0)
+# - bb5(rubyRegionId=0)
+bb2[rubyRegionId=0, firstDead=-1](<self>: Object):
     # outerLoops: 1
     <whileTemp>$3: TrueClass = true
     <whileTemp>$3 -> (TrueClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=0)
-bb3[rubyBlockId=0, firstDead=0]():
+# - bb2(rubyRegionId=0)
+bb3[rubyRegionId=0, firstDead=0]():
     <returnMethodTemp>$2 = nil
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=0)
-bb5[rubyBlockId=0, firstDead=-1](<self>: Object):
+# - bb2(rubyRegionId=0)
+bb5[rubyRegionId=0, firstDead=-1](<self>: Object):
     # outerLoops: 1
     <statTemp>$5: T.untyped = <self>: Object.good()
     <nextTemp>$8: T.untyped = <self>: Object.value()
@@ -38,7 +38,7 @@ bb5[rubyBlockId=0, firstDead=-1](<self>: Object):
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=6]():
+bb0[rubyRegionId=0, firstDead=6]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$6: Symbol(:foo) = :foo
@@ -48,8 +48,8 @@ bb0[rubyBlockId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/reassign_dead_block_bug.rb.cfg-text.exp
+++ b/test/testdata/cfg/reassign_dead_block_bug.rb.cfg-text.exp
@@ -1,35 +1,35 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <statTemp>$3: Integer(2) = 2
     <block-pre-call-temp>$4: Sorbet::Private::Static::Void = <statTemp>$3: Integer(2).times()
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-# - bb5(rubyBlockId=1)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb3(rubyRegionId=0)
+# - bb5(rubyRegionId=1)
+bb1[rubyRegionId=0, firstDead=-1]():
     x$1 = 10
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb2[rubyBlockId=1, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$4: Sorbet::Private::Static::Void):
+# - bb0(rubyRegionId=0)
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$4: Sorbet::Private::Static::Void):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb3[rubyBlockId=0, firstDead=3](<self>: T.class_of(<root>), <block-pre-call-temp>$4: Sorbet::Private::Static::Void):
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=3](<self>: T.class_of(<root>), <block-pre-call-temp>$4: Sorbet::Private::Static::Void):
     <returnMethodTemp>$2: Integer = Solve<<block-pre-call-temp>$4, times>
     <self>: T.class_of(<root>) = <self>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb5[rubyBlockId=1, firstDead=4](<self>: T.class_of(<root>)):
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=4](<self>: T.class_of(<root>)):
     # outerLoops: 1
     <self>: T.class_of(<root>) = loadSelf
     x$1: Integer(1) = 1

--- a/test/testdata/cfg/rescue.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue.rb.cfg-text.exp
@@ -1,63 +1,63 @@
 method ::Object#main {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <magic>$6: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.untyped = <get-current-exception>
     <exceptionValue>$3 -> (T.untyped ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyBlockId=3)
-# - bb9(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb6(rubyRegionId=3)
+# - bb9(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb4(rubyBlockId=1)
-bb3[rubyBlockId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$6: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+# - bb4(rubyRegionId=1)
+bb3[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$6: T.class_of(<Magic>)):
     <cfgAlias>$9: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$10: T.untyped = <exceptionValue>$3: T.untyped.is_a?(<cfgAlias>$9: T.class_of(StandardError))
     <isaCheckTemp>$10 -> (T.untyped ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb4[rubyBlockId=1, firstDead=-1](<self>: Object, <magic>$6: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+bb4[rubyRegionId=1, firstDead=-1](<self>: Object, <magic>$6: T.class_of(<Magic>)):
     <returnMethodTemp>$2: T.untyped = <self>: Object.a()
     <exceptionValue>$3: T.untyped = <get-current-exception>
     <exceptionValue>$3 -> (T.untyped ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyBlockId=1)
-bb5[rubyBlockId=4, firstDead=-1](<self>: Object):
+# - bb4(rubyRegionId=1)
+bb5[rubyRegionId=4, firstDead=-1](<self>: Object):
     <returnMethodTemp>$2: T.untyped = <self>: Object.c()
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyBlockId=4)
-# - bb7(rubyBlockId=2)
-# - bb8(rubyBlockId=2)
-bb6[rubyBlockId=3, firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$12: T.nilable(TrueClass)):
+# - bb5(rubyRegionId=4)
+# - bb7(rubyRegionId=2)
+# - bb8(rubyRegionId=2)
+bb6[rubyRegionId=3, firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$12: T.nilable(TrueClass)):
     <throwAwayTemp>$13: T.untyped = <self>: Object.d()
     <gotoDeadTemp>$12 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb7[rubyBlockId=2, firstDead=-1](<self>: Object, <magic>$6: T.class_of(<Magic>)):
+# - bb3(rubyRegionId=2)
+bb7[rubyRegionId=2, firstDead=-1](<self>: Object, <magic>$6: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$7: Sorbet::Private::Static::Void = <magic>$6: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <returnMethodTemp>$2: T.untyped = <self>: Object.b()
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb8[rubyBlockId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped):
+# - bb3(rubyRegionId=2)
+bb8[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped):
     <gotoDeadTemp>$12: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyBlockId=3)
-bb9[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
+# - bb6(rubyRegionId=3)
+bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
@@ -65,63 +65,63 @@ bb9[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
 
 method ::Object#a {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: Object = cast(<self>: NilClass, Object);
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Object#b {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: Object = cast(<self>: NilClass, Object);
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Object#c {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: Object = cast(<self>: NilClass, Object);
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Object#d {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: Object = cast(<self>: NilClass, Object);
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=24]():
+bb0[rubyRegionId=0, firstDead=24]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$7: Symbol(:main) = :main
@@ -149,8 +149,8 @@ bb0[rubyBlockId=0, firstDead=24]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/rescue_complex.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_complex.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=8]():
+bb0[rubyRegionId=0, firstDead=8]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <cfgAlias>$7: T.class_of(TestRescue) = alias <C TestRescue>
@@ -12,75 +12,75 @@ bb0[rubyBlockId=0, firstDead=8]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::TestRescue#meth {
 
-bb0[rubyBlockId=0, firstDead=3]():
+bb0[rubyRegionId=0, firstDead=3]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <returnMethodTemp>$2: Integer(0) = 0
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(0)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::TestRescue#foo {
 
-bb0[rubyBlockId=0, firstDead=3]():
+bb0[rubyRegionId=0, firstDead=3]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <returnMethodTemp>$2: Integer(1) = 1
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(1)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::TestRescue#bar {
 
-bb0[rubyBlockId=0, firstDead=3]():
+bb0[rubyRegionId=0, firstDead=3]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <returnMethodTemp>$2: Integer(2) = 2
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(2)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::TestRescue#baz {
 
-bb0[rubyBlockId=0, firstDead=3]():
+bb0[rubyRegionId=0, firstDead=3]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <returnMethodTemp>$2: Integer(3) = 3
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(3)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::TestRescue#take_arg {
 
-bb0[rubyBlockId=0, firstDead=4]():
+bb0[rubyRegionId=0, firstDead=4]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     x: T.untyped = load_arg(x)
     <returnMethodTemp>$2: T.untyped = x
@@ -88,15 +88,15 @@ bb0[rubyBlockId=0, firstDead=4]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::TestRescue#initialize {
 
-bb0[rubyBlockId=0, firstDead=11]():
+bb0[rubyRegionId=0, firstDead=11]():
     @ex$3: T.nilable(StandardError) = alias @ex
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <cfgAlias>$6: T.class_of(Sorbet::Private::Static) = alias <C Static>
@@ -111,86 +111,86 @@ bb0[rubyBlockId=0, firstDead=11]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::TestRescue#multiple_rescue {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.untyped = <get-current-exception>
     <exceptionValue>$3 -> (T.untyped ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyBlockId=3)
-# - bb11(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb6(rubyRegionId=3)
+# - bb11(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb4(rubyBlockId=1)
-bb3[rubyBlockId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+# - bb4(rubyRegionId=1)
+bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>)):
     <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$9: T.untyped = <exceptionValue>$3: T.untyped.is_a?(<cfgAlias>$8: T.class_of(StandardError))
     <isaCheckTemp>$9 -> (T.untyped ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb4[rubyBlockId=1, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+bb4[rubyRegionId=1, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.untyped = <get-current-exception>
     <exceptionValue>$3 -> (T.untyped ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyBlockId=1)
-bb5[rubyBlockId=4, firstDead=-1](<returnMethodTemp>$2: T.untyped):
+# - bb4(rubyRegionId=1)
+bb5[rubyRegionId=4, firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyBlockId=4)
-# - bb7(rubyBlockId=2)
-# - bb9(rubyBlockId=2)
-# - bb10(rubyBlockId=2)
-bb6[rubyBlockId=3, firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$16: T.nilable(TrueClass)):
+# - bb5(rubyRegionId=4)
+# - bb7(rubyRegionId=2)
+# - bb9(rubyRegionId=2)
+# - bb10(rubyRegionId=2)
+bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$16: T.nilable(TrueClass)):
     <gotoDeadTemp>$16 -> (T.nilable(TrueClass) ? bb1 : bb11)
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb7[rubyBlockId=2, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
+# - bb3(rubyRegionId=2)
+bb7[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.baz()
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb8[rubyBlockId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>)):
+# - bb3(rubyRegionId=2)
+bb8[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>)):
     <cfgAlias>$13: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$14: T.untyped = <exceptionValue>$3: T.untyped.is_a?(<cfgAlias>$13: T.class_of(StandardError))
     <isaCheckTemp>$14 -> (T.untyped ? bb9 : bb10)
 
 # backedges
-# - bb8(rubyBlockId=2)
-bb9[rubyBlockId=2, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
+# - bb8(rubyRegionId=2)
+bb9[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$11: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()
     <unconditional> -> bb6
 
 # backedges
-# - bb8(rubyBlockId=2)
-bb10[rubyBlockId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped):
+# - bb8(rubyRegionId=2)
+bb10[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <gotoDeadTemp>$16: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyBlockId=3)
-bb11[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
+# - bb6(rubyRegionId=3)
+bb11[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
@@ -198,71 +198,71 @@ bb11[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
 
 method ::TestRescue#multiple_rescue_classes {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.untyped = <get-current-exception>
     <exceptionValue>$3 -> (T.untyped ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyBlockId=3)
-# - bb10(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb6(rubyRegionId=3)
+# - bb10(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb4(rubyBlockId=1)
-bb3[rubyBlockId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+# - bb4(rubyRegionId=1)
+bb3[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>)):
     baz: T.untyped = <exceptionValue>$3
     <cfgAlias>$8: T.untyped = alias <C T.untyped>
     <isaCheckTemp>$9: T.untyped = baz: T.untyped.is_a?(<cfgAlias>$8: T.untyped)
     <isaCheckTemp>$9 -> (T.untyped ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb4[rubyBlockId=1, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+bb4[rubyRegionId=1, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.untyped = <get-current-exception>
     <exceptionValue>$3 -> (T.untyped ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyBlockId=1)
-bb5[rubyBlockId=4, firstDead=-1](<returnMethodTemp>$2: T.untyped):
+# - bb4(rubyRegionId=1)
+bb5[rubyRegionId=4, firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyBlockId=4)
-# - bb7(rubyBlockId=2)
-# - bb9(rubyBlockId=2)
-bb6[rubyBlockId=3, firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$13: T.nilable(TrueClass)):
+# - bb5(rubyRegionId=4)
+# - bb7(rubyRegionId=2)
+# - bb9(rubyRegionId=2)
+bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$13: T.nilable(TrueClass)):
     <gotoDeadTemp>$13 -> (T.nilable(TrueClass) ? bb1 : bb10)
 
 # backedges
-# - bb3(rubyBlockId=2)
-# - bb8(rubyBlockId=2)
-bb7[rubyBlockId=2, firstDead=-1](<magic>$5: T.class_of(<Magic>), baz: T.untyped):
+# - bb3(rubyRegionId=2)
+# - bb8(rubyRegionId=2)
+bb7[rubyRegionId=2, firstDead=-1](<magic>$5: T.class_of(<Magic>), baz: T.untyped):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <returnMethodTemp>$2: T.untyped = baz
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb8[rubyBlockId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped, <magic>$5: T.class_of(<Magic>), baz: T.untyped):
+# - bb3(rubyRegionId=2)
+bb8[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped, <magic>$5: T.class_of(<Magic>), baz: T.untyped):
     <cfgAlias>$11: T.untyped = alias <C T.untyped>
     <isaCheckTemp>$12: T.untyped = baz: T.untyped.is_a?(<cfgAlias>$11: T.untyped)
     <isaCheckTemp>$12 -> (T.untyped ? bb7 : bb9)
 
 # backedges
-# - bb8(rubyBlockId=2)
-bb9[rubyBlockId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped):
+# - bb8(rubyRegionId=2)
+bb9[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <gotoDeadTemp>$13: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyBlockId=3)
-bb10[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
+# - bb6(rubyRegionId=3)
+bb10[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
@@ -270,63 +270,63 @@ bb10[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
 
 method ::TestRescue#parse_rescue_ensure {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.untyped = <get-current-exception>
     <exceptionValue>$3 -> (T.untyped ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyBlockId=3)
-# - bb9(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb6(rubyRegionId=3)
+# - bb9(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb4(rubyBlockId=1)
-bb3[rubyBlockId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+# - bb4(rubyRegionId=1)
+bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>)):
     <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$9: T.untyped = <exceptionValue>$3: T.untyped.is_a?(<cfgAlias>$8: T.class_of(StandardError))
     <isaCheckTemp>$9 -> (T.untyped ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb4[rubyBlockId=1, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+bb4[rubyRegionId=1, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.untyped = <get-current-exception>
     <exceptionValue>$3 -> (T.untyped ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyBlockId=1)
-bb5[rubyBlockId=4, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped):
+# - bb4(rubyRegionId=1)
+bb5[rubyRegionId=4, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped):
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyBlockId=4)
-# - bb7(rubyBlockId=2)
-# - bb8(rubyBlockId=2)
-bb6[rubyBlockId=3, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: T.nilable(TrueClass)):
+# - bb5(rubyRegionId=4)
+# - bb7(rubyRegionId=2)
+# - bb8(rubyRegionId=2)
+bb6[rubyRegionId=3, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: T.nilable(TrueClass)):
     <throwAwayTemp>$12: T.untyped = <self>: TestRescue.bar()
     <gotoDeadTemp>$11 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb7[rubyBlockId=2, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
+# - bb3(rubyRegionId=2)
+bb7[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.baz()
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb8[rubyBlockId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped):
+# - bb3(rubyRegionId=2)
+bb8[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped):
     <gotoDeadTemp>$11: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyBlockId=3)
-bb9[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
+# - bb6(rubyRegionId=3)
+bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
@@ -334,60 +334,60 @@ bb9[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
 
 method ::TestRescue#parse_bug_rescue_empty_else {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <magic>$4: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.untyped = <get-current-exception>
     <exceptionValue>$3 -> (T.untyped ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyBlockId=3)
-# - bb9(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb6(rubyRegionId=3)
+# - bb9(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb4(rubyBlockId=1)
-bb3[rubyBlockId=2, firstDead=-1](<exceptionValue>$3: T.untyped, <magic>$4: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+# - bb4(rubyRegionId=1)
+bb3[rubyRegionId=2, firstDead=-1](<exceptionValue>$3: T.untyped, <magic>$4: T.class_of(<Magic>)):
     <cfgAlias>$7: T.class_of(LoadError) = alias <C LoadError>
     <isaCheckTemp>$8: T.untyped = <exceptionValue>$3: T.untyped.is_a?(<cfgAlias>$7: T.class_of(LoadError))
     <isaCheckTemp>$8 -> (T.untyped ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb4[rubyBlockId=1, firstDead=-1](<magic>$4: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+bb4[rubyRegionId=1, firstDead=-1](<magic>$4: T.class_of(<Magic>)):
     <exceptionValue>$3: T.untyped = <get-current-exception>
     <exceptionValue>$3 -> (T.untyped ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyBlockId=1)
-bb5[rubyBlockId=4, firstDead=-1]():
+# - bb4(rubyRegionId=1)
+bb5[rubyRegionId=4, firstDead=-1]():
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyBlockId=4)
-# - bb7(rubyBlockId=2)
-# - bb8(rubyBlockId=2)
-bb6[rubyBlockId=3, firstDead=-1](<gotoDeadTemp>$9: T.nilable(TrueClass)):
+# - bb5(rubyRegionId=4)
+# - bb7(rubyRegionId=2)
+# - bb8(rubyRegionId=2)
+bb6[rubyRegionId=3, firstDead=-1](<gotoDeadTemp>$9: T.nilable(TrueClass)):
     <gotoDeadTemp>$9 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb7[rubyBlockId=2, firstDead=-1](<magic>$4: T.class_of(<Magic>)):
+# - bb3(rubyRegionId=2)
+bb7[rubyRegionId=2, firstDead=-1](<magic>$4: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$5: Sorbet::Private::Static::Void = <magic>$4: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb8[rubyBlockId=2, firstDead=-1]():
+# - bb3(rubyRegionId=2)
+bb8[rubyRegionId=2, firstDead=-1]():
     <gotoDeadTemp>$9: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyBlockId=3)
-bb9[rubyBlockId=0, firstDead=1]():
+# - bb6(rubyRegionId=3)
+bb9[rubyRegionId=0, firstDead=1]():
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
@@ -395,62 +395,62 @@ bb9[rubyBlockId=0, firstDead=1]():
 
 method ::TestRescue#parse_ruby_bug_12686 {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <magic>$7: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$5: T.untyped = <get-current-exception>
     <exceptionValue>$5 -> (T.untyped ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyBlockId=3)
-# - bb9(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb6(rubyRegionId=3)
+# - bb9(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb4(rubyBlockId=1)
-bb3[rubyBlockId=2, firstDead=-1](<self>: TestRescue, <statTemp>$4: T.untyped, <exceptionValue>$5: T.untyped, <magic>$7: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+# - bb4(rubyRegionId=1)
+bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <statTemp>$4: T.untyped, <exceptionValue>$5: T.untyped, <magic>$7: T.class_of(<Magic>)):
     <cfgAlias>$10: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$11: T.untyped = <exceptionValue>$5: T.untyped.is_a?(<cfgAlias>$10: T.class_of(StandardError))
     <isaCheckTemp>$11 -> (T.untyped ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb4[rubyBlockId=1, firstDead=-1](<self>: TestRescue, <magic>$7: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+bb4[rubyRegionId=1, firstDead=-1](<self>: TestRescue, <magic>$7: T.class_of(<Magic>)):
     <statTemp>$4: T.untyped = <self>: TestRescue.bar()
     <exceptionValue>$5: T.untyped = <get-current-exception>
     <exceptionValue>$5 -> (T.untyped ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyBlockId=1)
-bb5[rubyBlockId=4, firstDead=-1](<self>: TestRescue, <statTemp>$4: T.untyped):
+# - bb4(rubyRegionId=1)
+bb5[rubyRegionId=4, firstDead=-1](<self>: TestRescue, <statTemp>$4: T.untyped):
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyBlockId=4)
-# - bb7(rubyBlockId=2)
-# - bb8(rubyBlockId=2)
-bb6[rubyBlockId=3, firstDead=-1](<self>: TestRescue, <statTemp>$4: T.untyped, <gotoDeadTemp>$12: T.nilable(TrueClass)):
+# - bb5(rubyRegionId=4)
+# - bb7(rubyRegionId=2)
+# - bb8(rubyRegionId=2)
+bb6[rubyRegionId=3, firstDead=-1](<self>: TestRescue, <statTemp>$4: T.untyped, <gotoDeadTemp>$12: T.nilable(TrueClass)):
     <gotoDeadTemp>$12 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb7[rubyBlockId=2, firstDead=-1](<self>: TestRescue, <magic>$7: T.class_of(<Magic>)):
+# - bb3(rubyRegionId=2)
+bb7[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <magic>$7: T.class_of(<Magic>)):
     <exceptionValue>$5: NilClass = nil
     <keepForCfgTemp>$8: Sorbet::Private::Static::Void = <magic>$7: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$5: NilClass)
     <statTemp>$4: NilClass = nil
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb8[rubyBlockId=2, firstDead=-1](<self>: TestRescue, <statTemp>$4: T.untyped):
+# - bb3(rubyRegionId=2)
+bb8[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <statTemp>$4: T.untyped):
     <gotoDeadTemp>$12: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyBlockId=3)
-bb9[rubyBlockId=0, firstDead=2](<self>: TestRescue, <statTemp>$4: T.untyped):
+# - bb6(rubyRegionId=3)
+bb9[rubyRegionId=0, firstDead=2](<self>: TestRescue, <statTemp>$4: T.untyped):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.take_arg(<statTemp>$4: T.untyped)
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
@@ -459,62 +459,62 @@ bb9[rubyBlockId=0, firstDead=2](<self>: TestRescue, <statTemp>$4: T.untyped):
 
 method ::TestRescue#parse_rescue_mod {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.untyped = <get-current-exception>
     <exceptionValue>$3 -> (T.untyped ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyBlockId=3)
-# - bb9(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb6(rubyRegionId=3)
+# - bb9(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb4(rubyBlockId=1)
-bb3[rubyBlockId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+# - bb4(rubyRegionId=1)
+bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>)):
     <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$9: T.untyped = <exceptionValue>$3: T.untyped.is_a?(<cfgAlias>$8: T.class_of(StandardError))
     <isaCheckTemp>$9 -> (T.untyped ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb4[rubyBlockId=1, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+bb4[rubyRegionId=1, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.untyped = <get-current-exception>
     <exceptionValue>$3 -> (T.untyped ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyBlockId=1)
-bb5[rubyBlockId=4, firstDead=-1](<returnMethodTemp>$2: T.untyped):
+# - bb4(rubyRegionId=1)
+bb5[rubyRegionId=4, firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyBlockId=4)
-# - bb7(rubyBlockId=2)
-# - bb8(rubyBlockId=2)
-bb6[rubyBlockId=3, firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: T.nilable(TrueClass)):
+# - bb5(rubyRegionId=4)
+# - bb7(rubyRegionId=2)
+# - bb8(rubyRegionId=2)
+bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: T.nilable(TrueClass)):
     <gotoDeadTemp>$11 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb7[rubyBlockId=2, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
+# - bb3(rubyRegionId=2)
+bb7[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb8[rubyBlockId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped):
+# - bb3(rubyRegionId=2)
+bb8[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <gotoDeadTemp>$11: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyBlockId=3)
-bb9[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
+# - bb6(rubyRegionId=3)
+bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
@@ -522,63 +522,63 @@ bb9[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
 
 method ::TestRescue#parse_resbody_list_var {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.untyped = <get-current-exception>
     <exceptionValue>$3 -> (T.untyped ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyBlockId=3)
-# - bb9(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb6(rubyRegionId=3)
+# - bb9(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb4(rubyBlockId=1)
-bb3[rubyBlockId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+# - bb4(rubyRegionId=1)
+bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>)):
     ex: T.untyped = <exceptionValue>$3
     <exceptionClassTemp>$7: T.untyped = <self>: TestRescue.foo()
     <isaCheckTemp>$9: T.untyped = ex: T.untyped.is_a?(<exceptionClassTemp>$7: T.untyped)
     <isaCheckTemp>$9 -> (T.untyped ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb4[rubyBlockId=1, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+bb4[rubyRegionId=1, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.untyped = <get-current-exception>
     <exceptionValue>$3 -> (T.untyped ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyBlockId=1)
-bb5[rubyBlockId=4, firstDead=-1](<returnMethodTemp>$2: T.untyped):
+# - bb4(rubyRegionId=1)
+bb5[rubyRegionId=4, firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyBlockId=4)
-# - bb7(rubyBlockId=2)
-# - bb8(rubyBlockId=2)
-bb6[rubyBlockId=3, firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: T.nilable(TrueClass)):
+# - bb5(rubyRegionId=4)
+# - bb7(rubyRegionId=2)
+# - bb8(rubyRegionId=2)
+bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: T.nilable(TrueClass)):
     <gotoDeadTemp>$11 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb7[rubyBlockId=2, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
+# - bb3(rubyRegionId=2)
+bb7[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb8[rubyBlockId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped):
+# - bb3(rubyRegionId=2)
+bb8[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <gotoDeadTemp>$11: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyBlockId=3)
-bb9[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
+# - bb6(rubyRegionId=3)
+bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
@@ -586,64 +586,64 @@ bb9[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
 
 method ::TestRescue#parse_rescue_else_ensure {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <magic>$6: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.untyped = <get-current-exception>
     <exceptionValue>$3 -> (T.untyped ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyBlockId=3)
-# - bb9(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb6(rubyRegionId=3)
+# - bb9(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb4(rubyBlockId=1)
-bb3[rubyBlockId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$6: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+# - bb4(rubyRegionId=1)
+bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$6: T.class_of(<Magic>)):
     <cfgAlias>$9: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$10: T.untyped = <exceptionValue>$3: T.untyped.is_a?(<cfgAlias>$9: T.class_of(StandardError))
     <isaCheckTemp>$10 -> (T.untyped ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb4[rubyBlockId=1, firstDead=-1](<self>: TestRescue, <magic>$6: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+bb4[rubyRegionId=1, firstDead=-1](<self>: TestRescue, <magic>$6: T.class_of(<Magic>)):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.untyped = <get-current-exception>
     <exceptionValue>$3 -> (T.untyped ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyBlockId=1)
-bb5[rubyBlockId=4, firstDead=-1](<self>: TestRescue):
+# - bb4(rubyRegionId=1)
+bb5[rubyRegionId=4, firstDead=-1](<self>: TestRescue):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.foo()
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyBlockId=4)
-# - bb7(rubyBlockId=2)
-# - bb8(rubyBlockId=2)
-bb6[rubyBlockId=3, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$12: T.nilable(TrueClass)):
+# - bb5(rubyRegionId=4)
+# - bb7(rubyRegionId=2)
+# - bb8(rubyRegionId=2)
+bb6[rubyRegionId=3, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$12: T.nilable(TrueClass)):
     <throwAwayTemp>$13: T.untyped = <self>: TestRescue.bar()
     <gotoDeadTemp>$12 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb7[rubyBlockId=2, firstDead=-1](<self>: TestRescue, <magic>$6: T.class_of(<Magic>)):
+# - bb3(rubyRegionId=2)
+bb7[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <magic>$6: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$7: Sorbet::Private::Static::Void = <magic>$6: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.baz()
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb8[rubyBlockId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped):
+# - bb3(rubyRegionId=2)
+bb8[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped):
     <gotoDeadTemp>$12: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyBlockId=3)
-bb9[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
+# - bb6(rubyRegionId=3)
+bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
@@ -651,62 +651,62 @@ bb9[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
 
 method ::TestRescue#parse_rescue {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.untyped = <get-current-exception>
     <exceptionValue>$3 -> (T.untyped ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyBlockId=3)
-# - bb9(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb6(rubyRegionId=3)
+# - bb9(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb4(rubyBlockId=1)
-bb3[rubyBlockId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+# - bb4(rubyRegionId=1)
+bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>)):
     <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$9: T.untyped = <exceptionValue>$3: T.untyped.is_a?(<cfgAlias>$8: T.class_of(StandardError))
     <isaCheckTemp>$9 -> (T.untyped ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb4[rubyBlockId=1, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+bb4[rubyRegionId=1, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.untyped = <get-current-exception>
     <exceptionValue>$3 -> (T.untyped ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyBlockId=1)
-bb5[rubyBlockId=4, firstDead=-1](<returnMethodTemp>$2: T.untyped):
+# - bb4(rubyRegionId=1)
+bb5[rubyRegionId=4, firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyBlockId=4)
-# - bb7(rubyBlockId=2)
-# - bb8(rubyBlockId=2)
-bb6[rubyBlockId=3, firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: T.nilable(TrueClass)):
+# - bb5(rubyRegionId=4)
+# - bb7(rubyRegionId=2)
+# - bb8(rubyRegionId=2)
+bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: T.nilable(TrueClass)):
     <gotoDeadTemp>$11 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb7[rubyBlockId=2, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
+# - bb3(rubyRegionId=2)
+bb7[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.foo()
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb8[rubyBlockId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped):
+# - bb3(rubyRegionId=2)
+bb8[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <gotoDeadTemp>$11: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyBlockId=3)
-bb9[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
+# - bb6(rubyRegionId=3)
+bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
@@ -714,63 +714,63 @@ bb9[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
 
 method ::TestRescue#parse_resbody_var {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.untyped = <get-current-exception>
     <exceptionValue>$3 -> (T.untyped ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyBlockId=3)
-# - bb9(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb6(rubyRegionId=3)
+# - bb9(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb4(rubyBlockId=1)
-bb3[rubyBlockId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+# - bb4(rubyRegionId=1)
+bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>)):
     ex: T.untyped = <exceptionValue>$3
     <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$9: T.untyped = ex: T.untyped.is_a?(<cfgAlias>$8: T.class_of(StandardError))
     <isaCheckTemp>$9 -> (T.untyped ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb4[rubyBlockId=1, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+bb4[rubyRegionId=1, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.untyped = <get-current-exception>
     <exceptionValue>$3 -> (T.untyped ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyBlockId=1)
-bb5[rubyBlockId=4, firstDead=-1](<returnMethodTemp>$2: T.untyped):
+# - bb4(rubyRegionId=1)
+bb5[rubyRegionId=4, firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyBlockId=4)
-# - bb7(rubyBlockId=2)
-# - bb8(rubyBlockId=2)
-bb6[rubyBlockId=3, firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: T.nilable(TrueClass)):
+# - bb5(rubyRegionId=4)
+# - bb7(rubyRegionId=2)
+# - bb8(rubyRegionId=2)
+bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$11: T.nilable(TrueClass)):
     <gotoDeadTemp>$11 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb7[rubyBlockId=2, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
+# - bb3(rubyRegionId=2)
+bb7[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb8[rubyBlockId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped):
+# - bb3(rubyRegionId=2)
+bb8[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <gotoDeadTemp>$11: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyBlockId=3)
-bb9[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
+# - bb6(rubyRegionId=3)
+bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
@@ -778,7 +778,7 @@ bb9[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
 
 method ::TestRescue#parse_resbody_var_1 {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     @ex$11: T.nilable(StandardError) = alias @ex
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
@@ -786,42 +786,42 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <exceptionValue>$3 -> (T.untyped ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyBlockId=3)
-# - bb9(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb6(rubyRegionId=3)
+# - bb9(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb4(rubyBlockId=1)
-bb3[rubyBlockId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>), @ex$11: T.nilable(StandardError)):
+# - bb0(rubyRegionId=0)
+# - bb4(rubyRegionId=1)
+bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>), @ex$11: T.nilable(StandardError)):
     <rescueTemp>$2: T.untyped = <exceptionValue>$3
     <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$9: T.untyped = <exceptionValue>$3: T.untyped.is_a?(<cfgAlias>$8: T.class_of(StandardError))
     <isaCheckTemp>$9 -> (T.untyped ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb4[rubyBlockId=1, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>), @ex$11: T.nilable(StandardError)):
+# - bb0(rubyRegionId=0)
+bb4[rubyRegionId=1, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>), @ex$11: T.nilable(StandardError)):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.untyped = <get-current-exception>
     <exceptionValue>$3 -> (T.untyped ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyBlockId=1)
-bb5[rubyBlockId=4, firstDead=-1](<returnMethodTemp>$2: T.untyped):
+# - bb4(rubyRegionId=1)
+bb5[rubyRegionId=4, firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyBlockId=4)
-# - bb7(rubyBlockId=2)
-# - bb8(rubyBlockId=2)
-bb6[rubyBlockId=3, firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$13: T.nilable(TrueClass)):
+# - bb5(rubyRegionId=4)
+# - bb7(rubyRegionId=2)
+# - bb8(rubyRegionId=2)
+bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$13: T.nilable(TrueClass)):
     <gotoDeadTemp>$13 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb7[rubyBlockId=2, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>), <rescueTemp>$2: T.untyped, @ex$11: T.nilable(StandardError)):
+# - bb3(rubyRegionId=2)
+bb7[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magic>), <rescueTemp>$2: T.untyped, @ex$11: T.nilable(StandardError)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     @ex$11: T.untyped = <rescueTemp>$2
@@ -829,14 +829,14 @@ bb7[rubyBlockId=2, firstDead=-1](<self>: TestRescue, <magic>$5: T.class_of(<Magi
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb8[rubyBlockId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped):
+# - bb3(rubyRegionId=2)
+bb8[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <gotoDeadTemp>$13: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyBlockId=3)
-bb9[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
+# - bb6(rubyRegionId=3)
+bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
@@ -844,7 +844,7 @@ bb9[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
 
 method ::TestRescue#parse_rescue_mod_op_assign {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <statTemp>$3: NilClass = foo
     <magic>$7: T.class_of(<Magic>) = alias <C <Magic>>
@@ -852,55 +852,55 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <exceptionValue>$5 -> (T.untyped ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyBlockId=3)
-# - bb9(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb6(rubyRegionId=3)
+# - bb9(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb4(rubyBlockId=1)
-bb3[rubyBlockId=2, firstDead=-1](<self>: TestRescue, <statTemp>$3: NilClass, <statTemp>$4: T.untyped, <exceptionValue>$5: T.untyped, <magic>$7: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+# - bb4(rubyRegionId=1)
+bb3[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <statTemp>$3: NilClass, <statTemp>$4: T.untyped, <exceptionValue>$5: T.untyped, <magic>$7: T.class_of(<Magic>)):
     <cfgAlias>$10: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$11: T.untyped = <exceptionValue>$5: T.untyped.is_a?(<cfgAlias>$10: T.class_of(StandardError))
     <isaCheckTemp>$11 -> (T.untyped ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb4[rubyBlockId=1, firstDead=-1](<self>: TestRescue, <statTemp>$3: NilClass, <magic>$7: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+bb4[rubyRegionId=1, firstDead=-1](<self>: TestRescue, <statTemp>$3: NilClass, <magic>$7: T.class_of(<Magic>)):
     <statTemp>$4: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$5: T.untyped = <get-current-exception>
     <exceptionValue>$5 -> (T.untyped ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyBlockId=1)
-bb5[rubyBlockId=4, firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: T.untyped):
+# - bb4(rubyRegionId=1)
+bb5[rubyRegionId=4, firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: T.untyped):
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyBlockId=4)
-# - bb7(rubyBlockId=2)
-# - bb8(rubyBlockId=2)
-bb6[rubyBlockId=3, firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: T.untyped, <gotoDeadTemp>$13: T.nilable(TrueClass)):
+# - bb5(rubyRegionId=4)
+# - bb7(rubyRegionId=2)
+# - bb8(rubyRegionId=2)
+bb6[rubyRegionId=3, firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: T.untyped, <gotoDeadTemp>$13: T.nilable(TrueClass)):
     <gotoDeadTemp>$13 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb7[rubyBlockId=2, firstDead=-1](<self>: TestRescue, <statTemp>$3: NilClass, <magic>$7: T.class_of(<Magic>)):
+# - bb3(rubyRegionId=2)
+bb7[rubyRegionId=2, firstDead=-1](<self>: TestRescue, <statTemp>$3: NilClass, <magic>$7: T.class_of(<Magic>)):
     <exceptionValue>$5: NilClass = nil
     <keepForCfgTemp>$8: Sorbet::Private::Static::Void = <magic>$7: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$5: NilClass)
     <statTemp>$4: T.untyped = <self>: TestRescue.bar()
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb8[rubyBlockId=2, firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: T.untyped):
+# - bb3(rubyRegionId=2)
+bb8[rubyRegionId=2, firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: T.untyped):
     <gotoDeadTemp>$13: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyBlockId=3)
-bb9[rubyBlockId=0, firstDead=3](<statTemp>$3: NilClass, <statTemp>$4: T.untyped):
+# - bb6(rubyRegionId=3)
+bb9[rubyRegionId=0, firstDead=3](<statTemp>$3: NilClass, <statTemp>$4: T.untyped):
     foo: T.untyped = <statTemp>$3: NilClass.+(<statTemp>$4: T.untyped)
     <returnMethodTemp>$2: T.untyped = foo
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
@@ -910,63 +910,63 @@ bb9[rubyBlockId=0, firstDead=3](<statTemp>$3: NilClass, <statTemp>$4: T.untyped)
 
 method ::TestRescue#parse_ruby_bug_12402 {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <magic>$7: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.untyped = <get-current-exception>
     <exceptionValue>$3 -> (T.untyped ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyBlockId=3)
-# - bb9(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb6(rubyRegionId=3)
+# - bb9(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb4(rubyBlockId=1)
-bb3[rubyBlockId=2, firstDead=-1](foo: NilClass, <exceptionValue>$3: T.untyped, <magic>$7: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+# - bb4(rubyRegionId=1)
+bb3[rubyRegionId=2, firstDead=-1](foo: NilClass, <exceptionValue>$3: T.untyped, <magic>$7: T.class_of(<Magic>)):
     <cfgAlias>$10: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$11: T.untyped = <exceptionValue>$3: T.untyped.is_a?(<cfgAlias>$10: T.class_of(StandardError))
     <isaCheckTemp>$11 -> (T.untyped ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb4[rubyBlockId=1, firstDead=2](<self>: TestRescue, <magic>$7: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+bb4[rubyRegionId=1, firstDead=2](<self>: TestRescue, <magic>$7: T.class_of(<Magic>)):
     <statTemp>$5: T.untyped = <self>: TestRescue.bar()
     foo: T.noreturn = <self>: TestRescue.raise(<statTemp>$5: T.untyped)
     <exceptionValue>$3 = <get-current-exception>
     <exceptionValue>$3 -> (<nullptr> ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyBlockId=1)
-bb5[rubyBlockId=4, firstDead=0](foo: NilClass):
+# - bb4(rubyRegionId=1)
+bb5[rubyRegionId=4, firstDead=0](foo: NilClass):
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyBlockId=4)
-# - bb7(rubyBlockId=2)
-# - bb8(rubyBlockId=2)
-bb6[rubyBlockId=3, firstDead=-1](foo: NilClass, <gotoDeadTemp>$12: T.nilable(TrueClass)):
+# - bb5(rubyRegionId=4)
+# - bb7(rubyRegionId=2)
+# - bb8(rubyRegionId=2)
+bb6[rubyRegionId=3, firstDead=-1](foo: NilClass, <gotoDeadTemp>$12: T.nilable(TrueClass)):
     <gotoDeadTemp>$12 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb7[rubyBlockId=2, firstDead=-1](<magic>$7: T.class_of(<Magic>)):
+# - bb3(rubyRegionId=2)
+bb7[rubyRegionId=2, firstDead=-1](<magic>$7: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$8: Sorbet::Private::Static::Void = <magic>$7: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     foo: NilClass = nil
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb8[rubyBlockId=2, firstDead=-1](foo: NilClass):
+# - bb3(rubyRegionId=2)
+bb8[rubyRegionId=2, firstDead=-1](foo: NilClass):
     <gotoDeadTemp>$12: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyBlockId=3)
-bb9[rubyBlockId=0, firstDead=2](foo: NilClass):
+# - bb6(rubyRegionId=3)
+bb9[rubyRegionId=0, firstDead=2](foo: NilClass):
     <returnMethodTemp>$2: NilClass = foo
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
@@ -975,7 +975,7 @@ bb9[rubyBlockId=0, firstDead=2](foo: NilClass):
 
 method ::TestRescue#parse_ruby_bug_12402_1 {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     <statTemp>$3: NilClass = foo
     <magic>$9: T.class_of(<Magic>) = alias <C <Magic>>
@@ -983,56 +983,56 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <exceptionValue>$5 -> (T.untyped ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyBlockId=3)
-# - bb9(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb6(rubyRegionId=3)
+# - bb9(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb4(rubyBlockId=1)
-bb3[rubyBlockId=2, firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: NilClass, <exceptionValue>$5: T.untyped, <magic>$9: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+# - bb4(rubyRegionId=1)
+bb3[rubyRegionId=2, firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: NilClass, <exceptionValue>$5: T.untyped, <magic>$9: T.class_of(<Magic>)):
     <cfgAlias>$12: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$13: T.untyped = <exceptionValue>$5: T.untyped.is_a?(<cfgAlias>$12: T.class_of(StandardError))
     <isaCheckTemp>$13 -> (T.untyped ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb4[rubyBlockId=1, firstDead=2](<self>: TestRescue, <statTemp>$3: NilClass, <magic>$9: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+bb4[rubyRegionId=1, firstDead=2](<self>: TestRescue, <statTemp>$3: NilClass, <magic>$9: T.class_of(<Magic>)):
     <statTemp>$7: T.untyped = <self>: TestRescue.bar()
     <statTemp>$4: T.noreturn = <self>: TestRescue.raise(<statTemp>$7: T.untyped)
     <exceptionValue>$5 = <get-current-exception>
     <exceptionValue>$5 -> (<nullptr> ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyBlockId=1)
-bb5[rubyBlockId=4, firstDead=0](<statTemp>$3: NilClass, <statTemp>$4: NilClass):
+# - bb4(rubyRegionId=1)
+bb5[rubyRegionId=4, firstDead=0](<statTemp>$3: NilClass, <statTemp>$4: NilClass):
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyBlockId=4)
-# - bb7(rubyBlockId=2)
-# - bb8(rubyBlockId=2)
-bb6[rubyBlockId=3, firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: NilClass, <gotoDeadTemp>$14: T.nilable(TrueClass)):
+# - bb5(rubyRegionId=4)
+# - bb7(rubyRegionId=2)
+# - bb8(rubyRegionId=2)
+bb6[rubyRegionId=3, firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: NilClass, <gotoDeadTemp>$14: T.nilable(TrueClass)):
     <gotoDeadTemp>$14 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb7[rubyBlockId=2, firstDead=-1](<statTemp>$3: NilClass, <magic>$9: T.class_of(<Magic>)):
+# - bb3(rubyRegionId=2)
+bb7[rubyRegionId=2, firstDead=-1](<statTemp>$3: NilClass, <magic>$9: T.class_of(<Magic>)):
     <exceptionValue>$5: NilClass = nil
     <keepForCfgTemp>$10: Sorbet::Private::Static::Void = <magic>$9: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$5: NilClass)
     <statTemp>$4: NilClass = nil
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb8[rubyBlockId=2, firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: NilClass):
+# - bb3(rubyRegionId=2)
+bb8[rubyRegionId=2, firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: NilClass):
     <gotoDeadTemp>$14: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyBlockId=3)
-bb9[rubyBlockId=0, firstDead=3](<statTemp>$3: NilClass, <statTemp>$4: NilClass):
+# - bb6(rubyRegionId=3)
+bb9[rubyRegionId=0, firstDead=3](<statTemp>$3: NilClass, <statTemp>$4: NilClass):
     foo: T.untyped = <statTemp>$3: NilClass.+(<statTemp>$4: NilClass)
     <returnMethodTemp>$2: T.untyped = foo
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
@@ -1042,7 +1042,7 @@ bb9[rubyBlockId=0, firstDead=3](<statTemp>$3: NilClass, <statTemp>$4: NilClass):
 
 method ::TestRescue#parse_ruby_bug_12402_2 {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: TestRescue = cast(<self>: NilClass, TestRescue);
     []$3: T.untyped = <self>: TestRescue.foo()
     []$4: Integer(0) = 0
@@ -1052,56 +1052,56 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <exceptionValue>$13 -> (T.untyped ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyBlockId=3)
-# - bb9(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb6(rubyRegionId=3)
+# - bb9(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb4(rubyBlockId=1)
-bb3[rubyBlockId=2, firstDead=-1]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <statTemp>$12: NilClass, <exceptionValue>$13: T.untyped, <magic>$17: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+# - bb4(rubyRegionId=1)
+bb3[rubyRegionId=2, firstDead=-1]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <statTemp>$12: NilClass, <exceptionValue>$13: T.untyped, <magic>$17: T.class_of(<Magic>)):
     <cfgAlias>$20: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$21: T.untyped = <exceptionValue>$13: T.untyped.is_a?(<cfgAlias>$20: T.class_of(StandardError))
     <isaCheckTemp>$21 -> (T.untyped ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb4[rubyBlockId=1, firstDead=2](<self>: TestRescue, []$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <magic>$17: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+bb4[rubyRegionId=1, firstDead=2](<self>: TestRescue, []$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <magic>$17: T.class_of(<Magic>)):
     <statTemp>$15: T.untyped = <self>: TestRescue.bar()
     <statTemp>$12: T.noreturn = <self>: TestRescue.raise(<statTemp>$15: T.untyped)
     <exceptionValue>$13 = <get-current-exception>
     <exceptionValue>$13 -> (<nullptr> ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyBlockId=1)
-bb5[rubyBlockId=4, firstDead=0]([]$3: NilClass, []$4: NilClass, <statTemp>$9: NilClass, <statTemp>$12: NilClass):
+# - bb4(rubyRegionId=1)
+bb5[rubyRegionId=4, firstDead=0]([]$3: NilClass, []$4: NilClass, <statTemp>$9: NilClass, <statTemp>$12: NilClass):
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyBlockId=4)
-# - bb7(rubyBlockId=2)
-# - bb8(rubyBlockId=2)
-bb6[rubyBlockId=3, firstDead=-1]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <statTemp>$12: NilClass, <gotoDeadTemp>$22: T.nilable(TrueClass)):
+# - bb5(rubyRegionId=4)
+# - bb7(rubyRegionId=2)
+# - bb8(rubyRegionId=2)
+bb6[rubyRegionId=3, firstDead=-1]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <statTemp>$12: NilClass, <gotoDeadTemp>$22: T.nilable(TrueClass)):
     <gotoDeadTemp>$22 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb7[rubyBlockId=2, firstDead=-1]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <magic>$17: T.class_of(<Magic>)):
+# - bb3(rubyRegionId=2)
+bb7[rubyRegionId=2, firstDead=-1]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <magic>$17: T.class_of(<Magic>)):
     <exceptionValue>$13: NilClass = nil
     <keepForCfgTemp>$18: Sorbet::Private::Static::Void = <magic>$17: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$13: NilClass)
     <statTemp>$12: NilClass = nil
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb8[rubyBlockId=2, firstDead=-1]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <statTemp>$12: NilClass):
+# - bb3(rubyRegionId=2)
+bb8[rubyRegionId=2, firstDead=-1]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <statTemp>$12: NilClass):
     <gotoDeadTemp>$22: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyBlockId=3)
-bb9[rubyBlockId=0, firstDead=3]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <statTemp>$12: NilClass):
+# - bb6(rubyRegionId=3)
+bb9[rubyRegionId=0, firstDead=3]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <statTemp>$12: NilClass):
     <statTemp>$8: T.untyped = <statTemp>$9: T.untyped.+(<statTemp>$12: NilClass)
     <returnMethodTemp>$2: T.untyped = []$3: T.untyped.[]=([]$4: Integer(0), <statTemp>$8: T.untyped)
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
@@ -1111,7 +1111,7 @@ bb9[rubyBlockId=0, firstDead=3]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9:
 
 method ::<Class:TestRescue>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=86]():
+bb0[rubyRegionId=0, firstDead=86]():
     <self>: T.class_of(TestRescue) = cast(<self>: NilClass, T.class_of(TestRescue));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$7: Symbol(:meth) = :meth
@@ -1201,8 +1201,8 @@ bb0[rubyBlockId=0, firstDead=86]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/rescue_else_block.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_else_block.rb.cfg-text.exp
@@ -1,68 +1,68 @@
 method ::Object#foo {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.untyped = <get-current-exception>
     <exceptionValue>$3 -> (T.untyped ? bb3 : bb4)
 
 # backedges
-# - bb9(rubyBlockId=3)
-# - bb12(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb9(rubyRegionId=3)
+# - bb12(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb4(rubyBlockId=1)
-bb3[rubyBlockId=2, firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+# - bb4(rubyRegionId=1)
+bb3[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>)):
     <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$9: T.untyped = <exceptionValue>$3: T.untyped.is_a?(<cfgAlias>$8: T.class_of(StandardError))
     <isaCheckTemp>$9 -> (T.untyped ? bb10 : bb11)
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb4[rubyBlockId=1, firstDead=-1](<magic>$5: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+bb4[rubyRegionId=1, firstDead=-1](<magic>$5: T.class_of(<Magic>)):
     <returnMethodTemp>$2: Integer(1) = 1
     <exceptionValue>$3: T.untyped = <get-current-exception>
     <exceptionValue>$3 -> (T.untyped ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyBlockId=1)
-bb5[rubyBlockId=4, firstDead=-1](<returnMethodTemp>$2: Integer(1)):
+# - bb4(rubyRegionId=1)
+bb5[rubyRegionId=4, firstDead=-1](<returnMethodTemp>$2: Integer(1)):
     <ifTemp>$4: Integer(2) = 2
     <ifTemp>$4 -> (Integer(2) ? bb6 : bb9)
 
 # backedges
-# - bb5(rubyBlockId=4)
-bb6[rubyBlockId=4, firstDead=-1]():
+# - bb5(rubyRegionId=4)
+bb6[rubyRegionId=4, firstDead=-1]():
     <returnMethodTemp>$2: Integer(3) = 3
     <unconditional> -> bb9
 
 # backedges
-# - bb5(rubyBlockId=4)
-# - bb6(rubyBlockId=4)
-# - bb10(rubyBlockId=2)
-# - bb11(rubyBlockId=2)
-bb9[rubyBlockId=3, firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <gotoDeadTemp>$10: T.nilable(TrueClass)):
+# - bb5(rubyRegionId=4)
+# - bb6(rubyRegionId=4)
+# - bb10(rubyRegionId=2)
+# - bb11(rubyRegionId=2)
+bb9[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <gotoDeadTemp>$10: T.nilable(TrueClass)):
     <gotoDeadTemp>$10 -> (T.nilable(TrueClass) ? bb1 : bb12)
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb10[rubyBlockId=2, firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <magic>$5: T.class_of(<Magic>)):
+# - bb3(rubyRegionId=2)
+bb10[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <magic>$5: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <unconditional> -> bb9
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb11[rubyBlockId=2, firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer)):
+# - bb3(rubyRegionId=2)
+bb11[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer)):
     <gotoDeadTemp>$10: TrueClass = true
     <unconditional> -> bb9
 
 # backedges
-# - bb9(rubyBlockId=3)
-bb12[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: T.nilable(Integer)):
+# - bb9(rubyRegionId=3)
+bb12[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.nilable(Integer)):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(Integer)
     <unconditional> -> bb1
 
@@ -70,7 +70,7 @@ bb12[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: T.nilable(Integer)):
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=6]():
+bb0[rubyRegionId=0, firstDead=6]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$6: Symbol(:foo) = :foo
@@ -80,8 +80,8 @@ bb0[rubyBlockId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/rescue_expression.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_expression.rb.cfg-text.exp
@@ -1,21 +1,21 @@
 method ::Object#foo {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <magic>$8: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.untyped = <get-current-exception>
     <exceptionValue>$3 -> (T.untyped ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyBlockId=3)
-# - bb9(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb6(rubyRegionId=3)
+# - bb9(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb4(rubyBlockId=1)
-bb3[rubyBlockId=2, firstDead=-1](<returnMethodTemp>$2: NilClass, <exceptionValue>$3: T.untyped, <magic>$8: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+# - bb4(rubyRegionId=1)
+bb3[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: NilClass, <exceptionValue>$3: T.untyped, <magic>$8: T.class_of(<Magic>)):
     e: T.untyped = <exceptionValue>$3
     <cfgAlias>$13: T.class_of(MyException) = alias <C MyException>
     <statTemp>$11: MyException = <cfgAlias>$13: T.class_of(MyException).new()
@@ -24,8 +24,8 @@ bb3[rubyBlockId=2, firstDead=-1](<returnMethodTemp>$2: NilClass, <exceptionValue
     <isaCheckTemp>$14 -> (T.untyped ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb4[rubyBlockId=1, firstDead=3](<self>: Object, <magic>$8: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+bb4[rubyRegionId=1, firstDead=3](<self>: Object, <magic>$8: T.class_of(<Magic>)):
     <cfgAlias>$7: T.class_of(MyException) = alias <C MyException>
     <statTemp>$5: MyException = <cfgAlias>$7: T.class_of(MyException).new()
     <returnMethodTemp>$2: T.noreturn = <self>: Object.raise(<statTemp>$5: MyException)
@@ -33,34 +33,34 @@ bb4[rubyBlockId=1, firstDead=3](<self>: Object, <magic>$8: T.class_of(<Magic>)):
     <exceptionValue>$3 -> (<nullptr> ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyBlockId=1)
-bb5[rubyBlockId=4, firstDead=0](<returnMethodTemp>$2: NilClass):
+# - bb4(rubyRegionId=1)
+bb5[rubyRegionId=4, firstDead=0](<returnMethodTemp>$2: NilClass):
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyBlockId=4)
-# - bb7(rubyBlockId=2)
-# - bb8(rubyBlockId=2)
-bb6[rubyBlockId=3, firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <gotoDeadTemp>$15: T.nilable(TrueClass)):
+# - bb5(rubyRegionId=4)
+# - bb7(rubyRegionId=2)
+# - bb8(rubyRegionId=2)
+bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <gotoDeadTemp>$15: T.nilable(TrueClass)):
     <gotoDeadTemp>$15 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb7[rubyBlockId=2, firstDead=-1](<magic>$8: T.class_of(<Magic>)):
+# - bb3(rubyRegionId=2)
+bb7[rubyRegionId=2, firstDead=-1](<magic>$8: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$9: Sorbet::Private::Static::Void = <magic>$8: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <returnMethodTemp>$2: Integer(3) = 3
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb8[rubyBlockId=2, firstDead=-1](<returnMethodTemp>$2: NilClass):
+# - bb3(rubyRegionId=2)
+bb8[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: NilClass):
     <gotoDeadTemp>$15: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyBlockId=3)
-bb9[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: Integer(3)):
+# - bb6(rubyRegionId=3)
+bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: Integer(3)):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(3)
     <unconditional> -> bb1
 
@@ -68,7 +68,7 @@ bb9[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: Integer(3)):
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=17]():
+bb0[rubyRegionId=0, firstDead=17]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$6: T.class_of(<Magic>) = alias <C <Magic>>
     <cfgAlias>$8: T.class_of(MyException) = alias <C MyException>
@@ -89,22 +89,22 @@ bb0[rubyBlockId=0, firstDead=17]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:MyException>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(MyException) = cast(<self>: NilClass, T.class_of(MyException));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/rescue_two_return.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_two_return.rb.cfg-text.exp
@@ -1,42 +1,42 @@
 method ::Object#foo {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <magic>$6: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$4: T.untyped = <get-current-exception>
     <exceptionValue>$4 -> (T.untyped ? bb3 : bb4)
 
 # backedges
-# - bb4(rubyBlockId=1)
-# - bb6(rubyBlockId=3)
-# - bb7(rubyBlockId=2)
-# - bb9(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb4(rubyRegionId=1)
+# - bb6(rubyRegionId=3)
+# - bb7(rubyRegionId=2)
+# - bb9(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <exceptionValue>$4 = <get-current-exception>
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb3[rubyBlockId=2, firstDead=-1](<self>: Object, <exceptionValue>$4: T.untyped, <magic>$6: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+bb3[rubyRegionId=2, firstDead=-1](<self>: Object, <exceptionValue>$4: T.untyped, <magic>$6: T.class_of(<Magic>)):
     <cfgAlias>$9: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$10: T.untyped = <exceptionValue>$4: T.untyped.is_a?(<cfgAlias>$9: T.class_of(StandardError))
     <isaCheckTemp>$10 -> (T.untyped ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb4[rubyBlockId=1, firstDead=2]():
+# - bb0(rubyRegionId=0)
+bb4[rubyRegionId=1, firstDead=2]():
     <returnTemp>$5: Integer(1) = 1
     <statTemp>$3: T.noreturn = return <returnTemp>$5: Integer(1)
     <unconditional> -> bb1
 
 # backedges
-# - bb8(rubyBlockId=2)
-bb6[rubyBlockId=3, firstDead=-1](<self>: Object, <gotoDeadTemp>$12: TrueClass):
+# - bb8(rubyRegionId=2)
+bb6[rubyRegionId=3, firstDead=-1](<self>: Object, <gotoDeadTemp>$12: TrueClass):
     <gotoDeadTemp>$12 -> (TrueClass ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb7[rubyBlockId=2, firstDead=4](<magic>$6: T.class_of(<Magic>)):
+# - bb3(rubyRegionId=2)
+bb7[rubyRegionId=2, firstDead=4](<magic>$6: T.class_of(<Magic>)):
     <exceptionValue>$4: NilClass = nil
     <keepForCfgTemp>$7: Sorbet::Private::Static::Void = <magic>$6: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)
     <returnTemp>$11: Integer(2) = 2
@@ -44,14 +44,14 @@ bb7[rubyBlockId=2, firstDead=4](<magic>$6: T.class_of(<Magic>)):
     <unconditional> -> bb1
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb8[rubyBlockId=2, firstDead=-1](<self>: Object):
+# - bb3(rubyRegionId=2)
+bb8[rubyRegionId=2, firstDead=-1](<self>: Object):
     <gotoDeadTemp>$12: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyBlockId=3)
-bb9[rubyBlockId=0, firstDead=0](<self>: Object):
+# - bb6(rubyRegionId=3)
+bb9[rubyRegionId=0, firstDead=0](<self>: Object):
     <returnMethodTemp>$2 = <self>.deadcode()
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
@@ -60,7 +60,7 @@ bb9[rubyBlockId=0, firstDead=0](<self>: Object):
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=6]():
+bb0[rubyRegionId=0, firstDead=6]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$6: Symbol(:foo) = :foo
@@ -70,8 +70,8 @@ bb0[rubyBlockId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/rescue_var_expression.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_var_expression.rb.cfg-text.exp
@@ -1,49 +1,49 @@
 method ::Object#foo {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <magic>$6: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.untyped = <get-current-exception>
     <exceptionValue>$3 -> (T.untyped ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyBlockId=3)
-# - bb9(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb6(rubyRegionId=3)
+# - bb9(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb4(rubyBlockId=1)
-bb3[rubyBlockId=2, firstDead=-1](<returnMethodTemp>$2: NilClass, <exceptionValue>$3: T.untyped, <magic>$6: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+# - bb4(rubyRegionId=1)
+bb3[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: NilClass, <exceptionValue>$3: T.untyped, <magic>$6: T.class_of(<Magic>)):
     <rescueTemp>$2: T.untyped = <exceptionValue>$3
     <cfgAlias>$9: T.class_of(Exception) = alias <C Exception>
     <isaCheckTemp>$10: T.untyped = <exceptionValue>$3: T.untyped.is_a?(<cfgAlias>$9: T.class_of(Exception))
     <isaCheckTemp>$10 -> (T.untyped ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb4[rubyBlockId=1, firstDead=2](<self>: Object, <magic>$6: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+bb4[rubyRegionId=1, firstDead=2](<self>: Object, <magic>$6: T.class_of(<Magic>)):
     <statTemp>$5: String("boop") = "boop"
     <returnMethodTemp>$2: T.noreturn = <self>: Object.raise(<statTemp>$5: String("boop"))
     <exceptionValue>$3 = <get-current-exception>
     <exceptionValue>$3 -> (<nullptr> ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyBlockId=1)
-bb5[rubyBlockId=4, firstDead=0](<returnMethodTemp>$2: NilClass):
+# - bb4(rubyRegionId=1)
+bb5[rubyRegionId=4, firstDead=0](<returnMethodTemp>$2: NilClass):
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyBlockId=4)
-# - bb7(rubyBlockId=2)
-# - bb8(rubyBlockId=2)
-bb6[rubyBlockId=3, firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <gotoDeadTemp>$16: T.nilable(TrueClass)):
+# - bb5(rubyRegionId=4)
+# - bb7(rubyRegionId=2)
+# - bb8(rubyRegionId=2)
+bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <gotoDeadTemp>$16: T.nilable(TrueClass)):
     <gotoDeadTemp>$16 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb7[rubyBlockId=2, firstDead=-1](<magic>$6: T.class_of(<Magic>), <rescueTemp>$2: T.untyped):
+# - bb3(rubyRegionId=2)
+bb7[rubyRegionId=2, firstDead=-1](<magic>$6: T.class_of(<Magic>), <rescueTemp>$2: T.untyped):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$7: Sorbet::Private::Static::Void = <magic>$6: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <cfgAlias>$14: T.class_of(MyClass) = alias <C MyClass>
@@ -53,14 +53,14 @@ bb7[rubyBlockId=2, firstDead=-1](<magic>$6: T.class_of(<Magic>), <rescueTemp>$2:
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb8[rubyBlockId=2, firstDead=-1](<returnMethodTemp>$2: NilClass):
+# - bb3(rubyRegionId=2)
+bb8[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: NilClass):
     <gotoDeadTemp>$16: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyBlockId=3)
-bb9[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: Integer(3)):
+# - bb6(rubyRegionId=3)
+bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: Integer(3)):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(3)
     <unconditional> -> bb1
 
@@ -68,7 +68,7 @@ bb9[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: Integer(3)):
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=14]():
+bb0[rubyRegionId=0, firstDead=14]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$6: T.class_of(<Magic>) = alias <C <Magic>>
     <cfgAlias>$8: T.class_of(MyClass) = alias <C MyClass>
@@ -86,29 +86,29 @@ bb0[rubyBlockId=0, firstDead=14]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::MyClass#foo= {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: MyClass = cast(<self>: NilClass, MyClass);
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:MyClass>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=6]():
+bb0[rubyRegionId=0, firstDead=6]():
     <self>: T.class_of(MyClass) = cast(<self>: NilClass, T.class_of(MyClass));
     <cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$6: Symbol(:foo=) = :foo=
@@ -118,8 +118,8 @@ bb0[rubyBlockId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/rescue_with_return.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_with_return.rb.cfg-text.exp
@@ -1,55 +1,55 @@
 method ::Object#a {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.untyped = <get-current-exception>
     <exceptionValue>$3 -> (T.untyped ? bb3 : bb4)
 
 # backedges
-# - bb4(rubyBlockId=1)
-# - bb6(rubyBlockId=3)
-# - bb9(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb4(rubyRegionId=1)
+# - bb6(rubyRegionId=3)
+# - bb9(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <exceptionValue>$3 = <get-current-exception>
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb3[rubyBlockId=2, firstDead=-1](<exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+bb3[rubyRegionId=2, firstDead=-1](<exceptionValue>$3: T.untyped, <magic>$5: T.class_of(<Magic>)):
     <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$9: T.untyped = <exceptionValue>$3: T.untyped.is_a?(<cfgAlias>$8: T.class_of(StandardError))
     <isaCheckTemp>$9 -> (T.untyped ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb4[rubyBlockId=1, firstDead=2]():
+# - bb0(rubyRegionId=0)
+bb4[rubyRegionId=1, firstDead=2]():
     <returnTemp>$4: Integer(1) = 1
     <returnMethodTemp>$2: T.noreturn = return <returnTemp>$4: Integer(1)
     <unconditional> -> bb1
 
 # backedges
-# - bb7(rubyBlockId=2)
-# - bb8(rubyBlockId=2)
-bb6[rubyBlockId=3, firstDead=-1](<gotoDeadTemp>$10: T.nilable(TrueClass)):
+# - bb7(rubyRegionId=2)
+# - bb8(rubyRegionId=2)
+bb6[rubyRegionId=3, firstDead=-1](<gotoDeadTemp>$10: T.nilable(TrueClass)):
     <gotoDeadTemp>$10 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb7[rubyBlockId=2, firstDead=-1](<magic>$5: T.class_of(<Magic>)):
+# - bb3(rubyRegionId=2)
+bb7[rubyRegionId=2, firstDead=-1](<magic>$5: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb8[rubyBlockId=2, firstDead=-1]():
+# - bb3(rubyRegionId=2)
+bb8[rubyRegionId=2, firstDead=-1]():
     <gotoDeadTemp>$10: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyBlockId=3)
-bb9[rubyBlockId=0, firstDead=1]():
+# - bb6(rubyRegionId=3)
+bb9[rubyRegionId=0, firstDead=1]():
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
@@ -57,7 +57,7 @@ bb9[rubyBlockId=0, firstDead=1]():
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=6]():
+bb0[rubyRegionId=0, firstDead=6]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$6: Symbol(:a) = :a
@@ -67,8 +67,8 @@ bb0[rubyBlockId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/retry.rb.cfg-text.exp
+++ b/test/testdata/cfg/retry.rb.cfg-text.exp
@@ -1,42 +1,42 @@
 method ::Object#main {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     try: Integer(0) = 0
     <magic>$13: T.class_of(<Magic>) = alias <C <Magic>>
     <unconditional> -> bb2
 
 # backedges
-# - bb9(rubyBlockId=3)
-# - bb12(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb9(rubyRegionId=3)
+# - bb12(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb10(rubyBlockId=2)
-bb2[rubyBlockId=0, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$13: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+# - bb10(rubyRegionId=2)
+bb2[rubyRegionId=0, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$13: T.class_of(<Magic>)):
     <exceptionValue>$4: T.untyped = <get-current-exception>
     <exceptionValue>$4 -> (T.untyped ? bb3 : bb4)
 
 # backedges
-# - bb2(rubyBlockId=0)
-# - bb7(rubyBlockId=1)
-bb3[rubyBlockId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: T.untyped, <magic>$13: T.class_of(<Magic>)):
+# - bb2(rubyRegionId=0)
+# - bb7(rubyRegionId=1)
+bb3[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: T.untyped, <magic>$13: T.class_of(<Magic>)):
     <cfgAlias>$16: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$17: T.untyped = <exceptionValue>$4: T.untyped.is_a?(<cfgAlias>$16: T.class_of(StandardError))
     <isaCheckTemp>$17 -> (T.untyped ? bb10 : bb11)
 
 # backedges
-# - bb2(rubyBlockId=0)
-bb4[rubyBlockId=1, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$13: T.class_of(<Magic>)):
+# - bb2(rubyRegionId=0)
+bb4[rubyRegionId=1, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$13: T.class_of(<Magic>)):
     <statTemp>$7: Integer(3) = 3
     <ifTemp>$5: T::Boolean = try: Integer(0).<(<statTemp>$7: Integer(3))
     <ifTemp>$5 -> (T::Boolean ? bb5 : bb7)
 
 # backedges
-# - bb4(rubyBlockId=1)
-bb5[rubyBlockId=1, firstDead=5](<self>: Object, try: Integer(0), <magic>$13: T.class_of(<Magic>)):
+# - bb4(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=5](<self>: Object, try: Integer(0), <magic>$13: T.class_of(<Magic>)):
     <statTemp>$9: Integer(0) = try
     <statTemp>$10: Integer(1) = 1
     try: Integer = <statTemp>$9: Integer(0).+(<statTemp>$10: Integer(1))
@@ -45,26 +45,26 @@ bb5[rubyBlockId=1, firstDead=5](<self>: Object, try: Integer(0), <magic>$13: T.c
     <unconditional> -> bb7
 
 # backedges
-# - bb4(rubyBlockId=1)
-# - bb5(rubyBlockId=1)
-bb7[rubyBlockId=1, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$13: T.class_of(<Magic>)):
+# - bb4(rubyRegionId=1)
+# - bb5(rubyRegionId=1)
+bb7[rubyRegionId=1, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$13: T.class_of(<Magic>)):
     <exceptionValue>$4: T.untyped = <get-current-exception>
     <exceptionValue>$4 -> (T.untyped ? bb3 : bb8)
 
 # backedges
-# - bb7(rubyBlockId=1)
-bb8[rubyBlockId=4, firstDead=-1](<returnMethodTemp>$2: NilClass):
+# - bb7(rubyRegionId=1)
+bb8[rubyRegionId=4, firstDead=-1](<returnMethodTemp>$2: NilClass):
     <unconditional> -> bb9
 
 # backedges
-# - bb8(rubyBlockId=4)
-# - bb11(rubyBlockId=2)
-bb9[rubyBlockId=3, firstDead=-1](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$24: T.nilable(TrueClass)):
+# - bb8(rubyRegionId=4)
+# - bb11(rubyRegionId=2)
+bb9[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$24: T.nilable(TrueClass)):
     <gotoDeadTemp>$24 -> (T.nilable(TrueClass) ? bb1 : bb12)
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb10[rubyBlockId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$13: T.class_of(<Magic>)):
+# - bb3(rubyRegionId=2)
+bb10[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$13: T.class_of(<Magic>)):
     <exceptionValue>$4: NilClass = nil
     <keepForCfgTemp>$14: Sorbet::Private::Static::Void = <magic>$13: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)
     <statTemp>$20: String("rescue") = "rescue"
@@ -74,14 +74,14 @@ bb10[rubyBlockId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb11[rubyBlockId=2, firstDead=-1](<returnMethodTemp>$2: NilClass):
+# - bb3(rubyRegionId=2)
+bb11[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: NilClass):
     <gotoDeadTemp>$24: TrueClass = true
     <unconditional> -> bb9
 
 # backedges
-# - bb9(rubyBlockId=3)
-bb12[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: NilClass):
+# - bb9(rubyRegionId=3)
+bb12[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: NilClass):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
@@ -89,7 +89,7 @@ bb12[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: NilClass):
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=7]():
+bb0[rubyRegionId=0, firstDead=7]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$7: Symbol(:main) = :main
@@ -100,8 +100,8 @@ bb0[rubyBlockId=0, firstDead=7]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/retry_multiple.rb.cfg-text.exp
+++ b/test/testdata/cfg/retry_multiple.rb.cfg-text.exp
@@ -1,43 +1,43 @@
 method ::Object#main {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     try: Integer(0) = 0
     <magic>$25: T.class_of(<Magic>) = alias <C <Magic>>
     <unconditional> -> bb2
 
 # backedges
-# - bb12(rubyBlockId=3)
-# - bb17(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb12(rubyRegionId=3)
+# - bb17(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb13(rubyBlockId=2)
-# - bb15(rubyBlockId=2)
-bb2[rubyBlockId=0, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+# - bb13(rubyRegionId=2)
+# - bb15(rubyRegionId=2)
+bb2[rubyRegionId=0, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
     <exceptionValue>$4: T.untyped = <get-current-exception>
     <exceptionValue>$4 -> (T.untyped ? bb3 : bb4)
 
 # backedges
-# - bb2(rubyBlockId=0)
-# - bb10(rubyBlockId=1)
-bb3[rubyBlockId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: T.untyped, <magic>$25: T.class_of(<Magic>)):
+# - bb2(rubyRegionId=0)
+# - bb10(rubyRegionId=1)
+bb3[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: T.untyped, <magic>$25: T.class_of(<Magic>)):
     <cfgAlias>$28: T.class_of(A) = alias <C A>
     <isaCheckTemp>$29: T.untyped = <exceptionValue>$4: T.untyped.is_a?(<cfgAlias>$28: T.class_of(A))
     <isaCheckTemp>$29 -> (T.untyped ? bb13 : bb14)
 
 # backedges
-# - bb2(rubyBlockId=0)
-bb4[rubyBlockId=1, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
+# - bb2(rubyRegionId=0)
+bb4[rubyRegionId=1, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
     <statTemp>$7: Integer(3) = 3
     <ifTemp>$5: T::Boolean = try: Integer(0).<(<statTemp>$7: Integer(3))
     <ifTemp>$5 -> (T::Boolean ? bb5 : bb6)
 
 # backedges
-# - bb4(rubyBlockId=1)
-bb5[rubyBlockId=1, firstDead=6](<self>: Object, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
+# - bb4(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=6](<self>: Object, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
     <statTemp>$9: Integer(0) = try
     <statTemp>$10: Integer(1) = 1
     try: Integer = <statTemp>$9: Integer(0).+(<statTemp>$10: Integer(1))
@@ -47,15 +47,15 @@ bb5[rubyBlockId=1, firstDead=6](<self>: Object, try: Integer(0), <magic>$25: T.c
     <unconditional> -> bb10
 
 # backedges
-# - bb4(rubyBlockId=1)
-bb6[rubyBlockId=1, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
+# - bb4(rubyRegionId=1)
+bb6[rubyRegionId=1, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
     <statTemp>$17: Integer(6) = 6
     <ifTemp>$15: T::Boolean = try: Integer(0).<(<statTemp>$17: Integer(6))
     <ifTemp>$15 -> (T::Boolean ? bb7 : bb10)
 
 # backedges
-# - bb6(rubyBlockId=1)
-bb7[rubyBlockId=1, firstDead=6](<self>: Object, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
+# - bb6(rubyRegionId=1)
+bb7[rubyRegionId=1, firstDead=6](<self>: Object, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
     <statTemp>$19: Integer(0) = try
     <statTemp>$20: Integer(1) = 1
     try: Integer = <statTemp>$19: Integer(0).+(<statTemp>$20: Integer(1))
@@ -65,27 +65,27 @@ bb7[rubyBlockId=1, firstDead=6](<self>: Object, try: Integer(0), <magic>$25: T.c
     <unconditional> -> bb10
 
 # backedges
-# - bb5(rubyBlockId=1)
-# - bb6(rubyBlockId=1)
-# - bb7(rubyBlockId=1)
-bb10[rubyBlockId=1, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
+# - bb5(rubyRegionId=1)
+# - bb6(rubyRegionId=1)
+# - bb7(rubyRegionId=1)
+bb10[rubyRegionId=1, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
     <exceptionValue>$4: T.untyped = <get-current-exception>
     <exceptionValue>$4 -> (T.untyped ? bb3 : bb11)
 
 # backedges
-# - bb10(rubyBlockId=1)
-bb11[rubyBlockId=4, firstDead=-1](<returnMethodTemp>$2: NilClass):
+# - bb10(rubyRegionId=1)
+bb11[rubyRegionId=4, firstDead=-1](<returnMethodTemp>$2: NilClass):
     <unconditional> -> bb12
 
 # backedges
-# - bb11(rubyBlockId=4)
-# - bb16(rubyBlockId=2)
-bb12[rubyBlockId=3, firstDead=-1](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$46: T.nilable(TrueClass)):
+# - bb11(rubyRegionId=4)
+# - bb16(rubyRegionId=2)
+bb12[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$46: T.nilable(TrueClass)):
     <gotoDeadTemp>$46 -> (T.nilable(TrueClass) ? bb1 : bb17)
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb13[rubyBlockId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
+# - bb3(rubyRegionId=2)
+bb13[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
     <exceptionValue>$4: NilClass = nil
     <keepForCfgTemp>$26: Sorbet::Private::Static::Void = <magic>$25: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)
     <statTemp>$32: String("rescue A ") = "rescue A "
@@ -95,15 +95,15 @@ bb13[rubyBlockId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb14[rubyBlockId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: T.untyped, <magic>$25: T.class_of(<Magic>)):
+# - bb3(rubyRegionId=2)
+bb14[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: T.untyped, <magic>$25: T.class_of(<Magic>)):
     <cfgAlias>$38: T.class_of(B) = alias <C B>
     <isaCheckTemp>$39: T.untyped = <exceptionValue>$4: T.untyped.is_a?(<cfgAlias>$38: T.class_of(B))
     <isaCheckTemp>$39 -> (T.untyped ? bb15 : bb16)
 
 # backedges
-# - bb14(rubyBlockId=2)
-bb15[rubyBlockId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
+# - bb14(rubyRegionId=2)
+bb15[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$25: T.class_of(<Magic>)):
     <exceptionValue>$4: NilClass = nil
     <keepForCfgTemp>$36: Sorbet::Private::Static::Void = <magic>$25: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)
     <statTemp>$42: String("rescue B ") = "rescue B "
@@ -113,14 +113,14 @@ bb15[rubyBlockId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass
     <unconditional> -> bb2
 
 # backedges
-# - bb14(rubyBlockId=2)
-bb16[rubyBlockId=2, firstDead=-1](<returnMethodTemp>$2: NilClass):
+# - bb14(rubyRegionId=2)
+bb16[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: NilClass):
     <gotoDeadTemp>$46: TrueClass = true
     <unconditional> -> bb12
 
 # backedges
-# - bb12(rubyBlockId=3)
-bb17[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: NilClass):
+# - bb12(rubyRegionId=3)
+bb17[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: NilClass):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
@@ -128,7 +128,7 @@ bb17[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: NilClass):
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=25]():
+bb0[rubyRegionId=0, firstDead=25]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$6: T.class_of(<Magic>) = alias <C <Magic>>
     <cfgAlias>$8: T.class_of(A) = alias <C A>
@@ -157,36 +157,36 @@ bb0[rubyBlockId=0, firstDead=25]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:A>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(A) = cast(<self>: NilClass, T.class_of(A));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:B>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(B) = cast(<self>: NilClass, T.class_of(B));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/retry_nested.rb.cfg-text.exp
+++ b/test/testdata/cfg/retry_nested.rb.cfg-text.exp
@@ -1,66 +1,66 @@
 method ::Object#main {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     try: Integer(0) = 0
     <magic>$42: T.class_of(<Magic>) = alias <C <Magic>>
     <unconditional> -> bb2
 
 # backedges
-# - bb15(rubyBlockId=7)
-# - bb20(rubyBlockId=3)
-# - bb23(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb15(rubyRegionId=7)
+# - bb20(rubyRegionId=3)
+# - bb23(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb21(rubyBlockId=2)
-bb2[rubyBlockId=0, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+# - bb21(rubyRegionId=2)
+bb2[rubyRegionId=0, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
     <exceptionValue>$4: T.untyped = <get-current-exception>
     <exceptionValue>$4 -> (T.untyped ? bb3 : bb4)
 
 # backedges
-# - bb2(rubyBlockId=0)
-# - bb18(rubyBlockId=1)
-bb3[rubyBlockId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: T.untyped, <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+# - bb2(rubyRegionId=0)
+# - bb18(rubyRegionId=1)
+bb3[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: T.untyped, <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
     <cfgAlias>$45: T.class_of(B) = alias <C B>
     <isaCheckTemp>$46: T.untyped = <exceptionValue>$4: T.untyped.is_a?(<cfgAlias>$45: T.class_of(B))
     <isaCheckTemp>$46 -> (T.untyped ? bb21 : bb22)
 
 # backedges
-# - bb2(rubyBlockId=0)
-bb4[rubyBlockId=1, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+# - bb2(rubyRegionId=0)
+bb4[rubyRegionId=1, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
     <statTemp>$7: String("top") = "top"
     <statTemp>$5: NilClass = <self>: Object.puts(<statTemp>$7: String("top"))
     <magic>$29: T.class_of(<Magic>) = alias <C <Magic>>
     <unconditional> -> bb5
 
 # backedges
-# - bb4(rubyBlockId=1)
-# - bb16(rubyBlockId=6)
-bb5[rubyBlockId=1, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+# - bb4(rubyRegionId=1)
+# - bb16(rubyRegionId=6)
+bb5[rubyRegionId=1, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
     <exceptionValue>$8: T.untyped = <get-current-exception>
     <exceptionValue>$8 -> (T.untyped ? bb6 : bb7)
 
 # backedges
-# - bb5(rubyBlockId=1)
-# - bb13(rubyBlockId=5)
-bb6[rubyBlockId=6, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$8: T.untyped, <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+# - bb5(rubyRegionId=1)
+# - bb13(rubyRegionId=5)
+bb6[rubyRegionId=6, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$8: T.untyped, <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
     <cfgAlias>$32: T.class_of(A) = alias <C A>
     <isaCheckTemp>$33: T.untyped = <exceptionValue>$8: T.untyped.is_a?(<cfgAlias>$32: T.class_of(A))
     <isaCheckTemp>$33 -> (T.untyped ? bb16 : bb17)
 
 # backedges
-# - bb5(rubyBlockId=1)
-bb7[rubyBlockId=5, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+# - bb5(rubyRegionId=1)
+bb7[rubyRegionId=5, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
     <statTemp>$11: Integer(3) = 3
     <ifTemp>$9: T::Boolean = try: Integer(0).<(<statTemp>$11: Integer(3))
     <ifTemp>$9 -> (T::Boolean ? bb8 : bb9)
 
 # backedges
-# - bb7(rubyBlockId=5)
-bb8[rubyBlockId=5, firstDead=6](<self>: Object, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+# - bb7(rubyRegionId=5)
+bb8[rubyRegionId=5, firstDead=6](<self>: Object, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
     <statTemp>$13: Integer(0) = try
     <statTemp>$14: Integer(1) = 1
     try: Integer = <statTemp>$13: Integer(0).+(<statTemp>$14: Integer(1))
@@ -70,15 +70,15 @@ bb8[rubyBlockId=5, firstDead=6](<self>: Object, try: Integer(0), <magic>$29: T.c
     <unconditional> -> bb13
 
 # backedges
-# - bb7(rubyBlockId=5)
-bb9[rubyBlockId=5, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+# - bb7(rubyRegionId=5)
+bb9[rubyRegionId=5, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
     <statTemp>$21: Integer(6) = 6
     <ifTemp>$19: T::Boolean = try: Integer(0).<(<statTemp>$21: Integer(6))
     <ifTemp>$19 -> (T::Boolean ? bb10 : bb13)
 
 # backedges
-# - bb9(rubyBlockId=5)
-bb10[rubyBlockId=5, firstDead=6](<self>: Object, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+# - bb9(rubyRegionId=5)
+bb10[rubyRegionId=5, firstDead=6](<self>: Object, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
     <statTemp>$23: Integer(0) = try
     <statTemp>$24: Integer(1) = 1
     try: Integer = <statTemp>$23: Integer(0).+(<statTemp>$24: Integer(1))
@@ -88,27 +88,27 @@ bb10[rubyBlockId=5, firstDead=6](<self>: Object, try: Integer(0), <magic>$29: T.
     <unconditional> -> bb13
 
 # backedges
-# - bb8(rubyBlockId=5)
-# - bb9(rubyBlockId=5)
-# - bb10(rubyBlockId=5)
-bb13[rubyBlockId=5, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+# - bb8(rubyRegionId=5)
+# - bb9(rubyRegionId=5)
+# - bb10(rubyRegionId=5)
+bb13[rubyRegionId=5, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
     <exceptionValue>$8: T.untyped = <get-current-exception>
     <exceptionValue>$8 -> (T.untyped ? bb6 : bb14)
 
 # backedges
-# - bb13(rubyBlockId=5)
-bb14[rubyBlockId=8, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+# - bb13(rubyRegionId=5)
+bb14[rubyRegionId=8, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
     <unconditional> -> bb15
 
 # backedges
-# - bb14(rubyBlockId=8)
-# - bb17(rubyBlockId=6)
-bb15[rubyBlockId=7, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: T.nilable(TrueClass), <magic>$42: T.class_of(<Magic>)):
+# - bb14(rubyRegionId=8)
+# - bb17(rubyRegionId=6)
+bb15[rubyRegionId=7, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: T.nilable(TrueClass), <magic>$42: T.class_of(<Magic>)):
     <gotoDeadTemp>$40 -> (T.nilable(TrueClass) ? bb1 : bb18)
 
 # backedges
-# - bb6(rubyBlockId=6)
-bb16[rubyBlockId=6, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+# - bb6(rubyRegionId=6)
+bb16[rubyRegionId=6, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$29: T.class_of(<Magic>), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
     <exceptionValue>$8: NilClass = nil
     <keepForCfgTemp>$30: Sorbet::Private::Static::Void = <magic>$29: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$8: NilClass)
     <statTemp>$36: String("rescue A") = "rescue A"
@@ -118,31 +118,31 @@ bb16[rubyBlockId=6, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass
     <unconditional> -> bb5
 
 # backedges
-# - bb6(rubyBlockId=6)
-bb17[rubyBlockId=6, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$42: T.class_of(<Magic>)):
+# - bb6(rubyRegionId=6)
+bb17[rubyRegionId=6, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <magic>$42: T.class_of(<Magic>)):
     <gotoDeadTemp>$40: TrueClass = true
     <unconditional> -> bb15
 
 # backedges
-# - bb15(rubyBlockId=7)
-bb18[rubyBlockId=1, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+# - bb15(rubyRegionId=7)
+bb18[rubyRegionId=1, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
     <exceptionValue>$4: T.untyped = <get-current-exception>
     <exceptionValue>$4 -> (T.untyped ? bb3 : bb19)
 
 # backedges
-# - bb18(rubyBlockId=1)
-bb19[rubyBlockId=4, firstDead=-1](<returnMethodTemp>$2: NilClass):
+# - bb18(rubyRegionId=1)
+bb19[rubyRegionId=4, firstDead=-1](<returnMethodTemp>$2: NilClass):
     <unconditional> -> bb20
 
 # backedges
-# - bb19(rubyBlockId=4)
-# - bb22(rubyBlockId=2)
-bb20[rubyBlockId=3, firstDead=-1](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$53: T.nilable(TrueClass)):
+# - bb19(rubyRegionId=4)
+# - bb22(rubyRegionId=2)
+bb20[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$53: T.nilable(TrueClass)):
     <gotoDeadTemp>$53 -> (T.nilable(TrueClass) ? bb1 : bb23)
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb21[rubyBlockId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
+# - bb3(rubyRegionId=2)
+bb21[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$40: NilClass, <magic>$42: T.class_of(<Magic>)):
     <exceptionValue>$4: NilClass = nil
     <keepForCfgTemp>$43: Sorbet::Private::Static::Void = <magic>$42: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)
     <statTemp>$49: String("rescue B ") = "rescue B "
@@ -152,14 +152,14 @@ bb21[rubyBlockId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb22[rubyBlockId=2, firstDead=-1](<returnMethodTemp>$2: NilClass):
+# - bb3(rubyRegionId=2)
+bb22[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: NilClass):
     <gotoDeadTemp>$53: TrueClass = true
     <unconditional> -> bb20
 
 # backedges
-# - bb20(rubyBlockId=3)
-bb23[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: NilClass):
+# - bb20(rubyRegionId=3)
+bb23[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: NilClass):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
@@ -167,7 +167,7 @@ bb23[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: NilClass):
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=25]():
+bb0[rubyRegionId=0, firstDead=25]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$6: T.class_of(<Magic>) = alias <C <Magic>>
     <cfgAlias>$8: T.class_of(A) = alias <C A>
@@ -196,36 +196,36 @@ bb0[rubyBlockId=0, firstDead=25]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:A>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(A) = cast(<self>: NilClass, T.class_of(A));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:B>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(B) = cast(<self>: NilClass, T.class_of(B));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/side_effects.rb.cfg-text.exp
+++ b/test/testdata/cfg/side_effects.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=8]():
+bb0[rubyRegionId=0, firstDead=8]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <cfgAlias>$7: T.class_of(Side) = alias <C Side>
@@ -12,15 +12,15 @@ bb0[rubyBlockId=0, firstDead=8]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Side#foo {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Side = cast(<self>: NilClass, Side);
     cond: T.untyped = load_arg(cond)
     a: Integer(1) = 1
@@ -29,26 +29,26 @@ bb0[rubyBlockId=0, firstDead=-1]():
     cond -> (T.untyped ? bb2 : bb3)
 
 # backedges
-# - bb4(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb4(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb2[rubyBlockId=0, firstDead=-1](<statTemp>$4: Integer(1), <statTemp>$5: Integer(1)):
+# - bb0(rubyRegionId=0)
+bb2[rubyRegionId=0, firstDead=-1](<statTemp>$4: Integer(1), <statTemp>$5: Integer(1)):
     a: TrueClass = true
     <unconditional> -> bb4
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb3[rubyBlockId=0, firstDead=-1](<statTemp>$4: Integer(1), <statTemp>$5: Integer(1)):
+# - bb0(rubyRegionId=0)
+bb3[rubyRegionId=0, firstDead=-1](<statTemp>$4: Integer(1), <statTemp>$5: Integer(1)):
     a: Integer(2) = 2
     <unconditional> -> bb4
 
 # backedges
-# - bb2(rubyBlockId=0)
-# - bb3(rubyBlockId=0)
-bb4[rubyBlockId=0, firstDead=2](a: T.any(TrueClass, Integer), <statTemp>$4: Integer(1), <statTemp>$5: Integer(1)):
+# - bb2(rubyRegionId=0)
+# - bb3(rubyRegionId=0)
+bb4[rubyRegionId=0, firstDead=2](a: T.any(TrueClass, Integer), <statTemp>$4: Integer(1), <statTemp>$5: Integer(1)):
     <returnMethodTemp>$2: T.untyped = <statTemp>$4: Integer(1).foo(<statTemp>$5: Integer(1), a: T.any(TrueClass, Integer))
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
@@ -57,7 +57,7 @@ bb4[rubyBlockId=0, firstDead=2](a: T.any(TrueClass, Integer), <statTemp>$4: Inte
 
 method ::<Class:Side>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=6]():
+bb0[rubyRegionId=0, firstDead=6]():
     <self>: T.class_of(Side) = cast(<self>: NilClass, T.class_of(Side));
     <cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$6: Symbol(:foo) = :foo
@@ -67,8 +67,8 @@ bb0[rubyBlockId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/side_effects2.rb.cfg-text.exp
+++ b/test/testdata/cfg/side_effects2.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=8]():
+bb0[rubyRegionId=0, firstDead=8]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <cfgAlias>$7: T.class_of(Side) = alias <C Side>
@@ -12,15 +12,15 @@ bb0[rubyBlockId=0, firstDead=8]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Side#foo {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Side = cast(<self>: NilClass, Side);
     cond: T.untyped = load_arg(cond)
     a: Side = <self>
@@ -29,26 +29,26 @@ bb0[rubyBlockId=0, firstDead=-1]():
     cond -> (T.untyped ? bb2 : bb3)
 
 # backedges
-# - bb4(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb4(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb2[rubyBlockId=0, firstDead=-1](<statTemp>$4: Side, <statTemp>$5: Side):
+# - bb0(rubyRegionId=0)
+bb2[rubyRegionId=0, firstDead=-1](<statTemp>$4: Side, <statTemp>$5: Side):
     a: TrueClass = true
     <unconditional> -> bb4
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb3[rubyBlockId=0, firstDead=-1](<statTemp>$4: Side, <statTemp>$5: Side):
+# - bb0(rubyRegionId=0)
+bb3[rubyRegionId=0, firstDead=-1](<statTemp>$4: Side, <statTemp>$5: Side):
     a: Integer(2) = 2
     <unconditional> -> bb4
 
 # backedges
-# - bb2(rubyBlockId=0)
-# - bb3(rubyBlockId=0)
-bb4[rubyBlockId=0, firstDead=2](a: T.any(TrueClass, Integer), <statTemp>$4: Side, <statTemp>$5: Side):
+# - bb2(rubyRegionId=0)
+# - bb3(rubyRegionId=0)
+bb4[rubyRegionId=0, firstDead=2](a: T.any(TrueClass, Integer), <statTemp>$4: Side, <statTemp>$5: Side):
     <returnMethodTemp>$2: T.untyped = <statTemp>$4: Side.bar(<statTemp>$5: Side, a: T.any(TrueClass, Integer), a: T.any(TrueClass, Integer))
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
@@ -57,7 +57,7 @@ bb4[rubyBlockId=0, firstDead=2](a: T.any(TrueClass, Integer), <statTemp>$4: Side
 
 method ::Side#bar {
 
-bb0[rubyBlockId=0, firstDead=6]():
+bb0[rubyRegionId=0, firstDead=6]():
     <self>: Side = cast(<self>: NilClass, Side);
     a: T.untyped = load_arg(a)
     b: T.untyped = load_arg(b)
@@ -67,15 +67,15 @@ bb0[rubyBlockId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Side>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=10]():
+bb0[rubyRegionId=0, firstDead=10]():
     <self>: T.class_of(Side) = cast(<self>: NilClass, T.class_of(Side));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$7: Symbol(:foo) = :foo
@@ -89,8 +89,8 @@ bb0[rubyBlockId=0, firstDead=10]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/textoutput.rb.cfg-text.exp
+++ b/test/testdata/cfg/textoutput.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$6: T.class_of(<Magic>) = alias <C <Magic>>
     <cfgAlias>$8: T.class_of(A) = alias <C A>
@@ -13,23 +13,23 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <exceptionValue>$15 -> (T.untyped ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyBlockId=3)
-# - bb9(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb6(rubyRegionId=3)
+# - bb9(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb4(rubyBlockId=1)
-bb3[rubyBlockId=2, firstDead=-1](<self>: T.class_of(<root>), <exceptionValue>$15: T.untyped, <magic>$26: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+# - bb4(rubyRegionId=1)
+bb3[rubyRegionId=2, firstDead=-1](<self>: T.class_of(<root>), <exceptionValue>$15: T.untyped, <magic>$26: T.class_of(<Magic>)):
     e: T.untyped = <exceptionValue>$15
     <cfgAlias>$29: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$30: T.untyped = e: T.untyped.is_a?(<cfgAlias>$29: T.class_of(StandardError))
     <isaCheckTemp>$30 -> (T.untyped ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb4[rubyBlockId=1, firstDead=-1](<self>: T.class_of(<root>), <magic>$26: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+bb4[rubyRegionId=1, firstDead=-1](<self>: T.class_of(<root>), <magic>$26: T.class_of(<Magic>)):
     <cfgAlias>$18: T.class_of(A) = alias <C A>
     <statTemp>$16: A = <cfgAlias>$18: T.class_of(A).new()
     <hashTemp>$20: Symbol(:z) = :z
@@ -44,22 +44,22 @@ bb4[rubyBlockId=1, firstDead=-1](<self>: T.class_of(<root>), <magic>$26: T.class
     <exceptionValue>$15 -> (T.untyped ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyBlockId=1)
-bb5[rubyBlockId=4, firstDead=-1](<self>: T.class_of(<root>)):
+# - bb4(rubyRegionId=1)
+bb5[rubyRegionId=4, firstDead=-1](<self>: T.class_of(<root>)):
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyBlockId=4)
-# - bb7(rubyBlockId=2)
-# - bb8(rubyBlockId=2)
-bb6[rubyBlockId=3, firstDead=-1](<self>: T.class_of(<root>), <gotoDeadTemp>$33: T.nilable(TrueClass)):
+# - bb5(rubyRegionId=4)
+# - bb7(rubyRegionId=2)
+# - bb8(rubyRegionId=2)
+bb6[rubyRegionId=3, firstDead=-1](<self>: T.class_of(<root>), <gotoDeadTemp>$33: T.nilable(TrueClass)):
     <statTemp>$36: String("done") = "done"
     <throwAwayTemp>$34: NilClass = <self>: T.class_of(<root>).p(<statTemp>$36: String("done"))
     <gotoDeadTemp>$33 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb7[rubyBlockId=2, firstDead=-1](<self>: T.class_of(<root>), <magic>$26: T.class_of(<Magic>)):
+# - bb3(rubyRegionId=2)
+bb7[rubyRegionId=2, firstDead=-1](<self>: T.class_of(<root>), <magic>$26: T.class_of(<Magic>)):
     <exceptionValue>$15: NilClass = nil
     <keepForCfgTemp>$27: Sorbet::Private::Static::Void = <magic>$26: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$15: NilClass)
     <statTemp>$32: String("whoops") = "whoops"
@@ -67,14 +67,14 @@ bb7[rubyBlockId=2, firstDead=-1](<self>: T.class_of(<root>), <magic>$26: T.class
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb8[rubyBlockId=2, firstDead=-1](<self>: T.class_of(<root>)):
+# - bb3(rubyRegionId=2)
+bb8[rubyRegionId=2, firstDead=-1](<self>: T.class_of(<root>)):
     <gotoDeadTemp>$33: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyBlockId=3)
-bb9[rubyBlockId=0, firstDead=1]():
+# - bb6(rubyRegionId=3)
+bb9[rubyRegionId=0, firstDead=1]():
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
@@ -82,7 +82,7 @@ bb9[rubyBlockId=0, firstDead=1]():
 
 method ::A#f {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: A = cast(<self>: NilClass, A);
     x: T.untyped = load_arg(x)
     y: T.untyped = load_arg(y)
@@ -91,27 +91,27 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb5(rubyBlockId=1)
-bb2[rubyBlockId=1, firstDead=-1](<self>: A, y: T.untyped, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: A):
+# - bb0(rubyRegionId=0)
+# - bb5(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: A, y: T.untyped, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: A):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb3[rubyBlockId=0, firstDead=2](<block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: A):
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=2](<block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: A):
     <returnMethodTemp>$2: T.untyped = Solve<<block-pre-call-temp>$4, map>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb5[rubyBlockId=1, firstDead=5](<self>: A, y: T.untyped, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: A):
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=5](<self>: A, y: T.untyped, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: A):
     # outerLoops: 1
     <self>: A = loadSelf
     <blk>$6: T.untyped = load_yield_params(map)
@@ -124,7 +124,7 @@ bb5[rubyBlockId=1, firstDead=5](<self>: A, y: T.untyped, <block-pre-call-temp>$4
 
 method ::A#g {
 
-bb0[rubyBlockId=0, firstDead=10]():
+bb0[rubyRegionId=0, firstDead=10]():
     <self>: A = cast(<self>: NilClass, A);
     x: T.untyped = load_arg(x)
     y: T.untyped = load_arg(y)
@@ -138,15 +138,15 @@ bb0[rubyBlockId=0, firstDead=10]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:A>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=10]():
+bb0[rubyRegionId=0, firstDead=10]():
     <self>: T.class_of(A) = cast(<self>: NilClass, T.class_of(A));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$7: Symbol(:f) = :f
@@ -160,8 +160,8 @@ bb0[rubyBlockId=0, firstDead=10]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/uaf1.rb.cfg-text.exp
+++ b/test/testdata/cfg/uaf1.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=8]():
+bb0[rubyRegionId=0, firstDead=8]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <cfgAlias>$7: T.class_of(A) = alias <C A>
@@ -12,15 +12,15 @@ bb0[rubyBlockId=0, firstDead=8]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::A#initialize {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: A = cast(<self>: NilClass, A);
     <statTemp>$3: T.untyped = <self>: A.spec_list()
     <block-pre-call-temp>$5: Sorbet::Private::Static::Void = <statTemp>$3: T.untyped.map()
@@ -28,28 +28,28 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-# - bb10(rubyBlockId=4)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb3(rubyRegionId=0)
+# - bb10(rubyRegionId=4)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb13(rubyBlockId=1)
-bb2[rubyBlockId=1, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$8: NilClass, <gotoDeadTemp>$15: NilClass):
+# - bb0(rubyRegionId=0)
+# - bb13(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$8: NilClass, <gotoDeadTemp>$15: NilClass):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb3[rubyBlockId=0, firstDead=2](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A):
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=2](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A):
     <returnMethodTemp>$2: T.untyped = Solve<<block-pre-call-temp>$5, map>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb5[rubyBlockId=1, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$8: NilClass, <gotoDeadTemp>$15: NilClass):
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$8: NilClass, <gotoDeadTemp>$15: NilClass):
     # outerLoops: 1
     <self>: A = loadSelf
     <magic>$10: T.class_of(<Magic>) = alias <C <Magic>>
@@ -57,9 +57,9 @@ bb5[rubyBlockId=1, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Pri
     <exceptionValue>$9 -> (T.untyped ? bb7 : bb8)
 
 # backedges
-# - bb5(rubyBlockId=1)
-# - bb8(rubyBlockId=2)
-bb7[rubyBlockId=3, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$8: T.nilable(Integer), <exceptionValue>$9: T.untyped, <magic>$10: T.class_of(<Magic>), <gotoDeadTemp>$15: NilClass):
+# - bb5(rubyRegionId=1)
+# - bb8(rubyRegionId=2)
+bb7[rubyRegionId=3, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$8: T.nilable(Integer), <exceptionValue>$9: T.untyped, <magic>$10: T.class_of(<Magic>), <gotoDeadTemp>$15: NilClass):
     # outerLoops: 1
     se$1: T.untyped = <exceptionValue>$9
     <cfgAlias>$13: T.class_of(StandardError) = alias <C StandardError>
@@ -67,30 +67,30 @@ bb7[rubyBlockId=3, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Pri
     <isaCheckTemp>$14 -> (T.untyped ? bb11 : bb12)
 
 # backedges
-# - bb5(rubyBlockId=1)
-bb8[rubyBlockId=2, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <magic>$10: T.class_of(<Magic>), <gotoDeadTemp>$15: NilClass):
+# - bb5(rubyRegionId=1)
+bb8[rubyRegionId=2, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <magic>$10: T.class_of(<Magic>), <gotoDeadTemp>$15: NilClass):
     # outerLoops: 1
     <blockReturnTemp>$8: Integer(1) = 1
     <exceptionValue>$9: T.untyped = <get-current-exception>
     <exceptionValue>$9 -> (T.untyped ? bb7 : bb9)
 
 # backedges
-# - bb8(rubyBlockId=2)
-bb9[rubyBlockId=5, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$8: Integer(1), <gotoDeadTemp>$15: NilClass):
+# - bb8(rubyRegionId=2)
+bb9[rubyRegionId=5, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$8: Integer(1), <gotoDeadTemp>$15: NilClass):
     # outerLoops: 1
     <unconditional> -> bb10
 
 # backedges
-# - bb9(rubyBlockId=5)
-# - bb11(rubyBlockId=3)
-# - bb12(rubyBlockId=3)
-bb10[rubyBlockId=4, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$8: T.nilable(Integer), <gotoDeadTemp>$15: T.nilable(TrueClass)):
+# - bb9(rubyRegionId=5)
+# - bb11(rubyRegionId=3)
+# - bb12(rubyRegionId=3)
+bb10[rubyRegionId=4, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$8: T.nilable(Integer), <gotoDeadTemp>$15: T.nilable(TrueClass)):
     # outerLoops: 1
     <gotoDeadTemp>$15 -> (T.nilable(TrueClass) ? bb1 : bb13)
 
 # backedges
-# - bb7(rubyBlockId=3)
-bb11[rubyBlockId=3, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <magic>$10: T.class_of(<Magic>), <gotoDeadTemp>$15: NilClass):
+# - bb7(rubyRegionId=3)
+bb11[rubyRegionId=3, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <magic>$10: T.class_of(<Magic>), <gotoDeadTemp>$15: NilClass):
     # outerLoops: 1
     <exceptionValue>$9: NilClass = nil
     <keepForCfgTemp>$11: Sorbet::Private::Static::Void = <magic>$10: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$9: NilClass)
@@ -98,15 +98,15 @@ bb11[rubyBlockId=3, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Pr
     <unconditional> -> bb10
 
 # backedges
-# - bb7(rubyBlockId=3)
-bb12[rubyBlockId=3, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$8: T.nilable(Integer)):
+# - bb7(rubyRegionId=3)
+bb12[rubyRegionId=3, firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$8: T.nilable(Integer)):
     # outerLoops: 1
     <gotoDeadTemp>$15: TrueClass = true
     <unconditional> -> bb10
 
 # backedges
-# - bb10(rubyBlockId=4)
-bb13[rubyBlockId=1, firstDead=1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$8: Integer, <gotoDeadTemp>$15: NilClass):
+# - bb10(rubyRegionId=4)
+bb13[rubyRegionId=1, firstDead=1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$8: Integer, <gotoDeadTemp>$15: NilClass):
     # outerLoops: 1
     <blockReturnTemp>$17: T.noreturn = blockreturn<map> <blockReturnTemp>$8: Integer
     <unconditional> -> bb2
@@ -115,7 +115,7 @@ bb13[rubyBlockId=1, firstDead=1](<self>: A, <block-pre-call-temp>$5: Sorbet::Pri
 
 method ::<Class:A>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=6]():
+bb0[rubyRegionId=0, firstDead=6]():
     <self>: T.class_of(A) = cast(<self>: NilClass, T.class_of(A));
     <cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$6: Symbol(:initialize) = :initialize
@@ -125,8 +125,8 @@ bb0[rubyBlockId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/desugar/ensure_without_rescue.rb.cfg-text.exp
+++ b/test/testdata/desugar/ensure_without_rescue.rb.cfg-text.exp
@@ -1,46 +1,46 @@
 method ::Object#main {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.untyped = <get-current-exception>
     <exceptionValue>$3 -> (T.untyped ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyBlockId=3)
-# - bb7(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb6(rubyRegionId=3)
+# - bb7(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb4(rubyBlockId=1)
-bb3[rubyBlockId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped):
+# - bb0(rubyRegionId=0)
+# - bb4(rubyRegionId=1)
+bb3[rubyRegionId=2, firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped):
     <gotoDeadTemp>$6: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb4[rubyBlockId=1, firstDead=-1](<self>: Object):
+# - bb0(rubyRegionId=0)
+bb4[rubyRegionId=1, firstDead=-1](<self>: Object):
     <returnMethodTemp>$2: T.untyped = <self>: Object.a()
     <exceptionValue>$3: T.untyped = <get-current-exception>
     <exceptionValue>$3 -> (T.untyped ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyBlockId=1)
-bb5[rubyBlockId=4, firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped):
+# - bb4(rubyRegionId=1)
+bb5[rubyRegionId=4, firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped):
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyBlockId=2)
-# - bb5(rubyBlockId=4)
-bb6[rubyBlockId=3, firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$6: T.nilable(TrueClass)):
+# - bb3(rubyRegionId=2)
+# - bb5(rubyRegionId=4)
+bb6[rubyRegionId=3, firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$6: T.nilable(TrueClass)):
     <throwAwayTemp>$7: T.untyped = <self>: Object.b()
     <gotoDeadTemp>$6 -> (T.nilable(TrueClass) ? bb1 : bb7)
 
 # backedges
-# - bb6(rubyBlockId=3)
-bb7[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
+# - bb6(rubyRegionId=3)
+bb7[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
@@ -48,35 +48,35 @@ bb7[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
 
 method ::Object#a {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: Object = cast(<self>: NilClass, Object);
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Object#b {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: Object = cast(<self>: NilClass, Object);
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=15]():
+bb0[rubyRegionId=0, firstDead=15]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$7: Symbol(:main) = :main
@@ -95,8 +95,8 @@ bb0[rubyBlockId=0, firstDead=15]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/desugar/for.rb.cfg-text.exp
+++ b/test/testdata/desugar/for.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=22]():
+bb0[rubyRegionId=0, firstDead=22]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$6: T.class_of(<Magic>) = alias <C <Magic>>
     <cfgAlias>$8: T.class_of(A) = alias <C A>
@@ -26,15 +26,15 @@ bb0[rubyBlockId=0, firstDead=22]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:A>#each {
 
-bb0[rubyBlockId=0, firstDead=15]():
+bb0[rubyRegionId=0, firstDead=15]():
     <self>: T.class_of(A) = cast(<self>: NilClass, T.class_of(A));
     blk: T.untyped = load_arg(blk)
     <statTemp>$5: Integer(1) = 1
@@ -53,15 +53,15 @@ bb0[rubyBlockId=0, firstDead=15]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:A>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=6]():
+bb0[rubyRegionId=0, firstDead=6]():
     <self>: T.class_of(A) = cast(<self>: NilClass, T.class_of(A));
     <cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$6: Symbol(:each) = :each
@@ -71,15 +71,15 @@ bb0[rubyBlockId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:E>#e= {
 
-bb0[rubyBlockId=0, firstDead=6]():
+bb0[rubyRegionId=0, firstDead=6]():
     @e$3: T.untyped = alias <C <undeclared-field-stub>> (@e)
     <self>: T.class_of(E) = cast(<self>: NilClass, T.class_of(E));
     e: T.untyped = load_arg(e)
@@ -89,15 +89,15 @@ bb0[rubyBlockId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:E>#e {
 
-bb0[rubyBlockId=0, firstDead=4]():
+bb0[rubyRegionId=0, firstDead=4]():
     @e$3: T.untyped = alias <C <undeclared-field-stub>> (@e)
     <self>: T.class_of(E) = cast(<self>: NilClass, T.class_of(E));
     <returnMethodTemp>$2: T.untyped = @e$3
@@ -105,15 +105,15 @@ bb0[rubyBlockId=0, firstDead=4]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:E>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=10]():
+bb0[rubyRegionId=0, firstDead=10]():
     <self>: T.class_of(E) = cast(<self>: NilClass, T.class_of(E));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$7: Symbol(:e=) = :e=
@@ -127,15 +127,15 @@ bb0[rubyBlockId=0, firstDead=10]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Main>#main {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     @a$105: T.untyped = alias <C <undeclared-field-stub>> (@a)
     @@b$109: T.untyped = alias <C <undeclared-field-stub>> (@@b)
     $c$113: T.untyped = alias <C <undeclared-field-stub>> ($c)
@@ -146,20 +146,20 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb23(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb23(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb5(rubyBlockId=1)
-bb2[rubyBlockId=1, firstDead=-1](<self>: T.class_of(Main), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Main), @a$105: T.untyped, @@b$109: T.untyped, $c$113: T.untyped):
+# - bb0(rubyRegionId=0)
+# - bb5(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Main), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Main), @a$105: T.untyped, @@b$109: T.untyped, $c$113: T.untyped):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb3[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Main), @a$105: T.untyped, @@b$109: T.untyped, $c$113: T.untyped):
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Main), @a$105: T.untyped, @@b$109: T.untyped, $c$113: T.untyped):
     <statTemp>$3: T.untyped = Solve<<block-pre-call-temp>$6, each>
     <self>: T.class_of(Main) = <selfRestore>$7
     <cfgAlias>$16: T.class_of(A) = alias <C A>
@@ -168,8 +168,8 @@ bb3[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$6: Sorbet::Private::Stati
     <unconditional> -> bb6
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb5[rubyBlockId=1, firstDead=6](<self>: T.class_of(Main), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Main), @a$105: T.untyped, @@b$109: T.untyped, $c$113: T.untyped):
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=6](<self>: T.class_of(Main), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Main), @a$105: T.untyped, @@b$109: T.untyped, $c$113: T.untyped):
     # outerLoops: 1
     <self>: T.class_of(Main) = loadSelf
     <blk>$8: T.untyped = load_yield_params(each)
@@ -180,15 +180,15 @@ bb5[rubyBlockId=1, firstDead=6](<self>: T.class_of(Main), <block-pre-call-temp>$
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-# - bb9(rubyBlockId=2)
-bb6[rubyBlockId=2, firstDead=-1](<self>: T.class_of(Main), <block-pre-call-temp>$17: Sorbet::Private::Static::Void, <selfRestore>$18: T.class_of(Main), @a$105: T.untyped, @@b$109: T.untyped, $c$113: T.untyped):
+# - bb3(rubyRegionId=0)
+# - bb9(rubyRegionId=2)
+bb6[rubyRegionId=2, firstDead=-1](<self>: T.class_of(Main), <block-pre-call-temp>$17: Sorbet::Private::Static::Void, <selfRestore>$18: T.class_of(Main), @a$105: T.untyped, @@b$109: T.untyped, $c$113: T.untyped):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
-# - bb6(rubyBlockId=2)
-bb7[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$17: Sorbet::Private::Static::Void, <selfRestore>$18: T.class_of(Main), @a$105: T.untyped, @@b$109: T.untyped, $c$113: T.untyped):
+# - bb6(rubyRegionId=2)
+bb7[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$17: Sorbet::Private::Static::Void, <selfRestore>$18: T.class_of(Main), @a$105: T.untyped, @@b$109: T.untyped, $c$113: T.untyped):
     <statTemp>$14: T.untyped = Solve<<block-pre-call-temp>$17, each>
     <self>: T.class_of(Main) = <selfRestore>$18
     <cfgAlias>$41: T.class_of(A) = alias <C A>
@@ -197,8 +197,8 @@ bb7[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$17: Sorbet::Private::Stat
     <unconditional> -> bb10
 
 # backedges
-# - bb6(rubyBlockId=2)
-bb9[rubyBlockId=2, firstDead=14](<self>: T.class_of(Main), <block-pre-call-temp>$17: Sorbet::Private::Static::Void, <selfRestore>$18: T.class_of(Main), @a$105: T.untyped, @@b$109: T.untyped, $c$113: T.untyped):
+# - bb6(rubyRegionId=2)
+bb9[rubyRegionId=2, firstDead=14](<self>: T.class_of(Main), <block-pre-call-temp>$17: Sorbet::Private::Static::Void, <selfRestore>$18: T.class_of(Main), @a$105: T.untyped, @@b$109: T.untyped, $c$113: T.untyped):
     # outerLoops: 1
     <self>: T.class_of(Main) = loadSelf
     <blk>$19: T.untyped = load_yield_params(each)
@@ -217,15 +217,15 @@ bb9[rubyBlockId=2, firstDead=14](<self>: T.class_of(Main), <block-pre-call-temp>
     <unconditional> -> bb6
 
 # backedges
-# - bb7(rubyBlockId=0)
-# - bb13(rubyBlockId=3)
-bb10[rubyBlockId=3, firstDead=-1](<self>: T.class_of(Main), <block-pre-call-temp>$42: Sorbet::Private::Static::Void, <selfRestore>$43: T.class_of(Main), @a$105: T.untyped, @@b$109: T.untyped, $c$113: T.untyped):
+# - bb7(rubyRegionId=0)
+# - bb13(rubyRegionId=3)
+bb10[rubyRegionId=3, firstDead=-1](<self>: T.class_of(Main), <block-pre-call-temp>$42: Sorbet::Private::Static::Void, <selfRestore>$43: T.class_of(Main), @a$105: T.untyped, @@b$109: T.untyped, $c$113: T.untyped):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb13 : bb11)
 
 # backedges
-# - bb10(rubyBlockId=3)
-bb11[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$42: Sorbet::Private::Static::Void, <selfRestore>$43: T.class_of(Main), @a$105: T.untyped, @@b$109: T.untyped, $c$113: T.untyped):
+# - bb10(rubyRegionId=3)
+bb11[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$42: Sorbet::Private::Static::Void, <selfRestore>$43: T.class_of(Main), @a$105: T.untyped, @@b$109: T.untyped, $c$113: T.untyped):
     <statTemp>$39: T.untyped = Solve<<block-pre-call-temp>$42, each>
     <self>: T.class_of(Main) = <selfRestore>$43
     <cfgAlias>$56: T.class_of(A) = alias <C A>
@@ -234,8 +234,8 @@ bb11[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$42: Sorbet::Private::Sta
     <unconditional> -> bb14
 
 # backedges
-# - bb10(rubyBlockId=3)
-bb13[rubyBlockId=3, firstDead=9](<self>: T.class_of(Main), <block-pre-call-temp>$42: Sorbet::Private::Static::Void, <selfRestore>$43: T.class_of(Main), @a$105: T.untyped, @@b$109: T.untyped, $c$113: T.untyped):
+# - bb10(rubyRegionId=3)
+bb13[rubyRegionId=3, firstDead=9](<self>: T.class_of(Main), <block-pre-call-temp>$42: Sorbet::Private::Static::Void, <selfRestore>$43: T.class_of(Main), @a$105: T.untyped, @@b$109: T.untyped, $c$113: T.untyped):
     # outerLoops: 1
     <self>: T.class_of(Main) = loadSelf
     <blk>$44: T.untyped = load_yield_params(each)
@@ -249,15 +249,15 @@ bb13[rubyBlockId=3, firstDead=9](<self>: T.class_of(Main), <block-pre-call-temp>
     <unconditional> -> bb10
 
 # backedges
-# - bb11(rubyBlockId=0)
-# - bb17(rubyBlockId=4)
-bb14[rubyBlockId=4, firstDead=-1](<self>: T.class_of(Main), <block-pre-call-temp>$57: Sorbet::Private::Static::Void, <selfRestore>$58: T.class_of(Main), @a$105: T.untyped, @@b$109: T.untyped, $c$113: T.untyped):
+# - bb11(rubyRegionId=0)
+# - bb17(rubyRegionId=4)
+bb14[rubyRegionId=4, firstDead=-1](<self>: T.class_of(Main), <block-pre-call-temp>$57: Sorbet::Private::Static::Void, <selfRestore>$58: T.class_of(Main), @a$105: T.untyped, @@b$109: T.untyped, $c$113: T.untyped):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb17 : bb15)
 
 # backedges
-# - bb14(rubyBlockId=4)
-bb15[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$57: Sorbet::Private::Static::Void, <selfRestore>$58: T.class_of(Main), @a$105: T.untyped, @@b$109: T.untyped, $c$113: T.untyped):
+# - bb14(rubyRegionId=4)
+bb15[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$57: Sorbet::Private::Static::Void, <selfRestore>$58: T.class_of(Main), @a$105: T.untyped, @@b$109: T.untyped, $c$113: T.untyped):
     <statTemp>$54: T.untyped = Solve<<block-pre-call-temp>$57, each>
     <self>: T.class_of(Main) = <selfRestore>$58
     <statTemp>$88: String("main") = "main"
@@ -268,8 +268,8 @@ bb15[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$57: Sorbet::Private::Sta
     <unconditional> -> bb18
 
 # backedges
-# - bb14(rubyBlockId=4)
-bb17[rubyBlockId=4, firstDead=18](<self>: T.class_of(Main), <block-pre-call-temp>$57: Sorbet::Private::Static::Void, <selfRestore>$58: T.class_of(Main), @a$105: T.untyped, @@b$109: T.untyped, $c$113: T.untyped):
+# - bb14(rubyRegionId=4)
+bb17[rubyRegionId=4, firstDead=18](<self>: T.class_of(Main), <block-pre-call-temp>$57: Sorbet::Private::Static::Void, <selfRestore>$58: T.class_of(Main), @a$105: T.untyped, @@b$109: T.untyped, $c$113: T.untyped):
     # outerLoops: 1
     <self>: T.class_of(Main) = loadSelf
     <blk>$59: T.untyped = load_yield_params(each)
@@ -292,15 +292,15 @@ bb17[rubyBlockId=4, firstDead=18](<self>: T.class_of(Main), <block-pre-call-temp
     <unconditional> -> bb14
 
 # backedges
-# - bb15(rubyBlockId=0)
-# - bb21(rubyBlockId=5)
-bb18[rubyBlockId=5, firstDead=-1](<self>: T.class_of(Main), <block-pre-call-temp>$92: Sorbet::Private::Static::Void, <selfRestore>$93: T.class_of(Main), @a$105: T.untyped, @@b$109: T.untyped, $c$113: T.untyped):
+# - bb15(rubyRegionId=0)
+# - bb21(rubyRegionId=5)
+bb18[rubyRegionId=5, firstDead=-1](<self>: T.class_of(Main), <block-pre-call-temp>$92: Sorbet::Private::Static::Void, <selfRestore>$93: T.class_of(Main), @a$105: T.untyped, @@b$109: T.untyped, $c$113: T.untyped):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb21 : bb19)
 
 # backedges
-# - bb18(rubyBlockId=5)
-bb19[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$92: Sorbet::Private::Static::Void, <selfRestore>$93: T.class_of(Main), @a$105: T.untyped, @@b$109: T.untyped, $c$113: T.untyped):
+# - bb18(rubyRegionId=5)
+bb19[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$92: Sorbet::Private::Static::Void, <selfRestore>$93: T.class_of(Main), @a$105: T.untyped, @@b$109: T.untyped, $c$113: T.untyped):
     <statTemp>$89: T.untyped = Solve<<block-pre-call-temp>$92, each>
     <self>: T.class_of(Main) = <selfRestore>$93
     <cfgAlias>$148: T.class_of(A) = alias <C A>
@@ -309,8 +309,8 @@ bb19[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$92: Sorbet::Private::Sta
     <unconditional> -> bb22
 
 # backedges
-# - bb18(rubyBlockId=5)
-bb21[rubyBlockId=5, firstDead=30](<self>: T.class_of(Main), <block-pre-call-temp>$92: Sorbet::Private::Static::Void, <selfRestore>$93: T.class_of(Main), @a$105: T.untyped, @@b$109: T.untyped, $c$113: T.untyped):
+# - bb18(rubyRegionId=5)
+bb21[rubyRegionId=5, firstDead=30](<self>: T.class_of(Main), <block-pre-call-temp>$92: Sorbet::Private::Static::Void, <selfRestore>$93: T.class_of(Main), @a$105: T.untyped, @@b$109: T.untyped, $c$113: T.untyped):
     # outerLoops: 1
     <self>: T.class_of(Main) = loadSelf
     <cfgAlias>$100: T.class_of(<Magic>) = alias <C <Magic>>
@@ -345,22 +345,22 @@ bb21[rubyBlockId=5, firstDead=30](<self>: T.class_of(Main), <block-pre-call-temp
     <unconditional> -> bb18
 
 # backedges
-# - bb19(rubyBlockId=0)
-# - bb25(rubyBlockId=6)
-bb22[rubyBlockId=6, firstDead=-1](<self>: T.class_of(Main), @a$105: T.untyped, @@b$109: T.untyped, $c$113: T.untyped, <block-pre-call-temp>$149: Sorbet::Private::Static::Void, <selfRestore>$150: T.class_of(Main)):
+# - bb19(rubyRegionId=0)
+# - bb25(rubyRegionId=6)
+bb22[rubyRegionId=6, firstDead=-1](<self>: T.class_of(Main), @a$105: T.untyped, @@b$109: T.untyped, $c$113: T.untyped, <block-pre-call-temp>$149: Sorbet::Private::Static::Void, <selfRestore>$150: T.class_of(Main)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb25 : bb23)
 
 # backedges
-# - bb22(rubyBlockId=6)
-bb23[rubyBlockId=0, firstDead=2](<block-pre-call-temp>$149: Sorbet::Private::Static::Void, <selfRestore>$150: T.class_of(Main)):
+# - bb22(rubyRegionId=6)
+bb23[rubyRegionId=0, firstDead=2](<block-pre-call-temp>$149: Sorbet::Private::Static::Void, <selfRestore>$150: T.class_of(Main)):
     <returnMethodTemp>$2: T.untyped = Solve<<block-pre-call-temp>$149, each>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
 # backedges
-# - bb22(rubyBlockId=6)
-bb25[rubyBlockId=6, firstDead=34](<self>: T.class_of(Main), @a$105: T.untyped, @@b$109: T.untyped, $c$113: T.untyped, <block-pre-call-temp>$149: Sorbet::Private::Static::Void, <selfRestore>$150: T.class_of(Main)):
+# - bb22(rubyRegionId=6)
+bb25[rubyRegionId=6, firstDead=34](<self>: T.class_of(Main), @a$105: T.untyped, @@b$109: T.untyped, $c$113: T.untyped, <block-pre-call-temp>$149: Sorbet::Private::Static::Void, <selfRestore>$150: T.class_of(Main)):
     # outerLoops: 1
     <self>: T.class_of(Main) = loadSelf
     <blk>$151: T.untyped = load_yield_params(each)
@@ -402,7 +402,7 @@ bb25[rubyBlockId=6, firstDead=34](<self>: T.class_of(Main), @a$105: T.untyped, @
 
 method ::<Class:Main>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=6]():
+bb0[rubyRegionId=0, firstDead=6]():
     <self>: T.class_of(Main) = cast(<self>: NilClass, T.class_of(Main));
     <cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$6: Symbol(:main) = :main
@@ -412,8 +412,8 @@ bb0[rubyBlockId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/infer/blocks2.rb.cfg-text.exp
+++ b/test/testdata/infer/blocks2.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=8]():
+bb0[rubyRegionId=0, firstDead=8]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <cfgAlias>$7: T.class_of(Foo) = alias <C Foo>
@@ -12,15 +12,15 @@ bb0[rubyBlockId=0, firstDead=8]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Foo#bar {
 
-bb0[rubyBlockId=0, firstDead=5]():
+bb0[rubyRegionId=0, firstDead=5]():
     <self>: Foo = cast(<self>: NilClass, Foo);
     <blk>: T.untyped = load_arg(<blk>)
     <statTemp>$4: Integer(1) = 1
@@ -29,42 +29,42 @@ bb0[rubyBlockId=0, firstDead=5]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Foo#baz {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Foo = cast(<self>: NilClass, Foo);
     <block-pre-call-temp>$4: Sorbet::Private::Static::Void = <self>: Foo.bar()
     <selfRestore>$5: Foo = <self>
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb5(rubyBlockId=1)
-bb2[rubyBlockId=1, firstDead=-1](<self>: Foo, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Foo):
+# - bb0(rubyRegionId=0)
+# - bb5(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: Foo, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Foo):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb3[rubyBlockId=0, firstDead=2](<block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Foo):
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=2](<block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Foo):
     <returnMethodTemp>$2: T.untyped = Solve<<block-pre-call-temp>$4, bar>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb5[rubyBlockId=1, firstDead=5](<self>: Foo, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Foo):
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=5](<self>: Foo, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Foo):
     # outerLoops: 1
     <self>: Foo = loadSelf
     <blk>$6: T.untyped = load_yield_params(bar)
@@ -77,7 +77,7 @@ bb5[rubyBlockId=1, firstDead=5](<self>: Foo, <block-pre-call-temp>$4: Sorbet::Pr
 
 method ::<Class:Foo>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=10]():
+bb0[rubyRegionId=0, firstDead=10]():
     <self>: T.class_of(Foo) = cast(<self>: NilClass, T.class_of(Foo));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$7: Symbol(:bar) = :bar
@@ -91,8 +91,8 @@ bb0[rubyBlockId=0, firstDead=10]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/infer/bound_proc.rb.cfg-text.exp
+++ b/test/testdata/infer/bound_proc.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$6: T.class_of(<Magic>) = alias <C <Magic>>
     <cfgAlias>$8: T.class_of(Base) = alias <C Base>
@@ -68,20 +68,20 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb5(rubyBlockId=1)
-bb2[rubyBlockId=1, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$115: Sorbet::Private::Static::Void, <selfRestore>$116: T.class_of(<root>)):
+# - bb0(rubyRegionId=0)
+# - bb5(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$115: Sorbet::Private::Static::Void, <selfRestore>$116: T.class_of(<root>)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb3[rubyBlockId=0, firstDead=29](<block-pre-call-temp>$115: Sorbet::Private::Static::Void, <selfRestore>$116: T.class_of(<root>)):
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=29](<block-pre-call-temp>$115: Sorbet::Private::Static::Void, <selfRestore>$116: T.class_of(<root>)):
     <statTemp>$112: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$115, class_helper>
     <self>: T.class_of(<root>) = <selfRestore>$116
     <cfgAlias>$134: T.class_of(T) = alias <C T>
@@ -114,8 +114,8 @@ bb3[rubyBlockId=0, firstDead=29](<block-pre-call-temp>$115: Sorbet::Private::Sta
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb5[rubyBlockId=1, firstDead=10](<self>: T.class_of(<root>), <block-pre-call-temp>$115: Sorbet::Private::Static::Void, <selfRestore>$116: T.class_of(<root>)):
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=10](<self>: T.class_of(<root>), <block-pre-call-temp>$115: Sorbet::Private::Static::Void, <selfRestore>$116: T.class_of(<root>)):
     # outerLoops: 1
     <self>: T.class_of(<root>) = loadSelf
     <cfgAlias>$122: T.class_of(Sorbet::Private::Static) = alias <C Static>
@@ -133,35 +133,35 @@ bb5[rubyBlockId=1, firstDead=10](<self>: T.class_of(<root>), <block-pre-call-tem
 
 method ::<Class:Base>#before_save {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(Base) = cast(<self>: NilClass, T.class_of(Base));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Base>#before_create {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(Base) = cast(<self>: NilClass, T.class_of(Base));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Base>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=10]():
+bb0[rubyRegionId=0, firstDead=10]():
     <self>: T.class_of(Base) = cast(<self>: NilClass, T.class_of(Base));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$7: Symbol(:before_save) = :before_save
@@ -175,15 +175,15 @@ bb0[rubyBlockId=0, firstDead=10]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Concern#included {
 
-bb0[rubyBlockId=0, firstDead=6]():
+bb0[rubyRegionId=0, firstDead=6]():
     @block$3: T.untyped = alias <C <undeclared-field-stub>> (@block)
     <self>: Concern = cast(<self>: NilClass, Concern);
     block: T.untyped = load_arg(block)
@@ -193,15 +193,15 @@ bb0[rubyBlockId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Concern>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=6]():
+bb0[rubyRegionId=0, firstDead=6]():
     <self>: T.class_of(Concern) = cast(<self>: NilClass, T.class_of(Concern));
     <cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$6: Symbol(:included) = :included
@@ -211,15 +211,15 @@ bb0[rubyBlockId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Readable>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(Readable) = cast(<self>: NilClass, T.class_of(Readable));
     <cfgAlias>$6: T.class_of(Concern) = alias <C Concern>
     <statTemp>$3: T.class_of(Readable) = <self>: T.class_of(Readable).extend(<cfgAlias>$6: T.class_of(Concern))
@@ -228,27 +228,27 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb5(rubyBlockId=1)
-bb2[rubyBlockId=1, firstDead=-1](<self>: T.class_of(Readable), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Readable)):
+# - bb0(rubyRegionId=0)
+# - bb5(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Readable), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Readable)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb3[rubyBlockId=0, firstDead=2](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Readable)):
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=2](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Readable)):
     <statTemp>$7: T.untyped = Solve<<block-pre-call-temp>$9, included>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb5[rubyBlockId=1, firstDead=4](<self>: T.class_of(Readable), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Readable)):
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=4](<self>: T.class_of(Readable), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Readable)):
     # outerLoops: 1
     <self>: T.class_of(Readable) = loadSelf
     <statTemp>$14: Symbol(:do_this) = :do_this
@@ -260,7 +260,7 @@ bb5[rubyBlockId=1, firstDead=4](<self>: T.class_of(Readable), <block-pre-call-te
 
 method ::<Class:Writable>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(Writable) = cast(<self>: NilClass, T.class_of(Writable));
     <cfgAlias>$6: T.class_of(Concern) = alias <C Concern>
     <statTemp>$3: T.class_of(Writable) = <self>: T.class_of(Writable).extend(<cfgAlias>$6: T.class_of(Concern))
@@ -269,27 +269,27 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb5(rubyBlockId=1)
-bb2[rubyBlockId=1, firstDead=-1](<self>: T.class_of(Writable), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Writable)):
+# - bb0(rubyRegionId=0)
+# - bb5(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Writable), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Writable)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb3[rubyBlockId=0, firstDead=2](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Writable)):
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=2](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Writable)):
     <statTemp>$7: T.untyped = Solve<<block-pre-call-temp>$9, included>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb5[rubyBlockId=1, firstDead=16](<self>: T.class_of(Writable), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Writable)):
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=16](<self>: T.class_of(Writable), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Writable)):
     # outerLoops: 1
     <self>: T.class_of(Writable) = loadSelf
     <cfgAlias>$16: T.class_of(Sorbet::Private::Static) = alias <C Static>
@@ -313,7 +313,7 @@ bb5[rubyBlockId=1, firstDead=16](<self>: T.class_of(Writable), <block-pre-call-t
 
 method ::<Class:Shareable>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(Shareable) = cast(<self>: NilClass, T.class_of(Shareable));
     <cfgAlias>$6: T.class_of(Concern) = alias <C Concern>
     <statTemp>$3: T.class_of(Shareable) = <self>: T.class_of(Shareable).extend(<cfgAlias>$6: T.class_of(Concern))
@@ -322,27 +322,27 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb5(rubyBlockId=1)
-bb2[rubyBlockId=1, firstDead=-1](<self>: T.class_of(Shareable), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Shareable)):
+# - bb0(rubyRegionId=0)
+# - bb5(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Shareable), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Shareable)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb3[rubyBlockId=0, firstDead=2](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Shareable)):
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=2](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Shareable)):
     <statTemp>$7: T.untyped = Solve<<block-pre-call-temp>$9, included>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb5[rubyBlockId=1, firstDead=11](<self>: T.class_of(Shareable), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Shareable)):
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=11](<self>: T.class_of(Shareable), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Shareable)):
     # outerLoops: 1
     <self>: T.class_of(Shareable) = loadSelf
     <cfgAlias>$16: T.class_of(Sorbet::Private::Static) = alias <C Static>
@@ -361,50 +361,50 @@ bb5[rubyBlockId=1, firstDead=11](<self>: T.class_of(Shareable), <block-pre-call-
 
 method ::<Class:Post>#some_class_method {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(Post) = cast(<self>: NilClass, T.class_of(Post));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Post#author {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: Post = cast(<self>: NilClass, Post);
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Post#should_run_callback? {
 
-bb0[rubyBlockId=0, firstDead=3]():
+bb0[rubyRegionId=0, firstDead=3]():
     <self>: Post = cast(<self>: NilClass, Post);
     <returnMethodTemp>$2: TrueClass = true
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: TrueClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Post#score {
 
-bb0[rubyBlockId=0, firstDead=5]():
+bb0[rubyRegionId=0, firstDead=5]():
     <self>: Post = cast(<self>: NilClass, Post);
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <cfgAlias>$7: T.class_of(Integer) = alias <C Integer>
@@ -413,15 +413,15 @@ bb0[rubyBlockId=0, firstDead=5]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Post>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(Post) = cast(<self>: NilClass, T.class_of(Post));
     <cfgAlias>$6: T.class_of(Readable) = alias <C Readable>
     <statTemp>$3: T.class_of(Post) = <self>: T.class_of(Post).include(<cfgAlias>$6: T.class_of(Readable))
@@ -436,20 +436,20 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb5(rubyBlockId=1)
-bb2[rubyBlockId=1, firstDead=-1](<self>: T.class_of(Post), <statTemp>$12: T.class_of(Post), <statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Post)):
+# - bb0(rubyRegionId=0)
+# - bb5(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Post), <statTemp>$12: T.class_of(Post), <statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Post)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb3[rubyBlockId=0, firstDead=20](<statTemp>$12: T.class_of(Post), <statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Post)):
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=20](<statTemp>$12: T.class_of(Post), <statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Post)):
     <hashTemp>$15: T.proc.returns(T.untyped) = Solve<<block-pre-call-temp>$18, lambda>
     <self>: T.class_of(Post) = <selfRestore>$19
     <statTemp>$11: T.untyped = <statTemp>$12: T.class_of(Post).before_create(<statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <hashTemp>$15: T.proc.returns(T.untyped))
@@ -473,8 +473,8 @@ bb3[rubyBlockId=0, firstDead=20](<statTemp>$12: T.class_of(Post), <statTemp>$13:
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb5[rubyBlockId=1, firstDead=3](<self>: T.class_of(Post), <statTemp>$12: T.class_of(Post), <statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Post)):
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=3](<self>: T.class_of(Post), <statTemp>$12: T.class_of(Post), <statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Post)):
     # outerLoops: 1
     <self>: T.class_of(Post) = loadSelf
     <blockReturnTemp>$21: T.untyped = <self>: T.class_of(Post).should_run_callback?()
@@ -485,36 +485,36 @@ bb5[rubyBlockId=1, firstDead=3](<self>: T.class_of(Post), <statTemp>$12: T.class
 
 method ::Article#author {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: Article = cast(<self>: NilClass, Article);
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Article#should_run_callback? {
 
-bb0[rubyBlockId=0, firstDead=3]():
+bb0[rubyRegionId=0, firstDead=3]():
     <self>: Article = cast(<self>: NilClass, Article);
     <returnMethodTemp>$2: TrueClass = true
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: TrueClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Article>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(Article) = cast(<self>: NilClass, T.class_of(Article));
     <cfgAlias>$6: T.class_of(Writable) = alias <C Writable>
     <statTemp>$3: T.class_of(Article) = <self>: T.class_of(Article).include(<cfgAlias>$6: T.class_of(Writable))
@@ -529,20 +529,20 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb5(rubyBlockId=1)
-bb2[rubyBlockId=1, firstDead=-1](<self>: T.class_of(Article), <statTemp>$12: T.class_of(Article), <statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Article)):
+# - bb0(rubyRegionId=0)
+# - bb5(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Article), <statTemp>$12: T.class_of(Article), <statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Article)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb3[rubyBlockId=0, firstDead=12](<statTemp>$12: T.class_of(Article), <statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Article)):
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=12](<statTemp>$12: T.class_of(Article), <statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Article)):
     <hashTemp>$15: T.proc.returns(T.untyped) = Solve<<block-pre-call-temp>$18, lambda>
     <self>: T.class_of(Article) = <selfRestore>$19
     <statTemp>$11: T.untyped = <statTemp>$12: T.class_of(Article).before_create(<statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <hashTemp>$15: T.proc.returns(T.untyped))
@@ -558,8 +558,8 @@ bb3[rubyBlockId=0, firstDead=12](<statTemp>$12: T.class_of(Article), <statTemp>$
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb5[rubyBlockId=1, firstDead=8](<self>: T.class_of(Article), <statTemp>$12: T.class_of(Article), <statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Article)):
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=8](<self>: T.class_of(Article), <statTemp>$12: T.class_of(Article), <statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Article)):
     # outerLoops: 1
     <self>: T.class_of(Article) = loadSelf
     <cfgAlias>$25: T.class_of(Sorbet::Private::Static) = alias <C Static>
@@ -575,21 +575,21 @@ bb5[rubyBlockId=1, firstDead=8](<self>: T.class_of(Article), <statTemp>$12: T.cl
 
 method ::A#instance_helper {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: A = cast(<self>: NilClass, A);
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:A>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(A) = cast(<self>: NilClass, T.class_of(A));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$7: Symbol(:instance_helper) = :instance_helper
@@ -601,20 +601,20 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb5(rubyBlockId=1)
-bb2[rubyBlockId=1, firstDead=-1](<self>: T.class_of(A), <block-pre-call-temp>$12: Sorbet::Private::Static::Void, <selfRestore>$13: T.class_of(A)):
+# - bb0(rubyRegionId=0)
+# - bb5(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(A), <block-pre-call-temp>$12: Sorbet::Private::Static::Void, <selfRestore>$13: T.class_of(A)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb3[rubyBlockId=0, firstDead=6](<block-pre-call-temp>$12: Sorbet::Private::Static::Void, <selfRestore>$13: T.class_of(A)):
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=6](<block-pre-call-temp>$12: Sorbet::Private::Static::Void, <selfRestore>$13: T.class_of(A)):
     f: T.proc.returns(T.untyped) = Solve<<block-pre-call-temp>$12, lambda>
     <self>: T.class_of(A) = <selfRestore>$13
     <cfgAlias>$31: T.class_of(T) = alias <C T>
@@ -624,8 +624,8 @@ bb3[rubyBlockId=0, firstDead=6](<block-pre-call-temp>$12: Sorbet::Private::Stati
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb5[rubyBlockId=1, firstDead=10](<self>: T.class_of(A), <block-pre-call-temp>$12: Sorbet::Private::Static::Void, <selfRestore>$13: T.class_of(A)):
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=10](<self>: T.class_of(A), <block-pre-call-temp>$12: Sorbet::Private::Static::Void, <selfRestore>$13: T.class_of(A)):
     # outerLoops: 1
     <self>: T.class_of(A) = loadSelf
     <cfgAlias>$19: T.class_of(Sorbet::Private::Static) = alias <C Static>
@@ -643,35 +643,35 @@ bb5[rubyBlockId=1, firstDead=10](<self>: T.class_of(A), <block-pre-call-temp>$12
 
 method ::<Class:B>#class_helper {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(B) = cast(<self>: NilClass, T.class_of(B));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::B#instance_helper {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: B = cast(<self>: NilClass, B);
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:B>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(B) = cast(<self>: NilClass, T.class_of(B));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
     <statTemp>$7: TrueClass = true
@@ -681,20 +681,20 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb5(rubyBlockId=1)
-bb2[rubyBlockId=1, firstDead=-1](<self>: T.class_of(B), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(B)):
+# - bb0(rubyRegionId=0)
+# - bb5(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(B), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(B)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb3[rubyBlockId=0, firstDead=14](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(B)):
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=14](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(B)):
     <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$9, sig>
     <self>: T.class_of(B) = <selfRestore>$10
     <cfgAlias>$24: T.class_of(T::Sig) = alias <C Sig>
@@ -712,8 +712,8 @@ bb3[rubyBlockId=0, firstDead=14](<block-pre-call-temp>$9: Sorbet::Private::Stati
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb5[rubyBlockId=1, firstDead=8](<self>: T.class_of(B), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(B)):
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=8](<self>: T.class_of(B), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(B)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf
     <hashTemp>$15: Symbol(:blk) = :blk
@@ -729,21 +729,21 @@ bb5[rubyBlockId=1, firstDead=8](<self>: T.class_of(B), <block-pre-call-temp>$9: 
 
 method ::N#helper_from_N {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: N = cast(<self>: NilClass, N);
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:N>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=6]():
+bb0[rubyRegionId=0, firstDead=6]():
     <self>: T.class_of(N) = cast(<self>: NilClass, T.class_of(N));
     <cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$6: Symbol(:helper_from_N) = :helper_from_N
@@ -753,29 +753,29 @@ bb0[rubyBlockId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::M#helper_from_M {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: M = cast(<self>: NilClass, M);
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::M#main {
 
-bb0[rubyBlockId=0, firstDead=14]():
+bb0[rubyRegionId=0, firstDead=14]():
     <self>: M = cast(<self>: NilClass, M);
     <cfgAlias>$6: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <cfgAlias>$9: T.class_of(T) = alias <C T>
@@ -793,15 +793,15 @@ bb0[rubyBlockId=0, firstDead=14]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:M>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=13]():
+bb0[rubyRegionId=0, firstDead=13]():
     <self>: T.class_of(M) = cast(<self>: NilClass, T.class_of(M));
     <cfgAlias>$6: T.class_of(T::Sig) = alias <C Sig>
     <cfgAlias>$8: T.class_of(T) = alias <C T>
@@ -818,15 +818,15 @@ bb0[rubyBlockId=0, firstDead=13]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::ThisSelf#main {
 
-bb0[rubyBlockId=0, firstDead=11]():
+bb0[rubyRegionId=0, firstDead=11]():
     <self>: ThisSelf = cast(<self>: NilClass, ThisSelf);
     <cfgAlias>$6: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <cfgAlias>$8: T.class_of(Kernel) = alias <C Kernel>
@@ -841,15 +841,15 @@ bb0[rubyBlockId=0, firstDead=11]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:ThisSelf>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=9]():
+bb0[rubyRegionId=0, firstDead=9]():
     <self>: T.class_of(ThisSelf) = cast(<self>: NilClass, T.class_of(ThisSelf));
     <cfgAlias>$6: T.class_of(T::Sig) = alias <C Sig>
     <cfgAlias>$8: T.class_of(T) = alias <C T>
@@ -862,29 +862,29 @@ bb0[rubyBlockId=0, firstDead=9]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Rescues>#takes_block {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(Rescues) = cast(<self>: NilClass, T.class_of(Rescues));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Rescues#foo {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Rescues = cast(<self>: NilClass, Rescues);
     <magic>$14: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.untyped = <get-current-exception>
@@ -892,22 +892,22 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <exceptionValue>$3 -> (T.untyped ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyBlockId=3)
-# - bb9(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb6(rubyRegionId=3)
+# - bb9(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb4(rubyBlockId=1)
-bb3[rubyBlockId=2, firstDead=-1](<self>: String, <returnMethodTemp>$2: T.nilable(String), <exceptionValue>$3: T.untyped, <magic>$14: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+# - bb4(rubyRegionId=1)
+bb3[rubyRegionId=2, firstDead=-1](<self>: String, <returnMethodTemp>$2: T.nilable(String), <exceptionValue>$3: T.untyped, <magic>$14: T.class_of(<Magic>)):
     <cfgAlias>$17: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$18: T.untyped = <exceptionValue>$3: T.untyped.is_a?(<cfgAlias>$17: T.class_of(StandardError))
     <isaCheckTemp>$18 -> (T.untyped ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb4[rubyBlockId=1, firstDead=-1](<self>: String, <magic>$14: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+bb4[rubyRegionId=1, firstDead=-1](<self>: String, <magic>$14: T.class_of(<Magic>)):
     <cfgAlias>$7: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <cfgAlias>$9: T.class_of(String) = alias <C String>
     <statTemp>$5: Sorbet::Private::Static::Void = <cfgAlias>$7: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<cfgAlias>$9: T.class_of(String))
@@ -919,22 +919,22 @@ bb4[rubyBlockId=1, firstDead=-1](<self>: String, <magic>$14: T.class_of(<Magic>)
     <exceptionValue>$3 -> (T.untyped ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyBlockId=1)
-bb5[rubyBlockId=4, firstDead=-1](<self>: String, <returnMethodTemp>$2: String):
+# - bb4(rubyRegionId=1)
+bb5[rubyRegionId=4, firstDead=-1](<self>: String, <returnMethodTemp>$2: String):
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyBlockId=4)
-# - bb7(rubyBlockId=2)
-# - bb8(rubyBlockId=2)
-bb6[rubyBlockId=3, firstDead=-1](<self>: String, <returnMethodTemp>$2: T.nilable(String), <gotoDeadTemp>$22: T.nilable(TrueClass)):
+# - bb5(rubyRegionId=4)
+# - bb7(rubyRegionId=2)
+# - bb8(rubyRegionId=2)
+bb6[rubyRegionId=3, firstDead=-1](<self>: String, <returnMethodTemp>$2: T.nilable(String), <gotoDeadTemp>$22: T.nilable(TrueClass)):
     <cfgAlias>$25: T.class_of(T) = alias <C T>
     <throwAwayTemp>$23: String = <cfgAlias>$25: T.class_of(T).reveal_type(<self>: String)
     <gotoDeadTemp>$22 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb7[rubyBlockId=2, firstDead=-1](<self>: String, <magic>$14: T.class_of(<Magic>)):
+# - bb3(rubyRegionId=2)
+bb7[rubyRegionId=2, firstDead=-1](<self>: String, <magic>$14: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$15: Sorbet::Private::Static::Void = <magic>$14: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <cfgAlias>$20: T.class_of(T) = alias <C T>
@@ -942,14 +942,14 @@ bb7[rubyBlockId=2, firstDead=-1](<self>: String, <magic>$14: T.class_of(<Magic>)
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb8[rubyBlockId=2, firstDead=-1](<self>: String, <returnMethodTemp>$2: T.nilable(String)):
+# - bb3(rubyRegionId=2)
+bb8[rubyRegionId=2, firstDead=-1](<self>: String, <returnMethodTemp>$2: T.nilable(String)):
     <gotoDeadTemp>$22: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyBlockId=3)
-bb9[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: String):
+# - bb6(rubyRegionId=3)
+bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: String):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: String
     <unconditional> -> bb1
 
@@ -957,7 +957,7 @@ bb9[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: String):
 
 method ::Rescues#bar {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Rescues = cast(<self>: NilClass, Rescues);
     <magic>$14: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$3: T.untyped = <get-current-exception>
@@ -967,22 +967,22 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <exceptionValue>$3 -> (T.untyped ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyBlockId=3)
-# - bb9(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb6(rubyRegionId=3)
+# - bb9(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb4(rubyBlockId=1)
-bb3[rubyBlockId=2, firstDead=-1](<self>: T.any(Float, String), <returnMethodTemp>$2: T.nilable(String), <exceptionValue>$3: T.untyped, <magic>$14: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+# - bb4(rubyRegionId=1)
+bb3[rubyRegionId=2, firstDead=-1](<self>: T.any(Float, String), <returnMethodTemp>$2: T.nilable(String), <exceptionValue>$3: T.untyped, <magic>$14: T.class_of(<Magic>)):
     <cfgAlias>$17: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$18: T.untyped = <exceptionValue>$3: T.untyped.is_a?(<cfgAlias>$17: T.class_of(StandardError))
     <isaCheckTemp>$18 -> (T.untyped ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb4[rubyBlockId=1, firstDead=-1](<self>: Float, <magic>$14: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+bb4[rubyRegionId=1, firstDead=-1](<self>: Float, <magic>$14: T.class_of(<Magic>)):
     <cfgAlias>$7: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <cfgAlias>$9: T.class_of(String) = alias <C String>
     <statTemp>$5: Sorbet::Private::Static::Void = <cfgAlias>$7: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<cfgAlias>$9: T.class_of(String))
@@ -994,15 +994,15 @@ bb4[rubyBlockId=1, firstDead=-1](<self>: Float, <magic>$14: T.class_of(<Magic>))
     <exceptionValue>$3 -> (T.untyped ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyBlockId=1)
-bb5[rubyBlockId=4, firstDead=-1](<self>: String, <returnMethodTemp>$2: String):
+# - bb4(rubyRegionId=1)
+bb5[rubyRegionId=4, firstDead=-1](<self>: String, <returnMethodTemp>$2: String):
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyBlockId=4)
-# - bb7(rubyBlockId=2)
-# - bb8(rubyBlockId=2)
-bb6[rubyBlockId=3, firstDead=-1](<self>: T.any(Float, String, Integer), <returnMethodTemp>$2: T.nilable(T.any(String, Integer)), <gotoDeadTemp>$29: T.nilable(TrueClass)):
+# - bb5(rubyRegionId=4)
+# - bb7(rubyRegionId=2)
+# - bb8(rubyRegionId=2)
+bb6[rubyRegionId=3, firstDead=-1](<self>: T.any(Float, String, Integer), <returnMethodTemp>$2: T.nilable(T.any(String, Integer)), <gotoDeadTemp>$29: T.nilable(TrueClass)):
     <cfgAlias>$34: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <cfgAlias>$36: T.class_of(Float) = alias <C Float>
     <statTemp>$32: Sorbet::Private::Static::Void = <cfgAlias>$34: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<cfgAlias>$36: T.class_of(Float))
@@ -1013,8 +1013,8 @@ bb6[rubyBlockId=3, firstDead=-1](<self>: T.any(Float, String, Integer), <returnM
     <gotoDeadTemp>$29 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb7[rubyBlockId=2, firstDead=-1](<self>: T.any(Float, String), <magic>$14: T.class_of(<Magic>)):
+# - bb3(rubyRegionId=2)
+bb7[rubyRegionId=2, firstDead=-1](<self>: T.any(Float, String), <magic>$14: T.class_of(<Magic>)):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$15: Sorbet::Private::Static::Void = <magic>$14: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$3: NilClass)
     <cfgAlias>$22: T.class_of(Sorbet::Private::Static) = alias <C Static>
@@ -1027,14 +1027,14 @@ bb7[rubyBlockId=2, firstDead=-1](<self>: T.any(Float, String), <magic>$14: T.cla
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb8[rubyBlockId=2, firstDead=-1](<self>: T.any(Float, String), <returnMethodTemp>$2: T.nilable(String)):
+# - bb3(rubyRegionId=2)
+bb8[rubyRegionId=2, firstDead=-1](<self>: T.any(Float, String), <returnMethodTemp>$2: T.nilable(String)):
     <gotoDeadTemp>$29: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyBlockId=3)
-bb9[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: T.any(Integer, String)):
+# - bb6(rubyRegionId=3)
+bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.any(Integer, String)):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.any(Integer, String)
     <unconditional> -> bb1
 
@@ -1042,7 +1042,7 @@ bb9[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: T.any(Integer, String)):
 
 method ::Rescues#baz {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Rescues = cast(<self>: NilClass, Rescues);
     <cfgAlias>$5: T.class_of(T) = alias <C T>
     <statTemp>$3: Rescues = <cfgAlias>$5: T.class_of(T).reveal_type(<self>: Rescues)
@@ -1052,22 +1052,22 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <exceptionValue>$7 -> (T.untyped ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyBlockId=3)
-# - bb9(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb6(rubyRegionId=3)
+# - bb9(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb4(rubyBlockId=1)
-bb3[rubyBlockId=2, firstDead=-1](<self>: String, <returnMethodTemp>$2: T.nilable(String), <exceptionValue>$7: T.untyped, <magic>$18: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+# - bb4(rubyRegionId=1)
+bb3[rubyRegionId=2, firstDead=-1](<self>: String, <returnMethodTemp>$2: T.nilable(String), <exceptionValue>$7: T.untyped, <magic>$18: T.class_of(<Magic>)):
     <cfgAlias>$21: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$22: T.untyped = <exceptionValue>$7: T.untyped.is_a?(<cfgAlias>$21: T.class_of(StandardError))
     <isaCheckTemp>$22 -> (T.untyped ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb4[rubyBlockId=1, firstDead=-1](<self>: String, <magic>$18: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+bb4[rubyRegionId=1, firstDead=-1](<self>: String, <magic>$18: T.class_of(<Magic>)):
     <cfgAlias>$11: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <cfgAlias>$13: T.class_of(String) = alias <C String>
     <statTemp>$9: Sorbet::Private::Static::Void = <cfgAlias>$11: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<cfgAlias>$13: T.class_of(String))
@@ -1079,20 +1079,20 @@ bb4[rubyBlockId=1, firstDead=-1](<self>: String, <magic>$18: T.class_of(<Magic>)
     <exceptionValue>$7 -> (T.untyped ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyBlockId=1)
-bb5[rubyBlockId=4, firstDead=-1](<returnMethodTemp>$2: String):
+# - bb4(rubyRegionId=1)
+bb5[rubyRegionId=4, firstDead=-1](<returnMethodTemp>$2: String):
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyBlockId=4)
-# - bb7(rubyBlockId=2)
-# - bb8(rubyBlockId=2)
-bb6[rubyBlockId=3, firstDead=-1](<returnMethodTemp>$2: T.nilable(String), <gotoDeadTemp>$26: T.nilable(TrueClass)):
+# - bb5(rubyRegionId=4)
+# - bb7(rubyRegionId=2)
+# - bb8(rubyRegionId=2)
+bb6[rubyRegionId=3, firstDead=-1](<returnMethodTemp>$2: T.nilable(String), <gotoDeadTemp>$26: T.nilable(TrueClass)):
     <gotoDeadTemp>$26 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb7[rubyBlockId=2, firstDead=-1](<self>: String, <magic>$18: T.class_of(<Magic>)):
+# - bb3(rubyRegionId=2)
+bb7[rubyRegionId=2, firstDead=-1](<self>: String, <magic>$18: T.class_of(<Magic>)):
     <exceptionValue>$7: NilClass = nil
     <keepForCfgTemp>$19: Sorbet::Private::Static::Void = <magic>$18: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$7: NilClass)
     <cfgAlias>$24: T.class_of(T) = alias <C T>
@@ -1100,14 +1100,14 @@ bb7[rubyBlockId=2, firstDead=-1](<self>: String, <magic>$18: T.class_of(<Magic>)
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb8[rubyBlockId=2, firstDead=-1](<returnMethodTemp>$2: T.nilable(String)):
+# - bb3(rubyRegionId=2)
+bb8[rubyRegionId=2, firstDead=-1](<returnMethodTemp>$2: T.nilable(String)):
     <gotoDeadTemp>$26: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyBlockId=3)
-bb9[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: String):
+# - bb6(rubyRegionId=3)
+bb9[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: String):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: String
     <unconditional> -> bb1
 
@@ -1115,7 +1115,7 @@ bb9[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: String):
 
 method ::<Class:Rescues>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(Rescues) = cast(<self>: NilClass, T.class_of(Rescues));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$7: Symbol(:takes_block) = :takes_block
@@ -1126,21 +1126,21 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-# - bb10(rubyBlockId=4)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb3(rubyRegionId=0)
+# - bb10(rubyRegionId=4)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb13(rubyBlockId=1)
-bb2[rubyBlockId=1, firstDead=-1](<self>: T.class_of(Rescues), <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: T.class_of(Rescues), <blockReturnTemp>$14: NilClass, <castTemp>$22: NilClass, <gotoDeadTemp>$34: NilClass):
+# - bb0(rubyRegionId=0)
+# - bb13(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Rescues), <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: T.class_of(Rescues), <blockReturnTemp>$14: NilClass, <castTemp>$22: NilClass, <gotoDeadTemp>$34: NilClass):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb3[rubyBlockId=0, firstDead=15](<block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: T.class_of(Rescues)):
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=15](<block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: T.class_of(Rescues)):
     <statTemp>$9: T.untyped = Solve<<block-pre-call-temp>$11, takes_block>
     <self>: T.class_of(Rescues) = <selfRestore>$12
     <cfgAlias>$39: T.class_of(Sorbet::Private::Static) = alias <C Static>
@@ -1159,8 +1159,8 @@ bb3[rubyBlockId=0, firstDead=15](<block-pre-call-temp>$11: Sorbet::Private::Stat
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb5[rubyBlockId=1, firstDead=-1](<self>: T.class_of(Rescues), <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: T.class_of(Rescues), <blockReturnTemp>$14: NilClass, <castTemp>$22: NilClass, <gotoDeadTemp>$34: NilClass):
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Rescues), <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: T.class_of(Rescues), <blockReturnTemp>$14: NilClass, <castTemp>$22: NilClass, <gotoDeadTemp>$34: NilClass):
     # outerLoops: 1
     <self>: T.class_of(Rescues) = loadSelf
     <magic>$26: T.class_of(<Magic>) = alias <C <Magic>>
@@ -1169,17 +1169,17 @@ bb5[rubyBlockId=1, firstDead=-1](<self>: T.class_of(Rescues), <block-pre-call-te
     <exceptionValue>$15 -> (T.untyped ? bb7 : bb8)
 
 # backedges
-# - bb5(rubyBlockId=1)
-# - bb8(rubyBlockId=2)
-bb7[rubyBlockId=3, firstDead=-1](<self>: Integer, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: T.class_of(Rescues), <blockReturnTemp>$14: T.nilable(Integer), <exceptionValue>$15: T.untyped, <castTemp>$22: T.nilable(Integer), <magic>$26: T.class_of(<Magic>), <gotoDeadTemp>$34: NilClass):
+# - bb5(rubyRegionId=1)
+# - bb8(rubyRegionId=2)
+bb7[rubyRegionId=3, firstDead=-1](<self>: Integer, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: T.class_of(Rescues), <blockReturnTemp>$14: T.nilable(Integer), <exceptionValue>$15: T.untyped, <castTemp>$22: T.nilable(Integer), <magic>$26: T.class_of(<Magic>), <gotoDeadTemp>$34: NilClass):
     # outerLoops: 1
     <cfgAlias>$29: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$30: T.untyped = <exceptionValue>$15: T.untyped.is_a?(<cfgAlias>$29: T.class_of(StandardError))
     <isaCheckTemp>$30 -> (T.untyped ? bb11 : bb12)
 
 # backedges
-# - bb5(rubyBlockId=1)
-bb8[rubyBlockId=2, firstDead=-1](<self>: Integer, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: T.class_of(Rescues), <magic>$26: T.class_of(<Magic>), <gotoDeadTemp>$34: NilClass):
+# - bb5(rubyRegionId=1)
+bb8[rubyRegionId=2, firstDead=-1](<self>: Integer, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: T.class_of(Rescues), <magic>$26: T.class_of(<Magic>), <gotoDeadTemp>$34: NilClass):
     # outerLoops: 1
     <cfgAlias>$19: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <cfgAlias>$21: T.class_of(Integer) = alias <C Integer>
@@ -1192,22 +1192,22 @@ bb8[rubyBlockId=2, firstDead=-1](<self>: Integer, <block-pre-call-temp>$11: Sorb
     <exceptionValue>$15 -> (T.untyped ? bb7 : bb9)
 
 # backedges
-# - bb8(rubyBlockId=2)
-bb9[rubyBlockId=5, firstDead=-1](<self>: Integer, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: T.class_of(Rescues), <blockReturnTemp>$14: Integer, <castTemp>$22: Integer, <gotoDeadTemp>$34: NilClass):
+# - bb8(rubyRegionId=2)
+bb9[rubyRegionId=5, firstDead=-1](<self>: Integer, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: T.class_of(Rescues), <blockReturnTemp>$14: Integer, <castTemp>$22: Integer, <gotoDeadTemp>$34: NilClass):
     # outerLoops: 1
     <unconditional> -> bb10
 
 # backedges
-# - bb9(rubyBlockId=5)
-# - bb11(rubyBlockId=3)
-# - bb12(rubyBlockId=3)
-bb10[rubyBlockId=4, firstDead=-1](<self>: Integer, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: T.class_of(Rescues), <blockReturnTemp>$14: T.nilable(Integer), <castTemp>$22: T.nilable(Integer), <gotoDeadTemp>$34: T.nilable(TrueClass)):
+# - bb9(rubyRegionId=5)
+# - bb11(rubyRegionId=3)
+# - bb12(rubyRegionId=3)
+bb10[rubyRegionId=4, firstDead=-1](<self>: Integer, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: T.class_of(Rescues), <blockReturnTemp>$14: T.nilable(Integer), <castTemp>$22: T.nilable(Integer), <gotoDeadTemp>$34: T.nilable(TrueClass)):
     # outerLoops: 1
     <gotoDeadTemp>$34 -> (T.nilable(TrueClass) ? bb1 : bb13)
 
 # backedges
-# - bb7(rubyBlockId=3)
-bb11[rubyBlockId=3, firstDead=-1](<self>: Integer, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: T.class_of(Rescues), <castTemp>$22: T.nilable(Integer), <magic>$26: T.class_of(<Magic>), <gotoDeadTemp>$34: NilClass):
+# - bb7(rubyRegionId=3)
+bb11[rubyRegionId=3, firstDead=-1](<self>: Integer, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: T.class_of(Rescues), <castTemp>$22: T.nilable(Integer), <magic>$26: T.class_of(<Magic>), <gotoDeadTemp>$34: NilClass):
     # outerLoops: 1
     <exceptionValue>$15: NilClass = nil
     <keepForCfgTemp>$27: Sorbet::Private::Static::Void = <magic>$26: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$15: NilClass)
@@ -1216,15 +1216,15 @@ bb11[rubyBlockId=3, firstDead=-1](<self>: Integer, <block-pre-call-temp>$11: Sor
     <unconditional> -> bb10
 
 # backedges
-# - bb7(rubyBlockId=3)
-bb12[rubyBlockId=3, firstDead=-1](<self>: Integer, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: T.class_of(Rescues), <blockReturnTemp>$14: T.nilable(Integer), <castTemp>$22: T.nilable(Integer)):
+# - bb7(rubyRegionId=3)
+bb12[rubyRegionId=3, firstDead=-1](<self>: Integer, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: T.class_of(Rescues), <blockReturnTemp>$14: T.nilable(Integer), <castTemp>$22: T.nilable(Integer)):
     # outerLoops: 1
     <gotoDeadTemp>$34: TrueClass = true
     <unconditional> -> bb10
 
 # backedges
-# - bb10(rubyBlockId=4)
-bb13[rubyBlockId=1, firstDead=1](<self>: Integer, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: T.class_of(Rescues), <blockReturnTemp>$14: Integer, <castTemp>$22: T.nilable(Integer), <gotoDeadTemp>$34: NilClass):
+# - bb10(rubyRegionId=4)
+bb13[rubyRegionId=1, firstDead=1](<self>: Integer, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: T.class_of(Rescues), <blockReturnTemp>$14: Integer, <castTemp>$22: T.nilable(Integer), <gotoDeadTemp>$34: NilClass):
     # outerLoops: 1
     <blockReturnTemp>$36: T.noreturn = blockreturn<takes_block> <blockReturnTemp>$14: Integer
     <unconditional> -> bb2

--- a/test/testdata/infer/casts.rb.cfg-text.exp
+++ b/test/testdata/infer/casts.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=8]():
+bb0[rubyRegionId=0, firstDead=8]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <cfgAlias>$7: T.class_of(TestCasts) = alias <C TestCasts>
@@ -12,29 +12,29 @@ bb0[rubyBlockId=0, firstDead=8]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::TestCasts#untyped {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: TestCasts = cast(<self>: NilClass, TestCasts);
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::TestCasts#test_casts {
 
-bb0[rubyBlockId=0, firstDead=52]():
+bb0[rubyRegionId=0, firstDead=52]():
     <self>: TestCasts = cast(<self>: NilClass, TestCasts);
     <cfgAlias>$6: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <cfgAlias>$8: T.class_of(Integer) = alias <C Integer>
@@ -90,15 +90,15 @@ bb0[rubyBlockId=0, firstDead=52]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:TestCasts>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=10]():
+bb0[rubyRegionId=0, firstDead=10]():
     <self>: T.class_of(TestCasts) = cast(<self>: NilClass, T.class_of(TestCasts));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$7: Symbol(:untyped) = :untyped
@@ -112,8 +112,8 @@ bb0[rubyBlockId=0, firstDead=10]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/infer/control_flow/complex_implication_1.rb.cfg-text.exp
+++ b/test/testdata/infer/control_flow/complex_implication_1.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=8]():
+bb0[rubyRegionId=0, firstDead=8]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <cfgAlias>$7: T.class_of(ModuleMethods) = alias <C ModuleMethods>
@@ -12,15 +12,15 @@ bb0[rubyBlockId=0, firstDead=8]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::ModuleMethods#instrumented_request {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: ModuleMethods = cast(<self>: NilClass, ModuleMethods);
     final_attempt: T.untyped = load_arg(final_attempt)
     foo: T.untyped = load_arg(foo)
@@ -29,116 +29,116 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <exceptionValue>$4 -> (T.untyped ? bb3 : bb4)
 
 # backedges
-# - bb6(rubyBlockId=3)
-# - bb24(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb6(rubyRegionId=3)
+# - bb24(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb4(rubyBlockId=1)
-bb3[rubyBlockId=2, firstDead=-1](final_attempt: T.untyped, foo: T.untyped, <exceptionValue>$4: T.untyped, <magic>$5: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+# - bb4(rubyRegionId=1)
+bb3[rubyRegionId=2, firstDead=-1](final_attempt: T.untyped, foo: T.untyped, <exceptionValue>$4: T.untyped, <magic>$5: T.class_of(<Magic>)):
     e: T.untyped = <exceptionValue>$4
     <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$9: T.untyped = e: T.untyped.is_a?(<cfgAlias>$8: T.class_of(StandardError))
     <isaCheckTemp>$9 -> (T.untyped ? bb7 : bb8)
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb4[rubyBlockId=1, firstDead=-1](final_attempt: T.untyped, foo: T.untyped, <magic>$5: T.class_of(<Magic>)):
+# - bb0(rubyRegionId=0)
+bb4[rubyRegionId=1, firstDead=-1](final_attempt: T.untyped, foo: T.untyped, <magic>$5: T.class_of(<Magic>)):
     <exceptionValue>$4: T.untyped = <get-current-exception>
     <exceptionValue>$4 -> (T.untyped ? bb3 : bb5)
 
 # backedges
-# - bb4(rubyBlockId=1)
-bb5[rubyBlockId=4, firstDead=-1](final_attempt: T.untyped, foo: T.untyped):
+# - bb4(rubyRegionId=1)
+bb5[rubyRegionId=4, firstDead=-1](final_attempt: T.untyped, foo: T.untyped):
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyBlockId=4)
-# - bb7(rubyBlockId=2)
-# - bb8(rubyBlockId=2)
-bb6[rubyBlockId=3, firstDead=-1](final_attempt: T.untyped, foo: T.untyped, err: T.nilable(StandardError), <gotoDeadTemp>$10: T.nilable(TrueClass)):
+# - bb5(rubyRegionId=4)
+# - bb7(rubyRegionId=2)
+# - bb8(rubyRegionId=2)
+bb6[rubyRegionId=3, firstDead=-1](final_attempt: T.untyped, foo: T.untyped, err: T.nilable(StandardError), <gotoDeadTemp>$10: T.nilable(TrueClass)):
     <gotoDeadTemp>$10 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb7[rubyBlockId=2, firstDead=-1](final_attempt: T.untyped, foo: T.untyped, <magic>$5: T.class_of(<Magic>), e: StandardError):
+# - bb3(rubyRegionId=2)
+bb7[rubyRegionId=2, firstDead=-1](final_attempt: T.untyped, foo: T.untyped, <magic>$5: T.class_of(<Magic>), e: StandardError):
     <exceptionValue>$4: NilClass = nil
     <keepForCfgTemp>$6: Sorbet::Private::Static::Void = <magic>$5: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$4: NilClass)
     err: StandardError = e
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyBlockId=2)
-bb8[rubyBlockId=2, firstDead=-1](final_attempt: T.untyped, foo: T.untyped):
+# - bb3(rubyRegionId=2)
+bb8[rubyRegionId=2, firstDead=-1](final_attempt: T.untyped, foo: T.untyped):
     <gotoDeadTemp>$10: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
-# - bb6(rubyBlockId=3)
-bb9[rubyBlockId=0, firstDead=-1](final_attempt: T.untyped, foo: T.untyped, err: T.nilable(StandardError)):
+# - bb6(rubyRegionId=3)
+bb9[rubyRegionId=0, firstDead=-1](final_attempt: T.untyped, foo: T.untyped, err: T.nilable(StandardError)):
     is_successful: T::Boolean = err: T.nilable(StandardError).nil?()
     is_successful -> (T::Boolean ? bb10 : bb11)
 
 # backedges
-# - bb9(rubyBlockId=0)
-bb10[rubyBlockId=0, firstDead=-1](foo: T.untyped, err: NilClass, is_successful: TrueClass):
+# - bb9(rubyRegionId=0)
+bb10[rubyRegionId=0, firstDead=-1](foo: T.untyped, err: NilClass, is_successful: TrueClass):
     ||$2: TrueClass = is_successful
     ||$2 -> (TrueClass ? bb13 : bb14)
 
 # backedges
-# - bb9(rubyBlockId=0)
-bb11[rubyBlockId=0, firstDead=-1](final_attempt: T.untyped, foo: T.untyped, err: StandardError, is_successful: FalseClass):
+# - bb9(rubyRegionId=0)
+bb11[rubyRegionId=0, firstDead=-1](final_attempt: T.untyped, foo: T.untyped, err: StandardError, is_successful: FalseClass):
     ||$2: T.untyped = final_attempt
     ||$2 -> (T.untyped ? bb13 : bb14)
 
 # backedges
-# - bb10(rubyBlockId=0)
-# - bb11(rubyBlockId=0)
-bb13[rubyBlockId=0, firstDead=-1](is_successful: T::Boolean, ||$2: T.untyped):
+# - bb10(rubyRegionId=0)
+# - bb11(rubyRegionId=0)
+bb13[rubyRegionId=0, firstDead=-1](is_successful: T::Boolean, ||$2: T.untyped):
     <ifTemp>$14: T.untyped = ||$2
     <ifTemp>$14 -> (T.untyped ? bb19 : bb24)
 
 # backedges
-# - bb10(rubyBlockId=0)
-# - bb11(rubyBlockId=0)
-bb14[rubyBlockId=0, firstDead=-1](foo: T.untyped, err: StandardError, is_successful: FalseClass):
+# - bb10(rubyRegionId=0)
+# - bb11(rubyRegionId=0)
+bb14[rubyRegionId=0, firstDead=-1](foo: T.untyped, err: StandardError, is_successful: FalseClass):
     err -> (StandardError ? bb15 : bb16)
 
 # backedges
-# - bb14(rubyBlockId=0)
-bb15[rubyBlockId=0, firstDead=-1](foo: T.untyped, is_successful: FalseClass):
+# - bb14(rubyRegionId=0)
+bb15[rubyRegionId=0, firstDead=-1](foo: T.untyped, is_successful: FalseClass):
     <ifTemp>$14: T.untyped = foo
     <ifTemp>$14 -> (T.untyped ? bb19 : bb24)
 
 # backedges
-# - bb14(rubyBlockId=0)
-bb16[rubyBlockId=0, firstDead=0](err: StandardError, is_successful: FalseClass):
+# - bb14(rubyRegionId=0)
+bb16[rubyRegionId=0, firstDead=0](err: StandardError, is_successful: FalseClass):
     <ifTemp>$14 = err
     <ifTemp>$14 -> (<nullptr> ? bb19 : bb24)
 
 # backedges
-# - bb13(rubyBlockId=0)
-# - bb15(rubyBlockId=0)
-# - bb16(rubyBlockId=0)
-bb19[rubyBlockId=0, firstDead=-1](is_successful: T::Boolean):
+# - bb13(rubyRegionId=0)
+# - bb15(rubyRegionId=0)
+# - bb16(rubyRegionId=0)
+bb19[rubyRegionId=0, firstDead=-1](is_successful: T::Boolean):
     <ifTemp>$19: T::Boolean = is_successful: T::Boolean.!()
     <ifTemp>$19 -> (T::Boolean ? bb21 : bb24)
 
 # backedges
-# - bb19(rubyBlockId=0)
-bb21[rubyBlockId=0, firstDead=-1]():
+# - bb19(rubyRegionId=0)
+bb21[rubyRegionId=0, firstDead=-1]():
     <returnMethodTemp>$2: Integer(1) = 1
     <unconditional> -> bb24
 
 # backedges
-# - bb13(rubyBlockId=0)
-# - bb15(rubyBlockId=0)
-# - bb16(rubyBlockId=0)
-# - bb19(rubyBlockId=0)
-# - bb21(rubyBlockId=0)
-bb24[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: T.nilable(Integer)):
+# - bb13(rubyRegionId=0)
+# - bb15(rubyRegionId=0)
+# - bb16(rubyRegionId=0)
+# - bb19(rubyRegionId=0)
+# - bb21(rubyRegionId=0)
+bb24[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.nilable(Integer)):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(Integer)
     <unconditional> -> bb1
 
@@ -146,7 +146,7 @@ bb24[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: T.nilable(Integer)):
 
 method ::<Class:ModuleMethods>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=6]():
+bb0[rubyRegionId=0, firstDead=6]():
     <self>: T.class_of(ModuleMethods) = cast(<self>: NilClass, T.class_of(ModuleMethods));
     <cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$6: Symbol(:instrumented_request) = :instrumented_request
@@ -156,8 +156,8 @@ bb0[rubyBlockId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/infer/control_flow/complex_implications_2.rb.cfg-text.exp
+++ b/test/testdata/infer/control_flow/complex_implications_2.rb.cfg-text.exp
@@ -1,47 +1,47 @@
 method ::Object#foo {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     foo: T.untyped = load_arg(foo)
     foo -> (T.untyped ? bb2 : bb7)
 
 # backedges
-# - bb10(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb10(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb2[rubyBlockId=0, firstDead=-1](foo: T.untyped):
+# - bb0(rubyRegionId=0)
+bb2[rubyRegionId=0, firstDead=-1](foo: T.untyped):
     <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
     bar: T.untyped = foo: T.untyped.is_a?(<cfgAlias>$8: T.class_of(StandardError))
     bar -> (T.untyped ? bb4 : bb7)
 
 # backedges
-# - bb2(rubyBlockId=0)
-bb4[rubyBlockId=0, firstDead=-1](foo: StandardError):
+# - bb2(rubyRegionId=0)
+bb4[rubyRegionId=0, firstDead=-1](foo: StandardError):
     e: StandardError = foo
     err: StandardError = e
     <unconditional> -> bb7
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb2(rubyBlockId=0)
-# - bb4(rubyBlockId=0)
-bb7[rubyBlockId=0, firstDead=-1](err: T.nilable(StandardError)):
+# - bb0(rubyRegionId=0)
+# - bb2(rubyRegionId=0)
+# - bb4(rubyRegionId=0)
+bb7[rubyRegionId=0, firstDead=-1](err: T.nilable(StandardError)):
     junk: T.nilable(StandardError) = err
     err -> (T.nilable(StandardError) ? bb8 : bb10)
 
 # backedges
-# - bb7(rubyBlockId=0)
-bb8[rubyBlockId=0, firstDead=-1]():
+# - bb7(rubyRegionId=0)
+bb8[rubyRegionId=0, firstDead=-1]():
     <returnMethodTemp>$2: Integer(1) = 1
     <unconditional> -> bb10
 
 # backedges
-# - bb7(rubyBlockId=0)
-# - bb8(rubyBlockId=0)
-bb10[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: T.nilable(Integer)):
+# - bb7(rubyRegionId=0)
+# - bb8(rubyRegionId=0)
+bb10[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.nilable(Integer)):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(Integer)
     <unconditional> -> bb1
 
@@ -49,7 +49,7 @@ bb10[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: T.nilable(Integer)):
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=6]():
+bb0[rubyRegionId=0, firstDead=6]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$6: Symbol(:foo) = :foo
@@ -59,8 +59,8 @@ bb0[rubyBlockId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/infer/control_flow/normalize_params.rb.cfg-text.exp
+++ b/test/testdata/infer/control_flow/normalize_params.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=8]():
+bb0[rubyRegionId=0, firstDead=8]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <cfgAlias>$7: T.class_of(Test) = alias <C Test>
@@ -12,15 +12,15 @@ bb0[rubyBlockId=0, firstDead=8]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Test#normalize_params {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Test = cast(<self>: NilClass, Test);
     v: T.untyped = load_arg(v)
     <cfgAlias>$6: T.class_of(Hash) = alias <C Hash>
@@ -28,54 +28,54 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <ifTemp>$3 -> (T.untyped ? bb2 : bb3)
 
 # backedges
-# - bb11(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb11(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb2[rubyBlockId=0, firstDead=-1](<self>: Test, v: T::Hash[T.untyped, T.untyped]):
+# - bb0(rubyRegionId=0)
+bb2[rubyRegionId=0, firstDead=-1](<self>: Test, v: T::Hash[T.untyped, T.untyped]):
     <statTemp>$9: T::Array[[T.untyped, T.untyped]] = v: T::Hash[T.untyped, T.untyped].to_a()
     <statTemp>$7: T.untyped = <self>: Test.normalize_params(<statTemp>$9: T::Array[[T.untyped, T.untyped]])
     <returnMethodTemp>$2: T.untyped = <statTemp>$7: T.untyped.sort()
     <unconditional> -> bb11
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb3[rubyBlockId=0, firstDead=-1](<self>: Test, v: T.untyped):
+# - bb0(rubyRegionId=0)
+bb3[rubyRegionId=0, firstDead=-1](<self>: Test, v: T.untyped):
     <cfgAlias>$14: T.class_of(Array) = alias <C Array>
     <ifTemp>$11: T.untyped = v: T.untyped.is_a?(<cfgAlias>$14: T.class_of(Array))
     <ifTemp>$11 -> (T.untyped ? bb4 : bb5)
 
 # backedges
-# - bb3(rubyBlockId=0)
-bb4[rubyBlockId=0, firstDead=-1](<self>: Test, v: T::Array[T.untyped]):
+# - bb3(rubyRegionId=0)
+bb4[rubyRegionId=0, firstDead=-1](<self>: Test, v: T::Array[T.untyped]):
     <block-pre-call-temp>$16: Sorbet::Private::Static::Void = v: T::Array[T.untyped].map()
     <selfRestore>$17: Test = <self>
     <unconditional> -> bb6
 
 # backedges
-# - bb3(rubyBlockId=0)
-bb5[rubyBlockId=0, firstDead=-1](v: T.untyped):
+# - bb3(rubyRegionId=0)
+bb5[rubyRegionId=0, firstDead=-1](v: T.untyped):
     <returnMethodTemp>$2: T.untyped = v
     <unconditional> -> bb11
 
 # backedges
-# - bb4(rubyBlockId=0)
-# - bb9(rubyBlockId=1)
-bb6[rubyBlockId=1, firstDead=-1](<self>: Test, <block-pre-call-temp>$16: Sorbet::Private::Static::Void, <selfRestore>$17: Test):
+# - bb4(rubyRegionId=0)
+# - bb9(rubyRegionId=1)
+bb6[rubyRegionId=1, firstDead=-1](<self>: Test, <block-pre-call-temp>$16: Sorbet::Private::Static::Void, <selfRestore>$17: Test):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
-# - bb6(rubyBlockId=1)
-bb7[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$16: Sorbet::Private::Static::Void, <selfRestore>$17: Test):
+# - bb6(rubyRegionId=1)
+bb7[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$16: Sorbet::Private::Static::Void, <selfRestore>$17: Test):
     <returnMethodTemp>$2: T::Array[T.untyped] = Solve<<block-pre-call-temp>$16, map>
     <unconditional> -> bb11
 
 # backedges
-# - bb6(rubyBlockId=1)
-bb9[rubyBlockId=1, firstDead=5](<self>: Test, <block-pre-call-temp>$16: Sorbet::Private::Static::Void, <selfRestore>$17: Test):
+# - bb6(rubyRegionId=1)
+bb9[rubyRegionId=1, firstDead=5](<self>: Test, <block-pre-call-temp>$16: Sorbet::Private::Static::Void, <selfRestore>$17: Test):
     # outerLoops: 1
     <self>: Test = loadSelf
     <blk>$18: [T.untyped] = load_yield_params(map)
@@ -85,10 +85,10 @@ bb9[rubyBlockId=1, firstDead=5](<self>: Test, <block-pre-call-temp>$16: Sorbet::
     <unconditional> -> bb6
 
 # backedges
-# - bb2(rubyBlockId=0)
-# - bb5(rubyBlockId=0)
-# - bb7(rubyBlockId=0)
-bb11[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
+# - bb2(rubyRegionId=0)
+# - bb5(rubyRegionId=0)
+# - bb7(rubyRegionId=0)
+bb11[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
@@ -96,7 +96,7 @@ bb11[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: T.untyped):
 
 method ::<Class:Test>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=6]():
+bb0[rubyRegionId=0, firstDead=6]():
     <self>: T.class_of(Test) = cast(<self>: NilClass, T.class_of(Test));
     <cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$6: Symbol(:normalize_params) = :normalize_params
@@ -106,8 +106,8 @@ bb0[rubyBlockId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/infer/control_flow/simple.rb.cfg-text.exp
+++ b/test/testdata/infer/control_flow/simple.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=8]():
+bb0[rubyRegionId=0, firstDead=8]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <cfgAlias>$7: T.class_of(ControlFlow) = alias <C ControlFlow>
@@ -12,35 +12,35 @@ bb0[rubyBlockId=0, firstDead=8]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::ControlFlow#orZero0 {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: ControlFlow = cast(<self>: NilClass, ControlFlow);
     a: T.nilable(Integer) = load_arg(a)
     a -> (T.nilable(Integer) ? bb2 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=0)
-# - bb3(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1](<returnMethodTemp>$2):
+# - bb2(rubyRegionId=0)
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1](<returnMethodTemp>$2):
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb2[rubyBlockId=0, firstDead=1](a: Integer):
+# - bb0(rubyRegionId=0)
+bb2[rubyRegionId=0, firstDead=1](a: Integer):
     <returnMethodTemp>$2: T.noreturn = return a: Integer
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb3[rubyBlockId=0, firstDead=2]():
+# - bb0(rubyRegionId=0)
+bb3[rubyRegionId=0, firstDead=2]():
     <returnTemp>$5: Integer(0) = 0
     <returnMethodTemp>$2: T.noreturn = return <returnTemp>$5: Integer(0)
     <unconditional> -> bb1
@@ -49,27 +49,27 @@ bb3[rubyBlockId=0, firstDead=2]():
 
 method ::ControlFlow#orZero0a {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: ControlFlow = cast(<self>: NilClass, ControlFlow);
     a: Integer = load_arg(a)
     a -> (Integer ? bb2 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=0)
-# - bb3(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1](<returnMethodTemp>$2):
+# - bb2(rubyRegionId=0)
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1](<returnMethodTemp>$2):
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb2[rubyBlockId=0, firstDead=1](a: Integer):
+# - bb0(rubyRegionId=0)
+bb2[rubyRegionId=0, firstDead=1](a: Integer):
     <returnMethodTemp>$2: T.noreturn = return a: Integer
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb3[rubyBlockId=0, firstDead=0]():
+# - bb0(rubyRegionId=0)
+bb3[rubyRegionId=0, firstDead=0]():
     <returnTemp>$5 = 0
     <returnMethodTemp>$2 = return <returnTemp>$5
     <unconditional> -> bb1
@@ -78,29 +78,29 @@ bb3[rubyBlockId=0, firstDead=0]():
 
 method ::ControlFlow#orZero0n {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: ControlFlow = cast(<self>: NilClass, ControlFlow);
     a: T.nilable(Integer) = load_arg(a)
     b: T::Boolean = a: T.nilable(Integer).!()
     b -> (T::Boolean ? bb2 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=0)
-# - bb3(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1](<returnMethodTemp>$2):
+# - bb2(rubyRegionId=0)
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1](<returnMethodTemp>$2):
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb2[rubyBlockId=0, firstDead=2]():
+# - bb0(rubyRegionId=0)
+bb2[rubyRegionId=0, firstDead=2]():
     <returnTemp>$6: Integer(0) = 0
     <returnMethodTemp>$2: T.noreturn = return <returnTemp>$6: Integer(0)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb3[rubyBlockId=0, firstDead=1](a: Integer):
+# - bb0(rubyRegionId=0)
+bb3[rubyRegionId=0, firstDead=1](a: Integer):
     <returnMethodTemp>$2: T.noreturn = return a: Integer
     <unconditional> -> bb1
 
@@ -108,7 +108,7 @@ bb3[rubyBlockId=0, firstDead=1](a: Integer):
 
 method ::ControlFlow#orZero1n {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: ControlFlow = cast(<self>: NilClass, ControlFlow);
     a: T.nilable(Integer) = load_arg(a)
     <cfgAlias>$7: T.class_of(Integer) = alias <C Integer>
@@ -117,22 +117,22 @@ bb0[rubyBlockId=0, firstDead=-1]():
     b -> (T::Boolean ? bb2 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=0)
-# - bb3(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1](<returnMethodTemp>$2):
+# - bb2(rubyRegionId=0)
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1](<returnMethodTemp>$2):
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb2[rubyBlockId=0, firstDead=2]():
+# - bb0(rubyRegionId=0)
+bb2[rubyRegionId=0, firstDead=2]():
     <returnTemp>$9: Integer(0) = 0
     <returnMethodTemp>$2: T.noreturn = return <returnTemp>$9: Integer(0)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb3[rubyBlockId=0, firstDead=1](a: Integer):
+# - bb0(rubyRegionId=0)
+bb3[rubyRegionId=0, firstDead=1](a: Integer):
     <returnMethodTemp>$2: T.noreturn = return a: Integer
     <unconditional> -> bb1
 
@@ -140,26 +140,26 @@ bb3[rubyBlockId=0, firstDead=1](a: Integer):
 
 method ::ControlFlow#orZero2 {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: ControlFlow = cast(<self>: NilClass, ControlFlow);
     a: T.nilable(Integer) = load_arg(a)
     a -> (T.nilable(Integer) ? bb4 : bb3)
 
 # backedges
-# - bb4(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb4(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb3[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb3[rubyRegionId=0, firstDead=-1]():
     a: Integer(0) = 0
     <unconditional> -> bb4
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb3(rubyBlockId=0)
-bb4[rubyBlockId=0, firstDead=2](a: Integer):
+# - bb0(rubyRegionId=0)
+# - bb3(rubyRegionId=0)
+bb4[rubyRegionId=0, firstDead=2](a: Integer):
     <returnMethodTemp>$2: Integer = a
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer
     <unconditional> -> bb1
@@ -168,44 +168,44 @@ bb4[rubyBlockId=0, firstDead=2](a: Integer):
 
 method ::ControlFlow#orZero3 {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: ControlFlow = cast(<self>: NilClass, ControlFlow);
     a: T.nilable(Integer) = load_arg(a)
     a -> (T.nilable(Integer) ? bb2 : bb3)
 
 # backedges
-# - bb5(rubyBlockId=0)
-# - bb6(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1](<returnMethodTemp>$2):
+# - bb5(rubyRegionId=0)
+# - bb6(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1](<returnMethodTemp>$2):
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb2[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb2[rubyRegionId=0, firstDead=-1]():
     <statTemp>$5: Integer(1) = 1
     <statTemp>$6: Integer(2) = 2
     <ifTemp>$3: T::Boolean = <statTemp>$5: Integer(1).==(<statTemp>$6: Integer(2))
     <ifTemp>$3 -> (T::Boolean ? bb5 : bb6)
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb3[rubyBlockId=0, firstDead=-1](a: NilClass):
+# - bb0(rubyRegionId=0)
+bb3[rubyRegionId=0, firstDead=-1](a: NilClass):
     <ifTemp>$3: NilClass = a
     <ifTemp>$3 -> (NilClass ? bb5 : bb6)
 
 # backedges
-# - bb2(rubyBlockId=0)
-# - bb3(rubyBlockId=0)
-bb5[rubyBlockId=0, firstDead=2]():
+# - bb2(rubyRegionId=0)
+# - bb3(rubyRegionId=0)
+bb5[rubyRegionId=0, firstDead=2]():
     <returnTemp>$7: Integer(1) = 1
     <returnMethodTemp>$2: T.noreturn = return <returnTemp>$7: Integer(1)
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=0)
-# - bb3(rubyBlockId=0)
-bb6[rubyBlockId=0, firstDead=2]():
+# - bb2(rubyRegionId=0)
+# - bb3(rubyRegionId=0)
+bb6[rubyRegionId=0, firstDead=2]():
     <returnTemp>$8: Integer(0) = 0
     <returnMethodTemp>$2: T.noreturn = return <returnTemp>$8: Integer(0)
     <unconditional> -> bb1
@@ -214,49 +214,49 @@ bb6[rubyBlockId=0, firstDead=2]():
 
 method ::ControlFlow#orZero3n {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: ControlFlow = cast(<self>: NilClass, ControlFlow);
     a: T.nilable(Integer) = load_arg(a)
     a -> (T.nilable(Integer) ? bb2 : bb3)
 
 # backedges
-# - bb5(rubyBlockId=0)
-# - bb6(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1](<returnMethodTemp>$2):
+# - bb5(rubyRegionId=0)
+# - bb6(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1](<returnMethodTemp>$2):
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb2[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb2[rubyRegionId=0, firstDead=-1]():
     <statTemp>$6: Integer(1) = 1
     <statTemp>$7: Integer(2) = 2
     <statTemp>$4: T::Boolean = <statTemp>$6: Integer(1).==(<statTemp>$7: Integer(2))
     <unconditional> -> bb4
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb3[rubyBlockId=0, firstDead=-1](a: NilClass):
+# - bb0(rubyRegionId=0)
+bb3[rubyRegionId=0, firstDead=-1](a: NilClass):
     <statTemp>$4: NilClass = a
     <unconditional> -> bb4
 
 # backedges
-# - bb2(rubyBlockId=0)
-# - bb3(rubyBlockId=0)
-bb4[rubyBlockId=0, firstDead=-1](<statTemp>$4: T.nilable(T::Boolean)):
+# - bb2(rubyRegionId=0)
+# - bb3(rubyRegionId=0)
+bb4[rubyRegionId=0, firstDead=-1](<statTemp>$4: T.nilable(T::Boolean)):
     b: T::Boolean = <statTemp>$4: T.nilable(T::Boolean).!()
     b -> (T::Boolean ? bb5 : bb6)
 
 # backedges
-# - bb4(rubyBlockId=0)
-bb5[rubyBlockId=0, firstDead=2]():
+# - bb4(rubyRegionId=0)
+bb5[rubyRegionId=0, firstDead=2]():
     <returnTemp>$9: Integer(0) = 0
     <returnMethodTemp>$2: T.noreturn = return <returnTemp>$9: Integer(0)
     <unconditional> -> bb1
 
 # backedges
-# - bb4(rubyBlockId=0)
-bb6[rubyBlockId=0, firstDead=2]():
+# - bb4(rubyRegionId=0)
+bb6[rubyRegionId=0, firstDead=2]():
     <returnTemp>$10: Integer(1) = 1
     <returnMethodTemp>$2: T.noreturn = return <returnTemp>$10: Integer(1)
     <unconditional> -> bb1
@@ -265,41 +265,41 @@ bb6[rubyBlockId=0, firstDead=2]():
 
 method ::ControlFlow#orZero4 {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: ControlFlow = cast(<self>: NilClass, ControlFlow);
     a: T.nilable(Integer) = load_arg(a)
     a -> (T.nilable(Integer) ? bb2 : bb3)
 
 # backedges
-# - bb5(rubyBlockId=0)
-# - bb6(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1](<returnMethodTemp>$2):
+# - bb5(rubyRegionId=0)
+# - bb6(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1](<returnMethodTemp>$2):
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb2[rubyBlockId=0, firstDead=-1](a: Integer):
+# - bb0(rubyRegionId=0)
+bb2[rubyRegionId=0, firstDead=-1](a: Integer):
     <ifTemp>$3: Integer = a
     <ifTemp>$3 -> (Integer ? bb5 : bb6)
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb3[rubyBlockId=0, firstDead=-1](a: NilClass):
+# - bb0(rubyRegionId=0)
+bb3[rubyRegionId=0, firstDead=-1](a: NilClass):
     <ifTemp>$3: TrueClass = true
     <ifTemp>$3 -> (TrueClass ? bb5 : bb6)
 
 # backedges
-# - bb2(rubyBlockId=0)
-# - bb3(rubyBlockId=0)
-bb5[rubyBlockId=0, firstDead=1](a: T.nilable(Integer)):
+# - bb2(rubyRegionId=0)
+# - bb3(rubyRegionId=0)
+bb5[rubyRegionId=0, firstDead=1](a: T.nilable(Integer)):
     <returnMethodTemp>$2: T.noreturn = return a: T.nilable(Integer)
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=0)
-# - bb3(rubyBlockId=0)
-bb6[rubyBlockId=0, firstDead=0]():
+# - bb2(rubyRegionId=0)
+# - bb3(rubyRegionId=0)
+bb6[rubyRegionId=0, firstDead=0]():
     <returnTemp>$6 = 0
     <returnMethodTemp>$2 = return <returnTemp>$6
     <unconditional> -> bb1
@@ -308,41 +308,41 @@ bb6[rubyBlockId=0, firstDead=0]():
 
 method ::ControlFlow#orZero5 {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: ControlFlow = cast(<self>: NilClass, ControlFlow);
     a: T.nilable(Integer) = load_arg(a)
     a -> (T.nilable(Integer) ? bb2 : bb3)
 
 # backedges
-# - bb5(rubyBlockId=0)
-# - bb6(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1](<returnMethodTemp>$2):
+# - bb5(rubyRegionId=0)
+# - bb6(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1](<returnMethodTemp>$2):
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb2[rubyBlockId=0, firstDead=-1](a: Integer):
+# - bb0(rubyRegionId=0)
+bb2[rubyRegionId=0, firstDead=-1](a: Integer):
     <ifTemp>$3: TrueClass = true
     <ifTemp>$3 -> (TrueClass ? bb5 : bb6)
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb3[rubyBlockId=0, firstDead=-1](a: NilClass):
+# - bb0(rubyRegionId=0)
+bb3[rubyRegionId=0, firstDead=-1](a: NilClass):
     <ifTemp>$3: NilClass = a
     <ifTemp>$3 -> (NilClass ? bb5 : bb6)
 
 # backedges
-# - bb2(rubyBlockId=0)
-# - bb3(rubyBlockId=0)
-bb5[rubyBlockId=0, firstDead=1](a: Integer):
+# - bb2(rubyRegionId=0)
+# - bb3(rubyRegionId=0)
+bb5[rubyRegionId=0, firstDead=1](a: Integer):
     <returnMethodTemp>$2: T.noreturn = return a: Integer
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=0)
-# - bb3(rubyBlockId=0)
-bb6[rubyBlockId=0, firstDead=2]():
+# - bb2(rubyRegionId=0)
+# - bb3(rubyRegionId=0)
+bb6[rubyRegionId=0, firstDead=2]():
     <returnTemp>$6: Integer(0) = 0
     <returnMethodTemp>$2: T.noreturn = return <returnTemp>$6: Integer(0)
     <unconditional> -> bb1
@@ -351,7 +351,7 @@ bb6[rubyBlockId=0, firstDead=2]():
 
 method ::<Class:ControlFlow>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(ControlFlow) = cast(<self>: NilClass, T.class_of(ControlFlow));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
     <statTemp>$7: FalseClass = false
@@ -361,20 +361,20 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb35(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb35(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb5(rubyBlockId=1)
-bb2[rubyBlockId=1, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(ControlFlow)):
+# - bb0(rubyRegionId=0)
+# - bb5(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(ControlFlow)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb3[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(ControlFlow)):
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(ControlFlow)):
     <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$9, sig>
     <self>: T.class_of(ControlFlow) = <selfRestore>$10
     <cfgAlias>$28: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
@@ -385,8 +385,8 @@ bb3[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$9: Sorbet::Private::Stati
     <unconditional> -> bb6
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb5[rubyBlockId=1, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(ControlFlow)):
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(ControlFlow)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf
     <hashTemp>$15: Symbol(:a) = :a
@@ -401,15 +401,15 @@ bb5[rubyBlockId=1, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-cal
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-# - bb9(rubyBlockId=2)
-bb6[rubyBlockId=2, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$32: Sorbet::Private::Static::Void, <selfRestore>$33: T.class_of(ControlFlow)):
+# - bb3(rubyRegionId=0)
+# - bb9(rubyRegionId=2)
+bb6[rubyRegionId=2, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$32: Sorbet::Private::Static::Void, <selfRestore>$33: T.class_of(ControlFlow)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
-# - bb6(rubyBlockId=2)
-bb7[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$32: Sorbet::Private::Static::Void, <selfRestore>$33: T.class_of(ControlFlow)):
+# - bb6(rubyRegionId=2)
+bb7[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$32: Sorbet::Private::Static::Void, <selfRestore>$33: T.class_of(ControlFlow)):
     <statTemp>$26: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$32, sig>
     <self>: T.class_of(ControlFlow) = <selfRestore>$33
     <cfgAlias>$46: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
@@ -420,8 +420,8 @@ bb7[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$32: Sorbet::Private::Stat
     <unconditional> -> bb10
 
 # backedges
-# - bb6(rubyBlockId=2)
-bb9[rubyBlockId=2, firstDead=7](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$32: Sorbet::Private::Static::Void, <selfRestore>$33: T.class_of(ControlFlow)):
+# - bb6(rubyRegionId=2)
+bb9[rubyRegionId=2, firstDead=7](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$32: Sorbet::Private::Static::Void, <selfRestore>$33: T.class_of(ControlFlow)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf
     <hashTemp>$38: Symbol(:a) = :a
@@ -433,15 +433,15 @@ bb9[rubyBlockId=2, firstDead=7](<self>: T.class_of(ControlFlow), <block-pre-call
     <unconditional> -> bb6
 
 # backedges
-# - bb7(rubyBlockId=0)
-# - bb13(rubyBlockId=3)
-bb10[rubyBlockId=3, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$50: Sorbet::Private::Static::Void, <selfRestore>$51: T.class_of(ControlFlow)):
+# - bb7(rubyRegionId=0)
+# - bb13(rubyRegionId=3)
+bb10[rubyRegionId=3, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$50: Sorbet::Private::Static::Void, <selfRestore>$51: T.class_of(ControlFlow)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb13 : bb11)
 
 # backedges
-# - bb10(rubyBlockId=3)
-bb11[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$50: Sorbet::Private::Static::Void, <selfRestore>$51: T.class_of(ControlFlow)):
+# - bb10(rubyRegionId=3)
+bb11[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$50: Sorbet::Private::Static::Void, <selfRestore>$51: T.class_of(ControlFlow)):
     <statTemp>$44: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$50, sig>
     <self>: T.class_of(ControlFlow) = <selfRestore>$51
     <cfgAlias>$69: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
@@ -452,8 +452,8 @@ bb11[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$50: Sorbet::Private::Sta
     <unconditional> -> bb14
 
 # backedges
-# - bb10(rubyBlockId=3)
-bb13[rubyBlockId=3, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$50: Sorbet::Private::Static::Void, <selfRestore>$51: T.class_of(ControlFlow)):
+# - bb10(rubyRegionId=3)
+bb13[rubyRegionId=3, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$50: Sorbet::Private::Static::Void, <selfRestore>$51: T.class_of(ControlFlow)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf
     <hashTemp>$56: Symbol(:a) = :a
@@ -468,15 +468,15 @@ bb13[rubyBlockId=3, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-ca
     <unconditional> -> bb10
 
 # backedges
-# - bb11(rubyBlockId=0)
-# - bb17(rubyBlockId=4)
-bb14[rubyBlockId=4, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$73: Sorbet::Private::Static::Void, <selfRestore>$74: T.class_of(ControlFlow)):
+# - bb11(rubyRegionId=0)
+# - bb17(rubyRegionId=4)
+bb14[rubyRegionId=4, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$73: Sorbet::Private::Static::Void, <selfRestore>$74: T.class_of(ControlFlow)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb17 : bb15)
 
 # backedges
-# - bb14(rubyBlockId=4)
-bb15[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$73: Sorbet::Private::Static::Void, <selfRestore>$74: T.class_of(ControlFlow)):
+# - bb14(rubyRegionId=4)
+bb15[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$73: Sorbet::Private::Static::Void, <selfRestore>$74: T.class_of(ControlFlow)):
     <statTemp>$67: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$73, sig>
     <self>: T.class_of(ControlFlow) = <selfRestore>$74
     <cfgAlias>$92: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
@@ -487,8 +487,8 @@ bb15[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$73: Sorbet::Private::Sta
     <unconditional> -> bb18
 
 # backedges
-# - bb14(rubyBlockId=4)
-bb17[rubyBlockId=4, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$73: Sorbet::Private::Static::Void, <selfRestore>$74: T.class_of(ControlFlow)):
+# - bb14(rubyRegionId=4)
+bb17[rubyRegionId=4, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$73: Sorbet::Private::Static::Void, <selfRestore>$74: T.class_of(ControlFlow)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf
     <hashTemp>$79: Symbol(:a) = :a
@@ -503,15 +503,15 @@ bb17[rubyBlockId=4, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-ca
     <unconditional> -> bb14
 
 # backedges
-# - bb15(rubyBlockId=0)
-# - bb21(rubyBlockId=5)
-bb18[rubyBlockId=5, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$96: Sorbet::Private::Static::Void, <selfRestore>$97: T.class_of(ControlFlow)):
+# - bb15(rubyRegionId=0)
+# - bb21(rubyRegionId=5)
+bb18[rubyRegionId=5, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$96: Sorbet::Private::Static::Void, <selfRestore>$97: T.class_of(ControlFlow)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb21 : bb19)
 
 # backedges
-# - bb18(rubyBlockId=5)
-bb19[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$96: Sorbet::Private::Static::Void, <selfRestore>$97: T.class_of(ControlFlow)):
+# - bb18(rubyRegionId=5)
+bb19[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$96: Sorbet::Private::Static::Void, <selfRestore>$97: T.class_of(ControlFlow)):
     <statTemp>$90: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$96, sig>
     <self>: T.class_of(ControlFlow) = <selfRestore>$97
     <cfgAlias>$115: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
@@ -522,8 +522,8 @@ bb19[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$96: Sorbet::Private::Sta
     <unconditional> -> bb22
 
 # backedges
-# - bb18(rubyBlockId=5)
-bb21[rubyBlockId=5, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$96: Sorbet::Private::Static::Void, <selfRestore>$97: T.class_of(ControlFlow)):
+# - bb18(rubyRegionId=5)
+bb21[rubyRegionId=5, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$96: Sorbet::Private::Static::Void, <selfRestore>$97: T.class_of(ControlFlow)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf
     <hashTemp>$102: Symbol(:a) = :a
@@ -538,15 +538,15 @@ bb21[rubyBlockId=5, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-ca
     <unconditional> -> bb18
 
 # backedges
-# - bb19(rubyBlockId=0)
-# - bb25(rubyBlockId=6)
-bb22[rubyBlockId=6, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$119: Sorbet::Private::Static::Void, <selfRestore>$120: T.class_of(ControlFlow)):
+# - bb19(rubyRegionId=0)
+# - bb25(rubyRegionId=6)
+bb22[rubyRegionId=6, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$119: Sorbet::Private::Static::Void, <selfRestore>$120: T.class_of(ControlFlow)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb25 : bb23)
 
 # backedges
-# - bb22(rubyBlockId=6)
-bb23[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$119: Sorbet::Private::Static::Void, <selfRestore>$120: T.class_of(ControlFlow)):
+# - bb22(rubyRegionId=6)
+bb23[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$119: Sorbet::Private::Static::Void, <selfRestore>$120: T.class_of(ControlFlow)):
     <statTemp>$113: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$119, sig>
     <self>: T.class_of(ControlFlow) = <selfRestore>$120
     <cfgAlias>$138: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
@@ -557,8 +557,8 @@ bb23[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$119: Sorbet::Private::St
     <unconditional> -> bb26
 
 # backedges
-# - bb22(rubyBlockId=6)
-bb25[rubyBlockId=6, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$119: Sorbet::Private::Static::Void, <selfRestore>$120: T.class_of(ControlFlow)):
+# - bb22(rubyRegionId=6)
+bb25[rubyRegionId=6, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$119: Sorbet::Private::Static::Void, <selfRestore>$120: T.class_of(ControlFlow)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf
     <hashTemp>$125: Symbol(:a) = :a
@@ -573,15 +573,15 @@ bb25[rubyBlockId=6, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-ca
     <unconditional> -> bb22
 
 # backedges
-# - bb23(rubyBlockId=0)
-# - bb29(rubyBlockId=7)
-bb26[rubyBlockId=7, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$142: Sorbet::Private::Static::Void, <selfRestore>$143: T.class_of(ControlFlow)):
+# - bb23(rubyRegionId=0)
+# - bb29(rubyRegionId=7)
+bb26[rubyRegionId=7, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$142: Sorbet::Private::Static::Void, <selfRestore>$143: T.class_of(ControlFlow)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb29 : bb27)
 
 # backedges
-# - bb26(rubyBlockId=7)
-bb27[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$142: Sorbet::Private::Static::Void, <selfRestore>$143: T.class_of(ControlFlow)):
+# - bb26(rubyRegionId=7)
+bb27[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$142: Sorbet::Private::Static::Void, <selfRestore>$143: T.class_of(ControlFlow)):
     <statTemp>$136: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$142, sig>
     <self>: T.class_of(ControlFlow) = <selfRestore>$143
     <cfgAlias>$161: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
@@ -592,8 +592,8 @@ bb27[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$142: Sorbet::Private::St
     <unconditional> -> bb30
 
 # backedges
-# - bb26(rubyBlockId=7)
-bb29[rubyBlockId=7, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$142: Sorbet::Private::Static::Void, <selfRestore>$143: T.class_of(ControlFlow)):
+# - bb26(rubyRegionId=7)
+bb29[rubyRegionId=7, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$142: Sorbet::Private::Static::Void, <selfRestore>$143: T.class_of(ControlFlow)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf
     <hashTemp>$148: Symbol(:a) = :a
@@ -608,15 +608,15 @@ bb29[rubyBlockId=7, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-ca
     <unconditional> -> bb26
 
 # backedges
-# - bb27(rubyBlockId=0)
-# - bb33(rubyBlockId=8)
-bb30[rubyBlockId=8, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$165: Sorbet::Private::Static::Void, <selfRestore>$166: T.class_of(ControlFlow)):
+# - bb27(rubyRegionId=0)
+# - bb33(rubyRegionId=8)
+bb30[rubyRegionId=8, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$165: Sorbet::Private::Static::Void, <selfRestore>$166: T.class_of(ControlFlow)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb33 : bb31)
 
 # backedges
-# - bb30(rubyBlockId=8)
-bb31[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$165: Sorbet::Private::Static::Void, <selfRestore>$166: T.class_of(ControlFlow)):
+# - bb30(rubyRegionId=8)
+bb31[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$165: Sorbet::Private::Static::Void, <selfRestore>$166: T.class_of(ControlFlow)):
     <statTemp>$159: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$165, sig>
     <self>: T.class_of(ControlFlow) = <selfRestore>$166
     <cfgAlias>$184: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
@@ -627,8 +627,8 @@ bb31[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$165: Sorbet::Private::St
     <unconditional> -> bb34
 
 # backedges
-# - bb30(rubyBlockId=8)
-bb33[rubyBlockId=8, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$165: Sorbet::Private::Static::Void, <selfRestore>$166: T.class_of(ControlFlow)):
+# - bb30(rubyRegionId=8)
+bb33[rubyRegionId=8, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$165: Sorbet::Private::Static::Void, <selfRestore>$166: T.class_of(ControlFlow)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf
     <hashTemp>$171: Symbol(:a) = :a
@@ -643,15 +643,15 @@ bb33[rubyBlockId=8, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-ca
     <unconditional> -> bb30
 
 # backedges
-# - bb31(rubyBlockId=0)
-# - bb37(rubyBlockId=9)
-bb34[rubyBlockId=9, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$188: Sorbet::Private::Static::Void, <selfRestore>$189: T.class_of(ControlFlow)):
+# - bb31(rubyRegionId=0)
+# - bb37(rubyRegionId=9)
+bb34[rubyRegionId=9, firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$188: Sorbet::Private::Static::Void, <selfRestore>$189: T.class_of(ControlFlow)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb37 : bb35)
 
 # backedges
-# - bb34(rubyBlockId=9)
-bb35[rubyBlockId=0, firstDead=42](<block-pre-call-temp>$188: Sorbet::Private::Static::Void, <selfRestore>$189: T.class_of(ControlFlow)):
+# - bb34(rubyRegionId=9)
+bb35[rubyRegionId=0, firstDead=42](<block-pre-call-temp>$188: Sorbet::Private::Static::Void, <selfRestore>$189: T.class_of(ControlFlow)):
     <statTemp>$182: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$188, sig>
     <self>: T.class_of(ControlFlow) = <selfRestore>$189
     <cfgAlias>$208: T.class_of(T::Sig) = alias <C Sig>
@@ -697,8 +697,8 @@ bb35[rubyBlockId=0, firstDead=42](<block-pre-call-temp>$188: Sorbet::Private::St
     <unconditional> -> bb1
 
 # backedges
-# - bb34(rubyBlockId=9)
-bb37[rubyBlockId=9, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$188: Sorbet::Private::Static::Void, <selfRestore>$189: T.class_of(ControlFlow)):
+# - bb34(rubyRegionId=9)
+bb37[rubyRegionId=9, firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$188: Sorbet::Private::Static::Void, <selfRestore>$189: T.class_of(ControlFlow)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf
     <hashTemp>$194: Symbol(:a) = :a

--- a/test/testdata/infer/fields.rb.cfg-text.exp
+++ b/test/testdata/infer/fields.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=8]():
+bb0[rubyRegionId=0, firstDead=8]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <cfgAlias>$7: T.class_of(Foo) = alias <C Foo>
@@ -12,15 +12,15 @@ bb0[rubyBlockId=0, firstDead=8]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Foo#initialize {
 
-bb0[rubyBlockId=0, firstDead=9]():
+bb0[rubyRegionId=0, firstDead=9]():
     @ivar$3: Integer = alias @ivar
     <self>: Foo = cast(<self>: NilClass, Foo);
     <cfgAlias>$6: T.class_of(Sorbet::Private::Static) = alias <C Static>
@@ -33,15 +33,15 @@ bb0[rubyBlockId=0, firstDead=9]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Foo#foo {
 
-bb0[rubyBlockId=0, firstDead=6]():
+bb0[rubyRegionId=0, firstDead=6]():
     @ivar$4: Integer = alias @ivar
     <self>: Foo = cast(<self>: NilClass, Foo);
     @ivar$4: Integer(2) = 2
@@ -51,15 +51,15 @@ bb0[rubyBlockId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Foo>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=10]():
+bb0[rubyRegionId=0, firstDead=10]():
     <self>: T.class_of(Foo) = cast(<self>: NilClass, T.class_of(Foo));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$7: Symbol(:initialize) = :initialize
@@ -73,8 +73,8 @@ bb0[rubyBlockId=0, firstDead=10]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/infer/hashes.rb.cfg-text.exp
+++ b/test/testdata/infer/hashes.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=8]():
+bb0[rubyRegionId=0, firstDead=8]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <cfgAlias>$7: T.class_of(Foo) = alias <C Foo>
@@ -12,43 +12,43 @@ bb0[rubyBlockId=0, firstDead=8]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Foo#bar {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Foo = cast(<self>: NilClass, Foo);
     cond: T.untyped = load_arg(cond)
     cond -> (T.untyped ? bb2 : bb3)
 
 # backedges
-# - bb4(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1](<returnMethodTemp>$2):
+# - bb4(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1](<returnMethodTemp>$2):
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb2[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb2[rubyRegionId=0, firstDead=-1]():
     <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
     s: {} = <magic>$5: T.class_of(<Magic>).<build-hash>()
     <unconditional> -> bb4
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb3[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb3[rubyRegionId=0, firstDead=-1]():
     <magic>$6: T.class_of(<Magic>) = alias <C <Magic>>
     s: {} = <magic>$6: T.class_of(<Magic>).<build-hash>()
     <unconditional> -> bb4
 
 # backedges
-# - bb2(rubyBlockId=0)
-# - bb3(rubyBlockId=0)
-bb4[rubyBlockId=0, firstDead=2](s: {}):
+# - bb2(rubyRegionId=0)
+# - bb3(rubyRegionId=0)
+bb4[rubyRegionId=0, firstDead=2](s: {}):
     r: {} = s
     <returnMethodTemp>$2: T.noreturn = return r: {}
     <unconditional> -> bb1
@@ -57,7 +57,7 @@ bb4[rubyBlockId=0, firstDead=2](s: {}):
 
 method ::<Class:Foo>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=6]():
+bb0[rubyRegionId=0, firstDead=6]():
     <self>: T.class_of(Foo) = cast(<self>: NilClass, T.class_of(Foo));
     <cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$6: Symbol(:bar) = :bar
@@ -67,8 +67,8 @@ bb0[rubyBlockId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/infer/huge_unions.rb.cfg-text.exp
+++ b/test/testdata/infer/huge_unions.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=164]():
+bb0[rubyRegionId=0, firstDead=164]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$6: T.class_of(<Magic>) = alias <C <Magic>>
     <cfgAlias>$8: T.class_of(C1) = alias <C C1>
@@ -168,379 +168,379 @@ bb0[rubyBlockId=0, firstDead=164]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C1>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(C1) = cast(<self>: NilClass, T.class_of(C1));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C2>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(C2) = cast(<self>: NilClass, T.class_of(C2));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C3>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(C3) = cast(<self>: NilClass, T.class_of(C3));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C4>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(C4) = cast(<self>: NilClass, T.class_of(C4));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C5>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(C5) = cast(<self>: NilClass, T.class_of(C5));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C6>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(C6) = cast(<self>: NilClass, T.class_of(C6));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C7>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(C7) = cast(<self>: NilClass, T.class_of(C7));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C8>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(C8) = cast(<self>: NilClass, T.class_of(C8));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C9>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(C9) = cast(<self>: NilClass, T.class_of(C9));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C10>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(C10) = cast(<self>: NilClass, T.class_of(C10));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C11>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(C11) = cast(<self>: NilClass, T.class_of(C11));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C12>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(C12) = cast(<self>: NilClass, T.class_of(C12));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C13>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(C13) = cast(<self>: NilClass, T.class_of(C13));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C13>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(C13) = cast(<self>: NilClass, T.class_of(C13));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C13>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(C13) = cast(<self>: NilClass, T.class_of(C13));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C13>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(C13) = cast(<self>: NilClass, T.class_of(C13));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C13>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(C13) = cast(<self>: NilClass, T.class_of(C13));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C13>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(C13) = cast(<self>: NilClass, T.class_of(C13));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C13>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(C13) = cast(<self>: NilClass, T.class_of(C13));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C14>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(C14) = cast(<self>: NilClass, T.class_of(C14));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C15>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(C15) = cast(<self>: NilClass, T.class_of(C15));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C16>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(C16) = cast(<self>: NilClass, T.class_of(C16));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C17>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(C17) = cast(<self>: NilClass, T.class_of(C17));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C18>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(C18) = cast(<self>: NilClass, T.class_of(C18));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C19>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(C19) = cast(<self>: NilClass, T.class_of(C19));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C20>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(C20) = cast(<self>: NilClass, T.class_of(C20));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:A>#send_beta_invitation {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(A) = cast(<self>: NilClass, T.class_of(A));
     invite: T.untyped = load_arg(invite)
     <statTemp>$6: Integer(1) = 1
@@ -548,314 +548,314 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <ifTemp>$5 -> (T::Boolean ? bb2 : bb3)
 
 # backedges
-# - bb61(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1](<returnMethodTemp>$2):
+# - bb61(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1](<returnMethodTemp>$2):
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb2[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb2[rubyRegionId=0, firstDead=-1]():
     <cfgAlias>$8: T.class_of(C1) = alias <C C1>
     r: T.class_of(C1) = <cfgAlias>$8
     <unconditional> -> bb61
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb3[rubyBlockId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
+# - bb0(rubyRegionId=0)
+bb3[rubyRegionId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
     <statTemp>$10: Integer(2) = 2
     <ifTemp>$9: T::Boolean = <statTemp>$10: Integer(2).===(invite: T.untyped)
     <ifTemp>$9 -> (T::Boolean ? bb4 : bb5)
 
 # backedges
-# - bb3(rubyBlockId=0)
-bb4[rubyBlockId=0, firstDead=-1]():
+# - bb3(rubyRegionId=0)
+bb4[rubyRegionId=0, firstDead=-1]():
     <cfgAlias>$12: T.class_of(C2) = alias <C C2>
     r: T.class_of(C2) = <cfgAlias>$12
     <unconditional> -> bb61
 
 # backedges
-# - bb3(rubyBlockId=0)
-bb5[rubyBlockId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
+# - bb3(rubyRegionId=0)
+bb5[rubyRegionId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
     <statTemp>$14: Integer(3) = 3
     <ifTemp>$13: T::Boolean = <statTemp>$14: Integer(3).===(invite: T.untyped)
     <ifTemp>$13 -> (T::Boolean ? bb6 : bb7)
 
 # backedges
-# - bb5(rubyBlockId=0)
-bb6[rubyBlockId=0, firstDead=-1]():
+# - bb5(rubyRegionId=0)
+bb6[rubyRegionId=0, firstDead=-1]():
     <cfgAlias>$16: T.class_of(C3) = alias <C C3>
     r: T.class_of(C3) = <cfgAlias>$16
     <unconditional> -> bb61
 
 # backedges
-# - bb5(rubyBlockId=0)
-bb7[rubyBlockId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
+# - bb5(rubyRegionId=0)
+bb7[rubyRegionId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
     <statTemp>$18: Integer(4) = 4
     <ifTemp>$17: T::Boolean = <statTemp>$18: Integer(4).===(invite: T.untyped)
     <ifTemp>$17 -> (T::Boolean ? bb8 : bb9)
 
 # backedges
-# - bb7(rubyBlockId=0)
-bb8[rubyBlockId=0, firstDead=-1]():
+# - bb7(rubyRegionId=0)
+bb8[rubyRegionId=0, firstDead=-1]():
     <cfgAlias>$20: T.class_of(C4) = alias <C C4>
     r: T.class_of(C4) = <cfgAlias>$20
     <unconditional> -> bb61
 
 # backedges
-# - bb7(rubyBlockId=0)
-bb9[rubyBlockId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
+# - bb7(rubyRegionId=0)
+bb9[rubyRegionId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
     <statTemp>$22: Integer(5) = 5
     <ifTemp>$21: T::Boolean = <statTemp>$22: Integer(5).===(invite: T.untyped)
     <ifTemp>$21 -> (T::Boolean ? bb10 : bb11)
 
 # backedges
-# - bb9(rubyBlockId=0)
-bb10[rubyBlockId=0, firstDead=-1]():
+# - bb9(rubyRegionId=0)
+bb10[rubyRegionId=0, firstDead=-1]():
     <cfgAlias>$24: T.class_of(C5) = alias <C C5>
     r: T.class_of(C5) = <cfgAlias>$24
     <unconditional> -> bb61
 
 # backedges
-# - bb9(rubyBlockId=0)
-bb11[rubyBlockId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
+# - bb9(rubyRegionId=0)
+bb11[rubyRegionId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
     <statTemp>$26: Integer(6) = 6
     <ifTemp>$25: T::Boolean = <statTemp>$26: Integer(6).===(invite: T.untyped)
     <ifTemp>$25 -> (T::Boolean ? bb12 : bb13)
 
 # backedges
-# - bb11(rubyBlockId=0)
-bb12[rubyBlockId=0, firstDead=-1]():
+# - bb11(rubyRegionId=0)
+bb12[rubyRegionId=0, firstDead=-1]():
     <cfgAlias>$28: T.class_of(C6) = alias <C C6>
     r: T.class_of(C6) = <cfgAlias>$28
     <unconditional> -> bb61
 
 # backedges
-# - bb11(rubyBlockId=0)
-bb13[rubyBlockId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
+# - bb11(rubyRegionId=0)
+bb13[rubyRegionId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
     <statTemp>$30: Integer(7) = 7
     <ifTemp>$29: T::Boolean = <statTemp>$30: Integer(7).===(invite: T.untyped)
     <ifTemp>$29 -> (T::Boolean ? bb14 : bb15)
 
 # backedges
-# - bb13(rubyBlockId=0)
-bb14[rubyBlockId=0, firstDead=-1]():
+# - bb13(rubyRegionId=0)
+bb14[rubyRegionId=0, firstDead=-1]():
     <cfgAlias>$32: T.class_of(C7) = alias <C C7>
     r: T.class_of(C7) = <cfgAlias>$32
     <unconditional> -> bb61
 
 # backedges
-# - bb13(rubyBlockId=0)
-bb15[rubyBlockId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
+# - bb13(rubyRegionId=0)
+bb15[rubyRegionId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
     <statTemp>$34: Integer(8) = 8
     <ifTemp>$33: T::Boolean = <statTemp>$34: Integer(8).===(invite: T.untyped)
     <ifTemp>$33 -> (T::Boolean ? bb16 : bb17)
 
 # backedges
-# - bb15(rubyBlockId=0)
-bb16[rubyBlockId=0, firstDead=-1]():
+# - bb15(rubyRegionId=0)
+bb16[rubyRegionId=0, firstDead=-1]():
     <cfgAlias>$36: T.class_of(C8) = alias <C C8>
     r: T.class_of(C8) = <cfgAlias>$36
     <unconditional> -> bb61
 
 # backedges
-# - bb15(rubyBlockId=0)
-bb17[rubyBlockId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
+# - bb15(rubyRegionId=0)
+bb17[rubyRegionId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
     <statTemp>$38: Integer(9) = 9
     <ifTemp>$37: T::Boolean = <statTemp>$38: Integer(9).===(invite: T.untyped)
     <ifTemp>$37 -> (T::Boolean ? bb18 : bb19)
 
 # backedges
-# - bb17(rubyBlockId=0)
-bb18[rubyBlockId=0, firstDead=-1]():
+# - bb17(rubyRegionId=0)
+bb18[rubyRegionId=0, firstDead=-1]():
     <cfgAlias>$40: T.class_of(C9) = alias <C C9>
     r: T.class_of(C9) = <cfgAlias>$40
     <unconditional> -> bb61
 
 # backedges
-# - bb17(rubyBlockId=0)
-bb19[rubyBlockId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
+# - bb17(rubyRegionId=0)
+bb19[rubyRegionId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
     <statTemp>$42: Integer(10) = 10
     <ifTemp>$41: T::Boolean = <statTemp>$42: Integer(10).===(invite: T.untyped)
     <ifTemp>$41 -> (T::Boolean ? bb20 : bb21)
 
 # backedges
-# - bb19(rubyBlockId=0)
-bb20[rubyBlockId=0, firstDead=-1]():
+# - bb19(rubyRegionId=0)
+bb20[rubyRegionId=0, firstDead=-1]():
     <cfgAlias>$44: T.class_of(C10) = alias <C C10>
     r: T.class_of(C10) = <cfgAlias>$44
     <unconditional> -> bb61
 
 # backedges
-# - bb19(rubyBlockId=0)
-bb21[rubyBlockId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
+# - bb19(rubyRegionId=0)
+bb21[rubyRegionId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
     <statTemp>$46: Integer(11) = 11
     <ifTemp>$45: T::Boolean = <statTemp>$46: Integer(11).===(invite: T.untyped)
     <ifTemp>$45 -> (T::Boolean ? bb22 : bb23)
 
 # backedges
-# - bb21(rubyBlockId=0)
-bb22[rubyBlockId=0, firstDead=-1]():
+# - bb21(rubyRegionId=0)
+bb22[rubyRegionId=0, firstDead=-1]():
     <cfgAlias>$48: T.class_of(C11) = alias <C C11>
     r: T.class_of(C11) = <cfgAlias>$48
     <unconditional> -> bb61
 
 # backedges
-# - bb21(rubyBlockId=0)
-bb23[rubyBlockId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
+# - bb21(rubyRegionId=0)
+bb23[rubyRegionId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
     <statTemp>$50: Integer(12) = 12
     <ifTemp>$49: T::Boolean = <statTemp>$50: Integer(12).===(invite: T.untyped)
     <ifTemp>$49 -> (T::Boolean ? bb24 : bb25)
 
 # backedges
-# - bb23(rubyBlockId=0)
-bb24[rubyBlockId=0, firstDead=-1]():
+# - bb23(rubyRegionId=0)
+bb24[rubyRegionId=0, firstDead=-1]():
     <cfgAlias>$52: T.class_of(C12) = alias <C C12>
     r: T.class_of(C12) = <cfgAlias>$52
     <unconditional> -> bb61
 
 # backedges
-# - bb23(rubyBlockId=0)
-bb25[rubyBlockId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
+# - bb23(rubyRegionId=0)
+bb25[rubyRegionId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
     <statTemp>$54: Integer(13) = 13
     <ifTemp>$53: T::Boolean = <statTemp>$54: Integer(13).===(invite: T.untyped)
     <ifTemp>$53 -> (T::Boolean ? bb26 : bb27)
 
 # backedges
-# - bb25(rubyBlockId=0)
-bb26[rubyBlockId=0, firstDead=-1]():
+# - bb25(rubyRegionId=0)
+bb26[rubyRegionId=0, firstDead=-1]():
     <cfgAlias>$56: T.class_of(C13) = alias <C C13>
     r: T.class_of(C13) = <cfgAlias>$56
     <unconditional> -> bb61
 
 # backedges
-# - bb25(rubyBlockId=0)
-bb27[rubyBlockId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
+# - bb25(rubyRegionId=0)
+bb27[rubyRegionId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
     <statTemp>$58: Integer(14) = 14
     <ifTemp>$57: T::Boolean = <statTemp>$58: Integer(14).===(invite: T.untyped)
     <ifTemp>$57 -> (T::Boolean ? bb28 : bb29)
 
 # backedges
-# - bb27(rubyBlockId=0)
-bb28[rubyBlockId=0, firstDead=-1]():
+# - bb27(rubyRegionId=0)
+bb28[rubyRegionId=0, firstDead=-1]():
     <cfgAlias>$60: T.class_of(C14) = alias <C C14>
     r: T.class_of(C14) = <cfgAlias>$60
     <unconditional> -> bb61
 
 # backedges
-# - bb27(rubyBlockId=0)
-bb29[rubyBlockId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
+# - bb27(rubyRegionId=0)
+bb29[rubyRegionId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
     <statTemp>$62: Integer(15) = 15
     <ifTemp>$61: T::Boolean = <statTemp>$62: Integer(15).===(invite: T.untyped)
     <ifTemp>$61 -> (T::Boolean ? bb30 : bb31)
 
 # backedges
-# - bb29(rubyBlockId=0)
-bb30[rubyBlockId=0, firstDead=-1]():
+# - bb29(rubyRegionId=0)
+bb30[rubyRegionId=0, firstDead=-1]():
     <cfgAlias>$64: T.class_of(C15) = alias <C C15>
     r: T.class_of(C15) = <cfgAlias>$64
     <unconditional> -> bb61
 
 # backedges
-# - bb29(rubyBlockId=0)
-bb31[rubyBlockId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
+# - bb29(rubyRegionId=0)
+bb31[rubyRegionId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
     <statTemp>$66: Integer(16) = 16
     <ifTemp>$65: T::Boolean = <statTemp>$66: Integer(16).===(invite: T.untyped)
     <ifTemp>$65 -> (T::Boolean ? bb32 : bb33)
 
 # backedges
-# - bb31(rubyBlockId=0)
-bb32[rubyBlockId=0, firstDead=-1]():
+# - bb31(rubyRegionId=0)
+bb32[rubyRegionId=0, firstDead=-1]():
     <cfgAlias>$68: T.class_of(C16) = alias <C C16>
     r: T.class_of(C16) = <cfgAlias>$68
     <unconditional> -> bb61
 
 # backedges
-# - bb31(rubyBlockId=0)
-bb33[rubyBlockId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
+# - bb31(rubyRegionId=0)
+bb33[rubyRegionId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
     <statTemp>$70: Integer(17) = 17
     <ifTemp>$69: T::Boolean = <statTemp>$70: Integer(17).===(invite: T.untyped)
     <ifTemp>$69 -> (T::Boolean ? bb34 : bb35)
 
 # backedges
-# - bb33(rubyBlockId=0)
-bb34[rubyBlockId=0, firstDead=-1]():
+# - bb33(rubyRegionId=0)
+bb34[rubyRegionId=0, firstDead=-1]():
     <cfgAlias>$72: T.class_of(C17) = alias <C C17>
     r: T.class_of(C17) = <cfgAlias>$72
     <unconditional> -> bb61
 
 # backedges
-# - bb33(rubyBlockId=0)
-bb35[rubyBlockId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
+# - bb33(rubyRegionId=0)
+bb35[rubyRegionId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
     <statTemp>$74: Integer(18) = 18
     <ifTemp>$73: T::Boolean = <statTemp>$74: Integer(18).===(invite: T.untyped)
     <ifTemp>$73 -> (T::Boolean ? bb36 : bb37)
 
 # backedges
-# - bb35(rubyBlockId=0)
-bb36[rubyBlockId=0, firstDead=-1]():
+# - bb35(rubyRegionId=0)
+bb36[rubyRegionId=0, firstDead=-1]():
     <cfgAlias>$76: T.class_of(C18) = alias <C C18>
     r: T.class_of(C18) = <cfgAlias>$76
     <unconditional> -> bb61
 
 # backedges
-# - bb35(rubyBlockId=0)
-bb37[rubyBlockId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
+# - bb35(rubyRegionId=0)
+bb37[rubyRegionId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
     <statTemp>$78: Integer(19) = 19
     <ifTemp>$77: T::Boolean = <statTemp>$78: Integer(19).===(invite: T.untyped)
     <ifTemp>$77 -> (T::Boolean ? bb38 : bb39)
 
 # backedges
-# - bb37(rubyBlockId=0)
-bb38[rubyBlockId=0, firstDead=-1]():
+# - bb37(rubyRegionId=0)
+bb38[rubyRegionId=0, firstDead=-1]():
     <cfgAlias>$80: T.class_of(C19) = alias <C C19>
     r: T.class_of(C19) = <cfgAlias>$80
     <unconditional> -> bb61
 
 # backedges
-# - bb37(rubyBlockId=0)
-bb39[rubyBlockId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
+# - bb37(rubyRegionId=0)
+bb39[rubyRegionId=0, firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
     <statTemp>$82: Integer(20) = 20
     <ifTemp>$81: T::Boolean = <statTemp>$82: Integer(20).===(invite: T.untyped)
     <ifTemp>$81 -> (T::Boolean ? bb40 : bb41)
 
 # backedges
-# - bb39(rubyBlockId=0)
-bb40[rubyBlockId=0, firstDead=-1]():
+# - bb39(rubyRegionId=0)
+bb40[rubyRegionId=0, firstDead=-1]():
     <cfgAlias>$84: T.class_of(C20) = alias <C C20>
     r: T.class_of(C20) = <cfgAlias>$84
     <unconditional> -> bb61
 
 # backedges
-# - bb39(rubyBlockId=0)
-bb41[rubyBlockId=0, firstDead=2](<self>: T.class_of(A)):
+# - bb39(rubyRegionId=0)
+bb41[rubyRegionId=0, firstDead=2](<self>: T.class_of(A)):
     <statTemp>$86: String("Bla bla bla") = "Bla bla bla"
     <statTemp>$3: T.noreturn = <self>: T.class_of(A).raise(<statTemp>$86: String("Bla bla bla"))
     <unconditional> -> bb61
 
 # backedges
-# - bb2(rubyBlockId=0)
-# - bb4(rubyBlockId=0)
-# - bb6(rubyBlockId=0)
-# - bb8(rubyBlockId=0)
-# - bb10(rubyBlockId=0)
-# - bb12(rubyBlockId=0)
-# - bb14(rubyBlockId=0)
-# - bb16(rubyBlockId=0)
-# - bb18(rubyBlockId=0)
-# - bb20(rubyBlockId=0)
-# - bb22(rubyBlockId=0)
-# - bb24(rubyBlockId=0)
-# - bb26(rubyBlockId=0)
-# - bb28(rubyBlockId=0)
-# - bb30(rubyBlockId=0)
-# - bb32(rubyBlockId=0)
-# - bb34(rubyBlockId=0)
-# - bb36(rubyBlockId=0)
-# - bb38(rubyBlockId=0)
-# - bb40(rubyBlockId=0)
-# - bb41(rubyBlockId=0)
-bb61[rubyBlockId=0, firstDead=2](r: T.any(T.class_of(C1), T.class_of(C2), T.class_of(C3), T.class_of(C4), T.class_of(C5), T.class_of(C6), T.class_of(C7), T.class_of(C8), T.class_of(C9), T.class_of(C10), T.class_of(C11), T.class_of(C12), T.class_of(C13), T.class_of(C14), T.class_of(C15), T.class_of(C16), T.class_of(C17), T.class_of(C18), T.class_of(C19), T.class_of(C20))):
+# - bb2(rubyRegionId=0)
+# - bb4(rubyRegionId=0)
+# - bb6(rubyRegionId=0)
+# - bb8(rubyRegionId=0)
+# - bb10(rubyRegionId=0)
+# - bb12(rubyRegionId=0)
+# - bb14(rubyRegionId=0)
+# - bb16(rubyRegionId=0)
+# - bb18(rubyRegionId=0)
+# - bb20(rubyRegionId=0)
+# - bb22(rubyRegionId=0)
+# - bb24(rubyRegionId=0)
+# - bb26(rubyRegionId=0)
+# - bb28(rubyRegionId=0)
+# - bb30(rubyRegionId=0)
+# - bb32(rubyRegionId=0)
+# - bb34(rubyRegionId=0)
+# - bb36(rubyRegionId=0)
+# - bb38(rubyRegionId=0)
+# - bb40(rubyRegionId=0)
+# - bb41(rubyRegionId=0)
+bb61[rubyRegionId=0, firstDead=2](r: T.any(T.class_of(C1), T.class_of(C2), T.class_of(C3), T.class_of(C4), T.class_of(C5), T.class_of(C6), T.class_of(C7), T.class_of(C8), T.class_of(C9), T.class_of(C10), T.class_of(C11), T.class_of(C12), T.class_of(C13), T.class_of(C14), T.class_of(C15), T.class_of(C16), T.class_of(C17), T.class_of(C18), T.class_of(C19), T.class_of(C20))):
     s: T.any(T.class_of(C1), T.class_of(C2), T.class_of(C3), T.class_of(C4), T.class_of(C5), T.class_of(C6), T.class_of(C7), T.class_of(C8), T.class_of(C9), T.class_of(C10), T.class_of(C11), T.class_of(C12), T.class_of(C13), T.class_of(C14), T.class_of(C15), T.class_of(C16), T.class_of(C17), T.class_of(C18), T.class_of(C19), T.class_of(C20)) = r
     <returnMethodTemp>$2: T.noreturn = return s: T.any(T.class_of(C1), T.class_of(C2), T.class_of(C3), T.class_of(C4), T.class_of(C5), T.class_of(C6), T.class_of(C7), T.class_of(C8), T.class_of(C9), T.class_of(C10), T.class_of(C11), T.class_of(C12), T.class_of(C13), T.class_of(C14), T.class_of(C15), T.class_of(C16), T.class_of(C17), T.class_of(C18), T.class_of(C19), T.class_of(C20))
     <unconditional> -> bb1
@@ -864,7 +864,7 @@ bb61[rubyBlockId=0, firstDead=2](r: T.any(T.class_of(C1), T.class_of(C2), T.clas
 
 method ::<Class:A>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=6]():
+bb0[rubyRegionId=0, firstDead=6]():
     <self>: T.class_of(A) = cast(<self>: NilClass, T.class_of(A));
     <cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$6: Symbol(:send_beta_invitation) = :send_beta_invitation
@@ -874,8 +874,8 @@ bb0[rubyBlockId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/infer/infer1.rb.cfg-text.exp
+++ b/test/testdata/infer/infer1.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::Object#baz1 {
 
-bb0[rubyBlockId=0, firstDead=5]():
+bb0[rubyRegionId=0, firstDead=5]():
     <self>: Object = cast(<self>: NilClass, Object);
     a: String("foo") = "foo"
     b: T.nilable(Integer) = a: String("foo").getbyte(a: String("foo"))
@@ -9,15 +9,15 @@ bb0[rubyBlockId=0, firstDead=5]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Object#baz2 {
 
-bb0[rubyBlockId=0, firstDead=6]():
+bb0[rubyRegionId=0, firstDead=6]():
     <self>: Object = cast(<self>: NilClass, Object);
     a: String("foo") = "foo"
     <statTemp>$5: String("foo") = "foo"
@@ -27,15 +27,15 @@ bb0[rubyBlockId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Object#baz3 {
 
-bb0[rubyBlockId=0, firstDead=6]():
+bb0[rubyRegionId=0, firstDead=6]():
     <self>: Object = cast(<self>: NilClass, Object);
     <statTemp>$3: String("foo") = "foo"
     <statTemp>$4: String("foo") = "foo"
@@ -45,15 +45,15 @@ bb0[rubyBlockId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Object#baz4 {
 
-bb0[rubyBlockId=0, firstDead=6]():
+bb0[rubyRegionId=0, firstDead=6]():
     <self>: Object = cast(<self>: NilClass, Object);
     <statTemp>$3: T.untyped = <self>: Object.a()
     <statTemp>$5: String("foo") = "foo"
@@ -63,40 +63,40 @@ bb0[rubyBlockId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Object#baz5 {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     cond: T.untyped = load_arg(cond)
     cond -> (T.untyped ? bb2 : bb3)
 
 # backedges
-# - bb4(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb4(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb2[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb2[rubyRegionId=0, firstDead=-1]():
     b: Integer(1) = 1
     <unconditional> -> bb4
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb3[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb3[rubyRegionId=0, firstDead=-1]():
     b: String("foo") = "foo"
     <unconditional> -> bb4
 
 # backedges
-# - bb2(rubyBlockId=0)
-# - bb3(rubyBlockId=0)
-bb4[rubyBlockId=0, firstDead=5](b: T.any(Integer, String)):
+# - bb2(rubyRegionId=0)
+# - bb3(rubyRegionId=0)
+bb4[rubyRegionId=0, firstDead=5](b: T.any(Integer, String)):
     <statTemp>$5: T.any(Integer, String) = b
     <statTemp>$6: Integer(1) = 1
     b: T.untyped = <statTemp>$5: T.any(Integer, String).getbyte(<statTemp>$6: Integer(1))
@@ -108,32 +108,32 @@ bb4[rubyBlockId=0, firstDead=5](b: T.any(Integer, String)):
 
 method ::Object#baz6 {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     cond: T.untyped = load_arg(cond)
     cond -> (T.untyped ? bb2 : bb3)
 
 # backedges
-# - bb4(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb4(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb2[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb2[rubyRegionId=0, firstDead=-1]():
     b: Integer(1) = 1
     <unconditional> -> bb4
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb3[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb3[rubyRegionId=0, firstDead=-1]():
     b: String("foo") = "foo"
     <unconditional> -> bb4
 
 # backedges
-# - bb2(rubyBlockId=0)
-# - bb3(rubyBlockId=0)
-bb4[rubyBlockId=0, firstDead=5](b: T.any(Integer, String)):
+# - bb2(rubyRegionId=0)
+# - bb3(rubyRegionId=0)
+bb4[rubyRegionId=0, firstDead=5](b: T.any(Integer, String)):
     <statTemp>$5: String("foo") = "foo"
     <statTemp>$6: T.any(Integer, String) = b
     b: T.nilable(Integer) = <statTemp>$5: String("foo").getbyte(<statTemp>$6: T.any(Integer, String))
@@ -145,26 +145,26 @@ bb4[rubyBlockId=0, firstDead=5](b: T.any(Integer, String)):
 
 method ::Object#baz7 {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     cond: T.untyped = load_arg(cond)
     cond -> (T.untyped ? bb2 : bb4)
 
 # backedges
-# - bb4(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb4(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb2[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb2[rubyRegionId=0, firstDead=-1]():
     b: Integer(1) = 1
     <unconditional> -> bb4
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb2(rubyBlockId=0)
-bb4[rubyBlockId=0, firstDead=5](b: T.nilable(Integer)):
+# - bb0(rubyRegionId=0)
+# - bb2(rubyRegionId=0)
+bb4[rubyRegionId=0, firstDead=5](b: T.nilable(Integer)):
     <statTemp>$5: String("foo") = "foo"
     <statTemp>$6: T.nilable(Integer) = b
     b: T.nilable(Integer) = <statTemp>$5: String("foo").getbyte(<statTemp>$6: T.nilable(Integer))
@@ -176,33 +176,33 @@ bb4[rubyBlockId=0, firstDead=5](b: T.nilable(Integer)):
 
 method ::Object#baz8 {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb5(rubyBlockId=0)
-bb2[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+# - bb5(rubyRegionId=0)
+bb2[rubyRegionId=0, firstDead=-1]():
     # outerLoops: 1
     <whileTemp>$3: TrueClass = true
     <whileTemp>$3 -> (TrueClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=0)
-bb3[rubyBlockId=0, firstDead=0]():
+# - bb2(rubyRegionId=0)
+bb3[rubyRegionId=0, firstDead=0]():
     <returnMethodTemp>$2 = nil
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=0)
-bb5[rubyBlockId=0, firstDead=-1]():
+# - bb2(rubyRegionId=0)
+bb5[rubyRegionId=0, firstDead=-1]():
     # outerLoops: 1
     b: Integer(1) = 1
     <unconditional> -> bb2
@@ -211,7 +211,7 @@ bb5[rubyBlockId=0, firstDead=-1]():
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=34]():
+bb0[rubyRegionId=0, firstDead=34]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$7: Symbol(:baz1) = :baz1
@@ -249,8 +249,8 @@ bb0[rubyBlockId=0, firstDead=34]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/infer/isa_generic.rb.cfg-text.exp
+++ b/test/testdata/infer/isa_generic.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::Object#f {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     x: T.any(Concrete, Other) = load_arg(x)
     <cfgAlias>$7: T.class_of(Concrete) = alias <C Concrete>
@@ -8,13 +8,13 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <ifTemp>$5 -> (T::Boolean ? bb2 : bb3)
 
 # backedges
-# - bb13(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb13(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb2[rubyBlockId=0, firstDead=-1](x: Concrete):
+# - bb0(rubyRegionId=0)
+bb2[rubyRegionId=0, firstDead=-1](x: Concrete):
     <cfgAlias>$11: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <cfgAlias>$13: T.class_of(Concrete) = alias <C Concrete>
     <statTemp>$9: Sorbet::Private::Static::Void = <cfgAlias>$11: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<cfgAlias>$13: T.class_of(Concrete))
@@ -23,15 +23,15 @@ bb2[rubyBlockId=0, firstDead=-1](x: Concrete):
     <unconditional> -> bb7
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb3[rubyBlockId=0, firstDead=-1](x: Other):
+# - bb0(rubyRegionId=0)
+bb3[rubyRegionId=0, firstDead=-1](x: Other):
     <cfgAlias>$17: T.class_of(Other) = alias <C Other>
     <ifTemp>$15: TrueClass = <cfgAlias>$17: T.class_of(Other).===(x: Other)
     <ifTemp>$15 -> (TrueClass ? bb4 : bb7)
 
 # backedges
-# - bb3(rubyBlockId=0)
-bb4[rubyBlockId=0, firstDead=-1](x: Other):
+# - bb3(rubyRegionId=0)
+bb4[rubyRegionId=0, firstDead=-1](x: Other):
     <cfgAlias>$21: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <cfgAlias>$23: T.class_of(Other) = alias <C Other>
     <statTemp>$19: Sorbet::Private::Static::Void = <cfgAlias>$21: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<cfgAlias>$23: T.class_of(Other))
@@ -40,17 +40,17 @@ bb4[rubyBlockId=0, firstDead=-1](x: Other):
     <unconditional> -> bb7
 
 # backedges
-# - bb2(rubyBlockId=0)
-# - bb3(rubyBlockId=0)
-# - bb4(rubyBlockId=0)
-bb7[rubyBlockId=0, firstDead=-1](x: T.any(Concrete, Other)):
+# - bb2(rubyRegionId=0)
+# - bb3(rubyRegionId=0)
+# - bb4(rubyRegionId=0)
+bb7[rubyRegionId=0, firstDead=-1](x: T.any(Concrete, Other)):
     <cfgAlias>$29: T.class_of(Concrete) = alias <C Concrete>
     <ifTemp>$26: T::Boolean = x: T.any(Concrete, Other).is_a?(<cfgAlias>$29: T.class_of(Concrete))
     <ifTemp>$26 -> (T::Boolean ? bb8 : bb10)
 
 # backedges
-# - bb7(rubyBlockId=0)
-bb8[rubyBlockId=0, firstDead=-1](x: Concrete):
+# - bb7(rubyRegionId=0)
+bb8[rubyRegionId=0, firstDead=-1](x: Concrete):
     <cfgAlias>$32: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <cfgAlias>$34: T.class_of(Concrete) = alias <C Concrete>
     <statTemp>$30: Sorbet::Private::Static::Void = <cfgAlias>$32: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<cfgAlias>$34: T.class_of(Concrete))
@@ -59,16 +59,16 @@ bb8[rubyBlockId=0, firstDead=-1](x: Concrete):
     <unconditional> -> bb10
 
 # backedges
-# - bb7(rubyBlockId=0)
-# - bb8(rubyBlockId=0)
-bb10[rubyBlockId=0, firstDead=-1](x: T.any(Other, Concrete)):
+# - bb7(rubyRegionId=0)
+# - bb8(rubyRegionId=0)
+bb10[rubyRegionId=0, firstDead=-1](x: T.any(Other, Concrete)):
     <cfgAlias>$39: T.class_of(Other) = alias <C Other>
     <ifTemp>$36: T::Boolean = x: T.any(Other, Concrete).is_a?(<cfgAlias>$39: T.class_of(Other))
     <ifTemp>$36 -> (T::Boolean ? bb13 : bb12)
 
 # backedges
-# - bb10(rubyBlockId=0)
-bb12[rubyBlockId=0, firstDead=-1](x: Concrete):
+# - bb10(rubyRegionId=0)
+bb12[rubyRegionId=0, firstDead=-1](x: Concrete):
     <cfgAlias>$42: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <cfgAlias>$44: T.class_of(Concrete) = alias <C Concrete>
     <statTemp>$40: Sorbet::Private::Static::Void = <cfgAlias>$42: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<cfgAlias>$44: T.class_of(Concrete))
@@ -77,9 +77,9 @@ bb12[rubyBlockId=0, firstDead=-1](x: Concrete):
     <unconditional> -> bb13
 
 # backedges
-# - bb10(rubyBlockId=0)
-# - bb12(rubyBlockId=0)
-bb13[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: T.nilable(Concrete)):
+# - bb10(rubyRegionId=0)
+# - bb12(rubyRegionId=0)
+bb13[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.nilable(Concrete)):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(Concrete)
     <unconditional> -> bb1
 
@@ -87,7 +87,7 @@ bb13[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: T.nilable(Concrete)):
 
 method ::Object#f2 {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     x: T.any(Base, Other) = load_arg(x)
     <cfgAlias>$6: T.class_of(Base)[T.untyped] = alias <C Base>
@@ -95,21 +95,21 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <ifTemp>$3 -> (T::Boolean ? bb2 : bb4)
 
 # backedges
-# - bb4(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb4(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb2[rubyBlockId=0, firstDead=-1](x: Base):
+# - bb0(rubyRegionId=0)
+bb2[rubyRegionId=0, firstDead=-1](x: Base):
     <cfgAlias>$8: T.class_of(T) = alias <C T>
     <returnMethodTemp>$2: Base = <cfgAlias>$8: T.class_of(T).reveal_type(x: Base)
     <unconditional> -> bb4
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb2(rubyBlockId=0)
-bb4[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: T.nilable(Base)):
+# - bb0(rubyRegionId=0)
+# - bb2(rubyRegionId=0)
+bb4[rubyRegionId=0, firstDead=1](<returnMethodTemp>$2: T.nilable(Base)):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(Base)
     <unconditional> -> bb1
 
@@ -117,7 +117,7 @@ bb4[rubyBlockId=0, firstDead=1](<returnMethodTemp>$2: T.nilable(Base)):
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
     <statTemp>$7: FalseClass = false
@@ -127,20 +127,20 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb7(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb7(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb5(rubyBlockId=1)
-bb2[rubyBlockId=1, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(<root>)):
+# - bb0(rubyRegionId=0)
+# - bb5(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(<root>)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb3[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(<root>)):
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(<root>)):
     <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$9, sig>
     <self>: T.class_of(<root>) = <selfRestore>$10
     <cfgAlias>$26: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
@@ -151,8 +151,8 @@ bb3[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$9: Sorbet::Private::Stati
     <unconditional> -> bb6
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb5[rubyBlockId=1, firstDead=9](<self>: T.class_of(<root>), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(<root>)):
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=9](<self>: T.class_of(<root>), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(<root>)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf
     <hashTemp>$15: Symbol(:x) = :x
@@ -166,15 +166,15 @@ bb5[rubyBlockId=1, firstDead=9](<self>: T.class_of(<root>), <block-pre-call-temp
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-# - bb9(rubyBlockId=2)
-bb6[rubyBlockId=2, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$30: Sorbet::Private::Static::Void, <selfRestore>$31: T.class_of(<root>)):
+# - bb3(rubyRegionId=0)
+# - bb9(rubyRegionId=2)
+bb6[rubyRegionId=2, firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$30: Sorbet::Private::Static::Void, <selfRestore>$31: T.class_of(<root>)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
-# - bb6(rubyBlockId=2)
-bb7[rubyBlockId=0, firstDead=35](<block-pre-call-temp>$30: Sorbet::Private::Static::Void, <selfRestore>$31: T.class_of(<root>)):
+# - bb6(rubyRegionId=2)
+bb7[rubyRegionId=0, firstDead=35](<block-pre-call-temp>$30: Sorbet::Private::Static::Void, <selfRestore>$31: T.class_of(<root>)):
     <statTemp>$24: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$30, sig>
     <self>: T.class_of(<root>) = <selfRestore>$31
     <cfgAlias>$48: T.class_of(T::Sig) = alias <C Sig>
@@ -213,8 +213,8 @@ bb7[rubyBlockId=0, firstDead=35](<block-pre-call-temp>$30: Sorbet::Private::Stat
     <unconditional> -> bb1
 
 # backedges
-# - bb6(rubyBlockId=2)
-bb9[rubyBlockId=2, firstDead=9](<self>: T.class_of(<root>), <block-pre-call-temp>$30: Sorbet::Private::Static::Void, <selfRestore>$31: T.class_of(<root>)):
+# - bb6(rubyRegionId=2)
+bb9[rubyRegionId=2, firstDead=9](<self>: T.class_of(<root>), <block-pre-call-temp>$30: Sorbet::Private::Static::Void, <selfRestore>$31: T.class_of(<root>)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf
     <hashTemp>$36: Symbol(:x) = :x
@@ -231,7 +231,7 @@ bb9[rubyBlockId=2, firstDead=9](<self>: T.class_of(<root>), <block-pre-call-temp
 
 method ::<Class:Base>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=7]():
+bb0[rubyRegionId=0, firstDead=7]():
     <C Klass>$10: <Type: T.class_of(Base)::Klass> = alias <C Klass>
     <self>: T.class_of(Base)[T.class_of(Base)::Klass] = cast(<self>: NilClass, T.class_of(Base)[T.class_of(Base)::Klass]);
     <cfgAlias>$6: T.class_of(T::Generic) = alias <C Generic>
@@ -242,15 +242,15 @@ bb0[rubyBlockId=0, firstDead=7]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Concrete>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=9]():
+bb0[rubyRegionId=0, firstDead=9]():
     <C Klass>$10: <Type: String> = alias <C Klass>
     <self>: T.class_of(Concrete) = cast(<self>: NilClass, T.class_of(Concrete));
     <cfgAlias>$6: T.class_of(T::Generic) = alias <C Generic>
@@ -263,22 +263,22 @@ bb0[rubyBlockId=0, firstDead=9]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Other>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(Other) = cast(<self>: NilClass, T.class_of(Other));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/infer/loops.rb.cfg-text.exp
+++ b/test/testdata/infer/loops.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=8]():
+bb0[rubyRegionId=0, firstDead=8]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <cfgAlias>$7: T.class_of(HasLoops) = alias <C HasLoops>
@@ -12,41 +12,41 @@ bb0[rubyBlockId=0, firstDead=8]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::HasLoops#variable_only_inside_loop {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: HasLoops = cast(<self>: NilClass, HasLoops);
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb5(rubyBlockId=0)
-bb2[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+# - bb5(rubyRegionId=0)
+bb2[rubyRegionId=0, firstDead=-1]():
     # outerLoops: 1
     <whileTemp>$3: TrueClass = true
     <whileTemp>$3 -> (TrueClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=0)
-bb3[rubyBlockId=0, firstDead=0]():
+# - bb2(rubyRegionId=0)
+bb3[rubyRegionId=0, firstDead=0]():
     <returnMethodTemp>$2 = nil
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=0)
-bb5[rubyBlockId=0, firstDead=-1]():
+# - bb2(rubyRegionId=0)
+bb5[rubyRegionId=0, firstDead=-1]():
     # outerLoops: 1
     a: Integer(1) = 1
     <unconditional> -> bb2
@@ -55,34 +55,34 @@ bb5[rubyBlockId=0, firstDead=-1]():
 
 method ::HasLoops#incorrect_assignment {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: HasLoops = cast(<self>: NilClass, HasLoops);
     a: String("s") = "s"
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb5(rubyBlockId=0)
-bb2[rubyBlockId=0, firstDead=-1](a: String("s")):
+# - bb0(rubyRegionId=0)
+# - bb5(rubyRegionId=0)
+bb2[rubyRegionId=0, firstDead=-1](a: String("s")):
     # outerLoops: 1
     <whileTemp>$4: TrueClass = true
     <whileTemp>$4 -> (TrueClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=0)
-bb3[rubyBlockId=0, firstDead=0]():
+# - bb2(rubyRegionId=0)
+bb3[rubyRegionId=0, firstDead=0]():
     <returnMethodTemp>$2 = nil
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=0)
-bb5[rubyBlockId=0, firstDead=-1](a: String("s")):
+# - bb2(rubyRegionId=0)
+bb5[rubyRegionId=0, firstDead=-1](a: String("s")):
     # outerLoops: 1
     a: T.untyped = 1
     <unconditional> -> bb2
@@ -91,34 +91,34 @@ bb5[rubyBlockId=0, firstDead=-1](a: String("s")):
 
 method ::HasLoops#correct_assignment {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: HasLoops = cast(<self>: NilClass, HasLoops);
     a: String("s") = "s"
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb5(rubyBlockId=0)
-bb2[rubyBlockId=0, firstDead=-1](a: String("s")):
+# - bb0(rubyRegionId=0)
+# - bb5(rubyRegionId=0)
+bb2[rubyRegionId=0, firstDead=-1](a: String("s")):
     # outerLoops: 1
     <whileTemp>$4: TrueClass = true
     <whileTemp>$4 -> (TrueClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=0)
-bb3[rubyBlockId=0, firstDead=0]():
+# - bb2(rubyRegionId=0)
+bb3[rubyRegionId=0, firstDead=0]():
     <returnMethodTemp>$2 = nil
     <finalReturn> = return <returnMethodTemp>$2
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=0)
-bb5[rubyBlockId=0, firstDead=-1](a: String("s")):
+# - bb2(rubyRegionId=0)
+bb5[rubyRegionId=0, firstDead=-1](a: String("s")):
     # outerLoops: 1
     a: String("a") = "a"
     <unconditional> -> bb2
@@ -127,7 +127,7 @@ bb5[rubyBlockId=0, firstDead=-1](a: String("s")):
 
 method ::<Class:HasLoops>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=14]():
+bb0[rubyRegionId=0, firstDead=14]():
     <self>: T.class_of(HasLoops) = cast(<self>: NilClass, T.class_of(HasLoops));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$7: Symbol(:variable_only_inside_loop) = :variable_only_inside_loop
@@ -145,8 +145,8 @@ bb0[rubyBlockId=0, firstDead=14]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/infer/meta_types.rb.cfg-text.exp
+++ b/test/testdata/infer/meta_types.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=8]():
+bb0[rubyRegionId=0, firstDead=8]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <cfgAlias>$7: T.class_of(TestMetaType) = alias <C TestMetaType>
@@ -12,29 +12,29 @@ bb0[rubyBlockId=0, firstDead=8]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::TestMetaType#_ {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: TestMetaType = cast(<self>: NilClass, TestMetaType);
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::TestMetaType#testit {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: TestMetaType = cast(<self>: NilClass, TestMetaType);
     <cfgAlias>$7: T.class_of(T::Array) = alias <C Array>
     <cfgAlias>$9: T.class_of(T) = alias <C T>
@@ -45,13 +45,13 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <ifTemp>$15 -> (T.untyped ? bb2 : bb3)
 
 # backedges
-# - bb7(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb7(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb2[rubyBlockId=0, firstDead=-1](<self>: TestMetaType):
+# - bb0(rubyRegionId=0)
+bb2[rubyRegionId=0, firstDead=-1](<self>: TestMetaType):
     <cfgAlias>$18: T.class_of(T::Array) = alias <C Array>
     <cfgAlias>$20: T.class_of(T) = alias <C T>
     <cfgAlias>$22: T.class_of(String) = alias <C String>
@@ -59,22 +59,22 @@ bb2[rubyBlockId=0, firstDead=-1](<self>: TestMetaType):
     <unconditional> -> bb4
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb3[rubyBlockId=0, firstDead=-1](<self>: TestMetaType):
+# - bb0(rubyRegionId=0)
+bb3[rubyRegionId=0, firstDead=-1](<self>: TestMetaType):
     <statTemp>$14: FalseClass = false
     <unconditional> -> bb4
 
 # backedges
-# - bb2(rubyBlockId=0)
-# - bb3(rubyBlockId=0)
-bb4[rubyBlockId=0, firstDead=-1](<self>: TestMetaType, <statTemp>$14: Object):
+# - bb2(rubyRegionId=0)
+# - bb3(rubyRegionId=0)
+bb4[rubyRegionId=0, firstDead=-1](<self>: TestMetaType, <statTemp>$14: Object):
     <statTemp>$12: NilClass = <self>: TestMetaType.puts(<statTemp>$14: Object)
     <ifTemp>$25: T.untyped = <self>: TestMetaType._()
     <ifTemp>$25 -> (T.untyped ? bb5 : bb6)
 
 # backedges
-# - bb4(rubyBlockId=0)
-bb5[rubyBlockId=0, firstDead=-1](<self>: TestMetaType):
+# - bb4(rubyRegionId=0)
+bb5[rubyRegionId=0, firstDead=-1](<self>: TestMetaType):
     <cfgAlias>$28: T.class_of(T::Array) = alias <C Array>
     <cfgAlias>$30: T.class_of(T) = alias <C T>
     <cfgAlias>$32: T.class_of(String) = alias <C String>
@@ -82,8 +82,8 @@ bb5[rubyBlockId=0, firstDead=-1](<self>: TestMetaType):
     <unconditional> -> bb7
 
 # backedges
-# - bb4(rubyBlockId=0)
-bb6[rubyBlockId=0, firstDead=-1](<self>: TestMetaType):
+# - bb4(rubyRegionId=0)
+bb6[rubyRegionId=0, firstDead=-1](<self>: TestMetaType):
     <cfgAlias>$34: T.class_of(T::Array) = alias <C Array>
     <cfgAlias>$36: T.class_of(T) = alias <C T>
     <cfgAlias>$38: T.class_of(Float) = alias <C Float>
@@ -91,9 +91,9 @@ bb6[rubyBlockId=0, firstDead=-1](<self>: TestMetaType):
     <unconditional> -> bb7
 
 # backedges
-# - bb5(rubyBlockId=0)
-# - bb6(rubyBlockId=0)
-bb7[rubyBlockId=0, firstDead=2](<self>: TestMetaType, <statTemp>$24: Object):
+# - bb5(rubyRegionId=0)
+# - bb6(rubyRegionId=0)
+bb7[rubyRegionId=0, firstDead=2](<self>: TestMetaType, <statTemp>$24: Object):
     <returnMethodTemp>$2: NilClass = <self>: TestMetaType.puts(<statTemp>$24: Object)
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
@@ -102,7 +102,7 @@ bb7[rubyBlockId=0, firstDead=2](<self>: TestMetaType, <statTemp>$24: Object):
 
 method ::<Class:TestMetaType>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=10]():
+bb0[rubyRegionId=0, firstDead=10]():
     <self>: T.class_of(TestMetaType) = cast(<self>: NilClass, T.class_of(TestMetaType));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$7: Symbol(:_) = :_
@@ -116,8 +116,8 @@ bb0[rubyBlockId=0, firstDead=10]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/infer/rebind.rb.cfg-text.exp
+++ b/test/testdata/infer/rebind.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=26]():
+bb0[rubyRegionId=0, firstDead=26]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$6: T.class_of(<Magic>) = alias <C <Magic>>
     <cfgAlias>$8: T.class_of(C) = alias <C C>
@@ -30,29 +30,29 @@ bb0[rubyBlockId=0, firstDead=26]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::C#only_on_C {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: C = cast(<self>: NilClass, C);
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=6]():
+bb0[rubyRegionId=0, firstDead=6]():
     <self>: T.class_of(C) = cast(<self>: NilClass, T.class_of(C));
     <cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$6: Symbol(:only_on_C) = :only_on_C
@@ -62,29 +62,29 @@ bb0[rubyBlockId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::B#only_on_B {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: B = cast(<self>: NilClass, B);
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:B>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(B) = cast(<self>: NilClass, T.class_of(B));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
     <statTemp>$7: FalseClass = false
@@ -94,20 +94,20 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb5(rubyBlockId=1)
-bb2[rubyBlockId=1, firstDead=-1](<self>: T.class_of(B), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(B)):
+# - bb0(rubyRegionId=0)
+# - bb5(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(B), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(B)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb3[rubyBlockId=0, firstDead=10](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(B)):
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=10](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(B)):
     <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$9, sig>
     <self>: T.class_of(B) = <selfRestore>$10
     <cfgAlias>$27: T.class_of(T::Sig) = alias <C Sig>
@@ -121,8 +121,8 @@ bb3[rubyBlockId=0, firstDead=10](<block-pre-call-temp>$9: Sorbet::Private::Stati
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb5[rubyBlockId=1, firstDead=10](<self>: T.class_of(B), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(B)):
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=10](<self>: T.class_of(B), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(B)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf
     <hashTemp>$15: Symbol(:blk) = :blk
@@ -140,21 +140,21 @@ bb5[rubyBlockId=1, firstDead=10](<self>: T.class_of(B), <block-pre-call-temp>$9:
 
 method ::<Class:A>#mySig {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(A) = cast(<self>: NilClass, T.class_of(A));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:A>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(A) = cast(<self>: NilClass, T.class_of(A));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
     <statTemp>$7: TrueClass = true
@@ -164,20 +164,20 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb5(rubyBlockId=1)
-bb2[rubyBlockId=1, firstDead=-1](<self>: T.class_of(A), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(A)):
+# - bb0(rubyRegionId=0)
+# - bb5(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(A), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(A)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb3[rubyBlockId=0, firstDead=10](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(A)):
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=10](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(A)):
     <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$9, sig>
     <self>: T.class_of(A) = <selfRestore>$10
     <cfgAlias>$27: T.class_of(T::Sig) = alias <C Sig>
@@ -191,8 +191,8 @@ bb3[rubyBlockId=0, firstDead=10](<block-pre-call-temp>$9: Sorbet::Private::Stati
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb5[rubyBlockId=1, firstDead=10](<self>: T.class_of(A), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(A)):
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=10](<self>: T.class_of(A), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(A)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf
     <hashTemp>$15: Symbol(:blk) = :blk
@@ -210,48 +210,48 @@ bb5[rubyBlockId=1, firstDead=10](<self>: T.class_of(A), <block-pre-call-temp>$9:
 
 method ::Use#only_on_Use {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: Use = cast(<self>: NilClass, Use);
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Use#shouldRemoveSelfTemp {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Use = cast(<self>: NilClass, Use);
     <block-pre-call-temp>$4: Sorbet::Private::Static::Void = <self>: Use.only_on_Use()
     <selfRestore>$5: Use = <self>
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb5(rubyBlockId=1)
-bb2[rubyBlockId=1, firstDead=-1](<self>: Use, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Use):
+# - bb0(rubyRegionId=0)
+# - bb5(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: Use, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Use):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb3[rubyBlockId=0, firstDead=2](<block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Use):
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=2](<block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Use):
     <returnMethodTemp>$2: T.untyped = Solve<<block-pre-call-temp>$4, only_on_Use>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb5[rubyBlockId=1, firstDead=3](<self>: Use, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Use):
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=3](<self>: Use, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Use):
     # outerLoops: 1
     <self>: Use = loadSelf
     <blockReturnTemp>$7: Integer(1) = 1
@@ -262,7 +262,7 @@ bb5[rubyBlockId=1, firstDead=3](<self>: Use, <block-pre-call-temp>$4: Sorbet::Pr
 
 method ::Use#jumpBetweenClasses {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Use = cast(<self>: NilClass, Use);
     <cfgAlias>$4: T.class_of(A) = alias <C A>
     <block-pre-call-temp>$5: Sorbet::Private::Static::Void = <cfgAlias>$4: T.class_of(A).mySig()
@@ -270,27 +270,27 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb7(rubyBlockId=1)
-bb2[rubyBlockId=1, firstDead=-1](<self>: Use, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Use):
+# - bb0(rubyRegionId=0)
+# - bb7(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: Use, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Use):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb3[rubyBlockId=0, firstDead=2](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Use):
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=2](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Use):
     <returnMethodTemp>$2: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$5, mySig>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Sorbet::Private::Static::Void
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb5[rubyBlockId=1, firstDead=-1](<self>: Use, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Use):
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=-1](<self>: Use, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Use):
     # outerLoops: 1
     <self>: B = loadSelf
     <statTemp>$9: T.untyped = <self>: B.only_on_Use()
@@ -300,15 +300,15 @@ bb5[rubyBlockId=1, firstDead=-1](<self>: Use, <block-pre-call-temp>$5: Sorbet::P
     <unconditional> -> bb6
 
 # backedges
-# - bb5(rubyBlockId=1)
-# - bb9(rubyBlockId=2)
-bb6[rubyBlockId=2, firstDead=-1](<self>: B, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Use, <block-pre-call-temp>$14: Sorbet::Private::Static::Void, <selfRestore>$15: B):
+# - bb5(rubyRegionId=1)
+# - bb9(rubyRegionId=2)
+bb6[rubyRegionId=2, firstDead=-1](<self>: B, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Use, <block-pre-call-temp>$14: Sorbet::Private::Static::Void, <selfRestore>$15: B):
     # outerLoops: 2
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
-# - bb6(rubyBlockId=2)
-bb7[rubyBlockId=1, firstDead=3](<self>: B, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Use, <block-pre-call-temp>$14: Sorbet::Private::Static::Void, <selfRestore>$15: B):
+# - bb6(rubyRegionId=2)
+bb7[rubyRegionId=1, firstDead=3](<self>: B, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Use, <block-pre-call-temp>$14: Sorbet::Private::Static::Void, <selfRestore>$15: B):
     # outerLoops: 1
     <blockReturnTemp>$8: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$14, only_on_B>
     <self>: B = <selfRestore>$15
@@ -316,8 +316,8 @@ bb7[rubyBlockId=1, firstDead=3](<self>: B, <block-pre-call-temp>$5: Sorbet::Priv
     <unconditional> -> bb2
 
 # backedges
-# - bb6(rubyBlockId=2)
-bb9[rubyBlockId=2, firstDead=4](<self>: B, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Use, <block-pre-call-temp>$14: Sorbet::Private::Static::Void, <selfRestore>$15: B):
+# - bb6(rubyRegionId=2)
+bb9[rubyRegionId=2, firstDead=4](<self>: B, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Use, <block-pre-call-temp>$14: Sorbet::Private::Static::Void, <selfRestore>$15: B):
     # outerLoops: 2
     <self>: C = loadSelf
     <statTemp>$18: T.untyped = <self>: C.only_on_B()
@@ -329,7 +329,7 @@ bb9[rubyBlockId=2, firstDead=4](<self>: B, <block-pre-call-temp>$5: Sorbet::Priv
 
 method ::<Class:Use>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=17]():
+bb0[rubyRegionId=0, firstDead=17]():
     <self>: T.class_of(Use) = cast(<self>: NilClass, T.class_of(Use));
     <cfgAlias>$6: T.class_of(T::Sig) = alias <C Sig>
     <cfgAlias>$8: T.class_of(T) = alias <C T>
@@ -350,8 +350,8 @@ bb0[rubyBlockId=0, firstDead=17]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/infer/self_type.rb.cfg-text.exp
+++ b/test/testdata/infer/self_type.rb.cfg-text.exp
@@ -1,20 +1,20 @@
 method ::Object#rnd {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: Object = cast(<self>: NilClass, Object);
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$6: T.class_of(<Magic>) = alias <C <Magic>>
     <cfgAlias>$8: T.class_of(Parent) = alias <C Parent>
@@ -73,13 +73,13 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <ifTemp>$90 -> (T::Boolean ? bb2 : bb4)
 
 # backedges
-# - bb7(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb7(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb2[rubyBlockId=0, firstDead=-1](<self>: T.class_of(<root>), a: T.all(Generic[String], B)):
+# - bb0(rubyRegionId=0)
+bb2[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>), a: T.all(Generic[String], B)):
     <cfgAlias>$96: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <cfgAlias>$99: T.class_of(T) = alias <C T>
     <cfgAlias>$102: T.class_of(Generic) = alias <C Generic>
@@ -93,9 +93,9 @@ bb2[rubyBlockId=0, firstDead=-1](<self>: T.class_of(<root>), a: T.all(Generic[St
     <unconditional> -> bb4
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb2(rubyBlockId=0)
-bb4[rubyBlockId=0, firstDead=-1](<self>: T.class_of(<root>)):
+# - bb0(rubyRegionId=0)
+# - bb2(rubyRegionId=0)
+bb4[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>)):
     <cfgAlias>$112: T.class_of(<Magic>) = alias <C <Magic>>
     <cfgAlias>$114: T.class_of(Array) = alias <C Array>
     <statTemp>$110: Sorbet::Private::Static::Void = <cfgAlias>$112: T.class_of(<Magic>).<define-top-class-or-module>(<cfgAlias>$114: T.class_of(Array))
@@ -135,32 +135,32 @@ bb4[rubyBlockId=0, firstDead=-1](<self>: T.class_of(<root>)):
     <unconditional> -> bb5
 
 # backedges
-# - bb4(rubyBlockId=0)
-# - bb8(rubyBlockId=0)
-# - bb9(rubyBlockId=0)
-bb5[rubyBlockId=0, firstDead=-1](<self>: T.class_of(<root>), s: A):
+# - bb4(rubyRegionId=0)
+# - bb8(rubyRegionId=0)
+# - bb9(rubyRegionId=0)
+bb5[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>), s: A):
     # outerLoops: 1
     <whileTemp>$167: T.untyped = <self>: T.class_of(<root>).rnd()
     <whileTemp>$167 -> (T.untyped ? bb8 : bb7)
 
 # backedges
-# - bb5(rubyBlockId=0)
-bb7[rubyBlockId=0, firstDead=2](<self>: T.class_of(<root>), s: A):
+# - bb5(rubyRegionId=0)
+bb7[rubyRegionId=0, firstDead=2](<self>: T.class_of(<root>), s: A):
     <statTemp>$175: NilClass = <self>: T.class_of(<root>).puts(s: A)
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb5(rubyBlockId=0)
-bb8[rubyBlockId=0, firstDead=-1](<self>: T.class_of(<root>), s: A):
+# - bb5(rubyRegionId=0)
+bb8[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>), s: A):
     # outerLoops: 1
     <cfgAlias>$173: T.class_of(B) = alias <C B>
     <ifTemp>$170: T::Boolean = s: A.is_a?(<cfgAlias>$173: T.class_of(B))
     <ifTemp>$170 -> (T::Boolean ? bb9 : bb5)
 
 # backedges
-# - bb8(rubyBlockId=0)
-bb9[rubyBlockId=0, firstDead=-1](<self>: T.class_of(<root>), s: T.all(A, B)):
+# - bb8(rubyRegionId=0)
+bb9[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>), s: T.all(A, B)):
     # outerLoops: 1
     <statTemp>$174: T.all(A, B) = s
     s: T.all(A, B) = <statTemp>$174: T.all(A, B).returns_self()
@@ -170,22 +170,22 @@ bb9[rubyBlockId=0, firstDead=-1](<self>: T.class_of(<root>), s: T.all(A, B)):
 
 method ::Parent#returns_self {
 
-bb0[rubyBlockId=0, firstDead=3]():
+bb0[rubyRegionId=0, firstDead=3]():
     <self>: Parent = cast(<self>: NilClass, Parent);
     <returnMethodTemp>$2: Parent = <self>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Parent
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Parent>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(Parent) = cast(<self>: NilClass, T.class_of(Parent));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
     <statTemp>$7: FalseClass = false
@@ -195,20 +195,20 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb5(rubyBlockId=1)
-bb2[rubyBlockId=1, firstDead=-1](<self>: T.class_of(Parent), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Parent)):
+# - bb0(rubyRegionId=0)
+# - bb5(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Parent), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Parent)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb3[rubyBlockId=0, firstDead=10](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Parent)):
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=10](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Parent)):
     <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$9, sig>
     <self>: T.class_of(Parent) = <selfRestore>$10
     <cfgAlias>$21: T.class_of(T::Sig) = alias <C Sig>
@@ -222,8 +222,8 @@ bb3[rubyBlockId=0, firstDead=10](<block-pre-call-temp>$9: Sorbet::Private::Stati
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb5[rubyBlockId=1, firstDead=5](<self>: T.class_of(Parent), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Parent)):
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=5](<self>: T.class_of(Parent), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Parent)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf
     <cfgAlias>$16: T.class_of(T) = alias <C T>
@@ -236,21 +236,21 @@ bb5[rubyBlockId=1, firstDead=5](<self>: T.class_of(Parent), <block-pre-call-temp
 
 method ::<Class:Normal>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(Normal) = cast(<self>: NilClass, T.class_of(Normal));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Generic#bad {
 
-bb0[rubyBlockId=0, firstDead=7]():
+bb0[rubyRegionId=0, firstDead=7]():
     <self>: Generic[Generic::TM] = cast(<self>: NilClass, Generic[Generic::TM]);
     <cfgAlias>$5: T.class_of(Generic) = alias <C Generic>
     <cfgAlias>$8: T.class_of(T) = alias <C T>
@@ -261,15 +261,15 @@ bb0[rubyBlockId=0, firstDead=7]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Generic>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <C TM>$28: <Type: Generic::TM> = alias <C TM>
     <self>: T.class_of(Generic) = cast(<self>: NilClass, T.class_of(Generic));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
@@ -280,20 +280,20 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb5(rubyBlockId=1)
-bb2[rubyBlockId=1, firstDead=-1](<self>: T.class_of(Generic), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Generic), <C TM>$28: <Type: Generic::TM>):
+# - bb0(rubyRegionId=0)
+# - bb5(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Generic), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Generic), <C TM>$28: <Type: Generic::TM>):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb3[rubyBlockId=0, firstDead=11](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Generic), <C TM>$28: <Type: Generic::TM>):
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=11](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Generic), <C TM>$28: <Type: Generic::TM>):
     <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$9, sig>
     <self>: T.class_of(Generic) = <selfRestore>$10
     <cfgAlias>$24: T.class_of(T::Generic) = alias <C Generic>
@@ -308,8 +308,8 @@ bb3[rubyBlockId=0, firstDead=11](<block-pre-call-temp>$9: Sorbet::Private::Stati
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb5[rubyBlockId=1, firstDead=7](<self>: T.class_of(Generic), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Generic), <C TM>$28: <Type: Generic::TM>):
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=7](<self>: T.class_of(Generic), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Generic), <C TM>$28: <Type: Generic::TM>):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf
     <cfgAlias>$16: T.class_of(Generic) = alias <C Generic>
@@ -324,36 +324,36 @@ bb5[rubyBlockId=1, firstDead=7](<self>: T.class_of(Generic), <block-pre-call-tem
 
 method ::<Class:B>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(B) = cast(<self>: NilClass, T.class_of(B));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Array#returns_self {
 
-bb0[rubyBlockId=0, firstDead=3]():
+bb0[rubyRegionId=0, firstDead=3]():
     <self>: T::Array[Array::Elem] = cast(<self>: NilClass, T::Array[Array::Elem]);
     <returnMethodTemp>$2: T::Array[Array::Elem] = <self>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T::Array[Array::Elem]
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Array>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(Array) = cast(<self>: NilClass, T.class_of(Array));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
     <statTemp>$7: FalseClass = false
@@ -363,20 +363,20 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb5(rubyBlockId=1)
-bb2[rubyBlockId=1, firstDead=-1](<self>: T.class_of(Array), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Array)):
+# - bb0(rubyRegionId=0)
+# - bb5(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Array), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Array)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb3[rubyBlockId=0, firstDead=10](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Array)):
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=10](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Array)):
     <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$9, sig>
     <self>: T.class_of(Array) = <selfRestore>$10
     <cfgAlias>$21: T.class_of(T::Sig) = alias <C Sig>
@@ -390,8 +390,8 @@ bb3[rubyBlockId=0, firstDead=10](<block-pre-call-temp>$9: Sorbet::Private::Stati
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb5[rubyBlockId=1, firstDead=5](<self>: T.class_of(Array), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Array)):
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=5](<self>: T.class_of(Array), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Array)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf
     <cfgAlias>$16: T.class_of(T) = alias <C T>
@@ -404,36 +404,36 @@ bb5[rubyBlockId=1, firstDead=5](<self>: T.class_of(Array), <block-pre-call-temp>
 
 method ::<Class:A>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(A) = cast(<self>: NilClass, T.class_of(A));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::B#returns_self {
 
-bb0[rubyBlockId=0, firstDead=3]():
+bb0[rubyRegionId=0, firstDead=3]():
     <self>: B = cast(<self>: NilClass, B);
     <returnMethodTemp>$2: B = <self>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: B
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:B>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(B) = cast(<self>: NilClass, T.class_of(B));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
     <statTemp>$7: FalseClass = false
@@ -443,20 +443,20 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb5(rubyBlockId=1)
-bb2[rubyBlockId=1, firstDead=-1](<self>: T.class_of(B), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(B)):
+# - bb0(rubyRegionId=0)
+# - bb5(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(B), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(B)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb3[rubyBlockId=0, firstDead=10](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(B)):
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=10](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(B)):
     <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$9, sig>
     <self>: T.class_of(B) = <selfRestore>$10
     <cfgAlias>$21: T.class_of(T::Sig) = alias <C Sig>
@@ -470,8 +470,8 @@ bb3[rubyBlockId=0, firstDead=10](<block-pre-call-temp>$9: Sorbet::Private::Stati
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb5[rubyBlockId=1, firstDead=5](<self>: T.class_of(B), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(B)):
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=5](<self>: T.class_of(B), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(B)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf
     <cfgAlias>$16: T.class_of(T) = alias <C T>

--- a/test/testdata/infer/sigil.rb.cfg-text.exp
+++ b/test/testdata/infer/sigil.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::Object#foo {
 
-bb0[rubyBlockId=0, firstDead=5]():
+bb0[rubyRegionId=0, firstDead=5]():
     <self>: Object = cast(<self>: NilClass, Object);
     <statTemp>$3: String("3") = "3"
     <statTemp>$4: Integer(3) = 3
@@ -9,15 +9,15 @@ bb0[rubyBlockId=0, firstDead=5]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=6]():
+bb0[rubyRegionId=0, firstDead=6]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$6: Symbol(:foo) = :foo
@@ -27,8 +27,8 @@ bb0[rubyBlockId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/infer/singleton_methods.rb.cfg-text.exp
+++ b/test/testdata/infer/singleton_methods.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=14]():
+bb0[rubyRegionId=0, firstDead=14]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$6: T.class_of(<Magic>) = alias <C <Magic>>
     <cfgAlias>$8: T.class_of(Foo) = alias <C Foo>
@@ -18,30 +18,30 @@ bb0[rubyBlockId=0, firstDead=14]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Foo>#bar {
 
-bb0[rubyBlockId=0, firstDead=3]():
+bb0[rubyRegionId=0, firstDead=3]():
     <self>: T.class_of(Foo) = cast(<self>: NilClass, T.class_of(Foo));
     <returnMethodTemp>$2: Integer(1) = 1
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(1)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Foo>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=6]():
+bb0[rubyRegionId=0, firstDead=6]():
     <self>: T.class_of(Foo) = cast(<self>: NilClass, T.class_of(Foo));
     <cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$6: Symbol(:bar) = :bar
@@ -51,15 +51,15 @@ bb0[rubyBlockId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Bar#baz {
 
-bb0[rubyBlockId=0, firstDead=4]():
+bb0[rubyRegionId=0, firstDead=4]():
     <self>: Bar = cast(<self>: NilClass, Bar);
     <cfgAlias>$4: T.class_of(Foo) = alias <C Foo>
     <returnMethodTemp>$2: T.untyped = <cfgAlias>$4: T.class_of(Foo).bar()
@@ -67,15 +67,15 @@ bb0[rubyBlockId=0, firstDead=4]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Bar>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=6]():
+bb0[rubyRegionId=0, firstDead=6]():
     <self>: T.class_of(Bar) = cast(<self>: NilClass, T.class_of(Bar));
     <cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$6: Symbol(:baz) = :baz
@@ -85,8 +85,8 @@ bb0[rubyBlockId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/infer/singleton_of_singleton.rb.cfg-text.exp
+++ b/test/testdata/infer/singleton_of_singleton.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=8]():
+bb0[rubyRegionId=0, firstDead=8]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$5: T.class_of(<Magic>) = alias <C <Magic>>
     <cfgAlias>$7: T.class_of(A) = alias <C A>
@@ -12,15 +12,15 @@ bb0[rubyBlockId=0, firstDead=8]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:A>#foo {
 
-bb0[rubyBlockId=0, firstDead=6]():
+bb0[rubyRegionId=0, firstDead=6]():
     <self>: T.class_of(A) = cast(<self>: NilClass, T.class_of(A));
     <cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$6: Symbol(:bar) = :bar
@@ -30,30 +30,30 @@ bb0[rubyBlockId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:A>#bar {
 
-bb0[rubyBlockId=0, firstDead=3]():
+bb0[rubyRegionId=0, firstDead=3]():
     <self>: T.class_of(A) = cast(<self>: NilClass, T.class_of(A));
     <returnMethodTemp>$2: T.class_of(A) = <self>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.class_of(A)
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:A>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=6]():
+bb0[rubyRegionId=0, firstDead=6]():
     <self>: T.class_of(A) = cast(<self>: NilClass, T.class_of(A));
     <cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$6: Symbol(:foo) = :foo
@@ -63,8 +63,8 @@ bb0[rubyBlockId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/infer/transitive.rb.cfg-text.exp
+++ b/test/testdata/infer/transitive.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=17]():
+bb0[rubyRegionId=0, firstDead=17]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$6: T.class_of(<Magic>) = alias <C <Magic>>
     <cfgAlias>$8: T.class_of(A) = alias <C A>
@@ -21,29 +21,29 @@ bb0[rubyBlockId=0, firstDead=17]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::A#foo {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: A = cast(<self>: NilClass, A);
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:A>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(A) = cast(<self>: NilClass, T.class_of(A));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
     <statTemp>$7: FalseClass = false
@@ -53,20 +53,20 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb5(rubyBlockId=1)
-bb2[rubyBlockId=1, firstDead=-1](<self>: T.class_of(A), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(A)):
+# - bb0(rubyRegionId=0)
+# - bb5(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(A), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(A)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb3[rubyBlockId=0, firstDead=10](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(A)):
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=10](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(A)):
     <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$9, sig>
     <self>: T.class_of(A) = <selfRestore>$10
     <cfgAlias>$20: T.class_of(T::Sig) = alias <C Sig>
@@ -80,8 +80,8 @@ bb3[rubyBlockId=0, firstDead=10](<block-pre-call-temp>$9: Sorbet::Private::Stati
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb5[rubyBlockId=1, firstDead=4](<self>: T.class_of(A), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(A)):
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=4](<self>: T.class_of(A), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(A)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf
     <cfgAlias>$15: T.class_of(Integer) = alias <C Integer>
@@ -93,22 +93,22 @@ bb5[rubyBlockId=1, firstDead=4](<self>: T.class_of(A), <block-pre-call-temp>$9: 
 
 method ::Bar#baz {
 
-bb0[rubyBlockId=0, firstDead=3]():
+bb0[rubyRegionId=0, firstDead=3]():
     <self>: Bar = cast(<self>: NilClass, Bar);
     <returnMethodTemp>$2: Integer = <self>: Bar.foo()
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Bar>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(Bar) = cast(<self>: NilClass, T.class_of(Bar));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
     <statTemp>$7: FalseClass = false
@@ -118,20 +118,20 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb5(rubyBlockId=1)
-bb2[rubyBlockId=1, firstDead=-1](<self>: T.class_of(Bar), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Bar)):
+# - bb0(rubyRegionId=0)
+# - bb5(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Bar), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Bar)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb3[rubyBlockId=0, firstDead=10](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Bar)):
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=10](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Bar)):
     <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$9, sig>
     <self>: T.class_of(Bar) = <selfRestore>$10
     <cfgAlias>$24: T.class_of(T::Sig) = alias <C Sig>
@@ -145,8 +145,8 @@ bb3[rubyBlockId=0, firstDead=10](<block-pre-call-temp>$9: Sorbet::Private::Stati
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb5[rubyBlockId=1, firstDead=7](<self>: T.class_of(Bar), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Bar)):
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=7](<self>: T.class_of(Bar), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Bar)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf
     <hashTemp>$15: Symbol(:arg) = :arg

--- a/test/testdata/infer/zsuper.rb.cfg-text.exp
+++ b/test/testdata/infer/zsuper.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=17]():
+bb0[rubyRegionId=0, firstDead=17]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$6: T.class_of(<Magic>) = alias <C <Magic>>
     <cfgAlias>$8: T.class_of(Foo) = alias <C Foo>
@@ -21,15 +21,15 @@ bb0[rubyBlockId=0, firstDead=17]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Foo#baz {
 
-bb0[rubyBlockId=0, firstDead=4]():
+bb0[rubyRegionId=0, firstDead=4]():
     <self>: Foo = cast(<self>: NilClass, Foo);
     a: T.untyped = load_arg(a)
     <returnMethodTemp>$2: NilClass = <self>: Foo.puts(a: T.untyped)
@@ -37,15 +37,15 @@ bb0[rubyBlockId=0, firstDead=4]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Foo>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=6]():
+bb0[rubyRegionId=0, firstDead=6]():
     <self>: T.class_of(Foo) = cast(<self>: NilClass, T.class_of(Foo));
     <cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$6: Symbol(:baz) = :baz
@@ -55,15 +55,15 @@ bb0[rubyBlockId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Bar#baz {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Bar = cast(<self>: NilClass, Bar);
     b: T.untyped = load_arg(b)
     <block-pre-call-temp>$5: Sorbet::Private::Static::Void = <self>: Bar.<super>(b: T.untyped)
@@ -71,27 +71,27 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb5(rubyBlockId=1)
-bb2[rubyBlockId=1, firstDead=-1](<self>: Bar, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Bar):
+# - bb0(rubyRegionId=0)
+# - bb5(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: Bar, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Bar):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb3[rubyBlockId=0, firstDead=2](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Bar):
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=2](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Bar):
     <returnMethodTemp>$2: T.untyped = Solve<<block-pre-call-temp>$5, <super>>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb5[rubyBlockId=1, firstDead=5](<self>: Bar, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Bar):
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=5](<self>: Bar, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Bar):
     # outerLoops: 1
     <self>: Bar = loadSelf
     <blk>$7: T.untyped = load_yield_params(<super>)
@@ -104,7 +104,7 @@ bb5[rubyBlockId=1, firstDead=5](<self>: Bar, <block-pre-call-temp>$5: Sorbet::Pr
 
 method ::<Class:Bar>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=6]():
+bb0[rubyRegionId=0, firstDead=6]():
     <self>: T.class_of(Bar) = cast(<self>: NilClass, T.class_of(Bar));
     <cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$6: Symbol(:baz) = :baz
@@ -114,8 +114,8 @@ bb0[rubyBlockId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/namer/module_function.rb.cfg-text.exp
+++ b/test/testdata/namer/module_function.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=14]():
+bb0[rubyRegionId=0, firstDead=14]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$6: T.class_of(<Magic>) = alias <C <Magic>>
     <cfgAlias>$8: T.class_of(Funcs) = alias <C Funcs>
@@ -18,15 +18,15 @@ bb0[rubyBlockId=0, firstDead=14]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Funcs#f {
 
-bb0[rubyBlockId=0, firstDead=4]():
+bb0[rubyRegionId=0, firstDead=4]():
     <self>: Funcs = cast(<self>: NilClass, Funcs);
     x: Integer = load_arg(x)
     <returnMethodTemp>$2: Integer = x
@@ -34,29 +34,29 @@ bb0[rubyBlockId=0, firstDead=4]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Funcs>#f {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(Funcs) = cast(<self>: NilClass, T.class_of(Funcs));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Funcs#g {
 
-bb0[rubyBlockId=0, firstDead=4]():
+bb0[rubyRegionId=0, firstDead=4]():
     <self>: Funcs = cast(<self>: NilClass, Funcs);
     s: Symbol = load_arg(s)
     <returnMethodTemp>$2: Symbol = s
@@ -64,15 +64,15 @@ bb0[rubyBlockId=0, firstDead=4]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Funcs>#g {
 
-bb0[rubyBlockId=0, firstDead=4]():
+bb0[rubyRegionId=0, firstDead=4]():
     <self>: T.class_of(Funcs) = cast(<self>: NilClass, T.class_of(Funcs));
     s: Symbol = load_arg(s)
     <returnMethodTemp>$2: Symbol = s
@@ -80,15 +80,15 @@ bb0[rubyBlockId=0, firstDead=4]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Funcs#h {
 
-bb0[rubyBlockId=0, firstDead=4]():
+bb0[rubyRegionId=0, firstDead=4]():
     <self>: Funcs = cast(<self>: NilClass, Funcs);
     s: String = load_arg(s)
     <returnMethodTemp>$2: String = s
@@ -96,15 +96,15 @@ bb0[rubyBlockId=0, firstDead=4]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Funcs>#h {
 
-bb0[rubyBlockId=0, firstDead=4]():
+bb0[rubyRegionId=0, firstDead=4]():
     <self>: T.class_of(Funcs) = cast(<self>: NilClass, T.class_of(Funcs));
     s: String = load_arg(s)
     <returnMethodTemp>$2: String = s
@@ -112,15 +112,15 @@ bb0[rubyBlockId=0, firstDead=4]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Funcs>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: T.class_of(Funcs) = cast(<self>: NilClass, T.class_of(Funcs));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
     <statTemp>$7: FalseClass = false
@@ -130,20 +130,20 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb19(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb19(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb5(rubyBlockId=1)
-bb2[rubyBlockId=1, firstDead=-1](<self>: T.class_of(Funcs), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Funcs)):
+# - bb0(rubyRegionId=0)
+# - bb5(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Funcs), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Funcs)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb3[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Funcs)):
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Funcs)):
     <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$9, sig>
     <self>: T.class_of(Funcs) = <selfRestore>$10
     <cfgAlias>$23: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
@@ -154,8 +154,8 @@ bb3[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$9: Sorbet::Private::Stati
     <unconditional> -> bb6
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb5[rubyBlockId=1, firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Funcs)):
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Funcs)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf
     <hashTemp>$15: Symbol(:x) = :x
@@ -167,15 +167,15 @@ bb5[rubyBlockId=1, firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp>
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-# - bb9(rubyBlockId=2)
-bb6[rubyBlockId=2, firstDead=-1](<self>: T.class_of(Funcs), <block-pre-call-temp>$27: Sorbet::Private::Static::Void, <selfRestore>$28: T.class_of(Funcs)):
+# - bb3(rubyRegionId=0)
+# - bb9(rubyRegionId=2)
+bb6[rubyRegionId=2, firstDead=-1](<self>: T.class_of(Funcs), <block-pre-call-temp>$27: Sorbet::Private::Static::Void, <selfRestore>$28: T.class_of(Funcs)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
-# - bb6(rubyBlockId=2)
-bb7[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$27: Sorbet::Private::Static::Void, <selfRestore>$28: T.class_of(Funcs)):
+# - bb6(rubyRegionId=2)
+bb7[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$27: Sorbet::Private::Static::Void, <selfRestore>$28: T.class_of(Funcs)):
     <statTemp>$21: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$27, sig>
     <self>: T.class_of(Funcs) = <selfRestore>$28
     <cfgAlias>$41: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
@@ -186,8 +186,8 @@ bb7[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$27: Sorbet::Private::Stat
     <unconditional> -> bb10
 
 # backedges
-# - bb6(rubyBlockId=2)
-bb9[rubyBlockId=2, firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp>$27: Sorbet::Private::Static::Void, <selfRestore>$28: T.class_of(Funcs)):
+# - bb6(rubyRegionId=2)
+bb9[rubyRegionId=2, firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp>$27: Sorbet::Private::Static::Void, <selfRestore>$28: T.class_of(Funcs)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf
     <hashTemp>$33: Symbol(:s) = :s
@@ -199,15 +199,15 @@ bb9[rubyBlockId=2, firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp>
     <unconditional> -> bb6
 
 # backedges
-# - bb7(rubyBlockId=0)
-# - bb13(rubyBlockId=3)
-bb10[rubyBlockId=3, firstDead=-1](<self>: T.class_of(Funcs), <block-pre-call-temp>$45: Sorbet::Private::Static::Void, <selfRestore>$46: T.class_of(Funcs)):
+# - bb7(rubyRegionId=0)
+# - bb13(rubyRegionId=3)
+bb10[rubyRegionId=3, firstDead=-1](<self>: T.class_of(Funcs), <block-pre-call-temp>$45: Sorbet::Private::Static::Void, <selfRestore>$46: T.class_of(Funcs)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb13 : bb11)
 
 # backedges
-# - bb10(rubyBlockId=3)
-bb11[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$45: Sorbet::Private::Static::Void, <selfRestore>$46: T.class_of(Funcs)):
+# - bb10(rubyRegionId=3)
+bb11[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$45: Sorbet::Private::Static::Void, <selfRestore>$46: T.class_of(Funcs)):
     <statTemp>$39: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$45, sig>
     <self>: T.class_of(Funcs) = <selfRestore>$46
     <cfgAlias>$59: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
@@ -218,8 +218,8 @@ bb11[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$45: Sorbet::Private::Sta
     <unconditional> -> bb14
 
 # backedges
-# - bb10(rubyBlockId=3)
-bb13[rubyBlockId=3, firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp>$45: Sorbet::Private::Static::Void, <selfRestore>$46: T.class_of(Funcs)):
+# - bb10(rubyRegionId=3)
+bb13[rubyRegionId=3, firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp>$45: Sorbet::Private::Static::Void, <selfRestore>$46: T.class_of(Funcs)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf
     <hashTemp>$51: Symbol(:s) = :s
@@ -231,15 +231,15 @@ bb13[rubyBlockId=3, firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp
     <unconditional> -> bb10
 
 # backedges
-# - bb11(rubyBlockId=0)
-# - bb17(rubyBlockId=4)
-bb14[rubyBlockId=4, firstDead=-1](<self>: T.class_of(Funcs), <block-pre-call-temp>$63: Sorbet::Private::Static::Void, <selfRestore>$64: T.class_of(Funcs)):
+# - bb11(rubyRegionId=0)
+# - bb17(rubyRegionId=4)
+bb14[rubyRegionId=4, firstDead=-1](<self>: T.class_of(Funcs), <block-pre-call-temp>$63: Sorbet::Private::Static::Void, <selfRestore>$64: T.class_of(Funcs)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb17 : bb15)
 
 # backedges
-# - bb14(rubyBlockId=4)
-bb15[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$63: Sorbet::Private::Static::Void, <selfRestore>$64: T.class_of(Funcs)):
+# - bb14(rubyRegionId=4)
+bb15[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$63: Sorbet::Private::Static::Void, <selfRestore>$64: T.class_of(Funcs)):
     <statTemp>$57: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$63, sig>
     <self>: T.class_of(Funcs) = <selfRestore>$64
     <cfgAlias>$77: T.class_of(Sorbet::Private::Static::ResolvedSig) = alias <C ResolvedSig>
@@ -250,8 +250,8 @@ bb15[rubyBlockId=0, firstDead=-1](<block-pre-call-temp>$63: Sorbet::Private::Sta
     <unconditional> -> bb18
 
 # backedges
-# - bb14(rubyBlockId=4)
-bb17[rubyBlockId=4, firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp>$63: Sorbet::Private::Static::Void, <selfRestore>$64: T.class_of(Funcs)):
+# - bb14(rubyRegionId=4)
+bb17[rubyRegionId=4, firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp>$63: Sorbet::Private::Static::Void, <selfRestore>$64: T.class_of(Funcs)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf
     <hashTemp>$69: Symbol(:s) = :s
@@ -263,15 +263,15 @@ bb17[rubyBlockId=4, firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp
     <unconditional> -> bb14
 
 # backedges
-# - bb15(rubyBlockId=0)
-# - bb21(rubyBlockId=5)
-bb18[rubyBlockId=5, firstDead=-1](<self>: T.class_of(Funcs), <block-pre-call-temp>$81: Sorbet::Private::Static::Void, <selfRestore>$82: T.class_of(Funcs)):
+# - bb15(rubyRegionId=0)
+# - bb21(rubyRegionId=5)
+bb18[rubyRegionId=5, firstDead=-1](<self>: T.class_of(Funcs), <block-pre-call-temp>$81: Sorbet::Private::Static::Void, <selfRestore>$82: T.class_of(Funcs)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb21 : bb19)
 
 # backedges
-# - bb18(rubyBlockId=5)
-bb19[rubyBlockId=0, firstDead=34](<block-pre-call-temp>$81: Sorbet::Private::Static::Void, <selfRestore>$82: T.class_of(Funcs)):
+# - bb18(rubyRegionId=5)
+bb19[rubyRegionId=0, firstDead=34](<block-pre-call-temp>$81: Sorbet::Private::Static::Void, <selfRestore>$82: T.class_of(Funcs)):
     <statTemp>$75: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$81, sig>
     <self>: T.class_of(Funcs) = <selfRestore>$82
     <cfgAlias>$96: T.class_of(T::Sig) = alias <C Sig>
@@ -309,8 +309,8 @@ bb19[rubyBlockId=0, firstDead=34](<block-pre-call-temp>$81: Sorbet::Private::Sta
     <unconditional> -> bb1
 
 # backedges
-# - bb18(rubyBlockId=5)
-bb21[rubyBlockId=5, firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp>$81: Sorbet::Private::Static::Void, <selfRestore>$82: T.class_of(Funcs)):
+# - bb18(rubyRegionId=5)
+bb21[rubyRegionId=5, firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp>$81: Sorbet::Private::Static::Void, <selfRestore>$82: T.class_of(Funcs)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf
     <hashTemp>$87: Symbol(:s) = :s
@@ -325,7 +325,7 @@ bb21[rubyBlockId=5, firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp
 
 method ::C#test_calls {
 
-bb0[rubyBlockId=0, firstDead=19]():
+bb0[rubyRegionId=0, firstDead=19]():
     <self>: C = cast(<self>: NilClass, C);
     <statTemp>$5: Integer(0) = 0
     <statTemp>$3: Integer = <self>: C.f(<statTemp>$5: Integer(0))
@@ -348,15 +348,15 @@ bb0[rubyBlockId=0, firstDead=19]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:C>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=8]():
+bb0[rubyRegionId=0, firstDead=8]():
     <self>: T.class_of(C) = cast(<self>: NilClass, T.class_of(C));
     <cfgAlias>$6: T.class_of(Funcs) = alias <C Funcs>
     <statTemp>$3: T.class_of(C) = <self>: T.class_of(C).include(<cfgAlias>$6: T.class_of(Funcs))
@@ -368,8 +368,8 @@ bb0[rubyBlockId=0, firstDead=8]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/namer/redefines_object.rb.cfg-text.exp
+++ b/test/testdata/namer/redefines_object.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=32]():
+bb0[rubyRegionId=0, firstDead=32]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$6: T.class_of(<Magic>) = alias <C <Magic>>
     <cfgAlias>$8: T.class_of(Object) = alias <C Object>
@@ -36,29 +36,29 @@ bb0[rubyBlockId=0, firstDead=32]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Object>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(Object) = cast(<self>: NilClass, T.class_of(Object));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Trigger#trigger {
 
-bb0[rubyBlockId=0, firstDead=4]():
+bb0[rubyRegionId=0, firstDead=4]():
     @__fake_logger$3: T.untyped = alias <C <undeclared-field-stub>> (@__fake_logger)
     <self>: Trigger = cast(<self>: NilClass, Trigger);
     <returnMethodTemp>$2: T.untyped = @__fake_logger$3
@@ -66,15 +66,15 @@ bb0[rubyBlockId=0, firstDead=4]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Trigger>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=6]():
+bb0[rubyRegionId=0, firstDead=6]():
     <self>: T.class_of(Trigger) = cast(<self>: NilClass, T.class_of(Trigger));
     <cfgAlias>$4: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$6: Symbol(:trigger) = :trigger
@@ -84,36 +84,36 @@ bb0[rubyBlockId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Foo>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(Foo) = cast(<self>: NilClass, T.class_of(Foo));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:Bar>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(Bar) = cast(<self>: NilClass, T.class_of(Bar));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/namer/yield.rb.cfg-text.exp
+++ b/test/testdata/namer/yield.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=11]():
+bb0[rubyRegionId=0, firstDead=11]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$6: T.class_of(<Magic>) = alias <C <Magic>>
     <cfgAlias>$8: T.class_of(Main) = alias <C Main>
@@ -15,15 +15,15 @@ bb0[rubyBlockId=0, firstDead=11]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Main#yielder {
 
-bb0[rubyBlockId=0, firstDead=6]():
+bb0[rubyRegionId=0, firstDead=6]():
     <self>: Main = cast(<self>: NilClass, Main);
     <blk>: T.untyped = load_arg(<blk>)
     <statTemp>$5: Integer(1) = 1
@@ -33,15 +33,15 @@ bb0[rubyBlockId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Main#blockpass {
 
-bb0[rubyBlockId=0, firstDead=6]():
+bb0[rubyRegionId=0, firstDead=6]():
     <self>: Main = cast(<self>: NilClass, Main);
     blk: T.untyped = load_arg(blk)
     <statTemp>$5: Integer(1) = 1
@@ -51,15 +51,15 @@ bb0[rubyBlockId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Main#mixed {
 
-bb0[rubyBlockId=0, firstDead=6]():
+bb0[rubyRegionId=0, firstDead=6]():
     <self>: Main = cast(<self>: NilClass, Main);
     blk: T.untyped = load_arg(blk)
     <statTemp>$5: Integer(1) = 1
@@ -69,15 +69,15 @@ bb0[rubyBlockId=0, firstDead=6]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::Main#blockyield {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Main = cast(<self>: NilClass, Main);
     <blk>: T.untyped = load_arg(<blk>)
     <block-pre-call-temp>$4: Sorbet::Private::Static::Void = <self>: Main.yielder()
@@ -85,27 +85,27 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb5(rubyBlockId=1)
-bb2[rubyBlockId=1, firstDead=-1](<self>: Main, <blk>: T.untyped, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Main):
+# - bb0(rubyRegionId=0)
+# - bb5(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: Main, <blk>: T.untyped, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Main):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb3[rubyBlockId=0, firstDead=2](<block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Main):
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=2](<block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Main):
     <returnMethodTemp>$2: T.untyped = Solve<<block-pre-call-temp>$4, yielder>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb5[rubyBlockId=1, firstDead=5](<self>: Main, <blk>: T.untyped, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Main):
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=5](<self>: Main, <blk>: T.untyped, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Main):
     # outerLoops: 1
     <self>: Main = loadSelf
     <blk>$6: T.untyped = load_yield_params(yielder)
@@ -118,27 +118,27 @@ bb5[rubyBlockId=1, firstDead=5](<self>: Main, <blk>: T.untyped, <block-pre-call-
 
 method ::Main#main {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Main = cast(<self>: NilClass, Main);
     <block-pre-call-temp>$5: Sorbet::Private::Static::Void = <self>: Main.lambda()
     <selfRestore>$6: Main = <self>
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb5(rubyBlockId=1)
-bb2[rubyBlockId=1, firstDead=-1](<self>: Main, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Main):
+# - bb0(rubyRegionId=0)
+# - bb5(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: Main, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Main):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb3[rubyBlockId=0, firstDead=15](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Main):
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=15](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Main):
     l: T.proc.params(arg0: T.untyped).returns(T.untyped) = Solve<<block-pre-call-temp>$5, lambda>
     <self>: Main = <selfRestore>$6
     <cfgAlias>$15: T.class_of(<Magic>) = alias <C <Magic>>
@@ -157,8 +157,8 @@ bb3[rubyBlockId=0, firstDead=15](<block-pre-call-temp>$5: Sorbet::Private::Stati
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb5[rubyBlockId=1, firstDead=6](<self>: Main, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Main):
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=6](<self>: Main, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Main):
     # outerLoops: 1
     <self>: Main = loadSelf
     <blk>$7: T.untyped = load_yield_params(lambda)
@@ -172,7 +172,7 @@ bb5[rubyBlockId=1, firstDead=6](<self>: Main, <block-pre-call-temp>$5: Sorbet::P
 
 method ::<Class:Main>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=22]():
+bb0[rubyRegionId=0, firstDead=22]():
     <self>: T.class_of(Main) = cast(<self>: NilClass, T.class_of(Main));
     <cfgAlias>$5: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <statTemp>$7: Symbol(:yielder) = :yielder
@@ -198,8 +198,8 @@ bb0[rubyBlockId=0, firstDead=22]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }

--- a/test/testdata/rewriter/t_enum_snapshot.rb.cfg-text.exp
+++ b/test/testdata/rewriter/t_enum_snapshot.rb.cfg-text.exp
@@ -1,6 +1,6 @@
 method ::<Class:<root>>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=38]():
+bb0[rubyRegionId=0, firstDead=38]():
     <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
     <cfgAlias>$6: T.class_of(<Magic>) = alias <C <Magic>>
     <cfgAlias>$8: T.class_of(MyEnum) = alias <C MyEnum>
@@ -42,15 +42,15 @@ bb0[rubyBlockId=0, firstDead=38]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:MyEnum>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <C X>$34: MyEnum::X = alias <C X>
     <C Y>$60: MyEnum::Y = alias <C Y>
     <C Z>$87: MyEnum::Z = alias <C Z>
@@ -64,27 +64,27 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb5(rubyBlockId=1)
-bb2[rubyBlockId=1, firstDead=-1](<self>: T.class_of(MyEnum), <block-pre-call-temp>$13: Sorbet::Private::Static::Void, <selfRestore>$14: T.class_of(MyEnum), <C X>$34: MyEnum::X, <C Y>$60: MyEnum::Y, <C Z>$87: MyEnum::Z):
+# - bb0(rubyRegionId=0)
+# - bb5(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(MyEnum), <block-pre-call-temp>$13: Sorbet::Private::Static::Void, <selfRestore>$14: T.class_of(MyEnum), <C X>$34: MyEnum::X, <C Y>$60: MyEnum::Y, <C Z>$87: MyEnum::Z):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb3[rubyBlockId=0, firstDead=2](<block-pre-call-temp>$13: Sorbet::Private::Static::Void, <selfRestore>$14: T.class_of(MyEnum)):
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=2](<block-pre-call-temp>$13: Sorbet::Private::Static::Void, <selfRestore>$14: T.class_of(MyEnum)):
     <statTemp>$11: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$13, enums>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb5[rubyBlockId=1, firstDead=49](<self>: T.class_of(MyEnum), <block-pre-call-temp>$13: Sorbet::Private::Static::Void, <selfRestore>$14: T.class_of(MyEnum), <C X>$34: MyEnum::X, <C Y>$60: MyEnum::Y, <C Z>$87: MyEnum::Z):
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=49](<self>: T.class_of(MyEnum), <block-pre-call-temp>$13: Sorbet::Private::Static::Void, <selfRestore>$14: T.class_of(MyEnum), <C X>$34: MyEnum::X, <C Y>$60: MyEnum::Y, <C Z>$87: MyEnum::Z):
     # outerLoops: 1
     <self>: T.class_of(MyEnum) = loadSelf
     <cfgAlias>$20: T.class_of(<Magic>) = alias <C <Magic>>
@@ -141,49 +141,49 @@ bb5[rubyBlockId=1, firstDead=49](<self>: T.class_of(MyEnum), <block-pre-call-tem
 
 method ::MyEnum::<Class:X>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(MyEnum::X) = cast(<self>: NilClass, T.class_of(MyEnum::X));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::MyEnum::<Class:Y>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(MyEnum::Y) = cast(<self>: NilClass, T.class_of(MyEnum::Y));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::MyEnum::<Class:Z>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(MyEnum::Z) = cast(<self>: NilClass, T.class_of(MyEnum::Z));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:NotAnEnum>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <C X>$9: T.untyped = alias <C X>
     <C Y>$16: NotAnEnum = alias <C Y>
     <self>: T.class_of(NotAnEnum) = cast(<self>: NilClass, T.class_of(NotAnEnum));
@@ -192,27 +192,27 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb5(rubyBlockId=1)
-bb2[rubyBlockId=1, firstDead=-1](<self>: T.class_of(NotAnEnum), <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: T.class_of(NotAnEnum), <C X>$9: T.untyped, <C Y>$16: NotAnEnum):
+# - bb0(rubyRegionId=0)
+# - bb5(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(NotAnEnum), <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: T.class_of(NotAnEnum), <C X>$9: T.untyped, <C Y>$16: NotAnEnum):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb3[rubyBlockId=0, firstDead=2](<block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: T.class_of(NotAnEnum)):
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=2](<block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: T.class_of(NotAnEnum)):
     <returnMethodTemp>$2: T.untyped = Solve<<block-pre-call-temp>$4, enums>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb5[rubyBlockId=1, firstDead=12](<self>: T.class_of(NotAnEnum), <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: T.class_of(NotAnEnum), <C X>$9: T.untyped, <C Y>$16: NotAnEnum):
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=12](<self>: T.class_of(NotAnEnum), <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: T.class_of(NotAnEnum), <C X>$9: T.untyped, <C Y>$16: NotAnEnum):
     # outerLoops: 1
     <self>: T.class_of(NotAnEnum) = loadSelf
     <cfgAlias>$11: T.class_of(<Magic>) = alias <C <Magic>>
@@ -232,21 +232,21 @@ bb5[rubyBlockId=1, firstDead=12](<self>: T.class_of(NotAnEnum), <block-pre-call-
 
 method ::EnumsDoEnum#something_outside {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: EnumsDoEnum = cast(<self>: NilClass, EnumsDoEnum);
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:EnumsDoEnum>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <C X>$34: EnumsDoEnum::X = alias <C X>
     <C Y>$60: EnumsDoEnum::Y = alias <C Y>
     <C Z>$87: EnumsDoEnum::Z = alias <C Z>
@@ -260,20 +260,20 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb5(rubyBlockId=1)
-bb2[rubyBlockId=1, firstDead=-1](<self>: T.class_of(EnumsDoEnum), <block-pre-call-temp>$13: Sorbet::Private::Static::Void, <selfRestore>$14: T.class_of(EnumsDoEnum), <C X>$34: EnumsDoEnum::X, <C Y>$60: EnumsDoEnum::Y, <C Z>$87: EnumsDoEnum::Z):
+# - bb0(rubyRegionId=0)
+# - bb5(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(EnumsDoEnum), <block-pre-call-temp>$13: Sorbet::Private::Static::Void, <selfRestore>$14: T.class_of(EnumsDoEnum), <C X>$34: EnumsDoEnum::X, <C Y>$60: EnumsDoEnum::Y, <C Z>$87: EnumsDoEnum::Z):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb3[rubyBlockId=0, firstDead=7](<block-pre-call-temp>$13: Sorbet::Private::Static::Void, <selfRestore>$14: T.class_of(EnumsDoEnum)):
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=7](<block-pre-call-temp>$13: Sorbet::Private::Static::Void, <selfRestore>$14: T.class_of(EnumsDoEnum)):
     <statTemp>$11: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$13, enums>
     <self>: T.class_of(EnumsDoEnum) = <selfRestore>$14
     <cfgAlias>$100: T.class_of(Sorbet::Private::Static) = alias <C Static>
@@ -284,8 +284,8 @@ bb3[rubyBlockId=0, firstDead=7](<block-pre-call-temp>$13: Sorbet::Private::Stati
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb5[rubyBlockId=1, firstDead=49](<self>: T.class_of(EnumsDoEnum), <block-pre-call-temp>$13: Sorbet::Private::Static::Void, <selfRestore>$14: T.class_of(EnumsDoEnum), <C X>$34: EnumsDoEnum::X, <C Y>$60: EnumsDoEnum::Y, <C Z>$87: EnumsDoEnum::Z):
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=49](<self>: T.class_of(EnumsDoEnum), <block-pre-call-temp>$13: Sorbet::Private::Static::Void, <selfRestore>$14: T.class_of(EnumsDoEnum), <C X>$34: EnumsDoEnum::X, <C Y>$60: EnumsDoEnum::Y, <C Z>$87: EnumsDoEnum::Z):
     # outerLoops: 1
     <self>: T.class_of(EnumsDoEnum) = loadSelf
     <cfgAlias>$20: T.class_of(<Magic>) = alias <C <Magic>>
@@ -342,49 +342,49 @@ bb5[rubyBlockId=1, firstDead=49](<self>: T.class_of(EnumsDoEnum), <block-pre-cal
 
 method ::EnumsDoEnum::<Class:X>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(EnumsDoEnum::X) = cast(<self>: NilClass, T.class_of(EnumsDoEnum::X));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::EnumsDoEnum::<Class:Y>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(EnumsDoEnum::Y) = cast(<self>: NilClass, T.class_of(EnumsDoEnum::Y));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::EnumsDoEnum::<Class:Z>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(EnumsDoEnum::Z) = cast(<self>: NilClass, T.class_of(EnumsDoEnum::Z));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::<Class:BadConsts>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=-1]():
+bb0[rubyRegionId=0, firstDead=-1]():
     <C Before>$28: BadConsts::Before = alias <C Before>
     <C StaticField1>$38: Integer = alias <C StaticField1>
     <C Inside>$62: BadConsts::Inside = alias <C Inside>
@@ -418,20 +418,20 @@ bb0[rubyBlockId=0, firstDead=-1]():
     <unconditional> -> bb2
 
 # backedges
-# - bb3(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb3(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-# - bb5(rubyBlockId=1)
-bb2[rubyBlockId=1, firstDead=-1](<self>: T.class_of(BadConsts), <block-pre-call-temp>$41: Sorbet::Private::Static::Void, <selfRestore>$42: T.class_of(BadConsts), <C Inside>$62: BadConsts::Inside, <C StaticField2>$72: Integer, <C After>$91: BadConsts::After, <C StaticField3>$101: Integer, <C StaticField4>$103: Integer):
+# - bb0(rubyRegionId=0)
+# - bb5(rubyRegionId=1)
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(BadConsts), <block-pre-call-temp>$41: Sorbet::Private::Static::Void, <selfRestore>$42: T.class_of(BadConsts), <C Inside>$62: BadConsts::Inside, <C StaticField2>$72: Integer, <C After>$91: BadConsts::After, <C StaticField3>$101: Integer, <C StaticField4>$103: Integer):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb3[rubyBlockId=0, firstDead=23](<block-pre-call-temp>$41: Sorbet::Private::Static::Void, <selfRestore>$42: T.class_of(BadConsts), <C After>$91: BadConsts::After, <C StaticField3>$101: Integer, <C StaticField4>$103: Integer):
+# - bb2(rubyRegionId=1)
+bb3[rubyRegionId=0, firstDead=23](<block-pre-call-temp>$41: Sorbet::Private::Static::Void, <selfRestore>$42: T.class_of(BadConsts), <C After>$91: BadConsts::After, <C StaticField3>$101: Integer, <C StaticField4>$103: Integer):
     <statTemp>$39: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$41, enums>
     <cfgAlias>$77: T.class_of(<Magic>) = alias <C <Magic>>
     <cfgAlias>$79: T.class_of(BadConsts::After) = alias <C After$1>
@@ -458,8 +458,8 @@ bb3[rubyBlockId=0, firstDead=23](<block-pre-call-temp>$41: Sorbet::Private::Stat
     <unconditional> -> bb1
 
 # backedges
-# - bb2(rubyBlockId=1)
-bb5[rubyBlockId=1, firstDead=19](<self>: T.class_of(BadConsts), <block-pre-call-temp>$41: Sorbet::Private::Static::Void, <selfRestore>$42: T.class_of(BadConsts), <C Inside>$62: BadConsts::Inside, <C StaticField2>$72: Integer, <C After>$91: BadConsts::After, <C StaticField3>$101: Integer, <C StaticField4>$103: Integer):
+# - bb2(rubyRegionId=1)
+bb5[rubyRegionId=1, firstDead=19](<self>: T.class_of(BadConsts), <block-pre-call-temp>$41: Sorbet::Private::Static::Void, <selfRestore>$42: T.class_of(BadConsts), <C Inside>$62: BadConsts::Inside, <C StaticField2>$72: Integer, <C After>$91: BadConsts::After, <C StaticField3>$101: Integer, <C StaticField4>$103: Integer):
     # outerLoops: 1
     <self>: T.class_of(BadConsts) = loadSelf
     <cfgAlias>$48: T.class_of(<Magic>) = alias <C <Magic>>
@@ -486,42 +486,42 @@ bb5[rubyBlockId=1, firstDead=19](<self>: T.class_of(BadConsts), <block-pre-call-
 
 method ::BadConsts::<Class:Before>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(BadConsts::Before) = cast(<self>: NilClass, T.class_of(BadConsts::Before));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::BadConsts::<Class:Inside>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(BadConsts::Inside) = cast(<self>: NilClass, T.class_of(BadConsts::Inside));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }
 
 method ::BadConsts::<Class:After>#<static-init> {
 
-bb0[rubyBlockId=0, firstDead=2]():
+bb0[rubyRegionId=0, firstDead=2]():
     <self>: T.class_of(BadConsts::After) = cast(<self>: NilClass, T.class_of(BadConsts::After));
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
-# - bb0(rubyBlockId=0)
-bb1[rubyBlockId=0, firstDead=-1]():
+# - bb0(rubyRegionId=0)
+bb1[rubyRegionId=0, firstDead=-1]():
     <unconditional> -> bb1
 
 }


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I can't possibly be the only person who's gotten confused between Ruby blocks and basic blocks (whether in Sorbet CFG terms or compiler terms).  And sometimes `rubyBlockId` doesn't actually refer to proper Ruby blocks (cf. how exception handling works)!

We settled internally on "region" as a better (but not perfect!) replacement.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
