### PR TITLE
Fix doc link

### DIFF
--- a/compiler/README.md
+++ b/compiler/README.md
@@ -64,7 +64,7 @@ TODO(jez) compiler internals
 ## Running Sorbet Ruby and the Sorbet Compiler
 
 For a more complete walk through, see
-[docs/running-compiled-code.md](docs/running-compiled-code.md).
+[docs/running-compiled-code.md](/docs/running-compiled-code.md).
 
 There's a fair amount of set up before you can run Sorbet Ruby on a file or load
 a compiled Ruby file:


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
When I'm reading the Compiler's README, found the doc link is wrong.

