### PR TITLE
Recover from &block args incorrectly wrapped in curly braces

### DIFF
--- a/parser/Parser.cc
+++ b/parser/Parser.cc
@@ -38,13 +38,11 @@ class ErrorToError {
                 if (source.has_value()) {
                     auto replacement = string(loc.source(gs).value());
                     size_t lCurlyPos = replacement.find("{");
-                    if (lCurlyPos != string::npos) {
-                        replacement = replacement.erase(lCurlyPos, 1);
-                        size_t rCurlyPos = replacement.rfind("}");
-                        if (rCurlyPos != string::npos) {
-                            replacement = replacement.erase(rCurlyPos, 1);
-                            e.replaceWith("Remove the curly braces", loc, replacement);
-                        }
+                    size_t rCurlyPos = replacement.rfind("}");
+                    if (lCurlyPos != string::npos && rCurlyPos != string::npos) {
+                        replacement[lCurlyPos] = '(';
+                        replacement[rCurlyPos] = ')';
+                        e.replaceWith("Replace the curly braces with parens", loc, replacement);
                     }
                 }
                 break;

--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -2517,7 +2517,8 @@ opt_block_args_tail:
                     }
                   | tAMPER arg_value
                     {
-                      $$ = driver.alloc.delimited_block(nullptr, driver.build.args(nullptr, nullptr, nullptr, nullptr, false), $2, nullptr, true);
+                      auto args = driver.build.args(self, nullptr, driver.alloc.node_list(), nullptr, false);
+                      $$ = driver.alloc.delimited_block(nullptr, args, $2, nullptr, true);
                     }
 
          do_body:   {

--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -367,6 +367,8 @@ using namespace std::string_literals;
   then
   relop
   k_return
+  lcurly_block_start
+  lbrace_cmd_block_start
 
 %type <delimited_list>
   defn_head
@@ -912,32 +914,26 @@ int maybe_inject_tNL_impl(parser::symbol_type &yyla, ruby_parser::TYPEDRUBY27 &d
                       $$ = driver.build.call_method(self, $1, $2, $3, nullptr, $4, nullptr);
                     }
 
- cmd_brace_block: tLBRACE_ARG
+lbrace_cmd_block_start:
+                  tLBRACE_ARG { driver.lex.context.push(Context::State::BLOCK); $$ = $1; }
+ cmd_brace_block: lbrace_cmd_block_start brace_body tRCURLY
                     {
-                      driver.lex.context.push(Context::State::BLOCK);
-                    }
-                  brace_body tRCURLY
-                    {
-                      auto &block = $3;
+                      auto &block = $2;
                       block->begin = $1;
-                      block->end = $4;
+                      block->end = $3;
                       $$ = block;
                       driver.lex.context.pop();
                     }
                   // Error-recovery case for typos like "foo {&:bar}"
-                | tLBRACE_ARG
-                    {
-                      driver.lex.context.push(Context::State::BLOCK);
-                    }
-                  tAMPER arg_value tRCURLY
+                | lbrace_cmd_block_start tAMPER arg_value tRCURLY
                     {
                       auto args = driver.build.args(self, nullptr, driver.alloc.node_list(), nullptr, false);
-                      auto block = driver.alloc.delimited_block(nullptr, args, $4, nullptr);
+                      auto block = driver.alloc.delimited_block(nullptr, args, $3, nullptr);
                       block->begin = $1;
-                      block->end = $5;
+                      block->end = $4;
                       $$ = block;
                       driver.diagnostics.emplace_back(dlevel::ERROR, dclass::CurlyBracesAroundBlockPass,
-                          diagnostic::range(@1.begin, @5.end));
+                          diagnostic::range(@1.begin, @4.end));
                       driver.lex.context.pop();
                     }
 
@@ -2482,33 +2478,26 @@ opt_block_args_tail:
                     {
                       $$ = driver.build.index(self, $1, $2, $3, $4);
                     }
-
-     brace_block: tLCURLY
+lcurly_block_start:
+                  tLCURLY { driver.lex.context.push(Context::State::BLOCK); $$ = $1; }
+     brace_block: lcurly_block_start brace_body tRCURLY
                     {
-                      driver.lex.context.push(Context::State::BLOCK);
-                    }
-                  brace_body tRCURLY
-                    {
-                      auto &block = $3;
+                      auto &block = $2;
                       block->begin = $1;
-                      block->end = $4;
+                      block->end = $3;
                       $$ = block;
                       driver.lex.context.pop();
                     }
                   // Error-recovery case for typos like "foo {&:bar}"
-                | tLCURLY
-                    {
-                      driver.lex.context.push(Context::State::BLOCK);
-                    }
-                  tAMPER arg_value tRCURLY
+                | lcurly_block_start tAMPER arg_value tRCURLY
                     {
                       auto args = driver.build.args(self, nullptr, driver.alloc.node_list(), nullptr, false);
-                      auto block = driver.alloc.delimited_block(nullptr, args, $4, nullptr);
+                      auto block = driver.alloc.delimited_block(nullptr, args, $3, nullptr);
                       block->begin = $1;
-                      block->end = $5;
+                      block->end = $4;
                       $$ = block;
                       driver.diagnostics.emplace_back(dlevel::ERROR, dclass::CurlyBracesAroundBlockPass,
-                          diagnostic::range(@1.begin, @5.end));
+                          diagnostic::range(@1.begin, @4.end));
                       driver.lex.context.pop();
                     }
                 | kDO

--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -2492,7 +2492,6 @@ opt_block_args_tail:
                       driver.lex.context.pop();
                     }
 
-
       brace_body:   {
                       driver.lex.extend_dynamic();
                       driver.numparam_stack.push(driver.alloc.node_list());

--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -586,7 +586,7 @@ int maybe_inject_tNL_impl(parser::symbol_type &yyla, ruby_parser::TYPEDRUBY27 &d
 
      begin_block: tLCURLY top_compstmt tRCURLY
                     {
-                      $$ = driver.alloc.delimited_block($1, nullptr, $2, $3, false);
+                      $$ = driver.alloc.delimited_block($1, nullptr, $2, $3);
                     }
 
         bodystmt: compstmt opt_rescue opt_else opt_ensure
@@ -921,11 +921,23 @@ int maybe_inject_tNL_impl(parser::symbol_type &yyla, ruby_parser::TYPEDRUBY27 &d
                       auto &block = $3;
                       block->begin = $1;
                       block->end = $4;
-                      if (block->invalidBlockPass) {
-                        driver.diagnostics.emplace_back(dlevel::ERROR, dclass::CurlyBracesAroundBlockPass,
-                          diagnostic::range(@1.begin, @4.end));
-                      }
                       $$ = block;
+                      driver.lex.context.pop();
+                    }
+                  // Error-recovery case for typos like "foo {&:bar}"
+                | tLBRACE_ARG
+                    {
+                      driver.lex.context.push(Context::State::BLOCK);
+                    }
+                  tAMPER arg_value tRCURLY
+                    {
+                      auto args = driver.build.args(self, nullptr, driver.alloc.node_list(), nullptr, false);
+                      auto block = driver.alloc.delimited_block(nullptr, args, $4, nullptr);
+                      block->begin = $1;
+                      block->end = $5;
+                      $$ = block;
+                      driver.diagnostics.emplace_back(dlevel::ERROR, dclass::CurlyBracesAroundBlockPass,
+                          diagnostic::range(@1.begin, @5.end));
                       driver.lex.context.pop();
                     }
 
@@ -2337,7 +2349,7 @@ opt_block_args_tail:
                     }
                   compstmt tRCURLY
                     {
-                      $$ = driver.alloc.delimited_block($1, nullptr, $3, $4, false);
+                      $$ = driver.alloc.delimited_block($1, nullptr, $3, $4);
                       driver.lex.context.pop();
                     }
                 | kDO_LAMBDA
@@ -2346,7 +2358,7 @@ opt_block_args_tail:
                     }
                   bodystmt kEND
                     {
-                      $$ = driver.alloc.delimited_block($1, nullptr, $3, $4, false);
+                      $$ = driver.alloc.delimited_block($1, nullptr, $3, $4);
                       driver.lex.context.pop();
                     }
 
@@ -2480,11 +2492,23 @@ opt_block_args_tail:
                       auto &block = $3;
                       block->begin = $1;
                       block->end = $4;
-                      if (block->invalidBlockPass) {
-                        driver.diagnostics.emplace_back(dlevel::ERROR, dclass::CurlyBracesAroundBlockPass,
-                          diagnostic::range(@1.begin, @4.end));
-                      }
                       $$ = block;
+                      driver.lex.context.pop();
+                    }
+                  // Error-recovery case for typos like "foo {&:bar}"
+                | tLCURLY
+                    {
+                      driver.lex.context.push(Context::State::BLOCK);
+                    }
+                  tAMPER arg_value tRCURLY
+                    {
+                      auto args = driver.build.args(self, nullptr, driver.alloc.node_list(), nullptr, false);
+                      auto block = driver.alloc.delimited_block(nullptr, args, $4, nullptr);
+                      block->begin = $1;
+                      block->end = $5;
+                      $$ = block;
+                      driver.diagnostics.emplace_back(dlevel::ERROR, dclass::CurlyBracesAroundBlockPass,
+                          diagnostic::range(@1.begin, @5.end));
                       driver.lex.context.pop();
                     }
                 | kDO
@@ -2508,17 +2532,12 @@ opt_block_args_tail:
                     {
                       if (driver.numparam_stack.seen_numparams()) {
                         auto numparams = driver.build.numparams(self, driver.numparam_stack.top()->decls);
-                        $$ = driver.alloc.delimited_block(nullptr, numparams, $3, nullptr, false);
+                        $$ = driver.alloc.delimited_block(nullptr, numparams, $3, nullptr);
                       } else {
-                        $$ = driver.alloc.delimited_block(nullptr, $2, $3, nullptr, false);
+                        $$ = driver.alloc.delimited_block(nullptr, $2, $3, nullptr);
                       }
                       driver.numparam_stack.pop();
                       driver.lex.unextend();
-                    }
-                  | tAMPER arg_value
-                    {
-                      auto args = driver.build.args(self, nullptr, driver.alloc.node_list(), nullptr, false);
-                      $$ = driver.alloc.delimited_block(nullptr, args, $2, nullptr, true);
                     }
 
          do_body:   {
@@ -2532,9 +2551,9 @@ opt_block_args_tail:
                     {
                       if (driver.numparam_stack.seen_numparams()) {
                         auto numparams = driver.build.numparams(self, driver.numparam_stack.top()->decls);
-                        $$ = driver.alloc.delimited_block(nullptr, numparams, $4, nullptr, false);
+                        $$ = driver.alloc.delimited_block(nullptr, numparams, $4, nullptr);
                       } else {
-                        $$ = driver.alloc.delimited_block(nullptr, $3, $4, nullptr, false);
+                        $$ = driver.alloc.delimited_block(nullptr, $3, $4, nullptr);
                       }
                       driver.lex.unextend();
 

--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -586,7 +586,7 @@ int maybe_inject_tNL_impl(parser::symbol_type &yyla, ruby_parser::TYPEDRUBY27 &d
 
      begin_block: tLCURLY top_compstmt tRCURLY
                     {
-                      $$ = driver.alloc.delimited_block($1, nullptr, $2, $3);
+                      $$ = driver.alloc.delimited_block($1, nullptr, $2, $3, false);
                     }
 
         bodystmt: compstmt opt_rescue opt_else opt_ensure
@@ -921,6 +921,10 @@ int maybe_inject_tNL_impl(parser::symbol_type &yyla, ruby_parser::TYPEDRUBY27 &d
                       auto &block = $3;
                       block->begin = $1;
                       block->end = $4;
+                      if (block->invalidBlockPass) {
+                        driver.diagnostics.emplace_back(dlevel::ERROR, dclass::CurlyBracesAroundBlockPass,
+                          diagnostic::range(@1.begin, @4.end));
+                      }
                       $$ = block;
                       driver.lex.context.pop();
                     }
@@ -2333,7 +2337,7 @@ opt_block_args_tail:
                     }
                   compstmt tRCURLY
                     {
-                      $$ = driver.alloc.delimited_block($1, nullptr, $3, $4);
+                      $$ = driver.alloc.delimited_block($1, nullptr, $3, $4, false);
                       driver.lex.context.pop();
                     }
                 | kDO_LAMBDA
@@ -2342,7 +2346,7 @@ opt_block_args_tail:
                     }
                   bodystmt kEND
                     {
-                      $$ = driver.alloc.delimited_block($1, nullptr, $3, $4);
+                      $$ = driver.alloc.delimited_block($1, nullptr, $3, $4, false);
                       driver.lex.context.pop();
                     }
 
@@ -2476,6 +2480,10 @@ opt_block_args_tail:
                       auto &block = $3;
                       block->begin = $1;
                       block->end = $4;
+                      if (block->invalidBlockPass) {
+                        driver.diagnostics.emplace_back(dlevel::ERROR, dclass::CurlyBracesAroundBlockPass,
+                          diagnostic::range(@1.begin, @4.end));
+                      }
                       $$ = block;
                       driver.lex.context.pop();
                     }
@@ -2500,18 +2508,16 @@ opt_block_args_tail:
                     {
                       if (driver.numparam_stack.seen_numparams()) {
                         auto numparams = driver.build.numparams(self, driver.numparam_stack.top()->decls);
-                        $$ = driver.alloc.delimited_block(nullptr, numparams, $3, nullptr);
+                        $$ = driver.alloc.delimited_block(nullptr, numparams, $3, nullptr, false);
                       } else {
-                        $$ = driver.alloc.delimited_block(nullptr, $2, $3, nullptr);
+                        $$ = driver.alloc.delimited_block(nullptr, $2, $3, nullptr, false);
                       }
                       driver.numparam_stack.pop();
                       driver.lex.unextend();
                     }
                   | tAMPER arg_value
                     {
-                      $$ = driver.alloc.delimited_block(nullptr, nullptr, nullptr, nullptr);
-                      driver.diagnostics.emplace_back(dlevel::ERROR, dclass::CurlyBracesAroundBlockPass,
-                        diagnostic::range(@1.begin, @2.end));
+                      $$ = driver.alloc.delimited_block(nullptr, driver.build.args(nullptr, nullptr, nullptr, nullptr, false), $2, nullptr, true);
                     }
 
          do_body:   {
@@ -2525,9 +2531,9 @@ opt_block_args_tail:
                     {
                       if (driver.numparam_stack.seen_numparams()) {
                         auto numparams = driver.build.numparams(self, driver.numparam_stack.top()->decls);
-                        $$ = driver.alloc.delimited_block(nullptr, numparams, $4, nullptr);
+                        $$ = driver.alloc.delimited_block(nullptr, numparams, $4, nullptr, false);
                       } else {
-                        $$ = driver.alloc.delimited_block(nullptr, $3, $4, nullptr);
+                        $$ = driver.alloc.delimited_block(nullptr, $3, $4, nullptr, false);
                       }
                       driver.lex.unextend();
 

--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -2492,6 +2492,7 @@ opt_block_args_tail:
                       driver.lex.context.pop();
                     }
 
+
       brace_body:   {
                       driver.lex.extend_dynamic();
                       driver.numparam_stack.push(driver.alloc.node_list());
@@ -2506,6 +2507,12 @@ opt_block_args_tail:
                       }
                       driver.numparam_stack.pop();
                       driver.lex.unextend();
+                    }
+                  | tAMPER arg_value
+                    {
+                      $$ = driver.alloc.delimited_block(nullptr, nullptr, nullptr, nullptr);
+                      driver.diagnostics.emplace_back(dlevel::ERROR, dclass::CurlyBracesAroundBlockPass,
+                        diagnostic::range(@1.begin, @2.end));
                     }
 
          do_body:   {

--- a/parser/parser/codegen/generate_diagnostics.cc
+++ b/parser/parser/codegen/generate_diagnostics.cc
@@ -66,6 +66,7 @@ tuple<string, string> MESSAGES[] = {
     {"PositionalAfterKeyword", "positional arg \\\"{}\\\" after keyword arg"},
     {"IfInsteadOfItForTest", "Unexpected token \\\"if\\\"; did you mean \\\"it\\\"?"},
     {"MissingCommaBetweenKwargs", "missing \\\",\\\" between keyword args"},
+    {"CurlyBracesAroundBlockPass", "block pass should not be enclosed in curly braces"},
 
     // Parser warnings
     {"UselessElse", "else without rescue is useless"},

--- a/parser/parser/include/ruby_parser/driver.hh
+++ b/parser/parser/include/ruby_parser/driver.hh
@@ -59,14 +59,13 @@ struct delimited_node_list {
 
 struct delimited_block {
     delimited_block() = default;
-    delimited_block(const token_t &begin, ForeignPtr args, ForeignPtr body, const token_t &end, bool invalidBlockPass)
-        : begin(begin), args(args), body(body), end(end), invalidBlockPass(invalidBlockPass) {}
+    delimited_block(const token_t &begin, ForeignPtr args, ForeignPtr body, const token_t &end)
+        : begin(begin), args(args), body(body), end(end) {}
 
     token_t begin = nullptr;
     ForeignPtr args = nullptr;
     ForeignPtr body = nullptr;
     token_t end = nullptr;
-    bool invalidBlockPass = false;
 };
 
 struct node_with_token {

--- a/parser/parser/include/ruby_parser/driver.hh
+++ b/parser/parser/include/ruby_parser/driver.hh
@@ -59,13 +59,14 @@ struct delimited_node_list {
 
 struct delimited_block {
     delimited_block() = default;
-    delimited_block(const token_t &begin, ForeignPtr args, ForeignPtr body, const token_t &end)
-        : begin(begin), args(args), body(body), end(end) {}
+    delimited_block(const token_t &begin, ForeignPtr args, ForeignPtr body, const token_t &end, bool invalidBlockPass)
+        : begin(begin), args(args), body(body), end(end), invalidBlockPass(invalidBlockPass) {}
 
     token_t begin = nullptr;
     ForeignPtr args = nullptr;
     ForeignPtr body = nullptr;
     token_t end = nullptr;
+    bool invalidBlockPass = false;
 };
 
 struct node_with_token {

--- a/test/cli/autocorrect-block-pass-curly-braces/autocorrect-block-pass-curly-braces.out
+++ b/test/cli/autocorrect-block-pass-curly-braces/autocorrect-block-pass-curly-braces.out
@@ -2,7 +2,7 @@ autocorrect-block-pass-curly-braces.rb:5: block pass should not be enclosed in c
      5 |    f {&:foo}
               ^^^^^^^
   Autocorrect: Done
-    autocorrect-block-pass-curly-braces.rb:5: Replaced with `&:foo`
+    autocorrect-block-pass-curly-braces.rb:5: Replaced with `(&:foo)`
      5 |    f {&:foo}
               ^^^^^^^
 
@@ -10,7 +10,7 @@ autocorrect-block-pass-curly-braces.rb:9: block pass should not be enclosed in c
      9 |    g {&(1+1)}
               ^^^^^^^^
   Autocorrect: Done
-    autocorrect-block-pass-curly-braces.rb:9: Replaced with `&(1+1)`
+    autocorrect-block-pass-curly-braces.rb:9: Replaced with `(&(1+1))`
      9 |    g {&(1+1)}
               ^^^^^^^^
 
@@ -18,8 +18,8 @@ autocorrect-block-pass-curly-braces.rb:13: block pass should not be enclosed in 
     13 |    h {&(T.unsafe(true) ? :sneeze
     14 |                        : :cough)}
   Autocorrect: Done
-    autocorrect-block-pass-curly-braces.rb:13: Replaced with `&(T.unsafe(true) ? :sneeze
-                        : :cough)`
+    autocorrect-block-pass-curly-braces.rb:13: Replaced with `(&(T.unsafe(true) ? :sneeze
+                        : :cough))`
     13 |    h {&(T.unsafe(true) ? :sneeze
     14 |                        : :cough)}
 Errors: 3
@@ -30,15 +30,15 @@ Errors: 3
 
 class A
   def f
-    f &:foo
+    f (&:foo)
   end
 
   def g
-    g &(1+1)
+    g (&(1+1))
   end
 
   def h
-    h &(T.unsafe(true) ? :sneeze
-                        : :cough)
+    h (&(T.unsafe(true) ? :sneeze
+                        : :cough))
   end
 end

--- a/test/cli/autocorrect-block-pass-curly-braces/autocorrect-block-pass-curly-braces.out
+++ b/test/cli/autocorrect-block-pass-curly-braces/autocorrect-block-pass-curly-braces.out
@@ -1,0 +1,44 @@
+autocorrect-block-pass-curly-braces.rb:5: block pass should not be enclosed in curly braces https://srb.help/2001
+     5 |    f {&:foo}
+              ^^^^^^^
+  Autocorrect: Done
+    autocorrect-block-pass-curly-braces.rb:5: Replaced with `&:foo`
+     5 |    f {&:foo}
+              ^^^^^^^
+
+autocorrect-block-pass-curly-braces.rb:9: block pass should not be enclosed in curly braces https://srb.help/2001
+     9 |    g {&(1+1)}
+              ^^^^^^^^
+  Autocorrect: Done
+    autocorrect-block-pass-curly-braces.rb:9: Replaced with `&(1+1)`
+     9 |    g {&(1+1)}
+              ^^^^^^^^
+
+autocorrect-block-pass-curly-braces.rb:13: block pass should not be enclosed in curly braces https://srb.help/2001
+    13 |    h {&(T.unsafe(true) ? :sneeze
+    14 |                        : :cough)}
+  Autocorrect: Done
+    autocorrect-block-pass-curly-braces.rb:13: Replaced with `&(T.unsafe(true) ? :sneeze
+                        : :cough)`
+    13 |    h {&(T.unsafe(true) ? :sneeze
+    14 |                        : :cough)}
+Errors: 3
+
+--------------------------------------------------------------------------
+
+# typed: true
+
+class A
+  def f
+    f &:foo
+  end
+
+  def g
+    g &(1+1)
+  end
+
+  def h
+    h &(T.unsafe(true) ? :sneeze
+                        : :cough)
+  end
+end

--- a/test/cli/autocorrect-block-pass-curly-braces/autocorrect-block-pass-curly-braces.rb
+++ b/test/cli/autocorrect-block-pass-curly-braces/autocorrect-block-pass-curly-braces.rb
@@ -1,0 +1,16 @@
+# typed: true
+
+class A
+  def f
+    f {&:foo}
+  end
+
+  def g
+    g {&(1+1)}
+  end
+
+  def h
+    h {&(T.unsafe(true) ? :sneeze
+                        : :cough)}
+  end
+end

--- a/test/cli/autocorrect-block-pass-curly-braces/autocorrect-block-pass-curly-braces.sh
+++ b/test/cli/autocorrect-block-pass-curly-braces/autocorrect-block-pass-curly-braces.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+tmp="$(mktemp -d)"
+infile="test/cli/autocorrect-block-pass-curly-braces/autocorrect-block-pass-curly-braces.rb"
+cp "$infile" "$tmp"
+
+cwd="$(pwd)"
+cd "$tmp" || exit 1
+
+"$cwd/main/sorbet" --silence-dev-message -a autocorrect-block-pass-curly-braces.rb 2>&1
+
+echo
+echo --------------------------------------------------------------------------
+echo
+
+cat autocorrect-block-pass-curly-braces.rb
+
+rm autocorrect-block-pass-curly-braces.rb
+rm "$tmp"

--- a/test/testdata/parser/curly_braces_block_pass.rb
+++ b/test/testdata/parser/curly_braces_block_pass.rb
@@ -1,0 +1,19 @@
+# typed: true
+
+class A
+  def f
+    f {&:foo}
+    # ^^^^^^^ error: block pass should not be enclosed in curly braces
+  end
+
+  def g
+    g {&(1+1)}
+    # ^^^^^^^^ error: block pass should not be enclosed in curly braces
+  end
+
+  def h
+    h {&(T.unsafe(true) ? :sneeze
+                        : :cough)}
+    # error: block pass should not be enclosed in curly braces
+  end
+end


### PR DESCRIPTION
Partially addresses #5179.

This lets us recover from parse errors for cases where the user types something like:

```
foo.map {&:to_s}
```

(Note the extraneous curly braces.) It also supplies an autocorrect.

This PR does not handle the (perhaps less common?) case raised in #5179 where the curlies include block args, e.g.

```
foo.map {|x| &:to_s}
```

Not sure how much that matters. It should be possible to support this, but it looked like it was going to require deeper refactoring of the parser to do so.

### Motivation
Better recovery from parse failures from common errors.

### Test plan
See included automated tests.
