### PR TITLE
Add package layer-checking to sorbet

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -466,6 +466,9 @@ void GlobalState::initEmpty() {
         enterMethod(*this, Symbols::PackageSpecSingleton(), Names::restrict_to_service()).arg(Names::arg0()).build();
     ENFORCE(method == Symbols::PackageSpec_restrict_to_service());
 
+    method = enterMethod(*this, Symbols::PackageSpecSingleton(), Names::layer()).arg(Names::arg0()).build();
+    ENFORCE(method == Symbols::PackageSpec_layer());
+
     klass = synthesizeClass(core::Names::Constants::Encoding());
     ENFORCE(klass == Symbols::Encoding());
 
@@ -1980,6 +1983,7 @@ const packages::PackageDB &GlobalState::packageDB() const {
 
 void GlobalState::setPackagerOptions(const std::vector<std::string> &secondaryTestPackageNamespaces,
                                      const std::vector<std::string> &extraPackageFilesDirectoryPrefixes,
+                                     const std::vector<std::string> &layerNames,
                                      std::string errorHint) {
     ENFORCE(packageDB_.secondaryTestPackageNamespaceRefs_.size() == 0);
     ENFORCE(!packageDB_.frozen);
@@ -1989,6 +1993,7 @@ void GlobalState::setPackagerOptions(const std::vector<std::string> &secondaryTe
     }
 
     packageDB_.extraPackageFilesDirectoryPrefixes_ = extraPackageFilesDirectoryPrefixes;
+    packageDB_.layerNames_ = layerNames;
     packageDB_.errorHint_ = errorHint;
 }
 

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -160,7 +160,8 @@ public:
 
     const packages::PackageDB &packageDB() const;
     void setPackagerOptions(const std::vector<std::string> &secondaryTestPackageNamespaces,
-                            const std::vector<std::string> &extraPackageFilesDirectoryPrefixes, std::string errorHint);
+                            const std::vector<std::string> &extraPackageFilesDirectoryPrefixes, 
+                            const std::vector<std::string> &layerNames, std::string errorHint);
     packages::UnfreezePackages unfreezePackages();
 
     void mangleRenameSymbol(SymbolRef what, NameRef origName);

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -938,6 +938,10 @@ public:
         return MethodRef::fromRaw(10);
     }
 
+    static MethodRef PackageSpec_layer() {
+        return MethodRef::fromRaw(11);
+    }
+
     static ClassOrModuleRef Encoding() {
         return ClassOrModuleRef::fromRaw(83);
     }
@@ -947,11 +951,11 @@ public:
     }
 
     static MethodRef Class_new() {
-        return MethodRef::fromRaw(11);
+        return MethodRef::fromRaw(12);
     }
 
     static MethodRef todoMethod() {
-        return MethodRef::fromRaw(12);
+        return MethodRef::fromRaw(13);
     }
 
     static ClassOrModuleRef Sorbet_Private_Static_ResolvedSig() {
@@ -993,7 +997,7 @@ public:
     }
 
     static constexpr int MAX_SYNTHETIC_CLASS_SYMBOLS = 203;
-    static constexpr int MAX_SYNTHETIC_METHOD_SYMBOLS = 44;
+    static constexpr int MAX_SYNTHETIC_METHOD_SYMBOLS = 45;
     static constexpr int MAX_SYNTHETIC_FIELD_SYMBOLS = 4;
     static constexpr int MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 4;
     static constexpr int MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 100;

--- a/core/errors/packager.h
+++ b/core/errors/packager.h
@@ -21,5 +21,7 @@ constexpr ErrorClass DefinitionPackageMismatch{3713, StrictLevel::False};
 constexpr ErrorClass ImportConflict{3714, StrictLevel::False};
 constexpr ErrorClass InvalidExportForTest{3715, StrictLevel::False};
 constexpr ErrorClass ExportConflict{3716, StrictLevel::False};
+constexpr ErrorClass InvalidLayer{3717, StrictLevel::False};
+constexpr ErrorClass ImportLayeringViolation{3718, StrictLevel::False};
 } // namespace sorbet::core::errors::Packager
 #endif

--- a/core/packages/Layer.cc
+++ b/core/packages/Layer.cc
@@ -1,0 +1,16 @@
+#include "core/GlobalState.h"
+#include "core/packages/Layer.h"
+
+namespace sorbet::core::packages {
+std::string_view Layer::show(core::Context ctx) const {
+    return ctx.state.packageDB().getLayerName(rank_);
+}
+
+bool Layer::operator<(const Layer rhs) const {
+    return rank_ < rhs.rank_;
+}
+
+bool Layer::operator==(const Layer rhs) const {
+    return rank_ == rhs.rank_;
+}
+} // namespace sorbet::core::packages

--- a/core/packages/Layer.h
+++ b/core/packages/Layer.h
@@ -1,0 +1,21 @@
+#ifndef SORBET_CORE_PACKAGES_LAYER_H
+#define SORBET_CORE_PACKAGES_LAYER_H
+
+#include "core/Context.h"
+#include <string_view>
+
+
+namespace sorbet::core::packages {
+class Layer final {
+public:
+    Layer() = default;
+    Layer(int rank) : rank_(rank) {};
+    std::string_view show(core::Context ctx) const;
+    bool operator<(const Layer rhs) const;
+    bool operator==(const Layer rhs) const;
+
+private:
+    uint8_t rank_;
+};
+} // namespace sorbet::core::packages
+#endif // SORBET_CORE_PACKAGES_LAYER_H

--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -4,6 +4,7 @@
 #include "core/AutocorrectSuggestion.h"
 #include "core/GlobalState.h"
 #include "core/Loc.h"
+#include "core/packages/Layer.h"
 
 using namespace std;
 
@@ -34,6 +35,11 @@ public:
     Loc definitionLoc() const {
         notImplemented();
         return Loc::none();
+    }
+
+    sorbet::core::packages::Layer layer() const {
+        notImplemented();
+        return Layer(-1);
     }
 
     std::optional<core::AutocorrectSuggestion> addImport(const core::GlobalState &gs, const PackageInfo &pkg,
@@ -166,6 +172,24 @@ const std::vector<std::string> &PackageDB::extraPackageFilesDirectoryPrefixes() 
 
 const std::string_view PackageDB::errorHint() const {
     return errorHint_;
+}
+
+const std::string_view PackageDB::getLayerName(uint8_t layerRank) const {
+    ENFORCE(layerRank < layerNames_.size());
+    return layerNames_.at(layerRank);
+}
+
+const uint8_t PackageDB::getLayerRank(std::string layerName) const {
+    for (std::size_t i = 0; i < layerNames_.size(); i++) {
+        if (layerNames_.at(i).compare(layerName) == 0) {
+            return i;
+        }
+    }
+    return 255;
+}
+
+const std::size_t PackageDB::getLayerCount() const {
+    return layerNames_.size();
 }
 
 bool PackageDB::isTestFile(const core::GlobalState &gs, const core::File &file) {

--- a/core/packages/PackageDB.h
+++ b/core/packages/PackageDB.h
@@ -49,12 +49,17 @@ public:
 
     const std::string_view errorHint() const;
 
+    const std::string_view getLayerName(uint8_t layerRank) const;
+    const uint8_t getLayerRank(std::string layerName) const;
+    const std::size_t getLayerCount() const;
+
     // NB: Do not call in hot path, this is SLOW due to string comparison!
     static bool isTestFile(const core::GlobalState &gs, const core::File &file);
 
 private:
     std::vector<NameRef> secondaryTestPackageNamespaceRefs_;
     std::vector<std::string> extraPackageFilesDirectoryPrefixes_;
+    std::vector<std::string> layerNames_;
     std::string errorHint_;
 
     UnorderedMap<core::NameRef, std::unique_ptr<packages::PackageInfo>> packages_;

--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -3,6 +3,7 @@
 
 #include "core/NameRef.h"
 #include "core/SymbolRef.h"
+#include "core/packages/Layer.h"
 #include <optional>
 #include <vector>
 
@@ -22,6 +23,7 @@ public:
     virtual const std::vector<std::string> &pathPrefixes() const = 0;
     virtual std::unique_ptr<PackageInfo> deepCopy() const = 0;
     virtual core::Loc definitionLoc() const = 0;
+    virtual sorbet::core::packages::Layer layer() const = 0;
     virtual bool exists() const final;
 
     // autocorrects

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -429,6 +429,7 @@ NameDef names[] = {
     {"test_import"},
     {"export_", "export"},
     {"export_for_test"},
+    {"layer"},
     {"restrict_to_service"},
     {"PackageSpec", "PackageSpec", true},
     {"PackageRegistry", "<PackageRegistry>", true},

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -358,6 +358,12 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
     options.add_options("advanced")("stripe-packages-hint-message",
                                     "Optional hint message to add to packaging related errors",
                                     cxxopts::value<string>()->default_value(""));
+    options.add_options("advanced")(
+        "stripe-packages-layers", 
+        "The possible layers a package can belong to, comma-"
+        "separated and ordered such that a layer can depend on any layer listed before it."
+        "If specified, at least 2 layers must be provided.",
+        cxxopts::value<vector<string>>(), "layer1,layer2,layer3");
     options.add_options("dev")("extra-package-files-directory-prefix",
                                "Extra parent directories which contain package files. "
                                "This option must be used in conjunction with --stripe-packages",
@@ -907,6 +913,21 @@ void readOptions(Options &opts,
                     throw EarlyReturnWithCode(1);
                 }
                 opts.secondaryTestPackageNamespaces.emplace_back(ns);
+            }
+        }
+        if (raw.count("stripe-packages-layers")) {
+            if (!opts.stripePackages) { 
+                logger->error("--stripe-packages-layers can only be specified in --stripe-packages mode");
+                throw EarlyReturnWithCode(1);
+            }
+            std::regex layerValid("[a-zA-Z0-9-_]+");
+            for (const string &layerName : raw["stripe-packages-layers"].as<vector<string>>()) {
+                if (!std::regex_match(layerName, layerValid)) {
+                    logger->error("--stripe-packages-layers must contain items that are alphanumeric using hyphen (-) "
+                                  " or underscore (_) as separators.");
+                    throw EarlyReturnWithCode(1);
+                }
+                opts.stripePackagesLayerNames.emplace_back(layerName);
             }
         }
         opts.stripePackagesHint = raw["stripe-packages-hint-message"].as<string>();

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -159,6 +159,7 @@ struct Options {
     bool stripeMode = false;
     bool stripePackages = false;
     std::string stripePackagesHint = "";
+    std::vector<std::string> stripePackagesLayerNames;
     std::vector<std::string> extraPackageFilesDirectoryPrefixes;
     std::vector<std::string> secondaryTestPackageNamespaces;
     std::string typedSource = "";

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -669,7 +669,7 @@ vector<ast::ParsedFile> package(core::GlobalState &gs, vector<ast::ParsedFile> w
             core::UnfreezeNameTable unfreezeToEnterPackagerOptionsGS(gs);
             core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = gs.unfreezePackages();
             gs.setPackagerOptions(opts.secondaryTestPackageNamespaces, opts.extraPackageFilesDirectoryPrefixes,
-                                  opts.stripePackagesHint);
+                                  opts.stripePackagesLayerNames, opts.stripePackagesHint);
         }
         what = packager::Packager::run(gs, workers, move(what));
         if (opts.print.Packager.enabled) {

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -12,6 +12,7 @@
 #include "core/AutocorrectSuggestion.h"
 #include "core/Unfreeze.h"
 #include "core/errors/packager.h"
+#include "core/packages/Layer.h"
 #include "core/packages/PackageInfo.h"
 #include <sys/stat.h>
 
@@ -207,6 +208,10 @@ public:
         return loc;
     }
 
+    core::packages::Layer layer() const {
+        return layer_;
+    }
+
     // The possible path prefixes associated with files in the package, including path separator at end.
     vector<std::string> packagePathPrefixes;
     PackageName name;
@@ -220,6 +225,8 @@ public:
 
     // loc for the package definition. Used for error messages.
     core::Loc loc;
+    // Layer info for the package.
+    sorbet::core::packages::Layer layer_;
     // The names of each package imported by this package.
     vector<Import> importedPackageNames;
     // List of exported items that form the body of this package's public API.

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1109,6 +1109,7 @@ struct PackageInfoFinder {
             case core::Names::export_().rawId():
             case core::Names::export_for_test().rawId():
             case core::Names::restrict_to_service().rawId():
+            case core::Names::layer().rawId():
                 return true;
             default:
                 return false;

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -143,6 +143,11 @@ Usage:
       --stripe-packages-hint-message arg
                                 Optional hint message to add to packaging
                                 related errors (default: "")
+      --stripe-packages-layers layer1,layer2,layer3
+                                The possible layers a package can belong to,
+                                comma-separated and ordered such that a layer
+                                can depend on any layer listed before it.If
+                                specified, at least 2 layers must be provided.
       --autogen-autoloader-exclude-require arg
                                 Names that should be excluded from top-level
                                 require statements in autoloader output. (e.g.

--- a/test/cli/package-layers-incorrect-names/another-bad-name/__package.rb
+++ b/test/cli/package-layers-incorrect-names/another-bad-name/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class C < PackageSpec
+  layer 'another_bad_name'
+end

--- a/test/cli/package-layers-incorrect-names/bad-layer-name/__package.rb
+++ b/test/cli/package-layers-incorrect-names/bad-layer-name/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class B < PackageSpec
+  layer 'bad_layer_name'
+end

--- a/test/cli/package-layers-incorrect-names/good-layer-name/__package.rb
+++ b/test/cli/package-layers-incorrect-names/good-layer-name/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class A < PackageSpec
+  layer 'good_layer_name'
+end

--- a/test/cli/package-layers-incorrect-names/package-layers-incorrect-names.out
+++ b/test/cli/package-layers-incorrect-names/package-layers-incorrect-names.out
@@ -1,0 +1,8 @@
+another-bad-name/__package.rb:4: Argument to `layer` is `another_bad_name` but must be a valid layer name (good_layer_name) https://srb.help/3717
+     4 |  layer 'another_bad_name'
+                ^^^^^^^^^^^^^^^^^^
+
+bad-layer-name/__package.rb:4: Argument to `layer` is `bad_layer_name` but must be a valid layer name (good_layer_name) https://srb.help/3717
+     4 |  layer 'bad_layer_name'
+                ^^^^^^^^^^^^^^^^
+Errors: 2

--- a/test/cli/package-layers-incorrect-names/package-layers-incorrect-names.sh
+++ b/test/cli/package-layers-incorrect-names/package-layers-incorrect-names.sh
@@ -1,0 +1,3 @@
+cd test/cli/package-layers-incorrect-names || exit 1
+
+../../../main/sorbet --silence-dev-message --stripe-packages --stripe-packages-layers=good_layer_name --max-threads=0 . 2>&1

--- a/test/cli/package-layers-violations/highest-layer-pkg/__package.rb
+++ b/test/cli/package-layers-violations/highest-layer-pkg/__package.rb
@@ -1,0 +1,8 @@
+# typed: strict
+
+class HighestLayerPackage < PackageSpec
+  layer 'highest'
+
+  import LayerRespectingPackage
+  import LowestLayerPackage
+end

--- a/test/cli/package-layers-violations/layer-respecting-pkg/__package.rb
+++ b/test/cli/package-layers-violations/layer-respecting-pkg/__package.rb
@@ -1,0 +1,7 @@
+# typed: strict
+
+class LayerRespectingPackage < PackageSpec
+  layer 'middle'
+  
+  import LowestLayerPackage
+end

--- a/test/cli/package-layers-violations/layer-violating-pkg/__package.rb
+++ b/test/cli/package-layers-violations/layer-violating-pkg/__package.rb
@@ -1,0 +1,9 @@
+# typed: strict
+
+class LayerViolatingPackage < PackageSpec
+  layer 'middle'
+
+  import LayerRespectingPackage
+  import HighestLayerPackage
+  import LowestLayerPackage
+end

--- a/test/cli/package-layers-violations/lowest-layer-pkg/__package.rb
+++ b/test/cli/package-layers-violations/lowest-layer-pkg/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class LowestLayerPackage < PackageSpec
+  layer 'lowest'
+end

--- a/test/cli/package-layers-violations/package-layers-violations.out
+++ b/test/cli/package-layers-violations/package-layers-violations.out
@@ -1,0 +1,4 @@
+layer-violating-pkg/__package.rb:7: Layering violation: package `LayerViolatingPackage` with layer `middle` imports package `HighestLayerPackage` which has layer `highest` https://srb.help/3718
+     7 |  import HighestLayerPackage
+                 ^^^^^^^^^^^^^^^^^^^
+Errors: 1

--- a/test/cli/package-layers-violations/package-layers-violations.sh
+++ b/test/cli/package-layers-violations/package-layers-violations.sh
@@ -1,0 +1,3 @@
+cd test/cli/package-layers-violations || exit 1
+
+../../../main/sorbet --silence-dev-message --stripe-packages --stripe-packages-layers=lowest,middle,highest --max-threads=0 . 2>&1


### PR DESCRIPTION
This PR adds a `--stripe-packages-layers` CLI argument which takes a comma-separated list of values, when set, causes Sorbet to error when:

* a `__package.rb` doesn't contain a `layer` prop
* a `__package.rb` contains a `layer` prop that isn't in the list passed to `--stripe-packages-layers`
* a `__package.rb` of a particular `layer` declares an `import` to another package whose `__package.rb` is of a `layer` that occurs earlier in the list passed to `--stripe-packages-layers`


### Motivation
Better organization of large codebases.

### Test plan

- [X] Added test cases
- [X] Tested on Stripe's codebase
- [ ] Measured performance

See included automated tests.
