### PR TITLE
Use system LibreSSL instead

### DIFF
--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -292,7 +292,7 @@ package(default_visibility = ["//visibility:public"])
 
     native.new_local_repository(
         name = "system_ssl_darwin",
-        path = "/usr/local/opt/openssl",
+        path = "/usr/lib",
         build_file = "@com_stripe_ruby_typer//third_party/openssl:darwin.BUILD",
     )
 


### PR DESCRIPTION
"./tools/scripts/build_compilation_db.sh" fails on master on Big Sur and Monterey.

macOS v12.2.1
$ pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | ag version
version: 13.2.0.0.1.1638488800

macOS v11.6.4
$ pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | ag version
version: 12.5.1.0.1.1623191612

$ ./tools/scripts/build_compilation_db.sh
INFO: Invocation ID: 161c6609-11c7-4b73-a677-11accb42f910
ERROR: /Users/dle/stripe-b/sorbet/WORKSPACE:5:29: fetching new_local_repository rule //external:system_ssl_darwin: java.io.IOException: The repository's path is "/usr/local/opt/openssl" (absolute: "/usr/local/opt/openssl") but this directory does not exist.
ERROR: /private/var/tmp/_bazel/bd548f8b913978ea2d710fc4d898e722/external/sorbet_ruby_2_7_for_compiler/BUILD.bazel:5:5: @sorbet_ruby_2_7_for_compiler//:ruby-dist depends on @system_ssl_darwin//:ssl in repository @system_ssl_darwin which failed to fetch. no such package '@system_ssl_darwin//': The repository's path is "/usr/local/opt/openssl" (absolute: "/usr/local/opt/openssl") but this directory does not exist.
ERROR: /private/var/tmp/_bazel/bd548f8b913978ea2d710fc4d898e722/external/sorbet_ruby_2_7_for_compiler/BUILD.bazel:5:5: @sorbet_ruby_2_7_for_compiler//:ruby-dist depends on @system_ssl_darwin//:crypto in repository @system_ssl_darwin which failed to fetch. no such package '@system_ssl_darwin//': The repository's path is "/usr/local/opt/openssl" (absolute: "/usr/local/opt/openssl") but this directory does not exist.
ERROR: Analysis of target '//tools:compdb' failed; build aborted: 
INFO: Elapsed time: 0.305s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (3 packages loaded, 0 targets configured)

### Motivation
https://github.com/sorbet/sorbet#editor-setup-for-c should be straightforward.

### Test plan
Manual test only.

Stripe handle: `@dle`.