### PR TITLE
Remove --report-ambiguous-definitions flag

### DIFF
--- a/main/lsp/wrapper.cc
+++ b/main/lsp/wrapper.cc
@@ -24,10 +24,6 @@ void setRequiredLSPOptions(core::GlobalState &gs, options::Options &options) {
         gs.suppressErrorClass(sorbet::core::errors::Namer::MultipleBehaviorDefs.code);
     }
 
-    if (!options.reportAmbiguousDefinitionErrors) {
-        gs.suppressErrorClass(sorbet::core::errors::Resolver::AmbiguousDefinitionError.code);
-    }
-
     gs.requiresAncestorEnabled = options.requiresAncestorEnabled;
 
     // Ensure LSP is enabled.

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -353,8 +353,6 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
         cxxopts::value<vector<string>>(), "string");
     options.add_options("advanced")("no-error-count", "Do not print the error count summary line");
     options.add_options("advanced")("autogen-version", "Autogen version to output", cxxopts::value<int>());
-    options.add_options("advanced")("report-ambiguous-definitions", "Enable ambiguous definition error enforcement",
-                                    cxxopts::value<bool>());
     options.add_options("advanced")("stripe-mode", "Enable Stripe specific error enforcement", cxxopts::value<bool>());
     options.add_options("advanced")("stripe-packages", "Enable support for Stripe's internal Ruby package system",
                                     cxxopts::value<bool>());
@@ -876,7 +874,6 @@ void readOptions(Options &opts,
             }
             opts.autogenVersion = raw["autogen-version"].as<int>();
         }
-        opts.reportAmbiguousDefinitionErrors = raw["report-ambiguous-definitions"].as<bool>();
         opts.stripeMode = raw["stripe-mode"].as<bool>();
         opts.stripePackages = raw["stripe-packages"].as<bool>();
         if (raw.count("extra-package-files-directory-prefix")) {

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -157,7 +157,6 @@ struct Options {
     int threads = 0;
     int logLevel = 0; // number of time -v was passed
     int autogenVersion = 0;
-    bool reportAmbiguousDefinitionErrors = false;
     bool stripeMode = false;
     bool stripePackages = false;
     std::vector<std::string> extraPackageFilesDirectoryPrefixes;

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -501,12 +501,6 @@ int realmain(int argc, char *argv[]) {
             gs->suppressErrorClass(core::errors::Namer::MultipleBehaviorDefs.code);
         }
     }
-    if (!opts.reportAmbiguousDefinitionErrors) {
-        // TODO (aadi-stripe, 1/16/2022): Determine whether this error should always be reported.
-        if (opts.isolateErrorCode.empty()) {
-            gs->suppressErrorClass(core::errors::Resolver::AmbiguousDefinitionError.code);
-        }
-    }
     if (opts.suggestTyped) {
         gs->ignoreErrorClassForSuggestTyped(core::errors::Infer::SuggestTyped.code);
         gs->ignoreErrorClassForSuggestTyped(core::errors::Resolver::SigInFileWithoutSigil.code);

--- a/test/cli/ambiguous-definitions-packages/ambiguous-definitions-packages.sh
+++ b/test/cli/ambiguous-definitions-packages/ambiguous-definitions-packages.sh
@@ -4,6 +4,6 @@ set -e
 
 cd test/cli/ambiguous-definitions-packages || exit 1
 
-../../../main/sorbet --silence-dev-message --report-ambiguous-definitions --stripe-packages . 2>&1
+../../../main/sorbet --silence-dev-message --stripe-packages . 2>&1
 
 

--- a/test/cli/ambiguous-definitions/ambiguous-definitions.sh
+++ b/test/cli/ambiguous-definitions/ambiguous-definitions.sh
@@ -2,5 +2,5 @@
 
 set -e
 
-main/sorbet --silence-dev-message --report-ambiguous-definitions test/cli/ambiguous-definitions/foo.rb 2>&1
+main/sorbet --silence-dev-message test/cli/ambiguous-definitions/foo.rb 2>&1
 

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -134,8 +134,6 @@ Usage:
                                 that understand them.
       --no-error-count          Do not print the error count summary line
       --autogen-version arg     Autogen version to output
-      --report-ambiguous-definitions
-                                Enable ambiguous definition error enforcement
       --stripe-mode             Enable Stripe specific error enforcement
       --stripe-packages         Enable support for Stripe's internal Ruby
                                 package system

--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -329,7 +329,6 @@ TEST_CASE("LSPTest") {
             }
             opts->secondaryTestPackageNamespaces.emplace_back("Critic");
         }
-        opts->reportAmbiguousDefinitionErrors = true;
         // Set to a number that is reasonable large for tests, but small enough that we can have a test to handle this
         // edge case. If you change this number, update the `lsp/fast_path/too_many_files` and `not_enough_files` tests.
         opts->lspMaxFilesOnFastPath = 10;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Early feedback suggested that this was not super annoying, and in many
cases helpful.

For those who wish to achieve the old behavior, feel free to add

    --suppress-error-code=5068

to the command line when invoking Sorbet, or to your `sorbet/config`
file.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.