### PR TITLE
copy a little less when merging similar methods

### DIFF
--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -155,12 +155,12 @@ SimilarMethodsByName similarMethodsForClass(const core::GlobalState &gs, core::C
 SimilarMethodsByName mergeSimilarMethods(SimilarMethodsByName left, SimilarMethodsByName right) {
     auto result = SimilarMethodsByName{};
 
-    for (auto [methodName, leftSimilarMethods] : left) {
+    for (auto &[methodName, leftSimilarMethods] : left) {
         if (right.contains(methodName)) {
-            for (auto similarMethod : leftSimilarMethods) {
+            for (auto &similarMethod : leftSimilarMethods) {
                 result[methodName].emplace_back(similarMethod);
             }
-            for (auto similarMethod : right[methodName]) {
+            for (auto &similarMethod : right[methodName]) {
                 result[methodName].emplace_back(similarMethod);
             }
         }


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Less copying is more better.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
