### PR TITLE
add ranged-for capabilities to `AbstractConcurrentBoundedQueue`

### DIFF
--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -1427,7 +1427,10 @@ ParsedFilesOrCancelled ParsedFilesOrCancelled::cancel(std::vector<ParsedFile> &&
         workers.multiplexJob("deleteTrees", [fileq, &threadBarrier]() {
             {
                 ast::ParsedFile job;
-                for (auto result = fileq->try_pop(job); !result.done(); result = fileq->try_pop(job)) {
+                for (auto result : fileq->popUntilEmpty(job)) {
+                    if (!result.gotItem()) {
+                        continue;
+                    }
                     // Do nothing; allow the destructor of `ast::ParsedFile` to run for `job`.
                 }
             }

--- a/common/concurrency/ConcurrentQueue.h
+++ b/common/concurrency/ConcurrentQueue.h
@@ -116,6 +116,46 @@ public:
         return try_pop(elem);
     }
 
+    template <typename Rep, typename Period>
+    class TimedPopper final {
+        AbstractConcurrentBoundedQueue<Elem, Queue> &queue;
+        Elem &elem;
+        const std::chrono::duration<Rep, Period> &timeout;
+        spdlog::logger &log;
+        const bool silent;
+        DequeueResult ret{false, true};
+
+    public:
+        TimedPopper(AbstractConcurrentBoundedQueue<Elem, Queue> &queue, Elem &elem, std::chrono::duration<Rep, Period> const &timeout,
+                    spdlog::logger &log, bool silent) : queue(queue), elem(elem), timeout(timeout), log(log), silent(silent) {}
+
+        TimedPopper &begin() {
+            this->ret = this->queue.wait_pop_timed(this->elem, timeout, log, silent);
+            return *this;
+        }
+        PopperSentinel end() {
+            return PopperSentinel{};
+        }
+
+        bool operator!=(PopperSentinel &) {
+            return !this->ret.done();
+        }
+
+        void operator++() {
+            this->ret = this->queue.wait_pop_timed(this->elem, timeout, log, silent);
+        }
+
+        const DequeueResult &operator*() {
+            return this->ret;
+        }
+    };
+
+    template<typename Rep, typename Period>
+    inline TimedPopper<Rep, Period> popUntilEmptyWithTimeout(Elem &elem, std::chrono::duration<Rep, Period> const &timeout,
+                                           spdlog::logger &log, bool silent = false) noexcept {
+        return TimedPopper<Rep, Period>{*this, elem, timeout, log, silent};
+    }
+
     int doneEstimate() {
         return elementsPopped.load(std::memory_order_relaxed);
     }

--- a/common/concurrency/ConcurrentQueue.h
+++ b/common/concurrency/ConcurrentQueue.h
@@ -116,8 +116,7 @@ public:
         return try_pop(elem);
     }
 
-    template <typename Rep, typename Period>
-    class TimedPopper final {
+    template <typename Rep, typename Period> class TimedPopper final {
         AbstractConcurrentBoundedQueue<Elem, Queue> &queue;
         Elem &elem;
         const std::chrono::duration<Rep, Period> &timeout;
@@ -126,8 +125,9 @@ public:
         DequeueResult ret{false, true};
 
     public:
-        TimedPopper(AbstractConcurrentBoundedQueue<Elem, Queue> &queue, Elem &elem, std::chrono::duration<Rep, Period> const &timeout,
-                    spdlog::logger &log, bool silent) : queue(queue), elem(elem), timeout(timeout), log(log), silent(silent) {}
+        TimedPopper(AbstractConcurrentBoundedQueue<Elem, Queue> &queue, Elem &elem,
+                    std::chrono::duration<Rep, Period> const &timeout, spdlog::logger &log, bool silent)
+            : queue(queue), elem(elem), timeout(timeout), log(log), silent(silent) {}
 
         TimedPopper &begin() {
             this->ret = this->queue.wait_pop_timed(this->elem, timeout, log, silent);
@@ -150,9 +150,10 @@ public:
         }
     };
 
-    template<typename Rep, typename Period>
-    inline TimedPopper<Rep, Period> popUntilEmptyWithTimeout(Elem &elem, std::chrono::duration<Rep, Period> const &timeout,
-                                           spdlog::logger &log, bool silent = false) noexcept {
+    template <typename Rep, typename Period>
+    inline TimedPopper<Rep, Period> popUntilEmptyWithTimeout(Elem &elem,
+                                                             std::chrono::duration<Rep, Period> const &timeout,
+                                                             spdlog::logger &log, bool silent = false) noexcept {
         return TimedPopper<Rep, Period>{*this, elem, timeout, log, silent};
     }
 

--- a/core/ErrorQueue.cc
+++ b/core/ErrorQueue.cc
@@ -29,7 +29,10 @@ void ErrorQueue::flushErrorsForFile(const GlobalState &gs, FileRef file) {
     Timer timeit(tracer, "ErrorQueue::flushErrorsForFile");
 
     core::ErrorQueueMessage msg;
-    for (auto result = queue.try_pop(msg); result.gotItem(); result = queue.try_pop(msg)) {
+    for (auto result : queue.popUntilEmpty(msg)) {
+        if (!result.gotItem()) {
+            break;
+        }
         collected[msg.whatFile].emplace_back(make_unique<ErrorQueueMessage>(move(msg)));
     }
 
@@ -70,7 +73,10 @@ UnorderedMap<core::FileRef, vector<unique_ptr<core::ErrorQueueMessage>>> ErrorQu
     checkOwned();
 
     core::ErrorQueueMessage msg;
-    for (auto result = queue.try_pop(msg); result.gotItem(); result = queue.try_pop(msg)) {
+    for (auto result : queue.popUntilEmpty(msg)) {
+        if (!result.gotItem()) {
+            break;
+        }
         collected[msg.whatFile].emplace_back(make_unique<ErrorQueueMessage>(move(msg)));
     }
 

--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -106,8 +106,7 @@ void Hashing::computeFileHashes(const vector<shared_ptr<core::File>> &files, spd
 
     {
         vector<pair<size_t, unique_ptr<const core::FileHash>>> threadResult;
-        for (auto result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), logger); !result.done();
-             result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), logger)) {
+        for (auto result : resultq->popUntilEmptyWithTimeout(threadResult, WorkerPool::BLOCK_INTERVAL(), logger)) {
             if (result.gotItem()) {
                 for (auto &a : threadResult) {
                     files[a.first]->setFileHash(move(a.second));
@@ -173,8 +172,7 @@ vector<ast::ParsedFile> Hashing::indexAndComputeFileHashes(unique_ptr<core::Glob
 
     {
         vector<pair<core::FileRef, unique_ptr<const core::FileHash>>> threadResult;
-        for (auto result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), logger); !result.done();
-             result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), logger)) {
+        for (auto result : resultq->popUntilEmptyWithTimeout(threadResult, WorkerPool::BLOCK_INTERVAL(), logger)) {
             if (result.gotItem()) {
                 for (auto &a : threadResult) {
                     a.first.data(*gs).setFileHash(move(a.second));

--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -86,7 +86,7 @@ void Hashing::computeFileHashes(const vector<shared_ptr<core::File>> &files, spd
         int processedByThread = 0;
         size_t job;
         {
-            for (auto result = fileq->try_pop(job); !result.done(); result = fileq->try_pop(job)) {
+            for (auto result : fileq->popUntilEmpty(job)) {
                 if (result.gotItem()) {
                     processedByThread++;
 
@@ -143,7 +143,7 @@ vector<ast::ParsedFile> Hashing::indexAndComputeFileHashes(unique_ptr<core::Glob
         int processedByThread = 0;
         size_t job;
         {
-            for (auto result = fileq->try_pop(job); !result.done(); result = fileq->try_pop(job)) {
+            for (auto result : fileq->popUntilEmpty(job)) {
                 if (result.gotItem()) {
                     if (timeit == nullptr) {
                         timeit = make_unique<Timer>(logger, "computeFileHashesWorker");

--- a/main/autogen/autoloader.cc
+++ b/main/autogen/autoloader.cc
@@ -481,8 +481,7 @@ void AutoloadWriter::writeAutoloads(const core::GlobalState &gs, WorkerPool &wor
     });
 
     CounterState out;
-    for (auto res = outputq->wait_pop_timed(out, WorkerPool::BLOCK_INTERVAL(), gs.tracer()); !res.done();
-         res = outputq->wait_pop_timed(out, WorkerPool::BLOCK_INTERVAL(), gs.tracer())) {
+    for (auto res : outputq->popUntilEmptyWithTimeout(out, WorkerPool::BLOCK_INTERVAL(), gs.tracer())) {
         if (!res.gotItem()) {
             continue;
         }

--- a/main/autogen/autoloader.cc
+++ b/main/autogen/autoloader.cc
@@ -467,7 +467,10 @@ void AutoloadWriter::writeAutoloads(const core::GlobalState &gs, WorkerPool &wor
             Timer timeit(gs.tracer(), "autogenWriteAutoloadsWorker");
             int idx = 0;
 
-            for (auto result = inputq->try_pop(idx); !result.done(); result = inputq->try_pop(idx)) {
+            for (auto result : inputq->popUntilEmpty(idx)) {
+                if (!result.gotItem()) {
+                    continue;
+                }
                 ++n;
                 auto &task = tasks[idx];
                 FileOps::writeIfDifferent(task.filePath, task.node.renderAutoloadSrc(gs, alCfg));

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -320,8 +320,7 @@ bool LSPTypechecker::copyIndexed(WorkerPool &workers, const UnorderedSet<int> &i
     {
         vector<ast::ParsedFile> threadResult;
         out.reserve(indexed.size());
-        for (auto result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), logger); !result.done();
-             result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), logger)) {
+        for (auto result : resultq->popUntilEmptyWithTimeout(threadResult, WorkerPool::BLOCK_INTERVAL(), logger)) {
             if (result.gotItem()) {
                 for (auto &copy : threadResult) {
                     out.push_back(move(copy));

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -297,7 +297,7 @@ bool LSPTypechecker::copyIndexed(WorkerPool &workers, const UnorderedSet<int> &i
         int processedByThread = 0;
         int job;
         {
-            for (auto result = fileq->try_pop(job); !result.done(); result = fileq->try_pop(job)) {
+            for (auto result : fileq->popUntilEmpty(job)) {
                 if (result.gotItem()) {
                     processedByThread++;
 

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -1080,7 +1080,8 @@ void typecheck(unique_ptr<core::GlobalState> &gs, vector<ast::ParsedFile> what, 
 
             vector<core::FileRef> files;
             {
-                for (auto result : outputq->popUntilEmptyWithTimeout(files, WorkerPool::BLOCK_INTERVAL(), gs->tracer())) {
+                for (auto result :
+                     outputq->popUntilEmptyWithTimeout(files, WorkerPool::BLOCK_INTERVAL(), gs->tracer())) {
                     if (result.gotItem()) {
                         for (auto &file : files) {
                             gs->errorQueue->flushErrorsForFile(*gs, file);

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -230,7 +230,10 @@ void runAutogen(const core::GlobalState &gs, options::Options &opts, const autog
             Timer timeit(logger, "autogenWorker");
             int idx = 0;
 
-            for (auto result = fileq->try_pop(idx); !result.done(); result = fileq->try_pop(idx)) {
+            for (auto result : fileq->popUntilEmpty(idx)) {
+                if (!result.gotItem()) {
+                    continue;
+                }
                 ++n;
                 auto &tree = indexed[idx];
                 if (tree.file.data(gs).isPackage()) {

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -287,8 +287,7 @@ void runAutogen(const core::GlobalState &gs, options::Options &opts, const autog
 
     autogen::DefTree root;
     AutogenResult out;
-    for (auto res = resultq->wait_pop_timed(out, WorkerPool::BLOCK_INTERVAL(), *logger); !res.done();
-         res = resultq->wait_pop_timed(out, WorkerPool::BLOCK_INTERVAL(), *logger)) {
+    for (auto res : resultq->popUntilEmptyWithTimeout(out, WorkerPool::BLOCK_INTERVAL(), *logger)) {
         if (!res.gotItem()) {
             continue;
         }

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1856,7 +1856,7 @@ vector<SymbolFinderResult> findSymbols(const core::GlobalState &gs, vector<ast::
         SymbolFinder finder;
         vector<SymbolFinderResult> output;
         ast::ParsedFile job;
-        for (auto result = fileq->try_pop(job); !result.done(); result = fileq->try_pop(job)) {
+        for (auto result : fileq->popUntilEmpty(job)) {
             if (result.gotItem()) {
                 Timer timeit(gs.tracer(), "naming.findSymbolsOne", {{"file", string(job.file.data(gs).path())}});
                 core::Context ctx(gs, core::Symbols::root(), job.file);
@@ -1926,7 +1926,7 @@ vector<ast::ParsedFile> symbolizeTrees(const core::GlobalState &gs, vector<ast::
         TreeSymbolizer inserter;
         vector<ast::ParsedFile> output;
         ast::ParsedFile job;
-        for (auto result = fileq->try_pop(job); !result.done(); result = fileq->try_pop(job)) {
+        for (auto result : fileq->popUntilEmpty(job)) {
             if (result.gotItem()) {
                 Timer timeit(gs.tracer(), "naming.symbolizeTreesOne", {{"file", string(job.file.data(gs).path())}});
                 core::Context ctx(gs, core::Symbols::root(), job.file);

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1873,9 +1873,7 @@ vector<SymbolFinderResult> findSymbols(const core::GlobalState &gs, vector<ast::
 
     {
         vector<SymbolFinderResult> threadResult;
-        for (auto result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer());
-             !result.done();
-             result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer())) {
+        for (auto result : resultq->popUntilEmptyWithTimeout(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer())) {
             if (result.gotItem()) {
                 allFoundDefinitions.insert(allFoundDefinitions.end(), make_move_iterator(threadResult.begin()),
                                            make_move_iterator(threadResult.end()));
@@ -1942,9 +1940,7 @@ vector<ast::ParsedFile> symbolizeTrees(const core::GlobalState &gs, vector<ast::
 
     {
         vector<ast::ParsedFile> threadResult;
-        for (auto result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer());
-             !result.done();
-             result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer())) {
+        for (auto result : resultq->popUntilEmptyWithTimeout(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer())) {
             if (result.gotItem()) {
                 trees.insert(trees.end(), make_move_iterator(threadResult.begin()),
                              make_move_iterator(threadResult.end()));

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1508,7 +1508,8 @@ vector<ast::ParsedFile> Packager::run(core::GlobalState &gs, WorkerPool &workers
 
         {
             vector<ast::ParsedFile> threadResult;
-            for (auto result : resultq->popUntilEmptyWithTimeout(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer())) {
+            for (auto result :
+                 resultq->popUntilEmptyWithTimeout(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer())) {
                 if (result.gotItem()) {
                     files.insert(files.end(), make_move_iterator(threadResult.begin()),
                                  make_move_iterator(threadResult.end()));

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1486,7 +1486,7 @@ vector<ast::ParsedFile> Packager::run(core::GlobalState &gs, WorkerPool &workers
             vector<ast::ParsedFile> results;
             uint32_t filesProcessed = 0;
             ast::ParsedFile job;
-            for (auto result = fileq->try_pop(job); !result.done(); result = fileq->try_pop(job)) {
+            for (auto result : fileq->popUntilEmpty(job)) {
                 if (result.gotItem()) {
                     filesProcessed++;
                     auto &file = job.file.data(gs);

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1508,9 +1508,7 @@ vector<ast::ParsedFile> Packager::run(core::GlobalState &gs, WorkerPool &workers
 
         {
             vector<ast::ParsedFile> threadResult;
-            for (auto result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer());
-                 !result.done();
-                 result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer())) {
+            for (auto result : resultq->popUntilEmptyWithTimeout(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer())) {
                 if (result.gotItem()) {
                     files.insert(files.end(), make_move_iterator(threadResult.begin()),
                                  make_move_iterator(threadResult.end()));

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1123,7 +1123,8 @@ public:
 
         {
             ResolveWalkResult threadResult;
-            for (auto result : resultq->popUntilEmptyWithTimeout(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer())) {
+            for (auto result :
+                 resultq->popUntilEmptyWithTimeout(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer())) {
                 if (result.gotItem()) {
                     todo.insert(todo.end(), make_move_iterator(threadResult.todo_.begin()),
                                 make_move_iterator(threadResult.todo_.end()));
@@ -2505,7 +2506,8 @@ public:
 
         {
             ResolveTypeMembersAndFieldsResult threadResult;
-            for (auto result : outputq->popUntilEmptyWithTimeout(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer())) {
+            for (auto result :
+                 outputq->popUntilEmptyWithTimeout(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer())) {
                 if (result.gotItem()) {
                     combinedFiles.insert(combinedFiles.end(), make_move_iterator(threadResult.files.begin()),
                                          make_move_iterator(threadResult.files.end()));

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -487,9 +487,7 @@ private:
 
         uint32_t retries = 0;
         pair<uint32_t, vector<ResolveItems<ResolutionItem>>> threadResult;
-        for (auto result = outputq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer());
-             !result.done();
-             result = outputq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer())) {
+        for (auto result : outputq->popUntilEmptyWithTimeout(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer())) {
             if (result.gotItem()) {
                 retries += threadResult.first;
                 jobs.insert(jobs.end(), make_move_iterator(threadResult.second.begin()),
@@ -1125,9 +1123,7 @@ public:
 
         {
             ResolveWalkResult threadResult;
-            for (auto result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer());
-                 !result.done();
-                 result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer())) {
+            for (auto result : resultq->popUntilEmptyWithTimeout(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer())) {
                 if (result.gotItem()) {
                     todo.insert(todo.end(), make_move_iterator(threadResult.todo_.begin()),
                                 make_move_iterator(threadResult.todo_.end()));
@@ -2509,9 +2505,7 @@ public:
 
         {
             ResolveTypeMembersAndFieldsResult threadResult;
-            for (auto result = outputq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer());
-                 !result.done();
-                 result = outputq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer())) {
+            for (auto result : outputq->popUntilEmptyWithTimeout(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer())) {
                 if (result.gotItem()) {
                     combinedFiles.insert(combinedFiles.end(), make_move_iterator(threadResult.files.begin()),
                                          make_move_iterator(threadResult.files.end()));
@@ -3266,9 +3260,7 @@ ast::ParsedFilesOrCancelled Resolver::resolveSigs(core::GlobalState &gs, vector<
     vector<ResolveSignaturesWalk::ResolveFileSignatures> combinedFileJobs;
     {
         ResolveSignaturesWalk::ResolveSignaturesWalkResult threadResult;
-        for (auto result = outputq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer());
-             !result.done();
-             result = outputq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer())) {
+        for (auto result : outputq->popUntilEmptyWithTimeout(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer())) {
             if (result.gotItem()) {
                 trees.insert(trees.end(), make_move_iterator(threadResult.trees.begin()),
                              make_move_iterator(threadResult.trees.end()));

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -465,7 +465,7 @@ private:
             ResolveItems<ResolutionItem> job(core::FileRef(), {});
             uint32_t processed = 0;
             uint32_t retries = 0;
-            for (auto result = inputq->try_pop(job); !result.done(); result = inputq->try_pop(job)) {
+            for (auto result : inputq->popUntilEmpty(job)) {
                 if (result.gotItem()) {
                     processed++;
                     core::Context ictx(gs, core::Symbols::root(), job.file);
@@ -1083,7 +1083,7 @@ public:
             ResolveWalkResult walkResult;
             vector<ast::ParsedFile> partiallyResolvedTrees;
             ast::ParsedFile job;
-            for (auto result = fileq->try_pop(job); !result.done(); result = fileq->try_pop(job)) {
+            for (auto result : fileq->popUntilEmpty(job)) {
                 if (result.gotItem()) {
                     core::Context ictx(igs, core::Symbols::root(), job.file);
                     job.tree = ast::TreeMap::apply(ictx, constants, std::move(job.tree));
@@ -2474,7 +2474,7 @@ public:
             ResolveTypeMembersAndFieldsWalk walk;
             ResolveTypeMembersAndFieldsResult output;
             ast::ParsedFile job;
-            for (auto result = inputq->try_pop(job); !result.done(); result = inputq->try_pop(job)) {
+            for (auto result : inputq->popUntilEmpty(job)) {
                 if (result.gotItem()) {
                     core::Context ctx(gs, core::Symbols::root(), job.file);
                     job.tree = ast::TreeMap::apply(ctx, walk, std::move(job.tree));
@@ -3246,7 +3246,7 @@ ast::ParsedFilesOrCancelled Resolver::resolveSigs(core::GlobalState &gs, vector<
         ResolveSignaturesWalk walk;
         ResolveSignaturesWalk::ResolveSignaturesWalkResult output;
         ast::ParsedFile job;
-        for (auto result = inputq->try_pop(job); !result.done(); result = inputq->try_pop(job)) {
+        for (auto result : inputq->popUntilEmpty(job)) {
             if (result.gotItem()) {
                 core::Context ctx(gs, core::Symbols::root(), job.file);
                 job.tree = ast::ShallowMap::apply(ctx, walk, std::move(job.tree));


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I got tired of seeing the same code repeated everywhere for popping elements from queues.  Now it's a little bit shorter...?

Also a good excuse to play with C++17's new feature that `begin()` and `end()` don't have to return the same type, which IMHO makes custom iterators easier to think about in many cases.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
