### PR TITLE
Contextual error messages

### DIFF
--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -1565,6 +1565,8 @@ int maybe_inject_tNL_impl(parser::symbol_type &yyla, ruby_parser::typedruby27 &d
                       args->emplace_back(driver.build.associate(self, nullptr, $5, nullptr));
                       args->concat($6);
                       $$ = args;
+                      driver.diagnostics.pop_back();
+                      driver.diagnostics.emplace_back(dlevel::ERROR, dclass::MissingToken, diagnostic::range(@3.end, @4.begin), "\",\"");
                     }
                 | block_arg
                     {
@@ -1636,6 +1638,8 @@ int maybe_inject_tNL_impl(parser::symbol_type &yyla, ruby_parser::typedruby27 &d
                       auto &list = $1;
                       list->emplace_back(driver.build.error_node(self, @2.end, @3.end));
                       $$ = $1;
+                      driver.diagnostics.pop_back();
+                      driver.diagnostics.emplace_back(dlevel::ERROR, dclass::UnexpectedToken, diagnostic::range(@2.begin, @2.end), "\",\"");
                     }
                 | args tCOMMA tSTAR arg_value
                     {
@@ -3572,6 +3576,8 @@ f_opt_paren_args: f_paren_args
                 | f_arg tCOMMA error
                     {
                       $$ = $1;
+                      driver.diagnostics.pop_back();
+                      driver.diagnostics.emplace_back(dlevel::ERROR, dclass::UnexpectedToken, diagnostic::range(@2.begin, @2.end), "\",\"");
                     }
 
          f_label: tLABEL
@@ -3726,6 +3732,8 @@ f_opt_paren_args: f_paren_args
                 | tCOMMA error
                     {
                       $$ = driver.alloc.node_list();
+                      driver.diagnostics.pop_back();
+                      driver.diagnostics.emplace_back(dlevel::ERROR, dclass::UnexpectedToken, diagnostic::range(@1.begin, @1.end), "\",\"");
                     }
                 |
                     {
@@ -3766,6 +3774,8 @@ f_opt_paren_args: f_paren_args
                 | assocs tCOMMA error
                     {
                       $$ = $1;
+                      driver.diagnostics.pop_back();
+                      driver.diagnostics.emplace_back(dlevel::ERROR, dclass::UnexpectedToken, diagnostic::range(@2.begin, @2.end), "\",\"");
                     }
                 | assocs tCOMMA tIDENTIFIER error
                     {
@@ -3774,6 +3784,8 @@ f_opt_paren_args: f_paren_args
                       auto err = driver.build.call_method(self, nullptr, nullptr, $3, nullptr, nullptr, nullptr);
                       list->emplace_back(driver.build.pair_keyword(self, $3, err));
                       $$ = list;
+                      driver.diagnostics.pop_back();
+                      driver.diagnostics.emplace_back(dlevel::ERROR, dclass::PositionalAfterKeyword, diagnostic::range(@3.begin, @3.end), $3->asString());
                     }
                 // There's quite a bit going on in these next two. What we'd really like is to do something like
                 //     assoc error assoc
@@ -3796,6 +3808,8 @@ f_opt_paren_args: f_paren_args
                       auto result = driver.alloc.node_list(driver.build.assoc_error(self, $1, $2));
                       result->emplace_back($4);
                       $$ = result;
+                      driver.diagnostics.pop_back();
+                      driver.diagnostics.emplace_back(dlevel::ERROR, dclass::MissingToken, diagnostic::range(@2.end, @3.begin), "\",\"");
                     }
                 | assocs tCOMMA tLABEL fcall error assoc
                     {
@@ -3803,6 +3817,8 @@ f_opt_paren_args: f_paren_args
                       list->emplace_back(driver.build.assoc_error(self, $3, $4));
                       list->emplace_back($6);
                       $$ = list;
+                      driver.diagnostics.pop_back();
+                      driver.diagnostics.emplace_back(dlevel::ERROR, dclass::MissingToken, diagnostic::range(@4.end, @5.begin), "\",\"");
                     }
 
            assoc: arg_value tASSOC arg_value

--- a/parser/parser/codegen/generate_diagnostics.cc
+++ b/parser/parser/codegen/generate_diagnostics.cc
@@ -38,6 +38,7 @@ tuple<string, string> MESSAGES[] = {
     {"InvalidAssignment", "cannot assign to a keyword"},
     {"ModuleNameConst", "class or module name must be a constant literal"},
     {"UnexpectedToken", "unexpected token {}"},
+    {"MissingToken", "missing token {}"},
     {"ArgumentConst", "formal argument cannot be a constant"},
     {"ArgumentIvar", "formal argument cannot be an instance variable"},
     {"ArgumentGvar", "formal argument cannot be a global variable"},
@@ -66,6 +67,7 @@ tuple<string, string> MESSAGES[] = {
     {"PatternLVarUndefined", "no such local variable: {}"},
     {"PatternDuplicateVariable", "duplicate variable name {}"},
     {"PatternDuplicateKey", "duplicate hash pattern key {}"},
+    {"PositionalAfterKeyword", "positional arg \\\"{}\\\" after keyword arg"},
 
     // Parser warnings
     {"UselessElse", "else without rescue is useless"},

--- a/test/testdata/lsp/completion/bad_arguments.rb
+++ b/test/testdata/lsp/completion/bad_arguments.rb
@@ -16,7 +16,7 @@ def various_bad_commas_in_send(a, b, x, y)
   #         ^ completion: alias, and, a, ...
   #          ^ completion: alias, and, a, ...
   #         ^ error: Method `a` does not exist
-  #          ^ error: unexpected token ")"
+  #         ^ error: positional arg "a" after keyword arg
 
   foo(a, , y: y) # error: unexpected token ","
   #      ^ completion: a, b, x, y, ...
@@ -31,7 +31,7 @@ def various_bad_commas_in_send(a, b, x, y)
   foo(a, x y: y)
   #       ^ completion: x, ...
   #      ^ error: Method `x` does not exist
-  #        ^^ error: unexpected token tLABEL
+  #       ^ error: missing token ","
 
   # Inserting new keyword arg into list
   foo(a, x: y: y) # error: unexpected token tLABEL
@@ -49,9 +49,9 @@ def various_bad_commas_in_send(a, b, x, y)
   foo(x: x y: y)
   #       ^ completion: x, ...
   #      ^ error: Method `x` does not exist
-  #        ^^ error: unexpected token tLABEL
+  #       ^ error: missing token ","
   foo(a: a, x: x y: y)
   #             ^ completion: x, ...
   #            ^ error: Method `x` does not exist
-  #              ^^ error: unexpected token tLABEL
+  #             ^ error: missing token ","
 end

--- a/test/testdata/parser/kwnil_errors.rb
+++ b/test/testdata/parser/kwnil_errors.rb
@@ -1,7 +1,7 @@
 # typed: true
 
-def f1(**nil, **nil); end # error: unexpected token "**"
-def f2(*args, **kwargs, **nil); end # error: unexpected token "**"
+def f1(**nil, **nil); end # error: unexpected token ","
+def f2(*args, **kwargs, **nil); end # error: unexpected token ","
 def f3(*args, a:, **nil); end # error: unexpected token "nil"
 def f4(a:, **nil); end # error: unexpected token "nil"
 def f5(**nil: 10); end # error: unexpected token tLABEL

--- a/test/testdata/parser/method_def_trailing_comma.rb
+++ b/test/testdata/parser/method_def_trailing_comma.rb
@@ -1,10 +1,10 @@
 # typed: false
 
-def comma_after_pos_args(x, y,) # error: unexpected token ")"
+def comma_after_pos_args(x, y,) # error: unexpected token ","
 end
 
-def comma_after_kwargs(x:, y:,) # error: unexpected token ")"
+def comma_after_kwargs(x:, y:,) # error: unexpected token ","
 end
 
-def comma_after_all_kwargs(a, b, x:, y:,) # error: unexpected token ")"
+def comma_after_all_kwargs(a, b, x:, y:,) # error: unexpected token ","
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

@froydnj suggested that we could do this in a code review comment, and it
sounded like a good idea.

Note: we have to `pop` the previous error message, because bison will always call our `parser::error` function before even shifting the `error` token, let alone trying to run one of our production rules that uses the `error` token.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.