### PR TITLE
Raise errors when keyword args are given to T combinators

### DIFF
--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -534,19 +534,13 @@ void unexpectedKwargs(core::Context ctx, const ast::Send &send) {
         name.append(send.fun.shortName(ctx));
         e.setHeader("`{}` does not accept keyword arguments", name);
 
-        core::LocOffsets start;
-        if (send.hasPosArgs()) {
-            // Using the endPos of the last positional argument ensures that we also cut out the trailing comma on that
-            // argument.
-            auto end = send.getPosArg(send.numPosArgs() - 1).loc().endPos();
-            start = core::LocOffsets{end, end};
-        } else {
-            start = send.getKwKey(0).loc();
-        }
-
+        auto start = send.getKwKey(0).loc();
         auto end = send.getKwValue(send.numKwArgs() - 1).loc();
-        if (start.exists()) {
-            e.replaceWith("Remove keyword args", core::Loc{ctx.file, start.join(end)}, "");
+        if (start.exists() && end.exists()) {
+            core::Loc loc{ctx.file, start.join(end)};
+            if (auto keywords = loc.source(ctx)) {
+                e.replaceWith("Remove keyword args", core::Loc{ctx.file, start.join(end)}, "{{{}}}", *keywords);
+            }
         }
     }
 }

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -524,11 +524,39 @@ bool recurseOrType(core::Context ctx, core::TypePtr type, std::vector<std::strin
     }
 }
 
+void unexpectedKwargs(core::Context ctx, const ast::Send &send) {
+    if (!send.hasKwArgs()) {
+        return;
+    }
+
+    if (auto e = ctx.beginError(send.loc, core::errors::Resolver::InvalidMethodSignature)) {
+        string name = "T.";
+        name.append(send.fun.shortName(ctx));
+        e.setHeader("`{}` does not accept keyword arguments", name);
+
+        core::LocOffsets start;
+        if (send.hasPosArgs()) {
+            // Using the endPos of the last positional argument ensures that we also cut out the trailing comma on that
+            // argument.
+            auto end = send.getPosArg(send.numPosArgs() - 1).loc().endPos();
+            start = core::LocOffsets{end, end};
+        } else {
+            start = send.getKwKey(0).loc();
+        }
+
+        auto end = send.getKwValue(send.numKwArgs() - 1).loc();
+        if (start.exists()) {
+            e.replaceWith("Remove keyword args", core::Loc{ctx.file, start.join(end)}, "");
+        }
+    }
+}
+
 TypeSyntax::ResultType interpretTCombinator(core::Context ctx, const ast::Send &send, const ParsedSig &sig,
                                             TypeSyntaxArgs args) {
     switch (send.fun.rawId()) {
         case core::Names::nilable().rawId(): {
             if (send.numPosArgs() != 1 || send.hasKwArgs()) {
+                unexpectedKwargs(ctx, send);
                 return TypeSyntax::ResultType{core::Types::untypedUntracked(),
                                               core::Symbols::noClassOrModule()}; // error will be reported in infer.
             }
@@ -554,8 +582,8 @@ TypeSyntax::ResultType interpretTCombinator(core::Context ctx, const ast::Send &
             return TypeSyntax::ResultType{core::Types::any(ctx, result.type, core::Types::nilClass()), result.rebind};
         }
         case core::Names::all().rawId(): {
-            if (send.numPosArgs() == 0) {
-                // Error will be reported in infer
+            if (send.numPosArgs() == 0 || send.hasKwArgs()) {
+                unexpectedKwargs(ctx, send);
                 return TypeSyntax::ResultType{core::Types::untypedUntracked(), core::Symbols::noClassOrModule()};
             }
             auto result = getResultTypeWithSelfTypeParams(ctx, send.getPosArg(0), sig, args);
@@ -568,8 +596,8 @@ TypeSyntax::ResultType interpretTCombinator(core::Context ctx, const ast::Send &
             return TypeSyntax::ResultType{result, core::Symbols::noClassOrModule()};
         }
         case core::Names::any().rawId(): {
-            if (send.numPosArgs() == 0) {
-                // Error will be reported in infer
+            if (send.numPosArgs() == 0 || send.hasKwArgs()) {
+                unexpectedKwargs(ctx, send);
                 return TypeSyntax::ResultType{core::Types::untypedUntracked(), core::Symbols::noClassOrModule()};
             }
             auto result = getResultTypeWithSelfTypeParams(ctx, send.getPosArg(0), sig, args);
@@ -582,8 +610,8 @@ TypeSyntax::ResultType interpretTCombinator(core::Context ctx, const ast::Send &
             return TypeSyntax::ResultType{result, core::Symbols::noClassOrModule()};
         }
         case core::Names::typeParameter().rawId(): {
-            if (send.numPosArgs() != 1) {
-                // Error will be reported in infer
+            if (send.numPosArgs() != 1 || send.hasKwArgs()) {
+                unexpectedKwargs(ctx, send);
                 return TypeSyntax::ResultType{core::Types::untypedUntracked(), core::Symbols::noClassOrModule()};
             }
             auto arr = ast::cast_tree<ast::Literal>(send.getPosArg(0));
@@ -604,8 +632,8 @@ TypeSyntax::ResultType interpretTCombinator(core::Context ctx, const ast::Send &
         }
         case core::Names::enum_().rawId():
         case core::Names::deprecatedEnum().rawId(): {
-            if (send.numPosArgs() != 1) {
-                // Error will be reported in infer
+            if (send.numPosArgs() != 1 || send.hasKwArgs()) {
+                unexpectedKwargs(ctx, send);
                 return TypeSyntax::ResultType{core::Types::untypedUntracked(), core::Symbols::noClassOrModule()};
             }
 
@@ -650,8 +678,8 @@ TypeSyntax::ResultType interpretTCombinator(core::Context ctx, const ast::Send &
             return TypeSyntax::ResultType{result, core::Symbols::noClassOrModule()};
         }
         case core::Names::classOf().rawId(): {
-            if (send.numPosArgs() != 1) {
-                // Error will be reported in infer
+            if (send.numPosArgs() != 1 || send.hasKwArgs()) {
+                unexpectedKwargs(ctx, send);
                 return TypeSyntax::ResultType{core::Types::untypedUntracked(), core::Symbols::noClassOrModule()};
             }
 

--- a/test/cli/autocorrect-t-combinator-kwargs/autocorrect-t-combinator-kwargs.out
+++ b/test/cli/autocorrect-t-combinator-kwargs/autocorrect-t-combinator-kwargs.out
@@ -1,0 +1,86 @@
+autocorrect-t-combinator-kwargs.rb:8: `T.nilable` does not accept keyword arguments https://srb.help/5003
+     8 |      nilable: T.nilable(x: Integer),
+                       ^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    autocorrect-t-combinator-kwargs.rb:8: Replaced with `{x: Integer}`
+     8 |      nilable: T.nilable(x: Integer),
+                                 ^^^^^^^^^^
+
+autocorrect-t-combinator-kwargs.rb:9: `T.all` does not accept keyword arguments https://srb.help/5003
+     9 |      all: T.all(Integer, M, a: Integer, b: String),
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    autocorrect-t-combinator-kwargs.rb:9: Replaced with `{a: Integer, b: String}`
+     9 |      all: T.all(Integer, M, a: Integer, b: String),
+                                     ^^^^^^^^^^^^^^^^^^^^^
+
+autocorrect-t-combinator-kwargs.rb:10: `T.any` does not accept keyword arguments https://srb.help/5003
+    10 |      any: T.any(Integer, String, a: Integer, b: String),
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    autocorrect-t-combinator-kwargs.rb:10: Replaced with `{a: Integer, b: String}`
+    10 |      any: T.any(Integer, String, a: Integer, b: String),
+                                          ^^^^^^^^^^^^^^^^^^^^^
+
+autocorrect-t-combinator-kwargs.rb:11: `T.type_parameter` does not accept keyword arguments https://srb.help/5003
+    11 |      param: T.type_parameter(a: Integer),
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    autocorrect-t-combinator-kwargs.rb:11: Replaced with `{a: Integer}`
+    11 |      param: T.type_parameter(a: Integer),
+                                      ^^^^^^^^^^
+
+autocorrect-t-combinator-kwargs.rb:12: `T.deprecated_enum` does not accept keyword arguments https://srb.help/5003
+    12 |      enum: T.deprecated_enum(a: Integer),
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    autocorrect-t-combinator-kwargs.rb:12: Replaced with `{a: Integer}`
+    12 |      enum: T.deprecated_enum(a: Integer),
+                                      ^^^^^^^^^^
+
+autocorrect-t-combinator-kwargs.rb:13: `T.class_of` does not accept keyword arguments https://srb.help/5003
+    13 |      klass: T.class_of(a: Integer),
+                     ^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    autocorrect-t-combinator-kwargs.rb:13: Replaced with `{a: Integer}`
+    13 |      klass: T.class_of(a: Integer),
+                                ^^^^^^^^^^
+
+autocorrect-t-combinator-kwargs.rb:9: Unsupported usage of literal type https://srb.help/7009
+     9 |      all: T.all(Integer, M, a: Integer, b: String),
+                                     ^
+
+autocorrect-t-combinator-kwargs.rb:9: Unsupported usage of literal type https://srb.help/7009
+     9 |      all: T.all(Integer, M, a: Integer, b: String),
+                                                 ^
+
+autocorrect-t-combinator-kwargs.rb:10: Unsupported usage of literal type https://srb.help/7009
+    10 |      any: T.any(Integer, String, a: Integer, b: String),
+                                          ^
+
+autocorrect-t-combinator-kwargs.rb:10: Unsupported usage of literal type https://srb.help/7009
+    10 |      any: T.any(Integer, String, a: Integer, b: String),
+                                                      ^
+Errors: 10
+
+--------------------------------------------------------------------------
+
+# typed: true
+
+module M
+  extend T::Sig
+
+  sig do
+    params(
+      nilable: T.nilable({x: Integer}),
+      all: T.all(Integer, M, {a: Integer, b: String}),
+      any: T.any(Integer, String, {a: Integer, b: String}),
+      param: T.type_parameter({a: Integer}),
+      enum: T.deprecated_enum({a: Integer}),
+      klass: T.class_of({a: Integer}),
+    ).void
+  end
+  def test(nilable, all, any, param, enum, klass)
+  end
+
+end

--- a/test/cli/autocorrect-t-combinator-kwargs/autocorrect-t-combinator-kwargs.rb
+++ b/test/cli/autocorrect-t-combinator-kwargs/autocorrect-t-combinator-kwargs.rb
@@ -1,0 +1,19 @@
+# typed: true
+
+module M
+  extend T::Sig
+
+  sig do
+    params(
+      nilable: T.nilable(x: Integer),
+      all: T.all(Integer, M, a: Integer, b: String),
+      any: T.any(Integer, String, a: Integer, b: String),
+      param: T.type_parameter(a: Integer),
+      enum: T.deprecated_enum(a: Integer),
+      klass: T.class_of(a: Integer),
+    ).void
+  end
+  def test(nilable, all, any, param, enum, klass)
+  end
+
+end

--- a/test/cli/autocorrect-t-combinator-kwargs/autocorrect-t-combinator-kwargs.sh
+++ b/test/cli/autocorrect-t-combinator-kwargs/autocorrect-t-combinator-kwargs.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+cwd="$(pwd)"
+infile="$cwd/test/cli/autocorrect-t-combinator-kwargs/autocorrect-t-combinator-kwargs.rb"
+
+tmp="$(mktemp -d)"
+
+cp "$infile" "$tmp"
+
+cd "$tmp" || exit 1
+if "$cwd/main/sorbet" --silence-dev-message -a autocorrect-t-combinator-kwargs.rb 2>&1; then
+  echo "Expected to fail!"
+  exit 1
+fi
+
+echo
+echo --------------------------------------------------------------------------
+echo
+
+# Also cat the file, to make that the autocorrect applied
+cat autocorrect-t-combinator-kwargs.rb
+
+rm autocorrect-t-combinator-kwargs.rb

--- a/test/testdata/resolver/t_combinator_kwargs.rb
+++ b/test/testdata/resolver/t_combinator_kwargs.rb
@@ -1,0 +1,29 @@
+# typed: true
+
+module M
+  extend T::Sig
+
+  sig do
+    params(
+      nilable: T.nilable(x: Integer),
+      #        ^^^^^^^^^^^^^^^^^^^^^ error: `T.nilable` does not accept keyword arguments
+      all: T.all(Integer, M, a: Integer, b: String),
+      #    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `T.all` does not accept keyword arguments
+      #                      ^ error: Unsupported usage of literal type
+      #                                  ^ error: Unsupported usage of literal type
+      any: T.any(Integer, String, a: Integer, b: String),
+      #    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `T.any` does not accept keyword arguments
+      #                           ^ error: Unsupported usage of literal type
+      #                                       ^ error: Unsupported usage of literal type
+      param: T.type_parameter(a: Integer),
+      #      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `T.type_parameter` does not accept keyword arguments
+      enum: T.deprecated_enum(a: Integer),
+      #     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `T.deprecated_enum` does not accept keyword arguments
+      klass: T.class_of(a: Integer),
+      #      ^^^^^^^^^^^^^^^^^^^^^^ error: `T.class_of` does not accept keyword arguments
+    ).void
+  end
+  def test(nilable, all, any, param, enum, klass)
+  end
+
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Currently `T.nilable(a: Integer)` will silently turn into `T.untyped`. The keyword args are treated as an implicit positional hash when type-checking the send itself, but the type is interpreted as `T.untyped` because of the early-exit in type_syntax.cc when interpreting `T.nilable`.

This PR adds an explicit error for T-combinators that shouldn't accept keyword arguments, and an autocorrect to wrap those arguments in curly braces.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Catching malformed uses of T-combinators.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
