### PR TITLE
compare FileRefs directly, rather than via their ids

### DIFF
--- a/core/AutocorrectSuggestion.cc
+++ b/core/AutocorrectSuggestion.cc
@@ -60,7 +60,7 @@ UnorderedMap<FileRef, string> AutocorrectSuggestion::apply(const GlobalState &gs
     // Sort the locs backwards
     auto compare = [](const AutocorrectSuggestion::Edit &left, const AutocorrectSuggestion::Edit &right) {
         if (left.loc.file() != right.loc.file()) {
-            return left.loc.file().id() > right.loc.file().id();
+            return left.loc.file() > right.loc.file();
         }
 
         auto a = left.loc.beginPos();

--- a/core/TypesAndOrigins.cc
+++ b/core/TypesAndOrigins.cc
@@ -32,7 +32,7 @@ vector<ErrorLine> TypeAndOrigins::origins2Explanations(const GlobalState &gs, Lo
         }
 
         if (left.file() != right.file()) {
-            return left.file().id() < right.file().id();
+            return left.file() < right.file();
         }
         if (left.beginPos() != right.beginPos()) {
             return left.beginPos() < right.beginPos();

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1958,7 +1958,7 @@ vector<ast::ParsedFile> symbolizeTrees(const core::GlobalState &gs, vector<ast::
             }
         }
     }
-    fast_sort(trees, [](const auto &lhs, const auto &rhs) -> bool { return lhs.file.id() < rhs.file.id(); });
+    fast_sort(trees, [](const auto &lhs, const auto &rhs) -> bool { return lhs.file < rhs.file; });
     return trees;
 }
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1269,18 +1269,18 @@ public:
         // Note: `todo` does not need to be sorted. There are no ordering effects on error production.
 
         fast_sort(todoAncestors,
-                  [](const auto &lhs, const auto &rhs) -> bool { return lhs.file.id() < rhs.file.id(); });
+                  [](const auto &lhs, const auto &rhs) -> bool { return lhs.file < rhs.file; });
         fast_sort(todoClassAliases,
-                  [](const auto &lhs, const auto &rhs) -> bool { return lhs.file.id() < rhs.file.id(); });
+                  [](const auto &lhs, const auto &rhs) -> bool { return lhs.file < rhs.file; });
         fast_sort(todoTypeAliases,
-                  [](const auto &lhs, const auto &rhs) -> bool { return lhs.file.id() < rhs.file.id(); });
+                  [](const auto &lhs, const auto &rhs) -> bool { return lhs.file < rhs.file; });
         fast_sort(todoClassMethods,
-                  [](const auto &lhs, const auto &rhs) -> bool { return lhs.file.id() < rhs.file.id(); });
+                  [](const auto &lhs, const auto &rhs) -> bool { return lhs.file < rhs.file; });
         fast_sort(todoRequiredAncestors,
-                  [](const auto &lhs, const auto &rhs) -> bool { return lhs.file.id() < rhs.file.id(); });
+                  [](const auto &lhs, const auto &rhs) -> bool { return lhs.file < rhs.file; });
 
         ENFORCE(todoRequiredAncestors.empty() || gs.requiresAncestorEnabled);
-        fast_sort(trees, [](const auto &lhs, const auto &rhs) -> bool { return lhs.file.id() < rhs.file.id(); });
+        fast_sort(trees, [](const auto &lhs, const auto &rhs) -> bool { return lhs.file < rhs.file; });
 
         Timer timeit1("resolver.resolve_constants.fixed_point");
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1268,16 +1268,11 @@ public:
 
         // Note: `todo` does not need to be sorted. There are no ordering effects on error production.
 
-        fast_sort(todoAncestors,
-                  [](const auto &lhs, const auto &rhs) -> bool { return lhs.file < rhs.file; });
-        fast_sort(todoClassAliases,
-                  [](const auto &lhs, const auto &rhs) -> bool { return lhs.file < rhs.file; });
-        fast_sort(todoTypeAliases,
-                  [](const auto &lhs, const auto &rhs) -> bool { return lhs.file < rhs.file; });
-        fast_sort(todoClassMethods,
-                  [](const auto &lhs, const auto &rhs) -> bool { return lhs.file < rhs.file; });
-        fast_sort(todoRequiredAncestors,
-                  [](const auto &lhs, const auto &rhs) -> bool { return lhs.file < rhs.file; });
+        fast_sort(todoAncestors, [](const auto &lhs, const auto &rhs) -> bool { return lhs.file < rhs.file; });
+        fast_sort(todoClassAliases, [](const auto &lhs, const auto &rhs) -> bool { return lhs.file < rhs.file; });
+        fast_sort(todoTypeAliases, [](const auto &lhs, const auto &rhs) -> bool { return lhs.file < rhs.file; });
+        fast_sort(todoClassMethods, [](const auto &lhs, const auto &rhs) -> bool { return lhs.file < rhs.file; });
+        fast_sort(todoRequiredAncestors, [](const auto &lhs, const auto &rhs) -> bool { return lhs.file < rhs.file; });
 
         ENFORCE(todoRequiredAncestors.empty() || gs.requiresAncestorEnabled);
         fast_sort(trees, [](const auto &lhs, const auto &rhs) -> bool { return lhs.file < rhs.file; });

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2642,7 +2642,7 @@ public:
         }
 
         // Put files into a consistent order for subsequent passes.
-        fast_sort(combinedFiles, [](auto &a, auto &b) -> bool { return a.file.id() < b.file.id(); });
+        fast_sort(combinedFiles, [](auto &a, auto &b) -> bool { return a.file < b.file; });
 
         for (auto &threadTodo : combinedTodoUntypedResultTypes) {
             for (auto sym : threadTodo) {


### PR DESCRIPTION
At some point, comparison operators were added to `FileRef`, but any number of places that still used `.id()` for comparisons weren't updated.  Let's do that update now.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Cleaner code.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
