### PR TITLE
fix overzealous `<stdint.h>` substitutions

### DIFF
--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -426,9 +426,9 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                         auto l2 = cast_type_nonnull<LiteralType>(t2);
                         auto underlyingL1 = l1.underlying(gs);
                         auto underlyingL2 = l2.underlying(gs);
-                        auto uint8_t = cast_type_nonnull<ClassType>(underlyingL1);
-                        auto uint16_t = cast_type_nonnull<ClassType>(underlyingL2);
-                        if (uint8_t.symbol == uint16_t.symbol) {
+                        auto class1 = cast_type_nonnull<ClassType>(underlyingL1);
+                        auto class2 = cast_type_nonnull<ClassType>(underlyingL2);
+                        if (class1.symbol == class2.symbol) {
                             if (l1.equals(l2)) {
                                 result = t1;
                             } else {
@@ -776,9 +776,9 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                     auto l2 = cast_type_nonnull<LiteralType>(t2);
                     auto underlyingL1 = l1.underlying(gs);
                     auto underlyingL2 = l2.underlying(gs);
-                    auto uint8_t = cast_type_nonnull<ClassType>(underlyingL1);
-                    auto uint16_t = cast_type_nonnull<ClassType>(underlyingL2);
-                    if (uint8_t.symbol == uint16_t.symbol) {
+                    auto class1 = cast_type_nonnull<ClassType>(underlyingL1);
+                    auto class2 = cast_type_nonnull<ClassType>(underlyingL2);
+                    if (class1.symbol == class2.symbol) {
                         if (l1.equals(l2)) {
                             result = t1;
                         } else {


### PR DESCRIPTION

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

#4987 was a little overzealous with regexes here; this PR makes the code somewhat less confusing.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
