### PR TITLE
change tokens to store `string_view`

### DIFF
--- a/common/StableStringStorage.h
+++ b/common/StableStringStorage.h
@@ -7,7 +7,7 @@
 
 namespace sorbet {
 
-template <size_t PageSize>
+template <size_t PageSize = 4096>
 class StableStringStorage {
 public:
     StableStringStorage() = default;

--- a/common/StableStringStorage.h
+++ b/common/StableStringStorage.h
@@ -2,19 +2,20 @@
 #define SORBET_STABLE_STRING_STORAGE_H
 
 #include <string>
-#include <vector>
 #include <utility>
+#include <vector>
 
 namespace sorbet {
 
-template <size_t PageSize = 4096>
-class StableStringStorage {
+template <size_t PageSize = 4096> class StableStringStorage {
 public:
     StableStringStorage() = default;
 
     StableStringStorage &operator=(const StableStringStorage &rhs);
 
-    bool empty() const { return strings.empty(); }
+    bool empty() const {
+        return strings.empty();
+    }
     std::string_view enterString(std::string_view str);
 
 private:
@@ -29,8 +30,7 @@ StableStringStorage<PageSize> &StableStringStorage<PageSize>::operator=(const St
     return *this;
 }
 
-template <size_t PageSize>
-std::string_view StableStringStorage<PageSize>::enterString(std::string_view str) {
+template <size_t PageSize> std::string_view StableStringStorage<PageSize>::enterString(std::string_view str) {
     char *from = nullptr;
     if (str.size() > PageSize) {
         auto &inserted = strings.emplace_back(std::make_unique<std::vector<char>>(str.size()));

--- a/common/StableStringStorage.h
+++ b/common/StableStringStorage.h
@@ -12,6 +12,8 @@ class StableStringStorage {
 public:
     StableStringStorage() = default;
 
+    StableStringStorage &operator=(const StableStringStorage &rhs);
+
     bool empty() const { return strings.empty(); }
     std::string_view enterString(std::string_view str);
 
@@ -19,6 +21,13 @@ private:
     std::vector<std::shared_ptr<std::vector<char>>> strings;
     size_t currentPagePosition = PageSize + 1;
 };
+
+template <size_t PageSize>
+StableStringStorage<PageSize> &StableStringStorage<PageSize>::operator=(const StableStringStorage<PageSize> &rhs) {
+    this->strings = rhs.strings;
+    this->currentPagePosition = PageSize + 1;
+    return *this;
+}
 
 template <size_t PageSize>
 std::string_view StableStringStorage<PageSize>::enterString(std::string_view str) {

--- a/common/StableStringStorage.h
+++ b/common/StableStringStorage.h
@@ -1,0 +1,56 @@
+#ifndef SORBET_STABLE_STRING_STORAGE_H
+#define SORBET_STABLE_STRING_STORAGE_H
+
+#include <string>
+#include <vector>
+#include <utility>
+
+namespace sorbet {
+
+template <size_t PageSize>
+class StableStringStorage {
+public:
+    StableStringStorage() = default;
+
+    bool empty() const { return strings.empty(); }
+    std::string_view enterString(std::string_view str);
+
+private:
+    std::vector<std::shared_ptr<std::vector<char>>> strings;
+    size_t currentPagePosition = PageSize + 1;
+};
+
+template <size_t PageSize>
+std::string_view StableStringStorage<PageSize>::enterString(std::string_view str) {
+    char *from = nullptr;
+    if (str.size() > PageSize) {
+        auto &inserted = strings.emplace_back(std::make_unique<std::vector<char>>(str.size()));
+        from = inserted->data();
+        if (strings.size() > 1) {
+            // last page wasn't full, keep it in the end
+            swap(*(strings.end() - 1), *(strings.end() - 2));
+
+            // NOTE: we do not update `currentPagePosition` here because it refers to the offset into the last page,
+            // which is swapped in by the line above.
+        } else {
+            // Insert a new empty page at the end to enforce the invariant that inserting a huge string will always
+            // leave a page that can be written to at the end of the table.
+            strings.emplace_back(std::make_unique<std::vector<char>>(PageSize));
+            currentPagePosition = 0;
+        }
+    } else {
+        if (currentPagePosition + str.size() > PageSize) {
+            strings.emplace_back(std::make_unique<std::vector<char>>(PageSize));
+            currentPagePosition = 0;
+        }
+        from = strings.back()->data() + currentPagePosition;
+        currentPagePosition += str.size();
+    }
+
+    memcpy(from, str.data(), str.size());
+    return std::string_view(from, str.size());
+}
+
+} // namespace sorbet
+
+#endif // SORBET_STABLE_STRING_STORAGE_H

--- a/common/StableStringStorage.h
+++ b/common/StableStringStorage.h
@@ -11,6 +11,11 @@ template <size_t PageSize = 4096> class StableStringStorage {
 public:
     StableStringStorage() = default;
 
+    // We override the copy constructor and assignment because we need to ensure
+    // that `currentPagePosition` in the copy forces a separate page to be allocated.
+    // The pages may be shared between `StableStringStorage` instances, but only
+    // one instance is ever permitted to write to a single page.
+    StableStringStorage(const StableStringStorage &rhs);
     StableStringStorage &operator=(const StableStringStorage &rhs);
 
     bool empty() const {
@@ -22,6 +27,10 @@ private:
     std::vector<std::shared_ptr<std::vector<char>>> strings;
     size_t currentPagePosition = PageSize + 1;
 };
+
+template <size_t PageSize>
+StableStringStorage<PageSize>::StableStringStorage(const StableStringStorage<PageSize> &rhs)
+    : strings(rhs.string), currentPagePosition(PageSize + 1) {}
 
 template <size_t PageSize>
 StableStringStorage<PageSize> &StableStringStorage<PageSize>::operator=(const StableStringStorage<PageSize> &rhs) {

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -2,6 +2,7 @@
 #define SORBET_GLOBAL_STATE_H
 #include "absl/synchronization/mutex.h"
 
+#include "common/StableStringStorage.h"
 #include "core/Error.h"
 #include "core/Files.h"
 #include "core/Loc.h"
@@ -300,9 +301,8 @@ private:
     std::vector<DeepCloneHistoryEntry> deepCloneHistory;
 
     static constexpr int STRINGS_PAGE_SIZE = 4096;
-    std::vector<std::shared_ptr<std::vector<char>>> strings;
+    StableStringStorage<STRINGS_PAGE_SIZE> strings;
     std::string_view enterString(std::string_view nm);
-    uint16_t stringsLastPageUsed = STRINGS_PAGE_SIZE + 1;
     std::vector<UTF8Name> utf8Names;
     std::vector<ConstantName> constantNames;
     std::vector<UniqueName> uniqueNames;

--- a/parser/Parser.cc
+++ b/parser/Parser.cc
@@ -59,7 +59,10 @@ unique_ptr<Node> Parser::run(sorbet::core::GlobalState &gs, core::FileRef file, 
     buffer.reserve(source.size() + 2);
     buffer += source;
     buffer += "\0\0"sv;
-    ruby_parser::typedruby27 driver(buffer, Builder::interface);
+    vector<char> scratch;
+    // This is perhaps a little optimistic, but at least it is a reasonable default.
+    scratch.reserve(buffer.size());
+    ruby_parser::typedruby27 driver(buffer, scratch, Builder::interface);
 
     for (string local : initialLocals) {
         driver.lex.declare(local);

--- a/parser/Parser.cc
+++ b/parser/Parser.cc
@@ -1,5 +1,6 @@
 #include "parser.h"
 #include "Builder.h"
+#include "common/StableStringStorage.h"
 #include "core/Loc.h"
 #include "core/errors/parser.h"
 #include "ruby_parser/driver.hh"
@@ -59,9 +60,7 @@ unique_ptr<Node> Parser::run(sorbet::core::GlobalState &gs, core::FileRef file, 
     buffer.reserve(source.size() + 2);
     buffer += source;
     buffer += "\0\0"sv;
-    vector<char> scratch;
-    // This is perhaps a little optimistic, but at least it is a reasonable default.
-    scratch.reserve(buffer.size());
+    StableStringStorage<> scratch;
     ruby_parser::typedruby27 driver(buffer, scratch, Builder::interface);
 
     for (string local : initialLocals) {

--- a/parser/parser/cc/driver.cc
+++ b/parser/parser/cc/driver.cc
@@ -6,10 +6,10 @@
 
 namespace ruby_parser {
 
-    base_driver::base_driver(ruby_version version, std::string_view source, std::vector<char> &scratch, const struct builder &builder)
+base_driver::base_driver(ruby_version version, std::string_view source, sorbet::StableStringStorage<> &scratch, const struct builder &builder)
     : build(builder), lex(diagnostics, version, source, scratch), pending_error(false), def_level(0), ast(nullptr) {}
 
-    typedruby27::typedruby27(std::string_view source, std::vector<char> &scratch, const struct builder &builder)
+typedruby27::typedruby27(std::string_view source, sorbet::StableStringStorage<> &scratch, const struct builder &builder)
     : base_driver(ruby_version::RUBY_27, source, scratch, builder) {}
 
 ForeignPtr typedruby27::parse(SelfPtr self, bool trace) {

--- a/parser/parser/cc/driver.cc
+++ b/parser/parser/cc/driver.cc
@@ -6,11 +6,11 @@
 
 namespace ruby_parser {
 
-base_driver::base_driver(ruby_version version, std::string_view source, const struct builder &builder)
-    : build(builder), lex(diagnostics, version, source), pending_error(false), def_level(0), ast(nullptr) {}
+    base_driver::base_driver(ruby_version version, std::string_view source, std::vector<char> &scratch, const struct builder &builder)
+    : build(builder), lex(diagnostics, version, source, scratch), pending_error(false), def_level(0), ast(nullptr) {}
 
-typedruby27::typedruby27(std::string_view source, const struct builder &builder)
-    : base_driver(ruby_version::RUBY_27, source, builder) {}
+    typedruby27::typedruby27(std::string_view source, std::vector<char> &scratch, const struct builder &builder)
+    : base_driver(ruby_version::RUBY_27, source, scratch, builder) {}
 
 ForeignPtr typedruby27::parse(SelfPtr self, bool trace) {
     bison::typedruby27::parser p(*this, self);

--- a/parser/parser/cc/driver.cc
+++ b/parser/parser/cc/driver.cc
@@ -6,7 +6,8 @@
 
 namespace ruby_parser {
 
-base_driver::base_driver(ruby_version version, std::string_view source, sorbet::StableStringStorage<> &scratch, const struct builder &builder)
+base_driver::base_driver(ruby_version version, std::string_view source, sorbet::StableStringStorage<> &scratch,
+                         const struct builder &builder)
     : build(builder), lex(diagnostics, version, source, scratch), pending_error(false), def_level(0), ast(nullptr) {}
 
 typedruby27::typedruby27(std::string_view source, sorbet::StableStringStorage<> &scratch, const struct builder &builder)

--- a/parser/parser/cc/lexer.rl
+++ b/parser/parser/cc/lexer.rl
@@ -120,10 +120,11 @@ using namespace std::string_literals;
 
 %% prepush { check_stack_capacity(); }
 
-lexer::lexer(diagnostics_t &diag, ruby_version version, std::string_view source_buffer)
+lexer::lexer(diagnostics_t &diag, ruby_version version, std::string_view source_buffer, std::vector<char> &scratch)
   : diagnostics(diag)
   , version(version)
   , source_buffer(source_buffer)
+  , scratch(scratch)
   , cs(lex_en_line_begin)
   , _p(source_buffer.data())
   , _pe(source_buffer.data() + source_buffer.size())

--- a/parser/parser/cc/lexer.rl
+++ b/parser/parser/cc/lexer.rl
@@ -2884,7 +2884,8 @@ token_t lexer::advance() {
 token_t lexer::unadvance(token_t tok_to_push, token_type type, size_t start, size_t end, const std::string &str) {
   token_queue.push_front(tok_to_push);
 
-  auto new_tok = mempool.alloc(type, start, end, str);
+  auto scratch_view = scratch.enterString(str);
+  auto new_tok = mempool.alloc(type, start, end, scratch_view);
 
   last_token_s = start;
   last_token_e = end;

--- a/parser/parser/cc/lexer.rl
+++ b/parser/parser/cc/lexer.rl
@@ -120,7 +120,7 @@ using namespace std::string_literals;
 
 %% prepush { check_stack_capacity(); }
 
-lexer::lexer(diagnostics_t &diag, ruby_version version, std::string_view source_buffer, std::vector<char> &scratch)
+lexer::lexer(diagnostics_t &diag, ruby_version version, std::string_view source_buffer, sorbet::StableStringStorage<> &scratch)
   : diagnostics(diag)
   , version(version)
   , source_buffer(source_buffer)
@@ -527,10 +527,7 @@ void lexer::emit(token_type type, const std::string &str, const char* start, con
   size_t offset_end = (size_t)(end - source_buffer.data());
 
   // Copy the string into stable storage.
-  // XXX need to handle the case where scratch doesn't have enough space left.
-  auto scratch_start = this->scratch.size();
-  this->scratch.insert(this->scratch.end(), str.begin(), str.end());
-  auto scratch_view = std::string_view{&this->scratch[scratch_start], this->scratch.size() - scratch_start};
+  auto scratch_view = scratch.enterString(str);
   token_queue.push(mempool.alloc(type, offset_start, offset_end, scratch_view));
 }
 

--- a/parser/parser/cc/lexer.rl
+++ b/parser/parser/cc/lexer.rl
@@ -497,10 +497,10 @@ token_t lexer::advance_() {
 
   if (cs == lex_error) {
     size_t start = (size_t)(p - source_buffer.data());
-    return mempool.alloc(token_type::error, start, start + 1, std::string(p - 1, 1));
+    return mempool.alloc(token_type::error, start, start + 1, std::string_view(p - 1, 1));
   }
 
-  return mempool.alloc(token_type::eof, source_buffer.size(), source_buffer.size(), "");
+  return mempool.alloc(token_type::eof, source_buffer.size(), source_buffer.size(), std::string_view("", 0));
 }
 
 void lexer::emit(token_type type) {

--- a/parser/parser/cc/lexer.rl
+++ b/parser/parser/cc/lexer.rl
@@ -518,6 +518,22 @@ void lexer::emit(token_type type, std::string_view str, const char* start, const
   token_queue.push_back(mempool.alloc(type, offset_start, offset_end, str));
 }
 
+void lexer::emit(token_type type, const std::string &str) {
+  emit(type, str, ts, te);
+}
+
+void lexer::emit(token_type type, const std::string &str, const char* start, const char* end) {
+  size_t offset_start = (size_t)(start - source_buffer.data());
+  size_t offset_end = (size_t)(end - source_buffer.data());
+
+  // Copy the string into stable storage.
+  // XXX need to handle the case where scratch doesn't have enough space left.
+  auto scratch_start = this->scratch.size();
+  this->scratch.insert(this->scratch.end(), str.begin(), str.end());
+  auto scratch_view = std::string_view{&this->scratch[scratch_start], this->scratch.size() - scratch_start};
+  token_queue.push(mempool.alloc(type, offset_start, offset_end, scratch_view));
+}
+
 void lexer::emit_do(bool do_block) {
   if (cond.active()) {
     emit(token_type::kDO_COND, "do");

--- a/parser/parser/cc/lexer.rl
+++ b/parser/parser/cc/lexer.rl
@@ -1189,7 +1189,7 @@ void lexer::set_state_expr_value() {
       }
     } else {
       // Try ending the literal with a newline.
-      auto str = tok();
+      auto str = tok_view();
       if (current_literal.nest_and_try_closing(str, ts, te)) {
         fnext *pop_literal(); fbreak;
       }

--- a/parser/parser/cc/lexer.rl
+++ b/parser/parser/cc/lexer.rl
@@ -2825,7 +2825,7 @@ void lexer::set_state_expr_value() {
           // next line as a separate statement.
           //
           // Note: block comments before leading dot are not supported on any version of Ruby.
-          emit(token_type::tNL, std::string(), newline_s, newline_s + 1);
+          emit(token_type::tNL, "", newline_s, newline_s + 1);
           fhold; fnext line_begin; fbreak;
         }
       };
@@ -2834,7 +2834,7 @@ void lexer::set_state_expr_value() {
       => { p = tm - 1; fgoto expr_end; };
 
       any
-      => { emit(token_type::tNL, std::string(), newline_s, newline_s + 1);
+      => { emit(token_type::tNL, "", newline_s, newline_s + 1);
            fhold; fnext line_begin; fbreak; };
   *|;
 

--- a/parser/parser/cc/lexer.rl
+++ b/parser/parser/cc/lexer.rl
@@ -528,7 +528,7 @@ void lexer::emit(token_type type, const std::string &str, const char* start, con
 
   // Copy the string into stable storage.
   auto scratch_view = scratch.enterString(str);
-  token_queue.push(mempool.alloc(type, offset_start, offset_end, scratch_view));
+  token_queue.push_back(mempool.alloc(type, offset_start, offset_end, scratch_view));
 }
 
 void lexer::emit_do(bool do_block) {

--- a/parser/parser/cc/literal.cc
+++ b/parser/parser/cc/literal.cc
@@ -294,6 +294,6 @@ void literal::emit(token_type tok, std::string_view value, const char *s, const 
     _lexer.emit(tok, value, s, e);
 }
 
-void literal::emit(token_type tok, const std::string &value, const char* s, const char* e) {
-  _lexer.emit(tok, value, s, e);
+void literal::emit(token_type tok, const std::string &value, const char *s, const char *e) {
+    _lexer.emit(tok, value, s, e);
 }

--- a/parser/parser/cc/literal.cc
+++ b/parser/parser/cc/literal.cc
@@ -2,6 +2,7 @@
 #include <ruby_parser/literal.hh>
 
 using namespace ruby_parser;
+using namespace std::literals::string_view_literals;
 
 literal::literal(lexer &lexer, literal_type type, std::string delimiter, const char *str_s, const char *heredoc_e,
                  bool indent, bool dedent_body, bool label_allowed)
@@ -243,8 +244,7 @@ void literal::extend_space(const char *ts, const char *te) {
     flush_string();
 
     if (!space_emitted) {
-        std::string nothing;
-        emit(token_type::tSPACE, nothing, ts, te);
+        emit(token_type::tSPACE, ""sv, ts, te);
 
         space_emitted = true;
     }
@@ -287,9 +287,13 @@ void literal::clear_buffer() {
 void literal::emit_start_token() {
     auto str_type_length = 1 /* TODO @str_type.length */;
     auto str_e = heredoc_e ? heredoc_e : str_s + str_type_length;
-    emit(start_token_type(), std::string_view{}, str_s, str_e);
+    emit(start_token_type(), ""sv, str_s, str_e);
 }
 
 void literal::emit(token_type tok, std::string_view value, const char *s, const char *e) {
     _lexer.emit(tok, value, s, e);
+}
+
+void literal::emit(token_type tok, const std::string &value, const char* s, const char* e) {
+  _lexer.emit(tok, value, s, e);
 }

--- a/parser/parser/cc/token.cc
+++ b/parser/parser/cc/token.cc
@@ -26,6 +26,6 @@ std::string_view token::view() const {
     return _string;
 }
 
-const std::string &token::asString() const {
-    return _string;
+std::string token::asString() const {
+    return std::string(_string);
 }

--- a/parser/parser/include/ruby_parser/driver.hh
+++ b/parser/parser/include/ruby_parser/driver.hh
@@ -4,6 +4,8 @@
 #include <memory>
 #include <vector>
 
+#include "common/StableStringStorage.h"
+
 #include "builder.hh"
 #include "common/common.h"
 #include "diagnostic.hh"
@@ -273,7 +275,7 @@ public:
     ForeignPtr ast;
     token_t last_token;
 
-    base_driver(ruby_version version, std::string_view source, std::vector<char> &scratch, const struct builder &builder);
+    base_driver(ruby_version version, std::string_view source, sorbet::StableStringStorage<> &scratch, const struct builder &builder);
     virtual ~base_driver() {}
     virtual ForeignPtr parse(SelfPtr self, bool trace) = 0;
 
@@ -306,7 +308,7 @@ public:
 
 class typedruby27 : public base_driver {
 public:
-    typedruby27(std::string_view source, std::vector<char> &scratch, const struct builder &builder);
+    typedruby27(std::string_view source, sorbet::StableStringStorage<> &scratch, const struct builder &builder);
     virtual ForeignPtr parse(SelfPtr self, bool trace);
     ~typedruby27() {}
 };

--- a/parser/parser/include/ruby_parser/driver.hh
+++ b/parser/parser/include/ruby_parser/driver.hh
@@ -2,6 +2,7 @@
 #define RUBY_PARSER_DRIVER_HH
 
 #include <memory>
+#include <vector>
 
 #include "builder.hh"
 #include "common/common.h"
@@ -272,7 +273,7 @@ public:
     ForeignPtr ast;
     token_t last_token;
 
-    base_driver(ruby_version version, std::string_view source, const struct builder &builder);
+    base_driver(ruby_version version, std::string_view source, std::vector<char> &scratch, const struct builder &builder);
     virtual ~base_driver() {}
     virtual ForeignPtr parse(SelfPtr self, bool trace) = 0;
 
@@ -305,7 +306,7 @@ public:
 
 class typedruby27 : public base_driver {
 public:
-    typedruby27(std::string_view source, const struct builder &builder);
+    typedruby27(std::string_view source, std::vector<char> &scratch, const struct builder &builder);
     virtual ForeignPtr parse(SelfPtr self, bool trace);
     ~typedruby27() {}
 };

--- a/parser/parser/include/ruby_parser/driver.hh
+++ b/parser/parser/include/ruby_parser/driver.hh
@@ -275,7 +275,8 @@ public:
     ForeignPtr ast;
     token_t last_token;
 
-    base_driver(ruby_version version, std::string_view source, sorbet::StableStringStorage<> &scratch, const struct builder &builder);
+    base_driver(ruby_version version, std::string_view source, sorbet::StableStringStorage<> &scratch,
+                const struct builder &builder);
     virtual ~base_driver() {}
     virtual ForeignPtr parse(SelfPtr self, bool trace) = 0;
 

--- a/parser/parser/include/ruby_parser/lexer.hh
+++ b/parser/parser/include/ruby_parser/lexer.hh
@@ -155,6 +155,8 @@ private:
     void emit(token_type type, const char (&str)[N], const char *start, const char *end) {
         emit(type, std::string_view{&str[0], N-1}, start, end);
     }
+    void emit(token_type type, const std::string &str);
+    void emit(token_type type, const std::string &str, const char *start, const char *end);
     void emit_do(bool do_block = false);
     void emit_table(const token_table_entry *table);
     void emit_num(const std::string &num);

--- a/parser/parser/include/ruby_parser/lexer.hh
+++ b/parser/parser/include/ruby_parser/lexer.hh
@@ -149,13 +149,11 @@ private:
     // Without these overloads, emit(..., "do") would be ambiguous.
     // It's OK to store points to constants, as they live in static storage and will
     // therefore not be going away.
-    template<size_t N>
-    void emit(token_type type, const char (&str)[N]) {
-        emit(type, std::string_view{&str[0], N-1});
+    template <size_t N> void emit(token_type type, const char (&str)[N]) {
+        emit(type, std::string_view{&str[0], N - 1});
     }
-    template<size_t N>
-    void emit(token_type type, const char (&str)[N], const char *start, const char *end) {
-        emit(type, std::string_view{&str[0], N-1}, start, end);
+    template <size_t N> void emit(token_type type, const char (&str)[N], const char *start, const char *end) {
+        emit(type, std::string_view{&str[0], N - 1}, start, end);
     }
     void emit(token_type type, const std::string &str);
     void emit(token_type type, const std::string &str, const char *start, const char *end);

--- a/parser/parser/include/ruby_parser/lexer.hh
+++ b/parser/parser/include/ruby_parser/lexer.hh
@@ -8,6 +8,7 @@
 #include <set>
 #include <stack>
 #include <string>
+#include <vector>
 
 #include "context.hh"
 #include "diagnostic.hh"
@@ -53,6 +54,7 @@ private:
 
     ruby_version version;
     std::string_view source_buffer;
+    std::vector<char> &scratch;
 
     std::stack<environment> static_env;
     std::stack<literal> literal_stack;
@@ -172,7 +174,8 @@ public:
     bool in_kwarg; // true at the end of "def foo a:"
     Context context;
 
-    lexer(diagnostics_t &diag, ruby_version version, std::string_view source_buffer);
+    lexer(diagnostics_t &diag, ruby_version version, std::string_view source_buffer,
+          std::vector<char> &scratch);
 
     // Main interface consumed by yylex function in parser
     token_t advance();

--- a/parser/parser/include/ruby_parser/lexer.hh
+++ b/parser/parser/include/ruby_parser/lexer.hh
@@ -140,6 +140,9 @@ private:
     std::string_view tok_view(const char *start) const;
     std::string_view tok_view(const char *start, const char *end) const;
     void emit(token_type type);
+    // NB: these overloads will also handle character literals coercing to string_views.
+    // This is fine in a world where tokens only store string_views, as the character
+    // literal data lives in static storage.
     void emit(token_type type, std::string_view str);
     void emit(token_type type, std::string_view str, const char *start, const char *end);
     void emit_do(bool do_block = false);

--- a/parser/parser/include/ruby_parser/lexer.hh
+++ b/parser/parser/include/ruby_parser/lexer.hh
@@ -142,11 +142,19 @@ private:
     std::string_view tok_view(const char *start) const;
     std::string_view tok_view(const char *start, const char *end) const;
     void emit(token_type type);
-    // NB: these overloads will also handle character literals coercing to string_views.
-    // This is fine in a world where tokens only store string_views, as the character
-    // literal data lives in static storage.
     void emit(token_type type, std::string_view str);
     void emit(token_type type, std::string_view str, const char *start, const char *end);
+    // Without these overloads, emit(..., "do") would be ambiguous.
+    // It's OK to store points to constants, as they live in static storage and will
+    // therefore not be going away.
+    template<size_t N>
+    void emit(token_type type, const char (&str)[N]) {
+        emit(type, std::string_view{&str[0], N-1});
+    }
+    template<size_t N>
+    void emit(token_type type, const char (&str)[N], const char *start, const char *end) {
+        emit(type, std::string_view{&str[0], N-1}, start, end);
+    }
     void emit_do(bool do_block = false);
     void emit_table(const token_table_entry *table);
     void emit_num(const std::string &num);

--- a/parser/parser/include/ruby_parser/lexer.hh
+++ b/parser/parser/include/ruby_parser/lexer.hh
@@ -10,6 +10,8 @@
 #include <string>
 #include <vector>
 
+#include "common/StableStringStorage.h"
+
 #include "context.hh"
 #include "diagnostic.hh"
 #include "literal.hh"
@@ -54,7 +56,7 @@ private:
 
     ruby_version version;
     std::string_view source_buffer;
-    std::vector<char> &scratch;
+    sorbet::StableStringStorage<> &scratch;
 
     std::stack<environment> static_env;
     std::stack<literal> literal_stack;
@@ -185,7 +187,7 @@ public:
     Context context;
 
     lexer(diagnostics_t &diag, ruby_version version, std::string_view source_buffer,
-          std::vector<char> &scratch);
+          sorbet::StableStringStorage<> &scratch);
 
     // Main interface consumed by yylex function in parser
     token_t advance();

--- a/parser/parser/include/ruby_parser/literal.hh
+++ b/parser/parser/include/ruby_parser/literal.hh
@@ -96,8 +96,8 @@ private:
     bool is_delimiter(std::string_view delimiter) const;
     void clear_buffer();
     void emit_start_token();
-    void emit(token_type tok, std::string_view value, const char* s, const char* e);
-    void emit(token_type tok, const std::string &value, const char* s, const char* e);
+    void emit(token_type tok, std::string_view value, const char *s, const char *e);
+    void emit(token_type tok, const std::string &value, const char *s, const char *e);
 };
 } // namespace ruby_parser
 

--- a/parser/parser/include/ruby_parser/literal.hh
+++ b/parser/parser/include/ruby_parser/literal.hh
@@ -96,7 +96,8 @@ private:
     bool is_delimiter(std::string_view delimiter) const;
     void clear_buffer();
     void emit_start_token();
-    void emit(token_type tok, std::string_view value, const char *s, const char *e);
+    void emit(token_type tok, std::string_view value, const char* s, const char* e);
+    void emit(token_type tok, const std::string &value, const char* s, const char* e);
 };
 } // namespace ruby_parser
 

--- a/parser/parser/include/ruby_parser/token.hh
+++ b/parser/parser/include/ruby_parser/token.hh
@@ -177,6 +177,10 @@ class token {
 
 public:
     token(token_type type, size_t start, size_t end, std::string_view str);
+    // Don't allow people to rely on implicit conversion to std::string_view:
+    // they should make sure their string views live in storage that will outlive
+    // the lexer.
+    token(token_type type, size_t start, size_t end, const std::string &str) = delete;
 
     token_type type() const;
     size_t start() const;

--- a/parser/parser/include/ruby_parser/token.hh
+++ b/parser/parser/include/ruby_parser/token.hh
@@ -173,7 +173,7 @@ class token {
     token_type _type;
     size_t _start;
     size_t _end;
-    std::string _string;
+    std::string_view _string;
 
 public:
     token(token_type type, size_t start, size_t end, std::string_view str);
@@ -183,7 +183,7 @@ public:
     size_t end() const;
     void setEnd(size_t end);
     std::string_view view() const;
-    const std::string &asString() const;
+    std::string asString() const;
 };
 
 using token_t = token *;


### PR DESCRIPTION
This completes the vision from #5094: we now let tokens store only a `string_view` of the actual token, which shrinks the size of the token (`string_view` is half the size of `string` with libstdc++).  This shrinking sadly doesn't matter that much; what does matter is that we're not constantly copying data into the `string`s associated with tokens.  (If we could figure out some way of not holding on to every single token we've ever lexed during parsing, that would be nice too.)

By and large, this view will point into the text being parsed.  For cases where that's not true (e.g. escaped strings), we maintain a scratch buffer for copying strings into and point the views into that.  (Tokens that are emitted as static character literals are a special case: we don't need to copy those into the scratch buffer.)  Fortunately, `GlobalState` already does something very similar, so we refactored some code from there and made the debugging process a lot easier.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Speed.  Doing this saves ~2% of instructions during parsing.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
