### PR TITLE
Handle test package exports when stubbing a package

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -415,6 +415,8 @@ private:
             }
 
             auto scopeSize = std::distance(start, scope.end());
+            ENFORCE(scopeSize > 0);
+
             const auto parent = absl::c_find_if(this->parents, [start, scopeSize, &scope](auto &p) {
                 return scopeSize == p.stub.fullName.size() && std::equal(start, scope.end(), p.stub.fullName.begin());
             });
@@ -484,7 +486,11 @@ private:
             sym = cls.data(gs)->owner;
         }
 
-        // Explicitly consider an empty top-level scope as one to skip.
+        // Explicitly consider an empty top-level scope as one to skip. This arises when the symbol passed in is
+        // `core::Symbols::root()`, which will always be the top-most parent for the `Nesting` linked list present for
+        // the `ResolutionItem` being stubbed. As this doesn't correspond to a prefix of the current package's
+        // namespace, we return false to signal that this scope doesn't need to be considered as either of the
+        // parent/child package special cases.
         if (res.empty()) {
             return false;
         }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -356,8 +356,8 @@ private:
         PackageStub stub;
         vector<core::NameRef> exports;
 
-        // NOTE: these are the public-facing exports of the package that start with the `Test::` special prefix, not the
-        // names that are private, but shared with the implicit test package.
+        // NOTE: these are the public-facing exports of the package that start with the `Test::` special prefix.  They are not the names
+        // exported to the implicit test package via `export_for_test`.
         vector<core::NameRef> testExports;
 
         ParentPackageStub(const core::packages::PackageInfo &info) : stub{info} {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -356,8 +356,8 @@ private:
         PackageStub stub;
         vector<core::NameRef> exports;
 
-        // NOTE: these are the public-facing exports of the package that start with the `Test::` special prefix.  They are not the names
-        // exported to the implicit test package via `export_for_test`.
+        // NOTE: these are the public-facing exports of the package that start with the `Test::` special prefix.  They
+        // are not the names exported to the implicit test package via `export_for_test`.
         vector<core::NameRef> testExports;
 
         ParentPackageStub(const core::packages::PackageInfo &info) : stub{info} {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -312,18 +312,29 @@ private:
 
         bool couldDefineChildNamespace(const core::GlobalState &gs, const std::vector<core::NameRef> &prefix,
                                        const std::vector<ast::ConstantLit *> &suffix) const {
+            ENFORCE(!prefix.empty());
+
+            auto start = prefix.begin();
+            if (*start == core::Names::Constants::Test()) {
+                ++start;
+            }
+            auto prefixSize = std::distance(start, prefix.end());
+            if (prefixSize == 0) {
+                return false;
+            }
+
             // The reasoning is as follows: the prefix is derived from a nesting scope paired with the symbol being
             // resolved. The nesting scopes could only define a package in the parent namespace, while this check is
             // only applied to packages that are known to not occupy that part of the namespace.
-            if (this->fullName.size() <= prefix.size()) {
+            if (this->fullName.size() <= prefixSize) {
                 return false;
             }
 
-            if (!std::equal(prefix.begin(), prefix.end(), this->fullName.begin())) {
+            if (!std::equal(start, prefix.end(), this->fullName.begin())) {
                 return false;
             }
 
-            auto it = this->fullName.begin() + prefix.size();
+            auto it = this->fullName.begin() + prefixSize;
             for (auto *cnst : suffix) {
                 if (it == this->fullName.end()) {
                     return true;
@@ -345,19 +356,30 @@ private:
         PackageStub stub;
         vector<core::NameRef> exports;
 
+        // NOTE: these are the public-facing exports of the package that start with the `Test::` special prefix, not the
+        // names that are private, but shared with the implicit test package.
+        vector<core::NameRef> testExports;
+
         ParentPackageStub(const core::packages::PackageInfo &info) : stub{info} {
             auto prefixLen = this->stub.fullName.size();
+            auto testPrefixLen = prefixLen + 1;
+
             for (auto &path : info.exports()) {
                 // We only need the unique part of the export's name. It's safe to assume that the exports are
                 // populated, as the only case we allow a full re-export of the module is for leaf modules, and we
                 // already know this not a leaf.
-                this->exports.emplace_back(path[prefixLen]);
+                if (path.front() == core::Names::Constants::Test()) {
+                    this->testExports.emplace_back(path[testPrefixLen]);
+                } else {
+                    this->exports.emplace_back(path[prefixLen]);
+                }
             }
         }
 
         // Check that the candidate name is one of the top-level exported names from a parent package.
-        bool exportsSymbol(core::NameRef candidate) const {
-            return absl::c_find(this->exports, candidate) != this->exports.end();
+        bool exportsSymbol(bool inTestNamespace, core::NameRef candidate) const {
+            auto &exportList = inTestNamespace ? this->testExports : this->exports;
+            return absl::c_find(exportList, candidate) != exportList.end();
         }
     };
 
@@ -385,8 +407,20 @@ private:
 
         // Determine if a package with the same name as `scope` is known to export the name `cnst`.
         bool packageExportsConstant(const std::vector<core::NameRef> &scope, core::NameRef cnst) const {
-            const auto parent = absl::c_find_if(this->parents, [&scope](auto &p) { return p.stub.fullName == scope; });
-            return parent != this->parents.end() && parent->exportsSymbol(cnst);
+            ENFORCE(!scope.empty());
+
+            auto start = scope.begin();
+            if (*start == core::Names::Constants::Test()) {
+                ++start;
+            }
+
+            auto scopeSize = std::distance(start, scope.end());
+            const auto parent = absl::c_find_if(this->parents, [start, scopeSize, &scope](auto &p) {
+                return scopeSize == p.stub.fullName.size() && std::equal(start, scope.end(), p.stub.fullName.begin());
+            });
+
+            bool inTestNamespace = start != scope.begin();
+            return parent != this->parents.end() && parent->exportsSymbol(inTestNamespace, cnst);
         }
 
         // Determine if a package is known to have a prefix that is a combination of the name defined by `scope`, and
@@ -435,6 +469,8 @@ private:
         stubConstant(ctx, owner, *last, possibleGenericType);
     }
 
+    // Turn a symbol into a vector of `NameRefs`. Returns true if a non-empty result vector was populated, and false if
+    // the scope was root, or one of the owning symbols in the hierarchy doesn't exist.
     static bool scopeToNames(core::GlobalState &gs, core::SymbolRef sym, std::vector<core::NameRef> &res) {
         res.clear();
         while (sym.exists() && sym != core::Symbols::root()) {
@@ -446,6 +482,11 @@ private:
             auto cls = sym.asClassOrModuleRef();
             res.emplace_back(cls.data(gs)->name);
             sym = cls.data(gs)->owner;
+        }
+
+        // Explicitly consider an empty top-level scope as one to skip.
+        if (res.empty()) {
+            return false;
         }
 
         absl::c_reverse(res);

--- a/test/cli/rbi-gen-single/family/bart/__package.rb
+++ b/test/cli/rbi-gen-single/family/bart/__package.rb
@@ -3,8 +3,11 @@
 class Family::Bart < PackageSpec
 
   import Family
+  import Family::Bart::Slingshot
   import Util
+  test_import Util::Testing
 
   export Family::Bart::Character
+  export Test::Family::Bart::BartTest
 
 end

--- a/test/cli/rbi-gen-single/family/bart/bart.test.rb
+++ b/test/cli/rbi-gen-single/family/bart/bart.test.rb
@@ -1,0 +1,19 @@
+# typed: true
+
+module Test::Family
+  module Bart
+    class BartTest
+      extend T::Sig
+
+      # This should resolve to Test::Family::TestFamily
+      sig {params(x: TestFamily).void}
+      def test1(x)
+      end
+
+      # This should be stubbed as Test::Family::Bart::Slingshot::TestSlingshot
+      sig {params(x: Slingshot::TestSlingshot).void}
+      def test2(x)
+      end
+    end
+  end
+end

--- a/test/cli/rbi-gen-single/family/bart/slingshot/__package.rb
+++ b/test/cli/rbi-gen-single/family/bart/slingshot/__package.rb
@@ -1,0 +1,7 @@
+# typed: strict
+
+class Family::Bart::Slingshot < PackageSpec
+
+  export Test::Family::Bart::Slingshot::TestSlingshot
+
+end

--- a/test/cli/rbi-gen-single/family/bart/slingshot/slingshot.test.rb
+++ b/test/cli/rbi-gen-single/family/bart/slingshot/slingshot.test.rb
@@ -1,0 +1,7 @@
+# typed: true
+
+module Test::Family::Bart::Slingshot
+
+  class TestSlingshot; end
+
+end

--- a/test/cli/rbi-gen-single/test.out
+++ b/test/cli/rbi-gen-single/test.out
@@ -43,30 +43,22 @@ class Family::Bart::Character < Object
   extend T::Sig
 end
 Family::Bart::Character::FamilyClass = Family::Simpsons
+-- Test RBI: ./test/cli/rbi-gen-single/family/bart/__package.rb (Family::Bart)
+# typed: true
+
+class Test::Family::Bart::BartTest < Object
+  sig {params(x: Test::Family::TestFamily).void}
+  def test1(x); end
+  sig {params(x: Test::Family::Bart::Slingshot::TestSlingshot).void}
+  def test2(x); end
+  extend T::Sig
+end
 -- JSON: ./test/cli/rbi-gen-single/family/bart/__package.rb (Family::Bart)
 {"packageRefs":["Family","Util"], "rbiRefs":[]}
--- ./test/cli/rbi-gen-single/util/__package.rb (Util)
--- RBI: ./test/cli/rbi-gen-single/util/__package.rb (Util)
+-- ./test/cli/rbi-gen-single/family/bart/slingshot/__package.rb (Family::Bart::Slingshot)
+-- Test RBI: ./test/cli/rbi-gen-single/family/bart/slingshot/__package.rb (Family::Bart::Slingshot)
 # typed: true
 
-class Util::GenericMessage < Object
-  Elem = type_member()
-  extend T::Generic
-  extend T::Helpers
+class Test::Family::Bart::Slingshot::TestSlingshot < Object
 end
-class Util::Messages < Object
-  extend T::Sig
-  sig {type_parameters(:T).params(msg: GenericMessage[T.type_parameter(:T)]).void}
-  def self.print_message(msg); end
-  sig {params(msg: String).void}
-  def self.say(msg); end
-end
--- JSON: ./test/cli/rbi-gen-single/util/__package.rb (Util)
-{"packageRefs":[], "rbiRefs":[]}
--- ./test/cli/rbi-gen-single/util/testing/__package.rb (Util::Testing)
--- Test RBI: ./test/cli/rbi-gen-single/util/testing/__package.rb (Util::Testing)
-# typed: true
-
-class Test::Util::Testing::TestCase < Object
-end
--- JSON: ./test/cli/rbi-gen-single/util/testing/__package.rb (Util::Testing)
+-- JSON: ./test/cli/rbi-gen-single/family/bart/slingshot/__package.rb (Family::Bart::Slingshot)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
When comparing constant scopes, ensure that the `Test::` scope is handled when looking for parent or child packages that might own the unresolved symbol.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Stabilizing single-package rbi generation.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
