### PR TITLE
Add a fake block arg to <unresolved-ancestors> so that it passes sanity checks

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -579,6 +579,11 @@ private:
             core::make_type<core::UnresolvedClassType>(unresolvedPath->first, move(unresolvedPath->second));
 
         auto uaSym = ctx.state.enterMethodSymbol(core::Loc::none(), item.klass, core::Names::unresolvedAncestors());
+
+        // Add a fake block argument so that this method symbol passes sanity checks
+        auto &arg = ctx.state.enterMethodArgumentSymbol(core::Loc::none(), uaSym, core::Names::blkArg());
+        arg.flags.isBlock = true;
+
         core::TypePtr resultType = uaSym.data(ctx)->resultType;
         if (!resultType) {
             uaSym.data(ctx)->resultType = core::make_type<core::TupleType>(vector<core::TypePtr>{ancestorType});


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
The `unresolvedAncestors` method symbol that's added during the resolver pass is used only to store data, but it still needs to look like a valid method. This PR adds the missing block argument so that it doesn't fail method sanity checks.

https://github.com/sorbet/sorbet/blob/5f0c8debc5a57c8efe08de4ae03a56bf1f4cf15e/core/Symbols.cc#L2119

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Avoid triggering enforces.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
