### PR TITLE
Mark LSPTypecheckerDelegate::workers as private

### DIFF
--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -134,11 +134,11 @@ public:
 class LSPTypecheckerDelegate {
     LSPTypechecker &typechecker;
 
-public:
     /** The WorkerPool on which work will be performed. If the task is multithreaded, the pool will contain multiple
      * worker threads. */
     WorkerPool &workers;
 
+public:
     /**
      * Creates a new delegate that runs LSPTypechecker operations on the WorkerPool threads.
      */


### PR DESCRIPTION
### Motivation
It looks like the `workers` field on `LSPTypecheckerDelegate` is not used by anything outside the class. Since the purpose of this class is to expose a safer interface than that exposed by `LSPTypechecker`, I figure it makes sense to `private`-ize.

### Test plan
If it compiles in CI, everything should be fine.