### PR TITLE
add a newline on package dependency files for nicer output

### DIFF
--- a/packager/rbi_gen.cc
+++ b/packager/rbi_gen.cc
@@ -1176,7 +1176,7 @@ private:
         rbiFiles.insert(rbiFiles.end(), referencedRBIs.begin(), referencedRBIs.end());
         fast_sort(rbiFiles, [](const auto &lhs, const auto &rhs) -> bool { return lhs < rhs; });
 
-        return fmt::format("{{\"packageRefs\":[{}], \"rbiRefs\":[{}]}}",
+        return fmt::format("{{\"packageRefs\":[{}], \"rbiRefs\":[{}]}}\n",
                            absl::StrJoin(packageNames.begin(), packageNames.end(), ",", QuoteStringFormatter()),
                            absl::StrJoin(rbiFiles.begin(), rbiFiles.end(), ",", QuoteStringFileFormatter(gs)));
     }

--- a/test/cli/rbi-gen-single/rbi-gen-single.out
+++ b/test/cli/rbi-gen-single/rbi-gen-single.out
@@ -13,7 +13,8 @@ end
 Family::Simpsons::MaybeBart = T.type_alias {T.nilable(Bart::Character)}
 Family::Simpsons::LocalBart = Bart::Character
 -- JSON: ./test/cli/rbi-gen-single/family/__package.rb (Family)
-{"packageRefs":[], "rbiRefs":[]}-- ./test/cli/rbi-gen-single/family/bart/__package.rb (Family::Bart)
+{"packageRefs":[], "rbiRefs":[]}
+-- ./test/cli/rbi-gen-single/family/bart/__package.rb (Family::Bart)
 -- RBI: ./test/cli/rbi-gen-single/family/bart/__package.rb (Family::Bart)
 # typed: true
 
@@ -26,7 +27,8 @@ class Family::Bart::Character < Object
 end
 Family::Bart::Character::FamilyClass = Family::Simpsons
 -- JSON: ./test/cli/rbi-gen-single/family/bart/__package.rb (Family::Bart)
-{"packageRefs":["Family"], "rbiRefs":[]}-- ./test/cli/rbi-gen-single/util/__package.rb (Util)
+{"packageRefs":["Family"], "rbiRefs":[]}
+-- ./test/cli/rbi-gen-single/util/__package.rb (Util)
 -- RBI: ./test/cli/rbi-gen-single/util/__package.rb (Util)
 # typed: true
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I think this is epsilon more consistent and it makes the output for the single RBI generation test slightly more legible.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
