### PR TITLE
Generate a third rbi for test-private symbols

### DIFF
--- a/packager/rbi_gen.cc
+++ b/packager/rbi_gen.cc
@@ -1200,12 +1200,11 @@ public:
         RBIGenerator::RBIOutput output;
         output.baseFilePath = pkg.mangledName().show(gs);
 
-        auto rawExports = pkg.exports();
-        auto rawTestExports = pkg.testExports();
-
         vector<core::SymbolRef> exports;
         vector<core::SymbolRef> testExports;
+        vector<core::SymbolRef> testPrivateExports;
 
+        auto rawExports = pkg.exports();
         for (auto &e : rawExports) {
             auto exportSymbol = lookupFQN(gs, e);
             if (exportSymbol.exists()) {
@@ -1218,10 +1217,12 @@ public:
             }
         }
 
-        for (auto e : rawTestExports) {
+        // These are `export_for_test` exports, which should only be visible to the test package.
+        auto rawTestExports = pkg.testExports();
+        for (auto &e : rawTestExports) {
             auto exportSymbol = lookupFQN(gs, e);
             if (exportSymbol.exists()) {
-                testExports.emplace_back(exportSymbol);
+                testPrivateExports.emplace_back(exportSymbol);
             }
         }
 
@@ -1249,6 +1250,20 @@ public:
             if (!rbiText.empty()) {
                 output.testRBI = "# typed: true\n\n" + rbiText;
                 output.testRBIPackageDependencies = buildPackageDependenciesString(gs);
+            }
+        }
+
+        if (!testPrivateExports.empty()) {
+            for (auto &exportSymbol : testPrivateExports) {
+                maybeEmit(exportSymbol);
+            }
+
+            emitLoop();
+
+            auto rbiText = out.toString();
+            if (!rbiText.empty()) {
+                output.testPrivateRBI = "# typed: true\n\n" + rbiText;
+                output.testPrivateRBIPackageDependencies = buildPackageDependenciesString(gs);
             }
         }
 
@@ -1325,6 +1340,13 @@ void RBIGenerator::run(core::GlobalState &gs, const UnorderedSet<core::ClassOrMo
                         FileOps::write(absl::StrCat(outputDir, "/", output.baseFilePath, ".test.deps.json"),
                                        output.testRBIPackageDependencies);
                     }
+
+                    if (!output.testPrivateRBI.empty()) {
+                        FileOps::write(absl::StrCat(outputDir, "/", output.baseFilePath, ".test.private.package.rbi"),
+                                       output.testPrivateRBI);
+                        FileOps::write(absl::StrCat(outputDir, "/", output.baseFilePath, ".test.private.deps.json"),
+                                       output.testPrivateRBIPackageDependencies);
+                    }
                 }
             }
             threadBarrier.DecrementCount();
@@ -1345,6 +1367,13 @@ void RBIGenerator::runSinglePackage(core::GlobalState &gs,
         FileOps::write(absl::StrCat(outputDir, "/", output.baseFilePath, ".test.package.rbi"), output.testRBI);
         FileOps::write(absl::StrCat(outputDir, "/", output.baseFilePath, ".test.deps.json"),
                        output.testRBIPackageDependencies);
+    }
+
+    if (!output.testPrivateRBI.empty()) {
+        FileOps::write(absl::StrCat(outputDir, "/", output.baseFilePath, ".test.private.package.rbi"),
+                       output.testPrivateRBI);
+        FileOps::write(absl::StrCat(outputDir, "/", output.baseFilePath, ".test.private.deps.json"),
+                       output.testPrivateRBIPackageDependencies);
     }
 }
 

--- a/packager/rbi_gen.h
+++ b/packager/rbi_gen.h
@@ -13,9 +13,11 @@ public:
         std::string baseFilePath;
         std::string rbi;
         std::string testRBI;
+        std::string testPrivateRBI;
         // each is a json array of mangled package names
         std::string rbiPackageDependencies;
         std::string testRBIPackageDependencies;
+        std::string testPrivateRBIPackageDependencies;
     };
 
     // Exposed for testing.

--- a/test/cli/rbi-gen-single/family/__package.rb
+++ b/test/cli/rbi-gen-single/family/__package.rb
@@ -8,11 +8,13 @@ class Family < PackageSpec
   export Family::Simpsons
   export Test::Family::TestFamily
 
-  # This illustrates a problem: the `Family::Flanders` symbol ends up in the
-  # .test.package.rbi file for this package, which means that it's available to
-  # all packages that `test_import` the `Family` package. The right solution
-  # here is to output a third rbi that represents the shared but private
-  # interface between a package and its test package.
+  # As `Family::Flanders` leaks out through the interface of
+  # `Test::Family::TestFamily`, it doesn't end up in the
+  # `.test.private.package.rbi` file.
   export_for_test Family::Flanders
+
+  # This name is only used internally in `Test::Family::TestFamily`, and as a
+  # result will remain in the `.test.private.package.rbi` file
+  export_for_test Family::Krabappel
 
 end

--- a/test/cli/rbi-gen-single/family/family.rb
+++ b/test/cli/rbi-gen-single/family/family.rb
@@ -29,5 +29,9 @@ module Family
     extend T::Sig
   end
 
+  class Krabappel
+    extend T::Sig
+  end
+
 end
 

--- a/test/cli/rbi-gen-single/family/family.test.rb
+++ b/test/cli/rbi-gen-single/family/family.test.rb
@@ -12,6 +12,13 @@ module Test::Family
     sig {params(fam: Family::Simpsons).void}
     def test_simpsons(fam)
     end
+
+    # Avoid leaking Krabappel through the interface, but still rely on it to
+    # typecheck this test file successfully.
+    sig {returns(Object)}
+    def test_krabappel
+      Family::Krabappel.new
+    end
   end
 
 end

--- a/test/cli/rbi-gen-single/test.out
+++ b/test/cli/rbi-gen-single/test.out
@@ -17,14 +17,22 @@ Family::Simpsons::FullyQualifiedBart = Family::Bart::Character
 -- Test RBI: ./test/cli/rbi-gen-single/family/__package.rb (Family)
 # typed: true
 
-class Family::Flanders < Object
-  extend T::Sig
-end
 class Test::Family::TestFamily < Test::Util::Testing::TestCase
   sig {params(fam: Family::Flanders).void}
   def test_flanders(fam); end
+  sig {returns(Object)}
+  def test_krabappel; end
   sig {params(fam: Family::Simpsons).void}
   def test_simpsons(fam); end
+  extend T::Sig
+end
+class Family::Flanders < Object
+  extend T::Sig
+end
+-- Test Private RBI: ./test/cli/rbi-gen-single/family/__package.rb (Family)
+# typed: true
+
+class Family::Krabappel < Object
   extend T::Sig
 end
 -- JSON: ./test/cli/rbi-gen-single/family/__package.rb (Family)

--- a/test/cli/rbi-gen-single/test.sh
+++ b/test/cli/rbi-gen-single/test.sh
@@ -22,7 +22,7 @@ find . -name __package.rb | sort | while read -r package; do
   echo "-- $package ($name)"
 
   "$sorbet" --silence-dev-message \
-    --ignore=__package.rb,"$rbis" \
+    --ignore=__package.rb \
     --package-rbi-output="$rbis" \
     --single-package="$name" "$test_path"
 
@@ -36,6 +36,12 @@ find . -name __package.rb | sort | while read -r package; do
   if [ -f "$test_rbi" ]; then
     echo "-- Test RBI: $package ($name)"
     cat "$test_rbi"
+  fi
+
+  test_private_rbi="$rbis/${name//::/_}_Package.test.private.package.rbi"
+  if [ -f "$test_private_rbi" ]; then
+    echo "-- Test Private RBI: $package ($name)"
+    cat "$test_private_rbi"
   fi
 
   echo "-- JSON: $package ($name)"

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -387,6 +387,12 @@ TEST_CASE("PerPhaseTest") { // NOLINT
                             return absl::StrCat("# ", test.folder, output.baseFilePath, ".test.rbi\n", output.testRBI);
                         });
                     }
+                    if (!output.testPrivateRBI.empty()) {
+                        handler.addObserved(*rbiGenGs, "rbi-gen", [&]() {
+                            return absl::StrCat("# ", test.folder, output.baseFilePath, ".test.private.package.rbi\n",
+                                                output.testPrivateRBI);
+                        });
+                    }
                 }
             }
         }

--- a/test/testdata/packager/lsp_features/__package.rbi-gen.exp
+++ b/test/testdata/packager/lsp_features/__package.rbi-gen.exp
@@ -9,7 +9,7 @@ class Simpsons::Family < Object
   extend T::Sig
 end
 
-# test/testdata/packager/lsp_features/Simpsons_Package.test.rbi
+# test/testdata/packager/lsp_features/Simpsons_Package.test.private.package.rbi
 # typed: true
 
 class Simpsons::Private < Object

--- a/test/testdata/packager/rbi_gen/__package.rbi-gen.exp
+++ b/test/testdata/packager/rbi_gen/__package.rbi-gen.exp
@@ -283,14 +283,18 @@ end
 # test/testdata/packager/rbi_gen/RBIGen_Package.test.rbi
 # typed: true
 
-class RBIGen::Sealed::TestChild < RBIGen::Sealed::Parent
-end
-class RBIGen::Private::PrivateClassForTests < Object
-end
 module Test::RBIGen
 end
 class Test::RBIGen::MyTestHelper < Object
 end
 class Test::RBIGen::MyTest < Object
+end
+
+# test/testdata/packager/rbi_gen/RBIGen_Package.test.private.package.rbi
+# typed: true
+
+class RBIGen::Sealed::TestChild < RBIGen::Sealed::Parent
+end
+class RBIGen::Private::PrivateClassForTests < Object
 end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
The current prototype for package rbi-generation implemented incorrect behavior for `export_for_test`: it treated these symbols as exported through the test rbi, rather than as private between the package and its test package.

This PR fixes this problem by emitting a third rbi that represents this private interface.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Stabilizing RBI generation.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
