### PR TITLE
Narrow signature for Enumerable#include?

### DIFF
--- a/rbi/core/enumerable.rbi
+++ b/rbi/core/enumerable.rbi
@@ -798,7 +798,7 @@ module Enumerable
   # ```
   sig do
     params(
-        arg0: BasicObject,
+        arg0: Elem,
     )
     .returns(T::Boolean)
   end

--- a/rbi/core/hash.rbi
+++ b/rbi/core/hash.rbi
@@ -757,6 +757,30 @@ class Hash < Object
   end
   def has_value?(arg0); end
 
+  # Returns `true` if the given key is present in *hsh*.
+  #
+  # ```ruby
+  # h = { "a" => 100, "b" => 200 }
+  # h.has_key?("a")   #=> true
+  # h.has_key?("z")   #=> false
+  # ```
+  #
+  # Note that
+  # [`include?`](https://docs.ruby-lang.org/en/2.7.0/Hash.html#method-i-include-3F)
+  # and
+  # [`member?`](https://docs.ruby-lang.org/en/2.7.0/Hash.html#method-i-member-3F)
+  # do not test member equality using `==` as do other Enumerables.
+  #
+  # See also
+  # [`Enumerable#include?`](https://docs.ruby-lang.org/en/2.7.0/Enumerable.html#method-i-include-3F)
+  sig do
+    params(
+        arg0: K,
+    )
+    .returns(T::Boolean)
+  end
+  def include?(arg0); end
+
   # Compute a hash-code for this hash. Two hashes with the same content will
   # have the same hash code (and will compare using `eql?`).
   #

--- a/rbi/sorbet/sorbet.rbi
+++ b/rbi/sorbet/sorbet.rbi
@@ -261,6 +261,14 @@ class Sorbet::Private::Static::ENVClass
 
   sig do
     params(
+        key: String
+    )
+    .returns(T::Boolean)
+  end
+  def include?(key); end
+
+  sig do
+    params(
         blk: T.proc.params(name: String, value: String).returns(BasicObject),
     )
     .returns(Sorbet::Private::Static::ENVClass)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

It's almost always a logic bug to ask `include?` something where Sorbet can know statically that the `Enumerable` collection could not possibly have such an element.

This comes at the slight cost (or maybe benefit honestly?) of rejecting `xs.include?(something_nilable)`, which some people have expressed a desire to use more widely in a typed codebase, but I'm of the opinion that I would rather have the type checker show me the type error and handle `nil` or `unsafe` the argument in those cases.

There were only 14 cases where this caused new type errors on Stripe's codebase, and almost all of them were concentrated in a single file.

It's also worth noting that `member?` (which is an alias for `include?` in Enumerable) and `key?` on `Hash` already have sigs specifying that `K` is required. Also `Set#include?` already had an override of `include?` that narrowed the types to this signature.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.