### PR TITLE
Put linter runs in their own output sections

### DIFF
--- a/.buildkite/linters.sh
+++ b/.buildkite/linters.sh
@@ -9,44 +9,60 @@ source .buildkite/tools/setup-bazel.sh
 set -x
 globalErr=0
 
+echo "~~~ Checking build files"
 if ! ./tools/scripts/format_build_files.sh -t &> buildifier; then
+    echo "^^^ +++"
     globalErr=$?
     buildkite-agent annotate --context tools/scripts/format_build_files.sh --style error --append < buildifier
 fi
 
+echo "~~~ Checking c++ formatting"
 if ! ./tools/scripts/format_cxx.sh -t &> format_cxx; then
+    echo "^^^ +++"
     globalErr=$?
     buildkite-agent annotate --context tools/scripts/format_cxx.sh --style error --append < format_cxx
 fi
 
+echo "~~~ Checking that the compilation db builds"
 if ! ./tools/scripts/build_compilation_db.sh &> compdb; then
+    echo "^^^ +++"
     globalErr=$?
     buildkite-agent annotate --context tools/scripts/build_compilation_db.sh --style error --append < compdb
 fi
 
+echo "~~~ Checking compilation db targets"
 if ! ./tools/scripts/generate_compdb_targets.sh -t &> compdb-targets; then
+    echo "^^^ +++"
     globalErr=$?
     buildkite-agent annotate --context tools/scripts/generate_compdb_targets.sh --style error --append < compdb-targets
 fi
 
+echo "~~~ Linting uses of \`using namespace std\`"
 if ! ./tools/scripts/check_using_namespace_std.sh &> std_check; then
+    echo "^^^ +++"
     globalErr=$?
     buildkite-agent annotate --context tools/scripts/check_using_namespace_std.sh --style error --append < std_check
 fi
 
+echo "~~~ Running shellcheck"
 if ! ./tools/scripts/lint_sh.sh -t &> lint_sh; then
+    echo "^^^ +++"
     globalErr=$?
     buildkite-agent annotate --context tools/scripts/lint_sh.sh --style error --append < lint_sh
 fi
 
+echo "~~~ Checking markdown formatting"
 if ! ./tools/scripts/format_website.sh -t &> format_website; then
+    echo "^^^ +++"
     globalErr=$?
     buildkite-agent annotate --context tools/scripts/format_website.sh --style error --append < format_website
 fi
 
+echo "~~~ Checking the vscode extension"
 pushd vscode_extension
 yarn install
 if ! yarn lint --output-file=yarn_lint; then
+    echo "^^^ +++"
     globalErr=$?
     buildkite-agent annotate --context 'yarn lint' --style error --append <<EOF
 There were eslint errors in vscode_extension/. Fix with:
@@ -58,6 +74,7 @@ EOF
 fi
 popd
 
+echo "~~~"
 if [ "$globalErr" -ne 0 ]; then
     exit $globalErr
 fi

--- a/.buildkite/linters.sh
+++ b/.buildkite/linters.sh
@@ -11,50 +11,50 @@ globalErr=0
 
 echo "~~~ Checking build files"
 if ! ./tools/scripts/format_build_files.sh -t &> buildifier; then
-    echo "^^^ +++"
     globalErr=$?
+    echo "^^^ +++"
     buildkite-agent annotate --context tools/scripts/format_build_files.sh --style error --append < buildifier
 fi
 
 echo "~~~ Checking c++ formatting"
 if ! ./tools/scripts/format_cxx.sh -t &> format_cxx; then
-    echo "^^^ +++"
     globalErr=$?
+    echo "^^^ +++"
     buildkite-agent annotate --context tools/scripts/format_cxx.sh --style error --append < format_cxx
 fi
 
 echo "~~~ Checking that the compilation db builds"
 if ! ./tools/scripts/build_compilation_db.sh &> compdb; then
-    echo "^^^ +++"
     globalErr=$?
+    echo "^^^ +++"
     buildkite-agent annotate --context tools/scripts/build_compilation_db.sh --style error --append < compdb
 fi
 
 echo "~~~ Checking compilation db targets"
 if ! ./tools/scripts/generate_compdb_targets.sh -t &> compdb-targets; then
-    echo "^^^ +++"
     globalErr=$?
+    echo "^^^ +++"
     buildkite-agent annotate --context tools/scripts/generate_compdb_targets.sh --style error --append < compdb-targets
 fi
 
 echo "~~~ Linting uses of \`using namespace std\`"
 if ! ./tools/scripts/check_using_namespace_std.sh &> std_check; then
-    echo "^^^ +++"
     globalErr=$?
+    echo "^^^ +++"
     buildkite-agent annotate --context tools/scripts/check_using_namespace_std.sh --style error --append < std_check
 fi
 
 echo "~~~ Running shellcheck"
 if ! ./tools/scripts/lint_sh.sh -t &> lint_sh; then
-    echo "^^^ +++"
     globalErr=$?
+    echo "^^^ +++"
     buildkite-agent annotate --context tools/scripts/lint_sh.sh --style error --append < lint_sh
 fi
 
 echo "~~~ Checking markdown formatting"
 if ! ./tools/scripts/format_website.sh -t &> format_website; then
-    echo "^^^ +++"
     globalErr=$?
+    echo "^^^ +++"
     buildkite-agent annotate --context tools/scripts/format_website.sh --style error --append < format_website
 fi
 
@@ -62,8 +62,8 @@ echo "~~~ Checking the vscode extension"
 pushd vscode_extension
 yarn install
 if ! yarn lint --output-file=yarn_lint; then
-    echo "^^^ +++"
     globalErr=$?
+    echo "^^^ +++"
     buildkite-agent annotate --context 'yarn lint' --style error --append <<EOF
 There were eslint errors in vscode_extension/. Fix with:
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Put linters in their own output sections in buildkite, to make it easier to track how long each runs, and make the log easier to look at when there's a failure.

https://buildkite.com/docs/pipelines/managing-log-output#collapsing-output

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Pretty logs.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

* Successful build: https://buildkite.com/sorbet/sorbet/builds/21028#8fb9f385-9140-4bdb-8313-2155efd68332 
* Failed build: https://buildkite.com/sorbet/sorbet/builds/21027#db18e6eb-476d-4025-ae28-696f21065ae9
  * Note on the failed build: it was generated when `echo "^^^ +++"` was the first statement in each `if` block, which is why the job succeeded as a whole. This has been fixed in 1ed7d68fecc29ea5a7a60e16b46f956a87fff12f, and the use of `$?` is correct again.