### PR TITLE
Remove hacks from definition validator

### DIFF
--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -464,10 +464,6 @@ void validateSealedAncestorHelper(core::Context ctx, const core::ClassOrModuleRe
         }
 
         auto klassFile = bestNonRBIFile(ctx, klass);
-        // HACK for RBI generator (see other comment)
-        if (klassFile.data(ctx).isRBI()) {
-            continue;
-        }
         if (absl::c_any_of(mixin.data(ctx)->sealedLocs(ctx),
                            [klassFile](auto loc) { return loc.file() == klassFile; })) {
             continue;
@@ -485,19 +481,13 @@ void validateSealed(core::Context ctx, const core::ClassOrModuleRef klass, const
     const auto superClass = klass.data(ctx)->superClass();
     if (superClass.exists() && superClass.data(ctx)->isClassOrModuleSealed()) {
         auto file = bestNonRBIFile(ctx, klass);
-        // HACK: Package.test.rbi may extend a class defined in Package.rbi because it contains a
-        // Package class only referenced by test exports.
-        if (!file.data(ctx).isRBI()) {
-            if (!absl::c_any_of(superClass.data(ctx)->sealedLocs(ctx),
-                                [file](auto loc) { return loc.file() == file; })) {
-                if (auto e = ctx.beginError(getAncestorLoc(ctx, classDef, superClass),
-                                            core::errors::Resolver::SealedAncestor)) {
-                    e.setHeader("`{}` is sealed and cannot be inherited by `{}`", superClass.show(ctx),
-                                klass.show(ctx));
-                    for (auto loc : superClass.data(ctx)->sealedLocs(ctx)) {
-                        e.addErrorLine(loc, "`{}` was marked sealed and can only be inherited in this file",
-                                       superClass.show(ctx));
-                    }
+        if (!absl::c_any_of(superClass.data(ctx)->sealedLocs(ctx), [file](auto loc) { return loc.file() == file; })) {
+            if (auto e =
+                    ctx.beginError(getAncestorLoc(ctx, classDef, superClass), core::errors::Resolver::SealedAncestor)) {
+                e.setHeader("`{}` is sealed and cannot be inherited by `{}`", superClass.show(ctx), klass.show(ctx));
+                for (auto loc : superClass.data(ctx)->sealedLocs(ctx)) {
+                    e.addErrorLine(loc, "`{}` was marked sealed and can only be inherited in this file",
+                                   superClass.show(ctx));
                 }
             }
         }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
These hacks are needed to generate RBIs, but as that feature is still in development it doesn't make sense to leave them in.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Fixing-forward definition validator.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
