### PR TITLE
Improve errors and suggestions for bad `import`s

### DIFF
--- a/resolver/SuggestPackage.cc
+++ b/resolver/SuggestPackage.cc
@@ -97,6 +97,25 @@ public:
             // TODO(gdritter-stripe) handle bad import
             return false;
         }
+
+    bool tryUnresolvedImportCorrections(const ast::ConstantLit::ResolutionScopes &scopes, core::NameRef name) const {
+        // there are two broader cases here: either the name we're
+        // looking for shares the same prefix as the package we're in,
+        // in which case it's probably an export we can't find (and we
+        // should let the normal constant resolution machinery do its
+        // work.) Otherwise, it's probably an import we can't find,
+        // and we can limit our search to only package names.
+
+        // TODO(gdritter): bail when it's clear that we're looking at
+        // an export
+        ctx.state.tracer().error("For: {}", name.toString(ctx));
+        for (auto &s : scopes) {
+            if (s.exists())
+                ctx.state.tracer().error("  - {}", s.show(ctx));
+            else
+                ctx.state.tracer().error("  - {}", s.show(ctx));
+        }
+        return true;
     }
 
 private:

--- a/resolver/SuggestPackage.cc
+++ b/resolver/SuggestPackage.cc
@@ -120,7 +120,6 @@ private:
         auto prefixSize = prefix.end() - prefixBegin;
 
         for (auto name : db().packages()) {
-            ctx.state.tracer().error("comparing against {}", name.toString(ctx));
             auto &other = db().getPackageInfo(name);
             auto &fullName = other.fullName();
             if (fullName.size() >= prefixSize && canImport(other) &&
@@ -163,30 +162,43 @@ private:
     }
 
     void tryUnresolvedImportCorrections(core::ErrorBuilder &e, ast::UnresolvedConstantLit &unresolved) {
-        vector<PackageMatch> matches;
-        vector<core::NameRef> prefix;
+        auto &scope = unresolved.scope;
+        // by default, we'll try to search for a matching package in the root scope
+        core::SymbolRef searchScope = core::Symbols::root();
+        // but if our parent is something that _was_ resolved, we can
+        // search in that scope instead
+        if (auto *cnst = ast::cast_tree<ast::ConstantLit>(scope)) {
+            searchScope = cnst->symbol;
+        }
 
-        ast::UnresolvedConstantLit* cnst = &unresolved;
-        while (cnst) {
-            prefix.emplace_back(cnst->cnst);
-            if (auto cnst_lit = ast::cast_tree<ast::UnresolvedConstantLit>(cnst->scope)) {
-                cnst = cnst_lit;
-            } else if (auto cnst_lit = ast::cast_tree<ast::ConstantLit>(cnst->scope)) {
-                cnst = ast::cast_tree<ast::UnresolvedConstantLit>(cnst_lit->original);
-            } else {
-                break;
+        // try to find a matching constant in the resolved parent
+        // scope (or root scope if that didn't exist)
+        auto matches = searchScope.asClassOrModuleRef().data(ctx)->findMemberFuzzyMatch(ctx, unresolved.cnst);
+        {
+            // remove anything that's not a package. Since we're
+            // searching from the root, that means we'll be finding
+            // the things which inherit from `PackageSpec`
+            // (i.e. something like `::MyPackage`, and not
+            // `::<PackageRegistry>::MyPackage`), and we can retain
+            // _only_ those constants which inherit from `PackageSpec`
+            // and throw out other suggestions
+            auto it = remove_if(matches.begin(), matches.end(), [&](auto &m) -> bool {
+                if (m.symbol.isClassOrModule()) {
+                    return m.symbol.asClassOrModuleRef().data(ctx)->superClass() != core::Symbols::PackageSpec();
+                } else {
+                    return true;
+                }
+            });
+            matches.erase(it, matches.end());
+
+            // only keep a tractable number of them
+            if (matches.size() > 4) {
+                matches.resize(4);
             }
         }
-        reverse(prefix.begin(), prefix.end());
-        ctx.state.tracer().error("-----");
-        for (auto n : prefix) {
-            ctx.state.tracer().error("  - {}", n.show(ctx));
-        }
-
-        findPackagesWithPrefix(prefix, matches);
-        ctx.state.tracer().error("found {} matches", matches.size());
-        for (auto match : matches) {
-            addMissingImportSuggestions(e, match);
+        // do the replacements
+        if (!matches.empty()) {
+            addReplacementSuggestions(e, unresolved, matches);
         }
     }
 

--- a/resolver/SuggestPackage.cc
+++ b/resolver/SuggestPackage.cc
@@ -98,7 +98,7 @@ public:
             return false;
         }
 
-    bool tryUnresolvedImportCorrections(const ast::ConstantLit::ResolutionScopes &scopes, core::NameRef name) const {
+    bool tryUnresolvedImportCorrections(const ast::ConstantLit::ResolutionScopes &scopes, core::NameRef name) {
         // there are two broader cases here: either the name we're
         // looking for shares the same prefix as the package we're in,
         // in which case it's probably an export we can't find (and we
@@ -108,7 +108,16 @@ public:
 
         // TODO(gdritter): bail when it's clear that we're looking at
         // an export
-        ctx.state.tracer().error("For: {}", name.toString(ctx));
+        vector<PackageMatch> matches;
+        vector<core::NameRef> prefix;
+
+        ast::UnresolvedConstantLit& cnst;
+        do {
+            prefix.emplace_back(unresolved.cnst);
+        } while (
+
+        findPackagesWithPrefix(prefix, matches);
+        ctx.state.tracer().error("For: {}", unresolved.toStringWithTabs(ctx));
         for (auto &s : scopes) {
             if (s.exists())
                 ctx.state.tracer().error("  - {}", s.show(ctx));

--- a/resolver/SuggestPackage.cc
+++ b/resolver/SuggestPackage.cc
@@ -122,8 +122,14 @@ public:
                 break;
             }
         }
+        reverse(prefix.begin(), prefix.end());
+        ctx.state.tracer().error("-----");
+        for (auto n : prefix) {
+            ctx.state.tracer().error("  - {}", n.show(ctx));
+        }
 
         findPackagesWithPrefix(prefix, matches);
+        ctx.state.tracer().error("found {} matches", matches.size());
         for (auto match : matches) {
             addMissingImportSuggestions(e, match);
         }
@@ -150,6 +156,7 @@ private:
         auto prefixSize = prefix.end() - prefixBegin;
 
         for (auto name : db().packages()) {
+            ctx.state.tracer().error("comparing against {}", name.toString(ctx));
             auto &other = db().getPackageInfo(name);
             auto &fullName = other.fullName();
             if (fullName.size() >= prefixSize && canImport(other) &&

--- a/test/cli/package-bad-imports/do_not/__package.rb
+++ b/test/cli/package-bad-imports/do_not/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class DoNot < PackageSpec
+  export DoNot::SuggestThis
+end

--- a/test/cli/package-bad-imports/do_not/suggest_this.rb
+++ b/test/cli/package-bad-imports/do_not/suggest_this.rb
@@ -1,0 +1,3 @@
+# typed: strict
+
+module DoNot::SuggestThis; end

--- a/test/cli/package-bad-imports/example/__package.rb
+++ b/test/cli/package-bad-imports/example/__package.rb
@@ -1,0 +1,12 @@
+# typed: strict
+
+class Some::Example < PackageSpec
+  # this shouldn't find anything similar
+  import NonexistentPackage
+  # this should NOT try to suggest `DoNot::SuggestThis`
+  import DoNot::SUggestThis
+  # this should correctly suggest the package `Suggestion`
+  import SUggestion
+  # a name with three parts, for testing reasons
+  import A::B::C
+end

--- a/test/cli/package-bad-imports/package-bad-imports.out
+++ b/test/cli/package-bad-imports/package-bad-imports.out
@@ -1,0 +1,39 @@
+example/__package.rb:5: Cannot find package `NonexistentPackage` https://srb.help/3704
+     5 |  import NonexistentPackage
+                 ^^^^^^^^^^^^^^^^^^
+
+example/__package.rb:7: Cannot find package `DoNot::SUggestThis` https://srb.help/3704
+     7 |  import DoNot::SUggestThis
+                 ^^^^^^^^^^^^^^^^^^
+
+example/__package.rb:9: Cannot find package `SUggestion` https://srb.help/3704
+     9 |  import SUggestion
+                 ^^^^^^^^^^
+
+example/__package.rb:11: Cannot find package `A::B::C` https://srb.help/3704
+    11 |  import A::B::C
+                 ^^^^^^^
+
+example/__package.rb:5: Unable to resolve constant `NonexistentPackage` https://srb.help/5002
+     5 |  import NonexistentPackage
+                 ^^^^^^^^^^^^^^^^^^
+
+example/__package.rb:7: Unable to resolve constant `SUggestThis` https://srb.help/5002
+     7 |  import DoNot::SUggestThis
+                 ^^^^^^^^^^^^^^^^^^
+
+example/__package.rb:9: Unable to resolve constant `SUggestion` https://srb.help/5002
+     9 |  import SUggestion
+                 ^^^^^^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    example/__package.rb:9: Replace with `Suggestion`
+     9 |  import SUggestion
+                 ^^^^^^^^^^
+    suggestion/__package.rb:3: Did you mean: `Suggestion`?
+     3 |class Suggestion < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+example/__package.rb:11: Unable to resolve constant `A` https://srb.help/5002
+    11 |  import A::B::C
+                 ^
+Errors: 8

--- a/test/cli/package-bad-imports/package-bad-imports.sh
+++ b/test/cli/package-bad-imports/package-bad-imports.sh
@@ -1,0 +1,3 @@
+cd test/cli/package-bad-imports || exit 1
+
+../../../main/sorbet --silence-dev-message --stripe-packages --max-threads=0 . 2>&1

--- a/test/cli/package-bad-imports/suggestion/__package.rb
+++ b/test/cli/package-bad-imports/suggestion/__package.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+class Suggestion < PackageSpec
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
This ensures that we only suggest packages (and never non-package constants) for `import` lines.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Added a CLI test which showcases the desired behavior.
