### PR TITLE
Update whitequark ref and ruby version for Ruby 3.1 support

### DIFF
--- a/tools/scripts/import_whitequark.sh
+++ b/tools/scripts/import_whitequark.sh
@@ -14,8 +14,8 @@
 set -euo pipefail
 set -x
 
-REF=49ed4dddfb1bf44d579fda001862149f4b9f7970
-TARGET_RUBY_VERSION="3.0"
+REF=3e421d6bc4d7a480d0a0e7aae23afe714a61ea87
+TARGET_RUBY_VERSION="3.1"
 
 SCRIPT=$(realpath "$0")
 ROOT="$(cd "$(dirname "$SCRIPT")/../.."; pwd)"


### PR DESCRIPTION
Co-authored-by: Alexandre Terrasa <alexandre.terrasa@shopify.com>

First changing the script, subsequent pull-requests will bring the imported tests and related parser changes.

### Motivation
First step in supporting new grammar in Ruby 3.1


### Test plan

See included automated tests.

@Morriar