### PR TITLE
Add auto compaction to sorbet

### DIFF
--- a/rbi/core/gc.rbi
+++ b/rbi/core/gc.rbi
@@ -50,6 +50,26 @@ module GC
   # Returns information about the most recent garbage collection.
   def self.latest_gc_info(*_); end
 
+  #  Returns whether or not automatic compaction has been enabled.
+  #
+  # ```ruby
+  # GC.auto_compact    #=> true or false
+  # ```
+  sig {returns(T::Boolean)}
+  def self.auto_compact(); end
+
+  #
+  #  Updates automatic compaction mode.
+  #
+  #  When enabled, the compactor will execute on every major collection.
+  #
+  #  Enabling compaction will degrade performance on major collections.
+  #
+  # ```ruby
+  # GC.auto_compact = flag
+  # ```
+  def self.auto_compact=(_); end
+
   # Initiates garbage collection, even if manually disabled.
   #
   # This method is defined with keyword arguments that default to true:


### PR DESCRIPTION
This adds GC.auto_compact and GC.auto_compact= signatures.


Hi,

This is my first time contributing so I'm not sure what to do exactly.  Do we need to write tests for this?  Also I noticed that other "setter" methods [don't seem to have a signature](https://github.com/sorbet/sorbet/blob/66cf53bcfece2e722d1d7f76fae8176e047f1d68/rbi/core/gc.rbi#L146-L162), so I didn't add a signature to `GC.auto_compact=` but I don't know if that's "right".