### PR TITLE
stub out generic types in single-package RBI generation mode

### DIFF
--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -50,7 +50,7 @@ string argTypeForUnresolvedAppliedType(const GlobalState &gs, const TypePtr &t, 
     }
     return t.show(gs, options);
 }
-}
+} // namespace
 
 string UnresolvedAppliedType::show(const GlobalState &gs, ShowOptions options) const {
     string resolvedString = options.showForRBI ? "" : " (unresolved)";
@@ -64,7 +64,11 @@ string UnresolvedAppliedType::show(const GlobalState &gs, ShowOptions options) c
     }
 
     return fmt::format("{}[{}]{}", symForPrinting.show(gs, options),
-                       fmt::map_join(targs, ", ", [&](auto targ) { return options.showForRBI ? argTypeForUnresolvedAppliedType(gs, targ, options) : targ.show(gs, options); }),
+                       fmt::map_join(targs, ", ",
+                                     [&](auto targ) {
+                                         return options.showForRBI ? argTypeForUnresolvedAppliedType(gs, targ, options)
+                                                                   : targ.show(gs, options);
+                                     }),
                        resolvedString);
 }
 

--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -45,8 +45,16 @@ string UnresolvedAppliedType::toStringWithTabs(const GlobalState &gs, int tabs) 
 
 string UnresolvedAppliedType::show(const GlobalState &gs, ShowOptions options) const {
     string resolvedString = options.showForRBI ? "" : " (unresolved)";
+    ClassOrModuleRef symForPrinting;
 
-    return fmt::format("{}[{}]{}", this->klass.show(gs, options),
+    if (options.showForRBI) {
+        auto attachedClass = this->klass.data(gs)->attachedClass(gs);
+        symForPrinting = attachedClass;
+    } else {
+        symForPrinting = this->klass;
+    }
+
+    return fmt::format("{}[{}]{}", symForPrinting.show(gs, options),
                        fmt::map_join(targs, ", ", [&](auto targ) { return targ.show(gs, options); }),
                        resolvedString);
 }

--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -43,6 +43,15 @@ string UnresolvedAppliedType::toStringWithTabs(const GlobalState &gs, int tabs) 
     return this->show(gs);
 }
 
+namespace {
+string argTypeForUnresolvedAppliedType(const GlobalState &gs, const TypePtr &t, ShowOptions options) {
+    if (auto *m = cast_type<MetaType>(t)) {
+        return m->wrapped.show(gs, options);
+    }
+    return t.show(gs, options);
+}
+}
+
 string UnresolvedAppliedType::show(const GlobalState &gs, ShowOptions options) const {
     string resolvedString = options.showForRBI ? "" : " (unresolved)";
     ClassOrModuleRef symForPrinting;
@@ -55,7 +64,7 @@ string UnresolvedAppliedType::show(const GlobalState &gs, ShowOptions options) c
     }
 
     return fmt::format("{}[{}]{}", symForPrinting.show(gs, options),
-                       fmt::map_join(targs, ", ", [&](auto targ) { return targ.show(gs, options); }),
+                       fmt::map_join(targs, ", ", [&](auto targ) { return options.showForRBI ? argTypeForUnresolvedAppliedType(gs, targ, options) : targ.show(gs, options); }),
                        resolvedString);
 }
 

--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -44,8 +44,11 @@ string UnresolvedAppliedType::toStringWithTabs(const GlobalState &gs, int tabs) 
 }
 
 string UnresolvedAppliedType::show(const GlobalState &gs, ShowOptions options) const {
-    return fmt::format("{}[{}] (unresolved)", this->klass.show(gs, options),
-                       fmt::map_join(targs, ", ", [&](auto targ) { return targ.show(gs, options); }));
+    string resolvedString = options.showForRBI ? "" : " (unresolved)";
+
+    return fmt::format("{}[{}]{}", this->klass.show(gs, options),
+                       fmt::map_join(targs, ", ", [&](auto targ) { return targ.show(gs, options); }),
+                       resolvedString);
 }
 
 string LiteralType::toStringWithTabs(const GlobalState &gs, int tabs) const {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -485,7 +485,8 @@ private:
 
         // When generating rbis in single-package mode, we may need to invent a symbol at this point
         if (singlePackageRbiGeneration) {
-            stubForRbiGeneration(ctx.withOwner(job.scope->scope), parentPackageStubs, job.scope.get(), job.out, job.possibleGenericType);
+            stubForRbiGeneration(ctx.withOwner(job.scope->scope), parentPackageStubs, job.scope.get(), job.out,
+                                 job.possibleGenericType);
             return;
         }
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -109,6 +109,7 @@ private:
         shared_ptr<Nesting> scope;
         ast::ConstantLit *out;
         bool resolutionFailed = false;
+        bool possibleGenericType = false;
 
         ResolutionItem() = default;
         ResolutionItem(const shared_ptr<Nesting> &scope, ast::ConstantLit *lit) : scope(scope), out(lit) {}
@@ -370,8 +371,22 @@ private:
     }
 
     static void stubForRbiGeneration(core::MutableContext ctx, const vector<ParentPackageStub> &parentPackageStubs,
-                                     const Nesting *scope, ast::ConstantLit *out) {
+                                     const Nesting *scope, ast::ConstantLit *out, bool possibleGenericType) {
         if (out->symbol.exists()) {
+            // In single-package RBI generation mode, we might have already
+            // resolved a class that we later identified as generic, and
+            // we need to attempt to fix that up.
+            if (!out->symbol.isClassOrModule()) {
+                return;
+            }
+            if (!possibleGenericType) {
+                return;
+            }
+            auto singletonClass = out->symbol.asClassOrModuleRef().data(ctx)->singletonClass(ctx);
+            auto &mixins = singletonClass.data(ctx)->mixins();
+            if (absl::c_find(mixins, core::Symbols::T_Generic()) == mixins.end()) {
+                mixins.emplace_back(core::Symbols::T_Generic());
+            }
             return;
         }
 
@@ -380,7 +395,9 @@ private:
         // if the scope of the constant lit is non-empty, attempt to resolve that first to help determine the owner.
         auto &original = ast::cast_tree_nonnull<ast::UnresolvedConstantLit>(out->original);
         if (auto *origScope = ast::cast_tree<ast::ConstantLit>(original.scope)) {
-            stubForRbiGeneration(ctx, parentPackageStubs, scope, origScope);
+            // The scope of the original is not a possible generic type.
+            const bool isGenericType = false;
+            stubForRbiGeneration(ctx, parentPackageStubs, scope, origScope, isGenericType);
             owner = origScope->symbol.asClassOrModuleRef();
         } else {
             for (auto *cursor = scope; cursor != nullptr; cursor = cursor->parent.get()) {
@@ -413,8 +430,15 @@ private:
         auto symbol = ctx.state.enterClassSymbol(core::Loc{ctx.file, out->loc}, owner,
                                                  ast::cast_tree<ast::UnresolvedConstantLit>(out->original)->cnst);
 
+        auto data = symbol.data(ctx);
         // force a singleton into existence
-        symbol.data(ctx)->singletonClass(ctx);
+        auto singletonClass = data->singletonClass(ctx);
+        if (possibleGenericType) {
+            auto &mixins = singletonClass.data(ctx)->mixins();
+            if (absl::c_find(mixins, core::Symbols::T_Generic()) == mixins.end()) {
+                mixins.emplace_back(core::Symbols::T_Generic());
+            }
+        }
 
         out->symbol = symbol;
     }
@@ -461,7 +485,7 @@ private:
 
         // When generating rbis in single-package mode, we may need to invent a symbol at this point
         if (singlePackageRbiGeneration) {
-            stubForRbiGeneration(ctx.withOwner(job.scope->scope), parentPackageStubs, job.scope.get(), job.out);
+            stubForRbiGeneration(ctx.withOwner(job.scope->scope), parentPackageStubs, job.scope.get(), job.out, job.possibleGenericType);
             return;
         }
 
@@ -564,6 +588,9 @@ private:
 
     static bool resolveJob(core::Context ctx, ResolutionItem &job) {
         if (isAlreadyResolved(ctx, *job.out)) {
+            if (job.possibleGenericType) {
+                return false;
+            }
             return true;
         }
         auto &original = ast::cast_tree_nonnull<ast::UnresolvedConstantLit>(job.out->original);
@@ -1268,6 +1295,15 @@ public:
             if (recvAsConstantLit != nullptr && recvAsConstantLit->symbol == core::Symbols::Magic() &&
                 send.fun == core::Names::mixesInClassMethods()) {
                 this->todoClassMethods_.emplace_back(ctx.file, ctx.owner, &send);
+            } else if (recvAsConstantLit != nullptr && send.fun == core::Names::squareBrackets() &&
+                       ctx.state.singlePackageParents.has_value()) {
+                // In single-package RBI generation mode, we treat Constant[...] as
+                // possible generic types.
+                ResolutionItem job{nesting_, recvAsConstantLit};
+                job.possibleGenericType = true;
+                if (!resolveJob(ctx, job)) {
+                    todo_.emplace_back(std::move(job));
+                }
             }
         }
         return tree;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -370,6 +370,13 @@ private:
         return stubs;
     }
 
+    static void ensureTGenericMixin(core::GlobalState &gs, core::ClassOrModuleRef klass) {
+        auto &mixins = klass.data(gs)->mixins();
+        if (absl::c_find(mixins, core::Symbols::T_Generic()) == mixins.end()) {
+            mixins.emplace_back(core::Symbols::T_Generic());
+        }
+    }
+
     static void stubForRbiGeneration(core::MutableContext ctx, const vector<ParentPackageStub> &parentPackageStubs,
                                      const Nesting *scope, ast::ConstantLit *out, bool possibleGenericType) {
         if (out->symbol.exists()) {
@@ -383,10 +390,7 @@ private:
                 return;
             }
             auto singletonClass = out->symbol.asClassOrModuleRef().data(ctx)->singletonClass(ctx);
-            auto &mixins = singletonClass.data(ctx)->mixins();
-            if (absl::c_find(mixins, core::Symbols::T_Generic()) == mixins.end()) {
-                mixins.emplace_back(core::Symbols::T_Generic());
-            }
+            ensureTGenericMixin(ctx, singletonClass);
             return;
         }
 
@@ -434,10 +438,7 @@ private:
         // force a singleton into existence
         auto singletonClass = data->singletonClass(ctx);
         if (possibleGenericType) {
-            auto &mixins = singletonClass.data(ctx)->mixins();
-            if (absl::c_find(mixins, core::Symbols::T_Generic()) == mixins.end()) {
-                mixins.emplace_back(core::Symbols::T_Generic());
-            }
+            ensureTGenericMixin(ctx, singletonClass);
         }
 
         out->symbol = symbol;

--- a/test/cli/rbi-gen-single/family/bart/bart.rb
+++ b/test/cli/rbi-gen-single/family/bart/bart.rb
@@ -20,6 +20,9 @@ module Family
 
       FamilyClass = Simpsons
 
+      sig {params(msg: Util::GenericMessage[String]).void}
+      def ignore(msg); end
+
     end
 
   end

--- a/test/cli/rbi-gen-single/rbi-gen-single.out
+++ b/test/cli/rbi-gen-single/rbi-gen-single.out
@@ -23,15 +23,22 @@ class Family::Bart::Character < Object
   def catchphrase; end
   sig {returns(T.class_of(Family::Simpsons))}
   def family; end
+  sig {params(msg: Util::GenericMessage[String]).void}
+  def ignore(msg); end
   extend T::Sig
 end
 Family::Bart::Character::FamilyClass = Family::Simpsons
 -- JSON: ./test/cli/rbi-gen-single/family/bart/__package.rb (Family::Bart)
-{"packageRefs":["Family"], "rbiRefs":[]}
+{"packageRefs":["Family","Util"], "rbiRefs":[]}
 -- ./test/cli/rbi-gen-single/util/__package.rb (Util)
 -- RBI: ./test/cli/rbi-gen-single/util/__package.rb (Util)
 # typed: true
 
+class Util::GenericMessage < Object
+  Elem = type_member()
+  extend T::Generic
+  extend T::Helpers
+end
 class Util::Messages < Object
   extend T::Sig
   sig {params(msg: String).void}

--- a/test/cli/rbi-gen-single/rbi-gen-single.out
+++ b/test/cli/rbi-gen-single/rbi-gen-single.out
@@ -41,6 +41,14 @@ class Util::GenericMessage < Object
 end
 class Util::Messages < Object
   extend T::Sig
+  sig do
+    type_parameters(:T)
+    .params(
+      msg: Util::GenericMessage[T.type_parameter(:T)]
+    )
+    .void
+  end
+  def self.print_message(msg); end
   sig {params(msg: String).void}
   def self.say(msg); end
 end

--- a/test/cli/rbi-gen-single/util/__package.rb
+++ b/test/cli/rbi-gen-single/util/__package.rb
@@ -4,4 +4,6 @@ class Util < PackageSpec
 
   export Util::Messages
 
+  export Util::GenericMessage
+
 end

--- a/test/cli/rbi-gen-single/util/generic_message.rb
+++ b/test/cli/rbi-gen-single/util/generic_message.rb
@@ -1,0 +1,12 @@
+# typed: true
+
+module Util
+
+  class GenericMessage
+    extend T::Generic
+    extend T::Helpers
+
+    Elem = type_member
+  end
+
+end

--- a/test/cli/rbi-gen-single/util/messages.rb
+++ b/test/cli/rbi-gen-single/util/messages.rb
@@ -10,6 +10,15 @@ module Util
       puts msg
     end
 
+    sig do
+      type_parameters(:T)
+        .params(msg: GenericMessage[T.type_parameter(:T)])
+        .void
+    end
+    def self.print_message(msg)
+      print msg
+    end
+
   end
 
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

In single-package RBI generation mode, we don't necessarily have access to full information about generic types in signatures and the like.  So we have to make guesses about what could be generic to get proper RBIs.  This is one way to do it.

Simply declaring every stubbed symbol as generic was a possibility, but one that seemed a little overly broad.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.  I haven't updated the exp files for the single-package RBI generation test we have, because the diffs come out looking not quite right (the generated RBIs aren't valid Ruby syntax) and I'm not totally sure what needs to be done there.
