### PR TITLE
Stripe packages: missing export_for_test error and correction

### DIFF
--- a/resolver/SuggestPackage.cc
+++ b/resolver/SuggestPackage.cc
@@ -61,7 +61,8 @@ public:
     }
 
     void addMissingExportSuggestions(core::ErrorBuilder &e, core::packages::PackageInfo::MissingExportMatch match) {
-        if (match.srcPkg == currentPkg.mangledName() && core::packages::PackageDB::isTestFile(ctx, ctx.file.data(ctx))) {
+        if (match.srcPkg == currentPkg.mangledName() &&
+            core::packages::PackageDB::isTestFile(ctx, ctx.file.data(ctx))) {
             addMissingExportForTestSuggestion(e, match);
             return;
         }
@@ -76,23 +77,24 @@ public:
 
         maybeAddErrorHint(e);
 
-        if (auto autocorrect = srcPkg.addExport(ctx, match.symbol, false)) {
+        if (auto autocorrect = srcPkg.addExport(ctx, match.symbol, /* isPrivateTestExport */ false)) {
             e.addAutocorrect(std::move(*autocorrect));
         }
     }
 
-    void addMissingExportForTestSuggestion(core::ErrorBuilder &e, core::packages::PackageInfo::MissingExportMatch match) {
+    void addMissingExportForTestSuggestion(core::ErrorBuilder &e,
+                                           core::packages::PackageInfo::MissingExportMatch match) {
         vector<core::ErrorLine> lines;
         auto &srcPkg = db().getPackageInfo(match.srcPkg);
-        // lines.emplace_back(core::ErrorLine::from(srcPkg.definitionLoc(), "Do you need to `{} {}` in package `{}`?",
-        lines.emplace_back(core::ErrorLine::from(srcPkg.definitionLoc(), "Names must be  TODO TODO Do you need to `{} {}` in package `{}`?",
-                                                 core::Names::export_for_test().show(ctx), match.symbol.show(ctx),
-                                                 formatPackageName(srcPkg)));
+        lines.emplace_back(core::ErrorLine::from(
+            srcPkg.definitionLoc(),
+            "To expose this name to a package's own tests it must be exported. Do you need to `{} {}` in this package?",
+            core::Names::export_for_test().show(ctx), match.symbol.show(ctx)));
         lines.emplace_back(
             core::ErrorLine::from(match.symbol.loc(ctx), "Constant `{}` is defined here:", match.symbol.show(ctx)));
         e.addErrorSection(core::ErrorSection(lines));
 
-        if (auto autocorrect = srcPkg.addExport(ctx, match.symbol, true)) {
+        if (auto autocorrect = srcPkg.addExport(ctx, match.symbol, /* isPrivateTestExport */ true)) {
             e.addAutocorrect(std::move(*autocorrect));
         }
         maybeAddErrorHint(e);

--- a/test/cli/package-error-missing-export/package-error-missing-export.out
+++ b/test/cli/package-error-missing-export/package-error-missing-export.out
@@ -15,8 +15,6 @@ foo_class.rb:10: Unable to resolve constant `NotExported` https://srb.help/5002
   export Foo::Bar::OtherPackage::NotExported`
      4 |  export Foo::Bar::OtherPackage::OtherClass
                                                    ^
-  Note:
-    Try running generate-packages.sh
 
 foo_class.rb:11: Unable to resolve constant `NotExported` https://srb.help/5002
     11 |      Bar::OtherPackage::NotExported
@@ -35,8 +33,6 @@ foo_class.rb:11: Unable to resolve constant `NotExported` https://srb.help/5002
   export Foo::Bar::OtherPackage::NotExported`
      4 |  export Foo::Bar::OtherPackage::OtherClass
                                                    ^
-  Note:
-    Try running generate-packages.sh
 
 foo_class.rb:12: Unable to resolve constant `Inner` https://srb.help/5002
     12 |      Foo::Bar::OtherPackage::Inner::AlsoNotExported
@@ -55,8 +51,6 @@ foo_class.rb:12: Unable to resolve constant `Inner` https://srb.help/5002
   export Foo::Bar::OtherPackage::Inner`
      4 |  export Foo::Bar::OtherPackage::OtherClass
                                                    ^
-  Note:
-    Try running generate-packages.sh
 
 foo_class.rb:13: Unable to resolve constant `Inner` https://srb.help/5002
     13 |      Bar::OtherPackage::Inner::AlsoNotExported
@@ -75,6 +69,4 @@ foo_class.rb:13: Unable to resolve constant `Inner` https://srb.help/5002
   export Foo::Bar::OtherPackage::Inner`
      4 |  export Foo::Bar::OtherPackage::OtherClass
                                                    ^
-  Note:
-    Try running generate-packages.sh
 Errors: 4

--- a/test/cli/package-error-no-export-for-test/__package.rb
+++ b/test/cli/package-error-no-export-for-test/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class Foo < PackageSpec
+  export Foo::Thing
+end

--- a/test/cli/package-error-no-export-for-test/foo_bar/__package.rb
+++ b/test/cli/package-error-no-export-for-test/foo_bar/__package.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+class Foo::Bar < PackageSpec
+end

--- a/test/cli/package-error-no-export-for-test/foo_bar/thing.rb
+++ b/test/cli/package-error-no-export-for-test/foo_bar/thing.rb
@@ -1,0 +1,8 @@
+# typed: strict
+
+class Foo::Bar::Thing
+  extend T::Sig
+
+  sig {returns(String)}
+  def foo_bar_thing; 'foo_bar_thing'; end
+end

--- a/test/cli/package-error-no-export-for-test/foo_bar/thing.test.rb
+++ b/test/cli/package-error-no-export-for-test/foo_bar/thing.test.rb
@@ -1,0 +1,8 @@
+# typed: true
+
+class Test::Foo::Bar
+  def aaa
+    f = Foo::Bar::Thing.new
+    f.foo_bar_thing
+  end
+end

--- a/test/cli/package-error-no-export-for-test/package-error-no-export-for-test.out
+++ b/test/cli/package-error-no-export-for-test/package-error-no-export-for-test.out
@@ -1,0 +1,15 @@
+foo_bar/thing.test.rb:5: Unable to resolve constant `Thing` https://srb.help/5002
+     5 |    f = Foo::Bar::Thing.new
+                ^^^^^^^^^^^^^^^
+    foo_bar/__package.rb:3: To expose this name to a package's own tests it must be exported. Do you need to `export_for_test Foo::Bar` in this package?
+     3 |class Foo::Bar < PackageSpec
+     4 |end
+    foo_bar/thing.rb:3: Constant `Foo::Bar` is defined here:
+     3 |class Foo::Bar::Thing
+              ^^^^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    foo_bar/__package.rb:3: Insert `
+  export_for_test Foo::Bar`
+     3 |class Foo::Bar < PackageSpec
+                                    ^
+Errors: 1

--- a/test/cli/package-error-no-export-for-test/package-error-no-export-for-test.sh
+++ b/test/cli/package-error-no-export-for-test/package-error-no-export-for-test.sh
@@ -1,0 +1,4 @@
+cd test/cli/package-error-no-export-for-test || exit 1
+
+../../../main/sorbet --silence-dev-message --stripe-packages \
+  --max-threads=0 . 2>&1

--- a/test/cli/package-error-no-export-for-test/thing.rb
+++ b/test/cli/package-error-no-export-for-test/thing.rb
@@ -1,0 +1,8 @@
+# typed: strict
+
+class Foo::Thing
+  extend T::Sig
+
+  sig {returns(String)}
+  def foo_thing; 'foo_thing'; end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
If a constant fails to resolve in a packaged _test_ file, we first check inside the associated normal code for the package and if the symbol is found there, instruct the user to `export_for_test`.  In this case we stop looking for other possible matches because this is almost certainly the right fix.

I also fixed an mistake in this this codepath that was adding the hint twice.

### Motivation
This is an easy to make error, but we were not showing good messaging around it.
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
