### PR TITLE
Improve LSP messaging for ignored files

### DIFF
--- a/main/lsp/LSPTask.cc
+++ b/main/lsp/LSPTask.cc
@@ -252,7 +252,7 @@ LSPQueryResult LSPTask::queryByLoc(LSPTypecheckerDelegate &typechecker, string_v
 
     if (!fref.exists() && config.isFileIgnored(config.remoteName2Local(uri))) {
         auto error = make_unique<ResponseError>(
-            (int)LSPErrorCodes::RequestFailed,
+            (int)LSPErrorCodes::InvalidParams,
             fmt::format("Ignored file at uri {} in {}", uri, convertLSPMethodToString(forMethod)));
         return LSPQueryResult{{}, move(error)};
     }

--- a/main/lsp/LSPTask.cc
+++ b/main/lsp/LSPTask.cc
@@ -249,6 +249,14 @@ LSPQueryResult LSPTask::queryByLoc(LSPTypecheckerDelegate &typechecker, string_v
     Timer timeit(config.logger, "setupLSPQueryByLoc");
     const core::GlobalState &gs = typechecker.state();
     auto fref = config.uri2FileRef(gs, uri);
+
+    if (!fref.exists() && config.isFileIgnored(config.remoteName2Local(uri))) {
+        auto error = make_unique<ResponseError>(
+            (int)LSPErrorCodes::RequestFailed,
+            fmt::format("Ignored file at uri {} in {}", uri, convertLSPMethodToString(forMethod)));
+        return LSPQueryResult{{}, move(error)};
+    }
+
     if (!fref.exists()) {
         auto error = make_unique<ResponseError>(
             (int)LSPErrorCodes::InvalidParams,

--- a/main/lsp/json_enums.h
+++ b/main/lsp/json_enums.h
@@ -18,6 +18,7 @@ enum class LSPErrorCodes {
 
     // Defined by the LSP
     RequestCancelled = -32800,
+    RequestFailed = -32803,
 };
 
 // Is not an enum, but is as simple as one. Putting it here reduces dependencies on json_types.h.

--- a/main/lsp/json_enums.h
+++ b/main/lsp/json_enums.h
@@ -18,7 +18,6 @@ enum class LSPErrorCodes {
 
     // Defined by the LSP
     RequestCancelled = -32800,
-    RequestFailed = -32803,
 };
 
 // Is not an enum, but is as simple as one. Putting it here reduces dependencies on json_types.h.


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Currently, files that are ignored by Sorbet simply display a message of
the form:

```
[Error - 2:26:36 PM] Request textDocument/hover failed.
  Message: Did not find file at uri file:///path/to/file in textDocument/hover
  Code: -32602
```

which isn't very helpful when trying to determine the cause of the error
itself. Instead, I've updated the messaging for _ignored_ files
specifically along with a more appropriate LSPErrorCode.

```
[Error - 2:26:36 PM] Request textDocument/hover failed.
  Message: Ignored file at uri file:///path/to/file in textDocument/hover
  Code: -32803
```

this is more descriptive and provides the `LSPErrorCodes::RequestFailed`
error which is more descriptive of what occurred.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
