### PR TITLE
Upgrade to LLVM 13

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -12,6 +12,9 @@ common:test --test_env=GTEST_INSTALL_FAILURE_SIGNAL_HANDLER=1
 ##
 ##  Custom toolchain.
 ##
+# The --crosstool_top option has been deprecated in favor of this incompatible cc toolchain resolution option for
+# selecting toolchains. This flag can be removed once https://github.com/bazelbuild/bazel/issues/7260 is closed and the
+# migration is complete
 build --incompatible_enable_cc_toolchain_resolution --copt=-D_LIBCPP_ENABLE_NODISCARD
 
 ##

--- a/.bazelrc
+++ b/.bazelrc
@@ -12,7 +12,7 @@ common:test --test_env=GTEST_INSTALL_FAILURE_SIGNAL_HANDLER=1
 ##
 ##  Custom toolchain.
 ##
-build --crosstool_top=@llvm_toolchain_12_0_0//:toolchain --copt=-D_LIBCPP_ENABLE_NODISCARD
+build --incompatible_enable_cc_toolchain_resolution --copt=-D_LIBCPP_ENABLE_NODISCARD
 
 ##
 ##  Common build options across all build configurations
@@ -202,9 +202,9 @@ build:ubsan --define unsanitized=false
 build:ubsan --copt=-DHAS_SANITIZER
 
 # Bazel links C++ files with $CC, not $CXX, this breaks UBSan
-build:sanitize-linux --linkopt=external/llvm_toolchain_12_0_0/lib/clang/12.0.0/lib/linux/libclang_rt.asan_cxx-x86_64.a
-build:sanitize-linux --linkopt=external/llvm_toolchain_12_0_0/lib/clang/12.0.0/lib/linux/libclang_rt.ubsan_standalone_cxx-x86_64.a
-build:sanitize-linux --linkopt=external/llvm_toolchain_12_0_0/lib/clang/12.0.0/lib/linux/libclang_rt.ubsan_standalone-x86_64.a
+build:sanitize-linux --linkopt=external/llvm_toolchain_13_0_0/lib/clang/13.0.0/lib/linux/libclang_rt.asan_cxx-x86_64.a
+build:sanitize-linux --linkopt=external/llvm_toolchain_13_0_0/lib/clang/13.0.0/lib/linux/libclang_rt.ubsan_standalone_cxx-x86_64.a
+build:sanitize-linux --linkopt=external/llvm_toolchain_13_0_0/lib/clang/13.0.0/lib/linux/libclang_rt.ubsan_standalone-x86_64.a
 build:sanitize-linux --config=sanitize
 
 build:sanitize-mac --config=sanitize
@@ -253,7 +253,7 @@ build:webasm --compilation_mode=opt
 build:webasm --copt=-DNDEBUG --linkopt=-DNDEBUG # for some reason emscripten doesn't pass those when -O2\-Oz are specified
 build:webasm --copt=--llvm-lto --copt=3 --linkopt=--llvm-lto --linkopt=3
 # Specify a "sane" C++ toolchain for the host platform.
-build:webasm --host_crosstool_top=@llvm_toolchain_12_0_0//:toolchain
+build:webasm --host_crosstool_top=@llvm_toolchain_13_0_0//:toolchain
 
 ##
 ## Stripe's ci passes --config=ci, we need it to exist

--- a/.bazelrc
+++ b/.bazelrc
@@ -254,7 +254,8 @@ build:webasm --cpu=webasm --spawn_strategy=local --genrule_strategy=local --copt
 build:webasm --define release=true
 build:webasm --compilation_mode=opt
 build:webasm --copt=-DNDEBUG --linkopt=-DNDEBUG # for some reason emscripten doesn't pass those when -O2\-Oz are specified
-build:webasm --copt=--llvm-lto --copt=3 --linkopt=--llvm-lto --linkopt=3
+build:webasm --copt=-DEMSCRIPTEN
+build:webasm --linkopt=-lto-O2
 # Specify a "sane" C++ toolchain for the host platform.
 build:webasm --host_crosstool_top=@llvm_toolchain_13_0_0//:toolchain
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,7 @@
   // Disable feature where Clangd auto-imports headers for missing references.
   // It inserts relative paths that we don't want.
   "clangd.arguments": ["--header-insertion=never"],
-  "clangd.path": "bazel-sorbet/external/llvm_toolchain_12_0_0/bin/clangd",
+  "clangd.path": "bazel-sorbet/external/llvm_toolchain_13_0_0/bin/clangd",
   "files.associations": {
     "*.rbi": "ruby",
     "*.rbupdated": "ruby",

--- a/README.md
+++ b/README.md
@@ -963,7 +963,7 @@ You are encouraged to play around with various clang-based tools which use the
 
     After successfully compiling Sorbet, point your editor to use the
     `clangd` executable located in
-    `bazel-sorbet/external/llvm_toolchain_12_0_0/bin/clangd`.
+    `bazel-sorbet/external/llvm_toolchain_13_0_0/bin/clangd`.
 
 -   [clang-format] -- Clang-based source code formatter
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -11,15 +11,18 @@ bazel_toolchain_dependencies()
 load("@com_grail_bazel_toolchain//toolchain:rules.bzl", "llvm_toolchain")
 
 llvm_toolchain(
-    name = "llvm_toolchain_12_0_0",
+    name = "llvm_toolchain_13_0_0",
     absolute_paths = True,
     llvm_mirror_prefixes = [
         "https://sorbet-deps.s3-us-west-2.amazonaws.com/",
         "https://artifactory-content.stripe.build/artifactory/github-archives/llvm/llvm-project/releases/download/llvmorg-",
         "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
     ],
-    llvm_version = "12.0.0",
+    llvm_version = "13.0.0",
 )
+
+load("@llvm_toolchain_13_0_0//:toolchains.bzl", "llvm_register_toolchains")
+llvm_register_toolchains()
 
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -22,6 +22,7 @@ llvm_toolchain(
 )
 
 load("@llvm_toolchain_13_0_0//:toolchains.bzl", "llvm_register_toolchains")
+
 llvm_register_toolchains()
 
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")

--- a/common/formatting.h
+++ b/common/formatting.h
@@ -38,14 +38,15 @@ struct formatter<arg_map_join<It, Char, UnaryOp, UnaryOpResult>, Char> : formatt
 
 template <typename It, class UnaryOp> auto map_join(It begin, It end, std::string_view sep, const UnaryOp &mapper) {
     return arg_map_join<It, char, UnaryOp,
-                        typename std::result_of<UnaryOp(typename std::iterator_traits<It>::value_type)>::type>(
+                        typename std::invoke_result<UnaryOp, typename std::iterator_traits<It>::value_type>::type>(
         begin, end, sep, mapper);
 }
 template <typename Container, class UnaryOp>
 auto map_join(const Container &collection, std::string_view sep, const UnaryOp &mapper) {
-    return arg_map_join<typename Container::const_iterator, char, UnaryOp,
-                        typename std::result_of<UnaryOp(
-                            typename std::iterator_traits<typename Container::const_iterator>::value_type)>::type>(
+    return arg_map_join<
+        typename Container::const_iterator, char, UnaryOp,
+        typename std::invoke_result<
+            UnaryOp, typename std::iterator_traits<typename Container::const_iterator>::value_type>::type>(
         collection.begin(), collection.end(), sep, mapper);
 }
 } // namespace fmt

--- a/common/os/mac.cc
+++ b/common/os/mac.cc
@@ -55,9 +55,7 @@ bool amIBeingDebugged()
     mib[3] = getpid();
 
     // Call sysctl.
-
-    size_t size = sizeof(info);
-    assert(sysctl(mib, sizeof(mib) / sizeof(*mib), &info, &size, nullptr, 0) == 0);
+    assert(sysctl(mib, sizeof(mib) / sizeof(*mib), &info, &sizeof(info), nullptr, 0) == 0);
 
     // We're being debugged if the P_TRACED flag is set.
 

--- a/common/os/mac.cc
+++ b/common/os/mac.cc
@@ -38,10 +38,8 @@ bool amIBeingDebugged()
 // Returns true if the current process is being debugged (either
 // running under the debugger or has a debugger attached post facto).
 {
-    int junk;
     int mib[4];
     struct kinfo_proc info;
-    size_t size;
 
     // Initialize the flags so that, if sysctl fails for some bizarre
     // reason, we get a predictable result.
@@ -58,9 +56,8 @@ bool amIBeingDebugged()
 
     // Call sysctl.
 
-    size = sizeof(info);
-    junk = sysctl(mib, sizeof(mib) / sizeof(*mib), &info, &size, nullptr, 0);
-    assert(junk == 0);
+    size_t size = sizeof(info);
+    assert(sysctl(mib, sizeof(mib) / sizeof(*mib), &info, &size, nullptr, 0) == 0);
 
     // We're being debugged if the P_TRACED flag is set.
 

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -613,12 +613,6 @@ TypeSyntax::ResultType interpretTCombinator(core::Context ctx, const ast::Send &
                 if (auto e = ctx.beginError(send.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                     e.setHeader("`{}` has been renamed to `{}`", "T.enum", "T.deprecated_enum");
 
-                    auto prefix = 0;
-                    auto sendSource = core::Loc(ctx.file, send.loc).source(ctx);
-                    if (sendSource.has_value() && absl::StartsWith(sendSource.value(), "::")) {
-                        prefix += 2;
-                    }
-
                     if (send.funLoc.exists() && !send.funLoc.empty()) {
                         e.replaceWith("Replace with `deprecated_enum`", core::Loc(ctx.file, send.funLoc), "{}",
                                       "deprecated_enum");

--- a/test/testdata/compiler/all_arguments.opt.ll.exp
+++ b/test/testdata/compiler/all_arguments.opt.ll.exp
@@ -2,16 +2,17 @@
 source_filename = "llvm-link"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 
-%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.3, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.4, [29 x i16] }
+%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.5, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.6, [29 x i16] }
 %struct.rb_global_vm_lock_struct = type { %struct.rb_thread_struct*, %union.pthread_mutex_t, %struct.list_head, %struct.rb_thread_struct*, i32, %union.pthread_cond_t, %union.pthread_cond_t, i32, i32 }
-%union.pthread_cond_t = type { %struct.anon.2 }
-%struct.anon.2 = type { i32, i32, i64, i64, i64, i8*, i32, i32 }
-%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.7, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
+%union.pthread_cond_t = type { %struct.__pthread_cond_s }
+%struct.__pthread_cond_s = type { %union.anon, %union.anon, [2 x i32], [2 x i32], i32, i32, [2 x i32] }
+%union.anon = type { i64 }
+%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.10, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
 %struct.list_node = type { %struct.list_node*, %struct.list_node* }
-%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.5 }
+%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.7 }
 %struct.rb_control_frame_struct = type { i64*, i64*, %struct.rb_iseq_struct*, i64, i64*, i8*, i64* }
-%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.14 }
-%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.13, i32, i32, i32, i32, i32, i8, i64 }
+%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.17 }
+%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.16, i32, i32, i32, i32, i32, i8, i64 }
 %struct.anon = type { %struct.anon.0, i32, i32, i32, i32, i32, i32, i32, i64*, %struct.rb_iseq_param_keyword* }
 %struct.anon.0 = type { i16, [2 x i8] }
 %struct.rb_iseq_param_keyword = type { i32, i32, i32, i32, i64*, i64* }
@@ -27,34 +28,34 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_cref_struct = type { i64, i64, i64, %struct.rb_cref_struct*, %struct.rb_scope_visi_struct }
 %struct.rb_scope_visi_struct = type { i8, [3 x i8] }
 %struct.rb_call_data = type { %struct.rb_call_cache, %struct.rb_call_info }
-%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.12 }
+%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.15 }
 %struct.rb_callable_method_entry_struct = type { i64, i64, %struct.rb_method_definition_struct*, i64, i64 }
-%struct.rb_method_definition_struct = type { i64, %union.anon.10, i64, i64 }
-%union.anon.10 = type { %struct.rb_method_cfunc_struct }
+%struct.rb_method_definition_struct = type { i64, %union.anon.13, i64, i64 }
+%union.anon.13 = type { %struct.rb_method_cfunc_struct }
 %struct.rb_method_cfunc_struct = type { i64 (...)*, i64 (i64, i32, i64*, i64 (...)*)*, i32 }
-%union.anon.12 = type { i32 }
+%union.anon.15 = type { i32 }
 %struct.rb_call_info = type { i64, i32, i32 }
-%struct.anon.13 = type { i64, i64, i64, i64* }
-%union.anon.14 = type { %struct.anon.15 }
-%struct.anon.15 = type { i64, i32 }
+%struct.anon.16 = type { i64, i64, i64, i64* }
+%union.anon.17 = type { %struct.anon.18 }
+%struct.anon.18 = type { i64, i32 }
 %struct.rb_vm_tag = type { i64, i64, [5 x i8*], %struct.rb_vm_tag*, i32 }
 %struct.rb_vm_protect_tag = type { %struct.rb_vm_protect_tag* }
 %struct.rb_ensure_list = type { %struct.rb_ensure_list*, %struct.rb_ensure_entry }
 %struct.rb_ensure_entry = type { i64, i64 (i64)*, i64 }
 %struct.rb_trace_arg_struct = type { i32, %struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, i64, i64, i64, i64, i64, i32, i32, i64 }
-%struct.anon.5 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
+%struct.anon.7 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
 %struct.__jmp_buf_tag = type { [8 x i64], i32, %struct.__sigset_t }
 %struct.__sigset_t = type { [16 x i64] }
 %struct.rb_calling_info = type { i64, i64, i32, i32 }
-%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.6 }
-%union.anon.6 = type { %union.pthread_cond_t }
+%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.9 }
+%union.anon.9 = type { %union.pthread_cond_t }
 %struct.rb_unblock_callback = type { void (i8*)*, i8* }
 %struct.rb_mutex_struct = type opaque
 %struct.rb_thread_list_struct = type { %struct.rb_thread_list_struct*, %struct.rb_thread_struct* }
-%union.anon.7 = type { %struct.anon.8 }
-%struct.anon.8 = type { i64, i64, i32 }
+%union.anon.10 = type { %struct.anon.11 }
+%struct.anon.11 = type { i64, i64, i32 }
 %struct.rb_fiber_struct = type opaque
-%struct.anon.3 = type { [65 x i64] }
+%struct.anon.5 = type { [65 x i64] }
 %struct.rb_hook_list_struct = type { %struct.rb_event_hook_struct*, i32, i32, i32 }
 %struct.rb_event_hook_struct = type opaque
 %struct.rb_postponed_job_struct = type opaque
@@ -68,7 +69,7 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.st_hash_type = type { i32 (i64, i64)*, i64 (i64)* }
 %struct.st_table_entry = type opaque
 %struct.rb_builtin_function = type opaque
-%struct.anon.4 = type { i64, i64, i64, i64 }
+%struct.anon.6 = type { i64, i64, i64, i64 }
 %struct.SorbetLineNumberInfo = type { i32, %struct.iseq_insn_info_entry*, i64* }
 %struct.FunctionInlineCache = type { %struct.rb_kwarg_call_data }
 %struct.rb_kwarg_call_data = type { %struct.rb_call_cache, %struct.rb_call_info_with_kwarg }
@@ -76,11 +77,11 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_call_info_kw_arg = type { i32, [1 x i64] }
 %struct.iseq_inline_iv_cache_entry = type { i64, i64 }
 
-@ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
-@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
+@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @"stackFramePrecomputed_func_Object#14take_arguments" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @rubyIdPrecomputed_take_arguments = internal unnamed_addr global i64 0, align 8
 @str_take_arguments = private unnamed_addr constant [15 x i8] c"take_arguments\00", align 1
@@ -139,7 +140,7 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ic_take_arguments.20 = internal global %struct.FunctionInlineCache zeroinitializer
 @rb_cObject = external local_unnamed_addr constant i64
 
-; Function Attrs: nounwind readnone willreturn
+; Function Attrs: nofree nosync nounwind readnone willreturn mustprogress
 declare i64 @rb_id2sym(i64) local_unnamed_addr #0
 
 ; Function Attrs: noreturn
@@ -234,17 +235,17 @@ functionEntryInitializers:
   %9 = and i64 %6, -9, !dbg !16
   %10 = icmp eq i64 %9, 0, !dbg !16
   %11 = or i1 %8, %10, !dbg !16
-  br i1 %11, label %sorbet_determineKwSplatArg.exit.thread77, label %sorbet_isa_Hash.exit, !dbg !16
+  br i1 %11, label %sorbet_determineKwSplatArg.exit.thread77, label %12, !dbg !16
 
-sorbet_isa_Hash.exit:                             ; preds = %2
-  %12 = inttoptr i64 %6 to %struct.iseq_inline_iv_cache_entry*, !dbg !16
-  %13 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %12, i64 0, i32 0, !dbg !16
-  %14 = load i64, i64* %13, align 8, !dbg !16, !tbaa !17
-  %15 = and i64 %14, 31, !dbg !16
-  %16 = icmp eq i64 %15, 8, !dbg !16
-  br i1 %16, label %fillRequiredArgs, label %sorbet_determineKwSplatArg.exit.thread77, !dbg !16
+12:                                               ; preds = %2
+  %13 = inttoptr i64 %6 to %struct.iseq_inline_iv_cache_entry*, !dbg !16
+  %14 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %13, i64 0, i32 0, !dbg !16
+  %15 = load i64, i64* %14, align 8, !dbg !16, !tbaa !17
+  %16 = and i64 %15, 31, !dbg !16
+  %17 = icmp eq i64 %16, 8, !dbg !16
+  br i1 %17, label %fillRequiredArgs, label %sorbet_determineKwSplatArg.exit.thread77, !dbg !16
 
-sorbet_determineKwSplatArg.exit.thread77:         ; preds = %sorbet_isa_Hash.exit, %2
+sorbet_determineKwSplatArg.exit.thread77:         ; preds = %2, %12
   br label %fillRequiredArgs, !dbg !16
 
 sorbet_determineKwSplatArg.exit:                  ; preds = %functionEntryInitializers
@@ -256,194 +257,192 @@ argCountFailBlock:                                ; preds = %sorbet_determineKwS
   unreachable, !dbg !16
 
 fillFromDefaultBlockDone1:                        ; preds = %sorbet_writeLocal.exit
-  %17 = getelementptr i64, i64* %argArray, i32 1, !dbg !16
-  %rawArg_b = load i64, i64* %17, align 8, !dbg !16
-  %18 = icmp sgt i32 %30, 2, !dbg !16
-  br i1 %18, label %20, label %fillFromDefaultBlockDone1.thread, !dbg !16
+  %18 = getelementptr i64, i64* %argArray, i32 1, !dbg !16
+  %rawArg_b = load i64, i64* %18, align 8, !dbg !16
+  %19 = icmp sgt i32 %31, 2, !dbg !16
+  br i1 %19, label %21, label %fillFromDefaultBlockDone1.thread, !dbg !16
 
 fillFromDefaultBlockDone1.thread:                 ; preds = %sorbet_writeLocal.exit, %fillFromDefaultBlockDone1
   %"<argPresent>.sroa.0.084" = phi i64 [ 20, %fillFromDefaultBlockDone1 ], [ 0, %sorbet_writeLocal.exit ]
   %b.sroa.0.182 = phi i64 [ %rawArg_b, %fillFromDefaultBlockDone1 ], [ 8, %sorbet_writeLocal.exit ]
-  %19 = tail call i64 @rb_ary_new() #11, !dbg !16
+  %20 = tail call i64 @rb_ary_new() #11, !dbg !16
   br label %sorbet_readRestArgs.exit, !dbg !16
 
-20:                                               ; preds = %fillFromDefaultBlockDone1
-  %21 = sub nuw nsw i32 %30, 2, !dbg !16
-  %22 = zext i32 %21 to i64
-  %23 = getelementptr inbounds i64, i64* %argArray, i64 2, !dbg !16
-  %24 = tail call i64 @rb_ary_new_from_values(i64 %22, i64* nonnull %23) #11, !dbg !16
+21:                                               ; preds = %fillFromDefaultBlockDone1
+  %22 = sub nuw nsw i32 %31, 2, !dbg !16
+  %23 = zext i32 %22 to i64
+  %24 = getelementptr inbounds i64, i64* %argArray, i64 2, !dbg !16
+  %25 = tail call i64 @rb_ary_new_from_values(i64 %23, i64* nonnull %24) #11, !dbg !16
   br label %sorbet_readRestArgs.exit, !dbg !16
 
-sorbet_readRestArgs.exit:                         ; preds = %fillFromDefaultBlockDone1.thread, %20
-  %"<argPresent>.sroa.0.083" = phi i64 [ %"<argPresent>.sroa.0.084", %fillFromDefaultBlockDone1.thread ], [ 20, %20 ]
-  %b.sroa.0.181 = phi i64 [ %b.sroa.0.182, %fillFromDefaultBlockDone1.thread ], [ %rawArg_b, %20 ]
-  %25 = phi i64 [ %19, %fillFromDefaultBlockDone1.thread ], [ %24, %20 ], !dbg !16
+sorbet_readRestArgs.exit:                         ; preds = %fillFromDefaultBlockDone1.thread, %21
+  %"<argPresent>.sroa.0.083" = phi i64 [ %"<argPresent>.sroa.0.084", %fillFromDefaultBlockDone1.thread ], [ 20, %21 ]
+  %b.sroa.0.181 = phi i64 [ %b.sroa.0.182, %fillFromDefaultBlockDone1.thread ], [ %rawArg_b, %21 ]
+  %26 = phi i64 [ %20, %fillFromDefaultBlockDone1.thread ], [ %25, %21 ], !dbg !16
   %rubyId_d = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !16
   %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_d), !dbg !16
-  %26 = icmp eq i64 %29, 52, !dbg !16
-  br i1 %26, label %kwArgContinue, label %sorbet_removeKWArg.exit74, !dbg !16
+  %27 = icmp eq i64 %30, 52, !dbg !16
+  br i1 %27, label %kwArgContinue, label %sorbet_removeKWArg.exit74, !dbg !16
 
 sorbet_removeKWArg.exit74:                        ; preds = %sorbet_readRestArgs.exit
-  %27 = tail call i64 @rb_hash_delete_entry(i64 %29, i64 %rawSym) #11, !dbg !16
-  %28 = icmp eq i64 %27, 52, !dbg !16
-  br i1 %28, label %kwArgContinue, label %kwArgContinue.thread, !dbg !16
+  %28 = tail call i64 @rb_hash_delete_entry(i64 %30, i64 %rawSym) #11, !dbg !16
+  %29 = icmp eq i64 %28, 52, !dbg !16
+  br i1 %29, label %kwArgContinue, label %kwArgContinue.thread, !dbg !16
 
 kwArgContinue.thread:                             ; preds = %sorbet_removeKWArg.exit74
   %rubyId_e87 = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !16
   %rawSym2088 = tail call i64 @rb_id2sym(i64 %rubyId_e87), !dbg !16
   br label %sorbet_removeKWArg.exit.thread, !dbg !16
 
-fillRequiredArgs:                                 ; preds = %sorbet_isa_Hash.exit, %sorbet_determineKwSplatArg.exit.thread77, %sorbet_determineKwSplatArg.exit
-  %29 = phi i64 [ 52, %sorbet_determineKwSplatArg.exit ], [ 52, %sorbet_determineKwSplatArg.exit.thread77 ], [ %6, %sorbet_isa_Hash.exit ]
-  %30 = phi i32 [ %argc, %sorbet_determineKwSplatArg.exit ], [ %argc, %sorbet_determineKwSplatArg.exit.thread77 ], [ %3, %sorbet_isa_Hash.exit ]
+fillRequiredArgs:                                 ; preds = %12, %sorbet_determineKwSplatArg.exit.thread77, %sorbet_determineKwSplatArg.exit
+  %30 = phi i64 [ 52, %sorbet_determineKwSplatArg.exit ], [ 52, %sorbet_determineKwSplatArg.exit.thread77 ], [ %6, %12 ]
+  %31 = phi i32 [ %argc, %sorbet_determineKwSplatArg.exit ], [ %argc, %sorbet_determineKwSplatArg.exit.thread77 ], [ %3, %12 ]
   %rawArg_a = load i64, i64* %argArray, align 8, !dbg !16
-  %31 = tail call i32 @rb_block_given_p() #11, !dbg !16
-  %32 = icmp eq i32 %31, 0, !dbg !16
-  br i1 %32, label %sorbet_getMethodBlockAsProc.exit, label %33, !dbg !16
+  %32 = tail call i32 @rb_block_given_p() #11, !dbg !16
+  %33 = icmp eq i32 %32, 0, !dbg !16
+  br i1 %33, label %sorbet_getMethodBlockAsProc.exit, label %34, !dbg !16
 
-33:                                               ; preds = %fillRequiredArgs
-  %34 = tail call i64 @rb_block_proc() #11, !dbg !16
+34:                                               ; preds = %fillRequiredArgs
+  %35 = tail call i64 @rb_block_proc() #11, !dbg !16
   br label %sorbet_getMethodBlockAsProc.exit, !dbg !16
 
-sorbet_getMethodBlockAsProc.exit:                 ; preds = %fillRequiredArgs, %33
-  %35 = phi i64 [ %34, %33 ], [ 8, %fillRequiredArgs ], !dbg !16
-  %36 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 4, !dbg !16
-  %37 = load i64*, i64** %36, align 8, !dbg !16, !tbaa !20
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !22), !dbg !16
-  %38 = load i64, i64* %37, align 8, !dbg !16, !tbaa !6
-  %39 = and i64 %38, 8, !dbg !16
-  %40 = icmp eq i64 %39, 0, !dbg !16
-  br i1 %40, label %41, label %43, !dbg !16, !prof !25
+sorbet_getMethodBlockAsProc.exit:                 ; preds = %fillRequiredArgs, %34
+  %36 = phi i64 [ %35, %34 ], [ 8, %fillRequiredArgs ], !dbg !16
+  %37 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 4, !dbg !16
+  %38 = load i64*, i64** %37, align 8, !dbg !16, !tbaa !20
+  %39 = load i64, i64* %38, align 8, !dbg !16, !tbaa !6
+  %40 = and i64 %39, 8, !dbg !16
+  %41 = icmp eq i64 %40, 0, !dbg !16
+  br i1 %41, label %42, label %44, !dbg !16, !prof !22
 
-41:                                               ; preds = %sorbet_getMethodBlockAsProc.exit
-  %42 = getelementptr inbounds i64, i64* %37, i64 -3, !dbg !16
-  store i64 %35, i64* %42, align 8, !dbg !16, !tbaa !6
+42:                                               ; preds = %sorbet_getMethodBlockAsProc.exit
+  %43 = getelementptr inbounds i64, i64* %38, i64 -3, !dbg !16
+  store i64 %36, i64* %43, align 8, !dbg !16, !tbaa !6
   br label %sorbet_writeLocal.exit, !dbg !16
 
-43:                                               ; preds = %sorbet_getMethodBlockAsProc.exit
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %37, i32 noundef -3, i64 %35) #11, !dbg !16
+44:                                               ; preds = %sorbet_getMethodBlockAsProc.exit
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 %38, i32 noundef -3, i64 %36) #11, !dbg !16
   br label %sorbet_writeLocal.exit, !dbg !16
 
-sorbet_writeLocal.exit:                           ; preds = %41, %43
-  %default0 = icmp eq i32 %30, 1, !dbg !16
+sorbet_writeLocal.exit:                           ; preds = %42, %44
+  %default0 = icmp eq i32 %31, 1, !dbg !16
   br i1 %default0, label %fillFromDefaultBlockDone1.thread, label %fillFromDefaultBlockDone1, !dbg !16, !prof !19
 
 kwArgContinue:                                    ; preds = %sorbet_readRestArgs.exit, %sorbet_removeKWArg.exit74
-  %44 = tail call i64 @sorbet_addMissingKWArg(i64 noundef 52, i64 %rawSym), !dbg !16
+  %45 = tail call i64 @sorbet_addMissingKWArg(i64 noundef 52, i64 %rawSym), !dbg !16
   %rubyId_e = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !16
   %rawSym20 = tail call i64 @rb_id2sym(i64 %rubyId_e), !dbg !16
-  br i1 %26, label %sorbet_removeKWArg.exit, label %sorbet_removeKWArg.exit.thread, !dbg !16
+  br i1 %27, label %sorbet_removeKWArg.exit, label %sorbet_removeKWArg.exit.thread, !dbg !16
 
 sorbet_removeKWArg.exit:                          ; preds = %kwArgContinue
-  %45 = icmp eq i64 %44, 52, !dbg !16
-  br i1 %45, label %sorbet_readKWRestArgs.exit.thread, label %49, !dbg !16, !prof !25
+  %46 = icmp eq i64 %45, 52, !dbg !16
+  br i1 %46, label %sorbet_readKWRestArgs.exit.thread, label %50, !dbg !16, !prof !22
 
 sorbet_removeKWArg.exit.thread:                   ; preds = %kwArgContinue, %kwArgContinue.thread
   %rawSym2093 = phi i64 [ %rawSym2088, %kwArgContinue.thread ], [ %rawSym20, %kwArgContinue ]
-  %missingArgsPhi91 = phi i64 [ 52, %kwArgContinue.thread ], [ %44, %kwArgContinue ]
-  %d.sroa.0.089 = phi i64 [ %27, %kwArgContinue.thread ], [ 8, %kwArgContinue ]
-  %46 = tail call i64 @rb_hash_delete_entry(i64 %29, i64 %rawSym2093) #11, !dbg !16
-  %47 = icmp eq i64 %46, 52, !dbg !16
-  %e.sroa.0.196 = select i1 %47, i64 8, i64 %46, !dbg !16
-  %"<argPresent>9.sroa.0.097" = select i1 %47, i64 0, i64 20, !dbg !16
-  %48 = icmp eq i64 %missingArgsPhi91, 52, !dbg !16
-  br i1 %48, label %sorbet_readKWRestArgs.exit, label %49, !dbg !16, !prof !25
+  %missingArgsPhi91 = phi i64 [ 52, %kwArgContinue.thread ], [ %45, %kwArgContinue ]
+  %d.sroa.0.089 = phi i64 [ %28, %kwArgContinue.thread ], [ 8, %kwArgContinue ]
+  %47 = tail call i64 @rb_hash_delete_entry(i64 %30, i64 %rawSym2093) #11, !dbg !16
+  %48 = icmp eq i64 %47, 52, !dbg !16
+  %e.sroa.0.196 = select i1 %48, i64 8, i64 %47, !dbg !16
+  %"<argPresent>9.sroa.0.097" = select i1 %48, i64 0, i64 20, !dbg !16
+  %49 = icmp eq i64 %missingArgsPhi91, 52, !dbg !16
+  br i1 %49, label %sorbet_readKWRestArgs.exit, label %50, !dbg !16, !prof !22
 
-49:                                               ; preds = %sorbet_removeKWArg.exit.thread, %sorbet_removeKWArg.exit
-  %missingArgsPhi9298 = phi i64 [ %missingArgsPhi91, %sorbet_removeKWArg.exit.thread ], [ %44, %sorbet_removeKWArg.exit ]
+50:                                               ; preds = %sorbet_removeKWArg.exit.thread, %sorbet_removeKWArg.exit
+  %missingArgsPhi9298 = phi i64 [ %missingArgsPhi91, %sorbet_removeKWArg.exit.thread ], [ %45, %sorbet_removeKWArg.exit ]
   tail call void @sorbet_raiseMissingKeywords(i64 %missingArgsPhi9298) #9, !dbg !16
   unreachable, !dbg !16
 
 sorbet_readKWRestArgs.exit.thread:                ; preds = %sorbet_removeKWArg.exit
-  %50 = tail call i64 @rb_hash_new() #11, !dbg !16
-  %51 = and i64 %"<argPresent>.sroa.0.083", -9, !dbg !26
-  %52 = icmp ne i64 %51, 0, !dbg !26
-  %b.sroa.0.0125 = select i1 %52, i64 %b.sroa.0.181, i64 3, !dbg !26
-  br label %58, !dbg !27
+  %51 = tail call i64 @rb_hash_new() #11, !dbg !16
+  %52 = and i64 %"<argPresent>.sroa.0.083", -9, !dbg !23
+  %53 = icmp ne i64 %52, 0, !dbg !23
+  %b.sroa.0.0125 = select i1 %53, i64 %b.sroa.0.181, i64 3, !dbg !23
+  br label %59, !dbg !24
 
 sorbet_readKWRestArgs.exit:                       ; preds = %sorbet_removeKWArg.exit.thread
-  %53 = tail call i64 @rb_hash_dup(i64 %29) #11, !dbg !16
-  %54 = and i64 %"<argPresent>.sroa.0.083", -9, !dbg !26
-  %55 = icmp ne i64 %54, 0, !dbg !26
-  %b.sroa.0.0 = select i1 %55, i64 %b.sroa.0.181, i64 3, !dbg !26
-  %56 = icmp ne i64 %"<argPresent>9.sroa.0.097", 0, !dbg !27
-  br i1 %56, label %57, label %58, !dbg !27
+  %54 = tail call i64 @rb_hash_dup(i64 %30) #11, !dbg !16
+  %55 = and i64 %"<argPresent>.sroa.0.083", -9, !dbg !23
+  %56 = icmp ne i64 %55, 0, !dbg !23
+  %b.sroa.0.0 = select i1 %56, i64 %b.sroa.0.181, i64 3, !dbg !23
+  %57 = icmp ne i64 %"<argPresent>9.sroa.0.097", 0, !dbg !24
+  br i1 %57, label %58, label %59, !dbg !24
 
-57:                                               ; preds = %sorbet_readKWRestArgs.exit
-  br label %58, !dbg !27
+58:                                               ; preds = %sorbet_readKWRestArgs.exit
+  br label %59, !dbg !24
 
-58:                                               ; preds = %sorbet_readKWRestArgs.exit.thread, %sorbet_readKWRestArgs.exit, %57
-  %b.sroa.0.0127 = phi i64 [ %b.sroa.0.0, %57 ], [ %b.sroa.0.0, %sorbet_readKWRestArgs.exit ], [ %b.sroa.0.0125, %sorbet_readKWRestArgs.exit.thread ]
-  %59 = phi i64 [ %53, %57 ], [ %53, %sorbet_readKWRestArgs.exit ], [ %50, %sorbet_readKWRestArgs.exit.thread ]
-  %d.sroa.0.09099109126 = phi i64 [ %d.sroa.0.089, %57 ], [ %d.sroa.0.089, %sorbet_readKWRestArgs.exit ], [ 8, %sorbet_readKWRestArgs.exit.thread ]
-  %60 = phi i64 [ %e.sroa.0.196, %57 ], [ 5, %sorbet_readKWRestArgs.exit ], [ 5, %sorbet_readKWRestArgs.exit.thread ]
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %0, align 8, !dbg !28, !tbaa !14
-  %callArgs0Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 0, !dbg !29
-  store i64 %rawArg_a, i64* %callArgs0Addr, align 8, !dbg !29
-  %callArgs1Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 1, !dbg !29
-  store i64 %b.sroa.0.0127, i64* %callArgs1Addr, align 8, !dbg !29
-  %callArgs2Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 2, !dbg !29
-  store i64 %25, i64* %callArgs2Addr, align 8, !dbg !29
-  %callArgs3Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 3, !dbg !29
-  store i64 %d.sroa.0.09099109126, i64* %callArgs3Addr, align 8, !dbg !29
-  %callArgs4Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 4, !dbg !29
-  store i64 %60, i64* %callArgs4Addr, align 8, !dbg !29
-  %callArgs5Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 5, !dbg !29
-  store i64 %59, i64* %callArgs5Addr, align 8, !dbg !29
-  %61 = load i64*, i64** %36, align 8, !dbg !29, !tbaa !20
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !30), !dbg !29
-  %62 = getelementptr inbounds i64, i64* %61, i64 -3, !dbg !29
-  %63 = load i64, i64* %62, align 8, !dbg !29, !tbaa !6
-  %callArgs6Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 6, !dbg !29
-  store i64 %63, i64* %callArgs6Addr, align 8, !dbg !29
-  %64 = getelementptr [8 x i64], [8 x i64]* %callArgs, i64 0, i64 0, !dbg !29
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !33) #12, !dbg !29
-  %65 = call i64 @rb_ary_new_from_values(i64 noundef 7, i64* noundef nonnull %64) #11, !dbg !29
-  %66 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !29
-  %67 = load i64*, i64** %66, align 8, !dbg !29
-  store i64 %65, i64* %67, align 8, !dbg !29, !tbaa !6
-  %68 = getelementptr inbounds i64, i64* %67, i64 1, !dbg !29
-  store i64* %68, i64** %66, align 8, !dbg !29
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_inspect, i64 0), !dbg !29
-  %69 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !36
-  %70 = load i64*, i64** %69, align 8, !dbg !36
-  store i64 %selfRaw, i64* %70, align 8, !dbg !36, !tbaa !6
-  %71 = getelementptr inbounds i64, i64* %70, i64 1, !dbg !36
-  store i64 %send, i64* %71, align 8, !dbg !36, !tbaa !6
-  %72 = getelementptr inbounds i64, i64* %71, i64 1, !dbg !36
-  store i64* %72, i64** %69, align 8, !dbg !36
-  %send121 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !36
+59:                                               ; preds = %sorbet_readKWRestArgs.exit.thread, %sorbet_readKWRestArgs.exit, %58
+  %b.sroa.0.0127 = phi i64 [ %b.sroa.0.0, %58 ], [ %b.sroa.0.0, %sorbet_readKWRestArgs.exit ], [ %b.sroa.0.0125, %sorbet_readKWRestArgs.exit.thread ]
+  %60 = phi i64 [ %54, %58 ], [ %54, %sorbet_readKWRestArgs.exit ], [ %51, %sorbet_readKWRestArgs.exit.thread ]
+  %d.sroa.0.09099109126 = phi i64 [ %d.sroa.0.089, %58 ], [ %d.sroa.0.089, %sorbet_readKWRestArgs.exit ], [ 8, %sorbet_readKWRestArgs.exit.thread ]
+  %61 = phi i64 [ %e.sroa.0.196, %58 ], [ 5, %sorbet_readKWRestArgs.exit ], [ 5, %sorbet_readKWRestArgs.exit.thread ]
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %0, align 8, !dbg !25, !tbaa !14
+  %callArgs0Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 0, !dbg !26
+  store i64 %rawArg_a, i64* %callArgs0Addr, align 8, !dbg !26
+  %callArgs1Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 1, !dbg !26
+  store i64 %b.sroa.0.0127, i64* %callArgs1Addr, align 8, !dbg !26
+  %callArgs2Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 2, !dbg !26
+  store i64 %26, i64* %callArgs2Addr, align 8, !dbg !26
+  %callArgs3Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 3, !dbg !26
+  store i64 %d.sroa.0.09099109126, i64* %callArgs3Addr, align 8, !dbg !26
+  %callArgs4Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 4, !dbg !26
+  store i64 %61, i64* %callArgs4Addr, align 8, !dbg !26
+  %callArgs5Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 5, !dbg !26
+  store i64 %60, i64* %callArgs5Addr, align 8, !dbg !26
+  %62 = load i64*, i64** %37, align 8, !dbg !26, !tbaa !20
+  %63 = getelementptr inbounds i64, i64* %62, i64 -3, !dbg !26
+  %64 = load i64, i64* %63, align 8, !dbg !26, !tbaa !6
+  %callArgs6Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i32 0, i64 6, !dbg !26
+  store i64 %64, i64* %callArgs6Addr, align 8, !dbg !26
+  %65 = getelementptr [8 x i64], [8 x i64]* %callArgs, i64 0, i64 0, !dbg !26
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !27) #12, !dbg !26
+  %66 = call i64 @rb_ary_new_from_values(i64 noundef 7, i64* noundef nonnull %65) #11, !dbg !26
+  %67 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !26
+  %68 = load i64*, i64** %67, align 8, !dbg !26
+  store i64 %66, i64* %68, align 8, !dbg !26, !tbaa !6
+  %69 = getelementptr inbounds i64, i64* %68, i64 1, !dbg !26
+  store i64* %69, i64** %67, align 8, !dbg !26
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_inspect, i64 0), !dbg !26
+  %70 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !30
+  %71 = load i64*, i64** %70, align 8, !dbg !30
+  store i64 %selfRaw, i64* %71, align 8, !dbg !30, !tbaa !6
+  %72 = getelementptr inbounds i64, i64* %71, i64 1, !dbg !30
+  store i64 %send, i64* %72, align 8, !dbg !30, !tbaa !6
+  %73 = getelementptr inbounds i64, i64* %72, i64 1, !dbg !30
+  store i64* %73, i64** %70, align 8, !dbg !30
+  %send121 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !30
   ret i64 %send121
 }
 
 ; Function Attrs: sspreq
 define void @Init_all_arguments() local_unnamed_addr #8 {
 entry:
-  %positional_table.i = alloca i64, i32 4, align 8, !dbg !37
-  %keyword_table.i = alloca i64, i32 3, align 8, !dbg !37
+  %positional_table.i = alloca i64, i32 4, align 8, !dbg !31
+  %keyword_table.i = alloca i64, i32 3, align 8, !dbg !31
   %locals.i164.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, align 8
-  %keywords.i = alloca i64, align 8, !dbg !39
-  %keywords4.i = alloca i64, align 8, !dbg !40
-  %keywords10.i = alloca i64, align 8, !dbg !41
-  %keywords16.i = alloca i64, align 8, !dbg !42
-  %keywords22.i = alloca i64, align 8, !dbg !43
-  %keywords28.i = alloca i64, align 8, !dbg !44
-  %keywords34.i = alloca i64, align 8, !dbg !45
-  %keywords40.i = alloca i64, i32 2, align 8, !dbg !46
-  %keywords47.i = alloca i64, i32 2, align 8, !dbg !47
-  %keywords55.i = alloca i64, i32 2, align 8, !dbg !48
-  %keywords63.i = alloca i64, i32 2, align 8, !dbg !49
-  %keywords71.i = alloca i64, i32 2, align 8, !dbg !50
-  %keywords79.i = alloca i64, i32 2, align 8, !dbg !51
-  %keywords87.i = alloca i64, i32 2, align 8, !dbg !52
-  %keywords95.i = alloca i64, i32 3, align 8, !dbg !53
-  %keywords104.i = alloca i64, i32 3, align 8, !dbg !54
-  %keywords114.i = alloca i64, i32 3, align 8, !dbg !55
-  %keywords124.i = alloca i64, i32 3, align 8, !dbg !56
-  %keywords134.i = alloca i64, i32 3, align 8, !dbg !57
-  %keywords144.i = alloca i64, i32 3, align 8, !dbg !58
-  %keywords154.i = alloca i64, i32 3, align 8, !dbg !59
+  %keywords.i = alloca i64, align 8, !dbg !33
+  %keywords4.i = alloca i64, align 8, !dbg !34
+  %keywords10.i = alloca i64, align 8, !dbg !35
+  %keywords16.i = alloca i64, align 8, !dbg !36
+  %keywords22.i = alloca i64, align 8, !dbg !37
+  %keywords28.i = alloca i64, align 8, !dbg !38
+  %keywords34.i = alloca i64, align 8, !dbg !39
+  %keywords40.i = alloca i64, i32 2, align 8, !dbg !40
+  %keywords47.i = alloca i64, i32 2, align 8, !dbg !41
+  %keywords55.i = alloca i64, i32 2, align 8, !dbg !42
+  %keywords63.i = alloca i64, i32 2, align 8, !dbg !43
+  %keywords71.i = alloca i64, i32 2, align 8, !dbg !44
+  %keywords79.i = alloca i64, i32 2, align 8, !dbg !45
+  %keywords87.i = alloca i64, i32 2, align 8, !dbg !46
+  %keywords95.i = alloca i64, i32 3, align 8, !dbg !47
+  %keywords104.i = alloca i64, i32 3, align 8, !dbg !48
+  %keywords114.i = alloca i64, i32 3, align 8, !dbg !49
+  %keywords124.i = alloca i64, i32 3, align 8, !dbg !50
+  %keywords134.i = alloca i64, i32 3, align 8, !dbg !51
+  %keywords144.i = alloca i64, i32 3, align 8, !dbg !52
+  %keywords154.i = alloca i64, i32 3, align 8, !dbg !53
   %realpath = tail call i64 @sorbet_readRealpath()
   %0 = bitcast i64* %keywords.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %0)
@@ -530,205 +529,205 @@ entry:
   %38 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_take_arguments.i.i, i64 %rubyId_take_arguments.i.i, i64 %"rubyStr_test/testdata/compiler/all_arguments.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i.i, i32 noundef 1, i32 noundef 8)
   store %struct.rb_iseq_struct* %38, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#14take_arguments", align 8
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %37)
-  %rubyId_inspect.i = load i64, i64* @rubyIdPrecomputed_inspect, align 8, !dbg !29
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_inspect, i64 %rubyId_inspect.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !29
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !36
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !36
+  %rubyId_inspect.i = load i64, i64* @rubyIdPrecomputed_inspect, align 8, !dbg !26
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_inspect, i64 %rubyId_inspect.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !26
+  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !30
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !30
   %39 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
   call void @rb_gc_register_mark_object(i64 %39) #11
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/all_arguments.rb.i163.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/all_arguments.rb", align 8
   %40 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %39, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/all_arguments.rb.i163.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i164.i, i32 noundef 0, i32 noundef 11)
   store %struct.rb_iseq_struct* %40, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %rubyId_take_arguments.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !39
-  %rubyId_d.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !39
-  %41 = call i64 @rb_id2sym(i64 %rubyId_d.i) #13, !dbg !39
-  store i64 %41, i64* %keywords.i, align 8, !dbg !39
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments, i64 %rubyId_take_arguments.i, i32 noundef 68, i32 noundef 8, i32 noundef 1, i64* noundef nonnull align 8 %keywords.i), !dbg !39
-  %rubyId_take_arguments3.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !40
-  %rubyId_d5.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !40
-  %42 = call i64 @rb_id2sym(i64 %rubyId_d5.i) #13, !dbg !40
-  store i64 %42, i64* %keywords4.i, align 8, !dbg !40
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.1, i64 %rubyId_take_arguments3.i, i32 noundef 68, i32 noundef 7, i32 noundef 1, i64* noundef nonnull align 8 %keywords4.i), !dbg !40
-  %rubyId_take_arguments9.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !41
-  %rubyId_d11.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !41
-  %43 = call i64 @rb_id2sym(i64 %rubyId_d11.i) #13, !dbg !41
-  store i64 %43, i64* %keywords10.i, align 8, !dbg !41
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.2, i64 %rubyId_take_arguments9.i, i32 noundef 68, i32 noundef 6, i32 noundef 1, i64* noundef nonnull align 8 %keywords10.i), !dbg !41
-  %rubyId_take_arguments15.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !42
-  %rubyId_d17.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !42
-  %44 = call i64 @rb_id2sym(i64 %rubyId_d17.i) #13, !dbg !42
-  store i64 %44, i64* %keywords16.i, align 8, !dbg !42
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.3, i64 %rubyId_take_arguments15.i, i32 noundef 68, i32 noundef 5, i32 noundef 1, i64* noundef nonnull align 8 %keywords16.i), !dbg !42
-  %rubyId_take_arguments21.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !43
-  %rubyId_d23.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !43
-  %45 = call i64 @rb_id2sym(i64 %rubyId_d23.i) #13, !dbg !43
-  store i64 %45, i64* %keywords22.i, align 8, !dbg !43
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.4, i64 %rubyId_take_arguments21.i, i32 noundef 68, i32 noundef 4, i32 noundef 1, i64* noundef nonnull align 8 %keywords22.i), !dbg !43
-  %rubyId_take_arguments27.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !44
-  %rubyId_d29.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !44
-  %46 = call i64 @rb_id2sym(i64 %rubyId_d29.i) #13, !dbg !44
-  store i64 %46, i64* %keywords28.i, align 8, !dbg !44
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.5, i64 %rubyId_take_arguments27.i, i32 noundef 68, i32 noundef 3, i32 noundef 1, i64* noundef nonnull align 8 %keywords28.i), !dbg !44
-  %rubyId_take_arguments33.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !45
-  %rubyId_d35.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !45
-  %47 = call i64 @rb_id2sym(i64 %rubyId_d35.i) #13, !dbg !45
-  store i64 %47, i64* %keywords34.i, align 8, !dbg !45
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.6, i64 %rubyId_take_arguments33.i, i32 noundef 68, i32 noundef 2, i32 noundef 1, i64* noundef nonnull align 8 %keywords34.i), !dbg !45
-  %rubyId_take_arguments39.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !46
-  %rubyId_d41.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !46
-  %48 = call i64 @rb_id2sym(i64 %rubyId_d41.i) #13, !dbg !46
-  store i64 %48, i64* %keywords40.i, align 8, !dbg !46
-  %rubyId_e.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !46
-  %49 = call i64 @rb_id2sym(i64 %rubyId_e.i) #13, !dbg !46
-  %50 = getelementptr i64, i64* %keywords40.i, i32 1, !dbg !46
-  store i64 %49, i64* %50, align 8, !dbg !46
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.7, i64 %rubyId_take_arguments39.i, i32 noundef 68, i32 noundef 9, i32 noundef 2, i64* noundef nonnull align 8 %keywords40.i), !dbg !46
-  %rubyId_take_arguments46.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !47
-  %rubyId_d48.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !47
-  %51 = call i64 @rb_id2sym(i64 %rubyId_d48.i) #13, !dbg !47
-  store i64 %51, i64* %keywords47.i, align 8, !dbg !47
-  %rubyId_e50.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !47
-  %52 = call i64 @rb_id2sym(i64 %rubyId_e50.i) #13, !dbg !47
-  %53 = getelementptr i64, i64* %keywords47.i, i32 1, !dbg !47
-  store i64 %52, i64* %53, align 8, !dbg !47
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.8, i64 %rubyId_take_arguments46.i, i32 noundef 68, i32 noundef 8, i32 noundef 2, i64* noundef nonnull align 8 %keywords47.i), !dbg !47
-  %rubyId_take_arguments54.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !48
-  %rubyId_d56.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !48
-  %54 = call i64 @rb_id2sym(i64 %rubyId_d56.i) #13, !dbg !48
-  store i64 %54, i64* %keywords55.i, align 8, !dbg !48
-  %rubyId_e58.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !48
-  %55 = call i64 @rb_id2sym(i64 %rubyId_e58.i) #13, !dbg !48
-  %56 = getelementptr i64, i64* %keywords55.i, i32 1, !dbg !48
-  store i64 %55, i64* %56, align 8, !dbg !48
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.9, i64 %rubyId_take_arguments54.i, i32 noundef 68, i32 noundef 7, i32 noundef 2, i64* noundef nonnull align 8 %keywords55.i), !dbg !48
-  %rubyId_take_arguments62.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !49
-  %rubyId_d64.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !49
-  %57 = call i64 @rb_id2sym(i64 %rubyId_d64.i) #13, !dbg !49
-  store i64 %57, i64* %keywords63.i, align 8, !dbg !49
-  %rubyId_e66.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !49
-  %58 = call i64 @rb_id2sym(i64 %rubyId_e66.i) #13, !dbg !49
-  %59 = getelementptr i64, i64* %keywords63.i, i32 1, !dbg !49
-  store i64 %58, i64* %59, align 8, !dbg !49
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.10, i64 %rubyId_take_arguments62.i, i32 noundef 68, i32 noundef 6, i32 noundef 2, i64* noundef nonnull align 8 %keywords63.i), !dbg !49
-  %rubyId_take_arguments70.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !50
-  %rubyId_d72.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !50
-  %60 = call i64 @rb_id2sym(i64 %rubyId_d72.i) #13, !dbg !50
-  store i64 %60, i64* %keywords71.i, align 8, !dbg !50
-  %rubyId_e74.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !50
-  %61 = call i64 @rb_id2sym(i64 %rubyId_e74.i) #13, !dbg !50
-  %62 = getelementptr i64, i64* %keywords71.i, i32 1, !dbg !50
-  store i64 %61, i64* %62, align 8, !dbg !50
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.11, i64 %rubyId_take_arguments70.i, i32 noundef 68, i32 noundef 5, i32 noundef 2, i64* noundef nonnull align 8 %keywords71.i), !dbg !50
-  %rubyId_take_arguments78.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !51
-  %rubyId_d80.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !51
-  %63 = call i64 @rb_id2sym(i64 %rubyId_d80.i) #13, !dbg !51
-  store i64 %63, i64* %keywords79.i, align 8, !dbg !51
-  %rubyId_e82.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !51
-  %64 = call i64 @rb_id2sym(i64 %rubyId_e82.i) #13, !dbg !51
-  %65 = getelementptr i64, i64* %keywords79.i, i32 1, !dbg !51
-  store i64 %64, i64* %65, align 8, !dbg !51
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.12, i64 %rubyId_take_arguments78.i, i32 noundef 68, i32 noundef 4, i32 noundef 2, i64* noundef nonnull align 8 %keywords79.i), !dbg !51
-  %rubyId_take_arguments86.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !52
-  %rubyId_d88.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !52
-  %66 = call i64 @rb_id2sym(i64 %rubyId_d88.i) #13, !dbg !52
-  store i64 %66, i64* %keywords87.i, align 8, !dbg !52
-  %rubyId_e90.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !52
-  %67 = call i64 @rb_id2sym(i64 %rubyId_e90.i) #13, !dbg !52
-  %68 = getelementptr i64, i64* %keywords87.i, i32 1, !dbg !52
-  store i64 %67, i64* %68, align 8, !dbg !52
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.13, i64 %rubyId_take_arguments86.i, i32 noundef 68, i32 noundef 3, i32 noundef 2, i64* noundef nonnull align 8 %keywords87.i), !dbg !52
-  %rubyId_take_arguments94.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !53
-  %rubyId_d96.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !53
-  %69 = call i64 @rb_id2sym(i64 %rubyId_d96.i) #13, !dbg !53
-  store i64 %69, i64* %keywords95.i, align 8, !dbg !53
-  %rubyId_e98.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !53
-  %70 = call i64 @rb_id2sym(i64 %rubyId_e98.i) #13, !dbg !53
-  %71 = getelementptr i64, i64* %keywords95.i, i32 1, !dbg !53
-  store i64 %70, i64* %71, align 8, !dbg !53
-  %rubyId_baz.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !53
-  %72 = call i64 @rb_id2sym(i64 %rubyId_baz.i) #13, !dbg !53
-  %73 = getelementptr i64, i64* %keywords95.i, i32 2, !dbg !53
-  store i64 %72, i64* %73, align 8, !dbg !53
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.14, i64 %rubyId_take_arguments94.i, i32 noundef 68, i32 noundef 10, i32 noundef 3, i64* noundef nonnull align 8 %keywords95.i), !dbg !53
-  %rubyId_take_arguments103.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !54
-  %rubyId_d105.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !54
-  %74 = call i64 @rb_id2sym(i64 %rubyId_d105.i) #13, !dbg !54
-  store i64 %74, i64* %keywords104.i, align 8, !dbg !54
-  %rubyId_e107.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !54
-  %75 = call i64 @rb_id2sym(i64 %rubyId_e107.i) #13, !dbg !54
-  %76 = getelementptr i64, i64* %keywords104.i, i32 1, !dbg !54
-  store i64 %75, i64* %76, align 8, !dbg !54
-  %rubyId_baz109.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !54
-  %77 = call i64 @rb_id2sym(i64 %rubyId_baz109.i) #13, !dbg !54
-  %78 = getelementptr i64, i64* %keywords104.i, i32 2, !dbg !54
-  store i64 %77, i64* %78, align 8, !dbg !54
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.15, i64 %rubyId_take_arguments103.i, i32 noundef 68, i32 noundef 9, i32 noundef 3, i64* noundef nonnull align 8 %keywords104.i), !dbg !54
-  %rubyId_take_arguments113.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !55
-  %rubyId_d115.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !55
-  %79 = call i64 @rb_id2sym(i64 %rubyId_d115.i) #13, !dbg !55
-  store i64 %79, i64* %keywords114.i, align 8, !dbg !55
-  %rubyId_e117.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !55
-  %80 = call i64 @rb_id2sym(i64 %rubyId_e117.i) #13, !dbg !55
-  %81 = getelementptr i64, i64* %keywords114.i, i32 1, !dbg !55
-  store i64 %80, i64* %81, align 8, !dbg !55
-  %rubyId_baz119.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !55
-  %82 = call i64 @rb_id2sym(i64 %rubyId_baz119.i) #13, !dbg !55
-  %83 = getelementptr i64, i64* %keywords114.i, i32 2, !dbg !55
-  store i64 %82, i64* %83, align 8, !dbg !55
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.16, i64 %rubyId_take_arguments113.i, i32 noundef 68, i32 noundef 8, i32 noundef 3, i64* noundef nonnull align 8 %keywords114.i), !dbg !55
-  %rubyId_take_arguments123.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !56
-  %rubyId_d125.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !56
-  %84 = call i64 @rb_id2sym(i64 %rubyId_d125.i) #13, !dbg !56
-  store i64 %84, i64* %keywords124.i, align 8, !dbg !56
-  %rubyId_e127.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !56
-  %85 = call i64 @rb_id2sym(i64 %rubyId_e127.i) #13, !dbg !56
-  %86 = getelementptr i64, i64* %keywords124.i, i32 1, !dbg !56
-  store i64 %85, i64* %86, align 8, !dbg !56
-  %rubyId_baz129.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !56
-  %87 = call i64 @rb_id2sym(i64 %rubyId_baz129.i) #13, !dbg !56
-  %88 = getelementptr i64, i64* %keywords124.i, i32 2, !dbg !56
-  store i64 %87, i64* %88, align 8, !dbg !56
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.17, i64 %rubyId_take_arguments123.i, i32 noundef 68, i32 noundef 7, i32 noundef 3, i64* noundef nonnull align 8 %keywords124.i), !dbg !56
-  %rubyId_take_arguments133.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !57
-  %rubyId_d135.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !57
-  %89 = call i64 @rb_id2sym(i64 %rubyId_d135.i) #13, !dbg !57
-  store i64 %89, i64* %keywords134.i, align 8, !dbg !57
-  %rubyId_e137.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !57
-  %90 = call i64 @rb_id2sym(i64 %rubyId_e137.i) #13, !dbg !57
-  %91 = getelementptr i64, i64* %keywords134.i, i32 1, !dbg !57
-  store i64 %90, i64* %91, align 8, !dbg !57
-  %rubyId_baz139.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !57
-  %92 = call i64 @rb_id2sym(i64 %rubyId_baz139.i) #13, !dbg !57
-  %93 = getelementptr i64, i64* %keywords134.i, i32 2, !dbg !57
-  store i64 %92, i64* %93, align 8, !dbg !57
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.18, i64 %rubyId_take_arguments133.i, i32 noundef 68, i32 noundef 6, i32 noundef 3, i64* noundef nonnull align 8 %keywords134.i), !dbg !57
-  %rubyId_take_arguments143.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !58
-  %rubyId_d145.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !58
-  %94 = call i64 @rb_id2sym(i64 %rubyId_d145.i) #13, !dbg !58
-  store i64 %94, i64* %keywords144.i, align 8, !dbg !58
-  %rubyId_e147.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !58
-  %95 = call i64 @rb_id2sym(i64 %rubyId_e147.i) #13, !dbg !58
-  %96 = getelementptr i64, i64* %keywords144.i, i32 1, !dbg !58
-  store i64 %95, i64* %96, align 8, !dbg !58
-  %rubyId_baz149.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !58
-  %97 = call i64 @rb_id2sym(i64 %rubyId_baz149.i) #13, !dbg !58
-  %98 = getelementptr i64, i64* %keywords144.i, i32 2, !dbg !58
-  store i64 %97, i64* %98, align 8, !dbg !58
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.19, i64 %rubyId_take_arguments143.i, i32 noundef 68, i32 noundef 5, i32 noundef 3, i64* noundef nonnull align 8 %keywords144.i), !dbg !58
-  %rubyId_take_arguments153.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !59
-  %rubyId_d155.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !59
-  %99 = call i64 @rb_id2sym(i64 %rubyId_d155.i) #13, !dbg !59
-  store i64 %99, i64* %keywords154.i, align 8, !dbg !59
-  %rubyId_e157.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !59
-  %100 = call i64 @rb_id2sym(i64 %rubyId_e157.i) #13, !dbg !59
-  %101 = getelementptr i64, i64* %keywords154.i, i32 1, !dbg !59
-  store i64 %100, i64* %101, align 8, !dbg !59
-  %rubyId_baz159.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !59
-  %102 = call i64 @rb_id2sym(i64 %rubyId_baz159.i) #13, !dbg !59
-  %103 = getelementptr i64, i64* %keywords154.i, i32 2, !dbg !59
-  store i64 %102, i64* %103, align 8, !dbg !59
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.20, i64 %rubyId_take_arguments153.i, i32 noundef 68, i32 noundef 4, i32 noundef 3, i64* noundef nonnull align 8 %keywords154.i), !dbg !59
+  %rubyId_take_arguments.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !33
+  %rubyId_d.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !33
+  %41 = call i64 @rb_id2sym(i64 %rubyId_d.i) #13, !dbg !33
+  store i64 %41, i64* %keywords.i, align 8, !dbg !33
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments, i64 %rubyId_take_arguments.i, i32 noundef 68, i32 noundef 8, i32 noundef 1, i64* noundef nonnull align 8 %keywords.i), !dbg !33
+  %rubyId_take_arguments3.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !34
+  %rubyId_d5.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !34
+  %42 = call i64 @rb_id2sym(i64 %rubyId_d5.i) #13, !dbg !34
+  store i64 %42, i64* %keywords4.i, align 8, !dbg !34
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.1, i64 %rubyId_take_arguments3.i, i32 noundef 68, i32 noundef 7, i32 noundef 1, i64* noundef nonnull align 8 %keywords4.i), !dbg !34
+  %rubyId_take_arguments9.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !35
+  %rubyId_d11.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !35
+  %43 = call i64 @rb_id2sym(i64 %rubyId_d11.i) #13, !dbg !35
+  store i64 %43, i64* %keywords10.i, align 8, !dbg !35
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.2, i64 %rubyId_take_arguments9.i, i32 noundef 68, i32 noundef 6, i32 noundef 1, i64* noundef nonnull align 8 %keywords10.i), !dbg !35
+  %rubyId_take_arguments15.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !36
+  %rubyId_d17.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !36
+  %44 = call i64 @rb_id2sym(i64 %rubyId_d17.i) #13, !dbg !36
+  store i64 %44, i64* %keywords16.i, align 8, !dbg !36
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.3, i64 %rubyId_take_arguments15.i, i32 noundef 68, i32 noundef 5, i32 noundef 1, i64* noundef nonnull align 8 %keywords16.i), !dbg !36
+  %rubyId_take_arguments21.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !37
+  %rubyId_d23.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !37
+  %45 = call i64 @rb_id2sym(i64 %rubyId_d23.i) #13, !dbg !37
+  store i64 %45, i64* %keywords22.i, align 8, !dbg !37
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.4, i64 %rubyId_take_arguments21.i, i32 noundef 68, i32 noundef 4, i32 noundef 1, i64* noundef nonnull align 8 %keywords22.i), !dbg !37
+  %rubyId_take_arguments27.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !38
+  %rubyId_d29.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !38
+  %46 = call i64 @rb_id2sym(i64 %rubyId_d29.i) #13, !dbg !38
+  store i64 %46, i64* %keywords28.i, align 8, !dbg !38
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.5, i64 %rubyId_take_arguments27.i, i32 noundef 68, i32 noundef 3, i32 noundef 1, i64* noundef nonnull align 8 %keywords28.i), !dbg !38
+  %rubyId_take_arguments33.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !39
+  %rubyId_d35.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !39
+  %47 = call i64 @rb_id2sym(i64 %rubyId_d35.i) #13, !dbg !39
+  store i64 %47, i64* %keywords34.i, align 8, !dbg !39
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.6, i64 %rubyId_take_arguments33.i, i32 noundef 68, i32 noundef 2, i32 noundef 1, i64* noundef nonnull align 8 %keywords34.i), !dbg !39
+  %rubyId_take_arguments39.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !40
+  %rubyId_d41.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !40
+  %48 = call i64 @rb_id2sym(i64 %rubyId_d41.i) #13, !dbg !40
+  store i64 %48, i64* %keywords40.i, align 8, !dbg !40
+  %rubyId_e.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !40
+  %49 = call i64 @rb_id2sym(i64 %rubyId_e.i) #13, !dbg !40
+  %50 = getelementptr i64, i64* %keywords40.i, i32 1, !dbg !40
+  store i64 %49, i64* %50, align 8, !dbg !40
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.7, i64 %rubyId_take_arguments39.i, i32 noundef 68, i32 noundef 9, i32 noundef 2, i64* noundef nonnull align 8 %keywords40.i), !dbg !40
+  %rubyId_take_arguments46.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !41
+  %rubyId_d48.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !41
+  %51 = call i64 @rb_id2sym(i64 %rubyId_d48.i) #13, !dbg !41
+  store i64 %51, i64* %keywords47.i, align 8, !dbg !41
+  %rubyId_e50.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !41
+  %52 = call i64 @rb_id2sym(i64 %rubyId_e50.i) #13, !dbg !41
+  %53 = getelementptr i64, i64* %keywords47.i, i32 1, !dbg !41
+  store i64 %52, i64* %53, align 8, !dbg !41
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.8, i64 %rubyId_take_arguments46.i, i32 noundef 68, i32 noundef 8, i32 noundef 2, i64* noundef nonnull align 8 %keywords47.i), !dbg !41
+  %rubyId_take_arguments54.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !42
+  %rubyId_d56.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !42
+  %54 = call i64 @rb_id2sym(i64 %rubyId_d56.i) #13, !dbg !42
+  store i64 %54, i64* %keywords55.i, align 8, !dbg !42
+  %rubyId_e58.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !42
+  %55 = call i64 @rb_id2sym(i64 %rubyId_e58.i) #13, !dbg !42
+  %56 = getelementptr i64, i64* %keywords55.i, i32 1, !dbg !42
+  store i64 %55, i64* %56, align 8, !dbg !42
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.9, i64 %rubyId_take_arguments54.i, i32 noundef 68, i32 noundef 7, i32 noundef 2, i64* noundef nonnull align 8 %keywords55.i), !dbg !42
+  %rubyId_take_arguments62.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !43
+  %rubyId_d64.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !43
+  %57 = call i64 @rb_id2sym(i64 %rubyId_d64.i) #13, !dbg !43
+  store i64 %57, i64* %keywords63.i, align 8, !dbg !43
+  %rubyId_e66.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !43
+  %58 = call i64 @rb_id2sym(i64 %rubyId_e66.i) #13, !dbg !43
+  %59 = getelementptr i64, i64* %keywords63.i, i32 1, !dbg !43
+  store i64 %58, i64* %59, align 8, !dbg !43
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.10, i64 %rubyId_take_arguments62.i, i32 noundef 68, i32 noundef 6, i32 noundef 2, i64* noundef nonnull align 8 %keywords63.i), !dbg !43
+  %rubyId_take_arguments70.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !44
+  %rubyId_d72.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !44
+  %60 = call i64 @rb_id2sym(i64 %rubyId_d72.i) #13, !dbg !44
+  store i64 %60, i64* %keywords71.i, align 8, !dbg !44
+  %rubyId_e74.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !44
+  %61 = call i64 @rb_id2sym(i64 %rubyId_e74.i) #13, !dbg !44
+  %62 = getelementptr i64, i64* %keywords71.i, i32 1, !dbg !44
+  store i64 %61, i64* %62, align 8, !dbg !44
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.11, i64 %rubyId_take_arguments70.i, i32 noundef 68, i32 noundef 5, i32 noundef 2, i64* noundef nonnull align 8 %keywords71.i), !dbg !44
+  %rubyId_take_arguments78.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !45
+  %rubyId_d80.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !45
+  %63 = call i64 @rb_id2sym(i64 %rubyId_d80.i) #13, !dbg !45
+  store i64 %63, i64* %keywords79.i, align 8, !dbg !45
+  %rubyId_e82.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !45
+  %64 = call i64 @rb_id2sym(i64 %rubyId_e82.i) #13, !dbg !45
+  %65 = getelementptr i64, i64* %keywords79.i, i32 1, !dbg !45
+  store i64 %64, i64* %65, align 8, !dbg !45
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.12, i64 %rubyId_take_arguments78.i, i32 noundef 68, i32 noundef 4, i32 noundef 2, i64* noundef nonnull align 8 %keywords79.i), !dbg !45
+  %rubyId_take_arguments86.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !46
+  %rubyId_d88.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !46
+  %66 = call i64 @rb_id2sym(i64 %rubyId_d88.i) #13, !dbg !46
+  store i64 %66, i64* %keywords87.i, align 8, !dbg !46
+  %rubyId_e90.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !46
+  %67 = call i64 @rb_id2sym(i64 %rubyId_e90.i) #13, !dbg !46
+  %68 = getelementptr i64, i64* %keywords87.i, i32 1, !dbg !46
+  store i64 %67, i64* %68, align 8, !dbg !46
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.13, i64 %rubyId_take_arguments86.i, i32 noundef 68, i32 noundef 3, i32 noundef 2, i64* noundef nonnull align 8 %keywords87.i), !dbg !46
+  %rubyId_take_arguments94.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !47
+  %rubyId_d96.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !47
+  %69 = call i64 @rb_id2sym(i64 %rubyId_d96.i) #13, !dbg !47
+  store i64 %69, i64* %keywords95.i, align 8, !dbg !47
+  %rubyId_e98.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !47
+  %70 = call i64 @rb_id2sym(i64 %rubyId_e98.i) #13, !dbg !47
+  %71 = getelementptr i64, i64* %keywords95.i, i32 1, !dbg !47
+  store i64 %70, i64* %71, align 8, !dbg !47
+  %rubyId_baz.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !47
+  %72 = call i64 @rb_id2sym(i64 %rubyId_baz.i) #13, !dbg !47
+  %73 = getelementptr i64, i64* %keywords95.i, i32 2, !dbg !47
+  store i64 %72, i64* %73, align 8, !dbg !47
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.14, i64 %rubyId_take_arguments94.i, i32 noundef 68, i32 noundef 10, i32 noundef 3, i64* noundef nonnull align 8 %keywords95.i), !dbg !47
+  %rubyId_take_arguments103.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !48
+  %rubyId_d105.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !48
+  %74 = call i64 @rb_id2sym(i64 %rubyId_d105.i) #13, !dbg !48
+  store i64 %74, i64* %keywords104.i, align 8, !dbg !48
+  %rubyId_e107.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !48
+  %75 = call i64 @rb_id2sym(i64 %rubyId_e107.i) #13, !dbg !48
+  %76 = getelementptr i64, i64* %keywords104.i, i32 1, !dbg !48
+  store i64 %75, i64* %76, align 8, !dbg !48
+  %rubyId_baz109.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !48
+  %77 = call i64 @rb_id2sym(i64 %rubyId_baz109.i) #13, !dbg !48
+  %78 = getelementptr i64, i64* %keywords104.i, i32 2, !dbg !48
+  store i64 %77, i64* %78, align 8, !dbg !48
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.15, i64 %rubyId_take_arguments103.i, i32 noundef 68, i32 noundef 9, i32 noundef 3, i64* noundef nonnull align 8 %keywords104.i), !dbg !48
+  %rubyId_take_arguments113.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !49
+  %rubyId_d115.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !49
+  %79 = call i64 @rb_id2sym(i64 %rubyId_d115.i) #13, !dbg !49
+  store i64 %79, i64* %keywords114.i, align 8, !dbg !49
+  %rubyId_e117.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !49
+  %80 = call i64 @rb_id2sym(i64 %rubyId_e117.i) #13, !dbg !49
+  %81 = getelementptr i64, i64* %keywords114.i, i32 1, !dbg !49
+  store i64 %80, i64* %81, align 8, !dbg !49
+  %rubyId_baz119.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !49
+  %82 = call i64 @rb_id2sym(i64 %rubyId_baz119.i) #13, !dbg !49
+  %83 = getelementptr i64, i64* %keywords114.i, i32 2, !dbg !49
+  store i64 %82, i64* %83, align 8, !dbg !49
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.16, i64 %rubyId_take_arguments113.i, i32 noundef 68, i32 noundef 8, i32 noundef 3, i64* noundef nonnull align 8 %keywords114.i), !dbg !49
+  %rubyId_take_arguments123.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !50
+  %rubyId_d125.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !50
+  %84 = call i64 @rb_id2sym(i64 %rubyId_d125.i) #13, !dbg !50
+  store i64 %84, i64* %keywords124.i, align 8, !dbg !50
+  %rubyId_e127.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !50
+  %85 = call i64 @rb_id2sym(i64 %rubyId_e127.i) #13, !dbg !50
+  %86 = getelementptr i64, i64* %keywords124.i, i32 1, !dbg !50
+  store i64 %85, i64* %86, align 8, !dbg !50
+  %rubyId_baz129.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !50
+  %87 = call i64 @rb_id2sym(i64 %rubyId_baz129.i) #13, !dbg !50
+  %88 = getelementptr i64, i64* %keywords124.i, i32 2, !dbg !50
+  store i64 %87, i64* %88, align 8, !dbg !50
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.17, i64 %rubyId_take_arguments123.i, i32 noundef 68, i32 noundef 7, i32 noundef 3, i64* noundef nonnull align 8 %keywords124.i), !dbg !50
+  %rubyId_take_arguments133.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !51
+  %rubyId_d135.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !51
+  %89 = call i64 @rb_id2sym(i64 %rubyId_d135.i) #13, !dbg !51
+  store i64 %89, i64* %keywords134.i, align 8, !dbg !51
+  %rubyId_e137.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !51
+  %90 = call i64 @rb_id2sym(i64 %rubyId_e137.i) #13, !dbg !51
+  %91 = getelementptr i64, i64* %keywords134.i, i32 1, !dbg !51
+  store i64 %90, i64* %91, align 8, !dbg !51
+  %rubyId_baz139.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !51
+  %92 = call i64 @rb_id2sym(i64 %rubyId_baz139.i) #13, !dbg !51
+  %93 = getelementptr i64, i64* %keywords134.i, i32 2, !dbg !51
+  store i64 %92, i64* %93, align 8, !dbg !51
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.18, i64 %rubyId_take_arguments133.i, i32 noundef 68, i32 noundef 6, i32 noundef 3, i64* noundef nonnull align 8 %keywords134.i), !dbg !51
+  %rubyId_take_arguments143.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !52
+  %rubyId_d145.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !52
+  %94 = call i64 @rb_id2sym(i64 %rubyId_d145.i) #13, !dbg !52
+  store i64 %94, i64* %keywords144.i, align 8, !dbg !52
+  %rubyId_e147.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !52
+  %95 = call i64 @rb_id2sym(i64 %rubyId_e147.i) #13, !dbg !52
+  %96 = getelementptr i64, i64* %keywords144.i, i32 1, !dbg !52
+  store i64 %95, i64* %96, align 8, !dbg !52
+  %rubyId_baz149.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !52
+  %97 = call i64 @rb_id2sym(i64 %rubyId_baz149.i) #13, !dbg !52
+  %98 = getelementptr i64, i64* %keywords144.i, i32 2, !dbg !52
+  store i64 %97, i64* %98, align 8, !dbg !52
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.19, i64 %rubyId_take_arguments143.i, i32 noundef 68, i32 noundef 5, i32 noundef 3, i64* noundef nonnull align 8 %keywords144.i), !dbg !52
+  %rubyId_take_arguments153.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !53
+  %rubyId_d155.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !53
+  %99 = call i64 @rb_id2sym(i64 %rubyId_d155.i) #13, !dbg !53
+  store i64 %99, i64* %keywords154.i, align 8, !dbg !53
+  %rubyId_e157.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !53
+  %100 = call i64 @rb_id2sym(i64 %rubyId_e157.i) #13, !dbg !53
+  %101 = getelementptr i64, i64* %keywords154.i, i32 1, !dbg !53
+  store i64 %100, i64* %101, align 8, !dbg !53
+  %rubyId_baz159.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !53
+  %102 = call i64 @rb_id2sym(i64 %rubyId_baz159.i) #13, !dbg !53
+  %103 = getelementptr i64, i64* %keywords154.i, i32 2, !dbg !53
+  store i64 %102, i64* %103, align 8, !dbg !53
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.20, i64 %rubyId_take_arguments153.i, i32 noundef 68, i32 noundef 4, i32 noundef 3, i64* noundef nonnull align 8 %keywords154.i), !dbg !53
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %0)
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %2)
@@ -752,17 +751,17 @@ entry:
   call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %20)
   %104 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
   %105 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %104, i64 0, i32 18
-  %106 = load i64, i64* %105, align 8, !tbaa !60
+  %106 = load i64, i64* %105, align 8, !tbaa !54
   %107 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %108 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %107, i64 0, i32 2
-  %109 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %108, align 8, !tbaa !70
+  %109 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %108, align 8, !tbaa !64
   %110 = bitcast i64* %positional_table.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 32, i8* nonnull %110)
   %111 = bitcast i64* %keyword_table.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %111)
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   %112 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %112, align 8, !tbaa !73
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %112, align 8, !tbaa !67
   %113 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 4
   %114 = load i64*, i64** %113, align 8, !tbaa !20
   %115 = load i64, i64* %114, align 8, !tbaa !6
@@ -770,452 +769,452 @@ entry:
   store i64 %116, i64* %114, align 8, !tbaa !6
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %107, %struct.rb_control_frame_struct* %109, %struct.rb_iseq_struct* %stackFrame.i) #11
   %117 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 0
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %117, align 8, !dbg !74, !tbaa !14
-  %118 = load i64, i64* @rb_cObject, align 8, !dbg !37
-  %stackFrame386.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#14take_arguments", align 8, !dbg !37
-  %119 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #14, !dbg !37
-  %120 = bitcast i8* %119 to i16*, !dbg !37
-  %121 = load i16, i16* %120, align 8, !dbg !37
-  %122 = and i16 %121, -384, !dbg !37
-  %123 = or i16 %122, 119, !dbg !37
-  store i16 %123, i16* %120, align 8, !dbg !37
-  %124 = getelementptr inbounds i8, i8* %119, i64 8, !dbg !37
-  %125 = bitcast i8* %124 to i32*, !dbg !37
-  %126 = getelementptr inbounds i8, i8* %119, i64 12, !dbg !37
-  %127 = bitcast i8* %126 to i32*, !dbg !37
-  %128 = getelementptr inbounds i8, i8* %119, i64 16, !dbg !37
-  %129 = getelementptr inbounds i8, i8* %119, i64 20, !dbg !37
-  %130 = bitcast i8* %129 to i32*, !dbg !37
-  store i32 0, i32* %130, align 4, !dbg !37, !tbaa !75
-  %131 = getelementptr inbounds i8, i8* %119, i64 24, !dbg !37
-  %132 = bitcast i8* %131 to i32*, !dbg !37
-  store i32 0, i32* %132, align 8, !dbg !37, !tbaa !78
-  %133 = getelementptr inbounds i8, i8* %119, i64 28, !dbg !37
-  %134 = bitcast i8* %133 to i32*, !dbg !37
-  store i32 3, i32* %134, align 4, !dbg !37, !tbaa !79
-  %135 = getelementptr inbounds i8, i8* %119, i64 4, !dbg !37
-  %136 = bitcast i8* %135 to i32*, !dbg !37
-  %137 = bitcast i32* %136 to <4 x i32>*, !dbg !37
-  store <4 x i32> <i32 7, i32 1, i32 1, i32 2>, <4 x i32>* %137, align 4, !dbg !37, !tbaa !80
-  %rubyId_a.i = load i64, i64* @rubyIdPrecomputed_a, align 8, !dbg !37
-  store i64 %rubyId_a.i, i64* %positional_table.i, align 8, !dbg !37
-  %rubyId_b.i = load i64, i64* @rubyIdPrecomputed_b, align 8, !dbg !37
-  %138 = getelementptr i64, i64* %positional_table.i, i32 1, !dbg !37
-  store i64 %rubyId_b.i, i64* %138, align 8, !dbg !37
-  %rubyId_c.i = load i64, i64* @rubyIdPrecomputed_c, align 8, !dbg !37
-  %139 = getelementptr i64, i64* %positional_table.i, i32 2, !dbg !37
-  store i64 %rubyId_c.i, i64* %139, align 8, !dbg !37
-  %rubyId_g.i = load i64, i64* @rubyIdPrecomputed_g, align 8, !dbg !37
-  %140 = getelementptr i64, i64* %positional_table.i, i32 3, !dbg !37
-  store i64 %rubyId_g.i, i64* %140, align 8, !dbg !37
-  %141 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 4, i64 noundef 8) #14, !dbg !37
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %141, i8* nocapture noundef nonnull readonly align 8 dereferenceable(24) %110, i64 noundef 32, i1 noundef false) #11, !dbg !37
-  %142 = getelementptr inbounds i8, i8* %119, i64 32, !dbg !37
-  %143 = bitcast i8* %142 to i8**, !dbg !37
-  store i8* %141, i8** %143, align 8, !dbg !37, !tbaa !81
-  %rubyId_d.i1 = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !37
-  store i64 %rubyId_d.i1, i64* %keyword_table.i, align 8, !dbg !37
-  %rubyId_e.i2 = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !37
-  %144 = getelementptr i64, i64* %keyword_table.i, i32 1, !dbg !37
-  store i64 %rubyId_e.i2, i64* %144, align 8, !dbg !37
-  %rubyId_f.i = load i64, i64* @rubyIdPrecomputed_f, align 8, !dbg !37
-  %145 = getelementptr i64, i64* %keyword_table.i, i32 2, !dbg !37
-  store i64 %rubyId_f.i, i64* %145, align 8, !dbg !37
-  %146 = getelementptr inbounds i8, i8* %119, i64 40, !dbg !37
-  %147 = bitcast i8* %146 to i32*, !dbg !37
-  store i32 2, i32* %147, align 8, !dbg !37, !tbaa !82
-  %148 = getelementptr inbounds i8, i8* %119, i64 44, !dbg !37
-  %149 = bitcast i8* %148 to i32*, !dbg !37
-  store i32 1, i32* %149, align 4, !dbg !37, !tbaa !83
-  %150 = load i32, i32* %125, align 8, !dbg !37, !tbaa !84
-  %151 = load i32, i32* %127, align 4, !dbg !37, !tbaa !85
-  %152 = add i32 %150, 2, !dbg !37
-  %153 = add i32 %152, %151, !dbg !37
-  %154 = getelementptr inbounds i8, i8* %119, i64 48, !dbg !37
-  %155 = bitcast i8* %154 to i32*, !dbg !37
-  store i32 %153, i32* %155, align 8, !dbg !37, !tbaa !86
-  %156 = load i16, i16* %120, align 8, !dbg !37
-  %157 = and i16 %156, 32, !dbg !37
-  %158 = icmp eq i16 %157, 0, !dbg !37
-  br i1 %158, label %"func_<root>.17<static-init>$152.exit", label %159, !dbg !37
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %117, align 8, !dbg !68, !tbaa !14
+  %118 = load i64, i64* @rb_cObject, align 8, !dbg !31
+  %stackFrame386.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#14take_arguments", align 8, !dbg !31
+  %119 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #14, !dbg !31
+  %120 = bitcast i8* %119 to i16*, !dbg !31
+  %121 = load i16, i16* %120, align 8, !dbg !31
+  %122 = and i16 %121, -384, !dbg !31
+  %123 = or i16 %122, 119, !dbg !31
+  store i16 %123, i16* %120, align 8, !dbg !31
+  %124 = getelementptr inbounds i8, i8* %119, i64 8, !dbg !31
+  %125 = bitcast i8* %124 to i32*, !dbg !31
+  %126 = getelementptr inbounds i8, i8* %119, i64 12, !dbg !31
+  %127 = bitcast i8* %126 to i32*, !dbg !31
+  %128 = getelementptr inbounds i8, i8* %119, i64 16, !dbg !31
+  %129 = getelementptr inbounds i8, i8* %119, i64 20, !dbg !31
+  %130 = bitcast i8* %129 to i32*, !dbg !31
+  store i32 0, i32* %130, align 4, !dbg !31, !tbaa !69
+  %131 = getelementptr inbounds i8, i8* %119, i64 24, !dbg !31
+  %132 = bitcast i8* %131 to i32*, !dbg !31
+  store i32 0, i32* %132, align 8, !dbg !31, !tbaa !72
+  %133 = getelementptr inbounds i8, i8* %119, i64 28, !dbg !31
+  %134 = bitcast i8* %133 to i32*, !dbg !31
+  store i32 3, i32* %134, align 4, !dbg !31, !tbaa !73
+  %135 = getelementptr inbounds i8, i8* %119, i64 4, !dbg !31
+  %136 = bitcast i8* %135 to i32*, !dbg !31
+  %137 = bitcast i32* %136 to <4 x i32>*, !dbg !31
+  store <4 x i32> <i32 7, i32 1, i32 1, i32 2>, <4 x i32>* %137, align 4, !dbg !31, !tbaa !74
+  %rubyId_a.i = load i64, i64* @rubyIdPrecomputed_a, align 8, !dbg !31
+  store i64 %rubyId_a.i, i64* %positional_table.i, align 8, !dbg !31
+  %rubyId_b.i = load i64, i64* @rubyIdPrecomputed_b, align 8, !dbg !31
+  %138 = getelementptr i64, i64* %positional_table.i, i32 1, !dbg !31
+  store i64 %rubyId_b.i, i64* %138, align 8, !dbg !31
+  %rubyId_c.i = load i64, i64* @rubyIdPrecomputed_c, align 8, !dbg !31
+  %139 = getelementptr i64, i64* %positional_table.i, i32 2, !dbg !31
+  store i64 %rubyId_c.i, i64* %139, align 8, !dbg !31
+  %rubyId_g.i = load i64, i64* @rubyIdPrecomputed_g, align 8, !dbg !31
+  %140 = getelementptr i64, i64* %positional_table.i, i32 3, !dbg !31
+  store i64 %rubyId_g.i, i64* %140, align 8, !dbg !31
+  %141 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 4, i64 noundef 8) #14, !dbg !31
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull align 1 %141, i8* noundef nonnull align 1 %110, i64 noundef 32, i1 noundef false) #11, !dbg !31
+  %142 = getelementptr inbounds i8, i8* %119, i64 32, !dbg !31
+  %143 = bitcast i8* %142 to i8**, !dbg !31
+  store i8* %141, i8** %143, align 8, !dbg !31, !tbaa !75
+  %rubyId_d.i1 = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !31
+  store i64 %rubyId_d.i1, i64* %keyword_table.i, align 8, !dbg !31
+  %rubyId_e.i2 = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !31
+  %144 = getelementptr i64, i64* %keyword_table.i, i32 1, !dbg !31
+  store i64 %rubyId_e.i2, i64* %144, align 8, !dbg !31
+  %rubyId_f.i = load i64, i64* @rubyIdPrecomputed_f, align 8, !dbg !31
+  %145 = getelementptr i64, i64* %keyword_table.i, i32 2, !dbg !31
+  store i64 %rubyId_f.i, i64* %145, align 8, !dbg !31
+  %146 = getelementptr inbounds i8, i8* %119, i64 40, !dbg !31
+  %147 = bitcast i8* %146 to i32*, !dbg !31
+  store i32 2, i32* %147, align 8, !dbg !31, !tbaa !76
+  %148 = getelementptr inbounds i8, i8* %119, i64 44, !dbg !31
+  %149 = bitcast i8* %148 to i32*, !dbg !31
+  store i32 1, i32* %149, align 4, !dbg !31, !tbaa !77
+  %150 = load i32, i32* %125, align 8, !dbg !31, !tbaa !78
+  %151 = load i32, i32* %127, align 4, !dbg !31, !tbaa !79
+  %152 = add i32 %150, 2, !dbg !31
+  %153 = add i32 %152, %151, !dbg !31
+  %154 = getelementptr inbounds i8, i8* %119, i64 48, !dbg !31
+  %155 = bitcast i8* %154 to i32*, !dbg !31
+  store i32 %153, i32* %155, align 8, !dbg !31, !tbaa !80
+  %156 = load i16, i16* %120, align 8, !dbg !31
+  %157 = and i16 %156, 32, !dbg !31
+  %158 = icmp eq i16 %157, 0, !dbg !31
+  br i1 %158, label %"func_<root>.17<static-init>$152.exit", label %159, !dbg !31
 
 159:                                              ; preds = %entry
-  %160 = add nsw i32 %153, 1, !dbg !37
-  %161 = getelementptr inbounds i8, i8* %119, i64 52, !dbg !37
-  %162 = bitcast i8* %161 to i32*, !dbg !37
-  store i32 %160, i32* %162, align 4, !dbg !37, !tbaa !87
-  br label %"func_<root>.17<static-init>$152.exit", !dbg !37
+  %160 = add nsw i32 %153, 1, !dbg !31
+  %161 = getelementptr inbounds i8, i8* %119, i64 52, !dbg !31
+  %162 = bitcast i8* %161 to i32*, !dbg !31
+  store i32 %160, i32* %162, align 4, !dbg !31, !tbaa !81
+  br label %"func_<root>.17<static-init>$152.exit", !dbg !31
 
 "func_<root>.17<static-init>$152.exit":           ; preds = %entry, %159
-  %163 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 3, i64 noundef 8) #14, !dbg !37
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %163, i8* nocapture noundef nonnull readonly align 8 dereferenceable(24) %111, i64 noundef 24, i1 noundef false) #11, !dbg !37
-  %164 = getelementptr inbounds i8, i8* %119, i64 56, !dbg !37
-  %165 = bitcast i8* %164 to i8**, !dbg !37
-  store i8* %163, i8** %165, align 8, !dbg !37, !tbaa !88
-  call void @sorbet_vm_define_method(i64 %118, i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @str_take_arguments, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#14take_arguments", i8* nonnull %119, %struct.rb_iseq_struct* %stackFrame386.i, i1 noundef zeroext false) #11, !dbg !37
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %117, align 8, !dbg !37, !tbaa !14
-  %166 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !39
-  %167 = load i64*, i64** %166, align 8, !dbg !39
-  store i64 %106, i64* %167, align 8, !dbg !39, !tbaa !6
-  %168 = getelementptr inbounds i64, i64* %167, i64 1, !dbg !39
-  %169 = getelementptr inbounds i64, i64* %168, i64 1, !dbg !39
-  %170 = getelementptr inbounds i64, i64* %169, i64 1, !dbg !39
-  %171 = getelementptr inbounds i64, i64* %170, i64 1, !dbg !39
-  %172 = bitcast i64* %168 to <4 x i64>*, !dbg !39
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %172, align 8, !dbg !39, !tbaa !6
-  %173 = getelementptr inbounds i64, i64* %171, i64 1, !dbg !39
-  %174 = getelementptr inbounds i64, i64* %173, i64 1, !dbg !39
-  %175 = bitcast i64* %173 to <2 x i64>*, !dbg !39
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %175, align 8, !dbg !39, !tbaa !6
-  %176 = getelementptr inbounds i64, i64* %174, i64 1, !dbg !39
-  store i64 -13, i64* %176, align 8, !dbg !39, !tbaa !6
-  %177 = getelementptr inbounds i64, i64* %176, i64 1, !dbg !39
-  store i64 -15, i64* %177, align 8, !dbg !39, !tbaa !6
-  %178 = getelementptr inbounds i64, i64* %177, i64 1, !dbg !39
-  store i64* %178, i64** %166, align 8, !dbg !39
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments, i64 0), !dbg !39
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %117, align 8, !dbg !39, !tbaa !14
-  %179 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !40
-  %180 = load i64*, i64** %179, align 8, !dbg !40
-  store i64 %106, i64* %180, align 8, !dbg !40, !tbaa !6
-  %181 = getelementptr inbounds i64, i64* %180, i64 1, !dbg !40
-  %182 = getelementptr inbounds i64, i64* %181, i64 1, !dbg !40
-  %183 = getelementptr inbounds i64, i64* %182, i64 1, !dbg !40
-  %184 = getelementptr inbounds i64, i64* %183, i64 1, !dbg !40
-  %185 = bitcast i64* %181 to <4 x i64>*, !dbg !40
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %185, align 8, !dbg !40, !tbaa !6
-  %186 = getelementptr inbounds i64, i64* %184, i64 1, !dbg !40
-  %187 = getelementptr inbounds i64, i64* %186, i64 1, !dbg !40
-  %188 = bitcast i64* %186 to <2 x i64>*, !dbg !40
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %188, align 8, !dbg !40, !tbaa !6
-  %189 = getelementptr inbounds i64, i64* %187, i64 1, !dbg !40
-  store i64 -15, i64* %189, align 8, !dbg !40, !tbaa !6
-  %190 = getelementptr inbounds i64, i64* %189, i64 1, !dbg !40
-  store i64* %190, i64** %179, align 8, !dbg !40
-  %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.1, i64 0), !dbg !40
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %117, align 8, !dbg !40, !tbaa !14
-  %191 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !41
-  %192 = load i64*, i64** %191, align 8, !dbg !41
-  store i64 %106, i64* %192, align 8, !dbg !41, !tbaa !6
-  %193 = getelementptr inbounds i64, i64* %192, i64 1, !dbg !41
-  %194 = getelementptr inbounds i64, i64* %193, i64 1, !dbg !41
-  %195 = getelementptr inbounds i64, i64* %194, i64 1, !dbg !41
-  %196 = getelementptr inbounds i64, i64* %195, i64 1, !dbg !41
-  %197 = bitcast i64* %193 to <4 x i64>*, !dbg !41
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %197, align 8, !dbg !41, !tbaa !6
-  %198 = getelementptr inbounds i64, i64* %196, i64 1, !dbg !41
-  %199 = getelementptr inbounds i64, i64* %198, i64 1, !dbg !41
-  %200 = bitcast i64* %198 to <2 x i64>*, !dbg !41
-  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %200, align 8, !dbg !41, !tbaa !6
-  %201 = getelementptr inbounds i64, i64* %199, i64 1, !dbg !41
-  store i64* %201, i64** %191, align 8, !dbg !41
-  %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.2, i64 0), !dbg !41
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %117, align 8, !dbg !41, !tbaa !14
-  %202 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !42
-  %203 = load i64*, i64** %202, align 8, !dbg !42
-  store i64 %106, i64* %203, align 8, !dbg !42, !tbaa !6
-  %204 = getelementptr inbounds i64, i64* %203, i64 1, !dbg !42
-  %205 = getelementptr inbounds i64, i64* %204, i64 1, !dbg !42
-  %206 = getelementptr inbounds i64, i64* %205, i64 1, !dbg !42
-  %207 = getelementptr inbounds i64, i64* %206, i64 1, !dbg !42
-  %208 = bitcast i64* %204 to <4 x i64>*, !dbg !42
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %208, align 8, !dbg !42, !tbaa !6
-  %209 = getelementptr inbounds i64, i64* %207, i64 1, !dbg !42
-  store i64 -15, i64* %209, align 8, !dbg !42, !tbaa !6
-  %210 = getelementptr inbounds i64, i64* %209, i64 1, !dbg !42
-  store i64* %210, i64** %202, align 8, !dbg !42
-  %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.3, i64 0), !dbg !42
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %117, align 8, !dbg !42, !tbaa !14
-  %211 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !43
-  %212 = load i64*, i64** %211, align 8, !dbg !43
-  store i64 %106, i64* %212, align 8, !dbg !43, !tbaa !6
-  %213 = getelementptr inbounds i64, i64* %212, i64 1, !dbg !43
-  %214 = getelementptr inbounds i64, i64* %213, i64 1, !dbg !43
-  %215 = getelementptr inbounds i64, i64* %214, i64 1, !dbg !43
-  %216 = getelementptr inbounds i64, i64* %215, i64 1, !dbg !43
-  %217 = bitcast i64* %213 to <4 x i64>*, !dbg !43
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %217, align 8, !dbg !43, !tbaa !6
-  %218 = getelementptr inbounds i64, i64* %216, i64 1, !dbg !43
-  store i64* %218, i64** %211, align 8, !dbg !43
-  %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.4, i64 0), !dbg !43
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %117, align 8, !dbg !43, !tbaa !14
-  %219 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !44
-  %220 = load i64*, i64** %219, align 8, !dbg !44
-  store i64 %106, i64* %220, align 8, !dbg !44, !tbaa !6
-  %221 = getelementptr inbounds i64, i64* %220, i64 1, !dbg !44
-  %222 = getelementptr inbounds i64, i64* %221, i64 1, !dbg !44
-  %223 = bitcast i64* %221 to <2 x i64>*, !dbg !44
-  store <2 x i64> <i64 -1, i64 -3>, <2 x i64>* %223, align 8, !dbg !44, !tbaa !6
-  %224 = getelementptr inbounds i64, i64* %222, i64 1, !dbg !44
-  store i64 -15, i64* %224, align 8, !dbg !44, !tbaa !6
-  %225 = getelementptr inbounds i64, i64* %224, i64 1, !dbg !44
-  store i64* %225, i64** %219, align 8, !dbg !44
-  %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.5, i64 0), !dbg !44
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %117, align 8, !dbg !44, !tbaa !14
-  %226 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !45
-  %227 = load i64*, i64** %226, align 8, !dbg !45
-  store i64 %106, i64* %227, align 8, !dbg !45, !tbaa !6
-  %228 = getelementptr inbounds i64, i64* %227, i64 1, !dbg !45
-  %229 = getelementptr inbounds i64, i64* %228, i64 1, !dbg !45
-  %230 = bitcast i64* %228 to <2 x i64>*, !dbg !45
-  store <2 x i64> <i64 -1, i64 -15>, <2 x i64>* %230, align 8, !dbg !45, !tbaa !6
-  %231 = getelementptr inbounds i64, i64* %229, i64 1, !dbg !45
-  store i64* %231, i64** %226, align 8, !dbg !45
-  %send14 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.6, i64 0), !dbg !45
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %117, align 8, !dbg !45, !tbaa !14
-  %232 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !46
-  %233 = load i64*, i64** %232, align 8, !dbg !46
-  store i64 %106, i64* %233, align 8, !dbg !46, !tbaa !6
-  %234 = getelementptr inbounds i64, i64* %233, i64 1, !dbg !46
-  %235 = getelementptr inbounds i64, i64* %234, i64 1, !dbg !46
-  %236 = getelementptr inbounds i64, i64* %235, i64 1, !dbg !46
-  %237 = getelementptr inbounds i64, i64* %236, i64 1, !dbg !46
-  %238 = bitcast i64* %234 to <4 x i64>*, !dbg !46
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %238, align 8, !dbg !46, !tbaa !6
-  %239 = getelementptr inbounds i64, i64* %237, i64 1, !dbg !46
-  %240 = getelementptr inbounds i64, i64* %239, i64 1, !dbg !46
-  %241 = bitcast i64* %239 to <2 x i64>*, !dbg !46
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %241, align 8, !dbg !46, !tbaa !6
-  %242 = getelementptr inbounds i64, i64* %240, i64 1, !dbg !46
-  store i64 -13, i64* %242, align 8, !dbg !46, !tbaa !6
-  %243 = getelementptr inbounds i64, i64* %242, i64 1, !dbg !46
-  store i64 -15, i64* %243, align 8, !dbg !46, !tbaa !6
-  %244 = getelementptr inbounds i64, i64* %243, i64 1, !dbg !46
-  store i64 -17, i64* %244, align 8, !dbg !46, !tbaa !6
-  %245 = getelementptr inbounds i64, i64* %244, i64 1, !dbg !46
-  store i64* %245, i64** %232, align 8, !dbg !46
-  %send16 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.7, i64 0), !dbg !46
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %117, align 8, !dbg !46, !tbaa !14
-  %246 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !47
-  %247 = load i64*, i64** %246, align 8, !dbg !47
-  store i64 %106, i64* %247, align 8, !dbg !47, !tbaa !6
-  %248 = getelementptr inbounds i64, i64* %247, i64 1, !dbg !47
-  %249 = getelementptr inbounds i64, i64* %248, i64 1, !dbg !47
-  %250 = getelementptr inbounds i64, i64* %249, i64 1, !dbg !47
-  %251 = getelementptr inbounds i64, i64* %250, i64 1, !dbg !47
-  %252 = bitcast i64* %248 to <4 x i64>*, !dbg !47
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %252, align 8, !dbg !47, !tbaa !6
-  %253 = getelementptr inbounds i64, i64* %251, i64 1, !dbg !47
-  %254 = getelementptr inbounds i64, i64* %253, i64 1, !dbg !47
-  %255 = bitcast i64* %253 to <2 x i64>*, !dbg !47
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %255, align 8, !dbg !47, !tbaa !6
-  %256 = getelementptr inbounds i64, i64* %254, i64 1, !dbg !47
-  store i64 -15, i64* %256, align 8, !dbg !47, !tbaa !6
-  %257 = getelementptr inbounds i64, i64* %256, i64 1, !dbg !47
-  store i64 -17, i64* %257, align 8, !dbg !47, !tbaa !6
-  %258 = getelementptr inbounds i64, i64* %257, i64 1, !dbg !47
-  store i64* %258, i64** %246, align 8, !dbg !47
-  %send18 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.8, i64 0), !dbg !47
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %117, align 8, !dbg !47, !tbaa !14
-  %259 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !48
-  %260 = load i64*, i64** %259, align 8, !dbg !48
-  store i64 %106, i64* %260, align 8, !dbg !48, !tbaa !6
-  %261 = getelementptr inbounds i64, i64* %260, i64 1, !dbg !48
-  %262 = getelementptr inbounds i64, i64* %261, i64 1, !dbg !48
-  %263 = getelementptr inbounds i64, i64* %262, i64 1, !dbg !48
-  %264 = getelementptr inbounds i64, i64* %263, i64 1, !dbg !48
-  %265 = bitcast i64* %261 to <4 x i64>*, !dbg !48
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %265, align 8, !dbg !48, !tbaa !6
-  %266 = getelementptr inbounds i64, i64* %264, i64 1, !dbg !48
-  %267 = getelementptr inbounds i64, i64* %266, i64 1, !dbg !48
-  %268 = bitcast i64* %266 to <2 x i64>*, !dbg !48
-  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %268, align 8, !dbg !48, !tbaa !6
-  %269 = getelementptr inbounds i64, i64* %267, i64 1, !dbg !48
-  store i64 -17, i64* %269, align 8, !dbg !48, !tbaa !6
-  %270 = getelementptr inbounds i64, i64* %269, i64 1, !dbg !48
-  store i64* %270, i64** %259, align 8, !dbg !48
-  %send20 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.9, i64 0), !dbg !48
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %117, align 8, !dbg !48, !tbaa !14
-  %271 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !49
-  %272 = load i64*, i64** %271, align 8, !dbg !49
-  store i64 %106, i64* %272, align 8, !dbg !49, !tbaa !6
-  %273 = getelementptr inbounds i64, i64* %272, i64 1, !dbg !49
-  %274 = getelementptr inbounds i64, i64* %273, i64 1, !dbg !49
-  %275 = getelementptr inbounds i64, i64* %274, i64 1, !dbg !49
-  %276 = getelementptr inbounds i64, i64* %275, i64 1, !dbg !49
-  %277 = bitcast i64* %273 to <4 x i64>*, !dbg !49
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %277, align 8, !dbg !49, !tbaa !6
-  %278 = getelementptr inbounds i64, i64* %276, i64 1, !dbg !49
-  %279 = getelementptr inbounds i64, i64* %278, i64 1, !dbg !49
-  %280 = bitcast i64* %278 to <2 x i64>*, !dbg !49
-  store <2 x i64> <i64 -15, i64 -17>, <2 x i64>* %280, align 8, !dbg !49, !tbaa !6
-  %281 = getelementptr inbounds i64, i64* %279, i64 1, !dbg !49
-  store i64* %281, i64** %271, align 8, !dbg !49
-  %send22 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.10, i64 0), !dbg !49
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 20), i64** %117, align 8, !dbg !49, !tbaa !14
-  %282 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !50
-  %283 = load i64*, i64** %282, align 8, !dbg !50
-  store i64 %106, i64* %283, align 8, !dbg !50, !tbaa !6
-  %284 = getelementptr inbounds i64, i64* %283, i64 1, !dbg !50
-  %285 = getelementptr inbounds i64, i64* %284, i64 1, !dbg !50
-  %286 = getelementptr inbounds i64, i64* %285, i64 1, !dbg !50
-  %287 = getelementptr inbounds i64, i64* %286, i64 1, !dbg !50
-  %288 = bitcast i64* %284 to <4 x i64>*, !dbg !50
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %288, align 8, !dbg !50, !tbaa !6
-  %289 = getelementptr inbounds i64, i64* %287, i64 1, !dbg !50
-  store i64 -17, i64* %289, align 8, !dbg !50, !tbaa !6
-  %290 = getelementptr inbounds i64, i64* %289, i64 1, !dbg !50
-  store i64* %290, i64** %282, align 8, !dbg !50
-  %send24 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.11, i64 0), !dbg !50
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %117, align 8, !dbg !50, !tbaa !14
-  %291 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !51
-  %292 = load i64*, i64** %291, align 8, !dbg !51
-  store i64 %106, i64* %292, align 8, !dbg !51, !tbaa !6
-  %293 = getelementptr inbounds i64, i64* %292, i64 1, !dbg !51
-  %294 = getelementptr inbounds i64, i64* %293, i64 1, !dbg !51
-  %295 = getelementptr inbounds i64, i64* %294, i64 1, !dbg !51
-  %296 = getelementptr inbounds i64, i64* %295, i64 1, !dbg !51
-  %297 = bitcast i64* %293 to <4 x i64>*, !dbg !51
-  store <4 x i64> <i64 -1, i64 -3, i64 -15, i64 -17>, <4 x i64>* %297, align 8, !dbg !51, !tbaa !6
-  %298 = getelementptr inbounds i64, i64* %296, i64 1, !dbg !51
-  store i64* %298, i64** %291, align 8, !dbg !51
-  %send26 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.12, i64 0), !dbg !51
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %117, align 8, !dbg !51, !tbaa !14
-  %299 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !52
-  %300 = load i64*, i64** %299, align 8, !dbg !52
-  store i64 %106, i64* %300, align 8, !dbg !52, !tbaa !6
-  %301 = getelementptr inbounds i64, i64* %300, i64 1, !dbg !52
-  %302 = getelementptr inbounds i64, i64* %301, i64 1, !dbg !52
-  %303 = bitcast i64* %301 to <2 x i64>*, !dbg !52
-  store <2 x i64> <i64 -1, i64 -15>, <2 x i64>* %303, align 8, !dbg !52, !tbaa !6
-  %304 = getelementptr inbounds i64, i64* %302, i64 1, !dbg !52
-  store i64 -17, i64* %304, align 8, !dbg !52, !tbaa !6
-  %305 = getelementptr inbounds i64, i64* %304, i64 1, !dbg !52
-  store i64* %305, i64** %299, align 8, !dbg !52
-  %send28 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.13, i64 0), !dbg !52
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %117, align 8, !dbg !52, !tbaa !14
-  %306 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !53
-  %307 = load i64*, i64** %306, align 8, !dbg !53
-  store i64 %106, i64* %307, align 8, !dbg !53, !tbaa !6
-  %308 = getelementptr inbounds i64, i64* %307, i64 1, !dbg !53
-  %309 = getelementptr inbounds i64, i64* %308, i64 1, !dbg !53
-  %310 = getelementptr inbounds i64, i64* %309, i64 1, !dbg !53
-  %311 = getelementptr inbounds i64, i64* %310, i64 1, !dbg !53
-  %312 = bitcast i64* %308 to <4 x i64>*, !dbg !53
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %312, align 8, !dbg !53, !tbaa !6
-  %313 = getelementptr inbounds i64, i64* %311, i64 1, !dbg !53
-  %314 = getelementptr inbounds i64, i64* %313, i64 1, !dbg !53
-  %315 = bitcast i64* %313 to <2 x i64>*, !dbg !53
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %315, align 8, !dbg !53, !tbaa !6
-  %316 = getelementptr inbounds i64, i64* %314, i64 1, !dbg !53
-  store i64 -13, i64* %316, align 8, !dbg !53, !tbaa !6
-  %317 = getelementptr inbounds i64, i64* %316, i64 1, !dbg !53
-  store i64 -15, i64* %317, align 8, !dbg !53, !tbaa !6
-  %318 = getelementptr inbounds i64, i64* %317, i64 1, !dbg !53
-  store i64 -17, i64* %318, align 8, !dbg !53, !tbaa !6
-  %319 = getelementptr inbounds i64, i64* %318, i64 1, !dbg !53
-  store i64 -19, i64* %319, align 8, !dbg !53, !tbaa !6
-  %320 = getelementptr inbounds i64, i64* %319, i64 1, !dbg !53
-  store i64* %320, i64** %306, align 8, !dbg !53
-  %send30 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.14, i64 0), !dbg !53
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %117, align 8, !dbg !53, !tbaa !14
-  %321 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !54
-  %322 = load i64*, i64** %321, align 8, !dbg !54
-  store i64 %106, i64* %322, align 8, !dbg !54, !tbaa !6
-  %323 = getelementptr inbounds i64, i64* %322, i64 1, !dbg !54
-  %324 = getelementptr inbounds i64, i64* %323, i64 1, !dbg !54
-  %325 = getelementptr inbounds i64, i64* %324, i64 1, !dbg !54
-  %326 = getelementptr inbounds i64, i64* %325, i64 1, !dbg !54
-  %327 = bitcast i64* %323 to <4 x i64>*, !dbg !54
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %327, align 8, !dbg !54, !tbaa !6
-  %328 = getelementptr inbounds i64, i64* %326, i64 1, !dbg !54
-  %329 = getelementptr inbounds i64, i64* %328, i64 1, !dbg !54
-  %330 = bitcast i64* %328 to <2 x i64>*, !dbg !54
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %330, align 8, !dbg !54, !tbaa !6
-  %331 = getelementptr inbounds i64, i64* %329, i64 1, !dbg !54
-  store i64 -15, i64* %331, align 8, !dbg !54, !tbaa !6
-  %332 = getelementptr inbounds i64, i64* %331, i64 1, !dbg !54
-  store i64 -17, i64* %332, align 8, !dbg !54, !tbaa !6
-  %333 = getelementptr inbounds i64, i64* %332, i64 1, !dbg !54
-  store i64 -19, i64* %333, align 8, !dbg !54, !tbaa !6
-  %334 = getelementptr inbounds i64, i64* %333, i64 1, !dbg !54
-  store i64* %334, i64** %321, align 8, !dbg !54
-  %send32 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.15, i64 0), !dbg !54
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %117, align 8, !dbg !54, !tbaa !14
-  %335 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !55
-  %336 = load i64*, i64** %335, align 8, !dbg !55
-  store i64 %106, i64* %336, align 8, !dbg !55, !tbaa !6
-  %337 = getelementptr inbounds i64, i64* %336, i64 1, !dbg !55
-  %338 = getelementptr inbounds i64, i64* %337, i64 1, !dbg !55
-  %339 = getelementptr inbounds i64, i64* %338, i64 1, !dbg !55
-  %340 = getelementptr inbounds i64, i64* %339, i64 1, !dbg !55
-  %341 = bitcast i64* %337 to <4 x i64>*, !dbg !55
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %341, align 8, !dbg !55, !tbaa !6
-  %342 = getelementptr inbounds i64, i64* %340, i64 1, !dbg !55
-  %343 = getelementptr inbounds i64, i64* %342, i64 1, !dbg !55
-  %344 = bitcast i64* %342 to <2 x i64>*, !dbg !55
-  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %344, align 8, !dbg !55, !tbaa !6
-  %345 = getelementptr inbounds i64, i64* %343, i64 1, !dbg !55
-  store i64 -17, i64* %345, align 8, !dbg !55, !tbaa !6
-  %346 = getelementptr inbounds i64, i64* %345, i64 1, !dbg !55
-  store i64 -19, i64* %346, align 8, !dbg !55, !tbaa !6
-  %347 = getelementptr inbounds i64, i64* %346, i64 1, !dbg !55
-  store i64* %347, i64** %335, align 8, !dbg !55
-  %send34 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.16, i64 0), !dbg !55
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %117, align 8, !dbg !55, !tbaa !14
-  %348 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !56
-  %349 = load i64*, i64** %348, align 8, !dbg !56
-  store i64 %106, i64* %349, align 8, !dbg !56, !tbaa !6
-  %350 = getelementptr inbounds i64, i64* %349, i64 1, !dbg !56
-  %351 = getelementptr inbounds i64, i64* %350, i64 1, !dbg !56
-  %352 = getelementptr inbounds i64, i64* %351, i64 1, !dbg !56
-  %353 = getelementptr inbounds i64, i64* %352, i64 1, !dbg !56
-  %354 = bitcast i64* %350 to <4 x i64>*, !dbg !56
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %354, align 8, !dbg !56, !tbaa !6
-  %355 = getelementptr inbounds i64, i64* %353, i64 1, !dbg !56
-  %356 = getelementptr inbounds i64, i64* %355, i64 1, !dbg !56
-  %357 = bitcast i64* %355 to <2 x i64>*, !dbg !56
-  store <2 x i64> <i64 -15, i64 -17>, <2 x i64>* %357, align 8, !dbg !56, !tbaa !6
-  %358 = getelementptr inbounds i64, i64* %356, i64 1, !dbg !56
-  store i64 -19, i64* %358, align 8, !dbg !56, !tbaa !6
-  %359 = getelementptr inbounds i64, i64* %358, i64 1, !dbg !56
-  store i64* %359, i64** %348, align 8, !dbg !56
-  %send36 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.17, i64 0), !dbg !56
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %117, align 8, !dbg !56, !tbaa !14
-  %360 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !57
-  %361 = load i64*, i64** %360, align 8, !dbg !57
-  store i64 %106, i64* %361, align 8, !dbg !57, !tbaa !6
-  %362 = getelementptr inbounds i64, i64* %361, i64 1, !dbg !57
-  %363 = getelementptr inbounds i64, i64* %362, i64 1, !dbg !57
-  %364 = getelementptr inbounds i64, i64* %363, i64 1, !dbg !57
-  %365 = getelementptr inbounds i64, i64* %364, i64 1, !dbg !57
-  %366 = bitcast i64* %362 to <4 x i64>*, !dbg !57
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %366, align 8, !dbg !57, !tbaa !6
-  %367 = getelementptr inbounds i64, i64* %365, i64 1, !dbg !57
-  %368 = getelementptr inbounds i64, i64* %367, i64 1, !dbg !57
-  %369 = bitcast i64* %367 to <2 x i64>*, !dbg !57
-  store <2 x i64> <i64 -17, i64 -19>, <2 x i64>* %369, align 8, !dbg !57, !tbaa !6
-  %370 = getelementptr inbounds i64, i64* %368, i64 1, !dbg !57
-  store i64* %370, i64** %360, align 8, !dbg !57
-  %send38 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.18, i64 0), !dbg !57
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 29), i64** %117, align 8, !dbg !57, !tbaa !14
-  %371 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !58
-  %372 = load i64*, i64** %371, align 8, !dbg !58
-  store i64 %106, i64* %372, align 8, !dbg !58, !tbaa !6
-  %373 = getelementptr inbounds i64, i64* %372, i64 1, !dbg !58
-  %374 = getelementptr inbounds i64, i64* %373, i64 1, !dbg !58
-  %375 = getelementptr inbounds i64, i64* %374, i64 1, !dbg !58
-  %376 = getelementptr inbounds i64, i64* %375, i64 1, !dbg !58
-  %377 = bitcast i64* %373 to <4 x i64>*, !dbg !58
-  store <4 x i64> <i64 -1, i64 -3, i64 -15, i64 -17>, <4 x i64>* %377, align 8, !dbg !58, !tbaa !6
-  %378 = getelementptr inbounds i64, i64* %376, i64 1, !dbg !58
-  store i64 -19, i64* %378, align 8, !dbg !58, !tbaa !6
-  %379 = getelementptr inbounds i64, i64* %378, i64 1, !dbg !58
-  store i64* %379, i64** %371, align 8, !dbg !58
-  %send40 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.19, i64 0), !dbg !58
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 30), i64** %117, align 8, !dbg !58, !tbaa !14
-  %380 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !59
-  %381 = load i64*, i64** %380, align 8, !dbg !59
-  store i64 %106, i64* %381, align 8, !dbg !59, !tbaa !6
-  %382 = getelementptr inbounds i64, i64* %381, i64 1, !dbg !59
-  %383 = getelementptr inbounds i64, i64* %382, i64 1, !dbg !59
-  %384 = getelementptr inbounds i64, i64* %383, i64 1, !dbg !59
-  %385 = getelementptr inbounds i64, i64* %384, i64 1, !dbg !59
-  %386 = bitcast i64* %382 to <4 x i64>*, !dbg !59
-  store <4 x i64> <i64 -1, i64 -15, i64 -17, i64 -19>, <4 x i64>* %386, align 8, !dbg !59, !tbaa !6
-  %387 = getelementptr inbounds i64, i64* %385, i64 1, !dbg !59
-  store i64* %387, i64** %380, align 8, !dbg !59
-  %send42 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.20, i64 0), !dbg !59
+  %163 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 3, i64 noundef 8) #14, !dbg !31
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull align 1 %163, i8* noundef nonnull align 1 %111, i64 noundef 24, i1 noundef false) #11, !dbg !31
+  %164 = getelementptr inbounds i8, i8* %119, i64 56, !dbg !31
+  %165 = bitcast i8* %164 to i8**, !dbg !31
+  store i8* %163, i8** %165, align 8, !dbg !31, !tbaa !82
+  call void @sorbet_vm_define_method(i64 %118, i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @str_take_arguments, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#14take_arguments", i8* nonnull %119, %struct.rb_iseq_struct* %stackFrame386.i, i1 noundef zeroext false) #11, !dbg !31
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %117, align 8, !dbg !31, !tbaa !14
+  %166 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !33
+  %167 = load i64*, i64** %166, align 8, !dbg !33
+  store i64 %106, i64* %167, align 8, !dbg !33, !tbaa !6
+  %168 = getelementptr inbounds i64, i64* %167, i64 1, !dbg !33
+  %169 = getelementptr inbounds i64, i64* %168, i64 1, !dbg !33
+  %170 = getelementptr inbounds i64, i64* %169, i64 1, !dbg !33
+  %171 = getelementptr inbounds i64, i64* %170, i64 1, !dbg !33
+  %172 = bitcast i64* %168 to <4 x i64>*, !dbg !33
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %172, align 8, !dbg !33, !tbaa !6
+  %173 = getelementptr inbounds i64, i64* %171, i64 1, !dbg !33
+  %174 = getelementptr inbounds i64, i64* %173, i64 1, !dbg !33
+  %175 = bitcast i64* %173 to <2 x i64>*, !dbg !33
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %175, align 8, !dbg !33, !tbaa !6
+  %176 = getelementptr inbounds i64, i64* %174, i64 1, !dbg !33
+  store i64 -13, i64* %176, align 8, !dbg !33, !tbaa !6
+  %177 = getelementptr inbounds i64, i64* %176, i64 1, !dbg !33
+  store i64 -15, i64* %177, align 8, !dbg !33, !tbaa !6
+  %178 = getelementptr inbounds i64, i64* %177, i64 1, !dbg !33
+  store i64* %178, i64** %166, align 8, !dbg !33
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments, i64 0), !dbg !33
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %117, align 8, !dbg !33, !tbaa !14
+  %179 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !34
+  %180 = load i64*, i64** %179, align 8, !dbg !34
+  store i64 %106, i64* %180, align 8, !dbg !34, !tbaa !6
+  %181 = getelementptr inbounds i64, i64* %180, i64 1, !dbg !34
+  %182 = getelementptr inbounds i64, i64* %181, i64 1, !dbg !34
+  %183 = getelementptr inbounds i64, i64* %182, i64 1, !dbg !34
+  %184 = getelementptr inbounds i64, i64* %183, i64 1, !dbg !34
+  %185 = bitcast i64* %181 to <4 x i64>*, !dbg !34
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %185, align 8, !dbg !34, !tbaa !6
+  %186 = getelementptr inbounds i64, i64* %184, i64 1, !dbg !34
+  %187 = getelementptr inbounds i64, i64* %186, i64 1, !dbg !34
+  %188 = bitcast i64* %186 to <2 x i64>*, !dbg !34
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %188, align 8, !dbg !34, !tbaa !6
+  %189 = getelementptr inbounds i64, i64* %187, i64 1, !dbg !34
+  store i64 -15, i64* %189, align 8, !dbg !34, !tbaa !6
+  %190 = getelementptr inbounds i64, i64* %189, i64 1, !dbg !34
+  store i64* %190, i64** %179, align 8, !dbg !34
+  %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.1, i64 0), !dbg !34
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %117, align 8, !dbg !34, !tbaa !14
+  %191 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !35
+  %192 = load i64*, i64** %191, align 8, !dbg !35
+  store i64 %106, i64* %192, align 8, !dbg !35, !tbaa !6
+  %193 = getelementptr inbounds i64, i64* %192, i64 1, !dbg !35
+  %194 = getelementptr inbounds i64, i64* %193, i64 1, !dbg !35
+  %195 = getelementptr inbounds i64, i64* %194, i64 1, !dbg !35
+  %196 = getelementptr inbounds i64, i64* %195, i64 1, !dbg !35
+  %197 = bitcast i64* %193 to <4 x i64>*, !dbg !35
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %197, align 8, !dbg !35, !tbaa !6
+  %198 = getelementptr inbounds i64, i64* %196, i64 1, !dbg !35
+  %199 = getelementptr inbounds i64, i64* %198, i64 1, !dbg !35
+  %200 = bitcast i64* %198 to <2 x i64>*, !dbg !35
+  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %200, align 8, !dbg !35, !tbaa !6
+  %201 = getelementptr inbounds i64, i64* %199, i64 1, !dbg !35
+  store i64* %201, i64** %191, align 8, !dbg !35
+  %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.2, i64 0), !dbg !35
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %117, align 8, !dbg !35, !tbaa !14
+  %202 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !36
+  %203 = load i64*, i64** %202, align 8, !dbg !36
+  store i64 %106, i64* %203, align 8, !dbg !36, !tbaa !6
+  %204 = getelementptr inbounds i64, i64* %203, i64 1, !dbg !36
+  %205 = getelementptr inbounds i64, i64* %204, i64 1, !dbg !36
+  %206 = getelementptr inbounds i64, i64* %205, i64 1, !dbg !36
+  %207 = getelementptr inbounds i64, i64* %206, i64 1, !dbg !36
+  %208 = bitcast i64* %204 to <4 x i64>*, !dbg !36
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %208, align 8, !dbg !36, !tbaa !6
+  %209 = getelementptr inbounds i64, i64* %207, i64 1, !dbg !36
+  store i64 -15, i64* %209, align 8, !dbg !36, !tbaa !6
+  %210 = getelementptr inbounds i64, i64* %209, i64 1, !dbg !36
+  store i64* %210, i64** %202, align 8, !dbg !36
+  %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.3, i64 0), !dbg !36
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %117, align 8, !dbg !36, !tbaa !14
+  %211 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !37
+  %212 = load i64*, i64** %211, align 8, !dbg !37
+  store i64 %106, i64* %212, align 8, !dbg !37, !tbaa !6
+  %213 = getelementptr inbounds i64, i64* %212, i64 1, !dbg !37
+  %214 = getelementptr inbounds i64, i64* %213, i64 1, !dbg !37
+  %215 = getelementptr inbounds i64, i64* %214, i64 1, !dbg !37
+  %216 = getelementptr inbounds i64, i64* %215, i64 1, !dbg !37
+  %217 = bitcast i64* %213 to <4 x i64>*, !dbg !37
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %217, align 8, !dbg !37, !tbaa !6
+  %218 = getelementptr inbounds i64, i64* %216, i64 1, !dbg !37
+  store i64* %218, i64** %211, align 8, !dbg !37
+  %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.4, i64 0), !dbg !37
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %117, align 8, !dbg !37, !tbaa !14
+  %219 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !38
+  %220 = load i64*, i64** %219, align 8, !dbg !38
+  store i64 %106, i64* %220, align 8, !dbg !38, !tbaa !6
+  %221 = getelementptr inbounds i64, i64* %220, i64 1, !dbg !38
+  %222 = getelementptr inbounds i64, i64* %221, i64 1, !dbg !38
+  %223 = bitcast i64* %221 to <2 x i64>*, !dbg !38
+  store <2 x i64> <i64 -1, i64 -3>, <2 x i64>* %223, align 8, !dbg !38, !tbaa !6
+  %224 = getelementptr inbounds i64, i64* %222, i64 1, !dbg !38
+  store i64 -15, i64* %224, align 8, !dbg !38, !tbaa !6
+  %225 = getelementptr inbounds i64, i64* %224, i64 1, !dbg !38
+  store i64* %225, i64** %219, align 8, !dbg !38
+  %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.5, i64 0), !dbg !38
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %117, align 8, !dbg !38, !tbaa !14
+  %226 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !39
+  %227 = load i64*, i64** %226, align 8, !dbg !39
+  store i64 %106, i64* %227, align 8, !dbg !39, !tbaa !6
+  %228 = getelementptr inbounds i64, i64* %227, i64 1, !dbg !39
+  %229 = getelementptr inbounds i64, i64* %228, i64 1, !dbg !39
+  %230 = bitcast i64* %228 to <2 x i64>*, !dbg !39
+  store <2 x i64> <i64 -1, i64 -15>, <2 x i64>* %230, align 8, !dbg !39, !tbaa !6
+  %231 = getelementptr inbounds i64, i64* %229, i64 1, !dbg !39
+  store i64* %231, i64** %226, align 8, !dbg !39
+  %send14 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.6, i64 0), !dbg !39
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %117, align 8, !dbg !39, !tbaa !14
+  %232 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !40
+  %233 = load i64*, i64** %232, align 8, !dbg !40
+  store i64 %106, i64* %233, align 8, !dbg !40, !tbaa !6
+  %234 = getelementptr inbounds i64, i64* %233, i64 1, !dbg !40
+  %235 = getelementptr inbounds i64, i64* %234, i64 1, !dbg !40
+  %236 = getelementptr inbounds i64, i64* %235, i64 1, !dbg !40
+  %237 = getelementptr inbounds i64, i64* %236, i64 1, !dbg !40
+  %238 = bitcast i64* %234 to <4 x i64>*, !dbg !40
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %238, align 8, !dbg !40, !tbaa !6
+  %239 = getelementptr inbounds i64, i64* %237, i64 1, !dbg !40
+  %240 = getelementptr inbounds i64, i64* %239, i64 1, !dbg !40
+  %241 = bitcast i64* %239 to <2 x i64>*, !dbg !40
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %241, align 8, !dbg !40, !tbaa !6
+  %242 = getelementptr inbounds i64, i64* %240, i64 1, !dbg !40
+  store i64 -13, i64* %242, align 8, !dbg !40, !tbaa !6
+  %243 = getelementptr inbounds i64, i64* %242, i64 1, !dbg !40
+  store i64 -15, i64* %243, align 8, !dbg !40, !tbaa !6
+  %244 = getelementptr inbounds i64, i64* %243, i64 1, !dbg !40
+  store i64 -17, i64* %244, align 8, !dbg !40, !tbaa !6
+  %245 = getelementptr inbounds i64, i64* %244, i64 1, !dbg !40
+  store i64* %245, i64** %232, align 8, !dbg !40
+  %send16 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.7, i64 0), !dbg !40
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %117, align 8, !dbg !40, !tbaa !14
+  %246 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !41
+  %247 = load i64*, i64** %246, align 8, !dbg !41
+  store i64 %106, i64* %247, align 8, !dbg !41, !tbaa !6
+  %248 = getelementptr inbounds i64, i64* %247, i64 1, !dbg !41
+  %249 = getelementptr inbounds i64, i64* %248, i64 1, !dbg !41
+  %250 = getelementptr inbounds i64, i64* %249, i64 1, !dbg !41
+  %251 = getelementptr inbounds i64, i64* %250, i64 1, !dbg !41
+  %252 = bitcast i64* %248 to <4 x i64>*, !dbg !41
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %252, align 8, !dbg !41, !tbaa !6
+  %253 = getelementptr inbounds i64, i64* %251, i64 1, !dbg !41
+  %254 = getelementptr inbounds i64, i64* %253, i64 1, !dbg !41
+  %255 = bitcast i64* %253 to <2 x i64>*, !dbg !41
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %255, align 8, !dbg !41, !tbaa !6
+  %256 = getelementptr inbounds i64, i64* %254, i64 1, !dbg !41
+  store i64 -15, i64* %256, align 8, !dbg !41, !tbaa !6
+  %257 = getelementptr inbounds i64, i64* %256, i64 1, !dbg !41
+  store i64 -17, i64* %257, align 8, !dbg !41, !tbaa !6
+  %258 = getelementptr inbounds i64, i64* %257, i64 1, !dbg !41
+  store i64* %258, i64** %246, align 8, !dbg !41
+  %send18 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.8, i64 0), !dbg !41
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %117, align 8, !dbg !41, !tbaa !14
+  %259 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !42
+  %260 = load i64*, i64** %259, align 8, !dbg !42
+  store i64 %106, i64* %260, align 8, !dbg !42, !tbaa !6
+  %261 = getelementptr inbounds i64, i64* %260, i64 1, !dbg !42
+  %262 = getelementptr inbounds i64, i64* %261, i64 1, !dbg !42
+  %263 = getelementptr inbounds i64, i64* %262, i64 1, !dbg !42
+  %264 = getelementptr inbounds i64, i64* %263, i64 1, !dbg !42
+  %265 = bitcast i64* %261 to <4 x i64>*, !dbg !42
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %265, align 8, !dbg !42, !tbaa !6
+  %266 = getelementptr inbounds i64, i64* %264, i64 1, !dbg !42
+  %267 = getelementptr inbounds i64, i64* %266, i64 1, !dbg !42
+  %268 = bitcast i64* %266 to <2 x i64>*, !dbg !42
+  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %268, align 8, !dbg !42, !tbaa !6
+  %269 = getelementptr inbounds i64, i64* %267, i64 1, !dbg !42
+  store i64 -17, i64* %269, align 8, !dbg !42, !tbaa !6
+  %270 = getelementptr inbounds i64, i64* %269, i64 1, !dbg !42
+  store i64* %270, i64** %259, align 8, !dbg !42
+  %send20 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.9, i64 0), !dbg !42
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %117, align 8, !dbg !42, !tbaa !14
+  %271 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !43
+  %272 = load i64*, i64** %271, align 8, !dbg !43
+  store i64 %106, i64* %272, align 8, !dbg !43, !tbaa !6
+  %273 = getelementptr inbounds i64, i64* %272, i64 1, !dbg !43
+  %274 = getelementptr inbounds i64, i64* %273, i64 1, !dbg !43
+  %275 = getelementptr inbounds i64, i64* %274, i64 1, !dbg !43
+  %276 = getelementptr inbounds i64, i64* %275, i64 1, !dbg !43
+  %277 = bitcast i64* %273 to <4 x i64>*, !dbg !43
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %277, align 8, !dbg !43, !tbaa !6
+  %278 = getelementptr inbounds i64, i64* %276, i64 1, !dbg !43
+  %279 = getelementptr inbounds i64, i64* %278, i64 1, !dbg !43
+  %280 = bitcast i64* %278 to <2 x i64>*, !dbg !43
+  store <2 x i64> <i64 -15, i64 -17>, <2 x i64>* %280, align 8, !dbg !43, !tbaa !6
+  %281 = getelementptr inbounds i64, i64* %279, i64 1, !dbg !43
+  store i64* %281, i64** %271, align 8, !dbg !43
+  %send22 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.10, i64 0), !dbg !43
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 20), i64** %117, align 8, !dbg !43, !tbaa !14
+  %282 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !44
+  %283 = load i64*, i64** %282, align 8, !dbg !44
+  store i64 %106, i64* %283, align 8, !dbg !44, !tbaa !6
+  %284 = getelementptr inbounds i64, i64* %283, i64 1, !dbg !44
+  %285 = getelementptr inbounds i64, i64* %284, i64 1, !dbg !44
+  %286 = getelementptr inbounds i64, i64* %285, i64 1, !dbg !44
+  %287 = getelementptr inbounds i64, i64* %286, i64 1, !dbg !44
+  %288 = bitcast i64* %284 to <4 x i64>*, !dbg !44
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %288, align 8, !dbg !44, !tbaa !6
+  %289 = getelementptr inbounds i64, i64* %287, i64 1, !dbg !44
+  store i64 -17, i64* %289, align 8, !dbg !44, !tbaa !6
+  %290 = getelementptr inbounds i64, i64* %289, i64 1, !dbg !44
+  store i64* %290, i64** %282, align 8, !dbg !44
+  %send24 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.11, i64 0), !dbg !44
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %117, align 8, !dbg !44, !tbaa !14
+  %291 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !45
+  %292 = load i64*, i64** %291, align 8, !dbg !45
+  store i64 %106, i64* %292, align 8, !dbg !45, !tbaa !6
+  %293 = getelementptr inbounds i64, i64* %292, i64 1, !dbg !45
+  %294 = getelementptr inbounds i64, i64* %293, i64 1, !dbg !45
+  %295 = getelementptr inbounds i64, i64* %294, i64 1, !dbg !45
+  %296 = getelementptr inbounds i64, i64* %295, i64 1, !dbg !45
+  %297 = bitcast i64* %293 to <4 x i64>*, !dbg !45
+  store <4 x i64> <i64 -1, i64 -3, i64 -15, i64 -17>, <4 x i64>* %297, align 8, !dbg !45, !tbaa !6
+  %298 = getelementptr inbounds i64, i64* %296, i64 1, !dbg !45
+  store i64* %298, i64** %291, align 8, !dbg !45
+  %send26 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.12, i64 0), !dbg !45
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %117, align 8, !dbg !45, !tbaa !14
+  %299 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !46
+  %300 = load i64*, i64** %299, align 8, !dbg !46
+  store i64 %106, i64* %300, align 8, !dbg !46, !tbaa !6
+  %301 = getelementptr inbounds i64, i64* %300, i64 1, !dbg !46
+  %302 = getelementptr inbounds i64, i64* %301, i64 1, !dbg !46
+  %303 = bitcast i64* %301 to <2 x i64>*, !dbg !46
+  store <2 x i64> <i64 -1, i64 -15>, <2 x i64>* %303, align 8, !dbg !46, !tbaa !6
+  %304 = getelementptr inbounds i64, i64* %302, i64 1, !dbg !46
+  store i64 -17, i64* %304, align 8, !dbg !46, !tbaa !6
+  %305 = getelementptr inbounds i64, i64* %304, i64 1, !dbg !46
+  store i64* %305, i64** %299, align 8, !dbg !46
+  %send28 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.13, i64 0), !dbg !46
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %117, align 8, !dbg !46, !tbaa !14
+  %306 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !47
+  %307 = load i64*, i64** %306, align 8, !dbg !47
+  store i64 %106, i64* %307, align 8, !dbg !47, !tbaa !6
+  %308 = getelementptr inbounds i64, i64* %307, i64 1, !dbg !47
+  %309 = getelementptr inbounds i64, i64* %308, i64 1, !dbg !47
+  %310 = getelementptr inbounds i64, i64* %309, i64 1, !dbg !47
+  %311 = getelementptr inbounds i64, i64* %310, i64 1, !dbg !47
+  %312 = bitcast i64* %308 to <4 x i64>*, !dbg !47
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %312, align 8, !dbg !47, !tbaa !6
+  %313 = getelementptr inbounds i64, i64* %311, i64 1, !dbg !47
+  %314 = getelementptr inbounds i64, i64* %313, i64 1, !dbg !47
+  %315 = bitcast i64* %313 to <2 x i64>*, !dbg !47
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %315, align 8, !dbg !47, !tbaa !6
+  %316 = getelementptr inbounds i64, i64* %314, i64 1, !dbg !47
+  store i64 -13, i64* %316, align 8, !dbg !47, !tbaa !6
+  %317 = getelementptr inbounds i64, i64* %316, i64 1, !dbg !47
+  store i64 -15, i64* %317, align 8, !dbg !47, !tbaa !6
+  %318 = getelementptr inbounds i64, i64* %317, i64 1, !dbg !47
+  store i64 -17, i64* %318, align 8, !dbg !47, !tbaa !6
+  %319 = getelementptr inbounds i64, i64* %318, i64 1, !dbg !47
+  store i64 -19, i64* %319, align 8, !dbg !47, !tbaa !6
+  %320 = getelementptr inbounds i64, i64* %319, i64 1, !dbg !47
+  store i64* %320, i64** %306, align 8, !dbg !47
+  %send30 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.14, i64 0), !dbg !47
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %117, align 8, !dbg !47, !tbaa !14
+  %321 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !48
+  %322 = load i64*, i64** %321, align 8, !dbg !48
+  store i64 %106, i64* %322, align 8, !dbg !48, !tbaa !6
+  %323 = getelementptr inbounds i64, i64* %322, i64 1, !dbg !48
+  %324 = getelementptr inbounds i64, i64* %323, i64 1, !dbg !48
+  %325 = getelementptr inbounds i64, i64* %324, i64 1, !dbg !48
+  %326 = getelementptr inbounds i64, i64* %325, i64 1, !dbg !48
+  %327 = bitcast i64* %323 to <4 x i64>*, !dbg !48
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %327, align 8, !dbg !48, !tbaa !6
+  %328 = getelementptr inbounds i64, i64* %326, i64 1, !dbg !48
+  %329 = getelementptr inbounds i64, i64* %328, i64 1, !dbg !48
+  %330 = bitcast i64* %328 to <2 x i64>*, !dbg !48
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %330, align 8, !dbg !48, !tbaa !6
+  %331 = getelementptr inbounds i64, i64* %329, i64 1, !dbg !48
+  store i64 -15, i64* %331, align 8, !dbg !48, !tbaa !6
+  %332 = getelementptr inbounds i64, i64* %331, i64 1, !dbg !48
+  store i64 -17, i64* %332, align 8, !dbg !48, !tbaa !6
+  %333 = getelementptr inbounds i64, i64* %332, i64 1, !dbg !48
+  store i64 -19, i64* %333, align 8, !dbg !48, !tbaa !6
+  %334 = getelementptr inbounds i64, i64* %333, i64 1, !dbg !48
+  store i64* %334, i64** %321, align 8, !dbg !48
+  %send32 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.15, i64 0), !dbg !48
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %117, align 8, !dbg !48, !tbaa !14
+  %335 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !49
+  %336 = load i64*, i64** %335, align 8, !dbg !49
+  store i64 %106, i64* %336, align 8, !dbg !49, !tbaa !6
+  %337 = getelementptr inbounds i64, i64* %336, i64 1, !dbg !49
+  %338 = getelementptr inbounds i64, i64* %337, i64 1, !dbg !49
+  %339 = getelementptr inbounds i64, i64* %338, i64 1, !dbg !49
+  %340 = getelementptr inbounds i64, i64* %339, i64 1, !dbg !49
+  %341 = bitcast i64* %337 to <4 x i64>*, !dbg !49
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %341, align 8, !dbg !49, !tbaa !6
+  %342 = getelementptr inbounds i64, i64* %340, i64 1, !dbg !49
+  %343 = getelementptr inbounds i64, i64* %342, i64 1, !dbg !49
+  %344 = bitcast i64* %342 to <2 x i64>*, !dbg !49
+  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %344, align 8, !dbg !49, !tbaa !6
+  %345 = getelementptr inbounds i64, i64* %343, i64 1, !dbg !49
+  store i64 -17, i64* %345, align 8, !dbg !49, !tbaa !6
+  %346 = getelementptr inbounds i64, i64* %345, i64 1, !dbg !49
+  store i64 -19, i64* %346, align 8, !dbg !49, !tbaa !6
+  %347 = getelementptr inbounds i64, i64* %346, i64 1, !dbg !49
+  store i64* %347, i64** %335, align 8, !dbg !49
+  %send34 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.16, i64 0), !dbg !49
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %117, align 8, !dbg !49, !tbaa !14
+  %348 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !50
+  %349 = load i64*, i64** %348, align 8, !dbg !50
+  store i64 %106, i64* %349, align 8, !dbg !50, !tbaa !6
+  %350 = getelementptr inbounds i64, i64* %349, i64 1, !dbg !50
+  %351 = getelementptr inbounds i64, i64* %350, i64 1, !dbg !50
+  %352 = getelementptr inbounds i64, i64* %351, i64 1, !dbg !50
+  %353 = getelementptr inbounds i64, i64* %352, i64 1, !dbg !50
+  %354 = bitcast i64* %350 to <4 x i64>*, !dbg !50
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %354, align 8, !dbg !50, !tbaa !6
+  %355 = getelementptr inbounds i64, i64* %353, i64 1, !dbg !50
+  %356 = getelementptr inbounds i64, i64* %355, i64 1, !dbg !50
+  %357 = bitcast i64* %355 to <2 x i64>*, !dbg !50
+  store <2 x i64> <i64 -15, i64 -17>, <2 x i64>* %357, align 8, !dbg !50, !tbaa !6
+  %358 = getelementptr inbounds i64, i64* %356, i64 1, !dbg !50
+  store i64 -19, i64* %358, align 8, !dbg !50, !tbaa !6
+  %359 = getelementptr inbounds i64, i64* %358, i64 1, !dbg !50
+  store i64* %359, i64** %348, align 8, !dbg !50
+  %send36 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.17, i64 0), !dbg !50
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %117, align 8, !dbg !50, !tbaa !14
+  %360 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !51
+  %361 = load i64*, i64** %360, align 8, !dbg !51
+  store i64 %106, i64* %361, align 8, !dbg !51, !tbaa !6
+  %362 = getelementptr inbounds i64, i64* %361, i64 1, !dbg !51
+  %363 = getelementptr inbounds i64, i64* %362, i64 1, !dbg !51
+  %364 = getelementptr inbounds i64, i64* %363, i64 1, !dbg !51
+  %365 = getelementptr inbounds i64, i64* %364, i64 1, !dbg !51
+  %366 = bitcast i64* %362 to <4 x i64>*, !dbg !51
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %366, align 8, !dbg !51, !tbaa !6
+  %367 = getelementptr inbounds i64, i64* %365, i64 1, !dbg !51
+  %368 = getelementptr inbounds i64, i64* %367, i64 1, !dbg !51
+  %369 = bitcast i64* %367 to <2 x i64>*, !dbg !51
+  store <2 x i64> <i64 -17, i64 -19>, <2 x i64>* %369, align 8, !dbg !51, !tbaa !6
+  %370 = getelementptr inbounds i64, i64* %368, i64 1, !dbg !51
+  store i64* %370, i64** %360, align 8, !dbg !51
+  %send38 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.18, i64 0), !dbg !51
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 29), i64** %117, align 8, !dbg !51, !tbaa !14
+  %371 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !52
+  %372 = load i64*, i64** %371, align 8, !dbg !52
+  store i64 %106, i64* %372, align 8, !dbg !52, !tbaa !6
+  %373 = getelementptr inbounds i64, i64* %372, i64 1, !dbg !52
+  %374 = getelementptr inbounds i64, i64* %373, i64 1, !dbg !52
+  %375 = getelementptr inbounds i64, i64* %374, i64 1, !dbg !52
+  %376 = getelementptr inbounds i64, i64* %375, i64 1, !dbg !52
+  %377 = bitcast i64* %373 to <4 x i64>*, !dbg !52
+  store <4 x i64> <i64 -1, i64 -3, i64 -15, i64 -17>, <4 x i64>* %377, align 8, !dbg !52, !tbaa !6
+  %378 = getelementptr inbounds i64, i64* %376, i64 1, !dbg !52
+  store i64 -19, i64* %378, align 8, !dbg !52, !tbaa !6
+  %379 = getelementptr inbounds i64, i64* %378, i64 1, !dbg !52
+  store i64* %379, i64** %371, align 8, !dbg !52
+  %send40 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.19, i64 0), !dbg !52
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 30), i64** %117, align 8, !dbg !52, !tbaa !14
+  %380 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !53
+  %381 = load i64*, i64** %380, align 8, !dbg !53
+  store i64 %106, i64* %381, align 8, !dbg !53, !tbaa !6
+  %382 = getelementptr inbounds i64, i64* %381, i64 1, !dbg !53
+  %383 = getelementptr inbounds i64, i64* %382, i64 1, !dbg !53
+  %384 = getelementptr inbounds i64, i64* %383, i64 1, !dbg !53
+  %385 = getelementptr inbounds i64, i64* %384, i64 1, !dbg !53
+  %386 = bitcast i64* %382 to <4 x i64>*, !dbg !53
+  store <4 x i64> <i64 -1, i64 -15, i64 -17, i64 -19>, <4 x i64>* %386, align 8, !dbg !53, !tbaa !6
+  %387 = getelementptr inbounds i64, i64* %385, i64 1, !dbg !53
+  store i64* %387, i64** %380, align 8, !dbg !53
+  %send42 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.20, i64 0), !dbg !53
   call void @llvm.lifetime.end.p0i8(i64 32, i8* nonnull %110)
   call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %111)
   ret void
@@ -1227,13 +1226,13 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #5
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #5
 
-attributes #0 = { nounwind readnone willreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #2 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { nofree nosync nounwind readnone willreturn mustprogress "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #1 = { noreturn "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #2 = { "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #3 = { inaccessiblememonly nofree nosync nounwind willreturn }
-attributes #4 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #4 = { allocsize(0,1) "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #5 = { argmemonly nofree nosync nounwind willreturn }
-attributes #6 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #6 = { nounwind ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #7 = { nounwind sspreq uwtable }
 attributes #8 = { sspreq }
 attributes #9 = { noreturn nounwind }
@@ -1268,70 +1267,64 @@ attributes #14 = { nounwind allocsize(0,1) }
 !19 = !{!"branch_weights", i32 1, i32 2000}
 !20 = !{!21, !15, i64 32}
 !21 = !{!"rb_control_frame_struct", !15, i64 0, !15, i64 8, !15, i64 16, !7, i64 24, !15, i64 32, !15, i64 40, !15, i64 48}
-!22 = !{!23}
-!23 = distinct !{!23, !24, !"vm_get_ep: argument 0"}
-!24 = distinct !{!24, !"vm_get_ep"}
-!25 = !{!"branch_weights", i32 2000, i32 1}
-!26 = !DILocation(line: 4, column: 23, scope: !10)
-!27 = !DILocation(line: 4, column: 36, scope: !10)
-!28 = !DILocation(line: 0, scope: !10)
-!29 = !DILocation(line: 5, column: 10, scope: !10)
-!30 = !{!31}
-!31 = distinct !{!31, !32, !"vm_get_ep: argument 0"}
-!32 = distinct !{!32, !"vm_get_ep"}
-!33 = !{!34}
-!34 = distinct !{!34, !35, !"sorbet_buildArrayIntrinsic: argument 0"}
-!35 = distinct !{!35, !"sorbet_buildArrayIntrinsic"}
-!36 = !DILocation(line: 5, column: 5, scope: !10)
-!37 = !DILocation(line: 4, column: 1, scope: !38)
-!38 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$152", scope: null, file: !4, line: 4, type: !11, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!39 = !DILocation(line: 8, column: 1, scope: !38)
-!40 = !DILocation(line: 9, column: 1, scope: !38)
-!41 = !DILocation(line: 10, column: 1, scope: !38)
-!42 = !DILocation(line: 11, column: 1, scope: !38)
-!43 = !DILocation(line: 12, column: 1, scope: !38)
-!44 = !DILocation(line: 13, column: 1, scope: !38)
-!45 = !DILocation(line: 14, column: 1, scope: !38)
-!46 = !DILocation(line: 16, column: 1, scope: !38)
-!47 = !DILocation(line: 17, column: 1, scope: !38)
-!48 = !DILocation(line: 18, column: 1, scope: !38)
-!49 = !DILocation(line: 19, column: 1, scope: !38)
-!50 = !DILocation(line: 20, column: 1, scope: !38)
-!51 = !DILocation(line: 21, column: 1, scope: !38)
-!52 = !DILocation(line: 22, column: 1, scope: !38)
-!53 = !DILocation(line: 24, column: 1, scope: !38)
-!54 = !DILocation(line: 25, column: 1, scope: !38)
-!55 = !DILocation(line: 26, column: 1, scope: !38)
-!56 = !DILocation(line: 27, column: 1, scope: !38)
-!57 = !DILocation(line: 28, column: 1, scope: !38)
-!58 = !DILocation(line: 29, column: 1, scope: !38)
-!59 = !DILocation(line: 30, column: 1, scope: !38)
-!60 = !{!61, !7, i64 400}
-!61 = !{!"rb_vm_struct", !7, i64 0, !62, i64 8, !15, i64 192, !15, i64 200, !15, i64 208, !66, i64 216, !8, i64 224, !63, i64 264, !63, i64 280, !63, i64 296, !63, i64 312, !7, i64 328, !65, i64 336, !65, i64 340, !65, i64 344, !65, i64 344, !65, i64 344, !65, i64 344, !65, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !15, i64 456, !15, i64 464, !67, i64 472, !68, i64 992, !15, i64 1016, !15, i64 1024, !65, i64 1032, !65, i64 1036, !63, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !65, i64 1136, !15, i64 1144, !15, i64 1152, !15, i64 1160, !15, i64 1168, !15, i64 1176, !15, i64 1184, !65, i64 1192, !69, i64 1200, !8, i64 1232}
-!62 = !{!"rb_global_vm_lock_struct", !15, i64 0, !8, i64 8, !63, i64 48, !15, i64 64, !65, i64 72, !8, i64 80, !8, i64 128, !65, i64 176, !65, i64 180}
-!63 = !{!"list_head", !64, i64 0}
-!64 = !{!"list_node", !15, i64 0, !15, i64 8}
-!65 = !{!"int", !8, i64 0}
-!66 = !{!"long long", !8, i64 0}
-!67 = !{!"", !8, i64 0}
-!68 = !{!"rb_hook_list_struct", !15, i64 0, !65, i64 8, !65, i64 12, !65, i64 16}
-!69 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
-!70 = !{!71, !15, i64 16}
-!71 = !{!"rb_execution_context_struct", !15, i64 0, !7, i64 8, !15, i64 16, !15, i64 24, !15, i64 32, !65, i64 40, !65, i64 44, !15, i64 48, !15, i64 56, !15, i64 64, !7, i64 72, !7, i64 80, !15, i64 88, !7, i64 96, !15, i64 104, !15, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !72, i64 152}
-!72 = !{!"", !15, i64 0, !15, i64 8, !7, i64 16, !8, i64 24}
-!73 = !{!21, !15, i64 16}
-!74 = !DILocation(line: 0, scope: !38)
-!75 = !{!76, !65, i64 20}
-!76 = !{!"rb_sorbet_param_struct", !77, i64 0, !65, i64 4, !65, i64 8, !65, i64 12, !65, i64 16, !65, i64 20, !65, i64 24, !65, i64 28, !15, i64 32, !65, i64 40, !65, i64 44, !65, i64 48, !65, i64 52, !15, i64 56}
-!77 = !{!"", !65, i64 0, !65, i64 0, !65, i64 0, !65, i64 0, !65, i64 0, !65, i64 0, !65, i64 0, !65, i64 0, !65, i64 1, !65, i64 1}
-!78 = !{!76, !65, i64 24}
-!79 = !{!76, !65, i64 28}
-!80 = !{!65, !65, i64 0}
-!81 = !{!76, !15, i64 32}
-!82 = !{!76, !65, i64 40}
-!83 = !{!76, !65, i64 44}
-!84 = !{!76, !65, i64 8}
-!85 = !{!76, !65, i64 12}
-!86 = !{!76, !65, i64 48}
-!87 = !{!76, !65, i64 52}
-!88 = !{!76, !15, i64 56}
+!22 = !{!"branch_weights", i32 2000, i32 1}
+!23 = !DILocation(line: 4, column: 23, scope: !10)
+!24 = !DILocation(line: 4, column: 36, scope: !10)
+!25 = !DILocation(line: 0, scope: !10)
+!26 = !DILocation(line: 5, column: 10, scope: !10)
+!27 = !{!28}
+!28 = distinct !{!28, !29, !"sorbet_buildArrayIntrinsic: argument 0"}
+!29 = distinct !{!29, !"sorbet_buildArrayIntrinsic"}
+!30 = !DILocation(line: 5, column: 5, scope: !10)
+!31 = !DILocation(line: 4, column: 1, scope: !32)
+!32 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$152", scope: null, file: !4, line: 4, type: !11, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!33 = !DILocation(line: 8, column: 1, scope: !32)
+!34 = !DILocation(line: 9, column: 1, scope: !32)
+!35 = !DILocation(line: 10, column: 1, scope: !32)
+!36 = !DILocation(line: 11, column: 1, scope: !32)
+!37 = !DILocation(line: 12, column: 1, scope: !32)
+!38 = !DILocation(line: 13, column: 1, scope: !32)
+!39 = !DILocation(line: 14, column: 1, scope: !32)
+!40 = !DILocation(line: 16, column: 1, scope: !32)
+!41 = !DILocation(line: 17, column: 1, scope: !32)
+!42 = !DILocation(line: 18, column: 1, scope: !32)
+!43 = !DILocation(line: 19, column: 1, scope: !32)
+!44 = !DILocation(line: 20, column: 1, scope: !32)
+!45 = !DILocation(line: 21, column: 1, scope: !32)
+!46 = !DILocation(line: 22, column: 1, scope: !32)
+!47 = !DILocation(line: 24, column: 1, scope: !32)
+!48 = !DILocation(line: 25, column: 1, scope: !32)
+!49 = !DILocation(line: 26, column: 1, scope: !32)
+!50 = !DILocation(line: 27, column: 1, scope: !32)
+!51 = !DILocation(line: 28, column: 1, scope: !32)
+!52 = !DILocation(line: 29, column: 1, scope: !32)
+!53 = !DILocation(line: 30, column: 1, scope: !32)
+!54 = !{!55, !7, i64 400}
+!55 = !{!"rb_vm_struct", !7, i64 0, !56, i64 8, !15, i64 192, !15, i64 200, !15, i64 208, !60, i64 216, !8, i64 224, !57, i64 264, !57, i64 280, !57, i64 296, !57, i64 312, !7, i64 328, !59, i64 336, !59, i64 340, !59, i64 344, !59, i64 344, !59, i64 344, !59, i64 344, !59, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !15, i64 456, !15, i64 464, !61, i64 472, !62, i64 992, !15, i64 1016, !15, i64 1024, !59, i64 1032, !59, i64 1036, !57, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !59, i64 1136, !15, i64 1144, !15, i64 1152, !15, i64 1160, !15, i64 1168, !15, i64 1176, !15, i64 1184, !59, i64 1192, !63, i64 1200, !8, i64 1232}
+!56 = !{!"rb_global_vm_lock_struct", !15, i64 0, !8, i64 8, !57, i64 48, !15, i64 64, !59, i64 72, !8, i64 80, !8, i64 128, !59, i64 176, !59, i64 180}
+!57 = !{!"list_head", !58, i64 0}
+!58 = !{!"list_node", !15, i64 0, !15, i64 8}
+!59 = !{!"int", !8, i64 0}
+!60 = !{!"long long", !8, i64 0}
+!61 = !{!"", !8, i64 0}
+!62 = !{!"rb_hook_list_struct", !15, i64 0, !59, i64 8, !59, i64 12, !59, i64 16}
+!63 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!64 = !{!65, !15, i64 16}
+!65 = !{!"rb_execution_context_struct", !15, i64 0, !7, i64 8, !15, i64 16, !15, i64 24, !15, i64 32, !59, i64 40, !59, i64 44, !15, i64 48, !15, i64 56, !15, i64 64, !7, i64 72, !7, i64 80, !15, i64 88, !7, i64 96, !15, i64 104, !15, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !66, i64 152}
+!66 = !{!"", !15, i64 0, !15, i64 8, !7, i64 16, !8, i64 24}
+!67 = !{!21, !15, i64 16}
+!68 = !DILocation(line: 0, scope: !32)
+!69 = !{!70, !59, i64 20}
+!70 = !{!"rb_sorbet_param_struct", !71, i64 0, !59, i64 4, !59, i64 8, !59, i64 12, !59, i64 16, !59, i64 20, !59, i64 24, !59, i64 28, !15, i64 32, !59, i64 40, !59, i64 44, !59, i64 48, !59, i64 52, !15, i64 56}
+!71 = !{!"", !59, i64 0, !59, i64 0, !59, i64 0, !59, i64 0, !59, i64 0, !59, i64 0, !59, i64 0, !59, i64 0, !59, i64 1, !59, i64 1}
+!72 = !{!70, !59, i64 24}
+!73 = !{!70, !59, i64 28}
+!74 = !{!59, !59, i64 0}
+!75 = !{!70, !15, i64 32}
+!76 = !{!70, !59, i64 40}
+!77 = !{!70, !59, i64 44}
+!78 = !{!70, !59, i64 8}
+!79 = !{!70, !59, i64 12}
+!80 = !{!70, !59, i64 48}
+!81 = !{!70, !59, i64 52}
+!82 = !{!70, !15, i64 56}

--- a/test/testdata/compiler/block_arg_expand.opt.ll.exp
+++ b/test/testdata/compiler/block_arg_expand.opt.ll.exp
@@ -2,10 +2,10 @@
 source_filename = "llvm-link"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 
-%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.5 }
+%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.7 }
 %struct.rb_control_frame_struct = type { i64*, i64*, %struct.rb_iseq_struct*, i64, i64*, i8*, i64* }
-%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.14 }
-%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.13, i32, i32, i32, i32, i32, i8, i64 }
+%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.17 }
+%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.16, i32, i32, i32, i32, i32, i8, i64 }
 %struct.anon = type { %struct.anon.0, i32, i32, i32, i32, i32, i32, i32, i64*, %struct.rb_iseq_param_keyword* }
 %struct.anon.0 = type { i16, [2 x i8] }
 %struct.rb_iseq_param_keyword = type { i32, i32, i32, i32, i64*, i64* }
@@ -21,27 +21,28 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_cref_struct = type { i64, i64, i64, %struct.rb_cref_struct*, %struct.rb_scope_visi_struct }
 %struct.rb_scope_visi_struct = type { i8, [3 x i8] }
 %struct.rb_call_data = type { %struct.rb_call_cache, %struct.rb_call_info }
-%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.12 }
+%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.15 }
 %struct.rb_callable_method_entry_struct = type { i64, i64, %struct.rb_method_definition_struct*, i64, i64 }
-%struct.rb_method_definition_struct = type { i64, %union.anon.10, i64, i64 }
-%union.anon.10 = type { %struct.rb_method_cfunc_struct }
+%struct.rb_method_definition_struct = type { i64, %union.anon.13, i64, i64 }
+%union.anon.13 = type { %struct.rb_method_cfunc_struct }
 %struct.rb_method_cfunc_struct = type { i64 (...)*, i64 (i64, i32, i64*, i64 (...)*)*, i32 }
 %struct.rb_calling_info = type { i64, i64, i32, i32 }
-%union.anon.12 = type { i32 }
+%union.anon.15 = type { i32 }
 %struct.rb_call_info = type { i64, i32, i32 }
-%struct.anon.13 = type { i64, i64, i64, i64* }
-%union.anon.14 = type { %struct.anon.15 }
-%struct.anon.15 = type { i64, i32 }
+%struct.anon.16 = type { i64, i64, i64, i64* }
+%union.anon.17 = type { %struct.anon.18 }
+%struct.anon.18 = type { i64, i32 }
 %struct.rb_vm_tag = type { i64, i64, [5 x i8*], %struct.rb_vm_tag*, i32 }
 %struct.rb_vm_protect_tag = type { %struct.rb_vm_protect_tag* }
 %struct.rb_fiber_struct = type opaque
-%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.7, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
+%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.10, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
 %struct.list_node = type { %struct.list_node*, %struct.list_node* }
-%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.3, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.4, [29 x i16] }
+%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.5, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.6, [29 x i16] }
 %struct.rb_global_vm_lock_struct = type { %struct.rb_thread_struct*, %union.pthread_mutex_t, %struct.list_head, %struct.rb_thread_struct*, i32, %union.pthread_cond_t, %union.pthread_cond_t, i32, i32 }
-%union.pthread_cond_t = type { %struct.anon.2 }
-%struct.anon.2 = type { i32, i32, i64, i64, i64, i8*, i32, i32 }
-%struct.anon.3 = type { [65 x i64] }
+%union.pthread_cond_t = type { %struct.__pthread_cond_s }
+%struct.__pthread_cond_s = type { %union.anon, %union.anon, [2 x i32], [2 x i32], i32, i32, [2 x i32] }
+%union.anon = type { i64 }
+%struct.anon.5 = type { [65 x i64] }
 %struct.rb_hook_list_struct = type { %struct.rb_event_hook_struct*, i32, i32, i32 }
 %struct.rb_event_hook_struct = type opaque
 %struct.rb_postponed_job_struct = type opaque
@@ -49,24 +50,24 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_objspace = type opaque
 %struct.rb_at_exit_list = type { void (%struct.rb_vm_struct*)*, %struct.rb_at_exit_list* }
 %struct.rb_builtin_function = type opaque
-%struct.anon.4 = type { i64, i64, i64, i64 }
-%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.6 }
-%union.anon.6 = type { %union.pthread_cond_t }
+%struct.anon.6 = type { i64, i64, i64, i64 }
+%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.9 }
+%union.anon.9 = type { %union.pthread_cond_t }
 %union.pthread_mutex_t = type { %struct.__pthread_mutex_s }
 %struct.__pthread_mutex_s = type { i32, i32, i32, i32, i32, i16, i16, %struct.__pthread_internal_list }
 %struct.__pthread_internal_list = type { %struct.__pthread_internal_list*, %struct.__pthread_internal_list* }
 %struct.rb_unblock_callback = type { void (i8*)*, i8* }
 %struct.rb_mutex_struct = type opaque
 %struct.rb_thread_list_struct = type { %struct.rb_thread_list_struct*, %struct.rb_thread_struct* }
-%union.anon.7 = type { %struct.anon.8 }
-%struct.anon.8 = type { i64, i64, i32 }
+%union.anon.10 = type { %struct.anon.11 }
+%struct.anon.11 = type { i64, i64, i32 }
 %struct.st_table = type { i8, i8, i8, i32, %struct.st_hash_type*, i64, i64*, i64, i64, %struct.st_table_entry* }
 %struct.st_hash_type = type { i32 (i64, i64)*, i64 (i64)* }
 %struct.st_table_entry = type opaque
 %struct.rb_ensure_list = type { %struct.rb_ensure_list*, %struct.rb_ensure_entry }
 %struct.rb_ensure_entry = type { i64, i64 (i64)*, i64 }
 %struct.rb_trace_arg_struct = type { i32, %struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, i64, i64, i64, i64, i64, i32, i32, i64 }
-%struct.anon.5 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
+%struct.anon.7 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
 %struct.__jmp_buf_tag = type { [8 x i64], i32, %struct.__sigset_t }
 %struct.__sigset_t = type { [16 x i64] }
 %struct.SorbetLineNumberInfo = type { i32, %struct.iseq_insn_info_entry*, i64* }
@@ -74,20 +75,19 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_kwarg_call_data = type { %struct.rb_call_cache, %struct.rb_call_info_with_kwarg }
 %struct.rb_call_info_with_kwarg = type { %struct.rb_call_info, %struct.rb_call_info_kw_arg* }
 %struct.rb_call_info_kw_arg = type { i32, [1 x i64] }
-%struct.rb_captured_block = type { i64, i64*, %union.anon.17 }
-%union.anon.17 = type { %struct.rb_iseq_struct* }
+%struct.rb_captured_block = type { i64, i64*, %union.anon.20 }
+%union.anon.20 = type { %struct.rb_iseq_struct* }
 %struct.vm_ifunc = type { i64, i64, i64 (i64, i64, i32, i64*, i64)*, i8*, %struct.rb_code_position_struct }
 %struct.iseq_inline_iv_cache_entry = type { i64, i64 }
-%struct.RArray = type { %struct.iseq_inline_iv_cache_entry, %union.anon.25 }
-%union.anon.25 = type { %struct.anon.26 }
-%struct.anon.26 = type { i64, %union.anon.27, i64* }
-%union.anon.27 = type { i64 }
+%struct.RArray = type { %struct.iseq_inline_iv_cache_entry, %union.anon.28 }
+%union.anon.28 = type { %struct.anon.29 }
+%struct.anon.29 = type { i64, %union.anon, i64* }
 %struct.sorbet_inlineIntrinsicEnv = type { i64, i64, i32, i64*, i64 }
 
-@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -134,7 +134,7 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ic_p.12 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_p.13 = internal global %struct.FunctionInlineCache zeroinitializer
 
-; Function Attrs: nounwind readnone willreturn
+; Function Attrs: nofree nosync nounwind readnone willreturn mustprogress
 declare i64 @rb_id2sym(i64) local_unnamed_addr #0
 
 ; Function Attrs: cold noreturn
@@ -196,14 +196,14 @@ declare %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)*, i8*,
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #7 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #12
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #13
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #7 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #12
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #13
   unreachable
 }
 
@@ -252,7 +252,7 @@ argArrayExpand:                                   ; preds = %sorbet_isa_Array.ex
   br i1 %23, label %25, label %24, !dbg !24
 
 24:                                               ; preds = %argArrayExpand
-  tail call void @rb_ary_detransient(i64 %arg1_maybeExpandToFullArgs) #13, !dbg !24
+  tail call void @rb_ary_detransient(i64 %arg1_maybeExpandToFullArgs) #14, !dbg !24
   br label %25, !dbg !24
 
 25:                                               ; preds = %24, %argArrayExpand
@@ -266,16 +266,16 @@ argArrayExpand:                                   ; preds = %sorbet_isa_Array.ex
   %31 = getelementptr inbounds %struct.RArray, %struct.RArray* %29, i64 0, i32 1, i32 0, i32 0, !dbg !24
   %32 = lshr i64 %26, 15, !dbg !24
   %33 = and i64 %32, 3, !dbg !24
-  br label %rb_array_len.exit, !dbg !24
+  br label %sorbet_rubyArrayLen.exit, !dbg !24
 
 34:                                               ; preds = %25
   %35 = getelementptr inbounds %struct.RArray, %struct.RArray* %29, i64 0, i32 1, i32 0, i32 2, !dbg !24
   %36 = load i64*, i64** %35, align 8, !dbg !24, !tbaa !27
   %37 = getelementptr inbounds %struct.RArray, %struct.RArray* %29, i64 0, i32 1, i32 0, i32 0, !dbg !24
   %38 = load i64, i64* %37, align 8, !dbg !24, !tbaa !27
-  br label %rb_array_len.exit, !dbg !24
+  br label %sorbet_rubyArrayLen.exit, !dbg !24
 
-rb_array_len.exit:                                ; preds = %30, %34
+sorbet_rubyArrayLen.exit:                         ; preds = %30, %34
   %39 = phi i64* [ %31, %30 ], [ %36, %34 ]
   %40 = phi i64 [ %33, %30 ], [ %38, %34 ], !dbg !24
   %41 = trunc i64 %40 to i32, !dbg !24
@@ -317,9 +317,9 @@ sorbet_isa_Integer.exit:                          ; preds = %45
   %55 = icmp eq i64 %54, 10, !dbg !30
   br i1 %55, label %typeTestSuccess, label %codeRepl38, !dbg !30, !prof !31
 
-fillRequiredArgs:                                 ; preds = %functionEntryInitializers, %rb_array_len.exit
-  %argcPhi = phi i32 [ %argc, %functionEntryInitializers ], [ %41, %rb_array_len.exit ], !dbg !24
-  %argArrayPhi = phi i64* [ %argArray, %functionEntryInitializers ], [ %39, %rb_array_len.exit ], !dbg !24
+fillRequiredArgs:                                 ; preds = %functionEntryInitializers, %sorbet_rubyArrayLen.exit
+  %argcPhi = phi i32 [ %argc, %functionEntryInitializers ], [ %41, %sorbet_rubyArrayLen.exit ], !dbg !24
+  %argArrayPhi = phi i64* [ %argArray, %functionEntryInitializers ], [ %39, %sorbet_rubyArrayLen.exit ], !dbg !24
   %default0 = icmp eq i32 %argcPhi, 0, !dbg !24
   br i1 %default0, label %fillFromDefaultBlockDone2.thread, label %fillFromArgBlock0, !dbg !24, !prof !28
 
@@ -352,59 +352,61 @@ sorbet_isa_Integer.exit39:                        ; preds = %58
 
 codeRepl38:                                       ; preds = %45, %sorbet_isa_Integer.exit
   %el1.sroa.0.147 = phi i64 [ %el1.sroa.0.146, %45 ], [ %el1.sroa.0.146, %sorbet_isa_Integer.exit ]
-  tail call fastcc void @"func_<root>.17<static-init>$152$block_1.cold.1"(i64 %el1.sroa.0.147) #14, !dbg !30
+  tail call fastcc void @"func_<root>.17<static-init>$152$block_1.cold.1"(i64 %el1.sroa.0.147) #15, !dbg !30
   unreachable
 
 codeRepl:                                         ; preds = %58, %sorbet_isa_Integer.exit39
   %el2.sroa.0.044 = phi i64 [ %el2.sroa.0.042, %58 ], [ %el2.sroa.0.042, %sorbet_isa_Integer.exit39 ]
-  tail call fastcc void @"func_<root>.17<static-init>$152$block_1.cold.1"(i64 %el2.sroa.0.044) #14, !dbg !32
+  tail call fastcc void @"func_<root>.17<static-init>$152$block_1.cold.1"(i64 %el2.sroa.0.044) #15, !dbg !32
   unreachable
 
 "fastSymCallIntrinsic_Integer_+":                 ; preds = %typeTestSuccess, %sorbet_isa_Integer.exit39
   tail call void @llvm.experimental.noalias.scope.decl(metadata !33), !dbg !30
-  %69 = and i64 %el2.sroa.0.042, 1, !dbg !30
-  %70 = and i64 %69, %el1.sroa.0.145, !dbg !30
-  %71 = icmp eq i64 %70, 0, !dbg !30
-  br i1 %71, label %81, label %72, !dbg !30, !prof !36
+  %69 = and i64 %el1.sroa.0.145, 1, !dbg !30
+  %70 = icmp eq i64 %69, 0, !dbg !30
+  %71 = and i64 %el2.sroa.0.042, 1, !dbg !30
+  %72 = icmp eq i64 %71, 0, !dbg !30
+  %73 = select i1 %70, i1 true, i1 %72, !dbg !30
+  br i1 %73, label %83, label %74, !dbg !30, !prof !36
 
-72:                                               ; preds = %"fastSymCallIntrinsic_Integer_+"
-  %73 = add nsw i64 %el2.sroa.0.042, -1, !dbg !30
-  %74 = tail call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %el1.sroa.0.145, i64 %73) #15, !dbg !30
-  %75 = extractvalue { i64, i1 } %74, 1, !dbg !30
-  %76 = extractvalue { i64, i1 } %74, 0, !dbg !30
-  br i1 %75, label %77, label %sorbet_rb_int_plus.exit, !dbg !30
+74:                                               ; preds = %"fastSymCallIntrinsic_Integer_+"
+  %75 = add nsw i64 %el2.sroa.0.042, -1, !dbg !30
+  %76 = tail call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %el1.sroa.0.145, i64 %75) #14, !dbg !30
+  %77 = extractvalue { i64, i1 } %76, 1, !dbg !30
+  %78 = extractvalue { i64, i1 } %76, 0, !dbg !30
+  br i1 %77, label %79, label %sorbet_rb_int_plus.exit, !dbg !30
 
-77:                                               ; preds = %72
-  %78 = ashr i64 %76, 1, !dbg !30
-  %79 = xor i64 %78, -9223372036854775808, !dbg !30
-  %80 = tail call i64 @rb_int2big(i64 %79) #13, !dbg !30, !noalias !33
+79:                                               ; preds = %74
+  %80 = ashr i64 %78, 1, !dbg !30
+  %81 = xor i64 %80, -9223372036854775808, !dbg !30
+  %82 = tail call i64 @rb_int2big(i64 %81) #14, !dbg !30, !noalias !33
   br label %sorbet_rb_int_plus.exit, !dbg !30
 
-81:                                               ; preds = %"fastSymCallIntrinsic_Integer_+"
-  %82 = tail call i64 @sorbet_rb_int_plus_slowpath(i64 %el1.sroa.0.145, i64 %el2.sroa.0.042) #13, !dbg !30, !noalias !33
+83:                                               ; preds = %"fastSymCallIntrinsic_Integer_+"
+  %84 = tail call i64 @sorbet_rb_int_plus_slowpath(i64 %el1.sroa.0.145, i64 %el2.sroa.0.042) #14, !dbg !30, !noalias !33
   br label %sorbet_rb_int_plus.exit, !dbg !30
 
-sorbet_rb_int_plus.exit:                          ; preds = %77, %72, %81
-  %83 = phi i64 [ %82, %81 ], [ %80, %77 ], [ %76, %72 ], !dbg !30
-  %84 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !30, !tbaa !15
-  %85 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %84, i64 0, i32 5, !dbg !30
-  %86 = load i32, i32* %85, align 8, !dbg !30, !tbaa !37
-  %87 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %84, i64 0, i32 6, !dbg !30
-  %88 = load i32, i32* %87, align 4, !dbg !30, !tbaa !38
-  %89 = xor i32 %88, -1, !dbg !30
-  %90 = and i32 %89, %86, !dbg !30
-  %91 = icmp eq i32 %90, 0, !dbg !30
-  br i1 %91, label %rb_vm_check_ints.exit, label %92, !dbg !30, !prof !31
+sorbet_rb_int_plus.exit:                          ; preds = %74, %79, %83
+  %85 = phi i64 [ %84, %83 ], [ %82, %79 ], [ %78, %74 ], !dbg !30
+  %86 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !30, !tbaa !15
+  %87 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %86, i64 0, i32 5, !dbg !30
+  %88 = load i32, i32* %87, align 8, !dbg !30, !tbaa !37
+  %89 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %86, i64 0, i32 6, !dbg !30
+  %90 = load i32, i32* %89, align 4, !dbg !30, !tbaa !38
+  %91 = xor i32 %90, -1, !dbg !30
+  %92 = and i32 %91, %88, !dbg !30
+  %93 = icmp eq i32 %92, 0, !dbg !30
+  br i1 %93, label %sorbet_afterIntrinsic.exit, label %94, !dbg !30, !prof !31
 
-92:                                               ; preds = %sorbet_rb_int_plus.exit
-  %93 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %84, i64 0, i32 8, !dbg !30
-  %94 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %93, align 8, !dbg !30, !tbaa !39
-  %95 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %94, i32 noundef 0) #13, !dbg !30
-  br label %rb_vm_check_ints.exit, !dbg !30
+94:                                               ; preds = %sorbet_rb_int_plus.exit
+  %95 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %86, i64 0, i32 8, !dbg !30
+  %96 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %95, align 8, !dbg !30, !tbaa !39
+  %97 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %96, i32 noundef 0) #14, !dbg !30
+  br label %sorbet_afterIntrinsic.exit, !dbg !30
 
-rb_vm_check_ints.exit:                            ; preds = %sorbet_rb_int_plus.exit, %92
+sorbet_afterIntrinsic.exit:                       ; preds = %sorbet_rb_int_plus.exit, %94
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !dbg !30, !tbaa !15
-  ret i64 %83, !dbg !40
+  ret i64 %85, !dbg !40
 }
 
 ; Function Attrs: ssp
@@ -589,7 +591,7 @@ argArrayExpand:                                   ; preds = %sorbet_isa_Array.ex
   br i1 %34, label %36, label %35, !dbg !55
 
 35:                                               ; preds = %argArrayExpand
-  tail call void @rb_ary_detransient(i64 %arg1_maybeExpandToFullArgs) #13, !dbg !55
+  tail call void @rb_ary_detransient(i64 %arg1_maybeExpandToFullArgs) #14, !dbg !55
   br label %36, !dbg !55
 
 36:                                               ; preds = %35, %argArrayExpand
@@ -603,16 +605,16 @@ argArrayExpand:                                   ; preds = %sorbet_isa_Array.ex
   %42 = getelementptr inbounds %struct.RArray, %struct.RArray* %40, i64 0, i32 1, i32 0, i32 0, !dbg !55
   %43 = lshr i64 %37, 15, !dbg !55
   %44 = and i64 %43, 3, !dbg !55
-  br label %rb_array_len.exit, !dbg !55
+  br label %sorbet_rubyArrayLen.exit, !dbg !55
 
 45:                                               ; preds = %36
   %46 = getelementptr inbounds %struct.RArray, %struct.RArray* %40, i64 0, i32 1, i32 0, i32 2, !dbg !55
   %47 = load i64*, i64** %46, align 8, !dbg !55, !tbaa !27
   %48 = getelementptr inbounds %struct.RArray, %struct.RArray* %40, i64 0, i32 1, i32 0, i32 0, !dbg !55
   %49 = load i64, i64* %48, align 8, !dbg !55, !tbaa !27
-  br label %rb_array_len.exit, !dbg !55
+  br label %sorbet_rubyArrayLen.exit, !dbg !55
 
-rb_array_len.exit:                                ; preds = %41, %45
+sorbet_rubyArrayLen.exit:                         ; preds = %41, %45
   %50 = phi i64* [ %42, %41 ], [ %47, %45 ]
   %51 = phi i64 [ %44, %41 ], [ %49, %45 ], !dbg !55
   %52 = trunc i64 %51 to i32, !dbg !55
@@ -623,9 +625,9 @@ fillFromArgBlock0:                                ; preds = %fillRequiredArgs
   %default1 = icmp eq i32 %argcPhi, 1, !dbg !55
   br i1 %default1, label %BB23.thread62, label %BB24, !dbg !55, !prof !28
 
-fillRequiredArgs:                                 ; preds = %functionEntryInitializers, %rb_array_len.exit
-  %argcPhi = phi i32 [ %argc, %functionEntryInitializers ], [ %52, %rb_array_len.exit ], !dbg !55
-  %argArrayPhi = phi i64* [ %argArray, %functionEntryInitializers ], [ %50, %rb_array_len.exit ], !dbg !55
+fillRequiredArgs:                                 ; preds = %functionEntryInitializers, %sorbet_rubyArrayLen.exit
+  %argcPhi = phi i32 [ %argc, %functionEntryInitializers ], [ %52, %sorbet_rubyArrayLen.exit ], !dbg !55
+  %argArrayPhi = phi i64* [ %argArray, %functionEntryInitializers ], [ %50, %sorbet_rubyArrayLen.exit ], !dbg !55
   %default0 = icmp eq i32 %argcPhi, 0, !dbg !55
   br i1 %default0, label %BB23.thread, label %fillFromArgBlock0, !dbg !55, !prof !28
 }
@@ -714,7 +716,7 @@ argArrayExpand:                                   ; preds = %sorbet_isa_Array.ex
   br i1 %34, label %36, label %35, !dbg !64
 
 35:                                               ; preds = %argArrayExpand
-  tail call void @rb_ary_detransient(i64 %arg1_maybeExpandToFullArgs) #13, !dbg !64
+  tail call void @rb_ary_detransient(i64 %arg1_maybeExpandToFullArgs) #14, !dbg !64
   br label %36, !dbg !64
 
 36:                                               ; preds = %35, %argArrayExpand
@@ -728,16 +730,16 @@ argArrayExpand:                                   ; preds = %sorbet_isa_Array.ex
   %42 = getelementptr inbounds %struct.RArray, %struct.RArray* %40, i64 0, i32 1, i32 0, i32 0, !dbg !64
   %43 = lshr i64 %37, 15, !dbg !64
   %44 = and i64 %43, 3, !dbg !64
-  br label %rb_array_len.exit, !dbg !64
+  br label %sorbet_rubyArrayLen.exit, !dbg !64
 
 45:                                               ; preds = %36
   %46 = getelementptr inbounds %struct.RArray, %struct.RArray* %40, i64 0, i32 1, i32 0, i32 2, !dbg !64
   %47 = load i64*, i64** %46, align 8, !dbg !64, !tbaa !27
   %48 = getelementptr inbounds %struct.RArray, %struct.RArray* %40, i64 0, i32 1, i32 0, i32 0, !dbg !64
   %49 = load i64, i64* %48, align 8, !dbg !64, !tbaa !27
-  br label %rb_array_len.exit, !dbg !64
+  br label %sorbet_rubyArrayLen.exit, !dbg !64
 
-rb_array_len.exit:                                ; preds = %41, %45
+sorbet_rubyArrayLen.exit:                         ; preds = %41, %45
   %50 = phi i64* [ %42, %41 ], [ %47, %45 ]
   %51 = phi i64 [ %44, %41 ], [ %49, %45 ], !dbg !64
   %52 = trunc i64 %51 to i32, !dbg !64
@@ -748,15 +750,18 @@ fillFromArgBlock0:                                ; preds = %fillRequiredArgs
   %default1 = icmp eq i32 %argcPhi, 1, !dbg !64
   br i1 %default1, label %BB32, label %BB31, !dbg !64, !prof !28
 
-fillRequiredArgs:                                 ; preds = %functionEntryInitializers, %rb_array_len.exit
-  %argcPhi = phi i32 [ %argc, %functionEntryInitializers ], [ %52, %rb_array_len.exit ], !dbg !64
-  %argArrayPhi = phi i64* [ %argArray, %functionEntryInitializers ], [ %50, %rb_array_len.exit ], !dbg !64
+fillRequiredArgs:                                 ; preds = %functionEntryInitializers, %sorbet_rubyArrayLen.exit
+  %argcPhi = phi i32 [ %argc, %functionEntryInitializers ], [ %52, %sorbet_rubyArrayLen.exit ], !dbg !64
+  %argArrayPhi = phi i64* [ %argArray, %functionEntryInitializers ], [ %50, %sorbet_rubyArrayLen.exit ], !dbg !64
   %default0 = icmp eq i32 %argcPhi, 0, !dbg !64
   br i1 %default0, label %BB32, label %fillFromArgBlock0, !dbg !64, !prof !28
 }
 
+; Function Attrs: nofree nosync nounwind willreturn
+declare void @llvm.assume(i1 noundef) #9
+
 ; Function Attrs: sspreq
-define void @Init_block_arg_expand() local_unnamed_addr #9 {
+define void @Init_block_arg_expand() local_unnamed_addr #10 {
 entry:
   %0 = alloca i64, align 8
   %1 = alloca i64, align 8
@@ -769,30 +774,30 @@ entry:
   %callArgs.i = alloca [3 x i64], align 8
   %locals.i.i = alloca i64, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #13
+  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #14
   store i64 %8, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @"str_<block-call>", i64 0, i64 0), i64 noundef 12) #13
+  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @"str_<block-call>", i64 0, i64 0), i64 noundef 12) #14
   store i64 %9, i64* @"rubyIdPrecomputed_<block-call>", align 8
-  %10 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #13
+  %10 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #14
   store i64 %10, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
-  %11 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_<build-array>", i64 0, i64 0), i64 noundef 13) #13
-  %12 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_each, i64 0, i64 0), i64 noundef 4) #13
+  %11 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_<build-array>", i64 0, i64 0), i64 noundef 13) #14
+  %12 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_each, i64 0, i64 0), i64 noundef 4) #14
   store i64 %12, i64* @rubyIdPrecomputed_each, align 8
-  %13 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_+", i64 0, i64 0), i64 noundef 1) #13
+  %13 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_+", i64 0, i64 0), i64 noundef 1) #14
   store i64 %13, i64* @"rubyIdPrecomputed_+", align 8
-  %14 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_p, i64 0, i64 0), i64 noundef 1) #13
+  %14 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_p, i64 0, i64 0), i64 noundef 1) #14
   store i64 %14, i64* @rubyIdPrecomputed_p, align 8
-  %15 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_x, i64 0, i64 0), i64 noundef 1) #13
+  %15 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_x, i64 0, i64 0), i64 noundef 1) #14
   store i64 %15, i64* @rubyIdPrecomputed_x, align 8
-  %16 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_default, i64 0, i64 0), i64 noundef 7) #13
+  %16 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_default, i64 0, i64 0), i64 noundef 7) #14
   store i64 %16, i64* @rubyIdPrecomputed_default, align 8
-  %17 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @str_something, i64 0, i64 0), i64 noundef 9) #13
+  %17 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @str_something, i64 0, i64 0), i64 noundef 9) #14
   store i64 %17, i64* @rubyIdPrecomputed_something, align 8
-  %18 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #13
-  tail call void @rb_gc_register_mark_object(i64 %18) #13
+  %18 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #14
+  tail call void @rb_gc_register_mark_object(i64 %18) #14
   store i64 %18, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %19 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([43 x i8], [43 x i8]* @"str_test/testdata/compiler/block_arg_expand.rb", i64 0, i64 0), i64 noundef 42) #13
-  tail call void @rb_gc_register_mark_object(i64 %19) #13
+  %19 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([43 x i8], [43 x i8]* @"str_test/testdata/compiler/block_arg_expand.rb", i64 0, i64 0), i64 noundef 42) #14
+  tail call void @rb_gc_register_mark_object(i64 %19) #14
   store i64 %19, i64* @"rubyStrFrozen_test/testdata/compiler/block_arg_expand.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 32)
   %20 = bitcast i64* %locals.i.i to i8*
@@ -805,8 +810,8 @@ entry:
   %21 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i.i, i32 noundef 1, i32 noundef 3)
   store %struct.rb_iseq_struct* %21, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %20)
-  %22 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #13
-  call void @rb_gc_register_mark_object(i64 %22) #13
+  %22 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #14
+  call void @rb_gc_register_mark_object(i64 %22) #14
   store i64 %22, i64* @"rubyStrFrozen_block in <top (required)>", align 8
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   %"rubyId_block in <top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
@@ -837,25 +842,25 @@ entry:
   %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i42.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_arg_expand.rb", align 8
   %27 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i41.i", i64 %"rubyId_block in <top (required)>.i40.i", i64 %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i42.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i39.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
   store %struct.rb_iseq_struct* %27, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152$block_5", align 8
-  %28 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$152$block_1", i8* noundef null, i32 noundef 2, i32 noundef 2) #13
+  %28 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$152$block_1", i8* noundef null, i32 noundef 2, i32 noundef 2) #14
   %29 = ptrtoint %struct.vm_ifunc* %28 to i64
   %30 = call i64 @sorbet_globalConstRegister(i64 %29)
   store i64 %30, i64* @"func_<root>.17<static-init>$152$block_1_ifunc", align 8
   %"rubyId_+.i" = load i64, i64* @"rubyIdPrecomputed_+", align 8, !dbg !30
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_+", i64 %"rubyId_+.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !30
-  %31 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$152$block_2", i8* noundef null, i32 noundef 1, i32 noundef 1) #13
+  %31 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$152$block_2", i8* noundef null, i32 noundef 1, i32 noundef 1) #14
   %32 = ptrtoint %struct.vm_ifunc* %31 to i64
   %33 = call i64 @sorbet_globalConstRegister(i64 %32)
   store i64 %33, i64* @"func_<root>.17<static-init>$152$block_2_ifunc", align 8
   %rubyId_p.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !45
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !45
-  %34 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$152$block_3", i8* noundef null, i32 noundef 0, i32 noundef 1) #13
+  %34 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$152$block_3", i8* noundef null, i32 noundef 0, i32 noundef 1) #14
   %35 = ptrtoint %struct.vm_ifunc* %34 to i64
   %36 = call i64 @sorbet_globalConstRegister(i64 %35)
   store i64 %36, i64* @"func_<root>.17<static-init>$152$block_3_ifunc", align 8
   %rubyId_p7.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !52
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.5, i64 %rubyId_p7.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !52
-  %37 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$152$block_4", i8* noundef null, i32 noundef 0, i32 noundef 2) #13
+  %37 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$152$block_4", i8* noundef null, i32 noundef 0, i32 noundef 2) #14
   %38 = ptrtoint %struct.vm_ifunc* %37 to i64
   %39 = call i64 @sorbet_globalConstRegister(i64 %38)
   store i64 %39, i64* @"func_<root>.17<static-init>$152$block_4_ifunc", align 8
@@ -863,7 +868,7 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.8, i64 %rubyId_p12.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !60
   %rubyId_p15.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !61
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.9, i64 %rubyId_p15.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !61
-  %40 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$152$block_5", i8* noundef null, i32 noundef 1, i32 noundef 2) #13
+  %40 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$152$block_5", i8* noundef null, i32 noundef 1, i32 noundef 2) #14
   %41 = ptrtoint %struct.vm_ifunc* %40 to i64
   %42 = call i64 @sorbet_globalConstRegister(i64 %41)
   store i64 %42, i64* @"func_<root>.17<static-init>$152$block_5_ifunc", align 8
@@ -885,681 +890,564 @@ entry:
   %51 = load i64, i64* %50, align 8, !tbaa !6
   %52 = and i64 %51, -33
   store i64 %52, i64* %50, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %43, %struct.rb_control_frame_struct* %47, %struct.rb_iseq_struct* %stackFrame.i) #13
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %43, %struct.rb_control_frame_struct* %47, %struct.rb_iseq_struct* %stackFrame.i) #14
   %53 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %45, i64 0, i32 0
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %53, align 8, !dbg !71, !tbaa !15
   %callArgs0Addr.i = getelementptr [3 x i64], [3 x i64]* %callArgs.i, i32 0, i64 0, !dbg !72
   %54 = bitcast i64* %callArgs0Addr.i to <2 x i64>*, !dbg !72
   store <2 x i64> <i64 3, i64 5>, <2 x i64>* %54, align 8, !dbg !72
   %55 = getelementptr [3 x i64], [3 x i64]* %callArgs.i, i64 0, i64 0, !dbg !72
-  call void @llvm.experimental.noalias.scope.decl(metadata !73) #13, !dbg !72
-  %56 = call i64 @rb_ary_new_from_values(i64 noundef 2, i64* noundef nonnull %55) #13, !dbg !72
+  call void @llvm.experimental.noalias.scope.decl(metadata !73) #14, !dbg !72
+  %56 = call i64 @rb_ary_new_from_values(i64 noundef 2, i64* noundef nonnull %55) #14, !dbg !72
   store i64 %56, i64* %callArgs0Addr.i, align 8, !dbg !76
-  call void @llvm.experimental.noalias.scope.decl(metadata !77) #13, !dbg !76
-  %57 = call i64 @rb_ary_new_from_values(i64 noundef 1, i64* noundef nonnull %55) #13, !dbg !76
+  call void @llvm.experimental.noalias.scope.decl(metadata !77) #14, !dbg !76
+  %57 = call i64 @rb_ary_new_from_values(i64 noundef 1, i64* noundef nonnull %55) #14, !dbg !76
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %53, align 8, !dbg !76, !tbaa !15
   %rubyId_each.i = load i64, i64* @rubyIdPrecomputed_each, align 8, !dbg !80
   %58 = load i64, i64* @"func_<root>.17<static-init>$152$block_1_ifunc", align 8, !dbg !80
-  %59 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %58) #13, !dbg !80
-  %60 = bitcast %struct.sorbet_inlineIntrinsicEnv* %6 to i8*, !dbg !80
-  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %60) #13, !dbg !80
-  %61 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %6, i64 0, i32 0, !dbg !80
+  %59 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %58) #14, !dbg !80
+  %60 = bitcast %struct.sorbet_inlineIntrinsicEnv* %3 to i8*, !dbg !80
+  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %60) #14, !dbg !80
+  %61 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %3, i64 0, i32 0, !dbg !80
   store i64 %57, i64* %61, align 8, !dbg !80, !tbaa !81
-  %62 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %6, i64 0, i32 1, !dbg !80
+  %62 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %3, i64 0, i32 1, !dbg !80
   store i64 %rubyId_each.i, i64* %62, align 8, !dbg !80, !tbaa !83
-  %63 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %6, i64 0, i32 2, !dbg !80
+  %63 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %3, i64 0, i32 2, !dbg !80
   store i32 0, i32* %63, align 8, !dbg !80, !tbaa !84
-  %64 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %6, i64 0, i32 3, !dbg !80
+  %64 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %3, i64 0, i32 3, !dbg !80
   %65 = bitcast i64** %64 to i8*, !dbg !80
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %65, i8 0, i64 16, i1 false) #13, !dbg !80
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %65, i8 0, i64 16, i1 false) #14, !dbg !80
   %66 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !80, !tbaa !15
   %67 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %66, i64 0, i32 2, !dbg !80
   %68 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %67, align 8, !dbg !80, !tbaa !17
   %69 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %68, i64 0, i32 3, !dbg !80
-  %70 = bitcast i64* %69 to %struct.rb_captured_block*, !dbg !80
-  %71 = getelementptr inbounds i64, i64* %69, i64 2, !dbg !80
-  %72 = bitcast i64* %71 to %struct.vm_ifunc**, !dbg !80
-  store %struct.vm_ifunc* %59, %struct.vm_ifunc** %72, align 8, !dbg !80, !tbaa !27
-  call void @llvm.experimental.noalias.scope.decl(metadata !85) #13, !dbg !80
-  %73 = ptrtoint %struct.rb_captured_block* %70 to i64, !dbg !80
-  %74 = or i64 %73, 3, !dbg !80
-  %75 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %66, i64 0, i32 17, !dbg !80
-  %76 = and i64 %74, -4, !dbg !88
-  %77 = inttoptr i64 %76 to %struct.rb_captured_block*, !dbg !88
-  store i64 0, i64* %75, align 8, !dbg !88, !tbaa !90
-  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %77) #13, !dbg !88
-  %78 = inttoptr i64 %57 to %struct.iseq_inline_iv_cache_entry*, !dbg !88
-  %79 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %78, i64 0, i32 0, !dbg !88
-  %80 = load i64, i64* %79, align 8, !dbg !88, !tbaa !25
-  %81 = and i64 %80, 8192, !dbg !88
-  %82 = icmp eq i64 %81, 0, !dbg !88
-  br i1 %82, label %86, label %83, !dbg !88
+  %70 = getelementptr inbounds i64, i64* %69, i64 2, !dbg !80
+  %71 = bitcast i64* %70 to %struct.vm_ifunc**, !dbg !80
+  store %struct.vm_ifunc* %59, %struct.vm_ifunc** %71, align 8, !dbg !80, !tbaa !27
+  %72 = ptrtoint i64* %69 to i64, !dbg !80
+  %73 = or i64 %72, 3, !dbg !80
+  %74 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %66, i64 0, i32 17, !dbg !80
+  %75 = and i64 %73, -4, !dbg !85
+  %76 = inttoptr i64 %75 to %struct.rb_captured_block*, !dbg !85
+  store i64 0, i64* %74, align 8, !dbg !85, !tbaa !87
+  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %76) #14, !dbg !85
+  %77 = inttoptr i64 %57 to %struct.iseq_inline_iv_cache_entry*, !dbg !85
+  %78 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %77, i64 0, i32 0, !dbg !85
+  %79 = inttoptr i64 %57 to %struct.RArray*, !dbg !85
+  %80 = getelementptr inbounds %struct.RArray, %struct.RArray* %79, i64 0, i32 1, i32 0, i32 0, !dbg !85
+  %81 = bitcast i64* %2 to i8*, !dbg !85
+  %82 = getelementptr inbounds %struct.RArray, %struct.RArray* %79, i64 0, i32 1, i32 0, i32 2, !dbg !85
+  br label %83, !dbg !85
 
-83:                                               ; preds = %entry
-  %84 = lshr i64 %80, 15, !dbg !88
-  %85 = and i64 %84, 3, !dbg !88
-  br label %rb_array_len.exit1.i3.i, !dbg !88
+83:                                               ; preds = %102, %entry
+  %84 = phi i64 [ %107, %102 ], [ 0, %entry ], !dbg !85
+  %85 = load i64, i64* %78, align 8, !dbg !85, !tbaa !25
+  %86 = and i64 %85, 8192, !dbg !85
+  %87 = icmp eq i64 %86, 0, !dbg !85
+  br i1 %87, label %91, label %88, !dbg !85
 
-86:                                               ; preds = %entry
-  %87 = inttoptr i64 %57 to %struct.RArray*, !dbg !88
-  %88 = getelementptr inbounds %struct.RArray, %struct.RArray* %87, i64 0, i32 1, i32 0, i32 0, !dbg !88
-  %89 = load i64, i64* %88, align 8, !dbg !88, !tbaa !27
-  br label %rb_array_len.exit1.i3.i, !dbg !88
+88:                                               ; preds = %83
+  %89 = lshr i64 %85, 15, !dbg !85
+  %90 = and i64 %89, 3, !dbg !85
+  br label %93, !dbg !85
 
-rb_array_len.exit1.i3.i:                          ; preds = %86, %83
-  %90 = phi i64 [ %85, %83 ], [ %89, %86 ], !dbg !88
-  %91 = icmp sgt i64 %90, 0, !dbg !88
-  br i1 %91, label %92, label %forward_sorbet_rb_array_each_withBlock.exit.i, !dbg !88
+91:                                               ; preds = %83
+  %92 = load i64, i64* %80, align 8, !dbg !85, !tbaa !27
+  br label %93, !dbg !85
 
-92:                                               ; preds = %rb_array_len.exit1.i3.i
-  %93 = bitcast i64* %1 to i8*, !dbg !88
-  %94 = inttoptr i64 %57 to %struct.RArray*, !dbg !80
-  %95 = getelementptr inbounds %struct.RArray, %struct.RArray* %94, i64 0, i32 1, i32 0, i32 0, !dbg !80
-  %96 = getelementptr inbounds %struct.RArray, %struct.RArray* %94, i64 0, i32 1, i32 0, i32 2, !dbg !80
-  br label %97, !dbg !88
+93:                                               ; preds = %91, %88
+  %94 = phi i64 [ %90, %88 ], [ %92, %91 ], !dbg !85
+  %95 = icmp sgt i64 %94, %84, !dbg !85
+  br i1 %95, label %96, label %forward_sorbet_rb_array_each_withBlock.exit.i, !dbg !85
 
-97:                                               ; preds = %rb_array_len.exit.i5.i, %92
-  %98 = phi i64 [ 0, %92 ], [ %108, %rb_array_len.exit.i5.i ], !dbg !88
-  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 dereferenceable(8) %93) #13, !dbg !88
-  %99 = load i64, i64* %79, align 8, !dbg !88, !tbaa !25
-  %100 = and i64 %99, 8192, !dbg !88
-  %101 = icmp eq i64 %100, 0, !dbg !88
-  br i1 %101, label %102, label %rb_array_const_ptr_transient.exit.i4.i, !dbg !88
+96:                                               ; preds = %93
+  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull %81) #14, !dbg !85
+  %97 = load i64, i64* %78, align 8, !dbg !85, !tbaa !25
+  %98 = and i64 %97, 8192, !dbg !85
+  %99 = icmp eq i64 %98, 0, !dbg !85
+  br i1 %99, label %100, label %102, !dbg !85
 
-102:                                              ; preds = %97
-  %103 = load i64*, i64** %96, align 8, !dbg !88, !tbaa !27
-  br label %rb_array_const_ptr_transient.exit.i4.i, !dbg !88
+100:                                              ; preds = %96
+  %101 = load i64*, i64** %82, align 8, !dbg !85, !tbaa !27
+  br label %102, !dbg !85
 
-rb_array_const_ptr_transient.exit.i4.i:           ; preds = %102, %97
-  %104 = phi i64* [ %103, %102 ], [ %95, %97 ], !dbg !88
-  %105 = getelementptr inbounds i64, i64* %104, i64 %98, !dbg !88
-  %106 = load i64, i64* %105, align 8, !dbg !88, !tbaa !6
-  store i64 %106, i64* %1, align 8, !dbg !88, !tbaa !6
-  %107 = call i64 @"func_<root>.17<static-init>$152$block_1"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %1, i64 undef) #13, !dbg !88
-  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %93) #13, !dbg !88
-  %108 = add nuw nsw i64 %98, 1, !dbg !88
-  %109 = load i64, i64* %79, align 8, !dbg !88, !tbaa !25
-  %110 = and i64 %109, 8192, !dbg !88
-  %111 = icmp eq i64 %110, 0, !dbg !88
-  br i1 %111, label %115, label %112, !dbg !88
+102:                                              ; preds = %100, %96
+  %103 = phi i64* [ %101, %100 ], [ %80, %96 ], !dbg !85
+  %104 = getelementptr inbounds i64, i64* %103, i64 %84, !dbg !85
+  %105 = load i64, i64* %104, align 8, !dbg !85, !tbaa !6
+  store i64 %105, i64* %2, align 8, !dbg !85, !tbaa !6
+  %106 = call i64 @"func_<root>.17<static-init>$152$block_1"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %2, i64 undef) #14, !dbg !85
+  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %81) #14, !dbg !85
+  %107 = add nuw nsw i64 %84, 1, !dbg !85
+  br label %83, !dbg !85, !llvm.loop !88
 
-112:                                              ; preds = %rb_array_const_ptr_transient.exit.i4.i
-  %113 = lshr i64 %109, 15, !dbg !88
-  %114 = and i64 %113, 3, !dbg !88
-  br label %rb_array_len.exit.i5.i, !dbg !88
+forward_sorbet_rb_array_each_withBlock.exit.i:    ; preds = %93
+  call void @sorbet_popFrame() #14, !dbg !85
+  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %60) #14, !dbg !80
+  %108 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !80, !tbaa !15
+  %109 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %108, i64 0, i32 5, !dbg !80
+  %110 = load i32, i32* %109, align 8, !dbg !80, !tbaa !37
+  %111 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %108, i64 0, i32 6, !dbg !80
+  %112 = load i32, i32* %111, align 4, !dbg !80, !tbaa !38
+  %113 = xor i32 %112, -1, !dbg !80
+  %114 = and i32 %113, %110, !dbg !80
+  %115 = icmp eq i32 %114, 0, !dbg !80
+  br i1 %115, label %120, label %116, !dbg !80, !prof !31
 
-115:                                              ; preds = %rb_array_const_ptr_transient.exit.i4.i
-  %116 = load i64, i64* %95, align 8, !dbg !88, !tbaa !27
-  br label %rb_array_len.exit.i5.i, !dbg !88
+116:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.exit.i
+  %117 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %108, i64 0, i32 8, !dbg !80
+  %118 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %117, align 8, !dbg !80, !tbaa !39
+  %119 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %118, i32 noundef 0) #14, !dbg !80
+  br label %120, !dbg !80
 
-rb_array_len.exit.i5.i:                           ; preds = %115, %112
-  %117 = phi i64 [ %114, %112 ], [ %116, %115 ], !dbg !88
-  %118 = icmp sgt i64 %117, %108, !dbg !88
-  br i1 %118, label %97, label %forward_sorbet_rb_array_each_withBlock.exit.i, !dbg !88, !llvm.loop !91
-
-forward_sorbet_rb_array_each_withBlock.exit.i:    ; preds = %rb_array_len.exit.i5.i, %rb_array_len.exit1.i3.i
-  call void @sorbet_popFrame() #13, !dbg !88
-  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %60) #13, !dbg !80
-  %119 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !80, !tbaa !15
-  %120 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %119, i64 0, i32 5, !dbg !80
-  %121 = load i32, i32* %120, align 8, !dbg !80, !tbaa !37
-  %122 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %119, i64 0, i32 6, !dbg !80
-  %123 = load i32, i32* %122, align 4, !dbg !80, !tbaa !38
-  %124 = xor i32 %123, -1, !dbg !80
-  %125 = and i32 %124, %121, !dbg !80
-  %126 = icmp eq i32 %125, 0, !dbg !80
-  br i1 %126, label %rb_check_arity.1.exit.i8.i, label %127, !dbg !80, !prof !31
-
-127:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.exit.i
-  %128 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %119, i64 0, i32 8, !dbg !80
-  %129 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %128, align 8, !dbg !80, !tbaa !39
-  %130 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %129, i32 noundef 0) #13, !dbg !80
-  br label %rb_check_arity.1.exit.i8.i, !dbg !80
-
-rb_check_arity.1.exit.i8.i:                       ; preds = %127, %forward_sorbet_rb_array_each_withBlock.exit.i
+120:                                              ; preds = %116, %forward_sorbet_rb_array_each_withBlock.exit.i
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %53, align 8, !dbg !80, !tbaa !15
-  %rubyId_each65.i = load i64, i64* @rubyIdPrecomputed_each, align 8, !dbg !93
-  %131 = load i64, i64* @"func_<root>.17<static-init>$152$block_2_ifunc", align 8, !dbg !93
-  %132 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %131) #13, !dbg !93
-  %133 = bitcast %struct.sorbet_inlineIntrinsicEnv* %5 to i8*, !dbg !93
-  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %133) #13, !dbg !93
-  %134 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %5, i64 0, i32 0, !dbg !93
-  store i64 %57, i64* %134, align 8, !dbg !93, !tbaa !81
-  %135 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %5, i64 0, i32 1, !dbg !93
-  store i64 %rubyId_each65.i, i64* %135, align 8, !dbg !93, !tbaa !83
-  %136 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %5, i64 0, i32 2, !dbg !93
-  store i32 0, i32* %136, align 8, !dbg !93, !tbaa !84
-  %137 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %5, i64 0, i32 3, !dbg !93
-  %138 = bitcast i64** %137 to i8*, !dbg !93
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %138, i8 0, i64 16, i1 false) #13, !dbg !93
-  %139 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !93, !tbaa !15
-  %140 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %139, i64 0, i32 2, !dbg !93
-  %141 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %140, align 8, !dbg !93, !tbaa !17
-  %142 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %141, i64 0, i32 3, !dbg !93
-  %143 = bitcast i64* %142 to %struct.rb_captured_block*, !dbg !93
-  %144 = getelementptr inbounds i64, i64* %142, i64 2, !dbg !93
-  %145 = bitcast i64* %144 to %struct.vm_ifunc**, !dbg !93
-  store %struct.vm_ifunc* %132, %struct.vm_ifunc** %145, align 8, !dbg !93, !tbaa !27
-  call void @llvm.experimental.noalias.scope.decl(metadata !94) #13, !dbg !93
-  %146 = ptrtoint %struct.rb_captured_block* %143 to i64, !dbg !93
-  %147 = or i64 %146, 3, !dbg !93
-  %148 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %139, i64 0, i32 17, !dbg !93
-  %149 = and i64 %147, -4, !dbg !97
-  %150 = inttoptr i64 %149 to %struct.rb_captured_block*, !dbg !97
-  store i64 0, i64* %148, align 8, !dbg !97, !tbaa !90
-  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %150) #13, !dbg !97
-  %151 = load i64, i64* %79, align 8, !dbg !97, !tbaa !25
-  %152 = and i64 %151, 8192, !dbg !97
-  %153 = icmp eq i64 %152, 0, !dbg !97
-  br i1 %153, label %157, label %154, !dbg !97
+  %rubyId_each65.i = load i64, i64* @rubyIdPrecomputed_each, align 8, !dbg !90
+  %121 = load i64, i64* @"func_<root>.17<static-init>$152$block_2_ifunc", align 8, !dbg !90
+  %122 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %121) #14, !dbg !90
+  %123 = bitcast %struct.sorbet_inlineIntrinsicEnv* %4 to i8*, !dbg !90
+  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %123) #14, !dbg !90
+  %124 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %4, i64 0, i32 0, !dbg !90
+  store i64 %57, i64* %124, align 8, !dbg !90, !tbaa !81
+  %125 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %4, i64 0, i32 1, !dbg !90
+  store i64 %rubyId_each65.i, i64* %125, align 8, !dbg !90, !tbaa !83
+  %126 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %4, i64 0, i32 2, !dbg !90
+  store i32 0, i32* %126, align 8, !dbg !90, !tbaa !84
+  %127 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %4, i64 0, i32 3, !dbg !90
+  %128 = bitcast i64** %127 to i8*, !dbg !90
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %128, i8 0, i64 16, i1 false) #14, !dbg !90
+  %129 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !90, !tbaa !15
+  %130 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %129, i64 0, i32 2, !dbg !90
+  %131 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %130, align 8, !dbg !90, !tbaa !17
+  %132 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %131, i64 0, i32 3, !dbg !90
+  %133 = getelementptr inbounds i64, i64* %132, i64 2, !dbg !90
+  %134 = bitcast i64* %133 to %struct.vm_ifunc**, !dbg !90
+  store %struct.vm_ifunc* %122, %struct.vm_ifunc** %134, align 8, !dbg !90, !tbaa !27
+  %135 = ptrtoint i64* %132 to i64, !dbg !90
+  %136 = or i64 %135, 3, !dbg !90
+  %137 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %129, i64 0, i32 17, !dbg !90
+  %138 = and i64 %136, -4, !dbg !91
+  %139 = inttoptr i64 %138 to %struct.rb_captured_block*, !dbg !91
+  store i64 0, i64* %137, align 8, !dbg !91, !tbaa !87
+  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %139) #14, !dbg !91
+  br label %140, !dbg !91
 
-154:                                              ; preds = %rb_check_arity.1.exit.i8.i
-  %155 = lshr i64 %151, 15, !dbg !97
-  %156 = and i64 %155, 3, !dbg !97
-  br label %rb_array_len.exit1.i9.i, !dbg !97
+140:                                              ; preds = %.thread15, %120
+  %141 = phi i64 [ %171, %.thread15 ], [ 0, %120 ], !dbg !91
+  %142 = load i64, i64* %78, align 8, !dbg !91, !tbaa !25
+  %143 = and i64 %142, 8192, !dbg !91
+  %144 = icmp eq i64 %143, 0, !dbg !91
+  br i1 %144, label %145, label %.thread, !dbg !91
 
-157:                                              ; preds = %rb_check_arity.1.exit.i8.i
-  %158 = inttoptr i64 %57 to %struct.RArray*, !dbg !97
-  %159 = getelementptr inbounds %struct.RArray, %struct.RArray* %158, i64 0, i32 1, i32 0, i32 0, !dbg !97
-  %160 = load i64, i64* %159, align 8, !dbg !97, !tbaa !27
-  br label %rb_array_len.exit1.i9.i, !dbg !97
+145:                                              ; preds = %140
+  %146 = load i64, i64* %80, align 8, !dbg !91, !tbaa !27
+  %147 = icmp sgt i64 %146, %141, !dbg !91
+  br i1 %147, label %151, label %forward_sorbet_rb_array_each_withBlock.1.exit.i, !dbg !91
 
-rb_array_len.exit1.i9.i:                          ; preds = %157, %154
-  %161 = phi i64 [ %156, %154 ], [ %160, %157 ], !dbg !97
-  %162 = icmp sgt i64 %161, 0, !dbg !97
-  br i1 %162, label %163, label %forward_sorbet_rb_array_each_withBlock.1.exit.i, !dbg !97
+.thread:                                          ; preds = %140
+  %148 = lshr i64 %142, 15, !dbg !91
+  %149 = and i64 %148, 3, !dbg !91
+  %150 = icmp sgt i64 %149, %141, !dbg !91
+  br i1 %150, label %.thread15, label %forward_sorbet_rb_array_each_withBlock.1.exit.i, !dbg !91
 
-163:                                              ; preds = %rb_array_len.exit1.i9.i
-  %164 = inttoptr i64 %57 to %struct.RArray*, !dbg !93
-  %165 = getelementptr inbounds %struct.RArray, %struct.RArray* %164, i64 0, i32 1, i32 0, i32 0, !dbg !93
-  %166 = getelementptr inbounds %struct.RArray, %struct.RArray* %164, i64 0, i32 1, i32 0, i32 2, !dbg !93
-  br label %167, !dbg !97
+151:                                              ; preds = %145
+  %152 = load i64*, i64** %82, align 8, !dbg !91, !tbaa !27
+  br label %.thread15, !dbg !91
 
-167:                                              ; preds = %rb_array_len.exit.i11.i, %163
-  %168 = phi i64 [ 0, %163 ], [ %192, %rb_array_len.exit.i11.i ], !dbg !97
-  %169 = load i64, i64* %79, align 8, !dbg !97, !tbaa !25
-  %170 = and i64 %169, 8192, !dbg !97
-  %171 = icmp eq i64 %170, 0, !dbg !97
-  br i1 %171, label %172, label %rb_array_const_ptr_transient.exit.i10.i, !dbg !97
+.thread15:                                        ; preds = %.thread, %151
+  %153 = phi i64* [ %152, %151 ], [ %80, %.thread ], !dbg !91
+  %154 = getelementptr inbounds i64, i64* %153, i64 %141, !dbg !91
+  %155 = load i64, i64* %154, align 8, !dbg !91, !tbaa !6
+  call void @llvm.experimental.noalias.scope.decl(metadata !93) #14, !dbg !91
+  %156 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !90, !tbaa !15, !noalias !93
+  %157 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %156, i64 0, i32 2, !dbg !90
+  %158 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %157, align 8, !dbg !90, !tbaa !17, !noalias !93
+  %159 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %158, i64 0, i32 3, !dbg !90
+  %160 = load i64, i64* %159, align 8, !dbg !90, !tbaa !42, !noalias !93
+  %stackFrame.i.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152$block_2", align 8, !dbg !90, !noalias !93
+  %161 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %158, i64 0, i32 2, !dbg !90
+  store %struct.rb_iseq_struct* %stackFrame.i.i.i, %struct.rb_iseq_struct** %161, align 8, !dbg !90, !tbaa !21, !noalias !93
+  %162 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %158, i64 0, i32 4, !dbg !90
+  %163 = load i64*, i64** %162, align 8, !dbg !90, !tbaa !23, !noalias !93
+  %164 = load i64, i64* %163, align 8, !dbg !90, !tbaa !6, !noalias !93
+  %165 = and i64 %164, -129, !dbg !90
+  store i64 %165, i64* %163, align 8, !dbg !90, !tbaa !6, !noalias !93
+  %166 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %158, i64 0, i32 0, !dbg !90
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %166, align 8, !dbg !96, !tbaa !15, !noalias !93
+  %167 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %158, i64 0, i32 1, !dbg !98
+  %168 = load i64*, i64** %167, align 8, !dbg !98
+  store i64 %160, i64* %168, align 8, !dbg !98, !tbaa !6
+  %169 = getelementptr inbounds i64, i64* %168, i64 1, !dbg !98
+  store i64 %155, i64* %169, align 8, !dbg !98, !tbaa !6
+  %170 = getelementptr inbounds i64, i64* %169, i64 1, !dbg !98
+  store i64* %170, i64** %167, align 8, !dbg !98
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p, i64 0), !dbg !98
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %166, align 8, !dbg !98, !tbaa !15, !noalias !93
+  %171 = add nuw nsw i64 %141, 1, !dbg !91
+  br label %140, !dbg !91, !llvm.loop !99
 
-172:                                              ; preds = %167
-  %173 = load i64*, i64** %166, align 8, !dbg !97, !tbaa !27
-  br label %rb_array_const_ptr_transient.exit.i10.i, !dbg !97
+forward_sorbet_rb_array_each_withBlock.1.exit.i:  ; preds = %.thread, %145
+  call void @sorbet_popFrame() #14, !dbg !91
+  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %123) #14, !dbg !90
+  %172 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !90, !tbaa !15
+  %173 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %172, i64 0, i32 5, !dbg !90
+  %174 = load i32, i32* %173, align 8, !dbg !90, !tbaa !37
+  %175 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %172, i64 0, i32 6, !dbg !90
+  %176 = load i32, i32* %175, align 4, !dbg !90, !tbaa !38
+  %177 = xor i32 %176, -1, !dbg !90
+  %178 = and i32 %177, %174, !dbg !90
+  %179 = icmp eq i32 %178, 0, !dbg !90
+  br i1 %179, label %184, label %180, !dbg !90, !prof !31
 
-rb_array_const_ptr_transient.exit.i10.i:          ; preds = %172, %167
-  %174 = phi i64* [ %173, %172 ], [ %165, %167 ], !dbg !97
-  %175 = getelementptr inbounds i64, i64* %174, i64 %168, !dbg !97
-  %176 = load i64, i64* %175, align 8, !dbg !97, !tbaa !6
-  call void @llvm.experimental.noalias.scope.decl(metadata !99) #13, !dbg !97
-  %177 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !93, !tbaa !15, !noalias !99
-  %178 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %177, i64 0, i32 2, !dbg !93
-  %179 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %178, align 8, !dbg !93, !tbaa !17, !noalias !99
-  %180 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %179, i64 0, i32 3, !dbg !93
-  %181 = load i64, i64* %180, align 8, !dbg !93, !tbaa !42, !noalias !99
-  %stackFrame.i.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152$block_2", align 8, !dbg !93, !noalias !99
-  %182 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %179, i64 0, i32 2, !dbg !93
-  store %struct.rb_iseq_struct* %stackFrame.i.i.i, %struct.rb_iseq_struct** %182, align 8, !dbg !93, !tbaa !21, !noalias !99
-  %183 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %179, i64 0, i32 4, !dbg !93
-  %184 = load i64*, i64** %183, align 8, !dbg !93, !tbaa !23, !noalias !99
-  %185 = load i64, i64* %184, align 8, !dbg !93, !tbaa !6, !noalias !99
-  %186 = and i64 %185, -129, !dbg !93
-  store i64 %186, i64* %184, align 8, !dbg !93, !tbaa !6, !noalias !99
-  %187 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %179, i64 0, i32 0, !dbg !93
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %187, align 8, !dbg !102, !tbaa !15, !noalias !99
-  %188 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %179, i64 0, i32 1, !dbg !104
-  %189 = load i64*, i64** %188, align 8, !dbg !104
-  store i64 %181, i64* %189, align 8, !dbg !104, !tbaa !6
-  %190 = getelementptr inbounds i64, i64* %189, i64 1, !dbg !104
-  store i64 %176, i64* %190, align 8, !dbg !104, !tbaa !6
-  %191 = getelementptr inbounds i64, i64* %190, i64 1, !dbg !104
-  store i64* %191, i64** %188, align 8, !dbg !104
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p, i64 0), !dbg !104
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %187, align 8, !dbg !104, !tbaa !15, !noalias !99
-  %192 = add nuw nsw i64 %168, 1, !dbg !97
-  %193 = load i64, i64* %79, align 8, !dbg !97, !tbaa !25
-  %194 = and i64 %193, 8192, !dbg !97
-  %195 = icmp eq i64 %194, 0, !dbg !97
-  br i1 %195, label %199, label %196, !dbg !97
+180:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.1.exit.i
+  %181 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %172, i64 0, i32 8, !dbg !90
+  %182 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %181, align 8, !dbg !90, !tbaa !39
+  %183 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %182, i32 noundef 0) #14, !dbg !90
+  br label %184, !dbg !90
 
-196:                                              ; preds = %rb_array_const_ptr_transient.exit.i10.i
-  %197 = lshr i64 %193, 15, !dbg !97
-  %198 = and i64 %197, 3, !dbg !97
-  br label %rb_array_len.exit.i11.i, !dbg !97
+184:                                              ; preds = %180, %forward_sorbet_rb_array_each_withBlock.1.exit.i
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %53, align 8, !dbg !90, !tbaa !15
+  %rubyId_each77.i = load i64, i64* @rubyIdPrecomputed_each, align 8, !dbg !100
+  %185 = load i64, i64* @"func_<root>.17<static-init>$152$block_3_ifunc", align 8, !dbg !100
+  %186 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %185) #14, !dbg !100
+  %187 = bitcast %struct.sorbet_inlineIntrinsicEnv* %5 to i8*, !dbg !100
+  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %187) #14, !dbg !100
+  %188 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %5, i64 0, i32 0, !dbg !100
+  store i64 %57, i64* %188, align 8, !dbg !100, !tbaa !81
+  %189 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %5, i64 0, i32 1, !dbg !100
+  store i64 %rubyId_each77.i, i64* %189, align 8, !dbg !100, !tbaa !83
+  %190 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %5, i64 0, i32 2, !dbg !100
+  store i32 0, i32* %190, align 8, !dbg !100, !tbaa !84
+  %191 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %5, i64 0, i32 3, !dbg !100
+  %192 = bitcast i64** %191 to i8*, !dbg !100
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %192, i8 0, i64 16, i1 false) #14, !dbg !100
+  %193 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !100, !tbaa !15
+  %194 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %193, i64 0, i32 2, !dbg !100
+  %195 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %194, align 8, !dbg !100, !tbaa !17
+  %196 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %195, i64 0, i32 3, !dbg !100
+  %197 = getelementptr inbounds i64, i64* %196, i64 2, !dbg !100
+  %198 = bitcast i64* %197 to %struct.vm_ifunc**, !dbg !100
+  store %struct.vm_ifunc* %186, %struct.vm_ifunc** %198, align 8, !dbg !100, !tbaa !27
+  %199 = ptrtoint i64* %196 to i64, !dbg !100
+  %200 = or i64 %199, 3, !dbg !100
+  %201 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %193, i64 0, i32 17, !dbg !100
+  %202 = and i64 %200, -4, !dbg !101
+  %203 = inttoptr i64 %202 to %struct.rb_captured_block*, !dbg !101
+  store i64 0, i64* %201, align 8, !dbg !101, !tbaa !87
+  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %203) #14, !dbg !101
+  br label %204, !dbg !101
 
-199:                                              ; preds = %rb_array_const_ptr_transient.exit.i10.i
-  %200 = load i64, i64* %165, align 8, !dbg !97, !tbaa !27
-  br label %rb_array_len.exit.i11.i, !dbg !97
+204:                                              ; preds = %.thread17, %184
+  %205 = phi i64 [ %235, %.thread17 ], [ 0, %184 ], !dbg !101
+  %206 = load i64, i64* %78, align 8, !dbg !101, !tbaa !25
+  %207 = and i64 %206, 8192, !dbg !101
+  %208 = icmp eq i64 %207, 0, !dbg !101
+  br i1 %208, label %209, label %.thread16, !dbg !101
 
-rb_array_len.exit.i11.i:                          ; preds = %199, %196
-  %201 = phi i64 [ %198, %196 ], [ %200, %199 ], !dbg !97
-  %202 = icmp sgt i64 %201, %192, !dbg !97
-  br i1 %202, label %167, label %forward_sorbet_rb_array_each_withBlock.1.exit.i, !dbg !97, !llvm.loop !105
+209:                                              ; preds = %204
+  %210 = load i64, i64* %80, align 8, !dbg !101, !tbaa !27
+  %211 = icmp sgt i64 %210, %205, !dbg !101
+  br i1 %211, label %215, label %forward_sorbet_rb_array_each_withBlock.3.exit.i, !dbg !101
 
-forward_sorbet_rb_array_each_withBlock.1.exit.i:  ; preds = %rb_array_len.exit.i11.i, %rb_array_len.exit1.i9.i
-  call void @sorbet_popFrame() #13, !dbg !97
-  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %133) #13, !dbg !93
-  %203 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !93, !tbaa !15
-  %204 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %203, i64 0, i32 5, !dbg !93
-  %205 = load i32, i32* %204, align 8, !dbg !93, !tbaa !37
-  %206 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %203, i64 0, i32 6, !dbg !93
-  %207 = load i32, i32* %206, align 4, !dbg !93, !tbaa !38
-  %208 = xor i32 %207, -1, !dbg !93
-  %209 = and i32 %208, %205, !dbg !93
-  %210 = icmp eq i32 %209, 0, !dbg !93
-  br i1 %210, label %rb_check_arity.1.exit.i14.i, label %211, !dbg !93, !prof !31
+.thread16:                                        ; preds = %204
+  %212 = lshr i64 %206, 15, !dbg !101
+  %213 = and i64 %212, 3, !dbg !101
+  %214 = icmp sgt i64 %213, %205, !dbg !101
+  br i1 %214, label %.thread17, label %forward_sorbet_rb_array_each_withBlock.3.exit.i, !dbg !101
 
-211:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.1.exit.i
-  %212 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %203, i64 0, i32 8, !dbg !93
-  %213 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %212, align 8, !dbg !93, !tbaa !39
-  %214 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %213, i32 noundef 0) #13, !dbg !93
-  br label %rb_check_arity.1.exit.i14.i, !dbg !93
+215:                                              ; preds = %209
+  %216 = load i64*, i64** %82, align 8, !dbg !101, !tbaa !27
+  br label %.thread17, !dbg !101
 
-rb_check_arity.1.exit.i14.i:                      ; preds = %211, %forward_sorbet_rb_array_each_withBlock.1.exit.i
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %53, align 8, !dbg !93, !tbaa !15
-  %rubyId_each77.i = load i64, i64* @rubyIdPrecomputed_each, align 8, !dbg !106
-  %215 = load i64, i64* @"func_<root>.17<static-init>$152$block_3_ifunc", align 8, !dbg !106
-  %216 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %215) #13, !dbg !106
-  %217 = bitcast %struct.sorbet_inlineIntrinsicEnv* %4 to i8*, !dbg !106
-  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %217) #13, !dbg !106
-  %218 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %4, i64 0, i32 0, !dbg !106
-  store i64 %57, i64* %218, align 8, !dbg !106, !tbaa !81
-  %219 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %4, i64 0, i32 1, !dbg !106
-  store i64 %rubyId_each77.i, i64* %219, align 8, !dbg !106, !tbaa !83
-  %220 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %4, i64 0, i32 2, !dbg !106
-  store i32 0, i32* %220, align 8, !dbg !106, !tbaa !84
-  %221 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %4, i64 0, i32 3, !dbg !106
-  %222 = bitcast i64** %221 to i8*, !dbg !106
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %222, i8 0, i64 16, i1 false) #13, !dbg !106
-  %223 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !106, !tbaa !15
-  %224 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %223, i64 0, i32 2, !dbg !106
-  %225 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %224, align 8, !dbg !106, !tbaa !17
-  %226 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %225, i64 0, i32 3, !dbg !106
-  %227 = bitcast i64* %226 to %struct.rb_captured_block*, !dbg !106
-  %228 = getelementptr inbounds i64, i64* %226, i64 2, !dbg !106
-  %229 = bitcast i64* %228 to %struct.vm_ifunc**, !dbg !106
-  store %struct.vm_ifunc* %216, %struct.vm_ifunc** %229, align 8, !dbg !106, !tbaa !27
-  call void @llvm.experimental.noalias.scope.decl(metadata !107) #13, !dbg !106
-  %230 = ptrtoint %struct.rb_captured_block* %227 to i64, !dbg !106
-  %231 = or i64 %230, 3, !dbg !106
-  %232 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %223, i64 0, i32 17, !dbg !106
-  %233 = and i64 %231, -4, !dbg !110
-  %234 = inttoptr i64 %233 to %struct.rb_captured_block*, !dbg !110
-  store i64 0, i64* %232, align 8, !dbg !110, !tbaa !90
-  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %234) #13, !dbg !110
-  %235 = load i64, i64* %79, align 8, !dbg !110, !tbaa !25
-  %236 = and i64 %235, 8192, !dbg !110
-  %237 = icmp eq i64 %236, 0, !dbg !110
-  br i1 %237, label %241, label %238, !dbg !110
+.thread17:                                        ; preds = %.thread16, %215
+  %217 = phi i64* [ %216, %215 ], [ %80, %.thread16 ], !dbg !101
+  %218 = getelementptr inbounds i64, i64* %217, i64 %205, !dbg !101
+  %219 = load i64, i64* %218, align 8, !dbg !101, !tbaa !6
+  call void @llvm.experimental.noalias.scope.decl(metadata !103) #14, !dbg !101
+  %220 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !100, !tbaa !15, !noalias !103
+  %221 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %220, i64 0, i32 2, !dbg !100
+  %222 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %221, align 8, !dbg !100, !tbaa !17, !noalias !103
+  %223 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %222, i64 0, i32 3, !dbg !100
+  %224 = load i64, i64* %223, align 8, !dbg !100, !tbaa !42, !noalias !103
+  %stackFrame.i.i1.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152$block_3", align 8, !dbg !100, !noalias !103
+  %225 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %222, i64 0, i32 2, !dbg !100
+  store %struct.rb_iseq_struct* %stackFrame.i.i1.i, %struct.rb_iseq_struct** %225, align 8, !dbg !100, !tbaa !21, !noalias !103
+  %226 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %222, i64 0, i32 4, !dbg !100
+  %227 = load i64*, i64** %226, align 8, !dbg !100, !tbaa !23, !noalias !103
+  %228 = load i64, i64* %227, align 8, !dbg !100, !tbaa !6, !noalias !103
+  %229 = and i64 %228, -129, !dbg !100
+  store i64 %229, i64* %227, align 8, !dbg !100, !tbaa !6, !noalias !103
+  %230 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %222, i64 0, i32 0, !dbg !100
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %230, align 8, !dbg !100, !tbaa !15, !noalias !103
+  %231 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %222, i64 0, i32 1, !dbg !106
+  %232 = load i64*, i64** %231, align 8, !dbg !106
+  store i64 %224, i64* %232, align 8, !dbg !106, !tbaa !6
+  %233 = getelementptr inbounds i64, i64* %232, i64 1, !dbg !106
+  store i64 %219, i64* %233, align 8, !dbg !106, !tbaa !6
+  %234 = getelementptr inbounds i64, i64* %233, i64 1, !dbg !106
+  store i64* %234, i64** %231, align 8, !dbg !106
+  %send14 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.5, i64 0), !dbg !106
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %230, align 8, !dbg !106, !tbaa !15, !noalias !103
+  %235 = add nuw nsw i64 %205, 1, !dbg !101
+  br label %204, !dbg !101, !llvm.loop !108
 
-238:                                              ; preds = %rb_check_arity.1.exit.i14.i
-  %239 = lshr i64 %235, 15, !dbg !110
-  %240 = and i64 %239, 3, !dbg !110
-  br label %rb_array_len.exit1.i15.i, !dbg !110
+forward_sorbet_rb_array_each_withBlock.3.exit.i:  ; preds = %.thread16, %209
+  call void @sorbet_popFrame() #14, !dbg !101
+  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %187) #14, !dbg !100
+  %236 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !100, !tbaa !15
+  %237 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %236, i64 0, i32 5, !dbg !100
+  %238 = load i32, i32* %237, align 8, !dbg !100, !tbaa !37
+  %239 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %236, i64 0, i32 6, !dbg !100
+  %240 = load i32, i32* %239, align 4, !dbg !100, !tbaa !38
+  %241 = xor i32 %240, -1, !dbg !100
+  %242 = and i32 %241, %238, !dbg !100
+  %243 = icmp eq i32 %242, 0, !dbg !100
+  br i1 %243, label %248, label %244, !dbg !100, !prof !31
 
-241:                                              ; preds = %rb_check_arity.1.exit.i14.i
-  %242 = inttoptr i64 %57 to %struct.RArray*, !dbg !110
-  %243 = getelementptr inbounds %struct.RArray, %struct.RArray* %242, i64 0, i32 1, i32 0, i32 0, !dbg !110
-  %244 = load i64, i64* %243, align 8, !dbg !110, !tbaa !27
-  br label %rb_array_len.exit1.i15.i, !dbg !110
+244:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.3.exit.i
+  %245 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %236, i64 0, i32 8, !dbg !100
+  %246 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %245, align 8, !dbg !100, !tbaa !39
+  %247 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %246, i32 noundef 0) #14, !dbg !100
+  br label %248, !dbg !100
 
-rb_array_len.exit1.i15.i:                         ; preds = %241, %238
-  %245 = phi i64 [ %240, %238 ], [ %244, %241 ], !dbg !110
-  %246 = icmp sgt i64 %245, 0, !dbg !110
-  br i1 %246, label %247, label %forward_sorbet_rb_array_each_withBlock.3.exit.i, !dbg !110
+248:                                              ; preds = %244, %forward_sorbet_rb_array_each_withBlock.3.exit.i
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %53, align 8, !dbg !100, !tbaa !15
+  %rubyId_each89.i = load i64, i64* @rubyIdPrecomputed_each, align 8, !dbg !109
+  %249 = load i64, i64* @"func_<root>.17<static-init>$152$block_4_ifunc", align 8, !dbg !109
+  %250 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %249) #14, !dbg !109
+  %251 = bitcast %struct.sorbet_inlineIntrinsicEnv* %6 to i8*, !dbg !109
+  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %251) #14, !dbg !109
+  %252 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %6, i64 0, i32 0, !dbg !109
+  store i64 %57, i64* %252, align 8, !dbg !109, !tbaa !81
+  %253 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %6, i64 0, i32 1, !dbg !109
+  store i64 %rubyId_each89.i, i64* %253, align 8, !dbg !109, !tbaa !83
+  %254 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %6, i64 0, i32 2, !dbg !109
+  store i32 0, i32* %254, align 8, !dbg !109, !tbaa !84
+  %255 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %6, i64 0, i32 3, !dbg !109
+  %256 = bitcast i64** %255 to i8*, !dbg !109
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %256, i8 0, i64 16, i1 false) #14, !dbg !109
+  %257 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !109, !tbaa !15
+  %258 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %257, i64 0, i32 2, !dbg !109
+  %259 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %258, align 8, !dbg !109, !tbaa !17
+  %260 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %259, i64 0, i32 3, !dbg !109
+  %261 = getelementptr inbounds i64, i64* %260, i64 2, !dbg !109
+  %262 = bitcast i64* %261 to %struct.vm_ifunc**, !dbg !109
+  store %struct.vm_ifunc* %250, %struct.vm_ifunc** %262, align 8, !dbg !109, !tbaa !27
+  %263 = ptrtoint i64* %260 to i64, !dbg !109
+  %264 = or i64 %263, 3, !dbg !109
+  %265 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %257, i64 0, i32 17, !dbg !109
+  %266 = and i64 %264, -4, !dbg !110
+  %267 = inttoptr i64 %266 to %struct.rb_captured_block*, !dbg !110
+  store i64 0, i64* %265, align 8, !dbg !110, !tbaa !87
+  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %267) #14, !dbg !110
+  %268 = bitcast i64* %1 to i8*, !dbg !110
+  br label %269, !dbg !110
 
-247:                                              ; preds = %rb_array_len.exit1.i15.i
-  %248 = inttoptr i64 %57 to %struct.RArray*, !dbg !106
-  %249 = getelementptr inbounds %struct.RArray, %struct.RArray* %248, i64 0, i32 1, i32 0, i32 0, !dbg !106
-  %250 = getelementptr inbounds %struct.RArray, %struct.RArray* %248, i64 0, i32 1, i32 0, i32 2, !dbg !106
-  br label %251, !dbg !110
+269:                                              ; preds = %288, %248
+  %270 = phi i64 [ %293, %288 ], [ 0, %248 ], !dbg !110
+  %271 = load i64, i64* %78, align 8, !dbg !110, !tbaa !25
+  %272 = and i64 %271, 8192, !dbg !110
+  %273 = icmp eq i64 %272, 0, !dbg !110
+  br i1 %273, label %277, label %274, !dbg !110
 
-251:                                              ; preds = %rb_array_len.exit.i18.i, %247
-  %252 = phi i64 [ 0, %247 ], [ %276, %rb_array_len.exit.i18.i ], !dbg !110
-  %253 = load i64, i64* %79, align 8, !dbg !110, !tbaa !25
-  %254 = and i64 %253, 8192, !dbg !110
-  %255 = icmp eq i64 %254, 0, !dbg !110
-  br i1 %255, label %256, label %rb_array_const_ptr_transient.exit.i17.i, !dbg !110
+274:                                              ; preds = %269
+  %275 = lshr i64 %271, 15, !dbg !110
+  %276 = and i64 %275, 3, !dbg !110
+  br label %279, !dbg !110
 
-256:                                              ; preds = %251
-  %257 = load i64*, i64** %250, align 8, !dbg !110, !tbaa !27
-  br label %rb_array_const_ptr_transient.exit.i17.i, !dbg !110
+277:                                              ; preds = %269
+  %278 = load i64, i64* %80, align 8, !dbg !110, !tbaa !27
+  br label %279, !dbg !110
 
-rb_array_const_ptr_transient.exit.i17.i:          ; preds = %256, %251
-  %258 = phi i64* [ %257, %256 ], [ %249, %251 ], !dbg !110
-  %259 = getelementptr inbounds i64, i64* %258, i64 %252, !dbg !110
-  %260 = load i64, i64* %259, align 8, !dbg !110, !tbaa !6
-  call void @llvm.experimental.noalias.scope.decl(metadata !112) #13, !dbg !110
-  %261 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !106, !tbaa !15, !noalias !112
-  %262 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %261, i64 0, i32 2, !dbg !106
-  %263 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %262, align 8, !dbg !106, !tbaa !17, !noalias !112
-  %264 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %263, i64 0, i32 3, !dbg !106
-  %265 = load i64, i64* %264, align 8, !dbg !106, !tbaa !42, !noalias !112
-  %stackFrame.i.i16.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152$block_3", align 8, !dbg !106, !noalias !112
-  %266 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %263, i64 0, i32 2, !dbg !106
-  store %struct.rb_iseq_struct* %stackFrame.i.i16.i, %struct.rb_iseq_struct** %266, align 8, !dbg !106, !tbaa !21, !noalias !112
-  %267 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %263, i64 0, i32 4, !dbg !106
-  %268 = load i64*, i64** %267, align 8, !dbg !106, !tbaa !23, !noalias !112
-  %269 = load i64, i64* %268, align 8, !dbg !106, !tbaa !6, !noalias !112
-  %270 = and i64 %269, -129, !dbg !106
-  store i64 %270, i64* %268, align 8, !dbg !106, !tbaa !6, !noalias !112
-  %271 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %263, i64 0, i32 0, !dbg !106
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %271, align 8, !dbg !106, !tbaa !15, !noalias !112
-  %272 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %263, i64 0, i32 1, !dbg !115
-  %273 = load i64*, i64** %272, align 8, !dbg !115
-  store i64 %265, i64* %273, align 8, !dbg !115, !tbaa !6
-  %274 = getelementptr inbounds i64, i64* %273, i64 1, !dbg !115
-  store i64 %260, i64* %274, align 8, !dbg !115, !tbaa !6
-  %275 = getelementptr inbounds i64, i64* %274, i64 1, !dbg !115
-  store i64* %275, i64** %272, align 8, !dbg !115
-  %send14 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.5, i64 0), !dbg !115
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %271, align 8, !dbg !115, !tbaa !15, !noalias !112
-  %276 = add nuw nsw i64 %252, 1, !dbg !110
-  %277 = load i64, i64* %79, align 8, !dbg !110, !tbaa !25
-  %278 = and i64 %277, 8192, !dbg !110
-  %279 = icmp eq i64 %278, 0, !dbg !110
-  br i1 %279, label %283, label %280, !dbg !110
+279:                                              ; preds = %277, %274
+  %280 = phi i64 [ %276, %274 ], [ %278, %277 ], !dbg !110
+  %281 = icmp sgt i64 %280, %270, !dbg !110
+  br i1 %281, label %282, label %forward_sorbet_rb_array_each_withBlock.6.exit.i, !dbg !110
 
-280:                                              ; preds = %rb_array_const_ptr_transient.exit.i17.i
-  %281 = lshr i64 %277, 15, !dbg !110
-  %282 = and i64 %281, 3, !dbg !110
-  br label %rb_array_len.exit.i18.i, !dbg !110
+282:                                              ; preds = %279
+  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull %268) #14, !dbg !110
+  %283 = load i64, i64* %78, align 8, !dbg !110, !tbaa !25
+  %284 = and i64 %283, 8192, !dbg !110
+  %285 = icmp eq i64 %284, 0, !dbg !110
+  br i1 %285, label %286, label %288, !dbg !110
 
-283:                                              ; preds = %rb_array_const_ptr_transient.exit.i17.i
-  %284 = load i64, i64* %249, align 8, !dbg !110, !tbaa !27
-  br label %rb_array_len.exit.i18.i, !dbg !110
+286:                                              ; preds = %282
+  %287 = load i64*, i64** %82, align 8, !dbg !110, !tbaa !27
+  br label %288, !dbg !110
 
-rb_array_len.exit.i18.i:                          ; preds = %283, %280
-  %285 = phi i64 [ %282, %280 ], [ %284, %283 ], !dbg !110
-  %286 = icmp sgt i64 %285, %276, !dbg !110
-  br i1 %286, label %251, label %forward_sorbet_rb_array_each_withBlock.3.exit.i, !dbg !110, !llvm.loop !117
+288:                                              ; preds = %286, %282
+  %289 = phi i64* [ %287, %286 ], [ %80, %282 ], !dbg !110
+  %290 = getelementptr inbounds i64, i64* %289, i64 %270, !dbg !110
+  %291 = load i64, i64* %290, align 8, !dbg !110, !tbaa !6
+  store i64 %291, i64* %1, align 8, !dbg !110, !tbaa !6
+  %292 = call i64 @"func_<root>.17<static-init>$152$block_4"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %1, i64 undef) #14, !dbg !110
+  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %268) #14, !dbg !110
+  %293 = add nuw nsw i64 %270, 1, !dbg !110
+  br label %269, !dbg !110, !llvm.loop !112
 
-forward_sorbet_rb_array_each_withBlock.3.exit.i:  ; preds = %rb_array_len.exit.i18.i, %rb_array_len.exit1.i15.i
-  call void @sorbet_popFrame() #13, !dbg !110
-  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %217) #13, !dbg !106
-  %287 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !106, !tbaa !15
-  %288 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %287, i64 0, i32 5, !dbg !106
-  %289 = load i32, i32* %288, align 8, !dbg !106, !tbaa !37
-  %290 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %287, i64 0, i32 6, !dbg !106
-  %291 = load i32, i32* %290, align 4, !dbg !106, !tbaa !38
-  %292 = xor i32 %291, -1, !dbg !106
-  %293 = and i32 %292, %289, !dbg !106
-  %294 = icmp eq i32 %293, 0, !dbg !106
-  br i1 %294, label %rb_check_arity.1.exit.i21.i, label %295, !dbg !106, !prof !31
+forward_sorbet_rb_array_each_withBlock.6.exit.i:  ; preds = %279
+  call void @sorbet_popFrame() #14, !dbg !110
+  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %251) #14, !dbg !109
+  %294 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !109, !tbaa !15
+  %295 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %294, i64 0, i32 5, !dbg !109
+  %296 = load i32, i32* %295, align 8, !dbg !109, !tbaa !37
+  %297 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %294, i64 0, i32 6, !dbg !109
+  %298 = load i32, i32* %297, align 4, !dbg !109, !tbaa !38
+  %299 = xor i32 %298, -1, !dbg !109
+  %300 = and i32 %299, %296, !dbg !109
+  %301 = icmp eq i32 %300, 0, !dbg !109
+  br i1 %301, label %306, label %302, !dbg !109, !prof !31
 
-295:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.3.exit.i
-  %296 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %287, i64 0, i32 8, !dbg !106
-  %297 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %296, align 8, !dbg !106, !tbaa !39
-  %298 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %297, i32 noundef 0) #13, !dbg !106
-  br label %rb_check_arity.1.exit.i21.i, !dbg !106
+302:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.6.exit.i
+  %303 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %294, i64 0, i32 8, !dbg !109
+  %304 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %303, align 8, !dbg !109, !tbaa !39
+  %305 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %304, i32 noundef 0) #14, !dbg !109
+  br label %306, !dbg !109
 
-rb_check_arity.1.exit.i21.i:                      ; preds = %295, %forward_sorbet_rb_array_each_withBlock.3.exit.i
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %53, align 8, !dbg !106, !tbaa !15
-  %rubyId_each89.i = load i64, i64* @rubyIdPrecomputed_each, align 8, !dbg !118
-  %299 = load i64, i64* @"func_<root>.17<static-init>$152$block_4_ifunc", align 8, !dbg !118
-  %300 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %299) #13, !dbg !118
-  %301 = bitcast %struct.sorbet_inlineIntrinsicEnv* %3 to i8*, !dbg !118
-  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %301) #13, !dbg !118
-  %302 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %3, i64 0, i32 0, !dbg !118
-  store i64 %57, i64* %302, align 8, !dbg !118, !tbaa !81
-  %303 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %3, i64 0, i32 1, !dbg !118
-  store i64 %rubyId_each89.i, i64* %303, align 8, !dbg !118, !tbaa !83
-  %304 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %3, i64 0, i32 2, !dbg !118
-  store i32 0, i32* %304, align 8, !dbg !118, !tbaa !84
-  %305 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %3, i64 0, i32 3, !dbg !118
-  %306 = bitcast i64** %305 to i8*, !dbg !118
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %306, i8 0, i64 16, i1 false) #13, !dbg !118
-  %307 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !118, !tbaa !15
-  %308 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %307, i64 0, i32 2, !dbg !118
-  %309 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %308, align 8, !dbg !118, !tbaa !17
-  %310 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %309, i64 0, i32 3, !dbg !118
-  %311 = bitcast i64* %310 to %struct.rb_captured_block*, !dbg !118
-  %312 = getelementptr inbounds i64, i64* %310, i64 2, !dbg !118
-  %313 = bitcast i64* %312 to %struct.vm_ifunc**, !dbg !118
-  store %struct.vm_ifunc* %300, %struct.vm_ifunc** %313, align 8, !dbg !118, !tbaa !27
-  call void @llvm.experimental.noalias.scope.decl(metadata !119) #13, !dbg !118
-  %314 = ptrtoint %struct.rb_captured_block* %311 to i64, !dbg !118
-  %315 = or i64 %314, 3, !dbg !118
-  %316 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %307, i64 0, i32 17, !dbg !118
-  %317 = and i64 %315, -4, !dbg !122
-  %318 = inttoptr i64 %317 to %struct.rb_captured_block*, !dbg !122
-  store i64 0, i64* %316, align 8, !dbg !122, !tbaa !90
-  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %318) #13, !dbg !122
-  %319 = load i64, i64* %79, align 8, !dbg !122, !tbaa !25
-  %320 = and i64 %319, 8192, !dbg !122
-  %321 = icmp eq i64 %320, 0, !dbg !122
-  br i1 %321, label %325, label %322, !dbg !122
+306:                                              ; preds = %302, %forward_sorbet_rb_array_each_withBlock.6.exit.i
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %53, align 8, !dbg !109, !tbaa !15
+  %rubyId_each101.i = load i64, i64* @rubyIdPrecomputed_each, align 8, !dbg !113
+  %307 = load i64, i64* @"func_<root>.17<static-init>$152$block_5_ifunc", align 8, !dbg !113
+  %308 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %307) #14, !dbg !113
+  %309 = bitcast %struct.sorbet_inlineIntrinsicEnv* %7 to i8*, !dbg !113
+  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %309) #14, !dbg !113
+  %310 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %7, i64 0, i32 0, !dbg !113
+  store i64 %57, i64* %310, align 8, !dbg !113, !tbaa !81
+  %311 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %7, i64 0, i32 1, !dbg !113
+  store i64 %rubyId_each101.i, i64* %311, align 8, !dbg !113, !tbaa !83
+  %312 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %7, i64 0, i32 2, !dbg !113
+  store i32 0, i32* %312, align 8, !dbg !113, !tbaa !84
+  %313 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %7, i64 0, i32 3, !dbg !113
+  %314 = bitcast i64** %313 to i8*, !dbg !113
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %314, i8 0, i64 16, i1 false) #14, !dbg !113
+  %315 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !113, !tbaa !15
+  %316 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %315, i64 0, i32 2, !dbg !113
+  %317 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %316, align 8, !dbg !113, !tbaa !17
+  %318 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %317, i64 0, i32 3, !dbg !113
+  %319 = getelementptr inbounds i64, i64* %318, i64 2, !dbg !113
+  %320 = bitcast i64* %319 to %struct.vm_ifunc**, !dbg !113
+  store %struct.vm_ifunc* %308, %struct.vm_ifunc** %320, align 8, !dbg !113, !tbaa !27
+  %321 = ptrtoint i64* %318 to i64, !dbg !113
+  %322 = or i64 %321, 3, !dbg !113
+  %323 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %315, i64 0, i32 17, !dbg !113
+  %324 = and i64 %322, -4, !dbg !114
+  %325 = inttoptr i64 %324 to %struct.rb_captured_block*, !dbg !114
+  store i64 0, i64* %323, align 8, !dbg !114, !tbaa !87
+  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %325) #14, !dbg !114
+  %326 = bitcast i64* %0 to i8*, !dbg !114
+  br label %327, !dbg !114
 
-322:                                              ; preds = %rb_check_arity.1.exit.i21.i
-  %323 = lshr i64 %319, 15, !dbg !122
-  %324 = and i64 %323, 3, !dbg !122
-  br label %rb_array_len.exit1.i22.i, !dbg !122
+327:                                              ; preds = %346, %306
+  %328 = phi i64 [ %351, %346 ], [ 0, %306 ], !dbg !114
+  %329 = load i64, i64* %78, align 8, !dbg !114, !tbaa !25
+  %330 = and i64 %329, 8192, !dbg !114
+  %331 = icmp eq i64 %330, 0, !dbg !114
+  br i1 %331, label %335, label %332, !dbg !114
 
-325:                                              ; preds = %rb_check_arity.1.exit.i21.i
-  %326 = inttoptr i64 %57 to %struct.RArray*, !dbg !122
-  %327 = getelementptr inbounds %struct.RArray, %struct.RArray* %326, i64 0, i32 1, i32 0, i32 0, !dbg !122
-  %328 = load i64, i64* %327, align 8, !dbg !122, !tbaa !27
-  br label %rb_array_len.exit1.i22.i, !dbg !122
+332:                                              ; preds = %327
+  %333 = lshr i64 %329, 15, !dbg !114
+  %334 = and i64 %333, 3, !dbg !114
+  br label %337, !dbg !114
 
-rb_array_len.exit1.i22.i:                         ; preds = %325, %322
-  %329 = phi i64 [ %324, %322 ], [ %328, %325 ], !dbg !122
-  %330 = icmp sgt i64 %329, 0, !dbg !122
-  br i1 %330, label %331, label %forward_sorbet_rb_array_each_withBlock.6.exit.i, !dbg !122
+335:                                              ; preds = %327
+  %336 = load i64, i64* %80, align 8, !dbg !114, !tbaa !27
+  br label %337, !dbg !114
 
-331:                                              ; preds = %rb_array_len.exit1.i22.i
-  %332 = bitcast i64* %0 to i8*, !dbg !122
-  %333 = inttoptr i64 %57 to %struct.RArray*, !dbg !118
-  %334 = getelementptr inbounds %struct.RArray, %struct.RArray* %333, i64 0, i32 1, i32 0, i32 0, !dbg !118
-  %335 = getelementptr inbounds %struct.RArray, %struct.RArray* %333, i64 0, i32 1, i32 0, i32 2, !dbg !118
-  br label %336, !dbg !122
+337:                                              ; preds = %335, %332
+  %338 = phi i64 [ %334, %332 ], [ %336, %335 ], !dbg !114
+  %339 = icmp sgt i64 %338, %328, !dbg !114
+  br i1 %339, label %340, label %forward_sorbet_rb_array_each_withBlock.10.exit.i, !dbg !114
 
-336:                                              ; preds = %rb_array_len.exit.i24.i, %331
-  %337 = phi i64 [ 0, %331 ], [ %347, %rb_array_len.exit.i24.i ], !dbg !122
-  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 dereferenceable(8) %332) #13, !dbg !122
-  %338 = load i64, i64* %79, align 8, !dbg !122, !tbaa !25
-  %339 = and i64 %338, 8192, !dbg !122
-  %340 = icmp eq i64 %339, 0, !dbg !122
-  br i1 %340, label %341, label %rb_array_const_ptr_transient.exit.i23.i, !dbg !122
+340:                                              ; preds = %337
+  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull %326) #14, !dbg !114
+  %341 = load i64, i64* %78, align 8, !dbg !114, !tbaa !25
+  %342 = and i64 %341, 8192, !dbg !114
+  %343 = icmp eq i64 %342, 0, !dbg !114
+  br i1 %343, label %344, label %346, !dbg !114
 
-341:                                              ; preds = %336
-  %342 = load i64*, i64** %335, align 8, !dbg !122, !tbaa !27
-  br label %rb_array_const_ptr_transient.exit.i23.i, !dbg !122
+344:                                              ; preds = %340
+  %345 = load i64*, i64** %82, align 8, !dbg !114, !tbaa !27
+  br label %346, !dbg !114
 
-rb_array_const_ptr_transient.exit.i23.i:          ; preds = %341, %336
-  %343 = phi i64* [ %342, %341 ], [ %334, %336 ], !dbg !122
-  %344 = getelementptr inbounds i64, i64* %343, i64 %337, !dbg !122
-  %345 = load i64, i64* %344, align 8, !dbg !122, !tbaa !6
-  store i64 %345, i64* %0, align 8, !dbg !122, !tbaa !6
-  %346 = call i64 @"func_<root>.17<static-init>$152$block_4"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %0, i64 undef) #13, !dbg !122
-  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %332) #13, !dbg !122
-  %347 = add nuw nsw i64 %337, 1, !dbg !122
-  %348 = load i64, i64* %79, align 8, !dbg !122, !tbaa !25
-  %349 = and i64 %348, 8192, !dbg !122
-  %350 = icmp eq i64 %349, 0, !dbg !122
-  br i1 %350, label %354, label %351, !dbg !122
+346:                                              ; preds = %344, %340
+  %347 = phi i64* [ %345, %344 ], [ %80, %340 ], !dbg !114
+  %348 = getelementptr inbounds i64, i64* %347, i64 %328, !dbg !114
+  %349 = load i64, i64* %348, align 8, !dbg !114, !tbaa !6
+  store i64 %349, i64* %0, align 8, !dbg !114, !tbaa !6
+  %350 = call i64 @"func_<root>.17<static-init>$152$block_5"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %0, i64 undef) #14, !dbg !114
+  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %326) #14, !dbg !114
+  %351 = add nuw nsw i64 %328, 1, !dbg !114
+  br label %327, !dbg !114, !llvm.loop !116
 
-351:                                              ; preds = %rb_array_const_ptr_transient.exit.i23.i
-  %352 = lshr i64 %348, 15, !dbg !122
-  %353 = and i64 %352, 3, !dbg !122
-  br label %rb_array_len.exit.i24.i, !dbg !122
+forward_sorbet_rb_array_each_withBlock.10.exit.i: ; preds = %337
+  call void @sorbet_popFrame() #14, !dbg !114
+  call void @llvm.lifetime.end.p0i8(i64 40, i8* nonnull %309) #14, !dbg !113
+  %352 = and i64 %57, 7, !dbg !113
+  %353 = icmp ne i64 %352, 0, !dbg !113
+  %354 = and i64 %57, -9, !dbg !113
+  %355 = icmp eq i64 %354, 0, !dbg !113
+  %356 = or i1 %353, %355, !dbg !113
+  br i1 %356, label %sorbet_isa_Array.exit, label %357, !dbg !113
 
-354:                                              ; preds = %rb_array_const_ptr_transient.exit.i23.i
-  %355 = load i64, i64* %334, align 8, !dbg !122, !tbaa !27
-  br label %rb_array_len.exit.i24.i, !dbg !122
+357:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.10.exit.i
+  %358 = inttoptr i64 %57 to %struct.iseq_inline_iv_cache_entry*, !dbg !113
+  %359 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %358, i64 0, i32 0, !dbg !113
+  %360 = load i64, i64* %359, align 8, !dbg !113, !tbaa !25
+  %361 = and i64 %360, 31, !dbg !113
+  %362 = icmp eq i64 %361, 7, !dbg !113
+  br label %sorbet_isa_Array.exit, !dbg !113
 
-rb_array_len.exit.i24.i:                          ; preds = %354, %351
-  %356 = phi i64 [ %353, %351 ], [ %355, %354 ], !dbg !122
-  %357 = icmp sgt i64 %356, %347, !dbg !122
-  br i1 %357, label %336, label %forward_sorbet_rb_array_each_withBlock.6.exit.i, !dbg !122, !llvm.loop !124
+sorbet_isa_Array.exit:                            ; preds = %forward_sorbet_rb_array_each_withBlock.10.exit.i, %357
+  %363 = phi i1 [ false, %forward_sorbet_rb_array_each_withBlock.10.exit.i ], [ %362, %357 ], !dbg !113
+  call void @llvm.assume(i1 %363) #14, !dbg !113
+  %364 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !113, !tbaa !15
+  %365 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %364, i64 0, i32 5, !dbg !113
+  %366 = load i32, i32* %365, align 8, !dbg !113, !tbaa !37
+  %367 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %364, i64 0, i32 6, !dbg !113
+  %368 = load i32, i32* %367, align 4, !dbg !113, !tbaa !38
+  %369 = xor i32 %368, -1, !dbg !113
+  %370 = and i32 %369, %366, !dbg !113
+  %371 = icmp eq i32 %370, 0, !dbg !113
+  br i1 %371, label %"func_<root>.17<static-init>$152.exit", label %372, !dbg !113, !prof !31
 
-forward_sorbet_rb_array_each_withBlock.6.exit.i:  ; preds = %rb_array_len.exit.i24.i, %rb_array_len.exit1.i22.i
-  call void @sorbet_popFrame() #13, !dbg !122
-  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %301) #13, !dbg !118
-  %358 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !118, !tbaa !15
-  %359 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %358, i64 0, i32 5, !dbg !118
-  %360 = load i32, i32* %359, align 8, !dbg !118, !tbaa !37
-  %361 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %358, i64 0, i32 6, !dbg !118
-  %362 = load i32, i32* %361, align 4, !dbg !118, !tbaa !38
-  %363 = xor i32 %362, -1, !dbg !118
-  %364 = and i32 %363, %360, !dbg !118
-  %365 = icmp eq i32 %364, 0, !dbg !118
-  br i1 %365, label %rb_check_arity.1.exit.i.i, label %366, !dbg !118, !prof !31
+372:                                              ; preds = %sorbet_isa_Array.exit
+  %373 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %364, i64 0, i32 8, !dbg !113
+  %374 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %373, align 8, !dbg !113, !tbaa !39
+  %375 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %374, i32 0) #14, !dbg !113
+  br label %"func_<root>.17<static-init>$152.exit", !dbg !113
 
-366:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.6.exit.i
-  %367 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %358, i64 0, i32 8, !dbg !118
-  %368 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %367, align 8, !dbg !118, !tbaa !39
-  %369 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %368, i32 noundef 0) #13, !dbg !118
-  br label %rb_check_arity.1.exit.i.i, !dbg !118
-
-rb_check_arity.1.exit.i.i:                        ; preds = %366, %forward_sorbet_rb_array_each_withBlock.6.exit.i
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %53, align 8, !dbg !118, !tbaa !15
-  %rubyId_each101.i = load i64, i64* @rubyIdPrecomputed_each, align 8, !dbg !125
-  %370 = load i64, i64* @"func_<root>.17<static-init>$152$block_5_ifunc", align 8, !dbg !125
-  %371 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %370) #13, !dbg !125
-  %372 = bitcast %struct.sorbet_inlineIntrinsicEnv* %7 to i8*, !dbg !125
-  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %372) #13, !dbg !125
-  %373 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %7, i64 0, i32 0, !dbg !125
-  store i64 %57, i64* %373, align 8, !dbg !125, !tbaa !81
-  %374 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %7, i64 0, i32 1, !dbg !125
-  store i64 %rubyId_each101.i, i64* %374, align 8, !dbg !125, !tbaa !83
-  %375 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %7, i64 0, i32 2, !dbg !125
-  store i32 0, i32* %375, align 8, !dbg !125, !tbaa !84
-  %376 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %7, i64 0, i32 3, !dbg !125
-  %377 = bitcast i64** %376 to i8*, !dbg !125
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %377, i8 0, i64 16, i1 false) #13, !dbg !125
-  %378 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !125, !tbaa !15
-  %379 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %378, i64 0, i32 2, !dbg !125
-  %380 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %379, align 8, !dbg !125, !tbaa !17
-  %381 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %380, i64 0, i32 3, !dbg !125
-  %382 = bitcast i64* %381 to %struct.rb_captured_block*, !dbg !125
-  %383 = getelementptr inbounds i64, i64* %381, i64 2, !dbg !125
-  %384 = bitcast i64* %383 to %struct.vm_ifunc**, !dbg !125
-  store %struct.vm_ifunc* %371, %struct.vm_ifunc** %384, align 8, !dbg !125, !tbaa !27
-  call void @llvm.experimental.noalias.scope.decl(metadata !126) #13, !dbg !125
-  %385 = ptrtoint %struct.rb_captured_block* %382 to i64, !dbg !125
-  %386 = or i64 %385, 3, !dbg !125
-  %387 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %378, i64 0, i32 17, !dbg !125
-  %388 = and i64 %386, -4, !dbg !129
-  %389 = inttoptr i64 %388 to %struct.rb_captured_block*, !dbg !129
-  store i64 0, i64* %387, align 8, !dbg !129, !tbaa !90
-  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %389) #13, !dbg !129
-  %390 = load i64, i64* %79, align 8, !dbg !129, !tbaa !25
-  %391 = and i64 %390, 8192, !dbg !129
-  %392 = icmp eq i64 %391, 0, !dbg !129
-  br i1 %392, label %396, label %393, !dbg !129
-
-393:                                              ; preds = %rb_check_arity.1.exit.i.i
-  %394 = lshr i64 %390, 15, !dbg !129
-  %395 = and i64 %394, 3, !dbg !129
-  br label %rb_array_len.exit1.i.i, !dbg !129
-
-396:                                              ; preds = %rb_check_arity.1.exit.i.i
-  %397 = inttoptr i64 %57 to %struct.RArray*, !dbg !129
-  %398 = getelementptr inbounds %struct.RArray, %struct.RArray* %397, i64 0, i32 1, i32 0, i32 0, !dbg !129
-  %399 = load i64, i64* %398, align 8, !dbg !129, !tbaa !27
-  br label %rb_array_len.exit1.i.i, !dbg !129
-
-rb_array_len.exit1.i.i:                           ; preds = %396, %393
-  %400 = phi i64 [ %395, %393 ], [ %399, %396 ], !dbg !129
-  %401 = icmp sgt i64 %400, 0, !dbg !129
-  br i1 %401, label %402, label %forward_sorbet_rb_array_each_withBlock.10.exit.i, !dbg !129
-
-402:                                              ; preds = %rb_array_len.exit1.i.i
-  %403 = bitcast i64* %2 to i8*, !dbg !129
-  %404 = inttoptr i64 %57 to %struct.RArray*, !dbg !125
-  %405 = getelementptr inbounds %struct.RArray, %struct.RArray* %404, i64 0, i32 1, i32 0, i32 0, !dbg !125
-  %406 = getelementptr inbounds %struct.RArray, %struct.RArray* %404, i64 0, i32 1, i32 0, i32 2, !dbg !125
-  br label %407, !dbg !129
-
-407:                                              ; preds = %rb_array_len.exit.i.i, %402
-  %408 = phi i64 [ 0, %402 ], [ %418, %rb_array_len.exit.i.i ], !dbg !129
-  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 dereferenceable(8) %403) #13, !dbg !129
-  %409 = load i64, i64* %79, align 8, !dbg !129, !tbaa !25
-  %410 = and i64 %409, 8192, !dbg !129
-  %411 = icmp eq i64 %410, 0, !dbg !129
-  br i1 %411, label %412, label %rb_array_const_ptr_transient.exit.i.i, !dbg !129
-
-412:                                              ; preds = %407
-  %413 = load i64*, i64** %406, align 8, !dbg !129, !tbaa !27
-  br label %rb_array_const_ptr_transient.exit.i.i, !dbg !129
-
-rb_array_const_ptr_transient.exit.i.i:            ; preds = %412, %407
-  %414 = phi i64* [ %413, %412 ], [ %405, %407 ], !dbg !129
-  %415 = getelementptr inbounds i64, i64* %414, i64 %408, !dbg !129
-  %416 = load i64, i64* %415, align 8, !dbg !129, !tbaa !6
-  store i64 %416, i64* %2, align 8, !dbg !129, !tbaa !6
-  %417 = call i64 @"func_<root>.17<static-init>$152$block_5"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %2, i64 undef) #13, !dbg !129
-  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %403) #13, !dbg !129
-  %418 = add nuw nsw i64 %408, 1, !dbg !129
-  %419 = load i64, i64* %79, align 8, !dbg !129, !tbaa !25
-  %420 = and i64 %419, 8192, !dbg !129
-  %421 = icmp eq i64 %420, 0, !dbg !129
-  br i1 %421, label %425, label %422, !dbg !129
-
-422:                                              ; preds = %rb_array_const_ptr_transient.exit.i.i
-  %423 = lshr i64 %419, 15, !dbg !129
-  %424 = and i64 %423, 3, !dbg !129
-  br label %rb_array_len.exit.i.i, !dbg !129
-
-425:                                              ; preds = %rb_array_const_ptr_transient.exit.i.i
-  %426 = load i64, i64* %405, align 8, !dbg !129, !tbaa !27
-  br label %rb_array_len.exit.i.i, !dbg !129
-
-rb_array_len.exit.i.i:                            ; preds = %425, %422
-  %427 = phi i64 [ %424, %422 ], [ %426, %425 ], !dbg !129
-  %428 = icmp sgt i64 %427, %418, !dbg !129
-  br i1 %428, label %407, label %forward_sorbet_rb_array_each_withBlock.10.exit.i, !dbg !129, !llvm.loop !131
-
-forward_sorbet_rb_array_each_withBlock.10.exit.i: ; preds = %rb_array_len.exit.i.i, %rb_array_len.exit1.i.i
-  call void @sorbet_popFrame() #13, !dbg !129
-  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %372) #13, !dbg !125
-  %429 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !125, !tbaa !15
-  %430 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %429, i64 0, i32 5, !dbg !125
-  %431 = load i32, i32* %430, align 8, !dbg !125, !tbaa !37
-  %432 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %429, i64 0, i32 6, !dbg !125
-  %433 = load i32, i32* %432, align 4, !dbg !125, !tbaa !38
-  %434 = xor i32 %433, -1, !dbg !125
-  %435 = and i32 %434, %431, !dbg !125
-  %436 = icmp eq i32 %435, 0, !dbg !125
-  br i1 %436, label %"func_<root>.17<static-init>$152.exit", label %437, !dbg !125, !prof !31
-
-437:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.10.exit.i
-  %438 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %429, i64 0, i32 8, !dbg !125
-  %439 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %438, align 8, !dbg !125, !tbaa !39
-  %440 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %439, i32 noundef 0) #13, !dbg !125
-  br label %"func_<root>.17<static-init>$152.exit", !dbg !125
-
-"func_<root>.17<static-init>$152.exit":           ; preds = %forward_sorbet_rb_array_each_withBlock.10.exit.i, %437
+"func_<root>.17<static-init>$152.exit":           ; preds = %sorbet_isa_Array.exit, %372
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %53, align 8, !tbaa !15
   call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %46)
   ret void
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #10
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #11
 
 ; Function Attrs: cold minsize noreturn ssp
-define internal fastcc void @"func_<root>.17<static-init>$152$block_1.cold.1"(i64 %el2.sroa.0.0) unnamed_addr #11 !dbg !132 {
+define internal fastcc void @"func_<root>.17<static-init>$152$block_1.cold.1"(i64 %el2.sroa.0.0) unnamed_addr #12 !dbg !117 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %el2.sroa.0.0, i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_T.let, i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #17, !dbg !134
-  unreachable, !dbg !134
+  tail call void @sorbet_cast_failure(i64 %el2.sroa.0.0, i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_T.let, i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #17, !dbg !119
+  unreachable, !dbg !119
 }
 
-attributes #0 = { nounwind readnone willreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { cold noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #2 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { nofree nosync nounwind readnone willreturn mustprogress "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #1 = { cold noreturn "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #2 = { "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #3 = { argmemonly nofree nosync nounwind willreturn }
-attributes #4 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #4 = { noreturn "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #5 = { nofree nosync nounwind readnone speculatable willreturn }
 attributes #6 = { inaccessiblememonly nofree nosync nounwind willreturn }
-attributes #7 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #7 = { nounwind ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #8 = { ssp }
-attributes #9 = { sspreq }
-attributes #10 = { argmemonly nofree nosync nounwind willreturn writeonly }
-attributes #11 = { cold minsize noreturn ssp }
-attributes #12 = { noreturn nounwind }
-attributes #13 = { nounwind }
-attributes #14 = { noinline }
-attributes #15 = { nounwind willreturn }
+attributes #9 = { nofree nosync nounwind willreturn }
+attributes #10 = { sspreq }
+attributes #11 = { argmemonly nofree nosync nounwind willreturn writeonly }
+attributes #12 = { cold minsize noreturn ssp }
+attributes #13 = { noreturn nounwind }
+attributes #14 = { nounwind }
+attributes #15 = { noinline }
 attributes #16 = { willreturn }
 attributes #17 = { noreturn }
 
@@ -1651,53 +1539,38 @@ attributes #17 = { noreturn }
 !82 = !{!"sorbet_inlineIntrinsicEnv", !7, i64 0, !7, i64 8, !19, i64 16, !16, i64 24, !7, i64 32}
 !83 = !{!82, !7, i64 8}
 !84 = !{!82, !19, i64 16}
-!85 = !{!86}
-!86 = distinct !{!86, !87, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
-!87 = distinct !{!87, !"VM_BH_FROM_IFUNC_BLOCK"}
-!88 = !DILocation(line: 8, column: 1, scope: !11, inlinedAt: !89)
-!89 = distinct !DILocation(line: 8, column: 1, scope: !11)
-!90 = !{!18, !7, i64 128}
-!91 = distinct !{!91, !92}
-!92 = !{!"llvm.loop.unroll.disable"}
-!93 = !DILocation(line: 13, column: 1, scope: !11)
-!94 = !{!95}
-!95 = distinct !{!95, !96, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
-!96 = distinct !{!96, !"VM_BH_FROM_IFUNC_BLOCK"}
-!97 = !DILocation(line: 13, column: 1, scope: !11, inlinedAt: !98)
-!98 = distinct !DILocation(line: 13, column: 1, scope: !11)
-!99 = !{!100}
-!100 = distinct !{!100, !101, !"func_<root>.17<static-init>$152$block_2: %argArray"}
-!101 = distinct !{!101, !"func_<root>.17<static-init>$152$block_2"}
-!102 = !DILocation(line: 13, column: 12, scope: !41, inlinedAt: !103)
-!103 = distinct !DILocation(line: 13, column: 1, scope: !11, inlinedAt: !98)
-!104 = !DILocation(line: 14, column: 3, scope: !41, inlinedAt: !103)
-!105 = distinct !{!105, !92}
-!106 = !DILocation(line: 18, column: 1, scope: !11)
-!107 = !{!108}
-!108 = distinct !{!108, !109, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
-!109 = distinct !{!109, !"VM_BH_FROM_IFUNC_BLOCK"}
-!110 = !DILocation(line: 18, column: 1, scope: !11, inlinedAt: !111)
-!111 = distinct !DILocation(line: 18, column: 1, scope: !11)
-!112 = !{!113}
-!113 = distinct !{!113, !114, !"func_<root>.17<static-init>$152$block_3: %argArray"}
-!114 = distinct !{!114, !"func_<root>.17<static-init>$152$block_3"}
-!115 = !DILocation(line: 19, column: 3, scope: !47, inlinedAt: !116)
-!116 = distinct !DILocation(line: 18, column: 1, scope: !11, inlinedAt: !111)
-!117 = distinct !{!117, !92}
-!118 = !DILocation(line: 23, column: 1, scope: !11)
-!119 = !{!120}
-!120 = distinct !{!120, !121, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
-!121 = distinct !{!121, !"VM_BH_FROM_IFUNC_BLOCK"}
-!122 = !DILocation(line: 23, column: 1, scope: !11, inlinedAt: !123)
-!123 = distinct !DILocation(line: 23, column: 1, scope: !11)
-!124 = distinct !{!124, !92}
-!125 = !DILocation(line: 28, column: 1, scope: !11)
-!126 = !{!127}
-!127 = distinct !{!127, !128, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
-!128 = distinct !{!128, !"VM_BH_FROM_IFUNC_BLOCK"}
-!129 = !DILocation(line: 28, column: 1, scope: !11, inlinedAt: !130)
-!130 = distinct !DILocation(line: 28, column: 1, scope: !11)
-!131 = distinct !{!131, !92}
-!132 = distinct !DISubprogram(name: "func_<root>.17<static-init>$152$block_1.cold.1", linkageName: "func_<root>.17<static-init>$152$block_1.cold.1", scope: null, file: !4, type: !133, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
-!133 = !DISubroutineType(types: !5)
-!134 = !DILocation(line: 9, column: 25, scope: !132)
+!85 = !DILocation(line: 8, column: 1, scope: !11, inlinedAt: !86)
+!86 = distinct !DILocation(line: 8, column: 1, scope: !11)
+!87 = !{!18, !7, i64 128}
+!88 = distinct !{!88, !89}
+!89 = !{!"llvm.loop.unroll.disable"}
+!90 = !DILocation(line: 13, column: 1, scope: !11)
+!91 = !DILocation(line: 13, column: 1, scope: !11, inlinedAt: !92)
+!92 = distinct !DILocation(line: 13, column: 1, scope: !11)
+!93 = !{!94}
+!94 = distinct !{!94, !95, !"func_<root>.17<static-init>$152$block_2: %argArray"}
+!95 = distinct !{!95, !"func_<root>.17<static-init>$152$block_2"}
+!96 = !DILocation(line: 13, column: 12, scope: !41, inlinedAt: !97)
+!97 = distinct !DILocation(line: 13, column: 1, scope: !11, inlinedAt: !92)
+!98 = !DILocation(line: 14, column: 3, scope: !41, inlinedAt: !97)
+!99 = distinct !{!99, !89}
+!100 = !DILocation(line: 18, column: 1, scope: !11)
+!101 = !DILocation(line: 18, column: 1, scope: !11, inlinedAt: !102)
+!102 = distinct !DILocation(line: 18, column: 1, scope: !11)
+!103 = !{!104}
+!104 = distinct !{!104, !105, !"func_<root>.17<static-init>$152$block_3: %argArray"}
+!105 = distinct !{!105, !"func_<root>.17<static-init>$152$block_3"}
+!106 = !DILocation(line: 19, column: 3, scope: !47, inlinedAt: !107)
+!107 = distinct !DILocation(line: 18, column: 1, scope: !11, inlinedAt: !102)
+!108 = distinct !{!108, !89}
+!109 = !DILocation(line: 23, column: 1, scope: !11)
+!110 = !DILocation(line: 23, column: 1, scope: !11, inlinedAt: !111)
+!111 = distinct !DILocation(line: 23, column: 1, scope: !11)
+!112 = distinct !{!112, !89}
+!113 = !DILocation(line: 28, column: 1, scope: !11)
+!114 = !DILocation(line: 28, column: 1, scope: !11, inlinedAt: !115)
+!115 = distinct !DILocation(line: 28, column: 1, scope: !11)
+!116 = distinct !{!116, !89}
+!117 = distinct !DISubprogram(name: "func_<root>.17<static-init>$152$block_1.cold.1", linkageName: "func_<root>.17<static-init>$152$block_1.cold.1", scope: null, file: !4, type: !118, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
+!118 = !DISubroutineType(types: !5)
+!119 = !DILocation(line: 9, column: 25, scope: !117)

--- a/test/testdata/compiler/block_args.opt.ll.exp
+++ b/test/testdata/compiler/block_args.opt.ll.exp
@@ -2,16 +2,17 @@
 source_filename = "llvm-link"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 
-%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.3, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.4, [29 x i16] }
+%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.5, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.6, [29 x i16] }
 %struct.rb_global_vm_lock_struct = type { %struct.rb_thread_struct*, %union.pthread_mutex_t, %struct.list_head, %struct.rb_thread_struct*, i32, %union.pthread_cond_t, %union.pthread_cond_t, i32, i32 }
-%union.pthread_cond_t = type { %struct.anon.2 }
-%struct.anon.2 = type { i32, i32, i64, i64, i64, i8*, i32, i32 }
-%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.7, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
+%union.pthread_cond_t = type { %struct.__pthread_cond_s }
+%struct.__pthread_cond_s = type { %union.anon, %union.anon, [2 x i32], [2 x i32], i32, i32, [2 x i32] }
+%union.anon = type { i64 }
+%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.10, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
 %struct.list_node = type { %struct.list_node*, %struct.list_node* }
-%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.5 }
+%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.7 }
 %struct.rb_control_frame_struct = type { i64*, i64*, %struct.rb_iseq_struct*, i64, i64*, i8*, i64* }
-%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.14 }
-%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.13, i32, i32, i32, i32, i32, i8, i64 }
+%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.17 }
+%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.16, i32, i32, i32, i32, i32, i8, i64 }
 %struct.anon = type { %struct.anon.0, i32, i32, i32, i32, i32, i32, i32, i64*, %struct.rb_iseq_param_keyword* }
 %struct.anon.0 = type { i16, [2 x i8] }
 %struct.rb_iseq_param_keyword = type { i32, i32, i32, i32, i64*, i64* }
@@ -27,34 +28,34 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_cref_struct = type { i64, i64, i64, %struct.rb_cref_struct*, %struct.rb_scope_visi_struct }
 %struct.rb_scope_visi_struct = type { i8, [3 x i8] }
 %struct.rb_call_data = type { %struct.rb_call_cache, %struct.rb_call_info }
-%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.12 }
+%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.15 }
 %struct.rb_callable_method_entry_struct = type { i64, i64, %struct.rb_method_definition_struct*, i64, i64 }
-%struct.rb_method_definition_struct = type { i64, %union.anon.10, i64, i64 }
-%union.anon.10 = type { %struct.rb_method_cfunc_struct }
+%struct.rb_method_definition_struct = type { i64, %union.anon.13, i64, i64 }
+%union.anon.13 = type { %struct.rb_method_cfunc_struct }
 %struct.rb_method_cfunc_struct = type { i64 (...)*, i64 (i64, i32, i64*, i64 (...)*)*, i32 }
-%union.anon.12 = type { i32 }
+%union.anon.15 = type { i32 }
 %struct.rb_call_info = type { i64, i32, i32 }
-%struct.anon.13 = type { i64, i64, i64, i64* }
-%union.anon.14 = type { %struct.anon.15 }
-%struct.anon.15 = type { i64, i32 }
+%struct.anon.16 = type { i64, i64, i64, i64* }
+%union.anon.17 = type { %struct.anon.18 }
+%struct.anon.18 = type { i64, i32 }
 %struct.rb_vm_tag = type { i64, i64, [5 x i8*], %struct.rb_vm_tag*, i32 }
 %struct.rb_vm_protect_tag = type { %struct.rb_vm_protect_tag* }
 %struct.rb_ensure_list = type { %struct.rb_ensure_list*, %struct.rb_ensure_entry }
 %struct.rb_ensure_entry = type { i64, i64 (i64)*, i64 }
 %struct.rb_trace_arg_struct = type { i32, %struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, i64, i64, i64, i64, i64, i32, i32, i64 }
-%struct.anon.5 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
+%struct.anon.7 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
 %struct.__jmp_buf_tag = type { [8 x i64], i32, %struct.__sigset_t }
 %struct.__sigset_t = type { [16 x i64] }
 %struct.rb_calling_info = type { i64, i64, i32, i32 }
-%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.6 }
-%union.anon.6 = type { %union.pthread_cond_t }
+%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.9 }
+%union.anon.9 = type { %union.pthread_cond_t }
 %struct.rb_unblock_callback = type { void (i8*)*, i8* }
 %struct.rb_mutex_struct = type opaque
 %struct.rb_thread_list_struct = type { %struct.rb_thread_list_struct*, %struct.rb_thread_struct* }
-%union.anon.7 = type { %struct.anon.8 }
-%struct.anon.8 = type { i64, i64, i32 }
+%union.anon.10 = type { %struct.anon.11 }
+%struct.anon.11 = type { i64, i64, i32 }
 %struct.rb_fiber_struct = type opaque
-%struct.anon.3 = type { [65 x i64] }
+%struct.anon.5 = type { [65 x i64] }
 %struct.rb_hook_list_struct = type { %struct.rb_event_hook_struct*, i32, i32, i32 }
 %struct.rb_event_hook_struct = type opaque
 %struct.rb_postponed_job_struct = type opaque
@@ -68,27 +69,26 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.st_hash_type = type { i32 (i64, i64)*, i64 (i64)* }
 %struct.st_table_entry = type opaque
 %struct.rb_builtin_function = type opaque
-%struct.anon.4 = type { i64, i64, i64, i64 }
+%struct.anon.6 = type { i64, i64, i64, i64 }
 %struct.SorbetLineNumberInfo = type { i32, %struct.iseq_insn_info_entry*, i64* }
 %struct.FunctionInlineCache = type { %struct.rb_kwarg_call_data }
 %struct.rb_kwarg_call_data = type { %struct.rb_call_cache, %struct.rb_call_info_with_kwarg }
 %struct.rb_call_info_with_kwarg = type { %struct.rb_call_info, %struct.rb_call_info_kw_arg* }
 %struct.rb_call_info_kw_arg = type { i32, [1 x i64] }
-%struct.rb_captured_block = type { i64, i64*, %union.anon.17 }
-%union.anon.17 = type { %struct.rb_iseq_struct* }
+%struct.rb_captured_block = type { i64, i64*, %union.anon.20 }
+%union.anon.20 = type { %struct.rb_iseq_struct* }
 %struct.vm_ifunc = type { i64, i64, i64 (i64, i64, i32, i64*, i64)*, i8*, %struct.rb_code_position_struct }
 %struct.iseq_inline_iv_cache_entry = type { i64, i64 }
 %struct.sorbet_inlineIntrinsicEnv = type { i64, i64, i32, i64*, i64 }
-%struct.RArray = type { %struct.iseq_inline_iv_cache_entry, %union.anon.25 }
-%union.anon.25 = type { %struct.anon.26 }
-%struct.anon.26 = type { i64, %union.anon.27, i64* }
-%union.anon.27 = type { i64 }
+%struct.RArray = type { %struct.iseq_inline_iv_cache_entry, %union.anon.28 }
+%union.anon.28 = type { %struct.anon.29 }
+%struct.anon.29 = type { i64, %union.anon, i64* }
 
-@ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
-@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
+@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -254,14 +254,14 @@ afterSend:                                        ; preds = %46, %sorbet_rb_int_
 31:                                               ; preds = %27
   %32 = ashr i64 %30, 1, !dbg !26
   %33 = xor i64 %32, -9223372036854775808, !dbg !26
-  %34 = tail call i64 @rb_int2big(i64 %33) #11, !dbg !26
+  %34 = tail call i64 @rb_int2big(i64 %33) #10, !dbg !26, !noalias !31
   br label %sorbet_rb_int_plus.exit, !dbg !26
 
 35:                                               ; preds = %"fastSymCallIntrinsic_Integer_+"
-  %36 = tail call i64 @sorbet_rb_int_plus_slowpath(i64 %x.sroa.0.016, i64 noundef 3) #11, !dbg !26, !noalias !31
+  %36 = tail call i64 @sorbet_rb_int_plus_slowpath(i64 %x.sroa.0.016, i64 noundef 3) #10, !dbg !26, !noalias !31
   br label %sorbet_rb_int_plus.exit, !dbg !26
 
-sorbet_rb_int_plus.exit:                          ; preds = %31, %27, %35
+sorbet_rb_int_plus.exit:                          ; preds = %27, %31, %35
   %37 = phi i64 [ %36, %35 ], [ %34, %31 ], [ %30, %27 ], !dbg !26
   %38 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !26, !tbaa !15
   %39 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %38, i64 0, i32 5, !dbg !26
@@ -276,7 +276,7 @@ sorbet_rb_int_plus.exit:                          ; preds = %31, %27, %35
 46:                                               ; preds = %sorbet_rb_int_plus.exit
   %47 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %38, i64 0, i32 8, !dbg !26
   %48 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %47, align 8, !dbg !26, !tbaa !37
-  %49 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %48, i32 noundef 0) #11, !dbg !26
+  %49 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %48, i32 noundef 0) #10, !dbg !26
   br label %afterSend, !dbg !26
 }
 
@@ -288,22 +288,22 @@ entry:
   %callArgs.i = alloca [3 x i64], align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
+  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #10
   store i64 %2, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #11
+  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #10
   store i64 %3, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
-  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_<build-array>", i64 0, i64 0), i64 noundef 13) #11
-  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_map, i64 0, i64 0), i64 noundef 3) #11
+  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_<build-array>", i64 0, i64 0), i64 noundef 13) #10
+  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_map, i64 0, i64 0), i64 noundef 3) #10
   store i64 %5, i64* @rubyIdPrecomputed_map, align 8
-  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_+", i64 0, i64 0), i64 noundef 1) #11
+  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_+", i64 0, i64 0), i64 noundef 1) #10
   store i64 %6, i64* @"rubyIdPrecomputed_+", align 8
-  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #11
+  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #10
   store i64 %7, i64* @rubyIdPrecomputed_puts, align 8
-  %8 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
-  tail call void @rb_gc_register_mark_object(i64 %8) #11
+  %8 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #10
+  tail call void @rb_gc_register_mark_object(i64 %8) #10
   store i64 %8, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %9 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([37 x i8], [37 x i8]* @"str_test/testdata/compiler/block_args.rb", i64 0, i64 0), i64 noundef 36) #11
-  tail call void @rb_gc_register_mark_object(i64 %9) #11
+  %9 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([37 x i8], [37 x i8]* @"str_test/testdata/compiler/block_args.rb", i64 0, i64 0), i64 noundef 36) #10
+  tail call void @rb_gc_register_mark_object(i64 %9) #10
   store i64 %9, i64* @"rubyStrFrozen_test/testdata/compiler/block_args.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 5)
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
@@ -311,14 +311,14 @@ entry:
   %"rubyStr_test/testdata/compiler/block_args.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_args.rb", align 8
   %10 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_args.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 3)
   store %struct.rb_iseq_struct* %10, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %11 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #11
-  call void @rb_gc_register_mark_object(i64 %11) #11
+  %11 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #10
+  call void @rb_gc_register_mark_object(i64 %11) #10
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   %"rubyId_block in <top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
   %"rubyStr_test/testdata/compiler/block_args.rb.i3.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_args.rb", align 8
   %12 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %11, i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_args.rb.i3.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
   store %struct.rb_iseq_struct* %12, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152$block_1", align 8
-  %13 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$152$block_1", i8* noundef null, i32 noundef 1, i32 noundef 1) #11
+  %13 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$152$block_1", i8* noundef null, i32 noundef 1, i32 noundef 1) #10
   %14 = ptrtoint %struct.vm_ifunc* %13 to i64
   %15 = call i64 @sorbet_globalConstRegister(i64 %14)
   store i64 %15, i64* @"func_<root>.17<static-init>$152$block_1_ifunc", align 8
@@ -343,20 +343,20 @@ entry:
   %27 = load i64, i64* %26, align 8, !tbaa !6
   %28 = and i64 %27, -33
   store i64 %28, i64* %26, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %19, %struct.rb_control_frame_struct* %23, %struct.rb_iseq_struct* %stackFrame.i) #11
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %19, %struct.rb_control_frame_struct* %23, %struct.rb_iseq_struct* %stackFrame.i) #10
   %29 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %21, i64 0, i32 0
   store i64* getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %29, align 8, !dbg !48, !tbaa !15
   %callArgs0Addr.i = getelementptr [3 x i64], [3 x i64]* %callArgs.i, i32 0, i64 0, !dbg !49
   %30 = bitcast i64* %callArgs0Addr.i to <2 x i64>*, !dbg !49
   store <2 x i64> <i64 3, i64 5>, <2 x i64>* %30, align 8, !dbg !49
   %31 = getelementptr [3 x i64], [3 x i64]* %callArgs.i, i64 0, i64 0, !dbg !49
-  call void @llvm.experimental.noalias.scope.decl(metadata !50) #11, !dbg !49
-  %32 = call i64 @rb_ary_new_from_values(i64 noundef 2, i64* noundef nonnull %31) #11, !dbg !49
+  call void @llvm.experimental.noalias.scope.decl(metadata !50) #10, !dbg !49
+  %32 = call i64 @rb_ary_new_from_values(i64 noundef 2, i64* noundef nonnull %31) #10, !dbg !49
   %rubyId_map.i = load i64, i64* @rubyIdPrecomputed_map, align 8, !dbg !49
   %33 = load i64, i64* @"func_<root>.17<static-init>$152$block_1_ifunc", align 8, !dbg !49
-  %34 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %33) #11, !dbg !49
+  %34 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %33) #10, !dbg !49
   %35 = bitcast %struct.sorbet_inlineIntrinsicEnv* %1 to i8*, !dbg !49
-  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %35) #11, !dbg !49
+  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %35) #10, !dbg !49
   %36 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %1, i64 0, i32 0, !dbg !49
   store i64 %32, i64* %36, align 8, !dbg !49, !tbaa !53
   %37 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %1, i64 0, i32 1, !dbg !49
@@ -365,140 +365,119 @@ entry:
   store i32 0, i32* %38, align 8, !dbg !49, !tbaa !56
   %39 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %1, i64 0, i32 3, !dbg !49
   %40 = bitcast i64** %39 to i8*, !dbg !49
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %40, i8 0, i64 16, i1 false) #11, !dbg !49
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %40, i8 0, i64 16, i1 false) #10, !dbg !49
   %41 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !49, !tbaa !15
   %42 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %41, i64 0, i32 2, !dbg !49
   %43 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %42, align 8, !dbg !49, !tbaa !17
   %44 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %43, i64 0, i32 3, !dbg !49
-  %45 = bitcast i64* %44 to %struct.rb_captured_block*, !dbg !49
-  %46 = getelementptr inbounds i64, i64* %44, i64 2, !dbg !49
-  %47 = bitcast i64* %46 to %struct.vm_ifunc**, !dbg !49
-  store %struct.vm_ifunc* %34, %struct.vm_ifunc** %47, align 8, !dbg !49, !tbaa !57
-  call void @llvm.experimental.noalias.scope.decl(metadata !58) #11, !dbg !49
-  %48 = ptrtoint %struct.rb_captured_block* %45 to i64, !dbg !49
-  %49 = or i64 %48, 3, !dbg !49
-  %50 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %41, i64 0, i32 17, !dbg !49
-  %51 = and i64 %49, -4, !dbg !61
-  %52 = inttoptr i64 %51 to %struct.rb_captured_block*, !dbg !61
-  store i64 0, i64* %50, align 8, !dbg !61, !tbaa !63
-  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %52) #11, !dbg !61
-  %53 = inttoptr i64 %32 to %struct.iseq_inline_iv_cache_entry*, !dbg !61
-  %54 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %53, i64 0, i32 0, !dbg !61
-  %55 = load i64, i64* %54, align 8, !dbg !61, !tbaa !27
-  %56 = and i64 %55, 8192, !dbg !61
-  %57 = icmp eq i64 %56, 0, !dbg !61
-  br i1 %57, label %61, label %58, !dbg !61
+  %45 = getelementptr inbounds i64, i64* %44, i64 2, !dbg !49
+  %46 = bitcast i64* %45 to %struct.vm_ifunc**, !dbg !49
+  store %struct.vm_ifunc* %34, %struct.vm_ifunc** %46, align 8, !dbg !49, !tbaa !57
+  %47 = ptrtoint i64* %44 to i64, !dbg !49
+  %48 = or i64 %47, 3, !dbg !49
+  %49 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %41, i64 0, i32 17, !dbg !49
+  %50 = and i64 %48, -4, !dbg !58
+  %51 = inttoptr i64 %50 to %struct.rb_captured_block*, !dbg !58
+  store i64 0, i64* %49, align 8, !dbg !58, !tbaa !60
+  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %51) #10, !dbg !58
+  %52 = inttoptr i64 %32 to %struct.iseq_inline_iv_cache_entry*, !dbg !58
+  %53 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %52, i64 0, i32 0, !dbg !58
+  %54 = load i64, i64* %53, align 8, !dbg !58, !tbaa !27
+  %55 = and i64 %54, 8192, !dbg !58
+  %56 = icmp eq i64 %55, 0, !dbg !58
+  br i1 %56, label %60, label %57, !dbg !58
 
-58:                                               ; preds = %entry
-  %59 = lshr i64 %55, 15, !dbg !61
-  %60 = and i64 %59, 3, !dbg !61
-  br label %rb_array_len.exit2.i.i, !dbg !61
+57:                                               ; preds = %entry
+  %58 = lshr i64 %54, 15, !dbg !58
+  %59 = and i64 %58, 3, !dbg !58
+  br label %64, !dbg !58
 
-61:                                               ; preds = %entry
-  %62 = inttoptr i64 %32 to %struct.RArray*, !dbg !61
-  %63 = getelementptr inbounds %struct.RArray, %struct.RArray* %62, i64 0, i32 1, i32 0, i32 0, !dbg !61
-  %64 = load i64, i64* %63, align 8, !dbg !61, !tbaa !57
-  br label %rb_array_len.exit2.i.i, !dbg !61
+60:                                               ; preds = %entry
+  %61 = inttoptr i64 %32 to %struct.RArray*, !dbg !58
+  %62 = getelementptr inbounds %struct.RArray, %struct.RArray* %61, i64 0, i32 1, i32 0, i32 0, !dbg !58
+  %63 = load i64, i64* %62, align 8, !dbg !58, !tbaa !57
+  br label %64, !dbg !58
 
-rb_array_len.exit2.i.i:                           ; preds = %61, %58
-  %65 = phi i64 [ %60, %58 ], [ %64, %61 ], !dbg !61
-  %66 = call i64 @rb_ary_new_capa(i64 %65) #11, !dbg !61
-  %67 = load i64, i64* %54, align 8, !dbg !61, !tbaa !27
-  %68 = and i64 %67, 8192, !dbg !61
-  %69 = icmp eq i64 %68, 0, !dbg !61
-  br i1 %69, label %73, label %70, !dbg !61
+64:                                               ; preds = %60, %57
+  %65 = phi i64 [ %59, %57 ], [ %63, %60 ], !dbg !58
+  %66 = call i64 @rb_ary_new_capa(i64 %65) #10, !dbg !58
+  %67 = inttoptr i64 %32 to %struct.RArray*, !dbg !58
+  %68 = getelementptr inbounds %struct.RArray, %struct.RArray* %67, i64 0, i32 1, i32 0, i32 0, !dbg !58
+  %69 = bitcast i64* %0 to i8*, !dbg !58
+  %70 = getelementptr inbounds %struct.RArray, %struct.RArray* %67, i64 0, i32 1, i32 0, i32 2, !dbg !58
+  br label %71, !dbg !58
 
-70:                                               ; preds = %rb_array_len.exit2.i.i
-  %71 = lshr i64 %67, 15, !dbg !61
-  %72 = and i64 %71, 3, !dbg !61
-  br label %rb_array_len.exit1.i.i, !dbg !61
+71:                                               ; preds = %90, %64
+  %72 = phi i64 [ 0, %64 ], [ %96, %90 ], !dbg !58
+  %73 = load i64, i64* %53, align 8, !dbg !58, !tbaa !27
+  %74 = and i64 %73, 8192, !dbg !58
+  %75 = icmp eq i64 %74, 0, !dbg !58
+  br i1 %75, label %79, label %76, !dbg !58
 
-73:                                               ; preds = %rb_array_len.exit2.i.i
-  %74 = inttoptr i64 %32 to %struct.RArray*, !dbg !61
-  %75 = getelementptr inbounds %struct.RArray, %struct.RArray* %74, i64 0, i32 1, i32 0, i32 0, !dbg !61
-  %76 = load i64, i64* %75, align 8, !dbg !61, !tbaa !57
-  br label %rb_array_len.exit1.i.i, !dbg !61
+76:                                               ; preds = %71
+  %77 = lshr i64 %73, 15, !dbg !58
+  %78 = and i64 %77, 3, !dbg !58
+  br label %81, !dbg !58
 
-rb_array_len.exit1.i.i:                           ; preds = %73, %70
-  %77 = phi i64 [ %72, %70 ], [ %76, %73 ], !dbg !61
-  %78 = icmp sgt i64 %77, 0, !dbg !61
-  br i1 %78, label %79, label %forward_sorbet_rb_array_collect_withBlock.exit.i, !dbg !61
+79:                                               ; preds = %71
+  %80 = load i64, i64* %68, align 8, !dbg !58, !tbaa !57
+  br label %81, !dbg !58
 
-79:                                               ; preds = %rb_array_len.exit1.i.i
-  %80 = bitcast i64* %0 to i8*, !dbg !61
-  %81 = inttoptr i64 %32 to %struct.RArray*, !dbg !49
-  %82 = getelementptr inbounds %struct.RArray, %struct.RArray* %81, i64 0, i32 1, i32 0, i32 0, !dbg !49
-  %83 = getelementptr inbounds %struct.RArray, %struct.RArray* %81, i64 0, i32 1, i32 0, i32 2, !dbg !49
-  br label %84, !dbg !61
+81:                                               ; preds = %79, %76
+  %82 = phi i64 [ %78, %76 ], [ %80, %79 ], !dbg !58
+  %83 = icmp slt i64 %72, %82, !dbg !58
+  br i1 %83, label %84, label %forward_sorbet_rb_array_collect_withBlock.exit.i, !dbg !58
 
-84:                                               ; preds = %rb_array_len.exit.i.i, %79
-  %85 = phi i64 [ 0, %79 ], [ %96, %rb_array_len.exit.i.i ], !dbg !61
-  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 dereferenceable(8) %80) #11, !dbg !61
-  %86 = load i64, i64* %54, align 8, !dbg !61, !tbaa !27
-  %87 = and i64 %86, 8192, !dbg !61
-  %88 = icmp eq i64 %87, 0, !dbg !61
-  br i1 %88, label %89, label %rb_array_const_ptr_transient.exit.i.i, !dbg !61
+84:                                               ; preds = %81
+  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull %69) #10, !dbg !58
+  %85 = load i64, i64* %53, align 8, !dbg !58, !tbaa !27
+  %86 = and i64 %85, 8192, !dbg !58
+  %87 = icmp eq i64 %86, 0, !dbg !58
+  br i1 %87, label %88, label %90, !dbg !58
 
-89:                                               ; preds = %84
-  %90 = load i64*, i64** %83, align 8, !dbg !61, !tbaa !57
-  br label %rb_array_const_ptr_transient.exit.i.i, !dbg !61
+88:                                               ; preds = %84
+  %89 = load i64*, i64** %70, align 8, !dbg !58, !tbaa !57
+  br label %90, !dbg !58
 
-rb_array_const_ptr_transient.exit.i.i:            ; preds = %89, %84
-  %91 = phi i64* [ %90, %89 ], [ %82, %84 ], !dbg !61
-  %92 = getelementptr inbounds i64, i64* %91, i64 %85, !dbg !61
-  %93 = load i64, i64* %92, align 8, !dbg !61, !tbaa !6
-  store i64 %93, i64* %0, align 8, !dbg !61, !tbaa !6
-  %94 = call i64 @"func_<root>.17<static-init>$152$block_1"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %0, i64 undef) #11, !dbg !61
-  %95 = call i64 @rb_ary_push(i64 %66, i64 %94) #11, !dbg !61
-  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %80) #11, !dbg !61
-  %96 = add nuw nsw i64 %85, 1, !dbg !61
-  %97 = load i64, i64* %54, align 8, !dbg !61, !tbaa !27
-  %98 = and i64 %97, 8192, !dbg !61
-  %99 = icmp eq i64 %98, 0, !dbg !61
-  br i1 %99, label %103, label %100, !dbg !61
+90:                                               ; preds = %88, %84
+  %91 = phi i64* [ %89, %88 ], [ %68, %84 ], !dbg !58
+  %92 = getelementptr inbounds i64, i64* %91, i64 %72, !dbg !58
+  %93 = load i64, i64* %92, align 8, !dbg !58, !tbaa !6
+  store i64 %93, i64* %0, align 8, !dbg !58, !tbaa !6
+  %94 = call i64 @"func_<root>.17<static-init>$152$block_1"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %0, i64 undef) #10, !dbg !58
+  %95 = call i64 @rb_ary_push(i64 %66, i64 %94) #10, !dbg !58
+  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %69) #10, !dbg !58
+  %96 = add nuw nsw i64 %72, 1, !dbg !58
+  br label %71, !dbg !58, !llvm.loop !61
 
-100:                                              ; preds = %rb_array_const_ptr_transient.exit.i.i
-  %101 = lshr i64 %97, 15, !dbg !61
-  %102 = and i64 %101, 3, !dbg !61
-  br label %rb_array_len.exit.i.i, !dbg !61
+forward_sorbet_rb_array_collect_withBlock.exit.i: ; preds = %81
+  call void @sorbet_popFrame() #10, !dbg !58
+  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %35) #10, !dbg !49
+  %97 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !49, !tbaa !15
+  %98 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %97, i64 0, i32 5, !dbg !49
+  %99 = load i32, i32* %98, align 8, !dbg !49, !tbaa !35
+  %100 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %97, i64 0, i32 6, !dbg !49
+  %101 = load i32, i32* %100, align 4, !dbg !49, !tbaa !36
+  %102 = xor i32 %101, -1, !dbg !49
+  %103 = and i32 %102, %99, !dbg !49
+  %104 = icmp eq i32 %103, 0, !dbg !49
+  br i1 %104, label %"func_<root>.17<static-init>$152.exit", label %105, !dbg !49, !prof !29
 
-103:                                              ; preds = %rb_array_const_ptr_transient.exit.i.i
-  %104 = load i64, i64* %82, align 8, !dbg !61, !tbaa !57
-  br label %rb_array_len.exit.i.i, !dbg !61
-
-rb_array_len.exit.i.i:                            ; preds = %103, %100
-  %105 = phi i64 [ %102, %100 ], [ %104, %103 ], !dbg !61
-  %106 = icmp slt i64 %96, %105, !dbg !61
-  br i1 %106, label %84, label %forward_sorbet_rb_array_collect_withBlock.exit.i, !dbg !61, !llvm.loop !64
-
-forward_sorbet_rb_array_collect_withBlock.exit.i: ; preds = %rb_array_len.exit.i.i, %rb_array_len.exit1.i.i
-  call void @sorbet_popFrame() #11, !dbg !61
-  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %35) #11, !dbg !49
-  %107 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !49, !tbaa !15
-  %108 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %107, i64 0, i32 5, !dbg !49
-  %109 = load i32, i32* %108, align 8, !dbg !49, !tbaa !35
-  %110 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %107, i64 0, i32 6, !dbg !49
-  %111 = load i32, i32* %110, align 4, !dbg !49, !tbaa !36
-  %112 = xor i32 %111, -1, !dbg !49
-  %113 = and i32 %112, %109, !dbg !49
-  %114 = icmp eq i32 %113, 0, !dbg !49
-  br i1 %114, label %"func_<root>.17<static-init>$152.exit", label %115, !dbg !49, !prof !29
-
-115:                                              ; preds = %forward_sorbet_rb_array_collect_withBlock.exit.i
-  %116 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %107, i64 0, i32 8, !dbg !49
-  %117 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %116, align 8, !dbg !49, !tbaa !37
-  %118 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %117, i32 noundef 0) #11, !dbg !49
+105:                                              ; preds = %forward_sorbet_rb_array_collect_withBlock.exit.i
+  %106 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %97, i64 0, i32 8, !dbg !49
+  %107 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %106, align 8, !dbg !49, !tbaa !37
+  %108 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %107, i32 noundef 0) #10, !dbg !49
   br label %"func_<root>.17<static-init>$152.exit", !dbg !49
 
-"func_<root>.17<static-init>$152.exit":           ; preds = %forward_sorbet_rb_array_collect_withBlock.exit.i, %115
+"func_<root>.17<static-init>$152.exit":           ; preds = %forward_sorbet_rb_array_collect_withBlock.exit.i, %105
   store i64* getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %29, align 8, !tbaa !15
-  %119 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %21, i64 0, i32 1, !dbg !38
-  %120 = load i64*, i64** %119, align 8, !dbg !38
-  store i64 %18, i64* %120, align 8, !dbg !38, !tbaa !6
-  %121 = getelementptr inbounds i64, i64* %120, i64 1, !dbg !38
-  store i64 %66, i64* %121, align 8, !dbg !38, !tbaa !6
-  %122 = getelementptr inbounds i64, i64* %121, i64 1, !dbg !38
-  store i64* %122, i64** %119, align 8, !dbg !38
+  %109 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %21, i64 0, i32 1, !dbg !38
+  %110 = load i64*, i64** %109, align 8, !dbg !38
+  store i64 %18, i64* %110, align 8, !dbg !38, !tbaa !6
+  %111 = getelementptr inbounds i64, i64* %110, i64 1, !dbg !38
+  store i64 %66, i64* %111, align 8, !dbg !38, !tbaa !6
+  %112 = getelementptr inbounds i64, i64* %111, i64 1, !dbg !38
+  store i64* %112, i64** %109, align 8, !dbg !38
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !38
   call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %22)
   ret void
@@ -507,18 +486,17 @@ forward_sorbet_rb_array_collect_withBlock.exit.i: ; preds = %rb_array_len.exit.i
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #8
 
-attributes #0 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }
-attributes #2 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { noreturn "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #3 = { nofree nosync nounwind readnone speculatable willreturn }
 attributes #4 = { inaccessiblememonly nofree nosync nounwind willreturn }
-attributes #5 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #5 = { nounwind ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #6 = { ssp }
 attributes #7 = { sspreq }
 attributes #8 = { argmemonly nofree nosync nounwind willreturn writeonly }
 attributes #9 = { noreturn nounwind }
-attributes #10 = { nounwind willreturn }
-attributes #11 = { nounwind }
+attributes #10 = { nounwind }
 
 !llvm.module.flags = !{!0, !1, !2}
 !llvm.dbg.cu = !{!3}
@@ -581,11 +559,8 @@ attributes #11 = { nounwind }
 !55 = !{!54, !7, i64 8}
 !56 = !{!54, !19, i64 16}
 !57 = !{!8, !8, i64 0}
-!58 = !{!59}
-!59 = distinct !{!59, !60, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
-!60 = distinct !{!60, !"VM_BH_FROM_IFUNC_BLOCK"}
-!61 = !DILocation(line: 4, column: 6, scope: !11, inlinedAt: !62)
-!62 = distinct !DILocation(line: 4, column: 6, scope: !11)
-!63 = !{!18, !7, i64 128}
-!64 = distinct !{!64, !65}
-!65 = !{!"llvm.loop.unroll.disable"}
+!58 = !DILocation(line: 4, column: 6, scope: !11, inlinedAt: !59)
+!59 = distinct !DILocation(line: 4, column: 6, scope: !11)
+!60 = !{!18, !7, i64 128}
+!61 = distinct !{!61, !62}
+!62 = !{!"llvm.loop.unroll.disable"}

--- a/test/testdata/compiler/block_no_args.opt.ll.exp
+++ b/test/testdata/compiler/block_no_args.opt.ll.exp
@@ -2,10 +2,10 @@
 source_filename = "llvm-link"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 
-%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.5 }
+%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.7 }
 %struct.rb_control_frame_struct = type { i64*, i64*, %struct.rb_iseq_struct*, i64, i64*, i8*, i64* }
-%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.14 }
-%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.13, i32, i32, i32, i32, i32, i8, i64 }
+%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.17 }
+%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.16, i32, i32, i32, i32, i32, i8, i64 }
 %struct.anon = type { %struct.anon.0, i32, i32, i32, i32, i32, i32, i32, i64*, %struct.rb_iseq_param_keyword* }
 %struct.anon.0 = type { i16, [2 x i8] }
 %struct.rb_iseq_param_keyword = type { i32, i32, i32, i32, i64*, i64* }
@@ -21,27 +21,28 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_cref_struct = type { i64, i64, i64, %struct.rb_cref_struct*, %struct.rb_scope_visi_struct }
 %struct.rb_scope_visi_struct = type { i8, [3 x i8] }
 %struct.rb_call_data = type { %struct.rb_call_cache, %struct.rb_call_info }
-%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.12 }
+%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.15 }
 %struct.rb_callable_method_entry_struct = type { i64, i64, %struct.rb_method_definition_struct*, i64, i64 }
-%struct.rb_method_definition_struct = type { i64, %union.anon.10, i64, i64 }
-%union.anon.10 = type { %struct.rb_method_cfunc_struct }
+%struct.rb_method_definition_struct = type { i64, %union.anon.13, i64, i64 }
+%union.anon.13 = type { %struct.rb_method_cfunc_struct }
 %struct.rb_method_cfunc_struct = type { i64 (...)*, i64 (i64, i32, i64*, i64 (...)*)*, i32 }
 %struct.rb_calling_info = type { i64, i64, i32, i32 }
-%union.anon.12 = type { i32 }
+%union.anon.15 = type { i32 }
 %struct.rb_call_info = type { i64, i32, i32 }
-%struct.anon.13 = type { i64, i64, i64, i64* }
-%union.anon.14 = type { %struct.anon.15 }
-%struct.anon.15 = type { i64, i32 }
+%struct.anon.16 = type { i64, i64, i64, i64* }
+%union.anon.17 = type { %struct.anon.18 }
+%struct.anon.18 = type { i64, i32 }
 %struct.rb_vm_tag = type { i64, i64, [5 x i8*], %struct.rb_vm_tag*, i32 }
 %struct.rb_vm_protect_tag = type { %struct.rb_vm_protect_tag* }
 %struct.rb_fiber_struct = type opaque
-%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.7, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
+%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.10, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
 %struct.list_node = type { %struct.list_node*, %struct.list_node* }
-%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.3, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.4, [29 x i16] }
+%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.5, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.6, [29 x i16] }
 %struct.rb_global_vm_lock_struct = type { %struct.rb_thread_struct*, %union.pthread_mutex_t, %struct.list_head, %struct.rb_thread_struct*, i32, %union.pthread_cond_t, %union.pthread_cond_t, i32, i32 }
-%union.pthread_cond_t = type { %struct.anon.2 }
-%struct.anon.2 = type { i32, i32, i64, i64, i64, i8*, i32, i32 }
-%struct.anon.3 = type { [65 x i64] }
+%union.pthread_cond_t = type { %struct.__pthread_cond_s }
+%struct.__pthread_cond_s = type { %union.anon, %union.anon, [2 x i32], [2 x i32], i32, i32, [2 x i32] }
+%union.anon = type { i64 }
+%struct.anon.5 = type { [65 x i64] }
 %struct.rb_hook_list_struct = type { %struct.rb_event_hook_struct*, i32, i32, i32 }
 %struct.rb_event_hook_struct = type opaque
 %struct.rb_postponed_job_struct = type opaque
@@ -49,24 +50,24 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_objspace = type opaque
 %struct.rb_at_exit_list = type { void (%struct.rb_vm_struct*)*, %struct.rb_at_exit_list* }
 %struct.rb_builtin_function = type opaque
-%struct.anon.4 = type { i64, i64, i64, i64 }
-%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.6 }
-%union.anon.6 = type { %union.pthread_cond_t }
+%struct.anon.6 = type { i64, i64, i64, i64 }
+%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.9 }
+%union.anon.9 = type { %union.pthread_cond_t }
 %union.pthread_mutex_t = type { %struct.__pthread_mutex_s }
 %struct.__pthread_mutex_s = type { i32, i32, i32, i32, i32, i16, i16, %struct.__pthread_internal_list }
 %struct.__pthread_internal_list = type { %struct.__pthread_internal_list*, %struct.__pthread_internal_list* }
 %struct.rb_unblock_callback = type { void (i8*)*, i8* }
 %struct.rb_mutex_struct = type opaque
 %struct.rb_thread_list_struct = type { %struct.rb_thread_list_struct*, %struct.rb_thread_struct* }
-%union.anon.7 = type { %struct.anon.8 }
-%struct.anon.8 = type { i64, i64, i32 }
+%union.anon.10 = type { %struct.anon.11 }
+%struct.anon.11 = type { i64, i64, i32 }
 %struct.st_table = type { i8, i8, i8, i32, %struct.st_hash_type*, i64, i64*, i64, i64, %struct.st_table_entry* }
 %struct.st_hash_type = type { i32 (i64, i64)*, i64 (i64)* }
 %struct.st_table_entry = type opaque
 %struct.rb_ensure_list = type { %struct.rb_ensure_list*, %struct.rb_ensure_entry }
 %struct.rb_ensure_entry = type { i64, i64 (i64)*, i64 }
 %struct.rb_trace_arg_struct = type { i32, %struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, i64, i64, i64, i64, i64, i32, i32, i64 }
-%struct.anon.5 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
+%struct.anon.7 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
 %struct.__jmp_buf_tag = type { [8 x i64], i32, %struct.__sigset_t }
 %struct.__sigset_t = type { [16 x i64] }
 %struct.SorbetLineNumberInfo = type { i32, %struct.iseq_insn_info_entry*, i64* }
@@ -74,14 +75,14 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_kwarg_call_data = type { %struct.rb_call_cache, %struct.rb_call_info_with_kwarg }
 %struct.rb_call_info_with_kwarg = type { %struct.rb_call_info, %struct.rb_call_info_kw_arg* }
 %struct.rb_call_info_kw_arg = type { i32, [1 x i64] }
-%struct.rb_captured_block = type { i64, i64*, %union.anon.17 }
-%union.anon.17 = type { %struct.rb_iseq_struct* }
+%struct.rb_captured_block = type { i64, i64*, %union.anon.20 }
+%union.anon.20 = type { %struct.rb_iseq_struct* }
 %struct.vm_ifunc = type { i64, i64, i64 (i64, i64, i32, i64*, i64)*, i8*, %struct.rb_code_position_struct }
 
-@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -138,14 +139,14 @@ declare %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)*, i8*,
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #2 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #6
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #5
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #2 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #6
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #5
   unreachable
 }
 
@@ -184,18 +185,18 @@ define void @Init_block_no_args() local_unnamed_addr #4 {
 entry:
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #7
+  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #6
   store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #7
+  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #6
   store i64 %1, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
-  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_times, i64 0, i64 0), i64 noundef 5) #7
-  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #7
+  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_times, i64 0, i64 0), i64 noundef 5) #6
+  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #6
   store i64 %3, i64* @rubyIdPrecomputed_puts, align 8
-  %4 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #7
-  tail call void @rb_gc_register_mark_object(i64 %4) #7
+  %4 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #6
+  tail call void @rb_gc_register_mark_object(i64 %4) #6
   store i64 %4, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %5 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([40 x i8], [40 x i8]* @"str_test/testdata/compiler/block_no_args.rb", i64 0, i64 0), i64 noundef 39) #7
-  tail call void @rb_gc_register_mark_object(i64 %5) #7
+  %5 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([40 x i8], [40 x i8]* @"str_test/testdata/compiler/block_no_args.rb", i64 0, i64 0), i64 noundef 39) #6
+  tail call void @rb_gc_register_mark_object(i64 %5) #6
   store i64 %5, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 7)
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
@@ -203,19 +204,19 @@ entry:
   %"rubyStr_test/testdata/compiler/block_no_args.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args.rb", align 8
   %6 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_no_args.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %6, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %7 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #7
-  call void @rb_gc_register_mark_object(i64 %7) #7
+  %7 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #6
+  call void @rb_gc_register_mark_object(i64 %7) #6
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   %"rubyId_block in <top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
   %"rubyStr_test/testdata/compiler/block_no_args.rb.i2.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args.rb", align 8
   %8 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %7, i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_no_args.rb.i2.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %8, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152$block_1", align 8
-  %9 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$152$block_1", i8* noundef null, i32 noundef 0, i32 noundef 0) #7
+  %9 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$152$block_1", i8* noundef null, i32 noundef 0, i32 noundef 0) #6
   %10 = ptrtoint %struct.vm_ifunc* %9 to i64
   %11 = call i64 @sorbet_globalConstRegister(i64 %10)
   store i64 %11, i64* @"func_<root>.17<static-init>$152$block_1_ifunc", align 8
-  %12 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_hi, i64 0, i64 0), i64 noundef 2) #7
-  call void @rb_gc_register_mark_object(i64 %12) #7
+  %12 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_hi, i64 0, i64 0), i64 noundef 2) #6
+  call void @rb_gc_register_mark_object(i64 %12) #6
   store i64 %12, i64* @rubyStrFrozen_hi, align 8
   %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !26
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !26
@@ -230,93 +231,87 @@ entry:
   %19 = load i64, i64* %18, align 8, !tbaa !6
   %20 = and i64 %19, -33
   store i64 %20, i64* %18, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %13, %struct.rb_control_frame_struct* %15, %struct.rb_iseq_struct* %stackFrame.i) #7
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %13, %struct.rb_control_frame_struct* %15, %struct.rb_iseq_struct* %stackFrame.i) #6
   %21 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 0
   store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %21, align 8, !dbg !27, !tbaa !15
   %22 = load i64, i64* @"func_<root>.17<static-init>$152$block_1_ifunc", align 8, !dbg !28
-  %23 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %22) #7, !dbg !28
+  %23 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %22) #6, !dbg !28
   %24 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !28, !tbaa !15
   %25 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %24, i64 0, i32 2, !dbg !28
   %26 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %25, align 8, !dbg !28, !tbaa !17
   %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 3, !dbg !28
-  %28 = bitcast i64* %27 to %struct.rb_captured_block*, !dbg !28
-  %29 = getelementptr inbounds i64, i64* %27, i64 2, !dbg !28
-  %30 = bitcast i64* %29 to %struct.vm_ifunc**, !dbg !28
-  store %struct.vm_ifunc* %23, %struct.vm_ifunc** %30, align 8, !dbg !28, !tbaa !29
-  call void @llvm.experimental.noalias.scope.decl(metadata !30) #7, !dbg !28
-  %31 = ptrtoint %struct.rb_captured_block* %28 to i64, !dbg !28
-  %32 = or i64 %31, 3, !dbg !28
-  %33 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %24, i64 0, i32 17, !dbg !28
-  %34 = and i64 %32, -4, !dbg !33
-  %35 = inttoptr i64 %34 to %struct.rb_captured_block*, !dbg !33
-  store i64 0, i64* %33, align 8, !dbg !33, !tbaa !35
-  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %35) #7, !dbg !33
-  %36 = load i64, i64* @rb_mKernel, align 8, !dbg !28
-  br label %37, !dbg !33
+  %28 = getelementptr inbounds i64, i64* %27, i64 2, !dbg !28
+  %29 = bitcast i64* %28 to %struct.vm_ifunc**, !dbg !28
+  store %struct.vm_ifunc* %23, %struct.vm_ifunc** %29, align 8, !dbg !28, !tbaa !29
+  %30 = ptrtoint i64* %27 to i64, !dbg !28
+  %31 = or i64 %30, 3, !dbg !28
+  %32 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %24, i64 0, i32 17, !dbg !28
+  %33 = and i64 %31, -4, !dbg !30
+  %34 = inttoptr i64 %33 to %struct.rb_captured_block*, !dbg !30
+  store i64 0, i64* %32, align 8, !dbg !30, !tbaa !32
+  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %34) #6, !dbg !30
+  %35 = load i64, i64* @rb_mKernel, align 8, !dbg !28
+  br label %36, !dbg !30
 
-37:                                               ; preds = %37, %entry
-  %38 = phi i64 [ 0, %entry ], [ %52, %37 ], !dbg !33
-  %39 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !28, !tbaa !15
-  %40 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %39, i64 0, i32 2, !dbg !28
-  %41 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %40, align 8, !dbg !28, !tbaa !17
-  %stackFrame.i1.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152$block_1", align 8, !dbg !28
-  %42 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 2, !dbg !28
-  store %struct.rb_iseq_struct* %stackFrame.i1.i.i, %struct.rb_iseq_struct** %42, align 8, !dbg !28, !tbaa !21
-  %43 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 4, !dbg !28
-  %44 = load i64*, i64** %43, align 8, !dbg !28, !tbaa !23
-  %45 = load i64, i64* %44, align 8, !dbg !28, !tbaa !6
-  %46 = and i64 %45, -129, !dbg !28
-  store i64 %46, i64* %44, align 8, !dbg !28, !tbaa !6
-  %47 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 0, !dbg !28
-  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %47, align 8, !dbg !36, !tbaa !15
-  %rubyStr_hi.i2.i.i = load i64, i64* @rubyStrFrozen_hi, align 8, !dbg !38
-  %48 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 1, !dbg !39
-  %49 = load i64*, i64** %48, align 8, !dbg !39
-  store i64 %36, i64* %49, align 8, !dbg !39, !tbaa !6
-  %50 = getelementptr inbounds i64, i64* %49, i64 1, !dbg !39
-  store i64 %rubyStr_hi.i2.i.i, i64* %50, align 8, !dbg !39, !tbaa !6
-  %51 = getelementptr inbounds i64, i64* %50, i64 1, !dbg !39
-  store i64* %51, i64** %48, align 8, !dbg !39
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !39
-  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %47, align 8, !dbg !39, !tbaa !15
-  %52 = add nuw nsw i64 %38, 1, !dbg !33
-  %53 = icmp eq i64 %52, 10, !dbg !33
-  br i1 %53, label %forward_sorbet_rb_int_dotimes_withBlock.exit.i, label %37, !dbg !33, !llvm.loop !40
+36:                                               ; preds = %36, %entry
+  %37 = phi i64 [ %51, %36 ], [ 0, %entry ], !dbg !30
+  %38 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !28, !tbaa !15
+  %39 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %38, i64 0, i32 2, !dbg !28
+  %40 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %39, align 8, !dbg !28, !tbaa !17
+  %stackFrame.i.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152$block_1", align 8, !dbg !28
+  %41 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %40, i64 0, i32 2, !dbg !28
+  store %struct.rb_iseq_struct* %stackFrame.i.i.i, %struct.rb_iseq_struct** %41, align 8, !dbg !28, !tbaa !21
+  %42 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %40, i64 0, i32 4, !dbg !28
+  %43 = load i64*, i64** %42, align 8, !dbg !28, !tbaa !23
+  %44 = load i64, i64* %43, align 8, !dbg !28, !tbaa !6
+  %45 = and i64 %44, -129, !dbg !28
+  store i64 %45, i64* %43, align 8, !dbg !28, !tbaa !6
+  %46 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %40, i64 0, i32 0, !dbg !28
+  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %46, align 8, !dbg !33, !tbaa !15
+  %rubyStr_hi.i.i.i = load i64, i64* @rubyStrFrozen_hi, align 8, !dbg !35
+  %47 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %40, i64 0, i32 1, !dbg !36
+  %48 = load i64*, i64** %47, align 8, !dbg !36
+  store i64 %35, i64* %48, align 8, !dbg !36, !tbaa !6
+  %49 = getelementptr inbounds i64, i64* %48, i64 1, !dbg !36
+  store i64 %rubyStr_hi.i.i.i, i64* %49, align 8, !dbg !36, !tbaa !6
+  %50 = getelementptr inbounds i64, i64* %49, i64 1, !dbg !36
+  store i64* %50, i64** %47, align 8, !dbg !36
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !36
+  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %46, align 8, !dbg !36, !tbaa !15
+  %51 = add nuw nsw i64 %37, 1, !dbg !30
+  %52 = icmp eq i64 %51, 10, !dbg !30
+  br i1 %52, label %forward_sorbet_rb_int_dotimes_withBlock.exit.i, label %36, !dbg !30, !llvm.loop !37
 
-forward_sorbet_rb_int_dotimes_withBlock.exit.i:   ; preds = %37
-  call void @sorbet_popFrame() #7, !dbg !33
-  %54 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !28, !tbaa !15
-  %55 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %54, i64 0, i32 5, !dbg !28
-  %56 = load i32, i32* %55, align 8, !dbg !28, !tbaa !42
-  %57 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %54, i64 0, i32 6, !dbg !28
-  %58 = load i32, i32* %57, align 4, !dbg !28, !tbaa !43
-  %59 = xor i32 %58, -1, !dbg !28
-  %60 = and i32 %59, %56, !dbg !28
-  %61 = icmp eq i32 %60, 0, !dbg !28
-  br i1 %61, label %"func_<root>.17<static-init>$152.exit", label %62, !dbg !28, !prof !44
+forward_sorbet_rb_int_dotimes_withBlock.exit.i:   ; preds = %36
+  call void @sorbet_popFrame() #6, !dbg !30
+  %53 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !28, !tbaa !15
+  %54 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %53, i64 0, i32 5, !dbg !28
+  %55 = load i32, i32* %54, align 8, !dbg !28, !tbaa !39
+  %56 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %53, i64 0, i32 6, !dbg !28
+  %57 = load i32, i32* %56, align 4, !dbg !28, !tbaa !40
+  %58 = xor i32 %57, -1, !dbg !28
+  %59 = and i32 %58, %55, !dbg !28
+  %60 = icmp eq i32 %59, 0, !dbg !28
+  br i1 %60, label %"func_<root>.17<static-init>$152.exit", label %61, !dbg !28, !prof !41
 
-62:                                               ; preds = %forward_sorbet_rb_int_dotimes_withBlock.exit.i
-  %63 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %54, i64 0, i32 8, !dbg !28
-  %64 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %63, align 8, !dbg !28, !tbaa !45
-  %65 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %64, i32 noundef 0) #7, !dbg !28
+61:                                               ; preds = %forward_sorbet_rb_int_dotimes_withBlock.exit.i
+  %62 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %53, i64 0, i32 8, !dbg !28
+  %63 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %62, align 8, !dbg !28, !tbaa !42
+  %64 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %63, i32 noundef 0) #6, !dbg !28
   br label %"func_<root>.17<static-init>$152.exit", !dbg !28
 
-"func_<root>.17<static-init>$152.exit":           ; preds = %forward_sorbet_rb_int_dotimes_withBlock.exit.i, %62
+"func_<root>.17<static-init>$152.exit":           ; preds = %forward_sorbet_rb_int_dotimes_withBlock.exit.i, %61
   store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %21, align 8, !tbaa !15
   ret void
 }
 
-; Function Attrs: inaccessiblememonly nofree nosync nounwind willreturn
-declare void @llvm.experimental.noalias.scope.decl(metadata) #5
-
-attributes #0 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #2 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #1 = { noreturn "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #2 = { nounwind ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #3 = { ssp }
 attributes #4 = { sspreq }
-attributes #5 = { inaccessiblememonly nofree nosync nounwind willreturn }
-attributes #6 = { noreturn nounwind }
-attributes #7 = { nounwind }
+attributes #5 = { noreturn nounwind }
+attributes #6 = { nounwind }
 
 !llvm.module.flags = !{!0, !1, !2}
 !llvm.dbg.cu = !{!3}
@@ -351,19 +346,16 @@ attributes #7 = { nounwind }
 !27 = !DILocation(line: 0, scope: !11)
 !28 = !DILocation(line: 4, column: 1, scope: !11)
 !29 = !{!8, !8, i64 0}
-!30 = !{!31}
-!31 = distinct !{!31, !32, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
-!32 = distinct !{!32, !"VM_BH_FROM_IFUNC_BLOCK"}
-!33 = !DILocation(line: 4, column: 1, scope: !11, inlinedAt: !34)
-!34 = distinct !DILocation(line: 4, column: 1, scope: !11)
-!35 = !{!18, !7, i64 128}
-!36 = !DILocation(line: 4, column: 1, scope: !10, inlinedAt: !37)
-!37 = distinct !DILocation(line: 4, column: 1, scope: !11, inlinedAt: !34)
-!38 = !DILocation(line: 5, column: 15, scope: !10, inlinedAt: !37)
-!39 = !DILocation(line: 5, column: 3, scope: !10, inlinedAt: !37)
-!40 = distinct !{!40, !41}
-!41 = !{!"llvm.loop.unroll.disable"}
-!42 = !{!18, !19, i64 40}
-!43 = !{!18, !19, i64 44}
-!44 = !{!"branch_weights", i32 2000, i32 1}
-!45 = !{!18, !16, i64 56}
+!30 = !DILocation(line: 4, column: 1, scope: !11, inlinedAt: !31)
+!31 = distinct !DILocation(line: 4, column: 1, scope: !11)
+!32 = !{!18, !7, i64 128}
+!33 = !DILocation(line: 4, column: 1, scope: !10, inlinedAt: !34)
+!34 = distinct !DILocation(line: 4, column: 1, scope: !11, inlinedAt: !31)
+!35 = !DILocation(line: 5, column: 15, scope: !10, inlinedAt: !34)
+!36 = !DILocation(line: 5, column: 3, scope: !10, inlinedAt: !34)
+!37 = distinct !{!37, !38}
+!38 = !{!"llvm.loop.unroll.disable"}
+!39 = !{!18, !19, i64 40}
+!40 = !{!18, !19, i64 44}
+!41 = !{!"branch_weights", i32 2000, i32 1}
+!42 = !{!18, !16, i64 56}

--- a/test/testdata/compiler/block_no_args_capture.opt.ll.exp
+++ b/test/testdata/compiler/block_no_args_capture.opt.ll.exp
@@ -2,10 +2,10 @@
 source_filename = "llvm-link"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 
-%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.5 }
+%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.7 }
 %struct.rb_control_frame_struct = type { i64*, i64*, %struct.rb_iseq_struct*, i64, i64*, i8*, i64* }
-%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.14 }
-%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.13, i32, i32, i32, i32, i32, i8, i64 }
+%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.17 }
+%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.16, i32, i32, i32, i32, i32, i8, i64 }
 %struct.anon = type { %struct.anon.0, i32, i32, i32, i32, i32, i32, i32, i64*, %struct.rb_iseq_param_keyword* }
 %struct.anon.0 = type { i16, [2 x i8] }
 %struct.rb_iseq_param_keyword = type { i32, i32, i32, i32, i64*, i64* }
@@ -21,27 +21,28 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_cref_struct = type { i64, i64, i64, %struct.rb_cref_struct*, %struct.rb_scope_visi_struct }
 %struct.rb_scope_visi_struct = type { i8, [3 x i8] }
 %struct.rb_call_data = type { %struct.rb_call_cache, %struct.rb_call_info }
-%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.12 }
+%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.15 }
 %struct.rb_callable_method_entry_struct = type { i64, i64, %struct.rb_method_definition_struct*, i64, i64 }
-%struct.rb_method_definition_struct = type { i64, %union.anon.10, i64, i64 }
-%union.anon.10 = type { %struct.rb_method_cfunc_struct }
+%struct.rb_method_definition_struct = type { i64, %union.anon.13, i64, i64 }
+%union.anon.13 = type { %struct.rb_method_cfunc_struct }
 %struct.rb_method_cfunc_struct = type { i64 (...)*, i64 (i64, i32, i64*, i64 (...)*)*, i32 }
 %struct.rb_calling_info = type { i64, i64, i32, i32 }
-%union.anon.12 = type { i32 }
+%union.anon.15 = type { i32 }
 %struct.rb_call_info = type { i64, i32, i32 }
-%struct.anon.13 = type { i64, i64, i64, i64* }
-%union.anon.14 = type { %struct.anon.15 }
-%struct.anon.15 = type { i64, i32 }
+%struct.anon.16 = type { i64, i64, i64, i64* }
+%union.anon.17 = type { %struct.anon.18 }
+%struct.anon.18 = type { i64, i32 }
 %struct.rb_vm_tag = type { i64, i64, [5 x i8*], %struct.rb_vm_tag*, i32 }
 %struct.rb_vm_protect_tag = type { %struct.rb_vm_protect_tag* }
 %struct.rb_fiber_struct = type opaque
-%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.7, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
+%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.10, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
 %struct.list_node = type { %struct.list_node*, %struct.list_node* }
-%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.3, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.4, [29 x i16] }
+%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.5, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.6, [29 x i16] }
 %struct.rb_global_vm_lock_struct = type { %struct.rb_thread_struct*, %union.pthread_mutex_t, %struct.list_head, %struct.rb_thread_struct*, i32, %union.pthread_cond_t, %union.pthread_cond_t, i32, i32 }
-%union.pthread_cond_t = type { %struct.anon.2 }
-%struct.anon.2 = type { i32, i32, i64, i64, i64, i8*, i32, i32 }
-%struct.anon.3 = type { [65 x i64] }
+%union.pthread_cond_t = type { %struct.__pthread_cond_s }
+%struct.__pthread_cond_s = type { %union.anon, %union.anon, [2 x i32], [2 x i32], i32, i32, [2 x i32] }
+%union.anon = type { i64 }
+%struct.anon.5 = type { [65 x i64] }
 %struct.rb_hook_list_struct = type { %struct.rb_event_hook_struct*, i32, i32, i32 }
 %struct.rb_event_hook_struct = type opaque
 %struct.rb_postponed_job_struct = type opaque
@@ -49,24 +50,24 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_objspace = type opaque
 %struct.rb_at_exit_list = type { void (%struct.rb_vm_struct*)*, %struct.rb_at_exit_list* }
 %struct.rb_builtin_function = type opaque
-%struct.anon.4 = type { i64, i64, i64, i64 }
-%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.6 }
-%union.anon.6 = type { %union.pthread_cond_t }
+%struct.anon.6 = type { i64, i64, i64, i64 }
+%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.9 }
+%union.anon.9 = type { %union.pthread_cond_t }
 %union.pthread_mutex_t = type { %struct.__pthread_mutex_s }
 %struct.__pthread_mutex_s = type { i32, i32, i32, i32, i32, i16, i16, %struct.__pthread_internal_list }
 %struct.__pthread_internal_list = type { %struct.__pthread_internal_list*, %struct.__pthread_internal_list* }
 %struct.rb_unblock_callback = type { void (i8*)*, i8* }
 %struct.rb_mutex_struct = type opaque
 %struct.rb_thread_list_struct = type { %struct.rb_thread_list_struct*, %struct.rb_thread_struct* }
-%union.anon.7 = type { %struct.anon.8 }
-%struct.anon.8 = type { i64, i64, i32 }
+%union.anon.10 = type { %struct.anon.11 }
+%struct.anon.11 = type { i64, i64, i32 }
 %struct.st_table = type { i8, i8, i8, i32, %struct.st_hash_type*, i64, i64*, i64, i64, %struct.st_table_entry* }
 %struct.st_hash_type = type { i32 (i64, i64)*, i64 (i64)* }
 %struct.st_table_entry = type opaque
 %struct.rb_ensure_list = type { %struct.rb_ensure_list*, %struct.rb_ensure_entry }
 %struct.rb_ensure_entry = type { i64, i64 (i64)*, i64 }
 %struct.rb_trace_arg_struct = type { i32, %struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, i64, i64, i64, i64, i64, i32, i32, i64 }
-%struct.anon.5 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
+%struct.anon.7 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
 %struct.__jmp_buf_tag = type { [8 x i64], i32, %struct.__sigset_t }
 %struct.__sigset_t = type { [16 x i64] }
 %struct.SorbetLineNumberInfo = type { i32, %struct.iseq_insn_info_entry*, i64* }
@@ -74,15 +75,15 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_kwarg_call_data = type { %struct.rb_call_cache, %struct.rb_call_info_with_kwarg }
 %struct.rb_call_info_with_kwarg = type { %struct.rb_call_info, %struct.rb_call_info_kw_arg* }
 %struct.rb_call_info_kw_arg = type { i32, [1 x i64] }
-%struct.rb_captured_block = type { i64, i64*, %union.anon.17 }
-%union.anon.17 = type { %struct.rb_iseq_struct* }
+%struct.rb_captured_block = type { i64, i64*, %union.anon.20 }
+%union.anon.20 = type { %struct.rb_iseq_struct* }
 %struct.vm_ifunc = type { i64, i64, i64 (i64, i64, i32, i64*, i64)*, i8*, %struct.rb_code_position_struct }
 %struct.sorbet_inlineIntrinsicEnv = type { i64, i64, i32, i64*, i64 }
 
-@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -150,20 +151,20 @@ declare %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)*, i8*,
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #3 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #8
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #7
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #3 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #8
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #7
   unreachable
 }
 
 ; Function Attrs: ssp
 define internal i64 @"func_<root>.17<static-init>$152$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #4 !dbg !10 {
-vm_get_ep.exit:
+functionEntryInitializers:
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
   %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !17
@@ -171,29 +172,29 @@ vm_get_ep.exit:
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
   store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %3, align 8, !tbaa !21
   %4 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %5 = load i64*, i64** %4, align 8
+  %5 = load i64*, i64** %4, align 8, !tbaa !23
   %6 = load i64, i64* %5, align 8, !tbaa !6
   %7 = and i64 %6, -129
   store i64 %7, i64* %5, align 8, !tbaa !6
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
-  store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %8, align 8, !dbg !23, !tbaa !15
-  %9 = getelementptr inbounds i64, i64* %5, i64 -1, !dbg !24
-  %10 = load i64, i64* %9, align 8, !dbg !24, !tbaa !6
-  %11 = and i64 %10, -4, !dbg !24
-  %12 = inttoptr i64 %11 to i64*, !dbg !24
-  %13 = getelementptr inbounds i64, i64* %12, i64 -3, !dbg !24
-  %14 = load i64, i64* %13, align 8, !dbg !24, !tbaa !6
-  %15 = load i64, i64* @rb_mKernel, align 8, !dbg !24
-  %16 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !24
-  %17 = load i64*, i64** %16, align 8, !dbg !24
-  store i64 %15, i64* %17, align 8, !dbg !24, !tbaa !6
-  %18 = getelementptr inbounds i64, i64* %17, i64 1, !dbg !24
-  store i64 %14, i64* %18, align 8, !dbg !24, !tbaa !6
-  %19 = getelementptr inbounds i64, i64* %18, i64 1, !dbg !24
-  store i64* %19, i64** %16, align 8, !dbg !24
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !24
-  store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %8, align 8, !dbg !24, !tbaa !15
-  ret i64 %send, !dbg !23
+  store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %8, align 8, !dbg !24, !tbaa !15
+  %9 = getelementptr inbounds i64, i64* %5, i64 -1, !dbg !25
+  %10 = load i64, i64* %9, align 8, !dbg !25, !tbaa !6
+  %11 = and i64 %10, -4, !dbg !25
+  %12 = inttoptr i64 %11 to i64*, !dbg !25
+  %13 = getelementptr inbounds i64, i64* %12, i64 -3, !dbg !25
+  %14 = load i64, i64* %13, align 8, !dbg !25, !tbaa !6
+  %15 = load i64, i64* @rb_mKernel, align 8, !dbg !25
+  %16 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !25
+  %17 = load i64*, i64** %16, align 8, !dbg !25
+  store i64 %15, i64* %17, align 8, !dbg !25, !tbaa !6
+  %18 = getelementptr inbounds i64, i64* %17, i64 1, !dbg !25
+  store i64 %14, i64* %18, align 8, !dbg !25, !tbaa !6
+  %19 = getelementptr inbounds i64, i64* %18, i64 1, !dbg !25
+  store i64* %19, i64** %16, align 8, !dbg !25
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !25
+  store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %8, align 8, !dbg !25, !tbaa !15
+  ret i64 %send, !dbg !24
 }
 
 ; Function Attrs: sspreq
@@ -202,21 +203,21 @@ entry:
   %0 = alloca %struct.sorbet_inlineIntrinsicEnv, align 8
   %locals.i.i = alloca i64, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #9
+  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #8
   store i64 %1, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_s, i64 0, i64 0), i64 noundef 1) #9
+  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_s, i64 0, i64 0), i64 noundef 1) #8
   store i64 %2, i64* @rubyIdPrecomputed_s, align 8
-  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #9
+  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #8
   store i64 %3, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
-  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_times, i64 0, i64 0), i64 noundef 5) #9
+  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_times, i64 0, i64 0), i64 noundef 5) #8
   store i64 %4, i64* @rubyIdPrecomputed_times, align 8
-  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #9
+  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #8
   store i64 %5, i64* @rubyIdPrecomputed_puts, align 8
-  %6 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #9
-  tail call void @rb_gc_register_mark_object(i64 %6) #9
+  %6 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #8
+  tail call void @rb_gc_register_mark_object(i64 %6) #8
   store i64 %6, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %7 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([48 x i8], [48 x i8]* @"str_test/testdata/compiler/block_no_args_capture.rb", i64 0, i64 0), i64 noundef 47) #9
-  tail call void @rb_gc_register_mark_object(i64 %7) #9
+  %7 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([48 x i8], [48 x i8]* @"str_test/testdata/compiler/block_no_args_capture.rb", i64 0, i64 0), i64 noundef 47) #8
+  tail call void @rb_gc_register_mark_object(i64 %7) #8
   store i64 %7, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args_capture.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 8)
   %8 = bitcast i64* %locals.i.i to i8*
@@ -229,22 +230,22 @@ entry:
   %9 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_no_args_capture.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i.i, i32 noundef 1, i32 noundef 2)
   store %struct.rb_iseq_struct* %9, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %8)
-  %10 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #9
-  call void @rb_gc_register_mark_object(i64 %10) #9
+  %10 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #8
+  call void @rb_gc_register_mark_object(i64 %10) #8
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   %"rubyId_block in <top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
   %"rubyStr_test/testdata/compiler/block_no_args_capture.rb.i2.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args_capture.rb", align 8
   %11 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %10, i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_no_args_capture.rb.i2.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %11, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152$block_1", align 8
-  %12 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_hi, i64 0, i64 0), i64 noundef 2) #9
-  call void @rb_gc_register_mark_object(i64 %12) #9
+  %12 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_hi, i64 0, i64 0), i64 noundef 2) #8
+  call void @rb_gc_register_mark_object(i64 %12) #8
   store i64 %12, i64* @rubyStrFrozen_hi, align 8
-  %13 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$152$block_1", i8* noundef null, i32 noundef 0, i32 noundef 0) #9
+  %13 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$152$block_1", i8* noundef null, i32 noundef 0, i32 noundef 0) #8
   %14 = ptrtoint %struct.vm_ifunc* %13 to i64
   %15 = call i64 @sorbet_globalConstRegister(i64 %14)
   store i64 %15, i64* @"func_<root>.17<static-init>$152$block_1_ifunc", align 8
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !24
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !24
+  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !25
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !25
   %16 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
   %17 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 2
   %18 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %17, align 8, !tbaa !17
@@ -252,15 +253,15 @@ entry:
   %19 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 2
   store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %19, align 8, !tbaa !21
   %20 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 4
-  %21 = load i64*, i64** %20, align 8, !tbaa !25
+  %21 = load i64*, i64** %20, align 8, !tbaa !23
   %22 = load i64, i64* %21, align 8, !tbaa !6
   %23 = and i64 %22, -33
   store i64 %23, i64* %21, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %16, %struct.rb_control_frame_struct* %18, %struct.rb_iseq_struct* %stackFrame.i) #9
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %16, %struct.rb_control_frame_struct* %18, %struct.rb_iseq_struct* %stackFrame.i) #8
   %24 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 0
   store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %24, align 8, !dbg !26, !tbaa !15
   %rubyStr_hi.i = load i64, i64* @rubyStrFrozen_hi, align 8, !dbg !27
-  %25 = load i64*, i64** %20, align 8, !dbg !27, !tbaa !25
+  %25 = load i64*, i64** %20, align 8, !dbg !27, !tbaa !23
   %26 = load i64, i64* %25, align 8, !dbg !27, !tbaa !6
   %27 = and i64 %26, 8, !dbg !27
   %28 = icmp eq i64 %27, 0, !dbg !27
@@ -272,16 +273,16 @@ entry:
   br label %32, !dbg !27
 
 31:                                               ; preds = %entry
-  call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %25, i32 noundef -3, i64 %rubyStr_hi.i) #9, !dbg !27
+  call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 %25, i32 noundef -3, i64 %rubyStr_hi.i) #8, !dbg !27
   br label %32, !dbg !27
 
 32:                                               ; preds = %31, %29
   store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %24, align 8, !dbg !27, !tbaa !15
   %rubyId_times.i = load i64, i64* @rubyIdPrecomputed_times, align 8, !dbg !29
   %33 = load i64, i64* @"func_<root>.17<static-init>$152$block_1_ifunc", align 8, !dbg !29
-  %34 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %33) #9, !dbg !29
+  %34 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %33) #8, !dbg !29
   %35 = bitcast %struct.sorbet_inlineIntrinsicEnv* %0 to i8*, !dbg !29
-  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %35) #9, !dbg !29
+  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %35) #8, !dbg !29
   %36 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %0, i64 0, i32 0, !dbg !29
   store i64 21, i64* %36, align 8, !dbg !29, !tbaa !30
   %37 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %0, i64 0, i32 1, !dbg !29
@@ -290,100 +291,94 @@ entry:
   store i32 0, i32* %38, align 8, !dbg !29, !tbaa !33
   %39 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %0, i64 0, i32 3, !dbg !29
   %40 = bitcast i64** %39 to i8*, !dbg !29
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %40, i8 0, i64 16, i1 false) #9, !dbg !29
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %40, i8 0, i64 16, i1 false) #8, !dbg !29
   %41 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !29, !tbaa !15
   %42 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %41, i64 0, i32 2, !dbg !29
   %43 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %42, align 8, !dbg !29, !tbaa !17
   %44 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %43, i64 0, i32 3, !dbg !29
-  %45 = bitcast i64* %44 to %struct.rb_captured_block*, !dbg !29
-  %46 = getelementptr inbounds i64, i64* %44, i64 2, !dbg !29
-  %47 = bitcast i64* %46 to %struct.vm_ifunc**, !dbg !29
-  store %struct.vm_ifunc* %34, %struct.vm_ifunc** %47, align 8, !dbg !29, !tbaa !34
-  call void @llvm.experimental.noalias.scope.decl(metadata !35) #9, !dbg !29
-  %48 = ptrtoint %struct.rb_captured_block* %45 to i64, !dbg !29
-  %49 = or i64 %48, 3, !dbg !29
-  %50 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %41, i64 0, i32 17, !dbg !29
-  %51 = and i64 %49, -4, !dbg !38
-  %52 = inttoptr i64 %51 to %struct.rb_captured_block*, !dbg !38
-  store i64 0, i64* %50, align 8, !dbg !38, !tbaa !40
-  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %52) #9, !dbg !38
-  %53 = load i64, i64* @rb_mKernel, align 8, !dbg !29
-  br label %54, !dbg !38
+  %45 = getelementptr inbounds i64, i64* %44, i64 2, !dbg !29
+  %46 = bitcast i64* %45 to %struct.vm_ifunc**, !dbg !29
+  store %struct.vm_ifunc* %34, %struct.vm_ifunc** %46, align 8, !dbg !29, !tbaa !34
+  %47 = ptrtoint i64* %44 to i64, !dbg !29
+  %48 = or i64 %47, 3, !dbg !29
+  %49 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %41, i64 0, i32 17, !dbg !29
+  %50 = and i64 %48, -4, !dbg !35
+  %51 = inttoptr i64 %50 to %struct.rb_captured_block*, !dbg !35
+  store i64 0, i64* %49, align 8, !dbg !35, !tbaa !37
+  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %51) #8, !dbg !35
+  %52 = load i64, i64* @rb_mKernel, align 8, !dbg !29
+  br label %53, !dbg !35
 
-54:                                               ; preds = %54, %32
-  %55 = phi i64 [ 0, %32 ], [ %75, %54 ], !dbg !38
-  %56 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !29, !tbaa !15
-  %57 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %56, i64 0, i32 2, !dbg !29
-  %58 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %57, align 8, !dbg !29, !tbaa !17
-  %stackFrame.i1.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152$block_1", align 8, !dbg !29
-  %59 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %58, i64 0, i32 2, !dbg !29
-  store %struct.rb_iseq_struct* %stackFrame.i1.i.i, %struct.rb_iseq_struct** %59, align 8, !dbg !29, !tbaa !21
-  %60 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %58, i64 0, i32 4, !dbg !29
-  %61 = load i64*, i64** %60, align 8, !dbg !29
-  %62 = load i64, i64* %61, align 8, !dbg !29, !tbaa !6
-  %63 = and i64 %62, -129, !dbg !29
-  store i64 %63, i64* %61, align 8, !dbg !29, !tbaa !6
-  %64 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %58, i64 0, i32 0, !dbg !29
-  store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %64, align 8, !dbg !41, !tbaa !15
-  %65 = getelementptr inbounds i64, i64* %61, i64 -1, !dbg !43
-  %66 = load i64, i64* %65, align 8, !dbg !43, !tbaa !6
-  %67 = and i64 %66, -4, !dbg !43
-  %68 = inttoptr i64 %67 to i64*, !dbg !43
-  %69 = getelementptr inbounds i64, i64* %68, i64 -3, !dbg !43
-  %70 = load i64, i64* %69, align 8, !dbg !43, !tbaa !6
-  %71 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %58, i64 0, i32 1, !dbg !43
-  %72 = load i64*, i64** %71, align 8, !dbg !43
-  store i64 %53, i64* %72, align 8, !dbg !43, !tbaa !6
-  %73 = getelementptr inbounds i64, i64* %72, i64 1, !dbg !43
-  store i64 %70, i64* %73, align 8, !dbg !43, !tbaa !6
-  %74 = getelementptr inbounds i64, i64* %73, i64 1, !dbg !43
-  store i64* %74, i64** %71, align 8, !dbg !43
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !43
-  store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %64, align 8, !dbg !43, !tbaa !15
-  %75 = add nuw nsw i64 %55, 1, !dbg !38
-  %76 = icmp eq i64 %75, 10, !dbg !38
-  br i1 %76, label %forward_sorbet_rb_int_dotimes_withBlock.exit.i, label %54, !dbg !38, !llvm.loop !44
+53:                                               ; preds = %53, %32
+  %54 = phi i64 [ %74, %53 ], [ 0, %32 ], !dbg !35
+  %55 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !29, !tbaa !15
+  %56 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %55, i64 0, i32 2, !dbg !29
+  %57 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %56, align 8, !dbg !29, !tbaa !17
+  %stackFrame.i.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152$block_1", align 8, !dbg !29
+  %58 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %57, i64 0, i32 2, !dbg !29
+  store %struct.rb_iseq_struct* %stackFrame.i.i.i, %struct.rb_iseq_struct** %58, align 8, !dbg !29, !tbaa !21
+  %59 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %57, i64 0, i32 4, !dbg !29
+  %60 = load i64*, i64** %59, align 8, !dbg !29, !tbaa !23
+  %61 = load i64, i64* %60, align 8, !dbg !29, !tbaa !6
+  %62 = and i64 %61, -129, !dbg !29
+  store i64 %62, i64* %60, align 8, !dbg !29, !tbaa !6
+  %63 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %57, i64 0, i32 0, !dbg !29
+  store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %63, align 8, !dbg !38, !tbaa !15
+  %64 = getelementptr inbounds i64, i64* %60, i64 -1, !dbg !40
+  %65 = load i64, i64* %64, align 8, !dbg !40, !tbaa !6
+  %66 = and i64 %65, -4, !dbg !40
+  %67 = inttoptr i64 %66 to i64*, !dbg !40
+  %68 = getelementptr inbounds i64, i64* %67, i64 -3, !dbg !40
+  %69 = load i64, i64* %68, align 8, !dbg !40, !tbaa !6
+  %70 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %57, i64 0, i32 1, !dbg !40
+  %71 = load i64*, i64** %70, align 8, !dbg !40
+  store i64 %52, i64* %71, align 8, !dbg !40, !tbaa !6
+  %72 = getelementptr inbounds i64, i64* %71, i64 1, !dbg !40
+  store i64 %69, i64* %72, align 8, !dbg !40, !tbaa !6
+  %73 = getelementptr inbounds i64, i64* %72, i64 1, !dbg !40
+  store i64* %73, i64** %70, align 8, !dbg !40
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !40
+  store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %63, align 8, !dbg !40, !tbaa !15
+  %74 = add nuw nsw i64 %54, 1, !dbg !35
+  %75 = icmp eq i64 %74, 10, !dbg !35
+  br i1 %75, label %forward_sorbet_rb_int_dotimes_withBlock.exit.i, label %53, !dbg !35, !llvm.loop !41
 
-forward_sorbet_rb_int_dotimes_withBlock.exit.i:   ; preds = %54
-  call void @sorbet_popFrame() #9, !dbg !38
-  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %35) #9, !dbg !29
-  %77 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !29, !tbaa !15
-  %78 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %77, i64 0, i32 5, !dbg !29
-  %79 = load i32, i32* %78, align 8, !dbg !29, !tbaa !46
-  %80 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %77, i64 0, i32 6, !dbg !29
-  %81 = load i32, i32* %80, align 4, !dbg !29, !tbaa !47
-  %82 = xor i32 %81, -1, !dbg !29
-  %83 = and i32 %82, %79, !dbg !29
-  %84 = icmp eq i32 %83, 0, !dbg !29
-  br i1 %84, label %"func_<root>.17<static-init>$152.exit", label %85, !dbg !29, !prof !28
+forward_sorbet_rb_int_dotimes_withBlock.exit.i:   ; preds = %53
+  call void @sorbet_popFrame() #8, !dbg !35
+  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %35) #8, !dbg !29
+  %76 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !29, !tbaa !15
+  %77 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %76, i64 0, i32 5, !dbg !29
+  %78 = load i32, i32* %77, align 8, !dbg !29, !tbaa !43
+  %79 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %76, i64 0, i32 6, !dbg !29
+  %80 = load i32, i32* %79, align 4, !dbg !29, !tbaa !44
+  %81 = xor i32 %80, -1, !dbg !29
+  %82 = and i32 %81, %78, !dbg !29
+  %83 = icmp eq i32 %82, 0, !dbg !29
+  br i1 %83, label %"func_<root>.17<static-init>$152.exit", label %84, !dbg !29, !prof !28
 
-85:                                               ; preds = %forward_sorbet_rb_int_dotimes_withBlock.exit.i
-  %86 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %77, i64 0, i32 8, !dbg !29
-  %87 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %86, align 8, !dbg !29, !tbaa !48
-  %88 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %87, i32 noundef 0) #9, !dbg !29
+84:                                               ; preds = %forward_sorbet_rb_int_dotimes_withBlock.exit.i
+  %85 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %76, i64 0, i32 8, !dbg !29
+  %86 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %85, align 8, !dbg !29, !tbaa !45
+  %87 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %86, i32 noundef 0) #8, !dbg !29
   br label %"func_<root>.17<static-init>$152.exit", !dbg !29
 
-"func_<root>.17<static-init>$152.exit":           ; preds = %forward_sorbet_rb_int_dotimes_withBlock.exit.i, %85
+"func_<root>.17<static-init>$152.exit":           ; preds = %forward_sorbet_rb_int_dotimes_withBlock.exit.i, %84
   store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %24, align 8, !tbaa !15
   ret void
 }
 
-; Function Attrs: inaccessiblememonly nofree nosync nounwind willreturn
-declare void @llvm.experimental.noalias.scope.decl(metadata) #6
-
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #7
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #6
 
-attributes #0 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }
-attributes #2 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #3 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { noreturn "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #3 = { nounwind ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #4 = { ssp }
 attributes #5 = { sspreq }
-attributes #6 = { inaccessiblememonly nofree nosync nounwind willreturn }
-attributes #7 = { argmemonly nofree nosync nounwind willreturn writeonly }
-attributes #8 = { noreturn nounwind }
-attributes #9 = { nounwind }
+attributes #6 = { argmemonly nofree nosync nounwind willreturn writeonly }
+attributes #7 = { noreturn nounwind }
+attributes #8 = { nounwind }
 
 !llvm.module.flags = !{!0, !1, !2}
 !llvm.dbg.cu = !{!3}
@@ -411,9 +406,9 @@ attributes #9 = { nounwind }
 !20 = !{!"", !16, i64 0, !16, i64 8, !7, i64 16, !8, i64 24}
 !21 = !{!22, !16, i64 16}
 !22 = !{!"rb_control_frame_struct", !16, i64 0, !16, i64 8, !16, i64 16, !7, i64 24, !16, i64 32, !16, i64 40, !16, i64 48}
-!23 = !DILocation(line: 5, column: 1, scope: !10)
-!24 = !DILocation(line: 6, column: 3, scope: !10)
-!25 = !{!22, !16, i64 32}
+!23 = !{!22, !16, i64 32}
+!24 = !DILocation(line: 5, column: 1, scope: !10)
+!25 = !DILocation(line: 6, column: 3, scope: !10)
 !26 = !DILocation(line: 0, scope: !11)
 !27 = !DILocation(line: 4, column: 5, scope: !11)
 !28 = !{!"branch_weights", i32 2000, i32 1}
@@ -423,17 +418,14 @@ attributes #9 = { nounwind }
 !32 = !{!31, !7, i64 8}
 !33 = !{!31, !19, i64 16}
 !34 = !{!8, !8, i64 0}
-!35 = !{!36}
-!36 = distinct !{!36, !37, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
-!37 = distinct !{!37, !"VM_BH_FROM_IFUNC_BLOCK"}
-!38 = !DILocation(line: 5, column: 1, scope: !11, inlinedAt: !39)
-!39 = distinct !DILocation(line: 5, column: 1, scope: !11)
-!40 = !{!18, !7, i64 128}
-!41 = !DILocation(line: 5, column: 1, scope: !10, inlinedAt: !42)
-!42 = distinct !DILocation(line: 5, column: 1, scope: !11, inlinedAt: !39)
-!43 = !DILocation(line: 6, column: 3, scope: !10, inlinedAt: !42)
-!44 = distinct !{!44, !45}
-!45 = !{!"llvm.loop.unroll.disable"}
-!46 = !{!18, !19, i64 40}
-!47 = !{!18, !19, i64 44}
-!48 = !{!18, !16, i64 56}
+!35 = !DILocation(line: 5, column: 1, scope: !11, inlinedAt: !36)
+!36 = distinct !DILocation(line: 5, column: 1, scope: !11)
+!37 = !{!18, !7, i64 128}
+!38 = !DILocation(line: 5, column: 1, scope: !10, inlinedAt: !39)
+!39 = distinct !DILocation(line: 5, column: 1, scope: !11, inlinedAt: !36)
+!40 = !DILocation(line: 6, column: 3, scope: !10, inlinedAt: !39)
+!41 = distinct !{!41, !42}
+!42 = !{!"llvm.loop.unroll.disable"}
+!43 = !{!18, !19, i64 40}
+!44 = !{!18, !19, i64 44}
+!45 = !{!18, !16, i64 56}

--- a/test/testdata/compiler/block_no_args_captures_constant.opt.ll.exp
+++ b/test/testdata/compiler/block_no_args_captures_constant.opt.ll.exp
@@ -2,16 +2,17 @@
 source_filename = "llvm-link"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 
-%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.3, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.4, [29 x i16] }
+%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.5, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.6, [29 x i16] }
 %struct.rb_global_vm_lock_struct = type { %struct.rb_thread_struct*, %union.pthread_mutex_t, %struct.list_head, %struct.rb_thread_struct*, i32, %union.pthread_cond_t, %union.pthread_cond_t, i32, i32 }
-%union.pthread_cond_t = type { %struct.anon.2 }
-%struct.anon.2 = type { i32, i32, i64, i64, i64, i8*, i32, i32 }
-%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.7, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
+%union.pthread_cond_t = type { %struct.__pthread_cond_s }
+%struct.__pthread_cond_s = type { %union.anon, %union.anon, [2 x i32], [2 x i32], i32, i32, [2 x i32] }
+%union.anon = type { i64 }
+%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.10, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
 %struct.list_node = type { %struct.list_node*, %struct.list_node* }
-%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.5 }
+%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.7 }
 %struct.rb_control_frame_struct = type { i64*, i64*, %struct.rb_iseq_struct*, i64, i64*, i8*, i64* }
-%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.14 }
-%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.13, i32, i32, i32, i32, i32, i8, i64 }
+%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.17 }
+%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.16, i32, i32, i32, i32, i32, i8, i64 }
 %struct.anon = type { %struct.anon.0, i32, i32, i32, i32, i32, i32, i32, i64*, %struct.rb_iseq_param_keyword* }
 %struct.anon.0 = type { i16, [2 x i8] }
 %struct.rb_iseq_param_keyword = type { i32, i32, i32, i32, i64*, i64* }
@@ -27,34 +28,34 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_cref_struct = type { i64, i64, i64, %struct.rb_cref_struct*, %struct.rb_scope_visi_struct }
 %struct.rb_scope_visi_struct = type { i8, [3 x i8] }
 %struct.rb_call_data = type { %struct.rb_call_cache, %struct.rb_call_info }
-%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.12 }
+%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.15 }
 %struct.rb_callable_method_entry_struct = type { i64, i64, %struct.rb_method_definition_struct*, i64, i64 }
-%struct.rb_method_definition_struct = type { i64, %union.anon.10, i64, i64 }
-%union.anon.10 = type { %struct.rb_method_cfunc_struct }
+%struct.rb_method_definition_struct = type { i64, %union.anon.13, i64, i64 }
+%union.anon.13 = type { %struct.rb_method_cfunc_struct }
 %struct.rb_method_cfunc_struct = type { i64 (...)*, i64 (i64, i32, i64*, i64 (...)*)*, i32 }
-%union.anon.12 = type { i32 }
+%union.anon.15 = type { i32 }
 %struct.rb_call_info = type { i64, i32, i32 }
-%struct.anon.13 = type { i64, i64, i64, i64* }
-%union.anon.14 = type { %struct.anon.15 }
-%struct.anon.15 = type { i64, i32 }
+%struct.anon.16 = type { i64, i64, i64, i64* }
+%union.anon.17 = type { %struct.anon.18 }
+%struct.anon.18 = type { i64, i32 }
 %struct.rb_vm_tag = type { i64, i64, [5 x i8*], %struct.rb_vm_tag*, i32 }
 %struct.rb_vm_protect_tag = type { %struct.rb_vm_protect_tag* }
 %struct.rb_ensure_list = type { %struct.rb_ensure_list*, %struct.rb_ensure_entry }
 %struct.rb_ensure_entry = type { i64, i64 (i64)*, i64 }
 %struct.rb_trace_arg_struct = type { i32, %struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, i64, i64, i64, i64, i64, i32, i32, i64 }
-%struct.anon.5 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
+%struct.anon.7 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
 %struct.__jmp_buf_tag = type { [8 x i64], i32, %struct.__sigset_t }
 %struct.__sigset_t = type { [16 x i64] }
 %struct.rb_calling_info = type { i64, i64, i32, i32 }
-%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.6 }
-%union.anon.6 = type { %union.pthread_cond_t }
+%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.9 }
+%union.anon.9 = type { %union.pthread_cond_t }
 %struct.rb_unblock_callback = type { void (i8*)*, i8* }
 %struct.rb_mutex_struct = type opaque
 %struct.rb_thread_list_struct = type { %struct.rb_thread_list_struct*, %struct.rb_thread_struct* }
-%union.anon.7 = type { %struct.anon.8 }
-%struct.anon.8 = type { i64, i64, i32 }
+%union.anon.10 = type { %struct.anon.11 }
+%struct.anon.11 = type { i64, i64, i32 }
 %struct.rb_fiber_struct = type opaque
-%struct.anon.3 = type { [65 x i64] }
+%struct.anon.5 = type { [65 x i64] }
 %struct.rb_hook_list_struct = type { %struct.rb_event_hook_struct*, i32, i32, i32 }
 %struct.rb_event_hook_struct = type opaque
 %struct.rb_postponed_job_struct = type opaque
@@ -68,22 +69,22 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.st_hash_type = type { i32 (i64, i64)*, i64 (i64)* }
 %struct.st_table_entry = type opaque
 %struct.rb_builtin_function = type opaque
-%struct.anon.4 = type { i64, i64, i64, i64 }
+%struct.anon.6 = type { i64, i64, i64, i64 }
 %struct.SorbetLineNumberInfo = type { i32, %struct.iseq_insn_info_entry*, i64* }
 %struct.FunctionInlineCache = type { %struct.rb_kwarg_call_data }
 %struct.rb_kwarg_call_data = type { %struct.rb_call_cache, %struct.rb_call_info_with_kwarg }
 %struct.rb_call_info_with_kwarg = type { %struct.rb_call_info, %struct.rb_call_info_kw_arg* }
 %struct.rb_call_info_kw_arg = type { i32, [1 x i64] }
-%struct.rb_captured_block = type { i64, i64*, %union.anon.17 }
-%union.anon.17 = type { %struct.rb_iseq_struct* }
+%struct.rb_captured_block = type { i64, i64*, %union.anon.20 }
+%union.anon.20 = type { %struct.rb_iseq_struct* }
 %struct.vm_ifunc = type { i64, i64, i64 (i64, i64, i32, i64*, i64)*, i8*, %struct.rb_code_position_struct }
 
-@ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
-@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @ruby_vm_global_constant_state = external local_unnamed_addr global i64, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
+@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @"stackFramePrecomputed_func_Object#3foo" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @rubyIdPrecomputed_foo = internal unnamed_addr global i64 0, align 8
 @str_foo = private unnamed_addr constant [4 x i8] c"foo\00", align 1
@@ -162,14 +163,14 @@ declare noalias nonnull i8* @ruby_xcalloc(i64, i64) local_unnamed_addr #2
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #3 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #10
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #9
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #3 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #10
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #9
   unreachable
 }
 
@@ -182,7 +183,7 @@ functionEntryInitializers:
   br i1 %tooManyArgs, label %argCountFailBlock, label %1, !dbg !16, !prof !17
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #11, !dbg !16
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 0, i32 noundef 0) #10, !dbg !16
   unreachable, !dbg !16
 
 1:                                                ; preds = %functionEntryInitializers
@@ -218,113 +219,111 @@ argCountFailBlock:                                ; preds = %functionEntryInitia
   %17 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 2, !dbg !23
   %18 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %17, align 8, !dbg !23, !tbaa !24
   %19 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 3, !dbg !23
-  %20 = bitcast i64* %19 to %struct.rb_captured_block*, !dbg !23
-  %21 = getelementptr inbounds i64, i64* %19, i64 2, !dbg !23
-  %22 = bitcast i64* %21 to %struct.vm_ifunc**, !dbg !23
-  store %struct.vm_ifunc* %15, %struct.vm_ifunc** %22, align 8, !dbg !23, !tbaa !28
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !29), !dbg !23
-  %23 = ptrtoint %struct.rb_captured_block* %20 to i64, !dbg !23
-  %24 = or i64 %23, 3, !dbg !23
-  %25 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 17, !dbg !23
-  %26 = and i64 %24, -4, !dbg !32
-  %27 = inttoptr i64 %26 to %struct.rb_captured_block*, !dbg !32
-  store i64 0, i64* %25, align 8, !dbg !32, !tbaa !34
-  tail call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %27) #12, !dbg !32
-  br label %28, !dbg !32
+  %20 = getelementptr inbounds i64, i64* %19, i64 2, !dbg !23
+  %21 = bitcast i64* %20 to %struct.vm_ifunc**, !dbg !23
+  store %struct.vm_ifunc* %15, %struct.vm_ifunc** %21, align 8, !dbg !23, !tbaa !28
+  %22 = ptrtoint i64* %19 to i64, !dbg !23
+  %23 = or i64 %22, 3, !dbg !23
+  %24 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 17, !dbg !23
+  %25 = and i64 %23, -4, !dbg !29
+  %26 = inttoptr i64 %25 to %struct.rb_captured_block*, !dbg !29
+  store i64 0, i64* %24, align 8, !dbg !29, !tbaa !31
+  tail call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %26) #11, !dbg !29
+  br label %27, !dbg !29
 
-28:                                               ; preds = %28, %5
-  %29 = phi i64 [ 0, %5 ], [ %43, %28 ], !dbg !32
-  %30 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !23, !tbaa !14
-  %31 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %30, i64 0, i32 2, !dbg !23
-  %32 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %31, align 8, !dbg !23, !tbaa !24
-  %stackFrame.i1.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo$block_1", align 8, !dbg !23
-  %33 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 2, !dbg !23
-  store %struct.rb_iseq_struct* %stackFrame.i1.i, %struct.rb_iseq_struct** %33, align 8, !dbg !23, !tbaa !35
-  %34 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 4, !dbg !23
-  %35 = load i64*, i64** %34, align 8, !dbg !23, !tbaa !37
-  %36 = load i64, i64* %35, align 8, !dbg !23, !tbaa !6
-  %37 = and i64 %36, -129, !dbg !23
-  store i64 %37, i64* %35, align 8, !dbg !23, !tbaa !6
-  %38 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 0, !dbg !23
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %38, align 8, !dbg !38, !tbaa !14
-  %39 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 1, !dbg !41
-  %40 = load i64*, i64** %39, align 8, !dbg !41
-  store i64 %9, i64* %40, align 8, !dbg !41, !tbaa !6
-  %41 = getelementptr inbounds i64, i64* %40, i64 1, !dbg !41
-  store i64 %6, i64* %41, align 8, !dbg !41, !tbaa !6
-  %42 = getelementptr inbounds i64, i64* %41, i64 1, !dbg !41
-  store i64* %42, i64** %39, align 8, !dbg !41
-  %send23 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.1, i64 0), !dbg !41
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %38, align 8, !dbg !41, !tbaa !14
-  %43 = add nuw nsw i64 %29, 1, !dbg !32
-  %44 = icmp eq i64 %43, 10, !dbg !32
-  br i1 %44, label %forward_sorbet_rb_int_dotimes_withBlock.exit, label %28, !dbg !32, !llvm.loop !42
+27:                                               ; preds = %27, %5
+  %28 = phi i64 [ %42, %27 ], [ 0, %5 ], !dbg !29
+  %29 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !23, !tbaa !14
+  %30 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %29, i64 0, i32 2, !dbg !23
+  %31 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %30, align 8, !dbg !23, !tbaa !24
+  %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo$block_1", align 8, !dbg !23
+  %32 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %31, i64 0, i32 2, !dbg !23
+  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %32, align 8, !dbg !23, !tbaa !32
+  %33 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %31, i64 0, i32 4, !dbg !23
+  %34 = load i64*, i64** %33, align 8, !dbg !23, !tbaa !34
+  %35 = load i64, i64* %34, align 8, !dbg !23, !tbaa !6
+  %36 = and i64 %35, -129, !dbg !23
+  store i64 %36, i64* %34, align 8, !dbg !23, !tbaa !6
+  %37 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %31, i64 0, i32 0, !dbg !23
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %37, align 8, !dbg !35, !tbaa !14
+  %38 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %31, i64 0, i32 1, !dbg !38
+  %39 = load i64*, i64** %38, align 8, !dbg !38
+  store i64 %9, i64* %39, align 8, !dbg !38, !tbaa !6
+  %40 = getelementptr inbounds i64, i64* %39, i64 1, !dbg !38
+  store i64 %6, i64* %40, align 8, !dbg !38, !tbaa !6
+  %41 = getelementptr inbounds i64, i64* %40, i64 1, !dbg !38
+  store i64* %41, i64** %38, align 8, !dbg !38
+  %send23 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.1, i64 0), !dbg !38
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %37, align 8, !dbg !38, !tbaa !14
+  %42 = add nuw nsw i64 %28, 1, !dbg !29
+  %43 = icmp eq i64 %42, 10, !dbg !29
+  br i1 %43, label %forward_sorbet_rb_int_dotimes_withBlock.exit, label %27, !dbg !29, !llvm.loop !39
 
-forward_sorbet_rb_int_dotimes_withBlock.exit:     ; preds = %28
-  tail call void @sorbet_popFrame() #12, !dbg !32
-  %45 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !23, !tbaa !14
-  %46 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %45, i64 0, i32 5, !dbg !23
-  %47 = load i32, i32* %46, align 8, !dbg !23, !tbaa !44
-  %48 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %45, i64 0, i32 6, !dbg !23
-  %49 = load i32, i32* %48, align 4, !dbg !23, !tbaa !45
-  %50 = xor i32 %49, -1, !dbg !23
-  %51 = and i32 %50, %47, !dbg !23
-  %52 = icmp eq i32 %51, 0, !dbg !23
-  br i1 %52, label %rb_vm_check_ints.exit, label %53, !dbg !23, !prof !46
+forward_sorbet_rb_int_dotimes_withBlock.exit:     ; preds = %27
+  tail call void @sorbet_popFrame() #11, !dbg !29
+  %44 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !23, !tbaa !14
+  %45 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %44, i64 0, i32 5, !dbg !23
+  %46 = load i32, i32* %45, align 8, !dbg !23, !tbaa !41
+  %47 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %44, i64 0, i32 6, !dbg !23
+  %48 = load i32, i32* %47, align 4, !dbg !23, !tbaa !42
+  %49 = xor i32 %48, -1, !dbg !23
+  %50 = and i32 %49, %46, !dbg !23
+  %51 = icmp eq i32 %50, 0, !dbg !23
+  br i1 %51, label %sorbet_afterIntrinsic.exit, label %52, !dbg !23, !prof !43
 
-53:                                               ; preds = %forward_sorbet_rb_int_dotimes_withBlock.exit
-  %54 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %45, i64 0, i32 8, !dbg !23
-  %55 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %54, align 8, !dbg !23, !tbaa !47
-  %56 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %55, i32 noundef 0) #12, !dbg !23
-  br label %rb_vm_check_ints.exit, !dbg !23
+52:                                               ; preds = %forward_sorbet_rb_int_dotimes_withBlock.exit
+  %53 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %44, i64 0, i32 8, !dbg !23
+  %54 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %53, align 8, !dbg !23, !tbaa !44
+  %55 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %54, i32 noundef 0) #11, !dbg !23
+  br label %sorbet_afterIntrinsic.exit, !dbg !23
 
-rb_vm_check_ints.exit:                            ; preds = %forward_sorbet_rb_int_dotimes_withBlock.exit, %53
+sorbet_afterIntrinsic.exit:                       ; preds = %forward_sorbet_rb_int_dotimes_withBlock.exit, %52
   store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %0, align 8, !tbaa !14
   ret i64 21
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_Object#3foo$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #5 !dbg !39 {
+define internal i64 @"func_Object#3foo$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #5 !dbg !36 {
 functionEntryInitializers:
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
   %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !24
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo$block_1", align 8
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %3, align 8, !tbaa !35
+  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %3, align 8, !tbaa !32
   %4 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %5 = load i64*, i64** %4, align 8, !tbaa !37
+  %5 = load i64*, i64** %4, align 8, !tbaa !34
   %6 = load i64, i64* %5, align 8, !tbaa !6
   %7 = and i64 %6, -129
   store i64 %7, i64* %5, align 8, !tbaa !6
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !dbg !48, !tbaa !14
-  %9 = load i64, i64* @guard_epoch_A, align 8, !dbg !49
-  %10 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !49, !tbaa !20
-  %needTakeSlowPath = icmp ne i64 %9, %10, !dbg !49
-  br i1 %needTakeSlowPath, label %11, label %12, !dbg !49, !prof !22
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !dbg !45, !tbaa !14
+  %9 = load i64, i64* @guard_epoch_A, align 8, !dbg !46
+  %10 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !46, !tbaa !20
+  %needTakeSlowPath = icmp ne i64 %9, %10, !dbg !46
+  br i1 %needTakeSlowPath, label %11, label %12, !dbg !46, !prof !22
 
 11:                                               ; preds = %functionEntryInitializers
-  tail call void @const_recompute_A(), !dbg !49
-  br label %12, !dbg !49
+  tail call void @const_recompute_A(), !dbg !46
+  br label %12, !dbg !46
 
 12:                                               ; preds = %functionEntryInitializers, %11
-  %13 = load i64, i64* @guarded_const_A, align 8, !dbg !49
-  %14 = load i64, i64* @guard_epoch_A, align 8, !dbg !49
-  %15 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !49, !tbaa !20
-  %guardUpdated = icmp eq i64 %14, %15, !dbg !49
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !49
-  %16 = load i64, i64* @rb_mKernel, align 8, !dbg !49
-  %17 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !49
-  %18 = load i64*, i64** %17, align 8, !dbg !49
-  store i64 %16, i64* %18, align 8, !dbg !49, !tbaa !6
-  %19 = getelementptr inbounds i64, i64* %18, i64 1, !dbg !49
-  store i64 %13, i64* %19, align 8, !dbg !49, !tbaa !6
-  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !49
-  store i64* %20, i64** %17, align 8, !dbg !49
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.1, i64 0), !dbg !49
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %8, align 8, !dbg !49, !tbaa !14
-  ret i64 %send, !dbg !48
+  %13 = load i64, i64* @guarded_const_A, align 8, !dbg !46
+  %14 = load i64, i64* @guard_epoch_A, align 8, !dbg !46
+  %15 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !46, !tbaa !20
+  %guardUpdated = icmp eq i64 %14, %15, !dbg !46
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !46
+  %16 = load i64, i64* @rb_mKernel, align 8, !dbg !46
+  %17 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !46
+  %18 = load i64*, i64** %17, align 8, !dbg !46
+  store i64 %16, i64* %18, align 8, !dbg !46, !tbaa !6
+  %19 = getelementptr inbounds i64, i64* %18, i64 1, !dbg !46
+  store i64 %13, i64* %19, align 8, !dbg !46, !tbaa !6
+  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !46
+  store i64* %20, i64** %17, align 8, !dbg !46
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.1, i64 0), !dbg !46
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %8, align 8, !dbg !46, !tbaa !14
+  ret i64 %send, !dbg !45
 }
 
 ; Function Attrs: sspreq
@@ -333,21 +332,21 @@ entry:
   %locals.i7.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #12
+  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #11
   store i64 %0, i64* @rubyIdPrecomputed_foo, align 8
-  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @"str_block in foo", i64 0, i64 0), i64 noundef 12) #12
+  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @"str_block in foo", i64 0, i64 0), i64 noundef 12) #11
   store i64 %1, i64* @"rubyIdPrecomputed_block in foo", align 8
-  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #12
+  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #11
   store i64 %2, i64* @rubyIdPrecomputed_puts, align 8
-  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_times, i64 0, i64 0), i64 noundef 5) #12
-  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #12
+  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_times, i64 0, i64 0), i64 noundef 5) #11
+  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
   store i64 %4, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #12
-  %6 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #12
-  tail call void @rb_gc_register_mark_object(i64 %6) #12
+  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #11
+  %6 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #11
+  tail call void @rb_gc_register_mark_object(i64 %6) #11
   store i64 %6, i64* @rubyStrFrozen_foo, align 8
-  %7 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([58 x i8], [58 x i8]* @"str_test/testdata/compiler/block_no_args_captures_constant.rb", i64 0, i64 0), i64 noundef 57) #12
-  tail call void @rb_gc_register_mark_object(i64 %7) #12
+  %7 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([58 x i8], [58 x i8]* @"str_test/testdata/compiler/block_no_args_captures_constant.rb", i64 0, i64 0), i64 noundef 57) #11
+  tail call void @rb_gc_register_mark_object(i64 %7) #11
   store i64 %7, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args_captures_constant.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 13)
   %rubyId_foo.i.i = load i64, i64* @rubyIdPrecomputed_foo, align 8
@@ -355,8 +354,8 @@ entry:
   %"rubyStr_test/testdata/compiler/block_no_args_captures_constant.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args_captures_constant.rb", align 8
   %8 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_foo.i.i, i64 %rubyId_foo.i.i, i64 %"rubyStr_test/testdata/compiler/block_no_args_captures_constant.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %8, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8
-  %9 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @"str_block in foo", i64 0, i64 0), i64 noundef 12) #12
-  call void @rb_gc_register_mark_object(i64 %9) #12
+  %9 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @"str_block in foo", i64 0, i64 0), i64 noundef 12) #11
+  call void @rb_gc_register_mark_object(i64 %9) #11
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8
   %"rubyId_block in foo.i.i" = load i64, i64* @"rubyIdPrecomputed_block in foo", align 8
   %"rubyStr_test/testdata/compiler/block_no_args_captures_constant.rb.i5.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args_captures_constant.rb", align 8
@@ -364,71 +363,68 @@ entry:
   store %struct.rb_iseq_struct* %10, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo$block_1", align 8
   %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !19
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
-  %11 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_Object#3foo$block_1", i8* noundef null, i32 noundef 0, i32 noundef 0) #12
+  %11 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_Object#3foo$block_1", i8* noundef null, i32 noundef 0, i32 noundef 0) #11
   %12 = ptrtoint %struct.vm_ifunc* %11 to i64
   %13 = call i64 @sorbet_globalConstRegister(i64 %12)
   store i64 %13, i64* @"func_Object#3foo$block_1_ifunc", align 8
-  %rubyId_puts2.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !49
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts2.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !49
-  %14 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #12
-  call void @rb_gc_register_mark_object(i64 %14) #12
+  %rubyId_puts2.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !46
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts2.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !46
+  %14 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
+  call void @rb_gc_register_mark_object(i64 %14) #11
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/block_no_args_captures_constant.rb.i6.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args_captures_constant.rb", align 8
   %15 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %14, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_no_args_captures_constant.rb.i6.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i7.i, i32 noundef 0, i32 noundef 4)
   store %struct.rb_iseq_struct* %15, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
-  %16 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_hi, i64 0, i64 0), i64 noundef 2) #12
-  call void @rb_gc_register_mark_object(i64 %16) #12
+  %16 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_hi, i64 0, i64 0), i64 noundef 2) #11
+  call void @rb_gc_register_mark_object(i64 %16) #11
   store i64 %16, i64* @rubyStrFrozen_hi, align 8
-  %rubyId_foo.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !50
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !50
+  %rubyId_foo.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !47
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !47
   %17 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
   %18 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %17, i64 0, i32 18
-  %19 = load i64, i64* %18, align 8, !tbaa !52
+  %19 = load i64, i64* %18, align 8, !tbaa !49
   %20 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
   %21 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %20, i64 0, i32 2
   %22 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %21, align 8, !tbaa !24
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$152", align 8
   %23 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %22, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %23, align 8, !tbaa !35
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %23, align 8, !tbaa !32
   %24 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %22, i64 0, i32 4
-  %25 = load i64*, i64** %24, align 8, !tbaa !37
+  %25 = load i64*, i64** %24, align 8, !tbaa !34
   %26 = load i64, i64* %25, align 8, !tbaa !6
   %27 = and i64 %26, -33
   store i64 %27, i64* %25, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %20, %struct.rb_control_frame_struct* %22, %struct.rb_iseq_struct* %stackFrame.i) #12
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %20, %struct.rb_control_frame_struct* %22, %struct.rb_iseq_struct* %stackFrame.i) #11
   %28 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %22, i64 0, i32 0
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %28, align 8, !dbg !60, !tbaa !14
-  %rubyStr_hi.i = load i64, i64* @rubyStrFrozen_hi, align 8, !dbg !61
-  %29 = load i64, i64* @rb_cObject, align 8, !dbg !61
-  %30 = call i64 @sorbet_setConstant(i64 %29, i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 noundef 1, i64 %rubyStr_hi.i) #12, !dbg !61
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %28, align 8, !dbg !61, !tbaa !14
-  %stackFrame12.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8, !dbg !62
-  %31 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #13, !dbg !62
-  %32 = bitcast i8* %31 to i16*, !dbg !62
-  %33 = load i16, i16* %32, align 8, !dbg !62
-  %34 = and i16 %33, -384, !dbg !62
-  store i16 %34, i16* %32, align 8, !dbg !62
-  %35 = getelementptr inbounds i8, i8* %31, i64 4, !dbg !62
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %35, i8 0, i64 28, i1 false) #12, !dbg !62
-  call void @sorbet_vm_define_method(i64 %29, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#3foo", i8* nonnull %31, %struct.rb_iseq_struct* %stackFrame12.i, i1 noundef zeroext false) #12, !dbg !62
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %28, align 8, !dbg !62, !tbaa !14
-  %36 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %22, i64 0, i32 1, !dbg !50
-  %37 = load i64*, i64** %36, align 8, !dbg !50
-  store i64 %19, i64* %37, align 8, !dbg !50, !tbaa !6
-  %38 = getelementptr inbounds i64, i64* %37, i64 1, !dbg !50
-  store i64* %38, i64** %36, align 8, !dbg !50
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo, i64 0), !dbg !50
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %28, align 8, !dbg !57, !tbaa !14
+  %rubyStr_hi.i = load i64, i64* @rubyStrFrozen_hi, align 8, !dbg !58
+  %29 = load i64, i64* @rb_cObject, align 8, !dbg !58
+  %30 = call i64 @sorbet_setConstant(i64 %29, i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 noundef 1, i64 %rubyStr_hi.i) #11, !dbg !58
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %28, align 8, !dbg !58, !tbaa !14
+  %stackFrame12.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8, !dbg !59
+  %31 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !59
+  %32 = bitcast i8* %31 to i16*, !dbg !59
+  %33 = load i16, i16* %32, align 8, !dbg !59
+  %34 = and i16 %33, -384, !dbg !59
+  store i16 %34, i16* %32, align 8, !dbg !59
+  %35 = getelementptr inbounds i8, i8* %31, i64 4, !dbg !59
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %35, i8 0, i64 28, i1 false) #11, !dbg !59
+  call void @sorbet_vm_define_method(i64 %29, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#3foo", i8* nonnull %31, %struct.rb_iseq_struct* %stackFrame12.i, i1 noundef zeroext false) #11, !dbg !59
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %28, align 8, !dbg !59, !tbaa !14
+  %36 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %22, i64 0, i32 1, !dbg !47
+  %37 = load i64*, i64** %36, align 8, !dbg !47
+  store i64 %19, i64* %37, align 8, !dbg !47, !tbaa !6
+  %38 = getelementptr inbounds i64, i64* %37, i64 1, !dbg !47
+  store i64* %38, i64** %36, align 8, !dbg !47
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo, i64 0), !dbg !47
   ret void
 }
 
-; Function Attrs: inaccessiblememonly nofree nosync nounwind willreturn
-declare void @llvm.experimental.noalias.scope.decl(metadata) #7
-
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #8
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #7
 
 ; Function Attrs: nofree nosync nounwind willreturn
-declare void @llvm.assume(i1 noundef) #9
+declare void @llvm.assume(i1 noundef) #8
 
 ; Function Attrs: ssp
 define linkonce void @const_recompute_A() local_unnamed_addr #5 {
@@ -439,20 +435,19 @@ define linkonce void @const_recompute_A() local_unnamed_addr #5 {
   ret void
 }
 
-attributes #0 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #2 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #3 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { noreturn "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #1 = { "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #2 = { allocsize(0,1) "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #3 = { nounwind ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #4 = { nounwind sspreq uwtable }
 attributes #5 = { ssp }
 attributes #6 = { sspreq }
-attributes #7 = { inaccessiblememonly nofree nosync nounwind willreturn }
-attributes #8 = { argmemonly nofree nosync nounwind willreturn writeonly }
-attributes #9 = { nofree nosync nounwind willreturn }
-attributes #10 = { noreturn nounwind }
-attributes #11 = { noreturn }
-attributes #12 = { nounwind }
-attributes #13 = { nounwind allocsize(0,1) }
+attributes #7 = { argmemonly nofree nosync nounwind willreturn writeonly }
+attributes #8 = { nofree nosync nounwind willreturn }
+attributes #9 = { noreturn nounwind }
+attributes #10 = { noreturn }
+attributes #11 = { nounwind }
+attributes #12 = { nounwind allocsize(0,1) }
 
 !llvm.module.flags = !{!0, !1, !2}
 !llvm.dbg.cu = !{!3}
@@ -486,37 +481,34 @@ attributes #13 = { nounwind allocsize(0,1) }
 !26 = !{!"int", !8, i64 0}
 !27 = !{!"", !15, i64 0, !15, i64 8, !7, i64 16, !8, i64 24}
 !28 = !{!8, !8, i64 0}
-!29 = !{!30}
-!30 = distinct !{!30, !31, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
-!31 = distinct !{!31, !"VM_BH_FROM_IFUNC_BLOCK"}
-!32 = !DILocation(line: 7, column: 3, scope: !10, inlinedAt: !33)
-!33 = distinct !DILocation(line: 7, column: 3, scope: !10)
-!34 = !{!25, !7, i64 128}
-!35 = !{!36, !15, i64 16}
-!36 = !{!"rb_control_frame_struct", !15, i64 0, !15, i64 8, !15, i64 16, !7, i64 24, !15, i64 32, !15, i64 40, !15, i64 48}
-!37 = !{!36, !15, i64 32}
-!38 = !DILocation(line: 7, column: 3, scope: !39, inlinedAt: !40)
-!39 = distinct !DISubprogram(name: "Object#foo", linkageName: "func_Object#3foo$block_1", scope: !10, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!40 = distinct !DILocation(line: 7, column: 3, scope: !10, inlinedAt: !33)
-!41 = !DILocation(line: 8, column: 5, scope: !39, inlinedAt: !40)
-!42 = distinct !{!42, !43}
-!43 = !{!"llvm.loop.unroll.disable"}
-!44 = !{!25, !26, i64 40}
-!45 = !{!25, !26, i64 44}
-!46 = !{!"branch_weights", i32 2000, i32 1}
-!47 = !{!25, !15, i64 56}
-!48 = !DILocation(line: 7, column: 3, scope: !39)
-!49 = !DILocation(line: 8, column: 5, scope: !39)
-!50 = !DILocation(line: 12, column: 1, scope: !51)
-!51 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$152", scope: null, file: !4, line: 4, type: !11, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!52 = !{!53, !7, i64 400}
-!53 = !{!"rb_vm_struct", !7, i64 0, !54, i64 8, !15, i64 192, !15, i64 200, !15, i64 208, !21, i64 216, !8, i64 224, !55, i64 264, !55, i64 280, !55, i64 296, !55, i64 312, !7, i64 328, !26, i64 336, !26, i64 340, !26, i64 344, !26, i64 344, !26, i64 344, !26, i64 344, !26, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !15, i64 456, !15, i64 464, !57, i64 472, !58, i64 992, !15, i64 1016, !15, i64 1024, !26, i64 1032, !26, i64 1036, !55, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !26, i64 1136, !15, i64 1144, !15, i64 1152, !15, i64 1160, !15, i64 1168, !15, i64 1176, !15, i64 1184, !26, i64 1192, !59, i64 1200, !8, i64 1232}
-!54 = !{!"rb_global_vm_lock_struct", !15, i64 0, !8, i64 8, !55, i64 48, !15, i64 64, !26, i64 72, !8, i64 80, !8, i64 128, !26, i64 176, !26, i64 180}
-!55 = !{!"list_head", !56, i64 0}
-!56 = !{!"list_node", !15, i64 0, !15, i64 8}
-!57 = !{!"", !8, i64 0}
-!58 = !{!"rb_hook_list_struct", !15, i64 0, !26, i64 8, !26, i64 12, !26, i64 16}
-!59 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
-!60 = !DILocation(line: 0, scope: !51)
-!61 = !DILocation(line: 4, column: 5, scope: !51)
-!62 = !DILocation(line: 5, column: 1, scope: !51)
+!29 = !DILocation(line: 7, column: 3, scope: !10, inlinedAt: !30)
+!30 = distinct !DILocation(line: 7, column: 3, scope: !10)
+!31 = !{!25, !7, i64 128}
+!32 = !{!33, !15, i64 16}
+!33 = !{!"rb_control_frame_struct", !15, i64 0, !15, i64 8, !15, i64 16, !7, i64 24, !15, i64 32, !15, i64 40, !15, i64 48}
+!34 = !{!33, !15, i64 32}
+!35 = !DILocation(line: 7, column: 3, scope: !36, inlinedAt: !37)
+!36 = distinct !DISubprogram(name: "Object#foo", linkageName: "func_Object#3foo$block_1", scope: !10, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!37 = distinct !DILocation(line: 7, column: 3, scope: !10, inlinedAt: !30)
+!38 = !DILocation(line: 8, column: 5, scope: !36, inlinedAt: !37)
+!39 = distinct !{!39, !40}
+!40 = !{!"llvm.loop.unroll.disable"}
+!41 = !{!25, !26, i64 40}
+!42 = !{!25, !26, i64 44}
+!43 = !{!"branch_weights", i32 2000, i32 1}
+!44 = !{!25, !15, i64 56}
+!45 = !DILocation(line: 7, column: 3, scope: !36)
+!46 = !DILocation(line: 8, column: 5, scope: !36)
+!47 = !DILocation(line: 12, column: 1, scope: !48)
+!48 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$152", scope: null, file: !4, line: 4, type: !11, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!49 = !{!50, !7, i64 400}
+!50 = !{!"rb_vm_struct", !7, i64 0, !51, i64 8, !15, i64 192, !15, i64 200, !15, i64 208, !21, i64 216, !8, i64 224, !52, i64 264, !52, i64 280, !52, i64 296, !52, i64 312, !7, i64 328, !26, i64 336, !26, i64 340, !26, i64 344, !26, i64 344, !26, i64 344, !26, i64 344, !26, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !15, i64 456, !15, i64 464, !54, i64 472, !55, i64 992, !15, i64 1016, !15, i64 1024, !26, i64 1032, !26, i64 1036, !52, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !26, i64 1136, !15, i64 1144, !15, i64 1152, !15, i64 1160, !15, i64 1168, !15, i64 1176, !15, i64 1184, !26, i64 1192, !56, i64 1200, !8, i64 1232}
+!51 = !{!"rb_global_vm_lock_struct", !15, i64 0, !8, i64 8, !52, i64 48, !15, i64 64, !26, i64 72, !8, i64 80, !8, i64 128, !26, i64 176, !26, i64 180}
+!52 = !{!"list_head", !53, i64 0}
+!53 = !{!"list_node", !15, i64 0, !15, i64 8}
+!54 = !{!"", !8, i64 0}
+!55 = !{!"rb_hook_list_struct", !15, i64 0, !26, i64 8, !26, i64 12, !26, i64 16}
+!56 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
+!57 = !DILocation(line: 0, scope: !48)
+!58 = !DILocation(line: 4, column: 5, scope: !48)
+!59 = !DILocation(line: 5, column: 1, scope: !48)

--- a/test/testdata/compiler/block_type_checking.opt.ll.exp
+++ b/test/testdata/compiler/block_type_checking.opt.ll.exp
@@ -2,16 +2,17 @@
 source_filename = "llvm-link"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 
-%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.3, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.4, [29 x i16] }
+%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.5, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.6, [29 x i16] }
 %struct.rb_global_vm_lock_struct = type { %struct.rb_thread_struct*, %union.pthread_mutex_t, %struct.list_head, %struct.rb_thread_struct*, i32, %union.pthread_cond_t, %union.pthread_cond_t, i32, i32 }
-%union.pthread_cond_t = type { %struct.anon.2 }
-%struct.anon.2 = type { i32, i32, i64, i64, i64, i8*, i32, i32 }
-%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.7, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
+%union.pthread_cond_t = type { %struct.__pthread_cond_s }
+%struct.__pthread_cond_s = type { %union.anon, %union.anon, [2 x i32], [2 x i32], i32, i32, [2 x i32] }
+%union.anon = type { i64 }
+%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.10, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
 %struct.list_node = type { %struct.list_node*, %struct.list_node* }
-%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.5 }
+%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.7 }
 %struct.rb_control_frame_struct = type { i64*, i64*, %struct.rb_iseq_struct*, i64, i64*, i8*, i64* }
-%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.14 }
-%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.13, i32, i32, i32, i32, i32, i8, i64 }
+%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.17 }
+%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.16, i32, i32, i32, i32, i32, i8, i64 }
 %struct.anon = type { %struct.anon.0, i32, i32, i32, i32, i32, i32, i32, i64*, %struct.rb_iseq_param_keyword* }
 %struct.anon.0 = type { i16, [2 x i8] }
 %struct.rb_iseq_param_keyword = type { i32, i32, i32, i32, i64*, i64* }
@@ -27,34 +28,34 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_cref_struct = type { i64, i64, i64, %struct.rb_cref_struct*, %struct.rb_scope_visi_struct }
 %struct.rb_scope_visi_struct = type { i8, [3 x i8] }
 %struct.rb_call_data = type { %struct.rb_call_cache, %struct.rb_call_info }
-%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.12 }
+%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.15 }
 %struct.rb_callable_method_entry_struct = type { i64, i64, %struct.rb_method_definition_struct*, i64, i64 }
-%struct.rb_method_definition_struct = type { i64, %union.anon.10, i64, i64 }
-%union.anon.10 = type { %struct.rb_method_cfunc_struct }
+%struct.rb_method_definition_struct = type { i64, %union.anon.13, i64, i64 }
+%union.anon.13 = type { %struct.rb_method_cfunc_struct }
 %struct.rb_method_cfunc_struct = type { i64 (...)*, i64 (i64, i32, i64*, i64 (...)*)*, i32 }
-%union.anon.12 = type { i32 }
+%union.anon.15 = type { i32 }
 %struct.rb_call_info = type { i64, i32, i32 }
-%struct.anon.13 = type { i64, i64, i64, i64* }
-%union.anon.14 = type { %struct.anon.15 }
-%struct.anon.15 = type { i64, i32 }
+%struct.anon.16 = type { i64, i64, i64, i64* }
+%union.anon.17 = type { %struct.anon.18 }
+%struct.anon.18 = type { i64, i32 }
 %struct.rb_vm_tag = type { i64, i64, [5 x i8*], %struct.rb_vm_tag*, i32 }
 %struct.rb_vm_protect_tag = type { %struct.rb_vm_protect_tag* }
 %struct.rb_ensure_list = type { %struct.rb_ensure_list*, %struct.rb_ensure_entry }
 %struct.rb_ensure_entry = type { i64, i64 (i64)*, i64 }
 %struct.rb_trace_arg_struct = type { i32, %struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, i64, i64, i64, i64, i64, i32, i32, i64 }
-%struct.anon.5 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
+%struct.anon.7 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
 %struct.__jmp_buf_tag = type { [8 x i64], i32, %struct.__sigset_t }
 %struct.__sigset_t = type { [16 x i64] }
 %struct.rb_calling_info = type { i64, i64, i32, i32 }
-%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.6 }
-%union.anon.6 = type { %union.pthread_cond_t }
+%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.9 }
+%union.anon.9 = type { %union.pthread_cond_t }
 %struct.rb_unblock_callback = type { void (i8*)*, i8* }
 %struct.rb_mutex_struct = type opaque
 %struct.rb_thread_list_struct = type { %struct.rb_thread_list_struct*, %struct.rb_thread_struct* }
-%union.anon.7 = type { %struct.anon.8 }
-%struct.anon.8 = type { i64, i64, i32 }
+%union.anon.10 = type { %struct.anon.11 }
+%struct.anon.11 = type { i64, i64, i32 }
 %struct.rb_fiber_struct = type opaque
-%struct.anon.3 = type { [65 x i64] }
+%struct.anon.5 = type { [65 x i64] }
 %struct.rb_hook_list_struct = type { %struct.rb_event_hook_struct*, i32, i32, i32 }
 %struct.rb_event_hook_struct = type opaque
 %struct.rb_postponed_job_struct = type opaque
@@ -68,23 +69,21 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.st_hash_type = type { i32 (i64, i64)*, i64 (i64)* }
 %struct.st_table_entry = type opaque
 %struct.rb_builtin_function = type opaque
-%struct.anon.4 = type { i64, i64, i64, i64 }
+%struct.anon.6 = type { i64, i64, i64, i64 }
 %struct.SorbetLineNumberInfo = type { i32, %struct.iseq_insn_info_entry*, i64* }
 %struct.FunctionInlineCache = type { %struct.rb_kwarg_call_data }
 %struct.rb_kwarg_call_data = type { %struct.rb_call_cache, %struct.rb_call_info_with_kwarg }
 %struct.rb_call_info_with_kwarg = type { %struct.rb_call_info, %struct.rb_call_info_kw_arg* }
 %struct.rb_call_info_kw_arg = type { i32, [1 x i64] }
 %struct.vm_ifunc = type { i64, i64, i64 (i64, i64, i32, i64*, i64)*, i8*, %struct.rb_code_position_struct }
-%struct.rb_captured_block = type { i64, i64*, %union.anon.17 }
-%union.anon.17 = type { %struct.rb_iseq_struct* }
 %struct.iseq_inline_iv_cache_entry = type { i64, i64 }
 
-@ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
-@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @ruby_vm_global_constant_state = external local_unnamed_addr global i64, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
+@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -150,7 +149,7 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @guarded_const_T = linkonce local_unnamed_addr global i64 0
 @rb_cInteger = external local_unnamed_addr constant i64
 
-; Function Attrs: nounwind readnone willreturn
+; Function Attrs: nofree nosync nounwind readnone willreturn mustprogress
 declare i64 @rb_id2sym(i64) local_unnamed_addr #0
 
 ; Function Attrs: cold noreturn
@@ -474,7 +473,7 @@ entry:
   %89 = getelementptr i64, i64* %positional_table.i.i, i32 1, !dbg !26
   store i64 %rubyId_blk.i.i, i64* %89, align 8, !dbg !26
   %90 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #19, !dbg !26
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %90, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %49, i64 noundef 16, i1 noundef false) #17, !dbg !26
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull align 1 %90, i8* noundef nonnull align 1 %49, i64 noundef 16, i1 noundef false) #17, !dbg !26
   %91 = getelementptr inbounds i8, i8* %77, i64 32, !dbg !26
   %92 = bitcast i8* %91 to i8**, !dbg !26
   store i8* %90, i8** %92, align 8, !dbg !26, !tbaa !56
@@ -519,139 +518,139 @@ fastNew.i:                                        ; preds = %73
   %110 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %109, i64 0, i32 2, !dbg !31
   %111 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %110, align 8, !dbg !31, !tbaa !17
   %112 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %111, i64 0, i32 3, !dbg !31
-  %113 = bitcast i64* %112 to %struct.rb_captured_block*, !dbg !31
-  %114 = getelementptr inbounds i64, i64* %112, i64 2, !dbg !31
-  %115 = bitcast i64* %114 to %struct.vm_ifunc**, !dbg !31
-  store %struct.vm_ifunc* %104, %struct.vm_ifunc** %115, align 8, !dbg !31, !tbaa !57
-  %116 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %109, i64 0, i32 17, !dbg !31
-  store i64 0, i64* %116, align 8, !dbg !31, !tbaa !58
-  call void @llvm.experimental.noalias.scope.decl(metadata !59) #17, !dbg !31
-  %117 = ptrtoint %struct.rb_captured_block* %113 to i64, !dbg !31
-  %118 = or i64 %117, 3, !dbg !31
-  %119 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_bar, i64 %118) #17, !dbg !31
+  %113 = getelementptr inbounds i64, i64* %112, i64 2, !dbg !31
+  %114 = bitcast i64* %113 to %struct.vm_ifunc**, !dbg !31
+  store %struct.vm_ifunc* %104, %struct.vm_ifunc** %114, align 8, !dbg !31, !tbaa !57
+  %115 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %109, i64 0, i32 17, !dbg !31
+  store i64 0, i64* %115, align 8, !dbg !31, !tbaa !58
+  %116 = ptrtoint i64* %112 to i64, !dbg !31
+  %117 = or i64 %116, 3, !dbg !31
+  %118 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_bar, i64 %117) #17, !dbg !31
   store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %45, align 8, !dbg !31, !tbaa !15
-  %120 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %39, i64 0, i32 1, !dbg !32
-  %121 = load i64*, i64** %120, align 8, !dbg !32
-  store i64 %36, i64* %121, align 8, !dbg !32, !tbaa !6
+  %119 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %39, i64 0, i32 1, !dbg !32
+  %120 = load i64*, i64** %119, align 8, !dbg !32
+  store i64 %36, i64* %120, align 8, !dbg !32, !tbaa !6
+  %121 = getelementptr inbounds i64, i64* %120, i64 1, !dbg !32
+  store i64 %118, i64* %121, align 8, !dbg !32, !tbaa !6
   %122 = getelementptr inbounds i64, i64* %121, i64 1, !dbg !32
-  store i64 %119, i64* %122, align 8, !dbg !32, !tbaa !6
-  %123 = getelementptr inbounds i64, i64* %122, i64 1, !dbg !32
-  store i64* %123, i64** %120, align 8, !dbg !32
+  store i64* %122, i64** %119, align 8, !dbg !32
   %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p, i64 0), !dbg !32
   ret void
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define internal i64 @"func_Foo#3bar"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #11 !dbg !62 {
+define internal i64 @"func_Foo#3bar"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #11 !dbg !59 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
   store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %0, align 8, !tbaa !15
-  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !63
-  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !63
-  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !63
-  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !63, !prof !64
+  %tooManyArgs = icmp ugt i32 %argc, 1, !dbg !60
+  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !60
+  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !60
+  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !60, !prof !61
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #20, !dbg !63
-  unreachable, !dbg !63
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #20, !dbg !60
+  unreachable, !dbg !60
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  %rawArg_x = load i64, i64* %argArray, align 8, !dbg !63
-  %1 = and i64 %rawArg_x, 1, !dbg !65
-  %2 = icmp eq i64 %1, 0, !dbg !65
-  br i1 %2, label %3, label %typeTestSuccess, !dbg !65, !prof !66
+  %rawArg_x = load i64, i64* %argArray, align 8, !dbg !60
+  %1 = and i64 %rawArg_x, 1, !dbg !62
+  %2 = icmp eq i64 %1, 0, !dbg !62
+  br i1 %2, label %3, label %typeTestSuccess, !dbg !62, !prof !63
 
 3:                                                ; preds = %fillRequiredArgs
-  %4 = and i64 %rawArg_x, 7, !dbg !65
-  %5 = icmp ne i64 %4, 0, !dbg !65
-  %6 = and i64 %rawArg_x, -9, !dbg !65
-  %7 = icmp eq i64 %6, 0, !dbg !65
-  %8 = or i1 %5, %7, !dbg !65
-  br i1 %8, label %codeRepl20, label %sorbet_isa_Integer.exit, !dbg !65
+  %4 = and i64 %rawArg_x, 7, !dbg !62
+  %5 = icmp ne i64 %4, 0, !dbg !62
+  %6 = and i64 %rawArg_x, -9, !dbg !62
+  %7 = icmp eq i64 %6, 0, !dbg !62
+  %8 = or i1 %5, %7, !dbg !62
+  br i1 %8, label %codeRepl20, label %sorbet_isa_Integer.exit, !dbg !62
 
 sorbet_isa_Integer.exit:                          ; preds = %3
-  %9 = inttoptr i64 %rawArg_x to %struct.iseq_inline_iv_cache_entry*, !dbg !65
-  %10 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %9, i64 0, i32 0, !dbg !65
-  %11 = load i64, i64* %10, align 8, !dbg !65, !tbaa !67
-  %12 = and i64 %11, 31, !dbg !65
-  %13 = icmp eq i64 %12, 10, !dbg !65
-  br i1 %13, label %typeTestSuccess, label %codeRepl20, !dbg !65, !prof !69
+  %9 = inttoptr i64 %rawArg_x to %struct.iseq_inline_iv_cache_entry*, !dbg !62
+  %10 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %9, i64 0, i32 0, !dbg !62
+  %11 = load i64, i64* %10, align 8, !dbg !62, !tbaa !64
+  %12 = and i64 %11, 31, !dbg !62
+  %13 = icmp eq i64 %12, 10, !dbg !62
+  br i1 %13, label %typeTestSuccess, label %codeRepl20, !dbg !62, !prof !66
 
 typeTestSuccess:                                  ; preds = %fillRequiredArgs, %sorbet_isa_Integer.exit
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %0, align 8, !dbg !70, !tbaa !15
-  %rawBlockSendResult = tail call i64 @sorbet_vm_callBlock(%struct.rb_control_frame_struct* nonnull %cfp, i32 noundef 0, i64* noundef null, i32 noundef 0), !dbg !71
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %0, align 8, !dbg !71, !tbaa !15
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !72), !dbg !75
-  %14 = and i64 %rawArg_x, 1, !dbg !75
-  %15 = and i64 %14, %rawBlockSendResult, !dbg !75
-  %16 = icmp eq i64 %15, 0, !dbg !75
-  br i1 %16, label %26, label %17, !dbg !75, !prof !64
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %0, align 8, !dbg !67, !tbaa !15
+  %rawBlockSendResult = tail call i64 @sorbet_vm_callBlock(%struct.rb_control_frame_struct* nonnull %cfp, i32 noundef 0, i64* noundef null, i32 noundef 0), !dbg !68
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %0, align 8, !dbg !68, !tbaa !15
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !69), !dbg !72
+  %14 = and i64 %rawArg_x, 1, !dbg !72
+  %15 = icmp eq i64 %14, 0, !dbg !72
+  %16 = and i64 %rawBlockSendResult, 1, !dbg !72
+  %17 = icmp eq i64 %16, 0, !dbg !72
+  %18 = select i1 %15, i1 true, i1 %17, !dbg !72
+  br i1 %18, label %28, label %19, !dbg !72, !prof !61
 
-17:                                               ; preds = %typeTestSuccess
-  %18 = add nsw i64 %rawBlockSendResult, -1, !dbg !75
-  %19 = tail call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %rawArg_x, i64 %18) #21, !dbg !75
-  %20 = extractvalue { i64, i1 } %19, 1, !dbg !75
-  %21 = extractvalue { i64, i1 } %19, 0, !dbg !75
-  br i1 %20, label %22, label %sorbet_rb_int_plus.exit, !dbg !75
+19:                                               ; preds = %typeTestSuccess
+  %20 = add nsw i64 %rawBlockSendResult, -1, !dbg !72
+  %21 = tail call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %rawArg_x, i64 %20) #17, !dbg !72
+  %22 = extractvalue { i64, i1 } %21, 1, !dbg !72
+  %23 = extractvalue { i64, i1 } %21, 0, !dbg !72
+  br i1 %22, label %24, label %sorbet_rb_int_plus.exit, !dbg !72
 
-22:                                               ; preds = %17
-  %23 = ashr i64 %21, 1, !dbg !75
-  %24 = xor i64 %23, -9223372036854775808, !dbg !75
-  %25 = tail call i64 @rb_int2big(i64 %24) #17, !dbg !75, !noalias !72
-  br label %sorbet_rb_int_plus.exit, !dbg !75
+24:                                               ; preds = %19
+  %25 = ashr i64 %23, 1, !dbg !72
+  %26 = xor i64 %25, -9223372036854775808, !dbg !72
+  %27 = tail call i64 @rb_int2big(i64 %26) #17, !dbg !72, !noalias !69
+  br label %sorbet_rb_int_plus.exit, !dbg !72
 
-26:                                               ; preds = %typeTestSuccess
-  %27 = tail call i64 @sorbet_rb_int_plus_slowpath(i64 %rawArg_x, i64 %rawBlockSendResult) #17, !dbg !75, !noalias !72
-  br label %sorbet_rb_int_plus.exit, !dbg !75
+28:                                               ; preds = %typeTestSuccess
+  %29 = tail call i64 @sorbet_rb_int_plus_slowpath(i64 %rawArg_x, i64 %rawBlockSendResult) #17, !dbg !72, !noalias !69
+  br label %sorbet_rb_int_plus.exit, !dbg !72
 
-sorbet_rb_int_plus.exit:                          ; preds = %22, %17, %26
-  %28 = phi i64 [ %27, %26 ], [ %25, %22 ], [ %21, %17 ], !dbg !75
-  %29 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !75, !tbaa !15
-  %30 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %29, i64 0, i32 5, !dbg !75
-  %31 = load i32, i32* %30, align 8, !dbg !75, !tbaa !76
-  %32 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %29, i64 0, i32 6, !dbg !75
-  %33 = load i32, i32* %32, align 4, !dbg !75, !tbaa !77
-  %34 = xor i32 %33, -1, !dbg !75
-  %35 = and i32 %34, %31, !dbg !75
-  %36 = icmp eq i32 %35, 0, !dbg !75
-  br i1 %36, label %rb_vm_check_ints.exit, label %37, !dbg !75, !prof !69
+sorbet_rb_int_plus.exit:                          ; preds = %19, %24, %28
+  %30 = phi i64 [ %29, %28 ], [ %27, %24 ], [ %23, %19 ], !dbg !72
+  %31 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !72, !tbaa !15
+  %32 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %31, i64 0, i32 5, !dbg !72
+  %33 = load i32, i32* %32, align 8, !dbg !72, !tbaa !73
+  %34 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %31, i64 0, i32 6, !dbg !72
+  %35 = load i32, i32* %34, align 4, !dbg !72, !tbaa !74
+  %36 = xor i32 %35, -1, !dbg !72
+  %37 = and i32 %36, %33, !dbg !72
+  %38 = icmp eq i32 %37, 0, !dbg !72
+  br i1 %38, label %sorbet_afterIntrinsic.exit, label %39, !dbg !72, !prof !66
 
-37:                                               ; preds = %sorbet_rb_int_plus.exit
-  %38 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %29, i64 0, i32 8, !dbg !75
-  %39 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %38, align 8, !dbg !75, !tbaa !78
-  %40 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %39, i32 noundef 0) #17, !dbg !75
-  br label %rb_vm_check_ints.exit, !dbg !75
+39:                                               ; preds = %sorbet_rb_int_plus.exit
+  %40 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %31, i64 0, i32 8, !dbg !72
+  %41 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %40, align 8, !dbg !72, !tbaa !75
+  %42 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %41, i32 noundef 0) #17, !dbg !72
+  br label %sorbet_afterIntrinsic.exit, !dbg !72
 
-rb_vm_check_ints.exit:                            ; preds = %sorbet_rb_int_plus.exit, %37
-  %41 = and i64 %28, 1
-  %42 = icmp eq i64 %41, 0
-  br i1 %42, label %43, label %typeTestSuccess13, !prof !66
+sorbet_afterIntrinsic.exit:                       ; preds = %sorbet_rb_int_plus.exit, %39
+  %43 = and i64 %30, 1
+  %44 = icmp eq i64 %43, 0
+  br i1 %44, label %45, label %typeTestSuccess13, !prof !63
 
-43:                                               ; preds = %rb_vm_check_ints.exit
-  %44 = and i64 %28, 7
-  %45 = icmp ne i64 %44, 0
-  %46 = and i64 %28, -9
-  %47 = icmp eq i64 %46, 0
-  %48 = or i1 %45, %47
-  br i1 %48, label %codeRepl, label %sorbet_isa_Integer.exit21
+45:                                               ; preds = %sorbet_afterIntrinsic.exit
+  %46 = and i64 %30, 7
+  %47 = icmp ne i64 %46, 0
+  %48 = and i64 %30, -9
+  %49 = icmp eq i64 %48, 0
+  %50 = or i1 %47, %49
+  br i1 %50, label %codeRepl, label %sorbet_isa_Integer.exit21
 
-sorbet_isa_Integer.exit21:                        ; preds = %43
-  %49 = inttoptr i64 %28 to %struct.iseq_inline_iv_cache_entry*
-  %50 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %49, i64 0, i32 0
-  %51 = load i64, i64* %50, align 8, !tbaa !67
-  %52 = and i64 %51, 31
-  %53 = icmp eq i64 %52, 10
-  br i1 %53, label %typeTestSuccess13, label %codeRepl, !prof !69
+sorbet_isa_Integer.exit21:                        ; preds = %45
+  %51 = inttoptr i64 %30 to %struct.iseq_inline_iv_cache_entry*
+  %52 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %51, i64 0, i32 0
+  %53 = load i64, i64* %52, align 8, !tbaa !64
+  %54 = and i64 %53, 31
+  %55 = icmp eq i64 %54, 10
+  br i1 %55, label %typeTestSuccess13, label %codeRepl, !prof !66
 
 codeRepl20:                                       ; preds = %3, %sorbet_isa_Integer.exit
-  tail call fastcc void @"func_Foo#3bar.cold.2"(i64 %rawArg_x) #22, !dbg !65
+  tail call fastcc void @"func_Foo#3bar.cold.2"(i64 %rawArg_x) #21, !dbg !62
   unreachable
 
-typeTestSuccess13:                                ; preds = %rb_vm_check_ints.exit, %sorbet_isa_Integer.exit21
-  ret i64 %28
+typeTestSuccess13:                                ; preds = %sorbet_afterIntrinsic.exit, %sorbet_isa_Integer.exit21
+  ret i64 %30
 
-codeRepl:                                         ; preds = %43, %sorbet_isa_Integer.exit21
-  tail call fastcc void @"func_Foo#3bar.cold.1"(i64 %28) #22, !dbg !79
+codeRepl:                                         ; preds = %45, %sorbet_isa_Integer.exit21
+  tail call fastcc void @"func_Foo#3bar.cold.1"(i64 %30) #21, !dbg !76
   unreachable
 }
 
@@ -662,7 +661,7 @@ functionEntryInitializers:
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
   %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !17
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !80
+  %4 = load i64, i64* %3, align 8, !tbaa !77
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>$block_1", align 8
   %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
   store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !21
@@ -721,24 +720,24 @@ functionEntryInitializers:
   %34 = getelementptr inbounds i64, i64* %33, i64 1, !dbg !29
   store i64* %34, i64** %31, align 8, !dbg !29
   %send45 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns.1, i64 0), !dbg !29
-  ret i64 %send45, !dbg !81
+  ret i64 %send45, !dbg !78
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #13
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
-define internal fastcc void @"func_Foo#3bar.cold.1"(i64 %0) unnamed_addr #14 !dbg !82 {
+define internal fastcc void @"func_Foo#3bar.cold.1"(i64 %0) unnamed_addr #14 !dbg !79 {
 newFuncRoot:
   tail call void @sorbet_cast_failure(i64 %0, i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @"str_Return value", i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #20
   unreachable
 }
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
-define internal fastcc void @"func_Foo#3bar.cold.2"(i64 %rawArg_x) unnamed_addr #14 !dbg !84 {
+define internal fastcc void @"func_Foo#3bar.cold.2"(i64 %rawArg_x) unnamed_addr #14 !dbg !81 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %rawArg_x, i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_Parameter 'x'", i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #20, !dbg !85
-  unreachable, !dbg !85
+  tail call void @sorbet_cast_failure(i64 %rawArg_x, i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_Parameter 'x'", i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #20, !dbg !82
+  unreachable, !dbg !82
 }
 
 ; Function Attrs: nofree nosync nounwind willreturn
@@ -771,15 +770,15 @@ define linkonce void @const_recompute_T() local_unnamed_addr #12 {
   ret void
 }
 
-attributes #0 = { nounwind readnone willreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { cold noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #2 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #3 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { nofree nosync nounwind readnone willreturn mustprogress "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #1 = { cold noreturn "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #2 = { noreturn "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #3 = { "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #4 = { argmemonly nofree nosync nounwind willreturn }
 attributes #5 = { nofree nosync nounwind readnone speculatable willreturn }
 attributes #6 = { inaccessiblememonly nofree nosync nounwind willreturn }
-attributes #7 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #8 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #7 = { allocsize(0,1) "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #8 = { nounwind ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #9 = { nofree nosync nounwind ssp willreturn }
 attributes #10 = { sspreq }
 attributes #11 = { nounwind sspreq uwtable }
@@ -792,8 +791,7 @@ attributes #17 = { nounwind }
 attributes #18 = { nounwind readnone willreturn }
 attributes #19 = { nounwind allocsize(0,1) }
 attributes #20 = { noreturn }
-attributes #21 = { nounwind willreturn }
-attributes #22 = { noinline }
+attributes #21 = { noinline }
 
 !llvm.module.flags = !{!0, !1, !2}
 !llvm.dbg.cu = !{!3}
@@ -857,30 +855,27 @@ attributes #22 = { noinline }
 !56 = !{!52, !16, i64 32}
 !57 = !{!8, !8, i64 0}
 !58 = !{!18, !7, i64 128}
-!59 = !{!60}
-!60 = distinct !{!60, !61, !"VM_BH_FROM_IFUNC_BLOCK: argument 0"}
-!61 = distinct !{!61, !"VM_BH_FROM_IFUNC_BLOCK"}
-!62 = distinct !DISubprogram(name: "Foo#bar", linkageName: "func_Foo#3bar", scope: null, file: !4, line: 9, type: !12, scopeLine: 9, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!63 = !DILocation(line: 9, column: 3, scope: !62)
-!64 = !{!"branch_weights", i32 4001, i32 4000000}
-!65 = !DILocation(line: 9, column: 11, scope: !62)
-!66 = !{!"branch_weights", i32 1, i32 2000}
-!67 = !{!68, !7, i64 0}
-!68 = !{!"RBasic", !7, i64 0, !7, i64 8}
-!69 = !{!"branch_weights", i32 2000, i32 1}
-!70 = !DILocation(line: 9, column: 15, scope: !62)
-!71 = !DILocation(line: 10, column: 9, scope: !62)
-!72 = !{!73}
-!73 = distinct !{!73, !74, !"sorbet_rb_int_plus: argument 0"}
-!74 = distinct !{!74, !"sorbet_rb_int_plus"}
-!75 = !DILocation(line: 11, column: 5, scope: !62)
-!76 = !{!18, !19, i64 40}
-!77 = !{!18, !19, i64 44}
-!78 = !{!18, !16, i64 56}
-!79 = !DILocation(line: 0, scope: !62)
-!80 = !{!22, !7, i64 24}
-!81 = !DILocation(line: 8, column: 3, scope: !30)
-!82 = distinct !DISubprogram(name: "func_Foo#3bar.cold.1", linkageName: "func_Foo#3bar.cold.1", scope: null, file: !4, type: !83, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
-!83 = !DISubroutineType(types: !5)
-!84 = distinct !DISubprogram(name: "func_Foo#3bar.cold.2", linkageName: "func_Foo#3bar.cold.2", scope: null, file: !4, type: !83, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
-!85 = !DILocation(line: 9, column: 11, scope: !84)
+!59 = distinct !DISubprogram(name: "Foo#bar", linkageName: "func_Foo#3bar", scope: null, file: !4, line: 9, type: !12, scopeLine: 9, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!60 = !DILocation(line: 9, column: 3, scope: !59)
+!61 = !{!"branch_weights", i32 4001, i32 4000000}
+!62 = !DILocation(line: 9, column: 11, scope: !59)
+!63 = !{!"branch_weights", i32 1, i32 2000}
+!64 = !{!65, !7, i64 0}
+!65 = !{!"RBasic", !7, i64 0, !7, i64 8}
+!66 = !{!"branch_weights", i32 2000, i32 1}
+!67 = !DILocation(line: 9, column: 15, scope: !59)
+!68 = !DILocation(line: 10, column: 9, scope: !59)
+!69 = !{!70}
+!70 = distinct !{!70, !71, !"sorbet_rb_int_plus: argument 0"}
+!71 = distinct !{!71, !"sorbet_rb_int_plus"}
+!72 = !DILocation(line: 11, column: 5, scope: !59)
+!73 = !{!18, !19, i64 40}
+!74 = !{!18, !19, i64 44}
+!75 = !{!18, !16, i64 56}
+!76 = !DILocation(line: 0, scope: !59)
+!77 = !{!22, !7, i64 24}
+!78 = !DILocation(line: 8, column: 3, scope: !30)
+!79 = distinct !DISubprogram(name: "func_Foo#3bar.cold.1", linkageName: "func_Foo#3bar.cold.1", scope: null, file: !4, type: !80, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
+!80 = !DISubroutineType(types: !5)
+!81 = distinct !DISubprogram(name: "func_Foo#3bar.cold.2", linkageName: "func_Foo#3bar.cold.2", scope: null, file: !4, type: !80, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
+!82 = !DILocation(line: 9, column: 11, scope: !81)

--- a/test/testdata/compiler/boolean_ops.opt.ll.exp
+++ b/test/testdata/compiler/boolean_ops.opt.ll.exp
@@ -2,16 +2,17 @@
 source_filename = "llvm-link"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 
-%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.3, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.4, [29 x i16] }
+%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.5, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.6, [29 x i16] }
 %struct.rb_global_vm_lock_struct = type { %struct.rb_thread_struct*, %union.pthread_mutex_t, %struct.list_head, %struct.rb_thread_struct*, i32, %union.pthread_cond_t, %union.pthread_cond_t, i32, i32 }
-%union.pthread_cond_t = type { %struct.anon.2 }
-%struct.anon.2 = type { i32, i32, i64, i64, i64, i8*, i32, i32 }
-%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.7, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
+%union.pthread_cond_t = type { %struct.__pthread_cond_s }
+%struct.__pthread_cond_s = type { %union.anon, %union.anon, [2 x i32], [2 x i32], i32, i32, [2 x i32] }
+%union.anon = type { i64 }
+%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.10, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
 %struct.list_node = type { %struct.list_node*, %struct.list_node* }
-%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.5 }
+%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.7 }
 %struct.rb_control_frame_struct = type { i64*, i64*, %struct.rb_iseq_struct*, i64, i64*, i8*, i64* }
-%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.14 }
-%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.13, i32, i32, i32, i32, i32, i8, i64 }
+%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.17 }
+%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.16, i32, i32, i32, i32, i32, i8, i64 }
 %struct.anon = type { %struct.anon.0, i32, i32, i32, i32, i32, i32, i32, i64*, %struct.rb_iseq_param_keyword* }
 %struct.anon.0 = type { i16, [2 x i8] }
 %struct.rb_iseq_param_keyword = type { i32, i32, i32, i32, i64*, i64* }
@@ -27,34 +28,34 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_cref_struct = type { i64, i64, i64, %struct.rb_cref_struct*, %struct.rb_scope_visi_struct }
 %struct.rb_scope_visi_struct = type { i8, [3 x i8] }
 %struct.rb_call_data = type { %struct.rb_call_cache, %struct.rb_call_info }
-%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.12 }
+%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.15 }
 %struct.rb_callable_method_entry_struct = type { i64, i64, %struct.rb_method_definition_struct*, i64, i64 }
-%struct.rb_method_definition_struct = type { i64, %union.anon.10, i64, i64 }
-%union.anon.10 = type { %struct.rb_method_cfunc_struct }
+%struct.rb_method_definition_struct = type { i64, %union.anon.13, i64, i64 }
+%union.anon.13 = type { %struct.rb_method_cfunc_struct }
 %struct.rb_method_cfunc_struct = type { i64 (...)*, i64 (i64, i32, i64*, i64 (...)*)*, i32 }
-%union.anon.12 = type { i32 }
+%union.anon.15 = type { i32 }
 %struct.rb_call_info = type { i64, i32, i32 }
-%struct.anon.13 = type { i64, i64, i64, i64* }
-%union.anon.14 = type { %struct.anon.15 }
-%struct.anon.15 = type { i64, i32 }
+%struct.anon.16 = type { i64, i64, i64, i64* }
+%union.anon.17 = type { %struct.anon.18 }
+%struct.anon.18 = type { i64, i32 }
 %struct.rb_vm_tag = type { i64, i64, [5 x i8*], %struct.rb_vm_tag*, i32 }
 %struct.rb_vm_protect_tag = type { %struct.rb_vm_protect_tag* }
 %struct.rb_ensure_list = type { %struct.rb_ensure_list*, %struct.rb_ensure_entry }
 %struct.rb_ensure_entry = type { i64, i64 (i64)*, i64 }
 %struct.rb_trace_arg_struct = type { i32, %struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, i64, i64, i64, i64, i64, i32, i32, i64 }
-%struct.anon.5 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
+%struct.anon.7 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
 %struct.__jmp_buf_tag = type { [8 x i64], i32, %struct.__sigset_t }
 %struct.__sigset_t = type { [16 x i64] }
 %struct.rb_calling_info = type { i64, i64, i32, i32 }
-%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.6 }
-%union.anon.6 = type { %union.pthread_cond_t }
+%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.9 }
+%union.anon.9 = type { %union.pthread_cond_t }
 %struct.rb_unblock_callback = type { void (i8*)*, i8* }
 %struct.rb_mutex_struct = type opaque
 %struct.rb_thread_list_struct = type { %struct.rb_thread_list_struct*, %struct.rb_thread_struct* }
-%union.anon.7 = type { %struct.anon.8 }
-%struct.anon.8 = type { i64, i64, i32 }
+%union.anon.10 = type { %struct.anon.11 }
+%struct.anon.11 = type { i64, i64, i32 }
 %struct.rb_fiber_struct = type opaque
-%struct.anon.3 = type { [65 x i64] }
+%struct.anon.5 = type { [65 x i64] }
 %struct.rb_hook_list_struct = type { %struct.rb_event_hook_struct*, i32, i32, i32 }
 %struct.rb_event_hook_struct = type opaque
 %struct.rb_postponed_job_struct = type opaque
@@ -68,18 +69,18 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.st_hash_type = type { i32 (i64, i64)*, i64 (i64)* }
 %struct.st_table_entry = type opaque
 %struct.rb_builtin_function = type opaque
-%struct.anon.4 = type { i64, i64, i64, i64 }
+%struct.anon.6 = type { i64, i64, i64, i64 }
 %struct.SorbetLineNumberInfo = type { i32, %struct.iseq_insn_info_entry*, i64* }
 %struct.FunctionInlineCache = type { %struct.rb_kwarg_call_data }
 %struct.rb_kwarg_call_data = type { %struct.rb_call_cache, %struct.rb_call_info_with_kwarg }
 %struct.rb_call_info_with_kwarg = type { %struct.rb_call_info, %struct.rb_call_info_kw_arg* }
 %struct.rb_call_info_kw_arg = type { i32, [1 x i64] }
 
-@ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
-@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
+@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -213,10 +214,10 @@ entry:
   ret void
 }
 
-attributes #0 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #1 = { noreturn "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #2 = { inaccessiblememonly nofree nosync nounwind willreturn }
-attributes #3 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #3 = { nounwind ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #4 = { sspreq }
 attributes #5 = { noreturn nounwind }
 attributes #6 = { nounwind }

--- a/test/testdata/compiler/casts.opt.ll.exp
+++ b/test/testdata/compiler/casts.opt.ll.exp
@@ -2,16 +2,17 @@
 source_filename = "llvm-link"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 
-%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.3, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.4, [29 x i16] }
+%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.5, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.6, [29 x i16] }
 %struct.rb_global_vm_lock_struct = type { %struct.rb_thread_struct*, %union.pthread_mutex_t, %struct.list_head, %struct.rb_thread_struct*, i32, %union.pthread_cond_t, %union.pthread_cond_t, i32, i32 }
-%union.pthread_cond_t = type { %struct.anon.2 }
-%struct.anon.2 = type { i32, i32, i64, i64, i64, i8*, i32, i32 }
-%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.7, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
+%union.pthread_cond_t = type { %struct.__pthread_cond_s }
+%struct.__pthread_cond_s = type { %union.anon, %union.anon, [2 x i32], [2 x i32], i32, i32, [2 x i32] }
+%union.anon = type { i64 }
+%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.10, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
 %struct.list_node = type { %struct.list_node*, %struct.list_node* }
-%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.5 }
+%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.7 }
 %struct.rb_control_frame_struct = type { i64*, i64*, %struct.rb_iseq_struct*, i64, i64*, i8*, i64* }
-%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.14 }
-%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.13, i32, i32, i32, i32, i32, i8, i64 }
+%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.17 }
+%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.16, i32, i32, i32, i32, i32, i8, i64 }
 %struct.anon = type { %struct.anon.0, i32, i32, i32, i32, i32, i32, i32, i64*, %struct.rb_iseq_param_keyword* }
 %struct.anon.0 = type { i16, [2 x i8] }
 %struct.rb_iseq_param_keyword = type { i32, i32, i32, i32, i64*, i64* }
@@ -27,34 +28,34 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_cref_struct = type { i64, i64, i64, %struct.rb_cref_struct*, %struct.rb_scope_visi_struct }
 %struct.rb_scope_visi_struct = type { i8, [3 x i8] }
 %struct.rb_call_data = type { %struct.rb_call_cache, %struct.rb_call_info }
-%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.12 }
+%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.15 }
 %struct.rb_callable_method_entry_struct = type { i64, i64, %struct.rb_method_definition_struct*, i64, i64 }
-%struct.rb_method_definition_struct = type { i64, %union.anon.10, i64, i64 }
-%union.anon.10 = type { %struct.rb_method_cfunc_struct }
+%struct.rb_method_definition_struct = type { i64, %union.anon.13, i64, i64 }
+%union.anon.13 = type { %struct.rb_method_cfunc_struct }
 %struct.rb_method_cfunc_struct = type { i64 (...)*, i64 (i64, i32, i64*, i64 (...)*)*, i32 }
-%union.anon.12 = type { i32 }
+%union.anon.15 = type { i32 }
 %struct.rb_call_info = type { i64, i32, i32 }
-%struct.anon.13 = type { i64, i64, i64, i64* }
-%union.anon.14 = type { %struct.anon.15 }
-%struct.anon.15 = type { i64, i32 }
+%struct.anon.16 = type { i64, i64, i64, i64* }
+%union.anon.17 = type { %struct.anon.18 }
+%struct.anon.18 = type { i64, i32 }
 %struct.rb_vm_tag = type { i64, i64, [5 x i8*], %struct.rb_vm_tag*, i32 }
 %struct.rb_vm_protect_tag = type { %struct.rb_vm_protect_tag* }
 %struct.rb_ensure_list = type { %struct.rb_ensure_list*, %struct.rb_ensure_entry }
 %struct.rb_ensure_entry = type { i64, i64 (i64)*, i64 }
 %struct.rb_trace_arg_struct = type { i32, %struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, i64, i64, i64, i64, i64, i32, i32, i64 }
-%struct.anon.5 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
+%struct.anon.7 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
 %struct.__jmp_buf_tag = type { [8 x i64], i32, %struct.__sigset_t }
 %struct.__sigset_t = type { [16 x i64] }
 %struct.rb_calling_info = type { i64, i64, i32, i32 }
-%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.6 }
-%union.anon.6 = type { %union.pthread_cond_t }
+%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.9 }
+%union.anon.9 = type { %union.pthread_cond_t }
 %struct.rb_unblock_callback = type { void (i8*)*, i8* }
 %struct.rb_mutex_struct = type opaque
 %struct.rb_thread_list_struct = type { %struct.rb_thread_list_struct*, %struct.rb_thread_struct* }
-%union.anon.7 = type { %struct.anon.8 }
-%struct.anon.8 = type { i64, i64, i32 }
+%union.anon.10 = type { %struct.anon.11 }
+%struct.anon.11 = type { i64, i64, i32 }
 %struct.rb_fiber_struct = type opaque
-%struct.anon.3 = type { [65 x i64] }
+%struct.anon.5 = type { [65 x i64] }
 %struct.rb_hook_list_struct = type { %struct.rb_event_hook_struct*, i32, i32, i32 }
 %struct.rb_event_hook_struct = type opaque
 %struct.rb_postponed_job_struct = type opaque
@@ -68,7 +69,7 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.st_hash_type = type { i32 (i64, i64)*, i64 (i64)* }
 %struct.st_table_entry = type opaque
 %struct.rb_builtin_function = type opaque
-%struct.anon.4 = type { i64, i64, i64, i64 }
+%struct.anon.6 = type { i64, i64, i64, i64 }
 %struct.SorbetLineNumberInfo = type { i32, %struct.iseq_insn_info_entry*, i64* }
 %struct.FunctionInlineCache = type { %struct.rb_kwarg_call_data }
 %struct.rb_kwarg_call_data = type { %struct.rb_call_cache, %struct.rb_call_info_with_kwarg }
@@ -76,11 +77,11 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_call_info_kw_arg = type { i32, [1 x i64] }
 %struct.iseq_inline_iv_cache_entry = type { i64, i64 }
 
-@ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
-@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
+@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @"stackFramePrecomputed_func_Object#6fooAll" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @rubyIdPrecomputed_fooAll = internal unnamed_addr global i64 0, align 8
 @str_fooAll = private unnamed_addr constant [7 x i8] c"fooAll\00", align 1
@@ -130,7 +131,7 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @rb_mKernel = external local_unnamed_addr constant i64
 @rb_cObject = external local_unnamed_addr constant i64
 
-; Function Attrs: nounwind readnone willreturn
+; Function Attrs: nofree nosync nounwind readnone willreturn mustprogress
 declare i64 @rb_obj_is_kind_of(i64, i64) local_unnamed_addr #0
 
 ; Function Attrs: cold noreturn
@@ -418,14 +419,14 @@ codeRepl:                                         ; preds = %3, %sorbet_isa_Inte
 21:                                               ; preds = %16
   %22 = ashr i64 %20, 1, !dbg !35
   %23 = xor i64 %22, -9223372036854775808, !dbg !35
-  %24 = tail call i64 @rb_int2big(i64 %23) #17, !dbg !35, !noalias !36
+  %24 = tail call i64 @rb_int2big(i64 %23) #16, !dbg !35, !noalias !36
   br label %sorbet_rb_int_plus.exit, !dbg !35
 
 25:                                               ; preds = %"fastSymCallIntrinsic_Integer_+"
-  %26 = tail call i64 @sorbet_rb_int_plus_slowpath(i64 %rawArg_arg, i64 %rawArg_arg) #17, !dbg !35, !noalias !36
+  %26 = tail call i64 @sorbet_rb_int_plus_slowpath(i64 %rawArg_arg, i64 %rawArg_arg) #16, !dbg !35, !noalias !36
   br label %sorbet_rb_int_plus.exit, !dbg !35
 
-sorbet_rb_int_plus.exit:                          ; preds = %21, %16, %25
+sorbet_rb_int_plus.exit:                          ; preds = %16, %21, %25
   %27 = phi i64 [ %26, %25 ], [ %24, %21 ], [ %20, %16 ], !dbg !35
   %28 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !35, !tbaa !14
   %29 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %28, i64 0, i32 5, !dbg !35
@@ -435,15 +436,15 @@ sorbet_rb_int_plus.exit:                          ; preds = %21, %16, %25
   %33 = xor i32 %32, -1, !dbg !35
   %34 = and i32 %33, %30, !dbg !35
   %35 = icmp eq i32 %34, 0, !dbg !35
-  br i1 %35, label %rb_vm_check_ints.exit, label %36, !dbg !35, !prof !20
+  br i1 %35, label %sorbet_afterIntrinsic.exit, label %36, !dbg !35, !prof !20
 
 36:                                               ; preds = %sorbet_rb_int_plus.exit
   %37 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %28, i64 0, i32 8, !dbg !35
   %38 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %37, align 8, !dbg !35, !tbaa !44
-  %39 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %38, i32 noundef 0) #17, !dbg !35
-  br label %rb_vm_check_ints.exit, !dbg !35
+  %39 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %38, i32 noundef 0) #16, !dbg !35
+  br label %sorbet_afterIntrinsic.exit, !dbg !35
 
-rb_vm_check_ints.exit:                            ; preds = %sorbet_rb_int_plus.exit, %36
+sorbet_afterIntrinsic.exit:                       ; preds = %sorbet_rb_int_plus.exit, %36
   ret i64 %27
 }
 
@@ -503,30 +504,30 @@ entry:
   %locals.i25.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_fooAll, i64 0, i64 0), i64 noundef 6) #17
+  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_fooAll, i64 0, i64 0), i64 noundef 6) #16
   store i64 %0, i64* @rubyIdPrecomputed_fooAll, align 8
-  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_fooAny1, i64 0, i64 0), i64 noundef 7) #17
+  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_fooAny1, i64 0, i64 0), i64 noundef 7) #16
   store i64 %1, i64* @rubyIdPrecomputed_fooAny1, align 8
-  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_fooAny2, i64 0, i64 0), i64 noundef 7) #17
+  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_fooAny2, i64 0, i64 0), i64 noundef 7) #16
   store i64 %2, i64* @rubyIdPrecomputed_fooAny2, align 8
-  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_fooInt, i64 0, i64 0), i64 noundef 6) #17
+  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_fooInt, i64 0, i64 0), i64 noundef 6) #16
   store i64 %3, i64* @rubyIdPrecomputed_fooInt, align 8
-  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_+", i64 0, i64 0), i64 noundef 1) #17
-  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_fooArray, i64 0, i64 0), i64 noundef 8) #17
+  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_+", i64 0, i64 0), i64 noundef 1) #16
+  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_fooArray, i64 0, i64 0), i64 noundef 8) #16
   store i64 %5, i64* @rubyIdPrecomputed_fooArray, align 8
-  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #17
+  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #16
   store i64 %6, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #17
-  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_arg, i64 0, i64 0), i64 noundef 3) #17
+  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #16
+  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_arg, i64 0, i64 0), i64 noundef 3) #16
   store i64 %8, i64* @rubyIdPrecomputed_arg, align 8
-  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #17
+  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #16
   store i64 %9, i64* @rubyIdPrecomputed_puts, align 8
-  %10 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_<build-array>", i64 0, i64 0), i64 noundef 13) #17
-  %11 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_fooAll, i64 0, i64 0), i64 noundef 6) #17
-  tail call void @rb_gc_register_mark_object(i64 %11) #17
+  %10 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_<build-array>", i64 0, i64 0), i64 noundef 13) #16
+  %11 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_fooAll, i64 0, i64 0), i64 noundef 6) #16
+  tail call void @rb_gc_register_mark_object(i64 %11) #16
   store i64 %11, i64* @rubyStrFrozen_fooAll, align 8
-  %12 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([32 x i8], [32 x i8]* @"str_test/testdata/compiler/casts.rb", i64 0, i64 0), i64 noundef 31) #17
-  tail call void @rb_gc_register_mark_object(i64 %12) #17
+  %12 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([32 x i8], [32 x i8]* @"str_test/testdata/compiler/casts.rb", i64 0, i64 0), i64 noundef 31) #16
+  tail call void @rb_gc_register_mark_object(i64 %12) #16
   store i64 %12, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 30)
   %rubyId_fooAll.i.i = load i64, i64* @rubyIdPrecomputed_fooAll, align 8
@@ -534,32 +535,32 @@ entry:
   %"rubyStr_test/testdata/compiler/casts.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
   %13 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_fooAll.i.i, i64 %rubyId_fooAll.i.i, i64 %"rubyStr_test/testdata/compiler/casts.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 0)
   store %struct.rb_iseq_struct* %13, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#6fooAll", align 8
-  %14 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_fooAny1, i64 0, i64 0), i64 noundef 7) #17
-  call void @rb_gc_register_mark_object(i64 %14) #17
+  %14 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_fooAny1, i64 0, i64 0), i64 noundef 7) #16
+  call void @rb_gc_register_mark_object(i64 %14) #16
   %rubyId_fooAny1.i.i = load i64, i64* @rubyIdPrecomputed_fooAny1, align 8
   %"rubyStr_test/testdata/compiler/casts.rb.i24.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
   %15 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %14, i64 %rubyId_fooAny1.i.i, i64 %"rubyStr_test/testdata/compiler/casts.rb.i24.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 9, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i25.i, i32 noundef 0, i32 noundef 0)
   store %struct.rb_iseq_struct* %15, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#7fooAny1", align 8
-  %16 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_fooAny2, i64 0, i64 0), i64 noundef 7) #17
-  call void @rb_gc_register_mark_object(i64 %16) #17
+  %16 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_fooAny2, i64 0, i64 0), i64 noundef 7) #16
+  call void @rb_gc_register_mark_object(i64 %16) #16
   %rubyId_fooAny2.i.i = load i64, i64* @rubyIdPrecomputed_fooAny2, align 8
   %"rubyStr_test/testdata/compiler/casts.rb.i26.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
   %17 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %16, i64 %rubyId_fooAny2.i.i, i64 %"rubyStr_test/testdata/compiler/casts.rb.i26.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 13, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i27.i, i32 noundef 0, i32 noundef 0)
   store %struct.rb_iseq_struct* %17, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#7fooAny2", align 8
-  %18 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_fooInt, i64 0, i64 0), i64 noundef 6) #17
-  call void @rb_gc_register_mark_object(i64 %18) #17
+  %18 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_fooInt, i64 0, i64 0), i64 noundef 6) #16
+  call void @rb_gc_register_mark_object(i64 %18) #16
   %rubyId_fooInt.i.i = load i64, i64* @rubyIdPrecomputed_fooInt, align 8
   %"rubyStr_test/testdata/compiler/casts.rb.i28.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
   %19 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %18, i64 %rubyId_fooInt.i.i, i64 %"rubyStr_test/testdata/compiler/casts.rb.i28.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 17, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i29.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %19, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#6fooInt", align 8
-  %20 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_fooArray, i64 0, i64 0), i64 noundef 8) #17
-  call void @rb_gc_register_mark_object(i64 %20) #17
+  %20 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_fooArray, i64 0, i64 0), i64 noundef 8) #16
+  call void @rb_gc_register_mark_object(i64 %20) #16
   %rubyId_fooArray.i.i = load i64, i64* @rubyIdPrecomputed_fooArray, align 8
   %"rubyStr_test/testdata/compiler/casts.rb.i30.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
   %21 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %20, i64 %rubyId_fooArray.i.i, i64 %"rubyStr_test/testdata/compiler/casts.rb.i30.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 21, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i31.i, i32 noundef 0, i32 noundef 0)
   store %struct.rb_iseq_struct* %21, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#8fooArray", align 8
-  %22 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #17
-  call void @rb_gc_register_mark_object(i64 %22) #17
+  %22 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #16
+  call void @rb_gc_register_mark_object(i64 %22) #16
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/casts.rb.i32.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
   %23 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %22, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/casts.rb.i32.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i33.i, i32 noundef 0, i32 noundef 4)
@@ -611,12 +612,12 @@ entry:
   %40 = load i64, i64* %39, align 8, !tbaa !6
   %41 = and i64 %40, -33
   store i64 %41, i64* %39, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %27, %struct.rb_control_frame_struct* %36, %struct.rb_iseq_struct* %stackFrame.i) #17
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %27, %struct.rb_control_frame_struct* %36, %struct.rb_iseq_struct* %stackFrame.i) #16
   %42 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 0
   store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %42, align 8, !dbg !78, !tbaa !14
   %43 = load i64, i64* @rb_cObject, align 8, !dbg !49
   %stackFrame73.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#6fooAll", align 8, !dbg !49
-  %44 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !49
+  %44 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #17, !dbg !49
   %45 = bitcast i8* %44 to i16*, !dbg !49
   %46 = load i16, i16* %45, align 8, !dbg !49
   %47 = and i16 %46, -384, !dbg !49
@@ -628,19 +629,19 @@ entry:
   %51 = getelementptr inbounds i8, i8* %44, i64 12, !dbg !49
   %52 = getelementptr inbounds i8, i8* %44, i64 4, !dbg !49
   %53 = bitcast i8* %52 to i32*, !dbg !49
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %51, i8 0, i64 20, i1 false) #17, !dbg !49
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %51, i8 0, i64 20, i1 false) #16, !dbg !49
   store i32 1, i32* %53, align 4, !dbg !49, !tbaa !82
   %rubyId_arg.i = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !49
   store i64 %rubyId_arg.i, i64* %positional_table.i, align 8, !dbg !49
-  %54 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !49
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %54, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %31, i64 noundef 8, i1 noundef false) #17, !dbg !49
+  %54 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #17, !dbg !49
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull align 1 %54, i8* noundef nonnull align 1 %31, i64 noundef 8, i1 noundef false) #16, !dbg !49
   %55 = getelementptr inbounds i8, i8* %44, i64 32, !dbg !49
   %56 = bitcast i8* %55 to i8**, !dbg !49
   store i8* %54, i8** %56, align 8, !dbg !49, !tbaa !83
-  call void @sorbet_vm_define_method(i64 %43, i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_fooAll, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#6fooAll", i8* nonnull %44, %struct.rb_iseq_struct* %stackFrame73.i, i1 noundef zeroext false) #17, !dbg !49
+  call void @sorbet_vm_define_method(i64 %43, i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_fooAll, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#6fooAll", i8* nonnull %44, %struct.rb_iseq_struct* %stackFrame73.i, i1 noundef zeroext false) #16, !dbg !49
   store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %42, align 8, !dbg !49, !tbaa !14
   %stackFrame82.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#7fooAny1", align 8, !dbg !51
-  %57 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !51
+  %57 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #17, !dbg !51
   %58 = bitcast i8* %57 to i16*, !dbg !51
   %59 = load i16, i16* %58, align 8, !dbg !51
   %60 = and i16 %59, -384, !dbg !51
@@ -652,19 +653,19 @@ entry:
   %64 = getelementptr inbounds i8, i8* %57, i64 12, !dbg !51
   %65 = getelementptr inbounds i8, i8* %57, i64 4, !dbg !51
   %66 = bitcast i8* %65 to i32*, !dbg !51
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %64, i8 0, i64 20, i1 false) #17, !dbg !51
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %64, i8 0, i64 20, i1 false) #16, !dbg !51
   store i32 1, i32* %66, align 4, !dbg !51, !tbaa !82
   %rubyId_arg85.i = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !51
   store i64 %rubyId_arg85.i, i64* %positional_table84.i, align 8, !dbg !51
-  %67 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !51
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %67, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %32, i64 noundef 8, i1 noundef false) #17, !dbg !51
+  %67 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #17, !dbg !51
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull align 1 %67, i8* noundef nonnull align 1 %32, i64 noundef 8, i1 noundef false) #16, !dbg !51
   %68 = getelementptr inbounds i8, i8* %57, i64 32, !dbg !51
   %69 = bitcast i8* %68 to i8**, !dbg !51
   store i8* %67, i8** %69, align 8, !dbg !51, !tbaa !83
-  call void @sorbet_vm_define_method(i64 %43, i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_fooAny1, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#7fooAny1", i8* nonnull %57, %struct.rb_iseq_struct* %stackFrame82.i, i1 noundef zeroext false) #17, !dbg !51
+  call void @sorbet_vm_define_method(i64 %43, i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_fooAny1, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#7fooAny1", i8* nonnull %57, %struct.rb_iseq_struct* %stackFrame82.i, i1 noundef zeroext false) #16, !dbg !51
   store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %42, align 8, !dbg !51, !tbaa !14
   %stackFrame94.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#7fooAny2", align 8, !dbg !52
-  %70 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !52
+  %70 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #17, !dbg !52
   %71 = bitcast i8* %70 to i16*, !dbg !52
   %72 = load i16, i16* %71, align 8, !dbg !52
   %73 = and i16 %72, -384, !dbg !52
@@ -676,19 +677,19 @@ entry:
   %77 = getelementptr inbounds i8, i8* %70, i64 12, !dbg !52
   %78 = getelementptr inbounds i8, i8* %70, i64 4, !dbg !52
   %79 = bitcast i8* %78 to i32*, !dbg !52
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %77, i8 0, i64 20, i1 false) #17, !dbg !52
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %77, i8 0, i64 20, i1 false) #16, !dbg !52
   store i32 1, i32* %79, align 4, !dbg !52, !tbaa !82
   %rubyId_arg97.i = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !52
   store i64 %rubyId_arg97.i, i64* %positional_table96.i, align 8, !dbg !52
-  %80 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !52
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %80, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %33, i64 noundef 8, i1 noundef false) #17, !dbg !52
+  %80 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #17, !dbg !52
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull align 1 %80, i8* noundef nonnull align 1 %33, i64 noundef 8, i1 noundef false) #16, !dbg !52
   %81 = getelementptr inbounds i8, i8* %70, i64 32, !dbg !52
   %82 = bitcast i8* %81 to i8**, !dbg !52
   store i8* %80, i8** %82, align 8, !dbg !52, !tbaa !83
-  call void @sorbet_vm_define_method(i64 %43, i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_fooAny2, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#7fooAny2", i8* nonnull %70, %struct.rb_iseq_struct* %stackFrame94.i, i1 noundef zeroext false) #17, !dbg !52
+  call void @sorbet_vm_define_method(i64 %43, i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_fooAny2, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#7fooAny2", i8* nonnull %70, %struct.rb_iseq_struct* %stackFrame94.i, i1 noundef zeroext false) #16, !dbg !52
   store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %42, align 8, !dbg !52, !tbaa !14
   %stackFrame106.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#6fooInt", align 8, !dbg !53
-  %83 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !53
+  %83 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #17, !dbg !53
   %84 = bitcast i8* %83 to i16*, !dbg !53
   %85 = load i16, i16* %84, align 8, !dbg !53
   %86 = and i16 %85, -384, !dbg !53
@@ -700,19 +701,19 @@ entry:
   %90 = getelementptr inbounds i8, i8* %83, i64 12, !dbg !53
   %91 = getelementptr inbounds i8, i8* %83, i64 4, !dbg !53
   %92 = bitcast i8* %91 to i32*, !dbg !53
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %90, i8 0, i64 20, i1 false) #17, !dbg !53
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %90, i8 0, i64 20, i1 false) #16, !dbg !53
   store i32 1, i32* %92, align 4, !dbg !53, !tbaa !82
   %rubyId_arg109.i = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !53
   store i64 %rubyId_arg109.i, i64* %positional_table108.i, align 8, !dbg !53
-  %93 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !53
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %93, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %34, i64 noundef 8, i1 noundef false) #17, !dbg !53
+  %93 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #17, !dbg !53
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull align 1 %93, i8* noundef nonnull align 1 %34, i64 noundef 8, i1 noundef false) #16, !dbg !53
   %94 = getelementptr inbounds i8, i8* %83, i64 32, !dbg !53
   %95 = bitcast i8* %94 to i8**, !dbg !53
   store i8* %93, i8** %95, align 8, !dbg !53, !tbaa !83
-  call void @sorbet_vm_define_method(i64 %43, i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_fooInt, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#6fooInt", i8* nonnull %83, %struct.rb_iseq_struct* %stackFrame106.i, i1 noundef zeroext false) #17, !dbg !53
+  call void @sorbet_vm_define_method(i64 %43, i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_fooInt, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#6fooInt", i8* nonnull %83, %struct.rb_iseq_struct* %stackFrame106.i, i1 noundef zeroext false) #16, !dbg !53
   store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %42, align 8, !dbg !53, !tbaa !14
   %stackFrame118.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#8fooArray", align 8, !dbg !54
-  %96 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !54
+  %96 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #17, !dbg !54
   %97 = bitcast i8* %96 to i16*, !dbg !54
   %98 = load i16, i16* %97, align 8, !dbg !54
   %99 = and i16 %98, -384, !dbg !54
@@ -724,16 +725,16 @@ entry:
   %103 = getelementptr inbounds i8, i8* %96, i64 12, !dbg !54
   %104 = getelementptr inbounds i8, i8* %96, i64 4, !dbg !54
   %105 = bitcast i8* %104 to i32*, !dbg !54
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %103, i8 0, i64 20, i1 false) #17, !dbg !54
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %103, i8 0, i64 20, i1 false) #16, !dbg !54
   store i32 1, i32* %105, align 4, !dbg !54, !tbaa !82
   %rubyId_arg121.i = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !54
   store i64 %rubyId_arg121.i, i64* %positional_table120.i, align 8, !dbg !54
-  %106 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !54
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %106, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %35, i64 noundef 8, i1 noundef false) #17, !dbg !54
+  %106 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #17, !dbg !54
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull align 1 %106, i8* noundef nonnull align 1 %35, i64 noundef 8, i1 noundef false) #16, !dbg !54
   %107 = getelementptr inbounds i8, i8* %96, i64 32, !dbg !54
   %108 = bitcast i8* %107 to i8**, !dbg !54
   store i8* %106, i8** %108, align 8, !dbg !54, !tbaa !83
-  call void @sorbet_vm_define_method(i64 %43, i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_fooArray, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#8fooArray", i8* nonnull %96, %struct.rb_iseq_struct* %stackFrame118.i, i1 noundef zeroext false) #17, !dbg !54
+  call void @sorbet_vm_define_method(i64 %43, i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_fooArray, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#8fooArray", i8* nonnull %96, %struct.rb_iseq_struct* %stackFrame118.i, i1 noundef zeroext false) #16, !dbg !54
   store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %42, align 8, !dbg !54, !tbaa !14
   %109 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 1, !dbg !55
   %110 = load i64*, i64** %109, align 8, !dbg !55
@@ -806,8 +807,8 @@ entry:
   %callArgs0Addr.i = getelementptr [4 x i64], [4 x i64]* %callArgs.i, i32 0, i64 0, !dbg !84
   store i64 5, i64* %callArgs0Addr.i, align 8, !dbg !84
   %141 = getelementptr [4 x i64], [4 x i64]* %callArgs.i, i64 0, i64 0, !dbg !84
-  call void @llvm.experimental.noalias.scope.decl(metadata !85) #17, !dbg !84
-  %142 = call i64 @rb_ary_new_from_values(i64 noundef 1, i64* noundef nonnull %141) #17, !dbg !84
+  call void @llvm.experimental.noalias.scope.decl(metadata !85) #16, !dbg !84
+  %142 = call i64 @rb_ary_new_from_values(i64 noundef 1, i64* noundef nonnull %141) #16, !dbg !84
   %143 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 1, !dbg !63
   %144 = load i64*, i64** %143, align 8, !dbg !63
   store i64 %26, i64* %144, align 8, !dbg !63, !tbaa !6
@@ -877,15 +878,15 @@ newFuncRoot:
   unreachable, !dbg !98
 }
 
-attributes #0 = { nounwind readnone willreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { cold noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #2 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #3 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { nofree nosync nounwind readnone willreturn mustprogress "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #1 = { cold noreturn "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #2 = { noreturn "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #3 = { "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #4 = { nofree nosync nounwind readnone speculatable willreturn }
 attributes #5 = { inaccessiblememonly nofree nosync nounwind willreturn }
-attributes #6 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #6 = { allocsize(0,1) "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #7 = { argmemonly nofree nosync nounwind willreturn }
-attributes #8 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #8 = { nounwind ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #9 = { nounwind sspreq uwtable }
 attributes #10 = { sspreq }
 attributes #11 = { argmemonly nofree nosync nounwind willreturn writeonly }
@@ -893,9 +894,8 @@ attributes #12 = { cold minsize noreturn nounwind sspreq uwtable }
 attributes #13 = { noreturn nounwind }
 attributes #14 = { noreturn }
 attributes #15 = { noinline }
-attributes #16 = { nounwind willreturn }
-attributes #17 = { nounwind }
-attributes #18 = { nounwind allocsize(0,1) }
+attributes #16 = { nounwind }
+attributes #17 = { nounwind allocsize(0,1) }
 
 !llvm.module.flags = !{!0, !1, !2}
 !llvm.dbg.cu = !{!3}

--- a/test/testdata/compiler/class.opt.ll.exp
+++ b/test/testdata/compiler/class.opt.ll.exp
@@ -2,10 +2,10 @@
 source_filename = "llvm-link"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 
-%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.5 }
+%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.7 }
 %struct.rb_control_frame_struct = type { i64*, i64*, %struct.rb_iseq_struct*, i64, i64*, i8*, i64* }
-%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.14 }
-%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.13, i32, i32, i32, i32, i32, i8, i64 }
+%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.17 }
+%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.16, i32, i32, i32, i32, i32, i8, i64 }
 %struct.anon = type { %struct.anon.0, i32, i32, i32, i32, i32, i32, i32, i64*, %struct.rb_iseq_param_keyword* }
 %struct.anon.0 = type { i16, [2 x i8] }
 %struct.rb_iseq_param_keyword = type { i32, i32, i32, i32, i64*, i64* }
@@ -21,27 +21,28 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_cref_struct = type { i64, i64, i64, %struct.rb_cref_struct*, %struct.rb_scope_visi_struct }
 %struct.rb_scope_visi_struct = type { i8, [3 x i8] }
 %struct.rb_call_data = type { %struct.rb_call_cache, %struct.rb_call_info }
-%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.12 }
+%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.15 }
 %struct.rb_callable_method_entry_struct = type { i64, i64, %struct.rb_method_definition_struct*, i64, i64 }
-%struct.rb_method_definition_struct = type { i64, %union.anon.10, i64, i64 }
-%union.anon.10 = type { %struct.rb_method_cfunc_struct }
+%struct.rb_method_definition_struct = type { i64, %union.anon.13, i64, i64 }
+%union.anon.13 = type { %struct.rb_method_cfunc_struct }
 %struct.rb_method_cfunc_struct = type { i64 (...)*, i64 (i64, i32, i64*, i64 (...)*)*, i32 }
 %struct.rb_calling_info = type { i64, i64, i32, i32 }
-%union.anon.12 = type { i32 }
+%union.anon.15 = type { i32 }
 %struct.rb_call_info = type { i64, i32, i32 }
-%struct.anon.13 = type { i64, i64, i64, i64* }
-%union.anon.14 = type { %struct.anon.15 }
-%struct.anon.15 = type { i64, i32 }
+%struct.anon.16 = type { i64, i64, i64, i64* }
+%union.anon.17 = type { %struct.anon.18 }
+%struct.anon.18 = type { i64, i32 }
 %struct.rb_vm_tag = type { i64, i64, [5 x i8*], %struct.rb_vm_tag*, i32 }
 %struct.rb_vm_protect_tag = type { %struct.rb_vm_protect_tag* }
 %struct.rb_fiber_struct = type opaque
-%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.7, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
+%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.10, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
 %struct.list_node = type { %struct.list_node*, %struct.list_node* }
-%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.3, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.4, [29 x i16] }
+%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.5, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.6, [29 x i16] }
 %struct.rb_global_vm_lock_struct = type { %struct.rb_thread_struct*, %union.pthread_mutex_t, %struct.list_head, %struct.rb_thread_struct*, i32, %union.pthread_cond_t, %union.pthread_cond_t, i32, i32 }
-%union.pthread_cond_t = type { %struct.anon.2 }
-%struct.anon.2 = type { i32, i32, i64, i64, i64, i8*, i32, i32 }
-%struct.anon.3 = type { [65 x i64] }
+%union.pthread_cond_t = type { %struct.__pthread_cond_s }
+%struct.__pthread_cond_s = type { %union.anon, %union.anon, [2 x i32], [2 x i32], i32, i32, [2 x i32] }
+%union.anon = type { i64 }
+%struct.anon.5 = type { [65 x i64] }
 %struct.rb_hook_list_struct = type { %struct.rb_event_hook_struct*, i32, i32, i32 }
 %struct.rb_event_hook_struct = type opaque
 %struct.rb_postponed_job_struct = type opaque
@@ -49,33 +50,33 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_objspace = type opaque
 %struct.rb_at_exit_list = type { void (%struct.rb_vm_struct*)*, %struct.rb_at_exit_list* }
 %struct.rb_builtin_function = type opaque
-%struct.anon.4 = type { i64, i64, i64, i64 }
-%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.6 }
-%union.anon.6 = type { %union.pthread_cond_t }
+%struct.anon.6 = type { i64, i64, i64, i64 }
+%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.9 }
+%union.anon.9 = type { %union.pthread_cond_t }
 %union.pthread_mutex_t = type { %struct.__pthread_mutex_s }
 %struct.__pthread_mutex_s = type { i32, i32, i32, i32, i32, i16, i16, %struct.__pthread_internal_list }
 %struct.__pthread_internal_list = type { %struct.__pthread_internal_list*, %struct.__pthread_internal_list* }
 %struct.rb_unblock_callback = type { void (i8*)*, i8* }
 %struct.rb_mutex_struct = type opaque
 %struct.rb_thread_list_struct = type { %struct.rb_thread_list_struct*, %struct.rb_thread_struct* }
-%union.anon.7 = type { %struct.anon.8 }
-%struct.anon.8 = type { i64, i64, i32 }
+%union.anon.10 = type { %struct.anon.11 }
+%struct.anon.11 = type { i64, i64, i32 }
 %struct.st_table = type { i8, i8, i8, i32, %struct.st_hash_type*, i64, i64*, i64, i64, %struct.st_table_entry* }
 %struct.st_hash_type = type { i32 (i64, i64)*, i64 (i64)* }
 %struct.st_table_entry = type opaque
 %struct.rb_ensure_list = type { %struct.rb_ensure_list*, %struct.rb_ensure_entry }
 %struct.rb_ensure_entry = type { i64, i64 (i64)*, i64 }
 %struct.rb_trace_arg_struct = type { i32, %struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, i64, i64, i64, i64, i64, i32, i32, i64 }
-%struct.anon.5 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
+%struct.anon.7 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
 %struct.__jmp_buf_tag = type { [8 x i64], i32, %struct.__sigset_t }
 %struct.__sigset_t = type { [16 x i64] }
 %struct.SorbetLineNumberInfo = type { i32, %struct.iseq_insn_info_entry*, i64* }
 
-@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @ruby_vm_global_constant_state = external local_unnamed_addr global i64, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -224,18 +225,18 @@ entry:
   store i64* getelementptr inbounds ([10 x i64], [10 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %8, align 8, !dbg !19, !tbaa !10
   %9 = tail call i64 @rb_define_module(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_Foo, i64 0, i64 0)) #8, !dbg !24
   %10 = tail call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %9) #8, !dbg !24
-  %stackFrame.i1.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>", align 8
+  %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>", align 8
   %11 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !10
   %12 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %11, i64 0, i32 2
   %13 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %12, align 8, !tbaa !12
   %14 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %13, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i1.i, %struct.rb_iseq_struct** %14, align 8, !tbaa !16
+  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %14, align 8, !tbaa !16
   %15 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %13, i64 0, i32 4
   %16 = load i64*, i64** %15, align 8, !tbaa !18
   %17 = load i64, i64* %16, align 8, !tbaa !6
   %18 = and i64 %17, -33
   store i64 %18, i64* %16, align 8, !tbaa !6
-  tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %11, %struct.rb_control_frame_struct* %13, %struct.rb_iseq_struct* %stackFrame.i1.i) #8
+  tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %11, %struct.rb_control_frame_struct* %13, %struct.rb_iseq_struct* %stackFrame.i.i) #8
   %19 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %10, i64 0, i32 0
   store i64* getelementptr inbounds ([10 x i64], [10 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %19, align 8, !dbg !25, !tbaa !10
   %20 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !28
@@ -275,18 +276,18 @@ entry:
   store i64* getelementptr inbounds ([10 x i64], [10 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !dbg !24, !tbaa !10
   %39 = tail call i64 @rb_define_class(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_Baz, i64 0, i64 0), i64 %27) #8, !dbg !35
   %40 = tail call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %39) #8, !dbg !35
-  %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Baz.13<static-init>", align 8
+  %stackFrame.i1.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Baz.13<static-init>", align 8
   %41 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !10
   %42 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %41, i64 0, i32 2
   %43 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %42, align 8, !tbaa !12
   %44 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %43, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %44, align 8, !tbaa !16
+  store %struct.rb_iseq_struct* %stackFrame.i1.i, %struct.rb_iseq_struct** %44, align 8, !tbaa !16
   %45 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %43, i64 0, i32 4
   %46 = load i64*, i64** %45, align 8, !tbaa !18
   %47 = load i64, i64* %46, align 8, !tbaa !6
   %48 = and i64 %47, -33
   store i64 %48, i64* %46, align 8, !tbaa !6
-  tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %41, %struct.rb_control_frame_struct* %43, %struct.rb_iseq_struct* %stackFrame.i.i) #8
+  tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %41, %struct.rb_control_frame_struct* %43, %struct.rb_iseq_struct* %stackFrame.i1.i) #8
   %49 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %40, i64 0, i32 0
   store i64* getelementptr inbounds ([10 x i64], [10 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %49, align 8, !dbg !36, !tbaa !10
   tail call void @sorbet_popFrame() #8, !dbg !35
@@ -392,9 +393,9 @@ define linkonce void @const_recompute_Foo() local_unnamed_addr #3 {
   ret void
 }
 
-attributes #0 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #2 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #1 = { noreturn "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #2 = { nounwind ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #3 = { ssp }
 attributes #4 = { nounwind ssp }
 attributes #5 = { sspreq }

--- a/test/testdata/compiler/classfields.opt.ll.exp
+++ b/test/testdata/compiler/classfields.opt.ll.exp
@@ -2,16 +2,17 @@
 source_filename = "llvm-link"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 
-%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.3, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.4, [29 x i16] }
+%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.5, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.6, [29 x i16] }
 %struct.rb_global_vm_lock_struct = type { %struct.rb_thread_struct*, %union.pthread_mutex_t, %struct.list_head, %struct.rb_thread_struct*, i32, %union.pthread_cond_t, %union.pthread_cond_t, i32, i32 }
-%union.pthread_cond_t = type { %struct.anon.2 }
-%struct.anon.2 = type { i32, i32, i64, i64, i64, i8*, i32, i32 }
-%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.7, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
+%union.pthread_cond_t = type { %struct.__pthread_cond_s }
+%struct.__pthread_cond_s = type { %union.anon, %union.anon, [2 x i32], [2 x i32], i32, i32, [2 x i32] }
+%union.anon = type { i64 }
+%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.10, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
 %struct.list_node = type { %struct.list_node*, %struct.list_node* }
-%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.5 }
+%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.7 }
 %struct.rb_control_frame_struct = type { i64*, i64*, %struct.rb_iseq_struct*, i64, i64*, i8*, i64* }
-%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.14 }
-%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.13, i32, i32, i32, i32, i32, i8, i64 }
+%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.17 }
+%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.16, i32, i32, i32, i32, i32, i8, i64 }
 %struct.anon = type { %struct.anon.0, i32, i32, i32, i32, i32, i32, i32, i64*, %struct.rb_iseq_param_keyword* }
 %struct.anon.0 = type { i16, [2 x i8] }
 %struct.rb_iseq_param_keyword = type { i32, i32, i32, i32, i64*, i64* }
@@ -27,34 +28,34 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_cref_struct = type { i64, i64, i64, %struct.rb_cref_struct*, %struct.rb_scope_visi_struct }
 %struct.rb_scope_visi_struct = type { i8, [3 x i8] }
 %struct.rb_call_data = type { %struct.rb_call_cache, %struct.rb_call_info }
-%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.12 }
+%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.15 }
 %struct.rb_callable_method_entry_struct = type { i64, i64, %struct.rb_method_definition_struct*, i64, i64 }
-%struct.rb_method_definition_struct = type { i64, %union.anon.10, i64, i64 }
-%union.anon.10 = type { %struct.rb_method_cfunc_struct }
+%struct.rb_method_definition_struct = type { i64, %union.anon.13, i64, i64 }
+%union.anon.13 = type { %struct.rb_method_cfunc_struct }
 %struct.rb_method_cfunc_struct = type { i64 (...)*, i64 (i64, i32, i64*, i64 (...)*)*, i32 }
-%union.anon.12 = type { i32 }
+%union.anon.15 = type { i32 }
 %struct.rb_call_info = type { i64, i32, i32 }
-%struct.anon.13 = type { i64, i64, i64, i64* }
-%union.anon.14 = type { %struct.anon.15 }
-%struct.anon.15 = type { i64, i32 }
+%struct.anon.16 = type { i64, i64, i64, i64* }
+%union.anon.17 = type { %struct.anon.18 }
+%struct.anon.18 = type { i64, i32 }
 %struct.rb_vm_tag = type { i64, i64, [5 x i8*], %struct.rb_vm_tag*, i32 }
 %struct.rb_vm_protect_tag = type { %struct.rb_vm_protect_tag* }
 %struct.rb_ensure_list = type { %struct.rb_ensure_list*, %struct.rb_ensure_entry }
 %struct.rb_ensure_entry = type { i64, i64 (i64)*, i64 }
 %struct.rb_trace_arg_struct = type { i32, %struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, i64, i64, i64, i64, i64, i32, i32, i64 }
-%struct.anon.5 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
+%struct.anon.7 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
 %struct.__jmp_buf_tag = type { [8 x i64], i32, %struct.__sigset_t }
 %struct.__sigset_t = type { [16 x i64] }
 %struct.rb_calling_info = type { i64, i64, i32, i32 }
-%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.6 }
-%union.anon.6 = type { %union.pthread_cond_t }
+%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.9 }
+%union.anon.9 = type { %union.pthread_cond_t }
 %struct.rb_unblock_callback = type { void (i8*)*, i8* }
 %struct.rb_mutex_struct = type opaque
 %struct.rb_thread_list_struct = type { %struct.rb_thread_list_struct*, %struct.rb_thread_struct* }
-%union.anon.7 = type { %struct.anon.8 }
-%struct.anon.8 = type { i64, i64, i32 }
+%union.anon.10 = type { %struct.anon.11 }
+%struct.anon.11 = type { i64, i64, i32 }
 %struct.rb_fiber_struct = type opaque
-%struct.anon.3 = type { [65 x i64] }
+%struct.anon.5 = type { [65 x i64] }
 %struct.rb_hook_list_struct = type { %struct.rb_event_hook_struct*, i32, i32, i32 }
 %struct.rb_event_hook_struct = type opaque
 %struct.rb_postponed_job_struct = type opaque
@@ -68,19 +69,19 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.st_hash_type = type { i32 (i64, i64)*, i64 (i64)* }
 %struct.st_table_entry = type opaque
 %struct.rb_builtin_function = type opaque
-%struct.anon.4 = type { i64, i64, i64, i64 }
+%struct.anon.6 = type { i64, i64, i64, i64 }
 %struct.SorbetLineNumberInfo = type { i32, %struct.iseq_insn_info_entry*, i64* }
 %struct.FunctionInlineCache = type { %struct.rb_kwarg_call_data }
 %struct.rb_kwarg_call_data = type { %struct.rb_call_cache, %struct.rb_call_info_with_kwarg }
 %struct.rb_call_info_with_kwarg = type { %struct.rb_call_info, %struct.rb_call_info_kw_arg* }
 %struct.rb_call_info_kw_arg = type { i32, [1 x i64] }
 
-@ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
-@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @ruby_vm_global_constant_state = external local_unnamed_addr global i64, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
+@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -346,7 +347,7 @@ entry:
   %rubyId_a.i.i = load i64, i64* @rubyIdPrecomputed_a, align 8, !dbg !10
   store i64 %rubyId_a.i.i, i64* %positional_table.i.i, align 8, !dbg !10
   %62 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !10
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %62, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %35, i64 noundef 8, i1 noundef false) #11, !dbg !10
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull align 1 %62, i8* noundef nonnull align 1 %35, i64 noundef 8, i1 noundef false) #11, !dbg !10
   %63 = getelementptr inbounds i8, i8* %52, i64 32, !dbg !10
   %64 = bitcast i8* %63 to i8**, !dbg !10
   store i8* %62, i8** %64, align 8, !dbg !10, !tbaa !49
@@ -585,11 +586,11 @@ define linkonce void @const_recompute_B() local_unnamed_addr #9 {
   ret void
 }
 
-attributes #0 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { noreturn "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #1 = { "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #2 = { argmemonly nofree nosync nounwind willreturn }
-attributes #3 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #4 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #3 = { allocsize(0,1) "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #4 = { nounwind ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #5 = { sspreq }
 attributes #6 = { nounwind sspreq uwtable }
 attributes #7 = { argmemonly nofree nosync nounwind willreturn writeonly }

--- a/test/testdata/compiler/constant_cache.opt.ll.exp
+++ b/test/testdata/compiler/constant_cache.opt.ll.exp
@@ -2,16 +2,17 @@
 source_filename = "llvm-link"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 
-%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.3, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.4, [29 x i16] }
+%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.5, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.6, [29 x i16] }
 %struct.rb_global_vm_lock_struct = type { %struct.rb_thread_struct*, %union.pthread_mutex_t, %struct.list_head, %struct.rb_thread_struct*, i32, %union.pthread_cond_t, %union.pthread_cond_t, i32, i32 }
-%union.pthread_cond_t = type { %struct.anon.2 }
-%struct.anon.2 = type { i32, i32, i64, i64, i64, i8*, i32, i32 }
-%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.7, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
+%union.pthread_cond_t = type { %struct.__pthread_cond_s }
+%struct.__pthread_cond_s = type { %union.anon, %union.anon, [2 x i32], [2 x i32], i32, i32, [2 x i32] }
+%union.anon = type { i64 }
+%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.10, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
 %struct.list_node = type { %struct.list_node*, %struct.list_node* }
-%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.5 }
+%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.7 }
 %struct.rb_control_frame_struct = type { i64*, i64*, %struct.rb_iseq_struct*, i64, i64*, i8*, i64* }
-%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.14 }
-%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.13, i32, i32, i32, i32, i32, i8, i64 }
+%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.17 }
+%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.16, i32, i32, i32, i32, i32, i8, i64 }
 %struct.anon = type { %struct.anon.0, i32, i32, i32, i32, i32, i32, i32, i64*, %struct.rb_iseq_param_keyword* }
 %struct.anon.0 = type { i16, [2 x i8] }
 %struct.rb_iseq_param_keyword = type { i32, i32, i32, i32, i64*, i64* }
@@ -27,34 +28,34 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_cref_struct = type { i64, i64, i64, %struct.rb_cref_struct*, %struct.rb_scope_visi_struct }
 %struct.rb_scope_visi_struct = type { i8, [3 x i8] }
 %struct.rb_call_data = type { %struct.rb_call_cache, %struct.rb_call_info }
-%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.12 }
+%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.15 }
 %struct.rb_callable_method_entry_struct = type { i64, i64, %struct.rb_method_definition_struct*, i64, i64 }
-%struct.rb_method_definition_struct = type { i64, %union.anon.10, i64, i64 }
-%union.anon.10 = type { %struct.rb_method_cfunc_struct }
+%struct.rb_method_definition_struct = type { i64, %union.anon.13, i64, i64 }
+%union.anon.13 = type { %struct.rb_method_cfunc_struct }
 %struct.rb_method_cfunc_struct = type { i64 (...)*, i64 (i64, i32, i64*, i64 (...)*)*, i32 }
-%union.anon.12 = type { i32 }
+%union.anon.15 = type { i32 }
 %struct.rb_call_info = type { i64, i32, i32 }
-%struct.anon.13 = type { i64, i64, i64, i64* }
-%union.anon.14 = type { %struct.anon.15 }
-%struct.anon.15 = type { i64, i32 }
+%struct.anon.16 = type { i64, i64, i64, i64* }
+%union.anon.17 = type { %struct.anon.18 }
+%struct.anon.18 = type { i64, i32 }
 %struct.rb_vm_tag = type { i64, i64, [5 x i8*], %struct.rb_vm_tag*, i32 }
 %struct.rb_vm_protect_tag = type { %struct.rb_vm_protect_tag* }
 %struct.rb_ensure_list = type { %struct.rb_ensure_list*, %struct.rb_ensure_entry }
 %struct.rb_ensure_entry = type { i64, i64 (i64)*, i64 }
 %struct.rb_trace_arg_struct = type { i32, %struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, i64, i64, i64, i64, i64, i32, i32, i64 }
-%struct.anon.5 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
+%struct.anon.7 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
 %struct.__jmp_buf_tag = type { [8 x i64], i32, %struct.__sigset_t }
 %struct.__sigset_t = type { [16 x i64] }
 %struct.rb_calling_info = type { i64, i64, i32, i32 }
-%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.6 }
-%union.anon.6 = type { %union.pthread_cond_t }
+%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.9 }
+%union.anon.9 = type { %union.pthread_cond_t }
 %struct.rb_unblock_callback = type { void (i8*)*, i8* }
 %struct.rb_mutex_struct = type opaque
 %struct.rb_thread_list_struct = type { %struct.rb_thread_list_struct*, %struct.rb_thread_struct* }
-%union.anon.7 = type { %struct.anon.8 }
-%struct.anon.8 = type { i64, i64, i32 }
+%union.anon.10 = type { %struct.anon.11 }
+%struct.anon.11 = type { i64, i64, i32 }
 %struct.rb_fiber_struct = type opaque
-%struct.anon.3 = type { [65 x i64] }
+%struct.anon.5 = type { [65 x i64] }
 %struct.rb_hook_list_struct = type { %struct.rb_event_hook_struct*, i32, i32, i32 }
 %struct.rb_event_hook_struct = type opaque
 %struct.rb_postponed_job_struct = type opaque
@@ -68,19 +69,19 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.st_hash_type = type { i32 (i64, i64)*, i64 (i64)* }
 %struct.st_table_entry = type opaque
 %struct.rb_builtin_function = type opaque
-%struct.anon.4 = type { i64, i64, i64, i64 }
+%struct.anon.6 = type { i64, i64, i64, i64 }
 %struct.SorbetLineNumberInfo = type { i32, %struct.iseq_insn_info_entry*, i64* }
 %struct.FunctionInlineCache = type { %struct.rb_kwarg_call_data }
 %struct.rb_kwarg_call_data = type { %struct.rb_call_cache, %struct.rb_call_info_with_kwarg }
 %struct.rb_call_info_with_kwarg = type { %struct.rb_call_info, %struct.rb_call_info_kw_arg* }
 %struct.rb_call_info_kw_arg = type { i32, [1 x i64] }
 
-@ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
-@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @ruby_vm_global_constant_state = external local_unnamed_addr global i64, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
+@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @"stackFramePrecomputed_func_Object#3foo" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @rubyIdPrecomputed_foo = internal unnamed_addr global i64 0, align 8
 @str_foo = private unnamed_addr constant [4 x i8] c"foo\00", align 1
@@ -346,10 +347,10 @@ define linkonce void @const_recompute_A() local_unnamed_addr #8 {
   ret void
 }
 
-attributes #0 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #2 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #3 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { noreturn "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #1 = { "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #2 = { allocsize(0,1) "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #3 = { nounwind ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #4 = { nounwind sspreq uwtable }
 attributes #5 = { sspreq }
 attributes #6 = { argmemonly nofree nosync nounwind willreturn writeonly }

--- a/test/testdata/compiler/custom_plus.opt.ll.exp
+++ b/test/testdata/compiler/custom_plus.opt.ll.exp
@@ -2,16 +2,17 @@
 source_filename = "llvm-link"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 
-%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.3, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.4, [29 x i16] }
+%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.5, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.6, [29 x i16] }
 %struct.rb_global_vm_lock_struct = type { %struct.rb_thread_struct*, %union.pthread_mutex_t, %struct.list_head, %struct.rb_thread_struct*, i32, %union.pthread_cond_t, %union.pthread_cond_t, i32, i32 }
-%union.pthread_cond_t = type { %struct.anon.2 }
-%struct.anon.2 = type { i32, i32, i64, i64, i64, i8*, i32, i32 }
-%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.7, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
+%union.pthread_cond_t = type { %struct.__pthread_cond_s }
+%struct.__pthread_cond_s = type { %union.anon, %union.anon, [2 x i32], [2 x i32], i32, i32, [2 x i32] }
+%union.anon = type { i64 }
+%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.10, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
 %struct.list_node = type { %struct.list_node*, %struct.list_node* }
-%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.5 }
+%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.7 }
 %struct.rb_control_frame_struct = type { i64*, i64*, %struct.rb_iseq_struct*, i64, i64*, i8*, i64* }
-%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.14 }
-%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.13, i32, i32, i32, i32, i32, i8, i64 }
+%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.17 }
+%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.16, i32, i32, i32, i32, i32, i8, i64 }
 %struct.anon = type { %struct.anon.0, i32, i32, i32, i32, i32, i32, i32, i64*, %struct.rb_iseq_param_keyword* }
 %struct.anon.0 = type { i16, [2 x i8] }
 %struct.rb_iseq_param_keyword = type { i32, i32, i32, i32, i64*, i64* }
@@ -27,34 +28,34 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_cref_struct = type { i64, i64, i64, %struct.rb_cref_struct*, %struct.rb_scope_visi_struct }
 %struct.rb_scope_visi_struct = type { i8, [3 x i8] }
 %struct.rb_call_data = type { %struct.rb_call_cache, %struct.rb_call_info }
-%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.12 }
+%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.15 }
 %struct.rb_callable_method_entry_struct = type { i64, i64, %struct.rb_method_definition_struct*, i64, i64 }
-%struct.rb_method_definition_struct = type { i64, %union.anon.10, i64, i64 }
-%union.anon.10 = type { %struct.rb_method_cfunc_struct }
+%struct.rb_method_definition_struct = type { i64, %union.anon.13, i64, i64 }
+%union.anon.13 = type { %struct.rb_method_cfunc_struct }
 %struct.rb_method_cfunc_struct = type { i64 (...)*, i64 (i64, i32, i64*, i64 (...)*)*, i32 }
-%union.anon.12 = type { i32 }
+%union.anon.15 = type { i32 }
 %struct.rb_call_info = type { i64, i32, i32 }
-%struct.anon.13 = type { i64, i64, i64, i64* }
-%union.anon.14 = type { %struct.anon.15 }
-%struct.anon.15 = type { i64, i32 }
+%struct.anon.16 = type { i64, i64, i64, i64* }
+%union.anon.17 = type { %struct.anon.18 }
+%struct.anon.18 = type { i64, i32 }
 %struct.rb_vm_tag = type { i64, i64, [5 x i8*], %struct.rb_vm_tag*, i32 }
 %struct.rb_vm_protect_tag = type { %struct.rb_vm_protect_tag* }
 %struct.rb_ensure_list = type { %struct.rb_ensure_list*, %struct.rb_ensure_entry }
 %struct.rb_ensure_entry = type { i64, i64 (i64)*, i64 }
 %struct.rb_trace_arg_struct = type { i32, %struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, i64, i64, i64, i64, i64, i32, i32, i64 }
-%struct.anon.5 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
+%struct.anon.7 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
 %struct.__jmp_buf_tag = type { [8 x i64], i32, %struct.__sigset_t }
 %struct.__sigset_t = type { [16 x i64] }
 %struct.rb_calling_info = type { i64, i64, i32, i32 }
-%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.6 }
-%union.anon.6 = type { %union.pthread_cond_t }
+%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.9 }
+%union.anon.9 = type { %union.pthread_cond_t }
 %struct.rb_unblock_callback = type { void (i8*)*, i8* }
 %struct.rb_mutex_struct = type opaque
 %struct.rb_thread_list_struct = type { %struct.rb_thread_list_struct*, %struct.rb_thread_struct* }
-%union.anon.7 = type { %struct.anon.8 }
-%struct.anon.8 = type { i64, i64, i32 }
+%union.anon.10 = type { %struct.anon.11 }
+%struct.anon.11 = type { i64, i64, i32 }
 %struct.rb_fiber_struct = type opaque
-%struct.anon.3 = type { [65 x i64] }
+%struct.anon.5 = type { [65 x i64] }
 %struct.rb_hook_list_struct = type { %struct.rb_event_hook_struct*, i32, i32, i32 }
 %struct.rb_event_hook_struct = type opaque
 %struct.rb_postponed_job_struct = type opaque
@@ -68,19 +69,19 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.st_hash_type = type { i32 (i64, i64)*, i64 (i64)* }
 %struct.st_table_entry = type opaque
 %struct.rb_builtin_function = type opaque
-%struct.anon.4 = type { i64, i64, i64, i64 }
+%struct.anon.6 = type { i64, i64, i64, i64 }
 %struct.SorbetLineNumberInfo = type { i32, %struct.iseq_insn_info_entry*, i64* }
 %struct.FunctionInlineCache = type { %struct.rb_kwarg_call_data }
 %struct.rb_kwarg_call_data = type { %struct.rb_call_cache, %struct.rb_call_info_with_kwarg }
 %struct.rb_call_info_with_kwarg = type { %struct.rb_call_info, %struct.rb_call_info_kw_arg* }
 %struct.rb_call_info_kw_arg = type { i32, [1 x i64] }
 
-@ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
-@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @ruby_vm_global_constant_state = external local_unnamed_addr global i64, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
+@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @"stackFramePrecomputed_func_Object#8delegate" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @rubyIdPrecomputed_delegate = internal unnamed_addr global i64 0, align 8
 @str_delegate = private unnamed_addr constant [9 x i8] c"delegate\00", align 1
@@ -304,7 +305,7 @@ functionEntryInitializers:
   %rubyId_b.i = load i64, i64* @rubyIdPrecomputed_b, align 8, !dbg !22
   store i64 %rubyId_b.i, i64* %positional_table.i, align 8, !dbg !22
   %39 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !22
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %39, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %12, i64 noundef 8, i1 noundef false) #11, !dbg !22
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull align 1 %39, i8* noundef nonnull align 1 %12, i64 noundef 8, i1 noundef false) #11, !dbg !22
   %40 = getelementptr inbounds i8, i8* %29, i64 32, !dbg !22
   %41 = bitcast i8* %40 to i8**, !dbg !22
   store i8* %39, i8** %41, align 8, !dbg !22, !tbaa !42
@@ -358,7 +359,7 @@ afterNew:                                         ; preds = %fastNew, %slowNew
   store i64 %rubyId_a, i64* %positional_table, align 8, !dbg !44
   %63 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !44
   %64 = bitcast i64* %positional_table to i8*, !dbg !44
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %63, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %64, i64 noundef 8, i1 noundef false) #11, !dbg !44
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull align 1 %63, i8* noundef nonnull align 1 %64, i64 noundef 8, i1 noundef false) #11, !dbg !44
   %65 = getelementptr inbounds i8, i8* %52, i64 32, !dbg !44
   %66 = bitcast i8* %65 to i8**, !dbg !44
   store i8* %63, i8** %66, align 8, !dbg !44, !tbaa !42
@@ -498,11 +499,11 @@ define linkonce void @const_recompute_A() local_unnamed_addr #6 {
   ret void
 }
 
-attributes #0 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { noreturn "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #1 = { "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #2 = { argmemonly nofree nosync nounwind willreturn }
-attributes #3 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #4 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #3 = { allocsize(0,1) "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #4 = { nounwind ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #5 = { nounwind sspreq uwtable }
 attributes #6 = { ssp }
 attributes #7 = { argmemonly nofree nosync nounwind willreturn writeonly }

--- a/test/testdata/compiler/direct_call.opt.ll.exp
+++ b/test/testdata/compiler/direct_call.opt.ll.exp
@@ -2,16 +2,17 @@
 source_filename = "llvm-link"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 
-%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.3, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.4, [29 x i16] }
+%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.5, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.6, [29 x i16] }
 %struct.rb_global_vm_lock_struct = type { %struct.rb_thread_struct*, %union.pthread_mutex_t, %struct.list_head, %struct.rb_thread_struct*, i32, %union.pthread_cond_t, %union.pthread_cond_t, i32, i32 }
-%union.pthread_cond_t = type { %struct.anon.2 }
-%struct.anon.2 = type { i32, i32, i64, i64, i64, i8*, i32, i32 }
-%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.7, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
+%union.pthread_cond_t = type { %struct.__pthread_cond_s }
+%struct.__pthread_cond_s = type { %union.anon, %union.anon, [2 x i32], [2 x i32], i32, i32, [2 x i32] }
+%union.anon = type { i64 }
+%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.10, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
 %struct.list_node = type { %struct.list_node*, %struct.list_node* }
-%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.5 }
+%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.7 }
 %struct.rb_control_frame_struct = type { i64*, i64*, %struct.rb_iseq_struct*, i64, i64*, i8*, i64* }
-%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.14 }
-%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.13, i32, i32, i32, i32, i32, i8, i64 }
+%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.17 }
+%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.16, i32, i32, i32, i32, i32, i8, i64 }
 %struct.anon = type { %struct.anon.0, i32, i32, i32, i32, i32, i32, i32, i64*, %struct.rb_iseq_param_keyword* }
 %struct.anon.0 = type { i16, [2 x i8] }
 %struct.rb_iseq_param_keyword = type { i32, i32, i32, i32, i64*, i64* }
@@ -27,34 +28,34 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_cref_struct = type { i64, i64, i64, %struct.rb_cref_struct*, %struct.rb_scope_visi_struct }
 %struct.rb_scope_visi_struct = type { i8, [3 x i8] }
 %struct.rb_call_data = type { %struct.rb_call_cache, %struct.rb_call_info }
-%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.12 }
+%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.15 }
 %struct.rb_callable_method_entry_struct = type { i64, i64, %struct.rb_method_definition_struct*, i64, i64 }
-%struct.rb_method_definition_struct = type { i64, %union.anon.10, i64, i64 }
-%union.anon.10 = type { %struct.rb_method_cfunc_struct }
+%struct.rb_method_definition_struct = type { i64, %union.anon.13, i64, i64 }
+%union.anon.13 = type { %struct.rb_method_cfunc_struct }
 %struct.rb_method_cfunc_struct = type { i64 (...)*, i64 (i64, i32, i64*, i64 (...)*)*, i32 }
-%union.anon.12 = type { i32 }
+%union.anon.15 = type { i32 }
 %struct.rb_call_info = type { i64, i32, i32 }
-%struct.anon.13 = type { i64, i64, i64, i64* }
-%union.anon.14 = type { %struct.anon.15 }
-%struct.anon.15 = type { i64, i32 }
+%struct.anon.16 = type { i64, i64, i64, i64* }
+%union.anon.17 = type { %struct.anon.18 }
+%struct.anon.18 = type { i64, i32 }
 %struct.rb_vm_tag = type { i64, i64, [5 x i8*], %struct.rb_vm_tag*, i32 }
 %struct.rb_vm_protect_tag = type { %struct.rb_vm_protect_tag* }
 %struct.rb_ensure_list = type { %struct.rb_ensure_list*, %struct.rb_ensure_entry }
 %struct.rb_ensure_entry = type { i64, i64 (i64)*, i64 }
 %struct.rb_trace_arg_struct = type { i32, %struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, i64, i64, i64, i64, i64, i32, i32, i64 }
-%struct.anon.5 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
+%struct.anon.7 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
 %struct.__jmp_buf_tag = type { [8 x i64], i32, %struct.__sigset_t }
 %struct.__sigset_t = type { [16 x i64] }
 %struct.rb_calling_info = type { i64, i64, i32, i32 }
-%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.6 }
-%union.anon.6 = type { %union.pthread_cond_t }
+%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.9 }
+%union.anon.9 = type { %union.pthread_cond_t }
 %struct.rb_unblock_callback = type { void (i8*)*, i8* }
 %struct.rb_mutex_struct = type opaque
 %struct.rb_thread_list_struct = type { %struct.rb_thread_list_struct*, %struct.rb_thread_struct* }
-%union.anon.7 = type { %struct.anon.8 }
-%struct.anon.8 = type { i64, i64, i32 }
+%union.anon.10 = type { %struct.anon.11 }
+%struct.anon.11 = type { i64, i64, i32 }
 %struct.rb_fiber_struct = type opaque
-%struct.anon.3 = type { [65 x i64] }
+%struct.anon.5 = type { [65 x i64] }
 %struct.rb_hook_list_struct = type { %struct.rb_event_hook_struct*, i32, i32, i32 }
 %struct.rb_event_hook_struct = type opaque
 %struct.rb_postponed_job_struct = type opaque
@@ -68,18 +69,18 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.st_hash_type = type { i32 (i64, i64)*, i64 (i64)* }
 %struct.st_table_entry = type opaque
 %struct.rb_builtin_function = type opaque
-%struct.anon.4 = type { i64, i64, i64, i64 }
+%struct.anon.6 = type { i64, i64, i64, i64 }
 %struct.SorbetLineNumberInfo = type { i32, %struct.iseq_insn_info_entry*, i64* }
 %struct.FunctionInlineCache = type { %struct.rb_kwarg_call_data }
 %struct.rb_kwarg_call_data = type { %struct.rb_call_cache, %struct.rb_call_info_with_kwarg }
 %struct.rb_call_info_with_kwarg = type { %struct.rb_call_info, %struct.rb_call_info_kw_arg* }
 %struct.rb_call_info_kw_arg = type { i32, [1 x i64] }
 
-@ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
-@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
+@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @"stackFramePrecomputed_func_Object#3foo" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @rubyIdPrecomputed_foo = internal unnamed_addr global i64 0, align 8
 @str_foo = private unnamed_addr constant [4 x i8] c"foo\00", align 1
@@ -289,10 +290,10 @@ entry:
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #6
 
-attributes #0 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #2 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #3 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { noreturn "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #1 = { "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #2 = { allocsize(0,1) "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #3 = { nounwind ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #4 = { nounwind sspreq uwtable }
 attributes #5 = { sspreq }
 attributes #6 = { argmemonly nofree nosync nounwind willreturn writeonly }

--- a/test/testdata/compiler/exceptions/basic.opt.ll.exp
+++ b/test/testdata/compiler/exceptions/basic.opt.ll.exp
@@ -2,16 +2,17 @@
 source_filename = "llvm-link"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 
-%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.3, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.4, [29 x i16] }
+%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.5, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.6, [29 x i16] }
 %struct.rb_global_vm_lock_struct = type { %struct.rb_thread_struct*, %union.pthread_mutex_t, %struct.list_head, %struct.rb_thread_struct*, i32, %union.pthread_cond_t, %union.pthread_cond_t, i32, i32 }
-%union.pthread_cond_t = type { %struct.anon.2 }
-%struct.anon.2 = type { i32, i32, i64, i64, i64, i8*, i32, i32 }
-%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.7, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
+%union.pthread_cond_t = type { %struct.__pthread_cond_s }
+%struct.__pthread_cond_s = type { %union.anon, %union.anon, [2 x i32], [2 x i32], i32, i32, [2 x i32] }
+%union.anon = type { i64 }
+%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.10, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
 %struct.list_node = type { %struct.list_node*, %struct.list_node* }
-%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.5 }
+%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.7 }
 %struct.rb_control_frame_struct = type { i64*, i64*, %struct.rb_iseq_struct*, i64, i64*, i8*, i64* }
-%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.14 }
-%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.13, i32, i32, i32, i32, i32, i8, i64 }
+%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.17 }
+%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.16, i32, i32, i32, i32, i32, i8, i64 }
 %struct.anon = type { %struct.anon.0, i32, i32, i32, i32, i32, i32, i32, i64*, %struct.rb_iseq_param_keyword* }
 %struct.anon.0 = type { i16, [2 x i8] }
 %struct.rb_iseq_param_keyword = type { i32, i32, i32, i32, i64*, i64* }
@@ -27,34 +28,34 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_cref_struct = type { i64, i64, i64, %struct.rb_cref_struct*, %struct.rb_scope_visi_struct }
 %struct.rb_scope_visi_struct = type { i8, [3 x i8] }
 %struct.rb_call_data = type { %struct.rb_call_cache, %struct.rb_call_info }
-%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.12 }
+%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.15 }
 %struct.rb_callable_method_entry_struct = type { i64, i64, %struct.rb_method_definition_struct*, i64, i64 }
-%struct.rb_method_definition_struct = type { i64, %union.anon.10, i64, i64 }
-%union.anon.10 = type { %struct.rb_method_cfunc_struct }
+%struct.rb_method_definition_struct = type { i64, %union.anon.13, i64, i64 }
+%union.anon.13 = type { %struct.rb_method_cfunc_struct }
 %struct.rb_method_cfunc_struct = type { i64 (...)*, i64 (i64, i32, i64*, i64 (...)*)*, i32 }
-%union.anon.12 = type { i32 }
+%union.anon.15 = type { i32 }
 %struct.rb_call_info = type { i64, i32, i32 }
-%struct.anon.13 = type { i64, i64, i64, i64* }
-%union.anon.14 = type { %struct.anon.15 }
-%struct.anon.15 = type { i64, i32 }
+%struct.anon.16 = type { i64, i64, i64, i64* }
+%union.anon.17 = type { %struct.anon.18 }
+%struct.anon.18 = type { i64, i32 }
 %struct.rb_vm_tag = type { i64, i64, [5 x i8*], %struct.rb_vm_tag*, i32 }
 %struct.rb_vm_protect_tag = type { %struct.rb_vm_protect_tag* }
 %struct.rb_ensure_list = type { %struct.rb_ensure_list*, %struct.rb_ensure_entry }
 %struct.rb_ensure_entry = type { i64, i64 (i64)*, i64 }
 %struct.rb_trace_arg_struct = type { i32, %struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, i64, i64, i64, i64, i64, i32, i32, i64 }
-%struct.anon.5 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
+%struct.anon.7 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
 %struct.__jmp_buf_tag = type { [8 x i64], i32, %struct.__sigset_t }
 %struct.__sigset_t = type { [16 x i64] }
 %struct.rb_calling_info = type { i64, i64, i32, i32 }
-%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.6 }
-%union.anon.6 = type { %union.pthread_cond_t }
+%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.9 }
+%union.anon.9 = type { %union.pthread_cond_t }
 %struct.rb_unblock_callback = type { void (i8*)*, i8* }
 %struct.rb_mutex_struct = type opaque
 %struct.rb_thread_list_struct = type { %struct.rb_thread_list_struct*, %struct.rb_thread_struct* }
-%union.anon.7 = type { %struct.anon.8 }
-%struct.anon.8 = type { i64, i64, i32 }
+%union.anon.10 = type { %struct.anon.11 }
+%struct.anon.11 = type { i64, i64, i32 }
 %struct.rb_fiber_struct = type opaque
-%struct.anon.3 = type { [65 x i64] }
+%struct.anon.5 = type { [65 x i64] }
 %struct.rb_hook_list_struct = type { %struct.rb_event_hook_struct*, i32, i32, i32 }
 %struct.rb_event_hook_struct = type opaque
 %struct.rb_postponed_job_struct = type opaque
@@ -68,20 +69,20 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.st_hash_type = type { i32 (i64, i64)*, i64 (i64)* }
 %struct.st_table_entry = type opaque
 %struct.rb_builtin_function = type opaque
-%struct.anon.4 = type { i64, i64, i64, i64 }
+%struct.anon.6 = type { i64, i64, i64, i64 }
 %struct.SorbetLineNumberInfo = type { i32, %struct.iseq_insn_info_entry*, i64* }
 %struct.FunctionInlineCache = type { %struct.rb_kwarg_call_data }
 %struct.rb_kwarg_call_data = type { %struct.rb_call_cache, %struct.rb_call_info_with_kwarg }
 %struct.rb_call_info_with_kwarg = type { %struct.rb_call_info, %struct.rb_call_info_kw_arg* }
 %struct.rb_call_info_kw_arg = type { i32, [1 x i64] }
 
-@ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
-@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @ruby_vm_global_constant_state = external local_unnamed_addr global i64, align 8
 @sorbet_getTRetry.retry = internal constant [25 x i8] c"T::Private::Retry::RETRY\00", align 16
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
+@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -220,8 +221,11 @@ define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #4 {
   unreachable
 }
 
+; Function Attrs: nofree nosync nounwind willreturn
+declare void @llvm.assume(i1 noundef) #5
+
 ; Function Attrs: sspreq
-define void @Init_basic() local_unnamed_addr #5 {
+define void @Init_basic() local_unnamed_addr #6 {
 entry:
   %positional_table.i.i = alloca i64, align 8, !dbg !10
   %locals.i31.i = alloca i64, i32 0, align 8
@@ -421,7 +425,7 @@ entry:
   %rubyId_x.i.i2 = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !10
   store i64 %rubyId_x.i.i2, i64* %positional_table.i.i, align 8, !dbg !10
   %79 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !10
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %79, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %52, i64 noundef 8, i1 noundef false) #11, !dbg !10
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull align 1 %79, i8* noundef nonnull align 1 %52, i64 noundef 8, i1 noundef false) #11, !dbg !10
   %80 = getelementptr inbounds i8, i8* %69, i64 32, !dbg !10
   %81 = bitcast i8* %80 to i8**, !dbg !10
   store i8* %79, i8** %81, align 8, !dbg !10, !tbaa !60
@@ -470,7 +474,7 @@ entry:
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define internal i64 @func_A.4test(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #6 !dbg !23 {
+define internal i64 @func_A.4test(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #7 !dbg !23 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %0, align 8, !tbaa !33
@@ -502,7 +506,7 @@ fillRequiredArgs:                                 ; preds = %functionEntryInitia
   br label %sorbet_writeLocal.exit, !dbg !63
 
 8:                                                ; preds = %fillRequiredArgs
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %2, i32 noundef -4, i64 %rawArg_x) #11, !dbg !63
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 %2, i32 noundef -4, i64 %rawArg_x) #11, !dbg !63
   br label %sorbet_writeLocal.exit, !dbg !63
 
 sorbet_writeLocal.exit:                           ; preds = %6, %8
@@ -522,7 +526,7 @@ exception-continue:                               ; preds = %sorbet_writeLocal.e
 }
 
 ; Function Attrs: ssp
-define internal noundef i64 @"func_A.4test$block_1"(i64** nocapture nonnull writeonly align 8 dereferenceable(8) %pc, i64 %localsOffset, %struct.rb_control_frame_struct* %cfp) #7 !dbg !22 {
+define internal noundef i64 @"func_A.4test$block_1"(i64** nocapture nonnull writeonly align 8 dereferenceable(8) %pc, i64 %localsOffset, %struct.rb_control_frame_struct* %cfp) #8 !dbg !22 {
 functionEntryInitializers:
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !33
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
@@ -582,7 +586,7 @@ BB5:                                              ; preds = %functionEntryInitia
   br label %BB7, !dbg !25
 
 32:                                               ; preds = %BB5
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %26, i32 noundef -5, i64 %send27) #11, !dbg !25
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 %26, i32 noundef -5, i64 %send27) #11, !dbg !25
   br label %BB7, !dbg !25
 
 BB7:                                              ; preds = %32, %30, %functionEntryInitializers
@@ -591,8 +595,8 @@ BB7:                                              ; preds = %32, %30, %functionE
 }
 
 ; Function Attrs: ssp
-define internal noundef i64 @"func_A.4test$block_2"(i64** nocapture nofree readnone %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #7 !dbg !27 {
-vm_get_ep.exit34:
+define internal noundef i64 @"func_A.4test$block_2"(i64** nocapture nofree readnone %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #8 !dbg !27 {
+functionEntryInitializers:
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !33
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
   %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !45
@@ -609,7 +613,7 @@ vm_get_ep.exit34:
   %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 2, !dbg !26
   %11 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %10, align 8, !dbg !26, !tbaa !45
   %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 4, !dbg !26
-  %13 = load i64*, i64** %12, align 8, !dbg !26
+  %13 = load i64*, i64** %12, align 8, !dbg !26, !tbaa !50
   %14 = getelementptr inbounds i64, i64* %13, i64 -1, !dbg !26
   %15 = load i64, i64* %14, align 8, !dbg !26, !tbaa !6
   %16 = and i64 %15, -4, !dbg !26
@@ -620,18 +624,18 @@ vm_get_ep.exit34:
   %21 = tail call i64 @sorbet_vm_isa_p(%struct.FunctionInlineCache* noundef @"ic_is_a?", %struct.rb_control_frame_struct* %11, i64 %19, i64 %20), !dbg !26
   %22 = and i64 %21, -9, !dbg !26
   %23 = icmp ne i64 %22, 0, !dbg !26
-  br i1 %23, label %vm_get_ep.exit32, label %vm_get_ep.exit, !dbg !26
+  br i1 %23, label %BB10, label %BB11, !dbg !26
 
 blockExit:                                        ; preds = %75, %73, %60, %58
   tail call void @sorbet_popFrame()
   ret i64 52
 
-vm_get_ep.exit32:                                 ; preds = %vm_get_ep.exit34
+BB10:                                             ; preds = %functionEntryInitializers
   %24 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !72, !tbaa !33
   %25 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %24, i64 0, i32 2, !dbg !72
   %26 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %25, align 8, !dbg !72, !tbaa !45
   %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 4, !dbg !72
-  %28 = load i64*, i64** %27, align 8, !dbg !72
+  %28 = load i64*, i64** %27, align 8, !dbg !72, !tbaa !50
   %29 = getelementptr inbounds i64, i64* %28, i64 -1, !dbg !72
   %30 = load i64, i64* %29, align 8, !dbg !72, !tbaa !6
   %31 = and i64 %30, -4, !dbg !72
@@ -641,16 +645,16 @@ vm_get_ep.exit32:                                 ; preds = %vm_get_ep.exit34
   %35 = icmp eq i64 %34, 0, !dbg !72
   br i1 %35, label %36, label %38, !dbg !72, !prof !66
 
-36:                                               ; preds = %vm_get_ep.exit32
+36:                                               ; preds = %BB10
   %37 = getelementptr inbounds i64, i64* %32, i64 -3, !dbg !72
   store i64 8, i64* %37, align 8, !dbg !72, !tbaa !6
-  br label %vm_get_ep.exit30, !dbg !72
+  br label %sorbet_writeLocal.exit28, !dbg !72
 
-38:                                               ; preds = %vm_get_ep.exit32
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %32, i32 noundef -3, i64 noundef 8) #11, !dbg !72
-  br label %vm_get_ep.exit30, !dbg !72
+38:                                               ; preds = %BB10
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 %32, i32 noundef -3, i64 noundef 8) #11, !dbg !72
+  br label %sorbet_writeLocal.exit28, !dbg !72
 
-vm_get_ep.exit30:                                 ; preds = %36, %38
+sorbet_writeLocal.exit28:                         ; preds = %36, %38
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %8, align 8, !dbg !73, !tbaa !33
   %39 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !28, !tbaa !33
   %40 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %39, i64 0, i32 2, !dbg !28
@@ -667,7 +671,7 @@ vm_get_ep.exit30:                                 ; preds = %36, %38
   %47 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %46, i64 0, i32 2, !dbg !28
   %48 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %47, align 8, !dbg !28, !tbaa !45
   %49 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %48, i64 0, i32 4, !dbg !28
-  %50 = load i64*, i64** %49, align 8, !dbg !28
+  %50 = load i64*, i64** %49, align 8, !dbg !28, !tbaa !50
   %51 = getelementptr inbounds i64, i64* %50, i64 -1, !dbg !28
   %52 = load i64, i64* %51, align 8, !dbg !28, !tbaa !6
   %53 = and i64 %52, -4, !dbg !28
@@ -677,22 +681,22 @@ vm_get_ep.exit30:                                 ; preds = %36, %38
   %57 = icmp eq i64 %56, 0, !dbg !28
   br i1 %57, label %58, label %60, !dbg !28, !prof !66
 
-58:                                               ; preds = %vm_get_ep.exit30
+58:                                               ; preds = %sorbet_writeLocal.exit28
   %59 = getelementptr inbounds i64, i64* %54, i64 -5, !dbg !28
   store i64 %send, i64* %59, align 8, !dbg !28, !tbaa !6
   br label %blockExit, !dbg !28
 
-60:                                               ; preds = %vm_get_ep.exit30
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %54, i32 noundef -5, i64 %send) #11, !dbg !28
+60:                                               ; preds = %sorbet_writeLocal.exit28
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 %54, i32 noundef -5, i64 %send) #11, !dbg !28
   br label %blockExit, !dbg !28
 
-vm_get_ep.exit:                                   ; preds = %vm_get_ep.exit34
+BB11:                                             ; preds = %functionEntryInitializers
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !tbaa !33
   %61 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !74, !tbaa !33
   %62 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %61, i64 0, i32 2, !dbg !74
   %63 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %62, align 8, !dbg !74, !tbaa !45
   %64 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %63, i64 0, i32 4, !dbg !74
-  %65 = load i64*, i64** %64, align 8, !dbg !74
+  %65 = load i64*, i64** %64, align 8, !dbg !74, !tbaa !50
   %66 = getelementptr inbounds i64, i64* %65, i64 -1, !dbg !74
   %67 = load i64, i64* %66, align 8, !dbg !74, !tbaa !6
   %68 = and i64 %67, -4, !dbg !74
@@ -702,18 +706,18 @@ vm_get_ep.exit:                                   ; preds = %vm_get_ep.exit34
   %72 = icmp eq i64 %71, 0, !dbg !74
   br i1 %72, label %73, label %75, !dbg !74, !prof !66
 
-73:                                               ; preds = %vm_get_ep.exit
+73:                                               ; preds = %BB11
   %74 = getelementptr inbounds i64, i64* %69, i64 -7, !dbg !74
   store i64 20, i64* %74, align 8, !dbg !74, !tbaa !6
   br label %blockExit, !dbg !74
 
-75:                                               ; preds = %vm_get_ep.exit
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %69, i32 noundef -7, i64 noundef 20) #11, !dbg !74
+75:                                               ; preds = %BB11
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 %69, i32 noundef -7, i64 noundef 20) #11, !dbg !74
   br label %blockExit, !dbg !74
 }
 
 ; Function Attrs: ssp
-define internal noundef i64 @"func_A.4test$block_3"(i64** nocapture nofree readnone %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #7 !dbg !32 {
+define internal noundef i64 @"func_A.4test$block_3"(i64** nocapture nofree readnone %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #8 !dbg !32 {
 functionEntryInitializers:
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !33
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
@@ -739,12 +743,27 @@ functionEntryInitializers:
   %15 = getelementptr inbounds i64, i64* %14, i64 1, !dbg !31
   store i64* %15, i64** %12, align 8, !dbg !31
   %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.7, i64 0), !dbg !31
+  %16 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !31, !tbaa !33
+  %17 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 2, !dbg !31
+  %18 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %17, align 8, !dbg !31, !tbaa !45
+  %19 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 4, !dbg !31
+  %20 = load i64*, i64** %19, align 8, !dbg !31, !tbaa !50
+  %21 = getelementptr inbounds i64, i64* %20, i64 -1, !dbg !31
+  %22 = load i64, i64* %21, align 8, !dbg !31, !tbaa !6
+  %23 = and i64 %22, -4, !dbg !31
+  %24 = inttoptr i64 %23 to i64*, !dbg !31
+  %25 = getelementptr inbounds i64, i64* %24, i64 -7, !dbg !31
+  %26 = load i64, i64* %25, align 8, !dbg !31, !tbaa !6
+  %27 = and i64 %26, -9, !dbg !31
+  %28 = icmp ne i64 %27, 0, !dbg !31
+  %29 = xor i1 %28, true, !dbg !31
+  tail call void @llvm.assume(i1 noundef %29), !dbg !31
   tail call void @sorbet_popFrame()
   ret i64 52
 }
 
 ; Function Attrs: ssp
-define internal noundef i64 @"func_A.4test$block_4"(i64** nocapture nonnull writeonly align 8 dereferenceable(8) %pc, i64 %localsOffset, %struct.rb_control_frame_struct* %cfp) #7 !dbg !30 {
+define internal noundef i64 @"func_A.4test$block_4"(i64** nocapture nonnull writeonly align 8 dereferenceable(8) %pc, i64 %localsOffset, %struct.rb_control_frame_struct* %cfp) #8 !dbg !30 {
 functionEntryInitializers:
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !33
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
@@ -774,7 +793,7 @@ functionEntryInitializers:
   br label %sorbet_writeLocal.exit, !dbg !29
 
 16:                                               ; preds = %functionEntryInitializers
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %10, i32 noundef -5, i64 %send) #11, !dbg !29
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 %10, i32 noundef -5, i64 %send) #11, !dbg !29
   br label %sorbet_writeLocal.exit, !dbg !29
 
 sorbet_writeLocal.exit:                           ; preds = %14, %16
@@ -782,13 +801,10 @@ sorbet_writeLocal.exit:                           ; preds = %14, %16
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #8
-
-; Function Attrs: nofree nosync nounwind willreturn
-declare void @llvm.assume(i1 noundef) #9
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #9
 
 ; Function Attrs: ssp
-define linkonce void @const_recompute_A() local_unnamed_addr #7 {
+define linkonce void @const_recompute_A() local_unnamed_addr #8 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 1)
   store i64 %1, i64* @guarded_const_A, align 8
   %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !54
@@ -796,16 +812,16 @@ define linkonce void @const_recompute_A() local_unnamed_addr #7 {
   ret void
 }
 
-attributes #0 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { noreturn "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #1 = { "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #2 = { argmemonly nofree nosync nounwind willreturn }
-attributes #3 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #4 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #5 = { sspreq }
-attributes #6 = { nounwind sspreq uwtable }
-attributes #7 = { ssp }
-attributes #8 = { argmemonly nofree nosync nounwind willreturn writeonly }
-attributes #9 = { nofree nosync nounwind willreturn }
+attributes #3 = { allocsize(0,1) "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #4 = { nounwind ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #5 = { nofree nosync nounwind willreturn }
+attributes #6 = { sspreq }
+attributes #7 = { nounwind sspreq uwtable }
+attributes #8 = { ssp }
+attributes #9 = { argmemonly nofree nosync nounwind willreturn writeonly }
 attributes #10 = { noreturn nounwind }
 attributes #11 = { nounwind }
 attributes #12 = { nounwind allocsize(0,1) }

--- a/test/testdata/compiler/float-intrinsics.opt.ll.exp
+++ b/test/testdata/compiler/float-intrinsics.opt.ll.exp
@@ -2,16 +2,17 @@
 source_filename = "llvm-link"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 
-%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.3, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.4, [29 x i16] }
+%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.5, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.6, [29 x i16] }
 %struct.rb_global_vm_lock_struct = type { %struct.rb_thread_struct*, %union.pthread_mutex_t, %struct.list_head, %struct.rb_thread_struct*, i32, %union.pthread_cond_t, %union.pthread_cond_t, i32, i32 }
-%union.pthread_cond_t = type { %struct.anon.2 }
-%struct.anon.2 = type { i32, i32, i64, i64, i64, i8*, i32, i32 }
-%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.7, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
+%union.pthread_cond_t = type { %struct.__pthread_cond_s }
+%struct.__pthread_cond_s = type { %union.anon, %union.anon, [2 x i32], [2 x i32], i32, i32, [2 x i32] }
+%union.anon = type { i64 }
+%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.10, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
 %struct.list_node = type { %struct.list_node*, %struct.list_node* }
-%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.5 }
+%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.7 }
 %struct.rb_control_frame_struct = type { i64*, i64*, %struct.rb_iseq_struct*, i64, i64*, i8*, i64* }
-%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.14 }
-%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.13, i32, i32, i32, i32, i32, i8, i64 }
+%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.17 }
+%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.16, i32, i32, i32, i32, i32, i8, i64 }
 %struct.anon = type { %struct.anon.0, i32, i32, i32, i32, i32, i32, i32, i64*, %struct.rb_iseq_param_keyword* }
 %struct.anon.0 = type { i16, [2 x i8] }
 %struct.rb_iseq_param_keyword = type { i32, i32, i32, i32, i64*, i64* }
@@ -27,34 +28,34 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_cref_struct = type { i64, i64, i64, %struct.rb_cref_struct*, %struct.rb_scope_visi_struct }
 %struct.rb_scope_visi_struct = type { i8, [3 x i8] }
 %struct.rb_call_data = type { %struct.rb_call_cache, %struct.rb_call_info }
-%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.12 }
+%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.15 }
 %struct.rb_callable_method_entry_struct = type { i64, i64, %struct.rb_method_definition_struct*, i64, i64 }
-%struct.rb_method_definition_struct = type { i64, %union.anon.10, i64, i64 }
-%union.anon.10 = type { %struct.rb_method_cfunc_struct }
+%struct.rb_method_definition_struct = type { i64, %union.anon.13, i64, i64 }
+%union.anon.13 = type { %struct.rb_method_cfunc_struct }
 %struct.rb_method_cfunc_struct = type { i64 (...)*, i64 (i64, i32, i64*, i64 (...)*)*, i32 }
-%union.anon.12 = type { i32 }
+%union.anon.15 = type { i32 }
 %struct.rb_call_info = type { i64, i32, i32 }
-%struct.anon.13 = type { i64, i64, i64, i64* }
-%union.anon.14 = type { %struct.anon.15 }
-%struct.anon.15 = type { i64, i32 }
+%struct.anon.16 = type { i64, i64, i64, i64* }
+%union.anon.17 = type { %struct.anon.18 }
+%struct.anon.18 = type { i64, i32 }
 %struct.rb_vm_tag = type { i64, i64, [5 x i8*], %struct.rb_vm_tag*, i32 }
 %struct.rb_vm_protect_tag = type { %struct.rb_vm_protect_tag* }
 %struct.rb_ensure_list = type { %struct.rb_ensure_list*, %struct.rb_ensure_entry }
 %struct.rb_ensure_entry = type { i64, i64 (i64)*, i64 }
 %struct.rb_trace_arg_struct = type { i32, %struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, i64, i64, i64, i64, i64, i32, i32, i64 }
-%struct.anon.5 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
+%struct.anon.7 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
 %struct.__jmp_buf_tag = type { [8 x i64], i32, %struct.__sigset_t }
 %struct.__sigset_t = type { [16 x i64] }
 %struct.rb_calling_info = type { i64, i64, i32, i32 }
-%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.6 }
-%union.anon.6 = type { %union.pthread_cond_t }
+%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.9 }
+%union.anon.9 = type { %union.pthread_cond_t }
 %struct.rb_unblock_callback = type { void (i8*)*, i8* }
 %struct.rb_mutex_struct = type opaque
 %struct.rb_thread_list_struct = type { %struct.rb_thread_list_struct*, %struct.rb_thread_struct* }
-%union.anon.7 = type { %struct.anon.8 }
-%struct.anon.8 = type { i64, i64, i32 }
+%union.anon.10 = type { %struct.anon.11 }
+%struct.anon.11 = type { i64, i64, i32 }
 %struct.rb_fiber_struct = type opaque
-%struct.anon.3 = type { [65 x i64] }
+%struct.anon.5 = type { [65 x i64] }
 %struct.rb_hook_list_struct = type { %struct.rb_event_hook_struct*, i32, i32, i32 }
 %struct.rb_event_hook_struct = type opaque
 %struct.rb_postponed_job_struct = type opaque
@@ -68,7 +69,7 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.st_hash_type = type { i32 (i64, i64)*, i64 (i64)* }
 %struct.st_table_entry = type opaque
 %struct.rb_builtin_function = type opaque
-%struct.anon.4 = type { i64, i64, i64, i64 }
+%struct.anon.6 = type { i64, i64, i64, i64 }
 %struct.SorbetLineNumberInfo = type { i32, %struct.iseq_insn_info_entry*, i64* }
 %struct.FunctionInlineCache = type { %struct.rb_kwarg_call_data }
 %struct.rb_kwarg_call_data = type { %struct.rb_call_cache, %struct.rb_call_info_with_kwarg }
@@ -76,12 +77,12 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_call_info_kw_arg = type { i32, [1 x i64] }
 %struct.iseq_inline_iv_cache_entry = type { i64, i64 }
 
-@ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
-@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @ruby_vm_global_constant_state = external local_unnamed_addr global i64, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
+@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @"stackFramePrecomputed_func_Object#4plus" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @rubyIdPrecomputed_plus = internal unnamed_addr global i64 0, align 8
 @str_plus = private unnamed_addr constant [5 x i8] c"plus\00", align 1
@@ -225,7 +226,7 @@ declare i64 @sorbet_flo_lt(i64, i64) local_unnamed_addr #0
 
 declare i64 @sorbet_flo_le(i64, i64) local_unnamed_addr #0
 
-; Function Attrs: nounwind readnone willreturn
+; Function Attrs: nofree nosync nounwind readnone willreturn mustprogress
 declare i64 @rb_id2sym(i64) local_unnamed_addr #1
 
 ; Function Attrs: cold noreturn
@@ -472,24 +473,24 @@ typeTestSuccess6:                                 ; preds = %fillRequiredArgs, %
   %23 = xor i32 %22, -1, !dbg !42
   %24 = and i32 %23, %20, !dbg !42
   %25 = icmp eq i32 %24, 0, !dbg !42
-  br i1 %25, label %rb_vm_check_ints.exit, label %26, !dbg !42, !prof !21
+  br i1 %25, label %sorbet_afterIntrinsic.exit, label %26, !dbg !42, !prof !21
 
 26:                                               ; preds = %typeTestSuccess6
   %27 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %18, i64 0, i32 8, !dbg !42
   %28 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %27, align 8, !dbg !42, !tbaa !32
   %29 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %28, i32 noundef 0) #17, !dbg !42
-  br label %rb_vm_check_ints.exit, !dbg !42
+  br label %sorbet_afterIntrinsic.exit, !dbg !42
 
-rb_vm_check_ints.exit:                            ; preds = %typeTestSuccess6, %26
+sorbet_afterIntrinsic.exit:                       ; preds = %typeTestSuccess6, %26
   switch i64 %17, label %codeRepl [
     i64 20, label %typeTestSuccess13
     i64 0, label %typeTestSuccess13
   ], !prof !46
 
-typeTestSuccess13:                                ; preds = %rb_vm_check_ints.exit, %rb_vm_check_ints.exit
+typeTestSuccess13:                                ; preds = %sorbet_afterIntrinsic.exit, %sorbet_afterIntrinsic.exit
   ret i64 %17
 
-codeRepl:                                         ; preds = %rb_vm_check_ints.exit
+codeRepl:                                         ; preds = %sorbet_afterIntrinsic.exit
   tail call fastcc void @"func_Object#2lt.cold.1"(i64 %17) #16, !dbg !47
   unreachable
 }
@@ -553,24 +554,24 @@ typeTestSuccess6:                                 ; preds = %fillRequiredArgs, %
   %23 = xor i32 %22, -1, !dbg !52
   %24 = and i32 %23, %20, !dbg !52
   %25 = icmp eq i32 %24, 0, !dbg !52
-  br i1 %25, label %rb_vm_check_ints.exit, label %26, !dbg !52, !prof !21
+  br i1 %25, label %sorbet_afterIntrinsic.exit, label %26, !dbg !52, !prof !21
 
 26:                                               ; preds = %typeTestSuccess6
   %27 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %18, i64 0, i32 8, !dbg !52
   %28 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %27, align 8, !dbg !52, !tbaa !32
   %29 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %28, i32 noundef 0) #17, !dbg !52
-  br label %rb_vm_check_ints.exit, !dbg !52
+  br label %sorbet_afterIntrinsic.exit, !dbg !52
 
-rb_vm_check_ints.exit:                            ; preds = %typeTestSuccess6, %26
+sorbet_afterIntrinsic.exit:                       ; preds = %typeTestSuccess6, %26
   switch i64 %17, label %codeRepl [
     i64 20, label %typeTestSuccess13
     i64 0, label %typeTestSuccess13
   ], !prof !46
 
-typeTestSuccess13:                                ; preds = %rb_vm_check_ints.exit, %rb_vm_check_ints.exit
+typeTestSuccess13:                                ; preds = %sorbet_afterIntrinsic.exit, %sorbet_afterIntrinsic.exit
   ret i64 %17
 
-codeRepl:                                         ; preds = %rb_vm_check_ints.exit
+codeRepl:                                         ; preds = %sorbet_afterIntrinsic.exit
   tail call fastcc void @"func_Object#2lt.cold.1"(i64 %17) #16, !dbg !56
   unreachable
 }
@@ -1240,7 +1241,7 @@ entry:
   %98 = getelementptr i64, i64* %positional_table.i, i32 1, !dbg !84
   store i64 %rubyId_y.i6, i64* %98, align 8, !dbg !84
   %99 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #19, !dbg !84
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %99, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %66, i64 noundef 16, i1 noundef false) #17, !dbg !84
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull align 1 %99, i8* noundef nonnull align 1 %66, i64 noundef 16, i1 noundef false) #17, !dbg !84
   %100 = getelementptr inbounds i8, i8* %88, i64 32, !dbg !84
   %101 = bitcast i8* %100 to i8**, !dbg !84
   store i8* %99, i8** %101, align 8, !dbg !84, !tbaa !146
@@ -1267,7 +1268,7 @@ entry:
   %112 = getelementptr i64, i64* %positional_table320.i, i32 1, !dbg !85
   store i64 %rubyId_y322.i, i64* %112, align 8, !dbg !85
   %113 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #19, !dbg !85
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %113, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %67, i64 noundef 16, i1 noundef false) #17, !dbg !85
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull align 1 %113, i8* noundef nonnull align 1 %67, i64 noundef 16, i1 noundef false) #17, !dbg !85
   %114 = getelementptr inbounds i8, i8* %102, i64 32, !dbg !85
   %115 = bitcast i8* %114 to i8**, !dbg !85
   store i8* %113, i8** %115, align 8, !dbg !85, !tbaa !146
@@ -1294,7 +1295,7 @@ entry:
   %126 = getelementptr i64, i64* %positional_table334.i, i32 1, !dbg !86
   store i64 %rubyId_y336.i, i64* %126, align 8, !dbg !86
   %127 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #19, !dbg !86
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %127, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %68, i64 noundef 16, i1 noundef false) #17, !dbg !86
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull align 1 %127, i8* noundef nonnull align 1 %68, i64 noundef 16, i1 noundef false) #17, !dbg !86
   %128 = getelementptr inbounds i8, i8* %116, i64 32, !dbg !86
   %129 = bitcast i8* %128 to i8**, !dbg !86
   store i8* %127, i8** %129, align 8, !dbg !86, !tbaa !146
@@ -1321,7 +1322,7 @@ entry:
   %140 = getelementptr i64, i64* %positional_table348.i, i32 1, !dbg !87
   store i64 %rubyId_y350.i, i64* %140, align 8, !dbg !87
   %141 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #19, !dbg !87
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %141, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %69, i64 noundef 16, i1 noundef false) #17, !dbg !87
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull align 1 %141, i8* noundef nonnull align 1 %69, i64 noundef 16, i1 noundef false) #17, !dbg !87
   %142 = getelementptr inbounds i8, i8* %130, i64 32, !dbg !87
   %143 = bitcast i8* %142 to i8**, !dbg !87
   store i8* %141, i8** %143, align 8, !dbg !87, !tbaa !146
@@ -1771,13 +1772,13 @@ define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #8 {
   ret void
 }
 
-attributes #0 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { nounwind readnone willreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #2 = { cold noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #3 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #4 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #1 = { nofree nosync nounwind readnone willreturn mustprogress "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #2 = { cold noreturn "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #3 = { noreturn "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #4 = { allocsize(0,1) "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #5 = { argmemonly nofree nosync nounwind willreturn }
-attributes #6 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #6 = { nounwind ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #7 = { nounwind sspreq uwtable }
 attributes #8 = { ssp }
 attributes #9 = { sspreq }

--- a/test/testdata/compiler/globalfields.opt.ll.exp
+++ b/test/testdata/compiler/globalfields.opt.ll.exp
@@ -2,16 +2,17 @@
 source_filename = "llvm-link"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 
-%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.3, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.4, [29 x i16] }
+%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.5, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.6, [29 x i16] }
 %struct.rb_global_vm_lock_struct = type { %struct.rb_thread_struct*, %union.pthread_mutex_t, %struct.list_head, %struct.rb_thread_struct*, i32, %union.pthread_cond_t, %union.pthread_cond_t, i32, i32 }
-%union.pthread_cond_t = type { %struct.anon.2 }
-%struct.anon.2 = type { i32, i32, i64, i64, i64, i8*, i32, i32 }
-%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.7, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
+%union.pthread_cond_t = type { %struct.__pthread_cond_s }
+%struct.__pthread_cond_s = type { %union.anon, %union.anon, [2 x i32], [2 x i32], i32, i32, [2 x i32] }
+%union.anon = type { i64 }
+%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.10, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
 %struct.list_node = type { %struct.list_node*, %struct.list_node* }
-%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.5 }
+%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.7 }
 %struct.rb_control_frame_struct = type { i64*, i64*, %struct.rb_iseq_struct*, i64, i64*, i8*, i64* }
-%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.14 }
-%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.13, i32, i32, i32, i32, i32, i8, i64 }
+%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.17 }
+%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.16, i32, i32, i32, i32, i32, i8, i64 }
 %struct.anon = type { %struct.anon.0, i32, i32, i32, i32, i32, i32, i32, i64*, %struct.rb_iseq_param_keyword* }
 %struct.anon.0 = type { i16, [2 x i8] }
 %struct.rb_iseq_param_keyword = type { i32, i32, i32, i32, i64*, i64* }
@@ -27,34 +28,34 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_cref_struct = type { i64, i64, i64, %struct.rb_cref_struct*, %struct.rb_scope_visi_struct }
 %struct.rb_scope_visi_struct = type { i8, [3 x i8] }
 %struct.rb_call_data = type { %struct.rb_call_cache, %struct.rb_call_info }
-%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.12 }
+%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.15 }
 %struct.rb_callable_method_entry_struct = type { i64, i64, %struct.rb_method_definition_struct*, i64, i64 }
-%struct.rb_method_definition_struct = type { i64, %union.anon.10, i64, i64 }
-%union.anon.10 = type { %struct.rb_method_cfunc_struct }
+%struct.rb_method_definition_struct = type { i64, %union.anon.13, i64, i64 }
+%union.anon.13 = type { %struct.rb_method_cfunc_struct }
 %struct.rb_method_cfunc_struct = type { i64 (...)*, i64 (i64, i32, i64*, i64 (...)*)*, i32 }
-%union.anon.12 = type { i32 }
+%union.anon.15 = type { i32 }
 %struct.rb_call_info = type { i64, i32, i32 }
-%struct.anon.13 = type { i64, i64, i64, i64* }
-%union.anon.14 = type { %struct.anon.15 }
-%struct.anon.15 = type { i64, i32 }
+%struct.anon.16 = type { i64, i64, i64, i64* }
+%union.anon.17 = type { %struct.anon.18 }
+%struct.anon.18 = type { i64, i32 }
 %struct.rb_vm_tag = type { i64, i64, [5 x i8*], %struct.rb_vm_tag*, i32 }
 %struct.rb_vm_protect_tag = type { %struct.rb_vm_protect_tag* }
 %struct.rb_ensure_list = type { %struct.rb_ensure_list*, %struct.rb_ensure_entry }
 %struct.rb_ensure_entry = type { i64, i64 (i64)*, i64 }
 %struct.rb_trace_arg_struct = type { i32, %struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, i64, i64, i64, i64, i64, i32, i32, i64 }
-%struct.anon.5 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
+%struct.anon.7 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
 %struct.__jmp_buf_tag = type { [8 x i64], i32, %struct.__sigset_t }
 %struct.__sigset_t = type { [16 x i64] }
 %struct.rb_calling_info = type { i64, i64, i32, i32 }
-%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.6 }
-%union.anon.6 = type { %union.pthread_cond_t }
+%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.9 }
+%union.anon.9 = type { %union.pthread_cond_t }
 %struct.rb_unblock_callback = type { void (i8*)*, i8* }
 %struct.rb_mutex_struct = type opaque
 %struct.rb_thread_list_struct = type { %struct.rb_thread_list_struct*, %struct.rb_thread_struct* }
-%union.anon.7 = type { %struct.anon.8 }
-%struct.anon.8 = type { i64, i64, i32 }
+%union.anon.10 = type { %struct.anon.11 }
+%struct.anon.11 = type { i64, i64, i32 }
 %struct.rb_fiber_struct = type opaque
-%struct.anon.3 = type { [65 x i64] }
+%struct.anon.5 = type { [65 x i64] }
 %struct.rb_hook_list_struct = type { %struct.rb_event_hook_struct*, i32, i32, i32 }
 %struct.rb_event_hook_struct = type opaque
 %struct.rb_postponed_job_struct = type opaque
@@ -68,7 +69,7 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.st_hash_type = type { i32 (i64, i64)*, i64 (i64)* }
 %struct.st_table_entry = type opaque
 %struct.rb_builtin_function = type opaque
-%struct.anon.4 = type { i64, i64, i64, i64 }
+%struct.anon.6 = type { i64, i64, i64, i64 }
 %struct.SorbetLineNumberInfo = type { i32, %struct.iseq_insn_info_entry*, i64* }
 %struct.FunctionInlineCache = type { %struct.rb_kwarg_call_data }
 %struct.rb_kwarg_call_data = type { %struct.rb_call_cache, %struct.rb_call_info_with_kwarg }
@@ -77,12 +78,12 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_global_entry = type { %struct.rb_global_variable*, i64 }
 %struct.rb_global_variable = type opaque
 
-@ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
-@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @ruby_vm_global_constant_state = external local_unnamed_addr global i64, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
+@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -346,7 +347,7 @@ entry:
   %rubyId_v.i.i = load i64, i64* @rubyIdPrecomputed_v, align 8, !dbg !10
   store i64 %rubyId_v.i.i, i64* %positional_table.i.i, align 8, !dbg !10
   %62 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !10
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %62, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %35, i64 noundef 8, i1 noundef false) #11, !dbg !10
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull align 1 %62, i8* noundef nonnull align 1 %35, i64 noundef 8, i1 noundef false) #11, !dbg !10
   %63 = getelementptr inbounds i8, i8* %52, i64 32, !dbg !10
   %64 = bitcast i8* %63 to i8**, !dbg !10
   store i8* %62, i8** %64, align 8, !dbg !10, !tbaa !51
@@ -506,11 +507,11 @@ define linkonce void @const_recompute_A() local_unnamed_addr #9 {
   ret void
 }
 
-attributes #0 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { noreturn "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #1 = { "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #2 = { argmemonly nofree nosync nounwind willreturn }
-attributes #3 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #4 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #3 = { allocsize(0,1) "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #4 = { nounwind ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #5 = { sspreq }
 attributes #6 = { nounwind sspreq uwtable }
 attributes #7 = { argmemonly nofree nosync nounwind willreturn writeonly }

--- a/test/testdata/compiler/hello.opt.ll.exp
+++ b/test/testdata/compiler/hello.opt.ll.exp
@@ -2,16 +2,17 @@
 source_filename = "llvm-link"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 
-%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.3, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.4, [29 x i16] }
+%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.5, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.6, [29 x i16] }
 %struct.rb_global_vm_lock_struct = type { %struct.rb_thread_struct*, %union.pthread_mutex_t, %struct.list_head, %struct.rb_thread_struct*, i32, %union.pthread_cond_t, %union.pthread_cond_t, i32, i32 }
-%union.pthread_cond_t = type { %struct.anon.2 }
-%struct.anon.2 = type { i32, i32, i64, i64, i64, i8*, i32, i32 }
-%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.7, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
+%union.pthread_cond_t = type { %struct.__pthread_cond_s }
+%struct.__pthread_cond_s = type { %union.anon, %union.anon, [2 x i32], [2 x i32], i32, i32, [2 x i32] }
+%union.anon = type { i64 }
+%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.10, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
 %struct.list_node = type { %struct.list_node*, %struct.list_node* }
-%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.5 }
+%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.7 }
 %struct.rb_control_frame_struct = type { i64*, i64*, %struct.rb_iseq_struct*, i64, i64*, i8*, i64* }
-%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.14 }
-%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.13, i32, i32, i32, i32, i32, i8, i64 }
+%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.17 }
+%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.16, i32, i32, i32, i32, i32, i8, i64 }
 %struct.anon = type { %struct.anon.0, i32, i32, i32, i32, i32, i32, i32, i64*, %struct.rb_iseq_param_keyword* }
 %struct.anon.0 = type { i16, [2 x i8] }
 %struct.rb_iseq_param_keyword = type { i32, i32, i32, i32, i64*, i64* }
@@ -27,34 +28,34 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_cref_struct = type { i64, i64, i64, %struct.rb_cref_struct*, %struct.rb_scope_visi_struct }
 %struct.rb_scope_visi_struct = type { i8, [3 x i8] }
 %struct.rb_call_data = type { %struct.rb_call_cache, %struct.rb_call_info }
-%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.12 }
+%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.15 }
 %struct.rb_callable_method_entry_struct = type { i64, i64, %struct.rb_method_definition_struct*, i64, i64 }
-%struct.rb_method_definition_struct = type { i64, %union.anon.10, i64, i64 }
-%union.anon.10 = type { %struct.rb_method_cfunc_struct }
+%struct.rb_method_definition_struct = type { i64, %union.anon.13, i64, i64 }
+%union.anon.13 = type { %struct.rb_method_cfunc_struct }
 %struct.rb_method_cfunc_struct = type { i64 (...)*, i64 (i64, i32, i64*, i64 (...)*)*, i32 }
-%union.anon.12 = type { i32 }
+%union.anon.15 = type { i32 }
 %struct.rb_call_info = type { i64, i32, i32 }
-%struct.anon.13 = type { i64, i64, i64, i64* }
-%union.anon.14 = type { %struct.anon.15 }
-%struct.anon.15 = type { i64, i32 }
+%struct.anon.16 = type { i64, i64, i64, i64* }
+%union.anon.17 = type { %struct.anon.18 }
+%struct.anon.18 = type { i64, i32 }
 %struct.rb_vm_tag = type { i64, i64, [5 x i8*], %struct.rb_vm_tag*, i32 }
 %struct.rb_vm_protect_tag = type { %struct.rb_vm_protect_tag* }
 %struct.rb_ensure_list = type { %struct.rb_ensure_list*, %struct.rb_ensure_entry }
 %struct.rb_ensure_entry = type { i64, i64 (i64)*, i64 }
 %struct.rb_trace_arg_struct = type { i32, %struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, i64, i64, i64, i64, i64, i32, i32, i64 }
-%struct.anon.5 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
+%struct.anon.7 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
 %struct.__jmp_buf_tag = type { [8 x i64], i32, %struct.__sigset_t }
 %struct.__sigset_t = type { [16 x i64] }
 %struct.rb_calling_info = type { i64, i64, i32, i32 }
-%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.6 }
-%union.anon.6 = type { %union.pthread_cond_t }
+%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.9 }
+%union.anon.9 = type { %union.pthread_cond_t }
 %struct.rb_unblock_callback = type { void (i8*)*, i8* }
 %struct.rb_mutex_struct = type opaque
 %struct.rb_thread_list_struct = type { %struct.rb_thread_list_struct*, %struct.rb_thread_struct* }
-%union.anon.7 = type { %struct.anon.8 }
-%struct.anon.8 = type { i64, i64, i32 }
+%union.anon.10 = type { %struct.anon.11 }
+%struct.anon.11 = type { i64, i64, i32 }
 %struct.rb_fiber_struct = type opaque
-%struct.anon.3 = type { [65 x i64] }
+%struct.anon.5 = type { [65 x i64] }
 %struct.rb_hook_list_struct = type { %struct.rb_event_hook_struct*, i32, i32, i32 }
 %struct.rb_event_hook_struct = type opaque
 %struct.rb_postponed_job_struct = type opaque
@@ -68,18 +69,18 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.st_hash_type = type { i32 (i64, i64)*, i64 (i64)* }
 %struct.st_table_entry = type opaque
 %struct.rb_builtin_function = type opaque
-%struct.anon.4 = type { i64, i64, i64, i64 }
+%struct.anon.6 = type { i64, i64, i64, i64 }
 %struct.SorbetLineNumberInfo = type { i32, %struct.iseq_insn_info_entry*, i64* }
 %struct.FunctionInlineCache = type { %struct.rb_kwarg_call_data }
 %struct.rb_kwarg_call_data = type { %struct.rb_call_cache, %struct.rb_call_info_with_kwarg }
 %struct.rb_call_info_with_kwarg = type { %struct.rb_call_info, %struct.rb_call_info_kw_arg* }
 %struct.rb_call_info_kw_arg = type { i32, [1 x i64] }
 
-@ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
-@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
+@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -184,9 +185,9 @@ entry:
   ret void
 }
 
-attributes #0 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #2 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #1 = { noreturn "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #2 = { nounwind ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #3 = { sspreq }
 attributes #4 = { noreturn nounwind }
 attributes #5 = { nounwind }

--- a/test/testdata/compiler/intrinsics/bang.opt.ll.exp
+++ b/test/testdata/compiler/intrinsics/bang.opt.ll.exp
@@ -2,10 +2,10 @@
 source_filename = "llvm-link"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 
-%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.5 }
+%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.7 }
 %struct.rb_control_frame_struct = type { i64*, i64*, %struct.rb_iseq_struct*, i64, i64*, i8*, i64* }
-%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.14 }
-%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.13, i32, i32, i32, i32, i32, i8, i64 }
+%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.17 }
+%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.16, i32, i32, i32, i32, i32, i8, i64 }
 %struct.anon = type { %struct.anon.0, i32, i32, i32, i32, i32, i32, i32, i64*, %struct.rb_iseq_param_keyword* }
 %struct.anon.0 = type { i16, [2 x i8] }
 %struct.rb_iseq_param_keyword = type { i32, i32, i32, i32, i64*, i64* }
@@ -21,27 +21,28 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_cref_struct = type { i64, i64, i64, %struct.rb_cref_struct*, %struct.rb_scope_visi_struct }
 %struct.rb_scope_visi_struct = type { i8, [3 x i8] }
 %struct.rb_call_data = type { %struct.rb_call_cache, %struct.rb_call_info }
-%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.12 }
+%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.15 }
 %struct.rb_callable_method_entry_struct = type { i64, i64, %struct.rb_method_definition_struct*, i64, i64 }
-%struct.rb_method_definition_struct = type { i64, %union.anon.10, i64, i64 }
-%union.anon.10 = type { %struct.rb_method_cfunc_struct }
+%struct.rb_method_definition_struct = type { i64, %union.anon.13, i64, i64 }
+%union.anon.13 = type { %struct.rb_method_cfunc_struct }
 %struct.rb_method_cfunc_struct = type { i64 (...)*, i64 (i64, i32, i64*, i64 (...)*)*, i32 }
 %struct.rb_calling_info = type { i64, i64, i32, i32 }
-%union.anon.12 = type { i32 }
+%union.anon.15 = type { i32 }
 %struct.rb_call_info = type { i64, i32, i32 }
-%struct.anon.13 = type { i64, i64, i64, i64* }
-%union.anon.14 = type { %struct.anon.15 }
-%struct.anon.15 = type { i64, i32 }
+%struct.anon.16 = type { i64, i64, i64, i64* }
+%union.anon.17 = type { %struct.anon.18 }
+%struct.anon.18 = type { i64, i32 }
 %struct.rb_vm_tag = type { i64, i64, [5 x i8*], %struct.rb_vm_tag*, i32 }
 %struct.rb_vm_protect_tag = type { %struct.rb_vm_protect_tag* }
 %struct.rb_fiber_struct = type opaque
-%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.7, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
+%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.10, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
 %struct.list_node = type { %struct.list_node*, %struct.list_node* }
-%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.3, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.4, [29 x i16] }
+%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.5, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.6, [29 x i16] }
 %struct.rb_global_vm_lock_struct = type { %struct.rb_thread_struct*, %union.pthread_mutex_t, %struct.list_head, %struct.rb_thread_struct*, i32, %union.pthread_cond_t, %union.pthread_cond_t, i32, i32 }
-%union.pthread_cond_t = type { %struct.anon.2 }
-%struct.anon.2 = type { i32, i32, i64, i64, i64, i8*, i32, i32 }
-%struct.anon.3 = type { [65 x i64] }
+%union.pthread_cond_t = type { %struct.__pthread_cond_s }
+%struct.__pthread_cond_s = type { %union.anon, %union.anon, [2 x i32], [2 x i32], i32, i32, [2 x i32] }
+%union.anon = type { i64 }
+%struct.anon.5 = type { [65 x i64] }
 %struct.rb_hook_list_struct = type { %struct.rb_event_hook_struct*, i32, i32, i32 }
 %struct.rb_event_hook_struct = type opaque
 %struct.rb_postponed_job_struct = type opaque
@@ -49,24 +50,24 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_objspace = type opaque
 %struct.rb_at_exit_list = type { void (%struct.rb_vm_struct*)*, %struct.rb_at_exit_list* }
 %struct.rb_builtin_function = type opaque
-%struct.anon.4 = type { i64, i64, i64, i64 }
-%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.6 }
-%union.anon.6 = type { %union.pthread_cond_t }
+%struct.anon.6 = type { i64, i64, i64, i64 }
+%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.9 }
+%union.anon.9 = type { %union.pthread_cond_t }
 %union.pthread_mutex_t = type { %struct.__pthread_mutex_s }
 %struct.__pthread_mutex_s = type { i32, i32, i32, i32, i32, i16, i16, %struct.__pthread_internal_list }
 %struct.__pthread_internal_list = type { %struct.__pthread_internal_list*, %struct.__pthread_internal_list* }
 %struct.rb_unblock_callback = type { void (i8*)*, i8* }
 %struct.rb_mutex_struct = type opaque
 %struct.rb_thread_list_struct = type { %struct.rb_thread_list_struct*, %struct.rb_thread_struct* }
-%union.anon.7 = type { %struct.anon.8 }
-%struct.anon.8 = type { i64, i64, i32 }
+%union.anon.10 = type { %struct.anon.11 }
+%struct.anon.11 = type { i64, i64, i32 }
 %struct.st_table = type { i8, i8, i8, i32, %struct.st_hash_type*, i64, i64*, i64, i64, %struct.st_table_entry* }
 %struct.st_hash_type = type { i32 (i64, i64)*, i64 (i64)* }
 %struct.st_table_entry = type opaque
 %struct.rb_ensure_list = type { %struct.rb_ensure_list*, %struct.rb_ensure_entry }
 %struct.rb_ensure_entry = type { i64, i64 (i64)*, i64 }
 %struct.rb_trace_arg_struct = type { i32, %struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, i64, i64, i64, i64, i64, i32, i32, i64 }
-%struct.anon.5 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
+%struct.anon.7 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
 %struct.__jmp_buf_tag = type { [8 x i64], i32, %struct.__sigset_t }
 %struct.__sigset_t = type { [16 x i64] }
 %struct.SorbetLineNumberInfo = type { i32, %struct.iseq_insn_info_entry*, i64* }
@@ -75,11 +76,11 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_call_info_with_kwarg = type { %struct.rb_call_info, %struct.rb_call_info_kw_arg* }
 %struct.rb_call_info_kw_arg = type { i32, [1 x i64] }
 
-@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @ruby_vm_global_constant_state = external local_unnamed_addr global i64, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -303,18 +304,18 @@ entry:
   %31 = load i64, i64* @rb_cObject, align 8, !dbg !39
   %32 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_Bad, i64 0, i64 0), i64 %31) #10, !dbg !39
   %33 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %32) #10, !dbg !39
-  %stackFrame.i1.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad.13<static-init>", align 8
+  %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad.13<static-init>", align 8
   %34 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !29
   %35 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %34, i64 0, i32 2
   %36 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %35, align 8, !tbaa !31
   %37 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i1.i, %struct.rb_iseq_struct** %37, align 8, !tbaa !35
+  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %37, align 8, !tbaa !35
   %38 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 4
   %39 = load i64*, i64** %38, align 8, !tbaa !37
   %40 = load i64, i64* %39, align 8, !tbaa !6
   %41 = and i64 %40, -33
   store i64 %41, i64* %39, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %34, %struct.rb_control_frame_struct* %36, %struct.rb_iseq_struct* %stackFrame.i1.i) #10
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %34, %struct.rb_control_frame_struct* %36, %struct.rb_iseq_struct* %stackFrame.i.i) #10
   %42 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 0
   store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %42, align 8, !dbg !40, !tbaa !29
   %43 = load i64, i64* @guard_epoch_Bad, align 8, !dbg !43
@@ -332,7 +333,7 @@ entry:
   %49 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !43, !tbaa !44
   %guardUpdated = icmp eq i64 %48, %49, !dbg !43
   call void @llvm.assume(i1 %guardUpdated), !dbg !43
-  %stackFrame7.i2.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad#1!", align 8, !dbg !43
+  %stackFrame7.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad#1!", align 8, !dbg !43
   %50 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #11, !dbg !43
   %51 = bitcast i8* %50 to i16*, !dbg !43
   %52 = load i16, i16* %51, align 8, !dbg !43
@@ -340,23 +341,23 @@ entry:
   store i16 %53, i16* %51, align 8, !dbg !43
   %54 = getelementptr inbounds i8, i8* %50, i64 4, !dbg !43
   call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %54, i8 0, i64 28, i1 false) #10, !dbg !43
-  call void @sorbet_vm_define_method(i64 %47, i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_!", i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Bad#1!", i8* nonnull %50, %struct.rb_iseq_struct* %stackFrame7.i2.i, i1 noundef zeroext false) #10, !dbg !43
+  call void @sorbet_vm_define_method(i64 %47, i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_!", i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Bad#1!", i8* nonnull %50, %struct.rb_iseq_struct* %stackFrame7.i.i, i1 noundef zeroext false) #10, !dbg !43
   call void @sorbet_popFrame() #10, !dbg !39
   store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %30, align 8, !dbg !39, !tbaa !29
   %55 = call i64 @rb_define_module(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_Main, i64 0, i64 0)) #10, !dbg !47
   %56 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %55) #10, !dbg !47
-  %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Main.13<static-init>", align 8
+  %stackFrame.i1.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Main.13<static-init>", align 8
   %57 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !29
   %58 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %57, i64 0, i32 2
   %59 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %58, align 8, !tbaa !31
   %60 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %59, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %60, align 8, !tbaa !35
+  store %struct.rb_iseq_struct* %stackFrame.i1.i, %struct.rb_iseq_struct** %60, align 8, !tbaa !35
   %61 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %59, i64 0, i32 4
   %62 = load i64*, i64** %61, align 8, !tbaa !37
   %63 = load i64, i64* %62, align 8, !tbaa !6
   %64 = and i64 %63, -33
   store i64 %64, i64* %62, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %57, %struct.rb_control_frame_struct* %59, %struct.rb_iseq_struct* %stackFrame.i.i) #10
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %57, %struct.rb_control_frame_struct* %59, %struct.rb_iseq_struct* %stackFrame.i1.i) #10
   %65 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 0
   store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %65, align 8, !dbg !48, !tbaa !29
   %66 = load i64, i64* @guard_epoch_Main, align 8, !dbg !51
@@ -374,7 +375,7 @@ entry:
   %72 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !51, !tbaa !44
   %guardUpdated2 = icmp eq i64 %71, %72, !dbg !51
   call void @llvm.assume(i1 %guardUpdated2), !dbg !51
-  %stackFrame7.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Main.4test, align 8, !dbg !51
+  %stackFrame7.i2.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Main.4test, align 8, !dbg !51
   %73 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #11, !dbg !51
   %74 = bitcast i8* %73 to i16*, !dbg !51
   %75 = load i16, i16* %74, align 8, !dbg !51
@@ -382,7 +383,7 @@ entry:
   store i16 %76, i16* %74, align 8, !dbg !51
   %77 = getelementptr inbounds i8, i8* %73, i64 4, !dbg !51
   call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %77, i8 0, i64 28, i1 false) #10, !dbg !51
-  call void @sorbet_vm_define_method(i64 %70, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_test, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_Main.4test, i8* nonnull %73, %struct.rb_iseq_struct* %stackFrame7.i.i, i1 noundef zeroext true) #10, !dbg !51
+  call void @sorbet_vm_define_method(i64 %70, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_test, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_Main.4test, i8* nonnull %73, %struct.rb_iseq_struct* %stackFrame7.i2.i, i1 noundef zeroext true) #10, !dbg !51
   call void @sorbet_popFrame() #10, !dbg !47
   store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %30, align 8, !dbg !47, !tbaa !29
   %78 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !10
@@ -551,10 +552,10 @@ define linkonce void @const_recompute_Main() local_unnamed_addr #8 {
   ret void
 }
 
-attributes #0 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #2 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #3 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { noreturn "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #1 = { "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #2 = { allocsize(0,1) "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #3 = { nounwind ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #4 = { sspreq }
 attributes #5 = { nounwind sspreq uwtable }
 attributes #6 = { argmemonly nofree nosync nounwind willreturn writeonly }

--- a/test/testdata/compiler/intrinsics/t_must.opt.ll.exp
+++ b/test/testdata/compiler/intrinsics/t_must.opt.ll.exp
@@ -2,10 +2,10 @@
 source_filename = "llvm-link"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 
-%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.5 }
+%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.7 }
 %struct.rb_control_frame_struct = type { i64*, i64*, %struct.rb_iseq_struct*, i64, i64*, i8*, i64* }
-%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.14 }
-%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.13, i32, i32, i32, i32, i32, i8, i64 }
+%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.17 }
+%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.16, i32, i32, i32, i32, i32, i8, i64 }
 %struct.anon = type { %struct.anon.0, i32, i32, i32, i32, i32, i32, i32, i64*, %struct.rb_iseq_param_keyword* }
 %struct.anon.0 = type { i16, [2 x i8] }
 %struct.rb_iseq_param_keyword = type { i32, i32, i32, i32, i64*, i64* }
@@ -21,27 +21,28 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_cref_struct = type { i64, i64, i64, %struct.rb_cref_struct*, %struct.rb_scope_visi_struct }
 %struct.rb_scope_visi_struct = type { i8, [3 x i8] }
 %struct.rb_call_data = type { %struct.rb_call_cache, %struct.rb_call_info }
-%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.12 }
+%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.15 }
 %struct.rb_callable_method_entry_struct = type { i64, i64, %struct.rb_method_definition_struct*, i64, i64 }
-%struct.rb_method_definition_struct = type { i64, %union.anon.10, i64, i64 }
-%union.anon.10 = type { %struct.rb_method_cfunc_struct }
+%struct.rb_method_definition_struct = type { i64, %union.anon.13, i64, i64 }
+%union.anon.13 = type { %struct.rb_method_cfunc_struct }
 %struct.rb_method_cfunc_struct = type { i64 (...)*, i64 (i64, i32, i64*, i64 (...)*)*, i32 }
 %struct.rb_calling_info = type { i64, i64, i32, i32 }
-%union.anon.12 = type { i32 }
+%union.anon.15 = type { i32 }
 %struct.rb_call_info = type { i64, i32, i32 }
-%struct.anon.13 = type { i64, i64, i64, i64* }
-%union.anon.14 = type { %struct.anon.15 }
-%struct.anon.15 = type { i64, i32 }
+%struct.anon.16 = type { i64, i64, i64, i64* }
+%union.anon.17 = type { %struct.anon.18 }
+%struct.anon.18 = type { i64, i32 }
 %struct.rb_vm_tag = type { i64, i64, [5 x i8*], %struct.rb_vm_tag*, i32 }
 %struct.rb_vm_protect_tag = type { %struct.rb_vm_protect_tag* }
 %struct.rb_fiber_struct = type opaque
-%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.7, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
+%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.10, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
 %struct.list_node = type { %struct.list_node*, %struct.list_node* }
-%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.3, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.4, [29 x i16] }
+%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.5, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.6, [29 x i16] }
 %struct.rb_global_vm_lock_struct = type { %struct.rb_thread_struct*, %union.pthread_mutex_t, %struct.list_head, %struct.rb_thread_struct*, i32, %union.pthread_cond_t, %union.pthread_cond_t, i32, i32 }
-%union.pthread_cond_t = type { %struct.anon.2 }
-%struct.anon.2 = type { i32, i32, i64, i64, i64, i8*, i32, i32 }
-%struct.anon.3 = type { [65 x i64] }
+%union.pthread_cond_t = type { %struct.__pthread_cond_s }
+%struct.__pthread_cond_s = type { %union.anon, %union.anon, [2 x i32], [2 x i32], i32, i32, [2 x i32] }
+%union.anon = type { i64 }
+%struct.anon.5 = type { [65 x i64] }
 %struct.rb_hook_list_struct = type { %struct.rb_event_hook_struct*, i32, i32, i32 }
 %struct.rb_event_hook_struct = type opaque
 %struct.rb_postponed_job_struct = type opaque
@@ -49,24 +50,24 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_objspace = type opaque
 %struct.rb_at_exit_list = type { void (%struct.rb_vm_struct*)*, %struct.rb_at_exit_list* }
 %struct.rb_builtin_function = type opaque
-%struct.anon.4 = type { i64, i64, i64, i64 }
-%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.6 }
-%union.anon.6 = type { %union.pthread_cond_t }
+%struct.anon.6 = type { i64, i64, i64, i64 }
+%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.9 }
+%union.anon.9 = type { %union.pthread_cond_t }
 %union.pthread_mutex_t = type { %struct.__pthread_mutex_s }
 %struct.__pthread_mutex_s = type { i32, i32, i32, i32, i32, i16, i16, %struct.__pthread_internal_list }
 %struct.__pthread_internal_list = type { %struct.__pthread_internal_list*, %struct.__pthread_internal_list* }
 %struct.rb_unblock_callback = type { void (i8*)*, i8* }
 %struct.rb_mutex_struct = type opaque
 %struct.rb_thread_list_struct = type { %struct.rb_thread_list_struct*, %struct.rb_thread_struct* }
-%union.anon.7 = type { %struct.anon.8 }
-%struct.anon.8 = type { i64, i64, i32 }
+%union.anon.10 = type { %struct.anon.11 }
+%struct.anon.11 = type { i64, i64, i32 }
 %struct.st_table = type { i8, i8, i8, i32, %struct.st_hash_type*, i64, i64*, i64, i64, %struct.st_table_entry* }
 %struct.st_hash_type = type { i32 (i64, i64)*, i64 (i64)* }
 %struct.st_table_entry = type opaque
 %struct.rb_ensure_list = type { %struct.rb_ensure_list*, %struct.rb_ensure_entry }
 %struct.rb_ensure_entry = type { i64, i64 (i64)*, i64 }
 %struct.rb_trace_arg_struct = type { i32, %struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, i64, i64, i64, i64, i64, i32, i32, i64 }
-%struct.anon.5 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
+%struct.anon.7 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
 %struct.__jmp_buf_tag = type { [8 x i64], i32, %struct.__sigset_t }
 %struct.__sigset_t = type { [16 x i64] }
 %struct.SorbetLineNumberInfo = type { i32, %struct.iseq_insn_info_entry*, i64* }
@@ -75,7 +76,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_call_info_with_kwarg = type { %struct.rb_call_info, %struct.rb_call_info_kw_arg* }
 %struct.rb_call_info_kw_arg = type { i32, [1 x i64] }
 
-@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @ruby_vm_global_constant_state = external local_unnamed_addr global i64, align 8
 @rb_eTypeError = external local_unnamed_addr global i64, align 8
 @.str.1 = private unnamed_addr constant [25 x i8] c"Passed `nil` into T.must\00", align 1
@@ -83,6 +83,7 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -225,8 +226,11 @@ define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #5 {
   unreachable
 }
 
+; Function Attrs: nofree nosync nounwind willreturn
+declare void @llvm.assume(i1 noundef) #6
+
 ; Function Attrs: sspreq
-define void @Init_t_must() local_unnamed_addr #6 {
+define void @Init_t_must() local_unnamed_addr #7 {
 entry:
   %positional_table.i.i = alloca i64, align 8, !dbg !10
   %locals.i32.i = alloca i64, i32 0, align 8
@@ -455,7 +459,7 @@ entry:
   %rubyId_arg.i.i2 = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !10
   store i64 %rubyId_arg.i.i2, i64* %positional_table.i.i, align 8, !dbg !10
   %89 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #15, !dbg !10
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %89, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %57, i64 noundef 8, i1 noundef false) #14, !dbg !10
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull align 1 %89, i8* noundef nonnull align 1 %57, i64 noundef 8, i1 noundef false) #14, !dbg !10
   %90 = getelementptr inbounds i8, i8* %79, i64 32, !dbg !10
   %91 = bitcast i8* %90 to i8**, !dbg !10
   store i8* %89, i8** %91, align 8, !dbg !10, !tbaa !51
@@ -500,7 +504,7 @@ entry:
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define internal i64 @func_Test.14test_known_nil(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #7 !dbg !23 {
+define internal i64 @func_Test.14test_known_nil(i32 %argc, i64* nocapture nofree readnone %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #8 !dbg !23 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %0, align 8, !tbaa !31
@@ -533,7 +537,7 @@ exception-continue:                               ; preds = %fillRequiredArgs
 }
 
 ; Function Attrs: noreturn nounwind ssp
-define internal i64 @"func_Test.14test_known_nil$block_1"(i64** nocapture nonnull writeonly align 8 dereferenceable(8) %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #8 !dbg !57 {
+define internal i64 @"func_Test.14test_known_nil$block_1"(i64** nocapture nonnull writeonly align 8 dereferenceable(8) %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #9 !dbg !57 {
 functionEntryInitializers:
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %pc, align 8, !tbaa !31
   tail call void @llvm.experimental.noalias.scope.decl(metadata !58) #17, !dbg !61
@@ -543,8 +547,8 @@ functionEntryInitializers:
 }
 
 ; Function Attrs: ssp
-define internal noundef i64 @"func_Test.14test_known_nil$block_2"(i64** nocapture nofree readnone %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #9 !dbg !22 {
-vm_get_ep.exit34:
+define internal noundef i64 @"func_Test.14test_known_nil$block_2"(i64** nocapture nofree readnone %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #10 !dbg !22 {
+functionEntryInitializers:
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !31
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
   %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !33
@@ -561,7 +565,7 @@ vm_get_ep.exit34:
   %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 2, !dbg !21
   %11 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %10, align 8, !dbg !21, !tbaa !33
   %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 4, !dbg !21
-  %13 = load i64*, i64** %12, align 8, !dbg !21
+  %13 = load i64*, i64** %12, align 8, !dbg !21, !tbaa !39
   %14 = getelementptr inbounds i64, i64* %13, i64 -1, !dbg !21
   %15 = load i64, i64* %14, align 8, !dbg !21, !tbaa !6
   %16 = and i64 %15, -4, !dbg !21
@@ -572,18 +576,18 @@ vm_get_ep.exit34:
   %21 = tail call i64 @sorbet_vm_isa_p(%struct.FunctionInlineCache* noundef @"ic_is_a?", %struct.rb_control_frame_struct* %11, i64 %19, i64 %20), !dbg !21
   %22 = and i64 %21, -9, !dbg !21
   %23 = icmp ne i64 %22, 0, !dbg !21
-  br i1 %23, label %vm_get_ep.exit32, label %vm_get_ep.exit, !dbg !21
+  br i1 %23, label %BB7, label %BB8, !dbg !21
 
 blockExit:                                        ; preds = %75, %73, %60, %58
   tail call void @sorbet_popFrame()
   ret i64 52
 
-vm_get_ep.exit32:                                 ; preds = %vm_get_ep.exit34
+BB7:                                              ; preds = %functionEntryInitializers
   %24 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !63, !tbaa !31
   %25 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %24, i64 0, i32 2, !dbg !63
   %26 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %25, align 8, !dbg !63, !tbaa !33
   %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 4, !dbg !63
-  %28 = load i64*, i64** %27, align 8, !dbg !63
+  %28 = load i64*, i64** %27, align 8, !dbg !63, !tbaa !39
   %29 = getelementptr inbounds i64, i64* %28, i64 -1, !dbg !63
   %30 = load i64, i64* %29, align 8, !dbg !63, !tbaa !6
   %31 = and i64 %30, -4, !dbg !63
@@ -593,16 +597,16 @@ vm_get_ep.exit32:                                 ; preds = %vm_get_ep.exit34
   %35 = icmp eq i64 %34, 0, !dbg !63
   br i1 %35, label %36, label %38, !dbg !63, !prof !64
 
-36:                                               ; preds = %vm_get_ep.exit32
+36:                                               ; preds = %BB7
   %37 = getelementptr inbounds i64, i64* %32, i64 -3, !dbg !63
   store i64 8, i64* %37, align 8, !dbg !63, !tbaa !6
-  br label %vm_get_ep.exit30, !dbg !63
+  br label %sorbet_writeLocal.exit28, !dbg !63
 
-38:                                               ; preds = %vm_get_ep.exit32
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %32, i32 noundef -3, i64 noundef 8) #14, !dbg !63
-  br label %vm_get_ep.exit30, !dbg !63
+38:                                               ; preds = %BB7
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 %32, i32 noundef -3, i64 noundef 8) #14, !dbg !63
+  br label %sorbet_writeLocal.exit28, !dbg !63
 
-vm_get_ep.exit30:                                 ; preds = %36, %38
+sorbet_writeLocal.exit28:                         ; preds = %36, %38
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %8, align 8, !dbg !65, !tbaa !31
   %39 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !24, !tbaa !31
   %40 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %39, i64 0, i32 2, !dbg !24
@@ -619,7 +623,7 @@ vm_get_ep.exit30:                                 ; preds = %36, %38
   %47 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %46, i64 0, i32 2, !dbg !24
   %48 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %47, align 8, !dbg !24, !tbaa !33
   %49 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %48, i64 0, i32 4, !dbg !24
-  %50 = load i64*, i64** %49, align 8, !dbg !24
+  %50 = load i64*, i64** %49, align 8, !dbg !24, !tbaa !39
   %51 = getelementptr inbounds i64, i64* %50, i64 -1, !dbg !24
   %52 = load i64, i64* %51, align 8, !dbg !24, !tbaa !6
   %53 = and i64 %52, -4, !dbg !24
@@ -629,22 +633,22 @@ vm_get_ep.exit30:                                 ; preds = %36, %38
   %57 = icmp eq i64 %56, 0, !dbg !24
   br i1 %57, label %58, label %60, !dbg !24, !prof !64
 
-58:                                               ; preds = %vm_get_ep.exit30
+58:                                               ; preds = %sorbet_writeLocal.exit28
   %59 = getelementptr inbounds i64, i64* %54, i64 -5, !dbg !24
   store i64 %send, i64* %59, align 8, !dbg !24, !tbaa !6
   br label %blockExit, !dbg !24
 
-60:                                               ; preds = %vm_get_ep.exit30
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %54, i32 noundef -5, i64 %send) #14, !dbg !24
+60:                                               ; preds = %sorbet_writeLocal.exit28
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 %54, i32 noundef -5, i64 %send) #14, !dbg !24
   br label %blockExit, !dbg !24
 
-vm_get_ep.exit:                                   ; preds = %vm_get_ep.exit34
+BB8:                                              ; preds = %functionEntryInitializers
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !tbaa !31
   %61 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !66, !tbaa !31
   %62 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %61, i64 0, i32 2, !dbg !66
   %63 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %62, align 8, !dbg !66, !tbaa !33
   %64 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %63, i64 0, i32 4, !dbg !66
-  %65 = load i64*, i64** %64, align 8, !dbg !66
+  %65 = load i64*, i64** %64, align 8, !dbg !66, !tbaa !39
   %66 = getelementptr inbounds i64, i64* %65, i64 -1, !dbg !66
   %67 = load i64, i64* %66, align 8, !dbg !66, !tbaa !6
   %68 = and i64 %67, -4, !dbg !66
@@ -654,18 +658,18 @@ vm_get_ep.exit:                                   ; preds = %vm_get_ep.exit34
   %72 = icmp eq i64 %71, 0, !dbg !66
   br i1 %72, label %73, label %75, !dbg !66, !prof !64
 
-73:                                               ; preds = %vm_get_ep.exit
+73:                                               ; preds = %BB8
   %74 = getelementptr inbounds i64, i64* %69, i64 -6, !dbg !66
   store i64 20, i64* %74, align 8, !dbg !66, !tbaa !6
   br label %blockExit, !dbg !66
 
-75:                                               ; preds = %vm_get_ep.exit
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %69, i32 noundef -6, i64 noundef 20) #14, !dbg !66
+75:                                               ; preds = %BB8
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 %69, i32 noundef -6, i64 noundef 20) #14, !dbg !66
   br label %blockExit, !dbg !66
 }
 
 ; Function Attrs: ssp
-define internal noundef i64 @"func_Test.14test_known_nil$block_3"(i64** nocapture nofree readnone %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #9 !dbg !67 {
+define internal noundef i64 @"func_Test.14test_known_nil$block_3"(i64** nocapture nofree readnone %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #10 !dbg !67 {
 functionEntryInitializers:
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.14test_known_nil$block_3", align 8
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !31
@@ -677,19 +681,34 @@ functionEntryInitializers:
   %5 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %4, align 8, !tbaa !33
   %6 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 0
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %6, align 8, !tbaa !31
+  %7 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !31
+  %8 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %7, i64 0, i32 2
+  %9 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %8, align 8, !tbaa !33
+  %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 4
+  %11 = load i64*, i64** %10, align 8, !tbaa !39
+  %12 = getelementptr inbounds i64, i64* %11, i64 -1
+  %13 = load i64, i64* %12, align 8, !tbaa !6
+  %14 = and i64 %13, -4
+  %15 = inttoptr i64 %14 to i64*
+  %16 = getelementptr inbounds i64, i64* %15, i64 -6
+  %17 = load i64, i64* %16, align 8, !tbaa !6
+  %18 = and i64 %17, -9
+  %19 = icmp ne i64 %18, 0
+  %20 = xor i1 %19, true
+  tail call void @llvm.assume(i1 noundef %20)
   tail call void @sorbet_popFrame()
   ret i64 52
 }
 
 ; Function Attrs: argmemonly nofree norecurse nosync nounwind ssp willreturn writeonly
-define internal noundef i64 @"func_Test.14test_known_nil$block_4"(i64** nocapture nofree nonnull writeonly align 8 dereferenceable(8) %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #10 !dbg !68 {
+define internal noundef i64 @"func_Test.14test_known_nil$block_4"(i64** nocapture nofree nonnull writeonly align 8 dereferenceable(8) %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #11 !dbg !68 {
 functionEntryInitializers:
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %pc, align 8, !tbaa !31
   ret i64 52
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define internal i64 @func_Test.16test_nilable_arg(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #7 !dbg !27 {
+define internal i64 @func_Test.16test_nilable_arg(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #8 !dbg !27 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %0, align 8, !tbaa !31
@@ -721,7 +740,7 @@ fillRequiredArgs:                                 ; preds = %functionEntryInitia
   br label %sorbet_writeLocal.exit, !dbg !69
 
 8:                                                ; preds = %fillRequiredArgs
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %2, i32 noundef -4, i64 %rawArg_arg) #14, !dbg !69
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 %2, i32 noundef -4, i64 %rawArg_arg) #14, !dbg !69
   br label %sorbet_writeLocal.exit, !dbg !69
 
 sorbet_writeLocal.exit:                           ; preds = %6, %8
@@ -741,7 +760,7 @@ exception-continue:                               ; preds = %sorbet_writeLocal.e
 }
 
 ; Function Attrs: ssp
-define internal noundef i64 @"func_Test.16test_nilable_arg$block_1"(i64** nocapture nonnull writeonly align 8 dereferenceable(8) %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(40) %cfp) #9 !dbg !26 {
+define internal noundef i64 @"func_Test.16test_nilable_arg$block_1"(i64** nocapture nonnull writeonly align 8 dereferenceable(8) %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(40) %cfp) #10 !dbg !26 {
 functionEntryInitializers:
   %callArgs = alloca [3 x i64], align 8
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !31
@@ -757,7 +776,7 @@ functionEntryInitializers:
   %callArgs0Addr = getelementptr [3 x i64], [3 x i64]* %callArgs, i32 0, i64 0, !dbg !74
   store i64 %8, i64* %callArgs0Addr, align 8, !dbg !74
   %9 = getelementptr [3 x i64], [3 x i64]* %callArgs, i64 0, i64 0, !dbg !74
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !75), !dbg !74
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !75) #17, !dbg !74
   %10 = load i64, i64* %9, align 8, !dbg !74, !tbaa !6, !alias.scope !75
   %11 = icmp eq i64 %10, 8, !dbg !74
   br i1 %11, label %12, label %sorbet_T_must.exit, !dbg !74, !prof !53
@@ -776,15 +795,15 @@ sorbet_T_must.exit:                               ; preds = %functionEntryInitia
   %19 = xor i32 %18, -1, !dbg !74
   %20 = and i32 %19, %16, !dbg !74
   %21 = icmp eq i32 %20, 0, !dbg !74
-  br i1 %21, label %rb_vm_check_ints.exit, label %22, !dbg !74, !prof !64
+  br i1 %21, label %sorbet_afterIntrinsic.exit, label %22, !dbg !74, !prof !64
 
 22:                                               ; preds = %sorbet_T_must.exit
   %23 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %14, i64 0, i32 8, !dbg !74
   %24 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %23, align 8, !dbg !74, !tbaa !80
   %25 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %24, i32 noundef 0) #14, !dbg !74
-  br label %rb_vm_check_ints.exit, !dbg !74
+  br label %sorbet_afterIntrinsic.exit, !dbg !74
 
-rb_vm_check_ints.exit:                            ; preds = %sorbet_T_must.exit, %22
+sorbet_afterIntrinsic.exit:                       ; preds = %sorbet_T_must.exit, %22
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %pc, align 8, !dbg !74, !tbaa !31
   %"rubyStr_ wasn't nil" = load i64, i64* @"rubyStrFrozen_ wasn't nil", align 8, !dbg !81
   %26 = load i64*, i64** %5, align 8, !dbg !82, !tbaa !39
@@ -809,13 +828,13 @@ rb_vm_check_ints.exit:                            ; preds = %sorbet_T_must.exit,
   %36 = icmp eq i64 %35, 0, !dbg !25
   br i1 %36, label %37, label %39, !dbg !25, !prof !64
 
-37:                                               ; preds = %rb_vm_check_ints.exit
+37:                                               ; preds = %sorbet_afterIntrinsic.exit
   %38 = getelementptr inbounds i64, i64* %33, i64 -6, !dbg !25
   store i64 %send, i64* %38, align 8, !dbg !25, !tbaa !6
   br label %sorbet_writeLocal.exit, !dbg !25
 
-39:                                               ; preds = %rb_vm_check_ints.exit
-  call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %33, i32 noundef -6, i64 %send) #14, !dbg !25
+39:                                               ; preds = %sorbet_afterIntrinsic.exit
+  call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 %33, i32 noundef -6, i64 %send) #14, !dbg !25
   br label %sorbet_writeLocal.exit, !dbg !25
 
 sorbet_writeLocal.exit:                           ; preds = %37, %39
@@ -824,8 +843,8 @@ sorbet_writeLocal.exit:                           ; preds = %37, %39
 }
 
 ; Function Attrs: ssp
-define internal noundef i64 @"func_Test.16test_nilable_arg$block_2"(i64** nocapture nofree readnone %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #9 !dbg !29 {
-vm_get_ep.exit34:
+define internal noundef i64 @"func_Test.16test_nilable_arg$block_2"(i64** nocapture nofree readnone %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #10 !dbg !29 {
+functionEntryInitializers:
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !31
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
   %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !33
@@ -842,7 +861,7 @@ vm_get_ep.exit34:
   %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 2, !dbg !28
   %11 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %10, align 8, !dbg !28, !tbaa !33
   %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 4, !dbg !28
-  %13 = load i64*, i64** %12, align 8, !dbg !28
+  %13 = load i64*, i64** %12, align 8, !dbg !28, !tbaa !39
   %14 = getelementptr inbounds i64, i64* %13, i64 -1, !dbg !28
   %15 = load i64, i64* %14, align 8, !dbg !28, !tbaa !6
   %16 = and i64 %15, -4, !dbg !28
@@ -853,18 +872,18 @@ vm_get_ep.exit34:
   %21 = tail call i64 @sorbet_vm_isa_p(%struct.FunctionInlineCache* noundef @"ic_is_a?.4", %struct.rb_control_frame_struct* %11, i64 %19, i64 %20), !dbg !28
   %22 = and i64 %21, -9, !dbg !28
   %23 = icmp ne i64 %22, 0, !dbg !28
-  br i1 %23, label %vm_get_ep.exit32, label %vm_get_ep.exit, !dbg !28
+  br i1 %23, label %BB7, label %BB8, !dbg !28
 
 blockExit:                                        ; preds = %75, %73, %60, %58
   tail call void @sorbet_popFrame()
   ret i64 52
 
-vm_get_ep.exit32:                                 ; preds = %vm_get_ep.exit34
+BB7:                                              ; preds = %functionEntryInitializers
   %24 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !83, !tbaa !31
   %25 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %24, i64 0, i32 2, !dbg !83
   %26 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %25, align 8, !dbg !83, !tbaa !33
   %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 4, !dbg !83
-  %28 = load i64*, i64** %27, align 8, !dbg !83
+  %28 = load i64*, i64** %27, align 8, !dbg !83, !tbaa !39
   %29 = getelementptr inbounds i64, i64* %28, i64 -1, !dbg !83
   %30 = load i64, i64* %29, align 8, !dbg !83, !tbaa !6
   %31 = and i64 %30, -4, !dbg !83
@@ -874,16 +893,16 @@ vm_get_ep.exit32:                                 ; preds = %vm_get_ep.exit34
   %35 = icmp eq i64 %34, 0, !dbg !83
   br i1 %35, label %36, label %38, !dbg !83, !prof !64
 
-36:                                               ; preds = %vm_get_ep.exit32
+36:                                               ; preds = %BB7
   %37 = getelementptr inbounds i64, i64* %32, i64 -3, !dbg !83
   store i64 8, i64* %37, align 8, !dbg !83, !tbaa !6
-  br label %vm_get_ep.exit30, !dbg !83
+  br label %sorbet_writeLocal.exit28, !dbg !83
 
-38:                                               ; preds = %vm_get_ep.exit32
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %32, i32 noundef -3, i64 noundef 8) #14, !dbg !83
-  br label %vm_get_ep.exit30, !dbg !83
+38:                                               ; preds = %BB7
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 %32, i32 noundef -3, i64 noundef 8) #14, !dbg !83
+  br label %sorbet_writeLocal.exit28, !dbg !83
 
-vm_get_ep.exit30:                                 ; preds = %36, %38
+sorbet_writeLocal.exit28:                         ; preds = %36, %38
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %8, align 8, !dbg !84, !tbaa !31
   %39 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !30, !tbaa !31
   %40 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %39, i64 0, i32 2, !dbg !30
@@ -900,7 +919,7 @@ vm_get_ep.exit30:                                 ; preds = %36, %38
   %47 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %46, i64 0, i32 2, !dbg !30
   %48 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %47, align 8, !dbg !30, !tbaa !33
   %49 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %48, i64 0, i32 4, !dbg !30
-  %50 = load i64*, i64** %49, align 8, !dbg !30
+  %50 = load i64*, i64** %49, align 8, !dbg !30, !tbaa !39
   %51 = getelementptr inbounds i64, i64* %50, i64 -1, !dbg !30
   %52 = load i64, i64* %51, align 8, !dbg !30, !tbaa !6
   %53 = and i64 %52, -4, !dbg !30
@@ -910,22 +929,22 @@ vm_get_ep.exit30:                                 ; preds = %36, %38
   %57 = icmp eq i64 %56, 0, !dbg !30
   br i1 %57, label %58, label %60, !dbg !30, !prof !64
 
-58:                                               ; preds = %vm_get_ep.exit30
+58:                                               ; preds = %sorbet_writeLocal.exit28
   %59 = getelementptr inbounds i64, i64* %54, i64 -6, !dbg !30
   store i64 %send, i64* %59, align 8, !dbg !30, !tbaa !6
   br label %blockExit, !dbg !30
 
-60:                                               ; preds = %vm_get_ep.exit30
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %54, i32 noundef -6, i64 %send) #14, !dbg !30
+60:                                               ; preds = %sorbet_writeLocal.exit28
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 %54, i32 noundef -6, i64 %send) #14, !dbg !30
   br label %blockExit, !dbg !30
 
-vm_get_ep.exit:                                   ; preds = %vm_get_ep.exit34
+BB8:                                              ; preds = %functionEntryInitializers
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %8, align 8, !tbaa !31
   %61 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !85, !tbaa !31
   %62 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %61, i64 0, i32 2, !dbg !85
   %63 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %62, align 8, !dbg !85, !tbaa !33
   %64 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %63, i64 0, i32 4, !dbg !85
-  %65 = load i64*, i64** %64, align 8, !dbg !85
+  %65 = load i64*, i64** %64, align 8, !dbg !85, !tbaa !39
   %66 = getelementptr inbounds i64, i64* %65, i64 -1, !dbg !85
   %67 = load i64, i64* %66, align 8, !dbg !85, !tbaa !6
   %68 = and i64 %67, -4, !dbg !85
@@ -935,18 +954,18 @@ vm_get_ep.exit:                                   ; preds = %vm_get_ep.exit34
   %72 = icmp eq i64 %71, 0, !dbg !85
   br i1 %72, label %73, label %75, !dbg !85, !prof !64
 
-73:                                               ; preds = %vm_get_ep.exit
+73:                                               ; preds = %BB8
   %74 = getelementptr inbounds i64, i64* %69, i64 -7, !dbg !85
   store i64 20, i64* %74, align 8, !dbg !85, !tbaa !6
   br label %blockExit, !dbg !85
 
-75:                                               ; preds = %vm_get_ep.exit
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %69, i32 noundef -7, i64 noundef 20) #14, !dbg !85
+75:                                               ; preds = %BB8
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 %69, i32 noundef -7, i64 noundef 20) #14, !dbg !85
   br label %blockExit, !dbg !85
 }
 
 ; Function Attrs: ssp
-define internal noundef i64 @"func_Test.16test_nilable_arg$block_3"(i64** nocapture nofree readnone %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #9 !dbg !86 {
+define internal noundef i64 @"func_Test.16test_nilable_arg$block_3"(i64** nocapture nofree readnone %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #10 !dbg !86 {
 functionEntryInitializers:
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.16test_nilable_arg$block_3", align 8
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !31
@@ -958,25 +977,37 @@ functionEntryInitializers:
   %5 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %4, align 8, !tbaa !33
   %6 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 0
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %6, align 8, !tbaa !31
+  %7 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !31
+  %8 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %7, i64 0, i32 2
+  %9 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %8, align 8, !tbaa !33
+  %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 4
+  %11 = load i64*, i64** %10, align 8, !tbaa !39
+  %12 = getelementptr inbounds i64, i64* %11, i64 -1
+  %13 = load i64, i64* %12, align 8, !tbaa !6
+  %14 = and i64 %13, -4
+  %15 = inttoptr i64 %14 to i64*
+  %16 = getelementptr inbounds i64, i64* %15, i64 -7
+  %17 = load i64, i64* %16, align 8, !tbaa !6
+  %18 = and i64 %17, -9
+  %19 = icmp ne i64 %18, 0
+  %20 = xor i1 %19, true
+  tail call void @llvm.assume(i1 noundef %20)
   tail call void @sorbet_popFrame()
   ret i64 52
 }
 
 ; Function Attrs: argmemonly nofree norecurse nosync nounwind ssp willreturn writeonly
-define internal noundef i64 @"func_Test.16test_nilable_arg$block_4"(i64** nocapture nofree nonnull writeonly align 8 dereferenceable(8) %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #10 !dbg !87 {
+define internal noundef i64 @"func_Test.16test_nilable_arg$block_4"(i64** nocapture nofree nonnull writeonly align 8 dereferenceable(8) %pc, i64 %localsOffset, %struct.rb_control_frame_struct* nocapture nofree readnone %cfp) #11 !dbg !87 {
 functionEntryInitializers:
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %pc, align 8, !tbaa !31
   ret i64 52
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #11
-
-; Function Attrs: nofree nosync nounwind willreturn
-declare void @llvm.assume(i1 noundef) #12
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #12
 
 ; Function Attrs: ssp
-define linkonce void @const_recompute_Test() local_unnamed_addr #9 {
+define linkonce void @const_recompute_Test() local_unnamed_addr #10 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @str_Test, i64 0, i64 0), i64 4)
   store i64 %1, i64* @guarded_const_Test, align 8
   %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !44
@@ -984,19 +1015,19 @@ define linkonce void @const_recompute_Test() local_unnamed_addr #9 {
   ret void
 }
 
-attributes #0 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { noreturn "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #1 = { "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #2 = { argmemonly nofree nosync nounwind willreturn }
 attributes #3 = { inaccessiblememonly nofree nosync nounwind willreturn }
-attributes #4 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #5 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #6 = { sspreq }
-attributes #7 = { nounwind sspreq uwtable }
-attributes #8 = { noreturn nounwind ssp }
-attributes #9 = { ssp }
-attributes #10 = { argmemonly nofree norecurse nosync nounwind ssp willreturn writeonly }
-attributes #11 = { argmemonly nofree nosync nounwind willreturn writeonly }
-attributes #12 = { nofree nosync nounwind willreturn }
+attributes #4 = { allocsize(0,1) "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #5 = { nounwind ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #6 = { nofree nosync nounwind willreturn }
+attributes #7 = { sspreq }
+attributes #8 = { nounwind sspreq uwtable }
+attributes #9 = { noreturn nounwind ssp }
+attributes #10 = { ssp }
+attributes #11 = { argmemonly nofree norecurse nosync nounwind ssp willreturn writeonly }
+attributes #12 = { argmemonly nofree nosync nounwind willreturn writeonly }
 attributes #13 = { noreturn nounwind }
 attributes #14 = { nounwind }
 attributes #15 = { nounwind allocsize(0,1) }

--- a/test/testdata/compiler/literal_hash.opt.ll.exp
+++ b/test/testdata/compiler/literal_hash.opt.ll.exp
@@ -2,16 +2,17 @@
 source_filename = "llvm-link"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 
-%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.3, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.4, [29 x i16] }
+%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.5, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.6, [29 x i16] }
 %struct.rb_global_vm_lock_struct = type { %struct.rb_thread_struct*, %union.pthread_mutex_t, %struct.list_head, %struct.rb_thread_struct*, i32, %union.pthread_cond_t, %union.pthread_cond_t, i32, i32 }
-%union.pthread_cond_t = type { %struct.anon.2 }
-%struct.anon.2 = type { i32, i32, i64, i64, i64, i8*, i32, i32 }
-%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.7, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
+%union.pthread_cond_t = type { %struct.__pthread_cond_s }
+%struct.__pthread_cond_s = type { %union.anon, %union.anon, [2 x i32], [2 x i32], i32, i32, [2 x i32] }
+%union.anon = type { i64 }
+%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.10, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
 %struct.list_node = type { %struct.list_node*, %struct.list_node* }
-%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.5 }
+%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.7 }
 %struct.rb_control_frame_struct = type { i64*, i64*, %struct.rb_iseq_struct*, i64, i64*, i8*, i64* }
-%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.14 }
-%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.13, i32, i32, i32, i32, i32, i8, i64 }
+%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.17 }
+%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.16, i32, i32, i32, i32, i32, i8, i64 }
 %struct.anon = type { %struct.anon.0, i32, i32, i32, i32, i32, i32, i32, i64*, %struct.rb_iseq_param_keyword* }
 %struct.anon.0 = type { i16, [2 x i8] }
 %struct.rb_iseq_param_keyword = type { i32, i32, i32, i32, i64*, i64* }
@@ -27,34 +28,34 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_cref_struct = type { i64, i64, i64, %struct.rb_cref_struct*, %struct.rb_scope_visi_struct }
 %struct.rb_scope_visi_struct = type { i8, [3 x i8] }
 %struct.rb_call_data = type { %struct.rb_call_cache, %struct.rb_call_info }
-%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.12 }
+%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.15 }
 %struct.rb_callable_method_entry_struct = type { i64, i64, %struct.rb_method_definition_struct*, i64, i64 }
-%struct.rb_method_definition_struct = type { i64, %union.anon.10, i64, i64 }
-%union.anon.10 = type { %struct.rb_method_cfunc_struct }
+%struct.rb_method_definition_struct = type { i64, %union.anon.13, i64, i64 }
+%union.anon.13 = type { %struct.rb_method_cfunc_struct }
 %struct.rb_method_cfunc_struct = type { i64 (...)*, i64 (i64, i32, i64*, i64 (...)*)*, i32 }
-%union.anon.12 = type { i32 }
+%union.anon.15 = type { i32 }
 %struct.rb_call_info = type { i64, i32, i32 }
-%struct.anon.13 = type { i64, i64, i64, i64* }
-%union.anon.14 = type { %struct.anon.15 }
-%struct.anon.15 = type { i64, i32 }
+%struct.anon.16 = type { i64, i64, i64, i64* }
+%union.anon.17 = type { %struct.anon.18 }
+%struct.anon.18 = type { i64, i32 }
 %struct.rb_vm_tag = type { i64, i64, [5 x i8*], %struct.rb_vm_tag*, i32 }
 %struct.rb_vm_protect_tag = type { %struct.rb_vm_protect_tag* }
 %struct.rb_ensure_list = type { %struct.rb_ensure_list*, %struct.rb_ensure_entry }
 %struct.rb_ensure_entry = type { i64, i64 (i64)*, i64 }
 %struct.rb_trace_arg_struct = type { i32, %struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, i64, i64, i64, i64, i64, i32, i32, i64 }
-%struct.anon.5 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
+%struct.anon.7 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
 %struct.__jmp_buf_tag = type { [8 x i64], i32, %struct.__sigset_t }
 %struct.__sigset_t = type { [16 x i64] }
 %struct.rb_calling_info = type { i64, i64, i32, i32 }
-%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.6 }
-%union.anon.6 = type { %union.pthread_cond_t }
+%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.9 }
+%union.anon.9 = type { %union.pthread_cond_t }
 %struct.rb_unblock_callback = type { void (i8*)*, i8* }
 %struct.rb_mutex_struct = type opaque
 %struct.rb_thread_list_struct = type { %struct.rb_thread_list_struct*, %struct.rb_thread_struct* }
-%union.anon.7 = type { %struct.anon.8 }
-%struct.anon.8 = type { i64, i64, i32 }
+%union.anon.10 = type { %struct.anon.11 }
+%struct.anon.11 = type { i64, i64, i32 }
 %struct.rb_fiber_struct = type opaque
-%struct.anon.3 = type { [65 x i64] }
+%struct.anon.5 = type { [65 x i64] }
 %struct.rb_hook_list_struct = type { %struct.rb_event_hook_struct*, i32, i32, i32 }
 %struct.rb_event_hook_struct = type opaque
 %struct.rb_postponed_job_struct = type opaque
@@ -68,18 +69,18 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.st_hash_type = type { i32 (i64, i64)*, i64 (i64)* }
 %struct.st_table_entry = type opaque
 %struct.rb_builtin_function = type opaque
-%struct.anon.4 = type { i64, i64, i64, i64 }
+%struct.anon.6 = type { i64, i64, i64, i64 }
 %struct.SorbetLineNumberInfo = type { i32, %struct.iseq_insn_info_entry*, i64* }
 %struct.FunctionInlineCache = type { %struct.rb_kwarg_call_data }
 %struct.rb_kwarg_call_data = type { %struct.rb_call_cache, %struct.rb_call_info_with_kwarg }
 %struct.rb_call_info_with_kwarg = type { %struct.rb_call_info, %struct.rb_call_info_kw_arg* }
 %struct.rb_call_info_kw_arg = type { i32, [1 x i64] }
 
-@ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
-@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
+@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -123,7 +124,7 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
 @str_puts = private unnamed_addr constant [5 x i8] c"puts\00", align 1
 
-; Function Attrs: nounwind readnone willreturn
+; Function Attrs: nofree nosync nounwind readnone willreturn mustprogress
 declare i64 @rb_id2sym(i64) local_unnamed_addr #0
 
 declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #1
@@ -399,10 +400,10 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #5
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #5
 
-attributes #0 = { nounwind readnone willreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #2 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #3 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { nofree nosync nounwind readnone willreturn mustprogress "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #1 = { "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #2 = { noreturn "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #3 = { nounwind ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #4 = { sspreq }
 attributes #5 = { argmemonly nofree nosync nounwind willreturn }
 attributes #6 = { noreturn nounwind }

--- a/test/testdata/compiler/literals.opt.ll.exp
+++ b/test/testdata/compiler/literals.opt.ll.exp
@@ -2,16 +2,17 @@
 source_filename = "llvm-link"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 
-%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.3, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.4, [29 x i16] }
+%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.5, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.6, [29 x i16] }
 %struct.rb_global_vm_lock_struct = type { %struct.rb_thread_struct*, %union.pthread_mutex_t, %struct.list_head, %struct.rb_thread_struct*, i32, %union.pthread_cond_t, %union.pthread_cond_t, i32, i32 }
-%union.pthread_cond_t = type { %struct.anon.2 }
-%struct.anon.2 = type { i32, i32, i64, i64, i64, i8*, i32, i32 }
-%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.7, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
+%union.pthread_cond_t = type { %struct.__pthread_cond_s }
+%struct.__pthread_cond_s = type { %union.anon, %union.anon, [2 x i32], [2 x i32], i32, i32, [2 x i32] }
+%union.anon = type { i64 }
+%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.10, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
 %struct.list_node = type { %struct.list_node*, %struct.list_node* }
-%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.5 }
+%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.7 }
 %struct.rb_control_frame_struct = type { i64*, i64*, %struct.rb_iseq_struct*, i64, i64*, i8*, i64* }
-%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.14 }
-%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.13, i32, i32, i32, i32, i32, i8, i64 }
+%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.17 }
+%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.16, i32, i32, i32, i32, i32, i8, i64 }
 %struct.anon = type { %struct.anon.0, i32, i32, i32, i32, i32, i32, i32, i64*, %struct.rb_iseq_param_keyword* }
 %struct.anon.0 = type { i16, [2 x i8] }
 %struct.rb_iseq_param_keyword = type { i32, i32, i32, i32, i64*, i64* }
@@ -27,34 +28,34 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_cref_struct = type { i64, i64, i64, %struct.rb_cref_struct*, %struct.rb_scope_visi_struct }
 %struct.rb_scope_visi_struct = type { i8, [3 x i8] }
 %struct.rb_call_data = type { %struct.rb_call_cache, %struct.rb_call_info }
-%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.12 }
+%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.15 }
 %struct.rb_callable_method_entry_struct = type { i64, i64, %struct.rb_method_definition_struct*, i64, i64 }
-%struct.rb_method_definition_struct = type { i64, %union.anon.10, i64, i64 }
-%union.anon.10 = type { %struct.rb_method_cfunc_struct }
+%struct.rb_method_definition_struct = type { i64, %union.anon.13, i64, i64 }
+%union.anon.13 = type { %struct.rb_method_cfunc_struct }
 %struct.rb_method_cfunc_struct = type { i64 (...)*, i64 (i64, i32, i64*, i64 (...)*)*, i32 }
-%union.anon.12 = type { i32 }
+%union.anon.15 = type { i32 }
 %struct.rb_call_info = type { i64, i32, i32 }
-%struct.anon.13 = type { i64, i64, i64, i64* }
-%union.anon.14 = type { %struct.anon.15 }
-%struct.anon.15 = type { i64, i32 }
+%struct.anon.16 = type { i64, i64, i64, i64* }
+%union.anon.17 = type { %struct.anon.18 }
+%struct.anon.18 = type { i64, i32 }
 %struct.rb_vm_tag = type { i64, i64, [5 x i8*], %struct.rb_vm_tag*, i32 }
 %struct.rb_vm_protect_tag = type { %struct.rb_vm_protect_tag* }
 %struct.rb_ensure_list = type { %struct.rb_ensure_list*, %struct.rb_ensure_entry }
 %struct.rb_ensure_entry = type { i64, i64 (i64)*, i64 }
 %struct.rb_trace_arg_struct = type { i32, %struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, i64, i64, i64, i64, i64, i32, i32, i64 }
-%struct.anon.5 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
+%struct.anon.7 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
 %struct.__jmp_buf_tag = type { [8 x i64], i32, %struct.__sigset_t }
 %struct.__sigset_t = type { [16 x i64] }
 %struct.rb_calling_info = type { i64, i64, i32, i32 }
-%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.6 }
-%union.anon.6 = type { %union.pthread_cond_t }
+%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.9 }
+%union.anon.9 = type { %union.pthread_cond_t }
 %struct.rb_unblock_callback = type { void (i8*)*, i8* }
 %struct.rb_mutex_struct = type opaque
 %struct.rb_thread_list_struct = type { %struct.rb_thread_list_struct*, %struct.rb_thread_struct* }
-%union.anon.7 = type { %struct.anon.8 }
-%struct.anon.8 = type { i64, i64, i32 }
+%union.anon.10 = type { %struct.anon.11 }
+%struct.anon.11 = type { i64, i64, i32 }
 %struct.rb_fiber_struct = type opaque
-%struct.anon.3 = type { [65 x i64] }
+%struct.anon.5 = type { [65 x i64] }
 %struct.rb_hook_list_struct = type { %struct.rb_event_hook_struct*, i32, i32, i32 }
 %struct.rb_event_hook_struct = type opaque
 %struct.rb_postponed_job_struct = type opaque
@@ -68,18 +69,18 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.st_hash_type = type { i32 (i64, i64)*, i64 (i64)* }
 %struct.st_table_entry = type opaque
 %struct.rb_builtin_function = type opaque
-%struct.anon.4 = type { i64, i64, i64, i64 }
+%struct.anon.6 = type { i64, i64, i64, i64 }
 %struct.SorbetLineNumberInfo = type { i32, %struct.iseq_insn_info_entry*, i64* }
 %struct.FunctionInlineCache = type { %struct.rb_kwarg_call_data }
 %struct.rb_kwarg_call_data = type { %struct.rb_call_cache, %struct.rb_call_info_with_kwarg }
 %struct.rb_call_info_with_kwarg = type { %struct.rb_call_info, %struct.rb_call_info_kw_arg* }
 %struct.rb_call_info_kw_arg = type { i32, [1 x i64] }
 
-@ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
-@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
+@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -102,7 +103,7 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ic_puts.5 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.6 = internal global %struct.FunctionInlineCache zeroinitializer
 
-; Function Attrs: nounwind readnone willreturn
+; Function Attrs: nofree nosync nounwind readnone willreturn mustprogress
 declare i64 @rb_id2sym(i64) local_unnamed_addr #0
 
 declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #1
@@ -265,10 +266,10 @@ entry:
   ret void
 }
 
-attributes #0 = { nounwind readnone willreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #2 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #3 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { nofree nosync nounwind readnone willreturn mustprogress "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #1 = { "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #2 = { noreturn "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #3 = { nounwind ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #4 = { sspreq }
 attributes #5 = { noreturn nounwind }
 attributes #6 = { nounwind }

--- a/test/testdata/compiler/repeated_casts.opt.ll.exp
+++ b/test/testdata/compiler/repeated_casts.opt.ll.exp
@@ -2,10 +2,10 @@
 source_filename = "llvm-link"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 
-%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.5 }
+%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.7 }
 %struct.rb_control_frame_struct = type { i64*, i64*, %struct.rb_iseq_struct*, i64, i64*, i8*, i64* }
-%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.14 }
-%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.13, i32, i32, i32, i32, i32, i8, i64 }
+%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.17 }
+%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.16, i32, i32, i32, i32, i32, i8, i64 }
 %struct.anon = type { %struct.anon.0, i32, i32, i32, i32, i32, i32, i32, i64*, %struct.rb_iseq_param_keyword* }
 %struct.anon.0 = type { i16, [2 x i8] }
 %struct.rb_iseq_param_keyword = type { i32, i32, i32, i32, i64*, i64* }
@@ -21,27 +21,28 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_cref_struct = type { i64, i64, i64, %struct.rb_cref_struct*, %struct.rb_scope_visi_struct }
 %struct.rb_scope_visi_struct = type { i8, [3 x i8] }
 %struct.rb_call_data = type { %struct.rb_call_cache, %struct.rb_call_info }
-%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.12 }
+%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.15 }
 %struct.rb_callable_method_entry_struct = type { i64, i64, %struct.rb_method_definition_struct*, i64, i64 }
-%struct.rb_method_definition_struct = type { i64, %union.anon.10, i64, i64 }
-%union.anon.10 = type { %struct.rb_method_cfunc_struct }
+%struct.rb_method_definition_struct = type { i64, %union.anon.13, i64, i64 }
+%union.anon.13 = type { %struct.rb_method_cfunc_struct }
 %struct.rb_method_cfunc_struct = type { i64 (...)*, i64 (i64, i32, i64*, i64 (...)*)*, i32 }
 %struct.rb_calling_info = type { i64, i64, i32, i32 }
-%union.anon.12 = type { i32 }
+%union.anon.15 = type { i32 }
 %struct.rb_call_info = type { i64, i32, i32 }
-%struct.anon.13 = type { i64, i64, i64, i64* }
-%union.anon.14 = type { %struct.anon.15 }
-%struct.anon.15 = type { i64, i32 }
+%struct.anon.16 = type { i64, i64, i64, i64* }
+%union.anon.17 = type { %struct.anon.18 }
+%struct.anon.18 = type { i64, i32 }
 %struct.rb_vm_tag = type { i64, i64, [5 x i8*], %struct.rb_vm_tag*, i32 }
 %struct.rb_vm_protect_tag = type { %struct.rb_vm_protect_tag* }
 %struct.rb_fiber_struct = type opaque
-%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.7, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
+%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.10, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
 %struct.list_node = type { %struct.list_node*, %struct.list_node* }
-%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.3, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.4, [29 x i16] }
+%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.5, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.6, [29 x i16] }
 %struct.rb_global_vm_lock_struct = type { %struct.rb_thread_struct*, %union.pthread_mutex_t, %struct.list_head, %struct.rb_thread_struct*, i32, %union.pthread_cond_t, %union.pthread_cond_t, i32, i32 }
-%union.pthread_cond_t = type { %struct.anon.2 }
-%struct.anon.2 = type { i32, i32, i64, i64, i64, i8*, i32, i32 }
-%struct.anon.3 = type { [65 x i64] }
+%union.pthread_cond_t = type { %struct.__pthread_cond_s }
+%struct.__pthread_cond_s = type { %union.anon, %union.anon, [2 x i32], [2 x i32], i32, i32, [2 x i32] }
+%union.anon = type { i64 }
+%struct.anon.5 = type { [65 x i64] }
 %struct.rb_hook_list_struct = type { %struct.rb_event_hook_struct*, i32, i32, i32 }
 %struct.rb_event_hook_struct = type opaque
 %struct.rb_postponed_job_struct = type opaque
@@ -49,24 +50,24 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_objspace = type opaque
 %struct.rb_at_exit_list = type { void (%struct.rb_vm_struct*)*, %struct.rb_at_exit_list* }
 %struct.rb_builtin_function = type opaque
-%struct.anon.4 = type { i64, i64, i64, i64 }
-%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.6 }
-%union.anon.6 = type { %union.pthread_cond_t }
+%struct.anon.6 = type { i64, i64, i64, i64 }
+%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.9 }
+%union.anon.9 = type { %union.pthread_cond_t }
 %union.pthread_mutex_t = type { %struct.__pthread_mutex_s }
 %struct.__pthread_mutex_s = type { i32, i32, i32, i32, i32, i16, i16, %struct.__pthread_internal_list }
 %struct.__pthread_internal_list = type { %struct.__pthread_internal_list*, %struct.__pthread_internal_list* }
 %struct.rb_unblock_callback = type { void (i8*)*, i8* }
 %struct.rb_mutex_struct = type opaque
 %struct.rb_thread_list_struct = type { %struct.rb_thread_list_struct*, %struct.rb_thread_struct* }
-%union.anon.7 = type { %struct.anon.8 }
-%struct.anon.8 = type { i64, i64, i32 }
+%union.anon.10 = type { %struct.anon.11 }
+%struct.anon.11 = type { i64, i64, i32 }
 %struct.st_table = type { i8, i8, i8, i32, %struct.st_hash_type*, i64, i64*, i64, i64, %struct.st_table_entry* }
 %struct.st_hash_type = type { i32 (i64, i64)*, i64 (i64)* }
 %struct.st_table_entry = type opaque
 %struct.rb_ensure_list = type { %struct.rb_ensure_list*, %struct.rb_ensure_entry }
 %struct.rb_ensure_entry = type { i64, i64 (i64)*, i64 }
 %struct.rb_trace_arg_struct = type { i32, %struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, i64, i64, i64, i64, i64, i32, i32, i64 }
-%struct.anon.5 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
+%struct.anon.7 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
 %struct.__jmp_buf_tag = type { [8 x i64], i32, %struct.__sigset_t }
 %struct.__sigset_t = type { [16 x i64] }
 %struct.SorbetLineNumberInfo = type { i32, %struct.iseq_insn_info_entry*, i64* }
@@ -75,11 +76,11 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_call_info_with_kwarg = type { %struct.rb_call_info, %struct.rb_call_info_kw_arg* }
 %struct.rb_call_info_kw_arg = type { i32, [1 x i64] }
 
-@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @ruby_vm_global_constant_state = external local_unnamed_addr global i64, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @"stackFramePrecomputed_func_Object#10doubleCast" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @rubyIdPrecomputed_doubleCast = internal unnamed_addr global i64 0, align 8
 @str_doubleCast = private unnamed_addr constant [11 x i8] c"doubleCast\00", align 1
@@ -108,7 +109,7 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @guarded_const_A = linkonce local_unnamed_addr global i64 0
 @rb_cObject = external local_unnamed_addr constant i64
 
-; Function Attrs: nounwind readnone willreturn
+; Function Attrs: nofree nosync nounwind readnone willreturn mustprogress
 declare i64 @rb_obj_is_kind_of(i64, i64) local_unnamed_addr #0
 
 ; Function Attrs: cold noreturn
@@ -365,7 +366,7 @@ entry:
   %rubyId_a.i = load i64, i64* @rubyIdPrecomputed_a, align 8, !dbg !25
   store i64 %rubyId_a.i, i64* %positional_table.i, align 8, !dbg !25
   %59 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #17, !dbg !25
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %59, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %18, i64 noundef 8, i1 noundef false) #16, !dbg !25
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull align 1 %59, i8* noundef nonnull align 1 %18, i64 noundef 8, i1 noundef false) #16, !dbg !25
   %60 = getelementptr inbounds i8, i8* %49, i64 32, !dbg !25
   %61 = bitcast i8* %60 to i8**, !dbg !25
   store i8* %59, i8** %61, align 8, !dbg !25, !tbaa !44
@@ -413,13 +414,13 @@ define linkonce void @const_recompute_A() local_unnamed_addr #12 {
   ret void
 }
 
-attributes #0 = { nounwind readnone willreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { cold noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #2 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #3 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { nofree nosync nounwind readnone willreturn mustprogress "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #1 = { cold noreturn "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #2 = { noreturn "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #3 = { "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #4 = { argmemonly nofree nosync nounwind willreturn }
-attributes #5 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #6 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #5 = { allocsize(0,1) "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #6 = { nounwind ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #7 = { nounwind sspreq uwtable }
 attributes #8 = { sspreq }
 attributes #9 = { argmemonly nofree nosync nounwind willreturn writeonly }

--- a/test/testdata/compiler/send_with_block_param.opt.ll.exp
+++ b/test/testdata/compiler/send_with_block_param.opt.ll.exp
@@ -2,16 +2,54 @@
 source_filename = "llvm-link"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 
-%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.3, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.4, [29 x i16] }
-%struct.rb_global_vm_lock_struct = type { %struct.rb_thread_struct*, %union.pthread_mutex_t, %struct.list_head, %struct.rb_thread_struct*, i32, %union.pthread_cond_t, %union.pthread_cond_t, i32, i32 }
-%union.pthread_cond_t = type { %struct.anon.2 }
-%struct.anon.2 = type { i32, i32, i64, i64, i64, i8*, i32, i32 }
-%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.7, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
+%struct.rb_call_data = type { %struct.rb_call_cache, %struct.rb_call_info }
+%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.15 }
+%struct.rb_callable_method_entry_struct = type { i64, i64, %struct.rb_method_definition_struct*, i64, i64 }
+%struct.rb_method_definition_struct = type { i64, %union.anon.13, i64, i64 }
+%union.anon.13 = type { %struct.rb_method_cfunc_struct }
+%struct.rb_method_cfunc_struct = type { i64 (...)*, i64 (i64, i32, i64*, i64 (...)*)*, i32 }
+%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.7 }
+%struct.rb_vm_tag = type { i64, i64, [5 x i8*], %struct.rb_vm_tag*, i32 }
+%struct.rb_vm_protect_tag = type { %struct.rb_vm_protect_tag* }
+%struct.rb_fiber_struct = type opaque
+%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.10, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
 %struct.list_node = type { %struct.list_node*, %struct.list_node* }
-%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.5 }
+%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.5, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.6, [29 x i16] }
+%struct.rb_global_vm_lock_struct = type { %struct.rb_thread_struct*, %union.pthread_mutex_t, %struct.list_head, %struct.rb_thread_struct*, i32, %union.pthread_cond_t, %union.pthread_cond_t, i32, i32 }
+%union.pthread_cond_t = type { %struct.__pthread_cond_s }
+%struct.__pthread_cond_s = type { %union.anon, %union.anon, [2 x i32], [2 x i32], i32, i32, [2 x i32] }
+%union.anon = type { i64 }
+%struct.anon.5 = type { [65 x i64] }
+%struct.rb_hook_list_struct = type { %struct.rb_event_hook_struct*, i32, i32, i32 }
+%struct.rb_event_hook_struct = type opaque
+%struct.rb_postponed_job_struct = type opaque
+%struct.list_head = type { %struct.list_node }
+%struct.rb_objspace = type opaque
+%struct.rb_at_exit_list = type { void (%struct.rb_vm_struct*)*, %struct.rb_at_exit_list* }
+%struct.rb_builtin_function = type opaque
+%struct.anon.6 = type { i64, i64, i64, i64 }
+%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.9 }
+%union.anon.9 = type { %union.pthread_cond_t }
+%union.pthread_mutex_t = type { %struct.__pthread_mutex_s }
+%struct.__pthread_mutex_s = type { i32, i32, i32, i32, i32, i16, i16, %struct.__pthread_internal_list }
+%struct.__pthread_internal_list = type { %struct.__pthread_internal_list*, %struct.__pthread_internal_list* }
+%struct.rb_unblock_callback = type { void (i8*)*, i8* }
+%struct.rb_mutex_struct = type opaque
+%struct.rb_thread_list_struct = type { %struct.rb_thread_list_struct*, %struct.rb_thread_struct* }
+%union.anon.10 = type { %struct.anon.11 }
+%struct.anon.11 = type { i64, i64, i32 }
+%struct.st_table = type { i8, i8, i8, i32, %struct.st_hash_type*, i64, i64*, i64, i64, %struct.st_table_entry* }
+%struct.st_hash_type = type { i32 (i64, i64)*, i64 (i64)* }
+%struct.st_table_entry = type opaque
+%struct.rb_ensure_list = type { %struct.rb_ensure_list*, %struct.rb_ensure_entry }
+%struct.rb_ensure_entry = type { i64, i64 (i64)*, i64 }
+%struct.rb_trace_arg_struct = type { i32, %struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, i64, i64, i64, i64, i64, i32, i32, i64 }
+%struct.anon.7 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
+%struct.__jmp_buf_tag = type { [8 x i64], i32, %struct.__sigset_t }
+%struct.__sigset_t = type { [16 x i64] }
 %struct.rb_control_frame_struct = type { i64*, i64*, %struct.rb_iseq_struct*, i64, i64*, i8*, i64* }
-%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.14 }
-%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.13, i32, i32, i32, i32, i32, i8, i64 }
+%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.17 }
+%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.16, i32, i32, i32, i32, i32, i8, i64 }
 %struct.anon = type { %struct.anon.0, i32, i32, i32, i32, i32, i32, i32, i64*, %struct.rb_iseq_param_keyword* }
 %struct.anon.0 = type { i16, [2 x i8] }
 %struct.rb_iseq_param_keyword = type { i32, i32, i32, i32, i64*, i64* }
@@ -26,62 +64,25 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.iseq_inline_cache_entry = type { i64, %struct.rb_cref_struct*, i64 }
 %struct.rb_cref_struct = type { i64, i64, i64, %struct.rb_cref_struct*, %struct.rb_scope_visi_struct }
 %struct.rb_scope_visi_struct = type { i8, [3 x i8] }
-%struct.rb_call_data = type { %struct.rb_call_cache, %struct.rb_call_info }
-%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.12 }
-%struct.rb_callable_method_entry_struct = type { i64, i64, %struct.rb_method_definition_struct*, i64, i64 }
-%struct.rb_method_definition_struct = type { i64, %union.anon.10, i64, i64 }
-%union.anon.10 = type { %struct.rb_method_cfunc_struct }
-%struct.rb_method_cfunc_struct = type { i64 (...)*, i64 (i64, i32, i64*, i64 (...)*)*, i32 }
-%union.anon.12 = type { i32 }
-%struct.rb_call_info = type { i64, i32, i32 }
-%struct.anon.13 = type { i64, i64, i64, i64* }
-%union.anon.14 = type { %struct.anon.15 }
-%struct.anon.15 = type { i64, i32 }
-%struct.rb_vm_tag = type { i64, i64, [5 x i8*], %struct.rb_vm_tag*, i32 }
-%struct.rb_vm_protect_tag = type { %struct.rb_vm_protect_tag* }
-%struct.rb_ensure_list = type { %struct.rb_ensure_list*, %struct.rb_ensure_entry }
-%struct.rb_ensure_entry = type { i64, i64 (i64)*, i64 }
-%struct.rb_trace_arg_struct = type { i32, %struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, i64, i64, i64, i64, i64, i32, i32, i64 }
-%struct.anon.5 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
-%struct.__jmp_buf_tag = type { [8 x i64], i32, %struct.__sigset_t }
-%struct.__sigset_t = type { [16 x i64] }
+%struct.anon.16 = type { i64, i64, i64, i64* }
+%union.anon.17 = type { %struct.anon.18 }
+%struct.anon.18 = type { i64, i32 }
 %struct.rb_calling_info = type { i64, i64, i32, i32 }
-%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.6 }
-%union.anon.6 = type { %union.pthread_cond_t }
-%struct.rb_unblock_callback = type { void (i8*)*, i8* }
-%struct.rb_mutex_struct = type opaque
-%struct.rb_thread_list_struct = type { %struct.rb_thread_list_struct*, %struct.rb_thread_struct* }
-%union.anon.7 = type { %struct.anon.8 }
-%struct.anon.8 = type { i64, i64, i32 }
-%struct.rb_fiber_struct = type opaque
-%struct.anon.3 = type { [65 x i64] }
-%struct.rb_hook_list_struct = type { %struct.rb_event_hook_struct*, i32, i32, i32 }
-%struct.rb_event_hook_struct = type opaque
-%struct.rb_postponed_job_struct = type opaque
-%struct.list_head = type { %struct.list_node }
-%union.pthread_mutex_t = type { %struct.__pthread_mutex_s }
-%struct.__pthread_mutex_s = type { i32, i32, i32, i32, i32, i16, i16, %struct.__pthread_internal_list }
-%struct.__pthread_internal_list = type { %struct.__pthread_internal_list*, %struct.__pthread_internal_list* }
-%struct.rb_objspace = type opaque
-%struct.rb_at_exit_list = type { void (%struct.rb_vm_struct*)*, %struct.rb_at_exit_list* }
-%struct.st_table = type { i8, i8, i8, i32, %struct.st_hash_type*, i64, i64*, i64, i64, %struct.st_table_entry* }
-%struct.st_hash_type = type { i32 (i64, i64)*, i64 (i64)* }
-%struct.st_table_entry = type opaque
-%struct.rb_builtin_function = type opaque
-%struct.anon.4 = type { i64, i64, i64, i64 }
+%union.anon.15 = type { i32 }
+%struct.rb_call_info = type { i64, i32, i32 }
 %struct.SorbetLineNumberInfo = type { i32, %struct.iseq_insn_info_entry*, i64* }
 %struct.FunctionInlineCache = type { %struct.rb_kwarg_call_data }
 %struct.rb_kwarg_call_data = type { %struct.rb_call_cache, %struct.rb_call_info_with_kwarg }
 %struct.rb_call_info_with_kwarg = type { %struct.rb_call_info, %struct.rb_call_info_kw_arg* }
 %struct.rb_call_info_kw_arg = type { i32, [1 x i64] }
 
-@ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
-@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
-@.str.7 = private unnamed_addr constant [8 x i8] c"to_proc\00", align 1
 @sorbet_makeBlockHandlerProc.rb_funcallv_data = internal global %struct.rb_call_data zeroinitializer, align 8
+@.str.7 = private unnamed_addr constant [8 x i8] c"to_proc\00", align 1
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
+@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -229,29 +230,29 @@ entry:
   %34 = xor i32 %33, -1, !dbg !36
   %35 = and i32 %34, %31, !dbg !36
   %36 = icmp eq i32 %35, 0, !dbg !36
-  br i1 %36, label %rb_vm_check_ints.exit.i, label %37, !dbg !36, !prof !42
+  br i1 %36, label %sorbet_afterIntrinsic.exit.i, label %37, !dbg !36, !prof !42
 
 37:                                               ; preds = %entry
   %38 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %29, i64 0, i32 8, !dbg !36
   %39 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %38, align 8, !dbg !36, !tbaa !43
   %40 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %39, i32 noundef 0) #7, !dbg !36
-  br label %rb_vm_check_ints.exit.i, !dbg !36
+  br label %sorbet_afterIntrinsic.exit.i, !dbg !36
 
-rb_vm_check_ints.exit.i:                          ; preds = %37, %entry
+sorbet_afterIntrinsic.exit.i:                     ; preds = %37, %entry
   store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %26, align 8, !dbg !36, !tbaa !16
   store i64 3, i64* %callArgs0Addr.i, align 8, !dbg !10
   call void @llvm.experimental.noalias.scope.decl(metadata !44) #7, !dbg !10
-  %41 = call i64 @rb_ary_new_from_values(i64 noundef 1, i64* noundef nonnull %27) #7, !dbg !10
+  %41 = call i64 @rb_ary_new_from_values(i64 noundef 1, i64* noundef nonnull align 8 %27) #7, !dbg !10
   %42 = icmp eq i64 %28, 8, !dbg !10
   br i1 %42, label %"func_<root>.17<static-init>$152.exit", label %43, !dbg !10
 
-43:                                               ; preds = %rb_vm_check_ints.exit.i
+43:                                               ; preds = %sorbet_afterIntrinsic.exit.i
   %44 = call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @.str.7, i64 0, i64 0), i64 noundef 7) #7, !dbg !10
   %45 = call i64 @rb_funcallv_with_cc(%struct.rb_call_data* noundef nonnull @sorbet_makeBlockHandlerProc.rb_funcallv_data, i64 %28, i64 %44, i32 noundef 0, i64* noundef null) #7, !dbg !10
   br label %"func_<root>.17<static-init>$152.exit", !dbg !10
 
-"func_<root>.17<static-init>$152.exit":           ; preds = %rb_vm_check_ints.exit.i, %43
-  %46 = phi i64 [ %45, %43 ], [ 0, %rb_vm_check_ints.exit.i ], !dbg !10
+"func_<root>.17<static-init>$152.exit":           ; preds = %sorbet_afterIntrinsic.exit.i, %43
+  %46 = phi i64 [ %45, %43 ], [ 0, %sorbet_afterIntrinsic.exit.i ], !dbg !10
   %47 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 1, !dbg !10
   %48 = load i64*, i64** %47, align 8, !dbg !10
   store i64 %41, i64* %48, align 8, !dbg !10, !tbaa !6
@@ -276,10 +277,10 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #5
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #5
 
-attributes #0 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #1 = { noreturn "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #2 = { inaccessiblememonly nofree nosync nounwind willreturn }
-attributes #3 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #3 = { nounwind ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #4 = { sspreq }
 attributes #5 = { argmemonly nofree nosync nounwind willreturn }
 attributes #6 = { noreturn nounwind }

--- a/test/testdata/compiler/sig_rewriter.opt.ll.exp
+++ b/test/testdata/compiler/sig_rewriter.opt.ll.exp
@@ -2,16 +2,17 @@
 source_filename = "llvm-link"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 
-%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.3, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.4, [29 x i16] }
+%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.5, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.6, [29 x i16] }
 %struct.rb_global_vm_lock_struct = type { %struct.rb_thread_struct*, %union.pthread_mutex_t, %struct.list_head, %struct.rb_thread_struct*, i32, %union.pthread_cond_t, %union.pthread_cond_t, i32, i32 }
-%union.pthread_cond_t = type { %struct.anon.2 }
-%struct.anon.2 = type { i32, i32, i64, i64, i64, i8*, i32, i32 }
-%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.7, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
+%union.pthread_cond_t = type { %struct.__pthread_cond_s }
+%struct.__pthread_cond_s = type { %union.anon, %union.anon, [2 x i32], [2 x i32], i32, i32, [2 x i32] }
+%union.anon = type { i64 }
+%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.10, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
 %struct.list_node = type { %struct.list_node*, %struct.list_node* }
-%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.5 }
+%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.7 }
 %struct.rb_control_frame_struct = type { i64*, i64*, %struct.rb_iseq_struct*, i64, i64*, i8*, i64* }
-%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.14 }
-%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.13, i32, i32, i32, i32, i32, i8, i64 }
+%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.17 }
+%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.16, i32, i32, i32, i32, i32, i8, i64 }
 %struct.anon = type { %struct.anon.0, i32, i32, i32, i32, i32, i32, i32, i64*, %struct.rb_iseq_param_keyword* }
 %struct.anon.0 = type { i16, [2 x i8] }
 %struct.rb_iseq_param_keyword = type { i32, i32, i32, i32, i64*, i64* }
@@ -27,34 +28,34 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_cref_struct = type { i64, i64, i64, %struct.rb_cref_struct*, %struct.rb_scope_visi_struct }
 %struct.rb_scope_visi_struct = type { i8, [3 x i8] }
 %struct.rb_call_data = type { %struct.rb_call_cache, %struct.rb_call_info }
-%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.12 }
+%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.15 }
 %struct.rb_callable_method_entry_struct = type { i64, i64, %struct.rb_method_definition_struct*, i64, i64 }
-%struct.rb_method_definition_struct = type { i64, %union.anon.10, i64, i64 }
-%union.anon.10 = type { %struct.rb_method_cfunc_struct }
+%struct.rb_method_definition_struct = type { i64, %union.anon.13, i64, i64 }
+%union.anon.13 = type { %struct.rb_method_cfunc_struct }
 %struct.rb_method_cfunc_struct = type { i64 (...)*, i64 (i64, i32, i64*, i64 (...)*)*, i32 }
-%union.anon.12 = type { i32 }
+%union.anon.15 = type { i32 }
 %struct.rb_call_info = type { i64, i32, i32 }
-%struct.anon.13 = type { i64, i64, i64, i64* }
-%union.anon.14 = type { %struct.anon.15 }
-%struct.anon.15 = type { i64, i32 }
+%struct.anon.16 = type { i64, i64, i64, i64* }
+%union.anon.17 = type { %struct.anon.18 }
+%struct.anon.18 = type { i64, i32 }
 %struct.rb_vm_tag = type { i64, i64, [5 x i8*], %struct.rb_vm_tag*, i32 }
 %struct.rb_vm_protect_tag = type { %struct.rb_vm_protect_tag* }
 %struct.rb_ensure_list = type { %struct.rb_ensure_list*, %struct.rb_ensure_entry }
 %struct.rb_ensure_entry = type { i64, i64 (i64)*, i64 }
 %struct.rb_trace_arg_struct = type { i32, %struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, i64, i64, i64, i64, i64, i32, i32, i64 }
-%struct.anon.5 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
+%struct.anon.7 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
 %struct.__jmp_buf_tag = type { [8 x i64], i32, %struct.__sigset_t }
 %struct.__sigset_t = type { [16 x i64] }
 %struct.rb_calling_info = type { i64, i64, i32, i32 }
-%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.6 }
-%union.anon.6 = type { %union.pthread_cond_t }
+%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.9 }
+%union.anon.9 = type { %union.pthread_cond_t }
 %struct.rb_unblock_callback = type { void (i8*)*, i8* }
 %struct.rb_mutex_struct = type opaque
 %struct.rb_thread_list_struct = type { %struct.rb_thread_list_struct*, %struct.rb_thread_struct* }
-%union.anon.7 = type { %struct.anon.8 }
-%struct.anon.8 = type { i64, i64, i32 }
+%union.anon.10 = type { %struct.anon.11 }
+%struct.anon.11 = type { i64, i64, i32 }
 %struct.rb_fiber_struct = type opaque
-%struct.anon.3 = type { [65 x i64] }
+%struct.anon.5 = type { [65 x i64] }
 %struct.rb_hook_list_struct = type { %struct.rb_event_hook_struct*, i32, i32, i32 }
 %struct.rb_event_hook_struct = type opaque
 %struct.rb_postponed_job_struct = type opaque
@@ -68,19 +69,19 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.st_hash_type = type { i32 (i64, i64)*, i64 (i64)* }
 %struct.st_table_entry = type opaque
 %struct.rb_builtin_function = type opaque
-%struct.anon.4 = type { i64, i64, i64, i64 }
+%struct.anon.6 = type { i64, i64, i64, i64 }
 %struct.SorbetLineNumberInfo = type { i32, %struct.iseq_insn_info_entry*, i64* }
 %struct.FunctionInlineCache = type { %struct.rb_kwarg_call_data }
 %struct.rb_kwarg_call_data = type { %struct.rb_call_cache, %struct.rb_call_info_with_kwarg }
 %struct.rb_call_info_with_kwarg = type { %struct.rb_call_info, %struct.rb_call_info_kw_arg* }
 %struct.rb_call_info_kw_arg = type { i32, [1 x i64] }
 
-@ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
-@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @ruby_vm_global_constant_state = external local_unnamed_addr global i64, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
+@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -124,7 +125,7 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @guarded_const_A = linkonce local_unnamed_addr global i64 0
 @rb_cInteger = external local_unnamed_addr constant i64
 
-; Function Attrs: nounwind readnone willreturn
+; Function Attrs: nofree nosync nounwind readnone willreturn mustprogress
 declare i64 @rb_id2sym(i64) local_unnamed_addr #0
 
 ; Function Attrs: noreturn
@@ -451,11 +452,11 @@ define linkonce void @const_recompute_A() local_unnamed_addr #7 {
   ret void
 }
 
-attributes #0 = { nounwind readnone willreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #2 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #3 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #4 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { nofree nosync nounwind readnone willreturn mustprogress "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #1 = { noreturn "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #2 = { "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #3 = { allocsize(0,1) "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #4 = { nounwind ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #5 = { sspreq }
 attributes #6 = { nounwind sspreq uwtable }
 attributes #7 = { ssp }

--- a/test/testdata/compiler/splat_assign.opt.ll.exp
+++ b/test/testdata/compiler/splat_assign.opt.ll.exp
@@ -2,16 +2,17 @@
 source_filename = "llvm-link"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 
-%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.3, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.4, [29 x i16] }
+%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.5, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.6, [29 x i16] }
 %struct.rb_global_vm_lock_struct = type { %struct.rb_thread_struct*, %union.pthread_mutex_t, %struct.list_head, %struct.rb_thread_struct*, i32, %union.pthread_cond_t, %union.pthread_cond_t, i32, i32 }
-%union.pthread_cond_t = type { %struct.anon.2 }
-%struct.anon.2 = type { i32, i32, i64, i64, i64, i8*, i32, i32 }
-%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.7, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
+%union.pthread_cond_t = type { %struct.__pthread_cond_s }
+%struct.__pthread_cond_s = type { %union.anon, %union.anon, [2 x i32], [2 x i32], i32, i32, [2 x i32] }
+%union.anon = type { i64 }
+%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.10, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
 %struct.list_node = type { %struct.list_node*, %struct.list_node* }
-%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.5 }
+%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.7 }
 %struct.rb_control_frame_struct = type { i64*, i64*, %struct.rb_iseq_struct*, i64, i64*, i8*, i64* }
-%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.14 }
-%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.13, i32, i32, i32, i32, i32, i8, i64 }
+%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.17 }
+%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.16, i32, i32, i32, i32, i32, i8, i64 }
 %struct.anon = type { %struct.anon.0, i32, i32, i32, i32, i32, i32, i32, i64*, %struct.rb_iseq_param_keyword* }
 %struct.anon.0 = type { i16, [2 x i8] }
 %struct.rb_iseq_param_keyword = type { i32, i32, i32, i32, i64*, i64* }
@@ -27,34 +28,34 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_cref_struct = type { i64, i64, i64, %struct.rb_cref_struct*, %struct.rb_scope_visi_struct }
 %struct.rb_scope_visi_struct = type { i8, [3 x i8] }
 %struct.rb_call_data = type { %struct.rb_call_cache, %struct.rb_call_info }
-%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.12 }
+%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.15 }
 %struct.rb_callable_method_entry_struct = type { i64, i64, %struct.rb_method_definition_struct*, i64, i64 }
-%struct.rb_method_definition_struct = type { i64, %union.anon.10, i64, i64 }
-%union.anon.10 = type { %struct.rb_method_cfunc_struct }
+%struct.rb_method_definition_struct = type { i64, %union.anon.13, i64, i64 }
+%union.anon.13 = type { %struct.rb_method_cfunc_struct }
 %struct.rb_method_cfunc_struct = type { i64 (...)*, i64 (i64, i32, i64*, i64 (...)*)*, i32 }
-%union.anon.12 = type { i32 }
+%union.anon.15 = type { i32 }
 %struct.rb_call_info = type { i64, i32, i32 }
-%struct.anon.13 = type { i64, i64, i64, i64* }
-%union.anon.14 = type { %struct.anon.15 }
-%struct.anon.15 = type { i64, i32 }
+%struct.anon.16 = type { i64, i64, i64, i64* }
+%union.anon.17 = type { %struct.anon.18 }
+%struct.anon.18 = type { i64, i32 }
 %struct.rb_vm_tag = type { i64, i64, [5 x i8*], %struct.rb_vm_tag*, i32 }
 %struct.rb_vm_protect_tag = type { %struct.rb_vm_protect_tag* }
 %struct.rb_ensure_list = type { %struct.rb_ensure_list*, %struct.rb_ensure_entry }
 %struct.rb_ensure_entry = type { i64, i64 (i64)*, i64 }
 %struct.rb_trace_arg_struct = type { i32, %struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, i64, i64, i64, i64, i64, i32, i32, i64 }
-%struct.anon.5 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
+%struct.anon.7 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
 %struct.__jmp_buf_tag = type { [8 x i64], i32, %struct.__sigset_t }
 %struct.__sigset_t = type { [16 x i64] }
 %struct.rb_calling_info = type { i64, i64, i32, i32 }
-%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.6 }
-%union.anon.6 = type { %union.pthread_cond_t }
+%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.9 }
+%union.anon.9 = type { %union.pthread_cond_t }
 %struct.rb_unblock_callback = type { void (i8*)*, i8* }
 %struct.rb_mutex_struct = type opaque
 %struct.rb_thread_list_struct = type { %struct.rb_thread_list_struct*, %struct.rb_thread_struct* }
-%union.anon.7 = type { %struct.anon.8 }
-%struct.anon.8 = type { i64, i64, i32 }
+%union.anon.10 = type { %struct.anon.11 }
+%struct.anon.11 = type { i64, i64, i32 }
 %struct.rb_fiber_struct = type opaque
-%struct.anon.3 = type { [65 x i64] }
+%struct.anon.5 = type { [65 x i64] }
 %struct.rb_hook_list_struct = type { %struct.rb_event_hook_struct*, i32, i32, i32 }
 %struct.rb_event_hook_struct = type opaque
 %struct.rb_postponed_job_struct = type opaque
@@ -68,18 +69,18 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.st_hash_type = type { i32 (i64, i64)*, i64 (i64)* }
 %struct.st_table_entry = type opaque
 %struct.rb_builtin_function = type opaque
-%struct.anon.4 = type { i64, i64, i64, i64 }
+%struct.anon.6 = type { i64, i64, i64, i64 }
 %struct.SorbetLineNumberInfo = type { i32, %struct.iseq_insn_info_entry*, i64* }
 %struct.FunctionInlineCache = type { %struct.rb_kwarg_call_data }
 %struct.rb_kwarg_call_data = type { %struct.rb_call_cache, %struct.rb_call_info_with_kwarg }
 %struct.rb_call_info_with_kwarg = type { %struct.rb_call_info, %struct.rb_call_info_kw_arg* }
 %struct.rb_call_info_kw_arg = type { i32, [1 x i64] }
 
-@ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
-@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
+@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -232,13 +233,13 @@ entry:
 34:                                               ; preds = %entry
   %35 = ashr i64 %31, 1, !dbg !40
   %36 = call i64 @rb_ary_entry(i64 %30, i64 %35) #7, !dbg !40
-  br label %sorbet_rb_array_square_br.exit369.i, !dbg !40
+  br label %sorbet_rb_array_square_br.exit372.i, !dbg !40
 
 37:                                               ; preds = %entry
   %38 = call i64 @sorbet_rb_array_square_br_slowpath(i64 %30, i64 %"rubyId_[].i", i32 noundef 1, i64* noundef nonnull %24, i64 (i64, i64, i32, i64*, i64)* noundef null, i64 noundef 0) #7, !dbg !40
-  br label %sorbet_rb_array_square_br.exit369.i, !dbg !40
+  br label %sorbet_rb_array_square_br.exit372.i, !dbg !40
 
-sorbet_rb_array_square_br.exit369.i:              ; preds = %37, %34
+sorbet_rb_array_square_br.exit372.i:              ; preds = %37, %34
   %39 = phi i64 [ %38, %37 ], [ %36, %34 ], !dbg !40
   %40 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !40, !tbaa !17
   %41 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %40, i64 0, i32 5, !dbg !40
@@ -248,15 +249,15 @@ sorbet_rb_array_square_br.exit369.i:              ; preds = %37, %34
   %45 = xor i32 %44, -1, !dbg !40
   %46 = and i32 %45, %42, !dbg !40
   %47 = icmp eq i32 %46, 0, !dbg !40
-  br i1 %47, label %rb_vm_check_ints.exit3.i, label %48, !dbg !40, !prof !50
+  br i1 %47, label %sorbet_afterIntrinsic.exit373.i, label %48, !dbg !40, !prof !50
 
-48:                                               ; preds = %sorbet_rb_array_square_br.exit369.i
+48:                                               ; preds = %sorbet_rb_array_square_br.exit372.i
   %49 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %40, i64 0, i32 8, !dbg !40
   %50 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %49, align 8, !dbg !40, !tbaa !51
   %51 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %50, i32 noundef 0) #7, !dbg !40
-  br label %rb_vm_check_ints.exit3.i, !dbg !40
+  br label %sorbet_afterIntrinsic.exit373.i, !dbg !40
 
-rb_vm_check_ints.exit3.i:                         ; preds = %48, %sorbet_rb_array_square_br.exit369.i
+sorbet_afterIntrinsic.exit373.i:                  ; preds = %48, %sorbet_rb_array_square_br.exit372.i
   %"rubyId_[]134.i" = load i64, i64* @"rubyIdPrecomputed_[]", align 8, !dbg !40
   store i64 -3, i64* %callArgs0Addr.i, align 8, !dbg !40
   call void @llvm.experimental.noalias.scope.decl(metadata !52) #7, !dbg !40
@@ -265,16 +266,16 @@ rb_vm_check_ints.exit3.i:                         ; preds = %48, %sorbet_rb_arra
   %54 = icmp eq i64 %53, 0, !dbg !40
   br i1 %54, label %58, label %55, !dbg !40, !prof !47
 
-55:                                               ; preds = %rb_vm_check_ints.exit3.i
+55:                                               ; preds = %sorbet_afterIntrinsic.exit373.i
   %56 = ashr i64 %52, 1, !dbg !40
   %57 = call i64 @rb_ary_entry(i64 %30, i64 %56) #7, !dbg !40
-  br label %sorbet_rb_array_square_br.exit370.i, !dbg !40
+  br label %sorbet_rb_array_square_br.exit374.i, !dbg !40
 
-58:                                               ; preds = %rb_vm_check_ints.exit3.i
+58:                                               ; preds = %sorbet_afterIntrinsic.exit373.i
   %59 = call i64 @sorbet_rb_array_square_br_slowpath(i64 %30, i64 %"rubyId_[]134.i", i32 noundef 1, i64* noundef nonnull %24, i64 (i64, i64, i32, i64*, i64)* noundef null, i64 noundef 0) #7, !dbg !40
-  br label %sorbet_rb_array_square_br.exit370.i, !dbg !40
+  br label %sorbet_rb_array_square_br.exit374.i, !dbg !40
 
-sorbet_rb_array_square_br.exit370.i:              ; preds = %58, %55
+sorbet_rb_array_square_br.exit374.i:              ; preds = %58, %55
   %60 = phi i64 [ %59, %58 ], [ %57, %55 ], !dbg !40
   %61 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !40, !tbaa !17
   %62 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %61, i64 0, i32 5, !dbg !40
@@ -284,15 +285,15 @@ sorbet_rb_array_square_br.exit370.i:              ; preds = %58, %55
   %66 = xor i32 %65, -1, !dbg !40
   %67 = and i32 %66, %63, !dbg !40
   %68 = icmp eq i32 %67, 0, !dbg !40
-  br i1 %68, label %rb_vm_check_ints.exit5.i, label %69, !dbg !40, !prof !50
+  br i1 %68, label %sorbet_afterIntrinsic.exit375.i, label %69, !dbg !40, !prof !50
 
-69:                                               ; preds = %sorbet_rb_array_square_br.exit370.i
+69:                                               ; preds = %sorbet_rb_array_square_br.exit374.i
   %70 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %61, i64 0, i32 8, !dbg !40
   %71 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %70, align 8, !dbg !40, !tbaa !51
   %72 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %71, i32 noundef 0) #7, !dbg !40
-  br label %rb_vm_check_ints.exit5.i, !dbg !40
+  br label %sorbet_afterIntrinsic.exit375.i, !dbg !40
 
-rb_vm_check_ints.exit5.i:                         ; preds = %69, %sorbet_rb_array_square_br.exit370.i
+sorbet_afterIntrinsic.exit375.i:                  ; preds = %69, %sorbet_rb_array_square_br.exit374.i
   %"rubyId_[]147.i" = load i64, i64* @"rubyIdPrecomputed_[]", align 8, !dbg !40
   store i64 -1, i64* %callArgs0Addr.i, align 8, !dbg !40
   call void @llvm.experimental.noalias.scope.decl(metadata !55) #7, !dbg !40
@@ -301,16 +302,16 @@ rb_vm_check_ints.exit5.i:                         ; preds = %69, %sorbet_rb_arra
   %75 = icmp eq i64 %74, 0, !dbg !40
   br i1 %75, label %79, label %76, !dbg !40, !prof !47
 
-76:                                               ; preds = %rb_vm_check_ints.exit5.i
+76:                                               ; preds = %sorbet_afterIntrinsic.exit375.i
   %77 = ashr i64 %73, 1, !dbg !40
   %78 = call i64 @rb_ary_entry(i64 %30, i64 %77) #7, !dbg !40
-  br label %sorbet_rb_array_square_br.exit371.i, !dbg !40
+  br label %sorbet_rb_array_square_br.exit376.i, !dbg !40
 
-79:                                               ; preds = %rb_vm_check_ints.exit5.i
+79:                                               ; preds = %sorbet_afterIntrinsic.exit375.i
   %80 = call i64 @sorbet_rb_array_square_br_slowpath(i64 %30, i64 %"rubyId_[]147.i", i32 noundef 1, i64* noundef nonnull %24, i64 (i64, i64, i32, i64*, i64)* noundef null, i64 noundef 0) #7, !dbg !40
-  br label %sorbet_rb_array_square_br.exit371.i, !dbg !40
+  br label %sorbet_rb_array_square_br.exit376.i, !dbg !40
 
-sorbet_rb_array_square_br.exit371.i:              ; preds = %79, %76
+sorbet_rb_array_square_br.exit376.i:              ; preds = %79, %76
   %81 = phi i64 [ %80, %79 ], [ %78, %76 ], !dbg !40
   %82 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !40, !tbaa !17
   %83 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %82, i64 0, i32 5, !dbg !40
@@ -320,15 +321,15 @@ sorbet_rb_array_square_br.exit371.i:              ; preds = %79, %76
   %87 = xor i32 %86, -1, !dbg !40
   %88 = and i32 %87, %84, !dbg !40
   %89 = icmp eq i32 %88, 0, !dbg !40
-  br i1 %89, label %rb_vm_check_ints.exit7.i, label %90, !dbg !40, !prof !50
+  br i1 %89, label %sorbet_afterIntrinsic.exit377.i, label %90, !dbg !40, !prof !50
 
-90:                                               ; preds = %sorbet_rb_array_square_br.exit371.i
+90:                                               ; preds = %sorbet_rb_array_square_br.exit376.i
   %91 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %82, i64 0, i32 8, !dbg !40
   %92 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %91, align 8, !dbg !40, !tbaa !51
   %93 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %92, i32 noundef 0) #7, !dbg !40
-  br label %rb_vm_check_ints.exit7.i, !dbg !40
+  br label %sorbet_afterIntrinsic.exit377.i, !dbg !40
 
-rb_vm_check_ints.exit7.i:                         ; preds = %90, %sorbet_rb_array_square_br.exit371.i
+sorbet_afterIntrinsic.exit377.i:                  ; preds = %90, %sorbet_rb_array_square_br.exit376.i
   store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %21, align 8, !dbg !35, !tbaa !17
   store i64 %39, i64* %callArgs0Addr.i, align 8, !dbg !58
   store i64 %60, i64* %callArgs1Addr.i, align 8, !dbg !58
@@ -361,16 +362,16 @@ rb_vm_check_ints.exit7.i:                         ; preds = %90, %sorbet_rb_arra
   %105 = icmp eq i64 %104, 0, !dbg !66
   br i1 %105, label %109, label %106, !dbg !66, !prof !47
 
-106:                                              ; preds = %rb_vm_check_ints.exit7.i
+106:                                              ; preds = %sorbet_afterIntrinsic.exit377.i
   %107 = ashr i64 %103, 1, !dbg !66
   %108 = call i64 @rb_ary_entry(i64 %102, i64 %107) #7, !dbg !66
-  br label %sorbet_rb_array_square_br.exit372.i, !dbg !66
+  br label %sorbet_rb_array_square_br.exit379.i, !dbg !66
 
-109:                                              ; preds = %rb_vm_check_ints.exit7.i
+109:                                              ; preds = %sorbet_afterIntrinsic.exit377.i
   %110 = call i64 @sorbet_rb_array_square_br_slowpath(i64 %102, i64 %"rubyId_[]206.i", i32 noundef 1, i64* noundef nonnull %24, i64 (i64, i64, i32, i64*, i64)* noundef null, i64 noundef 0) #7, !dbg !66
-  br label %sorbet_rb_array_square_br.exit372.i, !dbg !66
+  br label %sorbet_rb_array_square_br.exit379.i, !dbg !66
 
-sorbet_rb_array_square_br.exit372.i:              ; preds = %109, %106
+sorbet_rb_array_square_br.exit379.i:              ; preds = %109, %106
   %111 = phi i64 [ %110, %109 ], [ %108, %106 ], !dbg !66
   %112 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !66, !tbaa !17
   %113 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %112, i64 0, i32 5, !dbg !66
@@ -380,15 +381,15 @@ sorbet_rb_array_square_br.exit372.i:              ; preds = %109, %106
   %117 = xor i32 %116, -1, !dbg !66
   %118 = and i32 %117, %114, !dbg !66
   %119 = icmp eq i32 %118, 0, !dbg !66
-  br i1 %119, label %rb_vm_check_ints.exit8.i, label %120, !dbg !66, !prof !50
+  br i1 %119, label %sorbet_afterIntrinsic.exit380.i, label %120, !dbg !66, !prof !50
 
-120:                                              ; preds = %sorbet_rb_array_square_br.exit372.i
+120:                                              ; preds = %sorbet_rb_array_square_br.exit379.i
   %121 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %112, i64 0, i32 8, !dbg !66
   %122 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %121, align 8, !dbg !66, !tbaa !51
   %123 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %122, i32 noundef 0) #7, !dbg !66
-  br label %rb_vm_check_ints.exit8.i, !dbg !66
+  br label %sorbet_afterIntrinsic.exit380.i, !dbg !66
 
-rb_vm_check_ints.exit8.i:                         ; preds = %120, %sorbet_rb_array_square_br.exit372.i
+sorbet_afterIntrinsic.exit380.i:                  ; preds = %120, %sorbet_rb_array_square_br.exit379.i
   %"rubyId_[]219.i" = load i64, i64* @"rubyIdPrecomputed_[]", align 8, !dbg !66
   store i64 -3, i64* %callArgs0Addr.i, align 8, !dbg !66
   call void @llvm.experimental.noalias.scope.decl(metadata !73) #7, !dbg !66
@@ -397,16 +398,16 @@ rb_vm_check_ints.exit8.i:                         ; preds = %120, %sorbet_rb_arr
   %126 = icmp eq i64 %125, 0, !dbg !66
   br i1 %126, label %130, label %127, !dbg !66, !prof !47
 
-127:                                              ; preds = %rb_vm_check_ints.exit8.i
+127:                                              ; preds = %sorbet_afterIntrinsic.exit380.i
   %128 = ashr i64 %124, 1, !dbg !66
   %129 = call i64 @rb_ary_entry(i64 %102, i64 %128) #7, !dbg !66
-  br label %sorbet_rb_array_square_br.exit373.i, !dbg !66
+  br label %sorbet_rb_array_square_br.exit381.i, !dbg !66
 
-130:                                              ; preds = %rb_vm_check_ints.exit8.i
+130:                                              ; preds = %sorbet_afterIntrinsic.exit380.i
   %131 = call i64 @sorbet_rb_array_square_br_slowpath(i64 %102, i64 %"rubyId_[]219.i", i32 noundef 1, i64* noundef nonnull %24, i64 (i64, i64, i32, i64*, i64)* noundef null, i64 noundef 0) #7, !dbg !66
-  br label %sorbet_rb_array_square_br.exit373.i, !dbg !66
+  br label %sorbet_rb_array_square_br.exit381.i, !dbg !66
 
-sorbet_rb_array_square_br.exit373.i:              ; preds = %130, %127
+sorbet_rb_array_square_br.exit381.i:              ; preds = %130, %127
   %132 = phi i64 [ %131, %130 ], [ %129, %127 ], !dbg !66
   %133 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !66, !tbaa !17
   %134 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %133, i64 0, i32 5, !dbg !66
@@ -416,15 +417,15 @@ sorbet_rb_array_square_br.exit373.i:              ; preds = %130, %127
   %138 = xor i32 %137, -1, !dbg !66
   %139 = and i32 %138, %135, !dbg !66
   %140 = icmp eq i32 %139, 0, !dbg !66
-  br i1 %140, label %rb_vm_check_ints.exit6.i, label %141, !dbg !66, !prof !50
+  br i1 %140, label %sorbet_afterIntrinsic.exit382.i, label %141, !dbg !66, !prof !50
 
-141:                                              ; preds = %sorbet_rb_array_square_br.exit373.i
+141:                                              ; preds = %sorbet_rb_array_square_br.exit381.i
   %142 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %133, i64 0, i32 8, !dbg !66
   %143 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %142, align 8, !dbg !66, !tbaa !51
   %144 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %143, i32 noundef 0) #7, !dbg !66
-  br label %rb_vm_check_ints.exit6.i, !dbg !66
+  br label %sorbet_afterIntrinsic.exit382.i, !dbg !66
 
-rb_vm_check_ints.exit6.i:                         ; preds = %141, %sorbet_rb_array_square_br.exit373.i
+sorbet_afterIntrinsic.exit382.i:                  ; preds = %141, %sorbet_rb_array_square_br.exit381.i
   %"rubyId_[]232.i" = load i64, i64* @"rubyIdPrecomputed_[]", align 8, !dbg !66
   store i64 -1, i64* %callArgs0Addr.i, align 8, !dbg !66
   call void @llvm.experimental.noalias.scope.decl(metadata !76) #7, !dbg !66
@@ -433,16 +434,16 @@ rb_vm_check_ints.exit6.i:                         ; preds = %141, %sorbet_rb_arr
   %147 = icmp eq i64 %146, 0, !dbg !66
   br i1 %147, label %151, label %148, !dbg !66, !prof !47
 
-148:                                              ; preds = %rb_vm_check_ints.exit6.i
+148:                                              ; preds = %sorbet_afterIntrinsic.exit382.i
   %149 = ashr i64 %145, 1, !dbg !66
   %150 = call i64 @rb_ary_entry(i64 %102, i64 %149) #7, !dbg !66
-  br label %sorbet_rb_array_square_br.exit374.i, !dbg !66
+  br label %sorbet_rb_array_square_br.exit383.i, !dbg !66
 
-151:                                              ; preds = %rb_vm_check_ints.exit6.i
+151:                                              ; preds = %sorbet_afterIntrinsic.exit382.i
   %152 = call i64 @sorbet_rb_array_square_br_slowpath(i64 %102, i64 %"rubyId_[]232.i", i32 noundef 1, i64* noundef nonnull %24, i64 (i64, i64, i32, i64*, i64)* noundef null, i64 noundef 0) #7, !dbg !66
-  br label %sorbet_rb_array_square_br.exit374.i, !dbg !66
+  br label %sorbet_rb_array_square_br.exit383.i, !dbg !66
 
-sorbet_rb_array_square_br.exit374.i:              ; preds = %151, %148
+sorbet_rb_array_square_br.exit383.i:              ; preds = %151, %148
   %153 = phi i64 [ %152, %151 ], [ %150, %148 ], !dbg !66
   %154 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !66, !tbaa !17
   %155 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %154, i64 0, i32 5, !dbg !66
@@ -452,15 +453,15 @@ sorbet_rb_array_square_br.exit374.i:              ; preds = %151, %148
   %159 = xor i32 %158, -1, !dbg !66
   %160 = and i32 %159, %156, !dbg !66
   %161 = icmp eq i32 %160, 0, !dbg !66
-  br i1 %161, label %rb_vm_check_ints.exit4.i, label %162, !dbg !66, !prof !50
+  br i1 %161, label %sorbet_afterIntrinsic.exit378.i, label %162, !dbg !66, !prof !50
 
-162:                                              ; preds = %sorbet_rb_array_square_br.exit374.i
+162:                                              ; preds = %sorbet_rb_array_square_br.exit383.i
   %163 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %154, i64 0, i32 8, !dbg !66
   %164 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %163, align 8, !dbg !66, !tbaa !51
   %165 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %164, i32 noundef 0) #7, !dbg !66
-  br label %rb_vm_check_ints.exit4.i, !dbg !66
+  br label %sorbet_afterIntrinsic.exit378.i, !dbg !66
 
-rb_vm_check_ints.exit4.i:                         ; preds = %162, %sorbet_rb_array_square_br.exit374.i
+sorbet_afterIntrinsic.exit378.i:                  ; preds = %162, %sorbet_rb_array_square_br.exit383.i
   store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %21, align 8, !dbg !35, !tbaa !17
   store i64 %111, i64* %callArgs0Addr.i, align 8, !dbg !79
   store i64 %132, i64* %callArgs1Addr.i, align 8, !dbg !79
@@ -491,16 +492,16 @@ rb_vm_check_ints.exit4.i:                         ; preds = %162, %sorbet_rb_arr
   %176 = icmp eq i64 %175, 0, !dbg !87
   br i1 %176, label %180, label %177, !dbg !87, !prof !47
 
-177:                                              ; preds = %rb_vm_check_ints.exit4.i
+177:                                              ; preds = %sorbet_afterIntrinsic.exit378.i
   %178 = ashr i64 %174, 1, !dbg !87
   %179 = call i64 @rb_ary_entry(i64 %173, i64 %178) #7, !dbg !87
-  br label %sorbet_rb_array_square_br.exit375.i, !dbg !87
+  br label %sorbet_rb_array_square_br.exit371.i, !dbg !87
 
-180:                                              ; preds = %rb_vm_check_ints.exit4.i
+180:                                              ; preds = %sorbet_afterIntrinsic.exit378.i
   %181 = call i64 @sorbet_rb_array_square_br_slowpath(i64 %173, i64 %"rubyId_[]286.i", i32 noundef 1, i64* noundef nonnull %24, i64 (i64, i64, i32, i64*, i64)* noundef null, i64 noundef 0) #7, !dbg !87
-  br label %sorbet_rb_array_square_br.exit375.i, !dbg !87
+  br label %sorbet_rb_array_square_br.exit371.i, !dbg !87
 
-sorbet_rb_array_square_br.exit375.i:              ; preds = %180, %177
+sorbet_rb_array_square_br.exit371.i:              ; preds = %180, %177
   %182 = phi i64 [ %181, %180 ], [ %179, %177 ], !dbg !87
   %183 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !87, !tbaa !17
   %184 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %183, i64 0, i32 5, !dbg !87
@@ -510,15 +511,15 @@ sorbet_rb_array_square_br.exit375.i:              ; preds = %180, %177
   %188 = xor i32 %187, -1, !dbg !87
   %189 = and i32 %188, %185, !dbg !87
   %190 = icmp eq i32 %189, 0, !dbg !87
-  br i1 %190, label %rb_vm_check_ints.exit2.i, label %191, !dbg !87, !prof !50
+  br i1 %190, label %sorbet_afterIntrinsic.exit370.i, label %191, !dbg !87, !prof !50
 
-191:                                              ; preds = %sorbet_rb_array_square_br.exit375.i
+191:                                              ; preds = %sorbet_rb_array_square_br.exit371.i
   %192 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %183, i64 0, i32 8, !dbg !87
   %193 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %192, align 8, !dbg !87, !tbaa !51
   %194 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %193, i32 noundef 0) #7, !dbg !87
-  br label %rb_vm_check_ints.exit2.i, !dbg !87
+  br label %sorbet_afterIntrinsic.exit370.i, !dbg !87
 
-rb_vm_check_ints.exit2.i:                         ; preds = %191, %sorbet_rb_array_square_br.exit375.i
+sorbet_afterIntrinsic.exit370.i:                  ; preds = %191, %sorbet_rb_array_square_br.exit371.i
   %"rubyId_[]299.i" = load i64, i64* @"rubyIdPrecomputed_[]", align 8, !dbg !87
   store i64 -3, i64* %callArgs0Addr.i, align 8, !dbg !87
   call void @llvm.experimental.noalias.scope.decl(metadata !94) #7, !dbg !87
@@ -527,16 +528,16 @@ rb_vm_check_ints.exit2.i:                         ; preds = %191, %sorbet_rb_arr
   %197 = icmp eq i64 %196, 0, !dbg !87
   br i1 %197, label %201, label %198, !dbg !87, !prof !47
 
-198:                                              ; preds = %rb_vm_check_ints.exit2.i
+198:                                              ; preds = %sorbet_afterIntrinsic.exit370.i
   %199 = ashr i64 %195, 1, !dbg !87
   %200 = call i64 @rb_ary_entry(i64 %173, i64 %199) #7, !dbg !87
-  br label %sorbet_rb_array_square_br.exit368.i, !dbg !87
+  br label %sorbet_rb_array_square_br.exit369.i, !dbg !87
 
-201:                                              ; preds = %rb_vm_check_ints.exit2.i
+201:                                              ; preds = %sorbet_afterIntrinsic.exit370.i
   %202 = call i64 @sorbet_rb_array_square_br_slowpath(i64 %173, i64 %"rubyId_[]299.i", i32 noundef 1, i64* noundef nonnull %24, i64 (i64, i64, i32, i64*, i64)* noundef null, i64 noundef 0) #7, !dbg !87
-  br label %sorbet_rb_array_square_br.exit368.i, !dbg !87
+  br label %sorbet_rb_array_square_br.exit369.i, !dbg !87
 
-sorbet_rb_array_square_br.exit368.i:              ; preds = %201, %198
+sorbet_rb_array_square_br.exit369.i:              ; preds = %201, %198
   %203 = phi i64 [ %202, %201 ], [ %200, %198 ], !dbg !87
   %204 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !87, !tbaa !17
   %205 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %204, i64 0, i32 5, !dbg !87
@@ -546,15 +547,15 @@ sorbet_rb_array_square_br.exit368.i:              ; preds = %201, %198
   %209 = xor i32 %208, -1, !dbg !87
   %210 = and i32 %209, %206, !dbg !87
   %211 = icmp eq i32 %210, 0, !dbg !87
-  br i1 %211, label %rb_vm_check_ints.exit1.i, label %212, !dbg !87, !prof !50
+  br i1 %211, label %sorbet_afterIntrinsic.exit368.i, label %212, !dbg !87, !prof !50
 
-212:                                              ; preds = %sorbet_rb_array_square_br.exit368.i
+212:                                              ; preds = %sorbet_rb_array_square_br.exit369.i
   %213 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %204, i64 0, i32 8, !dbg !87
   %214 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %213, align 8, !dbg !87, !tbaa !51
   %215 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %214, i32 noundef 0) #7, !dbg !87
-  br label %rb_vm_check_ints.exit1.i, !dbg !87
+  br label %sorbet_afterIntrinsic.exit368.i, !dbg !87
 
-rb_vm_check_ints.exit1.i:                         ; preds = %212, %sorbet_rb_array_square_br.exit368.i
+sorbet_afterIntrinsic.exit368.i:                  ; preds = %212, %sorbet_rb_array_square_br.exit369.i
   %"rubyId_[]312.i" = load i64, i64* @"rubyIdPrecomputed_[]", align 8, !dbg !87
   store i64 -1, i64* %callArgs0Addr.i, align 8, !dbg !87
   call void @llvm.experimental.noalias.scope.decl(metadata !97) #7, !dbg !87
@@ -563,12 +564,12 @@ rb_vm_check_ints.exit1.i:                         ; preds = %212, %sorbet_rb_arr
   %218 = icmp eq i64 %217, 0, !dbg !87
   br i1 %218, label %222, label %219, !dbg !87, !prof !47
 
-219:                                              ; preds = %rb_vm_check_ints.exit1.i
+219:                                              ; preds = %sorbet_afterIntrinsic.exit368.i
   %220 = ashr i64 %216, 1, !dbg !87
   %221 = call i64 @rb_ary_entry(i64 %173, i64 %220) #7, !dbg !87
   br label %sorbet_rb_array_square_br.exit.i, !dbg !87
 
-222:                                              ; preds = %rb_vm_check_ints.exit1.i
+222:                                              ; preds = %sorbet_afterIntrinsic.exit368.i
   %223 = call i64 @sorbet_rb_array_square_br_slowpath(i64 %173, i64 %"rubyId_[]312.i", i32 noundef 1, i64* noundef nonnull %24, i64 (i64, i64, i32, i64*, i64)* noundef null, i64 noundef 0) #7, !dbg !87
   br label %sorbet_rb_array_square_br.exit.i, !dbg !87
 
@@ -615,10 +616,10 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #5
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #5
 
-attributes #0 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #1 = { noreturn "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #2 = { inaccessiblememonly nofree nosync nounwind willreturn }
-attributes #3 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #3 = { nounwind ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #4 = { sspreq }
 attributes #5 = { argmemonly nofree nosync nounwind willreturn }
 attributes #6 = { noreturn nounwind }

--- a/test/testdata/compiler/unsafe.opt.ll.exp
+++ b/test/testdata/compiler/unsafe.opt.ll.exp
@@ -2,16 +2,17 @@
 source_filename = "llvm-link"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 
-%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.3, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.4, [29 x i16] }
+%struct.rb_vm_struct = type { i64, %struct.rb_global_vm_lock_struct, %struct.rb_thread_struct*, %struct.rb_thread_struct*, i8*, i64, %union.pthread_mutex_t, %struct.list_head, %struct.list_head, %struct.list_head, %struct.list_head, i64, i32, i32, i8, i32, i64, [5 x i64], i64, i64, i64, i64, i64, i64, i64, %struct.st_table*, %struct.st_table*, %struct.anon.5, %struct.rb_hook_list_struct, %struct.st_table*, %struct.rb_postponed_job_struct*, i32, i32, %struct.list_head, %union.pthread_mutex_t, i64, i64, i64, i64, i64, i32, %struct.st_table*, %struct.rb_objspace*, %struct.rb_at_exit_list*, i64*, %struct.st_table*, %struct.rb_builtin_function*, i32, %struct.anon.6, [29 x i16] }
 %struct.rb_global_vm_lock_struct = type { %struct.rb_thread_struct*, %union.pthread_mutex_t, %struct.list_head, %struct.rb_thread_struct*, i32, %union.pthread_cond_t, %union.pthread_cond_t, i32, i32 }
-%union.pthread_cond_t = type { %struct.anon.2 }
-%struct.anon.2 = type { i32, i32, i64, i64, i64, i8*, i32, i32 }
-%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.7, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
+%union.pthread_cond_t = type { %struct.__pthread_cond_s }
+%struct.__pthread_cond_s = type { %union.anon, %union.anon, [2 x i32], [2 x i32], i32, i32, [2 x i32] }
+%union.anon = type { i64 }
+%struct.rb_thread_struct = type { %struct.list_node, i64, %struct.rb_vm_struct*, %struct.rb_execution_context_struct*, i64, %struct.rb_calling_info*, i64, i64, i64, i8, i8, i32, %struct.native_thread_data_struct, i8*, i64, i64, i64, i64, %union.pthread_mutex_t, %struct.rb_unblock_callback, i64, %struct.rb_mutex_struct*, %struct.rb_thread_list_struct*, %union.anon.10, i32, i64, %struct.rb_fiber_struct*, [5 x i8*], i64 }
 %struct.list_node = type { %struct.list_node*, %struct.list_node* }
-%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.5 }
+%struct.rb_execution_context_struct = type { i64*, i64, %struct.rb_control_frame_struct*, %struct.rb_vm_tag*, %struct.rb_vm_protect_tag*, i32, i32, %struct.rb_fiber_struct*, %struct.rb_thread_struct*, %struct.st_table*, i64, i64, i64*, i64, %struct.rb_ensure_list*, %struct.rb_trace_arg_struct*, i64, i64, i8, i8, i64, %struct.anon.7 }
 %struct.rb_control_frame_struct = type { i64*, i64*, %struct.rb_iseq_struct*, i64, i64*, i8*, i64* }
-%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.14 }
-%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.13, i32, i32, i32, i32, i32, i8, i64 }
+%struct.rb_iseq_struct = type { i64, i64, %struct.rb_iseq_constant_body*, %union.anon.17 }
+%struct.rb_iseq_constant_body = type { i32, i32, i64*, %struct.anon, %struct.rb_iseq_location_struct, %struct.iseq_insn_info, i64*, %struct.iseq_catch_table*, %struct.rb_iseq_struct*, %struct.rb_iseq_struct*, %union.iseq_inline_storage_entry*, %struct.rb_call_data*, %struct.anon.16, i32, i32, i32, i32, i32, i8, i64 }
 %struct.anon = type { %struct.anon.0, i32, i32, i32, i32, i32, i32, i32, i64*, %struct.rb_iseq_param_keyword* }
 %struct.anon.0 = type { i16, [2 x i8] }
 %struct.rb_iseq_param_keyword = type { i32, i32, i32, i32, i64*, i64* }
@@ -27,34 +28,34 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.rb_cref_struct = type { i64, i64, i64, %struct.rb_cref_struct*, %struct.rb_scope_visi_struct }
 %struct.rb_scope_visi_struct = type { i8, [3 x i8] }
 %struct.rb_call_data = type { %struct.rb_call_cache, %struct.rb_call_info }
-%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.12 }
+%struct.rb_call_cache = type { i64, [3 x i64], %struct.rb_callable_method_entry_struct*, i64, i64 (%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_calling_info*, %struct.rb_call_data*)*, %union.anon.15 }
 %struct.rb_callable_method_entry_struct = type { i64, i64, %struct.rb_method_definition_struct*, i64, i64 }
-%struct.rb_method_definition_struct = type { i64, %union.anon.10, i64, i64 }
-%union.anon.10 = type { %struct.rb_method_cfunc_struct }
+%struct.rb_method_definition_struct = type { i64, %union.anon.13, i64, i64 }
+%union.anon.13 = type { %struct.rb_method_cfunc_struct }
 %struct.rb_method_cfunc_struct = type { i64 (...)*, i64 (i64, i32, i64*, i64 (...)*)*, i32 }
-%union.anon.12 = type { i32 }
+%union.anon.15 = type { i32 }
 %struct.rb_call_info = type { i64, i32, i32 }
-%struct.anon.13 = type { i64, i64, i64, i64* }
-%union.anon.14 = type { %struct.anon.15 }
-%struct.anon.15 = type { i64, i32 }
+%struct.anon.16 = type { i64, i64, i64, i64* }
+%union.anon.17 = type { %struct.anon.18 }
+%struct.anon.18 = type { i64, i32 }
 %struct.rb_vm_tag = type { i64, i64, [5 x i8*], %struct.rb_vm_tag*, i32 }
 %struct.rb_vm_protect_tag = type { %struct.rb_vm_protect_tag* }
 %struct.rb_ensure_list = type { %struct.rb_ensure_list*, %struct.rb_ensure_entry }
 %struct.rb_ensure_entry = type { i64, i64 (i64)*, i64 }
 %struct.rb_trace_arg_struct = type { i32, %struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, i64, i64, i64, i64, i64, i32, i32, i64 }
-%struct.anon.5 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
+%struct.anon.7 = type { i64*, i64*, i64, [1 x %struct.__jmp_buf_tag] }
 %struct.__jmp_buf_tag = type { [8 x i64], i32, %struct.__sigset_t }
 %struct.__sigset_t = type { [16 x i64] }
 %struct.rb_calling_info = type { i64, i64, i32, i32 }
-%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.6 }
-%union.anon.6 = type { %union.pthread_cond_t }
+%struct.native_thread_data_struct = type { %struct.list_head, %union.anon.9 }
+%union.anon.9 = type { %union.pthread_cond_t }
 %struct.rb_unblock_callback = type { void (i8*)*, i8* }
 %struct.rb_mutex_struct = type opaque
 %struct.rb_thread_list_struct = type { %struct.rb_thread_list_struct*, %struct.rb_thread_struct* }
-%union.anon.7 = type { %struct.anon.8 }
-%struct.anon.8 = type { i64, i64, i32 }
+%union.anon.10 = type { %struct.anon.11 }
+%struct.anon.11 = type { i64, i64, i32 }
 %struct.rb_fiber_struct = type opaque
-%struct.anon.3 = type { [65 x i64] }
+%struct.anon.5 = type { [65 x i64] }
 %struct.rb_hook_list_struct = type { %struct.rb_event_hook_struct*, i32, i32, i32 }
 %struct.rb_event_hook_struct = type opaque
 %struct.rb_postponed_job_struct = type opaque
@@ -68,18 +69,18 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %struct.st_hash_type = type { i32 (i64, i64)*, i64 (i64)* }
 %struct.st_table_entry = type opaque
 %struct.rb_builtin_function = type opaque
-%struct.anon.4 = type { i64, i64, i64, i64 }
+%struct.anon.6 = type { i64, i64, i64, i64 }
 %struct.SorbetLineNumberInfo = type { i32, %struct.iseq_insn_info_entry*, i64* }
 %struct.FunctionInlineCache = type { %struct.rb_kwarg_call_data }
 %struct.rb_kwarg_call_data = type { %struct.rb_call_cache, %struct.rb_call_info_with_kwarg }
 %struct.rb_call_info_with_kwarg = type { %struct.rb_call_info, %struct.rb_call_info_kw_arg* }
 %struct.rb_call_info_kw_arg = type { i32, [1 x i64] }
 
-@ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
-@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @rb_eRuntimeError = external local_unnamed_addr global i64, align 8
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
+@ruby_current_vm_ptr = external local_unnamed_addr global %struct.rb_vm_struct*, align 8
+@ruby_current_execution_context_ptr = external local_unnamed_addr global %struct.rb_execution_context_struct*, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$152" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
@@ -203,10 +204,10 @@ entry:
   ret void
 }
 
-attributes #0 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
+attributes #1 = { noreturn "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #2 = { inaccessiblememonly nofree nosync nounwind willreturn }
-attributes #3 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #3 = { nounwind ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" }
 attributes #4 = { sspreq }
 attributes #5 = { noreturn nounwind }
 attributes #6 = { nounwind }

--- a/test/validate_exp.sh
+++ b/test/validate_exp.sh
@@ -48,7 +48,7 @@ rb=( "$@" )
 
 root=$PWD
 
-llvm_diff_path="$root/external/llvm_toolchain_12_0_0/bin/llvm-diff"
+llvm_diff_path="$root/external/llvm_toolchain_13_0_0/bin/llvm-diff"
 
 ruby="$(rlocation sorbet_ruby_2_7_for_compiler/ruby)"
 diff_diff="$(rlocation com_stripe_ruby_typer/test/diff-diff.rb)"

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -175,9 +175,9 @@ package(default_visibility = ["//visibility:public"])
     # NOTE: we use the sorbet branch for development to keep our changes rebasable on grailio/bazel-toolchain
     http_archive(
         name = "com_grail_bazel_toolchain",
-        urls = _github_public_urls("sorbet/bazel-toolchain/archive/a685e1e6bd1e7cc9a5b84f832539585bb68d8ab4.zip"),
-        sha256 = "90c59f14cada755706a38bdd0f5ad8f0402cbf766387929cfbee9c3f1b4c82d7",
-        strip_prefix = "bazel-toolchain-a685e1e6bd1e7cc9a5b84f832539585bb68d8ab4",
+        urls = _github_public_urls("sorbet/bazel-toolchain/archive/07293d34d4cae03aca3ce2d47bfd5bf0ec854d4e.zip"),
+        sha256 = "cfe10d1f3e18cdefeef2df71d3d9eec564d4f6200cdcdaff2674dad3473916eb",
+        strip_prefix = "bazel-toolchain-07293d34d4cae03aca3ce2d47bfd5bf0ec854d4e",
     )
 
     http_archive(

--- a/third_party/jemalloc.BUILD
+++ b/third_party/jemalloc.BUILD
@@ -29,7 +29,7 @@ JEMALLOC_BUILD_COMMAND = """
   [ "$$(uname)" = "Darwin" ] && export SDKROOT=$$(xcrun --show-sdk-path)
   export NM=$$(absolutize $(NM))
   export OBJCOPY=$$(absolutize $(OBJCOPY))
-  export CFLAGS=$(CC_FLAGS)
+  export CFLAGS="$(CC_FLAGS) -Wno-c++11-narrowing"
   export CXXFLAGS=$(CC_FLAGS)
   export LTOFLAGS="$$([ "$$(uname)" = "Linux" ] && echo "-flto=thin")" # todo: on next clang toolchain upgrade, check if it's fixed and we can re-enable thinlto on mac
   export EXTRA_CFLAGS="$${LTOFLAGS}"

--- a/third_party/jemalloc.BUILD
+++ b/third_party/jemalloc.BUILD
@@ -25,6 +25,8 @@ JEMALLOC_BUILD_COMMAND = """
   export CC=$$(absolutize $(CC))
   export CXX=$$(absolutize $(CC))
   [ "$$(uname)" = "Linux" ] && export AR=$$(absolutize $(AR))
+  [ "$$(uname)" = "Darwin" ] && export DEVELOPER_DIR=$$(xcode-select --print-path)
+  [ "$$(uname)" = "Darwin" ] && export SDKROOT=$$(xcrun --show-sdk-path)
   export NM=$$(absolutize $(NM))
   export OBJCOPY=$$(absolutize $(OBJCOPY))
   export CFLAGS=$(CC_FLAGS)

--- a/third_party/llvm/llvm.bzl
+++ b/third_party/llvm/llvm.bzl
@@ -339,6 +339,7 @@ llvm_copts = [
 
     # don't compile llvm with lto. It's too slow to compile and not worth it
     "-fno-lto",
+    "-Wno-unused-but-set-variable",
 ]
 
 # Platform specific sources for libSupport.

--- a/third_party/lmdb.BUILD
+++ b/third_party/lmdb.BUILD
@@ -10,7 +10,10 @@ cc_library(
         "libraries/liblmdb/lmdb.h",
         "libraries/liblmdb/midl.h",
     ],
-    copts = ["-Wno-implicit-fallthrough", "-Wno-unused-but-set-variable"],
+    copts = [
+        "-Wno-implicit-fallthrough",
+        "-Wno-unused-but-set-variable",
+    ],
     includes = [
         "libraries/liblmdb/",
     ],

--- a/third_party/lmdb.BUILD
+++ b/third_party/lmdb.BUILD
@@ -10,7 +10,7 @@ cc_library(
         "libraries/liblmdb/lmdb.h",
         "libraries/liblmdb/midl.h",
     ],
-    copts = ["-Wno-implicit-fallthrough"],
+    copts = ["-Wno-implicit-fallthrough", "-Wno-unused-but-set-variable"],
     includes = [
         "libraries/liblmdb/",
     ],

--- a/third_party/ruby/build-ruby.bzl
+++ b/third_party/ruby/build-ruby.bzl
@@ -609,6 +609,7 @@ _rubyfmt_static_deps = rule(
     },
     fragments = ["cpp"],
     implementation = _rubyfmt_static_deps_impl,
+    toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
 )
 
 def ruby(rubygems, gems, extra_srcs = None, append_srcs = None, configure_flags = [], copts = [], cppopts = [], linkopts = [], deps = [], post_build_patches = []):

--- a/tools/clang.bzl
+++ b/tools/clang.bzl
@@ -30,6 +30,6 @@ _clang_tool = rule(
 def clang_tool(name):
     _clang_tool(
         name = name,
-        tool = "@llvm_toolchain_12_0_0//:bin/" + name,
+        tool = "@llvm_toolchain_13_0_0//:bin/" + name,
         visibility = ["//visibility:public"],
     )

--- a/tools/scripts/fuzz.sh
+++ b/tools/scripts/fuzz.sh
@@ -28,7 +28,7 @@ echo "building $target"
 ./bazel build "//test/fuzz:$target" --config=fuzz -c opt
 
 # we want the bazel build command to run before this check so that bazel can download itself.
-export PATH="$PATH:$PWD/bazel-sorbet/external/llvm_toolchain_12_0_0/bin"
+export PATH="$PATH:$PWD/bazel-sorbet/external/llvm_toolchain_13_0_0/bin"
 if ! command -v llvm-symbolizer >/dev/null; then
   echo "fatal: command not found: llvm-symbolizer"
   exit 1

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -72,7 +72,7 @@ handle_TERM() {
 trap handle_INT SIGINT
 trap handle_TERM SIGTERM
 
-export PATH="$PATH:$PWD/bazel-sorbet/external/llvm_toolchain_12_0_0/bin"
+export PATH="$PATH:$PWD/bazel-sorbet/external/llvm_toolchain_13_0_0/bin"
 if ! command -v llvm-symbolizer >/dev/null; then
   echo "fatal: command not found: llvm-symbolizer"
   exit 1

--- a/tools/scripts/ll-view.sh
+++ b/tools/scripts/ll-view.sh
@@ -91,7 +91,7 @@ cp "$llvm_ir_file" "$input_file"
 
 # We could use bazel run here, but it's more convenient to use whatever happens
 # to have been built last, so that we don't have to potentially rebuild LLVM.
-llvm_opt="$project_root/bazel-sorbet/external/llvm_toolchain_12_0_0/bin/opt"
+llvm_opt="$project_root/bazel-sorbet/external/llvm_toolchain_13_0_0/bin/opt"
 
 if ! [ -x "$llvm_opt" ]; then
   # ... but if nothing was built yet, at least build something.


### PR DESCRIPTION
_This is part of the work for compiling Sorbet on M1 macs_

Upgrade to LLVM 13, which is the first version that supports signing binaries, which is required on M1s. It's easier to review this PR per commit, here's what they do:
- Upgrade to LLVM 13 and update all references
- Explicitly set DEVELOPER_DIR and SDKROOT in the jemalloc build. I'm not sure why these are not set after the upgrade, but this was the only way I could fix the build
- Fix usage of `result_of` which is now [deprecated](https://en.cppreference.com/w/cpp/types/result_of) in favour of `invoke_result`
- After the upgrade, we got a few errors for variables that are set but not used. Made a few changes to get past the errors and warnings
- Disabled the `unused-but-set-variable` for lmdb, which violates the rule

### Motivation

We will need LLVM 13 for signing binaries on the ARM64 builds.

### Test plan

Current tests should cover the upgrade.