### PR TITLE
Correct type signature of Hash#assoc

### DIFF
--- a/rbi/core/hash.rbi
+++ b/rbi/core/hash.rbi
@@ -302,7 +302,7 @@ class Hash < Object
     params(
         arg0: K,
     )
-    .returns(T::Array[T.any(K, V)])
+    .returns(T.nilable(T::Array[T.any(K, V)]))
   end
   def assoc(arg0); end
 


### PR DESCRIPTION
### Motivation
Working on making my work's Rails app use Sorbet, and got a type error involving `Hash#assoc`. Our work had to add `nil` handling due to a bug, so I was fairly confident that the Sorbet provided type signature of the method was incorrect.


### Test plan

The Ruby docs explain that the potential result of the method can be `nil`, hence the confidence in the change.
https://ruby-doc.org/core-3.0.3/Hash.html#method-i-assoc
