### PR TITLE
Adds Hash#except for Ruby 3

### DIFF
--- a/rbi/core/hash.rbi
+++ b/rbi/core/hash.rbi
@@ -696,15 +696,13 @@ class Hash < Object
   # h = { a: 100, b: 200, c: 300 }
   # h.except(:a)          #=> {:b=>200, :c=>300}
   # ```
-  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.0.0")
-    sig do
-      params(
-          args: K,
-      )
-      .returns(T::Hash[K, V])
-    end
-    def except(*args); end
+  sig do
+    params(
+        args: K,
+    )
+    .returns(T::Hash[K, V])
   end
+  def except(*args); end
 
   # Returns a new array that is a one-dimensional flattening of this hash. That
   # is, for every key or value that is an array, extract its elements into the

--- a/rbi/core/hash.rbi
+++ b/rbi/core/hash.rbi
@@ -689,6 +689,23 @@ class Hash < Object
   # ```
   def fetch_values(*_); end
 
+  # Returns a new Hash excluding entries for the given keys.
+  # [`Hash#except`](https://ruby-doc.org/core-3.0.0/Hash.html#method-i-except)
+  #
+  # ```ruby
+  # h = { a: 100, b: 200, c: 300 }
+  # h.except(:a)          #=> {:b=>200, :c=>300}
+  # ```
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.0.0")
+    sig do
+      params(
+          args: K,
+      )
+      .returns(T::Hash[K, V])
+    end
+    def except(*_); end
+  end
+
   # Returns a new array that is a one-dimensional flattening of this hash. That
   # is, for every key or value that is an array, extract its elements into the
   # new array. Unlike

--- a/rbi/core/hash.rbi
+++ b/rbi/core/hash.rbi
@@ -703,7 +703,7 @@ class Hash < Object
       )
       .returns(T::Hash[K, V])
     end
-    def except(*_); end
+    def except(*args); end
   end
 
   # Returns a new array that is a one-dimensional flattening of this hash. That


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Ruby 3  added `Hash#except`. Sorbet does not know yet. This PR attempts to change this.
See https://ruby-doc.org/core-3.0.0/Hash.html#method-i-except

This method should not be allowed for Ruby < 3, since when I'm outside a Rails/ActiveSupport context `Hash#except` simply does not exist.
Unsure if wrapping the method in a "unless Ruby 3" block is the prefered way.


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
This brings Sorbet closer to support Ruby 3 features, thus allowing to use `Hash#except` (when not using Rails, where `Hash#except` comes from ActiveSupport).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I couldn't find any unit tests for the other instance methods on Hash. Also unsure on how to test against different Rubies (it seems tests are run against Ruby 2.6 only?).

Head e.g. to sorbet.run, and try:

```ruby
some_hash = {
 foo: 'bar',
 bar: 'foo',
}

some_hash.except(:foo)
```

this will currently throw a type error. Given that the sandbox is (presumably) Ruby 2.x, this is actually correct.
It would be amazing, if we could choose the (major) Ruby version for the sandbox.


---

I felt opening an issue to ask for this is actually more effort than opening a PR, since this is effectively ~2 LOC.