### PR TITLE
Fix error location for `&.` error, add autocorrect

### DIFF
--- a/core/Loc.cc
+++ b/core/Loc.cc
@@ -262,6 +262,8 @@ optional<string_view> Loc::source(const GlobalState &gs) const {
 }
 
 bool Loc::contains(const Loc &other) const {
+    ENFORCE_NO_TIMER(this->exists());
+    ENFORCE_NO_TIMER(other.exists());
     return file() == other.file() && other.beginPos() >= beginPos() && other.endPos() <= endPos();
 }
 

--- a/core/lsp/Query.cc
+++ b/core/lsp/Query.cc
@@ -40,7 +40,7 @@ bool Query::matchesLoc(const core::Loc &loc) const {
     // N.B.: Sorbet inserts zero-length Locs for items that are implicitly inserted during parsing.
     // Example: `foo` may be translated into `self.foo`, where `self.` has a 0-length loc.
     // We disregard these in LSP matches, as they don't correspond to source text that the user is pointing at.
-    return kind == Query::Kind::LOC && (loc.endPos() - loc.beginPos()) > 0 && loc.contains(this->loc);
+    return this->kind == Query::Kind::LOC && loc.exists() && !loc.empty() && loc.contains(this->loc);
 }
 
 bool Query::matchesVar(const core::SymbolRef &owner, const core::LocalVariable &var) const {

--- a/test/cli/expected-got/expected-got.out
+++ b/test/cli/expected-got/expected-got.out
@@ -101,11 +101,15 @@ test/cli/expected-got/expected-got.rb:47: Revealed type: `Integer(42)` https://s
 
 test/cli/expected-got/expected-got.rb:57: Used `&.` operator on `Integer(1)`, which can never be nil https://srb.help/7034
     57 |1&.even?
-        ^
+         ^^
   Got `Integer(1)` originating from:
     test/cli/expected-got/expected-got.rb:57:
     57 |1&.even?
         ^
+  Autocorrect: Use `-a` to autocorrect
+    test/cli/expected-got/expected-got.rb:57: Replace with `.`
+    57 |1&.even?
+         ^^
 
 test/cli/expected-got/expected-got.rb:59: Method `top_level_does_not_exist` does not exist on `T.class_of(<root>)` https://srb.help/7003
     59 |top_level_does_not_exist

--- a/test/testdata/desugar/blockpass.rb
+++ b/test/testdata/desugar/blockpass.rb
@@ -45,7 +45,8 @@ def foo(&blk)
     calls_with_object(&HasToProc.new)
     calls_with_object {|*args| HasToProc.new.to_proc.call(*args)}
     CallsWithObject.calls_with_object(&:meth)
-    CallsWithObject&.calls_with_object(&:meth) # error: Used `&.` operator on `T.class_of(CallsWithObject)`, which can never be nil
+    CallsWithObject&.calls_with_object(&:meth)
+    #              ^^ error: Used `&.` operator on `T.class_of(CallsWithObject)`, which can never be nil
     CallsWithObjectChild.calls_with_object(&:meth)
     calls_arg_with_object(HasMeth.new, &:meth)
     calls_arg_with_object(HasMeth.new) {|x| x.meth}

--- a/test/testdata/infer/nil_safe_navigation.rb
+++ b/test/testdata/infer/nil_safe_navigation.rb
@@ -4,7 +4,8 @@ extend T::Sig
 
 sig {params(x: Integer, y: T.nilable(Integer)).void}
 def foo(x, y)
-  puts x&.to_s       # error: Used `&.` operator on `Integer`, which can never be nil
+  puts x&.to_s
+  #     ^^ error: Used `&.` operator on `Integer`, which can never be nil
   puts x.to_s
 
   puts y&.to_s

--- a/test/testdata/lsp/hover_ampersand_operations.rb
+++ b/test/testdata/lsp/hover_ampersand_operations.rb
@@ -19,24 +19,28 @@ def main
 
   # Safenav
   dog = Dog.new
-  breed = dog&.breed # error: Used `&.` operator on `Dog`, which can never be nil
+  breed = dog&.breed
+  #          ^^ error: Used `&.` operator on `Dog`, which can never be nil
 # ^ hover: String
-        # ^ hover: Dog
-            # ^ hover: sig {returns(String)}
+  #       ^ hover: Dog
+  #          ^ hover: Dog
+  #           ^ hover: sig {returns(String)}
+  #            ^ hover: sig {returns(String)}
+  #             ^ hover: sig {returns(String)}
 
   maybeDog = T.let(nil, T.nilable(Dog))
   maybeBreed = maybeDog&.breed
 # ^ hover: T.nilable(String)
-             # ^ hover: T.nilable(Dog)
-                      # ^ hover: sig {returns(String)}
-                       # ^ hover: sig {returns(String)}
+  #            ^ hover: T.nilable(Dog)
+  #                     ^ hover: NilClass
+  #                      ^ hover: sig {returns(String)}
   breed2 = T.let(nil, T.nilable(String))
   breed2 ||= maybeDog&.breed
 # ^ hover: T.nilable(String)
-                    # ^ hover: sig {returns(String)}
-                     # ^ hover: sig {returns(String)}
+  #                   ^ hover: NilClass
+  #                    ^ hover: sig {returns(String)}
   breed2 &&= maybeDog&.breed
   # ^ hover: T.nilable(String)
-                    # ^ hover: sig {returns(String)}
-                     # ^ hover: sig {returns(String)}
+  #                   ^ hover: NilClass
+  #                    ^ hover: sig {returns(String)}
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

@jvilk-stripe reported this bug while working on something at Stripe.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.