### PR TITLE
remove sorbet_ruby_2_6; add sorbet_ruby_2_7_unpatched to ruby-version…

### DIFF
--- a/third_party/ruby/ruby-versions.txt
+++ b/third_party/ruby/ruby-versions.txt
@@ -1,2 +1,2 @@
-sorbet_ruby_2_6
+sorbet_ruby_2_7_unpatched
 sorbet_ruby_2_7


### PR DESCRIPTION
…s.txt

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We created this for Stripe's CI.  While we don't need Ruby 2.6 building anymore, it can sometimes be useful to have an unpatched Ruby 2.7 around.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
