### PR TITLE
Add command line flag for experimental stale state features

### DIFF
--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -323,6 +323,9 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
                                     "Enable experimental LSP feature: Document Highlight");
     options.add_options("advanced")("enable-experimental-lsp-signature-help",
                                     "Enable experimental LSP feature: Signature Help");
+    options.add_options("advanced")("enable-experimental-lsp-stale-state", "Enable experimental LSP feature: fast "
+                                                                           "but approximate answers from stale "
+                                                                           "typechecker state");
     options.add_options("advanced")("enable-experimental-requires-ancestor",
                                     "Enable experimental `requires_ancestor` annotation");
 
@@ -722,6 +725,7 @@ void readOptions(Options &opts,
         opts.lspSignatureHelpEnabled = enableAllLSPFeatures || raw["enable-experimental-lsp-signature-help"].as<bool>();
         opts.lspDocumentFormatRubyfmtEnabled =
             enableAllLSPFeatures || raw["enable-experimental-lsp-document-formatting-rubyfmt"].as<bool>();
+        opts.lspStaleStateEnabled = enableAllLSPFeatures || raw["enable-experimental-lsp-stale-state"].as<bool>();
 
         if (raw.count("lsp-directories-missing-from-client") > 0) {
             auto lspDirsMissingFromClient = raw["lsp-directories-missing-from-client"].as<vector<string>>();

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -725,7 +725,12 @@ void readOptions(Options &opts,
         opts.lspSignatureHelpEnabled = enableAllLSPFeatures || raw["enable-experimental-lsp-signature-help"].as<bool>();
         opts.lspDocumentFormatRubyfmtEnabled =
             enableAllLSPFeatures || raw["enable-experimental-lsp-document-formatting-rubyfmt"].as<bool>();
-        opts.lspStaleStateEnabled = enableAllLSPFeatures || raw["enable-experimental-lsp-stale-state"].as<bool>();
+
+        // TODO(aprocter): For the moment, we are not including this flag in the "enableAllLSPFeatures" bundle, because
+        // it's likely to be even less stable than a typical experimental flag, and will be producing stub answers
+        // until we get some other groundwork in place. Once things stabilize a bit more, we can slap
+        // `enableAllLSPFeatures ||` onto the condition here.
+        opts.lspStaleStateEnabled = raw["enable-experimental-lsp-stale-state"].as<bool>();
 
         if (raw.count("lsp-directories-missing-from-client") > 0) {
             auto lspDirsMissingFromClient = raw["lsp-directories-missing-from-client"].as<vector<string>>();

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -232,6 +232,7 @@ struct Options {
     bool lspDocumentSymbolEnabled = false;
     bool lspDocumentFormatRubyfmtEnabled = false;
     bool lspSignatureHelpEnabled = false;
+    bool lspStaleStateEnabled = false;
 
     // Experimental feature `requires_ancestor`
     bool requiresAncestorEnabled = false;


### PR DESCRIPTION
Adds a `--enable-experimental-lsp-stale-state` flag to gate some features we're going to be working on for serving LSP requests from "stale" GlobalState while a slow path is running.


### Motivation
Want to turn this feature off by default since it will certainly be broken at first.


### Test plan
Didn't add any tests for setting the flag per se, but the code follows the pattern of existing flags for experimental LSP features so I figure that's probably okay.