### PR TITLE
Configure Stripe-internal CSAT

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -83,12 +83,14 @@ const users = [
   },
 ];
 
+const BASE_URL = '/';
+
 const siteConfig = {
   title: 'Sorbet',
   tagline: 'A static type checker for Ruby',
   url: 'https://sorbet.org',
   cname: 'sorbet.org',
-  baseUrl: '/',
+  baseUrl: BASE_URL,
   editUrl: 'https://github.com/sorbet/sorbet/edit/master/website/docs/',
 
   // Used for publishing and more
@@ -150,7 +152,12 @@ const siteConfig = {
   },
 
   // Add custom scripts here that would be placed in <script> tags.
-  scripts: [],
+  scripts: [
+    {
+      src: `${BASE_URL}js/stripe-internal-csat.js`,
+      async: true,
+    },
+  ],
 
   // Put Table of Contents on the right side of the page
   onPageNav: 'separate',

--- a/website/static/js/stripe-internal-csat.js
+++ b/website/static/js/stripe-internal-csat.js
@@ -1,0 +1,19 @@
+(() => {
+  if (document.querySelector('#csat-extension-config') != null) {
+    return;
+  }
+
+  const selector = '.mainContainer.docsContainer > .wrapper';
+  const main = document.querySelector(selector);
+  if (main != null) {
+    const csatDiv = document.createElement('div');
+    csatDiv.id = 'csat-extension-config';
+    const config = {
+      embedded: true,
+      prompt: 'Feedback for #sorbet?',
+      notify: '#sorbet',
+    };
+    csatDiv.setAttribute('data-config', JSON.stringify(config));
+    main.appendChild(csatDiv);
+  }
+})();


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Stripe has a Chrome extension to collect internal-only feedback on
websites that have been opted in.

This will let people at Stripe report feedback about Sorbet docs
directly to the Sorbet team.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I verified that the div is not rendered when the extension is not present. I
suspect it will work when the extension is present, but sorbet.org is not in the
allow list yet.