### PR TITLE
Fix crash in single-package stubbing

### DIFF
--- a/test/cli/rbi-gen-single/external/__package.rb
+++ b/test/cli/rbi-gen-single/external/__package.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+class External < PackageSpec
+end

--- a/test/cli/rbi-gen-single/external/who_knows.rbi
+++ b/test/cli/rbi-gen-single/external/who_knows.rbi
@@ -1,0 +1,3 @@
+# typed: true
+
+class ::WhoKnows; end

--- a/test/cli/rbi-gen-single/family/__package.rb
+++ b/test/cli/rbi-gen-single/family/__package.rb
@@ -2,6 +2,7 @@
 
 class Family < PackageSpec
 
+  import External
   import Family::Bart
   test_import Util::Testing
 

--- a/test/cli/rbi-gen-single/family/family.rb
+++ b/test/cli/rbi-gen-single/family/family.rb
@@ -14,6 +14,15 @@ module Family
       nil
     end
 
+    # `::WhoKnows` is defined in external.rbi, and is not managed by any package.
+    # In the resulting rbi for `family` it prints as just `WhoKnows`, but this
+    # is fine as the enclosing class is not nested at all, and the constant will
+    # resolve at the root.
+    sig {returns(::WhoKnows)}
+    def make_something
+      WhoKnows.new
+    end
+
     # These two constants will have the same RHS in the rbi file that's
     # generated.
     RelativeBart = Bart::Character

--- a/test/cli/rbi-gen-single/test.out
+++ b/test/cli/rbi-gen-single/test.out
@@ -1,4 +1,5 @@
 -- sanity-checking package with --stripe-packages
+-- ./test/cli/rbi-gen-single/external/__package.rb (External)
 -- ./test/cli/rbi-gen-single/family/__package.rb (Family)
 -- RBI (Family)
 # typed: true
@@ -6,6 +7,8 @@
 class Family::Simpsons
   sig {returns(Family::Bart::Character)}
   def bart; end
+  sig {returns(WhoKnows)}
+  def make_something; end
   sig {returns(T.nilable(Family::Bart::Character))}
   def no_bart; end
   extend T::Sig

--- a/test/cli/rbi-gen-single/test.out
+++ b/test/cli/rbi-gen-single/test.out
@@ -1,6 +1,6 @@
 -- sanity-checking package with --stripe-packages
 -- ./test/cli/rbi-gen-single/family/__package.rb (Family)
--- RBI: ./test/cli/rbi-gen-single/family/__package.rb (Family)
+-- RBI (Family)
 # typed: true
 
 class Family::Simpsons
@@ -14,7 +14,17 @@ Family::Simpsons::RelativeBart = Family::Bart::Character
 Family::Simpsons::MaybeBartFull = T.type_alias {T.nilable(Family::Bart::Character)}
 Family::Simpsons::MaybeBart = T.type_alias {T.nilable(Family::Bart::Character)}
 Family::Simpsons::FullyQualifiedBart = Family::Bart::Character
--- Test RBI: ./test/cli/rbi-gen-single/family/__package.rb (Family)
+-- RBI Deps (Family)
+{"packageRefs":["Family::Bart"], "rbiRefs":[]}
+-- Test Private RBI (Family)
+# typed: true
+
+class Family::Krabappel
+  extend T::Sig
+end
+-- Test Private RBI Deps (Family)
+{"packageRefs":["Family::Bart","Test::Util::Testing"], "rbiRefs":[]}
+-- Test RBI (Family)
 # typed: true
 
 class Test::Family::TestFamily < Test::Util::Testing::TestCase
@@ -29,44 +39,26 @@ end
 class Family::Flanders
   extend T::Sig
 end
--- Test Private RBI: ./test/cli/rbi-gen-single/family/__package.rb (Family)
-# typed: true
-
-class Family::Krabappel
-  extend T::Sig
-end
--- JSON: ./test/cli/rbi-gen-single/family/__package.rb (Family)
-{"packageRefs":["Family::Bart"], "rbiRefs":[]}
+-- Test RBI Deps (Family)
+{"packageRefs":["Family::Bart","Test::Util::Testing"], "rbiRefs":[]}
 -- ./test/cli/rbi-gen-single/family/bart/__package.rb (Family::Bart)
--- RBI: ./test/cli/rbi-gen-single/family/bart/__package.rb (Family::Bart)
-# typed: true
-
-class Family::Bart::Character
-  sig {void}
-  def catchphrase; end
-  sig {returns(T.class_of(Family::Simpsons))}
-  def family; end
-  sig {params(msg: Util::GenericMessage[String]).void}
-  def ignore(msg); end
-  extend T::Sig
-end
-Family::Bart::Character::FamilyClass = Family::Simpsons
--- Test RBI: ./test/cli/rbi-gen-single/family/bart/__package.rb (Family::Bart)
-# typed: true
-
-class Test::Family::Bart::BartTest
-  sig {params(x: Test::Family::TestFamily).void}
-  def test1(x); end
-  sig {params(x: Test::Family::Bart::Slingshot::TestSlingshot).void}
-  def test2(x); end
-  extend T::Sig
-end
--- JSON: ./test/cli/rbi-gen-single/family/bart/__package.rb (Family::Bart)
-{"packageRefs":["Family","Util"], "rbiRefs":[]}
 -- ./test/cli/rbi-gen-single/family/bart/slingshot/__package.rb (Family::Bart::Slingshot)
--- Test RBI: ./test/cli/rbi-gen-single/family/bart/slingshot/__package.rb (Family::Bart::Slingshot)
+-- ./test/cli/rbi-gen-single/util/__package.rb (Util)
+-- RBI (Util)
 # typed: true
 
-class Test::Family::Bart::Slingshot::TestSlingshot
+class Util::GenericMessage
+  Elem = type_member()
+  extend T::Generic
+  extend T::Helpers
 end
--- JSON: ./test/cli/rbi-gen-single/family/bart/slingshot/__package.rb (Family::Bart::Slingshot)
+class Util::Messages
+  extend T::Sig
+  sig {type_parameters(:T).params(msg: GenericMessage[T.type_parameter(:T)]).void}
+  def self.print_message(msg); end
+  sig {params(msg: String).void}
+  def self.say(msg); end
+end
+-- RBI Deps (Util)
+{"packageRefs":[], "rbiRefs":[]}
+-- ./test/cli/rbi-gen-single/util/testing/__package.rb (Util::Testing)

--- a/test/cli/rbi-gen-single/test.sh
+++ b/test/cli/rbi-gen-single/test.sh
@@ -15,6 +15,17 @@ echo "-- sanity-checking package with --stripe-packages"
   --dump-package-info="$rbis/package-info.json" \
   "$test_path"
 
+show_output() {
+  local name=$1
+  local label=$2
+  local suffix=$3
+  local file="${rbis}/${name}_Package.${suffix}"
+  if [ -f "$file" ]; then
+    echo "-- ${label} (${name})"
+    cat "${file}"
+  fi
+}
+
 # Generate rbis for each package
 find . -name __package.rb | sort | while read -r package; do
   name="$(awk '/class/ {print $2}' "$package")"
@@ -26,26 +37,11 @@ find . -name __package.rb | sort | while read -r package; do
     --package-rbi-output="$rbis" \
     --single-package="$name" "$test_path"
 
-  rbi="$rbis/${name//::/_}_Package.package.rbi"
-  if [ -f "$rbi" ]; then
-    echo "-- RBI: $package ($name)"
-    cat "$rbi"
-  fi
-
-  test_rbi="$rbis/${name//::/_}_Package.test.package.rbi"
-  if [ -f "$test_rbi" ]; then
-    echo "-- Test RBI: $package ($name)"
-    cat "$test_rbi"
-  fi
-
-  test_private_rbi="$rbis/${name//::/_}_Package.test.private.package.rbi"
-  if [ -f "$test_private_rbi" ]; then
-    echo "-- Test Private RBI: $package ($name)"
-    cat "$test_private_rbi"
-  fi
-
-  echo "-- JSON: $package ($name)"
-  cat "$rbis/${name//::/_}_Package.deps.json"
-
+  show_output "$name" "RBI"                   "package.rbi"
+  show_output "$name" "RBI Deps"              "deps.json"
+  show_output "$name" "Test Private RBI"      "test.private.package.rbi"
+  show_output "$name" "Test Private RBI Deps" "test.private.deps.json"
+  show_output "$name" "Test RBI"              "test.package.rbi"
+  show_output "$name" "Test RBI Deps"         "test.deps.json"
 done
 


### PR DESCRIPTION

Root constant references like `::Foo` weren't handled correctly during stubbing in single-package mode. Constants like that can be immediately stubbed without considering any of the heuristics for parent/child packages of the current namespace, so this simplifies the handling of those constants.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Stabilizing single-package rbi generation.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
