### PR TITLE
Fix parser error with while do

### DIFF
--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -379,6 +379,8 @@ using namespace std::string_literals;
   k_return
   lcurly_block_start
   lbrace_cmd_block_start
+  until
+  while
 
 %type <delimited_list>
   defn_head
@@ -863,14 +865,24 @@ int yylex(parser::semantic_type *lval, ruby_parser::location *lloc, ruby_parser:
 
       expr_value: expr
 
-   expr_value_do:   {
+
+           // We have to factor these like this because we need these rules to run before lexing any lookahead tokens,
+           // since we have two rules that read `kWHILE` (and `kUNTIL`), and all tokens that we lex after after such
+           // a token must be lexed assuming this side effect has taken place.
+           while: kWHILE
+                    {
                       driver.lex.cond.push(true);
                     }
-                  expr_value do
+           until: kUNTIL
+                    {
+                      driver.lex.cond.push(true);
+                    }
+
+   expr_value_do: expr_value do
                     {
                       driver.lex.cond.pop();
 
-                      $$ = driver.alloc.node_with_token($3, $2);
+                      $$ = driver.alloc.node_with_token($2, $1);
                     }
 
         def_name: fname
@@ -2057,23 +2069,23 @@ array_premature_end: eof
                       $$ = driver.build.condition(self, $1, err, nullptr, nullptr, nullptr, nullptr, nullptr);
                       driver.replace_last_diagnostic(dlevel::ERROR, dclass::UnexpectedToken, $1, driver.token_name($1->type()));
                     }
-                | kWHILE expr_value_do compstmt kEND
+                | while expr_value_do compstmt kEND
                     {
                       $$ = driver.build.loop_while(self, $1, $2->nod, $2->tok, $3->body, $4);
                       driver.rewind_if_dedented($1, $4);
                     }
-                | kWHILE error
+                | while error
                     {
                       auto err = driver.build.error_node(self, @1.endPos(), @2.beginPos());
                       $$ = driver.build.loop_while(self, $1, err, nullptr, nullptr, $1);
                       driver.replace_last_diagnostic(dlevel::ERROR, dclass::UnexpectedToken, $1, driver.token_name($1->type()));
                     }
-                | kUNTIL expr_value_do compstmt kEND
+                | until expr_value_do compstmt kEND
                     {
                       $$ = driver.build.loopUntil(self, $1, $2->nod, $2->tok, $3->body, $4);
                       driver.rewind_if_dedented($1, $4);
                     }
-                | kUNTIL error
+                | until error
                     {
                       auto err = driver.build.error_node(self, @1.endPos(), @2.beginPos());
                       $$ = driver.build.loopUntil(self, $1, err, nullptr, nullptr, $1);

--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -2144,9 +2144,13 @@ array_premature_end: eof
 			                  else_ ? else_->nod : nullptr, $5);
                       driver.rewind_if_dedented($1, $5);
                     }
-                | kFOR for_var kIN expr_value_do compstmt kEND
+                | kFOR for_var kIN
                     {
-                      $$ = driver.build.for_(self, $1, $2, $3, $4->nod, $4->tok, $5->body, $6);
+                      driver.lex.cond.push(true);
+                    }
+                    expr_value_do compstmt kEND
+                    {
+                      $$ = driver.build.for_(self, $1, $2, $3, $5->nod, $5->tok, $6->body, $7);
                     }
                 | kCLASS cpath superclass
                     {

--- a/test/testdata/parser/while_do.rb
+++ b/test/testdata/parser/while_do.rb
@@ -1,0 +1,7 @@
+# typed: false
+
+while (false) do
+end
+
+until (false) do
+end

--- a/test/testdata/parser/while_do.rb.parse-tree-whitequark.exp
+++ b/test/testdata/parser/while_do.rb.parse-tree-whitequark.exp
@@ -1,0 +1,7 @@
+s(:begin,
+  s(:while,
+    s(:begin,
+      s(:false)), nil),
+  s(:until,
+    s(:begin,
+      s(:false)), nil))


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Fix parser regression for `while ... do`

What was happening was that that having two rules using `kWHILE` forces
the parser to read a lookahead token to disambiguate which action to
take next.

- In the grammar before introducing the bug, it was unambiguous what to
  do next (immediately reduce the empty rule, running `cond.push` before
  lexing the next token).
- After the bug, it became ambiguous, so the grammar would read a token,
  and it would read `'('`. It just so happens that whenever we read one
  of those tokens, the **lexer** runs an additional `cond.push(false)`
  which it then pops when reading the matching `')'` (effectively saying
  that `do` means "do for block" inside `(...)`, even in a condition as
  long as there are parens around it.)

So the stack was supposed to look like

    ..., true, false

after reading a `(` token, but instead because the paren was getting
read as a lookahead token earlier than before, the stack looked like

    ..., false

after reading the `(` token, and then `true` was pushed later once the
parser decided to reduce the empty rule:

    ..., false, true

So upon reading the `)` token, which would pop the topmost boolean,
`cond.active()` would be `false` instead of `true`, which meant that
`"do"` lexed as `kDO` instead of `kDO_COND`.

- - - -

Some historical debugging context. Here's the good trace and the bad
trace:

```diff
❯ diff -u trace-good.txt trace-bad.txt
--- trace-good.txt      2022-03-07 13:32:18.662231915 -0800
+++ trace-bad.txt       2022-03-07 13:32:41.438250601 -0800
@@ -3,206 +3,182 @@
 Reading a token: Next token is token "while" ([0,5): )
 Shifting token "while" ([0,5): )
 Entering state 10
+Reading a token: Next token is token "(" ([6,7): )
 Reducing stack by rule 63 (line 866):
 driver.lex.cond.push(true)
 -> $$ = nterm $@4 ([0,5): )
 Stack now 10 0
-Entering state 262
-Reading a token: Next token is token "(" ([6,7): )
+Entering state 263
+Next token is token "(" ([6,7): )
 Shifting token "(" ([6,7): )
 Entering state 131
```

(computed by using `--trace-parser`, also I added some print statements
to show where the `cond.push(true)` happens)

We see that in the good trace (`-` lines), the `nterm $@4` reduction
happens before reading the `"("`, but in the bad trace (`+` lines), we
read a lookahead token before deciding to reduce one way or another.



### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #5419

- [x] @jez Figure out whether there's a better way to mitigate these sorts of
  lexer statefulness bugs, because this is probably not the only one.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.