### PR TITLE
add definitions for `T::Props::HasLazilySpecializedMethods::DecoratorMethods`

### DIFF
--- a/rbi/sorbet/tprops.rbi
+++ b/rbi/sorbet/tprops.rbi
@@ -202,6 +202,17 @@ module T::Props::HasLazilySpecializedMethods
   def self.disable_lazy_evaluation!; end
 end
 
+module T::Props::HasLazilySpecializedMethods::DecoratorMethods
+  def lazily_defined_methods; end
+  def lazily_defined_vm_methods; end
+  def eval_lazily_defined_method!(name); end
+  def eval_lazily_defined_vm_method!(name); end
+  def enqueue_lazy_method_definition!(name, &blk); end
+  def enqueue_lazy_vm_method_definition!(name, &blk); end
+  def eagerly_define_lazy_methods!; end
+  def eagerly_define_lazy_vm_methods!; end
+end
+
 module T::Props::GeneratedCodeValidation
   class ValidationError < RuntimeError; end
   def self.validate_deserialize(source); end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Stripe's codebase has places where this module is mixed in.  Since there are no definitions for it, package RBI generation stubs it out in the resolver.  This is ~fine for typechecking (?), but not so great when using the generated RBIs: `::Sorbet::Private::Static::StubModule` is inserted verbatim into the generated package RBI files, and then we try to do interesting things with that as a symbol we need to resolve.  Providing an actual definition of `HasLazilySpecializedMethods::DecoratorMethods` resolves these problems.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
