### PR TITLE
CHECK_EQ -> CHECK_EQ_DIFF in ApplyCompletionAssertion

### DIFF
--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -1253,10 +1253,9 @@ void ApplyCompletionAssertion::check(const UnorderedMap<std::string, std::shared
     auto actualEditedFileContents = applyEdit(file->source(), *file, *textEdit->range, textEdit->newText);
 
     {
-        INFO(fmt::format("The expected (rbedited) file contents for this completion did not match the actual file "
-                         "contents post-edit",
-                         expectedUpdatedFilePath));
-        CHECK_EQ(expectedEditedFileContents, actualEditedFileContents);
+        CHECK_EQ_DIFF(expectedEditedFileContents, actualEditedFileContents,
+                      "The expected (rbedited) file contents for this completion did not match the actual file "
+                      "contents post-edit");
     }
 }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

While working on #5381 it would have been nice if the test showed me the diff,
instead of the two strings that were not equal.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I tested this locally on a test that failed in #5381.