### PR TITLE
Remove an unused field from UndoState

### DIFF
--- a/main/lsp/UndoState.h
+++ b/main/lsp/UndoState.h
@@ -18,8 +18,6 @@ class UndoState final {
     UnorderedMap<int, ast::ParsedFile> evictedIndexed;
     // Stores the index trees stored in `gs` that were evicted because the slow path operation replaced `gs`.
     UnorderedMap<int, ast::ParsedFile> evictedIndexedFinalGS;
-    // Stores the list of files that had errors before the slow path began.
-    std::vector<core::FileRef> evictedFilesThatHaveErrors;
 
 public:
     // Epoch of the running slow path


### PR DESCRIPTION
### Motivation
This field seems to be unused, so we might as well get rid of it.


### Test plan
Existing CI should cover this.
