### PR TITLE
ResolveConstants: Reduce sorting overhead with per-file vectors.

### DIFF
--- a/test/testdata/namer/ancestors.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/ancestors.rb.symbol-table-raw.exp
@@ -17,7 +17,7 @@ class <C <U <root>>> < <C <U Object>> ()
     type-member(+) <S <C <U Mixin2>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U Mixin2>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=Mixin2) @ Loc {file=test/testdata/namer/ancestors.rb start=3:8 end=3:14}
     method <S <C <U Mixin2>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/ancestors.rb start=3:1 end=3:19}
       argument <blk><block> @ Loc {file=test/testdata/namer/ancestors.rb start=??? end=???}
-  class <C <U MultipleInclude>> < <C <U Object>> (<C <U Mixin2>>, <C <U Mixin1>>) @ Loc {file=test/testdata/namer/ancestors.rb start=13:1 end=13:22}
+  class <C <U MultipleInclude>> < <C <U Object>> (<C <U Mixin1>>, <C <U Mixin2>>) @ Loc {file=test/testdata/namer/ancestors.rb start=13:1 end=13:22}
   class <S <C <U MultipleInclude>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/namer/ancestors.rb start=13:7 end=13:22}
     type-member(+) <S <C <U MultipleInclude>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U MultipleInclude>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=MultipleInclude) @ Loc {file=test/testdata/namer/ancestors.rb start=13:7 end=13:22}
     method <S <C <U MultipleInclude>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/ancestors.rb start=13:1 end=15:4}

--- a/test/testdata/packager/simple_package/pass.flatten-tree.exp
+++ b/test/testdata/packager/simple_package/pass.flatten-tree.exp
@@ -3,37 +3,28 @@ begin
   class <emptyTree><<C <root>>> < (::<todo sym>)
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
-        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Bar_Package_Private)
-        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Bar_Package_Private)
+        ::<Magic>.<define-top-class-or-module>(::Project::Bar::CallsFoo)
+        ::Sorbet::Private::Static.keep_for_ide(::Project::Bar::CallsFoo)
         <emptyTree>
       end
     end
   end
-  module ::<PackageRegistry>::Project_Bar_Package_Private<<C Project_Bar_Package_Private$1>> < ()
-    def self.<static-init>(<blk>)
-      begin
-        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::CallsFoo)
-        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::CallsFoo)
-        <emptyTree>
-      end
-    end
-  end
-  module ::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::CallsFoo<<C CallsFoo>> < ()
+  module ::Project::Bar::CallsFoo<<C CallsFoo>> < ()
     def self.build_foo(<blk>)
-      ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo.new(10)
+      ::Project::Foo::Foo.new(10)
     end
 
     def self.build_bar(<blk>)
-      ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::CallsBar.build_bar()
+      ::Project::Foo::CallsBar.build_bar()
     end
 
     def self.<static-init>(<blk>)
       begin
         ::Sorbet::Private::Static::ResolvedSig.sig(<self>, true, :build_foo) do ||
-          <self>.returns(::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo)
+          <self>.returns(::Project::Foo::Foo)
         end
         ::Sorbet::Private::Static::ResolvedSig.sig(<self>, true, :build_bar) do ||
-          <self>.returns(::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar)
+          <self>.returns(::Project::Bar::Bar)
         end
         <self>.extend(::T::Sig)
         ::Sorbet::Private::Static.keep_self_def(<self>, :build_foo, :normal)
@@ -49,30 +40,21 @@ begin
   class <emptyTree><<C <root>>> < (::<todo sym>)
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
-        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Foo_Package_Private)
-        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Foo_Package_Private)
+        ::<Magic>.<define-top-class-or-module>(::Project::Foo::CallsBar)
+        ::Sorbet::Private::Static.keep_for_ide(::Project::Foo::CallsBar)
         <emptyTree>
       end
     end
   end
-  module ::<PackageRegistry>::Project_Foo_Package_Private<<C Project_Foo_Package_Private$1>> < ()
-    def self.<static-init>(<blk>)
-      begin
-        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::CallsBar)
-        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::CallsBar)
-        <emptyTree>
-      end
-    end
-  end
-  module ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::CallsBar<<C CallsBar>> < ()
+  module ::Project::Foo::CallsBar<<C CallsBar>> < ()
     def self.build_bar(<blk>)
-      ::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar.new(10)
+      ::Project::Bar::Bar.new(10)
     end
 
     def self.<static-init>(<blk>)
       begin
         ::Sorbet::Private::Static::ResolvedSig.sig(<self>, true, :build_bar) do ||
-          <self>.returns(::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar)
+          <self>.returns(::Project::Bar::Bar)
         end
         <self>.extend(::T::Sig)
         ::Sorbet::Private::Static.keep_self_def(<self>, :build_bar, :normal)
@@ -87,22 +69,13 @@ begin
   class <emptyTree><<C <root>>> < (::<todo sym>)
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
-        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Bar_Package_Private)
-        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Bar_Package_Private)
+        ::<Magic>.<define-top-class-or-module>(::Project::Bar::Bar)
+        ::Sorbet::Private::Static.keep_for_ide(::Project::Bar::Bar)
         <emptyTree>
       end
     end
   end
-  module ::<PackageRegistry>::Project_Bar_Package_Private<<C Project_Bar_Package_Private$1>> < ()
-    def self.<static-init>(<blk>)
-      begin
-        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar)
-        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar)
-        <emptyTree>
-      end
-    end
-  end
-  class ::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar<<C Bar>> < (::<todo sym>)
+  class ::Project::Bar::Bar<<C Bar>> < (::<todo sym>)
     def initialize(value, <blk>)
       @value = begin
         ::Sorbet::Private::Static.keep_for_typechecking(::Integer)
@@ -128,22 +101,13 @@ begin
   class <emptyTree><<C <root>>> < (::<todo sym>)
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
-        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Foo_Package_Private)
-        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Foo_Package_Private)
+        ::<Magic>.<define-top-class-or-module>(::Project::Foo::Foo)
+        ::Sorbet::Private::Static.keep_for_ide(::Project::Foo::Foo)
         <emptyTree>
       end
     end
   end
-  module ::<PackageRegistry>::Project_Foo_Package_Private<<C Project_Foo_Package_Private$1>> < ()
-    def self.<static-init>(<blk>)
-      begin
-        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo)
-        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo)
-        <emptyTree>
-      end
-    end
-  end
-  class ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo<<C Foo>> < (::<todo sym>)
+  class ::Project::Foo::Foo<<C Foo>> < (::<todo sym>)
     def initialize(value, <blk>)
       @value = begin
         ::Sorbet::Private::Static.keep_for_typechecking(::Integer)
@@ -169,32 +133,9 @@ begin
   class <emptyTree><<C <root>>> < (::<todo sym>)
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
-        begin
-          ::<Magic>.<define-top-class-or-module>(::Project::Bar)
-          ::Sorbet::Private::Static.keep_for_ide(::Project::Bar)
-          ::Sorbet::Private::Static.keep_for_ide(::PackageSpec)
-          <emptyTree>
-        end
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>)
-          <emptyTree>
-        end
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageTests>)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>)
-          <emptyTree>
-        end
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>)
-          <emptyTree>
-        end
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageTests>)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>)
-          <emptyTree>
-        end
+        ::<Magic>.<define-top-class-or-module>(::Project::Bar)
+        ::Sorbet::Private::Static.keep_for_ide(::Project::Bar)
+        ::Sorbet::Private::Static.keep_for_ide(::PackageSpec)
         <emptyTree>
       end
     end
@@ -203,93 +144,10 @@ begin
     def self.<static-init>(<blk>)
       begin
         <self>.import(::Project::Foo)
-        <self>.export(::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar)
-        <self>.export(::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::CallsFoo)
+        <self>.export(::Project::Bar::Bar)
+        <self>.export(::Project::Bar::CallsFoo)
         <emptyTree>
       end
-    end
-  end
-  module ::<PackageRegistry><<C <PackageRegistry>>> < ()
-    def self.<static-init>(<blk>)
-      begin
-        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Bar_Package_Private::Project)
-        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Bar_Package_Private::Project)
-        <emptyTree>
-      end
-    end
-  end
-  module ::<PackageRegistry>::Project_Bar_Package_Private::Project<<C Project>> < ()
-    def self.<static-init>(<blk>)
-      ::<PackageRegistry>::Project_Bar_Package_Private::Project::Foo = ::<PackageRegistry>::Project_Foo_Package::Project::Foo
-    end
-  end
-  module ::<PackageTests><<C <PackageTests>>> < ()
-    def self.<static-init>(<blk>)
-      begin
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageTests>::Project_Bar_Package_Private::Project::Bar)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>::Project_Bar_Package_Private::Project::Bar)
-          <emptyTree>
-        end
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageTests>::Project_Bar_Package_Private::Project::Bar)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>::Project_Bar_Package_Private::Project::Bar)
-          <emptyTree>
-        end
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageTests>::Project_Bar_Package_Private::Project)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>::Project_Bar_Package_Private::Project)
-          <emptyTree>
-        end
-        <emptyTree>
-      end
-    end
-  end
-  module ::<PackageTests>::Project_Bar_Package_Private::Project::Bar<<C Bar>> < ()
-    def self.<static-init>(<blk>)
-      ::<PackageTests>::Project_Bar_Package_Private::Project::Bar::Bar = ::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar
-    end
-  end
-  module ::<PackageTests>::Project_Bar_Package_Private::Project::Bar<<C Bar>> < ()
-    def self.<static-init>(<blk>)
-      ::<PackageTests>::Project_Bar_Package_Private::Project::Bar::CallsFoo = ::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::CallsFoo
-    end
-  end
-  module ::<PackageTests>::Project_Bar_Package_Private::Project<<C Project>> < ()
-    def self.<static-init>(<blk>)
-      ::<PackageTests>::Project_Bar_Package_Private::Project::Foo = ::<PackageRegistry>::Project_Foo_Package::Project::Foo
-    end
-  end
-  module ::<PackageRegistry><<C <PackageRegistry>>> < ()
-    def self.<static-init>(<blk>)
-      begin
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Bar_Package::Project::Bar)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Bar_Package::Project::Bar)
-          <emptyTree>
-        end
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Bar_Package::Project::Bar)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Bar_Package::Project::Bar)
-          <emptyTree>
-        end
-        <emptyTree>
-      end
-    end
-  end
-  module ::<PackageRegistry>::Project_Bar_Package::Project::Bar<<C Bar>> < ()
-    def self.<static-init>(<blk>)
-      ::<PackageRegistry>::Project_Bar_Package::Project::Bar::Bar = ::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar
-    end
-  end
-  module ::<PackageRegistry>::Project_Bar_Package::Project::Bar<<C Bar>> < ()
-    def self.<static-init>(<blk>)
-      ::<PackageRegistry>::Project_Bar_Package::Project::Bar::CallsFoo = ::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::CallsFoo
-    end
-  end
-  module ::<PackageTests><<C <PackageTests>>> < ()
-    def self.<static-init>(<blk>)
-      <emptyTree>
     end
   end
   <emptyTree>
@@ -299,32 +157,9 @@ begin
   class <emptyTree><<C <root>>> < (::<todo sym>)
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
-        begin
-          ::<Magic>.<define-top-class-or-module>(::Project::Foo)
-          ::Sorbet::Private::Static.keep_for_ide(::Project::Foo)
-          ::Sorbet::Private::Static.keep_for_ide(::PackageSpec)
-          <emptyTree>
-        end
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>)
-          <emptyTree>
-        end
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageTests>)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>)
-          <emptyTree>
-        end
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>)
-          <emptyTree>
-        end
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageTests>)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>)
-          <emptyTree>
-        end
+        ::<Magic>.<define-top-class-or-module>(::Project::Foo)
+        ::Sorbet::Private::Static.keep_for_ide(::Project::Foo)
+        ::Sorbet::Private::Static.keep_for_ide(::PackageSpec)
         <emptyTree>
       end
     end
@@ -333,93 +168,10 @@ begin
     def self.<static-init>(<blk>)
       begin
         <self>.import(::Project::Bar)
-        <self>.export(::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo)
-        <self>.export(::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::CallsBar)
+        <self>.export(::Project::Foo::Foo)
+        <self>.export(::Project::Foo::CallsBar)
         <emptyTree>
       end
-    end
-  end
-  module ::<PackageRegistry><<C <PackageRegistry>>> < ()
-    def self.<static-init>(<blk>)
-      begin
-        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Foo_Package_Private::Project)
-        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Foo_Package_Private::Project)
-        <emptyTree>
-      end
-    end
-  end
-  module ::<PackageRegistry>::Project_Foo_Package_Private::Project<<C Project>> < ()
-    def self.<static-init>(<blk>)
-      ::<PackageRegistry>::Project_Foo_Package_Private::Project::Bar = ::<PackageRegistry>::Project_Bar_Package::Project::Bar
-    end
-  end
-  module ::<PackageTests><<C <PackageTests>>> < ()
-    def self.<static-init>(<blk>)
-      begin
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageTests>::Project_Foo_Package_Private::Project)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>::Project_Foo_Package_Private::Project)
-          <emptyTree>
-        end
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageTests>::Project_Foo_Package_Private::Project::Foo)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>::Project_Foo_Package_Private::Project::Foo)
-          <emptyTree>
-        end
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageTests>::Project_Foo_Package_Private::Project::Foo)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>::Project_Foo_Package_Private::Project::Foo)
-          <emptyTree>
-        end
-        <emptyTree>
-      end
-    end
-  end
-  module ::<PackageTests>::Project_Foo_Package_Private::Project<<C Project>> < ()
-    def self.<static-init>(<blk>)
-      ::<PackageTests>::Project_Foo_Package_Private::Project::Bar = ::<PackageRegistry>::Project_Bar_Package::Project::Bar
-    end
-  end
-  module ::<PackageTests>::Project_Foo_Package_Private::Project::Foo<<C Foo>> < ()
-    def self.<static-init>(<blk>)
-      ::<PackageTests>::Project_Foo_Package_Private::Project::Foo::CallsBar = ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::CallsBar
-    end
-  end
-  module ::<PackageTests>::Project_Foo_Package_Private::Project::Foo<<C Foo>> < ()
-    def self.<static-init>(<blk>)
-      ::<PackageTests>::Project_Foo_Package_Private::Project::Foo::Foo = ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo
-    end
-  end
-  module ::<PackageRegistry><<C <PackageRegistry>>> < ()
-    def self.<static-init>(<blk>)
-      begin
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Foo_Package::Project::Foo)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Foo_Package::Project::Foo)
-          <emptyTree>
-        end
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Foo_Package::Project::Foo)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Foo_Package::Project::Foo)
-          <emptyTree>
-        end
-        <emptyTree>
-      end
-    end
-  end
-  module ::<PackageRegistry>::Project_Foo_Package::Project::Foo<<C Foo>> < ()
-    def self.<static-init>(<blk>)
-      ::<PackageRegistry>::Project_Foo_Package::Project::Foo::CallsBar = ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::CallsBar
-    end
-  end
-  module ::<PackageRegistry>::Project_Foo_Package::Project::Foo<<C Foo>> < ()
-    def self.<static-init>(<blk>)
-      ::<PackageRegistry>::Project_Foo_Package::Project::Foo::Foo = ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo
-    end
-  end
-  module ::<PackageTests><<C <PackageTests>>> < ()
-    def self.<static-init>(<blk>)
-      <emptyTree>
     end
   end
   <emptyTree>

--- a/test/testdata/packager/simple_package/pass.flatten-tree.exp
+++ b/test/testdata/packager/simple_package/pass.flatten-tree.exp
@@ -3,28 +3,37 @@ begin
   class <emptyTree><<C <root>>> < (::<todo sym>)
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
-        ::<Magic>.<define-top-class-or-module>(::Project::Bar::CallsFoo)
-        ::Sorbet::Private::Static.keep_for_ide(::Project::Bar::CallsFoo)
+        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Bar_Package_Private)
+        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Bar_Package_Private)
         <emptyTree>
       end
     end
   end
-  module ::Project::Bar::CallsFoo<<C CallsFoo>> < ()
+  module ::<PackageRegistry>::Project_Bar_Package_Private<<C Project_Bar_Package_Private$1>> < ()
+    def self.<static-init>(<blk>)
+      begin
+        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::CallsFoo)
+        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::CallsFoo)
+        <emptyTree>
+      end
+    end
+  end
+  module ::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::CallsFoo<<C CallsFoo>> < ()
     def self.build_foo(<blk>)
-      ::Project::Foo::Foo.new(10)
+      ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo.new(10)
     end
 
     def self.build_bar(<blk>)
-      ::Project::Foo::CallsBar.build_bar()
+      ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::CallsBar.build_bar()
     end
 
     def self.<static-init>(<blk>)
       begin
         ::Sorbet::Private::Static::ResolvedSig.sig(<self>, true, :build_foo) do ||
-          <self>.returns(::Project::Foo::Foo)
+          <self>.returns(::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo)
         end
         ::Sorbet::Private::Static::ResolvedSig.sig(<self>, true, :build_bar) do ||
-          <self>.returns(::Project::Bar::Bar)
+          <self>.returns(::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar)
         end
         <self>.extend(::T::Sig)
         ::Sorbet::Private::Static.keep_self_def(<self>, :build_foo, :normal)
@@ -40,21 +49,30 @@ begin
   class <emptyTree><<C <root>>> < (::<todo sym>)
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
-        ::<Magic>.<define-top-class-or-module>(::Project::Foo::CallsBar)
-        ::Sorbet::Private::Static.keep_for_ide(::Project::Foo::CallsBar)
+        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Foo_Package_Private)
+        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Foo_Package_Private)
         <emptyTree>
       end
     end
   end
-  module ::Project::Foo::CallsBar<<C CallsBar>> < ()
+  module ::<PackageRegistry>::Project_Foo_Package_Private<<C Project_Foo_Package_Private$1>> < ()
+    def self.<static-init>(<blk>)
+      begin
+        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::CallsBar)
+        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::CallsBar)
+        <emptyTree>
+      end
+    end
+  end
+  module ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::CallsBar<<C CallsBar>> < ()
     def self.build_bar(<blk>)
-      ::Project::Bar::Bar.new(10)
+      ::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar.new(10)
     end
 
     def self.<static-init>(<blk>)
       begin
         ::Sorbet::Private::Static::ResolvedSig.sig(<self>, true, :build_bar) do ||
-          <self>.returns(::Project::Bar::Bar)
+          <self>.returns(::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar)
         end
         <self>.extend(::T::Sig)
         ::Sorbet::Private::Static.keep_self_def(<self>, :build_bar, :normal)
@@ -69,13 +87,22 @@ begin
   class <emptyTree><<C <root>>> < (::<todo sym>)
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
-        ::<Magic>.<define-top-class-or-module>(::Project::Bar::Bar)
-        ::Sorbet::Private::Static.keep_for_ide(::Project::Bar::Bar)
+        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Bar_Package_Private)
+        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Bar_Package_Private)
         <emptyTree>
       end
     end
   end
-  class ::Project::Bar::Bar<<C Bar>> < (::<todo sym>)
+  module ::<PackageRegistry>::Project_Bar_Package_Private<<C Project_Bar_Package_Private$1>> < ()
+    def self.<static-init>(<blk>)
+      begin
+        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar)
+        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar)
+        <emptyTree>
+      end
+    end
+  end
+  class ::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar<<C Bar>> < (::<todo sym>)
     def initialize(value, <blk>)
       @value = begin
         ::Sorbet::Private::Static.keep_for_typechecking(::Integer)
@@ -101,13 +128,22 @@ begin
   class <emptyTree><<C <root>>> < (::<todo sym>)
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
-        ::<Magic>.<define-top-class-or-module>(::Project::Foo::Foo)
-        ::Sorbet::Private::Static.keep_for_ide(::Project::Foo::Foo)
+        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Foo_Package_Private)
+        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Foo_Package_Private)
         <emptyTree>
       end
     end
   end
-  class ::Project::Foo::Foo<<C Foo>> < (::<todo sym>)
+  module ::<PackageRegistry>::Project_Foo_Package_Private<<C Project_Foo_Package_Private$1>> < ()
+    def self.<static-init>(<blk>)
+      begin
+        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo)
+        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo)
+        <emptyTree>
+      end
+    end
+  end
+  class ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo<<C Foo>> < (::<todo sym>)
     def initialize(value, <blk>)
       @value = begin
         ::Sorbet::Private::Static.keep_for_typechecking(::Integer)
@@ -133,9 +169,32 @@ begin
   class <emptyTree><<C <root>>> < (::<todo sym>)
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
-        ::<Magic>.<define-top-class-or-module>(::Project::Bar)
-        ::Sorbet::Private::Static.keep_for_ide(::Project::Bar)
-        ::Sorbet::Private::Static.keep_for_ide(::PackageSpec)
+        begin
+          ::<Magic>.<define-top-class-or-module>(::Project::Bar)
+          ::Sorbet::Private::Static.keep_for_ide(::Project::Bar)
+          ::Sorbet::Private::Static.keep_for_ide(::PackageSpec)
+          <emptyTree>
+        end
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>)
+          <emptyTree>
+        end
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageTests>)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>)
+          <emptyTree>
+        end
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>)
+          <emptyTree>
+        end
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageTests>)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>)
+          <emptyTree>
+        end
         <emptyTree>
       end
     end
@@ -144,10 +203,93 @@ begin
     def self.<static-init>(<blk>)
       begin
         <self>.import(::Project::Foo)
-        <self>.export(::Project::Bar::Bar)
-        <self>.export(::Project::Bar::CallsFoo)
+        <self>.export(::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar)
+        <self>.export(::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::CallsFoo)
         <emptyTree>
       end
+    end
+  end
+  module ::<PackageRegistry><<C <PackageRegistry>>> < ()
+    def self.<static-init>(<blk>)
+      begin
+        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Bar_Package_Private::Project)
+        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Bar_Package_Private::Project)
+        <emptyTree>
+      end
+    end
+  end
+  module ::<PackageRegistry>::Project_Bar_Package_Private::Project<<C Project>> < ()
+    def self.<static-init>(<blk>)
+      ::<PackageRegistry>::Project_Bar_Package_Private::Project::Foo = ::<PackageRegistry>::Project_Foo_Package::Project::Foo
+    end
+  end
+  module ::<PackageTests><<C <PackageTests>>> < ()
+    def self.<static-init>(<blk>)
+      begin
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageTests>::Project_Bar_Package_Private::Project::Bar)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>::Project_Bar_Package_Private::Project::Bar)
+          <emptyTree>
+        end
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageTests>::Project_Bar_Package_Private::Project::Bar)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>::Project_Bar_Package_Private::Project::Bar)
+          <emptyTree>
+        end
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageTests>::Project_Bar_Package_Private::Project)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>::Project_Bar_Package_Private::Project)
+          <emptyTree>
+        end
+        <emptyTree>
+      end
+    end
+  end
+  module ::<PackageTests>::Project_Bar_Package_Private::Project::Bar<<C Bar>> < ()
+    def self.<static-init>(<blk>)
+      ::<PackageTests>::Project_Bar_Package_Private::Project::Bar::Bar = ::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar
+    end
+  end
+  module ::<PackageTests>::Project_Bar_Package_Private::Project::Bar<<C Bar>> < ()
+    def self.<static-init>(<blk>)
+      ::<PackageTests>::Project_Bar_Package_Private::Project::Bar::CallsFoo = ::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::CallsFoo
+    end
+  end
+  module ::<PackageTests>::Project_Bar_Package_Private::Project<<C Project>> < ()
+    def self.<static-init>(<blk>)
+      ::<PackageTests>::Project_Bar_Package_Private::Project::Foo = ::<PackageRegistry>::Project_Foo_Package::Project::Foo
+    end
+  end
+  module ::<PackageRegistry><<C <PackageRegistry>>> < ()
+    def self.<static-init>(<blk>)
+      begin
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Bar_Package::Project::Bar)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Bar_Package::Project::Bar)
+          <emptyTree>
+        end
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Bar_Package::Project::Bar)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Bar_Package::Project::Bar)
+          <emptyTree>
+        end
+        <emptyTree>
+      end
+    end
+  end
+  module ::<PackageRegistry>::Project_Bar_Package::Project::Bar<<C Bar>> < ()
+    def self.<static-init>(<blk>)
+      ::<PackageRegistry>::Project_Bar_Package::Project::Bar::Bar = ::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar
+    end
+  end
+  module ::<PackageRegistry>::Project_Bar_Package::Project::Bar<<C Bar>> < ()
+    def self.<static-init>(<blk>)
+      ::<PackageRegistry>::Project_Bar_Package::Project::Bar::CallsFoo = ::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::CallsFoo
+    end
+  end
+  module ::<PackageTests><<C <PackageTests>>> < ()
+    def self.<static-init>(<blk>)
+      <emptyTree>
     end
   end
   <emptyTree>
@@ -157,9 +299,32 @@ begin
   class <emptyTree><<C <root>>> < (::<todo sym>)
     def self.<static-init><<static-init>$CENSORED>(<blk>)
       begin
-        ::<Magic>.<define-top-class-or-module>(::Project::Foo)
-        ::Sorbet::Private::Static.keep_for_ide(::Project::Foo)
-        ::Sorbet::Private::Static.keep_for_ide(::PackageSpec)
+        begin
+          ::<Magic>.<define-top-class-or-module>(::Project::Foo)
+          ::Sorbet::Private::Static.keep_for_ide(::Project::Foo)
+          ::Sorbet::Private::Static.keep_for_ide(::PackageSpec)
+          <emptyTree>
+        end
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>)
+          <emptyTree>
+        end
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageTests>)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>)
+          <emptyTree>
+        end
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>)
+          <emptyTree>
+        end
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageTests>)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>)
+          <emptyTree>
+        end
         <emptyTree>
       end
     end
@@ -168,10 +333,93 @@ begin
     def self.<static-init>(<blk>)
       begin
         <self>.import(::Project::Bar)
-        <self>.export(::Project::Foo::Foo)
-        <self>.export(::Project::Foo::CallsBar)
+        <self>.export(::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo)
+        <self>.export(::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::CallsBar)
         <emptyTree>
       end
+    end
+  end
+  module ::<PackageRegistry><<C <PackageRegistry>>> < ()
+    def self.<static-init>(<blk>)
+      begin
+        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Foo_Package_Private::Project)
+        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Foo_Package_Private::Project)
+        <emptyTree>
+      end
+    end
+  end
+  module ::<PackageRegistry>::Project_Foo_Package_Private::Project<<C Project>> < ()
+    def self.<static-init>(<blk>)
+      ::<PackageRegistry>::Project_Foo_Package_Private::Project::Bar = ::<PackageRegistry>::Project_Bar_Package::Project::Bar
+    end
+  end
+  module ::<PackageTests><<C <PackageTests>>> < ()
+    def self.<static-init>(<blk>)
+      begin
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageTests>::Project_Foo_Package_Private::Project)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>::Project_Foo_Package_Private::Project)
+          <emptyTree>
+        end
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageTests>::Project_Foo_Package_Private::Project::Foo)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>::Project_Foo_Package_Private::Project::Foo)
+          <emptyTree>
+        end
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageTests>::Project_Foo_Package_Private::Project::Foo)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>::Project_Foo_Package_Private::Project::Foo)
+          <emptyTree>
+        end
+        <emptyTree>
+      end
+    end
+  end
+  module ::<PackageTests>::Project_Foo_Package_Private::Project<<C Project>> < ()
+    def self.<static-init>(<blk>)
+      ::<PackageTests>::Project_Foo_Package_Private::Project::Bar = ::<PackageRegistry>::Project_Bar_Package::Project::Bar
+    end
+  end
+  module ::<PackageTests>::Project_Foo_Package_Private::Project::Foo<<C Foo>> < ()
+    def self.<static-init>(<blk>)
+      ::<PackageTests>::Project_Foo_Package_Private::Project::Foo::CallsBar = ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::CallsBar
+    end
+  end
+  module ::<PackageTests>::Project_Foo_Package_Private::Project::Foo<<C Foo>> < ()
+    def self.<static-init>(<blk>)
+      ::<PackageTests>::Project_Foo_Package_Private::Project::Foo::Foo = ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo
+    end
+  end
+  module ::<PackageRegistry><<C <PackageRegistry>>> < ()
+    def self.<static-init>(<blk>)
+      begin
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Foo_Package::Project::Foo)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Foo_Package::Project::Foo)
+          <emptyTree>
+        end
+        begin
+          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Foo_Package::Project::Foo)
+          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Foo_Package::Project::Foo)
+          <emptyTree>
+        end
+        <emptyTree>
+      end
+    end
+  end
+  module ::<PackageRegistry>::Project_Foo_Package::Project::Foo<<C Foo>> < ()
+    def self.<static-init>(<blk>)
+      ::<PackageRegistry>::Project_Foo_Package::Project::Foo::CallsBar = ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::CallsBar
+    end
+  end
+  module ::<PackageRegistry>::Project_Foo_Package::Project::Foo<<C Foo>> < ()
+    def self.<static-init>(<blk>)
+      ::<PackageRegistry>::Project_Foo_Package::Project::Foo::Foo = ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo
+    end
+  end
+  module ::<PackageTests><<C <PackageTests>>> < ()
+    def self.<static-init>(<blk>)
+      <emptyTree>
     end
   end
   <emptyTree>

--- a/test/testdata/resolver/requires_ancestor_unrelated_classes.rb
+++ b/test/testdata/resolver/requires_ancestor_unrelated_classes.rb
@@ -54,7 +54,7 @@ module Test3
   end
 
   module M3
-  #      ^^ error: `T.class_of(Test3::M3)` requires unrelated classes `R3` and `R1` making it impossible to inherit
+  #      ^^ error: `T.class_of(Test3::M3)` requires unrelated classes `R1` and `R3` making it impossible to inherit
   #      ^^ error: `T.class_of(Test3::M3)` must inherit `R1` (required by `Test3::M1`)
   #      ^^ error: `T.class_of(Test3::M3)` must inherit `R3` (required by `Test3::M2`)
     extend M1, M2


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

ResolveConstants: Reduce sorting overhead with per-file vectors.

The sort order _within_ the per-file vectors is slightly changed but is still deterministic, hence a few tests have changed (tree visitation order rather than loc order).

cc @ngroman 

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Packager dramatically increases the size of these vectors and thus the cost of sorting them.

We can remove nearly all of this overhead by sorting per-file vectors.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
