### PR TITLE
Fix initialize signature for CSV::MalformedCSVError

### DIFF
--- a/rbi/stdlib/csv.rbi
+++ b/rbi/stdlib/csv.rbi
@@ -1172,6 +1172,8 @@ end
 # The error thrown when the parser encounters illegal
 # [`CSV`](https://docs.ruby-lang.org/en/2.7.0/CSV.html) formatting.
 class CSV::MalformedCSVError < RuntimeError
+  sig { params(message: String, line_number: Integer).void }
+  def initialize(message, line_number); end
 end
 
 # A [`CSV::Table`](https://docs.ruby-lang.org/en/2.7.0/CSV/Table.html) is a


### PR DESCRIPTION
### Motivation

Fixes this error:

```rb
CSV::MalformedCSVError.new("message", 1) # error: Too many arguments provided for method Exception#initialize. Expected: 0..1, got: 2
```

[[sorbet.run](https://sorbet.run/#%23%20typed%3A%20true%0A%0ACSV%3A%3AMalformedCSVError.new%28%22message%22%2C%201%29)]

As per the [documentation](https://ruby-doc.org/stdlib-3.0.1/libdoc/csv/rdoc/CSV/MalformedCSVError.html#method-c-new),  `CSV::MalformedCSVError#initialize` takes two arguments.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
