### PR TITLE
Add more benchmarks for `T.let`

### DIFF
--- a/gems/sorbet-runtime/bench/typecheck.rb
+++ b/gems/sorbet-runtime/bench/typecheck.rb
@@ -105,6 +105,21 @@ module SorbetBenchmarks
         nilable_integer_param(1)
       end
 
+      time_block("T.let(..., T.nilable(T.any(Integer, String)))") do
+        T.let(nil, T.nilable(T.any(Integer, String)))
+        T.let(1, T.nilable(T.any(Integer, String)))
+      end
+
+      time_block("T.let(..., T.nilable(T.any(Integer, String)), checked: false)") do
+        T.let(nil, T.nilable(T.any(Integer, String)), checked: false)
+        T.let(1, T.nilable(T.any(Integer, String)), checked: false)
+      end
+
+      time_block("sig {params(x: T.nilable(T.any(Integer, String))).void}") do
+        nilable_integer_or_string_param(nil)
+        nilable_integer_or_string_param(1)
+      end
+
       time_block("T.let(..., Example)") do
         T.let(example, Example)
         T.let(example, Example)
@@ -159,6 +174,9 @@ module SorbetBenchmarks
 
     sig {params(x: T.nilable(Integer)).void}
     def self.nilable_integer_param(x); end
+
+    sig {params(x: T.nilable(T.any(Integer, String))).void}
+    def self.nilable_integer_or_string_param(x); end
 
     sig {params(x: Example).void}
     def self.application_class_param(x); end


### PR DESCRIPTION
### Motivation

Initializing non-simple types is expensive which means using any inline types (e.g. `T.let/cast(...)`) even when `checked: false` incurs performance penalties. This adds some microbenchmarks to demonstrate this to give a starting point for any improvements to the performance here.

| Code | Time | |
| -- | -- | -- |
| T.let(..., Integer) | 366.56 ns | baseline |
| T.let(..., T.nilable(Integer)) | 1.078 μs | ~3x slower |
| T.let(..., T.nilable(T.any(Integer, String))) | 6.89 μs | ~18x slower |
| T.let(..., T.nilable(T.any(Integer, String)), checked: false) | 5.938 μs | ~16x slower |

### Test plan

No tests, just updating benchmarking code. Confirmed the code ran locally to produce the results.
