### PR TITLE
Retry class alias resolution after stubbing constants

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1566,7 +1566,8 @@ public:
 
             // Initialize the stubbed parent namespaces if we're generating an interface for a single package
             vector<ParentPackageStub> parentPackageStubs;
-            if (gs.singlePackageParents.has_value()) {
+            bool singlePackageRbiGeneration = gs.singlePackageParents.has_value();
+            if (singlePackageRbiGeneration) {
                 parentPackageStubs = initParentStubs(gs);
             }
 
@@ -1576,6 +1577,15 @@ public:
                 core::MutableContext ctx(gs, core::Symbols::root(), job.file);
                 for (auto &item : job.items) {
                     constantResolutionFailed(ctx, item, parentPackageStubs, suggestionCount);
+                }
+            }
+
+            if (singlePackageRbiGeneration) {
+                for (auto &job : todoClassAliases) {
+                    core::MutableContext ctx(gs, core::Symbols::root(), job.file);
+                    for (auto &item : job.items) {
+                        resolveClassAliasJob(ctx, item);
+                    }
                 }
             }
 

--- a/test/cli/rbi-gen-single/family/bart/bart.rb
+++ b/test/cli/rbi-gen-single/family/bart/bart.rb
@@ -18,6 +18,8 @@ module Family
         Util::Messages.say "eat pant"
       end
 
+      FamilyClass = Simpsons
+
     end
 
   end

--- a/test/cli/rbi-gen-single/family/family.rb
+++ b/test/cli/rbi-gen-single/family/family.rb
@@ -12,6 +12,8 @@ module Family
       nil
     end
 
+    LocalBart = Bart::Character
+
     sig {returns(Bart::Character)}
     def bart
       Bart::Character.new

--- a/test/cli/rbi-gen-single/family/family.rb
+++ b/test/cli/rbi-gen-single/family/family.rb
@@ -12,6 +12,8 @@ module Family
       nil
     end
 
+    # This exposes another problem, Bart::Character is used completely
+    # unqualified at the top level in the rbi.
     LocalBart = Bart::Character
 
     sig {returns(Bart::Character)}

--- a/test/cli/rbi-gen-single/rbi-gen-single.out
+++ b/test/cli/rbi-gen-single/rbi-gen-single.out
@@ -24,6 +24,7 @@ class Family::Bart::Character < Object
   def family; end
   extend T::Sig
 end
+Family::Bart::Character::FamilyClass = Family::Simpsons
 -- JSON: ./test/cli/rbi-gen-single/family/bart/__package.rb (Family::Bart)
 {"packageRefs":["Family"], "rbiRefs":[]}-- ./test/cli/rbi-gen-single/util/__package.rb (Util)
 -- RBI: ./test/cli/rbi-gen-single/util/__package.rb (Util)

--- a/test/cli/rbi-gen-single/rbi-gen-single.out
+++ b/test/cli/rbi-gen-single/rbi-gen-single.out
@@ -11,6 +11,7 @@ class Family::Simpsons < Object
   extend T::Sig
 end
 Family::Simpsons::MaybeBart = T.type_alias {T.nilable(Bart::Character)}
+Family::Simpsons::LocalBart = Bart::Character
 -- JSON: ./test/cli/rbi-gen-single/family/__package.rb (Family)
 {"packageRefs":[], "rbiRefs":[]}-- ./test/cli/rbi-gen-single/family/bart/__package.rb (Family::Bart)
 -- RBI: ./test/cli/rbi-gen-single/family/bart/__package.rb (Family::Bart)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
When stubbing constants for single-package rbi generation, class aliases will fail to resolve if the stubbed constants aren't available. This PR retries constant alias resolution after constants have been stubbed, correcting cases where class aliaes refer to constants from other packages.

While this does fix the issue in most cases, it also identifies another bug: when referring to an export from a child package without its full name the full name is not added in the class alias definition. I plan to address this in a future PR, as it would significantly complicate the changes here to address. There is a test added that exposes the problem, and a comment explaining what's going wrong.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Stabilizing single-package rbi generation.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
