### PR TITLE
Packages: Fix import suggestions for test_import -> import

### DIFF
--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -70,6 +70,11 @@ public:
         return vector<vector<core::NameRef>>();
     }
 
+    std::optional<ImportType> importsPackage(const PackageInfo &other) const {
+        notImplemented();
+        return nullopt;
+    }
+
     ~NonePackage() {}
 
 private:

--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -15,6 +15,11 @@ class Context;
 } // namespace sorbet::core
 
 namespace sorbet::core::packages {
+enum class ImportType {
+    Normal,
+    Test,
+};
+
 class PackageInfo {
 public:
     virtual core::NameRef mangledName() const = 0;
@@ -27,6 +32,8 @@ public:
     virtual std::unique_ptr<PackageInfo> deepCopy() const = 0;
     virtual core::Loc definitionLoc() const = 0;
     virtual bool exists() const final;
+
+    virtual std::optional<ImportType> importsPackage(const PackageInfo &other) const = 0;
 
     // autocorrects
     virtual std::optional<core::AutocorrectSuggestion> addImport(const core::GlobalState &gs, const PackageInfo &pkg,

--- a/resolver/SuggestPackage.cc
+++ b/resolver/SuggestPackage.cc
@@ -61,7 +61,7 @@ public:
 
         // Filter out duplicate imports from suggestions:
         bool isTestFile = ctx.file.data(ctx).isPackagedTest();
-        auto it = remove_if(matches.begin(), matches.end(), [&](auto m) {
+        auto it = remove_if(matches.begin(), matches.end(), [&](auto &m) {
             if (m.existingImportType == nullopt) {
                 return false;
             }

--- a/resolver/SuggestPackage.cc
+++ b/resolver/SuggestPackage.cc
@@ -275,10 +275,10 @@ bool SuggestPackage::tryPackageCorrections(core::Context ctx, core::ErrorBuilder
                                            const ast::ConstantLit::ResolutionScopes &scopes,
                                            ast::UnresolvedConstantLit &unresolved) {
     // Search strategy:
-    // 1. Look for un-exported names in packages *this package already imports* that defined the
-    //    unresolved literal.
-    // 2. Look for packages that we did not import that match the prefix of the unresolved constant
+    // 1. Look for packages that we did not import that match the prefix of the unresolved constant
     //    literal.
+    // 2. Look for un-exported names in packages *this package already imports* that defined the
+    //    unresolved literal.
     // Both of above look for EXACT matches only. If neither of these find anything we fall back to
     // the resolver's default behavior (Symbol::findMemberFuzzyMatch).
     if (ctx.state.packageDB().empty()) {
@@ -298,22 +298,21 @@ bool SuggestPackage::tryPackageCorrections(core::Context ctx, core::ErrorBuilder
     } else {
         missingImports = pkgCtx.findPossibleMissingImports(scopes, unresolved.cnst);
     }
-
-    if (missingImports.size() > 3) {
-        missingImports.resize(3);
-    }
     if (!missingImports.empty()) {
+        if (missingImports.size() > 3) {
+            missingImports.resize(3);
+        }
         for (auto match : missingImports) {
             pkgCtx.addMissingImportSuggestions(e, match);
         }
         return true;
     }
 
-    if (auto scope = ast::cast_tree<ast::ConstantLit>(unresolved.scope)) {
+    if (ast::isa_tree<ast::ConstantLit>(unresolved.scope)) {
         auto missingExports = pkgCtx.currentPkg.findMissingExports(
             ctx, ast::cast_tree_nonnull<ast::ConstantLit>(unresolved.scope).symbol, unresolved.cnst);
-        if (missingExports.size() > 5) {
-            missingExports.resize(5);
+        if (missingExports.size() > 3) {
+            missingExports.resize(3);
         }
         if (!missingExports.empty()) {
             for (auto match : missingExports) {

--- a/test/cli/package-error-missing-import/package-error-missing-import.out
+++ b/test/cli/package-error-missing-import/package-error-missing-import.out
@@ -6,8 +6,6 @@ foo_class.rb:7: Unable to resolve constant `Bar` https://srb.help/5002
      4 |  export Foo::Bar::OtherPackage::OtherClass
      5 |  export Test::Foo::Bar::OtherPackage::TestUtil
      6 |end
-  Note:
-    Try running generate-packages.sh
   Autocorrect: Use `-a` to autocorrect
     __package.rb:6: Insert `
   import Foo::Bar::OtherPackage`
@@ -24,8 +22,6 @@ foo_class.rb:8: Unable to resolve constant `Bar` https://srb.help/5002
      4 |  export Foo::Bar::OtherPackage::OtherClass
      5 |  export Test::Foo::Bar::OtherPackage::TestUtil
      6 |end
-  Note:
-    Try running generate-packages.sh
   Autocorrect: Use `-a` to autocorrect
     __package.rb:6: Insert `
   import Foo::Bar::OtherPackage`
@@ -42,8 +38,6 @@ foo_class.rb:14: Unable to resolve constant `Bar` https://srb.help/5002
      4 |  export Foo::Bar::OtherPackage::OtherClass
      5 |  export Test::Foo::Bar::OtherPackage::TestUtil
      6 |end
-  Note:
-    Try running generate-packages.sh
   Autocorrect: Use `-a` to autocorrect
     __package.rb:6: Insert `
   import Foo::Bar::OtherPackage`
@@ -60,8 +54,6 @@ foo.test.rb:4: Unable to resolve constant `Bar` https://srb.help/5002
      4 |  export Foo::Bar::OtherPackage::OtherClass
      5 |  export Test::Foo::Bar::OtherPackage::TestUtil
      6 |end
-  Note:
-    Try running generate-packages.sh
   Autocorrect: Use `-a` to autocorrect
     __package.rb:6: Insert `
   test_import Foo::Bar::OtherPackage`

--- a/test/cli/package-test-simple/package-test-simple.out
+++ b/test/cli/package-test-simple/package-test-simple.out
@@ -1,16 +1,14 @@
 main_lib/lib.rb:8: Unable to resolve constant `TestOnly` https://srb.help/5002
      8 |  Project::TestOnly::SomeHelper.new
           ^^^^^^^^^^^^^^^^^
-    test_only/__package.rb:5: Do you need to `export Project::TestOnly` in package `Project::TestOnly`?
+    test_only/__package.rb:5: Do you need to `import` package `Project::TestOnly`?
      5 |class Project::TestOnly < PackageSpec
      6 |  export Project::TestOnly::SomeHelper
      7 |end
-    test_only/some_helper.rb:4: Constant `Project::TestOnly` is defined here:
-     4 |class Project::TestOnly::SomeHelper
-              ^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test_only/__package.rb:6: Insert `
-  export Project::TestOnly`
-     6 |  export Project::TestOnly::SomeHelper
-                                              ^
+    main_lib/__package.rb:7: Replace with `import Project::TestOnly`
+     7 |  test_import Project::TestOnly
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Note:
+    RUN SCRIPT HINT
 Errors: 1

--- a/test/cli/package-test-simple/package-test-simple.sh
+++ b/test/cli/package-test-simple/package-test-simple.sh
@@ -1,3 +1,3 @@
 cd test/cli/package-test-simple || exit 1
 
-../../../main/sorbet --silence-dev-message --stripe-packages --secondary-test-package-namespaces=Critic --stripe-mode . 2>&1
+../../../main/sorbet --silence-dev-message --stripe-packages --secondary-test-package-namespaces=Critic --stripe-mode --stripe-packages-hint-message="RUN SCRIPT HINT" . 2>&1


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Fixes a bug where if a package name was shorter than the current package we would suggest bogus exports instead of imports.

Also adds an improvement where if an error could be fixed by converting a `test_import` to an `import` we now detect and provide an auto-correct.

Also fixed a duplicate hint in related code.

### Motivation
User bug report
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

Manual testing in VSCode
