### PR TITLE
Index packages before files when generating package rbis

### DIFF
--- a/packager/rbi_gen.cc
+++ b/packager/rbi_gen.cc
@@ -1257,10 +1257,9 @@ RBIGenerator::RBIOutput RBIGenerator::runOnce(const core::GlobalState &gs, core:
     return exporter.emit();
 }
 
-void RBIGenerator::run(core::GlobalState &gs, vector<ast::ParsedFile> packageFiles, string outputDir,
-                       WorkerPool &workers) {
+void RBIGenerator::run(core::GlobalState &gs, const UnorderedSet<core::ClassOrModuleRef> &packageNamespaces,
+                       string outputDir, WorkerPool &workers) {
     absl::BlockingCounter threadBarrier(std::max(workers.size(), 1));
-    UnorderedSet<core::ClassOrModuleRef> packageNamespaces = buildPackageNamespace(gs, packageFiles, workers);
 
     const auto &packageDB = gs.packageDB();
     auto &packages = packageDB.packages();

--- a/packager/rbi_gen.h
+++ b/packager/rbi_gen.h
@@ -24,8 +24,8 @@ public:
     static RBIOutput runOnce(const core::GlobalState &gs, core::NameRef pkg,
                              const UnorderedSet<core::ClassOrModuleRef> &packageNamespaces);
 
-    static void run(core::GlobalState &gs, std::vector<ast::ParsedFile> packageFiles, std::string outputDir,
-                    WorkerPool &workers);
+    static void run(core::GlobalState &gs, const UnorderedSet<core::ClassOrModuleRef> &packageNamspaces,
+                    std::string outputDir, WorkerPool &workers);
 };
 } // namespace sorbet::packager
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Instead of indexing package files after running all source files through the pipeline, index the package files first to build the package db.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Prework to simplify landing single-package rbi generation.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
