### PR TITLE
enable -fsized-deallocation for release builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -86,6 +86,7 @@ build:release-common --compilation_mode=opt
 build:release-common --config=backtracesymbols
 build:release-common --config=static-libs
 build:release-common --config=versioned
+build:release-common --cxxopt=-fsized-deallocation
 
 build:release-debug-common --config=forcedebug
 build:release-debug-common --config=debugsymbols

--- a/third_party/jemalloc.BUILD
+++ b/third_party/jemalloc.BUILD
@@ -46,7 +46,10 @@ JEMALLOC_BUILD_COMMAND = """
   export LDFLAGS
 
   # we need to include CFLAGS in CPPFLAGS so that the --sysroot flag makes it in
-  export CPPFLAGS="$${CFLAGS}"
+  #
+  # -fsized-deallocation is not enabled by default in clang; we enable it here
+  # to ensure that jemalloc defines the appropriate overrides for sized operator delete
+  export CPPFLAGS="$${CFLAGS} -fsized-deallocation"
 
   pushd $$(dirname $(location autogen.sh)) > /dev/null
 


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Sized deallocation is/should be somewhat faster in jemalloc because it avoids some memory operations to lookup the size of the object being deallocated.  (It's probably *not* any faster by default if you're not using a custom memory allocator because the default implementation of sized operator delete just forwards to regular operator delete.)

That being said, experimenting with it on my devbox suggests that it's about 5-10% slower in aggregate, which is the opposite direction that I would expect.  Opening a PR to send everything through the official Stripe build system so I can make sure I'm not doing something dumb.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
