### PR TITLE
Fix return type for `Module::alias_method` to return a Symbol

### DIFF
--- a/rbi/core/module.rbi
+++ b/rbi/core/module.rbi
@@ -212,7 +212,7 @@ class Module < Object
         new_name: Symbol,
         old_name: Symbol,
     )
-    .returns(T.self_type)
+    .returns(Symbol)
   end
   def alias_method(new_name, old_name); end
 


### PR DESCRIPTION
### Motivation

It seems this method actually [returns a symbol](https://github.com/ruby/ruby/blob/e89d80702bd98a8276243a7fcaa2a158b3bfb659/vm_method.c#L2190):

```
$ irb
> class Foo
>   alias_method(:foo, :to_s)
> end
=> :foo
```

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
