### PR TITLE
Ruby 3.1 support: omission of parentheses during pattern matching

### DIFF
--- a/test/whitequark/test_pattern_matching_required_parentheses_for_in_match_0.rb
+++ b/test/whitequark/test_pattern_matching_required_parentheses_for_in_match_0.rb
@@ -1,3 +1,0 @@
-# typed: true
-
-1 => a, b # error: unexpected token ","

--- a/test/whitequark/test_pattern_matching_required_parentheses_for_in_match_1.rb
+++ b/test/whitequark/test_pattern_matching_required_parentheses_for_in_match_1.rb
@@ -1,3 +1,0 @@
-# typed: true
-
-1 => a: # error: unexpected token tLABEL

--- a/test/whitequark/test_pattern_matching_single_line_allowed_omission_of_parentheses_0.parse-tree-whitequark.exp
+++ b/test/whitequark/test_pattern_matching_single_line_allowed_omission_of_parentheses_0.parse-tree-whitequark.exp
@@ -1,0 +1,9 @@
+s(:begin,
+  s(:match_pattern,
+    s(:array,
+      s(:int, "1"),
+      s(:int, "2")),
+    s(:array_pattern,
+      s(:match_var, :a),
+      s(:match_var, :b))),
+  s(:lvar, :a))

--- a/test/whitequark/test_pattern_matching_single_line_allowed_omission_of_parentheses_0.rb
+++ b/test/whitequark/test_pattern_matching_single_line_allowed_omission_of_parentheses_0.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+[1, 2] => a, b; a

--- a/test/whitequark/test_pattern_matching_single_line_allowed_omission_of_parentheses_1.parse-tree-whitequark.exp
+++ b/test/whitequark/test_pattern_matching_single_line_allowed_omission_of_parentheses_1.parse-tree-whitequark.exp
@@ -1,0 +1,9 @@
+s(:begin,
+  s(:match_pattern,
+    s(:hash,
+      s(:pair,
+        s(:sym, :a),
+        s(:int, "1"))),
+    s(:hash_pattern,
+      s(:match_var, :a))),
+  s(:lvar, :a))

--- a/test/whitequark/test_pattern_matching_single_line_allowed_omission_of_parentheses_1.rb
+++ b/test/whitequark/test_pattern_matching_single_line_allowed_omission_of_parentheses_1.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+{a: 1} => a:; a

--- a/test/whitequark/test_pattern_matching_single_line_allowed_omission_of_parentheses_2.parse-tree-whitequark.exp
+++ b/test/whitequark/test_pattern_matching_single_line_allowed_omission_of_parentheses_2.parse-tree-whitequark.exp
@@ -1,0 +1,9 @@
+s(:begin,
+  s(:match_pattern_p,
+    s(:array,
+      s(:int, "1"),
+      s(:int, "2")),
+    s(:array_pattern,
+      s(:match_var, :a),
+      s(:match_var, :b))),
+  s(:lvar, :a))

--- a/test/whitequark/test_pattern_matching_single_line_allowed_omission_of_parentheses_2.rb
+++ b/test/whitequark/test_pattern_matching_single_line_allowed_omission_of_parentheses_2.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+[1, 2] in a, b; a

--- a/test/whitequark/test_pattern_matching_single_line_allowed_omission_of_parentheses_3.parse-tree-whitequark.exp
+++ b/test/whitequark/test_pattern_matching_single_line_allowed_omission_of_parentheses_3.parse-tree-whitequark.exp
@@ -1,0 +1,9 @@
+s(:begin,
+  s(:match_pattern_p,
+    s(:hash,
+      s(:pair,
+        s(:sym, :a),
+        s(:int, "1"))),
+    s(:hash_pattern,
+      s(:match_var, :a))),
+  s(:lvar, :a))

--- a/test/whitequark/test_pattern_matching_single_line_allowed_omission_of_parentheses_3.rb
+++ b/test/whitequark/test_pattern_matching_single_line_allowed_omission_of_parentheses_3.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+{a: 1} in a:; a

--- a/third_party/parser/cc/grammars/typedruby.ypp
+++ b/third_party/parser/cc/grammars/typedruby.ypp
@@ -727,7 +727,7 @@ int yylex(parser::semantic_type *lval, ruby_parser::typedruby27 &driver) {
                       $<boolean>$ = driver.lex.in_kwarg;
                       driver.lex.in_kwarg = true;
                     }
-                  p_expr
+                  p_top_expr_body
                     {
                       driver.lex.in_kwarg = $<boolean>3;
                       $$ = driver.build.match_pattern(self, $1, $2, $4);
@@ -741,7 +741,7 @@ int yylex(parser::semantic_type *lval, ruby_parser::typedruby27 &driver) {
                       $<boolean>$ = driver.lex.in_kwarg;
                       driver.lex.in_kwarg = true;
                     }
-                  p_expr
+                  p_top_expr_body
                     {
                       driver.lex.in_kwarg = $<boolean>3;
                       $$ = driver.build.match_pattern_p(self, $1, $2, $4);


### PR DESCRIPTION
Follow up on https://github.com/sorbet/sorbet/pull/5098

Allow omission of parentheses in one line pattern matching.


```rb
[0, 1] => _, x
{y: 2} => y:
x #=> 1
y #=> 2
```

https://bugs.ruby-lang.org/issues/16182
https://github.com/whitequark/parser/commit/c7854d027415e318895007f3945f716f410d3b80

### Motivation
Ruby 3.1 Support


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

cc @Morriar 
