### PR TITLE
Support covariant cases with `T.class_of` and simple types in the runtime checker

### DIFF
--- a/gems/sorbet-runtime/lib/types/types/class_of.rb
+++ b/gems/sorbet-runtime/lib/types/types/class_of.rb
@@ -25,6 +25,8 @@ module T::Types
       case other
       when ClassOf
         @type <= other.type
+      when Simple
+        @type.is_a?(other.raw_type)
       else
         false
       end

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -1318,6 +1318,21 @@ module Opus::Types::Test
         it "returns false for a superclass" do
           assert_equal(false, subtype?(T.class_of(Base), T.class_of(Sub)))
         end
+
+        it "returns true for a simple superclass" do
+          assert_equal(true, subtype?(T.class_of(Base), Module))
+          assert_equal(true, subtype?(T.class_of(Sub), Module))
+
+          custom_module = Class.new(Module)
+          mod = custom_module.new
+
+          assert_equal(true, subtype?(T.class_of(mod), Module))
+          assert_equal(true, subtype?(T.class_of(mod), custom_module))
+        end
+
+        it "returns false for a simple unrelated class" do
+          assert_equal(false, subtype?(T.class_of(Base), Mixin1))
+        end
       end
 
       describe 'tuples' do


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Added a `subtype_of_single?` check for when `other` is a simple type which the class-of type is an instance of.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
The following code snippet is a valid and covariant way to override a method by returning a subtype of the super method. Moreover, the static checker [flags no errors](https://sorbet.run/#%23%20typed%3A%20true%0Arequire%20%22sorbet-runtime%22%0A%0Aclass%20Base%0A%20%20extend%20T%3A%3ASig%0A%0A%20%20sig%20%7B%20returns%28Module%29%20%7D%0A%20%20def%20foo%0A%20%20%20%20Module.new%0A%20%20end%0Aend%0A%0Aclass%20Sub%20%3C%20Base%0A%20%20extend%20T%3A%3ASig%0A%0A%20%20sig%20%7B%20override.returns%28T.class_of%28String%29%29%20%7D%0A%20%20def%20foo%0A%20%20%20%20String%0A%20%20end%0Aend%0A%0ASub.new.foo%0A) on this code.

```ruby
# typed: true
require "sorbet-runtime"

class Base
  extend T::Sig

  sig { returns(Module) }
  def foo
    Module.new
  end
end

class Sub < Base
  extend T::Sig

  sig { override.returns(T.class_of(String)) }
  def foo
    String
  end
end

Sub.new.foo
```

The runtime checker, though, is not happy and fails with the following error message:
```
signature_validation.rb:204:in `validate_override_types': Incompatible return type in signature for override of method `foo`: (RuntimeError)
* Base: `Module` (in Base at foo.rb:8)
* Override: `T.class_of(String)` (in Sub at foo.rb:18)
(The types must be covariant.)
```

`T.class_of(String)` is the type that `String` is an instance of, and because `String.is_a?(Module)`, String is also an instance of `Module` as well. Thus, this check should be passing in the runtime checker too.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
