### PR TITLE
Track more information for single-package rbi generation

### DIFF
--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -280,15 +280,9 @@ public:
     // If 'true', enforce use of Ruby 3.0-style keyword args.
     bool ruby3KeywordArgs = false;
 
-    // When present, this is a vector of mangled package names for the parent packages of the package whose interface
-    // we're currently generating. For example, if we're generating the interface for the package
-    //
-    // > Foo::Bar::Baz
-    //
-    // And both `Foo` and `Foo::Bar` are packages, the mangled names of those two packages would be in this vector.
-    // These names are used when deciding how to stub unknown constant references in the resolver, and this optional
-    // having a value is used to signal single-package interface generation.
-    std::optional<std::vector<core::NameRef>> singlePackageParents;
+    // When present, this indicates that single-package rbi generation is being performed, and contains metadata about
+    // the packages that are imported by the one whose interface is being generated.
+    std::optional<packages::ImportInfo> singlePackageImports;
 
     void ignoreErrorClassForSuggestTyped(int code);
     void suppressErrorClass(int code);

--- a/core/packages/PackageInfo.cc
+++ b/core/packages/PackageInfo.cc
@@ -1,4 +1,5 @@
 #include "core/packages/PackageInfo.h"
+#include "core/GlobalState.h"
 #include "core/Loc.h"
 #include "core/NameRef.h"
 #include "core/Symbols.h"
@@ -32,4 +33,34 @@ bool PackageInfo::lexCmp(const std::vector<core::NameRef> &lhs, const std::vecto
     return std::lexicographical_compare(lhs.begin(), lhs.end(), rhs.begin(), rhs.end(),
                                         [](NameRef a, NameRef b) -> bool { return a.rawId() < b.rawId(); });
 }
+
+ImportInfo ImportInfo::fromPackage(const core::GlobalState &gs, const PackageInfo &info) {
+    ImportInfo res;
+    res.package = info.mangledName();
+
+    auto &thisName = info.fullName();
+
+    auto &db = gs.packageDB();
+
+    for (auto pkg : db.packages()) {
+        auto &pkgInfo = db.getPackageInfo(pkg);
+        if (!info.importsPackage(pkgInfo)) {
+            continue;
+        }
+
+        auto &fullName = pkgInfo.fullName();
+
+        if (thisName.size() >= fullName.size()) {
+            if (std::equal(fullName.begin(), fullName.end(), thisName.begin())) {
+                res.parentImports.emplace_back(pkg);
+                continue;
+            }
+        }
+
+        res.regularImports.emplace_back(pkg);
+    }
+
+    return res;
+}
+
 } // namespace sorbet::core::packages

--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -64,5 +64,25 @@ public:
 
     static bool lexCmp(const std::vector<core::NameRef> &lhs, const std::vector<core::NameRef> &rhs);
 };
+
+// Information about the imports of a package. The imports are split into two categories, packages whose name falls
+// within the namespace of `package`, and everything else. The reason for pre-processing the imports this way is that it
+// simplifies some work when stubbing constants for rbi generation.
+class ImportInfo final {
+public:
+    // The mangled name of the package whose imports are described.
+    core::NameRef package;
+
+    // Imported packages whose name is a prefix of `package`. For example, if the package `Foo::Bar` imports `Foo` that
+    // package's name would be in `parentImports` because its name is a prefix of `Foo::Bar`.
+    std::vector<core::NameRef> parentImports;
+
+    // The mangled names of packages that are imported by this package, minus any imports that fall in the parent
+    // namespace of this package.
+    std::vector<core::NameRef> regularImports;
+
+    static ImportInfo fromPackage(const core::GlobalState &gs, const PackageInfo &info);
+};
+
 } // namespace sorbet::core::packages
 #endif

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -455,7 +455,6 @@ int realmain(int argc, char *argv[]) {
     gs->errorUrlBase = opts.errorUrlBase;
     gs->semanticExtensions = move(extensions);
     vector<ast::ParsedFile> indexed;
-    core::NameRef singlePackageTarget;
 
     gs->requiresAncestorEnabled = opts.requiresAncestorEnabled;
 
@@ -595,24 +594,25 @@ int realmain(int argc, char *argv[]) {
             if (!opts.singlePackage.empty()) {
                 Timer singlePackageTimer(logger, "singlePackage.setup");
 
-                auto info = packager::RBIGenerator::findSinglePackage(*gs, opts.singlePackage);
-                if (!info.packageName.exists()) {
+                auto &pkg = gs->packageDB().getPackageInfo(*gs, opts.singlePackage);
+                if (!pkg.exists()) {
                     logger->error("Unable to find package `{}`", opts.singlePackage);
                     return 1;
                 }
-                singlePackageTarget = info.packageName;
+
+                auto info = core::packages::ImportInfo::fromPackage(*gs, pkg);
 
                 // Only keep inputs that are part of the package whose interface we're generating
                 auto &db = gs->packageDB();
                 auto it = std::remove_if(inputFiles.begin(), inputFiles.end(), [&gs = *gs, &db, &info](auto file) {
                     auto &pkg = db.getPackageForFile(gs, file);
-                    return pkg.exists() && pkg.mangledName() != info.packageName;
+                    return pkg.exists() && pkg.mangledName() != info.package;
                 });
                 inputFiles.erase(it, inputFiles.end());
 
                 // Record parent information in GlobalState to guide the resolver when stubbing out constants that come
                 // from other packages.
-                gs->singlePackageParents.emplace(std::move(info.parents));
+                gs->singlePackageImports.emplace(std::move(info));
             }
 #endif
         }
@@ -769,7 +769,7 @@ int realmain(int argc, char *argv[]) {
             auto packageNamespaces = packager::RBIGenerator::buildPackageNamespace(*gs, *workers);
 
             if (!opts.singlePackage.empty()) {
-                packager::RBIGenerator::runSinglePackage(*gs, packageNamespaces, singlePackageTarget,
+                packager::RBIGenerator::runSinglePackage(*gs, packageNamespaces, gs->singlePackageImports->package,
                                                          opts.packageRBIOutput, *workers);
             } else {
                 packager::RBIGenerator::run(*gs, packageNamespaces, opts.packageRBIOutput, *workers);

--- a/packager/rbi_gen.cc
+++ b/packager/rbi_gen.cc
@@ -1348,37 +1348,4 @@ void RBIGenerator::runSinglePackage(core::GlobalState &gs,
     }
 }
 
-RBIGenerator::SinglePackageInfo RBIGenerator::findSinglePackage(core::GlobalState &gs, std::string packageName) {
-    SinglePackageInfo res;
-
-    auto &db = gs.packageDB();
-    auto &packages = db.packages();
-
-    auto nameParts = absl::StrSplit(packageName, "::");
-    auto nameSize = std::distance(nameParts.begin(), nameParts.end());
-    for (auto pkg : packages) {
-        auto &info = db.getPackageInfo(pkg);
-
-        auto &fullName = info.fullName();
-        if (nameSize < fullName.size()) {
-            continue;
-        }
-
-        // `nameParts` will be at least as long as `fullName` because of the check above, so using `nameParts` as the
-        // third argument to `std::equal` is safe. When the two don't match in length but prefixEqual is true,
-        // `pkg` is a parent package of the package we're looking for.
-        bool prefixEqual = std::equal(fullName.begin(), fullName.end(), nameParts.begin(),
-                                      [&gs](auto name, auto part) { return name.shortName(gs) == part; });
-        if (prefixEqual) {
-            if (nameSize == fullName.size()) {
-                res.packageName = pkg;
-            } else {
-                res.parents.emplace_back(pkg);
-            }
-        }
-    }
-
-    return res;
-}
-
 } // namespace sorbet::packager

--- a/packager/rbi_gen.h
+++ b/packager/rbi_gen.h
@@ -30,18 +30,6 @@ public:
     // Generate RBIs for a single package, provided as the mangled package name `package`.
     static void runSinglePackage(core::GlobalState &gs, const UnorderedSet<core::ClassOrModuleRef> &packageNamespaces,
                                  core::NameRef package, std::string outputDir, WorkerPool &workers);
-
-    struct SinglePackageInfo {
-        // The mangled name of the package we're generating an interface for.
-        core::NameRef packageName;
-
-        // The mangled names of all packages that lie in the parent namespace of `packageName` above. For example, if
-        // the package we're generating an interface for is `Foo::Bar` and `Foo` is also a package, the mangled name of
-        // `Foo` will be the only element in this vector.
-        std::vector<core::NameRef> parents;
-    };
-
-    static SinglePackageInfo findSinglePackage(core::GlobalState &gs, std::string packageName);
 };
 } // namespace sorbet::packager
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -352,7 +352,7 @@ private:
 
         auto &db = gs.packageDB();
 
-        for (auto parent : *gs.singlePackageParents) {
+        for (auto parent : gs.singlePackageImports->parentImports) {
             auto &info = db.getPackageInfo(parent);
 
             auto &stub = stubs.emplace_back();
@@ -429,7 +429,7 @@ private:
                                          const vector<ParentPackageStub> &parentPackageStubs, int &suggestionCount) {
         auto &original = ast::cast_tree_nonnull<ast::UnresolvedConstantLit>(job.out->original);
 
-        bool singlePackageRbiGeneration = ctx.state.singlePackageParents.has_value();
+        bool singlePackageRbiGeneration = ctx.state.singlePackageImports.has_value();
 
         auto resolved = resolveConstant(ctx.withOwner(job.scope->scope), job.scope, original, job.resolutionFailed);
         if (resolved.exists() && resolved.isTypeAlias(ctx)) {
@@ -1566,7 +1566,7 @@ public:
 
             // Initialize the stubbed parent namespaces if we're generating an interface for a single package
             vector<ParentPackageStub> parentPackageStubs;
-            bool singlePackageRbiGeneration = gs.singlePackageParents.has_value();
+            bool singlePackageRbiGeneration = gs.singlePackageImports.has_value();
             if (singlePackageRbiGeneration) {
                 parentPackageStubs = initParentStubs(gs);
             }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
We currently consider all parent packages for stubbing when generating rbis in single-package mode, but we need to only consider those that are explicitly imported. This PR makes that change, and also tracks all imported package names, which will be needed for stubbing constants that come from imported child packages.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
