### PR TITLE
Remove "mutable" from LSPTypechecker GlobalState pointer

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1957,12 +1957,10 @@ void GlobalState::markAsPayload() {
     }
 }
 
-unique_ptr<GlobalState> GlobalState::replaceFile(unique_ptr<GlobalState> inWhat, FileRef whatFile,
-                                                 const shared_ptr<File> &withWhat) {
-    ENFORCE(whatFile.id() < inWhat->filesUsed());
-    ENFORCE(whatFile.dataAllowingUnsafe(*inWhat).path() == withWhat->path());
-    inWhat->files[whatFile.id()] = withWhat;
-    return inWhat;
+void GlobalState::replaceFile(FileRef whatFile, const shared_ptr<File> &withWhat) {
+    ENFORCE(whatFile.id() < filesUsed());
+    ENFORCE(whatFile.dataAllowingUnsafe(*this).path() == withWhat->path());
+    files[whatFile.id()] = withWhat;
 }
 
 FileRef GlobalState::findFileByPath(string_view path) const {

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -154,8 +154,7 @@ public:
     FileRef enterFile(const std::shared_ptr<File> &file);
     FileRef enterNewFileAt(const std::shared_ptr<File> &file, FileRef id);
     FileRef reserveFileRef(std::string path);
-    static std::unique_ptr<GlobalState> replaceFile(std::unique_ptr<GlobalState> inWhat, FileRef whatFile,
-                                                    const std::shared_ptr<File> &withWhat);
+    void replaceFile(FileRef whatFile, const std::shared_ptr<File> &withWhat);
     static std::unique_ptr<GlobalState> markFileAsTombStone(std::unique_ptr<GlobalState>, FileRef fref);
     FileRef findFileByPath(std::string_view path) const;
 

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -230,7 +230,7 @@ LSPFileUpdates LSPIndexer::commitEdit(SorbetWorkspaceEditParams &edit, WorkerPoo
             auto fref = initialGS->findFileByPath(file->path());
             if (fref.exists()) {
                 newlyEvictedFiles[fref] = initialGS->getFiles()[fref.id()];
-                initialGS = core::GlobalState::replaceFile(move(initialGS), fref, file);
+                initialGS->replaceFile(fref, file);
             } else {
                 // This file update adds a new file to GlobalState.
                 update.hasNewFiles = true;

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -205,7 +205,7 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
                 set_difference(oldMethodHashes.begin(), oldMethodHashes.end(), newMethodHashes.begin(),
                                newMethodHashes.end(), inserter(changedMethodHashes, changedMethodHashes.begin()));
 
-                gs = core::GlobalState::replaceFile(move(gs), fref, f);
+                gs->replaceFile(fref, f);
                 // If file doesn't have a typed: sigil, then we need to ensure it's typechecked using typed: false.
                 fref.data(*gs).strictLevel = pipeline::decideStrictLevel(*gs, fref, config->opts);
                 subset.emplace_back(fref);
@@ -271,7 +271,7 @@ pair<unique_ptr<core::GlobalState>, ast::ParsedFile>
 updateFile(unique_ptr<core::GlobalState> gs, const shared_ptr<core::File> &file, const options::Options &opts) {
     core::FileRef fref = gs->findFileByPath(file->path());
     if (fref.exists()) {
-        gs = core::GlobalState::replaceFile(move(gs), fref, file);
+        gs->replaceFile(fref, file);
     } else {
         fref = gs->enterFile(file);
     }

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -34,9 +34,8 @@ class UndoState;
 class LSPTypechecker final {
     /** Contains the ID of the thread responsible for typechecking. */
     std::thread::id typecheckerThreadId;
-    /** GlobalState used for typechecking. Mutable because typechecking routines, even when not changing the GlobalState
-     * instance, actively consume and replace GlobalState. */
-    mutable std::unique_ptr<core::GlobalState> gs;
+    /** GlobalState used for typechecking. */
+    std::unique_ptr<core::GlobalState> gs;
     /** Trees that have been indexed (with initialGS) and can be reused between different runs */
     std::vector<ast::ParsedFile> indexed;
     /** Trees that have been indexed (with finalGS) and can be reused between different runs */

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -813,7 +813,7 @@ ast::ParsedFilesOrCancelled resolve(unique_ptr<core::GlobalState> &gs, vector<as
                     auto newSource = fmt::format("{}\n{}", string(prohibitedLines, '\n'), f.file.data(*gs).source());
                     auto newFile = make_shared<core::File>(string(f.file.data(*gs).path()), move(newSource),
                                                            f.file.data(*gs).sourceType);
-                    gs = core::GlobalState::replaceFile(move(gs), f.file, move(newFile));
+                    gs->replaceFile(f.file, move(newFile));
                     f.file.data(*gs).strictLevel = decideStrictLevel(*gs, f.file, opts);
                     auto reIndexed = indexOne(opts, *gs, f.file);
                     vector<ast::ParsedFile> toBeReResolved;
@@ -993,7 +993,7 @@ ast::ParsedFilesOrCancelled resolve(unique_ptr<core::GlobalState> &gs, vector<as
     return ast::ParsedFilesOrCancelled(move(what));
 }
 
-void typecheck(unique_ptr<core::GlobalState> &gs, vector<ast::ParsedFile> what, const options::Options &opts,
+void typecheck(const unique_ptr<core::GlobalState> &gs, vector<ast::ParsedFile> what, const options::Options &opts,
                WorkerPool &workers, bool cancelable,
                optional<shared_ptr<core::lsp::PreemptionTaskManager>> preemptionManager, bool presorted,
                bool intentionallyLeakASTs) {

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -36,8 +36,8 @@ ast::ParsedFilesOrCancelled name(core::GlobalState &gs, std::vector<ast::ParsedF
 // Note: `cancelable` and `preemption task manager` are only applicable to LSP.
 // If `intentionallyLeakASTs` is `true`, typecheck will leak the ASTs rather than pay the cost of deleting them
 // properly, which is a significant speedup on large codebases.
-void typecheck(std::unique_ptr<core::GlobalState> &gs, std::vector<ast::ParsedFile> what, const options::Options &opts,
-               WorkerPool &workers, bool cancelable = false,
+void typecheck(const std::unique_ptr<core::GlobalState> &gs, std::vector<ast::ParsedFile> what,
+               const options::Options &opts, WorkerPool &workers, bool cancelable = false,
                std::optional<std::shared_ptr<core::lsp::PreemptionTaskManager>> preemptionManager = std::nullopt,
                bool presorted = false, bool intentionallyLeakASTs = false);
 

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -598,7 +598,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
         auto newSource = absl::StrCat(string(prohibitedLines + 1, '\n'), f.file.data(*gs).source());
         auto newFile =
             make_shared<core::File>(string(f.file.data(*gs).path()), move(newSource), f.file.data(*gs).sourceType);
-        gs = core::GlobalState::replaceFile(move(gs), f.file, move(newFile));
+        gs->replaceFile(f.file, move(newFile));
 
         // this replicates the logic of pipeline::indexOne
         auto trace = false;


### PR DESCRIPTION
This removes the `mutable` qualifier from the `GlobalState` pointer in `LSPTypechecker`. In order to do this, we have to change `GlobalState::replaceFile` so that it doesn't "borrow" a unique_ptr to the GlobalState.

### Motivation
Just seems nice to drop `mutable` in cases where we don't actually need it.

### Test plan
Existing CI.

- [x] Some manual smoke testing against Stripe codebase with LSP