### PR TITLE
Allow value omission in hash literals

### DIFF
--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -3616,6 +3616,11 @@ f_opt_paren_args: f_paren_args
                     {
                       $$ = driver.build.pair_keyword(self, $1, $2);
                     }
+                | tLABEL
+                    {
+                      auto method_call = driver.build.call_method(self, nullptr, nullptr, $1, nullptr, nullptr, nullptr);
+                      $$ = driver.build.pair_keyword(self, $1, method_call);
+                    }
                 | tSTRING_BEG string_contents tLABEL_END arg_value
                     {
                       $$ = driver.build.pair_quoted(self, $1, $2, $3, $4);

--- a/test/whitequark/test_value_omission_0.parse-tree-whitequark.exp
+++ b/test/whitequark/test_value_omission_0.parse-tree-whitequark.exp
@@ -1,0 +1,7 @@
+s(:hash,
+  s(:pair,
+    s(:sym, :a),
+    s(:send, nil, :a)),
+  s(:pair,
+    s(:sym, :b),
+    s(:send, nil, :b)))

--- a/test/whitequark/test_value_omission_0.rb
+++ b/test/whitequark/test_value_omission_0.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+{a:, b:}


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Part of Ruby 3.1 support

`{x:, y:}` is a now equivalent to `{x: x, y: y}`

https://github.com/ruby/ruby/commit/c60dbcd
https://github.com/whitequark/parser/commit/22e6ca5c0b27bc377fd50d16698edabfad4f4970

Local variable support will be done in another PR as it's slightly complex

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Allowing developers to use Sorbet with Ruby 3.1

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

@Morriar