### PR TITLE
Remove redundant Loc from matchArgType

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -203,25 +203,9 @@ bool isSetter(const GlobalState &gs, NameRef fun) {
     return false;
 }
 
-uint32_t locSize(core::Loc loc) {
-    return loc.endPos() - loc.beginPos();
-}
-
-// Find the smallest applicable arg loc that falls within the callLoc. Returns the call site's loc if none found.
-// Used to ignore origins that are not relevant to call site.
-core::Loc smallestLocWithin(core::Loc callLoc, const core::TypeAndOrigins &argTpe) {
-    core::Loc chosen = callLoc;
-    for (auto loc : argTpe.origins) {
-        if (callLoc.contains(loc) && locSize(loc) < locSize(chosen)) {
-            chosen = loc;
-        }
-    }
-    return chosen;
-}
-
-unique_ptr<Error> matchArgType(const GlobalState &gs, TypeConstraint &constr, Loc callLoc, Loc receiverLoc,
-                               ClassOrModuleRef inClass, MethodRef method, const TypeAndOrigins &argTpe,
-                               const ArgInfo &argSym, const TypePtr &selfType, const vector<TypePtr> &targs, Loc loc,
+unique_ptr<Error> matchArgType(const GlobalState &gs, TypeConstraint &constr, Loc receiverLoc, ClassOrModuleRef inClass,
+                               MethodRef method, const TypeAndOrigins &argTpe, const ArgInfo &argSym,
+                               const TypePtr &selfType, const vector<TypePtr> &targs, Loc argLoc,
                                Loc originForUninitialized, bool mayBeSetter = false) {
     TypePtr expectedType = Types::resultTypeAsSeenFrom(gs, argSym.type, method.data(gs)->owner, inClass, targs);
     if (!expectedType) {
@@ -234,7 +218,7 @@ unique_ptr<Error> matchArgType(const GlobalState &gs, TypeConstraint &constr, Lo
         return nullptr;
     }
 
-    if (auto e = gs.beginError(smallestLocWithin(callLoc, argTpe), errors::Infer::MethodArgumentMismatch)) {
+    if (auto e = gs.beginError(argLoc, errors::Infer::MethodArgumentMismatch)) {
         if (mayBeSetter && isSetter(gs, method.data(gs)->name)) {
             e.setHeader("Assigning a value to `{}` that does not match expected type `{}`", argSym.argumentName(gs),
                         expectedType.show(gs));
@@ -246,7 +230,7 @@ unique_ptr<Error> matchArgType(const GlobalState &gs, TypeConstraint &constr, Lo
         }
         e.addErrorSection(argTpe.explainGot(gs, originForUninitialized));
         core::TypeErrorDiagnostics::explainTypeMismatch(gs, e, expectedType, argTpe.type);
-        TypeErrorDiagnostics::maybeAutocorrect(gs, e, loc, constr, expectedType, argTpe.type);
+        TypeErrorDiagnostics::maybeAutocorrect(gs, e, argLoc, constr, expectedType, argTpe.type);
         return e.build();
     }
     return nullptr;
@@ -799,9 +783,8 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
         }
 
         auto offset = ait - args.args.begin();
-        if (auto e =
-                matchArgType(gs, *constr, args.callLoc(), args.receiverLoc(), symbol, method, *arg, spec, args.selfType,
-                             targs, args.argLoc(offset), args.originForUninitialized, args.args.size() == 1)) {
+        if (auto e = matchArgType(gs, *constr, args.receiverLoc(), symbol, method, *arg, spec, args.selfType, targs,
+                                  args.argLoc(offset), args.originForUninitialized, args.args.size() == 1)) {
             result.main.errors.emplace_back(std::move(e));
         }
 
@@ -929,7 +912,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
 
             // If there are positional arguments left to be filled, but there were keyword arguments present,
             // consume the keyword args hash as though it was a positional arg.
-            if (auto e = matchArgType(gs, *constr, args.callLoc(), args.receiverLoc(), symbol, method,
+            if (auto e = matchArgType(gs, *constr, args.receiverLoc(), symbol, method,
                                       TypeAndOrigins{kwargs, {kwargsLoc}}, *pit, args.selfType, targs, kwargsLoc,
                                       args.originForUninitialized, args.args.size() == 1)) {
                 result.main.errors.emplace_back(std::move(e));
@@ -963,8 +946,8 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
             auto kwSplatTPO = TypeAndOrigins{kwSplatType, kwSplatArg->origins};
 
             if (hasKwSplatParam && !hasKwParam) {
-                if (auto e = matchArgType(gs, *constr, args.callLoc(), args.receiverLoc(), symbol, method, kwSplatTPO,
-                                          *kwSplatParam, args.selfType, targs, kwargsLoc, args.originForUninitialized,
+                if (auto e = matchArgType(gs, *constr, args.receiverLoc(), symbol, method, kwSplatTPO, *kwSplatParam,
+                                          args.selfType, targs, kwargsLoc, args.originForUninitialized,
                                           args.args.size() == 1)) {
                     result.main.errors.emplace_back(std::move(e));
                 }
@@ -1047,9 +1030,9 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                         tpe.origins = {kwargsLoc};
                         auto offset = it - hash->keys.begin();
                         tpe.type = hash->values[offset];
-                        if (auto e =
-                                matchArgType(gs, *constr, args.callLoc(), args.receiverLoc(), symbol, method, tpe, spec,
-                                             args.selfType, targs, Loc::none(), args.originForUninitialized)) {
+                        if (auto e = matchArgType(gs, *constr, args.receiverLoc(), symbol, method, tpe, spec,
+                                                  args.selfType, targs, kwargsLoc, args.originForUninitialized)) {
+                            stopInDebugger();
                             result.main.errors.emplace_back(std::move(e));
                         }
                     }
@@ -1103,11 +1086,11 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                 bool argInBounds = kwaValue < ait;
                 auto kwargOffset = kwaValue - args.args.begin();
                 auto originLoc = argInBounds ? args.argLoc(kwargOffset) : kwargsLoc;
-                auto argLoc = argInBounds ? args.argLoc(kwargOffset) : Loc::none();
+                auto argLoc = argInBounds ? args.argLoc(kwargOffset) : args.callLoc();
                 tpe.origins = {originLoc};
                 tpe.type = hash->values[offset];
-                if (auto e = matchArgType(gs, *constr, args.callLoc(), args.receiverLoc(), symbol, method, tpe, spec,
-                                          args.selfType, targs, argLoc, args.originForUninitialized)) {
+                if (auto e = matchArgType(gs, *constr, args.receiverLoc(), symbol, method, tpe, spec, args.selfType,
+                                          targs, argLoc, args.originForUninitialized)) {
                     result.main.errors.emplace_back(std::move(e));
                 }
             }

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1544,7 +1544,6 @@ class TreeSymbolizer {
                 if (auto e = ctx.beginError(arg.loc(), core::errors::Namer::AncestorNotConstant)) {
                     e.setHeader("`{}` must only contain constant literals", send->fun.show(ctx));
                 }
-                arg = ast::MK::EmptyTree();
             }
         }
     }

--- a/test/cli/autocorrect/autocorrect.out
+++ b/test/cli/autocorrect/autocorrect.out
@@ -28,7 +28,7 @@ autocorrect.rb:4: Method `[]` does not exist on `NilClass` component of `T.nilab
 
 autocorrect.rb:6: Expected `String` but found `T.nilable(String)` for argument `arg0` https://srb.help/7002
      6 |"hi" + foo
-        ^^^^^^^^^^
+               ^^^
   Expected `String` for argument `arg0` of method `String#+`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/string.rbi#L68:
     68 |        arg0: String,

--- a/test/cli/autocorrect_array_plus/autocorrect_array_plus.out
+++ b/test/cli/autocorrect_array_plus/autocorrect_array_plus.out
@@ -1,6 +1,6 @@
 autocorrect_array_plus.rb:6: Expected `T::Enumerable[Integer]` but found `T::Array[String]` for argument `arg0` https://srb.help/7002
      6 |ints + strings
-        ^^^^^^^^^^^^^^
+               ^^^^^^^
   Expected `T::Enumerable[Integer]` for argument `arg0` of method `Array#+`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/array.rbi#L448:
      448 |        arg0: T::Enumerable[Elem],
@@ -18,7 +18,7 @@ autocorrect_array_plus.rb:6: Expected `T::Enumerable[Integer]` but found `T::Arr
 
 autocorrect_array_plus.rb:8: Expected `T::Enumerable[Integer]` but found `T::Array[String]` for argument `arg0` https://srb.help/7002
      8 |ints + (strings)
-        ^^^^^^^^^^^^^^^^
+                ^^^^^^^
   Expected `T::Enumerable[Integer]` for argument `arg0` of method `Array#+`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/array.rbi#L448:
      448 |        arg0: T::Enumerable[Elem],
@@ -36,7 +36,7 @@ autocorrect_array_plus.rb:8: Expected `T::Enumerable[Integer]` but found `T::Arr
 
 autocorrect_array_plus.rb:9: Expected `T::Enumerable[Integer]` but found `T::Array[String]` for argument `arg0` https://srb.help/7002
      9 |ints + ((strings))
-        ^^^^^^^^^^^^^^^^^^
+                 ^^^^^^^
   Expected `T::Enumerable[Integer]` for argument `arg0` of method `Array#+`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/array.rbi#L448:
      448 |        arg0: T::Enumerable[Elem],
@@ -54,7 +54,7 @@ autocorrect_array_plus.rb:9: Expected `T::Enumerable[Integer]` but found `T::Arr
 
 autocorrect_array_plus.rb:10: Expected `T::Enumerable[Integer]` but found `T::Array[String]` for argument `arg0` https://srb.help/7002
     10 |ints.+(strings)
-        ^^^^^^^^^^^^^^^
+               ^^^^^^^
   Expected `T::Enumerable[Integer]` for argument `arg0` of method `Array#+`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/array.rbi#L448:
      448 |        arg0: T::Enumerable[Elem],
@@ -70,10 +70,9 @@ autocorrect_array_plus.rb:10: Expected `T::Enumerable[Integer]` but found `T::Ar
     10 |ints.+(strings)
             ^^^^^^^^^^^
 
-autocorrect_array_plus.rb:12: Expected `T::Enumerable[Integer]` but found `T::Array[String]` for argument `arg0` https://srb.help/7002
-    12 |ints.+(
+autocorrect_array_plus.rb:13: Expected `T::Enumerable[Integer]` but found `T::Array[String]` for argument `arg0` https://srb.help/7002
     13 |  strings
-    14 |)
+          ^^^^^^^
   Expected `T::Enumerable[Integer]` for argument `arg0` of method `Array#+`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/array.rbi#L448:
      448 |        arg0: T::Enumerable[Elem],
@@ -92,7 +91,7 @@ autocorrect_array_plus.rb:12: Expected `T::Enumerable[Integer]` but found `T::Ar
 
 autocorrect_array_plus.rb:16: Expected `T::Enumerable[Integer]` but found `T::Array[String]` for argument `arg0` https://srb.help/7002
     16 |ints + strings
-        ^^^^^^^^^^^^^^
+               ^^^^^^^
   Expected `T::Enumerable[Integer]` for argument `arg0` of method `Array#+`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/array.rbi#L448:
      448 |        arg0: T::Enumerable[Elem],
@@ -110,7 +109,7 @@ autocorrect_array_plus.rb:16: Expected `T::Enumerable[Integer]` but found `T::Ar
 
 autocorrect_array_plus.rb:18: Expected `T::Enumerable[Integer]` but found `T::Array[String]` for argument `arg0` https://srb.help/7002
     18 |ints += strings
-        ^^^^^^^^^^^^^^^
+                ^^^^^^^
   Expected `T::Enumerable[Integer]` for argument `arg0` of method `Array#+`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/array.rbi#L448:
      448 |        arg0: T::Enumerable[Elem],
@@ -128,7 +127,7 @@ autocorrect_array_plus.rb:18: Expected `T::Enumerable[Integer]` but found `T::Ar
 
 autocorrect_array_plus.rb:19: Expected `T::Enumerable[Integer]` but found `T::Array[String]` for argument `arg0` https://srb.help/7002
     19 |ints += strings
-        ^^^^^^^^^^^^^^^
+                ^^^^^^^
   Expected `T::Enumerable[Integer]` for argument `arg0` of method `Array#+`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/array.rbi#L448:
      448 |        arg0: T::Enumerable[Elem],
@@ -146,7 +145,7 @@ autocorrect_array_plus.rb:19: Expected `T::Enumerable[Integer]` but found `T::Ar
 
 autocorrect_array_plus.rb:20: Expected `T::Enumerable[Integer]` but found `T::Array[String]` for argument `arg0` https://srb.help/7002
     20 |ints += strings
-        ^^^^^^^^^^^^^^^
+                ^^^^^^^
   Expected `T::Enumerable[Integer]` for argument `arg0` of method `Array#+`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/array.rbi#L448:
      448 |        arg0: T::Enumerable[Elem],

--- a/test/cli/errors/errors.out
+++ b/test/cli/errors/errors.out
@@ -11,7 +11,7 @@ test/cli/errors/errors.rb:5: Unable to resolve constant `MyConstantWithTypo` htt
 
 test/cli/errors/errors.rb:15: Expected `String` but found `Integer` for argument `arg0` https://srb.help/7002
     .. |    raise arg # raise is defined by stdlib
-            ^^^^^^^^^
+                  ^^^
   Expected `String` for argument `arg0` of method `Kernel#raise (overload.1)`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L2744:
     .. |        arg0: String,
@@ -35,7 +35,7 @@ test/cli/errors/errors.rb:19: Expected `Integer` but found `String("foo")` for a
 
 test/cli/errors/errors.rb:33: Expected `Integer` but found `T.nilable(Integer)` for argument `a` https://srb.help/7002
     .. |    bar(a)
-            ^^^^^^
+                ^
   Expected `Integer` for argument `a` of method `ErrorLines#bar`:
     test/cli/errors/errors.rb:36:
     .. |  sig {params(a: Integer).returns(Integer)}
@@ -68,7 +68,7 @@ test/cli/errors/errors.rb:5: Unable to resolve constant `MyConstantWithTypo` htt
 
 test/cli/errors/errors.rb:15: Expected `String` but found `Integer` for argument `arg0` https://srb.help/7002
     .. |    raise arg # raise is defined by stdlib
-            ^^^^^^^^^
+                  ^^^
   Expected `String` for argument `arg0` of method `Kernel#raise (overload.1)`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L2744:
     .. |        arg0: String,
@@ -92,7 +92,7 @@ test/cli/errors/errors.rb:19: Expected `Integer` but found `String("foo")` for a
 
 test/cli/errors/errors.rb:33: Expected `Integer` but found `T.nilable(Integer)` for argument `a` https://srb.help/7002
     .. |    bar(a)
-            ^^^^^^
+                ^
   Expected `Integer` for argument `a` of method `ErrorLines#bar`:
     test/cli/errors/errors.rb:36:
     .. |  sig {params(a: Integer).returns(Integer)}
@@ -125,7 +125,7 @@ test/cli/errors/errors.rb:5: Unable to resolve constant `MyConstantWithTypo` htt
 
 test/cli/errors/errors.rb:15: Expected `String` but found `Integer` for argument `arg0` https://srb.help/7002
     .. |    raise arg # raise is defined by stdlib
-            ^^^^^^^^^
+                  ^^^
   Expected `String` for argument `arg0` of method `Kernel#raise (overload.1)`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L2744:
     .. |        arg0: String,
@@ -149,7 +149,7 @@ test/cli/errors/errors.rb:19: Expected `Integer` but found `String("foo")` for a
 
 test/cli/errors/errors.rb:33: Expected `Integer` but found `T.nilable(Integer)` for argument `a` https://srb.help/7002
     .. |    bar(a)
-            ^^^^^^
+                ^
   Expected `Integer` for argument `a` of method `ErrorLines#bar`:
     test/cli/errors/errors.rb:36:
     .. |  sig {params(a: Integer).returns(Integer)}

--- a/test/cli/expected-got/expected-got.out
+++ b/test/cli/expected-got/expected-got.out
@@ -24,7 +24,7 @@ test/cli/expected-got/expected-got.rb:12: Expected `Integer` but found `NilClass
 
 test/cli/expected-got/expected-got.rb:27: Expected `Integer` but found `T.any(String, Integer)` for argument `x` https://srb.help/7002
     27 |  takes_integer(x)
-          ^^^^^^^^^^^^^^^^
+                        ^
   Expected `Integer` for argument `x` of method `Object#takes_integer`:
     test/cli/expected-got/expected-got.rb:15:
     15 |sig {params(x: Integer).void}
@@ -137,7 +137,7 @@ test/cli/expected-got/expected-got.rb:68: Can not call method `foo` on void type
 
 test/cli/expected-got/expected-got.rb:73: Expected `T::Array[Integer]` but found `[Integer(1), Integer(2), T.nilable(Integer)]` for argument `xs` https://srb.help/7002
     73 |takes_int_array(xs)
-        ^^^^^^^^^^^^^^^^^^^
+                        ^^
   Expected `T::Array[Integer]` for argument `xs` of method `Object#takes_int_array`:
     test/cli/expected-got/expected-got.rb:70:
     70 |sig {params(xs: T::Array[Integer]).void}

--- a/test/cli/suggest_t_must/suggest_t_must.out
+++ b/test/cli/suggest_t_must/suggest_t_must.out
@@ -12,7 +12,7 @@ suggest_t_must.rb:4: Method `[]` does not exist on `NilClass` component of `T.ni
 
 suggest_t_must.rb:6: Expected `String` but found `T.nilable(String)` for argument `arg0` https://srb.help/7002
      6 |"hi" + foo
-        ^^^^^^^^^^
+               ^^^
   Expected `String` for argument `arg0` of method `String#+`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/string.rbi#L68:
     68 |        arg0: String,

--- a/test/cli/suggest_t_unsafe/suggest_t_unsafe.out
+++ b/test/cli/suggest_t_unsafe/suggest_t_unsafe.out
@@ -28,7 +28,7 @@ suggest_t_unsafe.rb:8: Method `[]` does not exist on `NilClass` component of `T.
 
 suggest_t_unsafe.rb:10: Expected `String` but found `T.nilable(String)` for argument `arg0` https://srb.help/7002
     10 |"hi" + foo
-        ^^^^^^^^^^
+               ^^^
   Expected `String` for argument `arg0` of method `String#+`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/string.rbi#L68:
     68 |        arg0: String,
@@ -144,7 +144,7 @@ suggest_t_unsafe.rb:8: Method `[]` does not exist on `NilClass` component of `T.
 
 suggest_t_unsafe.rb:10: Expected `String` but found `T.nilable(String)` for argument `arg0` https://srb.help/7002
     10 |"hi" + foo
-        ^^^^^^^^^^
+               ^^^
   Expected `String` for argument `arg0` of method `String#+`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/string.rbi#L68:
     68 |        arg0: String,

--- a/test/cli/uninitialized-explanation/uninitialized-explanation.out
+++ b/test/cli/uninitialized-explanation/uninitialized-explanation.out
@@ -1,6 +1,6 @@
 test/cli/uninitialized-explanation/uninitialized.rb:15: Expected `Integer` but found `T.nilable(Integer)` for argument `x` https://srb.help/7002
     15 |  takes_int(x)
-          ^^^^^^^^^^^^
+                    ^
   Expected `Integer` for argument `x` of method `Object#takes_int`:
     test/cli/uninitialized-explanation/uninitialized.rb:5:
      5 |sig {params(x: Integer).void}

--- a/test/testdata/namer/simple.rb
+++ b/test/testdata/namer/simple.rb
@@ -26,8 +26,8 @@ end
 class Child < Parent
   include Mixin
   include 3
-#         ^ error: `include` must only contain constant literals
-# ^^^^^^^^^ error: Expected `Module` but found `NilClass` for argument `arg0`
+  #       ^ error: `include` must only contain constant literals
+  #       ^ error: Expected `Module` but found `Integer(3)` for argument `arg0`
   include Mixin do; end
 # ^^^^^^^^^^^^^^^^^^^^^ error: Method `Module#include` does not take a block
 # ^^^^^^^^^^^^^^^^^^^^^ error: `include` can not be passed a block

--- a/test/testdata/namer/simple.rb.flatten-tree.exp
+++ b/test/testdata/namer/simple.rb.flatten-tree.exp
@@ -118,7 +118,7 @@ begin
     def self.<static-init>(<blk>)
       begin
         <self>.include(::Mixin)
-        <self>.include(<emptyTree>)
+        <self>.include(3)
         <self>.include(::Mixin) do ||
           <emptyTree>
         end

--- a/test/testdata/resolver/fuzz_ancester.rb
+++ b/test/testdata/resolver/fuzz_ancester.rb
@@ -5,17 +5,17 @@ class A < b::C # error: Superclasses must only contain constant literals
 end
 class A
   include b
-#         ^ error: `include` must only contain constant literals
-# ^^^^^^^^^ error: Expected `Module` but found `NilClass` for argument `arg0`
+  #       ^ error: `include` must only contain constant literals
+  #       ^ error: Method `b` does not exist on `T.class_of(A)`
 end
 class A
   extend b
-#        ^ error: `extend` must only contain constant literals
-# ^^^^^^^^ error: Expected `Module` but found `NilClass` for argument `arg0`
+  #      ^ error: `extend` must only contain constant literals
+  #      ^ error: Method `b` does not exist on `T.class_of(A)`
 end
 module B; end
 class A
   include B, c
-#            ^ error: `include` must only contain constant literals
-# ^^^^^^^^^^^^ error: Expected `Module` but found `NilClass` for argument `arg0`
+  #          ^ error: `include` must only contain constant literals
+  #          ^ error: Method `c` does not exist on `T.class_of(A)`
 end

--- a/test/testdata/resolver/fuzz_include_type_alias.rb
+++ b/test/testdata/resolver/fuzz_include_type_alias.rb
@@ -4,6 +4,6 @@ A = T.type_alias {Integer}
 
 class B
   include A
-#         ^ error: Superclasses and mixins may not be type aliases
-# ^^^^^^^^^ error: Expected `Module` but found `<Type: Integer>` for argument `arg0`
+  #       ^ error: Superclasses and mixins may not be type aliases
+  #       ^ error: Expected `Module` but found `<Type: Integer>` for argument `arg0`
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Pre-work for another change I wanted to make to improve some error messages.

Also lets us delete `smallestLocWithin` which was always a huge hack.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
