### PR TITLE
Upgrade jemalloc to 5.3 RC

### DIFF
--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -107,10 +107,10 @@ def register_sorbet_dependencies():
 
     http_archive(
         name = "jemalloc",
-        urls = _github_public_urls("jemalloc/jemalloc/archive/ea6b3e973b477b8061e0076bb257dbd7f3faa756.zip"),  # 5.2.1
-        sha256 = "7822c5cb2d06a2665cdbbcd5d949f09b92ef5b891ad8354c6382a3614c9cc9cc",
+        urls = _github_public_urls("jemalloc/jemalloc/archive/20f9802e4f25922884448d9581c66d76cc905c0c.zip"),  # 5.3
+        sha256 = "1cc1ec93701868691c73b371eb87e5452257996279a42303a91caad355374439",
         build_file = "@com_stripe_ruby_typer//third_party:jemalloc.BUILD",
-        strip_prefix = "jemalloc-ea6b3e973b477b8061e0076bb257dbd7f3faa756",
+        strip_prefix = "jemalloc-20f9802e4f25922884448d9581c66d76cc905c0c",
     )
 
     http_archive(

--- a/third_party/jemalloc.BUILD
+++ b/third_party/jemalloc.BUILD
@@ -20,6 +20,7 @@ JEMALLOC_BUILD_COMMAND = """
    echo "$$path"
   }
   export PATH="/usr/local/bin:$$PATH" # find autoconf on mac
+  export PATH="/opt/homebrew/bin:$$PATH" # find autoconf on mac arm64
   export PATH="/home/linuxbrew/.linuxbrew/bin:$$PATH" # find autoconf on linux using Linuxbrew
   export CC=$$(absolutize $(CC))
   export CXX=$$(absolutize $(CC))


### PR DESCRIPTION
_This is part of the work for compiling Sorbet on M1 macs_

Upgrade jemalloc to release candidate 5.3, which has support for ARM64. Additionally, we are now setting the path for homebrew openssl in M1 machines.

### Motivation

We need to upgrade to get ARM64 support.

### Test plan

Current tests should cover the upgrade.