### PR TITLE
Ruby 3.1: Parse anonymous block argument

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -724,11 +724,18 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                     // tuple type and call into the normal call merchanism.
                     unique_ptr<parser::Node> block;
                     auto argnodes = std::move(send->args);
+                    bool anonymousBlockPass = false;
+                    core::LocOffsets bpLoc;
                     auto it = absl::c_find_if(argnodes,
                                               [](auto &arg) { return parser::isa_node<parser::BlockPass>(arg.get()); });
                     if (it != argnodes.end()) {
                         auto *bp = parser::cast_node<parser::BlockPass>(it->get());
-                        block = std::move(bp->block);
+                        if (bp->block == nullptr) {
+                            anonymousBlockPass = true;
+                            bpLoc = bp->loc;
+                        } else {
+                            block = std::move(bp->block);
+                        }
                         argnodes.erase(it);
                     }
 
@@ -778,11 +785,17 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                     sendargs.emplace_back(std::move(args));
                     sendargs.emplace_back(std::move(kwargs));
                     ExpressionPtr res;
-                    if (block == nullptr) {
+                    if (block == nullptr && !anonymousBlockPass) {
                         res = MK::Send(loc, MK::Constant(loc, core::Symbols::Magic()), core::Names::callWithSplat(),
                                        locZeroLen, 4, std::move(sendargs), flags);
                     } else {
-                        auto convertedBlock = node2TreeImpl(dctx, std::move(block));
+                        ExpressionPtr convertedBlock;
+                        if (anonymousBlockPass) {
+                            ENFORCE(block == nullptr, "encountered a block while processing an anonymous block pass");
+                            convertedBlock = MK::Local(bpLoc, core::Names::ampersand());
+                        } else {
+                            convertedBlock = node2TreeImpl(dctx, std::move(block));
+                        }
                         Literal *lit;
                         if ((lit = cast_tree<Literal>(convertedBlock)) && lit->isSymbol(dctx.ctx)) {
                             res = MK::Send(loc, MK::Constant(loc, core::Symbols::Magic()), core::Names::callWithSplat(),
@@ -835,10 +848,17 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                     Send::ARGS_store args;
                     unique_ptr<parser::Node> block;
                     args.reserve(send->args.size());
+                    bool anonymousBlockPass = false;
+                    core::LocOffsets bpLoc;
                     for (auto &stat : send->args) {
                         if (auto bp = parser::cast_node<parser::BlockPass>(stat.get())) {
                             ENFORCE(block == nullptr, "passing a block where there is no block");
-                            block = std::move(bp->block);
+                            if (bp->block == nullptr) {
+                                anonymousBlockPass = true;
+                                bpLoc = bp->loc;
+                            } else {
+                                block = std::move(bp->block);
+                            }
 
                             // we don't count the block arg as part of the positional arguments anymore.
                             numPosArgs = max(0, numPosArgs - 1);
@@ -850,13 +870,19 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                     DuplicateHashKeyCheck::checkSendArgs(dctx, numPosArgs, args);
 
                     ExpressionPtr res;
-                    if (block == nullptr) {
+                    if (block == nullptr && !anonymousBlockPass) {
                         res = MK::Send(loc, std::move(rec), send->method, send->methodLoc, numPosArgs, std::move(args),
                                        flags);
                     } else {
                         auto method =
                             MK::Literal(loc, core::make_type<core::LiteralType>(core::Symbols::Symbol(), send->method));
-                        auto convertedBlock = node2TreeImpl(dctx, std::move(block));
+                        ExpressionPtr convertedBlock;
+                        if (anonymousBlockPass) {
+                            ENFORCE(block == nullptr, "encountered a block while processing an anonymous block pass");
+                            convertedBlock = MK::Local(bpLoc, core::Names::ampersand());
+                        } else {
+                            convertedBlock = node2TreeImpl(dctx, std::move(block));
+                        }
                         Literal *lit;
                         if ((lit = cast_tree<Literal>(convertedBlock)) && lit->isSymbol(dctx.ctx)) {
                             res = MK::Send(loc, std::move(rec), send->method, send->methodLoc, numPosArgs,

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -337,6 +337,7 @@ NameDef names[] = {
     {"kwargs", "<kwargs>"},
     {"blkArg", "<blk>"},
     {"blockGiven_p", "block_given?"},
+    {"anonymousBlock", "<anonymous-block>"},
 
     // Used to generate temporary names for destructuring arguments ala proc do
     //  |(x,y)|; end

--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -562,6 +562,10 @@ public:
     }
 
     unique_ptr<Node> blockPass(const token *amper, unique_ptr<Node> arg) {
+        if (arg == nullptr) {
+            return make_unique<BlockPass>(tokLoc(amper), nullptr);
+        }
+
         return make_unique<BlockPass>(tokLoc(amper).join(arg->loc), std::move(arg));
     }
 

--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -1811,6 +1811,14 @@ lbrace_cmd_block_start:
                     {
                       $$ = driver.build.blockPass(self, $1, $2);
                     }
+                | tAMPER
+                    {
+                      if (!driver.lex.is_declared_anonymous_args()) {
+                        driver.diagnostics.emplace_back(dlevel::ERROR, dclass::NoAnonymousBlockArg, $1);
+                      }
+
+                      $$ = driver.build.blockPass(self, $1, nullptr);
+                    }
 
    opt_block_arg: tCOMMA block_arg
                     {
@@ -4113,6 +4121,14 @@ f_opt_paren_args: f_paren_args
                       driver.lex.declare(ident->view());
 
                       auto blockarg = driver.build.blockarg(self, $1, ident);
+
+                      $$ = driver.alloc.node_list(blockarg);
+                    }
+                | blkarg_mark
+                    {
+                      driver.lex.declare_anonymous_args();
+
+                      auto blockarg = driver.build.blockarg(self, $1, nullptr);
 
                       $$ = driver.alloc.node_list(blockarg);
                     }

--- a/parser/parser/cc/lexer.rl
+++ b/parser/parser/cc/lexer.rl
@@ -3073,6 +3073,14 @@ bool lexer::is_declared_forward_args() {
   return is_declared(FORWARD_ARGS);
 }
 
+void lexer::declare_anonymous_args() {
+  declare(ANONYMOUS_BLOCKARG);
+}
+
+bool lexer::is_declared_anonymous_args() {
+  return is_declared(ANONYMOUS_BLOCKARG);
+}
+
 optional_size lexer::dedentLevel() {
   // We erase @dedentLevel as a precaution to avoid accidentally
   // using a stale value.

--- a/parser/parser/codegen/generate_diagnostics.cc
+++ b/parser/parser/codegen/generate_diagnostics.cc
@@ -73,6 +73,7 @@ tuple<string, string> MESSAGES[] = {
     {"EmptyCase", "{} statement must at least have one \\\"when\\\" clause"},
     {"ForwardArgAfterRestArg", "... after rest argument"},
     {"InvalidIdToGet", "identifier {} is not valid to get"},
+    {"NoAnonymousBlockArg", "no anonymous block parameter"},
 
     // Error recovery hints
     {"DedentedEnd", "Hint: this {} token might not be properly closed"},

--- a/parser/parser/include/ruby_parser/lexer.hh
+++ b/parser/parser/include/ruby_parser/lexer.hh
@@ -96,6 +96,7 @@ private:
     int act;
 
     const std::string FORWARD_ARGS = "FORWARD_ARGS";
+    const std::string ANONYMOUS_BLOCKARG = "ANONYMOUS_BLOCKARG";
 
     // State before =begin / =end block comment
     int cs_before_block_comment;
@@ -226,6 +227,8 @@ public:
     bool is_declared(std::string_view identifier) const;
     void declare_forward_args();
     bool is_declared_forward_args();
+    void declare_anonymous_args();
+    bool is_declared_anonymous_args();
 
     optional_size dedentLevel();
 };

--- a/test/testdata/desugar/anonymous_blockarg.rb
+++ b/test/testdata/desugar/anonymous_blockarg.rb
@@ -1,0 +1,11 @@
+# typed: true
+
+def foo(args, &)
+  bar(*args, &)
+end
+
+def bar(args, &)
+  baz(&)
+end
+
+foo (1) { 2 }

--- a/test/testdata/desugar/anonymous_blockarg.rb.desugar-tree.exp
+++ b/test/testdata/desugar/anonymous_blockarg.rb.desugar-tree.exp
@@ -1,0 +1,13 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  def foo<<todo method>>(args, &&$2)
+    ::<Magic>.<call-with-splat-and-block>(<self>, :bar, ::<Magic>.<splat>(args), nil, &)
+  end
+
+  def bar<<todo method>>(args, &&$3)
+    ::<Magic>.<call-with-block>(<self>, :baz, &)
+  end
+
+  <self>.foo(1) do ||
+    2
+  end
+end

--- a/test/testdata/parser/anon_blockarg.rb
+++ b/test/testdata/parser/anon_blockarg.rb
@@ -1,4 +1,0 @@
-# typed: true
-def foo(&)
-  #      ^ error: unexpected token ")"
-end

--- a/test/whitequark/test_anonymous_blockarg_0.parse-tree-whitequark.exp
+++ b/test/whitequark/test_anonymous_blockarg_0.parse-tree-whitequark.exp
@@ -1,0 +1,5 @@
+s(:def, :foo,
+  s(:args,
+    s(:blockarg, nil)),
+  s(:send, nil, :bar,
+    s(:block_pass, nil)))

--- a/test/whitequark/test_anonymous_blockarg_0.parse-tree-whitequark.exp
+++ b/test/whitequark/test_anonymous_blockarg_0.parse-tree-whitequark.exp
@@ -1,5 +1,5 @@
 s(:def, :foo,
   s(:args,
-    s(:blockarg, nil)),
+    s(:blockarg, :&)),
   s(:send, nil, :bar,
     s(:block_pass, nil)))

--- a/test/whitequark/test_anonymous_blockarg_0.rb
+++ b/test/whitequark/test_anonymous_blockarg_0.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def foo(&); bar(&); end

--- a/test/whitequark/test_anonymous_blockarg_1.rb
+++ b/test/whitequark/test_anonymous_blockarg_1.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def foo(); bar(&); end # error: no anonymous block parameter

--- a/test/whitequark/test_anonymous_blockarg_2.rb
+++ b/test/whitequark/test_anonymous_blockarg_2.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+def foo(&0); end # error: unexpected token tINTEGER


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Resolves https://github.com/sorbet/sorbet/issues/5155

https://bugs.ruby-lang.org/issues/11256
https://github.com/whitequark/parser/pull/833

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Allowing developers to use Sorbet with Ruby 3.1

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
