### PR TITLE
add an end-to-end test for RBI generation + typechecking with those RBIs

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -342,6 +342,20 @@ sh_binary(
 )
 
 sh_binary(
+    name = "single_package_runner",
+    srcs = ["test_single_package_runner.sh"],
+    data = [
+        "rbi_gen_package_runner.rb",
+        "//main:sorbet",
+        "@sorbet_ruby_2_7//:ruby",
+    ],
+    deps = [
+        ":logging",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)
+
+sh_binary(
     name = "filecheck",
     testonly = 1,
     srcs = ["filecheck.sh"],

--- a/test/BUILD
+++ b/test/BUILD
@@ -206,14 +206,9 @@ cc_binary(
 
 load(":pipeline_test.bzl", "pipeline_tests", "single_package_rbi_test")
 
-filegroup(
-    name = "rbi_gen_typechecking",
-    srcs = glob(["testdata/package/rbi_gen_typechecking/**/*.rb"]),
-)
-
 single_package_rbi_test(
     name = "end_to_end_rbi_test",
-    deps = [":rbi_gen_typechecking"],
+    rb_files = glob(["testdata/packager/rbi_gen_typechecking/**/*.rb"]),
 )
 
 pipeline_tests(

--- a/test/BUILD
+++ b/test/BUILD
@@ -356,8 +356,8 @@ sh_binary(
     srcs = ["test_single_package_runner.sh"],
     data = [
         "rbi_gen_package_runner.rb",
-        "//main:sorbet",
         "//gems/sorbet-runtime",
+        "//main:sorbet",
         "@sorbet_ruby_2_7//:ruby",
     ],
     deps = [

--- a/test/BUILD
+++ b/test/BUILD
@@ -204,7 +204,17 @@ cc_binary(
     deps = ["//common"],
 )
 
-load(":pipeline_test.bzl", "pipeline_tests")
+load(":pipeline_test.bzl", "pipeline_tests", "single_package_rbi_test")
+
+filegroup(
+    name = "rbi_gen_typechecking",
+    srcs = glob(["testdata/package/rbi_gen_typechecking/**/*.rb"]),
+)
+
+single_package_rbi_test(
+    name = "end_to_end_rbi_test",
+    deps = [":rbi_gen_typechecking"],
+)
 
 pipeline_tests(
     "test_corpus",

--- a/test/BUILD
+++ b/test/BUILD
@@ -357,6 +357,7 @@ sh_binary(
     data = [
         "rbi_gen_package_runner.rb",
         "//main:sorbet",
+        "//gems/sorbet-runtime",
         "@sorbet_ruby_2_7//:ruby",
     ],
     deps = [

--- a/test/BUILD
+++ b/test/BUILD
@@ -206,9 +206,14 @@ cc_binary(
 
 load(":pipeline_test.bzl", "pipeline_tests", "single_package_rbi_test")
 
+filegroup(
+    name = "rbi_gen_typechecking",
+    srcs = glob(["testdata/packager/rbi_gen_typechecking/**/*.rb"]),
+)
+
 single_package_rbi_test(
     name = "end_to_end_rbi_test",
-    rb_files = glob(["testdata/packager/rbi_gen_typechecking/**/*.rb"]),
+    rb_files = ["//test:rbi_gen_typechecking"],
 )
 
 pipeline_tests(

--- a/test/pipeline_test.bzl
+++ b/test/pipeline_test.bzl
@@ -87,7 +87,7 @@ end_to_end_rbi_test = rule(
             default = "//test:single_package_runner",
             executable = True,
         ),
-    }
+    },
 )
 
 def single_package_rbi_test(name, rb_files):

--- a/test/rbi_gen_package_runner.rb
+++ b/test/rbi_gen_package_runner.rb
@@ -170,7 +170,7 @@ module Runner
       puts "Copying RBI files #{rbi_files.to_a}"
       rbi_files.each do |rbi|
         source = File.join(rbi_package_dir, rbi)
-        FileUtils.cp(source, tmpdir)
+        FileUtils.cp(source, File.join(tmpdir, test_directory))
       end
 
       check_call([sorbet, '--stripe-mode', '--stripe-packages', test_directory],

--- a/test/rbi_gen_package_runner.rb
+++ b/test/rbi_gen_package_runner.rb
@@ -169,7 +169,14 @@ module Runner
         FileUtils.cp(source, File.join(tmpdir, test_directory))
       end
 
-      check_call([sorbet, '--stripe-mode', '--ignore', '__package.rb', test_directory],
+      check_call([
+                   sorbet,
+                   '--silence-dev-message',
+                   '--stripe-mode',
+                   '--ignore',
+                   '__package.rb',
+                   test_directory
+                 ],
                  chdir: tmpdir)
     end
   end
@@ -179,6 +186,7 @@ module Runner
     Tempfile.open('package_info') do |package_info_file|
       check_call([
                    sorbet,
+                   '--silence-dev-message',
                    '--stripe-mode',
                    '--stripe-packages',
                    '--dump-package-info',
@@ -200,6 +208,7 @@ module Runner
       Dir.mktmpdir do |rbi_package_dir|
         check_call([
                      sorbet,
+                     '--silence-dev-message',
                      '--stripe-mode',
                      '--package-rbi-output',
                      rbi_package_dir,

--- a/test/rbi_gen_package_runner.rb
+++ b/test/rbi_gen_package_runner.rb
@@ -141,22 +141,22 @@ module Runner
   end
 
   sig {params(sorbet: String, root: String, test_directory: String,
-              files: T::Set[String], rbi_package_dir: String,
+              required_files: T::Set[String], rbi_package_dir: String,
               rbi_files: T::Set[String]).void}
   def self.verify_single_package_typechecking(
-        sorbet, root, test_directory, files,
+        sorbet, root, test_directory, required_files,
         rbi_package_dir, rbi_files)
     Dir.mktmpdir do |tmpdir|
       # Copy the package's Ruby files to the tmpdir, mirroring the directory
       # structure.
-      dirnames = files.map {|f| File.dirname(f)}.uniq
+      dirnames = required_files.map {|f| File.dirname(f)}.uniq
       dirnames.each do |dirname|
         target = File.join(tmpdir, dirname)
         FileUtils.mkdir_p(target)
       end
 
       Dir.chdir(root) do |root|
-        files.each do |f|
+        required_files.each do |f|
           dirname = File.dirname(f)
           target = File.join(tmpdir, dirname)
           FileUtils.cp(f, target)

--- a/test/rbi_gen_package_runner.rb
+++ b/test/rbi_gen_package_runner.rb
@@ -211,15 +211,15 @@ module Runner
         db = PackageDB.new(rbi_package_dir, package_info)
 
         package_info.map do |info|
-          files = T.let(Set.new, T::Set[String])
+          required_files = T.let(Set.new, T::Set[String])
           rbi_files = T.let(Set.new, T::Set[String])
           visited = T.let(Set.new, T::Set[String])
           worklist = T.let([], T::Array[String])
 
           # We always need the rb files from the package itself, but we should only
           # need the RBI files from any transitive imports.
-          files.merge(info.files)
-          files.merge(info.testFiles)
+          required_files.merge(info.files)
+          required_files.merge(info.testFiles)
           visited.add(info.name)
           worklist.append(*info.imports)
           worklist.append(*info.testImports)
@@ -237,7 +237,7 @@ module Runner
             worklist.append(*info_for_dependency.testImports)
           end
 
-          verify_single_package_typechecking(sorbet, root, test_directory, files,
+          verify_single_package_typechecking(sorbet, root, test_directory, required_files,
                                              rbi_package_dir, rbi_files)
         end
       end

--- a/test/rbi_gen_package_runner.rb
+++ b/test/rbi_gen_package_runner.rb
@@ -123,7 +123,6 @@ module Runner
     if chdir
       opts[:chdir] = chdir
     end
-    puts "Calling #{command}"
     pid = T.unsafe(Process).spawn({}, *command, opts)
     Process.wait(pid)
     status = $?
@@ -150,7 +149,6 @@ module Runner
     Dir.mktmpdir do |tmpdir|
       # Copy the package's Ruby files to the tmpdir, mirroring the directory
       # structure.
-      puts "Copying in #{files.to_a}"
       dirnames = files.map {|f| File.dirname(f)}.uniq
       dirnames.each do |dirname|
         target = File.join(tmpdir, dirname)
@@ -161,13 +159,11 @@ module Runner
         files.each do |f|
           dirname = File.dirname(f)
           target = File.join(tmpdir, dirname)
-          puts "Copying #{f} to #{target}"
           FileUtils.cp(f, target)
         end
       end
 
       # Copy the RBI files into the root.
-      puts "Copying RBI files #{rbi_files.to_a}"
       rbi_files.each do |rbi|
         source = File.join(rbi_package_dir, rbi)
         FileUtils.cp(source, File.join(tmpdir, test_directory))

--- a/test/rbi_gen_package_runner.rb
+++ b/test/rbi_gen_package_runner.rb
@@ -1,0 +1,276 @@
+# frozen_string_literal: true
+# typed: true
+
+require 'json'
+require 'optparse'
+require 'set'
+require 'tempfile'
+
+require 'sorbet-runtime'
+
+class Module
+  include T::Sig
+end
+
+class PackageInfo
+  sig {returns(String)}
+  attr_reader :name
+
+  sig {returns(T::Array[String])}
+  attr_reader :imports
+
+  sig {returns(T::Array[String])}
+  attr_reader :testImports
+
+  sig {returns(T::Array[String])}
+  attr_reader :files
+
+  sig {returns(T::Array[String])}
+  attr_reader :testFiles
+
+  sig {returns(String)}
+  attr_reader :mangled_name
+
+  sig {params(hash: T::Hash[T.untyped, T.untyped]).returns(PackageInfo)}
+  def self.from_hash(hash)
+    self.new(hash.fetch("name"),
+                    hash.fetch("imports"),
+                    hash.fetch("testImports"),
+                    hash.fetch("files"),
+                    hash.fetch("testFiles"))
+  end
+
+  private_class_method :new
+
+  sig {params(
+         name: String,
+         imports: T::Array[String],
+         testImports: T::Array[String],
+         files: T::Array[String],
+         testFiles: T::Array[String]).void}
+  def initialize(name, imports, testImports, files, testFiles)
+    @name = name
+    @imports = imports
+    @testImports = testImports
+    @files = files
+    @testFiles = testFiles
+
+    @mangled_name = T.let("#{name.gsub('::', '_')}_Package", String)
+  end
+end
+
+class DependencyInfo < T::Struct
+  const :packageRefs, T::Array[String]
+  const :rbiRefs, T::Array[String]
+
+  def self.load(file)
+    from_hash(JSON.parse(File.read(file)))
+  end
+end
+
+class PackageDB
+  sig {returns(T::Hash[String, String])}
+  attr_reader :rbis
+
+  sig {returns(T::Hash[String, DependencyInfo])}
+  attr_reader :deps
+
+  sig {returns(T::Hash[String, PackageInfo])}
+  attr_reader :info
+
+  sig {params(package_dir: String, package_info: T::Array[PackageInfo]).void}
+  def initialize(package_dir, package_info)
+    @rbis = T.let({}, T::Hash[String, String])
+    @deps = T.let({}, T::Hash[String, DependencyInfo])
+    @info = T.let(package_info.to_h {|info| [info.name, info]}, T::Hash[String, PackageInfo])
+
+    Dir.new(package_dir).each do |entry|
+      next if entry == '.' or entry == '..'
+
+      case
+      when entry =~ /([^.]+).deps.json$/
+        @deps[$1] = DependencyInfo.load(File.join(package_dir, entry))
+      when entry =~ /([^.]+).package.rbi$/
+        @rbis[$1] = entry
+      else
+        raise "Unknown filename in package directory #{entry}"
+      end
+    end
+  end
+
+  sig {params(info: PackageInfo).returns(String)}
+  def lookup_rbi_for(info)
+    rbis.fetch(info.mangled_name)
+  end
+  
+  sig {params(info: PackageInfo).returns(DependencyInfo)}
+  def lookup_deps_for(info)
+    deps.fetch(info.mangled_name)
+  end
+
+  sig {params(name: String).returns(PackageInfo)}
+  def lookup_package_for(name)
+    info.fetch(name)
+  end
+end
+
+module Runner
+  include T::Sig
+
+  sig {params(command: T::Array[String], chdir: T.nilable(String)).void}
+  def self.check_call(command, chdir: nil)
+    opts = {}
+    if chdir
+      opts[:chdir] = chdir
+    end
+    puts "Calling #{command}"
+    pid = T.unsafe(Process).spawn({}, *command, opts)
+    Process.wait(pid)
+    status = $?
+    if status.to_i != 0
+      raise "#{command.join(" ")} exited with #{status.to_i}"
+    end
+  end
+
+  sig {params(package_info_file: Tempfile).returns(T::Array[PackageInfo])}
+  def self.load_package_info(package_info_file)
+    json = JSON.parse(File.read(package_info_file))
+
+    json.map do |package|
+      p = PackageInfo.from_hash(package)
+    end
+  end
+
+  sig {params(sorbet: String, root: String, test_directory: String,
+              files: T::Set[String], rbi_package_dir: String,
+              rbi_files: T::Set[String]).void}
+  def self.verify_single_package_typechecking(
+        sorbet, root, test_directory, files,
+        rbi_package_dir, rbi_files)
+    Dir.mktmpdir do |tmpdir|
+      # Copy the package's Ruby files to the tmpdir, mirroring the directory
+      # structure.
+      puts "Copying in #{files.to_a}"
+      dirnames = files.map {|f| File.dirname(f)}.uniq
+      dirnames.each do |dirname|
+        target = File.join(tmpdir, dirname)
+        FileUtils.mkdir_p(target)
+      end
+
+      Dir.chdir(root) do |root|
+        files.each do |f|
+          dirname = File.dirname(f)
+          target = File.join(tmpdir, dirname)
+          puts "Copying #{f} to #{target}"
+          FileUtils.cp(f, target)
+        end
+      end
+
+      # Copy the RBI files into the root.
+      puts "Copying RBI files #{rbi_files.to_a}"
+      rbi_files.each do |rbi|
+        source = File.join(rbi_package_dir, rbi)
+        FileUtils.cp(source, tmpdir)
+      end
+
+      check_call([sorbet, '--stripe-mode', '--stripe-packages', test_directory],
+                 chdir: tmpdir)
+    end
+  end
+
+  sig {params(sorbet: String, root: String, test_directory: String).void}
+  def self.main(sorbet:, root:, test_directory:)
+    Tempfile.open('package_info') do |package_info_file|
+      check_call([
+                   sorbet,
+                   '--stripe-mode',
+                   '--stripe-packages',
+                   '--dump-package-info',
+                   T.must(package_info_file.path),
+                   test_directory
+                 ], chdir: root)
+      
+      package_info = load_package_info(package_info_file)
+
+      package_directories = package_info.map do |package|
+        dirs = package.files.map {|f| File.dirname(f)}.uniq
+        if dirs.size != 1 
+          raise "Package #{package.name} must be limited to a single directory"
+        end
+
+        dirs[0]
+      end
+      
+      Dir.mktmpdir do |rbi_package_dir|
+        check_call([
+                     sorbet,
+                     '--stripe-mode',
+                     '--package-rbi-output',
+                     rbi_package_dir,
+                     '--ignore',
+                     '__package.rb',
+                     test_directory],
+                   chdir: root)
+
+        db = PackageDB.new(rbi_package_dir, package_info)
+
+        package_info.map do |info|
+          files = T.let(Set.new, T::Set[String])
+          rbi_files = T.let(Set.new, T::Set[String])
+          visited = T.let(Set.new, T::Set[String])
+          worklist = T.let([], T::Array[String])
+
+          # We always need the rb files from the package itself, but we should only
+          # need the RBI files from any transitive imports.
+          files.merge(info.files)
+          files.merge(info.testFiles)
+          visited.add(info.name)
+          worklist.append(*info.imports)
+          worklist.append(*info.testImports)
+
+          while !worklist.empty?
+            pkg = T.must(worklist.pop)
+            next if visited.include?(pkg)
+
+            visited.add(pkg)
+            info_for_dependency = db.lookup_package_for(pkg)
+
+            rbi_files.add(db.lookup_rbi_for(info_for_dependency))
+
+            worklist.append(*info_for_dependency.imports)
+            worklist.append(*info_for_dependency.testImports)
+          end
+
+          verify_single_package_typechecking(sorbet, root, test_directory, files,
+                                             rbi_package_dir, rbi_files)
+        end
+      end
+    end
+  end
+end
+
+if __FILE__ == $0
+  sorbet = T.let(nil, T.nilable(String))
+  root = T.let(nil, T.nilable(String))
+  test_directory = T.let(nil, T.nilable(String))
+
+  OptionParser.new do |opts|
+    opts.on '--sorbet=PATH', 'Path to the Sorbet executable' do |path|
+      sorbet = File.realpath(path)
+    end
+
+    opts.on '--root=PATH', 'Path to the root of the Sorbet checkout' do |path|
+      root = File.realpath(path)
+    end
+
+    opts.on '--test-directory=PATH', 'Relative path to the root of the checked directory' do |path|
+      test_directory = path
+    end
+  end.parse!
+
+  Runner.main(
+    sorbet: T.must(sorbet),
+    root: T.must(root),
+    test_directory: T.must(test_directory)
+  )
+end

--- a/test/rbi_gen_package_runner.rb
+++ b/test/rbi_gen_package_runner.rb
@@ -173,7 +173,7 @@ module Runner
         FileUtils.cp(source, File.join(tmpdir, test_directory))
       end
 
-      check_call([sorbet, '--stripe-mode', '--stripe-packages', test_directory],
+      check_call([sorbet, '--stripe-mode', '--ignore', '__package.rb', test_directory],
                  chdir: tmpdir)
     end
   end

--- a/test/test_single_package_runner.sh
+++ b/test/test_single_package_runner.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -euo pipefail
+
+# --- begin runfiles.bash initialization --- {{{
+# Copy-pasted from Bazel's Bash runfiles library https://github.com/bazelbuild/bazel/blob/defd737761be2b154908646121de47c30434ed51/tools/bash/runfiles/runfiles.bash
+if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  if [[ -f "$0.runfiles_manifest" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
+  elif [[ -f "$0.runfiles/MANIFEST" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
+  elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+    export RUNFILES_DIR="$0.runfiles"
+  fi
+fi
+if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+  # shellcheck disable=SC1090,SC1091
+  source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  # shellcheck disable=SC1090
+  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
+            "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-)"
+else
+  echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
+  exit 1
+fi
+# --- end runfiles.bash initialization --- }}}
+
+# shellcheck source-path=SCRIPTDIR/..
+source "test/logging.sh"
+
+# Argument Parsing #############################################################
+
+inputs=( "$@" )
+
+# Environment Setup ############################################################
+
+root="$PWD"
+
+sorbet="$(rlocation com_stripe_ruby_typer/main/sorbet)"
+ruby="$(rlocation sorbet_ruby_2_7/toolchain/bin/ruby)"
+sorbet_runtime="$(dirname $(rlocation com_stripe_ruby_typer/gems/sorbet-runtime/lib/sorbet-runtime.rb))"
+rbi_gen_package_runner="$(rlocation com_stripe_ruby_typer/test/rbi_gen_package_runner.rb)"
+
+# Main #########################################################################
+
+exec "$ruby" -I "${sorbet_runtime}" "${rbi_gen_package_runner}" --sorbet "${sorbet}" --root="$root" "${inputs[@]}"

--- a/test/test_single_package_runner.sh
+++ b/test/test_single_package_runner.sh
@@ -30,7 +30,7 @@ source "test/logging.sh"
 
 # Argument Parsing #############################################################
 
-inputs=( "$@" )
+test_directory=$1
 
 # Environment Setup ############################################################
 
@@ -43,4 +43,4 @@ rbi_gen_package_runner="$(rlocation com_stripe_ruby_typer/test/rbi_gen_package_r
 
 # Main #########################################################################
 
-exec "$ruby" -I "${sorbet_runtime}" "${rbi_gen_package_runner}" --sorbet "${sorbet}" --root="$root" "${inputs[@]}"
+exec "$ruby" -I "${sorbet_runtime}" "${rbi_gen_package_runner}" --sorbet "${sorbet}" --root="$root" --test-directory="${test_directory}"

--- a/test/testdata/packager/rbi_gen_typechecking/__package.rb
+++ b/test/testdata/packager/rbi_gen_typechecking/__package.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class RBIGenTypechecking < PackageSpec
+  export RBIGenTypechecking
+end

--- a/test/testdata/packager/rbi_gen_typechecking/abstract_class/__package.rb
+++ b/test/testdata/packager/rbi_gen_typechecking/abstract_class/__package.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+# typed: strict
+
+class AbstractClassPackage < PackageSpec
+  export AbstractClassPackage::AbstractClass
+end

--- a/test/testdata/packager/rbi_gen_typechecking/abstract_class/abstract_class.rb
+++ b/test/testdata/packager/rbi_gen_typechecking/abstract_class/abstract_class.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+# typed: strict
+
+class AbstractClassPackage::AbstractClass
+  extend T::Helpers
+  extend T::Sig
+  abstract!
+
+  sig {abstract.returns(String)}
+  def abstract_method; end
+end
+

--- a/test/testdata/packager/rbi_gen_typechecking/flatfiles/__package.rb
+++ b/test/testdata/packager/rbi_gen_typechecking/flatfiles/__package.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Flatfiles < PackageSpec
+  import Opus::Flatfiles
+
+  export Flatfiles::MyFlatfile
+  export Flatfiles::MyXMLNode
+end

--- a/test/testdata/packager/rbi_gen_typechecking/flatfiles/flatfiles.rb
+++ b/test/testdata/packager/rbi_gen_typechecking/flatfiles/flatfiles.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Flatfiles::MyFlatfile < Opus::Flatfiles::Record
+  dsl_required :deprecated?, String
+
+  flatfile do
+    from   1..2, :foo
+    pattern(/A-Za-z/, :bar)
+    field :baz
+  end
+end
+
+class Flatfiles::MyXMLNode < Opus::Flatfiles::MarkupLanguageNodeStruct
+  flatfile do
+    field :quux
+  end
+end

--- a/test/testdata/packager/rbi_gen_typechecking/implements_abstract_class/__package.rb
+++ b/test/testdata/packager/rbi_gen_typechecking/implements_abstract_class/__package.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# typed: strict
+
+class ImplementsAbstractClassPackage < PackageSpec
+  import AbstractClassPackage
+
+  export ImplementsAbstractClassPackage::ConcreteClass
+end

--- a/test/testdata/packager/rbi_gen_typechecking/implements_abstract_class/implementation.rb
+++ b/test/testdata/packager/rbi_gen_typechecking/implements_abstract_class/implementation.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+# typed: strict
+
+class ImplementsAbstractClassPackage::ConcreteClass < AbstractClassPackage::AbstractClass
+  extend T::Sig
+
+  sig {override.returns(String)}
+  def abstract_method
+    "not actually abstract"
+  end
+end

--- a/test/testdata/packager/rbi_gen_typechecking/module.rb
+++ b/test/testdata/packager/rbi_gen_typechecking/module.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+# typed: strict
+
+class RBIGenTypechecking
+end

--- a/test/testdata/packager/rbi_gen_typechecking/opus-flatfiles/__package.rb
+++ b/test/testdata/packager/rbi_gen_typechecking/opus-flatfiles/__package.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Opus::Flatfiles < PackageSpec
+  export Opus::Flatfiles::Record
+  export Opus::Flatfiles::MarkupLanguageNodeStruct
+end

--- a/test/testdata/packager/rbi_gen_typechecking/opus-flatfiles/flatfiles.rb
+++ b/test/testdata/packager/rbi_gen_typechecking/opus-flatfiles/flatfiles.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+# typed: strict
+
+module Opus; end
+module Opus::Flatfiles
+  class Record
+  extend T::Sig
+
+  sig {params(name: T.untyped, type: T.untyped).void}
+  def self.dsl_required(name, type); end
+
+  sig {params(blk: T.proc.void).void}
+  def self.flatfile(&blk); end
+
+  sig {params(name: T.untyped).void}
+  def self.field(name); end
+
+  sig {params(pattern: T.untyped, name: T.untyped).void}
+  def self.pattern(pattern, name); end
+
+  sig {params(pattern: T.untyped, name: T.untyped).void}
+  def self.from(pattern, name); end
+  end
+end
+
+
+module Opus::Flatfiles
+  class MarkupLanguageNodeStruct
+  extend T::Sig
+
+  sig {params(blk: T.proc.void).void}
+  def self.flatfile(&blk); end
+
+  sig {params(name: T.untyped).void}
+  def self.field(name); end
+  end
+end

--- a/test/testdata/packager/rbi_gen_typechecking/opus-flatfiles/flatfiles.rb
+++ b/test/testdata/packager/rbi_gen_typechecking/opus-flatfiles/flatfiles.rb
@@ -1,37 +1,33 @@
 # frozen_string_literal: true
 # typed: strict
 
-module Opus; end
-module Opus::Flatfiles
+class Opus::Flatfiles
   class Record
-  extend T::Sig
+    extend T::Sig
 
-  sig {params(name: T.untyped, type: T.untyped).void}
-  def self.dsl_required(name, type); end
+    sig {params(name: T.untyped, type: T.untyped).void}
+    def self.dsl_required(name, type); end
 
-  sig {params(blk: T.proc.void).void}
-  def self.flatfile(&blk); end
+    sig {params(blk: T.proc.void).void}
+    def self.flatfile(&blk); end
 
-  sig {params(name: T.untyped).void}
-  def self.field(name); end
+    sig {params(name: T.untyped).void}
+    def self.field(name); end
 
-  sig {params(pattern: T.untyped, name: T.untyped).void}
-  def self.pattern(pattern, name); end
+    sig {params(pattern: T.untyped, name: T.untyped).void}
+    def self.pattern(pattern, name); end
 
-  sig {params(pattern: T.untyped, name: T.untyped).void}
-  def self.from(pattern, name); end
+    sig {params(pattern: T.untyped, name: T.untyped).void}
+    def self.from(pattern, name); end
   end
-end
 
-
-module Opus::Flatfiles
   class MarkupLanguageNodeStruct
-  extend T::Sig
+    extend T::Sig
 
-  sig {params(blk: T.proc.void).void}
-  def self.flatfile(&blk); end
+    sig {params(blk: T.proc.void).void}
+    def self.flatfile(&blk); end
 
-  sig {params(name: T.untyped).void}
-  def self.field(name); end
+    sig {params(name: T.untyped).void}
+    def self.field(name); end
   end
 end

--- a/test/testdata/packager/rbi_gen_typechecking/support.rb
+++ b/test/testdata/packager/rbi_gen_typechecking/support.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+# typed: strict
+
+# Runtime support
+class ::Module < Object
+  extend T::Sig
+
+  sig {params(args: T.any(Symbol, String)).returns(T.self_type)}
+  def package_private(*args); self; end
+
+  sig {params(args: T.any(Symbol, String)).returns(T.self_type)}
+  def package_private_class_method(*args); self; end
+end

--- a/test/testdata/packager/rbi_gen_typechecking/uses-flatfiles/__package.rb
+++ b/test/testdata/packager/rbi_gen_typechecking/uses-flatfiles/__package.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# typed: strict
+
+class UsesFlatfiles < PackageSpec
+  import Flatfiles
+
+  export UsesFlatfiles::Client
+end

--- a/test/testdata/packager/rbi_gen_typechecking/uses-flatfiles/user.rb
+++ b/test/testdata/packager/rbi_gen_typechecking/uses-flatfiles/user.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+# typed: strict
+
+module UsesFlatfiles::Client
+  extend T::Sig
+
+  sig {params(x: Flatfiles::MyFlatfile).returns(T.untyped)}
+  def self.do_the_thing(x)
+    x.foo
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

We've landed some changes recently to generate "package RBIs": RBIs that describe the external interfaces of packages.  We also have tests for package RBI generation to ensure that we accurately describe the external interfaces for a range of different scenarios.

What we don't have today, and what this PR adds, is a test that verifies that those generated package RBIs can be used in the place of the packages themselves to type-check code.

The idea behind the PR is simple: given a "project" containing multiple packages that type-checks, we:

1. Generate a description of all the packages themselves: what files they contain, what other packages they depend on, etc.
2. Generate all the RBIs for the packages involved.
3. For each package, copy its files and all the dependent RBIs to a separate directory and typecheck that.

Step three should work for all the packages and provides some assurances that package RBIs can be used as a substitute for the original Ruby files.

This is a little bit different from existing tests; I don't think the logic for the above steps is straightforward to express as a shell scripts if you don't have `jq` or equivalent and I really didn't want to write the logic in C++.  So I wrote a Ruby script instead...and because we use Bazel, writing a shell script wrapper to invoke the ruby script seemed like the most straightforward thing to do.

I don't claim that the Bazel description is perfect, but it does have the merit of working.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

More tests are more better.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
