### PR TITLE
pass `NameRef` by value in `getCompletionItemForLocalName`

### DIFF
--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -465,7 +465,7 @@ unique_ptr<CompletionItem> getCompletionItemForConstant(const core::GlobalState 
 }
 
 unique_ptr<CompletionItem> getCompletionItemForLocalName(const core::GlobalState &gs, const LSPConfiguration &config,
-                                                         const core::NameRef &local, const core::Loc queryLoc,
+                                                         const core::NameRef local, const core::Loc queryLoc,
                                                          string_view prefix, size_t sortIdx) {
     auto label = string(local.shortName(gs));
     auto item = make_unique<CompletionItem>(label);


### PR DESCRIPTION

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

@elliottt noted this in #5389; I imagine inlining makes it a little moot exactly which type we choose, but passing by value is more consistent.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
