### PR TITLE
Fix kwarg deprecation in Ruby >= 2.7

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
@@ -158,7 +158,7 @@ module T::Private::Methods::CallValidation
     # this code is sig validation code.
     # Please issue `finish` to step out of it
 
-    return_value = T::Configuration::AT_LEAST_RUBY_2_7 ? original_method.bind_call(instance, *args, &blk) : original_method.bind(instance).call(*args, &blk)
+    return_value = T::Configuration::AT_LEAST_RUBY_2_7 ? original_method.bind_call(instance, **args, &blk) : original_method.bind(instance).call(*args, &blk)
 
     # The only type that is allowed to change the return value is `.void`.
     # It ignores what you returned and changes it to be a private singleton.


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
This fixes a kwarg deprecation warning for Ruby >= 2.7.


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Trying to get rid of deprecation warnings.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
