### PR TITLE
Allow props with `default: nil` to be considered nilable

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -290,7 +290,7 @@ class T::Props::Decorator
   def prop_defined(name, cls, rules={})
     cls = T::Utils.resolve_alias(cls)
 
-    if T::Utils::Nilable.is_union_with_nilclass(cls)
+    if T::Utils::Nilable.is_union_with_nilclass(cls) || (rules.key?(:default) && rules[:default].nil?)
       # :_tnilable is introduced internally for performance purpose so that clients do not need to call
       # T::Utils::Nilable.is_tnilable(cls) again.
       # It is strictly internal: clients should always use T::Props::Utils.required_prop?() or

--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -277,8 +277,10 @@ class T::Props::Decorator
     end
   end
 
-  # Returns `true` when the type of the prop is nilable, or a `:default` is
-  # present in the rules hash, and its value is `nil`.
+  # Returns `true` when the type of the prop is nilable, or the field is typed
+  # as `T.untyped`, a `:default` is present in the rules hash, and its value is
+  # `nil`. The latter case is a workaround for explicitly not supporting the use
+  # of `T.nilable(T.untyped)`.
   #
   # checked(:never) - Rules hash is expensive to check
   sig do

--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -277,6 +277,22 @@ class T::Props::Decorator
     end
   end
 
+  # Returns `true` when the type of the prop is nilable, or a `:default` is
+  # present in the rules hash, and its value is `nil`.
+  #
+  # checked(:never) - Rules hash is expensive to check
+  sig do
+    params(
+      cls: PropTypeOrClass,
+      rules: Rules,
+    )
+    .void
+    .checked(:never)
+  end
+  private def prop_nilable?(cls, rules)
+    T::Utils::Nilable.is_union_with_nilclass(cls) || (rules.key?(:default) && rules[:default].nil?)
+  end
+
   # checked(:never) - Rules hash is expensive to check
   sig do
     params(
@@ -290,7 +306,7 @@ class T::Props::Decorator
   def prop_defined(name, cls, rules={})
     cls = T::Utils.resolve_alias(cls)
 
-    if T::Utils::Nilable.is_union_with_nilclass(cls) || (rules.key?(:default) && rules[:default].nil?)
+    if prop_nilable?(cls, rules)
       # :_tnilable is introduced internally for performance purpose so that clients do not need to call
       # T::Utils::Nilable.is_tnilable(cls) again.
       # It is strictly internal: clients should always use T::Props::Utils.required_prop?() or

--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -290,7 +290,7 @@ class T::Props::Decorator
     .checked(:never)
   end
   private def prop_nilable?(cls, rules)
-    T::Utils::Nilable.is_union_with_nilclass(cls) || (rules.key?(:default) && rules[:default].nil?)
+    T::Utils::Nilable.is_union_with_nilclass(cls) || (cls == T.untyped && rules.key?(:default) && rules[:default].nil?)
   end
 
   # checked(:never) - Rules hash is expensive to check

--- a/gems/sorbet-runtime/test/types/props/constructor.rb
+++ b/gems/sorbet-runtime/test/types/props/constructor.rb
@@ -16,6 +16,11 @@ class Opus::Types::Test::Props::ConstructorTest < Critic::Unit::UnitTest
     prop :objs, T::Array[Inner]
   end
 
+  class UntypedField < T::Struct
+    const :untyped_const, T.untyped, default: nil
+    prop :untyped_prop, T.untyped, default: nil
+  end
+
   it "raises when omitting a required prop" do
     err = assert_raises(ArgumentError) do
       MyStruct.new(foo: 'foo')
@@ -52,5 +57,9 @@ class Opus::Types::Test::Props::ConstructorTest < Critic::Unit::UnitTest
   it 'can pass objects to an array of subdocs' do
     o = Outer.new(objs: [Inner.new(i: 4), Inner.new(i: 5)])
     assert_equal([4, 5], o.objs.map(&:i))
+  end
+
+  it 'can default untyped fields' do
+    UntypedField.new
   end
 end

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -39,6 +39,9 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
     prop :trueprop, T::Boolean, default: true
     prop :falseprop, T::Boolean, default: false
     prop :factoryprop, T::Boolean, factory: -> {true}
+
+    prop :untyped_prop1, T.untyped, default: nil
+    const :untyped_const1, T.untyped, default: nil
   end
 
   describe ':default and :factory' do

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -44,6 +44,11 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
     const :untyped_const1, T.untyped, default: nil
   end
 
+  class NilDefaultRequired < T::Struct
+    const :integer_const_nil_default, Integer, default: nil
+    prop :integer_prop_nil_default, Integer, default: nil
+  end
+
   describe ':default and :factory' do
     it 'defaults do not override on from_hash' do
       m = DefaultsStruct.from_hash('prop1' => 'value',
@@ -80,6 +85,11 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
     assert_equal(
       Set[:trueprop, :falseprop, :factoryprop],
       DefaultsStruct.decorator.required_props.to_set
+    )
+
+    assert_equal(
+      Set[:integer_const_nil_default, :integer_prop_nil_default],
+      NilDefaultRequired.decorator.required_props.to_set
     )
   end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Modify the prop dsl's internal tracking of nilable fields to include those with `default: nil`. This change allows us to give the prop/const being defined a type of `T.untyped`, while still keeping the fact that it's expected to be nilable. Previously writing `T.nilable(T.untyped)` worked somewhat by accident, as the underlying `T.any` type didn't automatically collapse to `T.untyped`.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Enabling us to make `T.nilable(T.untyped)` an error, merging in #5129.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Successful run on Stripe CI (modulo generated file changes): https://go/builds/bui_L0AK0aHJsuoooh

See included automated tests.
