### PR TITLE
Change how `T.deprecated_enum` is parsed

### DIFF
--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -55,8 +55,8 @@ TypeSyntax::ResultType TypeSyntax::getResultTypeAndBind(core::Context ctx, ast::
 namespace {
 
 // Parse a literal type for use with `T.deprecated_enum`. If the type is indeed a literal, this will return the
-// `underlying` of that literal. The effect of this change is that `T.deprecated_enum(["a", "b", true])` will be parsed
-// as the type `T.any(String, TrueClass)`.
+// `underlying` of that literal. The effect of using `underlying` is that `T.deprecated_enum(["a", "b", true])` will be
+// parsed as the type `T.any(String, TrueClass)`.
 core::TypePtr getResultLiteral(core::Context ctx, const ast::ExpressionPtr &expr) {
     core::TypePtr result;
     typecase(

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -52,10 +52,21 @@ TypeSyntax::ResultType TypeSyntax::getResultTypeAndBind(core::Context ctx, ast::
     return result;
 }
 
+namespace {
+
+// Parse a literal type for use with `T.deprecated_enum`. If the type is indeed a literal, this will return the
+// `underlying` of that literal. The effect of this change is that `T.deprecated_enum(["a", "b", true])` will be parsed
+// as the type `T.any(String, TrueClass)`.
 core::TypePtr getResultLiteral(core::Context ctx, const ast::ExpressionPtr &expr) {
     core::TypePtr result;
     typecase(
-        expr, [&](const ast::Literal &lit) { result = lit.value; },
+        expr,
+        [&](const ast::Literal &lit) {
+            result = lit.value;
+            if (core::isa_type<core::LiteralType>(result)) {
+                result = core::cast_type_nonnull<core::LiteralType>(result).underlying(ctx);
+            }
+        },
         [&](const ast::ExpressionPtr &e) {
             if (auto e = ctx.beginError(expr.loc(), core::errors::Resolver::InvalidTypeDeclaration)) {
                 e.setHeader("Unsupported type literal");
@@ -78,6 +89,8 @@ bool isTProc(core::Context ctx, const ast::Send *send) {
     }
     return false;
 }
+
+} // namespace
 
 bool TypeSyntax::isSig(core::Context ctx, const ast::Send &send) {
     if (send.fun != core::Names::sig()) {

--- a/test/testdata/resolver/deprecated_enum_underlying.rb
+++ b/test/testdata/resolver/deprecated_enum_underlying.rb
@@ -1,0 +1,14 @@
+# typed: true
+
+class A
+
+  extend T::Sig
+
+  # Verifies that the underlying type for the literals is used when constructing
+  # the union that approximates the `T.deprecated_enum` type.
+  sig {params(x: T.deprecated_enum(["a", 1, :foo, true, false])).void}
+  def foo(x)
+    T.reveal_type(x) # error: Revealed type: `T.any(String, Integer, Symbol, TrueClass, FalseClass)`
+  end
+
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Always construct a union of the `underlying` types when parsing `T.deprecated_enum`, avoiding any literals in the resulting type. This moves the existing behavior for `T.deprecated_enum` earlier in the pipeline, and avoids relying on the `LiteralType` case in subtyping.cc.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Avoiding literal types in `T.deprecated_enum`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
