### PR TITLE
Add CSV::Table as a return type for CSV.read

### DIFF
--- a/rbi/stdlib/csv.rbi
+++ b/rbi/stdlib/csv.rbi
@@ -551,7 +551,7 @@ class CSV < Object
         path: String,
         options: T::Hash[Symbol, T.untyped],
     )
-    .returns(T::Array[T::Array[T.nilable(String)]])
+    .returns(T.any(CSV::Table, T::Array[T::Array[T.nilable(String)]]))
   end
   def self.read(path, options=T.unsafe(nil)); end
 
@@ -983,6 +983,7 @@ class CSV::Row < Object
 
   # Alias for:
   # [`field`](https://docs.ruby-lang.org/en/2.7.0/CSV/Row.html#method-i-field)
+  sig { params(header_or_index: T.any(String, Integer), minimum_index: T.nilable(Integer)).returns(T.nilable(String)) }
   def [](header_or_index, minimum_index = _); end
 
   # Looks up the field by the semantics described in
@@ -1044,6 +1045,7 @@ class CSV::Row < Object
   #
   # Also aliased as:
   # [`[]`](https://docs.ruby-lang.org/en/2.7.0/CSV/Row.html#method-i-5B-5D)
+  sig { params(header_or_index: T.any(String, Integer), minimum_index: T.nilable(Integer)).returns(T.nilable(String)) }
   def field(header_or_index, minimum_index = _); end
 
   # Returns `true` if `data` matches a field in this row, and `false` otherwise.
@@ -1374,7 +1376,7 @@ class CSV::Table < Object
   # If no block is given, an
   # [`Enumerator`](https://docs.ruby-lang.org/en/2.7.0/Enumerator.html) is
   # returned.
-  sig { params(block: T.proc.params(arg0: T.untyped).void).returns(T.self_type) }
+  sig { params(block: T.proc.params(arg0: T.any(CSV::Row, T::Array[T.untyped])).void).returns(T.self_type) }
   sig { returns(T::Enumerator[T.untyped]) }
   def each(&block); end
 


### PR DESCRIPTION
Resolves #5131

### Motivation

`CSV::Table` is a valid return type when the `headers:` keyword argument is provided to
`.read`, it provides a superset of functionality over the array, such as
fetching elements by string arguments, or converting the row to a hash with
`to_hash`.

### Test plan

Wrote a [small file](https://sorbet.run/#%23%20typed%3A%20true%0Aextend%20T%3A%3ASig%0A%0ACSV.read%28%22filename.csv%22%2C%20headers%3A%20%3Afirst_row%29.each_with_object%28%7B%7D%29%20do%20%7Crow%2C%20obj%7C%0A%20%20obj%5Brow.field%28%22id%22%29%5D%20%3D%20row.to_hash%0Aend) that triggers the erroneous errors. 

Pre-patched sorbet throws errors, post-patched sorbet does not. 🎉 

Let me know if there are automated tests for this, I couldn't find 'em.