### PR TITLE
Add proper type for `Proc.new`

### DIFF
--- a/rbi/core/proc.rbi
+++ b/rbi/core/proc.rbi
@@ -361,7 +361,8 @@ class Proc < Object
   # proc = proc_from { "hello" }
   # proc.call   #=> "hello"
   # ```
-  def self.new(*_, &blk); end
+  sig {params(blk: T.untyped).returns(T.attached_class)}
+  def self.new(&blk); end
 
   # Invokes the block with `obj` as the proc's parameter like
   # [`Proc#call`](https://docs.ruby-lang.org/en/2.7.0/Proc.html#method-i-call).

--- a/test/testdata/rbi/proc.rb
+++ b/test/testdata/rbi/proc.rb
@@ -1,3 +1,6 @@
 # typed: true
 
 -> (x) { x }[123]
+
+my_proc = Proc.new {}
+T.reveal_type(my_proc) # error: type: `Proc`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

It looks like this change was accidentally made a long time ago.
Whenever there's an explicit override of `BasicObject.new`, it clobbers Sorbet's
ability to automatically infer the type of `.new` (because it can't know how
that override will necessarily behave--imagine that maybe someone has redefined
`new` to return `nil` in some cases).

There's also the question of docs. In this case, the override was likely added
to be able to show docs.

We can solve for both of these problems by just writing a better `sig` for
`Proc.new`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.