### PR TITLE
Add support for package-aware autoloading

### DIFF
--- a/main/autogen/autoloader.cc
+++ b/main/autogen/autoloader.cc
@@ -227,7 +227,7 @@ string DefTree::renderAutoloadSrc(const core::GlobalState &gs, const AutoloaderC
         if (pkgName.exists()) {
             ENFORCE(!gs.packageDB().empty());
             const string_view shortName = pkgName.shortName(gs);
-            const string_view mungedName = shortName.substr(0, shortName.rfind(core::PACKAGE_SUFFIX));
+            const string_view mungedName = shortName.substr(0, shortName.size() - core::PACKAGE_SUFFIX.size());
             fmt::format_to(std::back_inserter(buf), "\n{}.register_package({}, '{}')\n", alCfg.registryModule, fullName,
                            mungedName);
         }

--- a/main/autogen/autoloader.cc
+++ b/main/autogen/autoloader.cc
@@ -210,6 +210,7 @@ string DefTree::renderAutoloadSrc(const core::GlobalState &gs, const AutoloaderC
             fmt::format_to(std::back_inserter(buf), "{}.on_autoload('{}')\n", alCfg.registryModule, fullName);
             predeclare(gs, fullName, buf);
         }
+
         if (!children.empty()) {
             fmt::format_to(std::back_inserter(buf), "\n{}.autoload_map({}, {{\n", alCfg.registryModule, fullName);
             vector<pair<core::NameRef, string>> childNames;
@@ -221,6 +222,14 @@ string DefTree::renderAutoloadSrc(const core::GlobalState &gs, const AutoloaderC
                                children.at(pair.first)->path(gs));
             }
             fmt::format_to(std::back_inserter(buf), "}})\n", fullName);
+        }
+
+        if (pkgName.exists()) {
+            ENFORCE(!gs.packageDB().empty());
+            const string_view shortName = pkgName.shortName(gs);
+            const string_view mungedName = shortName.substr(0, shortName.rfind(core::PACKAGE_SUFFIX));
+            fmt::format_to(std::back_inserter(buf), "\n{}.register_package({}, '{}')\n", alCfg.registryModule, fullName,
+                           mungedName);
         }
     } else if (type == Definition::Type::Casgn || type == Definition::Type::Alias ||
                type == Definition::Type::TypeAlias) {
@@ -315,6 +324,26 @@ void DefTreeBuilder::addParsedFileDefinitions(const core::GlobalState &gs, const
     }
 }
 
+void DefTree::markPackageNamespace(core::NameRef mangledName, const vector<core::NameRef> &nameParts) {
+    DefTree *node = this;
+    for (auto nr : nameParts) {
+        auto it = node->children.find(nr);
+        if (it == node->children.end()) {
+            return;
+        }
+        node = it->second.get();
+    }
+    ENFORCE(!pkgName.exists(), "Package name should not be already set");
+    node->pkgName = mangledName;
+}
+
+void DefTreeBuilder::markPackages(const core::GlobalState &gs, DefTree &root) {
+    for (auto nr : gs.packageDB().packages()) {
+        auto &pkg = gs.packageDB().getPackageInfo(nr);
+        root.markPackageNamespace(pkg.mangledName(), pkg.fullName());
+    }
+}
+
 void DefTreeBuilder::addSingleDef(const core::GlobalState &gs, const AutoloaderConfig &alCfg,
                                   std::unique_ptr<DefTree> &root, NamedDefinition ndef) {
     if (!alCfg.include(ndef)) {
@@ -384,7 +413,7 @@ void DefTreeBuilder::collapseSameFileDefs(const core::GlobalState &gs, const Aut
                   // for why
         auto &child = copyIt->second;
 
-        if (child->hasDifferentFile(definingFile)) {
+        if (child->pkgName.exists() || child->hasDifferentFile(definingFile)) {
             collapseSameFileDefs(gs, alCfg, *child);
         } else {
             root.children.erase(copyIt);

--- a/main/autogen/autoloader.h
+++ b/main/autogen/autoloader.h
@@ -86,6 +86,7 @@ public:
     std::vector<NamedDefinition> namedDefs;
     std::unique_ptr<NamedDefinition> nonBehaviorDef;
     QualifiedName qname;
+    core::NameRef pkgName;
 
     bool root() const;
     core::NameRef name() const;
@@ -109,6 +110,7 @@ private:
     bool hasDef() const;
     const NamedDefinition &definition(const core::GlobalState &) const;
     Definition::Type definitionType(const core::GlobalState &) const;
+    void markPackageNamespace(core::NameRef mangledName, const std::vector<core::NameRef> &nameParts);
 
     friend class DefTreeBuilder;
 };
@@ -122,6 +124,7 @@ public:
                              NamedDefinition);
 
     static DefTree merge(const core::GlobalState &gs, DefTree lhs, DefTree rhs);
+    static void markPackages(const core::GlobalState &gs, DefTree &root);
     static void collapseSameFileDefs(const core::GlobalState &gs, const AutoloaderConfig &, DefTree &root);
 
 private:

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -628,6 +628,7 @@ bool extractAutoloaderConfig(cxxopts::ParseResult &raw, Options &opts, shared_pt
         logger->error("Flag --autogen-autoloader-packaged is currently not supported.");
         throw EarlyReturnWithCode(1);
     }
+
     cfg.rootObject = raw["autogen-root-object"].as<string>();
     return true;
 }

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -310,6 +310,10 @@ void runAutogen(const core::GlobalState &gs, options::Options &opts, const autog
     }
     if (opts.print.AutogenAutoloader.enabled) {
         {
+            Timer timeit(logger, "autogenMarkPackages");
+            autogen::DefTreeBuilder::markPackages(gs, root);
+        }
+        {
             Timer timeit(logger, "autogenAutoloaderPrune");
             autogen::DefTreeBuilder::collapseSameFileDefs(gs, autoloaderCfg, root);
         }

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1849,6 +1849,12 @@ vector<ast::ParsedFile> Packager::run(core::GlobalState &gs, WorkerPool &workers
     Timer timeit(gs.tracer(), "packager");
 
     files = findPackages(gs, workers, std::move(files));
+    if (gs.runningUnderAutogen) {
+        auto it = std::remove_if(files.begin(), files.end(),
+                                 [&gs](auto &file) -> bool { return file.file.data(gs).isPackage(); });
+        files.erase(it, files.end());
+        return files;
+    }
 
     // Step 2:
     // * Find package files and rewrite them into virtual AST mappings.

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1850,6 +1850,7 @@ vector<ast::ParsedFile> Packager::run(core::GlobalState &gs, WorkerPool &workers
 
     files = findPackages(gs, workers, std::move(files));
     if (gs.runningUnderAutogen) {
+        // Autogen only requires package metadata. Remove the package files.
         auto it = std::remove_if(files.begin(), files.end(),
                                  [&gs](auto &file) -> bool { return file.file.data(gs).isPackage(); });
         files.erase(it, files.end());

--- a/test/cli/autogen-pkg-autoloader/autogen-pkg-autoloader.out
+++ b/test/cli/autogen-pkg-autoloader/autogen-pkg-autoloader.out
@@ -11,8 +11,11 @@ end
 
 Opus::Require.autoload_map(RootPackage, {
   Foo: "autoloader/RootPackage/Foo.rb",
+  Nested: "autoloader/RootPackage/Nested.rb",
   Yabba: "autoloader/RootPackage/Yabba.rb",
 })
+
+Opus::Require.register_package(RootPackage, 'RootPackage')
 
 --- output/RootPackage/Foo.rb
 # frozen_string_literal: true
@@ -139,6 +142,19 @@ require 'in_method'
 require 'my_gem'
 
 Opus::Require.for_autoload(nil, "test/cli/autogen-pkg-autoloader/foo.rb", [RootPackage::Foo, :TOP_LEVEL_CONST])
+
+--- output/RootPackage/Nested.rb
+# frozen_string_literal: true
+# typed: true
+
+Opus::Require.on_autoload('RootPackage::Nested')
+
+module RootPackage::Nested
+end
+
+Opus::Require.register_package(RootPackage::Nested, 'RootPackage_Nested')
+
+Opus::Require.for_autoload(RootPackage::Nested, "test/cli/autogen-pkg-autoloader/nested/nested.rb")
 
 --- output/RootPackage/Yabba.rb
 # frozen_string_literal: true

--- a/test/cli/autogen-pkg-autoloader/autogen-pkg-autoloader.sh
+++ b/test/cli/autogen-pkg-autoloader/autogen-pkg-autoloader.sh
@@ -22,6 +22,7 @@ mkdir output
   --autogen-autoloader-ignore=scripts/ \
   --autogen-autoloader-preamble "$preamble" \
   test/cli/autogen-pkg-autoloader/{foo,bar,bar2,errors,__package}.rb \
+  test/cli/autogen-pkg-autoloader/nested/*.rb \
   test/cli/autogen-pkg-autoloader/scripts/baz.rb 2>&1
 
 for file in $(find output -type f | sort); do

--- a/test/cli/autogen-pkg-autoloader/nested/__package.rb
+++ b/test/cli/autogen-pkg-autoloader/nested/__package.rb
@@ -1,0 +1,6 @@
+# typed: strict
+# frozen_string_literal: true
+
+class RootPackage::Nested < PackageSpec
+end
+

--- a/test/cli/autogen-pkg-autoloader/nested/nested.rb
+++ b/test/cli/autogen-pkg-autoloader/nested/nested.rb
@@ -1,0 +1,4 @@
+# typed: strict
+# frozen_string_literal: true
+
+module RootPackage::Nested; end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Adds package-awareness to autogen, and functionality to register packages.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
As part of packaging work in autogen, we are requiring certain autoload definitions to be generated in the namespace of a given package.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Tested on Stripe codebase

cc @ngroman @aisamanra 