### PR TITLE
Single-package rbi generation prototype

### DIFF
--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -280,6 +280,8 @@ public:
     // If 'true', enforce use of Ruby 3.0-style keyword args.
     bool ruby3KeywordArgs = false;
 
+    std::optional<std::vector<core::NameRef>> singlePackageParents;
+
     void ignoreErrorClassForSuggestTyped(int code);
     void suppressErrorClass(int code);
     void onlyShowErrorClass(int code);

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -280,14 +280,14 @@ public:
     // If 'true', enforce use of Ruby 3.0-style keyword args.
     bool ruby3KeywordArgs = false;
 
-    // When present, this is a vector of all the mangled package names for all packages that lie in the parent namespace
-    // of the one whose interface is being generated. For example, if we're generating the interface for the package
+    // When present, this is a vector of mangled package names for the parent packages of the package whose interface
+    // we're currently generating. For example, if we're generating the interface for the package
     //
     // > Foo::Bar::Baz
     //
     // And both `Foo` and `Foo::Bar` are packages, the mangled names of those two packages would be in this vector.
     // These names are used when deciding how to stub unknown constant references in the resolver, and this optional
-    // being non-empty is used to signal single-package interface generation.
+    // having a value is used to signal single-package interface generation.
     std::optional<std::vector<core::NameRef>> singlePackageParents;
 
     void ignoreErrorClassForSuggestTyped(int code);

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -280,6 +280,14 @@ public:
     // If 'true', enforce use of Ruby 3.0-style keyword args.
     bool ruby3KeywordArgs = false;
 
+    // When present, this is a vector of all the mangled package names for all packages that lie in the parent namespace
+    // of the one whose interface is being generated. For example, if we're generating the interface for the package
+    //
+    // > Foo::Bar::Baz
+    //
+    // And both `Foo` and `Foo::Bar` are packages, the mangled names of those two packages would be in this vector.
+    // These names are used when deciding how to stub unknown constant references in the resolver, and this optional
+    // being non-empty is used to signal single-package interface generation.
     std::optional<std::vector<core::NameRef>> singlePackageParents;
 
     void ignoreErrorClassForSuggestTyped(int code);

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -922,10 +922,34 @@ void readOptions(Options &opts,
             }
         }
 
-        // TODO: these should also only be enabled along-side --stripe-packages
-        opts.singlePackage = raw["single-package"].as<string>();
         opts.packageRBIOutput = raw["package-rbi-output"].as<string>();
+        if (!opts.packageRBIOutput.empty()) {
+            if (opts.stripePackages) {
+                logger->error("--package-rbi-output must not be specified in --stripe-packages mode");
+                throw EarlyReturnWithCode(1);
+            }
+        }
+
+        opts.singlePackage = raw["single-package"].as<string>();
+        if (!opts.singlePackage.empty()) {
+            if (opts.stripePackages) {
+                logger->error("--single-package must not be specified in --stripe-packages mode");
+                throw EarlyReturnWithCode(1);
+            }
+
+            if (opts.packageRBIOutput.empty()) {
+                logger->error("--single-package requires --package-rbi-output also be provided");
+                throw EarlyReturnWithCode(1);
+            }
+        }
+
         opts.dumpPackageInfo = raw["dump-package-info"].as<string>();
+        if (!opts.dumpPackageInfo.empty()) {
+            if (!opts.stripePackages) {
+                logger->error("--dump-package-info can only be specified in --stripe-packages mode");
+                throw EarlyReturnWithCode(1);
+            }
+        }
 
         extractAutoloaderConfig(raw, opts, logger);
         opts.errorUrlBase = raw["error-url-base"].as<string>();

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -434,6 +434,8 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
                                "Errors not mentioned will be silenced. "
                                "This option can be passed multiple times.",
                                cxxopts::value<vector<int>>(), "errorCode");
+    options.add_options("dev")("single-package", "Run in single-package mode",
+                               cxxopts::value<string>()->default_value(""));
     options.add_options("dev")("package-rbi-output", "Serialize package RBIs to folder.",
                                cxxopts::value<string>()->default_value(""));
     options.add_options("dev")("dump-package-info", "Dump package info in JSON form to the given file.",
@@ -920,6 +922,8 @@ void readOptions(Options &opts,
             }
         }
 
+        // TODO: these should also only be enabled along-side --stripe-packages
+        opts.singlePackage = raw["single-package"].as<string>();
         opts.packageRBIOutput = raw["package-rbi-output"].as<string>();
         opts.dumpPackageInfo = raw["dump-package-info"].as<string>();
 

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -203,6 +203,7 @@ struct Options {
     std::map<std::string, std::string> metricsExtraTags; // be super careful with cardinality here
 
     std::string dumpPackageInfo = "";
+    std::string singlePackage = "";
     std::string packageRBIOutput = "";
 
     // Contains the allowed extensions Sorbet can parse.

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -602,7 +602,7 @@ int realmain(int argc, char *argv[]) {
                 }
                 singlePackageTarget = info.packageName;
 
-                // Only keep inputs that are part of the package we're generating rbis for
+                // Only keep inputs that are part of the package whose interface we're generating
                 auto &db = gs->packageDB();
                 auto it = std::remove_if(inputFiles.begin(), inputFiles.end(), [&gs = *gs, &db, &info](auto file) {
                     auto &pkg = db.getPackageForFile(gs, file);
@@ -610,8 +610,8 @@ int realmain(int argc, char *argv[]) {
                 });
                 inputFiles.erase(it, inputFiles.end());
 
-                // Record parent information in GlobalState to indicate to the resolver that we should stub out
-                // constants that fail to resolve.
+                // Record parent information in GlobalState to guide the resolver when stubbing out constants that come
+                // from other packages.
                 gs->singlePackageParents.emplace(std::move(info.parents));
             }
 #endif

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -455,6 +455,7 @@ int realmain(int argc, char *argv[]) {
     gs->errorUrlBase = opts.errorUrlBase;
     gs->semanticExtensions = move(extensions);
     vector<ast::ParsedFile> indexed;
+    core::NameRef singlePackageTarget;
 
     gs->requiresAncestorEnabled = opts.requiresAncestorEnabled;
 
@@ -548,6 +549,8 @@ int realmain(int argc, char *argv[]) {
             logger->warn("Package rbi generation is disabled in sorbet-orig for faster builds");
             return 1;
 #else
+            Timer rbiGenTimer(logger, "rbiGeneration.setup");
+
             if (opts.stripePackages) {
                 logger->error("Cannot serialize package RBIs in legacy stripe packages mode.");
                 return 1;
@@ -582,9 +585,35 @@ int realmain(int argc, char *argv[]) {
                 return 1;
             }
 
+            // Indexing package files is by far the most expensive part of rbi generation. If we could instead select
+            // only the package files that we know we need to load, it would cut down command-line rbi generation by
+            // seconds.
             auto packageFileRefs = pipeline::reserveFiles(gs, packageFiles);
             auto packages = pipeline::index(*gs, packageFileRefs, opts, *workers, nullptr);
             packages = packager::Packager::findPackages(*gs, *workers, move(packages));
+
+            if (!opts.singlePackage.empty()) {
+                Timer singlePackageTimer(logger, "singlePackage.setup");
+
+                auto info = packager::RBIGenerator::findSinglePackage(*gs, opts.singlePackage);
+                if (!info.packageName.exists()) {
+                    logger->error("Unable to find package `{}`", opts.singlePackage);
+                    return 1;
+                }
+                singlePackageTarget = info.packageName;
+
+                // Only keep inputs that are part of the package we're generating rbis for
+                auto &db = gs->packageDB();
+                auto it = std::remove_if(inputFiles.begin(), inputFiles.end(), [&gs = *gs, &db, &info](auto file) {
+                    auto &pkg = db.getPackageForFile(gs, file);
+                    return pkg.exists() && pkg.mangledName() != info.packageName;
+                });
+                inputFiles.erase(it, inputFiles.end());
+
+                // Record parent information in GlobalState to indicate to the resolver that we should stub out
+                // constants that fail to resolve.
+                gs->singlePackageParents.emplace(std::move(info.parents));
+            }
 #endif
         }
 
@@ -736,8 +765,15 @@ int realmain(int argc, char *argv[]) {
             logger->warn("Package rbi generation is disabled in sorbet-orig for faster builds");
             return 1;
 #else
+            Timer rbiGenTimer(logger, "rbiGeneration.run");
             auto packageNamespaces = packager::RBIGenerator::buildPackageNamespace(*gs, *workers);
-            packager::RBIGenerator::run(*gs, packageNamespaces, opts.packageRBIOutput, *workers);
+
+            if (gs->singlePackageParents.has_value()) {
+                packager::RBIGenerator::runSinglePackage(*gs, packageNamespaces, singlePackageTarget,
+                                                         opts.packageRBIOutput, *workers);
+            } else {
+                packager::RBIGenerator::run(*gs, packageNamespaces, opts.packageRBIOutput, *workers);
+            }
 #endif
         }
 

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -768,7 +768,7 @@ int realmain(int argc, char *argv[]) {
             Timer rbiGenTimer(logger, "rbiGeneration.run");
             auto packageNamespaces = packager::RBIGenerator::buildPackageNamespace(*gs, *workers);
 
-            if (gs->singlePackageParents.has_value()) {
+            if (!opts.singlePackage.empty()) {
                 packager::RBIGenerator::runSinglePackage(*gs, packageNamespaces, singlePackageTarget,
                                                          opts.packageRBIOutput, *workers);
             } else {

--- a/packager/rbi_gen.cc
+++ b/packager/rbi_gen.cc
@@ -1253,7 +1253,6 @@ UnorderedSet<core::ClassOrModuleRef> RBIGenerator::buildPackageNamespace(core::G
 
     auto &packages = packageDB.packages();
 
-    // TODO: should this be an enforce?
     if (packages.empty()) {
         Exception::raise("No packages found?");
     }

--- a/packager/rbi_gen.cc
+++ b/packager/rbi_gen.cc
@@ -1355,21 +1355,17 @@ RBIGenerator::SinglePackageInfo RBIGenerator::findSinglePackage(core::GlobalStat
             continue;
         }
 
-        bool equal = true;
-        auto it = fullName.begin();
-        for (auto part : nameParts) {
-            if (it == fullName.end() || it->shortName(gs) != part) {
-                equal = false;
-                break;
+        // `nameParts` will be at least as long as `fullName` because of the check above, so using `nameParts` as the
+        // third argument to `std::equal` is safe. When the two don't match in length but prefixEqual is true,
+        // `pkg` is a parent package of the package we're looking for.
+        bool prefixEqual = std::equal(fullName.begin(), fullName.end(), nameParts.begin(),
+                                      [&gs](auto name, auto part) { return name.shortName(gs) == part; });
+        if (prefixEqual) {
+            if (nameSize == fullName.size()) {
+                res.packageName = pkg;
+            } else {
+                res.parents.emplace_back(pkg);
             }
-
-            ++it;
-        }
-
-        if (equal) {
-            res.packageName = pkg;
-        } else if (it != fullName.begin()) {
-            res.parents.emplace_back(pkg);
         }
     }
 

--- a/packager/rbi_gen.h
+++ b/packager/rbi_gen.h
@@ -23,17 +23,21 @@ public:
     static RBIOutput runOnce(const core::GlobalState &gs, core::NameRef pkg,
                              const UnorderedSet<core::ClassOrModuleRef> &packageNamespaces);
 
-    // Generate RBIs for all packages named in `packageFiles`.
+    // Generate RBIs for all packages present in the package database of `gs`.
     static void run(core::GlobalState &gs, const UnorderedSet<core::ClassOrModuleRef> &packageNamespaces,
                     std::string outputDir, WorkerPool &workers);
 
-    // Generate RBIs for a single package, whose path is given by `packageName`. The `packageFiles` vector must include
-    // the file named by `packageName`, or an error will be raised.
+    // Generate RBIs for a single package, provided as the mangled package name `package`.
     static void runSinglePackage(core::GlobalState &gs, const UnorderedSet<core::ClassOrModuleRef> &packageNamespaces,
                                  core::NameRef package, std::string outputDir, WorkerPool &workers);
 
     struct SinglePackageInfo {
+        // The mangled name of the package we're generating an interface for.
         core::NameRef packageName;
+
+        // The mangled names of all packages that lie in the parent namespace of `packageName` above. For example, if
+        // the package we're generating an interface for is `Foo::Bar` and `Foo` is also a package, the mangled name of
+        // `Foo` will be the only element in this vector.
         std::vector<core::NameRef> parents;
     };
 

--- a/packager/rbi_gen.h
+++ b/packager/rbi_gen.h
@@ -23,8 +23,21 @@ public:
     static RBIOutput runOnce(const core::GlobalState &gs, core::NameRef pkg,
                              const UnorderedSet<core::ClassOrModuleRef> &packageNamespaces);
 
-    static void run(core::GlobalState &gs, const UnorderedSet<core::ClassOrModuleRef> &packageNamspaces,
+    // Generate RBIs for all packages named in `packageFiles`.
+    static void run(core::GlobalState &gs, const UnorderedSet<core::ClassOrModuleRef> &packageNamespaces,
                     std::string outputDir, WorkerPool &workers);
+
+    // Generate RBIs for a single package, whose path is given by `packageName`. The `packageFiles` vector must include
+    // the file named by `packageName`, or an error will be raised.
+    static void runSinglePackage(core::GlobalState &gs, const UnorderedSet<core::ClassOrModuleRef> &packageNamespaces,
+                                 core::NameRef package, std::string outputDir, WorkerPool &workers);
+
+    struct SinglePackageInfo {
+        core::NameRef packageName;
+        std::vector<core::NameRef> parents;
+    };
+
+    static SinglePackageInfo findSinglePackage(core::GlobalState &gs, std::string packageName);
 };
 } // namespace sorbet::packager
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -341,7 +341,6 @@ private:
 
         core::ClassOrModuleRef owner = core::Symbols::root();
         for (auto part : info.fullName()) {
-            // TODO: is none okay for the loc?
             owner = ctx.state.enterClassSymbol(core::Loc::none(), owner, part);
         }
 

--- a/test/cli/rbi-gen-single/family/__package.rb
+++ b/test/cli/rbi-gen-single/family/__package.rb
@@ -1,0 +1,9 @@
+# typed: strict
+
+class Family < PackageSpec
+
+  import Family::Bart
+
+  export Family::Simpsons
+
+end

--- a/test/cli/rbi-gen-single/family/bart/__package.rb
+++ b/test/cli/rbi-gen-single/family/bart/__package.rb
@@ -1,0 +1,10 @@
+# typed: strict
+
+class Family::Bart < PackageSpec
+
+  import Family
+  import Util
+
+  export Family::Bart::Character
+
+end

--- a/test/cli/rbi-gen-single/family/bart/bart.rb
+++ b/test/cli/rbi-gen-single/family/bart/bart.rb
@@ -1,0 +1,24 @@
+# typed: true
+
+module Family
+  module Bart
+
+    class Character
+      extend T::Sig
+
+      # Ensure that lookup in a parent namespace works correctly. This should
+      # show up as `Family::Simpsons` in the resulting rbi.
+      sig {returns(T.class_of(Simpsons))}
+      def family
+        Simpsons
+      end
+
+      sig {void}
+      def catchphrase
+        Util::Messages.say "eat pant"
+      end
+
+    end
+
+  end
+end

--- a/test/cli/rbi-gen-single/family/family.rb
+++ b/test/cli/rbi-gen-single/family/family.rb
@@ -1,0 +1,14 @@
+# typed: true
+
+module Family
+
+  class Simpsons
+    extend T::Sig
+
+    sig {returns(Bart::Character)}
+    def bart
+      Bart::Character.new
+    end
+  end
+
+end

--- a/test/cli/rbi-gen-single/rbi-gen-single.out
+++ b/test/cli/rbi-gen-single/rbi-gen-single.out
@@ -1,0 +1,34 @@
+-- sanity-checking package with --stripe-packages
+-- ./test/cli/rbi-gen-single/family/__package.rb (Family)
+-- RBI: ./test/cli/rbi-gen-single/family/__package.rb (Family)
+# typed: true
+
+class Family::Simpsons < Object
+  sig {returns(Bart::Character)}
+  def bart; end
+  extend T::Sig
+end
+-- JSON: ./test/cli/rbi-gen-single/family/__package.rb (Family)
+{"packageRefs":[], "rbiRefs":[]}-- ./test/cli/rbi-gen-single/family/bart/__package.rb (Family::Bart)
+-- RBI: ./test/cli/rbi-gen-single/family/bart/__package.rb (Family::Bart)
+# typed: true
+
+class Family::Bart::Character < Object
+  sig {void}
+  def catchphrase; end
+  sig {returns(T.class_of(Family::Simpsons))}
+  def family; end
+  extend T::Sig
+end
+-- JSON: ./test/cli/rbi-gen-single/family/bart/__package.rb (Family::Bart)
+{"packageRefs":["Family"], "rbiRefs":[]}-- ./test/cli/rbi-gen-single/util/__package.rb (Util)
+-- RBI: ./test/cli/rbi-gen-single/util/__package.rb (Util)
+# typed: true
+
+class Util::Messages < Object
+  extend T::Sig
+  sig {params(msg: String).void}
+  def self.say(msg); end
+end
+-- JSON: ./test/cli/rbi-gen-single/util/__package.rb (Util)
+{"packageRefs":[], "rbiRefs":[]}

--- a/test/cli/rbi-gen-single/rbi-gen-single.sh
+++ b/test/cli/rbi-gen-single/rbi-gen-single.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+test_path="$(dirname "$0")"
+
+sorbet="$PWD/main/sorbet"
+
+rbis="$(mktemp -d)"
+trap "rm -rf $rbis" EXIT
+
+echo "-- sanity-checking package with --stripe-packages"
+"$sorbet" --silence-dev-message \
+  --stripe-packages \
+  --dump-package-info="$rbis/package-info.json" \
+  "$test_path"
+
+# Generate rbis for each package
+find . -name __package.rb | sort | while read -r package; do
+  name="$(awk '/class/ {print $2}' "$package")"
+
+  echo "-- $package ($name)"
+
+  "$sorbet" --silence-dev-message \
+    --ignore=__package.rb,"$rbis" \
+    --package-rbi-output="$rbis" \
+    --single-package="$name" "$test_path"
+
+  echo "-- RBI: $package ($name)"
+  cat "$rbis/${name//::/_}_Package.package.rbi"
+
+  echo "-- JSON: $package ($name)"
+  cat "$rbis/${name//::/_}_Package.deps.json"
+
+done
+

--- a/test/cli/rbi-gen-single/util/__package.rb
+++ b/test/cli/rbi-gen-single/util/__package.rb
@@ -1,0 +1,7 @@
+# typed: strict
+
+class Util < PackageSpec
+
+  export Util::Messages
+
+end

--- a/test/cli/rbi-gen-single/util/messages.rb
+++ b/test/cli/rbi-gen-single/util/messages.rb
@@ -1,0 +1,15 @@
+# typed: true
+
+module Util
+
+  class Messages
+    extend T::Sig
+
+    sig {params(msg: String).void}
+    def self.say(msg)
+      puts msg
+    end
+
+  end
+
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Initial work on adding support for single-package rbi generation for Stripe. There are some issues remaining, but parent packages name resolution is implemented which was one of the main risks for this project.

This should be relatively un-invasive: all functionality is gated on passing the `--single-package=...` flag, and the new state on `GlobalState` will default-initialize to values that disable all of the single-package functionality.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Working towards incremental package rbi generation for Stripe's codebase.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
