### PR TITLE
Handle symbols from child packages in single-package rbi generation

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -307,7 +307,8 @@ private:
         core::NameRef packageId;
         vector<core::NameRef> fullName;
 
-        PackageStub(const core::packages::PackageInfo &info) : packageId{info.mangledName()}, fullName{info.fullName()} {}
+        PackageStub(const core::packages::PackageInfo &info)
+            : packageId{info.mangledName()}, fullName{info.fullName()} {}
 
         bool couldDefineChildNamespace(const core::GlobalState &gs, const std::vector<core::NameRef> &prefix,
                                        const std::vector<ast::ConstantLit *> &suffix) const {
@@ -338,7 +339,6 @@ private:
 
             return true;
         }
-
     };
 
     struct ParentPackageStub {

--- a/test/cli/rbi-gen-single/family/family.rb
+++ b/test/cli/rbi-gen-single/family/family.rb
@@ -5,16 +5,19 @@ module Family
   class Simpsons
     extend T::Sig
 
+    # These two aliases will have the same RHS in the rbi file that's generated.
     MaybeBart = T.type_alias{T.nilable(Bart::Character)}
+    MaybeBartFull = T.type_alias{T.nilable(Family::Bart::Character)}
 
     sig {returns(MaybeBart)}
     def no_bart
       nil
     end
 
-    # This exposes another problem, Bart::Character is used completely
-    # unqualified at the top level in the rbi.
-    LocalBart = Bart::Character
+    # These two constants will have the same RHS in the rbi file that's
+    # generated.
+    RelativeBart = Bart::Character
+    FullyQualifiedBart = Family::Bart::Character
 
     sig {returns(Bart::Character)}
     def bart

--- a/test/cli/rbi-gen-single/test.out
+++ b/test/cli/rbi-gen-single/test.out
@@ -4,16 +4,18 @@
 # typed: true
 
 class Family::Simpsons < Object
-  sig {returns(Bart::Character)}
+  sig {returns(Family::Bart::Character)}
   def bart; end
-  sig {returns(T.nilable(Bart::Character))}
+  sig {returns(T.nilable(Family::Bart::Character))}
   def no_bart; end
   extend T::Sig
 end
-Family::Simpsons::MaybeBart = T.type_alias {T.nilable(Bart::Character)}
-Family::Simpsons::LocalBart = Bart::Character
+Family::Simpsons::RelativeBart = Family::Bart::Character
+Family::Simpsons::MaybeBartFull = T.type_alias {T.nilable(Family::Bart::Character)}
+Family::Simpsons::MaybeBart = T.type_alias {T.nilable(Family::Bart::Character)}
+Family::Simpsons::FullyQualifiedBart = Family::Bart::Character
 -- JSON: ./test/cli/rbi-gen-single/family/__package.rb (Family)
-{"packageRefs":[], "rbiRefs":[]}
+{"packageRefs":["Family::Bart"], "rbiRefs":[]}
 -- ./test/cli/rbi-gen-single/family/bart/__package.rb (Family::Bart)
 -- RBI: ./test/cli/rbi-gen-single/family/bart/__package.rb (Family::Bart)
 # typed: true
@@ -41,13 +43,7 @@ class Util::GenericMessage < Object
 end
 class Util::Messages < Object
   extend T::Sig
-  sig do
-    type_parameters(:T)
-    .params(
-      msg: Util::GenericMessage[T.type_parameter(:T)]
-    )
-    .void
-  end
+  sig {type_parameters(:T).params(msg: GenericMessage[T.type_parameter(:T)]).void}
   def self.print_message(msg); end
   sig {params(msg: String).void}
   def self.say(msg); end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Rework stubbing of constants in single-package mode to handle the special cases that show up for constants defined in packages in both the parent and child portions of the current package's namespace.

The meat of the change here is due to the realization that we're not actually trying to find the most specific package that could define the symbol, but to implement ruby's constant name resolution for packages when constants fail to resolve. While the logic for finding a parent package that defines a constant remains largely the same, we add an additional step if that fails that looks for child packages that might match a prefix of the name being resolved. If that's the case we don't need to check exports to verify that this is the right name to stub with, as the vm will commit to that constant anyway at runtime.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Properly handle stubbing of constants from imported packages

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
