### PR TITLE
Define `TypeParameter` and `ClassOrModule` classes; delete `Symbol` class.

### DIFF
--- a/compiler/IREmitter/IREmitterContext.cc
+++ b/compiler/IREmitter/IREmitterContext.cc
@@ -742,8 +742,7 @@ string locationNameFor(CompilerState &cs, core::MethodRef symbol) {
         enclosingClassRef = enclosingClassRef.data(cs)->attachedClass(cs);
         ENFORCE(enclosingClassRef.exists());
         const auto &enclosingClass = enclosingClassRef.data(cs);
-        return fmt::format("<{}:{}>", enclosingClass->isClassOrModuleClass() ? "class"sv : "module"sv,
-                           enclosingClassRef.show(cs));
+        return fmt::format("<{}:{}>", enclosingClass->isClass() ? "class"sv : "module"sv, enclosingClassRef.show(cs));
     } else if (IREmitterHelpers::isFileStaticInit(cs, symbol)) {
         return string("<top (required)>"sv);
     } else {

--- a/compiler/IREmitter/IREmitterHelpers.cc
+++ b/compiler/IREmitter/IREmitterHelpers.cc
@@ -35,7 +35,7 @@ string getFunctionNamePrefix(CompilerState &cs, core::ClassOrModuleRef sym) {
     }
     string prefix = IREmitterHelpers::isRootishSymbol(cs, sym.data(cs)->owner)
                         ? ""
-                        : getFunctionNamePrefix(cs, sym.data(cs)->owner.asClassOrModuleRef()) + "::";
+                        : getFunctionNamePrefix(cs, sym.data(cs)->owner) + "::";
 
     return prefix + suffix;
 }

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -914,27 +914,26 @@ ClassOrModuleRef GlobalState::enterClassSymbol(Loc loc, ClassOrModuleRef owner, 
 }
 
 TypeMemberRef GlobalState::enterTypeMember(Loc loc, ClassOrModuleRef owner, NameRef name, Variance variance) {
-    uint32_t flags;
+    TypeParameter::Flags flags;
     ENFORCE(owner.exists() || name == Names::Constants::NoTypeMember());
     ENFORCE(name.exists());
     if (variance == Variance::Invariant) {
-        flags = Symbol::Flags::TYPE_INVARIANT;
+        flags.isInvariant = true;
     } else if (variance == Variance::CoVariant) {
-        flags = Symbol::Flags::TYPE_COVARIANT;
+        flags.isCovariant = true;
     } else if (variance == Variance::ContraVariant) {
-        flags = Symbol::Flags::TYPE_CONTRAVARIANT;
+        flags.isContravariant = true;
     } else {
         Exception::notImplemented();
     }
-
-    flags = flags | Symbol::Flags::TYPE_MEMBER;
+    flags.isTypeMember = true;
 
     SymbolData ownerScope = owner.dataAllowingNone(*this);
     histogramInc("symbol_enter_by_name", ownerScope->members().size());
 
     auto &store = ownerScope->members()[name];
     if (store.exists()) {
-        ENFORCE(store.isTypeMember() && (store.asTypeMemberRef().data(*this)->flags & flags) == flags,
+        ENFORCE(store.isTypeMember() && store.asTypeMemberRef().data(*this)->flags.hasFlags(flags),
                 "existing symbol has wrong flags");
         counterInc("symbols.hit");
         return store.asTypeMemberRef();
@@ -945,7 +944,7 @@ TypeMemberRef GlobalState::enterTypeMember(Loc loc, ClassOrModuleRef owner, Name
     store = result; // DO NOT MOVE this assignment down. emplace_back on typeMembers invalidates `store`
     typeMembers.emplace_back();
 
-    SymbolData data = result.dataAllowingNone(*this);
+    TypeParameterData data = result.dataAllowingNone(*this);
     data->name = name;
     data->flags = flags;
     data->owner = owner;
@@ -964,25 +963,24 @@ TypeArgumentRef GlobalState::enterTypeArgument(Loc loc, MethodRef owner, NameRef
     ENFORCE(owner.exists() || name == Names::Constants::NoTypeArgument() ||
             name == Names::Constants::TodoTypeArgument());
     ENFORCE(name.exists());
-    uint32_t flags;
+    TypeParameter::Flags flags;
     if (variance == Variance::Invariant) {
-        flags = Symbol::Flags::TYPE_INVARIANT;
+        flags.isInvariant = true;
     } else if (variance == Variance::CoVariant) {
-        flags = Symbol::Flags::TYPE_COVARIANT;
+        flags.isCovariant = true;
     } else if (variance == Variance::ContraVariant) {
-        flags = Symbol::Flags::TYPE_CONTRAVARIANT;
+        flags.isContravariant = true;
     } else {
         Exception::notImplemented();
     }
-
-    flags = flags | Symbol::Flags::TYPE_ARGUMENT;
+    flags.isTypeArgument = true;
 
     auto ownerScope = owner.dataAllowingNone(*this);
     histogramInc("symbol_enter_by_name", ownerScope->typeArguments.size());
 
     for (auto typeArg : ownerScope->typeArguments) {
         if (typeArg.dataAllowingNone(*this)->name == name) {
-            ENFORCE((typeArg.dataAllowingNone(*this)->flags & flags) == flags, "existing symbol has wrong flags");
+            ENFORCE(typeArg.dataAllowingNone(*this)->flags.hasFlags(flags), "existing symbol has wrong flags");
             counterInc("symbols.hit");
             return typeArg;
         }
@@ -992,7 +990,7 @@ TypeArgumentRef GlobalState::enterTypeArgument(Loc loc, MethodRef owner, NameRef
     auto result = TypeArgumentRef(*this, typeArguments.size());
     typeArguments.emplace_back();
 
-    SymbolData data = result.dataAllowingNone(*this);
+    TypeParameterData data = result.dataAllowingNone(*this);
     data->name = name;
     data->flags = flags;
     data->owner = owner;
@@ -1786,11 +1784,11 @@ unique_ptr<GlobalState> GlobalState::deepCopy(bool keepId) const {
     }
     result->typeArguments.reserve(this->typeArguments.capacity());
     for (auto &sym : this->typeArguments) {
-        result->typeArguments.emplace_back(sym.deepCopy(*result, keepId));
+        result->typeArguments.emplace_back(sym.deepCopy(*result));
     }
     result->typeMembers.reserve(this->typeMembers.capacity());
     for (auto &sym : this->typeMembers) {
-        result->typeMembers.emplace_back(sym.deepCopy(*result, keepId));
+        result->typeMembers.emplace_back(sym.deepCopy(*result));
     }
     result->pathPrefix = this->pathPrefix;
     for (auto &semanticExtension : this->semanticExtensions) {
@@ -2014,16 +2012,33 @@ unique_ptr<GlobalStateHash> GlobalState::hash() const {
     UnorderedMap<NameHash, uint32_t> methodHashes;
     int counter = 0;
 
-    for (const auto *symbolType : {&this->classAndModules, &this->typeArguments, &this->typeMembers}) {
-        counter = 0;
-        for (const auto &sym : *symbolType) {
-            if (!sym.ignoreInHashing(*this)) {
-                hierarchyHash = mix(hierarchyHash, sym.hash(*this));
-                counter++;
-                if (DEBUG_HASHING_TAIL && counter > symbolType->size() - 15) {
-                    errorQueue->logger.info("Hashing symbols: {}, {}", hierarchyHash, sym.name.show(*this));
-                }
+    for (const auto &sym : this->classAndModules) {
+        if (!sym.ignoreInHashing(*this)) {
+            hierarchyHash = mix(hierarchyHash, sym.hash(*this));
+            counter++;
+            if (DEBUG_HASHING_TAIL && counter > this->classAndModules.size() - 15) {
+                errorQueue->logger.info("Hashing symbols: {}, {}", hierarchyHash, sym.name.show(*this));
             }
+        }
+    }
+
+    counter = 0;
+    for (const auto &typeArg : this->typeArguments) {
+        counter++;
+        // No type arguments are ignored in hashing.
+        hierarchyHash = mix(hierarchyHash, typeArg.hash(*this));
+        if (DEBUG_HASHING_TAIL && counter > this->typeArguments.size() - 15) {
+            errorQueue->logger.info("Hashing symbols: {}, {}", hierarchyHash, typeArg.name.show(*this));
+        }
+    }
+
+    counter = 0;
+    for (const auto &typeMember : this->typeMembers) {
+        counter++;
+        // No type members are ignored in hashing.
+        hierarchyHash = mix(hierarchyHash, typeMember.hash(*this));
+        if (DEBUG_HASHING_TAIL && counter > this->typeMembers.size() - 15) {
+            errorQueue->logger.info("Hashing symbols: {}, {}", hierarchyHash, typeMember.name.show(*this));
         }
     }
 

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -137,7 +137,8 @@ ClassOrModuleRef GlobalState::synthesizeClass(NameRef nameId, uint32_t superclas
     // These will be added to Symbols::root().members later.
     ClassOrModuleRef symRef = ClassOrModuleRef(*this, classAndModules.size());
     classAndModules.emplace_back();
-    SymbolData data = symRef.dataAllowingNone(*this); // allowing noSymbol is needed because this enters noSymbol.
+    ClassOrModuleData data =
+        symRef.dataAllowingNone(*this); // allowing noSymbol is needed because this enters noSymbol.
     data->name = nameId;
     data->owner = Symbols::root();
     data->setIsModule(isModule);
@@ -886,7 +887,7 @@ SymbolRef GlobalState::findRenamedSymbol(ClassOrModuleRef owner, SymbolRef sym) 
 ClassOrModuleRef GlobalState::enterClassSymbol(Loc loc, ClassOrModuleRef owner, NameRef name) {
     // ENFORCE_NO_TIMER(!owner.exists()); // Owner may not exist on purely synthetic symbols.
     ENFORCE_NO_TIMER(name.isClassName(*this));
-    SymbolData ownerScope = owner.dataAllowingNone(*this);
+    ClassOrModuleData ownerScope = owner.dataAllowingNone(*this);
     histogramInc("symbol_enter_by_name", ownerScope->members().size());
 
     auto &store = ownerScope->members()[name];
@@ -900,7 +901,7 @@ ClassOrModuleRef GlobalState::enterClassSymbol(Loc loc, ClassOrModuleRef owner, 
     auto ret = ClassOrModuleRef(*this, classAndModules.size());
     store = ret; // DO NOT MOVE this assignment down. emplace_back on classAndModules invalidates `store`
     classAndModules.emplace_back();
-    SymbolData data = ret.data(*this);
+    ClassOrModuleData data = ret.data(*this);
     data->name = name;
     data->owner = owner;
     data->addLoc(*this, loc);
@@ -925,7 +926,7 @@ TypeMemberRef GlobalState::enterTypeMember(Loc loc, ClassOrModuleRef owner, Name
     }
     flags.isTypeMember = true;
 
-    SymbolData ownerScope = owner.dataAllowingNone(*this);
+    ClassOrModuleData ownerScope = owner.dataAllowingNone(*this);
     histogramInc("symbol_enter_by_name", ownerScope->members().size());
 
     auto &store = ownerScope->members()[name];
@@ -1000,7 +1001,7 @@ TypeArgumentRef GlobalState::enterTypeArgument(Loc loc, MethodRef owner, NameRef
 }
 
 MethodRef GlobalState::enterMethodSymbol(Loc loc, ClassOrModuleRef owner, NameRef name) {
-    SymbolData ownerScope = owner.dataAllowingNone(*this);
+    ClassOrModuleData ownerScope = owner.dataAllowingNone(*this);
     histogramInc("symbol_enter_by_name", ownerScope->members().size());
 
     auto &store = ownerScope->members()[name];
@@ -1061,7 +1062,7 @@ MethodRef GlobalState::enterNewMethodOverload(Loc sigLoc, MethodRef original, co
 FieldRef GlobalState::enterFieldSymbol(Loc loc, ClassOrModuleRef owner, NameRef name) {
     ENFORCE(name.exists());
 
-    SymbolData ownerScope = owner.dataAllowingNone(*this);
+    ClassOrModuleData ownerScope = owner.dataAllowingNone(*this);
     histogramInc("symbol_enter_by_name", ownerScope->members().size());
 
     auto &store = ownerScope->members()[name];
@@ -1092,7 +1093,7 @@ FieldRef GlobalState::enterFieldSymbol(Loc loc, ClassOrModuleRef owner, NameRef 
 FieldRef GlobalState::enterStaticFieldSymbol(Loc loc, ClassOrModuleRef owner, NameRef name) {
     ENFORCE(name.exists());
 
-    SymbolData ownerScope = owner.dataAllowingNone(*this);
+    ClassOrModuleData ownerScope = owner.dataAllowingNone(*this);
     histogramInc("symbol_enter_by_name", ownerScope->members().size());
 
     auto &store = ownerScope->members()[name];

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -140,8 +140,6 @@ ClassOrModuleRef GlobalState::synthesizeClass(NameRef nameId, uint32_t superclas
     SymbolData data = symRef.dataAllowingNone(*this); // allowing noSymbol is needed because this enters noSymbol.
     data->name = nameId;
     data->owner = Symbols::root();
-    data->flags = 0;
-    data->setClassOrModule();
     data->setIsModule(isModule);
     data->setSuperClass(ClassOrModuleRef(*this, superclass));
 
@@ -904,7 +902,6 @@ ClassOrModuleRef GlobalState::enterClassSymbol(Loc loc, ClassOrModuleRef owner, 
     classAndModules.emplace_back();
     SymbolData data = ret.data(*this);
     data->name = name;
-    data->flags = Symbol::Flags::CLASS_OR_MODULE;
     data->owner = owner;
     data->addLoc(*this, loc);
     DEBUG_ONLY(categoryCounterInc("symbols", "class"));

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -16,7 +16,7 @@
 namespace sorbet::core {
 
 class NameRef;
-class Symbol;
+class ClassOrModule;
 class SymbolRef;
 class ClassOrModuleRef;
 class MethodRef;
@@ -39,7 +39,7 @@ class SerializerImpl;
 
 class GlobalState final {
     friend NameRef;
-    friend Symbol;
+    friend ClassOrModule;
     friend Method;
     friend Field;
     friend TypeParameter;
@@ -309,7 +309,7 @@ private:
     std::vector<ConstantName> constantNames;
     std::vector<UniqueName> uniqueNames;
     UnorderedMap<std::string, FileRef> fileRefByPath;
-    std::vector<Symbol> classAndModules;
+    std::vector<ClassOrModule> classAndModules;
     std::vector<Method> methods;
     std::vector<Field> fields;
     std::vector<TypeParameter> typeMembers;

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -42,6 +42,7 @@ class GlobalState final {
     friend Symbol;
     friend Method;
     friend Field;
+    friend TypeParameter;
     friend SymbolRef;
     friend ClassOrModuleRef;
     friend MethodRef;
@@ -311,8 +312,8 @@ private:
     std::vector<Symbol> classAndModules;
     std::vector<Method> methods;
     std::vector<Field> fields;
-    std::vector<Symbol> typeMembers;
-    std::vector<Symbol> typeArguments;
+    std::vector<TypeParameter> typeMembers;
+    std::vector<TypeParameter> typeArguments;
     std::vector<std::pair<unsigned int, uint32_t>> namesByHash;
     std::vector<std::shared_ptr<File>> files;
     UnorderedSet<int> ignoredForSuggestTypedErrorClasses;

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -87,6 +87,28 @@ public:
 };
 CheckSize(ConstFieldData, 8, 8);
 
+class TypeParameter;
+class TypeParameterData : private DebugOnlyCheck<SymbolDataDebugCheck> {
+    TypeParameter &typeParam;
+
+public:
+    TypeParameterData(TypeParameter &ref, GlobalState &gs);
+
+    TypeParameter *operator->();
+    const TypeParameter *operator->() const;
+};
+CheckSize(TypeParameterData, 8, 8);
+
+class ConstTypeParameterData : private DebugOnlyCheck<SymbolDataDebugCheck> {
+    const TypeParameter &typeParam;
+
+public:
+    ConstTypeParameterData(const TypeParameter &ref, const GlobalState &gs);
+
+    const TypeParameter *operator->() const;
+};
+CheckSize(ConstTypeParameterData, 8, 8);
+
 class ClassOrModuleRef final {
     uint32_t _id;
 
@@ -253,9 +275,9 @@ public:
         return ref;
     }
 
-    SymbolData data(GlobalState &gs) const;
-    ConstSymbolData data(const GlobalState &gs) const;
-    SymbolData dataAllowingNone(GlobalState &gs) const;
+    TypeParameterData data(GlobalState &gs) const;
+    ConstTypeParameterData data(const GlobalState &gs) const;
+    TypeParameterData dataAllowingNone(GlobalState &gs) const;
     std::string_view showKind(const GlobalState &gs) const;
     std::string showFullName(const GlobalState &gs) const;
     std::string toStringFullName(const GlobalState &gs) const;
@@ -295,9 +317,9 @@ public:
         return ref;
     }
 
-    SymbolData data(GlobalState &gs) const;
-    ConstSymbolData data(const GlobalState &gs) const;
-    SymbolData dataAllowingNone(GlobalState &gs) const;
+    TypeParameterData data(GlobalState &gs) const;
+    ConstTypeParameterData data(const GlobalState &gs) const;
+    TypeParameterData dataAllowingNone(GlobalState &gs) const;
     std::string_view showKind(const GlobalState &gs) const;
     std::string showFullName(const GlobalState &gs) const;
     std::string toStringFullName(const GlobalState &gs) const;

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -5,7 +5,7 @@
 #include "core/DebugOnlyCheck.h"
 
 namespace sorbet::core {
-class Symbol;
+class ClassOrModule;
 class GlobalState;
 class NameRef;
 class Loc;
@@ -22,26 +22,26 @@ struct SymbolDataDebugCheck {
  *  Entering new symbols can invalidate `Symbol &`s and thus they are generally unsafe.
  *  This class ensures that all accesses are safe in debug builds and effectively is a `Symbol &` in optimized builds.
  */
-class SymbolData : private DebugOnlyCheck<SymbolDataDebugCheck> {
-    Symbol &symbol;
+class ClassOrModuleData : private DebugOnlyCheck<SymbolDataDebugCheck> {
+    ClassOrModule &symbol;
 
 public:
-    SymbolData(Symbol &ref, GlobalState &gs);
+    ClassOrModuleData(ClassOrModule &ref, GlobalState &gs);
 
-    Symbol *operator->();
-    const Symbol *operator->() const;
+    ClassOrModule *operator->();
+    const ClassOrModule *operator->() const;
 };
-CheckSize(SymbolData, 8, 8);
+CheckSize(ClassOrModuleData, 8, 8);
 
-class ConstSymbolData : private DebugOnlyCheck<SymbolDataDebugCheck> {
-    const Symbol &symbol;
+class ConstClassOrModuleData : private DebugOnlyCheck<SymbolDataDebugCheck> {
+    const ClassOrModule &symbol;
 
 public:
-    ConstSymbolData(const Symbol &ref, const GlobalState &gs);
+    ConstClassOrModuleData(const ClassOrModule &ref, const GlobalState &gs);
 
-    const Symbol *operator->() const;
+    const ClassOrModule *operator->() const;
 };
-CheckSize(ConstSymbolData, 8, 8);
+CheckSize(ConstClassOrModuleData, 8, 8);
 
 class Method;
 class MethodData : private DebugOnlyCheck<SymbolDataDebugCheck> {
@@ -137,10 +137,10 @@ public:
         return ref;
     }
 
-    SymbolData data(GlobalState &gs) const;
-    SymbolData dataAllowingNone(GlobalState &gs) const;
-    ConstSymbolData data(const GlobalState &gs) const;
-    ConstSymbolData dataAllowingNone(const GlobalState &gs) const;
+    ClassOrModuleData data(GlobalState &gs) const;
+    ClassOrModuleData dataAllowingNone(GlobalState &gs) const;
+    ConstClassOrModuleData data(const GlobalState &gs) const;
+    ConstClassOrModuleData dataAllowingNone(const GlobalState &gs) const;
 
     bool operator==(const ClassOrModuleRef &rhs) const;
     bool operator!=(const ClassOrModuleRef &rhs) const;
@@ -333,7 +333,7 @@ CheckSize(TypeArgumentRef, 4, 4);
 
 class SymbolRef final {
     friend class GlobalState;
-    friend class Symbol;
+    friend class ClassOrModule;
     // For toStringWithOptions.
     friend class ClassOrModuleRef;
     friend class MethodRef;

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -83,7 +83,6 @@ bool TypeArgumentRef::operator!=(const TypeArgumentRef &rhs) const {
 }
 
 vector<TypePtr> Symbol::selfTypeArgs(const GlobalState &gs) const {
-    ENFORCE(isClassOrModule()); // should be removed when we have generic methods
     vector<TypePtr> targs;
     for (auto tm : typeMembers()) {
         auto tmData = tm.data(gs);
@@ -99,7 +98,6 @@ vector<TypePtr> Symbol::selfTypeArgs(const GlobalState &gs) const {
     return targs;
 }
 TypePtr Symbol::selfType(const GlobalState &gs) const {
-    ENFORCE(isClassOrModule());
     // todo: in dotty it made sense to cache those.
     if (typeMembers().empty()) {
         return externalType();
@@ -120,7 +118,6 @@ TypePtr Symbol::externalType() const {
 }
 
 TypePtr Symbol::unsafeComputeExternalType(GlobalState &gs) {
-    ENFORCE_NO_TIMER(isClassOrModule());
     if (resultType != nullptr) {
         return resultType;
     }
@@ -191,15 +188,8 @@ bool Symbol::derivesFrom(const GlobalState &gs, ClassOrModuleRef sym) const {
 }
 
 SymbolRef Symbol::ref(const GlobalState &gs) const {
-    uint32_t distance = 0;
     auto type = SymbolRef::Kind::ClassOrModule;
-    if (isClassOrModule()) {
-        type = SymbolRef::Kind::ClassOrModule;
-        distance = this - gs.classAndModules.data();
-    } else {
-        ENFORCE(false, "Invalid/unrecognized symbol type");
-    }
-
+    uint32_t distance = this - gs.classAndModules.data();
     return SymbolRef(gs, type, distance);
 }
 
@@ -499,7 +489,6 @@ void Symbol::addMixinAt(ClassOrModuleRef sym, std::optional<uint16_t> index) {
 }
 
 bool Symbol::addMixin(const GlobalState &gs, ClassOrModuleRef sym, std::optional<uint16_t> index) {
-    ENFORCE(isClassOrModule());
     // Note: Symbols without an explicit declaration may not have class or module set. They default to modules in
     // GlobalPass.cc. We also do not complain if the mixin is BasicObject.
     bool isValidMixin = !sym.data(gs)->isClassModuleSet() || sym.data(gs)->isClassOrModuleModule() ||
@@ -533,7 +522,6 @@ bool Symbol::addMixin(const GlobalState &gs, ClassOrModuleRef sym, std::optional
 }
 
 uint16_t Symbol::addMixinPlaceholder(const GlobalState &gs) {
-    ENFORCE(isClassOrModule());
     ENFORCE(ref(gs) != core::Symbols::PlaceholderMixin(), "Created a cycle through PlaceholderMixin");
     mixins_.emplace_back(core::Symbols::PlaceholderMixin());
     ENFORCE(mixins_.size() < numeric_limits<uint16_t>::max());
@@ -557,7 +545,6 @@ MethodRef Symbol::findMethod(const GlobalState &gs, NameRef name) const {
 }
 
 SymbolRef Symbol::findMemberNoDealias(const GlobalState &gs, NameRef name) const {
-    ENFORCE(this->isClassOrModule(), "Only classes and modules have members");
     histogramInc("find_member_scope_size", members().size());
     auto fnd = members().find(name);
     if (fnd == members().end()) {
@@ -637,12 +624,10 @@ MethodRef findConcreteMethodTransitiveInternal(const GlobalState &gs, ClassOrMod
 } // namespace
 
 MethodRef Symbol::findConcreteMethodTransitive(const GlobalState &gs, NameRef name) const {
-    ENFORCE(this->isClassOrModule());
     return findConcreteMethodTransitiveInternal(gs, this->ref(gs).asClassOrModuleRef(), name, 100);
 }
 
 SymbolRef Symbol::findMemberTransitiveInternal(const GlobalState &gs, NameRef name, int maxDepth) const {
-    ENFORCE(this->isClassOrModule());
     if (maxDepth == 0) {
         if (auto e = gs.beginError(Loc::none(), errors::Internal::InternalError)) {
             e.setHeader("findMemberTransitive hit a loop while resolving `{}` in `{}`. Parents are: ", name.show(gs),
@@ -1586,7 +1571,7 @@ bool isMangledSingletonName(const GlobalState &gs, core::NameRef name) {
 } // namespace
 
 bool Symbol::isSingletonClass(const GlobalState &gs) const {
-    bool isSingleton = isClassOrModule() && (isSingletonName(gs, name) || isMangledSingletonName(gs, name));
+    bool isSingleton = isSingletonName(gs, name) || isMangledSingletonName(gs, name);
     DEBUG_ONLY(if (ref(gs) != Symbols::untyped()) { // Symbol::untyped is attached to itself
         if (isSingleton) {
             ENFORCE(attachedClass(gs).exists());
@@ -1629,7 +1614,6 @@ ClassOrModuleRef Symbol::singletonClass(GlobalState &gs) {
 }
 
 ClassOrModuleRef Symbol::lookupSingletonClass(const GlobalState &gs) const {
-    ENFORCE(this->isClassOrModule());
     ENFORCE(this->name.isClassName(gs));
 
     SymbolRef selfRef = this->ref(gs);
@@ -1641,7 +1625,6 @@ ClassOrModuleRef Symbol::lookupSingletonClass(const GlobalState &gs) const {
 }
 
 ClassOrModuleRef Symbol::attachedClass(const GlobalState &gs) const {
-    ENFORCE(this->isClassOrModule());
     if (this->ref(gs) == Symbols::untyped()) {
         return Symbols::untyped();
     }
@@ -1780,8 +1763,6 @@ bool Symbol::hasSingleSealedSubclass(const GlobalState &gs) const {
 // * RequiredAncestor.loc goes into the symbol loc
 // All fields for the same RequiredAncestor are stored at the same index.
 void Symbol::recordRequiredAncestorInternal(GlobalState &gs, Symbol::RequiredAncestor &ancestor, NameRef prop) {
-    ENFORCE(this->isClassOrModule(), "Symbol is not a class or module: {}", ref(gs).show(gs));
-
     // We store the required ancestors into a fake property called `<required-ancestors>`
     auto ancestors = this->findMethod(gs, prop);
     if (!ancestors.exists()) {
@@ -1822,8 +1803,6 @@ void Symbol::recordRequiredAncestorInternal(GlobalState &gs, Symbol::RequiredAnc
 
 // Locally required ancestors by this class or module
 vector<Symbol::RequiredAncestor> Symbol::readRequiredAncestorsInternal(const GlobalState &gs, NameRef prop) const {
-    ENFORCE(this->isClassOrModule(), "Symbol is not a class or module: {}", ref(gs).show(gs));
-
     vector<RequiredAncestor> res;
 
     auto ancestors = this->findMethod(gs, prop);
@@ -1906,7 +1885,6 @@ vector<Symbol::RequiredAncestor> Symbol::requiredAncestorsTransitive(const Globa
 
 void Symbol::computeRequiredAncestorLinearization(GlobalState &gs) {
     ENFORCE(gs.requiresAncestorEnabled);
-    ENFORCE(this->isClassOrModule(), "Symbol is not a class or module: {}", ref(gs).show(gs));
     std::vector<ClassOrModuleRef> seen;
     requiredAncestorsTransitiveInternal(gs, seen);
 }
@@ -2052,7 +2030,6 @@ TypeParameter TypeParameter::deepCopy(const GlobalState &to) const {
 }
 
 int Symbol::typeArity(const GlobalState &gs) const {
-    ENFORCE(this->isClassOrModule());
     int arity = 0;
     for (auto &tm : this->typeMembers()) {
         if (!tm.data(gs)->flags.isFixed) {
@@ -2184,7 +2161,7 @@ ClassOrModuleRef SymbolRef::enclosingClass(const GlobalState &gs) const {
 uint32_t Symbol::hash(const GlobalState &gs) const {
     uint32_t result = _hash(name.shortName(gs));
     result = mix(result, !this->resultType ? 0 : this->resultType.hash(gs));
-    result = mix(result, this->flags);
+    result = mix(result, this->flags.serialize());
     result = mix(result, this->owner._id);
     result = mix(result, this->superClass_.id());
     // argumentsOrMixins, typeParams, typeAliases
@@ -2303,10 +2280,7 @@ vector<uint32_t> Method::methodArgumentHash(const GlobalState &gs) const {
 }
 
 bool Symbol::ignoreInHashing(const GlobalState &gs) const {
-    if (isClassOrModule()) {
-        return superClass() == core::Symbols::StubModule();
-    }
-    return false;
+    return superClass() == core::Symbols::StubModule();
 }
 
 bool Method::ignoreInHashing(const GlobalState &gs) const {
@@ -2421,7 +2395,6 @@ void Symbol::addLoc(const core::GlobalState &gs, core::Loc loc) {
 }
 
 vector<std::pair<NameRef, SymbolRef>> Symbol::membersStableOrderSlow(const GlobalState &gs) const {
-    ENFORCE(this->isClassOrModule());
     vector<pair<NameRef, SymbolRef>> result;
     result.reserve(members().size());
     for (const auto &e : members()) {

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -168,7 +168,7 @@ TypePtr Symbol::unsafeComputeExternalType(GlobalState &gs) {
 }
 
 bool Symbol::derivesFrom(const GlobalState &gs, ClassOrModuleRef sym) const {
-    if (isClassOrModuleLinearizationComputed()) {
+    if (flags.isLinearizationComputed) {
         for (ClassOrModuleRef a : mixins()) {
             if (a == sym) {
                 return true;
@@ -491,10 +491,10 @@ void Symbol::addMixinAt(ClassOrModuleRef sym, std::optional<uint16_t> index) {
 bool Symbol::addMixin(const GlobalState &gs, ClassOrModuleRef sym, std::optional<uint16_t> index) {
     // Note: Symbols without an explicit declaration may not have class or module set. They default to modules in
     // GlobalPass.cc. We also do not complain if the mixin is BasicObject.
-    bool isValidMixin = !sym.data(gs)->isClassModuleSet() || sym.data(gs)->isClassOrModuleModule() ||
-                        sym == core::Symbols::BasicObject();
+    bool isValidMixin =
+        !sym.data(gs)->isClassModuleSet() || sym.data(gs)->isModule() || sym == core::Symbols::BasicObject();
 
-    if (!isClassOrModuleLinearizationComputed()) {
+    if (!flags.isLinearizationComputed) {
         // Symbol hasn't been linearized yet, so add symbol unconditionally (order matters, so dupes are OK and
         // semantically important!)
         // This is the 99% common case.
@@ -577,7 +577,7 @@ namespace {
 MethodRef findConcreteMethodTransitiveInternal(const GlobalState &gs, ClassOrModuleRef owner, NameRef name,
                                                int maxDepth) {
     // We can support it before linearization but it's more code to do so.
-    ENFORCE(owner.data(gs)->isClassOrModuleLinearizationComputed());
+    ENFORCE(owner.data(gs)->flags.isLinearizationComputed);
 
     if (maxDepth == 0) {
         if (auto e = gs.beginError(Loc::none(), errors::Internal::InternalError)) {
@@ -655,7 +655,7 @@ SymbolRef Symbol::findMemberTransitiveInternal(const GlobalState &gs, NameRef na
     if (result.exists()) {
         return result;
     }
-    if (isClassOrModuleLinearizationComputed()) {
+    if (flags.isLinearizationComputed) {
         for (auto it = this->mixins().begin(); it != this->mixins().end(); ++it) {
             ENFORCE(it->exists());
             result = it->data(gs)->findMember(gs, name);
@@ -1126,7 +1126,7 @@ string_view ClassOrModuleRef::showKind(const GlobalState &gs) const {
     auto sym = dataAllowingNone(gs);
     if (!sym->isClassModuleSet()) {
         return "class-or-module"sv;
-    } else if (sym->isClassOrModuleClass()) {
+    } else if (sym->isClass()) {
         return "class"sv;
     } else {
         return "module"sv;
@@ -1188,7 +1188,7 @@ string ClassOrModuleRef::toStringWithOptions(const GlobalState &gs, int tabs, bo
                        return showRaw ? name.showRaw(gs) : name.show(gs);
                    }));
 
-    if (sym->isClassOrModulePrivate()) {
+    if (sym->flags.isPrivate) {
         fmt::format_to(std::back_inserter(buf), " : private");
     }
     // root should have no locs. We used to have special handling here to hide locs on root
@@ -1648,7 +1648,7 @@ ClassOrModuleRef Symbol::topAttachedClass(const GlobalState &gs) const {
 }
 
 void Symbol::recordSealedSubclass(MutableContext ctx, ClassOrModuleRef subclass) {
-    ENFORCE(this->isClassOrModuleSealed(), "Class is not marked sealed: {}", ref(ctx).show(ctx));
+    ENFORCE(this->flags.isSealed, "Class is not marked sealed: {}", ref(ctx).show(ctx));
     ENFORCE(subclass.exists(), "Can't record sealed subclass for {} when subclass doesn't exist", ref(ctx).show(ctx));
 
     // Avoid using a clobbered `this` pointer, as `singletonClass` can cause the symbol table to move.
@@ -1691,7 +1691,7 @@ void Symbol::recordSealedSubclass(MutableContext ctx, ClassOrModuleRef subclass)
 }
 
 const InlinedVector<Loc, 2> &Symbol::sealedLocs(const GlobalState &gs) const {
-    ENFORCE(this->isClassOrModuleSealed(), "Class is not marked sealed: {}", ref(gs).show(gs));
+    ENFORCE(this->flags.isSealed, "Class is not marked sealed: {}", ref(gs).show(gs));
     auto sealedSubclasses = this->lookupSingletonClass(gs).data(gs)->findMethod(gs, core::Names::sealedSubclasses());
     auto &result = sealedSubclasses.data(gs)->locs();
     ENFORCE(result.size() > 0);
@@ -1699,7 +1699,7 @@ const InlinedVector<Loc, 2> &Symbol::sealedLocs(const GlobalState &gs) const {
 }
 
 TypePtr Symbol::sealedSubclassesToUnion(const GlobalState &gs) const {
-    ENFORCE(this->isClassOrModuleSealed(), "Class is not marked sealed: {}", ref(gs).show(gs));
+    ENFORCE(this->flags.isSealed, "Class is not marked sealed: {}", ref(gs).show(gs));
 
     auto sealedSubclasses = this->lookupSingletonClass(gs).data(gs)->findMethod(gs, core::Names::sealedSubclasses());
 
@@ -1735,12 +1735,12 @@ TypePtr Symbol::sealedSubclassesToUnion(const GlobalState &gs) const {
 }
 
 bool Symbol::hasSingleSealedSubclass(const GlobalState &gs) const {
-    ENFORCE(this->isClassOrModuleSealed(), "Class is not marked sealed: {}", ref(gs).show(gs));
+    ENFORCE(this->flags.isSealed, "Class is not marked sealed: {}", ref(gs).show(gs));
 
     auto sealedSubclasses = this->lookupSingletonClass(gs).data(gs)->findMethod(gs, core::Names::sealedSubclasses());
 
     // When the sealed type is a class, it must also be abstract for there to be a single subclass.
-    if (this->isClassOrModuleClass() && !this->isClassOrModuleAbstract()) {
+    if (this->isClass() && !this->flags.isAbstract) {
         return false;
     }
 

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -15,7 +15,7 @@
 
 template class std::vector<sorbet::core::TypeAndOrigins>;
 template class std::vector<std::pair<sorbet::core::NameRef, sorbet::core::SymbolRef>>;
-template class std::vector<const sorbet::core::Symbol *>;
+template class std::vector<const sorbet::core::ClassOrModule *>;
 
 namespace sorbet::core {
 
@@ -82,7 +82,7 @@ bool TypeArgumentRef::operator!=(const TypeArgumentRef &rhs) const {
     return rhs._id != this->_id;
 }
 
-vector<TypePtr> Symbol::selfTypeArgs(const GlobalState &gs) const {
+vector<TypePtr> ClassOrModule::selfTypeArgs(const GlobalState &gs) const {
     vector<TypePtr> targs;
     for (auto tm : typeMembers()) {
         auto tmData = tm.data(gs);
@@ -97,7 +97,7 @@ vector<TypePtr> Symbol::selfTypeArgs(const GlobalState &gs) const {
     }
     return targs;
 }
-TypePtr Symbol::selfType(const GlobalState &gs) const {
+TypePtr ClassOrModule::selfType(const GlobalState &gs) const {
     // todo: in dotty it made sense to cache those.
     if (typeMembers().empty()) {
         return externalType();
@@ -106,7 +106,7 @@ TypePtr Symbol::selfType(const GlobalState &gs) const {
     }
 }
 
-TypePtr Symbol::externalType() const {
+TypePtr ClassOrModule::externalType() const {
     ENFORCE_NO_TIMER(resultType);
     if (resultType == nullptr) {
         // Don't return nullptr in prod builds, which would cause a disruptive crash
@@ -117,7 +117,7 @@ TypePtr Symbol::externalType() const {
     return resultType;
 }
 
-TypePtr Symbol::unsafeComputeExternalType(GlobalState &gs) {
+TypePtr ClassOrModule::unsafeComputeExternalType(GlobalState &gs) {
     if (resultType != nullptr) {
         return resultType;
     }
@@ -167,7 +167,7 @@ TypePtr Symbol::unsafeComputeExternalType(GlobalState &gs) {
     return resultType;
 }
 
-bool Symbol::derivesFrom(const GlobalState &gs, ClassOrModuleRef sym) const {
+bool ClassOrModule::derivesFrom(const GlobalState &gs, ClassOrModuleRef sym) const {
     if (flags.isLinearizationComputed) {
         for (ClassOrModuleRef a : mixins()) {
             if (a == sym) {
@@ -187,7 +187,7 @@ bool Symbol::derivesFrom(const GlobalState &gs, ClassOrModuleRef sym) const {
     return false;
 }
 
-ClassOrModuleRef Symbol::ref(const GlobalState &gs) const {
+ClassOrModuleRef ClassOrModule::ref(const GlobalState &gs) const {
     uint32_t distance = this - gs.classAndModules.data();
     return ClassOrModuleRef(gs, distance);
 }
@@ -225,24 +225,24 @@ bool SymbolRef::isStaticField(const GlobalState &gs) const {
     return isFieldOrStaticField() && asFieldRef().dataAllowingNone(gs)->flags.isStaticField;
 }
 
-SymbolData ClassOrModuleRef::dataAllowingNone(GlobalState &gs) const {
+ClassOrModuleData ClassOrModuleRef::dataAllowingNone(GlobalState &gs) const {
     ENFORCE_NO_TIMER(_id < gs.classAndModulesUsed());
-    return SymbolData(gs.classAndModules[_id], gs);
+    return ClassOrModuleData(gs.classAndModules[_id], gs);
 }
 
-SymbolData ClassOrModuleRef::data(GlobalState &gs) const {
+ClassOrModuleData ClassOrModuleRef::data(GlobalState &gs) const {
     ENFORCE_NO_TIMER(this->exists());
     return dataAllowingNone(gs);
 }
 
-ConstSymbolData ClassOrModuleRef::data(const GlobalState &gs) const {
+ConstClassOrModuleData ClassOrModuleRef::data(const GlobalState &gs) const {
     ENFORCE_NO_TIMER(this->exists());
     return dataAllowingNone(gs);
 }
 
-ConstSymbolData ClassOrModuleRef::dataAllowingNone(const GlobalState &gs) const {
+ConstClassOrModuleData ClassOrModuleRef::dataAllowingNone(const GlobalState &gs) const {
     ENFORCE_NO_TIMER(_id < gs.classAndModulesUsed());
-    return ConstSymbolData(gs.classAndModules[_id], gs);
+    return ConstClassOrModuleData(gs.classAndModules[_id], gs);
 }
 
 MethodData MethodRef::data(GlobalState &gs) const {
@@ -476,7 +476,7 @@ TypePtr ArgInfo::argumentTypeAsSeenByImplementation(Context ctx, core::TypeConst
     return Types::arrayOf(ctx, instantiated);
 }
 
-void Symbol::addMixinAt(ClassOrModuleRef sym, std::optional<uint16_t> index) {
+void ClassOrModule::addMixinAt(ClassOrModuleRef sym, std::optional<uint16_t> index) {
     if (index.has_value()) {
         auto i = index.value();
         ENFORCE(mixins_.size() > i);
@@ -487,7 +487,7 @@ void Symbol::addMixinAt(ClassOrModuleRef sym, std::optional<uint16_t> index) {
     }
 }
 
-bool Symbol::addMixin(const GlobalState &gs, ClassOrModuleRef sym, std::optional<uint16_t> index) {
+bool ClassOrModule::addMixin(const GlobalState &gs, ClassOrModuleRef sym, std::optional<uint16_t> index) {
     // Note: Symbols without an explicit declaration may not have class or module set. They default to modules in
     // GlobalPass.cc. We also do not complain if the mixin is BasicObject.
     bool isValidMixin =
@@ -520,14 +520,14 @@ bool Symbol::addMixin(const GlobalState &gs, ClassOrModuleRef sym, std::optional
     return isValidMixin;
 }
 
-uint16_t Symbol::addMixinPlaceholder(const GlobalState &gs) {
+uint16_t ClassOrModule::addMixinPlaceholder(const GlobalState &gs) {
     ENFORCE(ref(gs) != core::Symbols::PlaceholderMixin(), "Created a cycle through PlaceholderMixin");
     mixins_.emplace_back(core::Symbols::PlaceholderMixin());
     ENFORCE(mixins_.size() < numeric_limits<uint16_t>::max());
     return mixins_.size() - 1;
 }
 
-SymbolRef Symbol::findMember(const GlobalState &gs, NameRef name) const {
+SymbolRef ClassOrModule::findMember(const GlobalState &gs, NameRef name) const {
     auto ret = findMemberNoDealias(gs, name);
     if (ret.exists()) {
         return ret.dealias(gs);
@@ -535,7 +535,7 @@ SymbolRef Symbol::findMember(const GlobalState &gs, NameRef name) const {
     return ret;
 }
 
-MethodRef Symbol::findMethod(const GlobalState &gs, NameRef name) const {
+MethodRef ClassOrModule::findMethod(const GlobalState &gs, NameRef name) const {
     auto sym = findMember(gs, name);
     if (sym.exists() && sym.isMethod()) {
         return sym.asMethodRef();
@@ -543,7 +543,7 @@ MethodRef Symbol::findMethod(const GlobalState &gs, NameRef name) const {
     return Symbols::noMethod();
 }
 
-SymbolRef Symbol::findMemberNoDealias(const GlobalState &gs, NameRef name) const {
+SymbolRef ClassOrModule::findMemberNoDealias(const GlobalState &gs, NameRef name) const {
     histogramInc("find_member_scope_size", members().size());
     auto fnd = members().find(name);
     if (fnd == members().end()) {
@@ -552,7 +552,7 @@ SymbolRef Symbol::findMemberNoDealias(const GlobalState &gs, NameRef name) const
     return fnd->second;
 }
 
-MethodRef Symbol::findMethodNoDealias(const GlobalState &gs, NameRef name) const {
+MethodRef ClassOrModule::findMethodNoDealias(const GlobalState &gs, NameRef name) const {
     auto sym = findMemberNoDealias(gs, name);
     if (!sym.isMethod()) {
         return Symbols::noMethod();
@@ -560,11 +560,11 @@ MethodRef Symbol::findMethodNoDealias(const GlobalState &gs, NameRef name) const
     return sym.asMethodRef();
 }
 
-SymbolRef Symbol::findMemberTransitive(const GlobalState &gs, NameRef name) const {
+SymbolRef ClassOrModule::findMemberTransitive(const GlobalState &gs, NameRef name) const {
     return findMemberTransitiveInternal(gs, name, 100);
 }
 
-MethodRef Symbol::findMethodTransitive(const GlobalState &gs, NameRef name) const {
+MethodRef ClassOrModule::findMethodTransitive(const GlobalState &gs, NameRef name) const {
     auto sym = findMemberTransitive(gs, name);
     if (sym.exists() && sym.isMethod()) {
         return sym.asMethodRef();
@@ -622,11 +622,11 @@ MethodRef findConcreteMethodTransitiveInternal(const GlobalState &gs, ClassOrMod
 }
 } // namespace
 
-MethodRef Symbol::findConcreteMethodTransitive(const GlobalState &gs, NameRef name) const {
+MethodRef ClassOrModule::findConcreteMethodTransitive(const GlobalState &gs, NameRef name) const {
     return findConcreteMethodTransitiveInternal(gs, this->ref(gs), name, 100);
 }
 
-SymbolRef Symbol::findMemberTransitiveInternal(const GlobalState &gs, NameRef name, int maxDepth) const {
+SymbolRef ClassOrModule::findMemberTransitiveInternal(const GlobalState &gs, NameRef name, int maxDepth) const {
     if (maxDepth == 0) {
         if (auto e = gs.beginError(Loc::none(), errors::Internal::InternalError)) {
             e.setHeader("findMemberTransitive hit a loop while resolving `{}` in `{}`. Parents are: ", name.show(gs),
@@ -678,9 +678,9 @@ SymbolRef Symbol::findMemberTransitiveInternal(const GlobalState &gs, NameRef na
     return Symbols::noSymbol();
 }
 
-vector<Symbol::FuzzySearchResult> Symbol::findMemberFuzzyMatch(const GlobalState &gs, NameRef name,
-                                                               int betterThan) const {
-    vector<Symbol::FuzzySearchResult> res;
+vector<ClassOrModule::FuzzySearchResult> ClassOrModule::findMemberFuzzyMatch(const GlobalState &gs, NameRef name,
+                                                                             int betterThan) const {
+    vector<ClassOrModule::FuzzySearchResult> res;
     // Don't run under the fuzzer, as otherwise fuzzy match dominates runtime.
     // N.B.: There are benefits to running this method under the fuzzer; we have found bugs in this method before
     // via fuzzing (e.g. https://github.com/sorbet/sorbet/issues/128).
@@ -713,7 +713,8 @@ vector<Symbol::FuzzySearchResult> Symbol::findMemberFuzzyMatch(const GlobalState
         }
         auto shortName = name.shortName(gs);
         if (!shortName.empty() && std::isupper(shortName.front())) {
-            vector<Symbol::FuzzySearchResult> constant_matches = findMemberFuzzyMatchConstant(gs, name, betterThan);
+            vector<ClassOrModule::FuzzySearchResult> constant_matches =
+                findMemberFuzzyMatchConstant(gs, name, betterThan);
             res.insert(res.end(), constant_matches.begin(), constant_matches.end());
         }
     } else if (name.kind() == NameKind::CONSTANT) {
@@ -722,15 +723,15 @@ vector<Symbol::FuzzySearchResult> Symbol::findMemberFuzzyMatch(const GlobalState
     return res;
 }
 
-vector<Symbol::FuzzySearchResult> Symbol::findMemberFuzzyMatchConstant(const GlobalState &gs, NameRef name,
-                                                                       int betterThan) const {
+vector<ClassOrModule::FuzzySearchResult>
+ClassOrModule::findMemberFuzzyMatchConstant(const GlobalState &gs, NameRef name, int betterThan) const {
     // Performance of this method is bad, to say the least.
     // It's written under assumption that it's called rarely
     // and that it's worth spending a lot of time finding a good candidate in ALL scopes.
     // It may return multiple candidates:
     //   - best candidate per every outer scope if it's better than all the candidates in inner scope
     //   - globally best candidate in ALL scopes.
-    vector<Symbol::FuzzySearchResult> result;
+    vector<ClassOrModule::FuzzySearchResult> result;
     FuzzySearchResult best;
     best.symbol = Symbols::noSymbol();
     best.name = NameRef::noName();
@@ -748,7 +749,7 @@ vector<Symbol::FuzzySearchResult> Symbol::findMemberFuzzyMatchConstant(const Glo
 
             // find scopes that would be considered for search
             vector<ClassOrModuleRef> candidateScopes;
-            vector<Symbol::FuzzySearchResult> scopeBest;
+            vector<ClassOrModule::FuzzySearchResult> scopeBest;
             candidateScopes.emplace_back(base);
             int i = 0;
             // this is quadratic in number of scopes that we traverse, but YOLO, this should rarely run
@@ -807,7 +808,7 @@ vector<Symbol::FuzzySearchResult> Symbol::findMemberFuzzyMatchConstant(const Glo
     if (best.distance > 0) {
         // find the closest by global dfs.
         auto globalBestDistance = best.distance - 1;
-        vector<Symbol::FuzzySearchResult> globalBest;
+        vector<ClassOrModule::FuzzySearchResult> globalBest;
         vector<ClassOrModuleRef> yetToGoDeeper;
         yetToGoDeeper.emplace_back(Symbols::root());
         while (!yetToGoDeeper.empty()) {
@@ -866,7 +867,8 @@ vector<Symbol::FuzzySearchResult> Symbol::findMemberFuzzyMatchConstant(const Glo
     return result;
 }
 
-Symbol::FuzzySearchResult Symbol::findMemberFuzzyMatchUTF8(const GlobalState &gs, NameRef name, int betterThan) const {
+ClassOrModule::FuzzySearchResult ClassOrModule::findMemberFuzzyMatchUTF8(const GlobalState &gs, NameRef name,
+                                                                         int betterThan) const {
     FuzzySearchResult result;
     result.symbol = Symbols::noSymbol();
     result.name = NameRef::noName();
@@ -1064,7 +1066,7 @@ string TypeMemberRef::toStringFullName(const GlobalState &gs) const {
     return toStringFullNameInternal(gs, sym->owner, sym->name, COLON_SEPARATOR);
 }
 
-bool Symbol::isPrintable(const GlobalState &gs) const {
+bool ClassOrModule::isPrintable(const GlobalState &gs) const {
     if (!isHiddenFromPrinting(gs, this->ref(gs))) {
         return true;
     }
@@ -1569,9 +1571,9 @@ bool isMangledSingletonName(const GlobalState &gs, core::NameRef name) {
 }
 } // namespace
 
-bool Symbol::isSingletonClass(const GlobalState &gs) const {
+bool ClassOrModule::isSingletonClass(const GlobalState &gs) const {
     bool isSingleton = isSingletonName(gs, name) || isMangledSingletonName(gs, name);
-    DEBUG_ONLY(if (ref(gs) != Symbols::untyped()) { // Symbol::untyped is attached to itself
+    DEBUG_ONLY(if (ref(gs) != Symbols::untyped()) { // ClassOrModule::untyped is attached to itself
         if (isSingleton) {
             ENFORCE(attachedClass(gs).exists());
         } else {
@@ -1581,7 +1583,7 @@ bool Symbol::isSingletonClass(const GlobalState &gs) const {
     return isSingleton;
 }
 
-ClassOrModuleRef Symbol::singletonClass(GlobalState &gs) {
+ClassOrModuleRef ClassOrModule::singletonClass(GlobalState &gs) {
     auto singleton = lookupSingletonClass(gs);
     if (singleton.exists()) {
         return singleton;
@@ -1593,7 +1595,7 @@ ClassOrModuleRef Symbol::singletonClass(GlobalState &gs) {
 
     NameRef singletonName = gs.freshNameUnique(UniqueNameKind::Singleton, this->name, 1);
     singleton = gs.enterClassSymbol(this->loc(), this->owner.asClassOrModuleRef(), singletonName);
-    SymbolData singletonInfo = singleton.data(gs);
+    ClassOrModuleData singletonInfo = singleton.data(gs);
 
     prodCounterInc("types.input.singleton_classes.total");
     singletonInfo->members()[Names::attached()] = selfRef;
@@ -1612,7 +1614,7 @@ ClassOrModuleRef Symbol::singletonClass(GlobalState &gs) {
     return singleton;
 }
 
-ClassOrModuleRef Symbol::lookupSingletonClass(const GlobalState &gs) const {
+ClassOrModuleRef ClassOrModule::lookupSingletonClass(const GlobalState &gs) const {
     ENFORCE(this->name.isClassName(gs));
 
     SymbolRef selfRef = this->ref(gs);
@@ -1623,7 +1625,7 @@ ClassOrModuleRef Symbol::lookupSingletonClass(const GlobalState &gs) const {
     return findMember(gs, Names::singleton()).asClassOrModuleRef();
 }
 
-ClassOrModuleRef Symbol::attachedClass(const GlobalState &gs) const {
+ClassOrModuleRef ClassOrModule::attachedClass(const GlobalState &gs) const {
     if (this->ref(gs) == Symbols::untyped()) {
         return Symbols::untyped();
     }
@@ -1632,7 +1634,7 @@ ClassOrModuleRef Symbol::attachedClass(const GlobalState &gs) const {
     return singleton.asClassOrModuleRef();
 }
 
-ClassOrModuleRef Symbol::topAttachedClass(const GlobalState &gs) const {
+ClassOrModuleRef ClassOrModule::topAttachedClass(const GlobalState &gs) const {
     ClassOrModuleRef classSymbol = this->ref(gs);
 
     while (true) {
@@ -1646,7 +1648,7 @@ ClassOrModuleRef Symbol::topAttachedClass(const GlobalState &gs) const {
     return classSymbol;
 }
 
-void Symbol::recordSealedSubclass(MutableContext ctx, ClassOrModuleRef subclass) {
+void ClassOrModule::recordSealedSubclass(MutableContext ctx, ClassOrModuleRef subclass) {
     ENFORCE(this->flags.isSealed, "Class is not marked sealed: {}", ref(ctx).show(ctx));
     ENFORCE(subclass.exists(), "Can't record sealed subclass for {} when subclass doesn't exist", ref(ctx).show(ctx));
 
@@ -1689,7 +1691,7 @@ void Symbol::recordSealedSubclass(MutableContext ctx, ClassOrModuleRef subclass)
     }
 }
 
-const InlinedVector<Loc, 2> &Symbol::sealedLocs(const GlobalState &gs) const {
+const InlinedVector<Loc, 2> &ClassOrModule::sealedLocs(const GlobalState &gs) const {
     ENFORCE(this->flags.isSealed, "Class is not marked sealed: {}", ref(gs).show(gs));
     auto sealedSubclasses = this->lookupSingletonClass(gs).data(gs)->findMethod(gs, core::Names::sealedSubclasses());
     auto &result = sealedSubclasses.data(gs)->locs();
@@ -1697,7 +1699,7 @@ const InlinedVector<Loc, 2> &Symbol::sealedLocs(const GlobalState &gs) const {
     return result;
 }
 
-TypePtr Symbol::sealedSubclassesToUnion(const GlobalState &gs) const {
+TypePtr ClassOrModule::sealedSubclassesToUnion(const GlobalState &gs) const {
     ENFORCE(this->flags.isSealed, "Class is not marked sealed: {}", ref(gs).show(gs));
 
     auto sealedSubclasses = this->lookupSingletonClass(gs).data(gs)->findMethod(gs, core::Names::sealedSubclasses());
@@ -1733,7 +1735,7 @@ TypePtr Symbol::sealedSubclassesToUnion(const GlobalState &gs) const {
     return result;
 }
 
-bool Symbol::hasSingleSealedSubclass(const GlobalState &gs) const {
+bool ClassOrModule::hasSingleSealedSubclass(const GlobalState &gs) const {
     ENFORCE(this->flags.isSealed, "Class is not marked sealed: {}", ref(gs).show(gs));
 
     auto sealedSubclasses = this->lookupSingletonClass(gs).data(gs)->findMethod(gs, core::Names::sealedSubclasses());
@@ -1761,7 +1763,8 @@ bool Symbol::hasSingleSealedSubclass(const GlobalState &gs) const {
 // * RequiredAncestor.origin goes into the first argument type tuple
 // * RequiredAncestor.loc goes into the symbol loc
 // All fields for the same RequiredAncestor are stored at the same index.
-void Symbol::recordRequiredAncestorInternal(GlobalState &gs, Symbol::RequiredAncestor &ancestor, NameRef prop) {
+void ClassOrModule::recordRequiredAncestorInternal(GlobalState &gs, ClassOrModule::RequiredAncestor &ancestor,
+                                                   NameRef prop) {
     // We store the required ancestors into a fake property called `<required-ancestors>`
     auto ancestors = this->findMethod(gs, prop);
     if (!ancestors.exists()) {
@@ -1801,7 +1804,8 @@ void Symbol::recordRequiredAncestorInternal(GlobalState &gs, Symbol::RequiredAnc
 }
 
 // Locally required ancestors by this class or module
-vector<Symbol::RequiredAncestor> Symbol::readRequiredAncestorsInternal(const GlobalState &gs, NameRef prop) const {
+vector<ClassOrModule::RequiredAncestor> ClassOrModule::readRequiredAncestorsInternal(const GlobalState &gs,
+                                                                                     NameRef prop) const {
     vector<RequiredAncestor> res;
 
     auto ancestors = this->findMethod(gs, prop);
@@ -1829,19 +1833,19 @@ vector<Symbol::RequiredAncestor> Symbol::readRequiredAncestorsInternal(const Glo
 }
 
 // Record a required ancestor for this class of module
-void Symbol::recordRequiredAncestor(GlobalState &gs, ClassOrModuleRef ancestor, Loc loc) {
+void ClassOrModule::recordRequiredAncestor(GlobalState &gs, ClassOrModuleRef ancestor, Loc loc) {
     RequiredAncestor req = {this->ref(gs), ancestor, loc};
     recordRequiredAncestorInternal(gs, req, Names::requiredAncestors());
 }
 
 // Locally required ancestors by this class or module
-vector<Symbol::RequiredAncestor> Symbol::requiredAncestors(const GlobalState &gs) const {
+vector<ClassOrModule::RequiredAncestor> ClassOrModule::requiredAncestors(const GlobalState &gs) const {
     return readRequiredAncestorsInternal(gs, Names::requiredAncestors());
 }
 
 // All required ancestors by this class or module
-std::vector<Symbol::RequiredAncestor> Symbol::requiredAncestorsTransitiveInternal(GlobalState &gs,
-                                                                                  std::vector<ClassOrModuleRef> &seen) {
+std::vector<ClassOrModule::RequiredAncestor>
+ClassOrModule::requiredAncestorsTransitiveInternal(GlobalState &gs, std::vector<ClassOrModuleRef> &seen) {
     if (absl::c_find(seen, this->ref(gs)) != seen.end()) {
         return requiredAncestors(gs); // Break recursive loops if we already visited this ancestor
     }
@@ -1877,12 +1881,12 @@ std::vector<Symbol::RequiredAncestor> Symbol::requiredAncestorsTransitiveInterna
 }
 
 // All required ancestors by this class or module
-vector<Symbol::RequiredAncestor> Symbol::requiredAncestorsTransitive(const GlobalState &gs) const {
+vector<ClassOrModule::RequiredAncestor> ClassOrModule::requiredAncestorsTransitive(const GlobalState &gs) const {
     ENFORCE(gs.requiresAncestorEnabled);
     return readRequiredAncestorsInternal(gs, Names::requiredAncestorsLin());
 }
 
-void Symbol::computeRequiredAncestorLinearization(GlobalState &gs) {
+void ClassOrModule::computeRequiredAncestorLinearization(GlobalState &gs) {
     ENFORCE(gs.requiresAncestorEnabled);
     std::vector<ClassOrModuleRef> seen;
     requiredAncestorsTransitiveInternal(gs, seen);
@@ -1908,7 +1912,7 @@ SymbolRef dealiasWithDefault(const GlobalState &gs, core::SymbolRef symbol, int 
 } // namespace
 
 // if dealiasing fails here, then we return Untyped instead
-SymbolRef Symbol::dealias(const GlobalState &gs, int depthLimit) const {
+SymbolRef ClassOrModule::dealias(const GlobalState &gs, int depthLimit) const {
     return dealiasWithDefault(gs, this->ref(gs), depthLimit, Symbols::untyped());
 }
 // if dealiasing fails here, then we return a bad alias method stub instead
@@ -1968,8 +1972,8 @@ void ArgInfo::ArgFlags::setFromU1(uint8_t flags) {
     isBlock = flags & 16;
 }
 
-Symbol Symbol::deepCopy(const GlobalState &to, bool keepGsId) const {
-    Symbol result;
+ClassOrModule ClassOrModule::deepCopy(const GlobalState &to, bool keepGsId) const {
+    ClassOrModule result;
     result.owner = this->owner;
     result.flags = this->flags;
     result.mixins_ = this->mixins_;
@@ -2028,7 +2032,7 @@ TypeParameter TypeParameter::deepCopy(const GlobalState &to) const {
     return result;
 }
 
-int Symbol::typeArity(const GlobalState &gs) const {
+int ClassOrModule::typeArity(const GlobalState &gs) const {
     int arity = 0;
     for (auto &tm : this->typeMembers()) {
         if (!tm.data(gs)->flags.isFixed) {
@@ -2038,7 +2042,7 @@ int Symbol::typeArity(const GlobalState &gs) const {
     return arity;
 }
 
-void Symbol::sanityCheck(const GlobalState &gs) const {
+void ClassOrModule::sanityCheck(const GlobalState &gs) const {
     if (!debug_mode) {
         return;
     }
@@ -2157,7 +2161,7 @@ ClassOrModuleRef SymbolRef::enclosingClass(const GlobalState &gs) const {
     }
 }
 
-uint32_t Symbol::hash(const GlobalState &gs) const {
+uint32_t ClassOrModule::hash(const GlobalState &gs) const {
     uint32_t result = _hash(name.shortName(gs));
     result = mix(result, !this->resultType ? 0 : this->resultType.hash(gs));
     result = mix(result, this->flags.serialize());
@@ -2278,7 +2282,7 @@ vector<uint32_t> Method::methodArgumentHash(const GlobalState &gs) const {
     return result;
 }
 
-bool Symbol::ignoreInHashing(const GlobalState &gs) const {
+bool ClassOrModule::ignoreInHashing(const GlobalState &gs) const {
     return superClass() == core::Symbols::StubModule();
 }
 
@@ -2293,7 +2297,7 @@ Loc Method::loc() const {
     return Loc::none();
 }
 
-Loc Symbol::loc() const {
+Loc ClassOrModule::loc() const {
     if (!locs_.empty()) {
         return locs_.back();
     }
@@ -2318,7 +2322,7 @@ const InlinedVector<Loc, 2> &Method::locs() const {
     return locs_;
 }
 
-const InlinedVector<Loc, 2> &Symbol::locs() const {
+const InlinedVector<Loc, 2> &ClassOrModule::locs() const {
     return locs_;
 }
 
@@ -2378,7 +2382,7 @@ void TypeParameter::addLoc(const core::GlobalState &gs, core::Loc loc) {
     addLocInternal(gs, loc, this->loc(), locs_);
 }
 
-void Symbol::addLoc(const core::GlobalState &gs, core::Loc loc) {
+void ClassOrModule::addLoc(const core::GlobalState &gs, core::Loc loc) {
     if (!loc.file().exists()) {
         return;
     }
@@ -2393,7 +2397,7 @@ void Symbol::addLoc(const core::GlobalState &gs, core::Loc loc) {
     addLocInternal(gs, loc, this->loc(), locs_);
 }
 
-vector<std::pair<NameRef, SymbolRef>> Symbol::membersStableOrderSlow(const GlobalState &gs) const {
+vector<std::pair<NameRef, SymbolRef>> ClassOrModule::membersStableOrderSlow(const GlobalState &gs) const {
     vector<pair<NameRef, SymbolRef>> result;
     result.reserve(members().size());
     for (const auto &e : members()) {
@@ -2436,9 +2440,10 @@ vector<std::pair<NameRef, SymbolRef>> Symbol::membersStableOrderSlow(const Globa
     return result;
 }
 
-SymbolData::SymbolData(Symbol &ref, GlobalState &gs) : DebugOnlyCheck(gs), symbol(ref) {}
+ClassOrModuleData::ClassOrModuleData(ClassOrModule &ref, GlobalState &gs) : DebugOnlyCheck(gs), symbol(ref) {}
 
-ConstSymbolData::ConstSymbolData(const Symbol &ref, const GlobalState &gs) : DebugOnlyCheck(gs), symbol(ref) {}
+ConstClassOrModuleData::ConstClassOrModuleData(const ClassOrModule &ref, const GlobalState &gs)
+    : DebugOnlyCheck(gs), symbol(ref) {}
 
 SymbolDataDebugCheck::SymbolDataDebugCheck(const GlobalState &gs)
     : gs(gs), symbolCountAtCreation(gs.symbolsUsedTotal()) {}
@@ -2447,17 +2452,17 @@ void SymbolDataDebugCheck::check() const {
     ENFORCE_NO_TIMER(symbolCountAtCreation == gs.symbolsUsedTotal());
 }
 
-Symbol *SymbolData::operator->() {
+ClassOrModule *ClassOrModuleData::operator->() {
     runDebugOnlyCheck();
     return &symbol;
 };
 
-const Symbol *SymbolData::operator->() const {
+const ClassOrModule *ClassOrModuleData::operator->() const {
     runDebugOnlyCheck();
     return &symbol;
 };
 
-const Symbol *ConstSymbolData::operator->() const {
+const ClassOrModule *ConstClassOrModuleData::operator->() const {
     runDebugOnlyCheck();
     return &symbol;
 };

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -87,7 +87,7 @@ vector<TypePtr> Symbol::selfTypeArgs(const GlobalState &gs) const {
     vector<TypePtr> targs;
     for (auto tm : typeMembers()) {
         auto tmData = tm.data(gs);
-        if (tmData->isFixed()) {
+        if (tmData->flags.isFixed) {
             auto *lambdaParam = cast_type<LambdaParam>(tmData->resultType);
             ENFORCE(lambdaParam != nullptr);
             targs.emplace_back(lambdaParam->upperBound);
@@ -149,11 +149,11 @@ TypePtr Symbol::unsafeComputeExternalType(GlobalState &gs) {
                 // For backwards compatibility, instantiate stdlib generics
                 // with T.untyped.
                 targs.emplace_back(Types::untyped(gs, ref));
-            } else if (tmData->isFixed() || tmData->isCovariant()) {
+            } else if (tmData->flags.isFixed || tmData->flags.isCovariant) {
                 // Default fixed or covariant parameters to their upper
                 // bound.
                 targs.emplace_back(lambdaParam->upperBound);
-            } else if (tmData->isInvariant()) {
+            } else if (tmData->flags.isInvariant) {
                 // We instantiate Invariant type members as T.untyped as
                 // this will behave a bit like a unification variable with
                 // Types::glb.
@@ -196,12 +196,6 @@ SymbolRef Symbol::ref(const GlobalState &gs) const {
     if (isClassOrModule()) {
         type = SymbolRef::Kind::ClassOrModule;
         distance = this - gs.classAndModules.data();
-    } else if (isTypeMember()) {
-        type = SymbolRef::Kind::TypeMember;
-        distance = this - gs.typeMembers.data();
-    } else if (isTypeArgument()) {
-        type = SymbolRef::Kind::TypeArgument;
-        distance = this - gs.typeArguments.data();
     } else {
         ENFORCE(false, "Invalid/unrecognized symbol type");
     }
@@ -217,6 +211,17 @@ FieldRef Field::ref(const GlobalState &gs) const {
 MethodRef Method::ref(const GlobalState &gs) const {
     uint32_t distance = this - gs.methods.data();
     return MethodRef(gs, distance);
+}
+
+SymbolRef TypeParameter::ref(const GlobalState &gs) const {
+    if (flags.isTypeArgument) {
+        uint32_t distance = this - gs.typeArguments.data();
+        return TypeArgumentRef(gs, distance);
+    } else {
+        ENFORCE_NO_TIMER(flags.isTypeMember);
+        uint32_t distance = this - gs.typeMembers.data();
+        return TypeMemberRef(gs, distance);
+    }
 }
 
 bool SymbolRef::isTypeAlias(const GlobalState &gs) const {
@@ -289,38 +294,38 @@ FieldData FieldRef::dataAllowingNone(GlobalState &gs) const {
     return FieldData(gs.fields[_id], gs);
 }
 
-SymbolData TypeMemberRef::data(GlobalState &gs) const {
+TypeParameterData TypeMemberRef::data(GlobalState &gs) const {
     ENFORCE_NO_TIMER(this->exists());
     ENFORCE_NO_TIMER(_id < gs.typeMembersUsed());
-    return SymbolData(gs.typeMembers[_id], gs);
+    return TypeParameterData(gs.typeMembers[_id], gs);
 }
 
-ConstSymbolData TypeMemberRef::data(const GlobalState &gs) const {
+ConstTypeParameterData TypeMemberRef::data(const GlobalState &gs) const {
     ENFORCE_NO_TIMER(this->exists());
     ENFORCE_NO_TIMER(_id < gs.typeMembersUsed());
-    return ConstSymbolData(gs.typeMembers[_id], gs);
+    return ConstTypeParameterData(gs.typeMembers[_id], gs);
 }
 
-SymbolData TypeMemberRef::dataAllowingNone(GlobalState &gs) const {
+TypeParameterData TypeMemberRef::dataAllowingNone(GlobalState &gs) const {
     ENFORCE_NO_TIMER(_id < gs.typeMembersUsed());
-    return SymbolData(gs.typeMembers[_id], gs);
+    return TypeParameterData(gs.typeMembers[_id], gs);
 }
 
-SymbolData TypeArgumentRef::data(GlobalState &gs) const {
+TypeParameterData TypeArgumentRef::data(GlobalState &gs) const {
     ENFORCE_NO_TIMER(this->exists());
     ENFORCE_NO_TIMER(_id < gs.typeArgumentsUsed());
-    return SymbolData(gs.typeArguments[_id], gs);
+    return TypeParameterData(gs.typeArguments[_id], gs);
 }
 
-ConstSymbolData TypeArgumentRef::data(const GlobalState &gs) const {
+ConstTypeParameterData TypeArgumentRef::data(const GlobalState &gs) const {
     ENFORCE_NO_TIMER(this->exists());
     ENFORCE_NO_TIMER(_id < gs.typeArgumentsUsed());
-    return ConstSymbolData(gs.typeArguments[_id], gs);
+    return ConstTypeParameterData(gs.typeArguments[_id], gs);
 }
 
-SymbolData TypeArgumentRef::dataAllowingNone(GlobalState &gs) const {
+TypeParameterData TypeArgumentRef::dataAllowingNone(GlobalState &gs) const {
     ENFORCE_NO_TIMER(_id < gs.typeArgumentsUsed());
-    return SymbolData(gs.typeArguments[_id], gs);
+    return TypeParameterData(gs.typeArguments[_id], gs);
 }
 
 bool SymbolRef::isSynthetic() const {
@@ -955,12 +960,12 @@ void printLocs(const GlobalState &gs, fmt::memory_buffer &buf, const InlinedVect
     }
 }
 
-string_view getVariance(ConstSymbolData &sym) {
-    if (sym->isCovariant()) {
+string_view getVariance(ConstTypeParameterData &sym) {
+    if (sym->flags.isCovariant) {
         return "(+)"sv;
-    } else if (sym->isContravariant()) {
+    } else if (sym->flags.isContravariant) {
         return "(-)"sv;
-    } else if (sym->isInvariant()) {
+    } else if (sym->flags.isInvariant) {
         return "(=)"sv;
     } else {
         Exception::raise("type without variance");
@@ -1113,6 +1118,10 @@ bool Field::isPrintable(const GlobalState &gs) const {
     return !isHiddenFromPrinting(gs, this->ref(gs));
 }
 
+bool TypeParameter::isPrintable(const GlobalState &gs) const {
+    return !isHiddenFromPrinting(gs, this->ref(gs));
+}
+
 string_view SymbolRef::showKind(const GlobalState &gs) const {
     switch (this->kind()) {
         case Kind::ClassOrModule:
@@ -1173,8 +1182,8 @@ string ClassOrModuleRef::toStringWithOptions(const GlobalState &gs, int tabs, bo
     fmt::format_to(std::back_inserter(buf), "{} {}", showKind(gs), showRaw ? toStringFullName(gs) : showFullName(gs));
 
     auto typeMembers = sym->typeMembers();
-    auto it =
-        remove_if(typeMembers.begin(), typeMembers.end(), [&gs](auto &sym) -> bool { return sym.data(gs)->isFixed(); });
+    auto it = remove_if(typeMembers.begin(), typeMembers.end(),
+                        [&gs](auto &sym) -> bool { return sym.data(gs)->flags.isFixed; });
     typeMembers.erase(it, typeMembers.end());
     if (!typeMembers.empty()) {
         fmt::format_to(std::back_inserter(buf), "[{}]", fmt::map_join(typeMembers, ", ", [&](auto symb) {
@@ -1267,8 +1276,8 @@ string MethodRef::toStringWithOptions(const GlobalState &gs, int tabs, bool show
     }
 
     auto typeMembers = sym->typeArguments;
-    auto it =
-        remove_if(typeMembers.begin(), typeMembers.end(), [&gs](auto &sym) -> bool { return sym.data(gs)->isFixed(); });
+    auto it = remove_if(typeMembers.begin(), typeMembers.end(),
+                        [&gs](auto &sym) -> bool { return sym.data(gs)->flags.isFixed; });
     typeMembers.erase(it, typeMembers.end());
     if (!typeMembers.empty()) {
         fmt::format_to(std::back_inserter(buf), "[{}]", fmt::map_join(typeMembers, ", ", [&](auto symb) {
@@ -1352,7 +1361,6 @@ string TypeMemberRef::toStringWithOptions(const GlobalState &gs, int tabs, bool 
 
     ENFORCE(!absl::c_any_of(to_string(buf), [](char c) { return c == '\n'; }));
     fmt::format_to(std::back_inserter(buf), "\n");
-    ENFORCE_NO_TIMER(sym->members().empty());
 
     return to_string(buf);
 }
@@ -1372,7 +1380,6 @@ string TypeArgumentRef::toStringWithOptions(const GlobalState &gs, int tabs, boo
 
     ENFORCE(!absl::c_any_of(to_string(buf), [](char c) { return c == '\n'; }));
     fmt::format_to(std::back_inserter(buf), "\n");
-    ENFORCE_NO_TIMER(sym->members().empty());
 
     return to_string(buf);
 }
@@ -1937,6 +1944,10 @@ SymbolRef Field::dealias(const GlobalState &gs, int depthLimit) const {
     return dealiasWithDefault(gs, this->ref(gs), depthLimit, Symbols::untyped());
 }
 
+SymbolRef TypeParameter::dealias(const GlobalState &gs, int depthLimit) const {
+    return dealiasWithDefault(gs, this->ref(gs), depthLimit, Symbols::untyped());
+}
+
 bool ArgInfo::isSyntheticBlockArgument() const {
     // Every block argument that we synthesize in desugar or enter manually into global state uses Loc::none().
     return flags.isBlock && !loc.exists();
@@ -2030,11 +2041,21 @@ Field Field::deepCopy(const GlobalState &to) const {
     return result;
 }
 
+TypeParameter TypeParameter::deepCopy(const GlobalState &to) const {
+    TypeParameter result;
+    result.owner = this->owner;
+    result.flags = this->flags;
+    result.resultType = this->resultType;
+    result.name = NameRef(to, this->name);
+    result.locs_ = this->locs_;
+    return result;
+}
+
 int Symbol::typeArity(const GlobalState &gs) const {
     ENFORCE(this->isClassOrModule());
     int arity = 0;
     for (auto &tm : this->typeMembers()) {
-        if (!tm.data(gs)->isFixed()) {
+        if (!tm.data(gs)->flags.isFixed) {
             ++arity;
         }
     }
@@ -2055,15 +2076,10 @@ void Symbol::sanityCheck(const GlobalState &gs) const {
                 break;
             case SymbolRef::Kind::Method:
             case SymbolRef::Kind::FieldOrStaticField:
-                ENFORCE(false, "Methods, fields, and static fields cannot be stored in the Symbol class");
-                break;
             case SymbolRef::Kind::TypeArgument:
-                current2 = const_cast<GlobalState &>(gs).enterTypeArgument(this->loc(), this->owner.asMethodRef(),
-                                                                           this->name, this->variance());
-                break;
             case SymbolRef::Kind::TypeMember:
-                current2 = const_cast<GlobalState &>(gs).enterTypeMember(this->loc(), this->owner.asClassOrModuleRef(),
-                                                                         this->name, this->variance());
+                ENFORCE(false,
+                        "Methods, fields, static fields, and type parameters cannot be stored in the Symbol class");
                 break;
         }
 
@@ -2113,6 +2129,33 @@ void Field::sanityCheck(const GlobalState &gs) const {
         current2 = const_cast<GlobalState &>(gs).enterStaticFieldSymbol(this->loc(), this->owner, this->name);
     }
     ENFORCE_NO_TIMER(current == current2);
+}
+
+void TypeParameter::sanityCheck(const GlobalState &gs) const {
+    if (!debug_mode) {
+        return;
+    }
+    SymbolRef current = this->ref(gs);
+    if (current != Symbols::root()) {
+        SymbolRef current2;
+        switch (current.kind()) {
+            case SymbolRef::Kind::ClassOrModule:
+            case SymbolRef::Kind::Method:
+            case SymbolRef::Kind::FieldOrStaticField:
+                ENFORCE(false, "Should not happen");
+                break;
+            case SymbolRef::Kind::TypeArgument:
+                current2 = const_cast<GlobalState &>(gs).enterTypeArgument(this->loc(), this->owner.asMethodRef(),
+                                                                           this->name, this->variance());
+                break;
+            case SymbolRef::Kind::TypeMember:
+                current2 = const_cast<GlobalState &>(gs).enterTypeMember(this->loc(), this->owner.asClassOrModuleRef(),
+                                                                         this->name, this->variance());
+                break;
+        }
+
+        ENFORCE_NO_TIMER(current == current2);
+    }
 }
 
 ClassOrModuleRef MethodRef::enclosingClass(const GlobalState &gs) const {
@@ -2216,6 +2259,14 @@ uint32_t Field::hash(const GlobalState &gs) const {
     return result;
 }
 
+uint32_t TypeParameter::hash(const GlobalState &gs) const {
+    uint32_t result = _hash(name.shortName(gs));
+    result = mix(result, !this->resultType ? 0 : this->resultType.hash(gs));
+    result = mix(result, this->flags.serialize());
+    result = mix(result, this->owner.rawId());
+    return result;
+}
+
 uint32_t Method::methodShapeHash(const GlobalState &gs) const {
     uint32_t result = _hash(name.shortName(gs));
     result = mix(result, this->flags.serialize());
@@ -2283,6 +2334,13 @@ Loc Field::loc() const {
     return Loc::none();
 }
 
+Loc TypeParameter::loc() const {
+    if (!locs_.empty()) {
+        return locs_.back();
+    }
+    return Loc::none();
+}
+
 const InlinedVector<Loc, 2> &Method::locs() const {
     return locs_;
 }
@@ -2292,6 +2350,10 @@ const InlinedVector<Loc, 2> &Symbol::locs() const {
 }
 
 const InlinedVector<Loc, 2> &Field::locs() const {
+    return locs_;
+}
+
+const InlinedVector<Loc, 2> &TypeParameter::locs() const {
     return locs_;
 }
 
@@ -2328,6 +2390,14 @@ void Method::addLoc(const core::GlobalState &gs, core::Loc loc) {
 }
 
 void Field::addLoc(const core::GlobalState &gs, core::Loc loc) {
+    if (!loc.file().exists()) {
+        return;
+    }
+
+    addLocInternal(gs, loc, this->loc(), locs_);
+}
+
+void TypeParameter::addLoc(const core::GlobalState &gs, core::Loc loc) {
     if (!loc.file().exists()) {
         return;
     }
@@ -2456,6 +2526,26 @@ const Field *FieldData::operator->() const {
 const Field *ConstFieldData::operator->() const {
     runDebugOnlyCheck();
     return &field;
+};
+
+TypeParameterData::TypeParameterData(TypeParameter &ref, GlobalState &gs) : DebugOnlyCheck(gs), typeParam(ref) {}
+
+ConstTypeParameterData::ConstTypeParameterData(const TypeParameter &ref, const GlobalState &gs)
+    : DebugOnlyCheck(gs), typeParam(ref) {}
+
+TypeParameter *TypeParameterData::operator->() {
+    runDebugOnlyCheck();
+    return &typeParam;
+};
+
+const TypeParameter *TypeParameterData::operator->() const {
+    runDebugOnlyCheck();
+    return &typeParam;
+};
+
+const TypeParameter *ConstTypeParameterData::operator->() const {
+    runDebugOnlyCheck();
+    return &typeParam;
 };
 
 } // namespace sorbet::core

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -304,40 +304,34 @@ public:
 
     class Flags {
     public:
-        static constexpr uint32_t NONE = 0;
-
-        // We're packing three different kinds of flags into separate ranges with the uint32_t's below:
-        //
-        // 0x0000'0000
-        //   ├▶    ◀┤└─ Applies to all types of symbol
-        //   │      │
-        //   │      └─ For our current symbol type, what flags does it have?
-        //   │         (New flags grow up towards MSB)
-        //   │
-        //   └─ What type of symbol is this?
-        //      (New flags grow down towards LSB)
-        //
-
-        // --- What type of symbol is this? ---
-        static constexpr uint32_t CLASS_OR_MODULE = 0x8000'0000;
-
-        // --- Applies to all types of Symbols ---
-
         // Synthesized by C++ code in a Rewriter pass
-        static constexpr uint32_t REWRITER_SYNTHESIZED = 0x0000'0001;
-
-        // --- For our current symbol type, what flags does it have?
+        bool isRewriterSynthesized : 1;
 
         // Class flags
-        static constexpr uint32_t CLASS_OR_MODULE_CLASS = 0x0000'0010;
-        static constexpr uint32_t CLASS_OR_MODULE_MODULE = 0x0000'0020;
-        static constexpr uint32_t CLASS_OR_MODULE_ABSTRACT = 0x0000'0040;
-        static constexpr uint32_t CLASS_OR_MODULE_INTERFACE = 0x0000'0080;
-        static constexpr uint32_t CLASS_OR_MODULE_LINEARIZATION_COMPUTED = 0x0000'0100;
-        static constexpr uint32_t CLASS_OR_MODULE_FINAL = 0x0000'0200;
-        static constexpr uint32_t CLASS_OR_MODULE_SEALED = 0x0000'0400;
-        static constexpr uint32_t CLASS_OR_MODULE_PRIVATE = 0x0000'0800;
+        bool isClass : 1;
+        bool isModule : 1;
+        bool isAbstract : 1;
+        bool isInterface : 1;
+        bool isLinearizationComputed : 1;
+        bool isFinal : 1;
+        bool isSealed : 1;
+        bool isPrivate : 1;
+
+        constexpr static uint16_t NUMBER_OF_FLAGS = 9;
+        constexpr static uint16_t VALID_BITS_MASK = (1 << NUMBER_OF_FLAGS) - 1;
+
+        Flags() noexcept
+            : isRewriterSynthesized(false), isClass(false), isModule(false), isAbstract(false), isInterface(false),
+              isLinearizationComputed(false), isFinal(false), isSealed(false), isPrivate(false) {}
+
+        uint16_t serialize() const {
+            // Can replace this with std::bit_cast in C++20
+            auto rawBits = *reinterpret_cast<const uint8_t *>(this);
+            // Mask the valid bits since uninitialized bits can be any value.
+            return rawBits & VALID_BITS_MASK;
+        }
     };
+    CheckSize(Flags, 2, 1);
 
     Loc loc() const;
     const InlinedVector<Loc, 2> &locs() const;
@@ -359,12 +353,10 @@ public:
     TypePtr unsafeComputeExternalType(GlobalState &gs);
 
     inline InlinedVector<ClassOrModuleRef, 4> &mixins() {
-        ENFORCE_NO_TIMER(isClassOrModule());
         return mixins_;
     }
 
     inline const InlinedVector<ClassOrModuleRef, 4> &mixins() const {
-        ENFORCE_NO_TIMER(isClassOrModule());
         return mixins_;
     }
 
@@ -377,12 +369,10 @@ public:
     uint16_t addMixinPlaceholder(const GlobalState &gs);
 
     inline InlinedVector<TypeMemberRef, 4> &typeMembers() {
-        ENFORCE(isClassOrModule());
         return typeParams;
     }
 
     inline const InlinedVector<TypeMemberRef, 4> &typeMembers() const {
-        ENFORCE(isClassOrModule());
         return typeParams;
     }
 
@@ -396,26 +386,22 @@ public:
     // TODO(dmitry) perf: most calls to this method could be eliminated as part of perf work.
     SymbolRef ref(const GlobalState &gs) const;
 
-    inline bool isClassOrModule() const {
-        return (flags & Symbol::Flags::CLASS_OR_MODULE) != 0;
-    }
-
     bool isSingletonClass(const GlobalState &gs) const;
 
     inline bool isClassOrModuleModule() const {
-        ENFORCE_NO_TIMER(isClassOrModule());
-        if (flags & Symbol::Flags::CLASS_OR_MODULE_MODULE) {
+        if (flags.isModule) {
             return true;
         }
-        if (flags & Symbol::Flags::CLASS_OR_MODULE_CLASS) {
+
+        if (flags.isClass) {
             return false;
         }
+
         Exception::raise("Should never happen");
     }
 
     inline bool isClassModuleSet() const {
-        ENFORCE_NO_TIMER(isClassOrModule());
-        return flags & (Symbol::Flags::CLASS_OR_MODULE_MODULE | Symbol::Flags::CLASS_OR_MODULE_CLASS);
+        return flags.isModule || flags.isClass;
     }
 
     inline bool isClassOrModuleClass() const {
@@ -423,85 +409,68 @@ public:
     }
 
     inline bool isClassOrModuleAbstract() const {
-        ENFORCE(isClassOrModule());
-        return (flags & Symbol::Flags::CLASS_OR_MODULE_ABSTRACT) != 0;
+        return flags.isAbstract;
     }
 
     inline bool isClassOrModuleInterface() const {
-        ENFORCE_NO_TIMER(isClassOrModule());
-        return (flags & Symbol::Flags::CLASS_OR_MODULE_INTERFACE) != 0;
+        return flags.isInterface;
     }
 
     inline bool isClassOrModuleLinearizationComputed() const {
-        ENFORCE_NO_TIMER(isClassOrModule());
-        return (flags & Symbol::Flags::CLASS_OR_MODULE_LINEARIZATION_COMPUTED) != 0;
+        return flags.isLinearizationComputed;
     }
 
     inline bool isClassOrModuleFinal() const {
-        ENFORCE_NO_TIMER(isClassOrModule());
-        return (flags & Symbol::Flags::CLASS_OR_MODULE_FINAL) != 0;
+        return flags.isFinal;
     }
 
     inline bool isClassOrModuleSealed() const {
-        ENFORCE_NO_TIMER(isClassOrModule());
-        return (flags & Symbol::Flags::CLASS_OR_MODULE_SEALED) != 0;
+        return flags.isSealed;
     }
 
     inline bool isClassOrModulePrivate() const {
-        ENFORCE_NO_TIMER(isClassOrModule());
-        return (flags & Symbol::Flags::CLASS_OR_MODULE_PRIVATE) != 0;
-    }
-
-    inline void setClassOrModule() {
-        flags |= Symbol::Flags::CLASS_OR_MODULE;
+        return flags.isPrivate;
     }
 
     inline void setIsModule(bool isModule) {
-        ENFORCE(isClassOrModule());
         if (isModule) {
-            ENFORCE((flags & Symbol::Flags::CLASS_OR_MODULE_CLASS) == 0);
-            flags |= Symbol::Flags::CLASS_OR_MODULE_MODULE;
+            ENFORCE(!flags.isClass);
+            flags.isModule = true;
         } else {
-            ENFORCE((flags & Symbol::Flags::CLASS_OR_MODULE_MODULE) == 0);
-            flags |= Symbol::Flags::CLASS_OR_MODULE_CLASS;
+            ENFORCE(!flags.isModule);
+            flags.isClass = true;
         }
     }
 
     inline void setClassOrModuleAbstract() {
-        ENFORCE(isClassOrModule());
-        flags |= Symbol::Flags::CLASS_OR_MODULE_ABSTRACT;
+        flags.isAbstract = true;
     }
 
     inline void setClassOrModuleInterface() {
-        ENFORCE(isClassOrModule());
-        flags |= Symbol::Flags::CLASS_OR_MODULE_INTERFACE;
+        flags.isInterface = true;
     }
 
     inline void setClassOrModuleLinearizationComputed() {
-        ENFORCE(isClassOrModule());
-        flags |= Symbol::Flags::CLASS_OR_MODULE_LINEARIZATION_COMPUTED;
+        flags.isLinearizationComputed = true;
     }
 
     inline void setClassOrModuleFinal() {
-        ENFORCE(isClassOrModule());
-        flags |= Symbol::Flags::CLASS_OR_MODULE_FINAL;
+        flags.isFinal = true;
     }
 
     inline void setClassOrModuleSealed() {
-        ENFORCE(isClassOrModule());
-        flags |= Symbol::Flags::CLASS_OR_MODULE_SEALED;
+        flags.isSealed = true;
     }
 
     inline void setClassOrModulePrivate() {
-        ENFORCE(isClassOrModule());
-        flags |= Symbol::Flags::CLASS_OR_MODULE_PRIVATE;
+        flags.isPrivate = true;
     }
 
     inline void setRewriterSynthesized() {
-        flags |= Symbol::Flags::REWRITER_SYNTHESIZED;
+        flags.isRewriterSynthesized = true;
     }
     inline bool isRewriterSynthesized() {
-        return (flags & Symbol::Flags::REWRITER_SYNTHESIZED) != 0;
+        return flags.isRewriterSynthesized;
     }
 
     SymbolRef findMember(const GlobalState &gs, NameRef name) const;
@@ -576,16 +545,14 @@ public:
     ClassOrModuleRef superClass_;
 
     inline ClassOrModuleRef superClass() const {
-        ENFORCE_NO_TIMER(isClassOrModule());
         return superClass_;
     }
 
     inline void setSuperClass(ClassOrModuleRef claz) {
-        ENFORCE(isClassOrModule());
         superClass_ = claz;
     }
 
-    uint32_t flags = Flags::NONE;
+    Flags flags;
     NameRef name; // todo: move out? it should not matter but it's important for name resolution
     TypePtr resultType;
 
@@ -639,8 +606,7 @@ private:
     SymbolRef findMemberTransitiveInternal(const GlobalState &gs, NameRef name, int maxDepth = 100) const;
 
     inline void unsetClassOrModuleLinearizationComputed() {
-        ENFORCE(isClassOrModule());
-        flags &= ~Symbol::Flags::CLASS_OR_MODULE_LINEARIZATION_COMPUTED;
+        flags.isLinearizationComputed = false;
     }
 
     void addMixinAt(ClassOrModuleRef sym, std::optional<uint16_t> index);

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -380,7 +380,7 @@ public:
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef sym) const;
 
     // TODO(dmitry) perf: most calls to this method could be eliminated as part of perf work.
-    SymbolRef ref(const GlobalState &gs) const;
+    ClassOrModuleRef ref(const GlobalState &gs) const;
 
     bool isSingletonClass(const GlobalState &gs) const;
 

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -236,41 +236,23 @@ public:
         bool isContravariant : 1;
         bool isFixed : 1;
 
+        constexpr static uint8_t NUMBER_OF_FLAGS = 6;
+        constexpr static uint8_t VALID_BITS_MASK = (1 << NUMBER_OF_FLAGS) - 1;
+
         Flags() noexcept
             : isTypeArgument(false), isTypeMember(false), isCovariant(false), isInvariant(false),
               isContravariant(false), isFixed(false) {}
 
         uint8_t serialize() const {
             // Can replace this with std::bit_cast in C++20
-            return *reinterpret_cast<const uint8_t *>(this);
+            auto rawBits = *reinterpret_cast<const uint8_t *>(this);
+            // Mask the valid bits since uninitialized bits can be any value.
+            return rawBits & VALID_BITS_MASK;
         }
 
         bool hasFlags(const Flags other) {
-            if (other.isTypeArgument && !this->isTypeArgument) {
-                return false;
-            }
-
-            if (other.isTypeMember && !this->isTypeMember) {
-                return false;
-            }
-
-            if (other.isCovariant && !this->isCovariant) {
-                return false;
-            }
-
-            if (other.isInvariant && !this->isInvariant) {
-                return false;
-            }
-
-            if (other.isContravariant && !this->isContravariant) {
-                return false;
-            }
-
-            if (other.isFixed && !this->isFixed) {
-                return false;
-            }
-
-            return true;
+            const auto otherSerialized = other.serialize();
+            return (this->serialize() & otherSerialized) == otherSerialized;
         }
     };
     CheckSize(Flags, 1, 1);

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -217,6 +217,103 @@ public:
 };
 CheckSize(Field, 64, 8);
 
+class TypeParameter final {
+    friend class serialize::SerializerImpl;
+
+public:
+    TypeParameter(const TypeParameter &) = delete;
+    TypeParameter() = default;
+    TypeParameter(TypeParameter &&) noexcept = default;
+
+    class Flags {
+    public:
+        bool isTypeArgument : 1;
+        bool isTypeMember : 1;
+
+        // Type flags
+        bool isCovariant : 1;
+        bool isInvariant : 1;
+        bool isContravariant : 1;
+        bool isFixed : 1;
+
+        Flags() noexcept
+            : isTypeArgument(false), isTypeMember(false), isCovariant(false), isInvariant(false),
+              isContravariant(false), isFixed(false) {}
+
+        uint8_t serialize() const {
+            // Can replace this with std::bit_cast in C++20
+            return *reinterpret_cast<const uint8_t *>(this);
+        }
+
+        bool hasFlags(const Flags other) {
+            if (other.isTypeArgument && !this->isTypeArgument) {
+                return false;
+            }
+
+            if (other.isTypeMember && !this->isTypeMember) {
+                return false;
+            }
+
+            if (other.isCovariant && !this->isCovariant) {
+                return false;
+            }
+
+            if (other.isInvariant && !this->isInvariant) {
+                return false;
+            }
+
+            if (other.isContravariant && !this->isContravariant) {
+                return false;
+            }
+
+            if (other.isFixed && !this->isFixed) {
+                return false;
+            }
+
+            return true;
+        }
+    };
+    CheckSize(Flags, 1, 1);
+
+    Loc loc() const;
+    const InlinedVector<Loc, 2> &locs() const;
+    void addLoc(const core::GlobalState &gs, core::Loc loc);
+
+    uint32_t hash(const GlobalState &gs) const;
+
+    bool isPrintable(const GlobalState &gs) const;
+
+    SymbolRef ref(const GlobalState &gs) const;
+
+    Variance variance() const {
+        if (flags.isInvariant) {
+            return Variance::Invariant;
+        }
+        if (flags.isCovariant) {
+            return Variance::CoVariant;
+        }
+        if (flags.isContravariant) {
+            return Variance::ContraVariant;
+        }
+        Exception::raise("Should not happen");
+    }
+
+    SymbolRef dealias(const GlobalState &gs, int depthLimit = 42) const;
+
+    void sanityCheck(const GlobalState &gs) const;
+
+    TypeParameter deepCopy(const GlobalState &gs) const;
+
+    Flags flags;
+    // Method for TypeArgument, ClassOrModule for TypeMember.
+    SymbolRef owner;
+    NameRef name;
+    TypePtr resultType;
+
+private:
+    InlinedVector<Loc, 2> locs_;
+};
+
 class Symbol final {
 public:
     Symbol(const Symbol &) = delete;
@@ -241,8 +338,6 @@ public:
 
         // --- What type of symbol is this? ---
         static constexpr uint32_t CLASS_OR_MODULE = 0x8000'0000;
-        static constexpr uint32_t TYPE_ARGUMENT = 0x0800'0000;
-        static constexpr uint32_t TYPE_MEMBER = 0x0400'0000;
 
         // --- Applies to all types of Symbols ---
 
@@ -260,12 +355,6 @@ public:
         static constexpr uint32_t CLASS_OR_MODULE_FINAL = 0x0000'0200;
         static constexpr uint32_t CLASS_OR_MODULE_SEALED = 0x0000'0400;
         static constexpr uint32_t CLASS_OR_MODULE_PRIVATE = 0x0000'0800;
-
-        // Type flags
-        static constexpr uint32_t TYPE_COVARIANT = 0x0000'0010;
-        static constexpr uint32_t TYPE_INVARIANT = 0x0000'0020;
-        static constexpr uint32_t TYPE_CONTRAVARIANT = 0x0000'0040;
-        static constexpr uint32_t TYPE_FIXED = 0x0000'0080;
     };
 
     Loc loc() const;
@@ -331,47 +420,6 @@ public:
 
     bool isSingletonClass(const GlobalState &gs) const;
 
-    inline bool isTypeMember() const {
-        return (flags & Symbol::Flags::TYPE_MEMBER) != 0;
-    }
-
-    inline bool isTypeArgument() const {
-        return (flags & Symbol::Flags::TYPE_ARGUMENT) != 0;
-    }
-
-    inline bool isCovariant() const {
-        ENFORCE_NO_TIMER(isTypeArgument() || isTypeMember());
-        return (flags & Symbol::Flags::TYPE_COVARIANT) != 0;
-    }
-
-    inline bool isInvariant() const {
-        ENFORCE_NO_TIMER(isTypeArgument() || isTypeMember());
-        return (flags & Symbol::Flags::TYPE_INVARIANT) != 0;
-    }
-
-    inline bool isContravariant() const {
-        ENFORCE_NO_TIMER(isTypeArgument() || isTypeMember());
-        return (flags & Symbol::Flags::TYPE_CONTRAVARIANT) != 0;
-    }
-
-    inline bool isFixed() const {
-        ENFORCE_NO_TIMER(isTypeArgument() || isTypeMember());
-        return (flags & Symbol::Flags::TYPE_FIXED) != 0;
-    }
-
-    Variance variance() const {
-        if (isInvariant()) {
-            return Variance::Invariant;
-        }
-        if (isCovariant()) {
-            return Variance::CoVariant;
-        }
-        if (isContravariant()) {
-            return Variance::ContraVariant;
-        }
-        Exception::raise("Should not happen");
-    }
-
     inline bool isClassOrModuleModule() const {
         ENFORCE_NO_TIMER(isClassOrModule());
         if (flags & Symbol::Flags::CLASS_OR_MODULE_MODULE) {
@@ -423,18 +471,7 @@ public:
     }
 
     inline void setClassOrModule() {
-        ENFORCE(!isTypeArgument() && !isTypeMember());
         flags |= Symbol::Flags::CLASS_OR_MODULE;
-    }
-
-    inline void setTypeArgument() {
-        ENFORCE(!isClassOrModule() && !isTypeMember());
-        flags |= Symbol::Flags::TYPE_ARGUMENT;
-    }
-
-    inline void setTypeMember() {
-        ENFORCE(!isClassOrModule() && !isTypeArgument());
-        flags |= Symbol::Flags::TYPE_MEMBER;
     }
 
     inline void setIsModule(bool isModule) {
@@ -446,29 +483,6 @@ public:
             ENFORCE((flags & Symbol::Flags::CLASS_OR_MODULE_MODULE) == 0);
             flags |= Symbol::Flags::CLASS_OR_MODULE_CLASS;
         }
-    }
-
-    inline void setCovariant() {
-        ENFORCE(isTypeArgument() || isTypeMember());
-        ENFORCE(!isContravariant() && !isInvariant());
-        flags |= Symbol::Flags::TYPE_COVARIANT;
-    }
-
-    inline void setContravariant() {
-        ENFORCE(isTypeArgument() || isTypeMember());
-        ENFORCE(!isCovariant() && !isInvariant());
-        flags |= Symbol::Flags::TYPE_CONTRAVARIANT;
-    }
-
-    inline void setInvariant() {
-        ENFORCE(isTypeArgument() || isTypeMember());
-        ENFORCE(!isCovariant() && !isContravariant());
-        flags |= Symbol::Flags::TYPE_INVARIANT;
-    }
-
-    inline void setFixed() {
-        ENFORCE(isTypeArgument() || isTypeMember());
-        flags |= Symbol::Flags::TYPE_FIXED;
     }
 
     inline void setClassOrModuleAbstract() {

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -304,10 +304,6 @@ public:
 
     class Flags {
     public:
-        // Synthesized by C++ code in a Rewriter pass
-        bool isRewriterSynthesized : 1;
-
-        // Class flags
         bool isClass : 1;
         bool isModule : 1;
         bool isAbstract : 1;
@@ -317,21 +313,21 @@ public:
         bool isSealed : 1;
         bool isPrivate : 1;
 
-        constexpr static uint16_t NUMBER_OF_FLAGS = 9;
-        constexpr static uint16_t VALID_BITS_MASK = (1 << NUMBER_OF_FLAGS) - 1;
+        constexpr static uint8_t NUMBER_OF_FLAGS = 8;
+        constexpr static uint8_t VALID_BITS_MASK = (1 << NUMBER_OF_FLAGS) - 1;
 
         Flags() noexcept
-            : isRewriterSynthesized(false), isClass(false), isModule(false), isAbstract(false), isInterface(false),
-              isLinearizationComputed(false), isFinal(false), isSealed(false), isPrivate(false) {}
+            : isClass(false), isModule(false), isAbstract(false), isInterface(false), isLinearizationComputed(false),
+              isFinal(false), isSealed(false), isPrivate(false) {}
 
-        uint16_t serialize() const {
+        uint8_t serialize() const {
             // Can replace this with std::bit_cast in C++20
             auto rawBits = *reinterpret_cast<const uint8_t *>(this);
             // Mask the valid bits since uninitialized bits can be any value.
             return rawBits & VALID_BITS_MASK;
         }
     };
-    CheckSize(Flags, 2, 1);
+    CheckSize(Flags, 1, 1);
 
     Loc loc() const;
     const InlinedVector<Loc, 2> &locs() const;
@@ -342,8 +338,8 @@ public:
     std::vector<TypePtr> selfTypeArgs(const GlobalState &gs) const;
 
     // selfType and externalType return the type of an instance of this Symbol
-    // (which must be isClassOrModule()), if instantiated without specific type
-    // parameters, as seen from inside or outside of the class, respectively.
+    // if instantiated without specific type parameters, as seen from inside or
+    // outside of the class, respectively.
     TypePtr selfType(const GlobalState &gs) const;
     TypePtr externalType() const;
 
@@ -388,7 +384,7 @@ public:
 
     bool isSingletonClass(const GlobalState &gs) const;
 
-    inline bool isClassOrModuleModule() const {
+    inline bool isModule() const {
         if (flags.isModule) {
             return true;
         }
@@ -404,32 +400,8 @@ public:
         return flags.isModule || flags.isClass;
     }
 
-    inline bool isClassOrModuleClass() const {
-        return !isClassOrModuleModule();
-    }
-
-    inline bool isClassOrModuleAbstract() const {
-        return flags.isAbstract;
-    }
-
-    inline bool isClassOrModuleInterface() const {
-        return flags.isInterface;
-    }
-
-    inline bool isClassOrModuleLinearizationComputed() const {
-        return flags.isLinearizationComputed;
-    }
-
-    inline bool isClassOrModuleFinal() const {
-        return flags.isFinal;
-    }
-
-    inline bool isClassOrModuleSealed() const {
-        return flags.isSealed;
-    }
-
-    inline bool isClassOrModulePrivate() const {
-        return flags.isPrivate;
+    inline bool isClass() const {
+        return !isModule();
     }
 
     inline void setIsModule(bool isModule) {
@@ -440,37 +412,6 @@ public:
             ENFORCE(!flags.isModule);
             flags.isClass = true;
         }
-    }
-
-    inline void setClassOrModuleAbstract() {
-        flags.isAbstract = true;
-    }
-
-    inline void setClassOrModuleInterface() {
-        flags.isInterface = true;
-    }
-
-    inline void setClassOrModuleLinearizationComputed() {
-        flags.isLinearizationComputed = true;
-    }
-
-    inline void setClassOrModuleFinal() {
-        flags.isFinal = true;
-    }
-
-    inline void setClassOrModuleSealed() {
-        flags.isSealed = true;
-    }
-
-    inline void setClassOrModulePrivate() {
-        flags.isPrivate = true;
-    }
-
-    inline void setRewriterSynthesized() {
-        flags.isRewriterSynthesized = true;
-    }
-    inline bool isRewriterSynthesized() {
-        return flags.isRewriterSynthesized;
     }
 
     SymbolRef findMember(const GlobalState &gs, NameRef name) const;

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -11,7 +11,7 @@
 #include <vector>
 
 namespace sorbet::core {
-class Symbol;
+class ClassOrModule;
 class GlobalState;
 struct GlobalStateHash;
 class Type;
@@ -40,7 +40,7 @@ enum class Visibility : uint8_t {
 
 class Method final {
 public:
-    friend class Symbol;
+    friend class ClassOrModule;
     friend class serialize::SerializerImpl;
 
     Method(const Method &) = delete;
@@ -296,11 +296,11 @@ private:
     InlinedVector<Loc, 2> locs_;
 };
 
-class Symbol final {
+class ClassOrModule final {
 public:
-    Symbol(const Symbol &) = delete;
-    Symbol() = default;
-    Symbol(Symbol &&) noexcept = default;
+    ClassOrModule(const ClassOrModule &) = delete;
+    ClassOrModule() = default;
+    ClassOrModule(ClassOrModule &&) noexcept = default;
 
     class Flags {
     public:
@@ -508,7 +508,7 @@ public:
 
     std::vector<std::pair<NameRef, SymbolRef>> membersStableOrderSlow(const GlobalState &gs) const;
 
-    Symbol deepCopy(const GlobalState &to, bool keepGsId = false) const;
+    ClassOrModule deepCopy(const GlobalState &to, bool keepGsId = false) const;
     void sanityCheck(const GlobalState &gs) const;
 
 private:

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -482,7 +482,7 @@ public:
 
     bool ignoreInHashing(const GlobalState &gs) const;
 
-    SymbolRef owner;
+    ClassOrModuleRef owner;
     ClassOrModuleRef superClass_;
 
     inline ClassOrModuleRef superClass() const {

--- a/core/TypeConstraint.cc
+++ b/core/TypeConstraint.cc
@@ -18,7 +18,7 @@ void TypeConstraint::defineDomain(const GlobalState &gs, const InlinedVector<Typ
         auto typ = cast_type<TypeVar>(ta.data(gs)->resultType);
         ENFORCE(typ != nullptr);
 
-        if (ta.data(gs)->isCovariant()) {
+        if (ta.data(gs)->flags.isCovariant) {
             findLowerBound(typ->sym) = Types::bottom();
         } else {
             findUpperBound(typ->sym) = Types::top();

--- a/core/Types.h
+++ b/core/Types.h
@@ -20,7 +20,7 @@ struct DispatchArgs;
 struct DispatchComponent;
 struct DispatchResult;
 struct CallLocs;
-class Symbol;
+class ClassOrModule;
 class TypeVar;
 class SendAndBlockLink;
 class TypeAndOrigins;
@@ -615,8 +615,8 @@ private:
     friend TypePtr filterOrComponents(const TypePtr &originalType, const InlinedVector<TypePtr, 4> &typeFilter);
     friend TypePtr Types::dropSubtypesOf(const GlobalState &gs, const TypePtr &from, ClassOrModuleRef klass);
     friend TypePtr Types::unwrapSelfTypeParam(Context ctx, const TypePtr &t1);
-    friend class Symbol; // the actual method is `recordSealedSubclass(Mutableconst GlobalState &gs, SymbolRef
-                         // subclass)`, but refering to it introduces a cycle
+    friend class ClassOrModule; // the actual method is `recordSealedSubclass(Mutableconst GlobalState &gs, SymbolRef
+                                // subclass)`, but refering to it introduces a cycle
 
     static TypePtr make_shared(const TypePtr &left, const TypePtr &right);
 };

--- a/core/packages/PackageInfo.cc
+++ b/core/packages/PackageInfo.cc
@@ -23,7 +23,7 @@ bool PackageInfo::isPackageModule(const core::GlobalState &gs, core::ClassOrModu
         if (klass == core::Symbols::PackageRegistry() || klass == core::Symbols::PackageTests()) {
             return true;
         }
-        klass = klass.data(gs)->owner.asClassOrModuleRef();
+        klass = klass.data(gs)->owner;
     }
     return false;
 }

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -590,7 +590,7 @@ Method SerializerImpl::unpickleMethod(UnPickler &p, const GlobalState *gs) {
 }
 
 void SerializerImpl::pickle(Pickler &p, const ClassOrModule &what) {
-    p.putU4(what.owner.rawId());
+    p.putU4(what.owner.id());
     p.putU4(what.name.rawId());
     p.putU4(what.superClass_.id());
     p.putU1(what.flags.serialize());
@@ -626,7 +626,7 @@ void SerializerImpl::pickle(Pickler &p, const ClassOrModule &what) {
 
 ClassOrModule SerializerImpl::unpickleClassOrModule(UnPickler &p, const GlobalState *gs) {
     ClassOrModule result;
-    result.owner = SymbolRef::fromRaw(p.getU4());
+    result.owner = ClassOrModuleRef::fromRaw(p.getU4());
     result.name = NameRef::fromRaw(*gs, p.getU4());
     result.superClass_ = ClassOrModuleRef::fromRaw(p.getU4());
     ClassOrModule::Flags flags;

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -593,7 +593,7 @@ void SerializerImpl::pickle(Pickler &p, const Symbol &what) {
     p.putU4(what.owner.rawId());
     p.putU4(what.name.rawId());
     p.putU4(what.superClass_.id());
-    p.putU4(what.flags.serialize());
+    p.putU1(what.flags.serialize());
     p.putU4(what.mixins_.size());
     for (ClassOrModuleRef s : what.mixins_) {
         p.putU4(s.id());
@@ -630,7 +630,7 @@ Symbol SerializerImpl::unpickleSymbol(UnPickler &p, const GlobalState *gs) {
     result.name = NameRef::fromRaw(*gs, p.getU4());
     result.superClass_ = ClassOrModuleRef::fromRaw(p.getU4());
     Symbol::Flags flags;
-    uint16_t flagsRaw = static_cast<uint16_t>(p.getU4());
+    uint8_t flagsRaw = p.getU1();
     ENFORCE(sizeof(flagsRaw) == sizeof(flags));
     // Can replace this with std::bit_cast in C++20
     memcpy(&flags, &flagsRaw, sizeof(flags));

--- a/core/serialize/test/serialize_test.cc
+++ b/core/serialize/test/serialize_test.cc
@@ -81,15 +81,25 @@ TEST_CASE("Strings") { // NOLINT
 TEST_CASE("Symbol flags") {
     Field::Flags fieldFlags;
     Method::Flags mflags;
+    TypeParameter::Flags tpflags;
+    ClassOrModule::Flags cmflags;
     // All unused bits should be zero, and all flags should default to false.
     CHECK_EQ(fieldFlags.serialize(), 0);
     CHECK_EQ(mflags.serialize(), 0);
+    CHECK_EQ(tpflags.serialize(), 0);
+    CHECK_EQ(cmflags.serialize(), 0);
 
     mflags.isAbstract = true;
     CHECK_NE(mflags.serialize(), 0);
 
     fieldFlags.isField = true;
     CHECK_NE(fieldFlags.serialize(), 0);
+
+    tpflags.isContravariant = true;
+    CHECK_NE(tpflags.serialize(), 0);
+
+    cmflags.isAbstract = true;
+    CHECK_NE(cmflags.serialize(), 0);
 
     // I wish I could check that the mask is correct.
     // https://stackoverflow.com/a/45837449 indicates it is possible to count the number of fields in a class, but it

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1697,7 +1697,7 @@ public:
             auto *memType = cast_type<LambdaParam>(memData->resultType);
             ENFORCE(memType != nullptr);
 
-            if (memData->isFixed()) {
+            if (memData->flags.isFixed) {
                 // Fixed args are implicitly applied, and won't consume type
                 // arguments from the list that's supplied.
                 targs.emplace_back(memType->upperBound);

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -623,9 +623,9 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                                   receiverLoc.source(gs).value());
                 }
             } else {
-                if (symbol.data(gs)->isClassOrModuleModule()) {
+                if (symbol.data(gs)->isModule()) {
                     auto objMeth = core::Symbols::Object().data(gs)->findMethodTransitive(gs, args.name);
-                    if (objMeth.exists() && objMeth.data(gs)->owner.data(gs)->isClassOrModuleModule()) {
+                    if (objMeth.exists() && objMeth.data(gs)->owner.data(gs)->isModule()) {
                         e.addErrorNote("Did you mean to `{}` in this module?",
                                        fmt::format("include {}", objMeth.data(gs)->owner.data(gs)->name.show(gs)));
                     }
@@ -3313,8 +3313,7 @@ public:
         // If at any point we ever change isSubType to transparently convert between sealed classes and a
         // union of subclasses, this code can go away. It's written like this now to limit the blast
         // radius of allocating large union types.
-        if (rhsSym.exists() && rhsSym.data(gs)->isClassOrModuleSealed() &&
-            rhsSym.data(gs)->hasSingleSealedSubclass(gs)) {
+        if (rhsSym.exists() && rhsSym.data(gs)->flags.isSealed && rhsSym.data(gs)->hasSingleSealedSubclass(gs)) {
             rhs = rhsSym.data(gs)->sealedSubclassesToUnion(gs);
         }
 
@@ -3384,8 +3383,7 @@ public:
         // If at any point we ever change isSubType to transparently convert between sealed classes and a
         // union of subclasses, this code can go away. It's written like this now to limit the blast
         // radius of allocating large union types.
-        if (rhsSym.exists() && rhsSym.data(gs)->isClassOrModuleSealed() &&
-            rhsSym.data(gs)->hasSingleSealedSubclass(gs)) {
+        if (rhsSym.exists() && rhsSym.data(gs)->flags.isSealed && rhsSym.data(gs)->hasSingleSealedSubclass(gs)) {
             rhs = rhsSym.data(gs)->sealedSubclassesToUnion(gs);
         }
 

--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -409,7 +409,7 @@ string AppliedType::show(const GlobalState &gs) const {
     auto it = targs.begin();
     for (auto typeMember : typeMembers) {
         auto tm = typeMember;
-        if (tm.data(gs)->isFixed()) {
+        if (tm.data(gs)->flags.isFixed) {
             it = targs.erase(it);
         } else if (typeMember.data(gs)->name == core::Names::Constants::AttachedClass()) {
             it = targs.erase(it);
@@ -430,7 +430,7 @@ string AppliedType::show(const GlobalState &gs) const {
 string LambdaParam::toStringWithTabs(const GlobalState &gs, int tabs) const {
     auto defName = this->definition.toStringFullName(gs);
     auto upperStr = this->upperBound.toString(gs);
-    if (this->definition.data(gs)->isFixed()) {
+    if (this->definition.data(gs)->flags.isFixed) {
         return fmt::format("LambdaParam({}, fixed={})", defName, upperStr);
     } else {
         auto lowerStr = this->lowerBound.toString(gs);

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -313,9 +313,9 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                 i++;
             }
             ENFORCE(i < a1->klass.data(gs)->typeMembers().size());
-            if (idxTypeMember.data(gs)->isCovariant()) {
+            if (idxTypeMember.data(gs)->flags.isCovariant) {
                 newTargs.emplace_back(Types::any(gs, a1->targs[i], a2->targs[j]));
-            } else if (idxTypeMember.data(gs)->isInvariant()) {
+            } else if (idxTypeMember.data(gs)->flags.isInvariant) {
                 if (!Types::equiv(gs, a1->targs[i], a2->targs[j])) {
                     return OrType::make_shared(t1s, t2s);
                 }
@@ -325,7 +325,7 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                     newTargs.emplace_back(a2->targs[j]);
                 }
 
-            } else if (idxTypeMember.data(gs)->isContravariant()) {
+            } else if (idxTypeMember.data(gs)->flags.isContravariant) {
                 newTargs.emplace_back(Types::all(gs, a1->targs[i], a2->targs[j]));
             }
             changedFromT2 = changedFromT2 || newTargs.back() != a2->targs[j];
@@ -933,9 +933,9 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
             if (i >= a2->klass.data(gs)->typeMembers().size()) { // a1 has more tparams, this is fine, it's a child
                 newTargs.emplace_back(a1->targs[j]);
             } else {
-                if (idxTypeMember.data(gs)->isCovariant()) {
+                if (idxTypeMember.data(gs)->flags.isCovariant) {
                     newTargs.emplace_back(Types::all(gs, a1->targs[j], a2->targs[i]));
-                } else if (idxTypeMember.data(gs)->isInvariant()) {
+                } else if (idxTypeMember.data(gs)->flags.isInvariant) {
                     if (!Types::equiv(gs, a1->targs[j], a2->targs[i])) {
                         return AndType::make_shared(t1, t2);
                     }
@@ -944,7 +944,7 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                     } else {
                         newTargs.emplace_back(a1->targs[j]);
                     }
-                } else if (idxTypeMember.data(gs)->isContravariant()) {
+                } else if (idxTypeMember.data(gs)->flags.isContravariant) {
                     newTargs.emplace_back(Types::any(gs, a1->targs[j], a2->targs[i]));
                 }
             }
@@ -1166,9 +1166,9 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
 
                 ENFORCE(i < a1->klass.data(gs)->typeMembers().size());
 
-                if (idxTypeMember.data(gs)->isCovariant()) {
+                if (idxTypeMember.data(gs)->flags.isCovariant) {
                     result = Types::isSubTypeUnderConstraint(gs, constr, a1->targs[i], a2->targs[j], mode);
-                } else if (idxTypeMember.data(gs)->isInvariant()) {
+                } else if (idxTypeMember.data(gs)->flags.isInvariant) {
                     auto &a = a1->targs[i];
                     auto &b = a2->targs[j];
                     if (mode == UntypedMode::AlwaysCompatible) {
@@ -1176,7 +1176,7 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
                     } else {
                         result = Types::equivNoUntyped(gs, a, b);
                     }
-                } else if (idxTypeMember.data(gs)->isContravariant()) {
+                } else if (idxTypeMember.data(gs)->flags.isContravariant) {
                     result = Types::isSubTypeUnderConstraint(gs, constr, a2->targs[j], a1->targs[i], mode);
                 }
                 if (!result) {

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -601,7 +601,7 @@ TypePtr glbGround(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) {
         categoryCounterInc("glb.<class>.collapsed", "yes");
         return t2;
     } else {
-        if (sym1.data(gs)->isClassOrModuleClass() && sym2.data(gs)->isClassOrModuleClass()) {
+        if (sym1.data(gs)->isClass() && sym2.data(gs)->isClass()) {
             categoryCounterInc("glb.<class>.collapsed", "bottom");
             return Types::bottom();
         }
@@ -885,14 +885,14 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
     if (auto *a1 = cast_type<AppliedType>(t1)) {
         auto *a2 = cast_type<AppliedType>(t2);
         if (a2 == nullptr) {
-            if (a1->klass.data(gs)->isClassOrModuleModule() || !isa_type<ClassType>(t2)) {
+            if (a1->klass.data(gs)->isModule() || !isa_type<ClassType>(t2)) {
                 return AndType::make_shared(t1, t2);
             }
             auto c2 = cast_type_nonnull<ClassType>(t2);
             if (a1->klass.data(gs)->derivesFrom(gs, c2.symbol)) {
                 return t1;
             }
-            if (c2.symbol.data(gs)->isClassOrModuleModule()) {
+            if (c2.symbol.data(gs)->isModule()) {
                 return AndType::make_shared(t1, t2);
             }
             return Types::bottom();
@@ -900,7 +900,7 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
         bool rtl = a1->klass == a2->klass || a1->klass.data(gs)->derivesFrom(gs, a2->klass);
         bool ltr = !rtl && a2->klass.data(gs)->derivesFrom(gs, a1->klass);
         if (!rtl && !ltr) {
-            if (a1->klass.data(gs)->isClassOrModuleClass() && a2->klass.data(gs)->isClassOrModuleClass()) {
+            if (a1->klass.data(gs)->isClass() && a2->klass.data(gs)->isClass()) {
                 // At this point, the two types are both classes, and unrelated
                 // to each other. Because ruby does not support multiple
                 // inheritance, this type is empty.

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -186,14 +186,13 @@ TypePtr Types::dropSubtypesOf(const GlobalState &gs, const TypePtr &from, ClassO
                 result = from;
             } else if (c.symbol == klass || c.derivesFrom(gs, klass)) {
                 result = Types::bottom();
-            } else if (c.symbol.data(gs)->isClassOrModuleClass() && klass.data(gs)->isClassOrModuleClass() &&
+            } else if (c.symbol.data(gs)->isClass() && klass.data(gs)->isClass() &&
                        !klass.data(gs)->derivesFrom(gs, c.symbol)) {
                 // We have two classes (not modules), and if the class we're
                 // removing doesn't derive from `c`, there's nothing to do,
                 // because of ruby having single inheretance.
                 result = from;
-            } else if (cdata->isClassOrModuleSealed() &&
-                       (cdata->isClassOrModuleAbstract() || cdata->isClassOrModuleModule())) {
+            } else if (cdata->flags.isSealed && (cdata->flags.isAbstract || cdata->isModule())) {
                 auto subclasses = cdata->sealedSubclassesToUnion(gs);
                 ENFORCE(!Types::equiv(gs, subclasses, from), "sealedSubclassesToUnion about to cause infinte loop");
                 result = dropSubtypesOf(gs, subclasses, klass);
@@ -498,7 +497,7 @@ InlinedVector<TypeMemberRef, 4> Types::alignBaseTypeArgs(const GlobalState &gs, 
         return currentAlignment;
     }
 
-    if (what == asIf || (asIf.data(gs)->isClassOrModuleClass() && what.data(gs)->isClassOrModuleClass() &&
+    if (what == asIf || (asIf.data(gs)->isClass() && what.data(gs)->isClass() &&
                          asIf.data(gs)->typeMembers().size() == what.data(gs)->typeMembers().size())) {
         currentAlignment = what.data(gs)->typeMembers();
     } else {

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -271,13 +271,13 @@ void validateOverriding(const core::Context ctx, core::MethodRef method) {
 
     // both of these match the behavior of the runtime checks, which will only allow public methods to be defined in
     // interfaces
-    if (klassData->isClassOrModuleInterface() && method.data(ctx)->flags.isPrivate) {
+    if (klassData->flags.isInterface && method.data(ctx)->flags.isPrivate) {
         if (auto e = ctx.state.beginError(method.data(ctx)->loc(), core::errors::Resolver::NonPublicAbstract)) {
             e.setHeader("Interface method `{}` cannot be private", method.show(ctx));
         }
     }
 
-    if (klassData->isClassOrModuleInterface() && method.data(ctx)->flags.isProtected) {
+    if (klassData->flags.isInterface && method.data(ctx)->flags.isProtected) {
         if (auto e = ctx.state.beginError(method.data(ctx)->loc(), core::errors::Resolver::NonPublicAbstract)) {
             e.setHeader("Interface method `{}` cannot be protected", method.show(ctx));
         }
@@ -285,7 +285,7 @@ void validateOverriding(const core::Context ctx, core::MethodRef method) {
 
     if (method.data(ctx)->flags.isAbstract && klassData->isSingletonClass(ctx)) {
         auto attached = klassData->attachedClass(ctx);
-        if (attached.exists() && attached.data(ctx)->isClassOrModuleModule()) {
+        if (attached.exists() && attached.data(ctx)->isModule()) {
             if (auto e =
                     ctx.state.beginError(method.data(ctx)->loc(), core::errors::Resolver::StaticAbstractModuleMethod)) {
                 e.setHeader("Static methods in a module cannot be abstract");
@@ -374,7 +374,7 @@ core::LocOffsets getAncestorLoc(const core::GlobalState &gs, const ast::ClassDef
 void validateFinalAncestorHelper(core::Context ctx, const core::ClassOrModuleRef klass, const ast::ClassDef &classDef,
                                  const core::ClassOrModuleRef errMsgClass, const string_view verb) {
     for (const auto &mixin : klass.data(ctx)->mixins()) {
-        if (!mixin.data(ctx)->isClassOrModuleFinal()) {
+        if (!mixin.data(ctx)->flags.isFinal) {
             continue;
         }
         if (auto e = ctx.beginError(getAncestorLoc(ctx, classDef, mixin), core::errors::Resolver::FinalAncestor)) {
@@ -387,7 +387,7 @@ void validateFinalAncestorHelper(core::Context ctx, const core::ClassOrModuleRef
 
 void validateFinalMethodHelper(const core::GlobalState &gs, const core::ClassOrModuleRef klass,
                                const core::ClassOrModuleRef errMsgClass) {
-    if (!klass.data(gs)->isClassOrModuleFinal()) {
+    if (!klass.data(gs)->flags.isFinal) {
         return;
     }
     for (const auto [name, sym] : klass.data(gs)->members()) {
@@ -411,7 +411,7 @@ void validateFinalMethodHelper(const core::GlobalState &gs, const core::ClassOrM
 
 void validateFinal(core::Context ctx, const core::ClassOrModuleRef klass, const ast::ClassDef &classDef) {
     const auto superClass = klass.data(ctx)->superClass();
-    if (superClass.exists() && superClass.data(ctx)->isClassOrModuleFinal()) {
+    if (superClass.exists() && superClass.data(ctx)->flags.isFinal) {
         if (auto e = ctx.beginError(getAncestorLoc(ctx, classDef, superClass), core::errors::Resolver::FinalAncestor)) {
             e.setHeader("`{}` was declared as final and cannot be inherited by `{}`", superClass.show(ctx),
                         klass.show(ctx));
@@ -459,7 +459,7 @@ core::FileRef bestNonRBIFile(core::Context ctx, const core::ClassOrModuleRef kla
 void validateSealedAncestorHelper(core::Context ctx, const core::ClassOrModuleRef klass, const ast::ClassDef &classDef,
                                   const core::ClassOrModuleRef errMsgClass, const string_view verb) {
     for (const auto &mixin : klass.data(ctx)->mixins()) {
-        if (!mixin.data(ctx)->isClassOrModuleSealed()) {
+        if (!mixin.data(ctx)->flags.isSealed) {
             continue;
         }
 
@@ -479,7 +479,7 @@ void validateSealedAncestorHelper(core::Context ctx, const core::ClassOrModuleRe
 
 void validateSealed(core::Context ctx, const core::ClassOrModuleRef klass, const ast::ClassDef &classDef) {
     const auto superClass = klass.data(ctx)->superClass();
-    if (superClass.exists() && superClass.data(ctx)->isClassOrModuleSealed()) {
+    if (superClass.exists() && superClass.data(ctx)->flags.isSealed) {
         auto file = bestNonRBIFile(ctx, klass);
         if (!absl::c_any_of(superClass.data(ctx)->sealedLocs(ctx), [file](auto loc) { return loc.file() == file; })) {
             if (auto e =
@@ -498,7 +498,7 @@ void validateSealed(core::Context ctx, const core::ClassOrModuleRef klass, const
 }
 
 void validateSuperClass(core::Context ctx, const core::ClassOrModuleRef sym, const ast::ClassDef &classDef) {
-    if (!sym.data(ctx)->isClassOrModuleClass()) {
+    if (!sym.data(ctx)->isClass()) {
         // In this case, a class with the same name as a module has been defined, and we'll already have raised an error
         // in the namer.
         return;
@@ -553,7 +553,7 @@ void validateUselessRequiredAncestors(core::Context ctx, const core::ClassOrModu
         if (data->derivesFrom(ctx, req.symbol)) {
             if (auto e = ctx.state.beginError(req.loc, core::errors::Resolver::UselessRequiredAncestor)) {
                 e.setHeader("`{}` is already {} by `{}`", req.symbol.show(ctx),
-                            req.symbol.data(ctx)->isClassOrModuleModule() ? "included" : "inherited", sym.show(ctx));
+                            req.symbol.data(ctx)->isModule() ? "included" : "inherited", sym.show(ctx));
             }
         }
     }
@@ -561,14 +561,14 @@ void validateUselessRequiredAncestors(core::Context ctx, const core::ClassOrModu
 
 void validateUnsatisfiedRequiredAncestors(core::Context ctx, const core::ClassOrModuleRef sym) {
     auto data = sym.data(ctx);
-    if (data->isClassOrModuleModule() || data->isClassOrModuleAbstract()) {
+    if (data->isModule() || data->flags.isAbstract) {
         return;
     }
     for (auto req : data->requiredAncestorsTransitive(ctx)) {
         if (sym != req.symbol && !data->derivesFrom(ctx, req.symbol)) {
             if (auto e = ctx.state.beginError(data->loc(), core::errors::Resolver::UnsatisfiedRequiredAncestor)) {
                 e.setHeader("`{}` must {} `{}` (required by `{}`)", sym.show(ctx),
-                            req.symbol.data(ctx)->isClassOrModuleModule() ? "include" : "inherit", req.symbol.show(ctx),
+                            req.symbol.data(ctx)->isModule() ? "include" : "inherit", req.symbol.show(ctx),
                             req.origin.show(ctx));
                 e.addErrorLine(req.loc, "required by `{}` here", req.origin.show(ctx));
             }
@@ -581,7 +581,7 @@ void validateUnsatisfiableRequiredAncestors(core::Context ctx, const core::Class
 
     vector<core::Symbol::RequiredAncestor> requiredClasses;
     for (auto ancst : data->requiredAncestorsTransitive(ctx)) {
-        if (ancst.symbol.data(ctx)->isClassOrModuleClass()) {
+        if (ancst.symbol.data(ctx)->isClass()) {
             requiredClasses.emplace_back(ancst);
         }
 
@@ -595,7 +595,7 @@ void validateUnsatisfiableRequiredAncestors(core::Context ctx, const core::Class
         }
     }
 
-    if (data->isClassOrModuleClass() && data->isClassOrModuleAbstract()) {
+    if (data->isClass() && data->flags.isAbstract) {
         for (auto ancst : requiredClasses) {
             if (!sym.data(ctx)->derivesFrom(ctx, ancst.symbol) && !ancst.symbol.data(ctx)->derivesFrom(ctx, sym)) {
                 if (auto e = ctx.state.beginError(data->loc(), core::errors::Resolver::UnsatisfiableRequiredAncestor)) {
@@ -621,7 +621,7 @@ void validateUnsatisfiableRequiredAncestors(core::Context ctx, const core::Class
                 if (auto e = ctx.state.beginError(data->loc(), core::errors::Resolver::UnsatisfiableRequiredAncestor)) {
                     e.setHeader("`{}` requires unrelated classes `{}` and `{}` making it impossible to {}",
                                 sym.show(ctx), ra1.symbol.show(ctx), ra2.symbol.show(ctx),
-                                data->isClassOrModuleModule() ? "include" : "inherit");
+                                data->isModule() ? "include" : "inherit");
                     e.addErrorLine(ra1.loc, "`{}` is required by `{}` here", ra1.symbol.show(ctx),
                                    ra1.origin.show(ctx));
                     e.addErrorLine(ra2.loc, "`{}` is required by `{}` here", ra2.symbol.show(ctx),
@@ -663,7 +663,7 @@ private:
             abstract.insert(abstract.end(), fromMixin.begin(), fromMixin.end());
         }
 
-        auto isAbstract = klass.data(gs)->isClassOrModuleAbstract();
+        auto isAbstract = klass.data(gs)->flags.isAbstract;
         if (isAbstract) {
             for (auto [name, sym] : klass.data(gs)->members()) {
                 if (sym.exists() && sym.isMethod() && sym.asMethodRef().data(gs)->flags.isAbstract) {
@@ -696,7 +696,7 @@ private:
     }
 
     void validateAbstract(const core::GlobalState &gs, core::ClassOrModuleRef sym) {
-        if (sym.data(gs)->isClassOrModuleAbstract()) {
+        if (sym.data(gs)->flags.isAbstract) {
             return;
         }
         auto loc = sym.data(gs)->loc();

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -579,7 +579,7 @@ void validateUnsatisfiedRequiredAncestors(core::Context ctx, const core::ClassOr
 void validateUnsatisfiableRequiredAncestors(core::Context ctx, const core::ClassOrModuleRef sym) {
     auto data = sym.data(ctx);
 
-    vector<core::Symbol::RequiredAncestor> requiredClasses;
+    vector<core::ClassOrModule::RequiredAncestor> requiredClasses;
     for (auto ancst : data->requiredAncestorsTransitive(ctx)) {
         if (ancst.symbol.data(ctx)->isClass()) {
             requiredClasses.emplace_back(ancst);

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -283,7 +283,7 @@ void validateOverriding(const core::Context ctx, core::MethodRef method) {
         }
     }
 
-    if (method.data(ctx)->flags.isAbstract && klassData->isClassOrModule() && klassData->isSingletonClass(ctx)) {
+    if (method.data(ctx)->flags.isAbstract && klassData->isSingletonClass(ctx)) {
         auto attached = klassData->attachedClass(ctx);
         if (attached.exists() && attached.data(ctx)->isClassOrModuleModule()) {
             if (auto e =

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -307,7 +307,7 @@ UnorderedMap<core::NameRef, core::TypePtr> guessArgumentTypes(core::Context ctx,
 core::MethodRef closestOverridenMethod(core::Context ctx, core::ClassOrModuleRef enclosingClassSymbol,
                                        core::NameRef name) {
     auto enclosingClass = enclosingClassSymbol.data(ctx);
-    ENFORCE(enclosingClass->isClassOrModuleLinearizationComputed(), "Should have been linearized by resolver");
+    ENFORCE(enclosingClass->flags.isLinearizationComputed, "Should have been linearized by resolver");
 
     for (const auto &mixin : enclosingClass->mixins()) {
         auto mixinMethod = mixin.data(ctx)->findMethod(ctx, name);
@@ -421,7 +421,7 @@ optional<core::AutocorrectSuggestion> SigSuggestion::maybeSuggestSig(core::Conte
     }
 
     fmt::format_to(std::back_inserter(ss), "sig");
-    if (enclosingClass.data(ctx)->isClassOrModuleFinal()) {
+    if (enclosingClass.data(ctx)->flags.isFinal) {
         fmt::format_to(std::back_inserter(ss), "(:final)");
     }
     fmt::format_to(std::back_inserter(ss), " {{");

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1060,7 +1060,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                     if (resultType != nullptr) {
                         if (symbol.isTypeMember()) {
                             auto tm = symbol.asTypeMemberRef();
-                            if (tm.data(ctx)->isFixed()) {
+                            if (tm.data(ctx)->flags.isFixed) {
                                 // pick the upper bound here, as
                                 // isFixed() => lowerBound == upperBound.
                                 auto lambdaParam = core::cast_type<core::LambdaParam>(resultType);

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -493,7 +493,7 @@ bool isSingleton(core::Context ctx, core::ClassOrModuleRef sym) {
     }
 
     // The Ruby stdlib has a Singleton module which lets people invent their own singletons.
-    return (sym.data(ctx)->derivesFrom(ctx, core::Symbols::Singleton()) && sym.data(ctx)->isClassOrModuleFinal());
+    return (sym.data(ctx)->derivesFrom(ctx, core::Symbols::Singleton()) && sym.data(ctx)->flags.isFinal);
 }
 
 } // namespace

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -264,10 +264,10 @@ core::TypePtr getResultType(const core::GlobalState &gs, const core::TypePtr &ty
 SymbolKind symbolRef2SymbolKind(const core::GlobalState &gs, core::SymbolRef symbol) {
     if (symbol.isClassOrModule()) {
         auto klass = symbol.asClassOrModuleRef();
-        if (klass.data(gs)->isClassOrModuleModule()) {
+        if (klass.data(gs)->isModule()) {
             return SymbolKind::Module;
         }
-        if (klass.data(gs)->isClassOrModuleClass()) {
+        if (klass.data(gs)->isClass()) {
             return SymbolKind::Class;
         }
     } else if (symbol.isMethod()) {

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -86,7 +86,7 @@ const RubyKeyword rubyKeywords[] = {
 vector<core::ClassOrModuleRef> ancestorsImpl(const core::GlobalState &gs, core::ClassOrModuleRef sym,
                                              vector<core::ClassOrModuleRef> &&acc) {
     // The implementation here is similar to Symbols::derivesFrom.
-    ENFORCE(sym.data(gs)->isClassOrModuleLinearizationComputed());
+    ENFORCE(sym.data(gs)->flags.isLinearizationComputed);
     acc.emplace_back(sym);
 
     for (auto mixin : sym.data(gs)->mixins()) {
@@ -390,14 +390,14 @@ unique_ptr<CompletionItem> getCompletionItemForConstant(const core::GlobalState 
 
     if (what.isClassOrModule()) {
         auto whatKlass = what.asClassOrModuleRef();
-        if (whatKlass.data(gs)->isClassOrModuleClass()) {
+        if (whatKlass.data(gs)->isClass()) {
             if (whatKlass.data(gs)->derivesFrom(gs, core::Symbols::T_Enum())) {
                 item->kind = CompletionItemKind::Enum;
             } else {
                 item->kind = CompletionItemKind::Class;
             }
         } else {
-            if (whatKlass.data(gs)->isClassOrModuleAbstract() || whatKlass.data(gs)->isClassOrModuleInterface()) {
+            if (whatKlass.data(gs)->flags.isAbstract || whatKlass.data(gs)->flags.isInterface) {
                 item->kind = CompletionItemKind::Interface;
             } else {
                 item->kind = CompletionItemKind::Module;

--- a/main/lsp/requests/implementation.cc
+++ b/main/lsp/requests/implementation.cc
@@ -106,7 +106,7 @@ unique_ptr<ResponseMessage> ImplementationTask::runRequest(LSPTypecheckerDelegat
         // User called "Go to Implementation" from the abstract class reference
         auto classSymbol = constant->symbol.asClassOrModuleRef();
 
-        if (!classSymbol.data(gs)->isClassOrModule() || !classSymbol.data(gs)->isClassOrModuleAbstract()) {
+        if (!classSymbol.data(gs)->isClassOrModuleAbstract()) {
             response->error = makeInvalidRequestError(classSymbol, gs);
             return response;
         }

--- a/main/lsp/requests/implementation.cc
+++ b/main/lsp/requests/implementation.cc
@@ -106,7 +106,7 @@ unique_ptr<ResponseMessage> ImplementationTask::runRequest(LSPTypecheckerDelegat
         // User called "Go to Implementation" from the abstract class reference
         auto classSymbol = constant->symbol.asClassOrModuleRef();
 
-        if (!classSymbol.data(gs)->isClassOrModuleAbstract()) {
+        if (!classSymbol.data(gs)->flags.isAbstract) {
             response->error = makeInvalidRequestError(classSymbol, gs);
             return response;
         }

--- a/main/minimize/minimize.cc
+++ b/main/minimize/minimize.cc
@@ -94,7 +94,7 @@ void writeClassDef(const core::GlobalState &rbiGS, options::PrinterConfig &outfi
     while (rbiEntry.data(rbiGS)->isSingletonClass(rbiGS)) {
         rbiEntry = rbiEntry.data(rbiGS)->attachedClass(rbiGS);
     }
-    auto defType = rbiEntry.data(rbiGS)->isClassOrModuleClass() ? "class" : "module";
+    auto defType = rbiEntry.data(rbiGS)->isClass() ? "class" : "module";
     auto fullName = rbiEntry.show(rbiGS);
     auto cbase = outputCategoryFromClassName(fullName) == OutputCategory::External ? "::" : "";
     // TODO: The old Ruby-powered version did not emit superclasses. Eventually, we might want to
@@ -191,7 +191,7 @@ void serializeMethods(const core::GlobalState &sourceGS, const core::GlobalState
                 continue;
             }
 
-            if (sourceClass.data(sourceGS)->isClassOrModuleAbstract() && rbiEntryName == core::Names::initialize()) {
+            if (sourceClass.data(sourceGS)->flags.isAbstract && rbiEntryName == core::Names::initialize()) {
                 // `abstract!` will define `initialize` in the class to raise unconditionally
                 // https://github.com/sorbet/sorbet/blob/026c60bf719d/gems/sorbet-runtime/lib/types/private/abstract/declare.rb#L37-L42
                 // Which is not useful to include in the minimized output.

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1237,8 +1237,7 @@ class SymbolDefiner {
 
     core::FieldRef insertStaticField(core::MutableContext ctx, const FoundStaticField &staticField) {
         // forbid dynamic constant definition
-        auto ownerData = ctx.owner.asClassOrModuleRef().data(ctx);
-        if (!ownerData->isClassOrModule() && !ownerData->isRewriterSynthesized()) {
+        if (!ctx.owner.isClassOrModule() && !ctx.owner.asClassOrModuleRef().data(ctx)->isRewriterSynthesized()) {
             if (auto e = ctx.state.beginError(core::Loc(ctx.file, staticField.asgnLoc),
                                               core::errors::Namer::DynamicConstantAssignment)) {
                 e.setHeader("Dynamic constant assignment");

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -779,8 +779,7 @@ class SymbolDefiner {
         // Common case: Everything is fine, user is trying to define a symbol on a class or module.
         if (scope.isClassOrModule()) {
             // Check if original symbol was mangled away. If so, complain.
-            auto renamedSymbol =
-                ctx.state.findRenamedSymbol(scope.asClassOrModuleRef().data(ctx)->owner.asClassOrModuleRef(), scope);
+            auto renamedSymbol = ctx.state.findRenamedSymbol(scope.asClassOrModuleRef().data(ctx)->owner, scope);
             if (renamedSymbol.exists()) {
                 if (auto e = ctx.state.beginError(core::Loc(ctx.file, loc), core::errors::Namer::InvalidClassOwner)) {
                     auto constLitName = name.show(ctx);
@@ -1155,7 +1154,7 @@ class SymbolDefiner {
             }
         } else {
             klassSymbol.data(ctx)->setIsModule(isModule);
-            auto renamed = ctx.state.findRenamedSymbol(klassSymbol.data(ctx)->owner.asClassOrModuleRef(), symbol);
+            auto renamed = ctx.state.findRenamedSymbol(klassSymbol.data(ctx)->owner, symbol);
             if (renamed.exists()) {
                 emitRedefinedConstantError(ctx, core::Loc(ctx.file, klass.loc), symbol, renamed);
             }
@@ -1569,8 +1568,8 @@ public:
             if (symbol == core::Symbols::todo()) {
                 auto squashedSymbol = squashNames(ctx, ctx.owner.enclosingClass(ctx), klass.name);
                 if (!squashedSymbol.isClassOrModule()) {
-                    klass.symbol = ctx.state.lookupClassSymbol(klass.symbol.data(ctx)->owner.asClassOrModuleRef(),
-                                                               klass.symbol.data(ctx)->name);
+                    klass.symbol =
+                        ctx.state.lookupClassSymbol(klass.symbol.data(ctx)->owner, klass.symbol.data(ctx)->name);
                     ENFORCE(klass.symbol.exists());
                 } else {
                     klass.symbol = squashedSymbol.asClassOrModuleRef();

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1104,7 +1104,7 @@ class SymbolDefiner {
         auto constant = ctx.state.lookupSymbol(owner, constantNameRef);
         if (constant.exists() && mod.name == core::Names::privateConstant()) {
             if (constant.isClassOrModule()) {
-                constant.asClassOrModuleRef().data(ctx)->setClassOrModulePrivate();
+                constant.asClassOrModuleRef().data(ctx)->flags.isPrivate = true;
             } else if (constant.isStaticField(ctx)) {
                 constant.asFieldRef().data(ctx)->flags.isStaticFieldPrivate = true;
             } else if (constant.isTypeMember()) {
@@ -1142,10 +1142,10 @@ class SymbolDefiner {
         }
 
         auto klassSymbol = symbol.asClassOrModuleRef();
-        if (klassSymbol.data(ctx)->isClassModuleSet() && isModule != klassSymbol.data(ctx)->isClassOrModuleModule()) {
+        if (klassSymbol.data(ctx)->isClassModuleSet() && isModule != klassSymbol.data(ctx)->isModule()) {
             if (auto e = ctx.state.beginError(declLoc, core::errors::Namer::ModuleKindRedefinition)) {
                 e.setHeader("`{}` was previously defined as a `{}`", symbol.show(ctx),
-                            klassSymbol.data(ctx)->isClassOrModuleModule() ? "module" : "class");
+                            klassSymbol.data(ctx)->isModule() ? "module" : "class");
 
                 for (auto loc : klassSymbol.data(ctx)->locs()) {
                     if (loc != declLoc) {
@@ -1201,11 +1201,11 @@ class SymbolDefiner {
         const auto fun = mod.name;
         auto symbolData = ctx.owner.asClassOrModuleRef().data(ctx);
         if (fun == core::Names::declareFinal()) {
-            symbolData->setClassOrModuleFinal();
-            symbolData->singletonClass(ctx).data(ctx)->setClassOrModuleFinal();
+            symbolData->flags.isFinal = true;
+            symbolData->singletonClass(ctx).data(ctx)->flags.isFinal = true;
         }
         if (fun == core::Names::declareSealed()) {
-            symbolData->setClassOrModuleSealed();
+            symbolData->flags.isSealed = true;
 
             auto classOfKlass = symbolData->singletonClass(ctx);
             auto sealedSubclasses = ctx.state.enterMethodSymbol(core::Loc(ctx.file, mod.loc), classOfKlass,
@@ -1221,12 +1221,12 @@ class SymbolDefiner {
                 core::make_type<core::AppliedType>(core::Symbols::Set(), move(targs));
         }
         if (fun == core::Names::declareInterface() || fun == core::Names::declareAbstract()) {
-            symbolData->setClassOrModuleAbstract();
-            symbolData->singletonClass(ctx).data(ctx)->setClassOrModuleAbstract();
+            symbolData->flags.isAbstract = true;
+            symbolData->singletonClass(ctx).data(ctx)->flags.isAbstract = true;
         }
         if (fun == core::Names::declareInterface()) {
-            symbolData->setClassOrModuleInterface();
-            if (!symbolData->isClassOrModuleModule()) {
+            symbolData->flags.isInterface = true;
+            if (!symbolData->isModule()) {
                 if (auto e = ctx.state.beginError(core::Loc(ctx.file, mod.loc), core::errors::Namer::InterfaceClass)) {
                     e.setHeader("Classes can't be interfaces. Use `abstract!` instead of `interface!`");
                     e.replaceWith("Change `interface!` to `abstract!`", core::Loc(ctx.file, mod.loc), "abstract!");
@@ -1237,7 +1237,7 @@ class SymbolDefiner {
 
     core::FieldRef insertStaticField(core::MutableContext ctx, const FoundStaticField &staticField) {
         // forbid dynamic constant definition
-        if (!ctx.owner.isClassOrModule() && !ctx.owner.asClassOrModuleRef().data(ctx)->isRewriterSynthesized()) {
+        if (!ctx.owner.isClassOrModule()) {
             if (auto e = ctx.state.beginError(core::Loc(ctx.file, staticField.asgnLoc),
                                               core::errors::Namer::DynamicConstantAssignment)) {
                 e.setHeader("Dynamic constant assignment");

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1365,7 +1365,7 @@ class SymbolDefiner {
         }
 
         if (typeMember.isFixed) {
-            sym.data(ctx)->setFixed();
+            sym.data(ctx)->flags.isFixed = true;
         }
 
         return sym;

--- a/namer/test/namer_test.cc
+++ b/namer/test/namer_test.cc
@@ -66,7 +66,7 @@ TEST_CASE("namer tests") {
         }
 
         const auto &objectScope = core::Symbols::Object().data(gs);
-        REQUIRE_EQ(core::Symbols::root(), objectScope->owner.asClassOrModuleRef());
+        REQUIRE_EQ(core::Symbols::root(), objectScope->owner);
 
         REQUIRE_EQ(4, objectScope->members().size());
         auto methodSym = objectScope->members().at(gs.enterNameUTF8("hello_world")).asMethodRef();

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -56,7 +56,7 @@ bool resolveTypeMember(core::GlobalState &gs, core::ClassOrModuleRef parent, cor
             e.addErrorLine(parentTypeMember.data(gs)->loc(), "`{}` declared in parent here", name.show(gs));
         }
         auto typeMember = gs.enterTypeMember(sym.data(gs)->loc(), sym, name, core::Variance::Invariant);
-        typeMember.data(gs)->setFixed();
+        typeMember.data(gs)->flags.isFixed = true;
         auto untyped = core::Types::untyped(gs, sym);
         typeMember.data(gs)->resultType = core::make_type<core::LambdaParam>(typeMember, untyped, untyped);
         return false;
@@ -67,7 +67,7 @@ bool resolveTypeMember(core::GlobalState &gs, core::ClassOrModuleRef parent, cor
         }
         auto synthesizedName = gs.freshNameUnique(core::UniqueNameKind::TypeVarName, name, 1);
         auto typeMember = gs.enterTypeMember(sym.data(gs)->loc(), sym, synthesizedName, core::Variance::Invariant);
-        typeMember.data(gs)->setFixed();
+        typeMember.data(gs)->flags.isFixed = true;
         auto untyped = core::Types::untyped(gs, sym);
         typeMember.data(gs)->resultType = core::make_type<core::LambdaParam>(typeMember, untyped, untyped);
         return false;

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -143,7 +143,7 @@ void resolveTypeMembers(core::GlobalState &gs, core::ClassOrModuleRef sym,
         }
     }
 
-    if (sym.data(gs)->isClassOrModuleClass()) {
+    if (sym.data(gs)->isClass()) {
         for (core::SymbolRef tp : sym.data(gs)->typeMembers()) {
             auto tm = tp.asTypeMemberRef();
             // AttachedClass is covariant, but not controlled by the user.
@@ -206,7 +206,7 @@ void Resolver::finalizeAncestors(core::GlobalState &gs) {
         }
         auto loc = ref.data(gs)->loc();
         if (loc.file().exists() && loc.file().data(gs).sourceType == core::File::Type::Normal) {
-            if (ref.data(gs)->isClassOrModuleClass()) {
+            if (ref.data(gs)->isClass()) {
                 classCount++;
             } else {
                 moduleCount++;
@@ -237,7 +237,7 @@ void Resolver::finalizeAncestors(core::GlobalState &gs) {
                 ref.data(gs)->setSuperClass(singleton);
             }
         } else {
-            if (ref.data(gs)->isClassOrModuleClass()) {
+            if (ref.data(gs)->isClass()) {
                 if (!core::Symbols::Object().data(gs)->derivesFrom(gs, ref) && core::Symbols::Object() != ref) {
                     ref.data(gs)->setSuperClass(core::Symbols::Object());
                 }
@@ -291,7 +291,7 @@ int maybeAddMixin(core::GlobalState &gs, core::ClassOrModuleRef forSym,
 ParentLinearizationInformation computeClassLinearization(core::GlobalState &gs, core::ClassOrModuleRef ofClass) {
     ENFORCE_NO_TIMER(ofClass.exists());
     auto data = ofClass.data(gs);
-    if (!data->isClassOrModuleLinearizationComputed()) {
+    if (!data->flags.isLinearizationComputed) {
         if (data->superClass().exists()) {
             computeClassLinearization(gs, data->superClass());
         }
@@ -309,7 +309,7 @@ ParentLinearizationInformation computeClassLinearization(core::GlobalState &gs, 
             }
             ParentLinearizationInformation mixinLinearization = computeClassLinearization(gs, mixin);
 
-            if (!mixin.data(gs)->isClassOrModuleModule()) {
+            if (!mixin.data(gs)->isModule()) {
                 // insert all transitive parents of class to bring methods back.
                 auto allMixins = mixinLinearization.fullLinearizationSlow(gs);
                 newMixins.insert(newMixins.begin(), allMixins.begin(), allMixins.end());
@@ -322,7 +322,7 @@ ParentLinearizationInformation computeClassLinearization(core::GlobalState &gs, 
             }
         }
         data->mixins() = std::move(newMixins);
-        data->setClassOrModuleLinearizationComputed();
+        data->flags.isLinearizationComputed = true;
         if (debug_mode) {
             for (auto oldMixin : currentMixins) {
                 ENFORCE(ofClass.data(gs)->derivesFrom(gs, oldMixin), "{} no longer derives from {}",
@@ -330,7 +330,7 @@ ParentLinearizationInformation computeClassLinearization(core::GlobalState &gs, 
             }
         }
     }
-    ENFORCE_NO_TIMER(data->isClassOrModuleLinearizationComputed());
+    ENFORCE_NO_TIMER(data->flags.isLinearizationComputed);
     return ParentLinearizationInformation{data->mixins(), data->superClass(), ofClass};
 }
 
@@ -341,7 +341,7 @@ void fullLinearizationSlowImpl(core::GlobalState &gs, const ParentLinearizationI
 
     for (auto m : info.mixins) {
         if (!absl::c_linear_search(acc, m)) {
-            if (m.data(gs)->isClassOrModuleModule()) {
+            if (m.data(gs)->isModule()) {
                 acc.emplace_back(m);
             } else {
                 fullLinearizationSlowImpl(gs, computeClassLinearization(gs, m), acc);

--- a/resolver/SuggestPackage.cc
+++ b/resolver/SuggestPackage.cc
@@ -203,7 +203,7 @@ private:
     }
 
     void addReplacementSuggestions(core::ErrorBuilder &e, ast::UnresolvedConstantLit &unresolved,
-                                   const vector<sorbet::core::Symbol::FuzzySearchResult> &matches) {
+                                   const vector<sorbet::core::ClassOrModule::FuzzySearchResult> &matches) {
         vector<core::ErrorLine> lines;
         for (auto suggestion : matches) {
             const auto replacement = suggestion.symbol.show(ctx);

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -509,7 +509,7 @@ private:
                 enclosingTypeMember = typeMembers[0];
                 break;
             }
-            enclosingClass = enclosingClass.data(ctx)->owner.enclosingClass(ctx);
+            enclosingClass = enclosingClass.data(ctx)->owner;
         }
         auto &rhs = *job.rhs;
         if (enclosingTypeMember.exists()) {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -285,7 +285,7 @@ private:
             // Private constants are allowed to be resolved, when there is no scope set (the scope is checked above),
             // otherwise we should error out. Private constant references _are not_ enforced inside RBI files.
             if (result.exists() &&
-                ((result.isClassOrModule() && result.asClassOrModuleRef().data(ctx)->isClassOrModulePrivate()) ||
+                ((result.isClassOrModule() && result.asClassOrModuleRef().data(ctx)->flags.isPrivate) ||
                  (result.isStaticField(ctx) && result.asFieldRef().data(ctx)->flags.isStaticFieldPrivate)) &&
                 !ctx.file.data(ctx).isRBI()) {
                 if (auto e = ctx.beginError(c.loc, core::errors::Resolver::PrivateConstantReferenced)) {
@@ -691,7 +691,7 @@ private:
     static void resolveClassMethodsJob(core::GlobalState &gs, const ClassMethodsResolutionItem &todo) {
         auto owner = todo.owner;
         auto send = todo.send;
-        if (!owner.isClassOrModule() || !owner.asClassOrModuleRef().data(gs)->isClassOrModuleModule()) {
+        if (!owner.isClassOrModule() || !owner.asClassOrModuleRef().data(gs)->isModule()) {
             if (auto e =
                     gs.beginError(core::Loc(todo.file, send->loc), core::errors::Resolver::InvalidMixinDeclaration)) {
                 e.setHeader("`{}` can only be declared inside a module, not a class", send->fun.show(gs));
@@ -733,7 +733,7 @@ private:
                 }
                 continue;
             }
-            if (id->symbol.asClassOrModuleRef().data(gs)->isClassOrModuleClass()) {
+            if (id->symbol.asClassOrModuleRef().data(gs)->isClass()) {
                 if (auto e =
                         gs.beginError(core::Loc(todo.file, id->loc), core::errors::Resolver::InvalidMixinDeclaration)) {
                     e.setHeader("`{}` is a class, not a module; Only modules may be mixins", id->symbol.show(gs));
@@ -780,7 +780,7 @@ private:
         auto send = todo.send;
         auto loc = core::Loc(todo.file, send->loc);
 
-        if (!owner.data(gs)->isClassOrModuleModule() && !owner.data(gs)->isClassOrModuleAbstract()) {
+        if (!owner.data(gs)->isModule() && !owner.data(gs)->flags.isAbstract) {
             if (auto e = gs.beginError(loc, core::errors::Resolver::InvalidRequiredAncestor)) {
                 e.setHeader("`{}` can only be declared inside a module or an abstract class", send->fun.show(gs));
             }
@@ -848,7 +848,7 @@ private:
         ENFORCE(job.ancestor->symbol.exists(), "Ancestor must exist, or we can't check whether it's sealed.");
         auto ancestorSym = job.ancestor->symbol.dealias(ctx).asClassOrModuleRef();
 
-        if (!ancestorSym.data(ctx)->isClassOrModuleSealed()) {
+        if (!ancestorSym.data(ctx)->flags.isSealed) {
             return;
         }
         Timer timeit(ctx.state.tracer(), "resolver.registerSealedSubclass");
@@ -2698,7 +2698,7 @@ private:
 
                 mdef.rhs = ast::MK::EmptyTree();
             }
-            if (!mdef.symbol.enclosingClass(ctx).data(ctx)->isClassOrModuleAbstract()) {
+            if (!mdef.symbol.enclosingClass(ctx).data(ctx)->flags.isAbstract) {
                 if (auto e = ctx.beginError(mdef.loc, core::errors::Resolver::AbstractMethodOutsideAbstract)) {
                     e.setHeader("Before declaring an abstract method, you must mark your class/module "
                                 "as abstract using `abstract!` or `interface!`");
@@ -2737,7 +2737,7 @@ private:
 
             auto self = ast::MK::Self(mdef.loc);
             mdef.rhs = ast::MK::Send(mdef.loc, std::move(self), core::Names::super(), numPosArgs, std::move(args));
-        } else if (mdef.symbol.enclosingClass(ctx).data(ctx)->isClassOrModuleInterface()) {
+        } else if (mdef.symbol.enclosingClass(ctx).data(ctx)->flags.isInterface) {
             if (auto e = ctx.beginError(mdef.loc, core::errors::Resolver::ConcreteMethodInInterface)) {
                 e.setHeader("All methods in an interface must be declared abstract");
             }
@@ -3320,7 +3320,7 @@ ast::ParsedFilesOrCancelled Resolver::runIncremental(core::GlobalState &gs, vect
     DEBUG_ONLY(for (auto i = 1; i < gs.classAndModulesUsed(); i++) {
         core::ClassOrModuleRef sym(gs, i);
         // If class is not marked as 'linearization computed', then we added a mixin to it since the last slow path.
-        ENFORCE_NO_TIMER(sym.data(gs)->isClassOrModuleLinearizationComputed(), "{}", sym.toString(gs));
+        ENFORCE_NO_TIMER(sym.data(gs)->flags.isLinearizationComputed, "{}", sym.toString(gs));
     })
     trees = ResolveTypeMembersAndFieldsWalk::run(gs, std::move(trees), *workers);
     auto result = resolveSigs(gs, std::move(trees), *workers);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Define `TypeParameter` and `ClassOrModule` classes; delete `Symbol` class.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Remove the monolithic `Symbol` class and instead have smaller symbol-type-specific classes with fewer ENFORCEs/weird corner cases/etc.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
