### PR TITLE
Skip processing `typed: ignore` package files

### DIFF
--- a/test/testdata/packager/ignored_package/__package.rb
+++ b/test/testdata/packager/ignored_package/__package.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# typed: ignore
+# enable-packager: true
+
+class Project::Foo < PackageSpec
+  export Project::Foo::Foo
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Right now we'll crash if we ever mark a `__package.rb` file as `typed: ignore`. This ensures that we don't process those.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. In addition to testing this locally, I also modified `pipeline_test_runner.cc` to actually skip `typed: ignore` files (whereas it was parsing them before) so I could add a real test of this.