### PR TITLE
Simplify test case rewriter

### DIFF
--- a/rewriter/TestCase.h
+++ b/rewriter/TestCase.h
@@ -24,15 +24,15 @@ namespace sorbet::rewriter {
  * into
  *
  *    class MyTest < AnyParent
- *      def setup
+ *      def initialize
  *        @a = 1
  *      end
  *
- *      def test_the_equality
+ *      test "the equality" do
  *        assert_equal 1, @a
  *      end
  *
- *      def teardown
+ *      teardown do
  *        @a = nil
  *      end
  *    end

--- a/test/testdata/rewriter/test_case.rb
+++ b/test/testdata/rewriter/test_case.rb
@@ -1,20 +1,22 @@
 # typed: strict
 
 class ActiveSupport::TestCase
-end
-
-class MyTest < ActiveSupport::TestCase
   extend T::Sig
+
+  # Helper method to direct calls to `test` instead of Kernel#test
+  sig { params(args: T.untyped, block: T.nilable(T.proc.bind(T.attached_class).void)).void }
+  def self.test(*args, &block)
+  end
+
   # Helper instance method
   sig { params(test: T.untyped).returns(T::Boolean) }
   def assert(test)
     test ? true : false
   end
+end
 
-  # Helper method to direct calls to `test` instead of Kernel#test
-  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).void }
-  def self.test(*args, &block)
-  end
+class MyTest < ActiveSupport::TestCase
+  extend T::Sig
 
   setup do
     @a = T.let(1, Integer)
@@ -25,67 +27,39 @@ class MyTest < ActiveSupport::TestCase
     bar # error: Method `bar` does not exist on `MyTest`
   end
 
-  # Method calls that shouldn't be rewritten
-  tesst "invalid", "method name" do # error: Method `tesst` does not exist on `T.class_of(MyTest)`
-  end
-
-  test "invalid", "parameter count" do
-  end
-
-  test "no block argument"
-
-  test :not_a_string do
-  end
-
-  test :not_a_string do
-    assert true # error: Method `assert` does not exist on `T.class_of(MyTest)`
-  end
-  # end unmodified method calls
-
   test "valid method call" do
   end
 
   test "block is evaluated in the context of an instance" do
     assert true
   end
-
-  teardown do
-    fiz # error: Method `fiz` does not exist on `MyTest`
-  end
-
-  teardown do
-    baz # error: Method `baz` does not exist on `MyTest`
-  end
 end
 
 class NoMatchTest < ActiveSupport::TestCase
   extend T::Sig
 
-  sig { params(block: T.proc.void).void }
+  sig { params(block: T.proc.bind(T.attached_class).void).void }
   def self.setup(&block); end
 
-  sig { params(block: T.proc.void).void }
-  def self.teardown(&block); end
-
   setup do
+    @a = T.let(1, Integer)
+  # ^^ error: The instance variable `@a` must be declared inside `initialize` or declared nilable
     foo
-  # ^^^ error: Method `foo` does not exist on `T.class_of(NoMatchTest)`
-  end
-
-  teardown do
-    bar
-  # ^^^ error: Method `bar` does not exist on `T.class_of(NoMatchTest)`
+  # ^^^ error: Method `foo` does not exist on `NoMatchTest`
   end
 end
 
 class NoParentClass
   extend T::Sig
 
-  sig { params(block: T.proc.void).void }
+  sig { params(block: T.proc.bind(T.attached_class).void).void }
   def self.setup(&block); end
 
-  sig { params(block: T.proc.void).void }
+  sig { params(block: T.proc.bind(T.attached_class).void).void }
   def self.teardown(&block); end
+
+  sig { params(name: String, block: T.proc.bind(T.attached_class).void).void }
+  def self.test(name, &block); end
 
   sig { params(a: T.untyped, b: T.untyped).void }
   def assert_equal(a, b); end
@@ -95,10 +69,6 @@ class NoParentClass
   end
 
   test "it works" do
-    assert_equal 1, @a
-  end
-
-  teardown do
-    @a = 5
+    assert_equal(1, @a)
   end
 end

--- a/test/testdata/rewriter/test_case.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/test_case.rb.rewrite-tree.exp
@@ -1,8 +1,13 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C ActiveSupport>::<C TestCase><<C <todo sym>>> < (::<todo sym>)
-  end
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.params(:args, <emptyTree>::<C T>.untyped(), :block, <emptyTree>::<C T>.nilable(<emptyTree>::<C T>.proc().bind(<emptyTree>::<C T>.attached_class()).void())).void()
+    end
 
-  class <emptyTree>::<C MyTest><<C <todo sym>>> < (<emptyTree>::<C ActiveSupport>::<C TestCase>)
+    def self.test<<todo method>>(*args, &block)
+      <emptyTree>
+    end
+
     ::Sorbet::Private::Static.sig(<self>) do ||
       <self>.params(:test, <emptyTree>::<C T>.untyped()).returns(<emptyTree>::<C T>::<C Boolean>)
     end
@@ -15,30 +20,14 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
     end
 
-    ::Sorbet::Private::Static.sig(<self>) do ||
-      <self>.params(:args, <emptyTree>::<C T>.untyped(), :block, <emptyTree>::<C T>.nilable(<emptyTree>::<C T>.proc().void())).void()
-    end
+    <self>.extend(<emptyTree>::<C T>::<C Sig>)
 
-    def self.test<<todo method>>(*args, &block)
-      <emptyTree>
-    end
+    ::Sorbet::Private::Static.keep_self_def(<self>, :test, :normal)
 
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
-    end
+    ::Sorbet::Private::Static.keep_def(<self>, :assert, :normal)
+  end
 
-    def test_valid_method_call<<todo method>>(&<blk>)
-      <emptyTree>
-    end
-
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
-    end
-
-    def test_block_is_evaluated_in_the_context_of_an_instance<<todo method>>(&<blk>)
-      <self>.assert(true)
-    end
-
+  class <emptyTree>::<C MyTest><<C <todo sym>>> < (<emptyTree>::<C ActiveSupport>::<C TestCase>)
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.void()
     end
@@ -58,73 +47,19 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.bar()
     end
 
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
-    end
-
-    def teardown<<todo method>>(&<blk>)
-      <self>.fiz()
-    end
-
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
-    end
-
-    def teardown<<todo method>>(&<blk>)
-      <self>.baz()
-    end
-
     <self>.extend(<emptyTree>::<C T>::<C Sig>)
 
-    ::Sorbet::Private::Static.keep_def(<self>, :assert, :normal)
-
-    ::Sorbet::Private::Static.keep_self_def(<self>, :test, :normal)
-
-    <self>.tesst("invalid", "method name") do ||
-      <emptyTree>
-    end
-
-    <self>.test("invalid", "parameter count") do ||
-      <emptyTree>
-    end
-
-    <self>.test("no block argument")
-
-    <self>.test(:not_a_string) do ||
-      <emptyTree>
-    end
-
-    <self>.test(:not_a_string) do ||
-      <self>.assert(true)
-    end
-
-    ::Sorbet::Private::Static.keep_def(<self>, :test_valid_method_call, :normal)
-
-    ::Sorbet::Private::Static.keep_def(<self>, :test_block_is_evaluated_in_the_context_of_an_instance, :normal)
-
     ::Sorbet::Private::Static.keep_def(<self>, :initialize, :normal)
 
     ::Sorbet::Private::Static.keep_def(<self>, :initialize, :normal)
-
-    ::Sorbet::Private::Static.keep_def(<self>, :teardown, :normal)
-
-    ::Sorbet::Private::Static.keep_def(<self>, :teardown, :normal)
   end
 
   class <emptyTree>::<C NoMatchTest><<C <todo sym>>> < (<emptyTree>::<C ActiveSupport>::<C TestCase>)
     ::Sorbet::Private::Static.sig(<self>) do ||
-      <self>.params(:block, <emptyTree>::<C T>.proc().void()).void()
+      <self>.params(:block, <emptyTree>::<C T>.proc().bind(<emptyTree>::<C T>.attached_class()).void()).void()
     end
 
     def self.setup<<todo method>>(&block)
-      <emptyTree>
-    end
-
-    ::Sorbet::Private::Static.sig(<self>) do ||
-      <self>.params(:block, <emptyTree>::<C T>.proc().void()).void()
-    end
-
-    def self.teardown<<todo method>>(&block)
       <emptyTree>
     end
 
@@ -132,20 +67,17 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     ::Sorbet::Private::Static.keep_self_def(<self>, :setup, :normal)
 
-    ::Sorbet::Private::Static.keep_self_def(<self>, :teardown, :normal)
-
     <self>.setup() do ||
-      <self>.foo()
-    end
-
-    <self>.teardown() do ||
-      <self>.bar()
+      begin
+        @a = <emptyTree>::<C T>.let(1, <emptyTree>::<C Integer>)
+        <self>.foo()
+      end
     end
   end
 
   class <emptyTree>::<C NoParentClass><<C <todo sym>>> < (::<todo sym>)
     ::Sorbet::Private::Static.sig(<self>) do ||
-      <self>.params(:block, <emptyTree>::<C T>.proc().void()).void()
+      <self>.params(:block, <emptyTree>::<C T>.proc().bind(<emptyTree>::<C T>.attached_class()).void()).void()
     end
 
     def self.setup<<todo method>>(&block)
@@ -153,10 +85,18 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     ::Sorbet::Private::Static.sig(<self>) do ||
-      <self>.params(:block, <emptyTree>::<C T>.proc().void()).void()
+      <self>.params(:block, <emptyTree>::<C T>.proc().bind(<emptyTree>::<C T>.attached_class()).void()).void()
     end
 
     def self.teardown<<todo method>>(&block)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.params(:name, <emptyTree>::<C String>, :block, <emptyTree>::<C T>.proc().bind(<emptyTree>::<C T>.attached_class()).void()).void()
+    end
+
+    def self.test<<todo method>>(name, &block)
       <emptyTree>
     end
 
@@ -172,24 +112,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
-    def test_it_works<<todo method>>(&<blk>)
-      <self>.assert_equal(1, @a)
-    end
-
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
-    end
-
     def initialize<<todo method>>(&<blk>)
       @a = <emptyTree>::<C T>.let(1, <emptyTree>::<C Integer>)
-    end
-
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
-    end
-
-    def teardown<<todo method>>(&<blk>)
-      @a = 5
     end
 
     <self>.extend(<emptyTree>::<C T>::<C Sig>)
@@ -198,12 +122,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     ::Sorbet::Private::Static.keep_self_def(<self>, :teardown, :normal)
 
+    ::Sorbet::Private::Static.keep_self_def(<self>, :test, :normal)
+
     ::Sorbet::Private::Static.keep_def(<self>, :assert_equal, :normal)
 
-    ::Sorbet::Private::Static.keep_def(<self>, :test_it_works, :normal)
-
     ::Sorbet::Private::Static.keep_def(<self>, :initialize, :normal)
-
-    ::Sorbet::Private::Static.keep_def(<self>, :teardown, :normal)
   end
 end


### PR DESCRIPTION
This is the first step in trying to get rid of the `Minitest` and `ActiveSupport::TestCase` rewriters (starting with `TestCase`).

1) Add signatures for the `test`, `setup` and `teardown` methods using blocks. One thing I should note about this is that the real structure inside Rails is slightly different. These methods are actually defined in modules and then extended. 

However, we cannot use `T.attached_class` in a non-singleton context, so the proper representation of these modules won't work. E.g.:
```ruby
module Declarative
  # Fails because T.attached_class is used outside of a singleton context
  sig { params(args: T.untyped, block: T.nilable(T.proc.bind(T.attached_class).void)).void }
  def setup(*args, &block); end
end

class TestCase
  extend Declarative
end
```
Because of this, instead of adding the signatures in modules, they were added straight into the `TestCase` class. I think this is fine, but let me know if there are concerns related to this approach.

2) Get rid of the re-writing the invocations to `test` and `teardown`. The only rewriting we kept is re-writing `setup` method invocations into an `initialize` definition, so that we don't get the error of nilable instance variables in `strict` files.
```ruby
# typed: strict
class MyTest < ActiveSupport::TestCase
  # We rewrite this to avoid emitting an error that the variable `a` must be nilable
  setup do
    @a = T.let(1, Integer)
  end
end
```

### Motivation

Now that we can express the block bindings in respect to `T.attached_class` and `T.self_type`, we can use them to minimize the amount of rewriting we are doing.

The next step is to add signatures for Minitest and try to simplify that rewriter as well. Hopefully, we can combine both rewriters into a single one and only rewrite the minimum necessary.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.