### PR TITLE
Fix call to pipeline::index in fuzz_dash_e

### DIFF
--- a/test/fuzz/fuzz_dash_e.cc
+++ b/test/fuzz/fuzz_dash_e.cc
@@ -70,7 +70,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
         file.data(*gs).strictLevel = core::StrictLevel::True;
     }
 
-    indexed = realmain::pipeline::index(gs, inputFiles, *opts, *workers, kvstore);
+    indexed = realmain::pipeline::index(*gs, inputFiles, *opts, *workers, kvstore);
     indexed = move(realmain::pipeline::resolve(gs, move(indexed), *opts, *workers).result());
     realmain::pipeline::typecheck(gs, move(indexed), *opts, *workers);
     return 0;


### PR DESCRIPTION
Fixes a tiny bit of bitrot in `fuzz_dash_e.cc`. (The signature of `pipeline::index` changed at some point in the past, and since we don't run `fuzz_dash_e` in CI I guess we didn't catch it.)

### Motivation
Make the fuzzer work.

### Test plan
Ran `tools/scripts/fuzz.sh fuzz_dash_e` and made sure the fuzzer built and ran correctly after the change.