### PR TITLE
Fix crash in canTakeFastPath

### DIFF
--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -164,7 +164,17 @@ private:
         }
 
         // We intentionally do not walk v->ancestors nor v->singletonAncestors.
-        // They are guaranteed to be simple trees in the desugarer.
+        //
+        // These lists used to be guaranteed to be simple trees (only constant literals) by desugar,
+        // but that was later relaxed. In places where walking ancestors is required, instead define
+        // your `preTransformClassDef` method to contain this:
+        //
+        //   for (auto &ancestor : klass.ancestors) {
+        //       ancestor = ast::TreeMap::apply(ctx, *this, std::move(ancestor))
+        //   }
+        //
+        // and that will have the same effect, without having to retroactively change all TreeMaps.
+
         for (auto &def : cast_tree_nonnull<ClassDef>(v).rhs) {
             def = mapIt(std::move(def), ctx.withOwner(cast_tree_nonnull<ClassDef>(v).symbol).withFile(ctx.file));
         }
@@ -624,7 +634,17 @@ private:
         }
 
         // We intentionally do not walk v->ancestors nor v->singletonAncestors.
-        // They are guaranteed to be simple trees in the desugarer.
+        //
+        // These lists used to be guaranteed to be simple trees (only constant literals) by desugar,
+        // but that was later relaxed. In places where walking ancestors is required, instead define
+        // your `preTransformClassDef` method to contain this:
+        //
+        //   for (auto &ancestor : klass.ancestors) {
+        //       ancestor = ast::TreeMap::apply(ctx, *this, std::move(ancestor))
+        //   }
+        //
+        // and that will have the same effect, without having to retroactively change all TreeMaps.
+
         for (auto &def : cast_tree_nonnull<ClassDef>(v).rhs) {
             def = mapIt(std::move(def), ctx.withOwner(cast_tree_nonnull<ClassDef>(v).symbol));
         }

--- a/local_vars/local_vars.cc
+++ b/local_vars/local_vars.cc
@@ -452,6 +452,11 @@ class LocalNameInserter {
 
 public:
     ast::ExpressionPtr preTransformClassDef(core::MutableContext ctx, ast::ExpressionPtr tree) {
+        auto &klass = ast::cast_tree_nonnull<ast::ClassDef>(tree);
+        for (auto &ancestor : klass.ancestors) {
+            ancestor = ast::TreeMap::apply(ctx, *this, std::move(ancestor));
+        }
+
         enterClass();
         return tree;
     }

--- a/test/testdata/lsp/fast_path/crash_local_vars.1.rbupdate
+++ b/test/testdata/lsp/fast_path/crash_local_vars.1.rbupdate
@@ -2,9 +2,10 @@
 
 class Outer
   describe 'client' do
+    #               ^^ error: Hint: this kDO_BLOCK token might not be properly closed
     class Inner <
-    it 'foo' do
+    it 'foo' do # error: Superclasses must only contain constant literals
       1.times {|x| puts(x)}
     end
   end
-end
+end # error: unexpected token "end of file"

--- a/test/testdata/lsp/fast_path/crash_local_vars.1.rbupdate
+++ b/test/testdata/lsp/fast_path/crash_local_vars.1.rbupdate
@@ -1,0 +1,10 @@
+# typed: strict
+
+class Outer
+  describe 'client' do
+    class Inner <
+    it 'foo' do
+      1.times {|x| puts(x)}
+    end
+  end
+end

--- a/test/testdata/lsp/fast_path/crash_local_vars.rb
+++ b/test/testdata/lsp/fast_path/crash_local_vars.rb
@@ -1,0 +1,9 @@
+# typed: strict
+
+class Outer
+  describe 'client' do
+    it 'foo' do
+      1.times {|x| puts(x)}
+    end
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We intentionally do not walk v->ancestors nor v->singletonAncestors.

These lists used to be guaranteed to be simple trees (only constant literals) by desugar, but that was later relaxed. Rather than changing the whole TreeMap data structure and affect all treemaps, I've decided to just change the TreeMap that would like to depend on having walked the ancestors list.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.