### PR TITLE
Fix sig for env hash on Process.spawn

### DIFF
--- a/rbi/core/process.rbi
+++ b/rbi/core/process.rbi
@@ -1292,7 +1292,7 @@ module Process
     params(
       args: T.any(
         String,
-        T::Hash[T.any(Symbol, String), T.untyped]
+        T::Hash[String, T.untyped]
       )
     ).returns(Integer)
   end


### PR DESCRIPTION
The docs say
```
  #   the keys and the values except for +nil+ must be strings.
```

### Motivation
Common misconception.  Every time I try to use symbols I get an error.

### Test plan
```
irb(main):001:0> Process.spawn({FOO: "bar"}, "env")
Traceback (most recent call last):
        5: from /usr/bin/irb:23:in `<main>'
        4: from /usr/bin/irb:23:in `load'
        3: from /Library/Ruby/Gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
        2: from (irb):1
        1: from (irb):1:in `spawn'
TypeError (no implicit conversion of Symbol into String)
irb(main):002:0> Process.spawn({"FOO" => "bar"}, "env")
=> 23960
irb(main):003:0> __CF_USER_TEXT_ENCODING=0x1F5:0x0:0x0
FOO=bar
```