### PR TITLE
Require stdlib's Set

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 # typed: strict
 
-require "set"
-
 # NB: This is not actually a decorator. It's just named that way for consistency
 # with DocumentDecorator and ModelDecorator (which both seem to have been written
 # with an incorrect understanding of the decorator pattern). These "decorators"
@@ -260,6 +258,7 @@ class T::Props::Decorator
     when T::Types::TypedHash, T::Types::FixedHash
       Hash
     when T::Types::TypedSet
+      require "set"
       Set
     when T::Types::Union
       # The below unwraps our T.nilable types for T::Props if we can.

--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 # typed: strict
 
+require "set"
+
 # NB: This is not actually a decorator. It's just named that way for consistency
 # with DocumentDecorator and ModelDecorator (which both seem to have been written
 # with an incorrect understanding of the decorator pattern). These "decorators"

--- a/gems/sorbet-runtime/test/types/props/decorator.rb
+++ b/gems/sorbet-runtime/test/types/props/decorator.rb
@@ -51,6 +51,10 @@ class Opus::Types::Test::Props::DecoratorTest < Critic::Unit::UnitTest
     prop :the_hash, T.nilable(T::Hash[String, CustomType])
   end
 
+  class SetStruct < T::Struct
+    prop :set, T.nilable(T::Set[String])
+  end
+
   describe 'typed arrays and hashes' do
     it 'can have string values' do
       doc = StringArrayAndHashStruct.new(
@@ -94,6 +98,14 @@ class Opus::Types::Test::Props::DecoratorTest < Critic::Unit::UnitTest
         include T::Props
         prop :fixed_array_prop, T::Utils.coerce([String, Numeric])
       end
+    end
+  end
+
+  describe 'typed sets' do
+    it 'can have set values' do
+      SetStruct.new(
+        set: ::Set.new(['one', 'two', 'three'])
+      )
     end
   end
 


### PR DESCRIPTION
```
NameError:
  uninitialized constant T::Props::Decorator::Set
  Did you mean?  T::Set
# ./vendor/bundle/ruby/2.7.0/gems/sorbet-runtime-0.5.9460/lib/types/props/decorator.rb:261:in `convert_type_to_class'
# ./vendor/bundle/ruby/2.7.0/gems/sorbet-runtime-0.5.9460/lib/types/private/methods/call_validation_2_7.rb:106:in `bind_call'
# ./vendor/bundle/ruby/2.7.0/gems/sorbet-runtime-0.5.9460/lib/types/private/methods/call_validation_2_7.rb:106:in `block in create_validator_method_fast1'
# ./vendor/bundle/ruby/2.7.0/gems/sorbet-runtime-0.5.9460/lib/types/props/decorator.rb:304:in `prop_defined'
# ./vendor/bundle/ruby/2.7.0/gems/sorbet-runtime-0.5.9460/lib/types/props/_props.rb:115:in `prop'
# ./vendor/bundle/ruby/2.7.0/gems/sorbet-runtime-0.5.9460/lib/types/private/methods/call_validation.rb:161:in `bind_call'
# ./vendor/bundle/ruby/2.7.0/gems/sorbet-runtime-0.5.9460/lib/types/private/methods/call_validation.rb:161:in `validate_call'
# ./vendor/bundle/ruby/2.7.0/gems/sorbet-runtime-0.5.9460/lib/types/private/methods/call_validation.rb:90:in `block in create_validator_slow'
# ./vendor/bundle/ruby/2.7.0/gems/sorbet-runtime-0.5.9460/lib/types/props/_props.rb:144:in `const'
# ./vendor/bundle/ruby/2.7.0/gems/sorbet-runtime-0.5.9460/lib/types/private/methods/call_validation.rb:161:in `bind_call'
# ./vendor/bundle/ruby/2.7.0/gems/sorbet-runtime-0.5.9460/lib/types/private/methods/call_validation.rb:161:in `validate_call'
# ./vendor/bundle/ruby/2.7.0/gems/sorbet-runtime-0.5.9460/lib/types/private/methods/call_validation.rb:90:in `block in create_validator_slow'
```

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
