### PR TITLE
Allow for incremental packaging in noop change

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1423,8 +1423,8 @@ vector<ast::ParsedFile> rewriteFilesFast(core::GlobalState &gs, vector<ast::Pars
         if (files[i].file.data(gs).isPackage()) {
             {
                 core::MutableContext ctx(gs, core::Symbols::root(), files[i].file);
-                auto pkg = getPackageInfo(ctx, files[i], gs.packageDB().extraPackageFilesDirectoryPrefixes());
-                ENFORCE(pkg != nullptr);
+                // Re-write imports and exports:
+                getPackageInfo(ctx, files[i], gs.packageDB().extraPackageFilesDirectoryPrefixes());
             }
             files[i] = rewritePackage(ctx, move(files[i]));
         } else {

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -606,8 +606,9 @@ TEST_CASE("PerPhaseTest") { // NOLINT
 
         newTrees.emplace_back(move(file));
     }
-
     trees = move(newTrees);
+    fast_sort(trees, [](auto &lhs, auto &rhs) { return lhs.file < rhs.file; });
+
     if (enablePackager) {
         trees = packager::Packager::runIncremental(*gs, move(trees));
         for (auto &tree : trees) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Remove conditions that caused all incremental paths to always add _all_ package specs if any spec was present. This is no longer needed because these are stored in GlobalState.

Note: that it is still the case that if a package spec changes we go through the slow path.


### Motivation
Fix performance of simple LSP queries (go-to def) when in `__package.rb` files.
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

Manually tested VSCode goto-def in Stripe's codebase. Validated that it now reacts quickly.
