### PR TITLE
Rewrite `Class.new do ... end` blocks to add a `T.bind`

### DIFF
--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -357,6 +357,14 @@ public:
         return Constant(loc, core::Symbols::T());
     }
 
+    static ExpressionPtr Bind(core::LocOffsets loc, ExpressionPtr value, ExpressionPtr type) {
+        return Send2(loc, T(loc), core::Names::bind(), loc, std::move(value), std::move(type));
+    }
+
+    static ExpressionPtr ClassOf(core::LocOffsets loc, ExpressionPtr value) {
+        return Send1(loc, T(loc), core::Names::classOf(), loc, std::move(value));
+    }
+
     static ExpressionPtr Let(core::LocOffsets loc, ExpressionPtr value, ExpressionPtr type) {
         return Send2(loc, T(loc), core::Names::let(), loc, std::move(value), std::move(type));
     }

--- a/rewriter/ClassNew.cc
+++ b/rewriter/ClassNew.cc
@@ -10,21 +10,9 @@ using namespace std;
 
 namespace sorbet::rewriter {
 
-vector<ast::ExpressionPtr> ClassNew::run(core::MutableContext ctx, ast::Assign *asgn) {
+vector<ast::ExpressionPtr> rewriteAsClassDef(core::MutableContext ctx, ast::Assign *asgn) {
     vector<ast::ExpressionPtr> empty;
     auto loc = asgn->loc;
-
-    if (ctx.state.runningUnderAutogen) {
-        // This is not safe to run under autogen, because we'd be outputing
-        // autoloader files that predeclare the class and cause "warning:
-        // already initialized constant" errors
-        return empty;
-    }
-
-    auto lhs = ast::cast_tree<ast::UnresolvedConstantLit>(asgn->lhs);
-    if (lhs == nullptr) {
-        return empty;
-    }
 
     auto send = ast::cast_tree<ast::Send>(asgn->rhs);
     if (send == nullptr) {
@@ -80,6 +68,90 @@ vector<ast::ExpressionPtr> ClassNew::run(core::MutableContext ctx, ast::Assign *
     vector<ast::ExpressionPtr> stats;
     stats.emplace_back(ast::MK::Class(loc, loc, std::move(asgn->lhs), std::move(ancestors), std::move(body)));
     return stats;
+}
+
+vector<ast::ExpressionPtr> rewriteWithBind(core::MutableContext ctx, ast::Send *send) {
+    vector<ast::ExpressionPtr> empty;
+
+    auto recv = ast::cast_tree<ast::UnresolvedConstantLit>(send->recv);
+    if (recv == nullptr) {
+        return empty;
+    }
+
+    if (!ast::isa_tree<ast::EmptyTree>(recv->scope) || recv->cnst != core::Names::Constants::Class() ||
+        send->fun != core::Names::new_()) {
+        return empty;
+    }
+
+    auto argc = send->numPosArgs();
+    if (argc > 1 || send->hasKwArgs()) {
+        return empty;
+    }
+
+    if (argc == 1 && !ast::isa_tree<ast::UnresolvedConstantLit>(send->getPosArg(0))) {
+        return empty;
+    }
+
+    auto *block = send->block();
+    if (block == nullptr) {
+        return empty;
+    }
+
+    ast::ExpressionPtr type;
+
+    if (argc == 0) {
+        type = ast::MK::Constant(send->loc, core::Symbols::Class());
+    } else {
+        auto target = send->getPosArg(0).deepCopy();
+        type = ast::MK::ClassOf(send->loc, std::move(target));
+    }
+
+    auto bind = ast::MK::Bind(send->loc, ast::MK::Self(send->loc), std::move(type));
+
+    ast::InsSeq::STATS_store blockStats;
+    blockStats.emplace_back(std::move(bind));
+
+    if (auto insSeq = ast::cast_tree<ast::InsSeq>(block->body)) {
+        for (auto &stat : insSeq->stats) {
+            blockStats.emplace_back(std::move(stat));
+        }
+        block->body = ast::MK::InsSeq(block->loc, std::move(blockStats), std::move(insSeq->expr));
+    } else {
+        block->body = ast::MK::InsSeq(block->loc, std::move(blockStats), std::move(block->body));
+    }
+
+    return empty;
+}
+
+vector<ast::ExpressionPtr> ClassNew::run(core::MutableContext ctx, ast::Assign *asgn) {
+    vector<ast::ExpressionPtr> empty;
+
+    if (ctx.state.runningUnderAutogen) {
+        // This is not safe to run under autogen, because we'd be outputing
+        // autoloader files that predeclare the class and cause "warning:
+        // already initialized constant" errors
+        return empty;
+    }
+
+    auto lhs = ast::cast_tree<ast::UnresolvedConstantLit>(asgn->lhs);
+    if (lhs == nullptr) {
+        // Case for a non-constant literal such as `c = Class.new(Parent) do ... end`
+
+        auto send = ast::cast_tree<ast::Send>(asgn->rhs);
+        if (send == nullptr) {
+            return empty;
+        }
+
+        return rewriteWithBind(ctx, send);
+    } else {
+        // Case for a constant literal such as `C = Class.new(Parent) do ... end`
+        return rewriteAsClassDef(ctx, asgn);
+    }
+}
+
+vector<ast::ExpressionPtr> ClassNew::run(core::MutableContext ctx, ast::Send *send) {
+    // Case for a send such as `Class.new(Parent) do ... end`
+    return rewriteWithBind(ctx, send);
 }
 
 }; // namespace sorbet::rewriter

--- a/rewriter/ClassNew.h
+++ b/rewriter/ClassNew.h
@@ -5,21 +5,50 @@
 namespace sorbet::rewriter {
 
 /**
- * This class desugars things of the form
+ * This class actually contains three different rewriters depending on the kind of `Class.new` we ecounter:
  *
- *   A = B::Class.new(Parent) do
+ * Assignments to a constant literal such as
+ *
+ *   A = Class.new(Parent) do
  *     ...
  *   end
  *
- * into
+ * Are rewritten into
  *
  *   class A < Parent
+ *     ...
+ *   end
+ *
+ * Assignments to a non-constant literal such as
+ *
+ *   c = Class.new(Parent) do
+ *     ...
+ *   end
+ *
+ * Are rewritten into
+ *
+ *   c = Class.new(Parent)
+ *     T.bind(self, T.class_of(Parent))
+ *     ...
+ *   end
+ *
+ * And sends such as
+ *
+ *   Class.new(Parent) do
+ *     ...
+ *   end
+ *
+ * Are rewritten into
+ *
+ *   Class.new(Parent)
+ *     T.bind(self, T.class_of(Parent))
  *     ...
  *   end
  */
 class ClassNew final {
 public:
     static std::vector<ast::ExpressionPtr> run(core::MutableContext ctx, ast::Assign *asgn);
+    static std::vector<ast::ExpressionPtr> run(core::MutableContext ctx, ast::Send *send);
 
     ClassNew() = delete;
 };

--- a/rewriter/rewriter.cc
+++ b/rewriter/rewriter.cc
@@ -137,6 +137,12 @@ public:
                         replaceNodes[stat.get()] = std::move(nodes);
                         return;
                     }
+
+                    nodes = ClassNew::run(ctx, &send);
+                    if (!nodes.empty()) {
+                        replaceNodes[stat.get()] = std::move(nodes);
+                        return;
+                    }
                 },
 
                 [&](ast::MethodDef &mdef) { Initializer::run(ctx, &mdef, prevStat); },

--- a/test/testdata/rewriter/class_new.rb
+++ b/test/testdata/rewriter/class_new.rb
@@ -40,4 +40,35 @@ E = Class.new(Top::Parent) do; end
 
 T.let(E.new, Top::Parent)
 
+#################
 
+class Foo
+  def self.foo; end
+end
+
+C1 = Class.new do
+  T.reveal_type self # error: Revealed type: `T.class_of(C1)`
+end
+
+C2 = Class.new(Foo) do
+  T.reveal_type self # error: Revealed type: `T.class_of(C2)`
+  foo
+end
+
+c1 = Class.new do
+  T.reveal_type self # error: Revealed type: `Class`
+end
+
+c2 = Class.new(Foo) do
+  T.reveal_type self # error: Revealed type: `T.class_of(Foo)`
+  foo
+end
+
+Class.new do
+  T.reveal_type(self) # error: Revealed type: `Class`
+end
+
+Class.new(Foo) do
+  T.reveal_type(self) # error: Revealed type: `T.class_of(Foo)`
+  foo
+end

--- a/test/testdata/rewriter/class_new.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/class_new.rb.rewrite-tree.exp
@@ -59,4 +59,52 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   <emptyTree>::<C T>.let(<emptyTree>::<C E>.new(), <emptyTree>::<C Top>::<C Parent>)
+
+  class <emptyTree>::<C Foo><<C <todo sym>>> < (::<todo sym>)
+    def self.foo<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.keep_self_def(<self>, :foo, :normal)
+  end
+
+  class <emptyTree>::<C C1><<C <todo sym>>> < (::<todo sym>)
+    <emptyTree>::<C T>.reveal_type(<self>)
+  end
+
+  class <emptyTree>::<C C2><<C <todo sym>>> < (<emptyTree>::<C Foo>)
+    <emptyTree>::<C T>.reveal_type(<self>)
+
+    <self>.foo()
+  end
+
+  c1 = <emptyTree>::<C Class>.new() do ||
+    begin
+      ::T.bind(<self>, ::Class)
+      <emptyTree>::<C T>.reveal_type(<self>)
+    end
+  end
+
+  c2 = <emptyTree>::<C Class>.new(<emptyTree>::<C Foo>) do ||
+    begin
+      ::T.bind(<self>, ::T.class_of(<emptyTree>::<C Foo>))
+      <emptyTree>::<C T>.reveal_type(<self>)
+      <self>.foo()
+    end
+  end
+
+  <emptyTree>::<C Class>.new() do ||
+    begin
+      ::T.bind(<self>, ::Class)
+      <emptyTree>::<C T>.reveal_type(<self>)
+    end
+  end
+
+  <emptyTree>::<C Class>.new(<emptyTree>::<C Foo>) do ||
+    begin
+      ::T.bind(<self>, ::T.class_of(<emptyTree>::<C Foo>))
+      <emptyTree>::<C T>.reveal_type(<self>)
+      <self>.foo()
+    end
+  end
 end


### PR DESCRIPTION
### Motivation

We added more functionality to the `ClassNew` rewriter to provide better handling for `Class.new do ... end` calls.

Before this PR, the rewriter was only handling `Class.new do ... end` when it was assigned to a constant literal:

```rb
A = Class.new(Parent) do
  # ...
end
```

Was rewritten into (and it still is the case after this PR)
 
```rb
class A < Parent
  # ...
end
```

In the cases where we cannot create a class definition for the `Class.new` send, we're now adding a `T.bind` at the beginning of the block.

So assignments to a non-constant literal such as

```rb
c = Class.new(Parent) do
  # ...
end
```

Are now rewritten into

```rb
c = Class.new(Parent)
  T.bind(self, T.class_of(Parent))
  # ...
end
```

And sends such as

```rb
Class.new(Parent) do
  # ...
end
```

Are now rewritten into

```rb
Class.new(Parent)
  T.bind(self, T.class_of(Parent))
  # ...
end
```

### Test plan

See included automated tests.

Closes https://github.com/sorbet/sorbet/pull/4766.