### PR TITLE
add timers for various phases of completion requests

### DIFF
--- a/main/lsp/LSPTask.cc
+++ b/main/lsp/LSPTask.cc
@@ -165,7 +165,7 @@ ConstExprStr LSPTask::methodString() const {
         case LSPMethod::TextDocumentCodeAction:
             return "textDocument.codeAction";
         case LSPMethod::TextDocumentCompletion:
-            return "textDocument.completion";
+            return LSP_COMPLETION_METRICS_PREFIX;
         case LSPMethod::TextDocumentDefinition:
             return "textDocument.definition";
         case LSPMethod::TextDocumentDocumentHighlight:

--- a/main/lsp/LSPTask.h
+++ b/main/lsp/LSPTask.h
@@ -151,6 +151,10 @@ public:
     bool cancel(const MessageId &id) override;
 };
 
+// Doubles as the `methodString` for a `TextDocumentCompletion` LSPTask and also as
+// the prefix for any metrics collected during completion itself.
+#define LSP_COMPLETION_METRICS_PREFIX "textDocument.completion"
+
 /**
  * A special form of LSPTask that has direct access to the typechecker and controls its own scheduling.
  * Is only used for slow path-related tasks. Do not use for anything else.


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We can see in our metrics that completion requests are relatively slow, but we have no insight into where that time is being spent.  This PR attempts to change that by adding timers for parts of responding to a completion request.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
