### PR TITLE
Remove an unnecessary case from `ClassOrModuleRef::show`

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -422,12 +422,6 @@ string ClassOrModuleRef::show(const GlobalState &gs) const {
         }
     }
 
-    if (sym->name == core::Names::Constants::AttachedClass()) {
-        auto attached = sym->owner.asClassOrModuleRef().data(gs)->attachedClass(gs);
-        ENFORCE(attached.exists());
-        return fmt::format("T.attached_class (of {})", attached.show(gs));
-    }
-
     return showInternal(gs, sym->owner, sym->name, COLON_SEPARATOR);
 }
 


### PR DESCRIPTION

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
`T.attached_class` is a type member on the singleton class, so having a special case for printing it as a `ClassOrModuleRef` seems like a leftover from when there was only one type of symbol.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Cleaning up code.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
