### PR TITLE
Point gems homepage to https://sorbet.org

### DIFF
--- a/gems/sorbet-runtime/sorbet-runtime.gemspec
+++ b/gems/sorbet-runtime/sorbet-runtime.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |s|
   s.description = "Sorbet's runtime type checking component"
   s.authors     = ['Stripe']
   s.files       = Dir.glob('lib/**/*')
-  s.homepage    = 'https://sorbet.run'
+  s.homepage    = 'https://sorbet.org'
   s.license     = 'Apache-2.0'
   s.metadata = {
     "source_code_uri" => "https://github.com/sorbet/sorbet",

--- a/gems/sorbet-static/sorbet-static.gemspec
+++ b/gems/sorbet-static/sorbet-static.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.email       = 'sorbet@stripe.com'
   s.files       = ['libexec/sorbet']
   s.executables = []
-  s.homepage    = 'https://sorbet.run'
+  s.homepage    = 'https://sorbet.org'
   s.license     = 'Apache-2.0'
   s.metadata = {
     "source_code_uri" => "https://github.com/sorbet/sorbet"

--- a/gems/sorbet/sorbet.gemspec
+++ b/gems/sorbet/sorbet.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.email       = 'sorbet@stripe.com'
   s.files       = Dir.glob('lib/**/*')
   s.executables = Dir.glob('bin/**/*').map {|path| path.gsub('bin/', '')}
-  s.homepage    = 'https://sorbet.run'
+  s.homepage    = 'https://sorbet.org'
   s.license     = 'Apache-2.0'
   s.metadata = {
     "source_code_uri" => "https://github.com/sorbet/sorbet"


### PR DESCRIPTION
As pointed in https://github.com/sorbet/sorbet/pull/4460#discussion_r683850694 gems still use https://sorbet.run instead of https://sorbet.org for homepage.

Let's fix this so the `Homepage` link on https://rubygems.org/gems/sorbet directs the user to the official page. 