### PR TITLE
Fix return type for String#sub!

### DIFF
--- a/rbi/core/string.rbi
+++ b/rbi/core/string.rbi
@@ -2104,14 +2104,14 @@ class String < Object
         arg0: T.any(Regexp, String),
         arg1: String,
     )
-    .returns(String)
+    .returns(T.nilable(String))
   end
   sig do
     params(
         arg0: T.any(Regexp, String),
         blk: T.proc.params(arg0: String).returns(BasicObject),
     )
-    .returns(String)
+    .returns(T.nilable(String))
   end
   def sub!(arg0, arg1=T.unsafe(nil), &blk); end
 


### PR DESCRIPTION
### Motivation

As documented [here](https://ruby-doc.org/core-2.7.0/String.html#method-i-sub-21), `gsub` returns `str` if a substitution was performed or `nil` if no substitution was performed:

```
$ irb
> "".sub!("A", "B")
=> nil
```

### Test plan

See included automated tests.
