### PR TITLE
use a faster-to-compile ragel parser for emscripten builds

### DIFF
--- a/parser/parser/BUILD
+++ b/parser/parser/BUILD
@@ -10,6 +10,7 @@ ragel(
     ragel_options = select({
         # emscripten builds are usually dealing with small amounts of Ruby source,
         # so they don't need a super-fast parser.
+        "@com_stripe_ruby_typer//tools/config:webasm_opt": [],
         "@com_stripe_ruby_typer//tools/config:webasm": [],
         "@com_stripe_ruby_typer//tools/config:opt": ["-G1"],
         "//conditions:default": [],

--- a/parser/parser/BUILD
+++ b/parser/parser/BUILD
@@ -8,6 +8,9 @@ ragel(
     src = "cc/lexer.rl",
     language = "c++",
     ragel_options = select({
+        # emscripten builds are usually dealing with small amounts of Ruby source,
+        # so they don't need a super-fast parser.
+        "@com_stripe_ruby_typer//tools/config:webasm": [],
         "@com_stripe_ruby_typer//tools/config:opt": ["-G1"],
         "//conditions:default": [],
     }),

--- a/tools/config/BUILD
+++ b/tools/config/BUILD
@@ -40,6 +40,14 @@ config_setting(
 )
 
 config_setting(
+    name = "webasm_opt",
+    values = {
+        "cpu": "webasm",
+        "compilation_mode": "opt",
+    },
+)
+
+config_setting(
     name = "linkshared",
     values = {
         "define": "linkshared=true",


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

I noticed yesterday that (successful) CI branch builds were taking ~40 minutes, which was about twice as long as usual.  Digging in, I noticed that the emscripten builds were taking upwards of 20 minutes, which was due to compiling `ragel_lexer.cc` (the generated ragel lexer) and then linking (presumably with LTO?  or maybe emscripten is just kinda slow).

In any event, we don't need our super-fast goto-optimized ragel parser for emscripten builds, since such builds are destined for sorbet.run and only processing small amounts of text: we can revert to using the default style for ragel lexers, which is much faster to compile.  Bazel doesn't like `selects` where conditions are possibly overlapping, so I added a `webasm_opt` that handles the CI build and then a separate `webasm` condition for people who might want to compile fastbuild or debug webasm builds.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Faster CI.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
