### PR TITLE
avoid dedenting strings in the common case

### DIFF
--- a/parser/Dedenter.h
+++ b/parser/Dedenter.h
@@ -1,3 +1,4 @@
+#include <optional>
 #include <string>
 
 namespace sorbet::parser {
@@ -7,13 +8,15 @@ class Dedenter final {
 public:
     Dedenter(int level) : dedentLevel(level), spacesToRemove(level) {}
 
-    std::string dedent(std::string_view str);
+    std::optional<std::string> dedent(std::string_view str);
 
     void interrupt() {
         at_line_begin = false;
     }
 
 private:
+    void update_state(std::string_view dedented_string);
+
     const unsigned int dedentLevel;
     bool at_line_begin = true;
     unsigned int spacesToRemove;


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Faster code: almost every file has strings, and depending on how long they are, this bypasses reallocating the string and re-hashing it in `GlobalState`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
