### PR TITLE
WIP: move test updating into bazel

### DIFF
--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -17,6 +17,7 @@ namespace spd = spdlog;
 using namespace std;
 
 string singleTest;
+string updateExpectations;
 string webTraceFile;
 
 bool isTestMessage(const LSPMessage &msg) {
@@ -671,6 +672,8 @@ int main(int argc, char *argv[]) {
                                                        cxxopts::value<std::string>()->default_value(""), "testpath");
     options.add_options("advanced")("web-trace-file", "Web trace file. For use with chrome about://tracing",
                                     cxxopts::value<std::string>()->default_value(""), "file");
+    options.add_options()("update_exp", "update expectations");
+
     auto res = options.parse(argc, argv);
 
     if (res.count("single_test") != 1) {
@@ -679,6 +682,7 @@ int main(int argc, char *argv[]) {
     }
 
     sorbet::test::singleTest = res["single_test"].as<std::string>();
+    sorbet::test::updateExpectations = res["update_exp"].as<bool>();
     sorbet::test::webTraceFile = res["web-trace-file"].as<std::string>();
 
     doctest::Context context(argc, argv);

--- a/test/parser_test_runner.cc
+++ b/test/parser_test_runner.cc
@@ -190,8 +190,8 @@ TEST_CASE("WhitequarkParserTest") {
 int main(int argc, char *argv[]) {
     cxxopts::Options options("test_corpus", "Test corpus for Sorbet typechecker");
     options.allow_unrecognised_options();
-    options.add_options()("single_test", "run over single test.",
-                          cxxopts::value<std::string>()->default_value(""), "testpath");
+    options.add_options()("single_test", "run over single test.", cxxopts::value<std::string>()->default_value(""),
+                          "testpath");
     options.add_options()("update_exp", "update expectations");
     auto res = options.parse(argc, argv);
 

--- a/test/parser_test_runner.cc
+++ b/test/parser_test_runner.cc
@@ -51,6 +51,7 @@ namespace spd = spdlog;
 using namespace std;
 
 string singleTest;
+string updateExpectations;
 
 UnorderedSet<string> knownExpectations = {
     "parse-tree",       "parse-tree-json", "parse-tree-whitequark", "desugar-tree", "desugar-tree-raw", "rewrite-tree",
@@ -153,12 +154,14 @@ TEST_CASE("WhitequarkParserTest") {
 
         auto checker = test.folder + expectation->second.begin()->second;
         auto expect = FileOps::read(checker.c_str());
-        {
+        if (!updateExpectations) {
             INFO("Mismatch on: " << checker);
             CHECK_EQ(expect, gotPhase.second);
         }
         if (expect == gotPhase.second) {
             MESSAGE(gotPhase.first << " OK");
+        } else if (updateExpectations) {
+            FileOps::write(checker, gotPhase.second);
         }
     }
 
@@ -186,8 +189,10 @@ TEST_CASE("WhitequarkParserTest") {
 
 int main(int argc, char *argv[]) {
     cxxopts::Options options("test_corpus", "Test corpus for Sorbet typechecker");
-    options.allow_unrecognised_options().add_options()("single_test", "run over single test.",
-                                                       cxxopts::value<std::string>()->default_value(""), "testpath");
+    options.allow_unrecognised_options();
+    options.add_options()("single_test", "run over single test.",
+                          cxxopts::value<std::string>()->default_value(""), "testpath");
+    options.add_options()("update_exp", "update expectations");
     auto res = options.parse(argc, argv);
 
     if (res.count("single_test") != 1) {
@@ -196,6 +201,7 @@ int main(int argc, char *argv[]) {
     }
 
     sorbet::test::singleTest = res["single_test"].as<std::string>();
+    sorbet::test::updateExpectations = res["update_exp"].as<bool>();
 
     doctest::Context context(argc, argv);
     return context.run();

--- a/test/pipeline_test.bzl
+++ b/test/pipeline_test.bzl
@@ -173,7 +173,15 @@ def pipeline_tests(suite_name, all_paths, test_name_prefix, extra_args = [], tag
 
         data = []
         if tests[name]["isDirectory"]:
-            data += native.glob(["{}**/*".format(prefix)])
+            data += native.glob(["{}**/*.rb".format(prefix)])
+
+            toplevel_exp = native.glob(["{}*.exp".format(prefix)])
+            all_exp = native.glob(["{}**/*.exp".format(prefix)])
+            if len(toplevel_exp) != len(all_exp):
+                fail("non-toplevel exp files not permitted in {}".format(prefix))
+            data += toplevel_exp
+
+            data += native.glob(["{}**/*.rbupdate".format(prefix)])
         elif tests[name]["isMultiFile"]:
             data += native.glob(["{}*".format(prefix)])
         else:

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -751,8 +751,8 @@ TEST_CASE("PerPhaseTest") { // NOLINT
 int main(int argc, char *argv[]) {
     cxxopts::Options options("test_corpus", "Test corpus for Sorbet typechecker");
     options.allow_unrecognised_options();
-    options.add_options()("single_test", "run over single test.",
-                          cxxopts::value<std::string>()->default_value(""), "testpath");
+    options.add_options()("single_test", "run over single test.", cxxopts::value<std::string>()->default_value(""),
+                          "testpath");
     options.add_options()("update_exp", "update expectations");
 
     auto res = options.parse(argc, argv);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Single source of truth in the build system.  The original idea was that you would run:

```
./bazel test //test:test_corpus
# Get some exp file changes then
./bazel test //test:test_corpus_update
```

and the second step would run much faster than `tools/scripts/update_testdata_exp.sh` because bazel would have already cached all the exp files, and could just copy things over in the second step.

Unfortunately things don't work like that: pipeline tests are currently just that, tests, and tests can't write output that other tests depend on.  In order to make things work like the above, we'd have to:

1. Change the current pipeline runner to actually be some kind of build step where we would record stderr, stdout, and write out any differing files.
2. Save those files somewhere and tell bazel that the above build step produces them.
3. Make the current `test_corpus` etc. consume that build step and basically dump stderr, stdout, etc.
4. Make the update step consume the above build step and update the exp files.

This proposed scheme might be somewhat slower, because now we'd be doing a bunch of file I/O in the test runner that we weren't before.

This PR is a half-hearted execution of the above, and just teaches the test runner how to update exp files, along with teaching bazel how to run the test runner in "update expectations" mode.  Having bazel do the work is not particularly fast; a default ("fastbuild") run on my machine (14C/28T) takes about 30 seconds; a `-c opt` build is about 6 seconds (which feels faster than `update_testdata_exp.sh`?).

Updating is also complicated because things could be racy -- if `test_corpus_update` and `test_corpus_lsp_update` are both running update jobs for the same file simultaneously, you might not properly update the expectation files.  So maybe you have to run the suites serially, which is not quite as nice.  I didn't feel like fully replicating `update_testdata_exp.sh`'s logic in Starlark, but that would be a more reliable path to updating everything in one go.

I haven't updated the LSP test runner to update document-symbols tests or rubyfmt bits.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
