### PR TITLE
Switch from a vector to an array in workspace_symbols.cc

### DIFF
--- a/main/lsp/requests/workspace_symbols.cc
+++ b/main/lsp/requests/workspace_symbols.cc
@@ -231,10 +231,10 @@ vector<unique_ptr<SymbolInformation>> SymbolMatcher::doQuery(string_view query_v
     }
     size_t ceilingScore = INT_MAX;
 
-    const vector<pair<core::SymbolRef::Kind, uint>> symbolKinds = {
-        {core::SymbolRef::Kind::ClassOrModule, gs.classAndModulesUsed()},
-        {core::SymbolRef::Kind::FieldOrStaticField, gs.fieldsUsed()},
-        {core::SymbolRef::Kind::Method, gs.methodsUsed()},
+    const std::array<pair<core::SymbolRef::Kind, size_t>, 3> symbolKinds{
+        std::make_pair(core::SymbolRef::Kind::ClassOrModule, gs.classAndModulesUsed()),
+        std::make_pair(core::SymbolRef::Kind::FieldOrStaticField, gs.fieldsUsed()),
+        std::make_pair(core::SymbolRef::Kind::Method, gs.methodsUsed()),
     };
 
     // First pass: prefix-only matches on namespace


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
No need to allocate this in the heap, we can use `std::array` instead and keep it on the stack.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Cleanup.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
