### PR TITLE
drop `*.exp.svg` files from Bazel test globs

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -222,7 +222,6 @@ pipeline_tests(
         [
             "testdata/**/*.rb",
             "testdata/**/*.exp",
-            "testdata/**/*.exp.svg",
         ],
         exclude = [
             "testdata/compiler/**/*",
@@ -258,7 +257,6 @@ pipeline_tests(
         [
             "testdata/**/*.rb",
             "testdata/**/*.exp",
-            "testdata/**/*.exp.svg",
         ],
         exclude = [
             "testdata/compiler/**/*",


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We no longer have such files in the tree, and even if we did, the test runners aren't picking them up.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
