### PR TITLE
Change build_compilation_db.sh to use ./bazel instead of system bazel

### DIFF
--- a/tools/scripts/build_compilation_db.sh
+++ b/tools/scripts/build_compilation_db.sh
@@ -6,6 +6,6 @@ cd "$(dirname "$0")/../.."
 
 ./bazel build //tools:compdb --config=dbg
 
-execution_root="$(bazel info execution_root)"
+execution_root="$(./bazel info execution_root)"
 
 sed "s|__EXEC_ROOT__|$execution_root|" bazel-bin/tools/compile_commands.json > compile_commands.json


### PR DESCRIPTION
This modifies `build_compilation_db.sh` to use `./bazel` in one spot where it currently uses system bazel, which is nice if one doesn't have bazel installed systemwide.

### Motivation
Was setting up a new PC and came across this quirk. :)

### Test plan
"Works on my machine!"