### PR TITLE
consistently return early for query errors in LSP requests

### DIFF
--- a/main/lsp/requests/definition.cc
+++ b/main/lsp/requests/definition.cc
@@ -17,43 +17,44 @@ unique_ptr<ResponseMessage> DefinitionTask::runRequest(LSPTypecheckerDelegate &t
     if (result.error) {
         // An error happened while setting up the query.
         response->error = move(result.error);
-    } else {
-        auto &queryResponses = result.responses;
-        vector<unique_ptr<Location>> result;
-        if (!queryResponses.empty()) {
-            const bool fileIsTyped =
-                config.uri2FileRef(gs, params->textDocument->uri).data(gs).strictLevel >= core::StrictLevel::True;
-            auto resp = move(queryResponses[0]);
+        return response;
+    }
 
-            // Only support go-to-definition on constants and fields in untyped files.
-            if (auto c = resp->isConstant()) {
-                auto sym = c->symbol;
-                for (auto loc : sym.locs(gs)) {
-                    addLocIfExists(gs, result, loc);
+    auto &queryResponses = result.responses;
+    vector<unique_ptr<Location>> result;
+    if (!queryResponses.empty()) {
+        const bool fileIsTyped =
+            config.uri2FileRef(gs, params->textDocument->uri).data(gs).strictLevel >= core::StrictLevel::True;
+        auto resp = move(queryResponses[0]);
+
+        // Only support go-to-definition on constants and fields in untyped files.
+        if (auto c = resp->isConstant()) {
+            auto sym = c->symbol;
+            for (auto loc : sym.locs(gs)) {
+                addLocIfExists(gs, result, loc);
+            }
+        } else if (resp->isField() || (fileIsTyped && (resp->isIdent() || resp->isLiteral()))) {
+            auto retType = resp->getTypeAndOrigins();
+            for (auto &originLoc : retType.origins) {
+                addLocIfExists(gs, result, originLoc);
+            }
+        } else if (fileIsTyped && resp->isDefinition()) {
+            auto sym = resp->isDefinition()->symbol;
+            for (auto loc : sym.locs(gs)) {
+                addLocIfExists(gs, result, loc);
+            }
+        } else if (fileIsTyped && resp->isSend()) {
+            auto sendResp = resp->isSend();
+            auto start = sendResp->dispatchResult.get();
+            while (start != nullptr) {
+                if (start->main.method.exists() && !start->main.receiver.isUntyped()) {
+                    addLocIfExists(gs, result, start->main.method.data(gs)->loc());
                 }
-            } else if (resp->isField() || (fileIsTyped && (resp->isIdent() || resp->isLiteral()))) {
-                auto retType = resp->getTypeAndOrigins();
-                for (auto &originLoc : retType.origins) {
-                    addLocIfExists(gs, result, originLoc);
-                }
-            } else if (fileIsTyped && resp->isDefinition()) {
-                auto sym = resp->isDefinition()->symbol;
-                for (auto loc : sym.locs(gs)) {
-                    addLocIfExists(gs, result, loc);
-                }
-            } else if (fileIsTyped && resp->isSend()) {
-                auto sendResp = resp->isSend();
-                auto start = sendResp->dispatchResult.get();
-                while (start != nullptr) {
-                    if (start->main.method.exists() && !start->main.receiver.isUntyped()) {
-                        addLocIfExists(gs, result, start->main.method.data(gs)->loc());
-                    }
-                    start = start->secondary.get();
-                }
+                start = start->secondary.get();
             }
         }
-        response->result = move(result);
     }
+    response->result = move(result);
     return response;
 }
 

--- a/main/lsp/requests/signature_help.cc
+++ b/main/lsp/requests/signature_help.cc
@@ -100,11 +100,11 @@ unique_ptr<ResponseMessage> SignatureHelpTask::runRequest(LSPTypecheckerDelegate
             addSignatureHelpItem(gs, firstDispatchComponentMethod, signatures, *sendResp, numberCommas);
         }
     }
-    auto result = make_unique<SignatureHelp>(move(signatures));
+    auto sigHelp = make_unique<SignatureHelp>(move(signatures));
     if (activeParameter != -1) {
-        result->activeParameter = activeParameter;
+        sigHelp->activeParameter = activeParameter;
     }
-    response->result = move(result);
+    response->result = move(sigHelp);
     return response;
 }
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/sorbet_show_symbol.cc
+++ b/main/lsp/requests/sorbet_show_symbol.cc
@@ -22,50 +22,51 @@ unique_ptr<ResponseMessage> SorbetShowSymbolTask::runRequest(LSPTypecheckerDeleg
     if (result.error) {
         // An error happened while setting up the query.
         response->error = move(result.error);
-    } else {
-        auto &queryResponses = result.responses;
-        if (queryResponses.empty()) {
-            // Note: Need to specifically specify the variant type here so the null gets placed into the proper slot.
-            response->result = variant<JSONNullObject, unique_ptr<SymbolInformation>>(JSONNullObject());
-            return response;
-        }
-
-        auto resp = move(queryResponses[0]);
-
-        core::SymbolRef sym;
-        if (auto c = resp->isConstant()) {
-            // Using symbolBeforeDealias instead of symbol here lets us show the name of the actual
-            // constant under the user's cursor, not what it aliases to.
-            sym = c->symbolBeforeDealias;
-        } else if (auto d = resp->isDefinition()) {
-            sym = d->symbol;
-        } else if (auto f = resp->isField()) {
-            sym = f->symbol;
-        } else if (auto s = resp->isSend()) {
-            if (s->dispatchResult->secondary == nullptr) {
-                // Multiple results not currently supported.
-                sym = s->dispatchResult->main.method;
-            }
-        }
-
-        if (!sym.exists()) {
-            // At time of writing, we decided that it only makes sense to respond with information in
-            // this request when there's a Symbol (in the GlobalState sense), and not to respond
-            // with results for say local variables and other things not in the symbol table.
-            response->result = variant<JSONNullObject, unique_ptr<SymbolInformation>>(JSONNullObject());
-            return response;
-        }
-
-        auto result = make_unique<SymbolInformation>(sym.show(gs), symbolRef2SymbolKind(gs, sym),
-                                                     config.loc2Location(gs, sym.loc(gs)));
-
-        auto container = sym.owner(gs);
-        if (container != core::Symbols::root()) {
-            result->containerName = container.show(gs);
-        }
-
-        response->result = std::move(result);
+        return response;
     }
+
+    auto &queryResponses = result.responses;
+    if (queryResponses.empty()) {
+        // Note: Need to specifically specify the variant type here so the null gets placed into the proper slot.
+        response->result = variant<JSONNullObject, unique_ptr<SymbolInformation>>(JSONNullObject());
+        return response;
+    }
+
+    auto resp = move(queryResponses[0]);
+
+    core::SymbolRef sym;
+    if (auto c = resp->isConstant()) {
+        // Using symbolBeforeDealias instead of symbol here lets us show the name of the actual
+        // constant under the user's cursor, not what it aliases to.
+        sym = c->symbolBeforeDealias;
+    } else if (auto d = resp->isDefinition()) {
+        sym = d->symbol;
+    } else if (auto f = resp->isField()) {
+        sym = f->symbol;
+    } else if (auto s = resp->isSend()) {
+        if (s->dispatchResult->secondary == nullptr) {
+            // Multiple results not currently supported.
+            sym = s->dispatchResult->main.method;
+        }
+    }
+
+    if (!sym.exists()) {
+        // At time of writing, we decided that it only makes sense to respond with information in
+        // this request when there's a Symbol (in the GlobalState sense), and not to respond
+        // with results for say local variables and other things not in the symbol table.
+        response->result = variant<JSONNullObject, unique_ptr<SymbolInformation>>(JSONNullObject());
+        return response;
+    }
+
+    auto result = make_unique<SymbolInformation>(sym.show(gs), symbolRef2SymbolKind(gs, sym),
+                                                 config.loc2Location(gs, sym.loc(gs)));
+
+    auto container = sym.owner(gs);
+    if (container != core::Symbols::root()) {
+        result->containerName = container.show(gs);
+    }
+
+    response->result = std::move(result);
     return response;
 }
 

--- a/main/lsp/requests/sorbet_show_symbol.cc
+++ b/main/lsp/requests/sorbet_show_symbol.cc
@@ -58,15 +58,15 @@ unique_ptr<ResponseMessage> SorbetShowSymbolTask::runRequest(LSPTypecheckerDeleg
         return response;
     }
 
-    auto result = make_unique<SymbolInformation>(sym.show(gs), symbolRef2SymbolKind(gs, sym),
-                                                 config.loc2Location(gs, sym.loc(gs)));
+    auto symInfo = make_unique<SymbolInformation>(sym.show(gs), symbolRef2SymbolKind(gs, sym),
+                                                  config.loc2Location(gs, sym.loc(gs)));
 
     auto container = sym.owner(gs);
     if (container != core::Symbols::root()) {
-        result->containerName = container.show(gs);
+        symInfo->containerName = container.show(gs);
     }
 
-    response->result = std::move(result);
+    response->result = std::move(symInfo);
     return response;
 }
 

--- a/main/lsp/requests/type_definition.cc
+++ b/main/lsp/requests/type_definition.cc
@@ -61,7 +61,7 @@ unique_ptr<ResponseMessage> TypeDefinitionTask::runRequest(LSPTypecheckerDelegat
     }
 
     auto &queryResponses = result.responses;
-    vector<unique_ptr<Location>> result;
+    vector<unique_ptr<Location>> locations;
     if (!queryResponses.empty()) {
         const bool fileIsTyped =
             config.uri2FileRef(gs, params->textDocument->uri).data(gs).strictLevel >= core::StrictLevel::True;
@@ -70,16 +70,16 @@ unique_ptr<ResponseMessage> TypeDefinitionTask::runRequest(LSPTypecheckerDelegat
         // Only support go-to-type-definition on constants and fields in untyped files.
         if (resp->isConstant() || resp->isField() || (fileIsTyped && (resp->isIdent() || resp->isLiteral()))) {
             for (auto loc : locsForType(gs, resp->getRetType())) {
-                addLocIfExists(gs, result, loc);
+                addLocIfExists(gs, locations, loc);
             }
         } else if (fileIsTyped && resp->isSend()) {
             auto sendResp = resp->isSend();
             for (auto loc : locsForType(gs, sendResp->dispatchResult->returnType)) {
-                addLocIfExists(gs, result, loc);
+                addLocIfExists(gs, locations, loc);
             }
         }
     }
-    response->result = move(result);
+    response->result = move(locations);
     return response;
 }
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/type_definition.cc
+++ b/main/lsp/requests/type_definition.cc
@@ -57,28 +57,29 @@ unique_ptr<ResponseMessage> TypeDefinitionTask::runRequest(LSPTypecheckerDelegat
     if (result.error) {
         // An error happened while setting up the query.
         response->error = move(result.error);
-    } else {
-        auto &queryResponses = result.responses;
-        vector<unique_ptr<Location>> result;
-        if (!queryResponses.empty()) {
-            const bool fileIsTyped =
-                config.uri2FileRef(gs, params->textDocument->uri).data(gs).strictLevel >= core::StrictLevel::True;
-            auto resp = move(queryResponses[0]);
+        return response;
+    }
 
-            // Only support go-to-type-definition on constants and fields in untyped files.
-            if (resp->isConstant() || resp->isField() || (fileIsTyped && (resp->isIdent() || resp->isLiteral()))) {
-                for (auto loc : locsForType(gs, resp->getRetType())) {
-                    addLocIfExists(gs, result, loc);
-                }
-            } else if (fileIsTyped && resp->isSend()) {
-                auto sendResp = resp->isSend();
-                for (auto loc : locsForType(gs, sendResp->dispatchResult->returnType)) {
-                    addLocIfExists(gs, result, loc);
-                }
+    auto &queryResponses = result.responses;
+    vector<unique_ptr<Location>> result;
+    if (!queryResponses.empty()) {
+        const bool fileIsTyped =
+            config.uri2FileRef(gs, params->textDocument->uri).data(gs).strictLevel >= core::StrictLevel::True;
+        auto resp = move(queryResponses[0]);
+
+        // Only support go-to-type-definition on constants and fields in untyped files.
+        if (resp->isConstant() || resp->isField() || (fileIsTyped && (resp->isIdent() || resp->isLiteral()))) {
+            for (auto loc : locsForType(gs, resp->getRetType())) {
+                addLocIfExists(gs, result, loc);
+            }
+        } else if (fileIsTyped && resp->isSend()) {
+            auto sendResp = resp->isSend();
+            for (auto loc : locsForType(gs, sendResp->dispatchResult->returnType)) {
+                addLocIfExists(gs, result, loc);
             }
         }
-        response->result = move(result);
     }
+    response->result = move(result);
     return response;
 }
 } // namespace sorbet::realmain::lsp


### PR DESCRIPTION
Some LSP requests return early when query errors happen.  Others introduce an extra level of indentation.  The first style is more readable, IMHO, even if the code is a little bit longer, so let's standardize.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Clearer code.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
