### PR TITLE
Allow `Module#===` on generic

### DIFF
--- a/rbi/core/module.rbi
+++ b/rbi/core/module.rbi
@@ -157,8 +157,9 @@ class Module < Object
   # instance of one of *mod*'s descendants. Of limited use for modules, but can
   # be used in `case` statements to classify objects by class.
   sig do
-    params(
-        other: BasicObject,
+    type_parameters(:U)
+    .params(
+        other: T.type_parameter(:U),
     )
     .returns(T::Boolean)
   end

--- a/test/cli/autocorrect-helpers/autocorrect-helpers.out
+++ b/test/cli/autocorrect-helpers/autocorrect-helpers.out
@@ -87,8 +87,8 @@ autocorrect-helpers.rb:30: Method `mixes_in_class_methods` does not exist on `T.
     30 |  mixes_in_class_methods(S1)
         ^
   Did you mean:
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/module.rbi#L1489: `Module#public_class_method`
-    1489 |  def public_class_method(*arg0); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/module.rbi#L1490: `Module#public_class_method`
+    1490 |  def public_class_method(*arg0); end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Errors: 9
 

--- a/test/testdata/rbi/module_triple_equals_generics.rb
+++ b/test/testdata/rbi/module_triple_equals_generics.rb
@@ -1,0 +1,18 @@
+# typed: true
+extend T::Sig
+
+sig do
+  type_parameters(:U)
+  .params(x: T.type_parameter(:U))
+  .returns(T.type_parameter(:U))
+end
+def fake_identity_function(x)
+  case x
+  when Integer
+    T.reveal_type(x) # error: `T.all(Integer, Object#fake_identity_function#U)`
+    return 0 # error: Expected `Object#fake_identity_function#U` but found `Integer(0)` for method result type
+  else
+    T.reveal_type(x) # error: `Object#fake_identity_function#U`
+    return x
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

There's technically no reason why you shouldn't be allowed to do

```
case x
when Integer
end
```

if `x` is a generic type_parameter.

It's a slightly weird signature. An alternative would be to use `T.untyped`, but I figured I'd avoid using `T.untyped`. Writing it this way is basically the only syntax I know to ask Sorbet to type an argument as having type `core::Types::top()` (because `BasicObject` is not the true top type—there are methods on `BasicObject` but no methods on `<top>`).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.