### PR TITLE
fix indentation of `p_expr_ref` and `nonlocal_var` in bison grammar

### DIFF
--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -2777,7 +2777,7 @@ opt_block_args_tail:
                       auto non_lvar = driver.build.accessible(self, $2);
                       $$ = driver.build.pin(self, $1, non_lvar);
                     }
-        p_expr_ref: tCARET tLPAREN expr_value tRPAREN
+      p_expr_ref: tCARET tLPAREN expr_value tRPAREN
                     {
                       auto expr = driver.build.begin(self, $2, $3, $4);
                       $$ = driver.build.pin(self, $1, expr);
@@ -3087,7 +3087,7 @@ regexp_contents: // nothing
                       $$ = driver.build.floatComplex(self, $1);
                     }
 
-        nonlocal_var: tIVAR
+    nonlocal_var: tIVAR
                     {
                       $$ = driver.build.ivar(self, $1);
                     }


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I munged @KaanOzkan's indentation of these constructs in my review comments for #5100 and made the file look completely ugly.  Here, I adjusted them back so the colon for the rules lines up in the column with colons for other rules and the `|` for rule alternations.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
