### PR TITLE
cleanup handling of ignoring `__package.rb` in `--package-rbi-output`

### DIFF
--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -706,18 +706,11 @@ int realmain(int argc, char *argv[]) {
                 return 1;
             }
 
-            auto relativeIgnorePatterns = opts.relativeIgnorePatterns;
-            auto it = absl::c_find(relativeIgnorePatterns, "/__package.rb");
-            if (it != relativeIgnorePatterns.end()) {
-                relativeIgnorePatterns.erase(it);
-            } else {
-                Exception::raise("Couldn't find ignore pattern.");
-            }
             auto packageFiles = opts.fs->listFilesInDir(opts.rawInputDirNames[0], opts.allowedExtensions, true,
-                                                        opts.absoluteIgnorePatterns, relativeIgnorePatterns);
+                                                        opts.absoluteIgnorePatterns, opts.relativeIgnorePatterns);
             packageFiles.erase(
                 remove_if(packageFiles.begin(), packageFiles.end(),
-                          [](const auto &packageFile) { return !absl::EndsWith(packageFile, "__package.rb"); }),
+                          [](const auto &packageFile) { return !absl::EndsWith(packageFile, "/__package.rb"); }),
                 packageFiles.end());
 
             if (packageFiles.empty()) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

The handling of `--ignore` with `--package-rbi-output` is a bit weird:

1. If we find `__package.rb` (`/__package.rb` post-normalization of the `--ignore` option) in `opts.relativeIgnorePatterns`, we remove it
2. If we don't find it, we crash with an inscrutable error message.

But regardless of the above, we remove all `__package.rb` files anyway just a couple of lines later:

https://github.com/sorbet/sorbet/blob/9c2b67e5a9ef7b72c66d72ef7aec80e731ea5d3c/main/realmain.cc#L707-L712

So why are we even bothering with munging `opts.relativeIgnorePatterns` in the first place?  Let's just remove that bit and clarify things for everyone.  (Well, it doesn't totally clarify things for me, because it's not super-obvious why we're removing the `__package.rb` file(s) there in the first place.  But at the very least this doesn't change existing behavior.)

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Clearer code.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
