### PR TITLE
Conditionally compile libb2 only on x86

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -76,6 +76,9 @@ test:coverage --spawn_strategy=local
 build --define=versioned=false
 build:versioned --workspace_status_command=tools/buildstamp/get_workspace_status --stamp --define=versioned=true
 
+build:dbg-darwin --config=dbg --platforms=@//tools/config:darwin_x86_64
+build:dbg-linux --config=dbg --platforms=@//tools/config:linux_x86_64
+
 ##
 ## Configurations used for releases
 ##
@@ -93,7 +96,7 @@ build:release-debug-common --config=skipslowenforce
 
 # harden: mark relocation sections read-only
 build:release-linux --linkopt=-Wl,-z,relro,-z,now
-build:release-linux --config=lto-linux --config=release-common
+build:release-linux --config=lto-linux --config=release-common --platforms=@//tools/config:linux_x86_64
 
 # This is to turn on vector instructions where available.
 # We used to do this unconditionally, but Rosetta 2 doesn't translate all vector instructions well.
@@ -106,7 +109,7 @@ build:release-linux --config=lto-linux --config=release-common
 build:release-linux           --copt=-march=sandybridge
 build:release-sanitized-linux --copt=-march=sandybridge
 
-build:release-mac --config=release-common
+build:release-mac --config=release-common --platforms=@//tools/config:darwin_x86_64
 
 build:release-debug-linux --config=release-linux
 build:release-debug-linux --config=release-debug-common

--- a/common/crypto_hashing/BUILD
+++ b/common/crypto_hashing/BUILD
@@ -8,6 +8,8 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = ["//common"] + select({
         "//tools/config:webasm": ["@com_github_blake2_blake2"],
-        "//conditions:default": ["@com_github_blake2_libb2"],
+        "//tools/config:darwin": ["@com_github_blake2_libb2"],
+        "//tools/config:linux": ["@com_github_blake2_libb2"],
+        "//conditions:default": ["@com_github_blake2_blake2"],
     }),
 )

--- a/common/crypto_hashing/crypto_hashing.h
+++ b/common/crypto_hashing/crypto_hashing.h
@@ -3,7 +3,7 @@
 
 #include "common/common.h"
 extern "C" {
-#ifndef EMSCRIPTEN
+#if defined(__i386__) || defined(__x86_64__)
 #include "blake2.h"
 #else
 #include "ref/blake2.h"
@@ -15,7 +15,7 @@ inline std::array<uint8_t, 64> hash64(std::string_view data) {
     static_assert(BLAKE2B_OUTBYTES == 64);
     std::array<uint8_t, 64> res;
 
-#ifndef EMSCRIPTEN
+#if defined(__i386__) || defined(__x86_64__)
     int err = blake2b(&res[0], data.begin(), nullptr, std::size(res), data.size(), 0);
 #else
     // it has different order of arguments \facepalm

--- a/tools/config/BUILD
+++ b/tools/config/BUILD
@@ -1,13 +1,35 @@
 package(default_visibility = ["//visibility:public"])
 
+platform(
+    name = "darwin_x86_64",
+    constraint_values = [
+        "@platforms//os:osx",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+platform(
+    name = "linux_x86_64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
 config_setting(
     name = "darwin",
-    values = {"host_cpu": "darwin"},
+    constraint_values = [
+        "@platforms//os:osx",
+        "@platforms//cpu:x86_64",
+    ],
 )
 
 config_setting(
     name = "linux",
-    values = {"host_cpu": "k8"},
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
 )
 
 config_setting(
@@ -56,8 +78,10 @@ config_setting(
 
 config_setting(
     name = "darwindbg",
+    constraint_values = [
+        "@platforms//os:osx",
+    ],
     values = {
-        "host_cpu": "darwin",
         "compilation_mode": "dbg",
     },
 )


### PR DESCRIPTION
_This is part of the work for compiling Sorbet on M1 macs_

Conditionally compile `libb2` only on x86 builds to keep the performance gains and use the portable version everywhere else.

### Motivation

We need to use the portable version `blake2` instead of the x86 specific `libb2` for ARM64 builds.

### Test plan

Current tests should cover it.