### PR TITLE
Automatically enable VS Code extension if sorbet/config exists

### DIFF
--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -4,7 +4,7 @@
   "description": "Ruby IDE features, powered by Sorbet.",
   "author": "Stripe Inc.",
   "license": "Apache-2.0",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "publisher": "sorbet",
   "icon": "icon.png",
   "repository": {


### PR DESCRIPTION
Enable the VS Code extension by default if a `sorbet/config` file exists in the workspace.

I used the `DefaultSorbetWorkspaceContext` so that we can test it out.

### Motivation

Having the extension enabled by default when detecting Sorbet is a nicer experience than having to manually turn it on for all projects using Sorbet.

### Test plan

See included automated tests.