### PR TITLE
Log when there are empty parse results

### DIFF
--- a/hashing/BUILD
+++ b/hashing/BUILD
@@ -16,6 +16,7 @@ cc_library(
         "//core",
         "//main/options",
         "//main/pipeline",
+        "@rapidjson",
     ],
 )
 
@@ -37,5 +38,6 @@ cc_library(
         "//core",
         "//main/options",
         "//main/pipeline:pipeline-orig",
+        "@rapidjson",
     ],
 )

--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -7,6 +7,7 @@
 #include "core/NameSubstitution.h"
 #include "core/Unfreeze.h"
 #include "main/pipeline/pipeline.h"
+#include "rapidjson/writer.h"
 
 using namespace std;
 namespace sorbet::hashing {
@@ -27,8 +28,50 @@ pair<ast::ParsedFile, core::UsageHash> rewriteAST(const core::GlobalState &origi
     return make_pair<ast::ParsedFile, core::UsageHash>(move(rewritten), subst.getAllNames());
 }
 
-unique_ptr<core::FileHash> computeFileHashForAST(unique_ptr<core::GlobalState> &lgs, core::UsageHash usageHash,
-                                                 ast::ParsedFile file) {
+bool isEmptyParseResult(const core::GlobalState &gs, const ast::ExpressionPtr &tree) {
+    if (ast::isa_tree<ast::EmptyTree>(tree)) {
+        return true;
+    }
+
+    auto *classDef = ast::cast_tree<ast::ClassDef>(tree);
+    if (classDef == nullptr || classDef->symbol != core::Symbols::root() || classDef->rhs.empty()) {
+        return false;
+    }
+
+    auto *rhsLiteral = ast::cast_tree<ast::Literal>(classDef->rhs[0]);
+    return rhsLiteral != nullptr && rhsLiteral->isNil(gs);
+}
+
+unique_ptr<core::FileHash> computeFileHashForAST(spdlog::logger &logger, unique_ptr<core::GlobalState> &lgs,
+                                                 core::UsageHash usageHash, ast::ParsedFile file) {
+    if (file.file.data(*lgs).hasParseErrors) {
+        if (isEmptyParseResult(*lgs, file.tree)) {
+            rapidjson::StringBuffer result;
+            rapidjson::Writer<rapidjson::StringBuffer> writer(result);
+
+            {
+                writer.StartObject();
+
+                writer.String("compute_file_hash_for_ast_empty");
+                writer.Bool(true);
+
+                writer.String("file_path");
+                writer.String(string(file.file.data(*lgs).path()));
+
+                writer.String("contents");
+                writer.String(string(file.file.data(*lgs).source()));
+
+                writer.EndObject();
+            }
+
+            logger.debug(result.GetString());
+
+            core::GlobalStateHash invalid;
+            invalid.hierarchyHash = core::GlobalStateHash::HASH_STATE_INVALID;
+            return make_unique<core::FileHash>(move(*lgs->hash()), move(usageHash));
+        }
+    }
+
     vector<ast::ParsedFile> single;
     single.emplace_back(move(file));
 
@@ -65,7 +108,7 @@ unique_ptr<core::FileHash> computeFileHashForFile(shared_ptr<core::File> forWhat
     core::LazyNameSubstitution subst(*lgs, *lgs);
     core::MutableContext ctx(*lgs, core::Symbols::root(), fref);
     ast.tree = ast::Substitute::run(ctx, subst, move(ast.tree));
-    return computeFileHashForAST(lgs, subst.getAllNames(), move(ast));
+    return computeFileHashForAST(logger, lgs, subst.getAllNames(), move(ast));
 }
 }; // namespace
 
@@ -161,7 +204,7 @@ vector<ast::ParsedFile> Hashing::indexAndComputeFileHashes(unique_ptr<core::Glob
                     auto [rewrittenAST, usageHash] = rewriteAST(sharedGs, *lgs, newFref, ast);
 
                     threadResult.emplace_back(ast.file,
-                                              computeFileHashForAST(lgs, move(usageHash), move(rewrittenAST)));
+                                              computeFileHashForAST(logger, lgs, move(usageHash), move(rewrittenAST)));
                 }
             }
         }

--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -68,7 +68,7 @@ unique_ptr<core::FileHash> computeFileHashForAST(spdlog::logger &logger, unique_
 
             core::GlobalStateHash invalid;
             invalid.hierarchyHash = core::GlobalStateHash::HASH_STATE_INVALID;
-            return make_unique<core::FileHash>(move(*lgs->hash()), move(usageHash));
+            return make_unique<core::FileHash>(move(invalid), move(usageHash));
         }
     }
 

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -247,7 +247,7 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
     fast_sort(subset);
     subset.resize(std::distance(subset.begin(), std::unique(subset.begin(), subset.end())));
 
-    config->logger->debug("Taking fast path");
+    config->logger->debug("Running fast path");
     ENFORCE(gs->errorQueue->isEmpty());
     vector<ast::ParsedFile> updatedIndexed;
     for (auto &f : subset) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I want to be able to let users generate test cases for me.

This log line will let me see what file contents people are seeing when they get
empty parse results.

(Note that we already effectively put the entire file contents into the log
file, because we log every LSP protocol message, including the
`textDocument/didChange` requests, this just makes it easier to correlate
"failure condition detected" and "file contents".)


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I tested this by running LSP with `--debug-log-file` locally and checking the
contents of the log file.

If we feel strongly, I can write a test for this, but it's a little annoying,
because it only shows up in LSP mode and in the log file. It'd be doable to try
to get the contents of that log file but require some originality.