### PR TITLE
use different options for ragel depending on configuration

### DIFF
--- a/third_party/parser/BUILD
+++ b/third_party/parser/BUILD
@@ -7,7 +7,10 @@ ragel(
     name = "ragel_lexer",
     src = "cc/lexer.rl",
     language = "c++",
-    ragel_options = ["-G1"],
+    ragel_options = select({
+        "@com_stripe_ruby_typer//tools/config:opt": ["-G1"],
+        "//conditions:default": [],
+    }),
 )
 
 bison(


### PR DESCRIPTION
Compiling `-G1` code with the default Bazel configuration can take quite a while, so revert to the default (slower) Ragel configuration on non-opt builds.  (Release builds use the `opt` config and will continue to use `-G1`.)

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
