### PR TITLE
Add an empty options struct to `TypePtr::show`

### DIFF
--- a/core/TypePtr.cc
+++ b/core/TypePtr.cc
@@ -324,8 +324,8 @@ uint32_t TypePtr::hash(const GlobalState &gs) const {
 #undef HASH
 }
 
-std::string TypePtr::show(const GlobalState &gs) const {
-#define SHOW(T) return cast_type_nonnull<T>(*this).show(gs);
+std::string TypePtr::show(const GlobalState &gs, const TypePtr::ShowOptions options) const {
+#define SHOW(T) return cast_type_nonnull<T>(*this).show(gs, options);
     GENERATE_TAG_SWITCH(tag(), SHOW)
 #undef SHOW
 }

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -311,8 +311,10 @@ public:
         return toStringWithTabs(gs);
     }
 
+    struct ShowOptions {};
+
     // User visible type. Should exactly match what the user can write.
-    std::string show(const GlobalState &gs) const;
+    std::string show(const GlobalState &gs, const ShowOptions options = ShowOptions{}) const;
     // Like show, but can include extra info. Does not necessarily match what the user can type.
     std::string showWithMoreInfo(const GlobalState &gs) const;
 

--- a/core/Types.h
+++ b/core/Types.h
@@ -333,7 +333,7 @@ public:
     ClassType(ClassOrModuleRef symbol);
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs) const;
+    std::string show(const GlobalState &gs, const TypePtr::ShowOptions options = TypePtr::ShowOptions{}) const;
     uint32_t hash(const GlobalState &gs) const;
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
 
@@ -376,7 +376,7 @@ public:
 
     LambdaParam(TypeMemberRef definition, TypePtr lower, TypePtr upper);
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs) const;
+    std::string show(const GlobalState &gs, const TypePtr::ShowOptions options = TypePtr::ShowOptions{}) const;
     uint32_t hash(const GlobalState &gs) const;
 
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const;
@@ -394,7 +394,7 @@ public:
 
     SelfTypeParam(const SymbolRef definition);
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs) const;
+    std::string show(const GlobalState &gs, const TypePtr::ShowOptions options = TypePtr::ShowOptions{}) const;
     uint32_t hash(const GlobalState &gs) const;
 
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const;
@@ -417,7 +417,7 @@ TYPE_INLINED(AliasType) final {
 public:
     AliasType(SymbolRef other);
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs) const;
+    std::string show(const GlobalState &gs, const TypePtr::ShowOptions options = TypePtr::ShowOptions{}) const;
     uint32_t hash(const GlobalState &gs) const;
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const;
 
@@ -447,7 +447,7 @@ TYPE_INLINED(SelfType) final {
 public:
     SelfType();
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs) const;
+    std::string show(const GlobalState &gs, const TypePtr::ShowOptions options = TypePtr::ShowOptions{}) const;
     std::string showValue(const GlobalState &gs) const;
     uint32_t hash(const GlobalState &gs) const;
 
@@ -490,7 +490,7 @@ public:
     core::NameRef unsafeAsName() const;
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs) const;
+    std::string show(const GlobalState &gs, const TypePtr::ShowOptions options = TypePtr::ShowOptions{}) const;
     std::string showValue(const GlobalState &gs) const;
     uint32_t hash(const GlobalState &gs) const;
 
@@ -560,7 +560,7 @@ public:
     TypeArgumentRef sym;
     TypeVar(TypeArgumentRef sym);
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs) const;
+    std::string show(const GlobalState &gs, const TypePtr::ShowOptions options = TypePtr::ShowOptions{}) const;
     uint32_t hash(const GlobalState &gs) const;
     void _sanityCheck(const GlobalState &gs) const;
 
@@ -577,7 +577,7 @@ public:
     TypePtr right;
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs) const;
+    std::string show(const GlobalState &gs, const TypePtr::ShowOptions options = TypePtr::ShowOptions{}) const;
     uint32_t hash(const GlobalState &gs) const;
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
     TypePtr getCallArguments(const GlobalState &gs, NameRef name) const;
@@ -628,7 +628,7 @@ public:
     TypePtr right;
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs) const;
+    std::string show(const GlobalState &gs, const TypePtr::ShowOptions options = TypePtr::ShowOptions{}) const;
     uint32_t hash(const GlobalState &gs) const;
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
 
@@ -671,7 +671,7 @@ public:
     ShapeType(std::vector<TypePtr> keys, std::vector<TypePtr> values);
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs) const;
+    std::string show(const GlobalState &gs, const TypePtr::ShowOptions options = TypePtr::ShowOptions{}) const;
     uint32_t hash(const GlobalState &gs) const;
     std::string showWithMoreInfo(const GlobalState &gs) const;
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
@@ -695,7 +695,7 @@ public:
     TupleType(std::vector<TypePtr> elements);
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs) const;
+    std::string show(const GlobalState &gs, const TypePtr::ShowOptions options = TypePtr::ShowOptions{}) const;
     std::string showWithMoreInfo(const GlobalState &gs) const;
     uint32_t hash(const GlobalState &gs) const;
     void _sanityCheck(const GlobalState &gs) const;
@@ -719,7 +719,7 @@ public:
     AppliedType(ClassOrModuleRef klass, std::vector<TypePtr> targs);
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs) const;
+    std::string show(const GlobalState &gs, const TypePtr::ShowOptions options = TypePtr::ShowOptions{}) const;
     uint32_t hash(const GlobalState &gs) const;
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
     void _sanityCheck(const GlobalState &gs) const;
@@ -749,7 +749,7 @@ public:
     MetaType(const TypePtr &wrapped);
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs) const;
+    std::string show(const GlobalState &gs, const TypePtr::ShowOptions options = TypePtr::ShowOptions{}) const;
     uint32_t hash(const GlobalState &gs) const;
 
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const;
@@ -911,7 +911,7 @@ public:
     UnresolvedClassType(SymbolRef scope, std::vector<core::NameRef> names)
         : ClassType(core::Symbols::untyped()), scope(scope), names(std::move(names)){};
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs) const;
+    std::string show(const GlobalState &gs, const TypePtr::ShowOptions options = TypePtr::ShowOptions{}) const;
     uint32_t hash(const GlobalState &gs) const;
 };
 
@@ -922,7 +922,7 @@ public:
     UnresolvedAppliedType(ClassOrModuleRef klass, std::vector<TypePtr> targs)
         : ClassType(core::Symbols::untyped()), klass(klass), targs(std::move(targs)){};
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs) const;
+    std::string show(const GlobalState &gs, const TypePtr::ShowOptions options = TypePtr::ShowOptions{}) const;
     uint32_t hash(const GlobalState &gs) const;
 };
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Making it easier to land #5067 by adding config options to `TypePtr::show`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
