### PR TITLE
use a faster output format for ragel state machines

### DIFF
--- a/third_party/parser/BUILD
+++ b/third_party/parser/BUILD
@@ -7,6 +7,7 @@ ragel(
     name = "ragel_lexer",
     src = "cc/lexer.rl",
     language = "c++",
+    ragel_options = ["-G1"],
 )
 
 bison(


### PR DESCRIPTION
Ragel has several different output formats for the state machines it produces.  The default corresponds to the `-T0` option, and is described as "binary search table-driven" in the Ragel user manual.

Profiling with `valgrind --tool=callgrind` indicated that a significant amount of time is spent in the binary search in the generated code: 10% or more of the total parse time for a large Ruby file (`ruby/lib/rdoc/markdown.rb`).

Experimenting with other output options revealed `-G1`, which uses `goto` to manage the state machine and features less code reuse between different actions, produced much faster code: 30% fewer instructions executed during parsing according to Callgrind.

Experimenting with this new option on Stripe's codebase on a devbox (using `--stop-after=parser` and an uncached build to force the parser to execute) reduced the max parse time by ~20% and the wall-clock time for the `--stop-after=parser` run by approximately the same percentage.

The binary size for a `--config=release-linux` build increases by about 300kb, which seems like a reasonable tradeoff.  The compilation time for such a build is increased, of course, but that also seems OK.  I considered using the default `-T0` for a normal development build, but I am inclined to lean on bazel's caching, since the lexer doesn't change that often.  And if it does become noticeably annoying for folks modifying the lexer, we can address that.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Make things go faster.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
