### PR TITLE
Use overloading for `show()`

### DIFF
--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -133,7 +133,10 @@ public:
     std::string_view showKind(const GlobalState &gs) const;
     std::string showFullName(const GlobalState &gs) const;
     std::string toStringFullName(const GlobalState &gs) const;
-    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
+    std::string show(const GlobalState &gs) const {
+        return show(gs, {});
+    };
+    std::string show(const GlobalState &gs, ShowOptions options) const;
 };
 CheckSize(ClassOrModuleRef, 4, 4);
 
@@ -177,7 +180,10 @@ public:
     std::string_view showKind(const GlobalState &gs) const;
     std::string showFullName(const GlobalState &gs) const;
     std::string toStringFullName(const GlobalState &gs) const;
-    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
+    std::string show(const GlobalState &gs) const {
+        return show(gs, {});
+    };
+    std::string show(const GlobalState &gs, ShowOptions options) const;
 
     bool operator==(const MethodRef &rhs) const;
 
@@ -219,7 +225,10 @@ public:
     std::string_view showKind(const GlobalState &gs) const;
     std::string showFullName(const GlobalState &gs) const;
     std::string toStringFullName(const GlobalState &gs) const;
-    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
+    std::string show(const GlobalState &gs) const {
+        return show(gs, {});
+    };
+    std::string show(const GlobalState &gs, ShowOptions options) const;
 
     bool operator==(const FieldRef &rhs) const;
 
@@ -260,7 +269,10 @@ public:
     std::string_view showKind(const GlobalState &gs) const;
     std::string showFullName(const GlobalState &gs) const;
     std::string toStringFullName(const GlobalState &gs) const;
-    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
+    std::string show(const GlobalState &gs) const {
+        return show(gs, {});
+    };
+    std::string show(const GlobalState &gs, ShowOptions options) const;
 
     bool operator==(const TypeMemberRef &rhs) const;
 
@@ -302,7 +314,10 @@ public:
     std::string_view showKind(const GlobalState &gs) const;
     std::string showFullName(const GlobalState &gs) const;
     std::string toStringFullName(const GlobalState &gs) const;
-    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
+    std::string show(const GlobalState &gs) const {
+        return show(gs, {});
+    };
+    std::string show(const GlobalState &gs, ShowOptions options) const;
 
     bool operator==(const TypeArgumentRef &rhs) const;
 
@@ -493,7 +508,10 @@ public:
         return toStringWithOptions(gs, 0, showFull, showRaw);
     }
     // Renders the full name of this Symbol in a form suitable for user display.
-    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
+    std::string show(const GlobalState &gs) const {
+        return show(gs, {});
+    };
+    std::string show(const GlobalState &gs, ShowOptions options) const;
 };
 CheckSize(SymbolRef, 4, 4);
 

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -313,7 +313,10 @@ public:
     }
 
     // User visible type. Should exactly match what the user can write.
-    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
+    std::string show(const GlobalState &gs) const {
+        return show(gs, {});
+    };
+    std::string show(const GlobalState &gs, ShowOptions options) const;
     // Like show, but can include extra info. Does not necessarily match what the user can type.
     std::string showWithMoreInfo(const GlobalState &gs) const;
 

--- a/core/Types.h
+++ b/core/Types.h
@@ -336,7 +336,10 @@ public:
     ClassType(ClassOrModuleRef symbol);
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
+    std::string show(const GlobalState &gs) const {
+        return show(gs, {});
+    };
+    std::string show(const GlobalState &gs, ShowOptions options) const;
     uint32_t hash(const GlobalState &gs) const;
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
 
@@ -379,7 +382,10 @@ public:
 
     LambdaParam(TypeMemberRef definition, TypePtr lower, TypePtr upper);
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
+    std::string show(const GlobalState &gs) const {
+        return show(gs, {});
+    };
+    std::string show(const GlobalState &gs, ShowOptions options) const;
     uint32_t hash(const GlobalState &gs) const;
 
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const;
@@ -397,7 +403,10 @@ public:
 
     SelfTypeParam(const SymbolRef definition);
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
+    std::string show(const GlobalState &gs) const {
+        return show(gs, {});
+    };
+    std::string show(const GlobalState &gs, ShowOptions options) const;
     uint32_t hash(const GlobalState &gs) const;
 
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const;
@@ -420,7 +429,10 @@ TYPE_INLINED(AliasType) final {
 public:
     AliasType(SymbolRef other);
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
+    std::string show(const GlobalState &gs) const {
+        return show(gs, {});
+    };
+    std::string show(const GlobalState &gs, ShowOptions options) const;
     uint32_t hash(const GlobalState &gs) const;
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const;
 
@@ -450,7 +462,10 @@ TYPE_INLINED(SelfType) final {
 public:
     SelfType();
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
+    std::string show(const GlobalState &gs) const {
+        return show(gs, {});
+    };
+    std::string show(const GlobalState &gs, ShowOptions options) const;
     std::string showValue(const GlobalState &gs) const;
     uint32_t hash(const GlobalState &gs) const;
 
@@ -493,7 +508,10 @@ public:
     core::NameRef unsafeAsName() const;
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
+    std::string show(const GlobalState &gs) const {
+        return show(gs, {});
+    };
+    std::string show(const GlobalState &gs, ShowOptions options) const;
     std::string showValue(const GlobalState &gs) const;
     uint32_t hash(const GlobalState &gs) const;
 
@@ -563,7 +581,10 @@ public:
     TypeArgumentRef sym;
     TypeVar(TypeArgumentRef sym);
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
+    std::string show(const GlobalState &gs) const {
+        return show(gs, {});
+    };
+    std::string show(const GlobalState &gs, ShowOptions options) const;
     uint32_t hash(const GlobalState &gs) const;
     void _sanityCheck(const GlobalState &gs) const;
 
@@ -580,7 +601,10 @@ public:
     TypePtr right;
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
+    std::string show(const GlobalState &gs) const {
+        return show(gs, {});
+    };
+    std::string show(const GlobalState &gs, ShowOptions options) const;
     uint32_t hash(const GlobalState &gs) const;
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
     TypePtr getCallArguments(const GlobalState &gs, NameRef name) const;
@@ -631,7 +655,10 @@ public:
     TypePtr right;
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
+    std::string show(const GlobalState &gs) const {
+        return show(gs, {});
+    };
+    std::string show(const GlobalState &gs, ShowOptions options) const;
     uint32_t hash(const GlobalState &gs) const;
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
 
@@ -674,7 +701,10 @@ public:
     ShapeType(std::vector<TypePtr> keys, std::vector<TypePtr> values);
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
+    std::string show(const GlobalState &gs) const {
+        return show(gs, {});
+    };
+    std::string show(const GlobalState &gs, ShowOptions options) const;
     uint32_t hash(const GlobalState &gs) const;
     std::string showWithMoreInfo(const GlobalState &gs) const;
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
@@ -698,7 +728,10 @@ public:
     TupleType(std::vector<TypePtr> elements);
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
+    std::string show(const GlobalState &gs) const {
+        return show(gs, {});
+    };
+    std::string show(const GlobalState &gs, ShowOptions options) const;
     std::string showWithMoreInfo(const GlobalState &gs) const;
     uint32_t hash(const GlobalState &gs) const;
     void _sanityCheck(const GlobalState &gs) const;
@@ -722,7 +755,10 @@ public:
     AppliedType(ClassOrModuleRef klass, std::vector<TypePtr> targs);
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
+    std::string show(const GlobalState &gs) const {
+        return show(gs, {});
+    };
+    std::string show(const GlobalState &gs, ShowOptions options) const;
     uint32_t hash(const GlobalState &gs) const;
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
     void _sanityCheck(const GlobalState &gs) const;
@@ -752,7 +788,10 @@ public:
     MetaType(const TypePtr &wrapped);
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
+    std::string show(const GlobalState &gs) const {
+        return show(gs, {});
+    };
+    std::string show(const GlobalState &gs, ShowOptions options) const;
     uint32_t hash(const GlobalState &gs) const;
 
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const;
@@ -918,7 +957,10 @@ public:
     UnresolvedClassType(SymbolRef scope, std::vector<core::NameRef> names)
         : ClassType(core::Symbols::untyped()), scope(scope), names(std::move(names)){};
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
+    std::string show(const GlobalState &gs) const {
+        return show(gs, {});
+    };
+    std::string show(const GlobalState &gs, ShowOptions options) const;
     uint32_t hash(const GlobalState &gs) const;
 };
 
@@ -929,7 +971,10 @@ public:
     UnresolvedAppliedType(ClassOrModuleRef klass, std::vector<TypePtr> targs)
         : ClassType(core::Symbols::untyped()), klass(klass), targs(std::move(targs)){};
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
-    std::string show(const GlobalState &gs, ShowOptions options = ShowOptions{}) const;
+    std::string show(const GlobalState &gs) const {
+        return show(gs, {});
+    };
+    std::string show(const GlobalState &gs, ShowOptions options) const;
     uint32_t hash(const GlobalState &gs) const;
 };
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

cc @elliottt

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This makes it easier to use `.show` in the debugger. LLDB doesn't know
about default arguments in header files, so it thinks that two args are
required. Since `show` is so commonly used for debugging things, it's
nice to keep it short and not introduce extra "required" args.

Overloading makes it work, because it actually shows up as two symbols
in the object file.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a. tried in lldb