### PR TITLE
Also emit error `Note:` lines in LSP mode

### DIFF
--- a/main/lsp/ErrorReporter.cc
+++ b/main/lsp/ErrorReporter.cc
@@ -144,6 +144,11 @@ void ErrorReporter::pushDiagnostics(uint32_t epoch, core::FileRef file, const ve
                 string message = errorLine.formattedMessage.length() > 0 ? errorLine.formattedMessage : sectionHeader;
                 auto location = config->loc2Location(gs, errorLine.loc);
                 if (location == nullptr) {
+                    // This was probably from an addErrorNote call. Still want to report the note.
+                    location = config->loc2Location(gs, error->loc);
+                    message = "\n    " + message;
+                }
+                if (location == nullptr) {
                     continue;
                 }
                 relatedInformation.push_back(make_unique<DiagnosticRelatedInformation>(std::move(location), message));


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

LSP error messages were missing error notes because they don't have
locations associated with them. The LSP protocol either lets you set the
message or related information. Most clients assume that the message is
a single line. All related information must have a location associated
with it or it's not rendered.

To at least get the error notes to show up, we re-use the error's
location itself.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

**Before**

<img width="774" alt="Screen Shot 2022-02-04 at 11 29 58 PM" src="https://user-images.githubusercontent.com/5544532/152633068-18d93d11-760c-400c-9751-371fc3d32337.png">

**After**

<img width="768" alt="Screen Shot 2022-02-04 at 11 29 19 PM" src="https://user-images.githubusercontent.com/5544532/152633073-c9d8b132-2706-4ed4-bf35-969190a5a0e2.png">
