### PR TITLE
Expand `OpAsgn` when suggesting `T.must`

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1244,8 +1244,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
 
                     auto prevValue = MK::Send(sendLoc, MK::Local(sendLoc, tempRecv), s->fun, s->funLoc, numPosArgs,
                                               std::move(readArgs), s->flags);
-                    auto newValue = MK::Send1(sendLoc, std::move(prevValue), opAsgn->op, sendLoc.copyWithZeroLength(),
-                                              std::move(rhs));
+                    auto newValue = MK::Send1(sendLoc, std::move(prevValue), opAsgn->op, opAsgn->opLoc, std::move(rhs));
                     auto numPosAssgnArgs = numPosArgs + 1;
                     assgnArgs.emplace_back(std::move(newValue));
 
@@ -1255,7 +1254,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                     result = std::move(wrapped);
                 } else if (isa_reference(recv)) {
                     auto lhs = MK::cpRef(recv);
-                    auto send = MK::Send1(loc, std::move(recv), opAsgn->op, locZeroLen, std::move(rhs));
+                    auto send = MK::Send1(loc, std::move(recv), opAsgn->op, opAsgn->opLoc, std::move(rhs));
                     auto res = MK::Assign(loc, std::move(lhs), std::move(send));
                     result = std::move(res);
                 } else if (auto i = cast_tree<UnresolvedConstantLit>(recv)) {
@@ -1286,8 +1285,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                     auto [tempRecv, stats, numPosArgs, readArgs, assgnArgs] = copyArgsForOpAsgn(dctx, s);
                     auto prevValue = MK::Send(sendLoc, MK::Local(sendLoc, tempRecv), s->fun, s->funLoc, numPosArgs,
                                               std::move(readArgs), s->flags);
-                    auto newValue = MK::Send1(sendLoc, std::move(prevValue), opAsgn->op, sendLoc.copyWithZeroLength(),
-                                              std::move(rhs));
+                    auto newValue = MK::Send1(sendLoc, std::move(prevValue), opAsgn->op, opAsgn->opLoc, std::move(rhs));
                     auto numPosAssgnArgs = numPosArgs + 1;
                     assgnArgs.emplace_back(std::move(newValue));
 

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -668,6 +668,10 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                                           " {{|x| {}(x).{}}}", wrapInFn, shortName);
                         }
                     }
+                } else if (errLoc == args.funLoc() &&
+                           args.funLoc().source(gs) == absl::StrCat(args.name.shortName(gs), "=")) {
+                    e.replaceWith(fmt::format("Wrap in `{}`", wrapInFn), args.funLoc(), "= {}({}) {}", wrapInFn,
+                                  receiverLoc.source(gs).value(), args.name.shortName(gs));
                 } else {
                     e.replaceWith(fmt::format("Wrap in `{}`", wrapInFn), receiverLoc, "{}({})", wrapInFn,
                                   receiverLoc.source(gs).value());

--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -1279,7 +1279,7 @@ public:
         if (op->view() == "||") {
             return make_unique<OrAsgn>(lhs->loc.join(rhs->loc), std::move(lhs), std::move(rhs));
         }
-        return make_unique<OpAsgn>(lhs->loc.join(rhs->loc), std::move(lhs), gs_.enterNameUTF8(op->view()),
+        return make_unique<OpAsgn>(lhs->loc.join(rhs->loc), std::move(lhs), gs_.enterNameUTF8(op->view()), tokLoc(op),
                                    std::move(rhs));
     }
 

--- a/parser/tools/generate_ast.cc
+++ b/parser/tools/generate_ast.cc
@@ -544,7 +544,12 @@ NodeDef nodes[] = {
     {
         "OpAsgn",
         "op_asgn",
-        vector<FieldDef>({{"left", FieldType::Node}, {"op", FieldType::Name}, {"right", FieldType::Node}}),
+        vector<FieldDef>({
+            {"left", FieldType::Node},
+            {"op", FieldType::Name},
+            {"opLoc", FieldType::Loc},
+            {"right", FieldType::Node},
+        }),
     },
     // logical or
     {

--- a/test/cli/autocorrect_op_asgn_must/autocorrect_op_asgn_must.out
+++ b/test/cli/autocorrect_op_asgn_must/autocorrect_op_asgn_must.out
@@ -1,62 +1,62 @@
 autocorrect_op_asgn_must.rb:25: Method `+` does not exist on `NilClass` component of `T.nilable(Integer)` https://srb.help/7003
     25 |  a.foo += 1
-          ^^^^^
+                ^^
   Got `T.nilable(Integer)` originating from:
     autocorrect_op_asgn_must.rb:25:
     25 |  a.foo += 1
           ^^^^^
   Autocorrect: Done
-    autocorrect_op_asgn_must.rb:25: Replaced with `T.must(a.foo)`
+    autocorrect_op_asgn_must.rb:25: Replaced with `= T.must(a.foo) +`
     25 |  a.foo += 1
-          ^^^^^
+                ^^
 
 autocorrect_op_asgn_must.rb:29: Method `+` does not exist on `NilClass` component of `T.nilable(Integer)` https://srb.help/7003
     29 |  A.new.foo += 1
-          ^^^^^^^^^
+                    ^^
   Got `T.nilable(Integer)` originating from:
     autocorrect_op_asgn_must.rb:29:
     29 |  A.new.foo += 1
           ^^^^^^^^^
   Autocorrect: Done
-    autocorrect_op_asgn_must.rb:29: Replaced with `T.must(A.new.foo)`
+    autocorrect_op_asgn_must.rb:29: Replaced with `= T.must(A.new.foo) +`
     29 |  A.new.foo += 1
-          ^^^^^^^^^
+                    ^^
 
 autocorrect_op_asgn_must.rb:31: Method `+` does not exist on `NilClass` component of `T.nilable(Integer)` https://srb.help/7003
     31 |  xs[0] += 1
-          ^^^^^
+                ^^
   Got `T.nilable(Integer)` originating from:
     autocorrect_op_asgn_must.rb:31:
     31 |  xs[0] += 1
           ^^^^^
   Autocorrect: Done
-    autocorrect_op_asgn_must.rb:31: Replaced with `T.must(xs[0])`
+    autocorrect_op_asgn_must.rb:31: Replaced with `= T.must(xs[0]) +`
     31 |  xs[0] += 1
-          ^^^^^
+                ^^
 
 autocorrect_op_asgn_must.rb:33: Method `+` does not exist on `NilClass` component of `T.nilable(Integer)` https://srb.help/7003
     33 |  opts[:foo] += 1
-          ^^^^^^^^^^
+                     ^^
   Got `T.nilable(Integer)` originating from:
     autocorrect_op_asgn_must.rb:33:
     33 |  opts[:foo] += 1
           ^^^^^^^^^^
   Autocorrect: Done
-    autocorrect_op_asgn_must.rb:33: Replaced with `T.must(opts[:foo])`
+    autocorrect_op_asgn_must.rb:33: Replaced with `= T.must(opts[:foo]) +`
     33 |  opts[:foo] += 1
-          ^^^^^^^^^^
+                     ^^
 
 autocorrect_op_asgn_must.rb:43: Method `+` does not exist on `NilClass` component of `T.nilable(Integer)` https://srb.help/7003
     43 |  maybe_a&.foo += 1
-          ^^^^^^^^^^^^
+                       ^^
   Got `T.nilable(Integer)` originating from:
     autocorrect_op_asgn_must.rb:43:
     43 |  maybe_a&.foo += 1
           ^^^^^^^^^^^^
   Autocorrect: Done
-    autocorrect_op_asgn_must.rb:43: Replaced with `T.must(maybe_a&.foo)`
+    autocorrect_op_asgn_must.rb:43: Replaced with `= T.must(maybe_a&.foo) +`
     43 |  maybe_a&.foo += 1
-          ^^^^^^^^^^^^
+                       ^^
 Errors: 5
 
 --------------------------------------------------------------------------
@@ -85,15 +85,15 @@ def example1(x, xs, opts, shape, maybe_a)
   # x += 1
 
   a = A.new
-  T.must(a.foo) += 1
+  a.foo = T.must(a.foo) + 1
 
   # This one is not great, because the autocorrect changes the meaning of the
   # program (doesn't increment the right instance of `A`).
-  T.must(A.new.foo) += 1
+  A.new.foo = T.must(A.new.foo) + 1
 
-  T.must(xs[0]) += 1
+  xs[0] = T.must(xs[0]) + 1
 
-  T.must(opts[:foo]) += 1
+  opts[:foo] = T.must(opts[:foo]) + 1
 
   # One day we will have better shape types, this will become an error, and
   # there should be an autocorrect.
@@ -103,7 +103,7 @@ def example1(x, xs, opts, shape, maybe_a)
   # because Sorbet will be able to know that the `&.` in T.must(maybe_a&.foo)
   # is redundant. We're fine with that being bad, because there's also an
   # auto-fix for that as well.
-  T.must(maybe_a&.foo) += 1
+  maybe_a&.foo = T.must(maybe_a&.foo) + 1
 
   # These aren't affected, because `||` and `&&` are available everywhere.
   bool = T.let(false, T.nilable(T::Boolean))
@@ -116,63 +116,63 @@ end
 
 autocorrect_op_asgn_must.rb:25: Method `+` does not exist on `NilClass` component of `T.nilable(Integer)` https://srb.help/7003
     25 |  a.foo += 1
-          ^^^^^
+                ^^
   Got `T.nilable(Integer)` originating from:
     autocorrect_op_asgn_must.rb:25:
     25 |  a.foo += 1
           ^^^^^
   Autocorrect: Done
-    autocorrect_op_asgn_must.rb:25: Replaced with `T.unsafe(a.foo)`
+    autocorrect_op_asgn_must.rb:25: Replaced with `= T.unsafe(a.foo) +`
     25 |  a.foo += 1
-          ^^^^^
+                ^^
 
 autocorrect_op_asgn_must.rb:29: Method `+` does not exist on `NilClass` component of `T.nilable(Integer)` https://srb.help/7003
     29 |  A.new.foo += 1
-          ^^^^^^^^^
+                    ^^
   Got `T.nilable(Integer)` originating from:
     autocorrect_op_asgn_must.rb:29:
     29 |  A.new.foo += 1
           ^^^^^^^^^
   Autocorrect: Done
-    autocorrect_op_asgn_must.rb:29: Replaced with `T.unsafe(A.new.foo)`
+    autocorrect_op_asgn_must.rb:29: Replaced with `= T.unsafe(A.new.foo) +`
     29 |  A.new.foo += 1
-          ^^^^^^^^^
+                    ^^
 
 autocorrect_op_asgn_must.rb:31: Method `+` does not exist on `NilClass` component of `T.nilable(Integer)` https://srb.help/7003
     31 |  xs[0] += 1
-          ^^^^^
+                ^^
   Got `T.nilable(Integer)` originating from:
     autocorrect_op_asgn_must.rb:31:
     31 |  xs[0] += 1
           ^^^^^
   Autocorrect: Done
-    autocorrect_op_asgn_must.rb:31: Replaced with `T.unsafe(xs[0])`
+    autocorrect_op_asgn_must.rb:31: Replaced with `= T.unsafe(xs[0]) +`
     31 |  xs[0] += 1
-          ^^^^^
+                ^^
 
 autocorrect_op_asgn_must.rb:33: Method `+` does not exist on `NilClass` component of `T.nilable(Integer)` https://srb.help/7003
     33 |  opts[:foo] += 1
-          ^^^^^^^^^^
+                     ^^
   Got `T.nilable(Integer)` originating from:
     autocorrect_op_asgn_must.rb:33:
     33 |  opts[:foo] += 1
           ^^^^^^^^^^
   Autocorrect: Done
-    autocorrect_op_asgn_must.rb:33: Replaced with `T.unsafe(opts[:foo])`
+    autocorrect_op_asgn_must.rb:33: Replaced with `= T.unsafe(opts[:foo]) +`
     33 |  opts[:foo] += 1
-          ^^^^^^^^^^
+                     ^^
 
 autocorrect_op_asgn_must.rb:43: Method `+` does not exist on `NilClass` component of `T.nilable(Integer)` https://srb.help/7003
     43 |  maybe_a&.foo += 1
-          ^^^^^^^^^^^^
+                       ^^
   Got `T.nilable(Integer)` originating from:
     autocorrect_op_asgn_must.rb:43:
     43 |  maybe_a&.foo += 1
           ^^^^^^^^^^^^
   Autocorrect: Done
-    autocorrect_op_asgn_must.rb:43: Replaced with `T.unsafe(maybe_a&.foo)`
+    autocorrect_op_asgn_must.rb:43: Replaced with `= T.unsafe(maybe_a&.foo) +`
     43 |  maybe_a&.foo += 1
-          ^^^^^^^^^^^^
+                       ^^
 Errors: 5
 
 --------------------------------------------------------------------------
@@ -201,15 +201,15 @@ def example1(x, xs, opts, shape, maybe_a)
   # x += 1
 
   a = A.new
-  T.unsafe(a.foo) += 1
+  a.foo = T.unsafe(a.foo) + 1
 
   # This one is not great, because the autocorrect changes the meaning of the
   # program (doesn't increment the right instance of `A`).
-  T.unsafe(A.new.foo) += 1
+  A.new.foo = T.unsafe(A.new.foo) + 1
 
-  T.unsafe(xs[0]) += 1
+  xs[0] = T.unsafe(xs[0]) + 1
 
-  T.unsafe(opts[:foo]) += 1
+  opts[:foo] = T.unsafe(opts[:foo]) + 1
 
   # One day we will have better shape types, this will become an error, and
   # there should be an autocorrect.
@@ -219,7 +219,7 @@ def example1(x, xs, opts, shape, maybe_a)
   # because Sorbet will be able to know that the `&.` in T.must(maybe_a&.foo)
   # is redundant. We're fine with that being bad, because there's also an
   # auto-fix for that as well.
-  T.unsafe(maybe_a&.foo) += 1
+  maybe_a&.foo = T.unsafe(maybe_a&.foo) + 1
 
   # These aren't affected, because `||` and `&&` are available everywhere.
   bool = T.let(false, T.nilable(T::Boolean))

--- a/test/cli/autocorrect_op_asgn_must/autocorrect_op_asgn_must.out
+++ b/test/cli/autocorrect_op_asgn_must/autocorrect_op_asgn_must.out
@@ -1,0 +1,229 @@
+autocorrect_op_asgn_must.rb:25: Method `+` does not exist on `NilClass` component of `T.nilable(Integer)` https://srb.help/7003
+    25 |  a.foo += 1
+          ^^^^^
+  Got `T.nilable(Integer)` originating from:
+    autocorrect_op_asgn_must.rb:25:
+    25 |  a.foo += 1
+          ^^^^^
+  Autocorrect: Done
+    autocorrect_op_asgn_must.rb:25: Replaced with `T.must(a.foo)`
+    25 |  a.foo += 1
+          ^^^^^
+
+autocorrect_op_asgn_must.rb:29: Method `+` does not exist on `NilClass` component of `T.nilable(Integer)` https://srb.help/7003
+    29 |  A.new.foo += 1
+          ^^^^^^^^^
+  Got `T.nilable(Integer)` originating from:
+    autocorrect_op_asgn_must.rb:29:
+    29 |  A.new.foo += 1
+          ^^^^^^^^^
+  Autocorrect: Done
+    autocorrect_op_asgn_must.rb:29: Replaced with `T.must(A.new.foo)`
+    29 |  A.new.foo += 1
+          ^^^^^^^^^
+
+autocorrect_op_asgn_must.rb:31: Method `+` does not exist on `NilClass` component of `T.nilable(Integer)` https://srb.help/7003
+    31 |  xs[0] += 1
+          ^^^^^
+  Got `T.nilable(Integer)` originating from:
+    autocorrect_op_asgn_must.rb:31:
+    31 |  xs[0] += 1
+          ^^^^^
+  Autocorrect: Done
+    autocorrect_op_asgn_must.rb:31: Replaced with `T.must(xs[0])`
+    31 |  xs[0] += 1
+          ^^^^^
+
+autocorrect_op_asgn_must.rb:33: Method `+` does not exist on `NilClass` component of `T.nilable(Integer)` https://srb.help/7003
+    33 |  opts[:foo] += 1
+          ^^^^^^^^^^
+  Got `T.nilable(Integer)` originating from:
+    autocorrect_op_asgn_must.rb:33:
+    33 |  opts[:foo] += 1
+          ^^^^^^^^^^
+  Autocorrect: Done
+    autocorrect_op_asgn_must.rb:33: Replaced with `T.must(opts[:foo])`
+    33 |  opts[:foo] += 1
+          ^^^^^^^^^^
+
+autocorrect_op_asgn_must.rb:43: Method `+` does not exist on `NilClass` component of `T.nilable(Integer)` https://srb.help/7003
+    43 |  maybe_a&.foo += 1
+          ^^^^^^^^^^^^
+  Got `T.nilable(Integer)` originating from:
+    autocorrect_op_asgn_must.rb:43:
+    43 |  maybe_a&.foo += 1
+          ^^^^^^^^^^^^
+  Autocorrect: Done
+    autocorrect_op_asgn_must.rb:43: Replaced with `T.must(maybe_a&.foo)`
+    43 |  maybe_a&.foo += 1
+          ^^^^^^^^^^^^
+Errors: 5
+
+--------------------------------------------------------------------------
+
+# typed: true
+
+extend T::Sig
+
+class A
+  extend T::Sig
+  sig {returns(T.nilable(Integer))}
+  attr_accessor :foo
+end
+
+sig do
+  params(
+    x: T.nilable(Integer),
+    xs: T::Array[T.nilable(Integer)],
+    opts: T::Hash[Symbol, T.nilable(Integer)],
+    shape: {foo: T.nilable(Integer)},
+    maybe_a: T.nilable(A),
+  )
+  .void
+end
+def example1(x, xs, opts, shape, maybe_a)
+  # x += 1
+
+  a = A.new
+  T.must(a.foo) += 1
+
+  # This one is not great, because the autocorrect changes the meaning of the
+  # program (doesn't increment the right instance of `A`).
+  T.must(A.new.foo) += 1
+
+  T.must(xs[0]) += 1
+
+  T.must(opts[:foo]) += 1
+
+  # One day we will have better shape types, this will become an error, and
+  # there should be an autocorrect.
+  shape[:foo] += 1
+
+  # This one is also not great, because the thing it suggests will error
+  # because Sorbet will be able to know that the `&.` in T.must(maybe_a&.foo)
+  # is redundant. We're fine with that being bad, because there's also an
+  # auto-fix for that as well.
+  T.must(maybe_a&.foo) += 1
+
+  # These aren't affected, because `||` and `&&` are available everywhere.
+  bool = T.let(false, T.nilable(T::Boolean))
+  bool ||= true
+  bool = T.let(false, T.nilable(T::Boolean))
+  bool &&= false
+end
+
+--------------------------------------------------------------------------
+
+autocorrect_op_asgn_must.rb:25: Method `+` does not exist on `NilClass` component of `T.nilable(Integer)` https://srb.help/7003
+    25 |  a.foo += 1
+          ^^^^^
+  Got `T.nilable(Integer)` originating from:
+    autocorrect_op_asgn_must.rb:25:
+    25 |  a.foo += 1
+          ^^^^^
+  Autocorrect: Done
+    autocorrect_op_asgn_must.rb:25: Replaced with `T.unsafe(a.foo)`
+    25 |  a.foo += 1
+          ^^^^^
+
+autocorrect_op_asgn_must.rb:29: Method `+` does not exist on `NilClass` component of `T.nilable(Integer)` https://srb.help/7003
+    29 |  A.new.foo += 1
+          ^^^^^^^^^
+  Got `T.nilable(Integer)` originating from:
+    autocorrect_op_asgn_must.rb:29:
+    29 |  A.new.foo += 1
+          ^^^^^^^^^
+  Autocorrect: Done
+    autocorrect_op_asgn_must.rb:29: Replaced with `T.unsafe(A.new.foo)`
+    29 |  A.new.foo += 1
+          ^^^^^^^^^
+
+autocorrect_op_asgn_must.rb:31: Method `+` does not exist on `NilClass` component of `T.nilable(Integer)` https://srb.help/7003
+    31 |  xs[0] += 1
+          ^^^^^
+  Got `T.nilable(Integer)` originating from:
+    autocorrect_op_asgn_must.rb:31:
+    31 |  xs[0] += 1
+          ^^^^^
+  Autocorrect: Done
+    autocorrect_op_asgn_must.rb:31: Replaced with `T.unsafe(xs[0])`
+    31 |  xs[0] += 1
+          ^^^^^
+
+autocorrect_op_asgn_must.rb:33: Method `+` does not exist on `NilClass` component of `T.nilable(Integer)` https://srb.help/7003
+    33 |  opts[:foo] += 1
+          ^^^^^^^^^^
+  Got `T.nilable(Integer)` originating from:
+    autocorrect_op_asgn_must.rb:33:
+    33 |  opts[:foo] += 1
+          ^^^^^^^^^^
+  Autocorrect: Done
+    autocorrect_op_asgn_must.rb:33: Replaced with `T.unsafe(opts[:foo])`
+    33 |  opts[:foo] += 1
+          ^^^^^^^^^^
+
+autocorrect_op_asgn_must.rb:43: Method `+` does not exist on `NilClass` component of `T.nilable(Integer)` https://srb.help/7003
+    43 |  maybe_a&.foo += 1
+          ^^^^^^^^^^^^
+  Got `T.nilable(Integer)` originating from:
+    autocorrect_op_asgn_must.rb:43:
+    43 |  maybe_a&.foo += 1
+          ^^^^^^^^^^^^
+  Autocorrect: Done
+    autocorrect_op_asgn_must.rb:43: Replaced with `T.unsafe(maybe_a&.foo)`
+    43 |  maybe_a&.foo += 1
+          ^^^^^^^^^^^^
+Errors: 5
+
+--------------------------------------------------------------------------
+
+# typed: true
+
+extend T::Sig
+
+class A
+  extend T::Sig
+  sig {returns(T.nilable(Integer))}
+  attr_accessor :foo
+end
+
+sig do
+  params(
+    x: T.nilable(Integer),
+    xs: T::Array[T.nilable(Integer)],
+    opts: T::Hash[Symbol, T.nilable(Integer)],
+    shape: {foo: T.nilable(Integer)},
+    maybe_a: T.nilable(A),
+  )
+  .void
+end
+def example1(x, xs, opts, shape, maybe_a)
+  # x += 1
+
+  a = A.new
+  T.unsafe(a.foo) += 1
+
+  # This one is not great, because the autocorrect changes the meaning of the
+  # program (doesn't increment the right instance of `A`).
+  T.unsafe(A.new.foo) += 1
+
+  T.unsafe(xs[0]) += 1
+
+  T.unsafe(opts[:foo]) += 1
+
+  # One day we will have better shape types, this will become an error, and
+  # there should be an autocorrect.
+  shape[:foo] += 1
+
+  # This one is also not great, because the thing it suggests will error
+  # because Sorbet will be able to know that the `&.` in T.must(maybe_a&.foo)
+  # is redundant. We're fine with that being bad, because there's also an
+  # auto-fix for that as well.
+  T.unsafe(maybe_a&.foo) += 1
+
+  # These aren't affected, because `||` and `&&` are available everywhere.
+  bool = T.let(false, T.nilable(T::Boolean))
+  bool ||= true
+  bool = T.let(false, T.nilable(T::Boolean))
+  bool &&= false
+end

--- a/test/cli/autocorrect_op_asgn_must/autocorrect_op_asgn_must.rb
+++ b/test/cli/autocorrect_op_asgn_must/autocorrect_op_asgn_must.rb
@@ -1,0 +1,50 @@
+# typed: true
+
+extend T::Sig
+
+class A
+  extend T::Sig
+  sig {returns(T.nilable(Integer))}
+  attr_accessor :foo
+end
+
+sig do
+  params(
+    x: T.nilable(Integer),
+    xs: T::Array[T.nilable(Integer)],
+    opts: T::Hash[Symbol, T.nilable(Integer)],
+    shape: {foo: T.nilable(Integer)},
+    maybe_a: T.nilable(A),
+  )
+  .void
+end
+def example1(x, xs, opts, shape, maybe_a)
+  # x += 1
+
+  a = A.new
+  a.foo += 1
+
+  # This one is not great, because the autocorrect changes the meaning of the
+  # program (doesn't increment the right instance of `A`).
+  A.new.foo += 1
+
+  xs[0] += 1
+
+  opts[:foo] += 1
+
+  # One day we will have better shape types, this will become an error, and
+  # there should be an autocorrect.
+  shape[:foo] += 1
+
+  # This one is also not great, because the thing it suggests will error
+  # because Sorbet will be able to know that the `&.` in T.must(maybe_a&.foo)
+  # is redundant. We're fine with that being bad, because there's also an
+  # auto-fix for that as well.
+  maybe_a&.foo += 1
+
+  # These aren't affected, because `||` and `&&` are available everywhere.
+  bool = T.let(false, T.nilable(T::Boolean))
+  bool ||= true
+  bool = T.let(false, T.nilable(T::Boolean))
+  bool &&= false
+end

--- a/test/cli/autocorrect_op_asgn_must/autocorrect_op_asgn_must.sh
+++ b/test/cli/autocorrect_op_asgn_must/autocorrect_op_asgn_must.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+cwd="$(pwd)"
+infile="$cwd/test/cli/autocorrect_op_asgn_must/autocorrect_op_asgn_must.rb"
+
+tmp="$(mktemp -d)"
+
+(
+  cp "$infile" "$tmp"
+
+  cd "$tmp" || exit 1
+  if "$cwd/main/sorbet" --silence-dev-message -a autocorrect_op_asgn_must.rb 2>&1; then
+    echo "Expected to fail!"
+    exit 1
+  fi
+
+  echo
+  echo --------------------------------------------------------------------------
+  echo
+
+  # Also cat the file, to make that the autocorrect applied
+  cat autocorrect_op_asgn_must.rb
+
+  rm autocorrect_op_asgn_must.rb
+)
+
+echo
+echo --------------------------------------------------------------------------
+echo
+
+(
+  cp "$infile" "$tmp"
+
+  cd "$tmp" || exit 1
+  if "$cwd/main/sorbet" --silence-dev-message --suggest-unsafe -a autocorrect_op_asgn_must.rb 2>&1; then
+    echo "Expected to fail!"
+    exit 1
+  fi
+
+  echo
+  echo --------------------------------------------------------------------------
+  echo
+
+  # Also cat the file, to make that the autocorrect applied
+  cat autocorrect_op_asgn_must.rb
+
+  rm autocorrect_op_asgn_must.rb
+)
+
+rm -r "$tmp"

--- a/test/cli/suggest_t_must/suggest_t_must.out
+++ b/test/cli/suggest_t_must/suggest_t_must.out
@@ -38,6 +38,18 @@ suggest_t_must.rb:8: Method `even?` does not exist on `NilClass` component of `T
      8 |T::Array[T.nilable(Integer)].new.map(&:even?)
                                             ^^^^^^^^^
 
+suggest_t_must.rb:25: Method `split` does not exist on `NilClass` component of `T.nilable(String)` https://srb.help/7003
+    25 |y.split
+          ^^^^^
+  Got `T.nilable(String)` originating from:
+    suggest_t_must.rb:24:
+    24 |x, y = [1, T.let('', T.nilable(String))]
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    suggest_t_must.rb:25: Replaced with `T.must(y)`
+    25 |y.split
+        ^
+
 suggest_t_must.rb:20: Expected `Integer` but found `T.nilable(Integer)` for field https://srb.help/7013
     20 |    @result = xs[i]
                       ^^^^^
@@ -53,7 +65,7 @@ suggest_t_must.rb:20: Expected `Integer` but found `T.nilable(Integer)` for fiel
     suggest_t_must.rb:20: Replaced with `T.must(xs[i])`
     20 |    @result = xs[i]
                       ^^^^^
-Errors: 4
+Errors: 5
 
 --------------------------------------------------------------------------
 
@@ -79,3 +91,6 @@ class A
     @result = T.must(xs[i])
   end
 end
+
+x, y = [1, T.let('', T.nilable(String))]
+T.must(y).split

--- a/test/cli/suggest_t_must/suggest_t_must.rb
+++ b/test/cli/suggest_t_must/suggest_t_must.rb
@@ -20,3 +20,6 @@ class A
     @result = xs[i]
   end
 end
+
+x, y = [1, T.let('', T.nilable(String))]
+y.split


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes <https://github.com/sorbet/sorbet/issues/3370>

This will also help unblock certain portions of the (eventual) migration to fix
shape types, because this is a common class of error that appears when shape
type are improved to actually check accessors (instead of being completely
untyped).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tests show before/after