### PR TITLE
Remove an unnecessary nullptr check in Trees.cc

### DIFF
--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -304,12 +304,6 @@ ConstantLit::fullUnresolvedPath(const core::GlobalState &gs) const {
     }
     ENFORCE(this->resolutionScopes != nullptr && !this->resolutionScopes->empty());
 
-    // TODO: investigate why this is necessary, it being after the ENFORCE suggests that it only happens in a release
-    // build
-    if (this->resolutionScopes == nullptr) {
-        return nullopt;
-    }
-
     vector<core::NameRef> namesFailedToResolve;
     auto *nested = this;
     {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
This nullptr check is no longer necessary -- I can't reproduce a crash with it removed. I suspect that the crash was related to the one fixed in #5232.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Cleaning up todos from mering #5067.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
