### PR TITLE
Add type_member bounds to rbi generation

### DIFF
--- a/test/testdata/packager/rbi_gen/__package.rbi-gen.exp
+++ b/test/testdata/packager/rbi_gen/__package.rbi-gen.exp
@@ -79,6 +79,8 @@ end
 RBIGen::Public::RefersToPrivateTypes::ClassAlias = RBIGen::Private::PrivateClassPulledInByClassAlias
 class RBIGen::Private::PrivateClassPulledInByClassAlias < Object
 end
+class RBIGen::Public::Parent < Object
+end
 class RBIGen::Public::MyStruct < T::Struct
   prop :foo, Integer
   const :singleton_type, T.class_of(RBIGen::Public::MyStruct)
@@ -113,6 +115,15 @@ end
 module RBIGen::Public::ModuleWithTypeParams
   A = type_member(:in)
   B = type_member(:out)
+  C = type_member(upper: RBIGen::Public::Parent)
+  D = type_member(lower: RBIGen::Public::Child)
+  E = type_member(upper: RBIGen::Public::Parent, lower: RBIGen::Public::Child)
+  F = type_member(:in, upper: RBIGen::Public::Parent)
+  G = type_member(:in, lower: RBIGen::Public::Child)
+  H = type_member(:in, upper: RBIGen::Public::Parent, lower: RBIGen::Public::Child)
+  I = type_member(:out, upper: RBIGen::Public::Parent)
+  J = type_member(:out, lower: RBIGen::Public::Child)
+  K = type_member(:out, upper: RBIGen::Public::Parent, lower: RBIGen::Public::Child)
   extend T::Generic
   extend T::Helpers
 end
@@ -222,6 +233,9 @@ class RBIGen::Public::CustomStruct < Object
 end
 class RBIGen::Public::ClassWithTypeParams < Object
   C = type_member()
+  D = type_member(upper: RBIGen::Public::Parent)
+  E = type_member(lower: RBIGen::Public::Child)
+  F = type_member(upper: RBIGen::Public::Parent, lower: RBIGen::Public::Child)
   extend T::Generic
   extend T::Helpers
   A = type_template(fixed: RBIGen::Private::PrivateClassPulledInByTypeTemplate)
@@ -229,6 +243,8 @@ class RBIGen::Public::ClassWithTypeParams < Object
 end
 class RBIGen::Public::ClassWithPrivateMethods < Object
   extend T::Sig
+end
+class RBIGen::Public::Child < RBIGen::Public::Parent
 end
 class RBIGen::Public::AttachedClassType < Object
   extend T::Sig

--- a/test/testdata/packager/rbi_gen/members.rb
+++ b/test/testdata/packager/rbi_gen/members.rb
@@ -245,12 +245,18 @@ module RBIGen::Public
     end
   end
 
+  class Parent; end
+  class Child < Parent; end
+
   class ClassWithTypeParams
     extend T::Generic
 
     A = type_template(fixed: RBIGen::Private::PrivateClassPulledInByTypeTemplate)
     B = type_template()
     C = type_member()
+    D = type_member(upper: Parent)
+    E = type_member(lower: Child)
+    F = type_member(upper: Parent, lower: Child)
   end
 
   module ModuleWithTypeParams
@@ -258,6 +264,15 @@ module RBIGen::Public
 
     A = type_member(:in)
     B = type_member(:out)
+    C = type_member(upper: Parent)
+    D = type_member(lower: Child)
+    E = type_member(upper: Parent, lower: Child)
+    F = type_member(:in, upper: Parent)
+    G = type_member(:in, lower: Child)
+    H = type_member(:in, upper: Parent, lower: Child)
+    I = type_member(:out, upper: Parent)
+    J = type_member(:out, lower: Child)
+    K = type_member(:out, upper: Parent, lower: Child)
   end
 
   module VariousMethods


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Add bounds information when emitting `type_member` and `type_template` declarations during rbi generation.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Stabilizing package rbi generation.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
