### PR TITLE
EnforcePackagePrefix: disallow sends/method defs in wrong scope

### DIFF
--- a/test/cli/package-prefix-enforcement/package-prefix-enforcement.out
+++ b/test/cli/package-prefix-enforcement/package-prefix-enforcement.out
@@ -2,13 +2,25 @@ nested/nested.rb:5: Class or method definition must match enclosing package name
      5 |module Wrong
                ^^^^^
 
-nested/nested.rb:6: Class or method definition must match enclosing package namespace `Root::Nested` https://srb.help/3713
-     6 |  class Inside; end
-                ^^^^^^
+nested/nested.rb:40: Class or method behavior may not be defined outside of the enclosing package namespace `Root::Nested` https://srb.help/3713
+    40 |  sig {returns(NilClass)}
+          ^^^^^^^^^^^^^^^^^^^^^^^
+
+nested/nested.rb:41: Class or method behavior may not be defined outside of the enclosing package namespace `Root::Nested` https://srb.help/3713
+    41 |  def self.method
+          ^^^^^^^^^^^^^^^
+
+nested/nested.rb:37: Class or method behavior may not be defined outside of the enclosing package namespace `Root::Nested` https://srb.help/3713
+    37 |  extend T::Sig
+          ^^^^^^^^^^^^^
 
 nested/nested.rb:38: Constants may not be defined outside of the enclosing package namespace `Root::Nested` https://srb.help/3713
     38 |  NOT_IN_PACKAGE = T.let(1, Integer)
           ^^^^^^^^^^^^^^
+
+nested/nested.rb:41: Class or method behavior may not be defined outside of the enclosing package namespace `Root::Nested` https://srb.help/3713
+    41 |  def self.method
+          ^^^^^^^^^^^^^^^
 
 nested/nested.rb:54: Class or method definition must match enclosing package namespace `Root::Nested` https://srb.help/3713
     54 |module Root::ModNotInPackage
@@ -29,4 +41,4 @@ nested/nested.test.rb:16: Class or method definition must match enclosing packag
 critic_prefix/real.test.rb:13: Constants may not be defined outside of the enclosing package namespace `Critic::SomePkg` https://srb.help/3713
     13 |SomeOtherNamespace::SomePkg::SomeConst = 4
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Errors: 8
+Errors: 11

--- a/test/testdata/packager/package-prefix-enforcement/nested/nested.rb
+++ b/test/testdata/packager/package-prefix-enforcement/nested/nested.rb
@@ -5,7 +5,6 @@ extend T::Sig
 module Wrong
      # ^^^^^ error: Class or method definition must match enclosing package namespace `Root::Nested`
   class Inside; end
-      # ^^^^^^ error: Class or method definition must match enclosing package namespace `Root::Nested`
 end
 
 Root::Nested::Foo::Bar = nil
@@ -43,11 +42,14 @@ end
 
 module Root
   extend T::Sig
+# ^^^^^^^^^^^^^ error: Class or method behavior may not be defined outside of the enclosing package namespace `Root::Nested`
   NOT_IN_PACKAGE = T.let(1, Integer)
 # ^^^^^^^^^^^^^^ error: Constants may not be defined outside of the enclosing package namespace `Root::Nested`
 
   sig {returns(NilClass)}
+# ^^^^^^^^^^^^^^^^^^^^^^^ error: Class or method behavior may not be defined outside of the enclosing package namespace `Root::Nested`
   def self.method
+# ^^^^^^^^^^^^^^^ error-with-dupes: Class or method behavior may not be defined outside of the enclosing package namespace `Root::Nested`
     nil
   end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
This extends prefix enforcement to also disallow method definitions and send's outside of the correct scope. The most complex part of this logic is the book-keeping to avoid many duplicates on a single line. For example `X = T.let(foo, Integer)` is a constant assignment and multiple sends.

### Motivation
More accurate packing enforcement
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

Ran on Stripe's codebase.