### PR TITLE
Rename GlobalSubstitution

### DIFF
--- a/ast/substitute/Substitute.cc
+++ b/ast/substitute/Substitute.cc
@@ -6,7 +6,7 @@
 namespace sorbet::ast {
 
 namespace {
-// Is used with GlobalSubstitution and LazyGlobalSubstitution, which implement the same interface.
+// Is used with NameSubstitution and LazyNameSubstitution, which implement the same interface.
 template <typename T> class SubstWalk {
 private:
     T &subst;
@@ -128,13 +128,13 @@ public:
 };
 } // namespace
 
-ExpressionPtr Substitute::run(core::MutableContext ctx, const core::GlobalSubstitution &subst, ExpressionPtr what) {
+ExpressionPtr Substitute::run(core::MutableContext ctx, const core::NameSubstitution &subst, ExpressionPtr what) {
     SubstWalk walk(subst);
     what = TreeMap::apply(ctx, walk, std::move(what));
     return what;
 }
 
-ExpressionPtr Substitute::run(core::MutableContext ctx, core::LazyGlobalSubstitution &subst, ExpressionPtr what) {
+ExpressionPtr Substitute::run(core::MutableContext ctx, core::LazyNameSubstitution &subst, ExpressionPtr what) {
     SubstWalk walk(subst);
     what = TreeMap::apply(ctx, walk, std::move(what));
     return what;

--- a/ast/substitute/Substitute.cc
+++ b/ast/substitute/Substitute.cc
@@ -2,7 +2,7 @@
 #include "ast/Helpers.h"
 #include "ast/treemap/treemap.h"
 #include "common/typecase.h"
-#include "core/GlobalSubstitution.h"
+#include "core/NameSubstitution.h"
 namespace sorbet::ast {
 
 namespace {

--- a/ast/substitute/substitute.h
+++ b/ast/substitute/substitute.h
@@ -5,14 +5,14 @@
 #include "core/Context.h"
 
 namespace sorbet::core {
-class LazyGlobalSubstitution;
+class LazyNameSubstitution;
 };
 
 namespace sorbet::ast {
 class Substitute {
 public:
-    static ExpressionPtr run(core::MutableContext ctx, const core::GlobalSubstitution &subst, ExpressionPtr what);
-    static ExpressionPtr run(core::MutableContext ctx, core::LazyGlobalSubstitution &subst, ExpressionPtr what);
+    static ExpressionPtr run(core::MutableContext ctx, const core::NameSubstitution &subst, ExpressionPtr what);
+    static ExpressionPtr run(core::MutableContext ctx, core::LazyNameSubstitution &subst, ExpressionPtr what);
 };
 } // namespace sorbet::ast
 #endif // SORBET_SUBSTITUTE_H

--- a/core/BUILD
+++ b/core/BUILD
@@ -17,7 +17,7 @@ cc_library(
         "Names_gen.cc",
     ],
     hdrs = [
-        "GlobalSubstitution.h",
+        "NameSubstitution.h",
         "core.h",
     ] + glob([
         "errors/*.h",

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -23,7 +23,7 @@ class MethodRef;
 class FieldRef;
 class TypeArgumentRef;
 class TypeMemberRef;
-class GlobalSubstitution;
+class NameSubstitution;
 class ErrorQueue;
 struct GlobalStateHash;
 
@@ -49,7 +49,7 @@ class GlobalState final {
     friend FieldRef;
     friend File;
     friend FileRef;
-    friend GlobalSubstitution;
+    friend NameSubstitution;
     friend ErrorBuilder;
     friend serialize::Serializer;
     friend serialize::SerializerImpl;

--- a/core/NameRef.h
+++ b/core/NameRef.h
@@ -4,7 +4,7 @@
 #include "core/DebugOnlyCheck.h"
 namespace sorbet::core {
 class GlobalState;
-class GlobalSubstitution;
+class NameSubstitution;
 struct UniqueName;
 struct ConstantName;
 struct UTF8Name;
@@ -63,7 +63,7 @@ struct NameRefDebugCheck {
     NameRefDebugCheck(const GlobalState &gs, NameKind kind, uint32_t id);
 
     void check(const GlobalState &gs, NameKind kind, uint32_t id) const;
-    void check(const GlobalSubstitution &subst) const;
+    void check(const NameSubstitution &subst) const;
 };
 
 constexpr std::string_view PACKAGE_SUFFIX = "_Package";
@@ -197,7 +197,7 @@ public:
     std::string show(const GlobalState &gs) const;
 
     void enforceCorrectGlobalState(const GlobalState &gs) const;
-    void sanityCheckSubstitution(const GlobalSubstitution &subst) const;
+    void sanityCheckSubstitution(const NameSubstitution &subst) const;
     void sanityCheck(const GlobalState &gs) const;
 };
 CheckSize(NameRef, 4, 4);

--- a/core/NameSubstitution.cc
+++ b/core/NameSubstitution.cc
@@ -5,8 +5,8 @@
 using namespace std;
 namespace sorbet::core {
 
-GlobalSubstitution::GlobalSubstitution(const GlobalState &from, GlobalState &to) : toGlobalStateId(to.globalStateId) {
-    Timer timeit(to.tracer(), "GlobalSubstitution.new", from.creation);
+NameSubstitution::NameSubstitution(const GlobalState &from, GlobalState &to) : toGlobalStateId(to.globalStateId) {
+    Timer timeit(to.tracer(), "NameSubstitution.new", from.creation);
 
     from.sanityCheck();
 
@@ -56,7 +56,7 @@ GlobalSubstitution::GlobalSubstitution(const GlobalState &from, GlobalState &to)
     to.sanityCheck();
 }
 
-void GlobalSubstitution::mergeFileTables(const GlobalState &from, GlobalState &to) {
+void NameSubstitution::mergeFileTables(const GlobalState &from, GlobalState &to) {
     UnfreezeFileTable unfreezeFiles(to);
     // id 0 is for non-existing FileRef
     for (int fileIdx = 1; fileIdx < from.filesUsed(); fileIdx++) {
@@ -71,13 +71,13 @@ void GlobalSubstitution::mergeFileTables(const GlobalState &from, GlobalState &t
     }
 }
 
-LazyGlobalSubstitution::LazyGlobalSubstitution(const GlobalState &fromGS, GlobalState &toGS)
+LazyNameSubstitution::LazyNameSubstitution(const GlobalState &fromGS, GlobalState &toGS)
     : fromGS(fromGS), toGS(toGS) {
     // Pre-define an entry for the empty name.
     nameSubstitution[core::NameRef()] = core::NameRef();
 };
 
-NameRef LazyGlobalSubstitution::defineName(NameRef from, bool allowSameFromTo) {
+NameRef LazyNameSubstitution::defineName(NameRef from, bool allowSameFromTo) {
     ENFORCE_NO_TIMER(&fromGS != &toGS);
 
     // Avoid failures in debug builds.
@@ -104,7 +104,7 @@ NameRef LazyGlobalSubstitution::defineName(NameRef from, bool allowSameFromTo) {
     return to;
 }
 
-core::UsageHash LazyGlobalSubstitution::getAllNames() {
+core::UsageHash LazyNameSubstitution::getAllNames() {
     core::NameHash::sortAndDedupe(acc.sends);
     core::NameHash::sortAndDedupe(acc.symbols);
     return move(acc);

--- a/core/NameSubstitution.cc
+++ b/core/NameSubstitution.cc
@@ -71,8 +71,7 @@ void NameSubstitution::mergeFileTables(const GlobalState &from, GlobalState &to)
     }
 }
 
-LazyNameSubstitution::LazyNameSubstitution(const GlobalState &fromGS, GlobalState &toGS)
-    : fromGS(fromGS), toGS(toGS) {
+LazyNameSubstitution::LazyNameSubstitution(const GlobalState &fromGS, GlobalState &toGS) : fromGS(fromGS), toGS(toGS) {
     // Pre-define an entry for the empty name.
     nameSubstitution[core::NameRef()] = core::NameRef();
 };

--- a/core/NameSubstitution.cc
+++ b/core/NameSubstitution.cc
@@ -1,4 +1,4 @@
-#include "core/GlobalSubstitution.h"
+#include "core/NameSubstitution.h"
 #include "core/GlobalState.h"
 #include "core/Names.h"
 #include "core/Unfreeze.h"

--- a/core/NameSubstitution.h
+++ b/core/NameSubstitution.h
@@ -11,15 +11,15 @@ namespace sorbet::core {
 class GlobalState;
 
 /**
- * With the ast::substitute pass, GlobalSubstitution makes it possible to rewrite ASTs from one GlobalState into ASTs
+ * With the ast::substitute pass, NameSubstitution makes it possible to rewrite ASTs from one GlobalState into ASTs
  * from a second GlobalState.
  *
  * The constructor builds up a lookup table from every NameRef in `from` to an equivalent NameRef in `to`, inserting new
  * names into `to` where needed. Then, that table can be used to rewrite multiple ASTs from `from`.
  */
-class GlobalSubstitution final {
+class NameSubstitution final {
 public:
-    GlobalSubstitution(const GlobalState &from, GlobalState &to);
+    NameSubstitution(const GlobalState &from, GlobalState &to);
 
     static void mergeFileTables(const GlobalState &from, GlobalState &to);
 
@@ -65,15 +65,15 @@ private:
 };
 
 /**
- * GlobalSubstitution, but lazily populates `nameSubstitution` _and_ builds up a UsageHash for the file.
+ * NameSubstitution, but lazily populates `nameSubstitution` _and_ builds up a UsageHash for the file.
  * Used in the hashing package as a part of the AST hashing process, which rewrites ASTs from the main GlobalState into
  * ASTs for new and empty GlobalStates.
  *
- * Unlike the GlobalSubstitution case, LazyGlobalSubstitution is intended to be used for rewriting a single AST. Hence,
+ * Unlike the NameSubstitution case, LazyNameSubstitution is intended to be used for rewriting a single AST. Hence,
  * the `nameSubstitution` map is sparse and built up lazily, since a single AST will only reference a small subset of
  * names in GlobalState.
  */
-class LazyGlobalSubstitution final {
+class LazyNameSubstitution final {
     const core::GlobalState &fromGS;
     core::GlobalState &toGS;
 
@@ -83,8 +83,8 @@ class LazyGlobalSubstitution final {
     NameRef defineName(NameRef from, bool allowSameFromTo);
 
 public:
-    LazyGlobalSubstitution(const GlobalState &fromGS, GlobalState &toGS);
-    ~LazyGlobalSubstitution() = default;
+    LazyNameSubstitution(const GlobalState &fromGS, GlobalState &toGS);
+    ~LazyNameSubstitution() = default;
 
     NameRef substitute(NameRef from, bool allowSameFromTo = false) {
         if (&fromGS == &toGS) {

--- a/core/NameSubstitution.h
+++ b/core/NameSubstitution.h
@@ -1,5 +1,5 @@
-#ifndef SORBET_CORE_GLOBAL_SUBSTITUTION_H
-#define SORBET_CORE_GLOBAL_SUBSTITUTION_H
+#ifndef SORBET_CORE_NAME_SUBSTITUTION_H
+#define SORBET_CORE_NAME_SUBSTITUTION_H
 
 #include "common/common.h"
 #include "core/NameHash.h"

--- a/core/Names.cc
+++ b/core/Names.cc
@@ -1,7 +1,7 @@
 #include "core/Names.h"
 #include "core/Context.h"
 #include "core/GlobalState.h"
-#include "core/GlobalSubstitution.h"
+#include "core/NameSubstitution.h"
 #include "core/Names.h"
 #include "core/hashing/hashing.h"
 #include <numeric> // accumulate

--- a/core/Names.cc
+++ b/core/Names.cc
@@ -322,7 +322,7 @@ void NameRefDebugCheck::check(const GlobalState &gs, NameKind kind, uint32_t ind
     ENFORCE(false, "NameRef not owned by correct GlobalState");
 }
 
-void NameRefDebugCheck::check(const GlobalSubstitution &subst) const {
+void NameRefDebugCheck::check(const NameSubstitution &subst) const {
     ENFORCE(globalStateId != subst.toGlobalStateId, "substituting a name twice!");
 }
 
@@ -330,7 +330,7 @@ void NameRef::enforceCorrectGlobalState(const GlobalState &gs) const {
     runDebugOnlyCheck(gs, kind(), unsafeTableIndex());
 }
 
-void NameRef::sanityCheckSubstitution(const GlobalSubstitution &subst) const {
+void NameRef::sanityCheckSubstitution(const NameSubstitution &subst) const {
     runDebugOnlyCheck(subst);
 }
 

--- a/core/Types.h
+++ b/core/Types.h
@@ -604,7 +604,7 @@ private:
      */
     friend TypePtr Types::falsyTypes();
     friend TypePtr Types::Boolean();
-    friend class GlobalSubstitution;
+    friend class NameSubstitution;
     friend class serialize::SerializerImpl;
     friend bool Types::isSubTypeUnderConstraint(const GlobalState &gs, TypeConstraint &constr, const TypePtr &t1,
                                                 const TypePtr &t2, UntypedMode mode);
@@ -647,7 +647,7 @@ private:
      */
     AndType(const TypePtr &left, const TypePtr &right);
 
-    friend class GlobalSubstitution;
+    friend class NameSubstitution;
     friend class serialize::SerializerImpl;
     friend class TypeConstraint;
 

--- a/core/test/core_test.cc
+++ b/core/test/core_test.cc
@@ -150,7 +150,7 @@ TEST_CASE("Substitute") { // NOLINT
         gs1.enterNameUTF8("name");
     }
 
-    GlobalSubstitution subst(gs1, gs2);
+    NameSubstitution subst(gs1, gs2);
 
     CHECK_EQ(subst.substitute(foo1), foo2);
     CHECK_EQ(subst.substitute(bar1), bar2);

--- a/core/test/core_test.cc
+++ b/core/test/core_test.cc
@@ -3,7 +3,7 @@
 #include "core/Error.h"
 #include "core/ErrorCollector.h"
 #include "core/ErrorQueue.h"
-#include "core/GlobalSubstitution.h"
+#include "core/NameSubstitution.h"
 #include "core/TypePtr.h"
 #include "core/Unfreeze.h"
 #include "core/core.h"

--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -20,7 +20,7 @@ pair<ast::ParsedFile, core::UsageHash> rewriteAST(const core::GlobalState &origi
                                                   core::FileRef newFref, const ast::ParsedFile &ast) {
     // TODO(jvilk): Switch to passing around compressed ASTs which are cheaper to copy + inflate.
     ast::ParsedFile rewritten{ast.tree.deepCopy(), newFref};
-    core::LazyGlobalSubstitution subst(originalGS, newGS);
+    core::LazyNameSubstitution subst(originalGS, newGS);
     core::MutableContext ctx(newGS, core::Symbols::root(), newFref);
     core::UnfreezeNameTable nameTableAccess(newGS);
     rewritten.tree = ast::Substitute::run(ctx, subst, move(rewritten.tree));
@@ -60,9 +60,9 @@ unique_ptr<core::FileHash> computeFileHashForFile(shared_ptr<core::File> forWhat
     core::FileRef fref = makeEmptyGlobalStateForFile(logger, move(forWhat), /* out param */ lgs, hashingOpts);
     auto ast = realmain::pipeline::indexOne(opts(), *lgs, fref);
 
-    // Calculate UsageHash. We use LazyGlobalSubstitution for this purpose, but it will not do any actual substitution
+    // Calculate UsageHash. We use LazyNameSubstitution for this purpose, but it will not do any actual substitution
     // when fromGS == toGS (hence we intentionally do not unfreeze name table).
-    core::LazyGlobalSubstitution subst(*lgs, *lgs);
+    core::LazyNameSubstitution subst(*lgs, *lgs);
     core::MutableContext ctx(*lgs, core::Symbols::root(), fref);
     ast.tree = ast::Substitute::run(ctx, subst, move(ast.tree));
     return computeFileHashForAST(lgs, subst.getAllNames(), move(ast));

--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -3,8 +3,8 @@
 #include "ast/treemap/treemap.h"
 #include "common/concurrency/ConcurrentQueue.h"
 #include "core/ErrorQueue.h"
-#include "core/NameSubstitution.h"
 #include "core/NameHash.h"
+#include "core/NameSubstitution.h"
 #include "core/Unfreeze.h"
 #include "main/pipeline/pipeline.h"
 

--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -3,7 +3,7 @@
 #include "ast/treemap/treemap.h"
 #include "common/concurrency/ConcurrentQueue.h"
 #include "core/ErrorQueue.h"
-#include "core/GlobalSubstitution.h"
+#include "core/NameSubstitution.h"
 #include "core/NameHash.h"
 #include "core/Unfreeze.h"
 #include "main/pipeline/pipeline.h"

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -434,14 +434,14 @@ struct IndexSubstitutionJob {
     // of serially in the main thread.
     unique_ptr<core::GlobalState> threadGs;
 
-    std::optional<core::GlobalSubstitution> subst;
+    std::optional<core::NameSubstitution> subst;
     vector<ast::ParsedFile> trees;
 
     IndexSubstitutionJob() {}
 
     IndexSubstitutionJob(core::GlobalState &to, IndexResult res)
         : threadGs{std::move(res.gs)}, subst{}, trees{std::move(res.trees)} {
-        core::GlobalSubstitution::mergeFileTables(*this->threadGs, to);
+        core::NameSubstitution::mergeFileTables(*this->threadGs, to);
         if (absl::c_any_of(this->trees, [this](auto &parsed) { return !parsed.file.data(*this->threadGs).cached; })) {
             this->subst.emplace(*this->threadGs, to);
         }

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -27,7 +27,7 @@
 #include "common/formatting.h"
 #include "common/sort.h"
 #include "core/ErrorQueue.h"
-#include "core/GlobalSubstitution.h"
+#include "core/NameSubstitution.h"
 #include "core/Unfreeze.h"
 #include "core/errors/parser.h"
 #include "core/lsp/PreemptionTaskManager.h"

--- a/main/pipeline/semantic_extension/SemanticExtension.h
+++ b/main/pipeline/semantic_extension/SemanticExtension.h
@@ -10,7 +10,7 @@ class Options;
 namespace sorbet {
 namespace core {
 class GlobalState;
-class GlobalSubstitution;
+class NameSubstitution;
 class MutableContext;
 class FileRef;
 } // namespace core
@@ -33,7 +33,7 @@ public:
     virtual void run(core::MutableContext &, ast::ClassDef *) const = 0;
     virtual ~SemanticExtension() = default;
     virtual std::unique_ptr<SemanticExtension> deepCopy(const core::GlobalState &from, core::GlobalState &to) = 0;
-    virtual void merge(const core::GlobalState &from, core::GlobalState &to, core::GlobalSubstitution &subst) = 0;
+    virtual void merge(const core::GlobalState &from, core::GlobalState &to, core::NameSubstitution &subst) = 0;
 };
 
 class SemanticExtensionProvider {

--- a/plugin_injector/plugin_injector.cc
+++ b/plugin_injector/plugin_injector.cc
@@ -353,7 +353,7 @@ public:
     virtual std::unique_ptr<SemanticExtension> deepCopy(const core::GlobalState &from, core::GlobalState &to) override {
         return make_unique<LLVMSemanticExtension>(this->compiledOutputDir, this->irOutputDir, this->forceCompiled);
     };
-    virtual void merge(const core::GlobalState &from, core::GlobalState &to, core::GlobalSubstitution &subst) override {
+    virtual void merge(const core::GlobalState &from, core::GlobalState &to, core::NameSubstitution &subst) override {
     }
 };
 

--- a/plugin_injector/plugin_injector.cc
+++ b/plugin_injector/plugin_injector.cc
@@ -353,8 +353,7 @@ public:
     virtual std::unique_ptr<SemanticExtension> deepCopy(const core::GlobalState &from, core::GlobalState &to) override {
         return make_unique<LLVMSemanticExtension>(this->compiledOutputDir, this->irOutputDir, this->forceCompiled);
     };
-    virtual void merge(const core::GlobalState &from, core::GlobalState &to, core::NameSubstitution &subst) override {
-    }
+    virtual void merge(const core::GlobalState &from, core::GlobalState &to, core::NameSubstitution &subst) override {}
 };
 
 class LLVMSemanticExtensionProvider : public SemanticExtensionProvider {

--- a/test/hello-test.cc
+++ b/test/hello-test.cc
@@ -8,7 +8,7 @@
 #include "common/common.h"
 #include "core/Error.h"
 #include "core/ErrorQueue.h"
-#include "core/GlobalSubstitution.h"
+#include "core/NameSubstitution.h"
 #include "core/Unfreeze.h"
 #include "core/serialize/serialize.h"
 #include "parser/parser.h"

--- a/test/hello-test.cc
+++ b/test/hello-test.cc
@@ -186,7 +186,7 @@ TEST_CASE("CloneSubstitutePayload") {
         n1 = c1->enterNameUTF8("test new name");
     }
 
-    sorbet::core::GlobalSubstitution subst(*c1, *c2);
+    sorbet::core::NameSubstitution subst(*c1, *c2);
     REQUIRE_EQ("<U test new name>", subst.substitute(n1).showRaw(*c2));
     REQUIRE_EQ(c1->symbolsUsedTotal(), c2->symbolsUsedTotal());
     REQUIRE_EQ(c1->symbolsUsedTotal(), gs.symbolsUsedTotal());

--- a/test/pkg_autocorrects_test.cc
+++ b/test/pkg_autocorrects_test.cc
@@ -6,7 +6,7 @@
 #include "common/concurrency/WorkerPool.h"
 #include "core/Error.h"
 #include "core/ErrorQueue.h"
-#include "core/GlobalSubstitution.h"
+#include "core/NameSubstitution.h"
 #include "core/Unfreeze.h"
 #include "local_vars/local_vars.h"
 #include "packager/packager.h"


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Rename GlobalSubstitution and LazyGlobalSubstitution to NameSubstitution and LazyNameSubstition respectively.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Make their name match their behavior: they will only generate substitutions for the name table.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
