### PR TITLE
make the lexer's requirement for null-terminated buffers more explicit

### DIFF
--- a/parser/Parser.cc
+++ b/parser/Parser.cc
@@ -53,7 +53,13 @@ unique_ptr<Node> Parser::run(sorbet::core::GlobalState &gs, core::FileRef file, 
                              std::vector<std::string> initialLocals) {
     Builder builder(gs, file);
     auto source = file.data(gs).source();
-    ruby_parser::typedruby27 driver(string(source.begin(), source.end()), Builder::interface);
+    // The lexer requires that its buffers end with a null terminator, which core::File
+    // does not guarantee.
+    string buffer;
+    buffer.reserve(source.size() + 1);
+    buffer += source;
+    buffer += '\0';
+    ruby_parser::typedruby27 driver(buffer, Builder::interface);
 
     for (string local : initialLocals) {
         driver.lex.declare(local);

--- a/parser/Parser.cc
+++ b/parser/Parser.cc
@@ -54,11 +54,11 @@ unique_ptr<Node> Parser::run(sorbet::core::GlobalState &gs, core::FileRef file, 
     Builder builder(gs, file);
     auto source = file.data(gs).source();
     // The lexer requires that its buffers end with a null terminator, which core::File
-    // does not guarantee.
+    // does not guarantee.  Parsing heredocs for some mysterious reason requires two.
     string buffer;
-    buffer.reserve(source.size() + 1);
+    buffer.reserve(source.size() + 2);
     buffer += source;
-    buffer += '\0';
+    buffer += "\0\0"sv;
     ruby_parser::typedruby27 driver(buffer, Builder::interface);
 
     for (string local : initialLocals) {

--- a/third_party/parser/cc/driver.cc
+++ b/third_party/parser/cc/driver.cc
@@ -6,10 +6,10 @@
 
 namespace ruby_parser {
 
-base_driver::base_driver(ruby_version version, const std::string &source, const struct builder &builder)
+base_driver::base_driver(ruby_version version, std::string_view source, const struct builder &builder)
     : build(builder), lex(diagnostics, version, source), pending_error(false), def_level(0), ast(nullptr) {}
 
-typedruby27::typedruby27(const std::string &source, const struct builder &builder)
+typedruby27::typedruby27(std::string_view source, const struct builder &builder)
     : base_driver(ruby_version::RUBY_27, source, builder) {}
 
 ForeignPtr typedruby27::parse(SelfPtr self, bool trace) {

--- a/third_party/parser/cc/lexer.rl
+++ b/third_party/parser/cc/lexer.rl
@@ -120,10 +120,10 @@ using namespace std::string_literals;
 
 %% prepush { check_stack_capacity(); }
 
-lexer::lexer(diagnostics_t &diag, ruby_version version, const std::string& source_buffer_)
+lexer::lexer(diagnostics_t &diag, ruby_version version, std::string_view source_buffer)
   : diagnostics(diag)
   , version(version)
-  , source_buffer(source_buffer_ + std::string("\0\0", 2))
+  , source_buffer(source_buffer)
   , cs(lex_en_line_begin)
   , _p(source_buffer.data())
   , _pe(source_buffer.data() + source_buffer.size())
@@ -144,6 +144,9 @@ lexer::lexer(diagnostics_t &diag, ruby_version version, const std::string& sourc
   , herebody_s(nullptr)
   , in_kwarg(false)
 {
+  assert(!source_buffer.empty());
+  assert(source_buffer.back() == '\0');
+
   // ensure the stack is non-empty so we can just double in
   // check_stack_capacity:
   stack.resize(16);

--- a/third_party/parser/include/ruby_parser/driver.hh
+++ b/third_party/parser/include/ruby_parser/driver.hh
@@ -272,7 +272,7 @@ public:
     ForeignPtr ast;
     token_t last_token;
 
-    base_driver(ruby_version version, const std::string &source, const struct builder &builder);
+    base_driver(ruby_version version, std::string_view source, const struct builder &builder);
     virtual ~base_driver() {}
     virtual ForeignPtr parse(SelfPtr self, bool trace) = 0;
 
@@ -299,7 +299,7 @@ public:
 
 class typedruby27 : public base_driver {
 public:
-    typedruby27(const std::string &source, const struct builder &builder);
+    typedruby27(std::string_view source, const struct builder &builder);
     virtual ForeignPtr parse(SelfPtr self, bool trace);
     ~typedruby27() {}
 };

--- a/third_party/parser/include/ruby_parser/lexer.hh
+++ b/third_party/parser/include/ruby_parser/lexer.hh
@@ -52,7 +52,7 @@ private:
     pool<token, 64> mempool;
 
     ruby_version version;
-    const std::string source_buffer;
+    std::string_view source_buffer;
 
     std::stack<environment> static_env;
     std::stack<literal> literal_stack;
@@ -169,7 +169,7 @@ public:
     bool in_kwarg; // true at the end of "def foo a:"
     Context context;
 
-    lexer(diagnostics_t &diag, ruby_version version, const std::string &source_buffer_);
+    lexer(diagnostics_t &diag, ruby_version version, std::string_view source_buffer);
 
     token_t advance();
 


### PR DESCRIPTION
Inside `lexer`'s constructor, we take the provided source buffer and append two null terminator characters to it:

https://github.com/sorbet/sorbet/blob/1094ce3ee273cdb4ecad81ecc803f33bf97db0ed/third_party/parser/cc/lexer.rl#L123-L126

We do this because the lexer's definition, as written, considers the null terminator to indicate EOF:

https://github.com/sorbet/sorbet/blob/1094ce3ee273cdb4ecad81ecc803f33bf97db0ed/third_party/parser/cc/lexer.rl#L694

Why we add *two* null terminators is a mystery to me, but empirically, we have test case failures with only one.

I think this is the wrong way to go about things: the lexer's contract is that null is EOF and therefore the caller should be in charge of enforcing that, not the lexer itself.  This PR changes things so that the caller appends the null terminators itself, and changes the lexer so that it stores a `string_view` of the source buffer, rather than the source buffer itself.

This change has several benefits:

1. As above, I think this is somewhat clearer, though I can see reasonable people disagreeing.
2. The current code actually copies the original file twice: once to create a `string` for the parser driver, and then again inside the lexer's constructor to append the null terminators.  The approach taken here at least creates only one copy.  (I guess we could have `File` itself append the null terminators when it was reading the file and have a separate `sourceNullTerminated` view on `File`'s data, if we wanted to stamp out copies.  The current `source()` would of course continue to return the non-null-terminated view.  Opinions welcome on that front.)
3. `.data()` on `string` (which we call quite a bit in the lexer) may require branches in `libc++`, so this change would be a micro-optimization for such platforms.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Somewhat clearer code.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
