### PR TITLE
Properly type Array#to_set

### DIFF
--- a/rbi/stdlib/set.rbi
+++ b/rbi/stdlib/set.rbi
@@ -1026,7 +1026,14 @@ end
 #
 # for pack.c
 class Array
-  sig { params(blk: T.nilable(T.proc.params(arg0: T.untyped).void)).returns(T::Set[T.untyped]) }
+  sig do
+    returns(T::Set[Elem])
+  end
+  sig do
+    type_parameters(:Return)
+    params(blk: T.nilable(T.proc.params(arg0: Elem).returns(T.type_parameter(:Return))))
+    .returns(T::Set[T.type_parameter(:Return)])
+  end
   def to_set(&blk); end
 end
 


### PR DESCRIPTION
Modifies the signature of `Array#to_set` to properly propagate the generic type.

### Motivation
Improved typing.

### Test plan
CI