### PR TITLE
fix loc information for desugared `===` calls in `when`

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1980,9 +1980,8 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                             auto ctree = node2TreeImpl(dctx, std::move(cnode));
                             if (temp.exists()) {
                                 auto local = MK::Local(cloc, temp);
-                                auto patternloc = ctree.loc();
                                 test =
-                                    MK::Send1(patternloc, std::move(ctree), core::Names::tripleEq(), std::move(local));
+                                    MK::Send1(when->loc, std::move(ctree), core::Names::tripleEq(), std::move(local));
                             } else {
                                 test = std::move(ctree);
                             }

--- a/test/testdata/lsp/when_eqeqeq.rb
+++ b/test/testdata/lsp/when_eqeqeq.rb
@@ -1,0 +1,20 @@
+# typed: true
+extend T::Sig
+
+module A
+  class B
+  end
+end
+
+sig {params(x: T.untyped).void}
+def foo(x)
+  case x.class
+  when Integer
+     # ^ hover: T.class_of(Integer)
+    1
+  when A::B
+     # ^ hover: T.class_of(A)
+        # ^ hover: T.class_of(A::B)
+    2
+  end
+end


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #4073.

It's not immediately clear to me *why* this fixes things, but the test seems to work?

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
