### PR TITLE
ResolveConstants: Parallelize processing ResolutionItems.

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1093,7 +1093,8 @@ public:
             }
         }
 
-        fast_sort(todo, [](const auto &lhs, const auto &rhs) -> bool { return lhs.file.id() < rhs.file.id(); });
+        // Note: `todo` does not need to be sorted. There are no ordering effects on error production.
+
         fast_sort(todoAncestors,
                   [](const auto &lhs, const auto &rhs) -> bool { return lhs.file.id() < rhs.file.id(); });
         fast_sort(todoClassAliases,


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

ResolveConstants: Parallelize processing ResolutionItems.

cc @ngroman 

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Packager dramatically increases the number of ResolutionItems. Processing them in parallel significantly reduces typechecking runtime without a big impact to unpackaged mode.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
