### PR TITLE
make `gsub` for lexing escaped strings take a `string_view`

### DIFF
--- a/third_party/parser/cc/lexer.rl
+++ b/third_party/parser/cc/lexer.rl
@@ -419,7 +419,7 @@ static bool split_codepoints(const std::string &str, std::string &output) {
   return true;
 }
 
-static std::string gsub(std::string_view str, const std::string&& search, const std::string&& replace) {
+static std::string gsub(std::string_view str, std::string_view search, std::string_view replace) {
   std::string result;
 
   std::string::size_type from = 0;

--- a/third_party/parser/cc/lexer.rl
+++ b/third_party/parser/cc/lexer.rl
@@ -419,7 +419,7 @@ static bool split_codepoints(const std::string &str, std::string &output) {
   return true;
 }
 
-static std::string gsub(const std::string&& str, const std::string&& search, const std::string&& replace) {
+static std::string gsub(std::string_view str, const std::string&& search, const std::string&& replace) {
   std::string result;
 
   std::string::size_type from = 0;
@@ -1100,12 +1100,12 @@ void lexer::set_state_expr_value() {
         //   "a\
         //   b"
         // must be parsed as "ab"
-        std::string str = gsub(tok(), "\\\n", "");
+        std::string str = gsub(tok_view(), "\\\n", "");
         current_literal.extend_string(str, ts, te);
       } else if (current_literal.regexp()) {
         // Regular expressions should include escape sequences in their
         // escaped form. On the other hand, escaped newlines are removed.
-        std::string str = gsub(tok(), "\\\n", "");
+        std::string str = gsub(tok_view(), "\\\n", "");
         current_literal.extend_string(str, ts, te);
       } else {
         auto str = escape ? *escape : tok();


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

There's no reason to materialize a new string from the lexing stream when we can do everything we need for this function with `string_view` instead.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
