### PR TITLE
Add a version of PackageDB::getPackageInfo that works with strings

### DIFF
--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -182,13 +182,7 @@ const PackageInfo &PackageDB::getPackageInfo(const core::GlobalState &gs, std::s
     if (!cnst.exists()) {
         return NONE_PKG;
     }
-
-    auto it = this->packages_.find(cnst);
-    if (it == this->packages_.end()) {
-        return NONE_PKG;
-    }
-
-    return *it->second;
+    return getPackageInfo(cnst);
 }
 
 const PackageInfo &PackageDB::getPackageInfo(core::NameRef mangledName) const {

--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -1,5 +1,6 @@
 #include "core/packages/PackageDB.h"
 #include "absl/strings/match.h"
+#include "absl/strings/str_replace.h"
 #include "common/sort.h"
 #include "core/AutocorrectSuggestion.h"
 #include "core/GlobalState.h"
@@ -163,6 +164,31 @@ const PackageInfo &PackageDB::getPackageForFile(const core::GlobalState &gs, cor
         curPrefixPos = path.find_last_of('/', curPrefixPos - 1);
     }
     return NONE_PKG;
+}
+
+const PackageInfo &PackageDB::getPackageInfo(const core::GlobalState &gs, std::string_view nameStr) const {
+    auto mangled = absl::StrCat(absl::StrReplaceAll(nameStr, {{"::", "_"}}), core::PACKAGE_SUFFIX);
+    auto utf8Name = gs.lookupNameUTF8(mangled);
+    if (!utf8Name.exists()) {
+        return NONE_PKG;
+    }
+
+    auto packagerName = gs.lookupNameUnique(core::UniqueNameKind::Packager, utf8Name, 1);
+    if (!packagerName.exists()) {
+        return NONE_PKG;
+    }
+
+    auto cnst = gs.lookupNameConstant(packagerName);
+    if (!cnst.exists()) {
+        return NONE_PKG;
+    }
+
+    auto it = this->packages_.find(cnst);
+    if (it == this->packages_.end()) {
+        return NONE_PKG;
+    }
+
+    return *it->second;
 }
 
 const PackageInfo &PackageDB::getPackageInfo(core::NameRef mangledName) const {

--- a/core/packages/PackageDB.h
+++ b/core/packages/PackageDB.h
@@ -28,6 +28,9 @@ public:
     const PackageInfo &getPackageForFile(const core::GlobalState &gs, core::FileRef file) const;
     const PackageInfo &getPackageInfo(core::NameRef mangledName) const;
 
+    // Lookup `PackageInfo` from the string representation of the un-mangled package name.
+    const PackageInfo &getPackageInfo(const core::GlobalState &gs, std::string_view str) const;
+
     bool empty() const;
     // Get mangled names for all packages.
     // Packages are ordered lexicographically with respect to the NameRef's that make up their


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
For single-package rbi generation, it's really useful to be able to find packages by their string name. This PR adds that functionality to `PackageDB` as prework for reworking namespace management in single-package mode.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Making it easier to find packages in single-package mode.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
