### PR TITLE
change error for `if "string" do ... end` and add an autocorrect

### DIFF
--- a/parser/Parser.cc
+++ b/parser/Parser.cc
@@ -25,11 +25,11 @@ class ErrorToError {
 
     static void maybeAddAutocorrect(core::ErrorBuilder &e, core::Loc loc, ruby_parser::dclass errorClass) {
         switch (errorClass) {
-        case ruby_parser::dclass::IfInsteadOfItForTest:
-            e.replaceWith("Replace with `it`", loc, "it");
-            break;
-        default:
-            break;
+            case ruby_parser::dclass::IfInsteadOfItForTest:
+                e.replaceWith("Replace with `it`", loc, "it");
+                break;
+            default:
+                break;
         }
     }
 

--- a/parser/Parser.cc
+++ b/parser/Parser.cc
@@ -23,6 +23,16 @@ class ErrorToError {
         return min((uint32_t)(pos), maxOff);
     }
 
+    static void maybeAddAutocorrect(core::ErrorBuilder &e, core::Loc loc, ruby_parser::dclass errorClass) {
+        switch (errorClass) {
+        case ruby_parser::dclass::IfInsteadOfItForTest:
+            e.replaceWith("Replace with `it`", loc, "it");
+            break;
+        default:
+            break;
+        }
+    }
+
 public:
     static void run(core::GlobalState &gs, core::FileRef file, ruby_parser::diagnostics_t diagnostics) {
         if (diagnostics.empty()) {
@@ -44,6 +54,7 @@ public:
             if (auto e = gs.beginError(loc, core::errors::Parser::ParserError)) {
                 e.setHeader("{}",
                             fmt::vformat(dclassStrings[(int)diag.error_class()], fmt::make_format_args(diag.data())));
+                maybeAddAutocorrect(e, loc, diag.error_class());
             }
         }
     }

--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -1823,7 +1823,7 @@ int maybe_inject_tNL_impl(parser::symbol_type &yyla, ruby_parser::typedruby27 &d
                     }
                 | kIF strings kDO compstmt if_tail kEND
                     {
-                      driver.diagnostics.emplace_back(dlevel::ERROR, dclass::IfInsteadOfItForTest, diagnostic::range(@1.begin, @1.end), "\"if\"");
+                      driver.diagnostics.emplace_back(dlevel::ERROR, dclass::IfInsteadOfItForTest, diagnostic::range(@1.begin, @1.end));
                       auto &else_ = $5;
                       $$ = driver.build.condition(self, $1, $2, $3, $4,
                         else_ ? else_->tok : nullptr,

--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -1823,9 +1823,7 @@ int maybe_inject_tNL_impl(parser::symbol_type &yyla, ruby_parser::typedruby27 &d
                     }
                 | kIF strings kDO compstmt if_tail kEND
                     {
-                      // TODO(jez) If we had proper Sorbet diagnostics here, we could have a "did you mean"
-                      // error line that suggested changing `if` to `it`
-                      driver.diagnostics.emplace_back(dlevel::ERROR, dclass::UnexpectedToken, diagnostic::range(@3.begin, @3.end), "\"do\"");
+                      driver.diagnostics.emplace_back(dlevel::ERROR, dclass::IfInsteadOfItForTest, diagnostic::range(@1.begin, @1.end), "\"if\"");
                       auto &else_ = $5;
                       $$ = driver.build.condition(self, $1, $2, $3, $4,
                         else_ ? else_->tok : nullptr,

--- a/parser/parser/codegen/generate_diagnostics.cc
+++ b/parser/parser/codegen/generate_diagnostics.cc
@@ -69,6 +69,7 @@ tuple<string, string> MESSAGES[] = {
     {"PatternDuplicateVariable", "duplicate variable name {}"},
     {"PatternDuplicateKey", "duplicate hash pattern key {}"},
     {"PositionalAfterKeyword", "positional arg \\\"{}\\\" after keyword arg"},
+    {"IfInsteadOfItForTest", "Unexpected use of {}; did you mean to use \\\"it\\\"?"},
 
     // Parser warnings
     {"UselessElse", "else without rescue is useless"},

--- a/parser/parser/codegen/generate_diagnostics.cc
+++ b/parser/parser/codegen/generate_diagnostics.cc
@@ -69,7 +69,7 @@ tuple<string, string> MESSAGES[] = {
     {"PatternDuplicateVariable", "duplicate variable name {}"},
     {"PatternDuplicateKey", "duplicate hash pattern key {}"},
     {"PositionalAfterKeyword", "positional arg \\\"{}\\\" after keyword arg"},
-    {"IfInsteadOfItForTest", "Unexpected use of {}; did you mean to use \\\"it\\\"?"},
+    {"IfInsteadOfItForTest", "Unexpected token \\\"if\\\"; did you mean \\\"it\\\"?"},
 
     // Parser warnings
     {"UselessElse", "else without rescue is useless"},

--- a/test/testdata/parser/error_recovery_if_do.rb
+++ b/test/testdata/parser/error_recovery_if_do.rb
@@ -2,6 +2,6 @@
 
 class A
   if 'thing' do
-  #          ^^ error: unexpected token "do"
+# ^^ error: Unexpected use of "if"; did you mean to use "it"?
   end
 end

--- a/test/testdata/parser/error_recovery_if_do.rb
+++ b/test/testdata/parser/error_recovery_if_do.rb
@@ -2,6 +2,6 @@
 
 class A
   if 'thing' do
-# ^^ error: Unexpected use of "if"; did you mean to use "it"?
+# ^^ error: Unexpected token "if"; did you mean to use "it"?
   end
 end

--- a/test/testdata/parser/error_recovery_if_do.rb
+++ b/test/testdata/parser/error_recovery_if_do.rb
@@ -2,6 +2,6 @@
 
 class A
   if 'thing' do
-# ^^ error: Unexpected token "if"; did you mean to use "it"?
+# ^^ error: Unexpected token "if"; did you mean "it"?
   end
 end


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I think this is a better error (since the user probably did mean to write `do` and didn't mean to write `if`) and by changing the error kind to a more specific one, it shows how we can add autocorrects in the context of the parser's diagnostic framework.  (I think we should not convert things to eagerly use Sorbet's errors, since we have things like `replace_last_diagnostic`, which wouldn't play well with Sorbet's errors AIUI.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
