### PR TITLE
Fixes Newton, Jacobian and LUSolve type declarations

### DIFF
--- a/rbi/stdlib/bigdecimal.rbi
+++ b/rbi/stdlib/bigdecimal.rbi
@@ -1378,10 +1378,21 @@ end
 module Jacobian
 
   # Computes the derivative of `f` at `x`. `fx` is the value of `f` at `x`.
+  def dfdxi(f, fx, x, i); end
+
+  # Computes the derivative of `f` at `x`. `fx` is the value of `f` at `x`.
   def self.dfdxi(f, fx, x, i); end
 
   # Determines the equality of two numbers by comparing to zero, or using the epsilon value
+  def isEqual(a, b, zero = 0.0, e = _); end
+
+  # Determines the equality of two numbers by comparing to zero, or using the epsilon value
   def self.isEqual(a, b, zero = 0.0, e = _); end
+
+  # Computes the
+  # [`Jacobian`](https://docs.ruby-lang.org/en/2.6.0/Jacobian.html)
+  # of `f` at `x`. `fx` is the value of `f` at `x`.
+  def jacobian(f, fx, x); end
 
   # Computes the
   # [`Jacobian`](https://docs.ruby-lang.org/en/2.6.0/Jacobian.html)
@@ -1392,7 +1403,18 @@ end
 # Solves a\*x = b for x, using LU decomposition.
 module LUSolve
   # Performs LU decomposition of the `n` by `n` matrix `a`.
+  def ludecomp(a, n, zero = 0, one = 1); end
+
+  # Performs LU decomposition of the `n` by `n` matrix `a`.
   def self.ludecomp(a, n, zero = 0, one = 1); end
+
+  # Solves `a*x = b` for `x`, using LU decomposition.
+  #
+  # `a` is a matrix, `b` is a constant vector, `x` is the solution vector.
+  #
+  # `ps` is the pivot, a vector which indicates the permutation of rows
+  # performed during LU decomposition.
+  def lusolve(a, b, ps, zero = 0.0); end
 
   # Solves `a*x = b` for `x`, using LU decomposition.
   #
@@ -1443,7 +1465,11 @@ module Newton
   include(::Jacobian)
   include(::LUSolve)
 
+  def nlsolve(f, x); end
+
   def self.nlsolve(f, x); end
+
+  def norm(fv, zero = _); end
 
   def self.norm(fv, zero = _); end
 end


### PR DESCRIPTION
Hey there, friends!

I'm working on some financial math and I'm using some of the methods available in BigDecimal. More specifically, the Newton module. I was having some trouble with sorbet trying to make my file `typed: strict` until I was joined by @vinistock and we learned that the type definitions for the Newton, Jacobian and LUSolve modules for the BigDecimal gem are incorrect.

They are only declared as class methods when they are, in fact, instance methods as well since all modules are declared as `module_functions`.
Newton: https://github.com/ruby/bigdecimal/blob/master/lib/bigdecimal/newton.rb#L44
Jacobian: https://github.com/ruby/bigdecimal/blob/master/lib/bigdecimal/jacobian.rb#L26
LUSolve: https://github.com/ruby/bigdecimal/blob/master/lib/bigdecimal/ludcmp.rb#L11

This PR fixes the incorrect rbi definitions for the Newton, Jacobian and LUSolve modules.

### Motivation
The missing definitions caused sorbet to behave erratically when trying to use the `Newton::nlsolve`. A `NoMethodError` pops up because sorbet is expecting a class method but is getting a mixed in instance method.

### Test plan
This is the original code from BigDecimal:
Newton: https://github.com/ruby/bigdecimal/blob/master/lib/bigdecimal/newton.rb#L44
Jacobian: https://github.com/ruby/bigdecimal/blob/master/lib/bigdecimal/jacobian.rb#L26
LUSolve: https://github.com/ruby/bigdecimal/blob/master/lib/bigdecimal/ludcmp.rb#L11

Note how they're declared as instance methods and class methods (with the help of `module_functions`).

In my project, I overrode sorbet's rbi with my own rbi that declares these methods as instance methods and sorbet is finally happy and all my tests execute correctly.
