### PR TITLE
Show user-meaningful token names in rest of errors

### DIFF
--- a/parser/parser/cc/driver.cc
+++ b/parser/parser/cc/driver.cc
@@ -19,6 +19,46 @@ const char *const base_driver::token_name(token_type type) {
     //
     // This hack allows to display the real token string instead of tBDOT2/tBDOT3 in parsing errors.
     switch (type) {
+        case token_type::kDO_COND:
+            return "\"do\"";
+        case token_type::kDO_BLOCK:
+            return "\"do\"";
+        case token_type::kDO_LAMBDA:
+            return "\"do\"";
+        case token_type::kIF_MOD:
+            return "\"if\"";
+        case token_type::kUNLESS_MOD:
+            return "\"unless\"";
+        case token_type::kWHILE_MOD:
+            return "\"while\"";
+        case token_type::kUNTIL_MOD:
+            return "\"until\"";
+        case token_type::kRESCUE_MOD:
+            return "\"rescue\"";
+        case token_type::tPOW:
+            return "\"**\"";
+        case token_type::tCOLON3:
+            return "\"::\"";
+        case token_type::tLPAREN2:
+            return "\"(\"";
+        case token_type::tLPAREN_ARG:
+            return "\"(\"";
+        case token_type::tLBRACK2:
+            return "\"[\"";
+        case token_type::tLBRACE_ARG:
+            return "\"{\"";
+        case token_type::tSTAR2:
+            return "\"*\"";
+        case token_type::tAMPER2:
+            return "\"&\"";
+        case token_type::tLCURLY:
+            return "\"{\"";
+        case token_type::tRCURLY:
+            return "\"}\"";
+        case token_type::tUMINUS:
+            return "\"-\"";
+        case token_type::tUPLUS:
+            return "\"+\"";
         case token_type::tBDOT2:
             return "\"..\"";
         case token_type::tBDOT3:

--- a/test/testdata/parser/error_recovery/missing_operator.rb
+++ b/test/testdata/parser/error_recovery/missing_operator.rb
@@ -39,10 +39,10 @@ class A
       puts 'hello'
     end
     puts(4 * 4)
-    puts(4 * ) # error: missing arg to tSTAR2 operator
-    if 4 * # error: missing arg to tSTAR2 operator
+    puts(4 * ) # error: missing arg to "*" operator
+    if 4 * # error: missing arg to "*" operator
     end
-    if 4 * # error: missing arg to tSTAR2 operator
+    if 4 * # error: missing arg to "*" operator
       puts 'hello'
     end
     puts(5 / 5)
@@ -60,38 +60,38 @@ class A
       puts 'hello'
     end
     puts(7 ** 7)
-    puts(7 ** ) # error: missing arg to tPOW operator
-    if 7 ** # error: missing arg to tPOW operator
+    puts(7 ** ) # error: missing arg to "**" operator
+    if 7 ** # error: missing arg to "**" operator
     end
-    if 7 ** # error: missing arg to tPOW operator
+    if 7 ** # error: missing arg to "**" operator
       puts 'hello'
     end
     puts(-8 ** 8)
-    puts(-8 ** ) # error: missing arg to tPOW operator
-    if -8 ** # error: missing arg to tPOW operator
+    puts(-8 ** ) # error: missing arg to "**" operator
+    if -8 ** # error: missing arg to "**" operator
     end
-    if -8 ** # error: missing arg to tPOW operator
+    if -8 ** # error: missing arg to "**" operator
       puts 'hello'
     end
     puts(+9 ** 9)
-    puts(+9 ** ) # error: missing arg to tPOW operator
-    if +9 ** # error: missing arg to tPOW operator
+    puts(+9 ** ) # error: missing arg to "**" operator
+    if +9 ** # error: missing arg to "**" operator
     end
-    if +9 ** # error: missing arg to tPOW operator
+    if +9 ** # error: missing arg to "**" operator
       puts 'hello'
     end
     puts(-10)
-    puts(-) # error: missing arg to tUMINUS operator
-    if - # error: missing arg to tUMINUS operator
+    puts(-) # error: missing arg to "-" operator
+    if - # error: missing arg to "-" operator
     end
-    if - # error: missing arg to tUMINUS operator
+    if - # error: missing arg to "-" operator
       puts 'hello'
     end
     puts(+10)
-    puts(+) # error: missing arg to tUPLUS operator
-    if + # error: missing arg to tUPLUS operator
+    puts(+) # error: missing arg to "+" operator
+    if + # error: missing arg to "+" operator
     end
-    if + # error: missing arg to tUPLUS operator
+    if + # error: missing arg to "+" operator
       puts 'hello'
     end
     puts(10 | 10)
@@ -109,10 +109,10 @@ class A
       puts 'hello'
     end
     puts(12 & 12)
-    puts(12 & ) # error: missing arg to tAMPER2 operator
-    if 12 & # error: missing arg to tAMPER2 operator
+    puts(12 & ) # error: missing arg to "&" operator
+    if 12 & # error: missing arg to "&" operator
     end
-    if 12 & # error: missing arg to tAMPER2 operator
+    if 12 & # error: missing arg to "&" operator
       puts 'hello'
     end
     puts(13 <=> 13)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We mostly show user-meaningful token names by way of Bison's `%token` directive,
but some of our tokens come from identical source strings (depending on lexer
state, they'll get parsed one way or another).

To make up for that, we use this helper, which previously only had a handful of
the tokens in it. This adds basically all the rest of them.

@froydnj requested this as a follow-up to a previous PR of mine.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.