### PR TITLE
Fix packager LSP behavior

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1232,21 +1232,23 @@ private:
                 //                               ^^^  jump to actual definition of `Baz` class
 
                 // Ensure import's do not add duplicate loc-s in the test_module
-                const auto &moduleLoc = [](auto &source, auto packageLoc) {
-                    // normal or test import
-                    if (source.isTestImport() || source.isNormalImport()) {
-                        return source.isEnumeratedImport ? source.importLoc : core::LocOffsets::none();
-                    }
-
-                    // friend import
-                    return packageLoc->offsets();
-                }(source, packageLoc);
+                const auto &moduleLoc = getModuleLoc(source, packageLoc);
 
                 auto mod = ast::MK::Module(core::LocOffsets::none(), moduleLoc,
                                            importModuleName(parts, moduleLoc, moduleType), {}, std::move(rhs));
                 modRhs.emplace_back(std::move(mod));
             }
         }
+    }
+
+    const core::LocOffsets getModuleLoc(ImportTree::Source &source, const core::Loc *packageLoc) {
+        // normal or test import
+        if (source.isTestImport() || source.isNormalImport()) {
+            return source.isEnumeratedImport ? source.importLoc : core::LocOffsets::none();
+        }
+
+        // friend import
+        return packageLoc->offsets();
     }
 
     // Create an error that occurs if a package imports two names where one is a prefix of another. This is disallowed,

--- a/test/testdata/packager/lsp_features/__package.rb
+++ b/test/testdata/packager/lsp_features/__package.rb
@@ -4,6 +4,8 @@
 
 class Simpsons < PackageSpec
     # ^^^^^^^^ symbol-search: "Simpsons", name = "Simpsons", container = "(nothing)"
+    # ^^^^^^^^ symbol-search: "Simpsons", name = "Simpsons", container = "Simpsons"
+    # ^^^^^^^^ symbol-search: "Simpsons", name = "Simpsons", container = "<PackageTests>::Simpsons_Package_Private"
     # ^ show-symbol: Simpsons
     # go-to-def on a reference to Bart within the package goes here, but go-to-def on Bart in `import Bart` goes to the
     # package.
@@ -18,13 +20,10 @@ class Simpsons < PackageSpec
     #           ^         show-symbol: Krabappel
 
     export Simpsons::Family
-    #      ^^^^^^^^ symbol-search: "Simpsons", name = "Simpsons", container = "Simpsons"
     #                ^^^^^^ usage: family
     #                ^      show-symbol: Simpsons::Family
 
     export_for_test Simpsons::Private
     #                         ^^^^^^^ usage: s-private
-    #               ^^^^^^^^^^^^^^^^^ symbol-search: "Simpsons", name = "Simpsons", container = "<PackageTests>::Simpsons_Package_Private"
     #                         ^       show-symbol: Simpsons::Private
-    #               ^                 show-symbol: Simpsons
 end

--- a/test/testdata/packager/lsp_features/bart/__package.rb
+++ b/test/testdata/packager/lsp_features/bart/__package.rb
@@ -5,18 +5,15 @@
 class Bart < PackageSpec
     # ^^^^ def: bartpkg
     # ^^^^ symbol-search: "Bart", name = "Bart", container = "(nothing)"
+    # ^^^^ symbol-search: "Bart", name = "Bart", container = "Bart"
+    # ^^^^ symbol-search: "Bart", name = "Bart", container = "<PackageTests>::Bart_Package_Private"
     # ^ show-symbol: Bart
     export Bart::Character
-    #      ^^^^ symbol-search: "Bart", name = "Bart", container = "Bart"
-    #      ^^^^ def: bart 1 not-def-of-self
     #      ^^^^ usage: bartmod
     #            ^^^^^^^^^ usage: character
     #            ^^^^^^^^^ hover: Character class description
-    #      ^^^^^^^^^^^^^^^ symbol-search: "Bart", name = "Bart", container = "<PackageTests>::Bart_Package_Private"
     #            ^ show-symbol: Bart::Character
-    #      ^ show-symbol: Bart
     export Bart::CatchPhrase
-    #      ^^^^ def: bart 2 not-def-of-self
     #      ^^^^ usage: bartmod
     #            ^^^^^^^^^^^ usage: catchphrase
     #            ^ show-symbol: Bart::CatchPhrase

--- a/test/testdata/packager/lsp_features/family.rb
+++ b/test/testdata/packager/lsp_features/family.rb
@@ -11,7 +11,6 @@ module Simpsons
       sig {returns(String)}
       def son_catchphrase
           Bart::CatchPhrase
-      #   ^^^^ usage: bart
       #   ^^^^ hover: T.class_of(Bart)
       #   ^    show-symbol: Bart
           #     ^^^^^^^^^^^ usage: catchphrase
@@ -20,11 +19,9 @@ module Simpsons
       end
 
       sig {returns(Bart::Character)}
-      #            ^^^^ usage: bart
       #                  ^^^^^^^^^ usage: character
       def son
           Bart::Character.new
-      #   ^^^^ usage: bart
           #     ^^^^^^^^^ usage: character
           #     ^^^^^^^^^ hover: T.class_of(Bart::Character)
           #     ^         show-symbol: Bart::Character
@@ -32,7 +29,6 @@ module Simpsons
           #               ^^^ hover: Description of Character initialize
           Bart::C # error: Unable to resolve constant `C`
           #      ^ completion: CatchPhrase, Character
-      #   ^^^^ usage: bart
       end
   end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Fixes jump-to-definition behavior in packager. For un-enumerated imports -- i.e. where the top-level namespace of the package is directly aliased into the importing package's namespace -- the current behavior for jump-to-def is to jump to the package file of the import itself. However, it jumps to the last export statement of the package file, which is confusing. Instead, we make it jump to the beginning of the file.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Better usability. Note that ideally, we'd want to standardize the behavior of jump-to-def regardless of whether the import is "enumerated" or "un-enumerated", as that's just an implementation detail of the packager. However, that's a little more complex to make work, and given that the current packager design is a stop-gap for the long run anyway, I think this is probably the local maximum we can achieve.

See jump-to-def behavior in [sorbet.run](https://sorbet.run/#%23%20typed%3A%20true%0Amodule%20PkgOpusFooPriv%0A%20%20module%20Opus%0A%20%20%20%20module%20Foo%0A%20%20%20%20%20%20module%20A%3B%20end%0A%20%20%20%20%20%20module%20B%3B%20end%0A%20%20%20%20end%0A%20%20end%0Aend%0A%0Amodule%20PkgOpusFooPub%0A%20%20module%20Opus%0A%20%20%20%20module%20Foo%0A%20%20%20%20%20%20A%20%3D%20PkgOpusFooPriv%3A%3AOpus%3A%3AFoo%3A%3AA%0A%20%20%20%20end%0A%0A%20%20%20%20module%20Foo%0A%20%20%20%20%20%20B%20%3D%20PkgOpusFooPriv%3A%3AOpus%3A%3AFoo%3A%3AB%0A%20%20%20%20end%0A%20%20end%0Aend%0A%0Amodule%20PkgOpusBar%0A%20%20module%20Opus%0A%20%20%20%20Foo%20%3D%20PkgOpusFooPub%3A%3AOpus%3A%3AFoo%0A%20%20end%0A%0A%20%20Opus%3A%3AFoo%3A%3AA%0A%23%20%20%20%20%20%20%20%5E%5E%5E%20Foo%20points%20to%20line%2017%0A%23%20%20%20%20%20%20%20%20%20%20%20%20%5E%20A%20points%20to%20line%205%0A%20%20Opus%3A%3AFoo%3A%3AB%0A%23%20%20%20%20%20%20%20%5E%5E%5E%20Foo%20points%20to%20line%2017%0A%23%20%20%20%20%20%20%20%20%20%20%20%20%5E%20B%20points%20to%20line%206%0Aend%0A%0A%23%20We%20effectively%20%22fake%22%20the%20location%20of%20line%2017%20to%20point%20to%20the%20top%20of%20the%20package%20file.) for a simulation.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tested on Stripe codebase, updated existing LSP test.

ptal: @ngroman 