### PR TITLE
Fix crash in completion with bad TypeConstraints

### DIFF
--- a/test/testdata/lsp/completion/constr.rb
+++ b/test/testdata/lsp/completion/constr.rb
@@ -1,0 +1,10 @@
+# typed: true
+
+extend T::Sig
+
+xs = T.let([], T::Array[Integer])
+
+xs.each.map do |x|
+  x
+end
+#  ^ completion: (nothing)

--- a/test/testdata/lsp/completion/constr.rb
+++ b/test/testdata/lsp/completion/constr.rb
@@ -4,7 +4,12 @@ extend T::Sig
 
 xs = T.let([], T::Array[Integer])
 
+# This completion result is a bit non-sensical at the moment (it doesn't makes
+# sense to return any results there) but at least it doesn't crash Sorbet like
+# it used to. If you made a change that improves this test, feel free to delete
+# this comment.
+
 xs.each.map do |x|
   x
 end
-#  ^ completion: (nothing)
+#  ^ completion: each, ...


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This was causing lots of crashes in LSP mode.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I confirmed that the included test caused a crash before this change.

The exception happened in `TypeConstraint::findSolution` because we would be
looking in a solved type constraint for the solution to a type variable that did
not exist in that `TypeConstraint`'s solution set.