### PR TITLE
add a `tok_view` method to `lexer`

### DIFF
--- a/third_party/parser/cc/lexer.rl
+++ b/third_party/parser/cc/lexer.rl
@@ -178,17 +178,29 @@ void lexer::emit_comment(const char* s, const char* e) {
 }
 
 std::string lexer::tok() {
-  return tok(ts);
+  return std::string{tok_view()};
 }
 
 std::string lexer::tok(const char* start) {
-  return tok(start, te);
+  return std::string{tok_view(start)};
 }
 
 std::string lexer::tok(const char* start, const char* end) {
+  return std::string{tok_view(start, end)};
+}
+
+std::string_view lexer::tok_view() {
+  return tok_view(ts);
+}
+
+std::string_view lexer::tok_view(const char* start) {
+  return tok_view(start, te);
+}
+
+std::string_view lexer::tok_view(const char* start, const char* end) {
   assert(start <= end);
 
-  return std::string(start, (size_t)(end - start));
+  return std::string_view(start, (size_t)(end - start));
 }
 
 char lexer::unescape(uint32_t codepoint) {

--- a/third_party/parser/include/ruby_parser/lexer.hh
+++ b/third_party/parser/include/ruby_parser/lexer.hh
@@ -113,6 +113,9 @@ private:
     std::string tok();
     std::string tok(const char *start);
     std::string tok(const char *start, const char *end);
+    std::string_view tok_view();
+    std::string_view tok_view(const char *start);
+    std::string_view tok_view(const char *start, const char *end);
     void emit(token_type type);
     void emit(token_type type, const std::string &str);
     void emit(token_type type, const std::string &str, const char *start, const char *end);
@@ -123,7 +126,7 @@ private:
     diagnostic::range range(const char *start, const char *end);
     void diagnostic_(dlevel level, dclass type, const std::string &data = "");
     void diagnostic_(dlevel level, dclass type, diagnostic::range &&range, const std::string &data = "");
-    template <typename... Args> int push_literal(Args &&... args);
+    template <typename... Args> int push_literal(Args &&...args);
     int next_state_for_literal(literal &lit);
     literal &literal_();
     int pop_literal();


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Sorbet's lexer is...less than efficient partly due to its insistence on turning everything into a `std::string`, all the time.  This PR is the first step towards addressing that inefficiency by letting the lexer hand out `std::string_view`s instead.

There are no uses of the new `tok_view` function; this is purely an interface change.  There are other changes I have that build on this one, but I figure I'd float this first.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
