### PR TITLE
Fix infinite loop in PackageDB when a path beginning in '/' is passed in

### DIFF
--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -120,7 +120,7 @@ const PackageInfo &PackageDB::getPackageForFile(const core::GlobalState &gs, cor
     auto &fileData = file.data(gs);
     string_view path = fileData.path();
     int curPrefixPos = path.find_last_of('/');
-    while (curPrefixPos != string::npos) {
+    while (curPrefixPos > 0) {
         const auto &it = packagesByPathPrefix.find(path.substr(0, curPrefixPos + 1));
         if (it != packagesByPathPrefix.end()) {
             const auto &pkg = getPackageInfo(it->second);

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -248,15 +248,20 @@ struct Options {
 
     void flushPrinters();
 
-    Options() = default;
+    Options clone() {
+        Options options(*this);
+        return options;
+    };
 
-    Options(const Options &) = delete;
+    Options() = default;
 
     Options(Options &&) = default;
 
-    Options &operator=(const Options &) = delete;
-
     Options &operator=(Options &&) = delete;
+
+private:
+    Options(const Options &) = default;
+    Options &operator=(const Options &) = default;
 };
 
 void readOptions(

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -625,7 +625,13 @@ int realmain(int argc, char *argv[]) {
             // The trick there is that they would all currently output to the same file, even for
             // multiple input files if we assume the naive implementation, which might not be the
             // API we want to expose.
-            Minimize::indexAndResolveForMinimize(gs, gsForMinimize, opts, *workers, opts.minimizeRBI);
+
+            auto optsForMinimize = opts.clone();
+            // Explicitly turn off the packager, because it doesn't make sense when the whole
+            // project is a single RBI file.
+            optsForMinimize.stripePackages = false;
+
+            Minimize::indexAndResolveForMinimize(gs, gsForMinimize, optsForMinimize, *workers, opts.minimizeRBI);
             Minimize::writeDiff(*gs, *gsForMinimize, opts.print.MinimizeRBI);
 #endif
         }

--- a/test/cli/simple-package-rbi-gen/foo/__package.rb
+++ b/test/cli/simple-package-rbi-gen/foo/__package.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Project::Foo < PackageSpec
+end

--- a/test/cli/simple-package-rbi-gen/foo/foo.rb
+++ b/test/cli/simple-package-rbi-gen/foo/foo.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# typed: strict
+
+module Project::Foo
+  class FooClass
+    extend T::Sig
+    sig { params(value: Integer).void }
+    def initialize(value)
+      @value = T.let(value, Integer)
+    end
+  end
+end

--- a/test/cli/simple-package-rbi-gen/simple-package-rbi-gen.out
+++ b/test/cli/simple-package-rbi-gen/simple-package-rbi-gen.out
@@ -1,0 +1,9 @@
+No errors! Great job.
+# typed: true
+
+class ::Project::Foo::FooClass
+  extend ::T::Sig
+  def dynamically_defined_method(); end
+  def initialize(value); end
+end
+

--- a/test/cli/simple-package-rbi-gen/simple-package-rbi-gen.sh
+++ b/test/cli/simple-package-rbi-gen/simple-package-rbi-gen.sh
@@ -1,0 +1,22 @@
+cd test/cli/simple-package-rbi-gen || exit 1
+
+../../../main/sorbet --silence-dev-message --stripe-packages . 2>&1
+
+stderr_log="$(mktemp)"
+minimize_rbi="$(mktemp)"
+trap 'rm -rf "$stderr_log" "$minimize_rbi"' EXIT
+
+cat > "$minimize_rbi" <<RUBY
+# typed: true
+module Project::Foo
+  class FooClass
+    extend T::Sig
+    def initialize(value)
+    end
+    def dynamically_defined_method
+    end
+  end
+end
+RUBY
+
+../../../main/sorbet --silence-dev-message --stripe-packages . --minimize-to-rbi="$minimize_rbi" --print=minimized-rbi


### PR DESCRIPTION
Also turn off stripePackages checking for file passed as --minimize-to-rbi  flag

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
RBI generation using the `minimize-to-rbi` flag currently doesn't work with `--stripe-packages`. This is because of an infinite loop in the code that finds the package where a file lives. This PR:
* Fixes the infinite loop
* Turns off `--stripe-packages` checking for the `minimize-to-rbi` file itself.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
