### PR TITLE
Fix package-private enforcement for intersection types

### DIFF
--- a/core/Types.h
+++ b/core/Types.h
@@ -175,8 +175,6 @@ public:
     /** Unwrap SelfTypeParam instances that belong to the given owner, to a bare LambdaParam */
     static TypePtr unwrapSelfTypeParam(Context ctx, const TypePtr &ty);
 
-    static core::ClassOrModuleRef getClassForAppliedOrClassType(const core::TypePtr &ty);
-
     // Given a type, return a SymbolRef for the Ruby class that has that type, or no symbol if no such class exists.
     // This is an internal method for implementing intrinsics. In the future we should make all updateKnowledge methods
     // be intrinsics so that this can become an anonymous helper function in calls.cc.

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -795,18 +795,6 @@ TypePtr Types::unwrapSelfTypeParam(Context ctx, const TypePtr &type) {
     return ret;
 }
 
-core::ClassOrModuleRef Types::getClassForAppliedOrClassType(const TypePtr &ty) {
-    if (isa_type<ClassType>(ty)) {
-        auto s = cast_type_nonnull<ClassType>(ty);
-        return s.symbol;
-    } else if (isa_type<AppliedType>(ty)) {
-        auto at = cast_type_nonnull<AppliedType>(ty);
-        return at.klass;
-    }
-
-    return core::Symbols::noClassOrModule();
-}
-
 core::ClassOrModuleRef Types::getRepresentedClass(const GlobalState &gs, const TypePtr &ty) {
     if (!ty.derivesFrom(gs, core::Symbols::Module())) {
         return core::Symbols::noClassOrModule();

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1014,7 +1014,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                         core::ClassOrModuleRef klass = it->main.method.data(ctx)->owner;
                         if (klass.exists()) {
                             const auto &curPkg = ctx.state.packageDB().getPackageForFile(ctx, ctx.file);
-                            if (curPkg.mangledName() != core::NameRef::noName() && !curPkg.ownsSymbol(ctx, klass)) {
+                            if (curPkg.exists() && !curPkg.ownsSymbol(ctx, klass)) {
                                 if (auto e = ctx.beginError(bind.loc, core::errors::Infer::PackagePrivateMethod)) {
                                     e.setHeader("Non-package-private call to package-private method `{}` on `{}`",
                                                 it->main.method.data(ctx)->name.show(ctx), it->main.receiver.show(ctx));

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1011,7 +1011,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                     }
 
                     if (it->main.method.exists() && it->main.method.data(ctx)->flags.isPackagePrivate) {
-                        core::ClassOrModuleRef klass = core::Types::getClassForAppliedOrClassType(it->main.receiver);
+                        core::ClassOrModuleRef klass = it->main.method.data(ctx)->owner;
                         if (klass.exists()) {
                             const auto &curPkg = ctx.state.packageDB().getPackageForFile(ctx, ctx.file);
                             if (curPkg.mangledName() != core::NameRef::noName() && !curPkg.ownsSymbol(ctx, klass)) {

--- a/rbi/core/module.rbi
+++ b/rbi/core/module.rbi
@@ -1333,41 +1333,6 @@ class Module < Object
   end
   def private_class_method(*arg0); end
 
-  # Makes a method package-private.
-  #
-  # [`String`](https://docs.ruby-lang.org/en/2.7.0/String.html) arguments are
-  # converted to symbols.
-  #
-  # class A
-  #   package_private def a(); end
-  # end
-  #
-  sig do
-    params(
-        arg0: T.any(Symbol, String),
-    )
-    .returns(T.self_type)
-  end
-  def package_private(*arg0); end
-
-  # Makes class methods package-private.
-  #
-  # [`String`](https://docs.ruby-lang.org/en/2.7.0/String.html) arguments are
-  # converted to symbols.
-  #
-  # ```ruby
-  # class SimpleSingleton
-  #   package_private_class_method :new
-  # end
-  # ```
-  sig do
-    params(
-        arg0: T.any(Symbol, String),
-    )
-    .returns(T.self_type)
-  end
-  def package_private_class_method(*arg0); end
-
   # Makes a list of existing constants private.
   sig do
     params(

--- a/test/cli/autocorrect-helpers/autocorrect-helpers.out
+++ b/test/cli/autocorrect-helpers/autocorrect-helpers.out
@@ -87,8 +87,8 @@ autocorrect-helpers.rb:30: Method `mixes_in_class_methods` does not exist on `T.
     30 |  mixes_in_class_methods(S1)
         ^
   Did you mean:
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/module.rbi#L1524: `Module#public_class_method`
-    1524 |  def public_class_method(*arg0); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/module.rbi#L1489: `Module#public_class_method`
+    1489 |  def public_class_method(*arg0); end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Errors: 9
 

--- a/test/cli/package-private/a/a.rbi
+++ b/test/cli/package-private/a/a.rbi
@@ -1,0 +1,19 @@
+# typed: strict
+
+class ::Module < Object
+  sig do
+    params(
+        arg0: T.any(Symbol, String),
+    )
+    .returns(T.self_type)
+  end
+  def package_private(*arg0); end
+
+  sig do
+    params(
+        arg0: T.any(Symbol, String),
+    )
+    .returns(T.self_type)
+  end
+  def package_private_class_method(*arg0); end
+end

--- a/test/cli/package-private/b/b.rb
+++ b/test/cli/package-private/b/b.rb
@@ -11,5 +11,12 @@ class B
     f = A.new
     f.foo
   end
+
+  module C; end
+
+  sig {params(c_and_a: T.all(C, A)).void}
+  def self.qux(c_and_a)
+    c_and_a.foo
+  end
 end
 

--- a/test/cli/package-private/package-private.out
+++ b/test/cli/package-private/package-private.out
@@ -1,25 +1,25 @@
-b/b.rb:8: Non-package-private call to package-private method `foo` on `T.class_of(A)` https://srb.help/7036
+b/b.rb:8: Method `foo` on `T.class_of(A)` is package-private and cannot be called from package `B` https://srb.help/7036
      8 |    A.foo
             ^^^^^
     a/a.rb:7: Defined in `T.class_of(A)` here
      7 |  package_private_class_method def self.foo
                                        ^^^^^^^^^^^^
 
-b/b.rb:9: Non-package-private call to package-private method `foo` on `A` https://srb.help/7036
+b/b.rb:9: Method `foo` on `A` is package-private and cannot be called from package `B` https://srb.help/7036
      9 |    A.new.foo
             ^^^^^^^^^
     a/a.rb:12: Defined in `A` here
     12 |  package_private def foo
                           ^^^^^^^
 
-b/b.rb:12: Non-package-private call to package-private method `foo` on `A` https://srb.help/7036
+b/b.rb:12: Method `foo` on `A` is package-private and cannot be called from package `B` https://srb.help/7036
     12 |    f.foo
             ^^^^^
     a/a.rb:12: Defined in `A` here
     12 |  package_private def foo
                           ^^^^^^^
 
-b/b.rb:19: Non-package-private call to package-private method `foo` on `T.all(B::C, A)` https://srb.help/7036
+b/b.rb:19: Method `foo` on `A` is package-private and cannot be called from package `B` https://srb.help/7036
     19 |    c_and_a.foo
             ^^^^^^^^^^^
     a/a.rb:12: Defined in `A` here

--- a/test/cli/package-private/package-private.out
+++ b/test/cli/package-private/package-private.out
@@ -18,4 +18,11 @@ b/b.rb:12: Non-package-private call to package-private method `foo` on `A` https
     a/a.rb:12: Defined in `A` here
     12 |  package_private def foo
                           ^^^^^^^
-Errors: 3
+
+b/b.rb:19: Non-package-private call to package-private method `foo` on `T.all(B::C, A)` https://srb.help/7036
+    19 |    c_and_a.foo
+            ^^^^^^^^^^^
+    a/a.rb:12: Defined in `A` here
+    12 |  package_private def foo
+                          ^^^^^^^
+Errors: 4


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

In #5127 , I added support for declaring methods package-private. However, there was a bug in my code -- it did not handle intersection types correctly, as it only looked at `AppliedType` or `ClassType` when checking the type of the receiver.

There is a simpler way to find the owning class ref, by looking method owner of the method, and this will handle all types. Making the change in order to fix the bug.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Package-private enforcement.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

cc @jez 