### PR TITLE
Thread `--trace-lexer` option through pipeline

### DIFF
--- a/ast/desugar/test/desugar_test.cc
+++ b/ast/desugar/test/desugar_test.cc
@@ -28,8 +28,8 @@ TEST_CASE("SimpleDesugar") { // NOLINT
     sorbet::core::UnfreezeFileTable ft(gs);
 
     sorbet::core::FileRef fileId = gs.enterFile("<test>", "def hello_world; p :hello; end");
-    auto trace = false;
-    auto ast = sorbet::parser::Parser::run(gs, fileId, trace);
+    auto settings = sorbet::parser::Parser::Settings{};
+    auto ast = sorbet::parser::Parser::run(gs, fileId, settings);
     sorbet::core::MutableContext ctx(gs, sorbet::core::Symbols::root(), fileId);
     auto o1 = sorbet::ast::desugar::node2Tree(ctx, move(ast));
 }

--- a/infer/test/infer_test.cc
+++ b/infer/test/infer_test.cc
@@ -32,8 +32,8 @@ void processSource(core::GlobalState &cb, string str) {
     sorbet::core::UnfreezeSymbolTable st(cb);
     sorbet::core::UnfreezeFileTable ft(cb);
     core::FileRef fileId = cb.enterFile("<test>", str);
-    auto trace = false;
-    auto ast = parser::Parser::run(cb, fileId, trace);
+    auto settings = parser::Parser::Settings{};
+    auto ast = parser::Parser::run(cb, fileId, settings);
     sorbet::core::MutableContext ctx(cb, core::Symbols::root(), fileId);
     auto tree = ast::ParsedFile{ast::desugar::node2Tree(ctx, move(ast)), fileId};
     tree.tree = rewriter::Rewriter::run(ctx, move(tree.tree));

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -404,6 +404,7 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
 
     // Developer options
     options.add_options("dev")("p,print", to_string(all_prints), cxxopts::value<vector<string>>(), "type");
+    options.add_options("dev")("trace-lexer", "Emit the lexer's token stream in a debug format");
     options.add_options("dev")("trace-parser", "Enable bison's parser trace functionality");
     options.add_options("dev")("autogen-subclasses-parent",
                                "Parent classes for which generate a list of subclasses. "
@@ -839,6 +840,7 @@ void readOptions(Options &opts,
             opts.suggestUnsafe = raw["suggest-unsafe"].as<string>();
         }
         opts.waitForDebugger = raw["wait-for-dbg"].as<bool>();
+        opts.traceLexer = raw["trace-lexer"].as<bool>();
         opts.traceParser = raw["trace-parser"].as<bool>();
         opts.stressIncrementalResolver = raw["stress-incremental-resolver"].as<bool>();
         opts.sleepInSlowPath = raw["sleep-in-slow-path"].as<bool>();

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -146,6 +146,7 @@ struct Options {
     std::string watchmanPath = "watchman";
     bool stressIncrementalResolver = false;
     bool sleepInSlowPath = false;
+    bool traceLexer = false;
     bool traceParser = false;
     bool noErrorCount = false;
     bool autocorrect = false;

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -108,12 +108,13 @@ ast::ExpressionPtr fetchTreeFromCache(core::GlobalState &gs, core::FileRef fref,
 }
 
 unique_ptr<parser::Node> runParser(core::GlobalState &gs, core::FileRef file, const options::Printers &print,
-                                   bool trace) {
+                                   bool traceLexer, bool traceParser) {
     Timer timeit(gs.tracer(), "runParser", {{"file", string(file.data(gs).path())}});
     unique_ptr<parser::Node> nodes;
     {
         core::UnfreezeNameTable nameTableAccess(gs); // enters strings from source code as names
-        nodes = parser::Parser::run(gs, file, trace);
+        auto settings = parser::Parser::Settings{traceLexer, traceParser};
+        nodes = parser::Parser::run(gs, file, settings);
     }
     if (print.ParseTree.enabled) {
         print.ParseTree.fmt("{}\n", nodes->toStringWithTabs(gs, 0));
@@ -177,7 +178,7 @@ ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, c
             if (file.data(lgs).strictLevel == core::StrictLevel::Ignore) {
                 return emptyParsedFile(file);
             }
-            auto parseTree = runParser(lgs, file, print, opts.traceParser);
+            auto parseTree = runParser(lgs, file, print, opts.traceLexer, opts.traceParser);
             if (opts.stopAfterPhase == options::Phase::PARSER) {
                 return emptyParsedFile(file);
             }

--- a/namer/test/namer_test.cc
+++ b/namer/test/namer_test.cc
@@ -30,8 +30,8 @@ ast::ParsedFile getTree(core::GlobalState &gs, string str) {
     sorbet::core::UnfreezeNameTable nameTableAccess(gs); // enters original strings
     sorbet::core::UnfreezeFileTable ft(gs);              // enters original strings
     auto file = gs.enterFile("<test>", str);
-    auto trace = false;
-    auto tree = parser::Parser::run(gs, file, trace);
+    auto settings = parser::Parser::Settings{};
+    auto tree = parser::Parser::run(gs, file, settings);
     file.data(gs).strictLevel = core::StrictLevel::Strict;
     sorbet::core::MutableContext ctx(gs, core::Symbols::root(), file);
     auto ast = ast::desugar::node2Tree(ctx, move(tree));

--- a/parser/parser.h
+++ b/parser/parser.h
@@ -7,7 +7,15 @@ namespace sorbet::parser {
 
 class Parser final {
 public:
-    static std::unique_ptr<Node> run(core::GlobalState &gs, core::FileRef file, bool trace,
+    struct Settings {
+        bool traceLexer : 1;
+        bool traceParser : 1;
+
+        Settings() : traceLexer(false), traceParser(false) {}
+        Settings(bool traceLexer, bool traceParser) : traceLexer(traceLexer), traceParser(traceParser) {}
+    };
+
+    static std::unique_ptr<Node> run(core::GlobalState &gs, core::FileRef file, Settings settings,
                                      std::vector<std::string> initialLocals = {});
 };
 

--- a/parser/parser/cc/driver.cc
+++ b/parser/parser/cc/driver.cc
@@ -8,12 +8,13 @@
 namespace ruby_parser {
 
 base_driver::base_driver(ruby_version version, std::string_view source, sorbet::StableStringStorage<> &scratch,
-                         const struct builder &builder)
-    : build(builder), lex(diagnostics, version, source, scratch), pending_error(false), def_level(0), ast(nullptr) {}
+                         const struct builder &builder, bool traceLexer)
+    : build(builder), lex(diagnostics, version, source, scratch, traceLexer), pending_error(false), def_level(0),
+      ast(nullptr) {}
 
 typedruby_release27::typedruby_release27(std::string_view source, sorbet::StableStringStorage<> &scratch,
-                                         const struct builder &builder)
-    : base_driver(ruby_version::RUBY_27, source, scratch, builder) {}
+                                         const struct builder &builder, bool traceLexer)
+    : base_driver(ruby_version::RUBY_27, source, scratch, builder, traceLexer) {}
 
 ForeignPtr typedruby_release27::parse(SelfPtr self, bool) {
     bison::typedruby_release27::parser p(*this, self);
@@ -22,12 +23,12 @@ ForeignPtr typedruby_release27::parse(SelfPtr self, bool) {
 }
 
 typedruby_debug27::typedruby_debug27(std::string_view source, sorbet::StableStringStorage<> &scratch,
-                                     const struct builder &builder)
-    : base_driver(ruby_version::RUBY_27, source, scratch, builder) {}
+                                     const struct builder &builder, bool traceLexer)
+    : base_driver(ruby_version::RUBY_27, source, scratch, builder, traceLexer) {}
 
-ForeignPtr typedruby_debug27::parse(SelfPtr self, bool trace) {
+ForeignPtr typedruby_debug27::parse(SelfPtr self, bool traceParser) {
     bison::typedruby_debug27::parser p(*this, self);
-    p.set_debug_level(trace ? 1 : 0);
+    p.set_debug_level(traceParser ? 1 : 0);
     p.parse();
     return ast;
 }

--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -486,7 +486,7 @@ void parser::error(const ruby_parser::location &lloc, const std::string &msg) {
 
 	driver.diagnostics.emplace_back(
 		dlevel::ERROR, dclass::UnexpectedToken,
-		diagnostic::range(driver.lex.last_token_s, driver.lex.last_token_e),
+		diagnostic::range(lloc.begin, lloc.end),
 		error_message);
 }
 

--- a/parser/parser/cc/lexer.rl
+++ b/parser/parser/cc/lexer.rl
@@ -2875,9 +2875,6 @@ void lexer::set_state_expr_value() {
 
 token_t lexer::advance() {
   auto tok = advance_();
-
-  last_token_s = tok->start();
-  last_token_e = tok->end();
   return tok;
 }
 

--- a/parser/parser/cc/lexer.rl
+++ b/parser/parser/cc/lexer.rl
@@ -120,7 +120,7 @@ using namespace std::string_literals;
 
 %% prepush { check_stack_capacity(); }
 
-lexer::lexer(diagnostics_t &diag, ruby_version version, std::string_view source_buffer, sorbet::StableStringStorage<> &scratch)
+lexer::lexer(diagnostics_t &diag, ruby_version version, std::string_view source_buffer, sorbet::StableStringStorage<> &scratch, bool traceLexer)
   : diagnostics(diag)
   , version(version)
   , source_buffer(source_buffer)
@@ -143,6 +143,7 @@ lexer::lexer(diagnostics_t &diag, ruby_version version, std::string_view source_
   , num_xfrm(num_xfrm_type::NONE)
   , escape_s(nullptr)
   , herebody_s(nullptr)
+  , traceLexer(traceLexer)
   , in_kwarg(false)
 {
   assert(!source_buffer.empty());
@@ -2875,6 +2876,11 @@ void lexer::set_state_expr_value() {
 
 token_t lexer::advance() {
   auto tok = advance_();
+
+  if (this->traceLexer) {
+    std::cerr << *tok << std::endl;
+  }
+
   return tok;
 }
 

--- a/parser/parser/cc/token.cc
+++ b/parser/parser/cc/token.cc
@@ -29,3 +29,9 @@ std::string_view token::view() const {
 std::string token::asString() const {
     return std::string(_string);
 }
+
+std::ostream &operator<<(std::ostream &o, const ruby_parser::token &token) {
+    return o << "ruby_parser::token{.start = " << token.start() << ", .end = " << token.end()
+             << ", .type = " << ruby_parser::token::tokenTypeName(token.type()) << ", .str = \"" << token.view()
+             << "\" }";
+}

--- a/parser/parser/include/ruby_parser/driver.hh
+++ b/parser/parser/include/ruby_parser/driver.hh
@@ -276,9 +276,9 @@ public:
     token_t last_token;
 
     base_driver(ruby_version version, std::string_view source, sorbet::StableStringStorage<> &scratch,
-                const struct builder &builder);
+                const struct builder &builder, bool traceLexer);
     virtual ~base_driver() {}
-    virtual ForeignPtr parse(SelfPtr self, bool trace) = 0;
+    virtual ForeignPtr parse(SelfPtr self, bool traceParser) = 0;
 
     bool valid_kwarg_name(const token *name) {
         char c = name->view().at(0);
@@ -309,15 +309,17 @@ public:
 
 class typedruby_release27 : public base_driver {
 public:
-    typedruby_release27(std::string_view source, sorbet::StableStringStorage<> &scratch, const struct builder &builder);
-    virtual ForeignPtr parse(SelfPtr self, bool trace);
+    typedruby_release27(std::string_view source, sorbet::StableStringStorage<> &scratch, const struct builder &builder,
+                        bool traceLexer);
+    virtual ForeignPtr parse(SelfPtr self, bool traceParser);
     ~typedruby_release27() {}
 };
 
 class typedruby_debug27 : public base_driver {
 public:
-    typedruby_debug27(std::string_view source, sorbet::StableStringStorage<> &scratch, const struct builder &builder);
-    virtual ForeignPtr parse(SelfPtr self, bool trace);
+    typedruby_debug27(std::string_view source, sorbet::StableStringStorage<> &scratch, const struct builder &builder,
+                      bool traceLexer);
+    virtual ForeignPtr parse(SelfPtr self, bool traceParser);
     ~typedruby_debug27() {}
 };
 

--- a/parser/parser/include/ruby_parser/lexer.hh
+++ b/parser/parser/include/ruby_parser/lexer.hh
@@ -135,6 +135,8 @@ private:
     // indentation purposes.
     optional_size dedentLevel_;
 
+    bool traceLexer;
+
     void check_stack_capacity();
     int stack_pop();
     int arg_or_cmdarg(int cmd_state);
@@ -185,7 +187,7 @@ public:
     Context context;
 
     lexer(diagnostics_t &diag, ruby_version version, std::string_view source_buffer,
-          sorbet::StableStringStorage<> &scratch);
+          sorbet::StableStringStorage<> &scratch, bool traceLexer);
 
     // Main interface consumed by yylex function in parser
     token_t advance();

--- a/parser/parser/include/ruby_parser/lexer.hh
+++ b/parser/parser/include/ruby_parser/lexer.hh
@@ -181,9 +181,6 @@ public:
     state_stack cond;
     state_stack cmdarg;
 
-    size_t last_token_s;
-    size_t last_token_e;
-
     bool in_kwarg; // true at the end of "def foo a:"
     Context context;
 

--- a/parser/parser/include/ruby_parser/token.hh
+++ b/parser/parser/include/ruby_parser/token.hh
@@ -188,9 +188,23 @@ public:
     void setEnd(size_t end);
     std::string_view view() const;
     std::string asString() const;
+
+    static std::string_view tokenTypeName(token_type type) {
+#ifndef YYBISON
+        switch (type) {
+#define XX(name, value)    \
+    case token_type::name: \
+        return std::string_view(#name);
+            RUBY_PARSER_TOKEN_TYPES(XX)
+#undef XX
+        }
+#endif
+    }
 };
 
 using token_t = token *;
 } // namespace ruby_parser
+
+std::ostream &operator<<(std::ostream &o, const ruby_parser::token &token);
 
 #endif

--- a/parser/test/parser_test.cc
+++ b/parser/test/parser_test.cc
@@ -25,13 +25,13 @@ TEST_CASE("SimpleParse") { // NOLINT
     gs.initEmpty();
     sorbet::core::UnfreezeNameTable nameTableAccess(gs);
     sorbet::core::UnfreezeFileTable ft(gs);
-    auto trace = false;
+    auto settings = sorbet::parser::Parser::Settings{};
     sorbet::core::FileRef fileId1 = gs.enterFile("<test1>", "def hello_world; p :hello; end");
-    sorbet::parser::Parser::run(gs, fileId1, trace);
+    sorbet::parser::Parser::run(gs, fileId1, settings);
     sorbet::core::FileRef fileId2 = gs.enterFile("<test2>", "class A; class B; end; end");
-    sorbet::parser::Parser::run(gs, fileId2, trace);
+    sorbet::parser::Parser::run(gs, fileId2, settings);
     sorbet::core::FileRef fileId3 = gs.enterFile("<test3>", "class A::B; module B; end; end");
-    sorbet::parser::Parser::run(gs, fileId3, trace);
+    sorbet::parser::Parser::run(gs, fileId3, settings);
 }
 
 struct DedentTest {

--- a/test/cli/help/help.out
+++ b/test/cli/help/help.out
@@ -206,6 +206,8 @@ Usage:
                                 file-table-full-messagepack, missing-constants, autogen,
                                 autogen-msgpack, autogen-autoloader,
                                 autogen-subclasses, package-tree, minimized-rbi]
+      --trace-lexer             Emit the lexer's token stream in a debug
+                                format
       --trace-parser            Enable bison's parser trace functionality
       --autogen-subclasses-parent string
                                 Parent classes for which generate a list of

--- a/test/error-check-test.cc
+++ b/test/error-check-test.cc
@@ -38,8 +38,8 @@ TEST_CASE("ParserCheck") {
     sorbet::core::UnfreezeFileTable ft(gs);
 
     core::FileRef fileId = gs.enterFile("<test input>", "a");
-    auto trace = false;
-    auto ast = sorbet::parser::Parser::run(gs, fileId, trace);
+    auto settings = parser::Parser::Settings{};
+    auto ast = sorbet::parser::Parser::run(gs, fileId, settings);
 
     try {
         sorbet::core::MutableContext ctx(gs, core::Symbols::root(), fileId);

--- a/test/parser_test_runner.cc
+++ b/test/parser_test_runner.cc
@@ -127,8 +127,8 @@ TEST_CASE("WhitequarkParserTest") {
             // whitequark/parser declares these 3 meta variables to
             // simplify testing cases around local variables
             vector<string> initialLocals = {"foo", "bar", "baz"};
-            auto trace = false;
-            nodes = parser::Parser::run(gs, file, trace, initialLocals);
+            auto settings = parser::Parser::Settings{};
+            nodes = parser::Parser::run(gs, file, settings, initialLocals);
         }
         {
             errorQueue->flushAllErrors(gs);

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -245,8 +245,8 @@ TEST_CASE("PerPhaseTest") { // NOLINT
         {
             core::UnfreezeNameTable nameTableAccess(*gs); // enters original strings
 
-            auto trace = false;
-            nodes = parser::Parser::run(*gs, file, trace);
+            auto settings = parser::Parser::Settings{};
+            nodes = parser::Parser::run(*gs, file, settings);
         }
 
         handler.drainErrors(*gs);
@@ -343,8 +343,8 @@ TEST_CASE("PerPhaseTest") { // NOLINT
             for (auto file : files) {
                 core::UnfreezeNameTable nameTableAccess(*rbiGenGs); // enters original strings
 
-                auto trace = false;
-                auto nodes = parser::Parser::run(*rbiGenGs, file, trace);
+                auto settings = parser::Parser::Settings{};
+                auto nodes = parser::Parser::run(*rbiGenGs, file, settings);
                 core::MutableContext ctx(*rbiGenGs, core::Symbols::root(), file);
                 auto tree = ast::ParsedFile{ast::desugar::node2Tree(ctx, move(nodes)), file};
                 tree = ast::ParsedFile{rewriter::Rewriter::run(ctx, move(tree.tree)), tree.file};
@@ -672,8 +672,8 @@ TEST_CASE("PerPhaseTest") { // NOLINT
         gs->replaceFile(f.file, move(newFile));
 
         // this replicates the logic of pipeline::indexOne
-        auto trace = false;
-        auto nodes = parser::Parser::run(*gs, f.file, trace);
+        auto settings = parser::Parser::Settings{};
+        auto nodes = parser::Parser::run(*gs, f.file, settings);
         handler.addObserved(*gs, "parse-tree", [&]() { return nodes->toString(*gs); });
         handler.addObserved(*gs, "parse-tree-json", [&]() { return nodes->toJSON(*gs); });
 

--- a/test/pkg_autocorrects_test.cc
+++ b/test/pkg_autocorrects_test.cc
@@ -51,8 +51,8 @@ struct TestPackageFile {
             core::UnfreezeNameTable nameTableAccess(gs);
             // run parser
             for (auto file : files) {
-                auto trace = false;
-                auto nodes = parser::Parser::run(gs, file, trace);
+                auto settings = parser::Parser::Settings{};
+                auto nodes = parser::Parser::run(gs, file, settings);
 
                 core::MutableContext ctx(gs, core::Symbols::root(), file);
                 auto parsedFile = ast::ParsedFile{ast::desugar::node2Tree(ctx, move(nodes)), file};


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Unlike Bison which has built-in support for tracing, Ragel just runs the code
you tell it to. I've added a simple `--trace-lexer` option that prints out the
tokens and some metadata about them.

I'm not attached to the particular format, and we might want to add (or even
remove) things from it in the future. In particular, it doesn't print the `cs`
variable (the lexer's current state machine state) because there's no easy way
to go from the `int` describing the state to a human-readable version of the
state. (I've [started a feature request][1] for that here.)

[1]: https://github.com/adrian-thurston/ragel/discussions/82

**ALSO**, I noticed that after the changes introduced in #5081 that the
`last_token_s` and `last_token_e` variables maintained in the lexer were
actually redundant, so I've removed them.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tested that this worked manually