### PR TITLE
remove dead filter argument for `pipeline_tests`

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -220,7 +220,6 @@ pipeline_tests(
         ],
     ),
     "PosTests",
-    filter = "PosTests",
 )
 
 pipeline_tests(
@@ -232,7 +231,6 @@ pipeline_tests(
         ],
     ),
     "PackagerTests",
-    filter = "PackagerTests",
 )
 
 pipeline_tests(
@@ -242,7 +240,6 @@ pipeline_tests(
         "whitequark/**/*.exp",
     ]),
     "WhitequarkParserTests",
-    filter = "WhitequarkParserTests",
 )
 
 pipeline_tests(
@@ -259,7 +256,6 @@ pipeline_tests(
         ],
     ),
     "LSPTests",
-    filter = "LSPTests",
 )
 
 test_suite(

--- a/test/pipeline_test.bzl
+++ b/test/pipeline_test.bzl
@@ -55,7 +55,7 @@ _TEST_RUNNERS = {
     "PackagerTests": ":pipeline_test_runner",
 }
 
-def pipeline_tests(suite_name, all_paths, test_name_prefix, filter = "*", extra_args = [], tags = []):
+def pipeline_tests(suite_name, all_paths, test_name_prefix, extra_args = [], tags = []):
     tests = {}  # test_name-> {"path": String, "prefix": String, "sentinel": String}
 
     # The packager step needs folder-based steps since folder structure dictates package membership.


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Bazel is confusing enough as it is, no need to add unneeded arguments everywhere.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
