### PR TITLE
fix typo for downloading artifacts in `publish.sh`

### DIFF
--- a/.buildkite/publish.sh
+++ b/.buildkite/publish.sh
@@ -30,7 +30,7 @@ prefix="0.5"
 release_version="$prefix.${git_commit_count}"
 long_release_version="${release_version}.$(git log --format=%cd-%h --date=format:%Y%m%d%H%M%S -1)"
 
-echo "--- Dowloading artifacts"
+echo "--- Downloading artifacts"
 rm -rf release
 rm -rf _out_
 buildkite-agent artifact download "_out_/**/*" .


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Less eye-twiching while reading CI logs.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
