### PR TITLE
Use ShowOptions on ref types as well

### DIFF
--- a/core/ShowOptions.h
+++ b/core/ShowOptions.h
@@ -1,0 +1,11 @@
+#ifndef CORE_SHOW_OPTIONS_H
+#define CORE_SHOW_OPTIONS_H
+
+namespace sorbet::core {
+
+// Options for controlling how the various `show` methods work.
+struct ShowOptions final {};
+
+} // namespace sorbet::core
+
+#endif

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -3,6 +3,7 @@
 
 #include "common/common.h"
 #include "core/DebugOnlyCheck.h"
+#include "core/ShowOptions.h"
 
 namespace sorbet::core {
 class Symbol;
@@ -132,7 +133,7 @@ public:
     std::string_view showKind(const GlobalState &gs) const;
     std::string showFullName(const GlobalState &gs) const;
     std::string toStringFullName(const GlobalState &gs) const;
-    std::string show(const GlobalState &gs) const;
+    std::string show(const GlobalState &gs, ShowOptions options) const;
 };
 CheckSize(ClassOrModuleRef, 4, 4);
 
@@ -176,7 +177,7 @@ public:
     std::string_view showKind(const GlobalState &gs) const;
     std::string showFullName(const GlobalState &gs) const;
     std::string toStringFullName(const GlobalState &gs) const;
-    std::string show(const GlobalState &gs) const;
+    std::string show(const GlobalState &gs, ShowOptions options) const;
 
     bool operator==(const MethodRef &rhs) const;
 
@@ -218,7 +219,7 @@ public:
     std::string_view showKind(const GlobalState &gs) const;
     std::string showFullName(const GlobalState &gs) const;
     std::string toStringFullName(const GlobalState &gs) const;
-    std::string show(const GlobalState &gs) const;
+    std::string show(const GlobalState &gs, ShowOptions options) const;
 
     bool operator==(const FieldRef &rhs) const;
 
@@ -259,7 +260,7 @@ public:
     std::string_view showKind(const GlobalState &gs) const;
     std::string showFullName(const GlobalState &gs) const;
     std::string toStringFullName(const GlobalState &gs) const;
-    std::string show(const GlobalState &gs) const;
+    std::string show(const GlobalState &gs, ShowOptions options) const;
 
     bool operator==(const TypeMemberRef &rhs) const;
 
@@ -301,7 +302,7 @@ public:
     std::string_view showKind(const GlobalState &gs) const;
     std::string showFullName(const GlobalState &gs) const;
     std::string toStringFullName(const GlobalState &gs) const;
-    std::string show(const GlobalState &gs) const;
+    std::string show(const GlobalState &gs, ShowOptions options) const;
 
     bool operator==(const TypeArgumentRef &rhs) const;
 
@@ -492,7 +493,7 @@ public:
         return toStringWithOptions(gs, 0, showFull, showRaw);
     }
     // Renders the full name of this Symbol in a form suitable for user display.
-    std::string show(const GlobalState &gs) const;
+    std::string show(const GlobalState &gs, ShowOptions options) const;
 };
 CheckSize(SymbolRef, 4, 4);
 

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -133,7 +133,7 @@ public:
     std::string_view showKind(const GlobalState &gs) const;
     std::string showFullName(const GlobalState &gs) const;
     std::string toStringFullName(const GlobalState &gs) const;
-    std::string show(const GlobalState &gs, ShowOptions options) const;
+    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
 };
 CheckSize(ClassOrModuleRef, 4, 4);
 
@@ -177,7 +177,7 @@ public:
     std::string_view showKind(const GlobalState &gs) const;
     std::string showFullName(const GlobalState &gs) const;
     std::string toStringFullName(const GlobalState &gs) const;
-    std::string show(const GlobalState &gs, ShowOptions options) const;
+    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
 
     bool operator==(const MethodRef &rhs) const;
 
@@ -219,7 +219,7 @@ public:
     std::string_view showKind(const GlobalState &gs) const;
     std::string showFullName(const GlobalState &gs) const;
     std::string toStringFullName(const GlobalState &gs) const;
-    std::string show(const GlobalState &gs, ShowOptions options) const;
+    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
 
     bool operator==(const FieldRef &rhs) const;
 
@@ -260,7 +260,7 @@ public:
     std::string_view showKind(const GlobalState &gs) const;
     std::string showFullName(const GlobalState &gs) const;
     std::string toStringFullName(const GlobalState &gs) const;
-    std::string show(const GlobalState &gs, ShowOptions options) const;
+    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
 
     bool operator==(const TypeMemberRef &rhs) const;
 
@@ -302,7 +302,7 @@ public:
     std::string_view showKind(const GlobalState &gs) const;
     std::string showFullName(const GlobalState &gs) const;
     std::string toStringFullName(const GlobalState &gs) const;
-    std::string show(const GlobalState &gs, ShowOptions options) const;
+    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
 
     bool operator==(const TypeArgumentRef &rhs) const;
 
@@ -493,7 +493,7 @@ public:
         return toStringWithOptions(gs, 0, showFull, showRaw);
     }
     // Renders the full name of this Symbol in a form suitable for user display.
-    std::string show(const GlobalState &gs, ShowOptions options) const;
+    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
 };
 CheckSize(SymbolRef, 4, 4);
 

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -375,27 +375,27 @@ TypeMemberRef::TypeMemberRef(const GlobalState &from, uint32_t id) : _id(id) {}
 
 TypeArgumentRef::TypeArgumentRef(const GlobalState &from, uint32_t id) : _id(id) {}
 
-string SymbolRef::show(const GlobalState &gs) const {
+string SymbolRef::show(const GlobalState &gs, ShowOptions options) const {
     switch (kind()) {
         case Kind::ClassOrModule:
-            return asClassOrModuleRef().show(gs);
+            return asClassOrModuleRef().show(gs, options);
         case Kind::Method:
-            return asMethodRef().show(gs);
+            return asMethodRef().show(gs, options);
         case Kind::FieldOrStaticField:
-            return asFieldRef().show(gs);
+            return asFieldRef().show(gs, options);
         case Kind::TypeArgument:
-            return asTypeArgumentRef().show(gs);
+            return asTypeArgumentRef().show(gs, options);
         case Kind::TypeMember:
-            return asTypeMemberRef().show(gs);
+            return asTypeMemberRef().show(gs, options);
     }
 }
 
-string ClassOrModuleRef::show(const GlobalState &gs) const {
+string ClassOrModuleRef::show(const GlobalState &gs, ShowOptions options) const {
     auto sym = dataAllowingNone(gs);
     if (sym->isSingletonClass(gs)) {
         auto attached = sym->attachedClass(gs);
         if (attached.exists()) {
-            return fmt::format("T.class_of({})", attached.show(gs));
+            return fmt::format("T.class_of({})", attached.show(gs, options));
         }
     }
 
@@ -425,30 +425,30 @@ string ClassOrModuleRef::show(const GlobalState &gs) const {
     return showInternal(gs, sym->owner, sym->name, COLON_SEPARATOR);
 }
 
-string MethodRef::show(const GlobalState &gs) const {
+string MethodRef::show(const GlobalState &gs, ShowOptions options) const {
     auto sym = data(gs);
     if (sym->owner.data(gs)->isSingletonClass(gs)) {
-        return absl::StrCat(sym->owner.data(gs)->attachedClass(gs).show(gs), ".", sym->name.show(gs));
+        return absl::StrCat(sym->owner.data(gs)->attachedClass(gs).show(gs, options), ".", sym->name.show(gs));
     }
     return showInternal(gs, sym->owner, sym->name, HASH_SEPARATOR);
 }
 
-string FieldRef::show(const GlobalState &gs) const {
+string FieldRef::show(const GlobalState &gs, ShowOptions options) const {
     auto sym = dataAllowingNone(gs);
     return showInternal(gs, sym->owner, sym->name, sym->flags.isStaticField ? COLON_SEPARATOR : HASH_SEPARATOR);
 }
 
-string TypeArgumentRef::show(const GlobalState &gs) const {
+string TypeArgumentRef::show(const GlobalState &gs, ShowOptions options) const {
     auto sym = data(gs);
     return showInternal(gs, sym->owner, sym->name, HASH_SEPARATOR);
 }
 
-string TypeMemberRef::show(const GlobalState &gs) const {
+string TypeMemberRef::show(const GlobalState &gs, ShowOptions options) const {
     auto sym = data(gs);
     if (sym->name == core::Names::Constants::AttachedClass()) {
         auto attached = sym->owner.asClassOrModuleRef().data(gs)->attachedClass(gs);
         ENFORCE(attached.exists());
-        return fmt::format("T.attached_class (of {})", attached.show(gs));
+        return fmt::format("T.attached_class (of {})", attached.show(gs, options));
     }
     return showInternal(gs, sym->owner, sym->name, COLON_SEPARATOR);
 }

--- a/core/TypePtr.cc
+++ b/core/TypePtr.cc
@@ -324,7 +324,7 @@ uint32_t TypePtr::hash(const GlobalState &gs) const {
 #undef HASH
 }
 
-std::string TypePtr::show(const GlobalState &gs, const TypePtr::ShowOptions options) const {
+std::string TypePtr::show(const GlobalState &gs, const ShowOptions options) const {
 #define SHOW(T) return cast_type_nonnull<T>(*this).show(gs, options);
     GENERATE_TAG_SWITCH(tag(), SHOW)
 #undef SHOW

--- a/core/TypePtr.cc
+++ b/core/TypePtr.cc
@@ -324,7 +324,7 @@ uint32_t TypePtr::hash(const GlobalState &gs) const {
 #undef HASH
 }
 
-std::string TypePtr::show(const GlobalState &gs, const ShowOptions options) const {
+std::string TypePtr::show(const GlobalState &gs, ShowOptions options) const {
 #define SHOW(T) return cast_type_nonnull<T>(*this).show(gs, options);
     GENERATE_TAG_SWITCH(tag(), SHOW)
 #undef SHOW

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -2,8 +2,8 @@
 #define SORBET_TYPEPTR_H
 #include "common/common.h"
 #include "core/NameRef.h"
-#include "core/SymbolRef.h"
 #include "core/ShowOptions.h"
+#include "core/SymbolRef.h"
 #include <memory>
 
 namespace sorbet::core {
@@ -313,7 +313,7 @@ public:
     }
 
     // User visible type. Should exactly match what the user can write.
-    std::string show(const GlobalState &gs, const ShowOptions options = ShowOptions{}) const;
+    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
     // Like show, but can include extra info. Does not necessarily match what the user can type.
     std::string showWithMoreInfo(const GlobalState &gs) const;
 

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -3,6 +3,7 @@
 #include "common/common.h"
 #include "core/NameRef.h"
 #include "core/SymbolRef.h"
+#include "core/ShowOptions.h"
 #include <memory>
 
 namespace sorbet::core {
@@ -310,8 +311,6 @@ public:
     std::string toString(const GlobalState &gs) const {
         return toStringWithTabs(gs);
     }
-
-    struct ShowOptions {};
 
     // User visible type. Should exactly match what the user can write.
     std::string show(const GlobalState &gs, const ShowOptions options = ShowOptions{}) const;

--- a/core/Types.h
+++ b/core/Types.h
@@ -5,6 +5,7 @@
 #include "common/Counters.h"
 #include "core/Context.h"
 #include "core/Error.h"
+#include "core/ShowOptions.h"
 #include "core/SymbolRef.h"
 #include "core/TypeConstraint.h"
 #include <memory>
@@ -333,7 +334,7 @@ public:
     ClassType(ClassOrModuleRef symbol);
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, const TypePtr::ShowOptions options = TypePtr::ShowOptions{}) const;
+    std::string show(const GlobalState &gs, const ShowOptions options = ShowOptions{}) const;
     uint32_t hash(const GlobalState &gs) const;
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
 
@@ -376,7 +377,7 @@ public:
 
     LambdaParam(TypeMemberRef definition, TypePtr lower, TypePtr upper);
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, const TypePtr::ShowOptions options = TypePtr::ShowOptions{}) const;
+    std::string show(const GlobalState &gs, const ShowOptions options = ShowOptions{}) const;
     uint32_t hash(const GlobalState &gs) const;
 
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const;
@@ -394,7 +395,7 @@ public:
 
     SelfTypeParam(const SymbolRef definition);
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, const TypePtr::ShowOptions options = TypePtr::ShowOptions{}) const;
+    std::string show(const GlobalState &gs, const ShowOptions options = ShowOptions{}) const;
     uint32_t hash(const GlobalState &gs) const;
 
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const;
@@ -417,7 +418,7 @@ TYPE_INLINED(AliasType) final {
 public:
     AliasType(SymbolRef other);
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, const TypePtr::ShowOptions options = TypePtr::ShowOptions{}) const;
+    std::string show(const GlobalState &gs, const ShowOptions options = ShowOptions{}) const;
     uint32_t hash(const GlobalState &gs) const;
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const;
 
@@ -447,7 +448,7 @@ TYPE_INLINED(SelfType) final {
 public:
     SelfType();
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, const TypePtr::ShowOptions options = TypePtr::ShowOptions{}) const;
+    std::string show(const GlobalState &gs, const ShowOptions options = ShowOptions{}) const;
     std::string showValue(const GlobalState &gs) const;
     uint32_t hash(const GlobalState &gs) const;
 
@@ -490,7 +491,7 @@ public:
     core::NameRef unsafeAsName() const;
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, const TypePtr::ShowOptions options = TypePtr::ShowOptions{}) const;
+    std::string show(const GlobalState &gs, const ShowOptions options = ShowOptions{}) const;
     std::string showValue(const GlobalState &gs) const;
     uint32_t hash(const GlobalState &gs) const;
 
@@ -560,7 +561,7 @@ public:
     TypeArgumentRef sym;
     TypeVar(TypeArgumentRef sym);
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, const TypePtr::ShowOptions options = TypePtr::ShowOptions{}) const;
+    std::string show(const GlobalState &gs, const ShowOptions options = ShowOptions{}) const;
     uint32_t hash(const GlobalState &gs) const;
     void _sanityCheck(const GlobalState &gs) const;
 
@@ -577,7 +578,7 @@ public:
     TypePtr right;
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, const TypePtr::ShowOptions options = TypePtr::ShowOptions{}) const;
+    std::string show(const GlobalState &gs, const ShowOptions options = ShowOptions{}) const;
     uint32_t hash(const GlobalState &gs) const;
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
     TypePtr getCallArguments(const GlobalState &gs, NameRef name) const;
@@ -628,7 +629,7 @@ public:
     TypePtr right;
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, const TypePtr::ShowOptions options = TypePtr::ShowOptions{}) const;
+    std::string show(const GlobalState &gs, const ShowOptions options = ShowOptions{}) const;
     uint32_t hash(const GlobalState &gs) const;
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
 
@@ -671,7 +672,7 @@ public:
     ShapeType(std::vector<TypePtr> keys, std::vector<TypePtr> values);
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, const TypePtr::ShowOptions options = TypePtr::ShowOptions{}) const;
+    std::string show(const GlobalState &gs, const ShowOptions options = ShowOptions{}) const;
     uint32_t hash(const GlobalState &gs) const;
     std::string showWithMoreInfo(const GlobalState &gs) const;
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
@@ -695,7 +696,7 @@ public:
     TupleType(std::vector<TypePtr> elements);
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, const TypePtr::ShowOptions options = TypePtr::ShowOptions{}) const;
+    std::string show(const GlobalState &gs, const ShowOptions options = ShowOptions{}) const;
     std::string showWithMoreInfo(const GlobalState &gs) const;
     uint32_t hash(const GlobalState &gs) const;
     void _sanityCheck(const GlobalState &gs) const;
@@ -719,7 +720,7 @@ public:
     AppliedType(ClassOrModuleRef klass, std::vector<TypePtr> targs);
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, const TypePtr::ShowOptions options = TypePtr::ShowOptions{}) const;
+    std::string show(const GlobalState &gs, const ShowOptions options = ShowOptions{}) const;
     uint32_t hash(const GlobalState &gs) const;
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
     void _sanityCheck(const GlobalState &gs) const;
@@ -749,7 +750,7 @@ public:
     MetaType(const TypePtr &wrapped);
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, const TypePtr::ShowOptions options = TypePtr::ShowOptions{}) const;
+    std::string show(const GlobalState &gs, const ShowOptions options = ShowOptions{}) const;
     uint32_t hash(const GlobalState &gs) const;
 
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const;
@@ -911,7 +912,7 @@ public:
     UnresolvedClassType(SymbolRef scope, std::vector<core::NameRef> names)
         : ClassType(core::Symbols::untyped()), scope(scope), names(std::move(names)){};
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, const TypePtr::ShowOptions options = TypePtr::ShowOptions{}) const;
+    std::string show(const GlobalState &gs, const ShowOptions options = ShowOptions{}) const;
     uint32_t hash(const GlobalState &gs) const;
 };
 
@@ -922,7 +923,7 @@ public:
     UnresolvedAppliedType(ClassOrModuleRef klass, std::vector<TypePtr> targs)
         : ClassType(core::Symbols::untyped()), klass(klass), targs(std::move(targs)){};
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, const TypePtr::ShowOptions options = TypePtr::ShowOptions{}) const;
+    std::string show(const GlobalState &gs, const ShowOptions options = ShowOptions{}) const;
     uint32_t hash(const GlobalState &gs) const;
 };
 

--- a/core/Types.h
+++ b/core/Types.h
@@ -334,7 +334,7 @@ public:
     ClassType(ClassOrModuleRef symbol);
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, const ShowOptions options = ShowOptions{}) const;
+    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
     uint32_t hash(const GlobalState &gs) const;
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
 
@@ -377,7 +377,7 @@ public:
 
     LambdaParam(TypeMemberRef definition, TypePtr lower, TypePtr upper);
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, const ShowOptions options = ShowOptions{}) const;
+    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
     uint32_t hash(const GlobalState &gs) const;
 
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const;
@@ -395,7 +395,7 @@ public:
 
     SelfTypeParam(const SymbolRef definition);
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, const ShowOptions options = ShowOptions{}) const;
+    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
     uint32_t hash(const GlobalState &gs) const;
 
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const;
@@ -418,7 +418,7 @@ TYPE_INLINED(AliasType) final {
 public:
     AliasType(SymbolRef other);
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, const ShowOptions options = ShowOptions{}) const;
+    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
     uint32_t hash(const GlobalState &gs) const;
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const;
 
@@ -448,7 +448,7 @@ TYPE_INLINED(SelfType) final {
 public:
     SelfType();
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, const ShowOptions options = ShowOptions{}) const;
+    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
     std::string showValue(const GlobalState &gs) const;
     uint32_t hash(const GlobalState &gs) const;
 
@@ -491,7 +491,7 @@ public:
     core::NameRef unsafeAsName() const;
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, const ShowOptions options = ShowOptions{}) const;
+    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
     std::string showValue(const GlobalState &gs) const;
     uint32_t hash(const GlobalState &gs) const;
 
@@ -561,7 +561,7 @@ public:
     TypeArgumentRef sym;
     TypeVar(TypeArgumentRef sym);
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, const ShowOptions options = ShowOptions{}) const;
+    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
     uint32_t hash(const GlobalState &gs) const;
     void _sanityCheck(const GlobalState &gs) const;
 
@@ -578,7 +578,7 @@ public:
     TypePtr right;
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, const ShowOptions options = ShowOptions{}) const;
+    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
     uint32_t hash(const GlobalState &gs) const;
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
     TypePtr getCallArguments(const GlobalState &gs, NameRef name) const;
@@ -629,7 +629,7 @@ public:
     TypePtr right;
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, const ShowOptions options = ShowOptions{}) const;
+    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
     uint32_t hash(const GlobalState &gs) const;
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
 
@@ -672,7 +672,7 @@ public:
     ShapeType(std::vector<TypePtr> keys, std::vector<TypePtr> values);
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, const ShowOptions options = ShowOptions{}) const;
+    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
     uint32_t hash(const GlobalState &gs) const;
     std::string showWithMoreInfo(const GlobalState &gs) const;
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
@@ -696,7 +696,7 @@ public:
     TupleType(std::vector<TypePtr> elements);
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, const ShowOptions options = ShowOptions{}) const;
+    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
     std::string showWithMoreInfo(const GlobalState &gs) const;
     uint32_t hash(const GlobalState &gs) const;
     void _sanityCheck(const GlobalState &gs) const;
@@ -720,7 +720,7 @@ public:
     AppliedType(ClassOrModuleRef klass, std::vector<TypePtr> targs);
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, const ShowOptions options = ShowOptions{}) const;
+    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
     uint32_t hash(const GlobalState &gs) const;
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
     void _sanityCheck(const GlobalState &gs) const;
@@ -750,7 +750,7 @@ public:
     MetaType(const TypePtr &wrapped);
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, const ShowOptions options = ShowOptions{}) const;
+    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
     uint32_t hash(const GlobalState &gs) const;
 
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const;
@@ -912,7 +912,7 @@ public:
     UnresolvedClassType(SymbolRef scope, std::vector<core::NameRef> names)
         : ClassType(core::Symbols::untyped()), scope(scope), names(std::move(names)){};
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, const ShowOptions options = ShowOptions{}) const;
+    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
     uint32_t hash(const GlobalState &gs) const;
 };
 
@@ -923,7 +923,7 @@ public:
     UnresolvedAppliedType(ClassOrModuleRef klass, std::vector<TypePtr> targs)
         : ClassType(core::Symbols::untyped()), klass(klass), targs(std::move(targs)){};
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, const ShowOptions options = ShowOptions{}) const;
+    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
     uint32_t hash(const GlobalState &gs) const;
 };
 

--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -26,7 +26,7 @@ string ClassType::toStringWithTabs(const GlobalState &gs, int tabs) const {
     return this->show(gs);
 }
 
-string ClassType::show(const GlobalState &gs, const TypePtr::ShowOptions options) const {
+string ClassType::show(const GlobalState &gs, const ShowOptions options) const {
     return this->symbol.show(gs);
 }
 
@@ -34,7 +34,7 @@ string UnresolvedClassType::toStringWithTabs(const GlobalState &gs, int tabs) co
     return this->show(gs);
 }
 
-string UnresolvedClassType::show(const GlobalState &gs, const TypePtr::ShowOptions options) const {
+string UnresolvedClassType::show(const GlobalState &gs, const ShowOptions options) const {
     return fmt::format("{}::{} (unresolved)", this->scope.show(gs),
                        fmt::map_join(this->names, "::", [&](const auto &el) -> string { return el.show(gs); }));
 }
@@ -43,7 +43,7 @@ string UnresolvedAppliedType::toStringWithTabs(const GlobalState &gs, int tabs) 
     return this->show(gs);
 }
 
-string UnresolvedAppliedType::show(const GlobalState &gs, const TypePtr::ShowOptions options) const {
+string UnresolvedAppliedType::show(const GlobalState &gs, const ShowOptions options) const {
     return fmt::format("{}[{}] (unresolved)", this->klass.show(gs),
                        fmt::map_join(targs, ", ", [&](auto targ) { return targ.show(gs, options); }));
 }
@@ -52,7 +52,7 @@ string LiteralType::toStringWithTabs(const GlobalState &gs, int tabs) const {
     return fmt::format("{}({})", this->underlying(gs).toStringWithTabs(gs, tabs), showValue(gs));
 }
 
-string LiteralType::show(const GlobalState &gs, const TypePtr::ShowOptions options) const {
+string LiteralType::show(const GlobalState &gs, const ShowOptions options) const {
     return fmt::format("{}({})", this->underlying(gs).show(gs, options), showValue(gs));
 }
 
@@ -89,7 +89,7 @@ string TupleType::toStringWithTabs(const GlobalState &gs, int tabs) const {
     return to_string(buf);
 }
 
-string TupleType::show(const GlobalState &gs, const TypePtr::ShowOptions options) const {
+string TupleType::show(const GlobalState &gs, const ShowOptions options) const {
     return fmt::format(
         "[{}]", fmt::map_join(this->elems, ", ", [&](const auto &el) -> string { return el.show(gs, options); }));
 }
@@ -113,7 +113,7 @@ string ShapeType::toStringWithTabs(const GlobalState &gs, int tabs) const {
     return to_string(buf);
 }
 
-string ShapeType::show(const GlobalState &gs, const TypePtr::ShowOptions options) const {
+string ShapeType::show(const GlobalState &gs, const ShowOptions options) const {
     fmt::memory_buffer buf;
     fmt::format_to(std::back_inserter(buf), "{{");
     auto valueIterator = this->values.begin();
@@ -147,7 +147,7 @@ string AliasType::toStringWithTabs(const GlobalState &gs, int tabs) const {
     return fmt::format("AliasType {{ symbol = {} }}", this->symbol.toStringFullName(gs));
 }
 
-string AliasType::show(const GlobalState &gs, const TypePtr::ShowOptions options) const {
+string AliasType::show(const GlobalState &gs, const ShowOptions options) const {
     return fmt::format("<Alias: {} >", this->symbol.showFullName(gs));
 }
 
@@ -160,22 +160,22 @@ string AndType::toStringWithTabs(const GlobalState &gs, int tabs) const {
                        rightBrace ? ")" : "");
 }
 
-string showAnds(const GlobalState &, const TypePtr::ShowOptions options, const TypePtr &, const TypePtr &);
+string showAnds(const GlobalState &, const ShowOptions options, const TypePtr &, const TypePtr &);
 
-string showAndElem(const GlobalState &gs, const TypePtr::ShowOptions options, const TypePtr &ty) {
+string showAndElem(const GlobalState &gs, const ShowOptions options, const TypePtr &ty) {
     if (auto andType = cast_type<AndType>(ty)) {
         return showAnds(gs, options, andType->left, andType->right);
     }
     return ty.show(gs, options);
 }
 
-string showAnds(const GlobalState &gs, const TypePtr::ShowOptions options, const TypePtr &left, const TypePtr &right) {
+string showAnds(const GlobalState &gs, const ShowOptions options, const TypePtr &left, const TypePtr &right) {
     auto leftStr = showAndElem(gs, options, left);
     auto rightStr = showAndElem(gs, options, right);
     return fmt::format("{}, {}", leftStr, rightStr);
 }
 
-string AndType::show(const GlobalState &gs, const TypePtr::ShowOptions options) const {
+string AndType::show(const GlobalState &gs, const ShowOptions options) const {
     auto str = showAnds(gs, options, this->left, this->right);
     return fmt::format("T.all({})", str);
 }
@@ -255,10 +255,10 @@ struct OrInfo {
     }
 };
 
-pair<OrInfo, optional<string>> showOrs(const GlobalState &, const TypePtr::ShowOptions options, const TypePtr &,
+pair<OrInfo, optional<string>> showOrs(const GlobalState &, const ShowOptions options, const TypePtr &,
                                        const TypePtr &);
 
-pair<OrInfo, optional<string>> showOrElem(const GlobalState &gs, const TypePtr::ShowOptions options,
+pair<OrInfo, optional<string>> showOrElem(const GlobalState &gs, const ShowOptions options,
                                           const TypePtr &ty) {
     if (isa_type<ClassType>(ty)) {
         auto classType = cast_type_nonnull<ClassType>(ty);
@@ -276,7 +276,7 @@ pair<OrInfo, optional<string>> showOrElem(const GlobalState &gs, const TypePtr::
     return make_pair(OrInfo::otherInfo(), make_optional(ty.show(gs, options)));
 }
 
-pair<OrInfo, optional<string>> showOrs(const GlobalState &gs, const TypePtr::ShowOptions options, const TypePtr &left,
+pair<OrInfo, optional<string>> showOrs(const GlobalState &gs, const ShowOptions options, const TypePtr &left,
                                        const TypePtr &right) {
     auto [leftInfo, leftStr] = showOrElem(gs, options, left);
     auto [rightInfo, rightStr] = showOrElem(gs, options, right);
@@ -293,7 +293,7 @@ pair<OrInfo, optional<string>> showOrs(const GlobalState &gs, const TypePtr::Sho
     }
 }
 
-string OrType::show(const GlobalState &gs, const TypePtr::ShowOptions options) const {
+string OrType::show(const GlobalState &gs, const ShowOptions options) const {
     auto [info, str] = showOrs(gs, options, this->left, this->right);
 
     // If str is empty at this point, all of the types present in the flattened
@@ -322,7 +322,7 @@ string TypeVar::toStringWithTabs(const GlobalState &gs, int tabs) const {
     return fmt::format("TypeVar({})", sym.data(gs)->name.showRaw(gs));
 }
 
-string TypeVar::show(const GlobalState &gs, const TypePtr::ShowOptions options) const {
+string TypeVar::show(const GlobalState &gs, const ShowOptions options) const {
     auto shown = sym.data(gs)->name.show(gs);
     if (absl::StrContains(shown, " ")) {
         return fmt::format("T.type_parameter(:{})", absl::CEscape(shown));
@@ -356,7 +356,7 @@ string AppliedType::toStringWithTabs(const GlobalState &gs, int tabs) const {
     return to_string(buf);
 }
 
-string AppliedType::show(const GlobalState &gs, const TypePtr::ShowOptions options) const {
+string AppliedType::show(const GlobalState &gs, const ShowOptions options) const {
     fmt::memory_buffer buf;
     if (this->klass == Symbols::Array()) {
         fmt::format_to(std::back_inserter(buf), "T::Array");
@@ -443,7 +443,7 @@ string LambdaParam::toStringWithTabs(const GlobalState &gs, int tabs) const {
     }
 }
 
-string LambdaParam::show(const GlobalState &gs, const TypePtr::ShowOptions options) const {
+string LambdaParam::show(const GlobalState &gs, const ShowOptions options) const {
     return this->definition.show(gs);
 }
 
@@ -451,7 +451,7 @@ string SelfTypeParam::toStringWithTabs(const GlobalState &gs, int tabs) const {
     return fmt::format("SelfTypeParam({})", this->definition.toStringFullName(gs));
 }
 
-string SelfTypeParam::show(const GlobalState &gs, const TypePtr::ShowOptions options) const {
+string SelfTypeParam::show(const GlobalState &gs, const ShowOptions options) const {
     return this->definition.show(gs);
 }
 
@@ -459,7 +459,7 @@ string SelfType::toStringWithTabs(const GlobalState &gs, int tabs) const {
     return show(gs);
 }
 
-string SelfType::show(const GlobalState &gs, const TypePtr::ShowOptions options) const {
+string SelfType::show(const GlobalState &gs, const ShowOptions options) const {
     return "T.self_type()";
 }
 
@@ -471,7 +471,7 @@ string MetaType::toStringWithTabs(const GlobalState &gs, int tabs) const {
     return "MetaType";
 }
 
-string MetaType::show(const GlobalState &gs, const TypePtr::ShowOptions options) const {
+string MetaType::show(const GlobalState &gs, const ShowOptions options) const {
     return "<Type: " + wrapped.show(gs, options) + ">";
 }
 

--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -26,7 +26,7 @@ string ClassType::toStringWithTabs(const GlobalState &gs, int tabs) const {
     return this->show(gs);
 }
 
-string ClassType::show(const GlobalState &gs, const ShowOptions options) const {
+string ClassType::show(const GlobalState &gs, ShowOptions options) const {
     return this->symbol.show(gs);
 }
 
@@ -34,7 +34,7 @@ string UnresolvedClassType::toStringWithTabs(const GlobalState &gs, int tabs) co
     return this->show(gs);
 }
 
-string UnresolvedClassType::show(const GlobalState &gs, const ShowOptions options) const {
+string UnresolvedClassType::show(const GlobalState &gs, ShowOptions options) const {
     return fmt::format("{}::{} (unresolved)", this->scope.show(gs),
                        fmt::map_join(this->names, "::", [&](const auto &el) -> string { return el.show(gs); }));
 }
@@ -43,7 +43,7 @@ string UnresolvedAppliedType::toStringWithTabs(const GlobalState &gs, int tabs) 
     return this->show(gs);
 }
 
-string UnresolvedAppliedType::show(const GlobalState &gs, const ShowOptions options) const {
+string UnresolvedAppliedType::show(const GlobalState &gs, ShowOptions options) const {
     return fmt::format("{}[{}] (unresolved)", this->klass.show(gs),
                        fmt::map_join(targs, ", ", [&](auto targ) { return targ.show(gs, options); }));
 }
@@ -52,7 +52,7 @@ string LiteralType::toStringWithTabs(const GlobalState &gs, int tabs) const {
     return fmt::format("{}({})", this->underlying(gs).toStringWithTabs(gs, tabs), showValue(gs));
 }
 
-string LiteralType::show(const GlobalState &gs, const ShowOptions options) const {
+string LiteralType::show(const GlobalState &gs, ShowOptions options) const {
     return fmt::format("{}({})", this->underlying(gs).show(gs, options), showValue(gs));
 }
 
@@ -89,7 +89,7 @@ string TupleType::toStringWithTabs(const GlobalState &gs, int tabs) const {
     return to_string(buf);
 }
 
-string TupleType::show(const GlobalState &gs, const ShowOptions options) const {
+string TupleType::show(const GlobalState &gs, ShowOptions options) const {
     return fmt::format(
         "[{}]", fmt::map_join(this->elems, ", ", [&](const auto &el) -> string { return el.show(gs, options); }));
 }
@@ -113,7 +113,7 @@ string ShapeType::toStringWithTabs(const GlobalState &gs, int tabs) const {
     return to_string(buf);
 }
 
-string ShapeType::show(const GlobalState &gs, const ShowOptions options) const {
+string ShapeType::show(const GlobalState &gs, ShowOptions options) const {
     fmt::memory_buffer buf;
     fmt::format_to(std::back_inserter(buf), "{{");
     auto valueIterator = this->values.begin();
@@ -147,7 +147,7 @@ string AliasType::toStringWithTabs(const GlobalState &gs, int tabs) const {
     return fmt::format("AliasType {{ symbol = {} }}", this->symbol.toStringFullName(gs));
 }
 
-string AliasType::show(const GlobalState &gs, const ShowOptions options) const {
+string AliasType::show(const GlobalState &gs, ShowOptions options) const {
     return fmt::format("<Alias: {} >", this->symbol.showFullName(gs));
 }
 
@@ -160,22 +160,22 @@ string AndType::toStringWithTabs(const GlobalState &gs, int tabs) const {
                        rightBrace ? ")" : "");
 }
 
-string showAnds(const GlobalState &, const ShowOptions options, const TypePtr &, const TypePtr &);
+string showAnds(const GlobalState &, ShowOptions options, const TypePtr &, const TypePtr &);
 
-string showAndElem(const GlobalState &gs, const ShowOptions options, const TypePtr &ty) {
+string showAndElem(const GlobalState &gs, ShowOptions options, const TypePtr &ty) {
     if (auto andType = cast_type<AndType>(ty)) {
         return showAnds(gs, options, andType->left, andType->right);
     }
     return ty.show(gs, options);
 }
 
-string showAnds(const GlobalState &gs, const ShowOptions options, const TypePtr &left, const TypePtr &right) {
+string showAnds(const GlobalState &gs, ShowOptions options, const TypePtr &left, const TypePtr &right) {
     auto leftStr = showAndElem(gs, options, left);
     auto rightStr = showAndElem(gs, options, right);
     return fmt::format("{}, {}", leftStr, rightStr);
 }
 
-string AndType::show(const GlobalState &gs, const ShowOptions options) const {
+string AndType::show(const GlobalState &gs, ShowOptions options) const {
     auto str = showAnds(gs, options, this->left, this->right);
     return fmt::format("T.all({})", str);
 }
@@ -255,11 +255,9 @@ struct OrInfo {
     }
 };
 
-pair<OrInfo, optional<string>> showOrs(const GlobalState &, const ShowOptions options, const TypePtr &,
-                                       const TypePtr &);
+pair<OrInfo, optional<string>> showOrs(const GlobalState &, ShowOptions options, const TypePtr &, const TypePtr &);
 
-pair<OrInfo, optional<string>> showOrElem(const GlobalState &gs, const ShowOptions options,
-                                          const TypePtr &ty) {
+pair<OrInfo, optional<string>> showOrElem(const GlobalState &gs, ShowOptions options, const TypePtr &ty) {
     if (isa_type<ClassType>(ty)) {
         auto classType = cast_type_nonnull<ClassType>(ty);
         if (classType.symbol == Symbols::NilClass()) {
@@ -276,7 +274,7 @@ pair<OrInfo, optional<string>> showOrElem(const GlobalState &gs, const ShowOptio
     return make_pair(OrInfo::otherInfo(), make_optional(ty.show(gs, options)));
 }
 
-pair<OrInfo, optional<string>> showOrs(const GlobalState &gs, const ShowOptions options, const TypePtr &left,
+pair<OrInfo, optional<string>> showOrs(const GlobalState &gs, ShowOptions options, const TypePtr &left,
                                        const TypePtr &right) {
     auto [leftInfo, leftStr] = showOrElem(gs, options, left);
     auto [rightInfo, rightStr] = showOrElem(gs, options, right);
@@ -293,7 +291,7 @@ pair<OrInfo, optional<string>> showOrs(const GlobalState &gs, const ShowOptions 
     }
 }
 
-string OrType::show(const GlobalState &gs, const ShowOptions options) const {
+string OrType::show(const GlobalState &gs, ShowOptions options) const {
     auto [info, str] = showOrs(gs, options, this->left, this->right);
 
     // If str is empty at this point, all of the types present in the flattened
@@ -322,7 +320,7 @@ string TypeVar::toStringWithTabs(const GlobalState &gs, int tabs) const {
     return fmt::format("TypeVar({})", sym.data(gs)->name.showRaw(gs));
 }
 
-string TypeVar::show(const GlobalState &gs, const ShowOptions options) const {
+string TypeVar::show(const GlobalState &gs, ShowOptions options) const {
     auto shown = sym.data(gs)->name.show(gs);
     if (absl::StrContains(shown, " ")) {
         return fmt::format("T.type_parameter(:{})", absl::CEscape(shown));
@@ -356,7 +354,7 @@ string AppliedType::toStringWithTabs(const GlobalState &gs, int tabs) const {
     return to_string(buf);
 }
 
-string AppliedType::show(const GlobalState &gs, const ShowOptions options) const {
+string AppliedType::show(const GlobalState &gs, ShowOptions options) const {
     fmt::memory_buffer buf;
     if (this->klass == Symbols::Array()) {
         fmt::format_to(std::back_inserter(buf), "T::Array");
@@ -443,7 +441,7 @@ string LambdaParam::toStringWithTabs(const GlobalState &gs, int tabs) const {
     }
 }
 
-string LambdaParam::show(const GlobalState &gs, const ShowOptions options) const {
+string LambdaParam::show(const GlobalState &gs, ShowOptions options) const {
     return this->definition.show(gs);
 }
 
@@ -451,7 +449,7 @@ string SelfTypeParam::toStringWithTabs(const GlobalState &gs, int tabs) const {
     return fmt::format("SelfTypeParam({})", this->definition.toStringFullName(gs));
 }
 
-string SelfTypeParam::show(const GlobalState &gs, const ShowOptions options) const {
+string SelfTypeParam::show(const GlobalState &gs, ShowOptions options) const {
     return this->definition.show(gs);
 }
 
@@ -459,7 +457,7 @@ string SelfType::toStringWithTabs(const GlobalState &gs, int tabs) const {
     return show(gs);
 }
 
-string SelfType::show(const GlobalState &gs, const ShowOptions options) const {
+string SelfType::show(const GlobalState &gs, ShowOptions options) const {
     return "T.self_type()";
 }
 
@@ -471,7 +469,7 @@ string MetaType::toStringWithTabs(const GlobalState &gs, int tabs) const {
     return "MetaType";
 }
 
-string MetaType::show(const GlobalState &gs, const ShowOptions options) const {
+string MetaType::show(const GlobalState &gs, ShowOptions options) const {
     return "<Type: " + wrapped.show(gs, options) + ">";
 }
 

--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -27,7 +27,7 @@ string ClassType::toStringWithTabs(const GlobalState &gs, int tabs) const {
 }
 
 string ClassType::show(const GlobalState &gs, ShowOptions options) const {
-    return this->symbol.show(gs);
+    return this->symbol.show(gs, options);
 }
 
 string UnresolvedClassType::toStringWithTabs(const GlobalState &gs, int tabs) const {
@@ -35,7 +35,7 @@ string UnresolvedClassType::toStringWithTabs(const GlobalState &gs, int tabs) co
 }
 
 string UnresolvedClassType::show(const GlobalState &gs, ShowOptions options) const {
-    return fmt::format("{}::{} (unresolved)", this->scope.show(gs),
+    return fmt::format("{}::{} (unresolved)", this->scope.show(gs, options),
                        fmt::map_join(this->names, "::", [&](const auto &el) -> string { return el.show(gs); }));
 }
 
@@ -44,7 +44,7 @@ string UnresolvedAppliedType::toStringWithTabs(const GlobalState &gs, int tabs) 
 }
 
 string UnresolvedAppliedType::show(const GlobalState &gs, ShowOptions options) const {
-    return fmt::format("{}[{}] (unresolved)", this->klass.show(gs),
+    return fmt::format("{}[{}] (unresolved)", this->klass.show(gs, options),
                        fmt::map_join(targs, ", ", [&](auto targ) { return targ.show(gs, options); }));
 }
 
@@ -297,7 +297,7 @@ string OrType::show(const GlobalState &gs, ShowOptions options) const {
     // If str is empty at this point, all of the types present in the flattened
     // OrType are NilClass.
     if (!str.has_value()) {
-        return Symbols::NilClass().show(gs);
+        return Symbols::NilClass().show(gs, options);
     }
 
     string res;
@@ -401,7 +401,7 @@ string AppliedType::show(const GlobalState &gs, ShowOptions options) const {
             }
             return to_string(buf);
         } else {
-            fmt::format_to(std::back_inserter(buf), "{}", this->klass.show(gs));
+            fmt::format_to(std::back_inserter(buf), "{}", this->klass.show(gs, options));
         }
     }
     auto targs = this->targs;
@@ -442,7 +442,7 @@ string LambdaParam::toStringWithTabs(const GlobalState &gs, int tabs) const {
 }
 
 string LambdaParam::show(const GlobalState &gs, ShowOptions options) const {
-    return this->definition.show(gs);
+    return this->definition.show(gs, options);
 }
 
 string SelfTypeParam::toStringWithTabs(const GlobalState &gs, int tabs) const {
@@ -450,7 +450,7 @@ string SelfTypeParam::toStringWithTabs(const GlobalState &gs, int tabs) const {
 }
 
 string SelfTypeParam::show(const GlobalState &gs, ShowOptions options) const {
-    return this->definition.show(gs);
+    return this->definition.show(gs, options);
 }
 
 string SelfType::toStringWithTabs(const GlobalState &gs, int tabs) const {


### PR DESCRIPTION
Move `ShowOptions` off of `TypePtr` and into its own header, and then add it as an argument to `SymbolRef::show` etc.

Reviewing by commits:
- e8e9febf0 Move `ShowOptions` out of `TypePtr`, and into its own header
- dbb42c87c `ShowOptions` doesn't need to be `const`
- b2b38a598 Add non-defaulted `ShowOptions` arguments to symbol ref show functions so that it's easy to tell where `core/printing.cc` should be updated
- 059e15e4e Add defaults for symbol ref show methods

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Pre-work towards landing #5067

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
