### PR TITLE
Ruby 3.1: Allow pin operator to accept an expression

### DIFF
--- a/test/whitequark/test_pin_expr_0.parse-tree-whitequark.exp
+++ b/test/whitequark/test_pin_expr_0.parse-tree-whitequark.exp
@@ -1,0 +1,7 @@
+s(:case_match,
+  s(:lvar, :foo),
+  s(:in_pattern,
+    s(:pin,
+      s(:begin,
+        s(:int, "42"))), nil,
+    s(:nil)), nil)

--- a/test/whitequark/test_pin_expr_0.rb
+++ b/test/whitequark/test_pin_expr_0.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+case foo; in ^(42) then nil; end

--- a/test/whitequark/test_pin_expr_1.parse-tree-whitequark.exp
+++ b/test/whitequark/test_pin_expr_1.parse-tree-whitequark.exp
@@ -1,0 +1,10 @@
+s(:case_match,
+  s(:lvar, :foo),
+  s(:in_pattern,
+    s(:hash_pattern,
+      s(:pair,
+        s(:sym, :foo),
+        s(:pin,
+          s(:begin,
+            s(:int, "42"))))), nil,
+    s(:nil)), nil)

--- a/test/whitequark/test_pin_expr_1.rb
+++ b/test/whitequark/test_pin_expr_1.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+case foo; in { foo: ^(42) } then nil; end

--- a/test/whitequark/test_pin_expr_2.parse-tree-whitequark.exp
+++ b/test/whitequark/test_pin_expr_2.parse-tree-whitequark.exp
@@ -1,0 +1,9 @@
+s(:case_match,
+  s(:lvar, :foo),
+  s(:in_pattern,
+    s(:pin,
+      s(:begin,
+        s(:send,
+          s(:int, "0"), :+,
+          s(:int, "0")))), nil,
+    s(:nil)), nil)

--- a/test/whitequark/test_pin_expr_2.rb
+++ b/test/whitequark/test_pin_expr_2.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+case foo; in ^(0+0) then nil; end

--- a/test/whitequark/test_pin_expr_3.parse-tree-whitequark.exp
+++ b/test/whitequark/test_pin_expr_3.parse-tree-whitequark.exp
@@ -1,0 +1,5 @@
+s(:case_match,
+  s(:lvar, :foo),
+  s(:in_pattern,
+    s(:pin,
+      s(:ivar, :@a)), nil, nil), nil)

--- a/test/whitequark/test_pin_expr_3.rb
+++ b/test/whitequark/test_pin_expr_3.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+case foo; in ^@a; end

--- a/test/whitequark/test_pin_expr_4.parse-tree-whitequark.exp
+++ b/test/whitequark/test_pin_expr_4.parse-tree-whitequark.exp
@@ -1,0 +1,5 @@
+s(:case_match,
+  s(:lvar, :foo),
+  s(:in_pattern,
+    s(:pin,
+      s(:cvar, :@@TestPatternMatching)), nil, nil), nil)

--- a/test/whitequark/test_pin_expr_4.rb
+++ b/test/whitequark/test_pin_expr_4.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+case foo; in ^@@TestPatternMatching; end

--- a/test/whitequark/test_pin_expr_5.parse-tree-whitequark.exp
+++ b/test/whitequark/test_pin_expr_5.parse-tree-whitequark.exp
@@ -1,0 +1,5 @@
+s(:case_match,
+  s(:lvar, :foo),
+  s(:in_pattern,
+    s(:pin,
+      s(:gvar, :$TestPatternMatching)), nil, nil), nil)

--- a/test/whitequark/test_pin_expr_5.rb
+++ b/test/whitequark/test_pin_expr_5.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+case foo; in ^$TestPatternMatching; end

--- a/third_party/parser/cc/grammars/typedruby.ypp
+++ b/third_party/parser/cc/grammars/typedruby.ypp
@@ -2777,7 +2777,7 @@ opt_block_args_tail:
                       auto non_lvar = driver.build.accessible(self, $2);
                       $$ = driver.build.pin(self, $1, non_lvar);
                     }
-       p_expr_ref: tCARET tLPAREN expr_value tRPAREN
+        p_expr_ref: tCARET tLPAREN expr_value tRPAREN
                     {
                       auto expr = driver.build.begin(self, $2, $3, $4);
                       $$ = driver.build.pin(self, $1, expr);

--- a/third_party/parser/cc/grammars/typedruby.ypp
+++ b/third_party/parser/cc/grammars/typedruby.ypp
@@ -3087,7 +3087,7 @@ regexp_contents: // nothing
                       $$ = driver.build.floatComplex(self, $1);
                     }
 
-    nonlocal_var: tIVAR
+        nonlocal_var: tIVAR
                     {
                       $$ = driver.build.ivar(self, $1);
                     }

--- a/third_party/parser/cc/grammars/typedruby.ypp
+++ b/third_party/parser/cc/grammars/typedruby.ypp
@@ -229,6 +229,7 @@ using namespace std::string_literals;
   mlhs_node
   mrhs_arg
   none
+  nonlocal_var
   numeric
   opt_block_param
   p_alt
@@ -237,6 +238,7 @@ using namespace std::string_literals;
   p_const
   p_expr
   p_expr_basic
+  p_expr_ref
   p_kw
   p_kw_label
   p_primitive
@@ -2463,6 +2465,7 @@ opt_block_args_tail:
                       driver.pattern_hash_keys.push();
                     }
     p_expr_basic: p_value
+                | p_variable
                 | p_const p_lparen p_args rparen
                     {
                       driver.pattern_hash_keys.pop();
@@ -2721,8 +2724,8 @@ opt_block_args_tail:
                     {
                       $$ = driver.build.range_exclusive(self, $1, $2, nullptr);
                     }
-                | p_variable
                 | p_var_ref
+                | p_expr_ref
                 | p_const
                 | tBDOT2 p_primitive
                     {
@@ -2768,6 +2771,16 @@ opt_block_args_tail:
                       auto pid = driver.build.p_ident(self, $2);
                       auto lvar = driver.build.accessible(self, pid);
                       $$ = driver.build.pin(self, $1, lvar);
+                    }
+                | tCARET nonlocal_var
+                    {
+                      auto non_lvar = driver.build.accessible(self, $2);
+                      $$ = driver.build.pin(self, $1, non_lvar);
+                    }
+       p_expr_ref: tCARET tLPAREN expr_value tRPAREN
+                    {
+                      auto expr = driver.build.begin(self, $2, $3, $4);
+                      $$ = driver.build.pin(self, $1, expr);
                     }
          p_const: tCOLON3 cname
                     {
@@ -3072,6 +3085,19 @@ regexp_contents: // nothing
                     {
                       driver.lex.set_state_expr_end();
                       $$ = driver.build.floatComplex(self, $1);
+                    }
+
+    nonlocal_var: tIVAR
+                    {
+                      $$ = driver.build.ivar(self, $1);
+                    }
+                | tGVAR
+                    {
+                      $$ = driver.build.gvar(self, $1);
+                    }
+                | tCVAR
+                    {
+                      $$ = driver.build.cvar(self, $1);
                     }
 
    user_variable: tIDENTIFIER


### PR DESCRIPTION
Follow up on https://github.com/sorbet/sorbet/pull/5098

https://bugs.ruby-lang.org/issues/17411
https://github.com/whitequark/parser/commit/70c82209f348a18b5ca76b4455bf081ca3385633
https://github.com/whitequark/parser/commit/11c7644365fe554217bb4670a4cbc905ab8504cd

### Motivation
Ruby 3.1 support which now has this feature


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

@Morriar