### PR TITLE
Remove PackageDB::lookupPackage, which is never used

### DIFF
--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -127,15 +127,6 @@ NameRef PackageDB::enterPackage(unique_ptr<PackageInfo> pkg) {
     return nr;
 }
 
-NameRef PackageDB::lookupPackage(NameRef pkgMangledName) const {
-    ENFORCE(pkgMangledName.exists());
-    auto it = packages_.find(pkgMangledName);
-    if (it == packages_.end()) {
-        return NameRef::noName();
-    }
-    return it->first;
-}
-
 const PackageInfo &PackageDB::getPackageForFile(const core::GlobalState &gs, core::FileRef file) const {
     ENFORCE(frozen);
 

--- a/core/packages/PackageDB.h
+++ b/core/packages/PackageDB.h
@@ -23,7 +23,6 @@ class PackageDB final {
 
 public:
     NameRef enterPackage(std::unique_ptr<PackageInfo> pkg);
-    NameRef lookupPackage(NameRef pkgMangledName) const;
 
     const PackageInfo &getPackageForFile(const core::GlobalState &gs, core::FileRef file) const;
     const PackageInfo &getPackageInfo(core::NameRef mangledName) const;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Remove PackageDB::lookupPackage, as it's never used.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Cleaning up.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
