### PR TITLE
make delimited literals faster to lex

### DIFF
--- a/third_party/parser/cc/lexer.rl
+++ b/third_party/parser/cc/lexer.rl
@@ -485,14 +485,14 @@ token_t lexer::advance_() {
 }
 
 void lexer::emit(token_type type) {
-  emit(type, tok());
+  emit(type, tok_view());
 }
 
-void lexer::emit(token_type type, const std::string& str) {
+void lexer::emit(token_type type, std::string_view str) {
   emit(type, str, ts, te);
 }
 
-void lexer::emit(token_type type, const std::string& str, const char* start, const char* end) {
+void lexer::emit(token_type type, std::string_view str, const char* start, const char* end) {
   size_t offset_start = (size_t)(start - source_buffer.data());
   size_t offset_end = (size_t)(end - source_buffer.data());
 

--- a/third_party/parser/cc/lexer.rl
+++ b/third_party/parser/cc/lexer.rl
@@ -1007,8 +1007,8 @@ void lexer::set_state_expr_value() {
   };
 
   action extend_string {
-    auto str = tok();
-    std::string lookahead;
+    auto str = tok_view();
+    std::string_view lookahead;
 
     // tLABEL_END is only possible in non-cond context on >= 2.2
     if (version >= ruby_version::RUBY_22 && !cond.active()) {
@@ -1019,7 +1019,7 @@ void lexer::set_state_expr_value() {
         lookahead_e = eof;
       }
 
-      lookahead = std::string(lookahead_s, (size_t)(lookahead_e - lookahead_s));
+      lookahead = std::string_view(lookahead_s, (size_t)(lookahead_e - lookahead_s));
     }
 
     auto& current_literal = literal_();

--- a/third_party/parser/cc/literal.cc
+++ b/third_party/parser/cc/literal.cc
@@ -186,7 +186,7 @@ static bool rb_isspace(char c) {
   return c == ' ' || ('\t' <= c && c <= '\r');
 }
 
-static void lstrip(std::string& str) {
+static std::string_view lstrip(std::string_view str) {
   size_t index = 0;
 
   while (index < str.size()) {
@@ -197,20 +197,19 @@ static void lstrip(std::string& str) {
     }
   }
 
-  str.erase(0, index);
+  return str.substr(index);
 }
 
-bool literal::is_delimiter(std::string& delimiter) const {
+bool literal::is_delimiter(std::string_view delimiter) const {
   if (indent) {
-    std::string stripped_delimiter = delimiter;
-    lstrip(stripped_delimiter);
+    std::string_view stripped_delimiter = lstrip(delimiter);
     return end_delim == stripped_delimiter;
   } else {
     return end_delim == delimiter;
   }
 }
 
-static bool lookahead_quoted_label(std::string& lookahead) {
+static bool lookahead_quoted_label(std::string_view lookahead) {
   switch (lookahead.size()) {
     case 0:
       return false;
@@ -223,7 +222,7 @@ static bool lookahead_quoted_label(std::string& lookahead) {
   }
 }
 
-bool literal::nest_and_try_closing(std::string& delimiter, const char* ts, const char* te, std::string lookahead) {
+bool literal::nest_and_try_closing(std::string_view delimiter, const char* ts, const char* te, std::string_view lookahead) {
   if (start_delim.size() > 0 && start_delim == delimiter) {
     _nesting++;
   } else if (is_delimiter(delimiter)) {
@@ -271,7 +270,7 @@ void literal::extend_space(const char* ts, const char* te) {
   }
 }
 
-void literal::extend_string(std::string& str, const char* ts, const char* te) {
+void literal::extend_string(std::string_view str, const char* ts, const char* te) {
   if (!buffer_s) {
     buffer_s = ts;
   }

--- a/third_party/parser/cc/literal.cc
+++ b/third_party/parser/cc/literal.cc
@@ -307,10 +307,9 @@ void literal::clear_buffer() {
 void literal::emit_start_token() {
   auto str_type_length = 1 /* TODO @str_type.length */;
   auto str_e = heredoc_e ? heredoc_e : str_s + str_type_length;
-  std::string nothing;
-  emit(start_token_type(), nothing, str_s, str_e);
+  emit(start_token_type(), std::string_view{}, str_s, str_e);
 }
 
-void literal::emit(token_type tok, std::string& value, const char* s, const char* e) {
+void literal::emit(token_type tok, std::string_view value, const char* s, const char* e) {
   _lexer.emit(tok, value, s, e);
 }

--- a/third_party/parser/cc/token.cc
+++ b/third_party/parser/cc/token.cc
@@ -3,7 +3,7 @@
 
 using namespace ruby_parser;
 
-token::token(token_type type, size_t start, size_t end, const std::string& str)
+token::token(token_type type, size_t start, size_t end, std::string_view str)
     : _type(type), _start(start), _end(end), _string(str)
 {}
 

--- a/third_party/parser/include/ruby_parser/lexer.hh
+++ b/third_party/parser/include/ruby_parser/lexer.hh
@@ -117,8 +117,8 @@ private:
     std::string_view tok_view(const char *start);
     std::string_view tok_view(const char *start, const char *end);
     void emit(token_type type);
-    void emit(token_type type, const std::string &str);
-    void emit(token_type type, const std::string &str, const char *start, const char *end);
+    void emit(token_type type, std::string_view str);
+    void emit(token_type type, std::string_view str, const char *start, const char *end);
     void emit_do(bool do_block = false);
     void emit_table(const token_table_entry *table);
     void emit_num(const std::string &num);

--- a/third_party/parser/include/ruby_parser/literal.hh
+++ b/third_party/parser/include/ruby_parser/literal.hh
@@ -82,16 +82,16 @@ namespace ruby_parser {
     void start_interp_brace();
     bool end_interp_brace_and_try_closing();
 
-    bool nest_and_try_closing(std::string& delimiter, const char* ts, const char* te, std::string lookahead = "");
+    bool nest_and_try_closing(std::string_view delimiter, const char* ts, const char* te, std::string_view lookahead = "");
 
     void extend_space(const char* ts, const char* te);
-    void extend_string(std::string& str, const char* ts, const char* te);
+    void extend_string(std::string_view str, const char* ts, const char* te);
     void extend_content();
 
     void flush_string();
 
   private:
-    bool is_delimiter(std::string& delimiter) const;
+    bool is_delimiter(std::string_view delimiter) const;
     void clear_buffer();
     void emit_start_token();
     void emit(token_type tok, std::string& value, const char* s, const char* e);

--- a/third_party/parser/include/ruby_parser/literal.hh
+++ b/third_party/parser/include/ruby_parser/literal.hh
@@ -94,7 +94,7 @@ namespace ruby_parser {
     bool is_delimiter(std::string_view delimiter) const;
     void clear_buffer();
     void emit_start_token();
-    void emit(token_type tok, std::string& value, const char* s, const char* e);
+    void emit(token_type tok, std::string_view value, const char* s, const char* e);
   };
 }
 

--- a/third_party/parser/include/ruby_parser/token.hh
+++ b/third_party/parser/include/ruby_parser/token.hh
@@ -173,7 +173,7 @@ class token {
     std::string _string;
 
 public:
-    token(token_type type, size_t start, size_t end, const std::string &str);
+    token(token_type type, size_t start, size_t end, std::string_view str);
 
     token_type type() const;
     size_t start() const;


### PR DESCRIPTION
Delimited literals (e.g. strings) required a bunch of unnecessary temporary strings to be constructed along the way.  Let's stop doing that.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Faster lexing.  Saves ~1% of instructions during the parse phase of `ruby/lib/rdoc/markdown.rb`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
