### PR TITLE
Never use -Os or -Oz to compile the parser

### DIFF
--- a/parser/parser/BUILD
+++ b/parser/parser/BUILD
@@ -104,7 +104,16 @@ cc_library(
     hdrs = glob(["include/**/*.hh"]),
     copts = [
         "-Wno-unused-const-variable",
-    ],
+    ] + select({
+        # What we really want here is to say "it's never ok to use -Os, because
+        # that will take 2+ minutes to compile." We have to do this to override
+        # the .bazelrc options.
+        "@com_stripe_ruby_typer//tools/config:dbg": ["-O0"],
+        "@com_stripe_ruby_typer//tools/config:opt": ["-O2"],
+        # worse to take too much time to compile in development than to run too
+        # slow in production, so -O2 by default.
+        "//conditions:default": ["-O2"],
+    }),
     includes = [
         "include",
         "include/ruby_parser",


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Without `-Os`, the parser only takes a few seconds to compile.

With, it would take upwards of 4 minutes (though it would "only" take 2
minutes back a few months ago before any of the recent parser changes).

Some raw notes:

> Here is a build from back in december before i started making any
> changes to the parser. at that point, it still took ~2min 45s (it's
> currently about 4min 40s)
>
> <https://buildkite.com/sorbet/sorbet/builds/19253#11b589a1-3847-4aa5-a6d8-10d8012f391a>
>
> the build times are pretty fast for me locally with
> `--config=test-static-sanitized`, but pretty slow with
> `--config=buildfarm-sanitized-linux` the only difference between the
> two is `--config=buildfarm`, which is defined like this:
>
> ```
> build:buildfarm --copt=-Os --linkopt=-Os --config=reduce-intermediate-file-size-base --config=rubyfmt
>
> build:reduce-intermediate-file-size-base --copt=-g0 --linkopt=-g0 # used by buildfarm to have less debug information on disk
> build:reduce-intermediate-file-size-base --strip=always
> build:reduce-intermediate-file-size-base --copt=-fno-standalone-debug --linkopt=-fno-standalone-debug # used by buildfarm to have less debug information on disk
>
> # integrates rubyfmt into sorbet
> build:rubyfmt --define rubyfmt=true --copt=-DRUBYFMT_ENABLED
> ```
>
> The PR that introduced that flags claims that this reduced the size of
> the bazel cache in CI by 4x
>
> <https://github.com/sorbet/sorbet/pull/383/files>
>
> Local `--config=test-static-sanitized` build drops from ~4 minutes to
> build those files down to ~30s when i remove the Os flags specifically

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.