### PR TITLE
Recover from `f(x:)` syntax error

### DIFF
--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -3746,7 +3746,9 @@ f_opt_paren_args: f_paren_args
                     }
                 | tLABEL
                     {
-                      auto method_call = driver.build.call_method(self, nullptr, nullptr, $1, nullptr, nullptr, nullptr);
+                      auto *selector = $1;
+                      selector->setEnd(selector->end() - 1);
+                      auto method_call = driver.build.call_method(self, nullptr, nullptr, selector, nullptr, nullptr, nullptr);
                       $$ = driver.build.pair_keyword(self, $1, method_call);
                     }
                 | tSTRING_BEG string_contents tLABEL_END arg_value

--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -187,6 +187,7 @@ using namespace std::string_literals;
 
 %printer { yyo << $$->view(); } tIDENTIFIER
 %printer { yyo << $$->view(); } tCONSTANT
+%printer { yyo << $$->view() << ":"; } tLABEL
 
 %type <node>
   arg

--- a/parser/parser/cc/token.cc
+++ b/parser/parser/cc/token.cc
@@ -18,6 +18,10 @@ size_t token::end() const {
     return _end;
 }
 
+void token::setEnd(size_t end) {
+    this->_end = end;
+}
+
 std::string_view token::view() const {
     return _string;
 }

--- a/parser/parser/include/ruby_parser/token.hh
+++ b/parser/parser/include/ruby_parser/token.hh
@@ -181,6 +181,7 @@ public:
     token_type type() const;
     size_t start() const;
     size_t end() const;
+    void setEnd(size_t end);
     std::string_view view() const;
     const std::string &asString() const;
 };

--- a/test/testdata/lsp/completion/missing_kwarg_value.rb
+++ b/test/testdata/lsp/completion/missing_kwarg_value.rb
@@ -1,0 +1,8 @@
+# typed: true
+def takes_keyword_args(x:)
+end
+
+def calls_with_keyword_args(x, y)
+  takes_keyword_args(x: ) # error: unexpected token ")"
+  #                     ^ completion: (nothing)
+end

--- a/test/testdata/lsp/completion/missing_kwarg_value.rb
+++ b/test/testdata/lsp/completion/missing_kwarg_value.rb
@@ -4,5 +4,5 @@ end
 
 def calls_with_keyword_args(x, y)
   takes_keyword_args(x: ) # error: unexpected token ")"
-  #                     ^ completion: (nothing)
+  #                     ^ completion: x, y, ...
 end

--- a/test/testdata/lsp/completion/missing_kwarg_value.rb
+++ b/test/testdata/lsp/completion/missing_kwarg_value.rb
@@ -2,7 +2,12 @@
 def takes_keyword_args(x:)
 end
 
+
 def calls_with_keyword_args(x, y)
-  takes_keyword_args(x: ) # error: unexpected token ")"
+  # TODO(jez) The error below is wrong, and should be fixed when we get proper
+  # Ruby 3.1 keyword punning support.
+  takes_keyword_args(x: )
+  #                  ^ error: Method `x` does not exist
   #                     ^ completion: x, y, ...
+  #                    ^ completion: x, y, ...
 end

--- a/test/testdata/lsp/completion/missing_kwarg_value.rb.desugar-tree.exp
+++ b/test/testdata/lsp/completion/missing_kwarg_value.rb.desugar-tree.exp
@@ -1,0 +1,9 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  def takes_keyword_args<<todo method>>(x:, &<blk>)
+    <emptyTree>
+  end
+
+  def calls_with_keyword_args<<todo method>>(x, y, &<blk>)
+    <emptyTree>
+  end
+end

--- a/test/testdata/lsp/completion/missing_kwarg_value.rb.desugar-tree.exp
+++ b/test/testdata/lsp/completion/missing_kwarg_value.rb.desugar-tree.exp
@@ -4,6 +4,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   def calls_with_keyword_args<<todo method>>(x, y, &<blk>)
-    <emptyTree>
+    <self>.takes_keyword_args(:x, <self>.x())
   end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Better parse results. Better completion.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.