### PR TITLE
Make prop ast queries const

### DIFF
--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -15,27 +15,27 @@ namespace {
 // these helpers work on a purely syntactic level. for instance, this function determines if an expression is `T`,
 // either with no scope or with the root scope (i.e. `::T`). this might not actually refer to the `T` that we define for
 // users, but we don't know that information in the Rewriter passes.
-bool isT(ast::ExpressionPtr &expr) {
+bool isT(const ast::ExpressionPtr &expr) {
     auto *t = ast::cast_tree<ast::UnresolvedConstantLit>(expr);
     return t != nullptr && t->cnst == core::Names::Constants::T() && ast::MK::isRootScope(t->scope);
 }
 
-bool isTNilable(ast::ExpressionPtr &expr) {
+bool isTNilable(const ast::ExpressionPtr &expr) {
     auto *nilable = ast::cast_tree<ast::Send>(expr);
     return nilable != nullptr && nilable->fun == core::Names::nilable() && isT(nilable->recv);
 }
 
-bool isTStruct(ast::ExpressionPtr &expr) {
+bool isTStruct(const ast::ExpressionPtr &expr) {
     auto *struct_ = ast::cast_tree<ast::UnresolvedConstantLit>(expr);
     return struct_ != nullptr && struct_->cnst == core::Names::Constants::Struct() && isT(struct_->scope);
 }
 
-bool isTInexactStruct(ast::ExpressionPtr &expr) {
+bool isTInexactStruct(const ast::ExpressionPtr &expr) {
     auto *struct_ = ast::cast_tree<ast::UnresolvedConstantLit>(expr);
     return struct_ != nullptr && struct_->cnst == core::Names::Constants::InexactStruct() && isT(struct_->scope);
 }
 
-bool isChalkODMDocument(ast::ExpressionPtr &expr) {
+bool isChalkODMDocument(const ast::ExpressionPtr &expr) {
     auto *document = ast::cast_tree<ast::UnresolvedConstantLit>(expr);
     if (document == nullptr || document->cnst != core::Names::Constants::Document()) {
         return false;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Make a few ast queries in `Prop.cc` accept `const ast::ExpressionPtr &` arguments.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Avoiding mutation when it's not needed.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
