### PR TITLE
Make sorbet/showSymbol work in `typed: false` files

### DIFF
--- a/main/lsp/requests/sorbet_show_symbol.cc
+++ b/main/lsp/requests/sorbet_show_symbol.cc
@@ -15,7 +15,7 @@ unique_ptr<ResponseMessage> SorbetShowSymbolTask::runRequest(LSPTypecheckerDeleg
 
     const core::GlobalState &gs = typechecker.state();
     // To match the behavior of Go To Definition, we don't error in an untyped file, but instead
-    // return an empty result.
+    // be okay with returning an empty result for certain queries.
     auto errorIfFileIsUntyped = false;
     auto result = queryByLoc(typechecker, params->textDocument->uri, *params->position, LSPMethod::SorbetShowSymbol,
                              errorIfFileIsUntyped);

--- a/main/lsp/requests/sorbet_show_symbol.cc
+++ b/main/lsp/requests/sorbet_show_symbol.cc
@@ -14,7 +14,11 @@ unique_ptr<ResponseMessage> SorbetShowSymbolTask::runRequest(LSPTypecheckerDeleg
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::SorbetShowSymbol);
 
     const core::GlobalState &gs = typechecker.state();
-    auto result = queryByLoc(typechecker, params->textDocument->uri, *params->position, LSPMethod::SorbetShowSymbol);
+    // To match the behavior of Go To Definition, we don't error in an untyped file, but instead
+    // return an empty result.
+    auto errorIfFileIsUntyped = false;
+    auto result = queryByLoc(typechecker, params->textDocument->uri, *params->position, LSPMethod::SorbetShowSymbol,
+                             errorIfFileIsUntyped);
     if (result.error) {
         // An error happened while setting up the query.
         response->error = move(result.error);

--- a/test/testdata/lsp/show_symbol_typed_false.rb
+++ b/test/testdata/lsp/show_symbol_typed_false.rb
@@ -1,0 +1,57 @@
+# typed: false
+
+module First
+  module Second
+    module Third
+      module Fourth
+        extend T::Generic
+
+        module NestedModule; end
+        #      ^ show-symbol: First::Second::Third::Fourth::NestedModule
+
+        puts NestedModule
+        #    ^ show-symbol: First::Second::Third::Fourth::NestedModule
+
+        NestedConstant = 1
+        # ^ show-symbol: First::Second::Third::Fourth::NestedConstant
+
+        NestedClassAlias = Integer
+        # ^ show-symbol: First::Second::Third::Fourth::NestedClassAlias
+
+        NestedTypeMember = type_member
+        # ^ show-symbol: First::Second::Third::Fourth::NestedTypeMember
+      end
+    end
+
+    NestedTypeAlias = T.type_alias {Integer}
+    # ^ show-symbol: First::Second::NestedTypeAlias
+  end
+end
+
+module Outer
+  module Middle
+    module Inner
+      extend T::Sig
+      sig {void}
+      def self.foo
+        #      ^ show-symbol: Outer::Middle::Inner.foo
+        # This is kind of ugly. It's possible that we want to return @foo here.
+        @foo = T.let(@foo, T.nilable(String))
+        #             ^ show-symbol: T.class_of(Outer::Middle::Inner)#@foo
+      end
+
+      foo
+      # ^ show-symbol: null
+
+      puts(:foo)
+      #    ^ show-symbol: null
+
+      sig {params(x: Integer).void}
+      def bar(x)
+        # ^ show-symbol: Outer::Middle::Inner#bar
+        Kernel.puts(x)
+        #           ^ show-symbol: null
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This matches the behavior of Go To Definition.

Basically everything works except for handling `SendResponse` (and honestly, the
most common use case for this is to show a fully-qualified constant symbol
name).

Making it not return an RPC error in `typed: false` files is a better user
experience.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.