### PR TITLE
don't bother with `LocalVariable` when `NameRef` will do in completion code

### DIFF
--- a/main/lsp/LocalVarFinder.cc
+++ b/main/lsp/LocalVarFinder.cc
@@ -22,7 +22,7 @@ ast::ExpressionPtr LocalVarFinder::preTransformBlock(core::Context ctx, ast::Exp
 
     auto parsedArgs = ast::ArgParsing::parseArgs(block.args);
     for (const auto &parsedArg : parsedArgs) {
-        this->result_.emplace_back(parsedArg.local);
+        this->result_.emplace_back(parsedArg.local._name);
     }
 
     return tree;
@@ -39,7 +39,7 @@ ast::ExpressionPtr LocalVarFinder::postTransformAssign(core::Context ctx, ast::E
     }
 
     if (methodStack.back() == this->targetMethod) {
-        this->result_.emplace_back(local->localVariable);
+        this->result_.emplace_back(local->localVariable._name);
     }
 
     return tree;
@@ -56,7 +56,7 @@ ast::ExpressionPtr LocalVarFinder::preTransformMethodDef(core::Context ctx, ast:
     if (currentMethod == this->targetMethod) {
         auto parsedArgs = ast::ArgParsing::parseArgs(methodDef.args);
         for (const auto &parsedArg : parsedArgs) {
-            this->result_.emplace_back(parsedArg.local);
+            this->result_.emplace_back(parsedArg.local._name);
         }
     }
 
@@ -89,7 +89,7 @@ ast::ExpressionPtr LocalVarFinder::postTransformClassDef(core::Context ctx, ast:
     return tree;
 }
 
-const vector<core::LocalVariable> &LocalVarFinder::result() const {
+const vector<core::NameRef> &LocalVarFinder::result() const {
     ENFORCE(this->methodStack.empty());
     return this->result_;
 }

--- a/main/lsp/LocalVarFinder.h
+++ b/main/lsp/LocalVarFinder.h
@@ -15,7 +15,7 @@ class LocalVarFinder {
     // flattened at this point. (LSP code should try to make minimal assumptions to be robust to changes.)
     std::vector<core::MethodRef> methodStack;
 
-    std::vector<core::LocalVariable> result_;
+    std::vector<core::NameRef> result_;
 
 public:
     LocalVarFinder(core::MethodRef targetMethod, core::Loc queryLoc) : targetMethod(targetMethod), queryLoc(queryLoc) {}
@@ -27,7 +27,7 @@ public:
     ast::ExpressionPtr preTransformClassDef(core::Context ctx, ast::ExpressionPtr classDef);
     ast::ExpressionPtr postTransformClassDef(core::Context ctx, ast::ExpressionPtr classDef);
 
-    const std::vector<core::LocalVariable> &result() const;
+    const std::vector<core::NameRef> &result() const;
 };
 }; // namespace sorbet::realmain::lsp
 

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -236,16 +236,16 @@ vector<RubyKeyword> allSimilarKeywords(string_view prefix) {
     return result;
 }
 
-vector<core::LocalVariable> allSimilarLocals(const core::GlobalState &gs, const vector<core::LocalVariable> &locals,
-                                             string_view prefix) {
-    auto result = vector<core::LocalVariable>{};
+vector<core::NameRef> allSimilarLocalNames(const core::GlobalState &gs, const vector<core::NameRef> &locals,
+                                                 string_view prefix) {
+    auto result = vector<core::NameRef>{};
     for (const auto &local : locals) {
-        if (hasAngleBrackets(local._name.shortName(gs))) {
+        if (hasAngleBrackets(local.shortName(gs))) {
             // Gets rid of locals like <blk>
             continue;
         }
 
-        if (hasSimilarName(gs, local._name, prefix)) {
+        if (hasSimilarName(gs, local, prefix)) {
             result.emplace_back(local);
         }
     }
@@ -464,10 +464,10 @@ unique_ptr<CompletionItem> getCompletionItemForConstant(const core::GlobalState 
     return item;
 }
 
-unique_ptr<CompletionItem> getCompletionItemForLocal(const core::GlobalState &gs, const LSPConfiguration &config,
-                                                     const core::LocalVariable &local, const core::Loc queryLoc,
-                                                     string_view prefix, size_t sortIdx) {
-    auto label = string(local._name.shortName(gs));
+unique_ptr<CompletionItem> getCompletionItemForLocalName(const core::GlobalState &gs, const LSPConfiguration &config,
+                                                         const core::NameRef &local, const core::Loc queryLoc,
+                                                         string_view prefix, size_t sortIdx) {
+    auto label = string(local.shortName(gs));
     auto item = make_unique<CompletionItem>(label);
     item->sortText = formatSortIndex(sortIdx);
     item->kind = CompletionItemKind::Variable;
@@ -483,8 +483,8 @@ unique_ptr<CompletionItem> getCompletionItemForLocal(const core::GlobalState &gs
     return item;
 }
 
-vector<core::LocalVariable> localsForMethod(LSPTypecheckerDelegate &typechecker, const core::MethodRef method,
-                                            const core::Loc queryLoc) {
+vector<core::NameRef> localNamesForMethod(LSPTypecheckerDelegate &typechecker, const core::MethodRef method,
+                                                const core::Loc queryLoc) {
     const auto &gs = typechecker.state();
     auto files = vector<core::FileRef>{};
     for (auto loc : method.data(gs)->locs()) {
@@ -502,10 +502,10 @@ vector<core::LocalVariable> localsForMethod(LSPTypecheckerDelegate &typechecker,
     auto result = localVarFinder.result();
     fast_sort(result, [&gs](const auto &left, const auto &right) {
         // Sort by actual name, not by NameRef id
-        if (left._name != right._name) {
-            return left._name.shortName(gs) < right._name.shortName(gs);
+        if (left != right) {
+            return left.shortName(gs) < right.shortName(gs);
         } else {
-            return left < right;
+            return left.rawId() < right.rawId();
         }
     });
 
@@ -837,10 +837,10 @@ vector<unique_ptr<CompletionItem>> CompletionTask::getCompletionItems(LSPTypeche
 
     // ----- locals -----
 
-    vector<core::LocalVariable> similarLocals;
+    vector<core::NameRef> similarLocals;
     if (params.enclosingMethod.exists()) {
-        auto locals = localsForMethod(typechecker, params.enclosingMethod, params.queryLoc);
-        similarLocals = allSimilarLocals(gs, locals, params.prefix);
+        auto locals = localNamesForMethod(typechecker, params.enclosingMethod, params.queryLoc);
+        similarLocals = allSimilarLocalNames(gs, locals, params.prefix);
     }
 
     // ----- keywords -----
@@ -914,7 +914,7 @@ vector<unique_ptr<CompletionItem>> CompletionTask::getCompletionItems(LSPTypeche
     }
     for (auto &similarLocal : similarLocals) {
         items.push_back(
-            getCompletionItemForLocal(gs, this->config, similarLocal, params.queryLoc, params.prefix, items.size()));
+            getCompletionItemForLocalName(gs, this->config, similarLocal, params.queryLoc, params.prefix, items.size()));
     }
     for (auto &similarMethod : dedupedSimilarMethods) {
         // Even though we might have one or more TypeConstraints on the DispatchResult that triggered this completion

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -237,7 +237,7 @@ vector<RubyKeyword> allSimilarKeywords(string_view prefix) {
 }
 
 vector<core::NameRef> allSimilarLocalNames(const core::GlobalState &gs, const vector<core::NameRef> &locals,
-                                                 string_view prefix) {
+                                           string_view prefix) {
     auto result = vector<core::NameRef>{};
     for (const auto &local : locals) {
         if (hasAngleBrackets(local.shortName(gs))) {
@@ -484,7 +484,7 @@ unique_ptr<CompletionItem> getCompletionItemForLocalName(const core::GlobalState
 }
 
 vector<core::NameRef> localNamesForMethod(LSPTypecheckerDelegate &typechecker, const core::MethodRef method,
-                                                const core::Loc queryLoc) {
+                                          const core::Loc queryLoc) {
     const auto &gs = typechecker.state();
     auto files = vector<core::FileRef>{};
     for (auto loc : method.data(gs)->locs()) {
@@ -913,8 +913,8 @@ vector<unique_ptr<CompletionItem>> CompletionTask::getCompletionItems(LSPTypeche
                                                     items.size()));
     }
     for (auto &similarLocal : similarLocals) {
-        items.push_back(
-            getCompletionItemForLocalName(gs, this->config, similarLocal, params.queryLoc, params.prefix, items.size()));
+        items.push_back(getCompletionItemForLocalName(gs, this->config, similarLocal, params.queryLoc, params.prefix,
+                                                      items.size()));
     }
     for (auto &similarMethod : dedupedSimilarMethods) {
         // Even though we might have one or more TypeConstraints on the DispatchResult that triggered this completion


### PR DESCRIPTION
I'm working on completion code for instance variables (more generally, "fields" in Sorbet parlance).  The way the code is looking right now, it should be possible to largely share the completion code for local variables and for fields.

Except for one small wrinkle: the completion code for locals works by finding all the `LocalVariable`s in a method and operating on those.  The completion code for instance variables is going to work by finding all `UnresolvedIdent`s and gathering up their names (as `NameRef`s) and working on those.  So we have a mismatch.

The saving grace is that the completion code for locals really only ever cares about the names of the `LocalVariable`s, which are, conveniently, `NameRef`s.  So this PR proposes to make the completion code and all supporting bits operate in terms of `NameRef`s rather than `LocalVariable`s.

I guess `LocalVarFinder` should really be `LocalNameFinder`, but I was lazy; please let me know if I should not be lazy.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Making future changes easier.  The code should also be slightly more efficient because we're operating on smaller data structures now.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This should be a no-op change and existing tests should cover this.
