### PR TITLE
Fix signature for `Array#at`

### DIFF
--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -701,7 +701,7 @@ class Array < Object
     params(
         arg0: Integer,
     )
-    .returns(Elem)
+    .returns(T.nilable(Elem))
   end
   def at(arg0); end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

If you want a similar method that will raise instead of returning `nil`
sometimes, you can use `Array#fetch` instead.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.