### PR TITLE
Fix crash in `textDocument/typeDefinition`

### DIFF
--- a/main/lsp/requests/type_definition.cc
+++ b/main/lsp/requests/type_definition.cc
@@ -40,6 +40,43 @@ vector<core::Loc> locsForType(const core::GlobalState &gs, const core::TypePtr &
             for (auto loc : locsForType(gs, t.right)) {
                 result.emplace_back(loc);
             }
+        },
+        [&](const core::SelfTypeParam &s) {
+            for (auto loc : s.definition.locs(gs)) {
+                result.emplace_back(loc);
+            }
+        },
+        [&](const core::LambdaParam &l) {
+            for (auto loc : l.definition.data(gs)->locs()) {
+                result.emplace_back(loc);
+            }
+        },
+        [&](const core::LiteralType &_) {
+            // nothing
+        },
+        [&](const core::ShapeType &_) {
+            // nothing
+        },
+        [&](const core::TupleType &_) {
+            // nothing
+        },
+        [&](const core::MetaType &_) {
+            // nothing
+        },
+        [&](const core::AliasType &a) {
+            ENFORCE(false, "Please add a test case for this test, and delete this enforce.");
+            for (auto loc : a.symbol.locs(gs)) {
+                result.emplace_back(loc);
+            }
+        },
+        [&](const core::SelfType &_) {
+            ENFORCE(false, "Please add a test case for this test, and delete this enforce.");
+        },
+        [&](const core::TypeVar &s) {
+            ENFORCE(false, "Please add a test case for this test, and delete this enforce.");
+        },
+        [&](const core::TypePtr &t) {
+            Exception::raise("Unhandled case in textDocument/typeDefinition: {}", core::TypePtr::tagToString(t.tag()));
         });
     return result;
 }

--- a/test/testdata/lsp/type_def_edge.rb
+++ b/test/testdata/lsp/type_def_edge.rb
@@ -1,0 +1,52 @@
+# typed: true
+
+extend T::Sig
+
+sig {type_parameters(:U).params(x: T.type_parameter(:U)).void}
+#                    ^^ type-def: test_self_type_param
+def test_self_type_param(x)
+  x
+# ^ type: test_self_type_param
+end
+
+class A
+end
+
+class Generic
+  extend T::Sig
+  extend T::Generic
+  X = type_member
+# ^^^^^^^^^^^^^^^ type-def: test_lambda_param
+
+  sig {params(x: X).void}
+  #              ^ type: test_lambda_param
+  def test_lambda_param(x)
+    x
+  end
+end
+
+class Wrapper
+  class Normal
+    extend T::Sig
+    extend T::Generic
+
+    sig {void}
+    def test_nothings
+      puts(:foo)
+      #      ^ type: (nothing)
+
+      shape = {foo: 0}
+      puts(shape)
+      #    ^ type: (nothing)
+
+      tuple = [0]
+      puts(tuple)
+      #    ^ type: (nothing)
+
+      meta = T.nilable(Integer)
+      puts(meta)
+      #    ^ type: (nothing)
+    end
+
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I noticed this showing up in some crash logs at Stripe.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

Some of the cases I couldn't find test cases for. I've implemented them so that
they won't crash anymore, but it would be nice to have tests for them.