### PR TITLE
Add Ruby 3.1 Class#subclasses

### DIFF
--- a/rbi/core/class.rbi
+++ b/rbi/core/class.rbi
@@ -143,6 +143,23 @@ class Class < Module
   sig {returns(T.nilable(String))}
   def name(); end
 
+  # Returns an array of classes where the receiver is the direct superclass of
+  # the class, excluding singleton classes. The order of the returned array is
+  # not defined.
+  #
+  # ```ruby
+  # class A; end
+  # class B < A; end
+  # class C < B; end
+  # class D < A; end
+  #
+  # A.subclasses        #=> [D, B]
+  # B.subclasses        #=> [C]
+  # C.subclasses        #=> []
+  # ```
+  sig { returns(T::Array[Class]) }
+  def subclasses(); end
+
   # Returns the superclass of *class*, or `nil`.
   #
   # ```ruby


### PR DESCRIPTION
### Motivation

As added in Ruby 3.1: https://ruby-doc.org/core-3.1.0/Class.html#method-i-subclasses

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
