### PR TITLE
Move `bool` fields on `File` into bitfields

### DIFF
--- a/core/Files.cc
+++ b/core/Files.cc
@@ -185,7 +185,7 @@ void File::setFileHash(unique_ptr<const FileHash> hash) {
     // If hash_ != nullptr, then the contents of hash_ and hash should be identical.
     // Avoid needlessly invalidating references to *hash_.
     if (hash_ == nullptr) {
-        cached = false;
+        flags.cached = false;
         hash_ = move(hash);
     }
 }
@@ -296,6 +296,26 @@ string File::censorFilePathForSnapshotTests(string_view orig) {
     } else {
         return string(result);
     }
+}
+
+bool File::isPackagedTest() const {
+    return flags.isPackagedTest;
+}
+
+bool File::hasParseErrors() const {
+    return flags.hasParseErrors;
+}
+
+void File::setHasParseErrors(bool value) {
+    flags.hasParseErrors = value;
+}
+
+bool File::cached() const {
+    return flags.cached;
+}
+
+void File::setCached(bool value) {
+    flags.cached = value;
 }
 
 } // namespace sorbet::core

--- a/core/Files.cc
+++ b/core/Files.cc
@@ -167,12 +167,10 @@ CompiledLevel File::fileCompiledSigil(string_view source) {
 }
 
 bool isTestPath(string_view path) {
-    return absl::EndsWith(path, ".test.rb") || absl::StartsWith(path, "./test/") ||
-           absl::StrContains(path, "/test/");
+    return absl::EndsWith(path, ".test.rb") || absl::StartsWith(path, "./test/") || absl::StrContains(path, "/test/");
 }
 
-File::Flags::Flags(string_view path)
-    : cached(false), hasParseErrors(false), isPackagedTest(isTestPath(path)) {}
+File::Flags::Flags(string_view path) : cached(false), hasParseErrors(false), isPackagedTest(isTestPath(path)) {}
 
 File::File(string &&path_, string &&source_, Type sourceType, uint32_t epoch)
     : epoch(epoch), sourceType(sourceType), flags(File::Flags(path_)), path_(move(path_)), source_(move(source_)),

--- a/core/Files.cc
+++ b/core/Files.cc
@@ -167,7 +167,7 @@ CompiledLevel File::fileCompiledSigil(string_view source) {
 }
 
 bool isTestPath(string_view path) {
-    return absl::EndsWith(path, ".test.rb") || absl::StartsWith(path, "./test/") || absl::StrContains(path, "/test/");
+    return absl::EndsWith(path, ".test.rb") || absl::StrContains(path, "/test/");
 }
 
 File::Flags::Flags(string_view path) : cached(false), hasParseErrors(false), isPackagedTest(isTestPath(path)) {}

--- a/core/Files.cc
+++ b/core/Files.cc
@@ -166,8 +166,16 @@ CompiledLevel File::fileCompiledSigil(string_view source) {
     }
 }
 
+bool isTestPath(string_view path) {
+    return absl::EndsWith(path, ".test.rb") || absl::StartsWith(path, "./test/") ||
+           absl::StrContains(path, "/test/");
+}
+
+File::Flags::Flags(string_view path)
+    : cached(false), hasParseErrors(false), isPackagedTest(isTestPath(path)) {}
+
 File::File(string &&path_, string &&source_, Type sourceType, uint32_t epoch)
-    : epoch(epoch), sourceType(sourceType), path_(move(path_)), source_(move(source_)),
+    : epoch(epoch), sourceType(sourceType), flags(File::Flags(path_)), path_(move(path_)), source_(move(source_)),
       originalSigil(fileStrictSigil(this->source_)), strictLevel(originalSigil),
       compiledLevel(fileCompiledSigil(this->source_)) {}
 

--- a/core/Files.h
+++ b/core/Files.h
@@ -129,6 +129,7 @@ private:
 
         Flags(std::string_view path);
     };
+    CheckSize(Flags, 1, 1);
 
     Flags flags;
 

--- a/core/Files.h
+++ b/core/Files.h
@@ -127,7 +127,7 @@ private:
         // only relevant in --stripe-packages mode: is the file a `.test.rb` file?
         bool isPackagedTest : 1;
 
-        Flags() : cached(false), hasParseErrors(false), isPackagedTest(false) {};
+        Flags(std::string_view path);
     };
 
     Flags flags;

--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -168,12 +168,6 @@ const std::string_view PackageDB::errorHint() const {
     return errorHint_;
 }
 
-bool PackageDB::isTestFile(const core::GlobalState &gs, const core::File &file) {
-    // TODO: (aadi-stripe, 11/26/2021) see if these can all be changed to use getPrintablePath
-    return absl::EndsWith(file.path(), ".test.rb") || absl::StartsWith(file.path(), "./test/") ||
-           absl::StrContains(gs.getPrintablePath(file.path()), "/test/");
-}
-
 PackageDB PackageDB::deepCopy() const {
     ENFORCE(frozen);
     PackageDB result;

--- a/core/packages/PackageDB.h
+++ b/core/packages/PackageDB.h
@@ -49,9 +49,6 @@ public:
 
     const std::string_view errorHint() const;
 
-    // NB: Do not call in hot path, this is SLOW due to string comparison!
-    static bool isTestFile(const core::GlobalState &gs, const core::File &file);
-
 private:
     std::vector<NameRef> secondaryTestPackageNamespaceRefs_;
     std::vector<std::string> extraPackageFilesDirectoryPrefixes_;

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -974,7 +974,7 @@ ast::ExpressionPtr Serializer::loadTree(const core::GlobalState &gs, core::File 
     }
     file.setFileHash(SerializerImpl::unpickleFileHash(p));
     // cached must be set _after_ setting the file hash, as setFileHash unsets the cached flag
-    file.cached = true;
+    file.setCached(true);
     return SerializerImpl::unpickleExpr(p, gs);
 }
 

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1076,7 +1076,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                                                       ctx.owner.asMethodRef()));
                 }
 
-                ENFORCE(ctx.file.data(ctx).hasParseErrors || !tp.origins.empty(), "Inferencer did not assign location");
+                ENFORCE(ctx.file.data(ctx).hasParseErrors() || !tp.origins.empty(), "Inferencer did not assign location");
             },
             [&](cfg::Alias &a) {
                 core::SymbolRef symbol = a.what.dealias(ctx);
@@ -1436,7 +1436,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
             }
             tp.type = core::Types::untypedUntracked();
         }
-        ENFORCE(ctx.file.data(ctx).hasParseErrors || !tp.origins.empty(), "Inferencer did not assign location");
+        ENFORCE(ctx.file.data(ctx).hasParseErrors() || !tp.origins.empty(), "Inferencer did not assign location");
 
         if (!noLoopChecking && loopCount != bindMinLoops) {
             auto pin = pinnedTypes.find(bind.bind.variable);

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1076,7 +1076,8 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                                                       ctx.owner.asMethodRef()));
                 }
 
-                ENFORCE(ctx.file.data(ctx).hasParseErrors() || !tp.origins.empty(), "Inferencer did not assign location");
+                ENFORCE(ctx.file.data(ctx).hasParseErrors() || !tp.origins.empty(),
+                        "Inferencer did not assign location");
             },
             [&](cfg::Alias &a) {
                 core::SymbolRef symbol = a.what.dealias(ctx);

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -258,7 +258,7 @@ public:
 
     vector<MissingExportMatch> findMissingExports(core::Context ctx, core::SymbolRef scope, core::NameRef name) const {
         vector<MissingExportMatch> res;
-        if (core::packages::PackageDB::isTestFile(ctx, ctx.file.data(ctx))) {
+        if (ctx.file.data(ctx).isPackagedTest()) {
             // In a test file first look to see in our own package to see if it's missing an `export_for_test`
             core::SymbolRef sym = findPrivateSymbol(ctx, scope, /* test */ false);
             if (sym.exists() && sym.isClassOrModule()) {
@@ -279,7 +279,7 @@ public:
                     res.emplace_back(MissingExportMatch{sym, imported.name.mangledName});
                 }
             }
-            if (core::packages::PackageDB::isTestFile(ctx, ctx.file.data(ctx))) {
+            if (ctx.file.data(ctx).isPackagedTest()) {
                 sym = PackageInfoImpl::from(info).findPrivateSymbol(ctx, scope, /* test */ true);
                 if (sym.exists() && sym.isClassOrModule()) {
                     sym = sym.asClassOrModuleRef().data(ctx)->findMember(ctx, name);
@@ -1729,7 +1729,7 @@ ast::ParsedFile rewritePackagedFile(core::Context ctx, ast::ParsedFile parsedFil
         // Wrap the file in a package module (ending with _Package_Private) to put it by default in the package's
         // private namespace (private-by-default paradigm).
         parsedFile = wrapFileInPackageModule(ctx, move(parsedFile), pkgImpl.privateMangledName, pkgImpl,
-                                             core::packages::PackageDB::isTestFile(ctx, file));
+                                             file.isPackagedTest());
     } else {
         // Don't transform, but raise an error on the first line.
         if (auto e = ctx.beginError(core::LocOffsets{0, 0}, core::errors::Packager::UnpackagedFile)) {

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1728,8 +1728,8 @@ ast::ParsedFile rewritePackagedFile(core::Context ctx, ast::ParsedFile parsedFil
 
         // Wrap the file in a package module (ending with _Package_Private) to put it by default in the package's
         // private namespace (private-by-default paradigm).
-        parsedFile = wrapFileInPackageModule(ctx, move(parsedFile), pkgImpl.privateMangledName, pkgImpl,
-                                             file.isPackagedTest());
+        parsedFile =
+            wrapFileInPackageModule(ctx, move(parsedFile), pkgImpl.privateMangledName, pkgImpl, file.isPackagedTest());
     } else {
         // Don't transform, but raise an error on the first line.
         if (auto e = ctx.beginError(core::LocOffsets{0, 0}, core::errors::Packager::UnpackagedFile)) {

--- a/parser/Parser.cc
+++ b/parser/Parser.cc
@@ -29,7 +29,7 @@ public:
             return;
         }
         uint32_t maxOff = file.data(gs).source().size();
-        file.data(gs).hasParseErrors = true;
+        file.data(gs).setHasParseErrors(true);
         for (auto &diag : diagnostics) {
             switch (diag.level()) {
                 case ruby_parser::dlevel::NOTE:

--- a/resolver/SuggestPackage.cc
+++ b/resolver/SuggestPackage.cc
@@ -62,7 +62,7 @@ public:
 
     void addMissingExportSuggestions(core::ErrorBuilder &e, core::packages::PackageInfo::MissingExportMatch match) {
         if (match.srcPkg == currentPkg.mangledName() &&
-            core::packages::PackageDB::isTestFile(ctx, ctx.file.data(ctx))) {
+            ctx.file.data(ctx).isPackagedTest()) {
             addMissingExportForTestSuggestion(e, match);
             return;
         }
@@ -103,7 +103,7 @@ public:
     void addMissingImportSuggestions(core::ErrorBuilder &e, PackageMatch &match) {
         vector<core::ErrorLine> lines;
         auto &otherPkg = db().getPackageInfo(match.mangledName);
-        bool isTestFile = core::packages::PackageDB::isTestFile(ctx, ctx.file.data(ctx));
+        bool isTestFile = ctx.file.data(ctx).isPackagedTest();
         auto importName = isTestFile ? core::Names::test_import() : core::Names::import();
 
         lines.emplace_back(core::ErrorLine::from(otherPkg.definitionLoc(), "Do you need to `{}` package `{}`?",

--- a/resolver/SuggestPackage.cc
+++ b/resolver/SuggestPackage.cc
@@ -61,8 +61,7 @@ public:
     }
 
     void addMissingExportSuggestions(core::ErrorBuilder &e, core::packages::PackageInfo::MissingExportMatch match) {
-        if (match.srcPkg == currentPkg.mangledName() &&
-            ctx.file.data(ctx).isPackagedTest()) {
+        if (match.srcPkg == currentPkg.mangledName() && ctx.file.data(ctx).isPackagedTest()) {
             addMissingExportForTestSuggestion(e, match);
             return;
         }

--- a/test/lsp/cache_protocol_test_corpus.cc
+++ b/test/lsp/cache_protocol_test_corpus.cc
@@ -97,7 +97,7 @@ TEST_CASE_FIXTURE(CacheProtocolTest, "LSPUsesCache") {
 
         core::File file{string(filePath), string(fileContents), core::File::Type::Normal};
         auto tree = core::serialize::Serializer::loadTree(*gs, file, contents.data);
-        CHECK(file.cached);
+        CHECK(file.cached());
         CHECK_NE(file.getFileHash(), nullptr);
         CHECK_NE(tree, nullptr);
 
@@ -149,7 +149,7 @@ TEST_CASE_FIXTURE(CacheProtocolTest, "LSPUsesCache") {
 
         core::File file{string(filePath), string(updatedFileContents), core::File::Type::Normal};
         auto cachedFile = core::serialize::Serializer::loadTree(*gs, file, updatedFileData.data);
-        CHECK(file.cached);
+        CHECK(file.cached());
         CHECK_NE(file.getFileHash(), nullptr);
         CHECK_NE(cachedFile, nullptr);
     }
@@ -199,7 +199,7 @@ TEST_CASE_FIXTURE(CacheProtocolTest, "LSPDoesNotUseCacheIfModified") {
 
         core::File file{string(filePath), string(fileContents), core::File::Type::Normal};
         auto tree = core::serialize::Serializer::loadTree(*gs, file, contents.data);
-        CHECK(file.cached);
+        CHECK(file.cached());
         CHECK_NE(file.getFileHash(), nullptr);
         CHECK_NE(tree, nullptr);
     }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
This takes the two existing `bool` fields and turns them into a bitfield class, and additionally adds a new one `isPackagedTest` that gets used by our packager mode.

### Motivation
The change here is twofold:
- one, this allows us to use memory more efficiently, packing this and any future flags into less space.
- two, this allows us to skip the expensive `isTestFile` check in the packager by computing it eagerly instead.


### Test plan
See included automated tests.
