### PR TITLE
add a lock to guard `cancellationUndoState` in `LSPTypechecker.cc`

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -106,9 +106,9 @@ bool LSPTypechecker::typecheck(LSPFileUpdates updates, WorkerPool &workers,
     ENFORCE(this_thread::get_id() == typecheckerThreadId, "Typechecker can only be used from the typechecker thread.");
     ENFORCE(this->initialized);
     if (updates.canceledSlowPath) {
+        absl::WriterMutexLock writerLock(&this->cancellationUndoStateRWLock);
         // This update canceled the last slow path, so we should have undo state to restore to go to the point _before_
         // that slow path. This should always be the case, but let's not crash release builds.
-        absl::WriterMutexLock writerLock(&this->cancellationUndoStateRWLock);
         ENFORCE(cancellationUndoState != nullptr);
         if (cancellationUndoState != nullptr) {
             // Restore the previous globalState

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -46,7 +46,7 @@ class LSPTypechecker final {
     absl::Mutex cancellationUndoStateRWLock;
     /** Set only when typechecking is happening on the slow path. Contains all of the state needed to restore
      * LSPTypechecker to its pre-slow-path state. Can be null, which indicates that no slow path is currently running */
-    std::unique_ptr<UndoState> cancellationUndoState;
+    std::unique_ptr<UndoState> cancellationUndoState ABSL_GUARDED_BY(cancellationUndoStateRWLock);
 
     std::shared_ptr<const LSPConfiguration> config;
     /** Used to preempt running slow paths. */

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -40,6 +40,10 @@ class LSPTypechecker final {
     std::vector<ast::ParsedFile> indexed;
     /** Trees that have been indexed (with finalGS) and can be reused between different runs */
     UnorderedMap<int, ast::ParsedFile> indexedFinalGS;
+
+    /** Used to guard access to `cancellationUndoState` and specifically the stale
+     * `GlobalState` residing inside of it. */
+    absl::Mutex cancellationUndoStateRWLock;
     /** Set only when typechecking is happening on the slow path. Contains all of the state needed to restore
      * LSPTypechecker to its pre-slow-path state. Can be null, which indicates that no slow path is currently running */
     std::unique_ptr<UndoState> cancellationUndoState;


### PR DESCRIPTION

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We want to enable some LSP requests to run on stale `GlobalState` data while there is an ongoing typechecking operation.  The hypothesis is that people get frustrated when certain operations randomly become inoperable during typechecking, and having at least some requests available will increase Sorbet's perceived responsiveness.

To this end, then, we need to carefully manage `cancellationUndoState`, as its contents may be used by a request at the point that `cancellationUndoState` needs to be accessed after a successful or preempted typechecking operation.  This PR is the first step in that respect: adding a lock around `cancellationUndoState` and acquiring it when necessary.  Future work will add various operations that would acquire a `ReaderMutexLock` around `cancellationUndoState` before accessing the `GlobalState` within.

At the moment, this should be effectively a no-op change: if we ever did have a situation where `cancellationUndoState` was getting used on multiple threads in a concurrent fashion, this PR would in fact be an improvement, because it would eliminate races.  It's true that we're doing slightly more work now in various places, but uncontended mutex operations are reasonably fast, and I think any cost here would be dwarfed by e.g. typechecking itself.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
