### PR TITLE
Add package layer-checking to sorbet

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -466,6 +466,9 @@ void GlobalState::initEmpty() {
         enterMethod(*this, Symbols::PackageSpecSingleton(), Names::restrict_to_service()).arg(Names::arg0()).build();
     ENFORCE(method == Symbols::PackageSpec_restrict_to_service());
 
+    method = enterMethod(*this, Symbols::PackageSpecSingleton(), Names::layer()).arg(Names::arg0()).build();
+    ENFORCE(method == Symbols::PackageSpec_layer());
+
     klass = synthesizeClass(core::Names::Constants::Encoding());
     ENFORCE(klass == Symbols::Encoding());
 
@@ -1980,12 +1983,16 @@ const packages::PackageDB &GlobalState::packageDB() const {
 
 void GlobalState::setPackagerOptions(const std::vector<std::string> &secondaryTestPackageNamespaces,
                                      const std::vector<std::string> &extraPackageFilesDirectoryPrefixes,
-                                     std::string errorHint) {
+                                     const std::vector<std::string> &layerNames, std::string errorHint) {
     ENFORCE(packageDB_.secondaryTestPackageNamespaceRefs_.size() == 0);
     ENFORCE(!packageDB_.frozen);
 
     for (const string &ns : secondaryTestPackageNamespaces) {
         packageDB_.secondaryTestPackageNamespaceRefs_.emplace_back(enterNameConstant(ns));
+    }
+
+    for (const string &layerName : layerNames) {
+        packageDB_.layerNames_.emplace_back(enterNameUTF8(layerName));
     }
 
     packageDB_.extraPackageFilesDirectoryPrefixes_ = extraPackageFilesDirectoryPrefixes;

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -160,7 +160,8 @@ public:
 
     const packages::PackageDB &packageDB() const;
     void setPackagerOptions(const std::vector<std::string> &secondaryTestPackageNamespaces,
-                            const std::vector<std::string> &extraPackageFilesDirectoryPrefixes, std::string errorHint);
+                            const std::vector<std::string> &extraPackageFilesDirectoryPrefixes,
+                            const std::vector<std::string> &layerNames, std::string errorHint);
     packages::UnfreezePackages unfreezePackages();
 
     void mangleRenameSymbol(SymbolRef what, NameRef origName);

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -938,6 +938,10 @@ public:
         return MethodRef::fromRaw(10);
     }
 
+    static MethodRef PackageSpec_layer() {
+        return MethodRef::fromRaw(11);
+    }
+
     static ClassOrModuleRef Encoding() {
         return ClassOrModuleRef::fromRaw(83);
     }
@@ -947,11 +951,11 @@ public:
     }
 
     static MethodRef Class_new() {
-        return MethodRef::fromRaw(11);
+        return MethodRef::fromRaw(12);
     }
 
     static MethodRef todoMethod() {
-        return MethodRef::fromRaw(12);
+        return MethodRef::fromRaw(13);
     }
 
     static ClassOrModuleRef Sorbet_Private_Static_ResolvedSig() {
@@ -993,7 +997,7 @@ public:
     }
 
     static constexpr int MAX_SYNTHETIC_CLASS_SYMBOLS = 203;
-    static constexpr int MAX_SYNTHETIC_METHOD_SYMBOLS = 44;
+    static constexpr int MAX_SYNTHETIC_METHOD_SYMBOLS = 45;
     static constexpr int MAX_SYNTHETIC_FIELD_SYMBOLS = 4;
     static constexpr int MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 4;
     static constexpr int MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 100;

--- a/core/errors/packager.h
+++ b/core/errors/packager.h
@@ -21,5 +21,8 @@ constexpr ErrorClass DefinitionPackageMismatch{3713, StrictLevel::False};
 constexpr ErrorClass ImportConflict{3714, StrictLevel::False};
 constexpr ErrorClass InvalidExportForTest{3715, StrictLevel::False};
 constexpr ErrorClass ExportConflict{3716, StrictLevel::False};
+constexpr ErrorClass InvalidLayer{3717, StrictLevel::False};
+constexpr ErrorClass ImportLayeringViolation{3718, StrictLevel::False};
+constexpr ErrorClass MissingLayer{3719, StrictLevel::False};
 } // namespace sorbet::core::errors::Packager
 #endif

--- a/core/packages/Layer.cc
+++ b/core/packages/Layer.cc
@@ -1,0 +1,22 @@
+#include "core/packages/Layer.h"
+#include "core/GlobalState.h"
+
+namespace sorbet::core::packages {
+core::NameRef Layer::show(core::Context ctx) const {
+    auto layers = ctx.state.packageDB().layerNames();
+    ENFORCE(rank_ < layers.size());
+    return layers[rank_];
+}
+
+bool Layer::exists() const {
+    return rank_ < 255;
+}
+
+bool Layer::operator<(const Layer rhs) const {
+    return rank_ < rhs.rank_;
+}
+
+bool Layer::operator==(const Layer rhs) const {
+    return rank_ == rhs.rank_;
+}
+} // namespace sorbet::core::packages

--- a/core/packages/Layer.h
+++ b/core/packages/Layer.h
@@ -1,0 +1,21 @@
+#ifndef SORBET_CORE_PACKAGES_LAYER_H
+#define SORBET_CORE_PACKAGES_LAYER_H
+
+#include "core/Context.h"
+#include <string_view>
+
+namespace sorbet::core::packages {
+class Layer final {
+public:
+    Layer() = default;
+    Layer(int rank) : rank_(rank){};
+    core::NameRef show(core::Context ctx) const;
+    bool exists() const;
+    bool operator<(const Layer rhs) const;
+    bool operator==(const Layer rhs) const;
+
+private:
+    uint8_t rank_ = 255;
+};
+} // namespace sorbet::core::packages
+#endif // SORBET_CORE_PACKAGES_LAYER_H

--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -4,6 +4,7 @@
 #include "core/AutocorrectSuggestion.h"
 #include "core/GlobalState.h"
 #include "core/Loc.h"
+#include "core/packages/Layer.h"
 
 using namespace std;
 
@@ -34,6 +35,11 @@ public:
     Loc definitionLoc() const {
         notImplemented();
         return Loc::none();
+    }
+
+    sorbet::core::packages::Layer layer() const {
+        notImplemented();
+        return Layer(-1);
     }
 
     std::optional<core::AutocorrectSuggestion> addImport(const core::GlobalState &gs, const PackageInfo &pkg,
@@ -168,6 +174,10 @@ const std::string_view PackageDB::errorHint() const {
     return errorHint_;
 }
 
+const std::vector<NameRef> &PackageDB::layerNames() const {
+    return layerNames_;
+}
+
 PackageDB PackageDB::deepCopy() const {
     ENFORCE(frozen);
     PackageDB result;
@@ -177,6 +187,7 @@ PackageDB PackageDB::deepCopy() const {
     }
     result.secondaryTestPackageNamespaceRefs_ = this->secondaryTestPackageNamespaceRefs_;
     result.extraPackageFilesDirectoryPrefixes_ = this->extraPackageFilesDirectoryPrefixes_;
+    result.layerNames_ = this->layerNames_;
     result.packagesByPathPrefix = this->packagesByPathPrefix;
     result.mangledNames = this->mangledNames;
     result.errorHint_ = this->errorHint_;

--- a/core/packages/PackageDB.h
+++ b/core/packages/PackageDB.h
@@ -49,9 +49,12 @@ public:
 
     const std::string_view errorHint() const;
 
+    const std::vector<NameRef> &layerNames() const;
+
 private:
     std::vector<NameRef> secondaryTestPackageNamespaceRefs_;
     std::vector<std::string> extraPackageFilesDirectoryPrefixes_;
+    std::vector<NameRef> layerNames_;
     std::string errorHint_;
 
     UnorderedMap<core::NameRef, std::unique_ptr<packages::PackageInfo>> packages_;
@@ -62,6 +65,7 @@ private:
     std::thread::id writerThread;
 
     friend class UnfreezePackages;
+    friend class Layer;
 };
 
 } // namespace sorbet::core::packages

--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -3,6 +3,7 @@
 
 #include "core/NameRef.h"
 #include "core/SymbolRef.h"
+#include "core/packages/Layer.h"
 #include <optional>
 #include <vector>
 
@@ -22,6 +23,7 @@ public:
     virtual const std::vector<std::string> &pathPrefixes() const = 0;
     virtual std::unique_ptr<PackageInfo> deepCopy() const = 0;
     virtual core::Loc definitionLoc() const = 0;
+    virtual sorbet::core::packages::Layer layer() const = 0;
     virtual bool exists() const final;
 
     // autocorrects

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -429,6 +429,7 @@ NameDef names[] = {
     {"test_import"},
     {"export_", "export"},
     {"export_for_test"},
+    {"layer"},
     {"restrict_to_service"},
     {"PackageSpec", "PackageSpec", true},
     {"PackageRegistry", "<PackageRegistry>", true},

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -159,6 +159,7 @@ struct Options {
     bool stripeMode = false;
     bool stripePackages = false;
     std::string stripePackagesHint = "";
+    std::vector<std::string> stripePackagesLayerNames;
     std::vector<std::string> extraPackageFilesDirectoryPrefixes;
     std::vector<std::string> secondaryTestPackageNamespaces;
     std::string typedSource = "";

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -669,7 +669,7 @@ vector<ast::ParsedFile> package(core::GlobalState &gs, vector<ast::ParsedFile> w
             core::UnfreezeNameTable unfreezeToEnterPackagerOptionsGS(gs);
             core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = gs.unfreezePackages();
             gs.setPackagerOptions(opts.secondaryTestPackageNamespaces, opts.extraPackageFilesDirectoryPrefixes,
-                                  opts.stripePackagesHint);
+                                  opts.stripePackagesLayerNames, opts.stripePackagesHint);
         }
         what = packager::Packager::run(gs, workers, move(what));
         if (opts.print.Packager.enabled) {

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -12,6 +12,7 @@
 #include "core/AutocorrectSuggestion.h"
 #include "core/Unfreeze.h"
 #include "core/errors/packager.h"
+#include "core/packages/Layer.h"
 #include "core/packages/PackageInfo.h"
 #include <sys/stat.h>
 
@@ -207,6 +208,10 @@ public:
         return loc;
     }
 
+    core::packages::Layer layer() const {
+        return layer_;
+    }
+
     // The possible path prefixes associated with files in the package, including path separator at end.
     vector<std::string> packagePathPrefixes;
     PackageName name;
@@ -220,6 +225,8 @@ public:
 
     // loc for the package definition. Used for error messages.
     core::Loc loc;
+    // Layer info for the package.
+    sorbet::core::packages::Layer layer_;
     // The names of each package imported by this package.
     vector<Import> importedPackageNames;
     // List of exported items that form the body of this package's public API.

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1115,6 +1115,7 @@ struct PackageInfoFinder {
             case core::Names::export_().rawId():
             case core::Names::export_for_test().rawId():
             case core::Names::restrict_to_service().rawId():
+            case core::Names::layer().rawId():
                 return true;
             default:
                 return false;

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -140,6 +140,11 @@ Usage:
       --stripe-packages-hint-message arg
                                 Optional hint message to add to packaging
                                 related errors (default: "")
+      --stripe-packages-layers layer1,layer2,layer3
+                                The possible layers a package can belong to,
+                                comma-separated and ordered such that a layer
+                                can depend on any layer listed before it.If
+                                specified, at least 2 layers must be provided.
       --autogen-autoloader-exclude-require arg
                                 Names that should be excluded from top-level
                                 require statements in autoloader output. (e.g.

--- a/test/cli/package-layers-disabled-no-layers/no-layer-specified/__package.rb
+++ b/test/cli/package-layers-disabled-no-layers/no-layer-specified/__package.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+class B < PackageSpec
+end

--- a/test/cli/package-layers-disabled-no-layers/package-layers-disabled-no-layers.out
+++ b/test/cli/package-layers-disabled-no-layers/package-layers-disabled-no-layers.out
@@ -1,0 +1,4 @@
+specifies-layer/__package.rb:4: Packages may only specify layers when --stripe-package-layers is set https://srb.help/3717
+     4 |  layer 'good_layer_name'
+          ^^^^^^^^^^^^^^^^^^^^^^^
+Errors: 1

--- a/test/cli/package-layers-disabled-no-layers/package-layers-disabled-no-layers.sh
+++ b/test/cli/package-layers-disabled-no-layers/package-layers-disabled-no-layers.sh
@@ -1,0 +1,3 @@
+cd test/cli/package-layers-disabled-no-layers || exit 1
+
+../../../main/sorbet --silence-dev-message --stripe-packages --max-threads=0 . 2>&1

--- a/test/cli/package-layers-disabled-no-layers/specifies-layer/__package.rb
+++ b/test/cli/package-layers-disabled-no-layers/specifies-layer/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class A < PackageSpec
+  layer 'good_layer_name'
+end

--- a/test/cli/package-layers-enabled-no-layers/no-layer-specified/__package.rb
+++ b/test/cli/package-layers-enabled-no-layers/no-layer-specified/__package.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+class B < PackageSpec
+end

--- a/test/cli/package-layers-enabled-no-layers/package-layers-enabled-no-layers.out
+++ b/test/cli/package-layers-enabled-no-layers/package-layers-enabled-no-layers.out
@@ -1,0 +1,4 @@
+no-layer-specified/__package.rb:3: --stripe-package-layers was set, but package `B` doesn't have a layer defined https://srb.help/3719
+     3 |class B < PackageSpec
+     4 |end
+Errors: 1

--- a/test/cli/package-layers-enabled-no-layers/package-layers-enabled-no-layers.sh
+++ b/test/cli/package-layers-enabled-no-layers/package-layers-enabled-no-layers.sh
@@ -1,0 +1,3 @@
+cd test/cli/package-layers-enabled-no-layers || exit 1
+
+../../../main/sorbet --silence-dev-message --stripe-packages --stripe-packages-layers=good_layer_name,unused_layer_name --max-threads=0 . 2>&1

--- a/test/cli/package-layers-enabled-no-layers/specifies-layer/__package.rb
+++ b/test/cli/package-layers-enabled-no-layers/specifies-layer/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class A < PackageSpec
+  layer 'good_layer_name'
+end

--- a/test/cli/package-layers-incorrect-names/another-bad-name/__package.rb
+++ b/test/cli/package-layers-incorrect-names/another-bad-name/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class C < PackageSpec
+  layer 'another_bad_name'
+end

--- a/test/cli/package-layers-incorrect-names/bad-layer-name/__package.rb
+++ b/test/cli/package-layers-incorrect-names/bad-layer-name/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class B < PackageSpec
+  layer 'bad_layer_name'
+end

--- a/test/cli/package-layers-incorrect-names/good-layer-name/__package.rb
+++ b/test/cli/package-layers-incorrect-names/good-layer-name/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class A < PackageSpec
+  layer 'good_layer_name'
+end

--- a/test/cli/package-layers-incorrect-names/package-layers-incorrect-names.out
+++ b/test/cli/package-layers-incorrect-names/package-layers-incorrect-names.out
@@ -1,0 +1,8 @@
+another-bad-name/__package.rb:4: Argument to `layer` is `another_bad_name` but must be a valid layer name (good_layer_name, unused_layer_name) https://srb.help/3717
+     4 |  layer 'another_bad_name'
+                ^^^^^^^^^^^^^^^^^^
+
+bad-layer-name/__package.rb:4: Argument to `layer` is `bad_layer_name` but must be a valid layer name (good_layer_name, unused_layer_name) https://srb.help/3717
+     4 |  layer 'bad_layer_name'
+                ^^^^^^^^^^^^^^^^
+Errors: 2

--- a/test/cli/package-layers-incorrect-names/package-layers-incorrect-names.sh
+++ b/test/cli/package-layers-incorrect-names/package-layers-incorrect-names.sh
@@ -1,0 +1,3 @@
+cd test/cli/package-layers-incorrect-names || exit 1
+
+../../../main/sorbet --silence-dev-message --stripe-packages --stripe-packages-layers=good_layer_name,unused_layer_name --max-threads=0 . 2>&1

--- a/test/cli/package-layers-violations/highest-layer-pkg/__package.rb
+++ b/test/cli/package-layers-violations/highest-layer-pkg/__package.rb
@@ -1,0 +1,8 @@
+# typed: strict
+
+class HighestLayerPackage < PackageSpec
+  layer 'highest'
+
+  import LayerRespectingPackage
+  import LowestLayerPackage
+end

--- a/test/cli/package-layers-violations/layer-respecting-pkg/__package.rb
+++ b/test/cli/package-layers-violations/layer-respecting-pkg/__package.rb
@@ -1,0 +1,8 @@
+# typed: strict
+
+class LayerRespectingPackage < PackageSpec
+  layer 'middle'
+  
+  import LowestLayerPackage
+  test_import HighestLayerPackage
+end

--- a/test/cli/package-layers-violations/layer-violating-pkg/__package.rb
+++ b/test/cli/package-layers-violations/layer-violating-pkg/__package.rb
@@ -1,0 +1,9 @@
+# typed: strict
+
+class LayerViolatingPackage < PackageSpec
+  layer 'middle'
+
+  import LayerRespectingPackage
+  import HighestLayerPackage
+  import LowestLayerPackage
+end

--- a/test/cli/package-layers-violations/lowest-layer-pkg/__package.rb
+++ b/test/cli/package-layers-violations/lowest-layer-pkg/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class LowestLayerPackage < PackageSpec
+  layer 'lowest'
+end

--- a/test/cli/package-layers-violations/package-layers-violations.out
+++ b/test/cli/package-layers-violations/package-layers-violations.out
@@ -1,0 +1,4 @@
+layer-violating-pkg/__package.rb:7: Layering violation: package `LayerViolatingPackage` with layer `middle` imports package `HighestLayerPackage` which has layer `highest` https://srb.help/3718
+     7 |  import HighestLayerPackage
+                 ^^^^^^^^^^^^^^^^^^^
+Errors: 1

--- a/test/cli/package-layers-violations/package-layers-violations.sh
+++ b/test/cli/package-layers-violations/package-layers-violations.sh
@@ -1,0 +1,3 @@
+cd test/cli/package-layers-violations || exit 1
+
+../../../main/sorbet --silence-dev-message --stripe-packages --stripe-packages-layers=lowest,middle,highest --max-threads=0 . 2>&1

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -300,6 +300,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
     if (enablePackager) {
         vector<std::string> extraPackageFilesDirectoryPrefixes;
         vector<std::string> secondaryTestPackageNamespaces = {"Critic"};
+        vector<std::string> stripePackagesLayerNames;
 
         auto extraDir = StringPropertyAssertion::getValue("extra-package-files-directory-prefix", assertions);
         if (extraDir.has_value()) {
@@ -310,7 +311,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
             core::UnfreezeNameTable packageNS(*gs);
             core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = gs->unfreezePackages();
             gs->setPackagerOptions(secondaryTestPackageNamespaces, extraPackageFilesDirectoryPrefixes,
-                                   "PACKAGE_ERROR_HINT");
+                                   stripePackagesLayerNames, "PACKAGE_ERROR_HINT");
         }
 
         // Packager runs over all trees.


### PR DESCRIPTION
This PR adds a `--stripe-packages-layers` CLI argument which takes a comma-separated list of values, when set, causes Sorbet to error when:

* a `__package.rb` doesn't contain a `layer` prop
* a `__package.rb` contains a `layer` prop that isn't in the list passed to `--stripe-packages-layers`
* a `__package.rb` of a particular `layer` declares an `import` to another package whose `__package.rb` is of a `layer` that occurs earlier in the list passed to `--stripe-packages-layers`


### Motivation
Better organization of large codebases.

### Test plan

- [X] Added test cases
- [X] Tested on Stripe's codebase
- [ ] Measured performance

See included automated tests.
