### PR TITLE
Debugging notes for required params after optional params error

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/signature.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature.rb
@@ -103,6 +103,12 @@ class T::Private::Methods::Signature
         if @arg_types.length > @req_arg_count
           # Note that this is actually is supported by Ruby, but it would add complexity to
           # support it here, and I'm happy to discourage its use anyway.
+          #
+          # If you are seeing this error and surprised by it, it's possible that you have
+          # overridden the method described in the error message. For example, Rails defines
+          # def self.update!(id = :all, attributes)
+          # on AR models. If you have also defined `self.update!` on an AR model you might
+          # see this error. The simplest resolution is to rename your method.
           raise "Required params after optional params are not supported in method declarations. Method: #{method_desc}"
         end
         @arg_types << [param_name, type]


### PR DESCRIPTION
I spent a bunch of time today debugging an error I was seeing on a Rails 7 app, where we were getting this error and it was pointing here: https://github.com/rails/rails/blob/2459c20afb508c987347f52148210d874a9af4fa/activerecord/lib/active_record/persistence.rb#L405

Eventually, with the help of @jeffcarbs and @paracycle I tracked it down to a `def self.update!` in an Active Record model. This method had a `sig { void }` but it seems like for some reason the names matching still triggered this error.

I'm not sure how to fix that or if it's even a bug, but I thought some debugging notes might help the next person to come across it. If it is considered a bug, happy to provide more info to help with replication.