### PR TITLE
More consistent error messages for malformed signatures

### DIFF
--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -158,7 +158,7 @@ ParsedSig parseSigWithSelfTypeParams(core::Context ctx, const ast::Send &sigSend
             if (tsend->fun == core::Names::typeParameters()) {
                 if (parent != nullptr) {
                     if (auto e = ctx.beginError(tsend->loc, core::errors::Resolver::InvalidMethodSignature)) {
-                        e.setHeader("Malformed signature; Type parameters can only be specified in outer sig");
+                        e.setHeader("Malformed `{}`: Type parameters can only be specified in outer sig", "sig");
                     }
                     break;
                 }
@@ -170,7 +170,7 @@ ParsedSig parseSigWithSelfTypeParams(core::Context ctx, const ast::Send &sigSend
                             if (typeArgSpec.type) {
                                 if (auto e =
                                         ctx.beginError(arg.loc(), core::errors::Resolver::InvalidMethodSignature)) {
-                                    e.setHeader("Malformed signature; Type argument `{}` was specified twice",
+                                    e.setHeader("Malformed `{}`: Type argument `{}` was specified twice", "sig",
                                                 name.show(ctx));
                                 }
                             }
@@ -178,12 +178,12 @@ ParsedSig parseSigWithSelfTypeParams(core::Context ctx, const ast::Send &sigSend
                             typeArgSpec.loc = core::Loc(ctx.file, arg.loc());
                         } else {
                             if (auto e = ctx.beginError(arg.loc(), core::errors::Resolver::InvalidMethodSignature)) {
-                                e.setHeader("Malformed signature; Type parameters are specified with symbols");
+                                e.setHeader("Malformed `{}`: Type parameters are specified with symbols", "sig");
                             }
                         }
                     } else {
                         if (auto e = ctx.beginError(arg.loc(), core::errors::Resolver::InvalidMethodSignature)) {
-                            e.setHeader("Malformed signature; Type parameters are specified with symbols");
+                            e.setHeader("Malformed `{}`: Type parameters are specified with symbols");
                         }
                     }
                 }
@@ -192,14 +192,14 @@ ParsedSig parseSigWithSelfTypeParams(core::Context ctx, const ast::Send &sigSend
                 for (auto i = 0; i < numKwArgs; ++i) {
                     auto &kwkey = tsend->getKwKey(i);
                     if (auto e = ctx.beginError(kwkey.loc(), core::errors::Resolver::InvalidMethodSignature)) {
-                        e.setHeader("Malformed signature; Type parameters are specified with symbols");
+                        e.setHeader("Malformed `{}`: Type parameters are specified with symbols", "sig");
                     }
                 }
 
                 if (tsend->kwSplat()) {
                     if (auto e =
                             ctx.beginError(tsend->kwSplat()->loc(), core::errors::Resolver::InvalidMethodSignature)) {
-                        e.setHeader("Malformed signature; Type parameters are specified with symbols");
+                        e.setHeader("Malformed `{}`: Type parameters are specified with symbols", "sig");
                     }
                 }
             }
@@ -452,7 +452,7 @@ ParsedSig parseSigWithSelfTypeParams(core::Context ctx, const ast::Send &sigSend
                 default:
                     if (auto e = ctx.beginError(send->loc, core::errors::Resolver::InvalidMethodSignature)) {
                         reportedInvalidMethod = true;
-                        e.setHeader("Malformed signature: `{}` is invalid in this context", send->fun.show(ctx));
+                        e.setHeader("Malformed `{}`: `{}` is invalid in this context", "sig", send->fun.show(ctx));
                         e.addErrorLine(core::Loc(ctx.file, send->loc),
                                        "Consult https://sorbet.org/docs/sigs for signature syntax");
                     }
@@ -464,7 +464,7 @@ ParsedSig parseSigWithSelfTypeParams(core::Context ctx, const ast::Send &sigSend
                 if (!send->recv.isSelfReference()) {
                     if (!sig.seen.proc) {
                         if (auto e = ctx.beginError(send->loc, core::errors::Resolver::InvalidMethodSignature)) {
-                            e.setHeader("Malformed signature: `{}` being invoked on an invalid receiver",
+                            e.setHeader("Malformed `{}`: `{}` being invoked on an invalid receiver", "sig",
                                         send->fun.show(ctx));
                         }
                     }

--- a/test/cli/suggest-sig/suggest-sig.out
+++ b/test/cli/suggest-sig/suggest-sig.out
@@ -12,14 +12,14 @@ suggest-sig.rb:92: Method `with_block` uses `yield` but does not mention a block
     93 |  yield
           ^^^^^
 
-suggest-sig.rb:124: Malformed signature: `generated` is invalid in this context https://srb.help/5003
+suggest-sig.rb:124: Malformed `sig`: `generated` is invalid in this context https://srb.help/5003
      124 |sig {params(a: T.untyped, cond: T::Boolean).returns(T.untyped).generated} # error: `generated` is deprecated
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     suggest-sig.rb:124: Consult https://sorbet.org/docs/sigs for signature syntax
      124 |sig {params(a: T.untyped, cond: T::Boolean).returns(T.untyped).generated} # error: `generated` is deprecated
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-suggest-sig.rb:135: Malformed signature: `generated` is invalid in this context https://srb.help/5003
+suggest-sig.rb:135: Malformed `sig`: `generated` is invalid in this context https://srb.help/5003
      135 |  params(a: T.untyped, cond: T::Boolean). # error: `generated` is deprecated
      136 |  returns(T.untyped).
      137 |  generated

--- a/test/testdata/infer/generic_methods/genericMethodsErrors.rb
+++ b/test/testdata/infer/generic_methods/genericMethodsErrors.rb
@@ -3,7 +3,7 @@ class Foo
   extend T::Generic
   extend T::Sig
 
-  sig {type_parameters(:A, :A).params(a: T.type_parameter(:A)).returns(T.type_parameter(:A))}  # error: Malformed signature
+  sig {type_parameters(:A, :A).params(a: T.type_parameter(:A)).returns(T.type_parameter(:A))}  # error: Malformed `sig`
   def id0(a)
     a
   end

--- a/test/testdata/resolver/sig_generated.rb
+++ b/test/testdata/resolver/sig_generated.rb
@@ -3,7 +3,7 @@
 extend T::Sig
 
 sig {returns(NilClass).generated}
-#    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Malformed signature: `generated` is invalid in this context
+#    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Malformed `sig`: `generated` is invalid in this context
 #    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Non-private call to private method `generated` on `T::Private::Methods::DeclBuilder`
 def generated
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
More consistent message formatting for signature parsing errors.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
