### PR TITLE
store token table entries as string views

### DIFF
--- a/third_party/parser/cc/lexer.rl
+++ b/third_party/parser/cc/lexer.rl
@@ -270,7 +270,7 @@ static const lexer::token_table_entry PUNCTUATION[] = {
   { "`", token_type::tBACK_REF2 },
   { "!@", token_type::tBANG },
   { "&.", token_type::tANDDOT },
-  { NULL, token_type::error },
+  { "", token_type::error },
 };
 
 static const lexer::token_table_entry PUNCTUATION_BEGIN[] = {
@@ -283,7 +283,7 @@ static const lexer::token_table_entry PUNCTUATION_BEGIN[] = {
   { "(", token_type::tLPAREN },
   { "{", token_type::tLBRACE },
   { "[", token_type::tLBRACK },
-  { NULL, token_type::error },
+  { "", token_type::error },
 };
 
 static const lexer::token_table_entry KEYWORDS[] = {
@@ -328,7 +328,7 @@ static const lexer::token_table_entry KEYWORDS[] = {
   { "__FILE__", token_type::k__FILE__ },
   { "__LINE__", token_type::k__LINE__ },
   { "__ENCODING__", token_type::k__ENCODING__ },
-  { NULL, token_type::error },
+  { "", token_type::error },
 };
 
 static const lexer::token_table_entry KEYWORDS_BEGIN[] = {
@@ -373,7 +373,7 @@ static const lexer::token_table_entry KEYWORDS_BEGIN[] = {
   { "__FILE__", token_type::k__FILE__ },
   { "__LINE__", token_type::k__LINE__ },
   { "__ENCODING__", token_type::k__ENCODING__ },
-  { NULL, token_type::error },
+  { "", token_type::error },
 };
 
 static size_t utf8_encode_char(int32_t uc, std::string &dst) {
@@ -512,7 +512,7 @@ void lexer::emit_do(bool do_block) {
 void lexer::emit_table(const token_table_entry* table) {
   auto value = tok();
 
-  for (; table->token; ++table) {
+  for (; !table->token.empty(); ++table) {
     if (value == table->token) {
       emit(table->type, value);
       return;

--- a/third_party/parser/include/ruby_parser/lexer.hh
+++ b/third_party/parser/include/ruby_parser/lexer.hh
@@ -34,7 +34,7 @@ class lexer {
 public:
     using environment = std::set<std::string>;
     struct token_table_entry {
-        const char *token;
+        std::string_view token;
         token_type type;
     };
 


### PR DESCRIPTION
This ensures that sizes are available for string comparisons when figuring out what kind of token we found; using `char *` means that we would be recomputing string lengths (or at least looking for null terminators) on every single string comparison.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Faster lexing; this single change makes the parse phase take ~7% fewer instructions (as measured by `valgrind --tool=callgrind`) on `ruby/lib/rdoc/markdown.rb`.  (This may not be the greatest testcase, but it was the largest Ruby file in Ruby's source tree, so it seemed like a sort-of-reasonable testcase.)

For now, let's ignore the wisdom of having a finite state machine linearly scan through a table to figure out what kind of token it found, shall we?

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
