### PR TITLE
show documentation for methods with multi-line final sigs

### DIFF
--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -375,13 +375,14 @@ optional<string> findDocumentation(string_view sourceCode, int beginIndex) {
 
         // Handle multi-line sig block
         else if (absl::StartsWith(line, "end")) {
-            // ASSUMPTION: We either hit the start of file, a `sig do` or an `end`
+            // ASSUMPTION: We either hit the start of file, a `sig do`/`sig(:final) do` or an `end`
             it++;
             while (
                 // SOF
                 it != all_lines.rend()
                 // Start of sig block
-                && !absl::StartsWith(absl::StripAsciiWhitespace(*it), "sig do")
+                && !(absl::StartsWith(absl::StripAsciiWhitespace(*it), "sig do") ||
+                     absl::StartsWith(absl::StripAsciiWhitespace(*it), "sig(:final) do"))
                 // Invalid end keyword
                 && !absl::StartsWith(absl::StripAsciiWhitespace(*it), "end")) {
                 it++;
@@ -397,10 +398,11 @@ optional<string> findDocumentation(string_view sourceCode, int beginIndex) {
 
             // Reached a sig block.
             line = absl::StripAsciiWhitespace(*it);
-            ENFORCE(absl::StartsWith(line, "sig do"));
+            ENFORCE(absl::StartsWith(line, "sig do") || absl::StartsWith(line, "sig(:final) do"));
 
             // Stop looking if this is a single-line block e.g `sig do; <block>; end`
-            if (absl::StartsWith(line, "sig do;") && absl::EndsWith(line, "end")) {
+            if ((absl::StartsWith(line, "sig do;") || absl::StartsWith(line, "sig(:final) do;")) &&
+                absl::EndsWith(line, "end")) {
                 break;
             }
 

--- a/main/lsp/test/lsp_test.cc
+++ b/main/lsp/test/lsp_test.cc
@@ -58,6 +58,16 @@ const string file_string = "# typed: true\n"
                            "    end\n"
                            "\n"
                            "    # This is a method with documentation above its\n"
+                           "    # multi-line sig(:final) block.\n"
+                           "    sig(:final) do\n"
+                           "      params(x: Integer)\n"
+                           "      .returns(Integer)\n"
+                           "    end\n"
+                           "    def multi_line_sig_final_block\n"
+                           "      1\n"
+                           "    end\n"
+                           "\n"
+                           "    # This is a method with documentation above its\n"
                            "    # broken multi-line sig block. You shouldn't see this. \n"
                            "    not_a_sig do \n"
                            "      params(x: Integer)\n"
@@ -147,6 +157,11 @@ TEST_CASE("MultiLineSig") {
     int position = file.find("multi_line_sig_block");
     optional<string> b = findDocumentation(file, position);
     REQUIRE_EQ(*b, "This is a method with documentation above its\nmulti-line sig block.");
+}
+TEST_CASE("MultiLineSigFinal") {
+    int position = file.find("multi_line_sig_final_block");
+    optional<string> b = findDocumentation(file, position);
+    REQUIRE_EQ(*b, "This is a method with documentation above its\nmulti-line sig(:final) block.");
 }
 TEST_CASE("BrokenMultiLineSig") {
     int position = file.find("broken_multi_line_sig_block");

--- a/test/testdata/lsp/sig_final_docs.rb
+++ b/test/testdata/lsp/sig_final_docs.rb
@@ -1,0 +1,13 @@
+# typed: true
+class A
+  extend T::Sig
+
+  # These docs should show!
+  sig(:final) do
+    params(x: Integer).returns(String)
+  end
+  def bar(x)
+    # ^ hover: These docs should show!
+    x.to_s
+  end
+end


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #2306.

I did not think it was worth trying to factor out a helper to recognize `sig do` and permutations, because the `sig do;` case would make it more complicated.  But the reviewer may feel differently.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.  The tests might be redundant, but it was educational writing both of them.
