### PR TITLE
make `token`'s external interface primarily oriented around `string_view`

### DIFF
--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -221,9 +221,9 @@ public:
 
     unique_ptr<Node> arg(const token *name) {
         core::LocOffsets loc = tokLoc(name);
-        checkReservedForNumberedParameters(name->string(), loc);
+        checkReservedForNumberedParameters(name->view(), loc);
 
-        return make_unique<Arg>(loc, gs_.enterNameUTF8(name->string()));
+        return make_unique<Arg>(loc, gs_.enterNameUTF8(name->view()));
     }
 
     unique_ptr<Node> args(const token *begin, sorbet::parser::NodeVec args, const token *end, bool check_args) {
@@ -331,9 +331,9 @@ public:
     }
 
     unique_ptr<Node> attrAsgn(unique_ptr<Node> receiver, const token *dot, const token *selector, bool masgn) {
-        core::NameRef method = gs_.enterNameUTF8(selector->string() + "=");
+        core::NameRef method = gs_.enterNameUTF8(selector->view() + "=");
         core::LocOffsets loc = receiver->loc.join(tokLoc(selector));
-        if ((dot != nullptr) && dot->string() == "&.") {
+        if ((dot != nullptr) && dot->view() == "&.") {
             if (masgn) {
                 error(ruby_parser::dclass::CSendInLHSOfMAsgn, tokLoc(dot));
             }
@@ -343,7 +343,7 @@ public:
     }
 
     unique_ptr<Node> backRef(const token *tok) {
-        return make_unique<Backref>(tokLoc(tok), gs_.enterNameUTF8(tok->string()));
+        return make_unique<Backref>(tokLoc(tok), gs_.enterNameUTF8(tok->view()));
     }
 
     unique_ptr<Node> begin(const token *begin, unique_ptr<Node> body, const token *end) {
@@ -433,7 +433,7 @@ public:
         sorbet::parser::NodeVec args;
         args.emplace_back(std::move(arg));
 
-        return make_unique<Send>(loc, std::move(receiver), gs_.enterNameUTF8(oper->string()), std::move(args));
+        return make_unique<Send>(loc, std::move(receiver), gs_.enterNameUTF8(oper->view()), std::move(args));
     }
 
     unique_ptr<Node> block(unique_ptr<Node> methodCall, const token *begin, unique_ptr<Node> args,
@@ -509,8 +509,8 @@ public:
 
         if (name != nullptr) {
             loc = tokLoc(name);
-            nm = gs_.enterNameUTF8(name->string());
-            checkReservedForNumberedParameters(name->string(), loc);
+            nm = gs_.enterNameUTF8(name->view());
+            checkReservedForNumberedParameters(name->view(), loc);
         } else {
             loc = tokLoc(amper);
             nm = gs_.freshNameUnique(core::UniqueNameKind::Parser, core::Names::ampersand(), ++uniqueCounter_);
@@ -553,10 +553,10 @@ public:
             // when the selector is missing, this is a use of the `call` method.
             method = core::Names::call();
         } else {
-            method = gs_.enterNameUTF8(selector->string());
+            method = gs_.enterNameUTF8(selector->view());
         }
 
-        if ((dot != nullptr) && dot->string() == "&.") {
+        if ((dot != nullptr) && dot->view() == "&.") {
             return make_unique<CSend>(loc, std::move(receiver), method, std::move(args));
         } else {
             return make_unique<Send>(loc, std::move(receiver), method, std::move(args));
@@ -579,11 +579,11 @@ public:
     }
 
     unique_ptr<Node> character(const token *char_) {
-        return make_unique<String>(tokLoc(char_), gs_.enterNameUTF8(char_->string()));
+        return make_unique<String>(tokLoc(char_), gs_.enterNameUTF8(char_->view()));
     }
 
     unique_ptr<Node> complex(const token *tok) {
-        return make_unique<Complex>(tokLoc(tok), tok->string());
+        return make_unique<Complex>(tokLoc(tok), tok->view());
     }
 
     unique_ptr<Node> compstmt(sorbet::parser::NodeVec nodes) {
@@ -629,7 +629,7 @@ public:
     }
 
     unique_ptr<Node> const_(const token *name) {
-        return make_unique<Const>(tokLoc(name), nullptr, gs_.enterNameConstant(name->string()));
+        return make_unique<Const>(tokLoc(name), nullptr, gs_.enterNameConstant(name->view()));
     }
 
     unique_ptr<Node> const_pattern(unique_ptr<Node> const_, const token *begin, unique_ptr<Node> pattern,
@@ -639,12 +639,12 @@ public:
 
     unique_ptr<Node> constFetch(unique_ptr<Node> scope, const token *colon, const token *name) {
         return make_unique<Const>(scope->loc.join(tokLoc(name)), std::move(scope),
-                                  gs_.enterNameConstant(name->string()));
+                                  gs_.enterNameConstant(name->view()));
     }
 
     unique_ptr<Node> constGlobal(const token *colon, const token *name) {
         return make_unique<Const>(tokLoc(colon).join(tokLoc(name)), make_unique<Cbase>(tokLoc(colon)),
-                                  gs_.enterNameConstant(name->string()));
+                                  gs_.enterNameConstant(name->view()));
     }
 
     unique_ptr<Node> constOpAssignable(unique_ptr<Node> node) {
@@ -656,7 +656,7 @@ public:
     }
 
     unique_ptr<Node> cvar(const token *tok) {
-        return make_unique<CVar>(tokLoc(tok), gs_.enterNameUTF8(tok->string()));
+        return make_unique<CVar>(tokLoc(tok), gs_.enterNameUTF8(tok->view()));
     }
 
     unique_ptr<Node> dedentString(unique_ptr<Node> node, size_t dedentLevel) {
@@ -724,7 +724,7 @@ public:
                                       unique_ptr<Node> body) {
         core::LocOffsets declLoc = tokLoc(def, tname).join(maybe_loc(args));
         core::LocOffsets loc = tokLoc(def).join(body->loc);
-        std::string name = tname->string();
+        std::string name = tname->view();
 
         checkEndlessSetter(name, declLoc);
         checkReservedForNumberedParameters(name, declLoc);
@@ -750,9 +750,9 @@ public:
         core::LocOffsets declLoc = tokLoc(def, name).join(maybe_loc(args));
         core::LocOffsets loc = tokLoc(def, end);
 
-        checkReservedForNumberedParameters(name->string(), declLoc);
+        checkReservedForNumberedParameters(name->view(), declLoc);
 
-        return make_unique<DefMethod>(loc, declLoc, gs_.enterNameUTF8(name->string()), std::move(args),
+        return make_unique<DefMethod>(loc, declLoc, gs_.enterNameUTF8(name->view()), std::move(args),
                                       std::move(body));
     }
 
@@ -772,7 +772,7 @@ public:
     unique_ptr<Node> defsHead(const token *def, unique_ptr<Node> definee, const token *dot, const token *name) {
         core::LocOffsets declLoc = tokLoc(def, name);
 
-        return make_unique<DefsHead>(declLoc, std::move(definee), gs_.enterNameUTF8(name->string()));
+        return make_unique<DefsHead>(declLoc, std::move(definee), gs_.enterNameUTF8(name->view()));
     }
 
     unique_ptr<Node> defSingleton(unique_ptr<Node> defHead, unique_ptr<Node> args, unique_ptr<Node> body,
@@ -820,11 +820,11 @@ public:
     }
 
     unique_ptr<Node> float_(const token *tok) {
-        return make_unique<Float>(tokLoc(tok), tok->string());
+        return make_unique<Float>(tokLoc(tok), tok->view());
     }
 
     unique_ptr<Node> floatComplex(const token *tok) {
-        return make_unique<Complex>(tokLoc(tok), tok->string());
+        return make_unique<Complex>(tokLoc(tok), tok->view());
     }
 
     unique_ptr<Node> for_(const token *for_, unique_ptr<Node> iterator, const token *in_, unique_ptr<Node> iteratee,
@@ -845,7 +845,7 @@ public:
     }
 
     unique_ptr<Node> gvar(const token *tok) {
-        return make_unique<GVar>(tokLoc(tok), gs_.enterNameUTF8(tok->string()));
+        return make_unique<GVar>(tokLoc(tok), gs_.enterNameUTF8(tok->view()));
     }
 
     unique_ptr<Node> hash_pattern(const token *begin, sorbet::parser::NodeVec kwargs, const token *end) {
@@ -862,7 +862,7 @@ public:
     }
 
     unique_ptr<Node> ident(const token *tok) {
-        return make_unique<Ident>(tokLoc(tok), gs_.enterNameUTF8(tok->string()));
+        return make_unique<Ident>(tokLoc(tok), gs_.enterNameUTF8(tok->view()));
     }
 
     unique_ptr<Node> if_guard(const token *tok, unique_ptr<Node> if_body) {
@@ -888,11 +888,11 @@ public:
     }
 
     unique_ptr<Node> integer(const token *tok) {
-        return make_unique<Integer>(tokLoc(tok), tok->string());
+        return make_unique<Integer>(tokLoc(tok), tok->view());
     }
 
     unique_ptr<Node> ivar(const token *tok) {
-        return make_unique<IVar>(tokLoc(tok), gs_.enterNameUTF8(tok->string()));
+        return make_unique<IVar>(tokLoc(tok), gs_.enterNameUTF8(tok->view()));
     }
 
     unique_ptr<Node> keywordBreak(const token *keyword, const token *lparen, sorbet::parser::NodeVec args,
@@ -949,16 +949,16 @@ public:
 
     unique_ptr<Node> kwarg(const token *name) {
         core::LocOffsets loc = tokLoc(name);
-        checkReservedForNumberedParameters(name->string(), loc);
+        checkReservedForNumberedParameters(name->view(), loc);
 
-        return make_unique<Kwarg>(loc, gs_.enterNameUTF8(name->string()));
+        return make_unique<Kwarg>(loc, gs_.enterNameUTF8(name->view()));
     }
 
     unique_ptr<Node> kwoptarg(const token *name, unique_ptr<Node> value) {
         core::LocOffsets loc = tokLoc(name);
-        checkReservedForNumberedParameters(name->string(), loc);
+        checkReservedForNumberedParameters(name->view(), loc);
 
-        return make_unique<Kwoptarg>(loc.join(value->loc), gs_.enterNameUTF8(name->string()), tokLoc(name),
+        return make_unique<Kwoptarg>(loc.join(value->loc), gs_.enterNameUTF8(name->view()), tokLoc(name),
                                      std::move(value));
     }
 
@@ -972,8 +972,8 @@ public:
 
         if (name != nullptr) {
             loc = loc.join(tokLoc(name));
-            nm = gs_.enterNameUTF8(name->string());
-            checkReservedForNumberedParameters(name->string(), loc);
+            nm = gs_.enterNameUTF8(name->view());
+            checkReservedForNumberedParameters(name->view(), loc);
         } else {
             nm = gs_.freshNameUnique(core::UniqueNameKind::Parser, core::Names::starStar(), ++uniqueCounter_);
         }
@@ -1054,7 +1054,7 @@ public:
         core::LocOffsets loc = receiver->loc.join(arg->loc);
         sorbet::parser::NodeVec args;
         args.emplace_back(std::move(arg));
-        return make_unique<Send>(loc, std::move(receiver), gs_.enterNameUTF8(oper->string()), std::move(args));
+        return make_unique<Send>(loc, std::move(receiver), gs_.enterNameUTF8(oper->view()), std::move(args));
     }
 
     unique_ptr<Node> match_pattern(unique_ptr<Node> lhs, const token *tok, unique_ptr<Node> rhs) {
@@ -1095,7 +1095,7 @@ public:
     }
 
     unique_ptr<Node> match_var(const token *name) {
-        return match_var_hash(tokLoc(name), name->string());
+        return match_var_hash(tokLoc(name), name->view());
     }
 
     unique_ptr<Node> match_var_hash(core::LocOffsets loc, const std::string name_str) {
@@ -1168,7 +1168,7 @@ public:
     }
 
     unique_ptr<Node> nth_ref(const token *tok) {
-        return make_unique<NthRef>(tokLoc(tok), atoi(tok->string().c_str()));
+        return make_unique<NthRef>(tokLoc(tok), atoi(tok->view().c_str()));
     }
 
     unique_ptr<Node> numparams(sorbet::parser::NodeVec declaringNodes) {
@@ -1187,26 +1187,26 @@ public:
             error(ruby_parser::dclass::BackrefAssignment, lhs->loc);
         }
 
-        if (op->string() == "&&") {
+        if (op->view() == "&&") {
             return make_unique<AndAsgn>(lhs->loc.join(rhs->loc), std::move(lhs), std::move(rhs));
         }
-        if (op->string() == "||") {
+        if (op->view() == "||") {
             return make_unique<OrAsgn>(lhs->loc.join(rhs->loc), std::move(lhs), std::move(rhs));
         }
-        return make_unique<OpAsgn>(lhs->loc.join(rhs->loc), std::move(lhs), gs_.enterNameUTF8(op->string()),
+        return make_unique<OpAsgn>(lhs->loc.join(rhs->loc), std::move(lhs), gs_.enterNameUTF8(op->view()),
                                    std::move(rhs));
     }
 
     unique_ptr<Node> optarg_(const token *name, const token *eql, unique_ptr<Node> value) {
         core::LocOffsets loc = tokLoc(name);
-        checkReservedForNumberedParameters(name->string(), loc);
+        checkReservedForNumberedParameters(name->view(), loc);
 
-        return make_unique<Optarg>(loc.join(value->loc), gs_.enterNameUTF8(name->string()), tokLoc(name),
+        return make_unique<Optarg>(loc.join(value->loc), gs_.enterNameUTF8(name->view()), tokLoc(name),
                                    std::move(value));
     }
 
     unique_ptr<Node> p_ident(const token *tok) {
-        auto name_str = tok->string();
+        auto name_str = tok->view();
         if (!driver_->lex.is_declared(name_str)) {
             error(ruby_parser::dclass::PatternLVarUndefined, tokLoc(tok), name_str);
         }
@@ -1222,7 +1222,7 @@ public:
             core::LocOffsets{clamp((uint32_t)key->start()), clamp((uint32_t)key->end() - 1)}; // drop the trailing :
 
         return make_unique<Pair>(tokLoc(key).join(maybe_loc(value)),
-                                 make_unique<Symbol>(keyLoc, gs_.enterNameUTF8(key->string())), std::move(value));
+                                 make_unique<Symbol>(keyLoc, gs_.enterNameUTF8(key->view())), std::move(value));
     }
 
     unique_ptr<Node> pair_quoted(const token *begin, sorbet::parser::NodeVec parts, const token *end,
@@ -1259,13 +1259,13 @@ public:
     }
 
     unique_ptr<Node> rational(const token *tok) {
-        return make_unique<Rational>(tokLoc(tok), tok->string());
+        return make_unique<Rational>(tokLoc(tok), tok->view());
     }
 
     unique_ptr<Node> rational_complex(const token *tok) {
         // TODO(nelhage): We're losing this information that this was marked as
         // a Rational in the source.
-        return make_unique<Complex>(tokLoc(tok), tok->string());
+        return make_unique<Complex>(tokLoc(tok), tok->view());
     }
 
     unique_ptr<Node> regexp_compose(const token *begin, sorbet::parser::NodeVec parts, const token *end,
@@ -1275,7 +1275,7 @@ public:
     }
 
     unique_ptr<Node> regexp_options(const token *regopt) {
-        return make_unique<Regopt>(tokLoc(regopt), regopt->string());
+        return make_unique<Regopt>(tokLoc(regopt), regopt->view());
     }
 
     unique_ptr<Node> rescue_body(const token *rescue, unique_ptr<Node> excList, const token *assoc,
@@ -1301,8 +1301,8 @@ public:
         if (name != nullptr) {
             nameLoc = tokLoc(name);
             loc = loc.join(nameLoc);
-            nm = gs_.enterNameUTF8(name->string());
-            checkReservedForNumberedParameters(name->string(), nameLoc);
+            nm = gs_.enterNameUTF8(name->view());
+            checkReservedForNumberedParameters(name->view(), nameLoc);
         } else {
             // case like 'def m(*); end'
             nm = gs_.freshNameUnique(core::UniqueNameKind::Parser, core::Names::star(), ++uniqueCounter_);
@@ -1317,9 +1317,9 @@ public:
 
     unique_ptr<Node> shadowarg(const token *name) {
         core::LocOffsets loc = tokLoc(name);
-        checkReservedForNumberedParameters(name->string(), loc);
+        checkReservedForNumberedParameters(name->view(), loc);
 
-        return make_unique<Shadowarg>(loc, gs_.enterNameUTF8(name->string()));
+        return make_unique<Shadowarg>(loc, gs_.enterNameUTF8(name->view()));
     }
 
     unique_ptr<Node> splat(const token *star, unique_ptr<Node> arg) {
@@ -1332,7 +1332,7 @@ public:
     }
 
     unique_ptr<Node> string(const token *string_) {
-        return make_unique<String>(tokLoc(string_), gs_.enterNameUTF8(string_->string()));
+        return make_unique<String>(tokLoc(string_), gs_.enterNameUTF8(string_->view()));
     }
 
     unique_ptr<Node> string_compose(const token *begin, sorbet::parser::NodeVec parts, const token *end) {
@@ -1359,11 +1359,11 @@ public:
     }
 
     unique_ptr<Node> string_internal(const token *string_) {
-        return make_unique<String>(tokLoc(string_), gs_.enterNameUTF8(string_->string()));
+        return make_unique<String>(tokLoc(string_), gs_.enterNameUTF8(string_->view()));
     }
 
     unique_ptr<Node> symbol(const token *symbol) {
-        return make_unique<Symbol>(tokLoc(symbol), gs_.enterNameUTF8(symbol->string()));
+        return make_unique<Symbol>(tokLoc(symbol), gs_.enterNameUTF8(symbol->view()));
     }
 
     unique_ptr<Node> symbol_compose(const token *begin, sorbet::parser::NodeVec parts, const token *end) {
@@ -1381,7 +1381,7 @@ public:
     }
 
     unique_ptr<Node> symbol_internal(const token *symbol) {
-        return make_unique<Symbol>(tokLoc(symbol), gs_.enterNameUTF8(symbol->string()));
+        return make_unique<Symbol>(tokLoc(symbol), gs_.enterNameUTF8(symbol->view()));
     }
 
     unique_ptr<Node> symbols_compose(const token *begin, sorbet::parser::NodeVec parts, const token *end) {
@@ -1414,25 +1414,25 @@ public:
         core::LocOffsets loc = tokLoc(oper).join(receiver->loc);
 
         if (auto *num = parser::cast_node<Integer>(receiver.get())) {
-            return make_unique<Integer>(loc, oper->string() + num->val);
+            return make_unique<Integer>(loc, oper->view() + num->val);
         }
 
         if (oper->type() != ruby_parser::token_type::tTILDE) {
             if (auto *num = parser::cast_node<Float>(receiver.get())) {
-                return make_unique<Float>(loc, oper->string() + num->val);
+                return make_unique<Float>(loc, oper->view() + num->val);
             }
             if (auto *num = parser::cast_node<Rational>(receiver.get())) {
-                return make_unique<Rational>(loc, oper->string() + num->val);
+                return make_unique<Rational>(loc, oper->view() + num->val);
             }
         }
 
         core::NameRef op;
-        if (oper->string() == "+") {
+        if (oper->view() == "+") {
             op = core::Names::unaryPlus();
-        } else if (oper->string() == "-") {
+        } else if (oper->view() == "-") {
             op = core::Names::unaryMinus();
         } else {
-            op = gs_.enterNameUTF8(oper->string());
+            op = gs_.enterNameUTF8(oper->view());
         }
 
         return make_unique<Send>(loc, std::move(receiver), op, sorbet::parser::NodeVec());

--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -638,8 +638,7 @@ public:
     }
 
     unique_ptr<Node> constFetch(unique_ptr<Node> scope, const token *colon, const token *name) {
-        return make_unique<Const>(scope->loc.join(tokLoc(name)), std::move(scope),
-                                  gs_.enterNameConstant(name->view()));
+        return make_unique<Const>(scope->loc.join(tokLoc(name)), std::move(scope), gs_.enterNameConstant(name->view()));
     }
 
     unique_ptr<Node> constGlobal(const token *colon, const token *name) {
@@ -752,8 +751,7 @@ public:
 
         checkReservedForNumberedParameters(name->asString(), declLoc);
 
-        return make_unique<DefMethod>(loc, declLoc, gs_.enterNameUTF8(name->view()), std::move(args),
-                                      std::move(body));
+        return make_unique<DefMethod>(loc, declLoc, gs_.enterNameUTF8(name->view()), std::move(args), std::move(body));
     }
 
     unique_ptr<Node> defModule(const token *module, unique_ptr<Node> name, unique_ptr<Node> body, const token *end_) {

--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -221,7 +221,7 @@ public:
 
     unique_ptr<Node> arg(const token *name) {
         core::LocOffsets loc = tokLoc(name);
-        checkReservedForNumberedParameters(name->view(), loc);
+        checkReservedForNumberedParameters(name->asString(), loc);
 
         return make_unique<Arg>(loc, gs_.enterNameUTF8(name->view()));
     }
@@ -331,7 +331,7 @@ public:
     }
 
     unique_ptr<Node> attrAsgn(unique_ptr<Node> receiver, const token *dot, const token *selector, bool masgn) {
-        core::NameRef method = gs_.enterNameUTF8(selector->view() + "=");
+        core::NameRef method = gs_.enterNameUTF8(selector->asString() + "=");
         core::LocOffsets loc = receiver->loc.join(tokLoc(selector));
         if ((dot != nullptr) && dot->view() == "&.") {
             if (masgn) {
@@ -510,7 +510,7 @@ public:
         if (name != nullptr) {
             loc = tokLoc(name);
             nm = gs_.enterNameUTF8(name->view());
-            checkReservedForNumberedParameters(name->view(), loc);
+            checkReservedForNumberedParameters(name->asString(), loc);
         } else {
             loc = tokLoc(amper);
             nm = gs_.freshNameUnique(core::UniqueNameKind::Parser, core::Names::ampersand(), ++uniqueCounter_);
@@ -724,7 +724,7 @@ public:
                                       unique_ptr<Node> body) {
         core::LocOffsets declLoc = tokLoc(def, tname).join(maybe_loc(args));
         core::LocOffsets loc = tokLoc(def).join(body->loc);
-        std::string name = tname->view();
+        std::string name{tname->view()};
 
         checkEndlessSetter(name, declLoc);
         checkReservedForNumberedParameters(name, declLoc);
@@ -750,7 +750,7 @@ public:
         core::LocOffsets declLoc = tokLoc(def, name).join(maybe_loc(args));
         core::LocOffsets loc = tokLoc(def, end);
 
-        checkReservedForNumberedParameters(name->view(), declLoc);
+        checkReservedForNumberedParameters(name->asString(), declLoc);
 
         return make_unique<DefMethod>(loc, declLoc, gs_.enterNameUTF8(name->view()), std::move(args),
                                       std::move(body));
@@ -949,14 +949,14 @@ public:
 
     unique_ptr<Node> kwarg(const token *name) {
         core::LocOffsets loc = tokLoc(name);
-        checkReservedForNumberedParameters(name->view(), loc);
+        checkReservedForNumberedParameters(name->asString(), loc);
 
         return make_unique<Kwarg>(loc, gs_.enterNameUTF8(name->view()));
     }
 
     unique_ptr<Node> kwoptarg(const token *name, unique_ptr<Node> value) {
         core::LocOffsets loc = tokLoc(name);
-        checkReservedForNumberedParameters(name->view(), loc);
+        checkReservedForNumberedParameters(name->asString(), loc);
 
         return make_unique<Kwoptarg>(loc.join(value->loc), gs_.enterNameUTF8(name->view()), tokLoc(name),
                                      std::move(value));
@@ -973,7 +973,7 @@ public:
         if (name != nullptr) {
             loc = loc.join(tokLoc(name));
             nm = gs_.enterNameUTF8(name->view());
-            checkReservedForNumberedParameters(name->view(), loc);
+            checkReservedForNumberedParameters(name->asString(), loc);
         } else {
             nm = gs_.freshNameUnique(core::UniqueNameKind::Parser, core::Names::starStar(), ++uniqueCounter_);
         }
@@ -1095,7 +1095,7 @@ public:
     }
 
     unique_ptr<Node> match_var(const token *name) {
-        return match_var_hash(tokLoc(name), name->view());
+        return match_var_hash(tokLoc(name), name->asString());
     }
 
     unique_ptr<Node> match_var_hash(core::LocOffsets loc, const std::string name_str) {
@@ -1168,7 +1168,7 @@ public:
     }
 
     unique_ptr<Node> nth_ref(const token *tok) {
-        return make_unique<NthRef>(tokLoc(tok), atoi(tok->view().c_str()));
+        return make_unique<NthRef>(tokLoc(tok), atoi(tok->asString().c_str()));
     }
 
     unique_ptr<Node> numparams(sorbet::parser::NodeVec declaringNodes) {
@@ -1199,14 +1199,14 @@ public:
 
     unique_ptr<Node> optarg_(const token *name, const token *eql, unique_ptr<Node> value) {
         core::LocOffsets loc = tokLoc(name);
-        checkReservedForNumberedParameters(name->view(), loc);
+        checkReservedForNumberedParameters(name->asString(), loc);
 
         return make_unique<Optarg>(loc.join(value->loc), gs_.enterNameUTF8(name->view()), tokLoc(name),
                                    std::move(value));
     }
 
     unique_ptr<Node> p_ident(const token *tok) {
-        auto name_str = tok->view();
+        auto name_str = tok->asString();
         if (!driver_->lex.is_declared(name_str)) {
             error(ruby_parser::dclass::PatternLVarUndefined, tokLoc(tok), name_str);
         }
@@ -1302,7 +1302,7 @@ public:
             nameLoc = tokLoc(name);
             loc = loc.join(nameLoc);
             nm = gs_.enterNameUTF8(name->view());
-            checkReservedForNumberedParameters(name->view(), nameLoc);
+            checkReservedForNumberedParameters(name->asString(), nameLoc);
         } else {
             // case like 'def m(*); end'
             nm = gs_.freshNameUnique(core::UniqueNameKind::Parser, core::Names::star(), ++uniqueCounter_);
@@ -1317,7 +1317,7 @@ public:
 
     unique_ptr<Node> shadowarg(const token *name) {
         core::LocOffsets loc = tokLoc(name);
-        checkReservedForNumberedParameters(name->view(), loc);
+        checkReservedForNumberedParameters(name->asString(), loc);
 
         return make_unique<Shadowarg>(loc, gs_.enterNameUTF8(name->view()));
     }
@@ -1414,15 +1414,15 @@ public:
         core::LocOffsets loc = tokLoc(oper).join(receiver->loc);
 
         if (auto *num = parser::cast_node<Integer>(receiver.get())) {
-            return make_unique<Integer>(loc, oper->view() + num->val);
+            return make_unique<Integer>(loc, oper->asString() + num->val);
         }
 
         if (oper->type() != ruby_parser::token_type::tTILDE) {
             if (auto *num = parser::cast_node<Float>(receiver.get())) {
-                return make_unique<Float>(loc, oper->view() + num->val);
+                return make_unique<Float>(loc, oper->asString() + num->val);
             }
             if (auto *num = parser::cast_node<Rational>(receiver.get())) {
-                return make_unique<Rational>(loc, oper->view() + num->val);
+                return make_unique<Rational>(loc, oper->asString() + num->val);
             }
         }
 

--- a/parser/tools/generate_ast.cc
+++ b/parser/tools/generate_ast.cc
@@ -758,6 +758,25 @@ NodeDef nodes[] = {
     },
 };
 
+string constructorArgType(FieldType arg) {
+    switch (arg) {
+        case FieldType::Name:
+            return "core::NameRef";
+        case FieldType::Node:
+            return "std::unique_ptr<Node>";
+        case FieldType::NodeVec:
+            return "NodeVec";
+        case FieldType::String:
+            return "std::string_view";
+        case FieldType::Uint:
+            return "uint32_t";
+        case FieldType::Loc:
+            return "core::LocOffsets";
+        case FieldType::Bool:
+            return "bool";
+    }
+}
+
 string fieldType(FieldType arg) {
     switch (arg) {
         case FieldType::Name:
@@ -784,7 +803,7 @@ void emitNodeHeader(ostream &out, NodeDef &node) {
     // generate constructor
     out << "    " << node.name << "(core::LocOffsets loc";
     for (auto &arg : node.fields) {
-        out << ", " << fieldType(arg.type) << " " << arg.name;
+        out << ", " << constructorArgType(arg.type) << " " << arg.name;
     }
     out << ")" << '\n';
     out << "        : Node(loc)";

--- a/third_party/parser/cc/capi.cc
+++ b/third_party/parser/cc/capi.cc
@@ -38,8 +38,8 @@ size_t rbtoken_get_end(const ruby_parser::token *tok) {
 }
 
 size_t rbtoken_get_string(const ruby_parser::token *tok, const char **out_ptr) {
-    *out_ptr = tok->string().data();
-    return tok->string().size();
+    *out_ptr = tok->view().data();
+    return tok->view().size();
 }
 
 size_t rblist_get_length(const ruby_parser::node_list *list) {

--- a/third_party/parser/cc/grammars/typedruby.ypp
+++ b/third_party/parser/cc/grammars/typedruby.ypp
@@ -2111,7 +2111,7 @@ opt_block_args_tail:
             bvar: tIDENTIFIER
                     {
                       auto ident = $1;
-                      driver.lex.declare(ident->string());
+                      driver.lex.declare(ident->view());
                       $$ = driver.build.shadowarg(self, ident);
                     }
                 | f_bad_arg
@@ -3374,14 +3374,14 @@ f_opt_paren_args: f_paren_args
                 | tIDENTIFIER
                     {
                       auto ident = $1;
-                      driver.lex.declare(ident->string());
+                      driver.lex.declare(ident->view());
                       driver.numparam_stack.set_ordinary_params();
                       $$ = ident;
                     }
 
       f_arg_asgn: f_norm_arg
                     {
-                      driver.current_arg_stack.set($1[0].string());
+                      driver.current_arg_stack.set($1[0].view());
                       $$ = $1;
                     }
 
@@ -3413,8 +3413,8 @@ f_opt_paren_args: f_paren_args
                         driver.diagnostics.emplace_back(dlevel::ERROR, dclass::ArgumentConst, label);
                         YYERROR;
                       }
-                      driver.lex.declare(label->string());
-                      driver.current_arg_stack.set($1[0].string());
+                      driver.lex.declare(label->view());
+                      driver.current_arg_stack.set($1[0].view());
                       driver.numparam_stack.set_ordinary_params();
                       $$ = label;
                     }
@@ -3472,7 +3472,7 @@ f_opt_paren_args: f_paren_args
                     {
                       auto ident = $2;
 
-                      driver.lex.declare(ident->string());
+                      driver.lex.declare(ident->view());
 
                       auto kwrestarg = driver.build.kwrestarg(self, $1, ident);
 
@@ -3525,7 +3525,7 @@ f_opt_paren_args: f_paren_args
                     {
                       auto ident = $2;
 
-                      driver.lex.declare(ident->string());
+                      driver.lex.declare(ident->view());
 
                       auto restarg = driver.build.restarg(self, $1, ident);
 
@@ -3544,7 +3544,7 @@ f_opt_paren_args: f_paren_args
                     {
                       auto ident = $2;
 
-                      driver.lex.declare(ident->string());
+                      driver.lex.declare(ident->view());
 
                       auto blockarg = driver.build.blockarg(self, $1, ident);
 

--- a/third_party/parser/cc/token.cc
+++ b/third_party/parser/cc/token.cc
@@ -19,6 +19,6 @@ size_t token::end() const {
   return _end;
 }
 
-const std::string& token::string() const {
+const std::string& token::view() const {
   return _string;
 }

--- a/third_party/parser/cc/token.cc
+++ b/third_party/parser/cc/token.cc
@@ -1,28 +1,27 @@
-#include <ruby_parser/token.hh>
 #include <map>
+#include <ruby_parser/token.hh>
 
 using namespace ruby_parser;
 
 token::token(token_type type, size_t start, size_t end, std::string_view str)
-    : _type(type), _start(start), _end(end), _string(str)
-{}
+    : _type(type), _start(start), _end(end), _string(str) {}
 
 token_type token::type() const {
-  return _type;
+    return _type;
 }
 
 size_t token::start() const {
-  return _start;
+    return _start;
 }
 
 size_t token::end() const {
-  return _end;
+    return _end;
 }
 
 std::string_view token::view() const {
-  return _string;
+    return _string;
 }
 
 const std::string &token::asString() const {
-  return _string;
+    return _string;
 }

--- a/third_party/parser/cc/token.cc
+++ b/third_party/parser/cc/token.cc
@@ -19,6 +19,10 @@ size_t token::end() const {
   return _end;
 }
 
-const std::string& token::view() const {
+std::string_view token::view() const {
+  return _string;
+}
+
+const std::string &token::asString() const {
   return _string;
 }

--- a/third_party/parser/include/ruby_parser/driver.hh
+++ b/third_party/parser/include/ruby_parser/driver.hh
@@ -130,13 +130,16 @@ class current_arg_stack {
     std::vector<std::string> stack;
 
 public:
-    void push(std::string value) {
-        stack.push_back(value);
+    void push(std::string_view value) {
+        stack.emplace_back(value);
     }
 
-    void set(std::string value) {
-        pop();
-        push(value);
+    void set(std::string_view value) {
+        if (stack.empty()) {
+            push(value);
+        } else {
+            stack.back() = value;
+        }
     }
 
     void pop() {
@@ -149,8 +152,9 @@ public:
         stack.clear();
     }
 
-    std::string top() {
-        return stack.empty() ? "" : stack.back();
+    const std::string &top() {
+        static std::string empty("");
+        return stack.empty() ? empty : stack.back();
     }
 };
 

--- a/third_party/parser/include/ruby_parser/driver.hh
+++ b/third_party/parser/include/ruby_parser/driver.hh
@@ -281,7 +281,7 @@ public:
     virtual ForeignPtr parse(SelfPtr self, bool trace) = 0;
 
     bool valid_kwarg_name(const token *name) {
-        char c = name->string().at(0);
+        char c = name->view().at(0);
         return !(c >= 'A' && c <= 'Z');
     }
 

--- a/third_party/parser/include/ruby_parser/token.hh
+++ b/third_party/parser/include/ruby_parser/token.hh
@@ -178,7 +178,7 @@ public:
     token_type type() const;
     size_t start() const;
     size_t end() const;
-    const std::string &string() const;
+    const std::string &view() const;
 };
 
 using token_t = token *;

--- a/third_party/parser/include/ruby_parser/token.hh
+++ b/third_party/parser/include/ruby_parser/token.hh
@@ -178,7 +178,8 @@ public:
     token_type type() const;
     size_t start() const;
     size_t end() const;
-    const std::string &view() const;
+    std::string_view view() const;
+    const std::string &asString() const;
 };
 
 using token_t = token *;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

This PR changes the primary way consumers interact with `token`: the preferred interface should be accessing a `string_view` of the token.  Because we have a fair number of places that still expect tokens to be able to turn themselves into `const string&`, we needed to have an `asString()` method on tokens...but such uses should be considered bugs, IMHO.  The commit to change the name of the accessor and the commit to rename/change its interface (and also add `asString()` to fix compile errors) have been separated out so it's easier to see what got changed where.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I think `token` should store `string_view` instead of `string`, and this would be the first step towards getting us there.  I want to do this because `string_view` is significantly smaller than `string`, so that would make tokens smaller (and we could come up with other ways to compact the data `token` stores further, which would let us be slightly more efficient with the token pool).  `string_view` is also less complicated to destroy, which would mean that destroying the lexer's token pool would do less work.  (For cases where we have to munge the data for the token such that it doesn't correspond to the original source, my plan is to have a scratch buffer that a token's `string_view` could point at.  I am not 100% sure this is going to work out, but my intuition is that it should wind up being faster overall.)

The one risk that's worth calling out is that `string_view` is more subject to being misused than `string`.  With `string`, you know that the relevant data is stored in the object itself, so you don't have to think very hard about object lifetimes.  With `string_view`, you would have to be more conscious of this.  (In Rust terms, the lifetimes of the `string_view` in `token` would be tied to the lifetime of the lexer.)  I am mildly optimistic that this won't be a problem in practice, since tokens don't escape outside of the parser+lexer as-is.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
