### PR TITLE
Split package db loading up from namespace generation

### DIFF
--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -455,7 +455,6 @@ int realmain(int argc, char *argv[]) {
     gs->errorUrlBase = opts.errorUrlBase;
     gs->semanticExtensions = move(extensions);
     vector<ast::ParsedFile> indexed;
-    UnorderedSet<core::ClassOrModuleRef> packageNamespaces;
 
     gs->requiresAncestorEnabled = opts.requiresAncestorEnabled;
 
@@ -585,7 +584,7 @@ int realmain(int argc, char *argv[]) {
 
             auto packageFileRefs = pipeline::reserveFiles(gs, packageFiles);
             auto packages = pipeline::index(*gs, packageFileRefs, opts, *workers, nullptr);
-            packageNamespaces = packager::RBIGenerator::buildPackageNamespace(*gs, packages, *workers);
+            packages = packager::Packager::findPackages(*gs, *workers, move(packages));
 #endif
         }
 
@@ -737,6 +736,7 @@ int realmain(int argc, char *argv[]) {
             logger->warn("Package rbi generation is disabled in sorbet-orig for faster builds");
             return 1;
 #else
+            auto packageNamespaces = packager::RBIGenerator::buildPackageNamespace(*gs, *workers);
             packager::RBIGenerator::run(*gs, packageNamespaces, opts.packageRBIOutput, *workers);
 #endif
         }

--- a/packager/rbi_gen.cc
+++ b/packager/rbi_gen.cc
@@ -1215,11 +1215,7 @@ public:
 };
 } // namespace
 
-UnorderedSet<core::ClassOrModuleRef>
-RBIGenerator::buildPackageNamespace(core::GlobalState &gs, vector<ast::ParsedFile> &packageFiles, WorkerPool &workers) {
-    // Populate package database.
-    packageFiles = Packager::findPackages(gs, workers, move(packageFiles));
-
+UnorderedSet<core::ClassOrModuleRef> RBIGenerator::buildPackageNamespace(core::GlobalState &gs, WorkerPool &workers) {
     const auto &packageDB = gs.packageDB();
 
     auto &packages = packageDB.packages();

--- a/packager/rbi_gen.h
+++ b/packager/rbi_gen.h
@@ -19,8 +19,7 @@ public:
     };
 
     // Exposed for testing.
-    static UnorderedSet<core::ClassOrModuleRef>
-    buildPackageNamespace(core::GlobalState &gs, std::vector<ast::ParsedFile> &packageFiles, WorkerPool &workers);
+    static UnorderedSet<core::ClassOrModuleRef> buildPackageNamespace(core::GlobalState &gs, WorkerPool &workers);
     static RBIOutput runOnce(const core::GlobalState &gs, core::NameRef pkg,
                              const UnorderedSet<core::ClassOrModuleRef> &packageNamespaces);
 

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -350,7 +350,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
                 tree = ast::ParsedFile{rewriter::Rewriter::run(ctx, move(tree.tree)), tree.file};
                 tree = testSerialize(*gs, local_vars::LocalVars::run(ctx, move(tree)));
 
-                if (FileOps::getFileName(tree.file.data(*rbiGenGs).path()) == packageFileName) {
+                if (tree.file.data(*rbiGenGs).isPackage()) {
                     packageTrees.emplace_back(move(tree));
                 } else {
                     trees.emplace_back(move(tree));
@@ -373,8 +373,8 @@ TEST_CASE("PerPhaseTest") { // NOLINT
 
             // RBI generation
             {
-                auto packageNamespaces =
-                    packager::RBIGenerator::buildPackageNamespace(*rbiGenGs, packageTrees, *workers);
+                packageTrees = packager::Packager::findPackages(*rbiGenGs, *workers, move(packageTrees));
+                auto packageNamespaces = packager::RBIGenerator::buildPackageNamespace(*rbiGenGs, *workers);
                 for (auto &package : rbiGenGs->packageDB().packages()) {
                     auto output = packager::RBIGenerator::runOnce(*rbiGenGs, package, packageNamespaces);
                     if (!output.rbi.empty()) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
RBI generation depends on the resolver having run to identify package dependencies for the public interface. This PR delays building the `packageNamespace` set until after the resolver has run, when generating RBIs for packages.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Fixing package rbi generation.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
