### PR TITLE
lsp: Implement a generic approach to reporting run metrics

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -129,6 +129,10 @@ template <class From, class To> To *fast_cast(From *what) {
 // Rounds the provided number up to the nearest power of two. If v is already a power of two, it returns v.
 uint32_t nextPowerOfTwo(uint32_t v);
 
+// To get exhaustiveness checking with std::visit.
+// From: https://en.cppreference.com/w/cpp/utility/variant/visit#Example
+template <class> inline constexpr bool always_false_v = false;
+
 } // namespace sorbet
 
 std::string demangle(const char *mangled);

--- a/main/lsp/LSPTask.cc
+++ b/main/lsp/LSPTask.cc
@@ -63,8 +63,13 @@ ResponseMessageStatus statusForResponse(const ResponseMessage &response) {
                     }
                 } else if constexpr (is_same_v<T, variant<JSONNullObject, unique_ptr<Hover>>>) {
                     // textDocument/hover
-                    return holds_alternative<JSONNullObject>(res) ? ResponseMessageStatus::EmptyResult
-                                                                  : ResponseMessageStatus::Succeeded;
+                    if (const auto *hoverPtr = get_if<unique_ptr<Hover>>(&res)) {
+                        auto &hover = *hoverPtr;
+                        return hover->contents->value.empty() ? ResponseMessageStatus::EmptyResult
+                                                              : ResponseMessageStatus::Succeeded;
+                    } else {
+                        return ResponseMessageStatus::EmptyResult;
+                    }
                 } else if constexpr (is_same_v<T, unique_ptr<CompletionList>>) {
                     // textDocument/completion
                     return res->items.empty() ? ResponseMessageStatus::EmptyResult : ResponseMessageStatus::Succeeded;

--- a/main/lsp/LSPTask.cc
+++ b/main/lsp/LSPTask.cc
@@ -59,7 +59,7 @@ ResponseMessageStatus statusForResponse(const ResponseMessage &response) {
                     return ResponseMessageStatus::Unknown;
                 } else if constexpr (is_same_v<T, unique_ptr<CompletionList>>) {
                     // textDocument/completion
-                    return ResponseMessageStatus::Unknown;
+                    return res->items.empty() ? ResponseMessageStatus::EmptyResult : ResponseMessageStatus::Succeeded;
                 } else if constexpr (is_same_v<T, variant<JSONNullObject, unique_ptr<PrepareRenameResult>>>) {
                     // textDocument/prepareRename
                     return ResponseMessageStatus::Unknown;

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -770,7 +770,7 @@ void CompletionTask::findSimilarConstants(const core::GlobalState &gs, const cor
     }
 }
 
-unique_ptr<ResponseMessage> CompletionTask::runRequestImpl(LSPTypecheckerDelegate &typechecker) {
+unique_ptr<ResponseMessage> CompletionTask::runRequest(LSPTypecheckerDelegate &typechecker) {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentCompletion);
     auto emptyResult = make_unique<CompletionList>(false, vector<unique_ptr<CompletionItem>>{});
 
@@ -885,30 +885,6 @@ unique_ptr<ResponseMessage> CompletionTask::runRequestImpl(LSPTypecheckerDelegat
 
     response->result = make_unique<CompletionList>(false, move(items));
     return response;
-}
-
-unique_ptr<ResponseMessage> CompletionTask::runRequest(LSPTypecheckerDelegate &typechecker) {
-    auto result = runRequestImpl(typechecker);
-
-    if (result->result.has_value()) {
-        if (const auto *completionListPtr = get_if<unique_ptr<CompletionList>>(&result->result.value())) {
-            const auto &completionList = *completionListPtr;
-            if (completionList != nullptr && !completionList->items.empty()) {
-                prodCategoryCounterInc("lsp.messages.run.succeeded", methodString());
-            } else {
-                prodCategoryCounterInc("lsp.messages.run.emptyresult", methodString());
-            }
-        } else {
-            ENFORCE(false, "got wrong result variant for completion task");
-        }
-    } else if (result->error.has_value()) {
-        prodCategoryCounterInc("lsp.messages.run.errored", methodString());
-    } else {
-        ENFORCE(result->error.has_value() || result->result.has_value(),
-                "Neither result nor error were set on completion task result");
-    }
-
-    return result;
 }
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/completion.h
+++ b/main/lsp/requests/completion.h
@@ -20,8 +20,6 @@ class CompletionTask final : public LSPRequestTask {
                                                                core::Loc queryLoc, std::string_view prefix,
                                                                size_t sortIdx, uint16_t totalArgs) const;
 
-    std::unique_ptr<ResponseMessage> runRequestImpl(LSPTypecheckerDelegate &typechecker);
-
 public:
     CompletionTask(const LSPConfiguration &config, MessageId id, std::unique_ptr<CompletionParams> params);
 

--- a/test/lsp/protocol_test_corpus.cc
+++ b/test/lsp/protocol_test_corpus.cc
@@ -566,7 +566,9 @@ TEST_CASE_FIXTURE(ProtocolTest, "RequestReportsEmptyResultsMetrics") {
                                                "def foo; end\n"
                                                "end\n"
                                                "A.new.fo\n"
-                                               "A.new.no_completion_results\n")),
+                                               "A.new.no_completion_results\n"
+                                               "A.new.foo\n"
+                                               "\n")),
                       {
                           {"foo.rb", 4, "does not exist"},
                           {"foo.rb", 5, "does not exist"},
@@ -592,6 +594,24 @@ TEST_CASE_FIXTURE(ProtocolTest, "RequestReportsEmptyResultsMetrics") {
     CHECK_EQ(counters2.getCategoryCounter("lsp.messages.run.succeeded", "textDocument.completion"), 0);
     CHECK_EQ(counters2.getCategoryCounter("lsp.messages.run.emptyresult", "textDocument.completion"), 1);
     CHECK_EQ(counters2.getCategoryCounter("lsp.messages.run.errored", "textDocument.completion"), 0);
+
+    send(*getDefinition("foo.rb", 6, 7));
+
+    auto counters3 = getCounters();
+    CHECK_EQ(counters3.getCategoryCounter("lsp.messages.processed", "textDocument.definition"), 1);
+    CHECK_EQ(counters3.getCategoryCounter("lsp.messages.canceled", "textDocument.definition"), 0);
+    CHECK_EQ(counters3.getCategoryCounter("lsp.messages.run.succeeded", "textDocument.definition"), 1);
+    CHECK_EQ(counters3.getCategoryCounter("lsp.messages.run.emptyresult", "textDocument.definition"), 0);
+    CHECK_EQ(counters3.getCategoryCounter("lsp.messages.run.errored", "textDocument.definition"), 0);
+
+    send(*getDefinition("foo.rb", 5, 7));
+
+    auto counters4 = getCounters();
+    CHECK_EQ(counters4.getCategoryCounter("lsp.messages.processed", "textDocument.definition"), 1);
+    CHECK_EQ(counters4.getCategoryCounter("lsp.messages.canceled", "textDocument.definition"), 0);
+    CHECK_EQ(counters4.getCategoryCounter("lsp.messages.run.succeeded", "textDocument.definition"), 0);
+    CHECK_EQ(counters4.getCategoryCounter("lsp.messages.run.emptyresult", "textDocument.definition"), 1);
+    CHECK_EQ(counters4.getCategoryCounter("lsp.messages.run.errored", "textDocument.definition"), 0);
 }
 
 } // namespace sorbet::test::lsp

--- a/test/lsp/protocol_test_corpus.cc
+++ b/test/lsp/protocol_test_corpus.cc
@@ -568,6 +568,7 @@ TEST_CASE_FIXTURE(ProtocolTest, "RequestReportsEmptyResultsMetrics") {
                                                "A.new.fo\n"
                                                "A.new.no_completion_results\n"
                                                "A.new.foo\n"
+                                               "T.unsafe(nil).foo\n"
                                                "\n")),
                       {
                           {"foo.rb", 4, "does not exist"},
@@ -612,6 +613,24 @@ TEST_CASE_FIXTURE(ProtocolTest, "RequestReportsEmptyResultsMetrics") {
     CHECK_EQ(counters4.getCategoryCounter("lsp.messages.run.succeeded", "textDocument.definition"), 0);
     CHECK_EQ(counters4.getCategoryCounter("lsp.messages.run.emptyresult", "textDocument.definition"), 1);
     CHECK_EQ(counters4.getCategoryCounter("lsp.messages.run.errored", "textDocument.definition"), 0);
+
+    send(*hover("foo.rb", 6, 7));
+
+    auto counters5 = getCounters();
+    CHECK_EQ(counters5.getCategoryCounter("lsp.messages.processed", "textDocument.hover"), 1);
+    CHECK_EQ(counters5.getCategoryCounter("lsp.messages.canceled", "textDocument.hover"), 0);
+    CHECK_EQ(counters5.getCategoryCounter("lsp.messages.run.succeeded", "textDocument.hover"), 1);
+    CHECK_EQ(counters5.getCategoryCounter("lsp.messages.run.emptyresult", "textDocument.hover"), 0);
+    CHECK_EQ(counters5.getCategoryCounter("lsp.messages.run.errored", "textDocument.hover"), 0);
+
+    send(*hover("foo.rb", 7, 16));
+
+    auto counters6 = getCounters();
+    CHECK_EQ(counters6.getCategoryCounter("lsp.messages.processed", "textDocument.hover"), 1);
+    CHECK_EQ(counters6.getCategoryCounter("lsp.messages.canceled", "textDocument.hover"), 0);
+    CHECK_EQ(counters6.getCategoryCounter("lsp.messages.run.succeeded", "textDocument.hover"), 0);
+    CHECK_EQ(counters6.getCategoryCounter("lsp.messages.run.emptyresult", "textDocument.hover"), 1);
+    CHECK_EQ(counters6.getCategoryCounter("lsp.messages.run.errored", "textDocument.hover"), 0);
 }
 
 } // namespace sorbet::test::lsp


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

In #5040 I implemented something to start tracking metrics for completion.

I also wanted those metrics for a handful of other methods (mostly
go-to-definition and hover).

Given that, I wanted to go with a slightly more extensible approach.

### Commit summary

I recommend reviewing by commit, because I refactored some old code and wrote new code in separate commits.

- **More generic approach to reporting run metrics** (f636eb0f3)


- **Replace completion metrics using generic approach** (013813615)


- **Implement more requests** (8b161fbb6)


- **The old test does not need multi-threading** (d37c6cecb)


- **Add more tests for getDefinition** (2b5921ab0)


- **Add test for hover** (c382bd086)

  Writing this test actually caught a bug in the implementation which was
  great.




### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.