### PR TITLE
Only highlight `funLoc` for document highlight

### DIFF
--- a/main/lsp/LSPTask.cc
+++ b/main/lsp/LSPTask.cc
@@ -380,7 +380,11 @@ LSPTask::extractLocations(const core::GlobalState &gs,
                           vector<unique_ptr<Location>> locations) const {
     auto queryResponsesFiltered = filterAndDedup(gs, queryResponses);
     for (auto &q : queryResponsesFiltered) {
-        addLocIfExists(gs, locations, q->getLoc());
+        if (auto *send = q->isSend()) {
+            addLocIfExists(gs, locations, send->funLoc);
+        } else {
+            addLocIfExists(gs, locations, q->getLoc());
+        }
     }
     return locations;
 }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The current document highlight highlights way too much of the screen when you
put your cursor anywhere inside a method.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

There the fact that this didn't cause any tests to fail is a little surprising. It does look like there are two test files that were added in https://github.com/sorbet/sorbet/pull/2105 when the document highlight feature was added, but both of those tests only use the existing `def`/`usage` assertions that things like jump-to-def and find-all-refs use.

That's probably why this feature hasn't been graduated out of the experimental features, and I don't really want to change that right now. I just want https://sorbet.run examples to not suffer from this bug.


**before**

![Screenshot from 2022-02-26 18-41-07](https://user-images.githubusercontent.com/5544532/155866063-ab79086f-7d98-403e-9caf-d8cc466af792.png)

**after**

![Screenshot from 2022-02-26 18-38-38](https://user-images.githubusercontent.com/5544532/155866075-c3e47c06-e598-4955-be50-14c06d72a1a2.png)