### PR TITLE
Introduce a dedicated Field class.

### DIFF
--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -41,6 +41,7 @@ class GlobalState final {
     friend NameRef;
     friend Symbol;
     friend Method;
+    friend Field;
     friend SymbolRef;
     friend ClassOrModuleRef;
     friend MethodRef;
@@ -309,7 +310,7 @@ private:
     UnorderedMap<std::string, FileRef> fileRefByPath;
     std::vector<Symbol> classAndModules;
     std::vector<Method> methods;
-    std::vector<Symbol> fields;
+    std::vector<Field> fields;
     std::vector<Symbol> typeMembers;
     std::vector<Symbol> typeArguments;
     std::vector<std::pair<unsigned int, uint32_t>> namesByHash;

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -65,6 +65,28 @@ public:
 };
 CheckSize(ConstMethodData, 8, 8);
 
+class Field;
+class FieldData : private DebugOnlyCheck<SymbolDataDebugCheck> {
+    Field &field;
+
+public:
+    FieldData(Field &ref, GlobalState &gs);
+
+    Field *operator->();
+    const Field *operator->() const;
+};
+CheckSize(FieldData, 8, 8);
+
+class ConstFieldData : private DebugOnlyCheck<SymbolDataDebugCheck> {
+    const Field &field;
+
+public:
+    ConstFieldData(const Field &ref, const GlobalState &gs);
+
+    const Field *operator->() const;
+};
+CheckSize(ConstFieldData, 8, 8);
+
 class ClassOrModuleRef final {
     uint32_t _id;
 
@@ -189,10 +211,10 @@ public:
         return ref;
     }
 
-    SymbolData data(GlobalState &gs) const;
-    ConstSymbolData data(const GlobalState &gs) const;
-    ConstSymbolData dataAllowingNone(const GlobalState &gs) const;
-    SymbolData dataAllowingNone(GlobalState &gs) const;
+    FieldData data(GlobalState &gs) const;
+    ConstFieldData data(const GlobalState &gs) const;
+    ConstFieldData dataAllowingNone(const GlobalState &gs) const;
+    FieldData dataAllowingNone(GlobalState &gs) const;
     std::string_view showKind(const GlobalState &gs) const;
     std::string showFullName(const GlobalState &gs) const;
     std::string toStringFullName(const GlobalState &gs) const;

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -166,8 +166,6 @@ public:
 
     class Flags {
     public:
-        // Synthesized by C++ code in a Rewriter pass
-        bool isRewriterSynthesized : 1;
         bool isField : 1;
         bool isStaticField : 1;
 
@@ -175,12 +173,11 @@ public:
         bool isStaticFieldTypeAlias : 1;
         bool isStaticFieldPrivate : 1;
 
-        constexpr static uint8_t NUMBER_OF_FLAGS = 5;
+        constexpr static uint8_t NUMBER_OF_FLAGS = 4;
         constexpr static uint8_t VALID_BITS_MASK = (1 << NUMBER_OF_FLAGS) - 1;
 
         Flags() noexcept
-            : isRewriterSynthesized(false), isField(false), isStaticField(false), isStaticFieldTypeAlias(false),
-              isStaticFieldPrivate(false) {}
+            : isField(false), isStaticField(false), isStaticFieldTypeAlias(false), isStaticFieldPrivate(false) {}
 
         uint8_t serialize() const {
             ENFORCE(sizeof(Flags) == sizeof(uint8_t));

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -59,14 +59,21 @@ public:
         bool isFinal : 1;
         bool isOverride : 1;
         bool isIncompatibleOverride : 1;
+
+        constexpr static uint16_t NUMBER_OF_FLAGS = 10;
+        constexpr static uint16_t VALID_BITS_MASK = (1 << NUMBER_OF_FLAGS) - 1;
         Flags() noexcept
             : isRewriterSynthesized(false), isProtected(false), isPrivate(false), isOverloaded(false),
               isAbstract(false), isGenericMethod(false), isOverridable(false), isFinal(false), isOverride(false),
               isIncompatibleOverride(false) {}
 
         uint16_t serialize() const {
+            ENFORCE(sizeof(Flags) == sizeof(uint16_t));
             // Can replace this with std::bit_cast in C++20
-            return *reinterpret_cast<const uint16_t *>(this);
+            auto rawBits = *reinterpret_cast<const uint16_t *>(this);
+
+            // We need to mask the valid bits since uninitialized memory isn't zeroed in C++.
+            return rawBits & VALID_BITS_MASK;
         }
     };
     CheckSize(Flags, 2, 1);
@@ -168,13 +175,19 @@ public:
         bool isStaticFieldTypeAlias : 1;
         bool isStaticFieldPrivate : 1;
 
+        constexpr static uint8_t NUMBER_OF_FLAGS = 5;
+        constexpr static uint8_t VALID_BITS_MASK = (1 << NUMBER_OF_FLAGS) - 1;
+
         Flags() noexcept
             : isRewriterSynthesized(false), isField(false), isStaticField(false), isStaticFieldTypeAlias(false),
               isStaticFieldPrivate(false) {}
 
         uint8_t serialize() const {
+            ENFORCE(sizeof(Flags) == sizeof(uint8_t));
             // Can replace this with std::bit_cast in C++20
-            return *reinterpret_cast<const uint8_t *>(this);
+            auto rawBits = *reinterpret_cast<const uint8_t *>(this);
+            // We need to mask the valid bits since uninitialized memory isn't zeroed in C++.
+            return rawBits & VALID_BITS_MASK;
         }
     };
     CheckSize(Flags, 1, 1);

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -148,6 +148,64 @@ public:
 };
 CheckSize(Method, 192, 8);
 
+// Contains a field or a static field
+class Field final {
+    friend class serialize::SerializerImpl;
+
+public:
+    Field(const Field &) = delete;
+    Field() = default;
+    Field(Field &&) noexcept = default;
+
+    class Flags {
+    public:
+        // Synthesized by C++ code in a Rewriter pass
+        bool isRewriterSynthesized : 1;
+        bool isField : 1;
+        bool isStaticField : 1;
+
+        // Static Field flags
+        bool isStaticFieldTypeAlias : 1;
+        bool isStaticFieldPrivate : 1;
+
+        Flags() noexcept
+            : isRewriterSynthesized(false), isField(false), isStaticField(false), isStaticFieldTypeAlias(false),
+              isStaticFieldPrivate(false) {}
+
+        uint8_t serialize() const {
+            // Can replace this with std::bit_cast in C++20
+            return *reinterpret_cast<const uint8_t *>(this);
+        }
+    };
+    CheckSize(Flags, 1, 1);
+
+    Loc loc() const;
+    const InlinedVector<Loc, 2> &locs() const;
+    void addLoc(const core::GlobalState &gs, core::Loc loc);
+
+    uint32_t hash(const GlobalState &gs) const;
+
+    void sanityCheck(const GlobalState &gs) const;
+
+    Field deepCopy(const GlobalState &to) const;
+
+    bool isPrintable(const GlobalState &gs) const;
+
+    FieldRef ref(const GlobalState &gs) const;
+
+    SymbolRef dealias(const GlobalState &gs, int depthLimit = 42) const;
+
+    // dealias?
+
+    Flags flags;
+    NameRef name;
+    ClassOrModuleRef owner;
+    TypePtr resultType;
+
+private:
+    InlinedVector<Loc, 2> locs_;
+};
+
 class Symbol final {
 public:
     Symbol(const Symbol &) = delete;
@@ -172,8 +230,6 @@ public:
 
         // --- What type of symbol is this? ---
         static constexpr uint32_t CLASS_OR_MODULE = 0x8000'0000;
-        static constexpr uint32_t FIELD = 0x2000'0000;
-        static constexpr uint32_t STATIC_FIELD = 0x1000'0000;
         static constexpr uint32_t TYPE_ARGUMENT = 0x0800'0000;
         static constexpr uint32_t TYPE_MEMBER = 0x0400'0000;
 
@@ -199,10 +255,6 @@ public:
         static constexpr uint32_t TYPE_INVARIANT = 0x0000'0020;
         static constexpr uint32_t TYPE_CONTRAVARIANT = 0x0000'0040;
         static constexpr uint32_t TYPE_FIXED = 0x0000'0080;
-
-        // Static Field flags
-        static constexpr uint32_t STATIC_FIELD_TYPE_ALIAS = 0x0000'0010;
-        static constexpr uint32_t STATIC_FIELD_PRIVATE = 0x0000'0020;
     };
 
     Loc loc() const;
@@ -267,14 +319,6 @@ public:
     }
 
     bool isSingletonClass(const GlobalState &gs) const;
-
-    inline bool isStaticField() const {
-        return (flags & Symbol::Flags::STATIC_FIELD) != 0;
-    }
-
-    inline bool isField() const {
-        return (flags & Symbol::Flags::FIELD) != 0;
-    }
 
     inline bool isTypeMember() const {
         return (flags & Symbol::Flags::TYPE_MEMBER) != 0;
@@ -367,33 +411,18 @@ public:
         return (flags & Symbol::Flags::CLASS_OR_MODULE_PRIVATE) != 0;
     }
 
-    inline bool isStaticFieldPrivate() const {
-        ENFORCE_NO_TIMER(isStaticField());
-        return (flags & Symbol::Flags::STATIC_FIELD_PRIVATE) != 0;
-    }
-
     inline void setClassOrModule() {
-        ENFORCE(!isStaticField() && !isField() && !isTypeArgument() && !isTypeMember());
+        ENFORCE(!isTypeArgument() && !isTypeMember());
         flags |= Symbol::Flags::CLASS_OR_MODULE;
     }
 
-    inline void setStaticField() {
-        ENFORCE(!isClassOrModule() && !isField() && !isTypeArgument() && !isTypeMember());
-        flags |= Symbol::Flags::STATIC_FIELD;
-    }
-
-    inline void setField() {
-        ENFORCE(!isClassOrModule() && !isStaticField() && !isTypeArgument() && !isTypeMember());
-        flags |= Symbol::Flags::FIELD;
-    }
-
     inline void setTypeArgument() {
-        ENFORCE(!isClassOrModule() && !isStaticField() && !isField() && !isTypeMember());
+        ENFORCE(!isClassOrModule() && !isTypeMember());
         flags |= Symbol::Flags::TYPE_ARGUMENT;
     }
 
     inline void setTypeMember() {
-        ENFORCE(!isClassOrModule() && !isStaticField() && !isField() && !isTypeArgument());
+        ENFORCE(!isClassOrModule() && !isTypeArgument());
         flags |= Symbol::Flags::TYPE_MEMBER;
     }
 
@@ -459,24 +488,6 @@ public:
     inline void setClassOrModulePrivate() {
         ENFORCE(isClassOrModule());
         flags |= Symbol::Flags::CLASS_OR_MODULE_PRIVATE;
-    }
-
-    inline void setTypeAlias() {
-        ENFORCE(isStaticField());
-        flags |= Symbol::Flags::STATIC_FIELD_TYPE_ALIAS;
-    }
-    inline bool isTypeAlias() const {
-        // We should only be able to set the type alias bit on static fields.
-        // But it's rather unweidly to ask "isStaticField() && isTypeAlias()" just to satisfy the ENFORCE.
-        // To make things nicer, we relax the ENFORCE here to also allow asking whether "some constant" is a type
-        // alias.
-        ENFORCE(isClassOrModule() || isStaticField() || isTypeMember());
-        return isStaticField() && (flags & Symbol::Flags::STATIC_FIELD_TYPE_ALIAS) != 0;
-    }
-
-    inline void setStaticFieldPrivate() {
-        ENFORCE(isStaticField());
-        flags |= Symbol::Flags::STATIC_FIELD_PRIVATE;
     }
 
     inline void setRewriterSynthesized() {

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -195,16 +195,17 @@ public:
 
     SymbolRef dealias(const GlobalState &gs, int depthLimit = 42) const;
 
-    // dealias?
-
-    Flags flags;
     NameRef name;
     ClassOrModuleRef owner;
     TypePtr resultType;
 
 private:
     InlinedVector<Loc, 2> locs_;
+
+public:
+    Flags flags;
 };
+CheckSize(Field, 64, 8);
 
 class Symbol final {
 public:

--- a/core/serialize/test/serialize_test.cc
+++ b/core/serialize/test/serialize_test.cc
@@ -77,4 +77,22 @@ TEST_CASE("Strings") { // NOLINT
     CHECK_EQ(u.getStr(), "НЯ");
     CHECK_EQ(u.getStr(), "\0\0\0\t\n\f\rНЯЯЯЯЯ");
 }
+
+TEST_CASE("Symbol flags") {
+    Field::Flags fieldFlags;
+    Method::Flags mflags;
+    // All unused bits should be zero, and all flags should default to false.
+    CHECK_EQ(fieldFlags.serialize(), 0);
+    CHECK_EQ(mflags.serialize(), 0);
+
+    mflags.isAbstract = true;
+    CHECK_NE(mflags.serialize(), 0);
+
+    fieldFlags.isField = true;
+    CHECK_NE(fieldFlags.serialize(), 0);
+
+    // I wish I could check that the mask is correct.
+    // https://stackoverflow.com/a/45837449 indicates it is possible to count the number of fields in a class, but it
+    // requires a lot of shenanigans.
+}
 } // namespace sorbet::core::serialize

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1052,7 +1052,9 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                     ENFORCE(singletonClass.exists(), "Every class should have a singleton class by now.");
                     tp.type = singletonClass.data(ctx)->externalType();
                     tp.origins.emplace_back(core::Loc(ctx.file, bind.loc));
-                } else if (symbol.isField(ctx) || (symbol.isStaticField(ctx) && !symbol.isTypeAlias(ctx)) ||
+                } else if (symbol.isField(ctx) ||
+                           (symbol.isStaticField(ctx) &&
+                            !symbol.asFieldRef().data(ctx)->flags.isStaticFieldTypeAlias) ||
                            symbol.isTypeMember()) {
                     auto resultType = symbol.resultType(ctx);
                     if (resultType != nullptr) {

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1106,7 +1106,7 @@ class SymbolDefiner {
             if (constant.isClassOrModule()) {
                 constant.asClassOrModuleRef().data(ctx)->setClassOrModulePrivate();
             } else if (constant.isStaticField(ctx)) {
-                constant.asFieldRef().data(ctx)->setStaticFieldPrivate();
+                constant.asFieldRef().data(ctx)->flags.isStaticFieldPrivate = true;
             } else if (constant.isTypeMember()) {
                 // Visibility on type members is special (even more restrictive than private),
                 // so we ignore requests to mark type members private.
@@ -1266,7 +1266,7 @@ class SymbolDefiner {
         sym = ctx.state.enterStaticFieldSymbol(core::Loc(ctx.file, staticField.lhsLoc), scope, name);
 
         if (staticField.isTypeAlias) {
-            sym.data(ctx)->setTypeAlias();
+            sym.data(ctx)->flags.isStaticFieldTypeAlias = true;
         }
 
         return sym;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -286,7 +286,7 @@ private:
             // otherwise we should error out. Private constant references _are not_ enforced inside RBI files.
             if (result.exists() &&
                 ((result.isClassOrModule() && result.asClassOrModuleRef().data(ctx)->isClassOrModulePrivate()) ||
-                 (result.isStaticField(ctx) && result.asFieldRef().data(ctx)->isStaticFieldPrivate())) &&
+                 (result.isStaticField(ctx) && result.asFieldRef().data(ctx)->flags.isStaticFieldPrivate)) &&
                 !ctx.file.data(ctx).isRBI()) {
                 if (auto e = ctx.beginError(c.loc, core::errors::Resolver::PrivateConstantReferenced)) {
                     e.setHeader("Non-private reference to private constant `{}` referenced", result.show(ctx));
@@ -1614,7 +1614,7 @@ class ResolveTypeMembersAndFieldsWalk {
 
     // Tries to resolve the given static field. Returns Types::todo() if it is unable to resolve the field.
     [[nodiscard]] static core::TypePtr tryResolveStaticField(core::Context ctx, ResolveStaticFieldItem &job) {
-        ENFORCE(job.sym.data(ctx)->isStaticField());
+        ENFORCE(job.sym.data(ctx)->flags.isStaticField);
         auto &asgn = job.asgn;
         auto data = job.sym.data(ctx);
         if (data->resultType == nullptr) {
@@ -1628,7 +1628,7 @@ class ResolveTypeMembersAndFieldsWalk {
     }
 
     [[nodiscard]] static core::TypePtr resolveStaticField(core::Context ctx, ResolveStaticFieldItem &job) {
-        ENFORCE(job.sym.data(ctx)->isStaticField());
+        ENFORCE(job.sym.data(ctx)->flags.isStaticField);
         auto &asgn = job.asgn;
         auto data = job.sym.data(ctx);
         if (data->resultType == nullptr) {


### PR DESCRIPTION

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Introduce a dedicated Field class.

The packager pass dramatically increases the number of static fields. Making this class cheaper to allocate reduces Namer::defineName's runtime by a little bit in packager mode.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Speed, slightly reduce memory, tighter symbol *refs for `owner` field.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
