### PR TITLE
add autocorrect heuristics for non-final methods in a final module

### DIFF
--- a/definition_validator/BUILD
+++ b/definition_validator/BUILD
@@ -23,5 +23,6 @@ cc_library(
         "//ast/desugar",
         "//ast/treemap",
         "//core",
+        "@com_google_absl//absl/strings",
     ],
 )

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -410,14 +410,7 @@ void validateFinalMethodHelper(const core::GlobalState &gs, const core::ClassOrM
                         errMsgClass.show(gs), sym.name(gs).show(gs));
 
             // We don't have a direct link to the signature for the method, so we
-            // heuristically look for the matching signature.  This heuristic
-            // assumes that sigs and method definitions appear on separate lines
-            // and would get tripped up by something like:
-            //
-            // sig {...}; def foo; ...; end
-            // def bar; ... end
-            //
-            // finding the `sig` for `bar` even though the `sig` belongs to `foo`.
+            // heuristically look for the matching signature.
             auto source = defLoc.file().data(gs).source();
             core::LocOffsets sigLocOffsets;
 

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -1,3 +1,5 @@
+#include "absl/strings/ascii.h"
+#include "absl/strings/match.h"
 #include "ast/ast.h"
 #include "ast/treemap/treemap.h"
 #include "common/Timer.h"
@@ -406,6 +408,104 @@ void validateFinalMethodHelper(const core::GlobalState &gs, const core::ClassOrM
         if (auto e = gs.beginError(defLoc, core::errors::Resolver::FinalModuleNonFinalMethod)) {
             e.setHeader("`{}` was declared as final but its method `{}` was not declared as final",
                         errMsgClass.show(gs), sym.name(gs).show(gs));
+
+            // We don't have a direct link to the signature for the method, so we
+            // heuristically look for the matching signature.  This heuristic
+            // assumes that sigs and method definitions appear on separate lines
+            // and would get tripped up by something like:
+            //
+            // sig {...}; def foo; ...; end
+            // def bar; ... end
+            //
+            // finding the `sig` for `bar` even though the `sig` belongs to `foo`.
+            auto source = defLoc.file().data(gs).source();
+            core::LocOffsets sigLocOffsets;
+
+            // We only care about everything prior to the definition.
+            auto line_end = defLoc.beginPos();
+            auto prev_line_end = source.rfind('\n', line_end);
+            bool startFromDefinition = true;
+            while (prev_line_end != source.npos) {
+                auto line_start = prev_line_end + 1;
+                auto line = source.substr(line_start, line_end - line_start);
+                line = absl::StripAsciiWhitespace(line);
+                // We skip empty lines, contra LSP's documentation finder.  But
+                // we permit empty lines (i.e. whitespace) prior to the symbol
+                // definition.
+                if (line.empty()) {
+                    if (!startFromDefinition) {
+                        break;
+                    }
+                    line_end = prev_line_end;
+                    prev_line_end = source.rfind('\n', line_end - 1);
+                    startFromDefinition = false;
+                    continue;
+                }
+
+                const auto singleLineSig = "sig"sv;
+                const uint32_t singleLineSigSize = singleLineSig.size();
+                const auto alreadyFinalSig = "sig(:final)"sv;
+                const auto multiLineSigEnd = "end"sv;
+                const auto multiLineSigStart = "sig do"sv;
+
+                // If something went wrong, we might find ourselves looking at an
+                // existing `sig(:final)`.  Bail instead of suggesting an autocorrect
+                // to an already final sig.
+                if (absl::StartsWith(line, alreadyFinalSig)) {
+                    break;
+                }
+
+                if (absl::StartsWith(line, singleLineSig)) {
+                    uint32_t offset = line.data() - source.data();
+                    sigLocOffsets = core::LocOffsets{offset, offset + singleLineSigSize};
+                    break;
+                }
+
+                if (absl::StartsWith(line, multiLineSigEnd)) {
+                    // Loop backwards searching for the matching `sig do`.  We're
+                    // going to:
+                    // - Find it;
+                    // - Hit an `end` or an already-final sig;
+                    // - Hit the start of the file.
+                    line_end = prev_line_end;
+                    prev_line_end = source.rfind('\n', line_end - 1);
+                    while (prev_line_end != source.npos) {
+                        auto line_start = prev_line_end + 1;
+                        line = source.substr(line_start, line_end - line_start);
+                        line = absl::StripAsciiWhitespace(line);
+
+                        // Found the start of the multi-line sig we were looking for.
+                        if (absl::StartsWith(line, multiLineSigStart)) {
+                            uint32_t offset = line.data() - source.data();
+                            sigLocOffsets = core::LocOffsets{offset, offset + singleLineSigSize};
+                            break;
+                        }
+
+                        if (absl::StartsWith(line, alreadyFinalSig)) {
+                            break;
+                        }
+
+                        // We hit an `end` in a place we didn't expect.  Bail.
+                        if (absl::StartsWith(line, multiLineSigEnd)) {
+                            break;
+                        }
+
+                        line_end = prev_line_end;
+                        prev_line_end = source.rfind('\n', line_end - 1);
+                    }
+
+                    // However we exited the above loop, we are done.
+                    break;
+                }
+
+                // If we find anything else, even a blank line, assume that the heuristic
+                // has failed.
+                break;
+            }
+
+            if (sigLocOffsets.exists()) {
+                e.replaceWith("Mark it as `sig(:final)`", core::Loc{defLoc.file(), sigLocOffsets}, "sig(:final)");
+            }
         }
     }
 }

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -402,7 +402,8 @@ void validateFinalMethodHelper(const core::GlobalState &gs, const core::ClassOrM
             sym.name(gs) == core::Names::unresolvedAncestors()) {
             continue;
         }
-        if (auto e = gs.beginError(sym.loc(gs), core::errors::Resolver::FinalModuleNonFinalMethod)) {
+        auto defLoc = sym.loc(gs);
+        if (auto e = gs.beginError(defLoc, core::errors::Resolver::FinalModuleNonFinalMethod)) {
             e.setHeader("`{}` was declared as final but its method `{}` was not declared as final",
                         errMsgClass.show(gs), sym.name(gs).show(gs));
         }

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -429,9 +429,10 @@ void validateFinalMethodHelper(const core::GlobalState &gs, const core::ClassOrM
                 auto line_start = prev_line_end + 1;
                 auto line = source.substr(line_start, line_end - line_start);
                 line = absl::StripAsciiWhitespace(line);
-                // We skip empty lines, contra LSP's documentation finder.  But
-                // we permit empty lines (i.e. whitespace) prior to the symbol
-                // definition.
+                // We do not skip empty lines, contra LSP's documentation finder.
+                // But as we are starting from just before the method definition,
+                // the beginning of that line could look like an empty line, and
+                // we want to move to the previous line in that case.
                 if (line.empty()) {
                     if (!startFromDefinition) {
                         break;

--- a/test/cli/autocorrect-non-final-methods-final-module/autocorrect-non-final-methods-final-module.out
+++ b/test/cli/autocorrect-non-final-methods-final-module/autocorrect-non-final-methods-final-module.out
@@ -9,23 +9,23 @@ class FinalClass
 
   final!
 
-  sig {returns(T.untyped)}
+  sig(:final) {returns(T.untyped)}
   def needs_autocorrect; end
   def no_sig_suggestion1; end
 
-  sig {returns(T.untyped)}
+  sig(:final) {returns(T.untyped)}
   def needs_autocorrect_multiline
     nil
   end
   def no_sig_suggestion2; end
 
-  sig do
+  sig(:final) do
     returns(T.untyped)
   end
   def needs_autocorrect_multiline_sig; end
   def no_sig_suggestion3; end
 
-  sig do
+  sig(:final) do
     returns(T.untyped)
   end
   def needs_autocorrect_multiline_multiline_sig
@@ -39,19 +39,19 @@ class FinalClass
 
   attr_reader :no_sig_attr
 
-  sig {returns(T.untyped)}
+  sig(:final) {returns(T.untyped)}
   attr_reader :sig_attr
   def no_sig_suggestion5; end
 
-  sig {params(sig_writer: T.untyped).returns(T.untyped)}
+  sig(:final) {params(sig_writer: T.untyped).returns(T.untyped)}
   attr_writer :sig_writer
   def no_sig_suggestion6; end
 
-  sig {returns(T.untyped)}
+  sig(:final) {returns(T.untyped)}
   attr_accessor :sig_accessor
   def no_sig_suggestion7; end
 
-  sig {returns(T.untyped)}
+  sig(:final) {returns(T.untyped)}
   attr_reader :sig_attr_multi1, :sig_attr_multi2
   def no_sig_suggestion8; end
 

--- a/test/cli/autocorrect-non-final-methods-final-module/autocorrect-non-final-methods-final-module.out
+++ b/test/cli/autocorrect-non-final-methods-final-module/autocorrect-non-final-methods-final-module.out
@@ -1,0 +1,67 @@
+
+--------------------------------------------------------------------------
+
+# typed: true
+
+class FinalClass
+  extend T::Sig
+  extend T::Helpers
+
+  final!
+
+  sig {returns(T.untyped)}
+  def needs_autocorrect; end
+  def no_sig_suggestion1; end
+
+  sig {returns(T.untyped)}
+  def needs_autocorrect_multiline
+    nil
+  end
+  def no_sig_suggestion2; end
+
+  sig do
+    returns(T.untyped)
+  end
+  def needs_autocorrect_multiline_sig; end
+  def no_sig_suggestion3; end
+
+  sig do
+    returns(T.untyped)
+  end
+  def needs_autocorrect_multiline_multiline_sig
+    nil
+  end
+  def no_sig_suggestion4; end
+
+  def no_sig_suggestion_multiline
+    nil
+  end
+
+  attr_reader :no_sig_attr
+
+  sig {returns(T.untyped)}
+  attr_reader :sig_attr
+  def no_sig_suggestion5; end
+
+  sig {params(sig_writer: T.untyped).returns(T.untyped)}
+  attr_writer :sig_writer
+  def no_sig_suggestion6; end
+
+  sig {returns(T.untyped)}
+  attr_accessor :sig_accessor
+  def no_sig_suggestion7; end
+
+  sig {returns(T.untyped)}
+  attr_reader :sig_attr_multi1, :sig_attr_multi2
+  def no_sig_suggestion8; end
+
+  sig(:final) {returns T.untyped}
+  attr_reader :sig_attr_final1
+  def no_sig_suggestion9; end
+
+  sig(:final) do
+    returns T.untyped
+  end
+  attr_reader :sig_attr_final2
+  def no_sig_suggestion10; end
+end

--- a/test/cli/autocorrect-non-final-methods-final-module/autocorrect-non-final-methods-final-module.rb
+++ b/test/cli/autocorrect-non-final-methods-final-module/autocorrect-non-final-methods-final-module.rb
@@ -1,0 +1,64 @@
+# typed: true
+
+class FinalClass
+  extend T::Sig
+  extend T::Helpers
+
+  final!
+
+  sig {returns(T.untyped)}
+  def needs_autocorrect; end
+  def no_sig_suggestion1; end
+
+  sig {returns(T.untyped)}
+  def needs_autocorrect_multiline
+    nil
+  end
+  def no_sig_suggestion2; end
+
+  sig do
+    returns(T.untyped)
+  end
+  def needs_autocorrect_multiline_sig; end
+  def no_sig_suggestion3; end
+
+  sig do
+    returns(T.untyped)
+  end
+  def needs_autocorrect_multiline_multiline_sig
+    nil
+  end
+  def no_sig_suggestion4; end
+
+  def no_sig_suggestion_multiline
+    nil
+  end
+
+  attr_reader :no_sig_attr
+
+  sig {returns(T.untyped)}
+  attr_reader :sig_attr
+  def no_sig_suggestion5; end
+
+  sig {params(sig_writer: T.untyped).returns(T.untyped)}
+  attr_writer :sig_writer
+  def no_sig_suggestion6; end
+
+  sig {returns(T.untyped)}
+  attr_accessor :sig_accessor
+  def no_sig_suggestion7; end
+
+  sig {returns(T.untyped)}
+  attr_reader :sig_attr_multi1, :sig_attr_multi2
+  def no_sig_suggestion8; end
+
+  sig(:final) {returns T.untyped}
+  attr_reader :sig_attr_final1
+  def no_sig_suggestion9; end
+
+  sig(:final) do
+    returns T.untyped
+  end
+  attr_reader :sig_attr_final2
+  def no_sig_suggestion10; end
+end

--- a/test/cli/autocorrect-non-final-methods-final-module/autocorrect-non-final-methods-final-module.sh
+++ b/test/cli/autocorrect-non-final-methods-final-module/autocorrect-non-final-methods-final-module.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+cwd="$(pwd)"
+infile="$cwd/test/cli/autocorrect-non-final-methods-final-module/autocorrect-non-final-methods-final-module.rb"
+
+tmp="$(mktemp -d)"
+
+cp "$infile" "$tmp"
+
+cd "$tmp" || exit 1
+# Suppress all output because the ordering of errors about non-final methods is
+# dependent on hash table iteration order.
+if "$cwd/main/sorbet" --silence-dev-message -a autocorrect-non-final-methods-final-module.rb 1>/dev/null 2>&1; then
+  echo "Expected to fail!"
+  exit 1
+fi
+
+echo
+echo --------------------------------------------------------------------------
+echo
+
+# Cat the file, to make that the autocorrect applied
+cat autocorrect-non-final-methods-final-module.rb
+
+rm autocorrect-non-final-methods-final-module.rb
+
+rmdir "$tmp"


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is a fairly easy mistake to make while live coding, and having this offers the possibility of mass-conversion of methods to `sig(:final)` once the enclosing module is marked `final!`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.  The test was written with the current behavior (no autocorrects) and then updated once the autocorrect was in place, so the diff update is probably more helpful to look at.
