### PR TITLE
Move the signature finding code into separate class

### DIFF
--- a/main/sig_finder/BUILD.bazel
+++ b/main/sig_finder/BUILD.bazel
@@ -1,17 +1,13 @@
 cc_library(
-    name = "definition_validator",
+    name = "sig_finder",
     srcs = glob(
         [
             "*.cc",
             "*.h",
         ],
-        exclude = [
-            "*_test.cc",
-            "flycheck_*",
-        ],
     ),
     hdrs = [
-        "validator.h",
+        "sig_finder.h",
     ],
     linkstatic = select({
         "//tools/config:linkshared": 0,
@@ -19,11 +15,7 @@ cc_library(
     }),
     visibility = ["//visibility:public"],
     deps = [
-        "//ast",
-        "//ast/desugar",
-        "//ast/treemap",
         "//core",
-        "//main/sig_finder",
         "@com_google_absl//absl/strings",
     ],
 )

--- a/main/sig_finder/sig_finder.cc
+++ b/main/sig_finder/sig_finder.cc
@@ -1,0 +1,113 @@
+#include "absl/strings/ascii.h"
+#include "absl/strings/match.h"
+#include "core/core.h"
+
+#include "main/sig_finder/sig_finder.h"
+
+using namespace std;
+
+namespace sorbet::sig_finder {
+
+std::optional<SigLoc> findSignature(const core::GlobalState &gs, const core::SymbolRef &methodDef) {
+    auto defLoc = methodDef.loc(gs);
+    // We don't have a direct link to the signature for the method, so we
+    // heuristically look for the matching signature.
+    string_view source = defLoc.file().data(gs).source();
+    core::LocOffsets sigLocOffsets;
+    core::LocOffsets bodyLocOffsets;
+
+    // We only care about everything prior to the definition.
+    auto line_end = defLoc.beginPos();
+    auto prev_line_end = source.rfind('\n', line_end);
+    bool startFromDefinition = true;
+    while (prev_line_end != source.npos) {
+        auto line_start = prev_line_end + 1;
+        auto line = source.substr(line_start, line_end - line_start);
+        line = absl::StripAsciiWhitespace(line);
+        // We do not skip empty lines, contra LSP's documentation finder.
+        // But as we are starting from just before the method definition,
+        // the beginning of that line could look like an empty line, and
+        // we want to move to the previous line in that case.
+        if (line.empty()) {
+            if (!startFromDefinition) {
+                break;
+            }
+            line_end = prev_line_end;
+            prev_line_end = source.rfind('\n', line_end - 1);
+            startFromDefinition = false;
+            continue;
+        }
+
+        const auto singleLineSig = "sig"sv;
+        const uint32_t singleLineSigSize = singleLineSig.size();
+        const auto alreadyFinalSig = "sig(:final)"sv;
+        const auto multiLineSigEnd = "end"sv;
+        const uint32_t multiLineSigEndSize = multiLineSigEnd.size();
+        const auto multiLineSigStart = "sig do"sv;
+
+        // If something went wrong, we might find ourselves looking at an
+        // existing `sig(:final)`.  Bail instead of suggesting an autocorrect
+        // to an already final sig.
+        if (absl::StartsWith(line, alreadyFinalSig)) {
+            break;
+        }
+
+        if (absl::StartsWith(line, singleLineSig)) {
+            uint32_t offset = line.data() - source.data();
+            sigLocOffsets = core::LocOffsets{offset, offset + singleLineSigSize};
+            bodyLocOffsets =
+                core::LocOffsets{offset + singleLineSigSize + 1, static_cast<uint32_t>(offset + line.size())};
+            break;
+        }
+
+        if (absl::StartsWith(line, multiLineSigEnd)) {
+            // Loop backwards searching for the matching `sig do`.  We're
+            // going to:
+            // - Find it;
+            // - Hit an `end` or an already-final sig;
+            // - Hit the start of the file.
+            line_end = prev_line_end;
+            prev_line_end = source.rfind('\n', line_end - 1);
+            auto multiLineSigEndPos = line.data() - source.data() + multiLineSigEndSize;
+            while (prev_line_end != source.npos) {
+                auto line_start = prev_line_end + 1;
+                line = source.substr(line_start, line_end - line_start);
+                line = absl::StripAsciiWhitespace(line);
+
+                // Found the start of the multi-line sig we were looking for.
+                if (absl::StartsWith(line, multiLineSigStart)) {
+                    uint32_t offset = line.data() - source.data();
+                    sigLocOffsets = core::LocOffsets{offset, offset + singleLineSigSize};
+                    bodyLocOffsets =
+                        core::LocOffsets{offset + singleLineSigSize + 1, static_cast<uint32_t>(multiLineSigEndPos)};
+                    break;
+                }
+
+                if (absl::StartsWith(line, alreadyFinalSig)) {
+                    break;
+                }
+
+                // We hit an `end` in a place we didn't expect.  Bail.
+                if (absl::StartsWith(line, multiLineSigEnd)) {
+                    break;
+                }
+
+                line_end = prev_line_end;
+                prev_line_end = source.rfind('\n', line_end - 1);
+            }
+
+            // However we exited the above loop, we are done.
+            break;
+        }
+
+        // If we find anything else, even a blank line, assume that the heuristic
+        // has failed.
+        break;
+    }
+    if (sigLocOffsets.exists() && bodyLocOffsets.exists()) {
+        return SigLoc{sigLocOffsets, bodyLocOffsets};
+    } else {
+        return std::nullopt;
+    }
+}
+} // namespace sorbet::sig_finder

--- a/main/sig_finder/sig_finder.h
+++ b/main/sig_finder/sig_finder.h
@@ -1,0 +1,15 @@
+#ifndef SORBET_SIG_FINDER
+#define SORBET_SIG_FINDER
+#include "core/core.h"
+
+namespace sorbet::sig_finder {
+
+struct SigLoc {
+    core::LocOffsets sig;
+    core::LocOffsets body;
+};
+
+std::optional<SigLoc> findSignature(const core::GlobalState &gs, const core::SymbolRef &methodDef);
+} // namespace sorbet::sig_finder
+
+#endif // SORBET_SIG_FINDER

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -81,6 +81,7 @@ compilation_database(
         "//main/pipeline:pipeline-orig",
         "//main/pipeline/semantic_extension:interface",
         "//main/pipeline/semantic_extension:none",
+        "//main/sig_finder:sig_finder",
         "//namer:namer",
         "//namer:namer_test",
         "//packager:packager",


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Per the tin. The change moves a code, which finds a `sig` location by a symbol reference into a separate class.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
I need this to move forward with a "Move method" refactoring
https://github.com/sorbet/sorbet/pull/5309

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
