### PR TITLE
Revert hack for python3

### DIFF
--- a/third_party/llvm/llvm.bzl
+++ b/third_party/llvm/llvm.bzl
@@ -141,11 +141,7 @@ def expand_cmake_vars(name, src, dst, cmake_vars):
         srcs = [src],
         tools = [expand_cmake_vars_tool],
         outs = [dst],
-        # Work around this issue: https://github.com/bazelbuild/bazel/issues/8685
-        # TODO(jez) Delete python3 if ^ this issue is resolved.
-        # tl;dr: Bazel hardcodes searching for `python` on the PATH in a py_binary wrapper script.
-        # Ubuntu 20.04 has removed `python` from the PATH in favor of `python3`.
-        cmd = ("python3 $(location {}) ".format(expand_cmake_vars_tool) + cmake_vars +
+        cmd = ("$(location {}) ".format(expand_cmake_vars_tool) + cmake_vars +
                "< $< > $@"),
     )
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The default `stub_shebang` changed from looking for a `python` binary to
`python3` binary in Bazel 5.0.0

See this commit:

<https://github.com/bazelbuild/bazel/commit/2945ef5072f659878dfd88b421c7b80aa4fb6c80>

This means we don't have to have this TODO in the codebase anymore.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.