### PR TITLE
[rbi-gen] Don't emit sigs for package_private methods

### DIFF
--- a/packager/rbi_gen.cc
+++ b/packager/rbi_gen.cc
@@ -323,6 +323,7 @@ private:
         if (!method.exists()) {
             return "";
         }
+
         auto methodData = method.data(gs);
 
         string visibility = "";
@@ -964,6 +965,13 @@ private:
         if (method.data(gs)->name == core::Names::staticInit()) {
             return;
         }
+
+        // This method will still be available at runtime, but not exposing it through the package interface means that
+        // we'll raise errors statically if it's used.
+        if (method.data(gs)->flags.isPackagePrivate) {
+            return;
+        }
+
         emittedSymbols.insert(method);
 
         // Note: We have to emit private methods because `include`ing a module with private methods will make those

--- a/test/testdata/packager/rbi_gen/__package.rbi-gen.exp
+++ b/test/testdata/packager/rbi_gen/__package.rbi-gen.exp
@@ -217,6 +217,9 @@ class RBIGen::Public::ClassWithTypeParams < Object
   A = type_template(fixed: RBIGen::Private::PrivateClassPulledInByTypeTemplate)
   B = type_template()
 end
+class RBIGen::Public::ClassWithPrivateMethods < Object
+  extend T::Sig
+end
 class RBIGen::Public::AttachedClassType < Object
   extend T::Sig
   sig {params(a: T.proc.params(arg0: T.attached_class).void).void}

--- a/test/testdata/packager/rbi_gen/members.rb
+++ b/test/testdata/packager/rbi_gen/members.rb
@@ -7,7 +7,7 @@ module ::Opus::Flatfiles
 
     sig {params(name: T.untyped, type: T.untyped).void}
     def self.dsl_required(name, type); end
-    
+
     sig {params(blk: T.proc.void).void}
     def self.flatfile(&blk); end
 
@@ -23,7 +23,7 @@ module ::Opus::Flatfiles
 
   class MarkupLanguageNodeStruct
     extend T::Sig
-    
+
     sig {params(blk: T.proc.void).void}
     def self.flatfile(&blk); end
 
@@ -106,7 +106,7 @@ module RBIGen::Public
 
   class MyEnum < T::Enum
     extend T::Sig
-    
+
     enums do
       Spades = new
       Hearts = new
@@ -122,7 +122,7 @@ module RBIGen::Public
 
   class MyStruct < T::Struct
     extend T::Sig
-    
+
     prop :foo, Integer
     const :bar, T.nilable(String)
     const :quz, Float, default: 0.5
@@ -166,7 +166,7 @@ module RBIGen::Public
 
   class FieldCheck
     extend T::Sig
-  
+
     Alias = RBIGen::Public::FieldCheck
     Constant = T.let(0, Integer)
     AliasConstant = T.let(RBIGen::Public::FieldCheck, T.class_of(RBIGen::Public::FieldCheck))
@@ -207,7 +207,7 @@ module RBIGen::Public
 
   class ClassWithTypeParams
     extend T::Generic
-    
+
     A = type_template(fixed: RBIGen::Private::PrivateClassPulledInByTypeTemplate)
     B = type_template()
     C = type_member()
@@ -295,7 +295,7 @@ module RBIGen::Public
     @static_field = T.let(10, Integer)
     class << self
       extend Forwardable
-      
+
       def_delegators :@static_field, :method1, :method2
       def_delegator :@static_field, :method3
     end
@@ -308,7 +308,7 @@ module RBIGen::Public
 
   MaybeString = T.type_alias {T.nilable(String)}
   ShapeType = T.type_alias{{:$str => String}}
-  
+
   class AttachedClassType
     extend T::Sig
 

--- a/test/testdata/packager/rbi_gen/members.rb
+++ b/test/testdata/packager/rbi_gen/members.rb
@@ -1,5 +1,16 @@
 # typed: strict
 
+# Runtime support
+class ::Module < Object
+  extend T::Sig
+
+  sig {params(args: T.any(Symbol, String)).returns(T.self_type)}
+  def package_private(*args); self; end
+
+  sig {params(args: T.any(Symbol, String)).returns(T.self_type)}
+  def package_private_class_method(*args); self; end
+end
+
 # Cheating
 module ::Opus::Flatfiles
   class Record
@@ -202,6 +213,19 @@ module RBIGen::Public
     sig {params(other: BasicObject).returns(T::Boolean)}
     def ==(other)
       false
+    end
+  end
+
+  # Methods marked `package_private` should not show up in the package rbi.
+  class ClassWithPrivateMethods
+    extend T::Sig
+
+    sig {void}
+    package_private def private_instance_method()
+    end
+
+    sig {void}
+    package_private_class_method def self.private_class_method()
     end
   end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Methods marked `package_private` or `package_private_class_method` aren't meant to be exposed through the package interface. This PR prevents them from being emitted during rbi generation.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Trimming down the public interface for packages.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
