### PR TITLE
Use `todo.file` instead of looking it up on the owner

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -753,13 +753,12 @@ private:
 
             // Get the fake property holding the mixes
             auto mixMethod = ownerKlass.data(gs)->findMethod(gs, core::Names::mixedInClassMethods());
-            auto loc = core::Loc(ownerKlass.data(gs)->loc().file(), send->loc);
             if (!mixMethod.exists()) {
                 // We never stored a mixin in this symbol
                 // Create a the fake property that will hold the mixed in modules
-                mixMethod = gs.enterMethodSymbol(loc, ownerKlass, core::Names::mixedInClassMethods());
-                vector<core::TypePtr> targs;
-                mixMethod.data(gs)->resultType = core::make_type<core::TupleType>(move(targs));
+                mixMethod = gs.enterMethodSymbol(core::Loc{todo.file, send->loc}, ownerKlass,
+                                                 core::Names::mixedInClassMethods());
+                mixMethod.data(gs)->resultType = core::make_type<core::TupleType>(vector<core::TypePtr>{});
 
                 // Create a dummy block argument to satisfy sanitycheck during GlobalState::expandNames
                 auto &arg = gs.enterMethodArgumentSymbol(core::Loc::none(), mixMethod, core::Names::blkArg());


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
This is a follow-on fix for the problem that was addressed in #5232: the symptom of that crash is that a segfault occurred when a file's contents were indexed with a loc whose bounds were invalid. The root is the handling of `mixes_in_class_methods` in the resolver, where the file present on the owning symbol didn't match the context of the `mixes_in_class_methods` send. The solution is to use `todo.file` instead, as that will match the `LocOffsets` of the send, which is used as the location for the magic `<mixed_in_class_methods>` method symbol.

I also moved the loc construction into the conditional, as theres no need to construct it if the symbol already exists.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Consistent file on `Loc`s created when processing `mixes_in_class_methods`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
