### PR TITLE
Switch to FileRef::dataAllowingUnsafe when finding packages for files

### DIFF
--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -138,7 +138,7 @@ NameRef PackageDB::lookupPackage(NameRef pkgMangledName) const {
 
 const PackageInfo &PackageDB::getPackageForFile(const core::GlobalState &gs, core::FileRef file) const {
     ENFORCE(frozen);
-    auto &fileData = file.data(gs);
+    auto &fileData = file.dataAllowingUnsafe(gs);
     string_view path = fileData.path();
     int curPrefixPos = path.find_last_of('/');
     while (curPrefixPos > 0) {

--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -138,7 +138,14 @@ NameRef PackageDB::lookupPackage(NameRef pkgMangledName) const {
 
 const PackageInfo &PackageDB::getPackageForFile(const core::GlobalState &gs, core::FileRef file) const {
     ENFORCE(frozen);
+
+    // Note about safety: we're only using the file data for two pieces of information: the file path and the
+    // sourceType. The path is present even on unloaded files, and the sourceType we're interested in is `Package`,
+    // which will have been loaded by a previous step for the packageDB to be valid.
+    //
+    // See https://github.com/sorbet/sorbet/pull/5291 for more information.
     auto &fileData = file.dataAllowingUnsafe(gs);
+
     string_view path = fileData.path();
     int curPrefixPos = path.find_last_of('/');
     while (curPrefixPos > 0) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
`PackageDB::packageForFile` only looks at the path of the file, and as a result would be fine to use on reserved but not read files. This PR makes that change by switching the call to `FileRef::data` to `FileRef::dataAllowingUnsafe`.

The only case where this could be a problem is if the `FileRef` given refers to an unread package file. However, I believe that case won't show up for the following reason: if we're looking for package info for a file, the package database will already have been loaded by a previous step. In the case of the packager pass, all `__package.rb` files will be read during indexing, and in the case of rbi generation, we explicitly index all `__package.rb` files before running anything else through the pipeline.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Allow package membership to be queried for files, before the files have been read. This allows us to filter down the files that we run through the pipeline based on package membership, significantly improving the time to generate a single package's rbi.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
