### PR TITLE
Ruby 3.1: Allow command syntax in endless method definitions

### DIFF
--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -686,6 +686,52 @@ int yylex(parser::semantic_type *lval, ruby_parser::typedruby27 &driver) {
                       $$ = driver.build.op_assign(self, driver.build.call_method(self, $1, $2, $3, nullptr, nullptr, nullptr), $4, $5);
                       DIAGCHECK();
                     }
+                | defn_head f_opt_paren_args tEQL command
+                    {
+                      $$ = driver.build.defEndlessMethod(self, $1->begin, $1->end, $2, $3, $4);
+
+                      driver.lex.cmdarg.pop();
+                      driver.lex.cond.pop();
+                      driver.lex.unextend();
+                      driver.lex.context.pop();
+                      driver.current_arg_stack.pop();
+                    }
+                | defn_head f_opt_paren_args tEQL command kRESCUE_MOD arg
+                    {
+                      auto rescue_body = driver.build.rescue_body(self, $5, nullptr, nullptr, nullptr, nullptr, $6);
+                      auto method_body = driver.build.beginBody(self, $4, driver.alloc.node_list(rescue_body), nullptr, nullptr, nullptr, nullptr);
+
+                      $$ = driver.build.defEndlessMethod(self, $1->begin, $1->end, $2, $3, method_body);
+
+                      driver.lex.cmdarg.pop();
+                      driver.lex.cond.pop();
+                      driver.lex.unextend();
+                      driver.lex.context.pop();
+                      driver.current_arg_stack.pop();
+                    }
+                | defs_head f_opt_paren_args tEQL command
+                    {
+                      $$ = driver.build.defEndlessSingleton(self, $1, $2, $3, $4);
+
+                      driver.lex.cmdarg.pop();
+                      driver.lex.cond.pop();
+                      driver.lex.unextend();
+                      driver.lex.context.pop();
+                      driver.current_arg_stack.pop();
+                    }
+                | defs_head f_opt_paren_args tEQL command kRESCUE_MOD arg
+                    {
+                      auto rescue_body = driver.build.rescue_body(self, $5, nullptr, nullptr, nullptr, nullptr, $6);
+                      auto method_body = driver.build.beginBody(self, $4, driver.alloc.node_list(rescue_body), nullptr, nullptr, nullptr, nullptr);
+
+                      $$ = driver.build.defEndlessSingleton(self, $1, $2, $3, method_body);
+
+                      driver.lex.cmdarg.pop();
+                      driver.lex.cond.pop();
+                      driver.lex.unextend();
+                      driver.lex.context.pop();
+                      driver.current_arg_stack.pop();
+                    }
                 | backref tOP_ASGN command_rhs
                     {
                       $$ = driver.build.op_assign(self, $1, $2, $3);

--- a/test/whitequark/test_endless_method_command_syntax_0.parse-tree-whitequark.exp
+++ b/test/whitequark/test_endless_method_command_syntax_0.parse-tree-whitequark.exp
@@ -1,0 +1,3 @@
+s(:def, :foo, nil,
+  s(:send, nil, :puts,
+    s(:str, "Hello")))

--- a/test/whitequark/test_endless_method_command_syntax_0.rb
+++ b/test/whitequark/test_endless_method_command_syntax_0.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def foo = puts "Hello"

--- a/test/whitequark/test_endless_method_command_syntax_1.parse-tree-whitequark.exp
+++ b/test/whitequark/test_endless_method_command_syntax_1.parse-tree-whitequark.exp
@@ -1,0 +1,4 @@
+s(:def, :foo,
+  s(:args),
+  s(:send, nil, :puts,
+    s(:str, "Hello")))

--- a/test/whitequark/test_endless_method_command_syntax_1.rb
+++ b/test/whitequark/test_endless_method_command_syntax_1.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def foo() = puts "Hello"

--- a/test/whitequark/test_endless_method_command_syntax_2.parse-tree-whitequark.exp
+++ b/test/whitequark/test_endless_method_command_syntax_2.parse-tree-whitequark.exp
@@ -1,0 +1,5 @@
+s(:def, :foo,
+  s(:args,
+    s(:arg, :x)),
+  s(:send, nil, :puts,
+    s(:lvar, :x)))

--- a/test/whitequark/test_endless_method_command_syntax_2.rb
+++ b/test/whitequark/test_endless_method_command_syntax_2.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def foo(x) = puts x

--- a/test/whitequark/test_endless_method_command_syntax_3.parse-tree-whitequark.exp
+++ b/test/whitequark/test_endless_method_command_syntax_3.parse-tree-whitequark.exp
@@ -1,0 +1,4 @@
+s(:defs,
+  s(:send, nil, :obj), :foo, nil,
+  s(:send, nil, :puts,
+    s(:str, "Hello")))

--- a/test/whitequark/test_endless_method_command_syntax_3.rb
+++ b/test/whitequark/test_endless_method_command_syntax_3.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def obj.foo = puts "Hello"

--- a/test/whitequark/test_endless_method_command_syntax_4.parse-tree-whitequark.exp
+++ b/test/whitequark/test_endless_method_command_syntax_4.parse-tree-whitequark.exp
@@ -1,0 +1,5 @@
+s(:defs,
+  s(:send, nil, :obj), :foo,
+  s(:args),
+  s(:send, nil, :puts,
+    s(:str, "Hello")))

--- a/test/whitequark/test_endless_method_command_syntax_4.rb
+++ b/test/whitequark/test_endless_method_command_syntax_4.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def obj.foo() = puts "Hello"

--- a/test/whitequark/test_endless_method_command_syntax_5.parse-tree-whitequark.exp
+++ b/test/whitequark/test_endless_method_command_syntax_5.parse-tree-whitequark.exp
@@ -1,0 +1,11 @@
+s(:def, :rescued,
+  s(:args,
+    s(:arg, :x)),
+  s(:rescue,
+    s(:send, nil, :raise,
+      s(:str, "to be caught")),
+    s(:resbody, nil, nil,
+      s(:dstr,
+        s(:str, "instance "),
+        s(:begin,
+          s(:lvar, :x)))), nil))

--- a/test/whitequark/test_endless_method_command_syntax_5.rb
+++ b/test/whitequark/test_endless_method_command_syntax_5.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def rescued(x) = raise "to be caught" rescue "instance #{x}"

--- a/test/whitequark/test_endless_method_command_syntax_6.parse-tree-whitequark.exp
+++ b/test/whitequark/test_endless_method_command_syntax_6.parse-tree-whitequark.exp
@@ -1,0 +1,12 @@
+s(:defs,
+  s(:self), :rescued,
+  s(:args,
+    s(:arg, :x)),
+  s(:rescue,
+    s(:send, nil, :raise,
+      s(:str, "to be caught")),
+    s(:resbody, nil, nil,
+      s(:dstr,
+        s(:str, "class "),
+        s(:begin,
+          s(:lvar, :x)))), nil))

--- a/test/whitequark/test_endless_method_command_syntax_6.rb
+++ b/test/whitequark/test_endless_method_command_syntax_6.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def self.rescued(x) = raise "to be caught" rescue "class #{x}"

--- a/test/whitequark/test_endless_method_command_syntax_7.parse-tree-whitequark.exp
+++ b/test/whitequark/test_endless_method_command_syntax_7.parse-tree-whitequark.exp
@@ -1,0 +1,6 @@
+s(:defs,
+  s(:send, nil, :obj), :foo,
+  s(:args,
+    s(:arg, :x)),
+  s(:send, nil, :puts,
+    s(:lvar, :x)))

--- a/test/whitequark/test_endless_method_command_syntax_7.rb
+++ b/test/whitequark/test_endless_method_command_syntax_7.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def obj.foo(x) = puts x

--- a/test/whitequark/test_private_endless_method_command_syntax_0.rb
+++ b/test/whitequark/test_private_endless_method_command_syntax_0.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+private def foo = puts "Hello" # error: unexpected token tSTRING

--- a/test/whitequark/test_private_endless_method_command_syntax_1.rb
+++ b/test/whitequark/test_private_endless_method_command_syntax_1.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+private def foo() = puts "Hello" # error: unexpected token tSTRING

--- a/test/whitequark/test_private_endless_method_command_syntax_2.rb
+++ b/test/whitequark/test_private_endless_method_command_syntax_2.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+private def foo(x) = puts x # error: unexpected token tIDENTIFIER

--- a/test/whitequark/test_private_endless_method_command_syntax_3.rb
+++ b/test/whitequark/test_private_endless_method_command_syntax_3.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+private def obj.foo = puts "Hello" # error: unexpected token tSTRING

--- a/test/whitequark/test_private_endless_method_command_syntax_4.rb
+++ b/test/whitequark/test_private_endless_method_command_syntax_4.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+private def obj.foo() = puts "Hello" # error: unexpected token tSTRING

--- a/test/whitequark/test_private_endless_method_command_syntax_5.rb
+++ b/test/whitequark/test_private_endless_method_command_syntax_5.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+private def obj.foo(x) = puts x # error: unexpected token tIDENTIFIER


### PR DESCRIPTION
Part of Ruby 3.1 support

https://bugs.ruby-lang.org/issues/17398
https://github.com/whitequark/parser/commit/7ecddb67b2f82df92e424d36b6642cb887148cbc


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Allowing developers to use Sorbet with Ruby 3.1

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

@Morriar