### PR TITLE
Stub implementation of stale-state hover and codeAction

### DIFF
--- a/main/lsp/LSPTask.cc
+++ b/main/lsp/LSPTask.cc
@@ -360,6 +360,10 @@ bool LSPTask::canPreempt(const LSPIndexer &indexer) const {
     return !needsMultithreading(indexer);
 }
 
+bool LSPTask::canUseStaleData() const {
+    return false;
+}
+
 // Filter for untyped locations, and dedup responses that are at the same location
 vector<unique_ptr<core::lsp::QueryResponse>>
 LSPTask::filterAndDedup(const core::GlobalState &gs,

--- a/main/lsp/LSPTask.h
+++ b/main/lsp/LSPTask.h
@@ -111,6 +111,9 @@ public:
 
     virtual bool canPreempt(const LSPIndexer &) const;
 
+    // Returns true if the task can operate on typechecker stale state.
+    virtual bool canUseStaleData() const;
+
     virtual bool needsMultithreading(const LSPIndexer &) const;
 
     // Returns the phase at which the task is complete. Some tasks only need to interface with the preprocessor or the

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -614,6 +614,16 @@ void LSPTypechecker::changeThread() {
     typecheckerThreadId = newId;
 }
 
+bool LSPTypechecker::tryRunOnStaleState(std::function<void(UndoState &)> func) {
+    absl::ReaderMutexLock lock(&cancellationUndoStateRWLock);
+    if (cancellationUndoState == nullptr) {
+        return false;
+    } else {
+        func(*cancellationUndoState);
+        return true;
+    }
+}
+
 LSPTypecheckerDelegate::LSPTypecheckerDelegate(WorkerPool &workers, LSPTypechecker &typechecker)
     : typechecker(typechecker), workers(workers) {}
 
@@ -647,5 +657,35 @@ std::vector<ast::ParsedFile> LSPTypecheckerDelegate::getResolved(const std::vect
 const core::GlobalState &LSPTypecheckerDelegate::state() const {
     return typechecker.state();
 }
+
+void LSPStaleTypechecker::typecheckOnFastPath(LSPFileUpdates updates,
+                                              std::vector<std::unique_ptr<Timer>> diagnosticLatencyTimers) {
+    ENFORCE(false, "typecheckOnFastPath not implemented");
+}
+
+std::vector<std::unique_ptr<core::Error>> LSPStaleTypechecker::retypecheck(std::vector<core::FileRef> frefs) const {
+    ENFORCE(false, "retypecheck not implemented");
+    return {};
+}
+
+LSPQueryResult LSPStaleTypechecker::query(const core::lsp::Query &q,
+                                          const std::vector<core::FileRef> &filesForQuery) const {
+    ENFORCE(false, "query not implemented");
+    return LSPQueryResult();
+}
+
+const ast::ParsedFile &LSPStaleTypechecker::getIndexed(core::FileRef fref) const {
+    ENFORCE(false, "getIndexed not implemented");
+    return *pf;
+}
+
+std::vector<ast::ParsedFile> LSPStaleTypechecker::getResolved(const std::vector<core::FileRef> &frefs) const {
+    ENFORCE(false, "getResolved not implemented");
+    return {};
+}
+
+const core::GlobalState &LSPStaleTypechecker::state() const {
+    return undoState.getEvictedGs();
+};
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/LSPTypecheckerCoordinator.cc
+++ b/main/lsp/LSPTypecheckerCoordinator.cc
@@ -138,6 +138,19 @@ void LSPTypecheckerCoordinator::syncRun(unique_ptr<LSPTask> task) {
     wrappedTask->blockUntilComplete();
 }
 
+unique_ptr<LSPTask> LSPTypecheckerCoordinator::syncRunOnStaleState(unique_ptr<LSPTask> task) {
+    bool success = typechecker.tryRunOnStaleState([&task](UndoState &undoState) {
+        LSPStaleTypechecker typechecker(undoState);
+        task->run(typechecker);
+    });
+
+    if (success) {
+        return nullptr;
+    } else {
+        return task;
+    }
+}
+
 shared_ptr<core::lsp::Task>
 LSPTypecheckerCoordinator::trySchedulePreemption(std::unique_ptr<LSPQueuePreemptionTask> preemptTask) {
     auto wrappedTask = make_shared<TypecheckerTask>(*config, move(preemptTask),

--- a/main/lsp/LSPTypecheckerCoordinator.h
+++ b/main/lsp/LSPTypecheckerCoordinator.h
@@ -60,6 +60,12 @@ public:
     void typecheckOnSlowPath(std::unique_ptr<SorbetWorkspaceEditTask> typecheckTask);
 
     /**
+     * Tries to runs a task on stale state, on the indexing thread. Blocks until it completes. Returns the task back to
+     * the caller if we're unsuccessful, else returns nullptr.
+     */
+    std::unique_ptr<LSPTask> syncRunOnStaleState(std::unique_ptr<LSPTask> task);
+
+    /**
      * Schedules a task to run on the typechecker thread. Blocks until it completes.
      */
     void syncRun(std::unique_ptr<LSPTask> task);

--- a/main/lsp/UndoState.cc
+++ b/main/lsp/UndoState.cc
@@ -33,4 +33,8 @@ void UndoState::restore(unique_ptr<core::GlobalState> &gs, vector<ast::ParsedFil
     gs = move(evictedGs);
 }
 
+const core::GlobalState &UndoState::getEvictedGs() const {
+    return *evictedGs;
+}
+
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/UndoState.h
+++ b/main/lsp/UndoState.h
@@ -36,6 +36,11 @@ public:
      */
     void restore(std::unique_ptr<core::GlobalState> &gs, std::vector<ast::ParsedFile> &indexed,
                  UnorderedMap<int, ast::ParsedFile> &indexedFinalGS);
+
+    /**
+     * Retrieves the evicted global state.
+     */
+    const core::GlobalState &getEvictedGs() const;
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/code_action.cc
+++ b/main/lsp/requests/code_action.cc
@@ -36,6 +36,12 @@ unique_ptr<ResponseMessage> CodeActionTask::runRequest(LSPTypecheckerInterface &
 
     vector<unique_ptr<CodeAction>> result;
 
+    if (typechecker.isStale()) {
+        config.logger->debug("CodeActionTask running on stale, returning empty result");
+        response->result = move(result);
+        return response;
+    }
+
     const core::GlobalState &gs = typechecker.state();
     core::FileRef file = config.uri2FileRef(gs, params->textDocument->uri);
     if (!file.exists()) {
@@ -107,5 +113,9 @@ unique_ptr<ResponseMessage> CodeActionTask::runRequest(LSPTypecheckerInterface &
 
     response->result = move(result);
     return response;
+}
+
+bool CodeActionTask::canUseStaleData() const {
+    return true;
 }
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/code_action.h
+++ b/main/lsp/requests/code_action.h
@@ -12,6 +12,8 @@ public:
     CodeActionTask(const LSPConfiguration &config, MessageId id, std::unique_ptr<CodeActionParams> params);
 
     std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerInterface &typechecker) override;
+
+    bool canUseStaleData() const override;
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/hover.h
+++ b/main/lsp/requests/hover.h
@@ -12,6 +12,8 @@ public:
     HoverTask(const LSPConfiguration &config, MessageId id, std::unique_ptr<TextDocumentPositionParams> params);
 
     std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerInterface &typechecker) override;
+
+    bool canUseStaleData() const override;
 };
 
 } // namespace sorbet::realmain::lsp


### PR DESCRIPTION
This adds a stubbed implementation of stale-state `textDocument/hover` and `textDocument/codeAction` queries.

Why those two queries? Because it seems that this is the minimal set we need to stub in order to get interesting behavior out of vscode.

### Motivation
Would be nice to review the basic design around locking/multithreading separately from logic tweaks.


### Test plan
No unit tests for the moment (open to ideas on how to improve that situation!) but everything should be hidden behind the `--enable-experimental-lsp-stale-state` flag.

For a basic smoke test, I've set up a sandbox project in vscode with `--sleep-in-slow-path` and `--enable-experimental-lsp-stale-state` and verified that we get stub answers for hover while a slowpath is running:

<img width="479" alt="Screen Shot 2022-03-10 at 11 58 16 AM" src="https://user-images.githubusercontent.com/680992/157744953-80a7de56-fc07-4c96-97f9-768ef6081a6e.png">

- [x] TODO: Test by hand against Stripe's codebase to make sure that the `--enable-experimental-lsp-stale-state` flag is indeed properly gating this feature.