### PR TITLE
[RFC] Do not error on `**kwargs` parameters name mismatch

### DIFF
--- a/ast/ArgParsing.cc
+++ b/ast/ArgParsing.cc
@@ -77,7 +77,12 @@ std::vector<uint32_t> ArgParsing::hashArgs(core::Context ctx, const std::vector<
         uint32_t arg = 0;
         uint8_t flags = 0;
         if (e.flags.isKeyword) {
-            arg = core::mix(arg, core::_hash(e.local._name.shortName(ctx)));
+            if (e.flags.isRepeated && e.local._name != core::Names::fwdKwargs()) {
+                auto name = core::Names::kwargs();
+                arg = core::mix(arg, core::_hash(name.shortName(ctx)));
+            } else {
+                arg = core::mix(arg, core::_hash(e.local._name.shortName(ctx)));
+            }
             flags += 1;
         }
         if (e.flags.isRepeated) {

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1577,10 +1577,9 @@ string ArgInfo::toString(const GlobalState &gs) const {
 }
 
 string_view ArgInfo::argumentName(const GlobalState &gs) const {
-    if (flags.isKeyword) {
+    if (flags.isKeyword && !flags.isRepeated) {
         return name.shortName(gs);
     } else {
-        // positional arg
         if (auto source = loc.source(gs)) {
             return source.value();
         } else {

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -334,6 +334,7 @@ NameDef names[] = {
     {"blockCall", "<block-call>"},
     {"blockBreakAssign", "<block-break-assign>"},
     {"arg", "<arg>"},
+    {"kwargs", "<kwargs>"},
     {"blkArg", "<blk>"},
     {"blockGiven_p", "block_given?"},
 

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -844,7 +844,15 @@ class SymbolDefiner {
 
         core::NameRef name;
         if (parsedArg.flags.isKeyword) {
-            name = parsedArg.local._name;
+            if (parsedArg.flags.isRepeated) {
+                if (parsedArg.local._name == core::Names::fwdKwargs()) {
+                    name = core::Names::fwdKwargs();
+                } else {
+                    name = core::Names::kwargs();
+                }
+            } else {
+                name = parsedArg.local._name;
+            }
         } else if (parsedArg.flags.isBlock) {
             name = core::Names::blkArg();
         } else {

--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -1085,7 +1085,7 @@ public:
         core::NameRef nm;
 
         if (name != nullptr) {
-            loc = loc.join(tokLoc(name));
+            loc = tokLoc(name);
             nm = gs_.enterNameUTF8(name->view());
             checkReservedForNumberedParameters(name->view(), loc);
         } else {

--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -1081,7 +1081,7 @@ public:
     }
 
     unique_ptr<Node> kwrestarg(const token *dstar, const token *name) {
-        core::LocOffsets loc = tokLoc(dstar);
+        core::LocOffsets loc;
         core::NameRef nm;
 
         if (name != nullptr) {
@@ -1089,6 +1089,7 @@ public:
             nm = gs_.enterNameUTF8(name->view());
             checkReservedForNumberedParameters(name->view(), loc);
         } else {
+            loc = tokLoc(dstar);
             nm = gs_.freshNameUnique(core::UniqueNameKind::Parser, core::Names::starStar(), ++uniqueCounter_);
         }
 

--- a/test/cli/minimize-rbi/test.out
+++ b/test/cli/minimize-rbi/test.out
@@ -64,11 +64,11 @@ class ::<root> < ::Object ()
       argument x5<repeated> @ Loc {file=test/cli/minimize-rbi/unknown.rbi start=13:24 end=13:26}
       argument x3<keyword> @ Loc {file=test/cli/minimize-rbi/unknown.rbi start=13:28 end=13:31}
       argument x4<optional, keyword> @ Loc {file=test/cli/minimize-rbi/unknown.rbi start=13:33 end=13:36}
-      argument x6<keyword, repeated> @ Loc {file=test/cli/minimize-rbi/unknown.rbi start=13:42 end=13:46}
+      argument x6<keyword, repeated> @ Loc {file=test/cli/minimize-rbi/unknown.rbi start=13:44 end=13:46}
       argument x7<block> @ Loc {file=test/cli/minimize-rbi/unknown.rbi start=13:49 end=13:51}
-    method ::OnlyInSecond#fwd_args (..., <fwd-kwargs>, ...) @ test/cli/minimize-rbi/unknown.rbi:15
+    method ::OnlyInSecond#fwd_args (..., ..., ...) @ test/cli/minimize-rbi/unknown.rbi:15
       argument ...<repeated> @ Loc {file=test/cli/minimize-rbi/unknown.rbi start=15:16 end=15:19}
-      argument <fwd-kwargs><keyword, repeated> @ Loc {file=test/cli/minimize-rbi/unknown.rbi start=15:16 end=15:19}
+      argument ...<keyword, repeated> @ Loc {file=test/cli/minimize-rbi/unknown.rbi start=15:16 end=15:19}
       argument ...<block> @ Loc {file=test/cli/minimize-rbi/unknown.rbi start=15:16 end=15:19}
   class ::<Class:OnlyInSecond>[<AttachedClass>] < ::<Class:Object> (ModuleOnlyInSecond) @ test/cli/minimize-rbi/unknown.rbi:9
     type-member(+) ::<Class:OnlyInSecond>::<AttachedClass> -> T.attached_class (of OnlyInSecond) @ test/cli/minimize-rbi/unknown.rbi:9

--- a/test/testdata/namer/arguments.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/arguments.rb.symbol-table-raw.exp
@@ -9,7 +9,7 @@ class <C <U <root>>> < <C <U Object>> ()
       argument c<repeated> @ Loc {file=test/testdata/namer/arguments.rb start=3:31 end=3:32}
       argument d<keyword> @ Loc {file=test/testdata/namer/arguments.rb start=3:34 end=3:36}
       argument e<optional, keyword> @ Loc {file=test/testdata/namer/arguments.rb start=3:38 end=3:40}
-      argument f<keyword, repeated> @ Loc {file=test/testdata/namer/arguments.rb start=3:43 end=3:46}
+      argument f<keyword, repeated> @ Loc {file=test/testdata/namer/arguments.rb start=3:45 end=3:46}
       argument g<block> @ Loc {file=test/testdata/namer/arguments.rb start=3:49 end=3:50}
   class <S <C <U A>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/namer/arguments.rb start=2:7 end=2:8}
     type-member(+) <S <C <U A>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U A>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=A) @ Loc {file=test/testdata/namer/arguments.rb start=2:7 end=2:8}

--- a/test/testdata/namer/parameter_names.rb
+++ b/test/testdata/namer/parameter_names.rb
@@ -1,0 +1,32 @@
+# typed: true
+extend T::Sig
+
+sig { params(arg: T.untyped).void}
+def m1(arg); end
+
+sig { params(argX: T.untyped).void}
+def m1(argX); end # ok
+
+sig { params(arg: T.untyped).void}
+def m2(*arg); end
+
+sig { params(argX: T.untyped).void}
+def m2(*argX); end # ok
+
+sig { params(block: T.untyped).void}
+def m3(&block); end
+
+sig { params(blockX: T.untyped).void}
+def m3(&blockX); end # ok
+
+sig { params(kwarg: T.untyped).void}
+def m4(kwarg:); end
+
+sig { params(kwarg1: T.untyped).void}
+def m4(kwarg1:); end # error: Method `Object#m4` redefined with mismatched keyword argument name. Expected: `kwarg`, got: `kwarg1`
+
+sig { params(kwargs: T.untyped).void}
+def m5(**kwargs); end
+
+sig { params(kwargs1: T.untyped).void}
+def m5(**kwargs1); end # ok

--- a/test/testdata/namer/parameter_names.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/parameter_names.rb.symbol-table-raw.exp
@@ -1,0 +1,23 @@
+class <C <U <root>>> < <C <U Object>> ()
+  class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U Sig>>)
+    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/parameter_names.rb start=2:1 end=32:23}
+      argument <blk><block> @ Loc {file=test/testdata/namer/parameter_names.rb start=??? end=???}
+  class <C <U Object>> < <C <U BasicObject>> (<C <U Kernel>>) @ Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi start=removed end=removed}
+    method <C <U Object>>#<U m1> : private (argX, <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/namer/parameter_names.rb start=8:1 end=8:13}
+      argument argX<> -> T.untyped @ Loc {file=test/testdata/namer/parameter_names.rb start=7:14 end=7:18}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/namer/parameter_names.rb start=??? end=???}
+    method <C <U Object>>#<U m2> : private (argX, <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/namer/parameter_names.rb start=14:1 end=14:14}
+      argument argX<repeated> -> T.untyped @ Loc {file=test/testdata/namer/parameter_names.rb start=13:14 end=13:18}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/namer/parameter_names.rb start=??? end=???}
+    method <C <U Object>>#<U m3> : private (blockX) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/namer/parameter_names.rb start=20:1 end=20:16}
+      argument blockX<block> -> T.untyped @ Loc {file=test/testdata/namer/parameter_names.rb start=19:14 end=19:20}
+    method <C <U Object>>#<M <U m4> $1> : private (kwarg, <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/namer/parameter_names.rb start=23:1 end=23:15}
+      argument kwarg<keyword> -> T.untyped @ Loc {file=test/testdata/namer/parameter_names.rb start=22:14 end=22:19}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/namer/parameter_names.rb start=??? end=???}
+    method <C <U Object>>#<U m4> : private (kwarg1, <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/namer/parameter_names.rb start=26:1 end=26:16}
+      argument kwarg1<keyword> -> T.untyped @ Loc {file=test/testdata/namer/parameter_names.rb start=25:14 end=25:20}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/namer/parameter_names.rb start=??? end=???}
+    method <C <U Object>>#<U m5> : private (kwargs1, <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/namer/parameter_names.rb start=32:1 end=32:18}
+      argument kwargs1<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/namer/parameter_names.rb start=31:14 end=31:21}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/namer/parameter_names.rb start=??? end=???}
+

--- a/test/testdata/rewriter/prop.rb.symbol-table-raw.exp
+++ b/test/testdata/rewriter/prop.rb.symbol-table-raw.exp
@@ -32,44 +32,44 @@ class <C <U <root>>> < <C <U Object>> ()
     method <C <U AdvancedODM>>#<U foreign=> (foreign, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=52:5 end=52:49}
       argument foreign<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=52:11 end=52:18}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>>#<U foreign_> (opts, <blk>) -> ForeignClass | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=52:5 end=52:49}
-      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=52:11 end=52:18}
+    method <C <U AdvancedODM>>#<U foreign_> (foreign, <blk>) -> ForeignClass | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=52:5 end=52:49}
+      argument foreign<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=52:11 end=52:18}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>>#<U foreign_!> (opts, <blk>) -> ForeignClass @ Loc {file=test/testdata/rewriter/prop.rb start=52:5 end=52:49}
-      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=52:11 end=52:18}
+    method <C <U AdvancedODM>>#<U foreign_!> (foreign, <blk>) -> ForeignClass @ Loc {file=test/testdata/rewriter/prop.rb start=52:5 end=52:49}
+      argument foreign<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=52:11 end=52:18}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
     method <C <U AdvancedODM>>#<U foreign_invalid> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=55:5 end=55:65}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
     method <C <U AdvancedODM>>#<U foreign_invalid=> (foreign_invalid, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=55:5 end=55:65}
       argument foreign_invalid<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=55:11 end=55:26}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>>#<U foreign_invalid_> (opts, <blk>) -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=55:5 end=55:65}
-      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=55:11 end=55:26}
+    method <C <U AdvancedODM>>#<U foreign_invalid_> (foreign_invalid, <blk>) -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=55:5 end=55:65}
+      argument foreign_invalid<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=55:11 end=55:26}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>>#<U foreign_invalid_!> (opts, <blk>) -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=55:5 end=55:65}
-      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=55:11 end=55:26}
+    method <C <U AdvancedODM>>#<U foreign_invalid_!> (foreign_invalid, <blk>) -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=55:5 end=55:65}
+      argument foreign_invalid<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=55:11 end=55:26}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
     method <C <U AdvancedODM>>#<U foreign_lazy> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=53:5 end=53:59}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
     method <C <U AdvancedODM>>#<U foreign_lazy=> (foreign_lazy, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=53:5 end=53:59}
       argument foreign_lazy<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=53:11 end=53:23}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>>#<U foreign_lazy_> (opts, <blk>) -> ForeignClass | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=53:5 end=53:59}
-      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=53:11 end=53:23}
+    method <C <U AdvancedODM>>#<U foreign_lazy_> (foreign_lazy, <blk>) -> ForeignClass | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=53:5 end=53:59}
+      argument foreign_lazy<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=53:11 end=53:23}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>>#<U foreign_lazy_!> (opts, <blk>) -> ForeignClass @ Loc {file=test/testdata/rewriter/prop.rb start=53:5 end=53:59}
-      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=53:11 end=53:23}
+    method <C <U AdvancedODM>>#<U foreign_lazy_!> (foreign_lazy, <blk>) -> ForeignClass @ Loc {file=test/testdata/rewriter/prop.rb start=53:5 end=53:59}
+      argument foreign_lazy<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=53:11 end=53:23}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
     method <C <U AdvancedODM>>#<U foreign_proc> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=54:5 end=54:61}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
     method <C <U AdvancedODM>>#<U foreign_proc=> (foreign_proc, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=54:5 end=54:61}
       argument foreign_proc<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=54:11 end=54:23}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>>#<U foreign_proc_> (opts, <blk>) -> ForeignClass | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=54:5 end=54:61}
-      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=54:11 end=54:23}
+    method <C <U AdvancedODM>>#<U foreign_proc_> (foreign_proc, <blk>) -> ForeignClass | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=54:5 end=54:61}
+      argument foreign_proc<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=54:11 end=54:23}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <C <U AdvancedODM>>#<U foreign_proc_!> (opts, <blk>) -> ForeignClass @ Loc {file=test/testdata/rewriter/prop.rb start=54:5 end=54:61}
-      argument opts<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=54:11 end=54:23}
+    method <C <U AdvancedODM>>#<U foreign_proc_!> (foreign_proc, <blk>) -> ForeignClass @ Loc {file=test/testdata/rewriter/prop.rb start=54:5 end=54:61}
+      argument foreign_proc<keyword, repeated> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=54:11 end=54:23}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
     method <C <U AdvancedODM>>#<U hash_of> (<blk>) -> AppliedType {       klass = <C <U Hash>>       targs = [         <C <U K>> = Symbol         <C <U V>> = String         <C <U Elem>> = TupleType {             0 = Symbol             1 = String           }       ]     } @ Loc {file=test/testdata/rewriter/prop.rb start=45:5 end=45:43}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}


### PR DESCRIPTION
### Motivation

When Sorbet is checking methods redefinitions, it errors on mismatching names for keyword arguments and `**kwargs`:

```rb
# typed: true
extend T::Sig

sig { params(arg: T.untyped).void}
def m1(arg); end

sig { params(argX: T.untyped).void}
def m1(argX); end # ok

sig { params(arg: T.untyped).void}
def m2(*arg); end

sig { params(argX: T.untyped).void}
def m2(*argX); end # ok

sig { params(block: T.untyped).void}
def m3(&block); end

sig { params(blockX: T.untyped).void}
def m3(&blockX); end # ok

sig { params(kwarg: T.untyped).void}
def m4(kwarg:); end

sig { params(kwarg1: T.untyped).void}
def m4(kwarg1:); end # error: Method `Object#m4` redefined with mismatched keyword argument name. Expected: `kwarg`, got: `kwarg1`

sig { params(kwargs: T.untyped).void}
def m5(**kwargs); end

sig { params(kwargs1: T.untyped).void}
def m5(**kwargs1); end # error: Method `Object#m5` redefined with mismatched keyword argument name. Expected: `kwargs`, got: `kwargs1`
```

While this verification makes sense for keyword arguments (they should be the same in all the definitions of the same methods), I'm not sure it applies to `**kwargs`.

Consider the following case:

```rb
# sorbet/rbi/gems/foo.rbi (generated)

class View
  sig { params(kwargs: T.untyped).void }
  def render(**kwargs); end
end
```

```rb
# sorbet/rbi/shims/foo.rbi (manually written shim)

class View
  sig { params(options: T::Hash[Symbol, String]).void }
  def render(**options); end
end
```

The renaming in the shim file should be allowed as it still is compatible with the generated definition for `View#render`.

### Implementation

Added a possible implementation for this change to see what else would break.

### Test plan

See included automated tests.
