### PR TITLE
Traverse generic bounds during rbi generation

### DIFF
--- a/packager/rbi_gen.cc
+++ b/packager/rbi_gen.cc
@@ -495,10 +495,9 @@ private:
                 break;
             }
             case core::TypePtr::Tag::LambdaParam: {
-                // Running .show on LambdaParam doesn't print out the types.
-                // const auto &lambdaParam = core::cast_type_nonnull<core::LambdaParam>(type);
-                // enqueueSymbolsInType(lambdaParam.lowerBound);
-                // enqueueSymbolsInType(lambdaParam.upperBound);
+                const auto &lambdaParam = core::cast_type_nonnull<core::LambdaParam>(type);
+                enqueueSymbolsInType(lambdaParam.lowerBound);
+                enqueueSymbolsInType(lambdaParam.upperBound);
                 break;
             }
         }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
This was an oversight in the original implementation: bounds weren't being explicitly printed, and seemed like they wouldn't affect the external interface of a package. This was corrected in a follow up PR that explicitly traverses the lower and upper bounds of the `type_member`, but it seems good to traverse them here as well so that we don't accidentally miss a dependency.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Stabilizing rbi generation.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

It's difficult to write a test for this as the `LambdaParam`'s bounds are being traversed explicitly in `RBIExporter::typeMemberDetails`; this change is more for consistency.