### PR TITLE
Optional --stripe-packages-hint-message for packager errors

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1978,7 +1978,8 @@ const packages::PackageDB &GlobalState::packageDB() const {
 }
 
 void GlobalState::setPackagerOptions(const std::vector<std::string> &secondaryTestPackageNamespaces,
-                                     const std::vector<std::string> &extraPackageFilesDirectoryPrefixes) {
+                                     const std::vector<std::string> &extraPackageFilesDirectoryPrefixes,
+                                     std::string errorHint) {
     ENFORCE(packageDB_.secondaryTestPackageNamespaceRefs_.size() == 0);
     ENFORCE(!packageDB_.frozen);
 
@@ -1987,6 +1988,7 @@ void GlobalState::setPackagerOptions(const std::vector<std::string> &secondaryTe
     }
 
     packageDB_.extraPackageFilesDirectoryPrefixes_ = extraPackageFilesDirectoryPrefixes;
+    packageDB_.errorHint_ = errorHint;
 }
 
 packages::UnfreezePackages GlobalState::unfreezePackages() {

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -161,7 +161,7 @@ public:
 
     const packages::PackageDB &packageDB() const;
     void setPackagerOptions(const std::vector<std::string> &secondaryTestPackageNamespaces,
-                            const std::vector<std::string> &extraPackageFilesDirectoryPrefixes);
+                            const std::vector<std::string> &extraPackageFilesDirectoryPrefixes, std::string errorHint);
     packages::UnfreezePackages unfreezePackages();
 
     void mangleRenameSymbol(SymbolRef what, NameRef origName);

--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -161,6 +161,10 @@ const std::vector<std::string> &PackageDB::extraPackageFilesDirectoryPrefixes() 
     return extraPackageFilesDirectoryPrefixes_;
 }
 
+const std::string_view PackageDB::errorHint() const {
+    return errorHint_;
+}
+
 bool PackageDB::isTestFile(const core::GlobalState &gs, const core::File &file) {
     // TODO: (aadi-stripe, 11/26/2021) see if these can all be changed to use getPrintablePath
     return absl::EndsWith(file.path(), ".test.rb") || absl::StartsWith(file.path(), "./test/") ||
@@ -178,6 +182,7 @@ PackageDB PackageDB::deepCopy() const {
     result.extraPackageFilesDirectoryPrefixes_ = this->extraPackageFilesDirectoryPrefixes_;
     result.packagesByPathPrefix = this->packagesByPathPrefix;
     result.mangledNames = this->mangledNames;
+    result.errorHint_ = this->errorHint_;
     return result;
 }
 

--- a/core/packages/PackageDB.h
+++ b/core/packages/PackageDB.h
@@ -45,12 +45,15 @@ public:
     const std::vector<core::NameRef> &secondaryTestPackageNamespaceRefs() const;
     const std::vector<std::string> &extraPackageFilesDirectoryPrefixes() const;
 
+    const std::string_view errorHint() const;
+
     // NB: Do not call in hot path, this is SLOW due to string comparison!
     static bool isTestFile(const core::GlobalState &gs, const core::File &file);
 
 private:
     std::vector<NameRef> secondaryTestPackageNamespaceRefs_;
     std::vector<std::string> extraPackageFilesDirectoryPrefixes_;
+    std::string errorHint_;
 
     UnorderedMap<core::NameRef, std::unique_ptr<packages::PackageInfo>> packages_;
     UnorderedMap<std::string, core::NameRef> packagesByPathPrefix;

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -354,7 +354,7 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
     options.add_options("advanced")("stripe-packages", "Enable support for Stripe's internal Ruby package system",
                                     cxxopts::value<bool>());
     options.add_options("advanced")("stripe-packages-hint-message",
-                                    "Optional hit message to add to packaging related errors",
+                                    "Optional hint message to add to packaging related errors",
                                     cxxopts::value<string>()->default_value(""));
     options.add_options("dev")("extra-package-files-directory-prefix",
                                "Extra parent directories which contain package files. "

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -353,6 +353,9 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
     options.add_options("advanced")("stripe-mode", "Enable Stripe specific error enforcement", cxxopts::value<bool>());
     options.add_options("advanced")("stripe-packages", "Enable support for Stripe's internal Ruby package system",
                                     cxxopts::value<bool>());
+    options.add_options("advanced")("stripe-packages-hint-message",
+                                    "Optional hit message to add to packaging related errors",
+                                    cxxopts::value<string>()->default_value(""));
     options.add_options("dev")("extra-package-files-directory-prefix",
                                "Extra parent directories which contain package files. "
                                "This option must be used in conjunction with --stripe-packages",
@@ -900,6 +903,13 @@ void readOptions(Options &opts,
                     throw EarlyReturnWithCode(1);
                 }
                 opts.secondaryTestPackageNamespaces.emplace_back(ns);
+            }
+        }
+        opts.stripePackagesHint = raw["stripe-packages-hint-message"].as<string>();
+        if (!opts.stripePackagesHint.empty() && !opts.stripePackages) {
+            if (!opts.stripePackages) {
+                logger->error("--stripe-packages-hint-message can only be specified in --stripe-packages mode");
+                throw EarlyReturnWithCode(1);
             }
         }
 

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -158,6 +158,7 @@ struct Options {
     int autogenVersion = 0;
     bool stripeMode = false;
     bool stripePackages = false;
+    std::string stripePackagesHint = "";
     std::vector<std::string> extraPackageFilesDirectoryPrefixes;
     std::vector<std::string> secondaryTestPackageNamespaces;
     std::string typedSource = "";

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -668,7 +668,8 @@ vector<ast::ParsedFile> package(core::GlobalState &gs, vector<ast::ParsedFile> w
         {
             core::UnfreezeNameTable unfreezeToEnterPackagerOptionsGS(gs);
             core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = gs.unfreezePackages();
-            gs.setPackagerOptions(opts.secondaryTestPackageNamespaces, opts.extraPackageFilesDirectoryPrefixes);
+            gs.setPackagerOptions(opts.secondaryTestPackageNamespaces, opts.extraPackageFilesDirectoryPrefixes,
+                                  opts.stripePackagesHint);
         }
         what = packager::Packager::run(gs, workers, move(what));
         if (opts.print.Packager.enabled) {

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -137,6 +137,9 @@ Usage:
       --stripe-mode             Enable Stripe specific error enforcement
       --stripe-packages         Enable support for Stripe's internal Ruby
                                 package system
+      --stripe-packages-hint-message arg
+                                Optional hit message to add to packaging
+                                related errors (default: "")
       --autogen-autoloader-exclude-require arg
                                 Names that should be excluded from top-level
                                 require statements in autoloader output. (e.g.

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -138,7 +138,7 @@ Usage:
       --stripe-packages         Enable support for Stripe's internal Ruby
                                 package system
       --stripe-packages-hint-message arg
-                                Optional hit message to add to packaging
+                                Optional hint message to add to packaging
                                 related errors (default: "")
       --autogen-autoloader-exclude-require arg
                                 Names that should be excluded from top-level

--- a/test/cli/package-error-missing-export/package-error-missing-export.out
+++ b/test/cli/package-error-missing-export/package-error-missing-export.out
@@ -8,11 +8,15 @@ foo_class.rb:10: Unable to resolve constant `NotExported` https://srb.help/5002
     other/other_class.rb:7: Constant `Foo::Bar::OtherPackage::NotExported` is defined here:
      7 |  class NotExported
           ^^^^^^^^^^^^^^^^^
+  Note:
+    Try running generate-packages.sh
   Autocorrect: Use `-a` to autocorrect
     other/__package.rb:4: Insert `
   export Foo::Bar::OtherPackage::NotExported`
      4 |  export Foo::Bar::OtherPackage::OtherClass
                                                    ^
+  Note:
+    Try running generate-packages.sh
 
 foo_class.rb:11: Unable to resolve constant `NotExported` https://srb.help/5002
     11 |      Bar::OtherPackage::NotExported
@@ -24,11 +28,15 @@ foo_class.rb:11: Unable to resolve constant `NotExported` https://srb.help/5002
     other/other_class.rb:7: Constant `Foo::Bar::OtherPackage::NotExported` is defined here:
      7 |  class NotExported
           ^^^^^^^^^^^^^^^^^
+  Note:
+    Try running generate-packages.sh
   Autocorrect: Use `-a` to autocorrect
     other/__package.rb:4: Insert `
   export Foo::Bar::OtherPackage::NotExported`
      4 |  export Foo::Bar::OtherPackage::OtherClass
                                                    ^
+  Note:
+    Try running generate-packages.sh
 
 foo_class.rb:12: Unable to resolve constant `Inner` https://srb.help/5002
     12 |      Foo::Bar::OtherPackage::Inner::AlsoNotExported
@@ -40,11 +48,15 @@ foo_class.rb:12: Unable to resolve constant `Inner` https://srb.help/5002
     other/other_class.rb:10: Constant `Foo::Bar::OtherPackage::Inner` is defined here:
     10 |  class Inner::AlsoNotExported
                 ^^^^^
+  Note:
+    Try running generate-packages.sh
   Autocorrect: Use `-a` to autocorrect
     other/__package.rb:4: Insert `
   export Foo::Bar::OtherPackage::Inner`
      4 |  export Foo::Bar::OtherPackage::OtherClass
                                                    ^
+  Note:
+    Try running generate-packages.sh
 
 foo_class.rb:13: Unable to resolve constant `Inner` https://srb.help/5002
     13 |      Bar::OtherPackage::Inner::AlsoNotExported
@@ -56,9 +68,13 @@ foo_class.rb:13: Unable to resolve constant `Inner` https://srb.help/5002
     other/other_class.rb:10: Constant `Foo::Bar::OtherPackage::Inner` is defined here:
     10 |  class Inner::AlsoNotExported
                 ^^^^^
+  Note:
+    Try running generate-packages.sh
   Autocorrect: Use `-a` to autocorrect
     other/__package.rb:4: Insert `
   export Foo::Bar::OtherPackage::Inner`
      4 |  export Foo::Bar::OtherPackage::OtherClass
                                                    ^
+  Note:
+    Try running generate-packages.sh
 Errors: 4

--- a/test/cli/package-error-missing-export/package-error-missing-export.sh
+++ b/test/cli/package-error-missing-export/package-error-missing-export.sh
@@ -1,3 +1,5 @@
 cd test/cli/package-error-missing-export || exit 1
 
-../../../main/sorbet --silence-dev-message --stripe-packages --max-threads=0 . 2>&1
+../../../main/sorbet --silence-dev-message --stripe-packages \
+  --stripe-packages-hint-message="Try running generate-packages.sh" \
+  --max-threads=0 . 2>&1

--- a/test/cli/package-error-missing-import/package-error-missing-import.out
+++ b/test/cli/package-error-missing-import/package-error-missing-import.out
@@ -6,11 +6,15 @@ foo_class.rb:7: Unable to resolve constant `Bar` https://srb.help/5002
      4 |  export Foo::Bar::OtherPackage::OtherClass
      5 |  export Test::Foo::Bar::OtherPackage::TestUtil
      6 |end
+  Note:
+    Try running generate-packages.sh
   Autocorrect: Use `-a` to autocorrect
     __package.rb:6: Insert `
   import Foo::Bar::OtherPackage`
      6 |  # import Foo::Bar::OtherPackage ## MISSING!
                                                      ^
+  Note:
+    Try running generate-packages.sh
 
 foo_class.rb:8: Unable to resolve constant `Bar` https://srb.help/5002
      8 |      Bar::OtherPackage::OtherClass # resolves via `module Foo`
@@ -20,11 +24,15 @@ foo_class.rb:8: Unable to resolve constant `Bar` https://srb.help/5002
      4 |  export Foo::Bar::OtherPackage::OtherClass
      5 |  export Test::Foo::Bar::OtherPackage::TestUtil
      6 |end
+  Note:
+    Try running generate-packages.sh
   Autocorrect: Use `-a` to autocorrect
     __package.rb:6: Insert `
   import Foo::Bar::OtherPackage`
      6 |  # import Foo::Bar::OtherPackage ## MISSING!
                                                      ^
+  Note:
+    Try running generate-packages.sh
 
 foo_class.rb:14: Unable to resolve constant `Bar` https://srb.help/5002
     14 |  Foo::Bar::OtherPackage::OtherClass # resolves via root
@@ -34,11 +42,15 @@ foo_class.rb:14: Unable to resolve constant `Bar` https://srb.help/5002
      4 |  export Foo::Bar::OtherPackage::OtherClass
      5 |  export Test::Foo::Bar::OtherPackage::TestUtil
      6 |end
+  Note:
+    Try running generate-packages.sh
   Autocorrect: Use `-a` to autocorrect
     __package.rb:6: Insert `
   import Foo::Bar::OtherPackage`
      6 |  # import Foo::Bar::OtherPackage ## MISSING!
                                                      ^
+  Note:
+    Try running generate-packages.sh
 
 foo.test.rb:4: Unable to resolve constant `Bar` https://srb.help/5002
      4 |  Test::Foo::Bar::OtherPackage::TestUtil
@@ -48,9 +60,13 @@ foo.test.rb:4: Unable to resolve constant `Bar` https://srb.help/5002
      4 |  export Foo::Bar::OtherPackage::OtherClass
      5 |  export Test::Foo::Bar::OtherPackage::TestUtil
      6 |end
+  Note:
+    Try running generate-packages.sh
   Autocorrect: Use `-a` to autocorrect
     __package.rb:6: Insert `
   test_import Foo::Bar::OtherPackage`
      6 |  # import Foo::Bar::OtherPackage ## MISSING!
                                                      ^
+  Note:
+    Try running generate-packages.sh
 Errors: 4

--- a/test/cli/package-error-missing-import/package-error-missing-import.sh
+++ b/test/cli/package-error-missing-import/package-error-missing-import.sh
@@ -1,3 +1,5 @@
 cd test/cli/package-error-missing-import || exit 1
 
-../../../main/sorbet --silence-dev-message --stripe-packages --max-threads=0 . 2>&1
+../../../main/sorbet --silence-dev-message --stripe-packages \
+  --stripe-packages-hint-message="Try running generate-packages.sh" \
+  --max-threads=0 . 2>&1

--- a/test/cli/package-error-unresolved-export/package-error-unresolved-export.out
+++ b/test/cli/package-error-unresolved-export/package-error-unresolved-export.out
@@ -3,6 +3,8 @@ __package.rb:7: Unable to resolve constant `WildlyMisspelled` https://srb.help/5
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Note:
     To be exported it must be defined in package `Foo::BasePkg`
+  Note:
+    Try running generate-packages.sh
 
 __package.rb:8: Unable to resolve constant `NameWithTipo` https://srb.help/5002
      8 |  export Foo::BasePkg::NameWithTipo
@@ -14,4 +16,6 @@ __package.rb:8: Unable to resolve constant `NameWithTipo` https://srb.help/5002
     base.rb:7: Did you mean: `Foo::BasePkg::NameWithTypo`?
      7 |  class NameWithTypo; end
           ^^^^^^^^^^^^^^^^^^
+  Note:
+    Try running generate-packages.sh
 Errors: 2

--- a/test/cli/package-error-unresolved-export/package-error-unresolved-export.sh
+++ b/test/cli/package-error-unresolved-export/package-error-unresolved-export.sh
@@ -1,3 +1,5 @@
 cd test/cli/package-error-unresolved-export || exit 1
 
-../../../main/sorbet --silence-dev-message --stripe-packages --max-threads=0 . 2>&1
+../../../main/sorbet --silence-dev-message --stripe-packages \
+  --stripe-packages-hint-message="Try running generate-packages.sh" \
+  --max-threads=0 . 2>&1

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -309,7 +309,8 @@ TEST_CASE("PerPhaseTest") { // NOLINT
         {
             core::UnfreezeNameTable packageNS(*gs);
             core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = gs->unfreezePackages();
-            gs->setPackagerOptions(secondaryTestPackageNamespaces, extraPackageFilesDirectoryPrefixes);
+            gs->setPackagerOptions(secondaryTestPackageNamespaces, extraPackageFilesDirectoryPrefixes,
+                                   "PACKAGE_ERROR_HINT");
         }
 
         // Packager runs over all trees.


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Adds `--stripe-packages-hint-message` that can be used to communicate extra information, such as a fix-up script to run, when users encounter packaging errors.

### Motivation
User experience
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See update CLI tests.
