### PR TITLE
expand the range of invalid `Loc` positions

### DIFF
--- a/core/Loc.h
+++ b/core/Loc.h
@@ -11,7 +11,7 @@ class GlobalState;
 class Context;
 class MutableContext;
 
-constexpr int INVALID_POS_LOC = 0xffffff;
+constexpr int INVALID_POS_LOC = 0xfffffff;
 struct LocOffsets {
     uint32_t beginLoc = INVALID_POS_LOC;
     uint32_t endLoc = INVALID_POS_LOC;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

When generating package RBIs, some packages have, shall we say, large API surface areas that cause the RBI size to be larger than the currently permitted `Loc` position range.  This PR expands the range by a factor of 16, because 256MB should be enough for anybody.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Handling large files with debug assertions turned on.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
