### PR TITLE
Ruby 3.1: Parse forward arg without parentheses

### DIFF
--- a/parser/parser/cc/context.cc
+++ b/parser/parser/cc/context.cc
@@ -59,6 +59,10 @@ bool Context::indirectlyInDef() {
     return contains(State::DEF) || contains(State::DEFS);
 }
 
+bool Context::inDefOpenArgs() {
+    return !stack.empty() && stack[stack.size() - 1] == State::DEF_OPEN_ARGS;
+}
+
 bool Context::classDefintinionAllowed() {
     auto defIndex = std::max(lastIndexOfState(State::DEF), lastIndexOfState(State::DEFS));
     auto sclassIndex = lastIndexOfState(State::SCLASS);

--- a/parser/parser/cc/driver.cc
+++ b/parser/parser/cc/driver.cc
@@ -63,7 +63,7 @@ void base_driver::rewind_if_dedented(token_t token, token_t kEND, bool force) {
 
 typedruby_release::typedruby_release(std::string_view source, sorbet::StableStringStorage<> &scratch,
                                      const struct builder &builder, bool traceLexer, bool indentationAware)
-    : base_driver(ruby_version::RUBY_27, source, scratch, builder, traceLexer, indentationAware) {}
+    : base_driver(ruby_version::RUBY_31, source, scratch, builder, traceLexer, indentationAware) {}
 
 ForeignPtr typedruby_release::parse(SelfPtr self, bool) {
     bison::typedruby_release::parser p(*this, self);
@@ -73,7 +73,7 @@ ForeignPtr typedruby_release::parse(SelfPtr self, bool) {
 
 typedruby_debug::typedruby_debug(std::string_view source, sorbet::StableStringStorage<> &scratch,
                                  const struct builder &builder, bool traceLexer, bool indentationAware)
-    : base_driver(ruby_version::RUBY_27, source, scratch, builder, traceLexer, indentationAware) {}
+    : base_driver(ruby_version::RUBY_31, source, scratch, builder, traceLexer, indentationAware) {}
 
 ForeignPtr typedruby_debug::parse(SelfPtr self, bool traceParser) {
     bison::typedruby_debug::parser p(*this, self);

--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -3645,28 +3645,15 @@ f_opt_paren_args: f_paren_args
                       driver.lex.set_state_expr_value();
                       $$ = driver.build.args(self, $1, $2, $3, true);
                     }
-                | tLPAREN2 f_arg tCOMMA args_forward rparen
-                    {
-                      driver.lex.declare_forward_args();
-                      auto forward_arg = driver.build.forward_arg(self, nullptr, $4, nullptr);
-                      $2->emplace_back(forward_arg);
-                      $$ = driver.build.args(self, $1, $2, $5, true);
-                    }
-                | tLPAREN2 args_forward rparen
-                    {
-                      driver.lex.set_state_expr_value();
-                      driver.lex.declare_forward_args();
-                      auto forward_arg = driver.build.forward_arg(self, $1, $2, $3);
-                      auto node_list = driver.alloc.node_list(forward_arg);
-                      $$ = driver.build.args(self, $1, node_list, $3, true);
-                    }
        f_arglist: f_paren_args
                 |   {
                       $<boolean>$ = driver.lex.in_kwarg;
                       driver.lex.in_kwarg = true;
+                      driver.lex.context.push(Context::State::DEF_OPEN_ARGS);
                     }
                   f_args term
                     {
+                      driver.lex.context.pop();
                       driver.lex.in_kwarg = $<boolean>1;
                       $$ = driver.build.args(self, nullptr, $2, nullptr, true);
                       DIAGCHECK();
@@ -3700,6 +3687,21 @@ f_opt_paren_args: f_paren_args
                 | f_block_arg
                     {
                       $$ = $1;
+                    }
+                | args_forward
+                    {
+                      if (driver.lex.context.inLambda()) {
+                        // This is supposed to be caught by the grammar.
+                        // However, we don't generate a `ForwardArgs` node in the builder.cc unlike whitequark parser.
+                        // So, we have to manually raise a parse error to forbid `->(...)` usage
+                        // Last argument adds extra double quotes to circumvent an internal check
+                        driver.diagnostics.emplace_back(dlevel::ERROR, dclass::UnexpectedToken, $1, "\"...\"");
+                      }
+
+                      driver.lex.declare_forward_args();
+                      auto result = driver.alloc.node_list();
+                      result->emplace_back(driver.build.forward_arg(self, nullptr, $1, nullptr));
+                      $$ = result;
                     }
 
    opt_args_tail: tCOMMA args_tail

--- a/parser/parser/cc/lexer.rl
+++ b/parser/parser/cc/lexer.rl
@@ -1730,6 +1730,19 @@ void lexer::set_state_expr_value() {
       => { emit(token_type::tLABEL, tok_view(ts, te - 2), ts, te - 1);
            fhold; fnext expr_labelarg; fbreak; };
 
+      '...' c_nl
+      => {
+        if (version >= ruby_version::RUBY_31) {
+          auto ident = tok_view(ts, te - 2);
+          emit(token_type::tBDOT3, ident, ts, te - 1);
+          emit(token_type::tNL, "", newline_s, newline_s + 1);
+          fnext expr_end; fbreak;
+        } else {
+          p -= 4;
+          fhold; fgoto expr_end;
+        }
+      };
+
       w_space_comment;
 
       c_any
@@ -2445,17 +2458,38 @@ void lexer::set_state_expr_value() {
         fnext expr_beg; fbreak;
       };
 
-      '...'
+      # Here we scan and conditionally emit "\n":
+      # + if it's there
+      #   + and emitted we do nothing
+      #   + and not emitted we return `p` to "\n" to process it on the next scan
+      # + if it's not there we do nothing
+      '...' c_nl?
       => {
+        bool followed_by_nl = te - 1 == newline_s;
+        bool nl_emitted = false;
+        auto dots_te = followed_by_nl ? te - 1 : te;
+
         auto ident = tok_view(ts, te - 2);
-        if (version >= ruby_version::RUBY_27) {
-          emit(token_type::tBDOT3, ident, ts, te);
-        } else {
+        if (version >= ruby_version::RUBY_30) {
           if (!lambda_stack.empty() && lambda_stack.top() == paren_nest) {
-            emit(token_type::tDOT3, ident, ts, te);
+            emit(token_type::tDOT3, ident, ts, dots_te);
           } else {
-            emit(token_type::tBDOT3, ident, ts, te);
+            emit(token_type::tBDOT3, ident, ts, dots_te);
+
+            if (version >= ruby_version::RUBY_31 && followed_by_nl && context.inDefOpenArgs()) {
+              emit(token_type::tNL, "", newline_s, newline_s + 1);
+              nl_emitted = true;
+            }
           }
+        } else if (version >= ruby_version::RUBY_27) {
+          emit(token_type::tBDOT3, ident, ts, dots_te);
+        } else {
+          emit(token_type::tDOT3, ident, ts, dots_te);
+        }
+
+         if (followed_by_nl && !nl_emitted) {
+          // return "\n" to process it on the next scan
+          fhold;
         }
 
         fnext expr_beg; fbreak;

--- a/parser/parser/codegen/generate_diagnostics.cc
+++ b/parser/parser/codegen/generate_diagnostics.cc
@@ -71,6 +71,7 @@ tuple<string, string> MESSAGES[] = {
     {"MissingOperatorArg", "missing arg to {} operator"},
     {"CurlyBracesAroundBlockPass", "block pass should not be enclosed in curly braces"},
     {"EmptyCase", "{} statement must at least have one \\\"when\\\" clause"},
+    {"ForwardArgAfterRestArg", "... after rest argument"},
 
     // Error recovery hints
     {"DedentedEnd", "Hint: this {} token might not be properly closed"},

--- a/parser/parser/include/ruby_parser/context.hh
+++ b/parser/parser/include/ruby_parser/context.hh
@@ -17,6 +17,7 @@ public:
         DEFS,
         BLOCK,
         LAMBDA,
+        DEF_OPEN_ARGS,
     };
 
     void push(State state);
@@ -26,6 +27,7 @@ public:
     bool inClass();
     bool inDynamicBlock();
     bool inLambda();
+    bool inDefOpenArgs();
     bool indirectlyInDef();
     bool classDefintinionAllowed();
     bool moduleDefintinionAllowed();

--- a/parser/parser/include/ruby_parser/lexer.hh
+++ b/parser/parser/include/ruby_parser/lexer.hh
@@ -31,6 +31,8 @@ enum class ruby_version {
     RUBY_25,
     RUBY_26,
     RUBY_27,
+    RUBY_30,
+    RUBY_31,
 };
 
 class lexer {

--- a/test/testdata/parser/forward_arg_after_restarg.rb
+++ b/test/testdata/parser/forward_arg_after_restarg.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def foo *rest, ...; end # error: ... after rest argument

--- a/test/whitequark/test_forward_arg_with_open_args_0.parse-tree-whitequark.exp
+++ b/test/whitequark/test_forward_arg_with_open_args_0.parse-tree-whitequark.exp
@@ -1,0 +1,3 @@
+s(:def, :foo,
+  s(:args,
+    s(:forward_arg)), nil)

--- a/test/whitequark/test_forward_arg_with_open_args_0.rb
+++ b/test/whitequark/test_forward_arg_with_open_args_0.rb
@@ -1,0 +1,4 @@
+# typed: true
+
+def foo ...
+end

--- a/test/whitequark/test_forward_arg_with_open_args_1.parse-tree-whitequark.exp
+++ b/test/whitequark/test_forward_arg_with_open_args_1.parse-tree-whitequark.exp
@@ -1,0 +1,6 @@
+s(:def, :foo,
+  s(:args,
+    s(:arg, :a),
+    s(:optarg, :b,
+      s(:int, "1")),
+    s(:forward_arg)), nil)

--- a/test/whitequark/test_forward_arg_with_open_args_1.rb
+++ b/test/whitequark/test_forward_arg_with_open_args_1.rb
@@ -1,0 +1,4 @@
+# typed: true
+
+def foo a, b = 1, ...
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Part of Ruby 3.1 support

https://github.com/whitequark/parser/commit/bb6c4a8e22917fafa1ba9e1b99a3b6598791a694
https://bugs.ruby-lang.org/issues/18267

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Allowing developers to use Sorbet with Ruby 3.1

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

cc @Morriar 