### PR TITLE
Add error case for `if ... do; end`

### DIFF
--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -1828,7 +1828,7 @@ int maybe_inject_tNL_impl(parser::symbol_type &yyla, ruby_parser::typedruby27 &d
                     {
                       // TODO(jez) If we had proper Sorbet diagnostics here, we could have a "did you mean"
                       // error line that suggested changing `if` to `it`
-                      driver.diagnostics.emplace_back(dlevel::ERROR, dclass::UnexpectedToken, diagnostic::range(@3.begin, @3.end), "do");
+                      driver.diagnostics.emplace_back(dlevel::ERROR, dclass::UnexpectedToken, diagnostic::range(@3.begin, @3.end), "\"do\"");
                       auto &else_ = $5;
                       $$ = driver.build.condition(self, $1, $2, $3, $4,
                         else_ ? else_->tok : nullptr,

--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -1824,6 +1824,16 @@ int maybe_inject_tNL_impl(parser::symbol_type &yyla, ruby_parser::typedruby27 &d
                         else_ ? else_->tok : nullptr,
                         else_ ? else_->nod : nullptr, $6);
                     }
+                | kIF strings kDO compstmt if_tail kEND
+                    {
+                      // TODO(jez) If we had proper Sorbet diagnostics here, we could have a "did you mean"
+                      // error line that suggested changing `if` to `it`
+                      driver.diagnostics.emplace_back(dlevel::ERROR, dclass::UnexpectedToken, diagnostic::range(@3.begin, @3.end), "do");
+                      auto &else_ = $5;
+                      $$ = driver.build.condition(self, $1, $2, $3, $4,
+                        else_ ? else_->tok : nullptr,
+                        else_ ? else_->nod : nullptr, $6);
+                    }
                 | kUNLESS expr_value then compstmt opt_else kEND
                     {
                       auto &else_ = $5;

--- a/test/testdata/parser/error_recovery_if_do.rb
+++ b/test/testdata/parser/error_recovery_if_do.rb
@@ -2,5 +2,6 @@
 
 class A
   if 'thing' do
+  #          ^^ error: unexpected token "do"
   end
 end

--- a/test/testdata/parser/error_recovery_if_do.rb
+++ b/test/testdata/parser/error_recovery_if_do.rb
@@ -1,0 +1,6 @@
+# typed: true
+
+class A
+  if 'thing' do
+  end
+end

--- a/test/testdata/parser/error_recovery_if_do.rb.parse-tree-whitequark.exp
+++ b/test/testdata/parser/error_recovery_if_do.rb.parse-tree-whitequark.exp
@@ -1,2 +1,4 @@
 s(:class,
-  s(:const, nil, :A), nil, nil)
+  s(:const, nil, :A), nil,
+  s(:if,
+    s(:str, "thing"), nil, nil))

--- a/test/testdata/parser/error_recovery_if_do.rb.parse-tree-whitequark.exp
+++ b/test/testdata/parser/error_recovery_if_do.rb.parse-tree-whitequark.exp
@@ -1,0 +1,2 @@
+s(:class,
+  s(:const, nil, :A), nil, nil)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is a common typo people make. Doesn't make sense to delete the whole `if`
when a better outcome is to suggest that they delete the `do` keyword or change
the `if` to `it`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

tests show before/after