### PR TITLE
Fix AST cast bug in packager for eigenclass declarations in debug mode

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -518,12 +518,16 @@ public:
             return tree;
         }
 
-        auto &constantLit = ast::cast_tree_nonnull<ast::UnresolvedConstantLit>(classDef.name);
-        pushConstantLit(&constantLit);
+        ast::UnresolvedConstantLit *constantLit = ast::cast_tree<ast::UnresolvedConstantLit>(classDef.name);
+        if (constantLit == nullptr) {
+            return tree;
+        }
+
+        pushConstantLit(constantLit);
         auto &pkgName = requiredNamespace(ctx.state);
 
         if (rootConsts == 0 && !sharesPrefix(pkgName, nameParts)) {
-            if (auto e = ctx.beginError(constantLit.loc, core::errors::Packager::DefinitionPackageMismatch)) {
+            if (auto e = ctx.beginError(constantLit->loc, core::errors::Packager::DefinitionPackageMismatch)) {
                 e.setHeader(
                     "Class or method definition must match enclosing package namespace `{}`",
                     fmt::map_join(pkgName.begin(), pkgName.end(), "::", [&](const auto &nr) { return nr.show(ctx); }));
@@ -542,11 +546,17 @@ public:
             ENFORCE(skipPush == 0);
             return tree;
         }
-        auto *constantLit = &ast::cast_tree_nonnull<ast::UnresolvedConstantLit>(classDef.name);
+
         if (skipPush > 0) {
             skipPush--;
             return tree;
         }
+
+        ast::UnresolvedConstantLit *constantLit = ast::cast_tree<ast::UnresolvedConstantLit>(classDef.name);
+        if (constantLit == nullptr) {
+            return tree;
+        }
+
         popConstantLit(constantLit);
         return tree;
     }

--- a/test/cli/package-eigenclass/__package.rb
+++ b/test/cli/package-eigenclass/__package.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Root < PackageSpec
+end

--- a/test/cli/package-eigenclass/a.rb
+++ b/test/cli/package-eigenclass/a.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Root::A
+  class << self
+  end
+end
+

--- a/test/cli/package-eigenclass/package-eigenclass.out
+++ b/test/cli/package-eigenclass/package-eigenclass.out
@@ -1,0 +1,1 @@
+No errors! Great job.

--- a/test/cli/package-eigenclass/package-eigenclass.sh
+++ b/test/cli/package-eigenclass/package-eigenclass.sh
@@ -1,0 +1,4 @@
+cd test/cli/package-eigenclass || exit 0
+
+../../../main/sorbet --silence-dev-message --stripe-packages --max-threads=0 . 2>&1
+


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Currently, there is a bug due to the fact that the AST node associated with eigenclass declarations (`class << self`) is differently shaped in debug mode, leading to an ENFORCE failure due to an unsafe `non_null` AST cast. This change guards against the error by using a safe cast.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
In order to make some tooling in Stripe's codebase work in `--stripe-packages` mode, we need to make sure the debug build of Sorbet works correctly.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Added a unit test.