### PR TITLE
error if `--package-rbi-output` directory does not exist

### DIFF
--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -697,6 +697,11 @@ int realmain(int argc, char *argv[]) {
                 return 1;
             }
 
+            if (!FileOps::dirExists(opts.packageRBIOutput)) {
+                logger->error("Directory {} for serialized package RBIs does not exist.", opts.packageRBIOutput);
+                return 1;
+            }
+
             auto relativeIgnorePatterns = opts.relativeIgnorePatterns;
             auto it = absl::c_find(relativeIgnorePatterns, "/__package.rb");
             if (it != relativeIgnorePatterns.end()) {


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Actual error messages are better than weird crashes later on.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
