### PR TITLE
delete unused AccessorInfo::type field

### DIFF
--- a/main/lsp/LSPTask.h
+++ b/main/lsp/LSPTask.h
@@ -16,7 +16,6 @@ class DocumentHighlight;
 enum class FieldAccessorType { None, Reader, Writer, Accessor };
 
 struct AccessorInfo {
-    core::NameRef type;
     FieldAccessorType accessorType = FieldAccessorType::None;
     core::FieldRef fieldSymbol;
     core::MethodRef readerSymbol;


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

No sense having this field if we're not using it.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
