### PR TITLE
Fix crash with malformed `type_parameters`

### DIFF
--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -226,7 +226,7 @@ ParsedSig parseSigWithSelfTypeParams(core::Context ctx, const ast::Send &sigSend
                     }
                 } else {
                     if (auto e = ctx.beginError(arg.loc(), core::errors::Resolver::InvalidMethodSignature)) {
-                        e.setHeader("Malformed `{}`: Type parameters are specified with symbols");
+                        e.setHeader("Unexpected `{}`: Type parameters are specified with symbols", arg.nodeName());
                     }
                 }
             }

--- a/test/testdata/parser/bad_argument_crash.rb
+++ b/test/testdata/parser/bad_argument_crash.rb
@@ -1,15 +1,22 @@
 # typed: true
 extend T::Sig
 
-sig {type_parameters(:)}
+sig {type_parameters(:).void}
+#                    ^ error: unexpected token ":"
+#                    ^ error: Unexpected `ConstantLit`
 def ex1; end
 
-sig {type_parameters(x)}
+sig {type_parameters(x).void}
+#                    ^ error: Unexpected `Send`
+#                    ^ error: Method `x` does not exist
 def ex2; end
 
-sig {type_parameters(X)}
+sig {type_parameters(X).void}
+#                    ^ error: Unable to resolve constant `X`
+#                    ^ error: Unexpected `ConstantLit`
 def ex3; end
 
 y = nil
-sig {type_parameters(y)}
+sig {type_parameters(y).void}
+#                    ^ error: Unexpected `Local`
 def ex4; end

--- a/test/testdata/parser/bad_argument_crash.rb
+++ b/test/testdata/parser/bad_argument_crash.rb
@@ -1,0 +1,15 @@
+# typed: true
+extend T::Sig
+
+sig {type_parameters(:)}
+def ex1; end
+
+sig {type_parameters(x)}
+def ex2; end
+
+sig {type_parameters(X)}
+def ex3; end
+
+y = nil
+sig {type_parameters(y)}
+def ex4; end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We had a latent crash in Sorbet, which was made particularly more common once
the changes in #5114 landed.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tests show before/after