### PR TITLE
Invert compare_indent_level

### DIFF
--- a/parser/parser/cc/driver.cc
+++ b/parser/parser/cc/driver.cc
@@ -54,7 +54,7 @@ void base_driver::rewind_and_reset(size_t newPos) {
 }
 
 void base_driver::rewind_if_dedented(token_t token, token_t kEND, bool force) {
-    if ((force || this->indentationAware) && this->lex.compare_indent_level(token, kEND) < 0) {
+    if ((force || this->indentationAware) && this->lex.compare_indent_level(token, kEND) > 0) {
         this->rewind_and_reset(kEND->start());
         const char *token_str_name = this->token_name(token->type());
         this->diagnostics.emplace_back(dlevel::ERROR, dclass::DedentedEnd, token, token_str_name, kEND);

--- a/parser/parser/cc/lexer.rl
+++ b/parser/parser/cc/lexer.rl
@@ -205,11 +205,11 @@ int lexer::compare_indent_level(token_t left, token_t right) {
         auto rightIsSpace = rightChar == ' ' || rightChar == '\t';
 
         if (leftIsSpace && !rightIsSpace) {
-            return 1; // left < right
+            return 1; // left > right
         } else if (!leftIsSpace && !rightIsSpace) {
             return 0; // left == right
         } else if (!leftIsSpace && rightIsSpace) {
-            return -1;  // left > right
+            return -1;  // left < right
         }
 
         if (leftChar != rightChar) {

--- a/parser/parser/cc/lexer.rl
+++ b/parser/parser/cc/lexer.rl
@@ -205,11 +205,11 @@ int lexer::compare_indent_level(token_t left, token_t right) {
         auto rightIsSpace = rightChar == ' ' || rightChar == '\t';
 
         if (leftIsSpace && !rightIsSpace) {
-            return -1; // left < right
+            return 1; // left < right
         } else if (!leftIsSpace && !rightIsSpace) {
             return 0; // left == right
         } else if (!leftIsSpace && rightIsSpace) {
-            return 1;  // left > right
+            return -1;  // left > right
         }
 
         if (leftChar != rightChar) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

It used to be the case that for something like

    def foo
      if
    end

if you were comparing the indent level of the `if` token (which is 2
spaces) and the `end` token (which is 0 spaces), that

    compare_indent_level(ifTok, endTok) == -1

which is weird because typically `(A <=> B) < 0` is true if `A < B` but
in this case we were effectively comparing `2 < 0` and saying that was
true.

It was just the case that I had also inverted the `>` in the one places
where this function is called, so it didn't matter.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.