### PR TITLE
Use portable debug traps

### DIFF
--- a/common/os/linux.cc
+++ b/common/os/linux.cc
@@ -89,7 +89,7 @@ bool amIBeingDebugged() {
 
 bool stopInDebugger() {
     if (amIBeingDebugged()) {
-        __asm__("int $3");
+        __builtin_debugtrap();
         return true;
     }
     return false;

--- a/common/os/mac.cc
+++ b/common/os/mac.cc
@@ -69,7 +69,7 @@ bool amIBeingDebugged()
 
 bool stopInDebugger() {
     if (amIBeingDebugged()) {
-        __asm__("int $3");
+        __builtin_debugtrap();
         return true;
     }
     return false;

--- a/compiler/IREmitter/Payload/vm-payload.c
+++ b/compiler/IREmitter/Payload/vm-payload.c
@@ -20,6 +20,7 @@
 // reason
 #include "internal.h"
 #include "ruby.h"
+#include <signal.h>
 
 // This is probably a bad idea but is needed for so many things
 #include "vm_core.h"
@@ -54,7 +55,7 @@ const char *sorbet_dbg_p(VALUE obj) {
 }
 
 void sorbet_stopInDebugger() {
-    __builtin_debugtrap();
+    raise(SIGTRAP);
 }
 
 // ****

--- a/compiler/IREmitter/Payload/vm-payload.c
+++ b/compiler/IREmitter/Payload/vm-payload.c
@@ -54,7 +54,7 @@ const char *sorbet_dbg_p(VALUE obj) {
 }
 
 void sorbet_stopInDebugger() {
-    __asm__("int $3");
+    __builtin_debugtrap();
 }
 
 // ****


### PR DESCRIPTION
_This is part of the work for compiling Sorbet on M1 macs_

Use portable debug traps instead of embedded x86 assembly.

### Motivation

The x86 instructions will not compile on ARM64, so we need to use a portable alternative.

### Test plan

Current tests should cover it.