### PR TITLE
Find ambiguous definitions in resolver

### DIFF
--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -478,6 +478,7 @@ public:
     // Prints the fully qualified name of the symbol in a format that is suitable for showing to the user (e.g.
     // "Owner::SymbolName")
     std::string showFullName(const GlobalState &gs) const;
+    std::string showFullNameWithoutPackagePrefix(const GlobalState &gs) const;
     std::string toStringFullName(const GlobalState &gs) const;
 
     std::string showRaw(const GlobalState &gs) const {

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1,5 +1,6 @@
 #include "core/Symbols.h"
 #include "absl/strings/match.h"
+#include "absl/strings/str_join.h"
 #include "absl/strings/str_replace.h"
 #include "common/JSON.h"
 #include "common/Levenstein.h"
@@ -1007,6 +1008,19 @@ string SymbolRef::showFullName(const GlobalState &gs) const {
         case Kind::TypeMember:
             return asTypeMemberRef().showFullName(gs);
     }
+}
+
+string SymbolRef::showFullNameWithoutPackagePrefix(const GlobalState &gs) const {
+    vector<std::string> parts;
+    auto curSym = *this;
+    while (curSym.exists() && curSym.owner(gs) != core::Symbols::PackageRegistry() &&
+           curSym.owner(gs) != core::Symbols::PackageTests() && curSym != core::Symbols::root()) {
+        parts.emplace_back(curSym.name(gs).show(gs));
+        curSym = curSym.owner(gs);
+    }
+
+    reverse(parts.begin(), parts.end());
+    return absl::StrJoin(parts, "::");
 }
 
 string ClassOrModuleRef::showFullName(const GlobalState &gs) const {

--- a/core/errors/resolver.h
+++ b/core/errors/resolver.h
@@ -73,6 +73,7 @@ constexpr ErrorClass UnsatisfiedRequiredAncestor{5064, StrictLevel::True};
 constexpr ErrorClass UnsatisfiableRequiredAncestor{5065, StrictLevel::True};
 constexpr ErrorClass ExperimentalRequiredAncestor{5066, StrictLevel::False};
 constexpr ErrorClass NonClassSuperclass{5067, StrictLevel::False};
+constexpr ErrorClass AmbiguousDefinitionError{5068, StrictLevel::False};
 } // namespace sorbet::core::errors::Resolver
 
 #endif

--- a/main/lsp/wrapper.cc
+++ b/main/lsp/wrapper.cc
@@ -2,6 +2,7 @@
 #include "core/ErrorQueue.h"
 #include "core/NullFlusher.h"
 #include "core/errors/namer.h"
+#include "core/errors/resolver.h"
 #include "main/cache/cache.h"
 #include "main/lsp/LSPInput.h"
 #include "main/lsp/LSPOutput.h"
@@ -21,6 +22,10 @@ void setRequiredLSPOptions(core::GlobalState &gs, options::Options &options) {
         // Definitions in multiple locations interact poorly with autoloader this error is enforced
         // in Stripe code.
         gs.suppressErrorClass(sorbet::core::errors::Namer::MultipleBehaviorDefs.code);
+    }
+
+    if (!options.reportAmbiguousDefinitionErrors) {
+        gs.suppressErrorClass(sorbet::core::errors::Resolver::AmbiguousDefinitionError.code);
     }
 
     gs.requiresAncestorEnabled = options.requiresAncestorEnabled;

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -353,7 +353,7 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
         cxxopts::value<vector<string>>(), "string");
     options.add_options("advanced")("no-error-count", "Do not print the error count summary line");
     options.add_options("advanced")("autogen-version", "Autogen version to output", cxxopts::value<int>());
-    options.add_options("advanced")("report-ambiguous-defs", "Enable ambiguous definition error enforcement",
+    options.add_options("advanced")("report-ambiguous-definitions", "Enable ambiguous definition error enforcement",
                                     cxxopts::value<bool>());
     options.add_options("advanced")("stripe-mode", "Enable Stripe specific error enforcement", cxxopts::value<bool>());
     options.add_options("advanced")("stripe-packages", "Enable support for Stripe's internal Ruby package system",
@@ -876,7 +876,7 @@ void readOptions(Options &opts,
             }
             opts.autogenVersion = raw["autogen-version"].as<int>();
         }
-        opts.reportAmbiguousDefinitionErrors = raw["report-ambiguous-defs"].as<bool>();
+        opts.reportAmbiguousDefinitionErrors = raw["report-ambiguous-definitions"].as<bool>();
         opts.stripeMode = raw["stripe-mode"].as<bool>();
         opts.stripePackages = raw["stripe-packages"].as<bool>();
         if (raw.count("extra-package-files-directory-prefix")) {

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -353,6 +353,8 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
         cxxopts::value<vector<string>>(), "string");
     options.add_options("advanced")("no-error-count", "Do not print the error count summary line");
     options.add_options("advanced")("autogen-version", "Autogen version to output", cxxopts::value<int>());
+    options.add_options("advanced")("report-ambiguous-defs", "Enable ambiguous definition error enforcement",
+                                    cxxopts::value<bool>());
     options.add_options("advanced")("stripe-mode", "Enable Stripe specific error enforcement", cxxopts::value<bool>());
     options.add_options("advanced")("stripe-packages", "Enable support for Stripe's internal Ruby package system",
                                     cxxopts::value<bool>());
@@ -874,6 +876,7 @@ void readOptions(Options &opts,
             }
             opts.autogenVersion = raw["autogen-version"].as<int>();
         }
+        opts.reportAmbiguousDefinitionErrors = raw["report-ambiguous-defs"].as<bool>();
         opts.stripeMode = raw["stripe-mode"].as<bool>();
         opts.stripePackages = raw["stripe-packages"].as<bool>();
         if (raw.count("extra-package-files-directory-prefix")) {

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -157,6 +157,7 @@ struct Options {
     int threads = 0;
     int logLevel = 0; // number of time -v was passed
     int autogenVersion = 0;
+    bool reportAmbiguousDefinitionErrors = false;
     bool stripeMode = false;
     bool stripePackages = false;
     std::vector<std::string> extraPackageFilesDirectoryPrefixes;

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -501,6 +501,12 @@ int realmain(int argc, char *argv[]) {
             gs->suppressErrorClass(core::errors::Namer::MultipleBehaviorDefs.code);
         }
     }
+    if (!opts.reportAmbiguousDefinitionErrors) {
+        // TODO (aadi-stripe, 1/16/2022): Determine whether this error should always be reported.
+        if (opts.isolateErrorCode.empty()) {
+            gs->suppressErrorClass(core::errors::Resolver::AmbiguousDefinitionError.code);
+        }
+    }
     if (opts.suggestTyped) {
         gs->ignoreErrorClassForSuggestTyped(core::errors::Infer::SuggestTyped.code);
         gs->ignoreErrorClassForSuggestTyped(core::errors::Resolver::SigInFileWithoutSigil.code);

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -203,6 +203,10 @@ void Resolver::finalizeAncestors(core::GlobalState &gs) {
         if (!ref.data(gs)->isClassModuleSet()) {
             // we did not see a declaration for this type not did we see it used. Default to module.
             ref.data(gs)->setIsModule(true);
+
+            // allow us to catch undeclared modules in LSP fast path, so we can report ambiguous
+            // definition errors.
+            ref.data(gs)->setClassModuleUndeclared();
         }
         auto loc = ref.data(gs)->loc();
         if (loc.file().exists() && loc.file().data(gs).sourceType == core::File::Type::Normal) {

--- a/test/cli/ambiguous-definitions-packages/ambiguous-definitions-packages.out
+++ b/test/cli/ambiguous-definitions-packages/ambiguous-definitions-packages.out
@@ -1,0 +1,12 @@
+foo/a.rb:5: Class definition is ambiguous https://srb.help/5068
+     5 |    module Foo::D # ambiguous
+     6 |    end
+    foo/a.rb:4: Alternate definition Opus::Foo here
+     4 |  module Foo
+          ^^^^^^^^^^
+
+foo/a.rb:8: Class definition is ambiguous https://srb.help/5068
+     8 |    module Bar::C # ambiguous
+     9 |    end
+    foo/__package.rb: Alternate definition Opus::Bar here
+Errors: 2

--- a/test/cli/ambiguous-definitions-packages/ambiguous-definitions-packages.sh
+++ b/test/cli/ambiguous-definitions-packages/ambiguous-definitions-packages.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+cd test/cli/ambiguous-definitions-packages || exit 1
+
+../../../main/sorbet --silence-dev-message --report-ambiguous-defs --stripe-packages . 2>&1
+
+

--- a/test/cli/ambiguous-definitions-packages/ambiguous-definitions-packages.sh
+++ b/test/cli/ambiguous-definitions-packages/ambiguous-definitions-packages.sh
@@ -4,6 +4,6 @@ set -e
 
 cd test/cli/ambiguous-definitions-packages || exit 1
 
-../../../main/sorbet --silence-dev-message --report-ambiguous-defs --stripe-packages . 2>&1
+../../../main/sorbet --silence-dev-message --report-ambiguous-definitions --stripe-packages . 2>&1
 
 

--- a/test/cli/ambiguous-definitions-packages/bar/__package.rb
+++ b/test/cli/ambiguous-definitions-packages/bar/__package.rb
@@ -1,0 +1,6 @@
+# typed: strict
+
+class Opus::Bar < PackageSpec
+  export Opus::Bar::B
+end
+

--- a/test/cli/ambiguous-definitions-packages/bar/b.rb
+++ b/test/cli/ambiguous-definitions-packages/bar/b.rb
@@ -1,0 +1,9 @@
+# typed: strict
+
+module Opus
+  module Bar
+    module B; end
+
+    module Foo::C; end # unambiguous
+  end
+end

--- a/test/cli/ambiguous-definitions-packages/foo/__package.rb
+++ b/test/cli/ambiguous-definitions-packages/foo/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class Opus::Foo < PackageSpec
+  import Opus::Bar
+end

--- a/test/cli/ambiguous-definitions-packages/foo/a.rb
+++ b/test/cli/ambiguous-definitions-packages/foo/a.rb
@@ -1,0 +1,11 @@
+# typed: strict
+
+module Opus
+  module Foo
+    module Foo::D # ambiguous
+    end
+
+    module Bar::C # ambiguous
+    end
+  end
+end

--- a/test/cli/ambiguous-definitions-packages/foo/test/a_test.rb
+++ b/test/cli/ambiguous-definitions-packages/foo/test/a_test.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+module ::Test; end
+
+module Test::Opus::Foo; end # unambiguous, ignore package-top-level "Test"

--- a/test/cli/ambiguous-definitions/ambiguous-definitions.out
+++ b/test/cli/ambiguous-definitions/ambiguous-definitions.out
@@ -1,0 +1,7 @@
+test/cli/ambiguous-definitions/foo.rb:5: Class definition is ambiguous https://srb.help/5068
+     5 |    module Foo::Bar # ambiguous
+     6 |    end
+    test/cli/ambiguous-definitions/foo.rb:4: Alternate definition Opus::Foo here
+     4 |  module Foo
+          ^^^^^^^^^^
+Errors: 1

--- a/test/cli/ambiguous-definitions/ambiguous-definitions.sh
+++ b/test/cli/ambiguous-definitions/ambiguous-definitions.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+main/sorbet --silence-dev-message --report-ambiguous-defs test/cli/ambiguous-definitions/foo.rb 2>&1
+

--- a/test/cli/ambiguous-definitions/ambiguous-definitions.sh
+++ b/test/cli/ambiguous-definitions/ambiguous-definitions.sh
@@ -2,5 +2,5 @@
 
 set -e
 
-main/sorbet --silence-dev-message --report-ambiguous-defs test/cli/ambiguous-definitions/foo.rb 2>&1
+main/sorbet --silence-dev-message --report-ambiguous-definitions test/cli/ambiguous-definitions/foo.rb 2>&1
 

--- a/test/cli/ambiguous-definitions/foo.rb
+++ b/test/cli/ambiguous-definitions/foo.rb
@@ -1,0 +1,8 @@
+# typed: strict
+
+module Opus
+  module Foo
+    module Foo::Bar # ambiguous
+    end
+  end
+end

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -134,7 +134,8 @@ Usage:
                                 that understand them.
       --no-error-count          Do not print the error count summary line
       --autogen-version arg     Autogen version to output
-      --report-ambiguous-defs   Enable ambiguous definition error enforcement
+      --report-ambiguous-definitions
+                                Enable ambiguous definition error enforcement
       --stripe-mode             Enable Stripe specific error enforcement
       --stripe-packages         Enable support for Stripe's internal Ruby
                                 package system

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -134,6 +134,7 @@ Usage:
                                 that understand them.
       --no-error-count          Do not print the error count summary line
       --autogen-version arg     Autogen version to output
+      --report-ambiguous-defs   Enable ambiguous definition error enforcement
       --stripe-mode             Enable Stripe specific error enforcement
       --stripe-packages         Enable support for Stripe's internal Ruby
                                 package system

--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -329,6 +329,7 @@ TEST_CASE("LSPTest") {
             }
             opts->secondaryTestPackageNamespaces.emplace_back("Critic");
         }
+        opts->reportAmbiguousDefinitionErrors = true;
         // Set to a number that is reasonable large for tests, but small enough that we can have a test to handle this
         // edge case. If you change this number, update the `lsp/fast_path/too_many_files` and `not_enough_files` tests.
         opts->lspMaxFilesOnFastPath = 10;

--- a/test/testdata/deviations/non_ruby_names.rb
+++ b/test/testdata/deviations/non_ruby_names.rb
@@ -4,6 +4,6 @@ end
 
 module A
   # In real Ruby this will be `B::C` but we make it `A::B::C`
-  class B::C
+  class B::C # error: Class definition is ambiguous
   end
 end

--- a/test/testdata/namer/fuzz_class_in_field.rb
+++ b/test/testdata/namer/fuzz_class_in_field.rb
@@ -1,7 +1,7 @@
 # typed: true
 module D 
   D=1
-  class D::D; end
+  class D::D; end # error: Class definition is ambiguous
       # ^^^^ error: Can't nest `D` under `D::D` because `D::D` is not a class or module
 end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Adds resolver functionality to find and report "ambiguous definitions".

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
In the Stripe codebase, we can face issues at runtime due to [this](https://sorbet.run/#%23%20typed%3A%20strict%0A%0Amodule%20Opus%0A%20%20%23%20module%20Opus%3A%3AFoo%3A%3AFoo%3B%20end%20%3C--%20filler%20node%0A%0A%20%20module%20Foo%0A%20%20%20%20module%20Foo%3A%3ABar%0A%20%20%20%20end%0A%20%20end%0Aend%0A%0AOpus%3A%3AFoo%3A%3AFoo%3A%3ABar%20%23%20%3C-%20Sorbet%0AOpus%3A%3AFoo%3A%3ABar%20%23%20%3C-%20Ruby%20VM) kind of code, where a symbol definition is scoped differently in Sorbet vs the Ruby VM. Usually, the autoloader we use at Stripe creates "filler" nodes which forward declare namespaces. However, the autoloader doesn't cover all cases. It only works at file granularity (and not for inner defs within a file itself).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Also tested on Stripe codebase.

Runtime
--------
Before
<img width="1382" alt="trace_old_sp" src="https://user-images.githubusercontent.com/83986377/146282469-41ea70c4-4c68-41d3-867c-04ac30ad10cf.png">

After
<img width="1371" alt="trace_new_sp" src="https://user-images.githubusercontent.com/83986377/146282490-79fbf0bf-debc-4527-81e7-3e8f12eb8109.png">