### PR TITLE
Remove version numbers from typedruby_release and typedruby_debug

### DIFF
--- a/parser/Parser.cc
+++ b/parser/Parser.cc
@@ -100,11 +100,11 @@ unique_ptr<ruby_parser::base_driver> makeDriver(Parser::Settings settings, strin
                                                 StableStringStorage<> &scratch, const vector<string> &initialLocals) {
     unique_ptr<ruby_parser::base_driver> driver;
     if (settings.traceParser) {
-        driver = make_unique<ruby_parser::typedruby_debug27>(buffer, scratch, Builder::interface, !!settings.traceLexer,
-                                                             !!settings.indentationAware);
+        driver = make_unique<ruby_parser::typedruby_debug>(buffer, scratch, Builder::interface, !!settings.traceLexer,
+                                                           !!settings.indentationAware);
     } else {
-        driver = make_unique<ruby_parser::typedruby_release27>(buffer, scratch, Builder::interface,
-                                                               !!settings.traceLexer, !!settings.indentationAware);
+        driver = make_unique<ruby_parser::typedruby_release>(buffer, scratch, Builder::interface, !!settings.traceLexer,
+                                                             !!settings.indentationAware);
     }
 
     for (string local : initialLocals) {

--- a/parser/parser/cc/driver.cc
+++ b/parser/parser/cc/driver.cc
@@ -61,22 +61,22 @@ void base_driver::rewind_if_dedented(token_t token, token_t kEND, bool force) {
     }
 }
 
-typedruby_release27::typedruby_release27(std::string_view source, sorbet::StableStringStorage<> &scratch,
-                                         const struct builder &builder, bool traceLexer, bool indentationAware)
+typedruby_release::typedruby_release(std::string_view source, sorbet::StableStringStorage<> &scratch,
+                                     const struct builder &builder, bool traceLexer, bool indentationAware)
     : base_driver(ruby_version::RUBY_27, source, scratch, builder, traceLexer, indentationAware) {}
 
-ForeignPtr typedruby_release27::parse(SelfPtr self, bool) {
-    bison::typedruby_release27::parser p(*this, self);
+ForeignPtr typedruby_release::parse(SelfPtr self, bool) {
+    bison::typedruby_release::parser p(*this, self);
     p.parse();
     return ast;
 }
 
-typedruby_debug27::typedruby_debug27(std::string_view source, sorbet::StableStringStorage<> &scratch,
-                                     const struct builder &builder, bool traceLexer, bool indentationAware)
+typedruby_debug::typedruby_debug(std::string_view source, sorbet::StableStringStorage<> &scratch,
+                                 const struct builder &builder, bool traceLexer, bool indentationAware)
     : base_driver(ruby_version::RUBY_27, source, scratch, builder, traceLexer, indentationAware) {}
 
-ForeignPtr typedruby_debug27::parse(SelfPtr self, bool traceParser) {
-    bison::typedruby_debug27::parser p(*this, self);
+ForeignPtr typedruby_debug::parse(SelfPtr self, bool traceParser) {
+    bison::typedruby_debug::parser p(*this, self);
     p.set_debug_level(traceParser ? 1 : 0);
     p.parse();
     return ast;

--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -20,7 +20,7 @@ using namespace std::string_literals;
 #endif
 }
 
-%param { ruby_parser::TYPEDRUBY27& driver }
+%param { ruby_parser::TYPEDRUBY& driver }
 %parse-param { ruby_parser::SelfPtr self }
 // This code runs at the beginning of typedruby_release27::parser::parse()
 // We use it to stash some otherwise-private members of the parser so that we
@@ -32,8 +32,8 @@ using namespace std::string_literals;
   // referenced by the yyclearin macro.
   this->driver.clear_lookahead = [&yyla]() { yyclearin; };
 }
-%define api.namespace {ruby_parser::bison::TYPEDRUBY27}
-%define api.prefix {TYPEDRUBY27}
+%define api.namespace {ruby_parser::bison::TYPEDRUBY}
+%define api.prefix {TYPEDRUBY}
 %define api.value.type { union parser_value }
 // TODO(jez) Does this degrade parser performance?
 %define api.location.type { location }
@@ -437,7 +437,7 @@ using namespace std::string_literals;
 
 namespace ruby_parser {
 namespace bison {
-namespace TYPEDRUBY27 {
+namespace TYPEDRUBY {
 union parser_value {
   ruby_parser::token *token;
   ruby_parser::delimited_node_list *delimited_list;
@@ -459,7 +459,7 @@ union parser_value {
 %code {
 namespace ruby_parser {
 namespace bison {
-namespace TYPEDRUBY27 {
+namespace TYPEDRUBY {
 
 #define DIAGCHECK() do { \
 	if (driver.pending_error) { \
@@ -497,7 +497,7 @@ void parser::error(const ruby_parser::location &lloc, const std::string &msg) {
 		error_message);
 }
 
-int yylex(parser::semantic_type *lval, ruby_parser::location *lloc, ruby_parser::TYPEDRUBY27 &driver) {
+int yylex(parser::semantic_type *lval, ruby_parser::location *lloc, ruby_parser::TYPEDRUBY &driver) {
 	auto token = driver.lex.advance();
 	driver.last_token = token;
 	int token_type = static_cast<int>(token->type());

--- a/parser/parser/cc/lexer.rl
+++ b/parser/parser/cc/lexer.rl
@@ -2272,7 +2272,7 @@ void lexer::set_state_expr_value() {
           | '@@' %{ tm = p - 2; }
           ) [0-9]*
       => {
-        if (version == ruby_version::RUBY_27) {
+        if (version >= ruby_version::RUBY_27) {
           if (ts[0] == ':' && ts[1] == '@' && ts[2] == '@') {
             diagnostic_(dlevel::ERROR, dclass::CvarName, tok(ts + 1, te));
           } else {

--- a/parser/parser/include/ruby_parser/driver.hh
+++ b/parser/parser/include/ruby_parser/driver.hh
@@ -363,20 +363,20 @@ public:
     void rewind_if_dedented(token_t token, token_t kEND, bool force = false);
 };
 
-class typedruby_release27 : public base_driver {
+class typedruby_release : public base_driver {
 public:
-    typedruby_release27(std::string_view source, sorbet::StableStringStorage<> &scratch, const struct builder &builder,
-                        bool traceLexer, bool indentationAware);
-    virtual ForeignPtr parse(SelfPtr self, bool traceParser);
-    ~typedruby_release27() {}
-};
-
-class typedruby_debug27 : public base_driver {
-public:
-    typedruby_debug27(std::string_view source, sorbet::StableStringStorage<> &scratch, const struct builder &builder,
+    typedruby_release(std::string_view source, sorbet::StableStringStorage<> &scratch, const struct builder &builder,
                       bool traceLexer, bool indentationAware);
     virtual ForeignPtr parse(SelfPtr self, bool traceParser);
-    ~typedruby_debug27() {}
+    ~typedruby_release() {}
+};
+
+class typedruby_debug : public base_driver {
+public:
+    typedruby_debug(std::string_view source, sorbet::StableStringStorage<> &scratch, const struct builder &builder,
+                    bool traceLexer, bool indentationAware);
+    virtual ForeignPtr parse(SelfPtr self, bool traceParser);
+    ~typedruby_debug() {}
 };
 
 } // namespace ruby_parser


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Removes version numbers from `typedruby_release` and `typedruby_debug` classes.


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Including the version numbers create extra overhead while making lexer/parser changes. Such as https://github.com/sorbet/sorbet/pull/3226/files#diff-534a21ccf64c1a7b69ffc494938680a4223ef1dab50618d2a675c46095451dceR55 and similarly for Ruby 3.1 in the upcoming PR I was working on.

I don't think they bring enough value to justify the maintenance overhead and they can be removed. Thoughts?

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
