### PR TITLE
Improve colors for "Method does not exist" error

### DIFF
--- a/core/Error.cc
+++ b/core/Error.cc
@@ -131,9 +131,11 @@ void ErrorBuilder::_setHeader(string &&header) {
     this->header = move(header);
 }
 
-void ErrorBuilder::addErrorSection(ErrorSection &&section) {
+void ErrorBuilder::addErrorSection(optional<ErrorSection> &&section) {
     ENFORCE(state == State::WillBuild);
-    this->sections.emplace_back(move(section));
+    if (section.has_value()) {
+        this->sections.emplace_back(move(*section));
+    }
 }
 
 void ErrorBuilder::addAutocorrect(AutocorrectSuggestion &&autocorrect) {

--- a/core/Error.h
+++ b/core/Error.h
@@ -147,7 +147,7 @@ public:
         ENFORCE(state != State::DidBuild);
         return state == State::WillBuild;
     }
-    void addErrorSection(ErrorSection &&section);
+    void addErrorSection(std::optional<ErrorSection> &&section);
     template <typename... Args> void addErrorLine(Loc loc, fmt::format_string<Args...> msg, Args &&...args) {
         std::string formatted = ErrorColors::format(msg, std::forward<Args>(args)...);
         addErrorSection(ErrorSection({ErrorLine(loc, formatted)}));

--- a/core/Types.h
+++ b/core/Types.h
@@ -826,7 +826,7 @@ public:
 
     static ErrorSection explainExpected(const GlobalState &gs, TypePtr type, Loc origin, const std::string &for_);
     ErrorSection explainExpected(const GlobalState &gs, const std::string &for_, Loc originForUninitialized) const;
-    ErrorSection explainGot(const GlobalState &gs, Loc originForUninitialized) const;
+    std::optional<ErrorSection> explainGot(const GlobalState &gs, Loc originForUninitialized) const;
 
     ~TypeAndOrigins() noexcept;
     TypeAndOrigins() = default;

--- a/core/TypesAndOrigins.cc
+++ b/core/TypesAndOrigins.cc
@@ -74,9 +74,14 @@ ErrorSection TypeAndOrigins::explainExpected(const GlobalState &gs, const string
     return ErrorSection(header, this->origins2Explanations(gs, originForUninitialized));
 }
 
-ErrorSection TypeAndOrigins::explainGot(const GlobalState &gs, Loc originForUninitialized) const {
+optional<ErrorSection> TypeAndOrigins::explainGot(const GlobalState &gs, Loc originForUninitialized) const {
     auto header = ErrorColors::format("Got `{}` originating from:", this->type.showWithMoreInfo(gs));
-    return ErrorSection(header, this->origins2Explanations(gs, originForUninitialized));
+    auto explanations = this->origins2Explanations(gs, originForUninitialized);
+    if (explanations.empty()) {
+        return nullopt;
+    } else {
+        return ErrorSection(header, explanations);
+    }
 }
 
 TypeAndOrigins::~TypeAndOrigins() noexcept {

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -602,11 +602,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                     }
                 }
             }
-            auto explanations = args.fullType.origins2Explanations(gs, args.originForUninitialized);
-            if (!explanations.empty()) {
-                e.addErrorSection(
-                    ErrorSection("Got " + args.fullType.type.show(gs) + " originating from:", explanations));
-            }
+            e.addErrorSection(args.fullType.explainGot(gs, args.originForUninitialized));
             auto receiverLoc = core::Loc{args.locs.file, args.locs.receiver};
             if (receiverLoc.exists() && (gs.suggestUnsafe.has_value() ||
                                          (args.fullType.type != args.thisType && symbol == Symbols::NilClass()))) {

--- a/test/cli/autocorrect-private-not-suggested/autocorrect-private-not-suggested.out
+++ b/test/cli/autocorrect-private-not-suggested/autocorrect-private-not-suggested.out
@@ -1,7 +1,7 @@
 autocorrect-private-not-suggested.rb:11: Method `my_private_metho` does not exist on `A` https://srb.help/7003
     11 |A.new.my_private_metho
               ^^^^^^^^^^^^^^^^
-  Got A originating from:
+  Got `A` originating from:
     autocorrect-private-not-suggested.rb:11:
     11 |A.new.my_private_metho
         ^^^^^

--- a/test/cli/autocorrect/autocorrect.out
+++ b/test/cli/autocorrect/autocorrect.out
@@ -17,7 +17,7 @@ autocorrect.rb:19: Method `params` does not exist on `T.class_of(<root>)` https:
 autocorrect.rb:4: Method `[]` does not exist on `NilClass` component of `T.nilable(String)` https://srb.help/7003
      4 |foo[0]
         ^^^^^^
-  Got T.nilable(String) originating from:
+  Got `T.nilable(String)` originating from:
     autocorrect.rb:3:
      3 |foo = T.let(nil, T.nilable(String))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -61,7 +61,7 @@ autocorrect.rb:10: Expected `String` but found `T.nilable(String)` for argument 
 autocorrect.rb:12: Method `bar` does not exist on `String` component of `T.nilable(String)` https://srb.help/7003
     12 |foo.bar ||= "a"
             ^^^
-  Got T.nilable(String) originating from:
+  Got `T.nilable(String)` originating from:
     autocorrect.rb:3:
      3 |foo = T.let(nil, T.nilable(String))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -69,7 +69,7 @@ autocorrect.rb:12: Method `bar` does not exist on `String` component of `T.nilab
 autocorrect.rb:12: Method `bar` does not exist on `NilClass` component of `T.nilable(String)` https://srb.help/7003
     12 |foo.bar ||= "a"
             ^^^
-  Got T.nilable(String) originating from:
+  Got `T.nilable(String)` originating from:
     autocorrect.rb:3:
      3 |foo = T.let(nil, T.nilable(String))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -81,7 +81,7 @@ autocorrect.rb:12: Method `bar` does not exist on `NilClass` component of `T.nil
 autocorrect.rb:12: Method `bar=` does not exist on `String` component of `T.nilable(String)` https://srb.help/7003
     12 |foo.bar ||= "a"
         ^^^^^^^
-  Got T.nilable(String) originating from:
+  Got `T.nilable(String)` originating from:
     autocorrect.rb:3:
      3 |foo = T.let(nil, T.nilable(String))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -93,7 +93,7 @@ autocorrect.rb:12: Method `bar=` does not exist on `String` component of `T.nila
 autocorrect.rb:12: Method `bar=` does not exist on `NilClass` component of `T.nilable(String)` https://srb.help/7003
     12 |foo.bar ||= "a"
         ^^^^^^^
-  Got T.nilable(String) originating from:
+  Got `T.nilable(String)` originating from:
     autocorrect.rb:3:
      3 |foo = T.let(nil, T.nilable(String))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -105,7 +105,7 @@ autocorrect.rb:12: Method `bar=` does not exist on `NilClass` component of `T.ni
 autocorrect.rb:13: Method `bar` does not exist on `String` component of `T.nilable(String)` https://srb.help/7003
     13 |foo.bar &&= "a"
             ^^^
-  Got T.nilable(String) originating from:
+  Got `T.nilable(String)` originating from:
     autocorrect.rb:3:
      3 |foo = T.let(nil, T.nilable(String))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -113,7 +113,7 @@ autocorrect.rb:13: Method `bar` does not exist on `String` component of `T.nilab
 autocorrect.rb:13: Method `bar` does not exist on `NilClass` component of `T.nilable(String)` https://srb.help/7003
     13 |foo.bar &&= "a"
             ^^^
-  Got T.nilable(String) originating from:
+  Got `T.nilable(String)` originating from:
     autocorrect.rb:3:
      3 |foo = T.let(nil, T.nilable(String))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -125,7 +125,7 @@ autocorrect.rb:13: Method `bar` does not exist on `NilClass` component of `T.nil
 autocorrect.rb:13: Method `bar=` does not exist on `String` component of `T.nilable(String)` https://srb.help/7003
     13 |foo.bar &&= "a"
         ^^^^^^^
-  Got T.nilable(String) originating from:
+  Got `T.nilable(String)` originating from:
     autocorrect.rb:3:
      3 |foo = T.let(nil, T.nilable(String))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -137,7 +137,7 @@ autocorrect.rb:13: Method `bar=` does not exist on `String` component of `T.nila
 autocorrect.rb:13: Method `bar=` does not exist on `NilClass` component of `T.nilable(String)` https://srb.help/7003
     13 |foo.bar &&= "a"
         ^^^^^^^
-  Got T.nilable(String) originating from:
+  Got `T.nilable(String)` originating from:
     autocorrect.rb:3:
      3 |foo = T.let(nil, T.nilable(String))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -149,7 +149,7 @@ autocorrect.rb:13: Method `bar=` does not exist on `NilClass` component of `T.ni
 autocorrect.rb:14: Method `bar` does not exist on `String` component of `T.nilable(String)` https://srb.help/7003
     14 |foo.bar |= "a"
             ^^^
-  Got T.nilable(String) originating from:
+  Got `T.nilable(String)` originating from:
     autocorrect.rb:3:
      3 |foo = T.let(nil, T.nilable(String))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -157,7 +157,7 @@ autocorrect.rb:14: Method `bar` does not exist on `String` component of `T.nilab
 autocorrect.rb:14: Method `bar` does not exist on `NilClass` component of `T.nilable(String)` https://srb.help/7003
     14 |foo.bar |= "a"
             ^^^
-  Got T.nilable(String) originating from:
+  Got `T.nilable(String)` originating from:
     autocorrect.rb:3:
      3 |foo = T.let(nil, T.nilable(String))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -169,7 +169,7 @@ autocorrect.rb:14: Method `bar` does not exist on `NilClass` component of `T.nil
 autocorrect.rb:14: Method `bar=` does not exist on `String` component of `T.nilable(String)` https://srb.help/7003
     14 |foo.bar |= "a"
         ^^^^^^^
-  Got T.nilable(String) originating from:
+  Got `T.nilable(String)` originating from:
     autocorrect.rb:3:
      3 |foo = T.let(nil, T.nilable(String))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -181,7 +181,7 @@ autocorrect.rb:14: Method `bar=` does not exist on `String` component of `T.nila
 autocorrect.rb:14: Method `bar=` does not exist on `NilClass` component of `T.nilable(String)` https://srb.help/7003
     14 |foo.bar |= "a"
         ^^^^^^^
-  Got T.nilable(String) originating from:
+  Got `T.nilable(String)` originating from:
     autocorrect.rb:3:
      3 |foo = T.let(nil, T.nilable(String))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -193,7 +193,7 @@ autocorrect.rb:14: Method `bar=` does not exist on `NilClass` component of `T.ni
 autocorrect.rb:15: Method `bar` does not exist on `String` component of `T.nilable(String)` https://srb.help/7003
     15 |foo.bar &= "a"
             ^^^
-  Got T.nilable(String) originating from:
+  Got `T.nilable(String)` originating from:
     autocorrect.rb:3:
      3 |foo = T.let(nil, T.nilable(String))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -201,7 +201,7 @@ autocorrect.rb:15: Method `bar` does not exist on `String` component of `T.nilab
 autocorrect.rb:15: Method `bar` does not exist on `NilClass` component of `T.nilable(String)` https://srb.help/7003
     15 |foo.bar &= "a"
             ^^^
-  Got T.nilable(String) originating from:
+  Got `T.nilable(String)` originating from:
     autocorrect.rb:3:
      3 |foo = T.let(nil, T.nilable(String))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -213,7 +213,7 @@ autocorrect.rb:15: Method `bar` does not exist on `NilClass` component of `T.nil
 autocorrect.rb:15: Method `bar=` does not exist on `String` component of `T.nilable(String)` https://srb.help/7003
     15 |foo.bar &= "a"
         ^^^^^^^
-  Got T.nilable(String) originating from:
+  Got `T.nilable(String)` originating from:
     autocorrect.rb:3:
      3 |foo = T.let(nil, T.nilable(String))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -225,7 +225,7 @@ autocorrect.rb:15: Method `bar=` does not exist on `String` component of `T.nila
 autocorrect.rb:15: Method `bar=` does not exist on `NilClass` component of `T.nilable(String)` https://srb.help/7003
     15 |foo.bar &= "a"
         ^^^^^^^
-  Got T.nilable(String) originating from:
+  Got `T.nilable(String)` originating from:
     autocorrect.rb:3:
      3 |foo = T.let(nil, T.nilable(String))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -237,7 +237,7 @@ autocorrect.rb:15: Method `bar=` does not exist on `NilClass` component of `T.ni
 autocorrect.rb:17: Method `[]` does not exist on `NilClass` component of `T.nilable(Integer)` https://srb.help/7003
     17 |[1].max_by {|l,r| 1}[2]
         ^^^^^^^^^^^^^^^^^^^^^^^
-  Got T.nilable(Integer) originating from:
+  Got `T.nilable(Integer)` originating from:
     autocorrect.rb:17:
     17 |[1].max_by {|l,r| 1}[2]
         ^^^^^^^^^^^^^^^^^^^^

--- a/test/cli/cache-dsl/cache-dsl.out
+++ b/test/cli/cache-dsl/cache-dsl.out
@@ -2,7 +2,7 @@ No errors! Great job.
 test/cli/cache-dsl/attr_accessor.rb:7: Method `prop=` does not exist on `A` https://srb.help/7003
      7 |a.prop = 7
           ^^^^^^
-  Got A originating from:
+  Got `A` originating from:
     test/cli/cache-dsl/attr_accessor.rb:6:
      6 |a = A.new
             ^^^^^
@@ -14,7 +14,7 @@ test/cli/cache-dsl/attr_accessor.rb:7: Method `prop=` does not exist on `A` http
 test/cli/cache-dsl/attr_accessor.rb:8: Method `prop` does not exist on `A` https://srb.help/7003
      8 |a.prop
           ^^^^
-  Got A originating from:
+  Got `A` originating from:
     test/cli/cache-dsl/attr_accessor.rb:6:
      6 |a = A.new
             ^^^^^
@@ -26,7 +26,7 @@ Errors: 2
 test/cli/cache-dsl/attr_accessor.rb:7: Method `prop=` does not exist on `A` https://srb.help/7003
      7 |a.prop = 7
           ^^^^^^
-  Got A originating from:
+  Got `A` originating from:
     test/cli/cache-dsl/attr_accessor.rb:6:
      6 |a = A.new
             ^^^^^
@@ -38,7 +38,7 @@ test/cli/cache-dsl/attr_accessor.rb:7: Method `prop=` does not exist on `A` http
 test/cli/cache-dsl/attr_accessor.rb:8: Method `prop` does not exist on `A` https://srb.help/7003
      8 |a.prop
           ^^^^
-  Got A originating from:
+  Got `A` originating from:
     test/cli/cache-dsl/attr_accessor.rb:6:
      6 |a = A.new
             ^^^^^

--- a/test/cli/config-file-recursive/config-file-recursive.out
+++ b/test/cli/config-file-recursive/config-file-recursive.out
@@ -1,7 +1,7 @@
 config-file-recursive.rb:2: Method `+` does not exist on `Symbol` component of `Symbol(:sym)` https://srb.help/7003
      2 |puts :sym + ''
                   ^
-  Got Symbol(:sym) originating from:
+  Got `Symbol(:sym)` originating from:
     config-file-recursive.rb:2:
      2 |puts :sym + ''
              ^^^^

--- a/test/cli/config-file/config-file.out
+++ b/test/cli/config-file/config-file.out
@@ -1,7 +1,7 @@
 config-file.rb:2: Method `+` does not exist on `Symbol` component of `Symbol(:sym)` https://srb.help/7003
      2 |puts :sym + ''
                   ^
-  Got Symbol(:sym) originating from:
+  Got `Symbol(:sym)` originating from:
     config-file.rb:2:
      2 |puts :sym + ''
              ^^^^

--- a/test/cli/deprecated-enum/deprecated-enum.out
+++ b/test/cli/deprecated-enum/deprecated-enum.out
@@ -45,7 +45,7 @@ deprecated-enum.rb:20: `T.enum` has been renamed to `T.deprecated_enum` https://
 deprecated-enum.rb:5: Method `enum` does not exist on `T.class_of(T)` https://srb.help/7003
      5 |sig {params(x: T.enum([:yes, :no])).void}
                          ^^^^
-  Got T.class_of(T) originating from:
+  Got `T.class_of(T)` originating from:
     deprecated-enum.rb:5:
      5 |sig {params(x: T.enum([:yes, :no])).void}
                        ^
@@ -53,7 +53,7 @@ deprecated-enum.rb:5: Method `enum` does not exist on `T.class_of(T)` https://sr
 deprecated-enum.rb:9: Method `enum` does not exist on `T.class_of(T)` https://srb.help/7003
      9 |sig {params(x: ::T.enum([:yes, :no])).void}
                            ^^^^
-  Got T.class_of(T) originating from:
+  Got `T.class_of(T)` originating from:
     deprecated-enum.rb:9:
      9 |sig {params(x: ::T.enum([:yes, :no])).void}
                        ^^^
@@ -61,7 +61,7 @@ deprecated-enum.rb:9: Method `enum` does not exist on `T.class_of(T)` https://sr
 deprecated-enum.rb:13: Method `enum` does not exist on `T.class_of(T)` https://srb.help/7003
     13 |sig {params(x: T.enum(
                          ^^^^
-  Got T.class_of(T) originating from:
+  Got `T.class_of(T)` originating from:
     deprecated-enum.rb:13:
     13 |sig {params(x: T.enum(
                        ^
@@ -69,7 +69,7 @@ deprecated-enum.rb:13: Method `enum` does not exist on `T.class_of(T)` https://s
 deprecated-enum.rb:20: Method `enum` does not exist on `T.class_of(T)` https://srb.help/7003
     20 |sig {params(x: ::T.enum(
                            ^^^^
-  Got T.class_of(T) originating from:
+  Got `T.class_of(T)` originating from:
     deprecated-enum.rb:20:
     20 |sig {params(x: ::T.enum(
                        ^^^
@@ -77,7 +77,7 @@ deprecated-enum.rb:20: Method `enum` does not exist on `T.class_of(T)` https://s
 deprecated-enum.rb:28: Method `enum` does not exist on `T.class_of(T)` https://srb.help/7003
     28 |T.cast(:yes, T.enum)
                        ^^^^
-  Got T.class_of(T) originating from:
+  Got `T.class_of(T)` originating from:
     deprecated-enum.rb:28:
     28 |T.cast(:yes, T.enum)
                      ^
@@ -85,7 +85,7 @@ deprecated-enum.rb:28: Method `enum` does not exist on `T.class_of(T)` https://s
 deprecated-enum.rb:29: Method `enum` does not exist on `T.class_of(T)` https://srb.help/7003
     29 |T.cast(:yes, T.enum([:yes]))
                        ^^^^
-  Got T.class_of(T) originating from:
+  Got `T.class_of(T)` originating from:
     deprecated-enum.rb:29:
     29 |T.cast(:yes, T.enum([:yes]))
                      ^

--- a/test/cli/make_accessible/make_accessible.out
+++ b/test/cli/make_accessible/make_accessible.out
@@ -1,7 +1,7 @@
 test/cli/make_accessible/suit.rb:17: Method `spades` does not exist on `T.class_of(Suit)` https://srb.help/7003
     17 |Suit.spades
              ^^^^^^
-  Got T.class_of(Suit) originating from:
+  Got `T.class_of(Suit)` originating from:
     test/cli/make_accessible/suit.rb:17:
     17 |Suit.spades
         ^^^^

--- a/test/cli/suggest-sig/suggest-sig.out
+++ b/test/cli/suggest-sig/suggest-sig.out
@@ -250,7 +250,7 @@ suggest-sig.rb:155: This function does not have a `sig` https://srb.help/7017
 suggest-sig.rb:124: Method `generated` does not exist on `T::Private::Methods::DeclBuilder` https://srb.help/7003
      124 |sig {params(a: T.untyped, cond: T::Boolean).returns(T.untyped).generated} # error: `generated` is deprecated
                                                                          ^^^^^^^^^
-  Got T::Private::Methods::DeclBuilder originating from:
+  Got `T::Private::Methods::DeclBuilder` originating from:
     suggest-sig.rb:124:
      124 |sig {params(a: T.untyped, cond: T::Boolean).returns(T.untyped).generated} # error: `generated` is deprecated
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -262,7 +262,7 @@ suggest-sig.rb:124: Method `generated` does not exist on `T::Private::Methods::D
 suggest-sig.rb:137: Method `generated` does not exist on `T::Private::Methods::DeclBuilder` https://srb.help/7003
      137 |  generated
             ^^^^^^^^^
-  Got T::Private::Methods::DeclBuilder originating from:
+  Got `T::Private::Methods::DeclBuilder` originating from:
     suggest-sig.rb:135:
      135 |  params(a: T.untyped, cond: T::Boolean). # error: `generated` is deprecated
      136 |  returns(T.untyped).

--- a/test/cli/suggest-singleton/suggest-singleton.out
+++ b/test/cli/suggest-singleton/suggest-singleton.out
@@ -1,7 +1,7 @@
 test/cli/suggest-singleton/suggest-singleton.rb:9: Method `foo` does not exist on `T.class_of(A)` https://srb.help/7003
      9 |A.foo
           ^^^
-  Got T.class_of(A) originating from:
+  Got `T.class_of(A)` originating from:
     test/cli/suggest-singleton/suggest-singleton.rb:9:
      9 |A.foo
         ^
@@ -13,7 +13,7 @@ test/cli/suggest-singleton/suggest-singleton.rb:9: Method `foo` does not exist o
 test/cli/suggest-singleton/suggest-singleton.rb:10: Method `bar` does not exist on `A` https://srb.help/7003
     10 |A.new.bar
               ^^^
-  Got A originating from:
+  Got `A` originating from:
     test/cli/suggest-singleton/suggest-singleton.rb:10:
     10 |A.new.bar
         ^^^^^

--- a/test/cli/suggest-typos/suggest-typos.out
+++ b/test/cli/suggest-typos/suggest-typos.out
@@ -1,7 +1,7 @@
 -e:1: Method `to_` does not exist on `Integer` component of `Integer(1)` https://srb.help/7003
      1 |1.to_
           ^^^
-  Got Integer(1) originating from:
+  Got `Integer(1)` originating from:
     -e:1:
      1 |1.to_
         ^

--- a/test/cli/suggest_static/suggest_static.out
+++ b/test/cli/suggest_static/suggest_static.out
@@ -1,7 +1,7 @@
 test/cli/suggest_static/suggest_static.rb:11: Method `foo` does not exist on `A` https://srb.help/7003
     11 |A.new.foo
               ^^^
-  Got A originating from:
+  Got `A` originating from:
     test/cli/suggest_static/suggest_static.rb:11:
     11 |A.new.foo
         ^^^^^

--- a/test/cli/suggest_t_must/suggest_t_must.out
+++ b/test/cli/suggest_t_must/suggest_t_must.out
@@ -1,7 +1,7 @@
 suggest_t_must.rb:4: Method `[]` does not exist on `NilClass` component of `T.nilable(String)` https://srb.help/7003
      4 |foo[0]
         ^^^^^^
-  Got T.nilable(String) originating from:
+  Got `T.nilable(String)` originating from:
     suggest_t_must.rb:3:
      3 |foo = T.let(nil, T.nilable(String))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -29,7 +29,7 @@ suggest_t_must.rb:6: Expected `String` but found `T.nilable(String)` for argumen
 suggest_t_must.rb:8: Method `even?` does not exist on `NilClass` component of `T.nilable(Integer)` https://srb.help/7003
      8 |T::Array[T.nilable(Integer)].new.map(&:even?)
                                               ^^^^^^
-  Got T.nilable(Integer) originating from:
+  Got `T.nilable(Integer)` originating from:
     suggest_t_must.rb:8:
      8 |T::Array[T.nilable(Integer)].new.map(&:even?)
                                               ^

--- a/test/cli/suggest_t_unsafe/suggest_t_unsafe.out
+++ b/test/cli/suggest_t_unsafe/suggest_t_unsafe.out
@@ -17,7 +17,7 @@ suggest_t_unsafe.rb:25: Expected `String` but found `T.nilable(String)` for argu
 suggest_t_unsafe.rb:8: Method `[]` does not exist on `NilClass` component of `T.nilable(String)` https://srb.help/7003
      8 |foo[0]
         ^^^^^^
-  Got T.nilable(String) originating from:
+  Got `T.nilable(String)` originating from:
     suggest_t_unsafe.rb:7:
      7 |foo = T.let(nil, T.nilable(String))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -45,7 +45,7 @@ suggest_t_unsafe.rb:10: Expected `String` but found `T.nilable(String)` for argu
 suggest_t_unsafe.rb:13: Method `even?` does not exist on `String` component of `T.any(Integer, String)` https://srb.help/7003
     13 |bar.even?
             ^^^^^
-  Got T.any(Integer, String) originating from:
+  Got `T.any(Integer, String)` originating from:
     suggest_t_unsafe.rb:12:
     12 |bar = T.let(1, T.any(Integer, String))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -73,7 +73,7 @@ suggest_t_unsafe.rb:15: Expected `String` but found `Integer(1)` for argument `a
 suggest_t_unsafe.rb:17: Method `even?` does not exist on `NilClass` component of `T.nilable(Integer)` https://srb.help/7003
     17 |T::Array[T.nilable(Integer)].new.map(&:even?)
                                               ^^^^^^
-  Got T.nilable(Integer) originating from:
+  Got `T.nilable(Integer)` originating from:
     suggest_t_unsafe.rb:17:
     17 |T::Array[T.nilable(Integer)].new.map(&:even?)
                                               ^
@@ -133,7 +133,7 @@ suggest_t_unsafe.rb:25: Expected `String` but found `T.nilable(String)` for argu
 suggest_t_unsafe.rb:8: Method `[]` does not exist on `NilClass` component of `T.nilable(String)` https://srb.help/7003
      8 |foo[0]
         ^^^^^^
-  Got T.nilable(String) originating from:
+  Got `T.nilable(String)` originating from:
     suggest_t_unsafe.rb:7:
      7 |foo = T.let(nil, T.nilable(String))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -161,7 +161,7 @@ suggest_t_unsafe.rb:10: Expected `String` but found `T.nilable(String)` for argu
 suggest_t_unsafe.rb:13: Method `even?` does not exist on `String` component of `T.any(Integer, String)` https://srb.help/7003
     13 |bar.even?
             ^^^^^
-  Got T.any(Integer, String) originating from:
+  Got `T.any(Integer, String)` originating from:
     suggest_t_unsafe.rb:12:
     12 |bar = T.let(1, T.any(Integer, String))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -189,7 +189,7 @@ suggest_t_unsafe.rb:15: Expected `String` but found `Integer(1)` for argument `a
 suggest_t_unsafe.rb:17: Method `even?` does not exist on `NilClass` component of `T.nilable(Integer)` https://srb.help/7003
     17 |T::Array[T.nilable(Integer)].new.map(&:even?)
                                               ^^^^^^
-  Got T.nilable(Integer) originating from:
+  Got `T.nilable(Integer)` originating from:
     suggest_t_unsafe.rb:17:
     17 |T::Array[T.nilable(Integer)].new.map(&:even?)
                                               ^

--- a/test/cli/suggest_unsafe_dead/suggest_unsafe_dead.out
+++ b/test/cli/suggest_unsafe_dead/suggest_unsafe_dead.out
@@ -147,7 +147,6 @@ suggest_unsafe_dead.rb:81: This code is unreachable https://srb.help/7006
     suggest_unsafe_dead.rb:80: Replaced with `T.unsafe(self)`
     80 |    unless self
                    ^^^^
-  Got `A` originating from:
 
 suggest_unsafe_dead.rb:89: This code is unreachable https://srb.help/7006
     89 |      do_something
@@ -159,7 +158,6 @@ suggest_unsafe_dead.rb:89: This code is unreachable https://srb.help/7006
     suggest_unsafe_dead.rb:88: Replaced with `T.unsafe(this)`
     88 |    unless this
                    ^^^^
-  Got `A` originating from:
 Errors: 11
 
 --------------------------------------------------------------------------


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This previously was not using our `explainGot` helper, which made it slightly
different from all the other "Got `Type` ..." error sections.

Now the errors have colors.

I had to make one change to the `explainGot` helper, which was to not emit the
`ErrorSection` if we had no explanation for where the type came from.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See changes to existing tests.