### PR TITLE
Recover from syntax errors in assignments

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -505,6 +505,9 @@ void GlobalState::initEmpty() {
     field.data(*this)->resultType =
         make_type<LiteralType>(Symbols::String(), enterNameUTF8(sorbet_full_version_string));
 
+    // ::<ErrorNode>
+    field = enterStaticFieldSymbol(Loc::none(), Symbols::root(), Names::Constants::ErrorNode());
+
     // Synthesize <Magic>.<build-hash>(*vs : T.untyped) => Hash
     method = enterMethod(*this, Symbols::MagicSingleton(), Names::buildHash())
                  .repeatedUntypedArg(Names::arg0())

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -976,7 +976,7 @@ public:
 
     static constexpr int MAX_SYNTHETIC_CLASS_SYMBOLS = 203;
     static constexpr int MAX_SYNTHETIC_METHOD_SYMBOLS = 44;
-    static constexpr int MAX_SYNTHETIC_FIELD_SYMBOLS = 3;
+    static constexpr int MAX_SYNTHETIC_FIELD_SYMBOLS = 4;
     static constexpr int MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 4;
     static constexpr int MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 100;
 };

--- a/core/lsp/QueryResponse.h
+++ b/core/lsp/QueryResponse.h
@@ -50,9 +50,9 @@ class ConstantResponse final {
 public:
     using Scopes = InlinedVector<core::SymbolRef, 1>;
     ConstantResponse(core::SymbolRef symbol, core::SymbolRef symbolBeforeDealias, core::Loc termLoc, Scopes scopes,
-                     core::NameRef name, core::TypeAndOrigins retType)
+                     core::NameRef name, core::TypeAndOrigins retType, core::MethodRef enclosingMethod)
         : symbol(symbol), symbolBeforeDealias(symbolBeforeDealias), termLoc(termLoc), scopes(scopes), name(name),
-          retType(std::move(retType)){};
+          retType(std::move(retType)), enclosingMethod(enclosingMethod){};
     const core::SymbolRef symbol;
     // You probably don't want this. Almost all of Sorbet's type system operates on dealiased
     // symbols transparently (e.g., for a constant like `X = Integer`, Sorbet reports that `''` is
@@ -66,6 +66,7 @@ public:
     const Scopes scopes;
     const core::NameRef name;
     const core::TypeAndOrigins retType;
+    const core::MethodRef enclosingMethod;
 };
 
 class FieldResponse final {

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -58,6 +58,7 @@ NameDef names[] = {
 
     // Used in parser for error recovery
     {"methodNameMissing", "<method-name-missing>"},
+    {"ErrorNode", "<ErrorNode>", true},
 
     // used in CFG for temporaries
     {"whileTemp", "<whileTemp>"},

--- a/main/lsp/requests/completion.h
+++ b/main/lsp/requests/completion.h
@@ -37,6 +37,11 @@ class CompletionTask final : public LSPRequestTask {
         // If empty(), won't suggest constants.
         core::lsp::ConstantResponse::Scopes scopes;
     };
+    static MethodSearchParams methodSearchParamsForEmptyAssign(const core::GlobalState &gs,
+                                                               core::MethodRef enclosingMethod);
+    static SearchParams searchParamsForEmptyAssign(const core::GlobalState &gs, core::Loc queryLoc,
+                                                   core::MethodRef enclosingMethod,
+                                                   core::lsp::ConstantResponse::Scopes scopes);
     std::vector<std::unique_ptr<CompletionItem>> getCompletionItems(LSPTypecheckerDelegate &typechecker,
                                                                     SearchParams &params);
 

--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -848,6 +848,10 @@ public:
         return make_unique<EncodingLiteral>(tokLoc(tok));
     }
 
+    unique_ptr<Node> error_node(size_t begin, size_t end) {
+        return make_unique<Const>(locOffset(begin, end), nullptr, core::Names::Constants::ErrorNode());
+    }
+
     unique_ptr<Node> false_(const token *tok) {
         return make_unique<False>(tokLoc(tok));
     }
@@ -1971,6 +1975,11 @@ ForeignPtr encodingLiteral(SelfPtr builder, const token *tok) {
     return build->toForeign(build->encodingLiteral(tok));
 }
 
+ForeignPtr error_node(SelfPtr builder, size_t begin, size_t end) {
+    auto build = cast_builder(builder);
+    return build->toForeign(build->error_node(begin, end));
+}
+
 ForeignPtr false_(SelfPtr builder, const token *tok) {
     auto build = cast_builder(builder);
     return build->toForeign(build->false_(tok));
@@ -2522,6 +2531,7 @@ struct ruby_parser::builder Builder::interface = {
     defsHead,
     defSingleton,
     encodingLiteral,
+    error_node,
     false_,
     find_pattern,
     fileLiteral,

--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -1228,13 +1228,17 @@ int maybe_inject_tNL_impl(parser::symbol_type &yyla, ruby_parser::typedruby27 &d
                     }
                 | lhs tEQL error
                     {
-                      // Have to use @2.end for the start of the error node so that completion requests are
-                      // more likely to fall into the query range. Consider:
+                      // The choice of location information below is worth explaining. Consider:
                       //     def foo(x)
                       //       y =
+                      //       #  ^
                       //     end
-                      // @3 will be the `end` token's begin & end, which means a completion query right after
-                      // the `=` would be outside the range of the error_node if we used those locs.
+                      // @3 will be the `end` token's begin & end. To get a completion response at the caret,
+                      // the error_node's location has to include the gap between the two tokens. Also, to
+                      // avoid setting the error_node's loc to a zero-width loc (e.g. `y =end`) which Sorbet's
+                      // LSP would skip over when responding to editor queries, we use the error token's
+                      // end location as the end of the error_node's location (instead of strictly setting it
+                      // to the gap).
                       $$ = driver.build.assign(self, $1, $2, driver.build.error_node(self, @2.end, @3.end));
                     }
                 | var_lhs tOP_ASGN arg_rhs

--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -1226,6 +1226,17 @@ int maybe_inject_tNL_impl(parser::symbol_type &yyla, ruby_parser::typedruby27 &d
                     {
                       $$ = driver.build.assign(self, $1, $2, $3);
                     }
+                | lhs tEQL error
+                    {
+                      // Have to use @2.end for the start of the error node so that completion requests are
+                      // more likely to fall into the query range. Consider:
+                      //     def foo(x)
+                      //       y =
+                      //     end
+                      // @3 will be the `end` token's begin & end, which means a completion query right after
+                      // the `=` would be outside the range of the error_node if we used those locs.
+                      $$ = driver.build.assign(self, $1, $2, driver.build.error_node(self, @2.end, @3.end));
+                    }
                 | var_lhs tOP_ASGN arg_rhs
                     {
                       $$ = driver.build.op_assign(self, $1, $2, $3);
@@ -3785,6 +3796,9 @@ f_opt_paren_args: f_paren_args
                   }
                 | tNL
 
+
+           // "terms" here stands for "terminators" (as in line terminators),
+           // not "terms" as in types & terms
            terms: term
                 | terms tSEMI
 

--- a/parser/parser/include/ruby_parser/builder.hh
+++ b/parser/parser/include/ruby_parser/builder.hh
@@ -70,6 +70,7 @@ struct builder {
     ForeignPtr (*defsHead)(SelfPtr builder, const token *def, ForeignPtr definee, const token *dot, const token *name);
     ForeignPtr (*defSingleton)(SelfPtr builder, ForeignPtr defHead, ForeignPtr args, ForeignPtr body, const token *end);
     ForeignPtr (*encodingLiteral)(SelfPtr builder, const token *tok);
+    ForeignPtr (*error_node)(SelfPtr builder, size_t begin, size_t end);
     ForeignPtr (*false_)(SelfPtr builder, const token *tok);
     ForeignPtr (*find_pattern)(SelfPtr builder, const token *lbrack_t, const node_list *elements,
                                const token *rbrack_t);

--- a/test/testdata/infer/fuzz_uninitialized_vars.rb
+++ b/test/testdata/infer/fuzz_uninitialized_vars.rb
@@ -1,8 +1,8 @@
 # typed: true
 foo = a(b
 if @c && foo # error: unexpected token "if"
-  d # error: This code is unreachable
-end
+  d
+end # error: unexpected token "end"
 
 if @d && foo
 end

--- a/test/testdata/lsp/completion/existing_ident.rb
+++ b/test/testdata/lsp/completion/existing_ident.rb
@@ -1,0 +1,6 @@
+# typed: true
+
+def test_before_variable(arg, arg1, arg2, arg3)
+  arg
+  #  ^ completion: arg, arg1, arg2, arg3
+end

--- a/test/testdata/lsp/completion/locals.rb
+++ b/test/testdata/lsp/completion/locals.rb
@@ -43,11 +43,10 @@ def before_after
   x_2 = 1
 end
 
-# We don't yet complete locals when the position is already a valid local
 def already_valid_local
   x_1 = nil
   x_1
-  #  ^ completion: (nothing)
+  #  ^ completion: x_1
 end
 
 class A

--- a/test/testdata/lsp/completion/missing_assign_rhs.rb
+++ b/test/testdata/lsp/completion/missing_assign_rhs.rb
@@ -1,6 +1,9 @@
 # typed: true
 
-def test_missing_rhs(x)
-  y =
-  #  ^ completion: (nothing)
-end # error: unexpected token "end"
+class A
+  def foo; end
+  def test_missing_rhs(x)
+    y =
+    #  ^ completion: x, y, foo, test_missing_rhs, ...
+  end # error: unexpected token "end"
+end

--- a/test/testdata/lsp/completion/missing_assign_rhs.rb
+++ b/test/testdata/lsp/completion/missing_assign_rhs.rb
@@ -1,0 +1,6 @@
+# typed: true
+
+def test_missing_rhs(x)
+  y =
+  #  ^ completion: (nothing)
+end # error: unexpected token "end"

--- a/test/testdata/lsp/completion/missing_assign_rhs.rb
+++ b/test/testdata/lsp/completion/missing_assign_rhs.rb
@@ -2,25 +2,32 @@
 
 class A
   def foo; end
+  attr_writer :foo_writer
+
   def test_missing_rhs(x)
     y =
-    #  ^ completion: x, y, foo, test_missing_rhs, ...
+    #  ^ completion: x, y, foo, ...
   end # error: unexpected token "end"
 
   def test_variable_after_method(x)
     puts 'before'
     y =
-    #  ^ completion: x, y, foo, test_missing_rhs, ...
+    #  ^ completion: x, y, foo, ...
   end # error: unexpected token "end"
 
   def test_variable_end_same_line(x)
     puts 'before'
     y =end # error: unexpected token "end"
-    #  ^ completion: x, y, foo, test_missing_rhs, ...
+    #  ^ completion: x, y, foo, ...
 
   def test_variable_end_same_line_after(x)
     # This one is admittedly janky. There's a note about it in the parser.
     puts 'before'
     y =end # error: unexpected token "end"
-    #     ^ completion: x, y, foo, test_missing_rhs, ...
+    #     ^ completion: x, y, foo, ...
+
+  def test_attr_writer(x)
+    self.foo_writer =
+    #                ^ completion: x, foo, foo_writer=, ...
+  end # error: unexpected token "end"
 end

--- a/test/testdata/lsp/completion/missing_assign_rhs.rb
+++ b/test/testdata/lsp/completion/missing_assign_rhs.rb
@@ -12,4 +12,15 @@ class A
     y =
     #  ^ completion: x, y, foo, test_missing_rhs, ...
   end # error: unexpected token "end"
+
+  def test_variable_end_same_line(x)
+    puts 'before'
+    y =end # error: unexpected token "end"
+    #  ^ completion: x, y, foo, test_missing_rhs, ...
+
+  def test_variable_end_same_line_after(x)
+    # This one is admittedly janky. There's a note about it in the parser.
+    puts 'before'
+    y =end # error: unexpected token "end"
+    #     ^ completion: x, y, foo, test_missing_rhs, ...
 end

--- a/test/testdata/lsp/completion/missing_assign_rhs.rb
+++ b/test/testdata/lsp/completion/missing_assign_rhs.rb
@@ -30,4 +30,10 @@ class A
     self.foo_writer =
     #                ^ completion: x, foo, foo_writer=, ...
   end # error: unexpected token "end"
+
+  def test_before_variable(x)
+    y =
+    #  ^ completion: x, y, z, foo, ...
+    z = nil
+  end
 end

--- a/test/testdata/lsp/completion/missing_assign_rhs.rb
+++ b/test/testdata/lsp/completion/missing_assign_rhs.rb
@@ -6,4 +6,10 @@ class A
     y =
     #  ^ completion: x, y, foo, test_missing_rhs, ...
   end # error: unexpected token "end"
+
+  def test_variable_after_method(x)
+    puts 'before'
+    y =
+    #  ^ completion: x, y, foo, test_missing_rhs, ...
+  end # error: unexpected token "end"
 end

--- a/test/testdata/lsp/completion/missing_assign_rhs.rb.desugar-tree.exp
+++ b/test/testdata/lsp/completion/missing_assign_rhs.rb.desugar-tree.exp
@@ -34,5 +34,9 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     def test_attr_writer<<todo method>>(x, &<blk>)
       <self>.foo_writer=(<emptyTree>::<C <ErrorNode>>)
     end
+
+    def test_before_variable<<todo method>>(x, &<blk>)
+      y = z = nil
+    end
   end
 end

--- a/test/testdata/lsp/completion/missing_assign_rhs.rb.desugar-tree.exp
+++ b/test/testdata/lsp/completion/missing_assign_rhs.rb.desugar-tree.exp
@@ -14,5 +14,19 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         y = <emptyTree>::<C <ErrorNode>>
       end
     end
+
+    def test_variable_end_same_line<<todo method>>(x, &<blk>)
+      begin
+        <self>.puts("before")
+        y = <emptyTree>::<C <ErrorNode>>
+      end
+    end
+
+    def test_variable_end_same_line_after<<todo method>>(x, &<blk>)
+      begin
+        <self>.puts("before")
+        y = <emptyTree>::<C <ErrorNode>>
+      end
+    end
   end
 end

--- a/test/testdata/lsp/completion/missing_assign_rhs.rb.desugar-tree.exp
+++ b/test/testdata/lsp/completion/missing_assign_rhs.rb.desugar-tree.exp
@@ -7,5 +7,12 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     def test_missing_rhs<<todo method>>(x, &<blk>)
       y = <emptyTree>::<C <ErrorNode>>
     end
+
+    def test_variable_after_method<<todo method>>(x, &<blk>)
+      begin
+        <self>.puts("before")
+        y = <emptyTree>::<C <ErrorNode>>
+      end
+    end
   end
 end

--- a/test/testdata/lsp/completion/missing_assign_rhs.rb.desugar-tree.exp
+++ b/test/testdata/lsp/completion/missing_assign_rhs.rb.desugar-tree.exp
@@ -4,6 +4,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>
     end
 
+    <self>.attr_writer(:foo_writer)
+
     def test_missing_rhs<<todo method>>(x, &<blk>)
       y = <emptyTree>::<C <ErrorNode>>
     end
@@ -27,6 +29,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <self>.puts("before")
         y = <emptyTree>::<C <ErrorNode>>
       end
+    end
+
+    def test_attr_writer<<todo method>>(x, &<blk>)
+      <self>.foo_writer=(<emptyTree>::<C <ErrorNode>>)
     end
   end
 end

--- a/test/testdata/lsp/completion/missing_assign_rhs.rb.desugar-tree.exp
+++ b/test/testdata/lsp/completion/missing_assign_rhs.rb.desugar-tree.exp
@@ -1,0 +1,5 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  def test_missing_rhs<<todo method>>(x, &<blk>)
+    y = <emptyTree>::<C <ErrorNode>>
+  end
+end

--- a/test/testdata/lsp/completion/missing_assign_rhs.rb.desugar-tree.exp
+++ b/test/testdata/lsp/completion/missing_assign_rhs.rb.desugar-tree.exp
@@ -1,5 +1,11 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  def test_missing_rhs<<todo method>>(x, &<blk>)
-    y = <emptyTree>::<C <ErrorNode>>
+  class <emptyTree>::<C A><<C <todo sym>>> < (::<todo sym>)
+    def foo<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    def test_missing_rhs<<todo method>>(x, &<blk>)
+      y = <emptyTree>::<C <ErrorNode>>
+    end
   end
 end

--- a/test/testdata/parser/error_recovery_assign.rb.parse-tree.exp
+++ b/test/testdata/parser/error_recovery_assign.rb.parse-tree.exp
@@ -7,5 +7,13 @@ DefMethod {
       }
     ]
   }
-  body = NULL
+  body = Assign {
+    lhs = LVarLhs {
+      name = <U x>
+    }
+    rhs = Const {
+      scope = NULL
+      name = <C <U <ErrorNode>>>
+    }
+  }
 }

--- a/test/testdata/parser/error_recovery_multiple_stmts.rb.parse-tree.exp
+++ b/test/testdata/parser/error_recovery_multiple_stmts.rb.parse-tree.exp
@@ -1,12 +1,33 @@
 DefMethod {
   name = <U test_method_with_multiple_stmts>
   args = NULL
-  body = Assign {
-    lhs = LVarLhs {
-      name = <U y>
-    }
-    rhs = Integer {
-      val = "1"
-    }
+  body = Begin {
+    stmts = [
+      Assign {
+        lhs = LVarLhs {
+          name = <U x>
+        }
+        rhs = Integer {
+          val = "1"
+        }
+      }
+      Assign {
+        lhs = LVarLhs {
+          name = <U x>
+        }
+        rhs = Const {
+          scope = NULL
+          name = <C <U <ErrorNode>>>
+        }
+      }
+      Assign {
+        lhs = LVarLhs {
+          name = <U y>
+        }
+        rhs = Integer {
+          val = "1"
+        }
+      }
+    ]
   }
 }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

More fast paths, better completion.

Review by commit.

### Note about `error_node`

I've chosen to implement this as an (unresolved) constant reference. I
think that making a fake constant node will be easier than having to
update all the places in the codebase that might want to exhaustively
handle all pieces of syntax.

I've chosen to make it a constant node because it's allowed in more
places (versus say, a variable name or method name).

Another option was to make it an empty `begin; end` node, but that would
become an `EmptyTree` after desugar, and I think that this is more
useful in case we want to detect this somewhere later in the pipeline.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.