### PR TITLE
avoid allocating strings for sorting package module children

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1547,7 +1547,11 @@ private:
         std::transform(node->children.begin(), node->children.end(), back_inserter(childPairs),
                        [](const auto &pair) { return make_pair(pair.first, pair.second.get()); });
         fast_sort(childPairs, [&ctx](const auto &lhs, const auto &rhs) -> bool {
-            return lhs.first.show(ctx) < rhs.first.show(ctx);
+            int compareResult = lhs.first.shortName(ctx).compare(rhs.first.shortName(ctx));
+            if (compareResult == 0) {
+                return lhs.first.show(ctx) < rhs.first.show(ctx);
+            }
+            return compareResult < 0;
         });
         for (auto const &[nameRef, child] : childPairs) {
             if (parts.empty()) {

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1548,9 +1548,6 @@ private:
                        [](const auto &pair) { return make_pair(pair.first, pair.second.get()); });
         fast_sort(childPairs, [&ctx](const auto &lhs, const auto &rhs) -> bool {
             int compareResult = lhs.first.shortName(ctx).compare(rhs.first.shortName(ctx));
-            if (compareResult == 0) {
-                return lhs.first.show(ctx) < rhs.first.show(ctx);
-            }
             return compareResult < 0;
         });
         for (auto const &[nameRef, child] : childPairs) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

We can go faster if we just sort the `shortName`s of the `NameRef`s that we're dealing with here.  In the rare case that they compare equal, we can stabilize the sort by using their full name.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

`++speed;`  This speeds up the workers part of the package pass on Stripe's codebase by about 20%.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
