### PR TITLE
change `approximateSubtract(..., Types::nilClass())` to `dropNil(...)`

### DIFF
--- a/core/TypeErrorDiagnostics.cc
+++ b/core/TypeErrorDiagnostics.cc
@@ -56,7 +56,7 @@ void TypeErrorDiagnostics::maybeAutocorrect(const GlobalState &gs, ErrorBuilder 
         e.replaceWith(fmt::format("Wrap in `{}`", *gs.suggestUnsafe), loc, "{}({})", *gs.suggestUnsafe,
                       loc.source(gs).value());
     } else {
-        auto withoutNil = Types::approximateSubtract(gs, actualType, Types::nilClass());
+        auto withoutNil = Types::dropNil(gs, actualType);
         if (!withoutNil.isBottom() &&
             Types::isSubTypeUnderConstraint(gs, constr, withoutNil, expectedType, UntypedMode::AlwaysCompatible)) {
             e.replaceWith("Wrap in `T.must`", loc, "T.must({})", loc.source(gs).value());

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1522,7 +1522,7 @@ public:
             }
             return;
         }
-        auto ret = Types::approximateSubtract(gs, args.args[0]->type, Types::nilClass());
+        auto ret = Types::dropNil(gs, args.args[0]->type);
         if (ret == args.args[0]->type) {
             if (auto e = gs.beginError(loc, errors::Infer::InvalidCast)) {
                 if (args.args[0]->type.isUntyped()) {
@@ -3314,7 +3314,7 @@ public:
         ENFORCE(!ap->targs.empty());
         element = ap->targs.front();
 
-        auto ret = Types::approximateSubtract(gs, element, Types::nilClass());
+        auto ret = Types::dropNil(gs, element);
         res.returnType = Types::arrayOf(gs, ret);
     }
 } Array_compact;


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

@jez mentioned this pattern in #5328, and it turns out we do the inefficient thing in a couple of places.  The code is tidier, and `T.must` might even be epsilon faster as a result of this change.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
