### PR TITLE
fix missing methods generation with the `algolia` gem

### DIFF
--- a/main/minimize/minimize.cc
+++ b/main/minimize/minimize.cc
@@ -52,7 +52,7 @@ OutputCategory outputCategoryFromClassName(string_view fullName) {
     } else if (absl::StrContains(fullName, "::Mutator")) {
         return OutputCategory::Mutator;
     } else if (absl::StrContains(fullName, "::Model")) {
-        if (absl::StartsWith(fullName, "Plaid")) {
+        if (absl::StartsWith(fullName, "Plaid") || absl::StartsWith(fullName, "Algolia")) {
             return OutputCategory::External;
         } else {
             return OutputCategory::Model;

--- a/test/testdata/minimize-rbi/algolia.rb
+++ b/test/testdata/minimize-rbi/algolia.rb
@@ -1,0 +1,1 @@
+# typed: true

--- a/test/testdata/minimize-rbi/algolia.rb.minimize.rbi
+++ b/test/testdata/minimize-rbi/algolia.rb.minimize.rbi
@@ -1,0 +1,4 @@
+# typed: true
+
+class Algolia::Recommend::Model
+end

--- a/test/testdata/minimize-rbi/algolia.rb.minimized-rbi.exp
+++ b/test/testdata/minimize-rbi/algolia.rb.minimized-rbi.exp
@@ -1,0 +1,11 @@
+# typed: true
+
+module ::Algolia
+end
+
+module ::Algolia::Recommend
+end
+
+class Algolia::Recommend::Model
+end
+

--- a/test/testdata/minimize-rbi/algolia.rb.minimized-rbi.exp
+++ b/test/testdata/minimize-rbi/algolia.rb.minimized-rbi.exp
@@ -6,6 +6,6 @@ end
 module ::Algolia::Recommend
 end
 
-class Algolia::Recommend::Model
+class ::Algolia::Recommend::Model
 end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

`Algolia::Recommend::Model` incorrectly gets classified as something we don't want to prefix with `::`, leading to peculiar build errors when missing methods are regenerated and then Sorbet type-checks the file.  This PR adds a special case similar to what we already have for `"Plaid"` to address this.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
