### PR TITLE
Convert LSPTypecheckerDelegate to an interface

### DIFF
--- a/main/lsp/LSPTask.cc
+++ b/main/lsp/LSPTask.cc
@@ -204,7 +204,7 @@ void LSPTask::index(LSPIndexer &indexer) {}
 LSPRequestTask::LSPRequestTask(const LSPConfiguration &config, MessageId id, LSPMethod method)
     : LSPTask(config, method), id(move(id)) {}
 
-void LSPRequestTask::run(LSPTypecheckerDelegate &typechecker) {
+void LSPRequestTask::run(LSPTypecheckerInterface &typechecker) {
     auto response = runRequest(typechecker);
     ENFORCE(response != nullptr);
 
@@ -244,7 +244,7 @@ bool LSPRequestTask::cancel(const MessageId &id) {
     return false;
 }
 
-LSPQueryResult LSPTask::queryByLoc(LSPTypecheckerDelegate &typechecker, string_view uri, const Position &pos,
+LSPQueryResult LSPTask::queryByLoc(LSPTypecheckerInterface &typechecker, string_view uri, const Position &pos,
                                    const LSPMethod forMethod, bool errorIfFileIsUntyped) const {
     Timer timeit(config.logger, "setupLSPQueryByLoc");
     const core::GlobalState &gs = typechecker.state();
@@ -274,14 +274,14 @@ LSPQueryResult LSPTask::queryByLoc(LSPTypecheckerDelegate &typechecker, string_v
     return typechecker.query(core::lsp::Query::createLocQuery(loc), {fref});
 }
 
-LSPQueryResult LSPTask::queryBySymbolInFiles(LSPTypecheckerDelegate &typechecker, core::SymbolRef sym,
+LSPQueryResult LSPTask::queryBySymbolInFiles(LSPTypecheckerInterface &typechecker, core::SymbolRef sym,
                                              vector<core::FileRef> frefs) const {
     Timer timeit(config.logger, "setupLSPQueryBySymbolInFiles");
     ENFORCE(sym.exists());
     return typechecker.query(core::lsp::Query::createSymbolQuery(sym), frefs);
 }
 
-LSPQueryResult LSPTask::queryBySymbol(LSPTypecheckerDelegate &typechecker, core::SymbolRef sym) const {
+LSPQueryResult LSPTask::queryBySymbol(LSPTypecheckerInterface &typechecker, core::SymbolRef sym) const {
     Timer timeit(config.logger, "setupLSPQueryBySymbol");
     ENFORCE(sym.exists());
     vector<core::FileRef> frefs;
@@ -312,7 +312,7 @@ LSPQueryResult LSPTask::queryBySymbol(LSPTypecheckerDelegate &typechecker, core:
     return typechecker.query(core::lsp::Query::createSymbolQuery(sym), frefs);
 }
 
-void LSPTask::getRenameEdits(LSPTypecheckerDelegate &typechecker, shared_ptr<AbstractRenamer> renamer,
+void LSPTask::getRenameEdits(LSPTypecheckerInterface &typechecker, shared_ptr<AbstractRenamer> renamer,
                              core::SymbolRef symbol, string newName) {
     const core::GlobalState &gs = typechecker.state();
     auto originalName = symbol.name(gs).show(gs);
@@ -421,7 +421,7 @@ LSPTask::extractLocations(const core::GlobalState &gs,
 }
 
 vector<unique_ptr<core::lsp::QueryResponse>>
-LSPTask::getReferencesToSymbol(LSPTypecheckerDelegate &typechecker, core::SymbolRef symbol,
+LSPTask::getReferencesToSymbol(LSPTypecheckerInterface &typechecker, core::SymbolRef symbol,
                                vector<unique_ptr<core::lsp::QueryResponse>> &&priorRefs) const {
     if (symbol.exists()) {
         auto run2 = queryBySymbol(typechecker, symbol);
@@ -431,7 +431,7 @@ LSPTask::getReferencesToSymbol(LSPTypecheckerDelegate &typechecker, core::Symbol
 }
 
 vector<unique_ptr<core::lsp::QueryResponse>>
-LSPTask::getReferencesToSymbolInFile(LSPTypecheckerDelegate &typechecker, core::FileRef fref, core::SymbolRef symbol,
+LSPTask::getReferencesToSymbolInFile(LSPTypecheckerInterface &typechecker, core::FileRef fref, core::SymbolRef symbol,
                                      vector<unique_ptr<core::lsp::QueryResponse>> &&priorRefs) const {
     if (symbol.exists() && fref.exists()) {
         auto run2 = queryBySymbolInFiles(typechecker, symbol, {fref});
@@ -446,7 +446,7 @@ LSPTask::getReferencesToSymbolInFile(LSPTypecheckerDelegate &typechecker, core::
 }
 
 vector<unique_ptr<DocumentHighlight>>
-LSPTask::getHighlights(LSPTypecheckerDelegate &typechecker,
+LSPTask::getHighlights(LSPTypecheckerInterface &typechecker,
                        const vector<unique_ptr<core::lsp::QueryResponse>> &queryResponses) const {
     vector<unique_ptr<DocumentHighlight>> highlights;
     auto locations = extractLocations(typechecker.state(), queryResponses);
@@ -510,7 +510,8 @@ void populateFieldAccessorType(const core::GlobalState &gs, AccessorInfo &info) 
 } // namespace
 
 vector<unique_ptr<core::lsp::QueryResponse>>
-LSPTask::getReferencesToAccessor(LSPTypecheckerDelegate &typechecker, const AccessorInfo info, core::SymbolRef fallback,
+LSPTask::getReferencesToAccessor(LSPTypecheckerInterface &typechecker, const AccessorInfo info,
+                                 core::SymbolRef fallback,
                                  vector<unique_ptr<core::lsp::QueryResponse>> &&priorRefs) const {
     switch (info.accessorType) {
         case FieldAccessorType::None:
@@ -604,8 +605,8 @@ AccessorInfo LSPTask::getAccessorInfo(const core::GlobalState &gs, core::SymbolR
 }
 
 vector<unique_ptr<core::lsp::QueryResponse>>
-LSPTask::getReferencesToAccessorInFile(LSPTypecheckerDelegate &typechecker, core::FileRef fref, const AccessorInfo info,
-                                       core::SymbolRef fallback,
+LSPTask::getReferencesToAccessorInFile(LSPTypecheckerInterface &typechecker, core::FileRef fref,
+                                       const AccessorInfo info, core::SymbolRef fallback,
                                        vector<unique_ptr<core::lsp::QueryResponse>> &&priorRefs) const {
     switch (info.accessorType) {
         case FieldAccessorType::None:
@@ -641,7 +642,7 @@ LSPQueuePreemptionTask::LSPQueuePreemptionTask(const LSPConfiguration &config, a
     : LSPTask(config, LSPMethod::SorbetError), finished(finished), taskQueueMutex(taskQueueMutex), taskQueue(taskQueue),
       indexer(indexer) {}
 
-void LSPQueuePreemptionTask::run(LSPTypecheckerDelegate &tc) {
+void LSPQueuePreemptionTask::run(LSPTypecheckerInterface &tc) {
     for (;;) {
         unique_ptr<LSPTask> task;
         {
@@ -674,7 +675,7 @@ void LSPQueuePreemptionTask::run(LSPTypecheckerDelegate &tc) {
 LSPDangerousTypecheckerTask::LSPDangerousTypecheckerTask(const LSPConfiguration &config, LSPMethod method)
     : LSPTask(config, method) {}
 
-void LSPDangerousTypecheckerTask::run(LSPTypecheckerDelegate &tc) {
+void LSPDangerousTypecheckerTask::run(LSPTypecheckerInterface &tc) {
     Exception::raise("Bug: Dangerous typechecker tasks are expected to run specially");
 }
 

--- a/main/lsp/LSPTask.h
+++ b/main/lsp/LSPTask.h
@@ -37,14 +37,14 @@ protected:
     // Task helper methods.
 
     std::vector<std::unique_ptr<core::lsp::QueryResponse>>
-    getReferencesToSymbol(LSPTypecheckerDelegate &typechecker, core::SymbolRef symbol,
+    getReferencesToSymbol(LSPTypecheckerInterface &typechecker, core::SymbolRef symbol,
                           std::vector<std::unique_ptr<core::lsp::QueryResponse>> &&priorRefs = {}) const;
     std::vector<std::unique_ptr<core::lsp::QueryResponse>>
-    getReferencesToSymbolInFile(LSPTypecheckerDelegate &typechecker, core::FileRef file, core::SymbolRef symbol,
+    getReferencesToSymbolInFile(LSPTypecheckerInterface &typechecker, core::FileRef file, core::SymbolRef symbol,
                                 std::vector<std::unique_ptr<core::lsp::QueryResponse>> &&priorRefs = {}) const;
 
     std::vector<std::unique_ptr<DocumentHighlight>>
-    getHighlights(LSPTypecheckerDelegate &typechecker,
+    getHighlights(LSPTypecheckerInterface &typechecker,
                   const std::vector<std::unique_ptr<core::lsp::QueryResponse>> &responses) const;
     void addLocIfExists(const core::GlobalState &gs, std::vector<std::unique_ptr<Location>> &locs, core::Loc loc) const;
     std::vector<std::unique_ptr<Location>>
@@ -55,11 +55,11 @@ protected:
     filterAndDedup(const core::GlobalState &gs,
                    const std::vector<std::unique_ptr<core::lsp::QueryResponse>> &queryResponses) const;
 
-    LSPQueryResult queryByLoc(LSPTypecheckerDelegate &typechecker, std::string_view uri, const Position &pos,
+    LSPQueryResult queryByLoc(LSPTypecheckerInterface &typechecker, std::string_view uri, const Position &pos,
                               LSPMethod forMethod, bool errorIfFileIsUntyped = true) const;
-    LSPQueryResult queryBySymbolInFiles(LSPTypecheckerDelegate &typechecker, core::SymbolRef symbol,
+    LSPQueryResult queryBySymbolInFiles(LSPTypecheckerInterface &typechecker, core::SymbolRef symbol,
                                         std::vector<core::FileRef> frefs) const;
-    LSPQueryResult queryBySymbol(LSPTypecheckerDelegate &typechecker, core::SymbolRef symbol) const;
+    LSPQueryResult queryBySymbol(LSPTypecheckerInterface &typechecker, core::SymbolRef symbol) const;
 
     // Given a method or field symbol, checks if the symbol belongs to a `prop`, `const`, `attr_reader`, `attr_writer`,
     // etc, and populates an AccessorInfo object.
@@ -67,17 +67,17 @@ protected:
 
     // Get references to the given accessor. If `info.accessorType` is `None`, it returns references to `fallback` only.
     std::vector<std::unique_ptr<core::lsp::QueryResponse>>
-    getReferencesToAccessor(LSPTypecheckerDelegate &typechecker, const AccessorInfo info, core::SymbolRef fallback,
+    getReferencesToAccessor(LSPTypecheckerInterface &typechecker, const AccessorInfo info, core::SymbolRef fallback,
                             std::vector<std::unique_ptr<core::lsp::QueryResponse>> &&priorRefs = {}) const;
 
     // Get references to the given accessor in the given file. If `info.accessorType` is `None`, it returns highlights
     // to `fallback` only.
     std::vector<std::unique_ptr<core::lsp::QueryResponse>>
-    getReferencesToAccessorInFile(LSPTypecheckerDelegate &typechecker, core::FileRef fref, const AccessorInfo info,
+    getReferencesToAccessorInFile(LSPTypecheckerInterface &typechecker, core::FileRef fref, const AccessorInfo info,
                                   core::SymbolRef fallback,
                                   std::vector<std::unique_ptr<core::lsp::QueryResponse>> &&priorRefs = {}) const;
 
-    void getRenameEdits(LSPTypecheckerDelegate &typechecker, std::shared_ptr<AbstractRenamer> renamer,
+    void getRenameEdits(LSPTypecheckerInterface &typechecker, std::shared_ptr<AbstractRenamer> renamer,
                         core::SymbolRef symbol, std::string newName);
 
     LSPTask(const LSPConfiguration &config, LSPMethod method);
@@ -128,7 +128,7 @@ public:
 
     // Runs the task. Is only ever invoked from the typechecker thread. Since it is exceedingly rare for a request to
     // not need to interface with the typechecker, this method must be implemented by all subclasses.
-    virtual void run(LSPTypecheckerDelegate &typechecker) = 0;
+    virtual void run(LSPTypecheckerInterface &typechecker) = 0;
 };
 
 /**
@@ -140,10 +140,10 @@ protected:
 
     LSPRequestTask(const LSPConfiguration &config, MessageId id, LSPMethod method);
 
-    virtual std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerDelegate &typechecker) = 0;
+    virtual std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerInterface &typechecker) = 0;
 
 public:
-    void run(LSPTypecheckerDelegate &typechecker) override;
+    void run(LSPTypecheckerInterface &typechecker) override;
 
     // Requests cannot override this method, as runRequest must be run (and it only runs during the RUN phase).
     Phase finalPhase() const override;
@@ -165,7 +165,7 @@ protected:
 
 public:
     // Should never be called; throws an exception. May be overridden by tasks that can be dangerous or not dangerous.
-    virtual void run(LSPTypecheckerDelegate &typechecker) override;
+    virtual void run(LSPTypecheckerInterface &typechecker) override;
     // Performs the actual work on the task.
     virtual void runSpecial(LSPTypechecker &typechecker, WorkerPool &worker) = 0;
     // Tells the scheduler how long to wait before it can schedule more tasks.
@@ -188,7 +188,7 @@ public:
     LSPQueuePreemptionTask(const LSPConfiguration &config, absl::Notification &finished, absl::Mutex &taskQueueMutex,
                            TaskQueueState &taskQueue, LSPIndexer &indexer);
 
-    void run(LSPTypecheckerDelegate &tc) override;
+    void run(LSPTypecheckerInterface &tc) override;
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/LSPTypecheckerCoordinator.cc
+++ b/main/lsp/LSPTypecheckerCoordinator.cc
@@ -107,7 +107,7 @@ public:
         return false;
     }
 
-    void run(LSPTypecheckerDelegate &_) override {
+    void run(LSPTypecheckerInterface &_) override {
         shouldTerminate = true;
         gs = typechecker.destroy();
     }

--- a/main/lsp/lsp.cc
+++ b/main/lsp/lsp.cc
@@ -62,7 +62,7 @@ public:
         return false;
     }
 
-    void run(LSPTypecheckerDelegate &tc) override {
+    void run(LSPTypecheckerInterface &tc) override {
         count = tc.state().lspTypecheckCount;
     }
 };

--- a/main/lsp/notifications/cancel_request.cc
+++ b/main/lsp/notifications/cancel_request.cc
@@ -16,6 +16,6 @@ void CancelRequestTask::preprocess(LSPPreprocessor &preprocessor) {
     preprocessor.cancelRequest(*params);
 }
 
-void CancelRequestTask::run(LSPTypecheckerDelegate &tc) {}
+void CancelRequestTask::run(LSPTypecheckerInterface &tc) {}
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/notifications/cancel_request.h
+++ b/main/lsp/notifications/cancel_request.h
@@ -15,7 +15,7 @@ public:
 
     void preprocess(LSPPreprocessor &preprocessor) override;
 
-    void run(LSPTypecheckerDelegate &tc) override;
+    void run(LSPTypecheckerInterface &tc) override;
 };
 } // namespace sorbet::realmain::lsp
 

--- a/main/lsp/notifications/exit.cc
+++ b/main/lsp/notifications/exit.cc
@@ -16,6 +16,6 @@ void ExitTask::preprocess(LSPPreprocessor &preprocessor) {
     preprocessor.exit(exitCode);
 }
 
-void ExitTask::run(LSPTypecheckerDelegate &tc) {}
+void ExitTask::run(LSPTypecheckerInterface &tc) {}
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/notifications/exit.h
+++ b/main/lsp/notifications/exit.h
@@ -14,7 +14,7 @@ public:
 
     void preprocess(LSPPreprocessor &preprocessor) override;
 
-    void run(LSPTypecheckerDelegate &tc) override;
+    void run(LSPTypecheckerInterface &tc) override;
 };
 } // namespace sorbet::realmain::lsp
 

--- a/main/lsp/notifications/sorbet_fence.cc
+++ b/main/lsp/notifications/sorbet_fence.cc
@@ -12,7 +12,7 @@ bool SorbetFenceTask::canPreempt(const LSPIndexer &indexer) const {
     return false;
 }
 
-void SorbetFenceTask::run(LSPTypecheckerDelegate &tc) {
+void SorbetFenceTask::run(LSPTypecheckerInterface &tc) {
     // Send the same fence back to acknowledge the fence.
     // NOTE: Fence is a notification rather than a request so that we don't have to worry about clashes with
     // client-chosen IDs when using fences internally.

--- a/main/lsp/notifications/sorbet_fence.h
+++ b/main/lsp/notifications/sorbet_fence.h
@@ -12,7 +12,7 @@ public:
 
     bool canPreempt(const LSPIndexer &indexer) const override;
 
-    void run(LSPTypecheckerDelegate &tc) override;
+    void run(LSPTypecheckerInterface &tc) override;
 };
 } // namespace sorbet::realmain::lsp
 

--- a/main/lsp/notifications/sorbet_pause.cc
+++ b/main/lsp/notifications/sorbet_pause.cc
@@ -12,5 +12,5 @@ void SorbetPauseTask::preprocess(LSPPreprocessor &preprocessor) {
     preprocessor.pause();
 }
 
-void SorbetPauseTask::run(LSPTypecheckerDelegate &tc) {}
+void SorbetPauseTask::run(LSPTypecheckerInterface &tc) {}
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/notifications/sorbet_pause.h
+++ b/main/lsp/notifications/sorbet_pause.h
@@ -12,7 +12,7 @@ public:
 
     void preprocess(LSPPreprocessor &preprocessor) override;
 
-    void run(LSPTypecheckerDelegate &tc) override;
+    void run(LSPTypecheckerInterface &tc) override;
 };
 } // namespace sorbet::realmain::lsp
 

--- a/main/lsp/notifications/sorbet_resume.cc
+++ b/main/lsp/notifications/sorbet_resume.cc
@@ -12,5 +12,5 @@ void SorbetResumeTask::preprocess(LSPPreprocessor &preprocessor) {
     preprocessor.resume();
 }
 
-void SorbetResumeTask::run(LSPTypecheckerDelegate &tc) {}
+void SorbetResumeTask::run(LSPTypecheckerInterface &tc) {}
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/notifications/sorbet_resume.h
+++ b/main/lsp/notifications/sorbet_resume.h
@@ -12,7 +12,7 @@ public:
 
     void preprocess(LSPPreprocessor &preprocessor) override;
 
-    void run(LSPTypecheckerDelegate &tc) override;
+    void run(LSPTypecheckerInterface &tc) override;
 };
 } // namespace sorbet::realmain::lsp
 

--- a/main/lsp/notifications/sorbet_workspace_edit.cc
+++ b/main/lsp/notifications/sorbet_workspace_edit.cc
@@ -65,7 +65,7 @@ void SorbetWorkspaceEditTask::index(LSPIndexer &indexer) {
     }
 }
 
-void SorbetWorkspaceEditTask::run(LSPTypecheckerDelegate &typechecker) {
+void SorbetWorkspaceEditTask::run(LSPTypecheckerInterface &typechecker) {
     if (latencyTimer != nullptr) {
         latencyTimer->setTag("path", "fast");
     }

--- a/main/lsp/notifications/sorbet_workspace_edit.h
+++ b/main/lsp/notifications/sorbet_workspace_edit.h
@@ -30,7 +30,7 @@ public:
     void mergeNewer(SorbetWorkspaceEditTask &task);
     void preprocess(LSPPreprocessor &preprocess) override;
     void index(LSPIndexer &indexer) override;
-    void run(LSPTypecheckerDelegate &typechecker) override;
+    void run(LSPTypecheckerInterface &typechecker) override;
     void runSpecial(LSPTypechecker &typechecker, WorkerPool &workers) override;
     void schedulerWaitUntilReady() override;
 

--- a/main/lsp/requests/code_action.cc
+++ b/main/lsp/requests/code_action.cc
@@ -31,7 +31,7 @@ vector<unique_ptr<TextDocumentEdit>> getEdits(const LSPConfiguration &config, co
 }
 } // namespace
 
-unique_ptr<ResponseMessage> CodeActionTask::runRequest(LSPTypecheckerDelegate &typechecker) {
+unique_ptr<ResponseMessage> CodeActionTask::runRequest(LSPTypecheckerInterface &typechecker) {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentCodeAction);
 
     vector<unique_ptr<CodeAction>> result;

--- a/main/lsp/requests/code_action.h
+++ b/main/lsp/requests/code_action.h
@@ -11,7 +11,7 @@ class CodeActionTask final : public LSPRequestTask {
 public:
     CodeActionTask(const LSPConfiguration &config, MessageId id, std::unique_ptr<CodeActionParams> params);
 
-    std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerDelegate &typechecker) override;
+    std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerInterface &typechecker) override;
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -483,7 +483,7 @@ unique_ptr<CompletionItem> getCompletionItemForLocalName(const core::GlobalState
     return item;
 }
 
-vector<core::NameRef> localNamesForMethod(LSPTypecheckerDelegate &typechecker, const core::MethodRef method,
+vector<core::NameRef> localNamesForMethod(LSPTypecheckerInterface &typechecker, const core::MethodRef method,
                                           const core::Loc queryLoc) {
     const auto &gs = typechecker.state();
     auto files = vector<core::FileRef>{};
@@ -515,7 +515,7 @@ vector<core::NameRef> localNamesForMethod(LSPTypecheckerDelegate &typechecker, c
     return result;
 }
 
-core::MethodRef firstMethodAfterQuery(LSPTypecheckerDelegate &typechecker, const core::Loc queryLoc) {
+core::MethodRef firstMethodAfterQuery(LSPTypecheckerInterface &typechecker, const core::Loc queryLoc) {
     const auto &gs = typechecker.state();
     auto files = vector<core::FileRef>{queryLoc.file()};
     auto resolved = typechecker.getResolved(files);
@@ -556,7 +556,7 @@ constexpr string_view suggestSigDocs =
     "Sorbet suggests this signature given the method below. Sorbet's suggested sigs are imperfect. It doesn't always "
     "guess the correct types (or any types at all), but they're usually a good starting point."sv;
 
-unique_ptr<CompletionItem> trySuggestSig(LSPTypecheckerDelegate &typechecker,
+unique_ptr<CompletionItem> trySuggestSig(LSPTypecheckerInterface &typechecker,
                                          const LSPClientConfiguration &clientConfig, core::SymbolRef what,
                                          core::TypePtr receiverType, const core::Loc queryLoc, string_view prefix,
                                          size_t sortIdx) {
@@ -740,7 +740,7 @@ CompletionTask::CompletionTask(const LSPConfiguration &config, MessageId id, uni
     : LSPRequestTask(config, move(id), LSPMethod::TextDocumentCompletion), params(move(params)) {}
 
 unique_ptr<CompletionItem>
-CompletionTask::getCompletionItemForMethod(LSPTypecheckerDelegate &typechecker, core::DispatchResult &dispatchResult,
+CompletionTask::getCompletionItemForMethod(LSPTypecheckerInterface &typechecker, core::DispatchResult &dispatchResult,
                                            core::MethodRef maybeAlias, const core::TypePtr &receiverType,
                                            const core::TypeConstraint *constraint, core::Loc queryLoc,
                                            string_view prefix, size_t sortIdx, uint16_t totalArgs) const {
@@ -831,7 +831,7 @@ CompletionTask::SearchParams CompletionTask::searchParamsForEmptyAssign(const co
     };
 }
 
-vector<unique_ptr<CompletionItem>> CompletionTask::getCompletionItems(LSPTypecheckerDelegate &typechecker,
+vector<unique_ptr<CompletionItem>> CompletionTask::getCompletionItems(LSPTypecheckerInterface &typechecker,
                                                                       SearchParams &params) {
     const auto &gs = typechecker.state();
 
@@ -957,7 +957,7 @@ vector<unique_ptr<CompletionItem>> CompletionTask::getCompletionItems(LSPTypeche
     return items;
 }
 
-unique_ptr<ResponseMessage> CompletionTask::runRequest(LSPTypecheckerDelegate &typechecker) {
+unique_ptr<ResponseMessage> CompletionTask::runRequest(LSPTypecheckerInterface &typechecker) {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentCompletion);
     auto emptyResult = make_unique<CompletionList>(false, vector<unique_ptr<CompletionItem>>{});
 

--- a/main/lsp/requests/completion.h
+++ b/main/lsp/requests/completion.h
@@ -42,10 +42,10 @@ class CompletionTask final : public LSPRequestTask {
     static SearchParams searchParamsForEmptyAssign(const core::GlobalState &gs, core::Loc queryLoc,
                                                    core::MethodRef enclosingMethod,
                                                    core::lsp::ConstantResponse::Scopes scopes);
-    std::vector<std::unique_ptr<CompletionItem>> getCompletionItems(LSPTypecheckerDelegate &typechecker,
+    std::vector<std::unique_ptr<CompletionItem>> getCompletionItems(LSPTypecheckerInterface &typechecker,
                                                                     SearchParams &params);
 
-    std::unique_ptr<CompletionItem> getCompletionItemForMethod(LSPTypecheckerDelegate &typechecker,
+    std::unique_ptr<CompletionItem> getCompletionItemForMethod(LSPTypecheckerInterface &typechecker,
                                                                core::DispatchResult &dispatchResult,
                                                                core::MethodRef what, const core::TypePtr &receiverType,
                                                                const core::TypeConstraint *constraint,
@@ -55,7 +55,7 @@ class CompletionTask final : public LSPRequestTask {
 public:
     CompletionTask(const LSPConfiguration &config, MessageId id, std::unique_ptr<CompletionParams> params);
 
-    std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerDelegate &typechecker) override;
+    std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerInterface &typechecker) override;
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/definition.cc
+++ b/main/lsp/requests/definition.cc
@@ -9,7 +9,7 @@ DefinitionTask::DefinitionTask(const LSPConfiguration &config, MessageId id,
                                unique_ptr<TextDocumentPositionParams> params)
     : LSPRequestTask(config, move(id), LSPMethod::TextDocumentDefinition), params(move(params)) {}
 
-unique_ptr<ResponseMessage> DefinitionTask::runRequest(LSPTypecheckerDelegate &typechecker) {
+unique_ptr<ResponseMessage> DefinitionTask::runRequest(LSPTypecheckerInterface &typechecker) {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentDefinition);
     const core::GlobalState &gs = typechecker.state();
     auto result =

--- a/main/lsp/requests/definition.h
+++ b/main/lsp/requests/definition.h
@@ -11,7 +11,7 @@ class DefinitionTask final : public LSPRequestTask {
 public:
     DefinitionTask(const LSPConfiguration &config, MessageId id, std::unique_ptr<TextDocumentPositionParams> params);
 
-    std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerDelegate &typechecker) override;
+    std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerInterface &typechecker) override;
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/document_formatting.cc
+++ b/main/lsp/requests/document_formatting.cc
@@ -67,7 +67,7 @@ void DocumentFormattingTask::index(LSPIndexer &index) {
 }
 
 // Since finalPhase is `preprocess`, this method should never be called.
-unique_ptr<ResponseMessage> DocumentFormattingTask::runRequest(LSPTypecheckerDelegate &typechecker) {
+unique_ptr<ResponseMessage> DocumentFormattingTask::runRequest(LSPTypecheckerInterface &typechecker) {
     Exception::raise("Unimplemented and unused");
 }
 

--- a/main/lsp/requests/document_formatting.h
+++ b/main/lsp/requests/document_formatting.h
@@ -16,7 +16,7 @@ public:
 
     void index(LSPIndexer &index) override;
 
-    std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerDelegate &typechecker) override;
+    std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerInterface &typechecker) override;
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/document_highlight.cc
+++ b/main/lsp/requests/document_highlight.cc
@@ -26,7 +26,7 @@ DocumentHighlightTask::DocumentHighlightTask(const LSPConfiguration &config, Mes
                                              unique_ptr<TextDocumentPositionParams> params)
     : LSPRequestTask(config, move(id), LSPMethod::TextDocumentDocumentHighlight), params(move(params)) {}
 
-unique_ptr<ResponseMessage> DocumentHighlightTask::runRequest(LSPTypecheckerDelegate &typechecker) {
+unique_ptr<ResponseMessage> DocumentHighlightTask::runRequest(LSPTypecheckerInterface &typechecker) {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentDocumentHighlight);
     if (!config.opts.lspDocumentHighlightEnabled) {
         response->error = make_unique<ResponseError>(

--- a/main/lsp/requests/document_highlight.h
+++ b/main/lsp/requests/document_highlight.h
@@ -12,7 +12,7 @@ public:
     DocumentHighlightTask(const LSPConfiguration &config, MessageId id,
                           std::unique_ptr<TextDocumentPositionParams> params);
 
-    std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerDelegate &typechecker) override;
+    std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerInterface &typechecker) override;
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/document_symbol.cc
+++ b/main/lsp/requests/document_symbol.cc
@@ -83,7 +83,7 @@ bool DocumentSymbolTask::isDelayable() const {
     return true;
 }
 
-unique_ptr<ResponseMessage> DocumentSymbolTask::runRequest(LSPTypecheckerDelegate &typechecker) {
+unique_ptr<ResponseMessage> DocumentSymbolTask::runRequest(LSPTypecheckerInterface &typechecker) {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentDocumentSymbol);
     if (!config.opts.lspDocumentSymbolEnabled) {
         response->error =

--- a/main/lsp/requests/document_symbol.h
+++ b/main/lsp/requests/document_symbol.h
@@ -13,7 +13,7 @@ public:
 
     bool isDelayable() const override;
 
-    std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerDelegate &typechecker) override;
+    std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerInterface &typechecker) override;
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/get_counters.cc
+++ b/main/lsp/requests/get_counters.cc
@@ -25,6 +25,6 @@ void GetCountersTask::index(LSPIndexer &indexer) {
     config.output->write(move(response));
 }
 
-void GetCountersTask::run(LSPTypecheckerDelegate &typechecker) {}
+void GetCountersTask::run(LSPTypecheckerInterface &typechecker) {}
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/get_counters.h
+++ b/main/lsp/requests/get_counters.h
@@ -16,7 +16,7 @@ public:
 
     void index(LSPIndexer &indexer) override;
 
-    void run(LSPTypecheckerDelegate &typechecker) override;
+    void run(LSPTypecheckerInterface &typechecker) override;
 };
 } // namespace sorbet::realmain::lsp
 

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -34,7 +34,7 @@ string methodInfoString(const core::GlobalState &gs, const core::TypePtr &retTyp
 HoverTask::HoverTask(const LSPConfiguration &config, MessageId id, std::unique_ptr<TextDocumentPositionParams> params)
     : LSPRequestTask(config, move(id), LSPMethod::TextDocumentHover), params(move(params)) {}
 
-unique_ptr<ResponseMessage> HoverTask::runRequest(LSPTypecheckerDelegate &typechecker) {
+unique_ptr<ResponseMessage> HoverTask::runRequest(LSPTypecheckerInterface &typechecker) {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentHover);
 
     const core::GlobalState &gs = typechecker.state();

--- a/main/lsp/requests/hover.h
+++ b/main/lsp/requests/hover.h
@@ -11,7 +11,7 @@ class HoverTask final : public LSPRequestTask {
 public:
     HoverTask(const LSPConfiguration &config, MessageId id, std::unique_ptr<TextDocumentPositionParams> params);
 
-    std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerDelegate &typechecker) override;
+    std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerInterface &typechecker) override;
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/implementation.cc
+++ b/main/lsp/requests/implementation.cc
@@ -60,7 +60,7 @@ ImplementationTask::ImplementationTask(const LSPConfiguration &config, MessageId
                                        std::unique_ptr<ImplementationParams> params)
     : LSPRequestTask(config, move(id), LSPMethod::TextDocumentImplementation), params(move(params)) {}
 
-unique_ptr<ResponseMessage> ImplementationTask::runRequest(LSPTypecheckerDelegate &typechecker) {
+unique_ptr<ResponseMessage> ImplementationTask::runRequest(LSPTypecheckerInterface &typechecker) {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentImplementation);
 
     const core::GlobalState &gs = typechecker.state();

--- a/main/lsp/requests/implementation.h
+++ b/main/lsp/requests/implementation.h
@@ -12,7 +12,7 @@ class ImplementationTask final : public LSPRequestTask {
 public:
     ImplementationTask(const LSPConfiguration &config, MessageId id, std::unique_ptr<ImplementationParams> params);
 
-    std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerDelegate &typechecker) override;
+    std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerInterface &typechecker) override;
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/initialize.cc
+++ b/main/lsp/requests/initialize.cc
@@ -18,7 +18,7 @@ void InitializeTask::preprocess(LSPPreprocessor &preprocessor) {
     mutableConfig.setClientConfig(make_shared<LSPClientConfiguration>(*params));
 }
 
-unique_ptr<ResponseMessage> InitializeTask::runRequest(LSPTypecheckerDelegate &ts) {
+unique_ptr<ResponseMessage> InitializeTask::runRequest(LSPTypecheckerInterface &ts) {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::Initialize);
     const auto &opts = config.opts;
     auto serverCap = make_unique<ServerCapabilities>();

--- a/main/lsp/requests/initialize.h
+++ b/main/lsp/requests/initialize.h
@@ -19,7 +19,7 @@ protected:
 
     void preprocess(LSPPreprocessor &preprocessor) override;
 
-    std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerDelegate &ts) override;
+    std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerInterface &ts) override;
 };
 } // namespace sorbet::realmain::lsp
 

--- a/main/lsp/requests/prepare_rename.cc
+++ b/main/lsp/requests/prepare_rename.cc
@@ -48,7 +48,7 @@ PrepareRenameTask::PrepareRenameTask(const LSPConfiguration &config, MessageId i
                                      unique_ptr<TextDocumentPositionParams> params)
     : LSPRequestTask(config, move(id), LSPMethod::TextDocumentPrepareRename), params(move(params)) {}
 
-unique_ptr<ResponseMessage> PrepareRenameTask::runRequest(LSPTypecheckerDelegate &typechecker) {
+unique_ptr<ResponseMessage> PrepareRenameTask::runRequest(LSPTypecheckerInterface &typechecker) {
     const core::GlobalState &gs = typechecker.state();
 
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentPrepareRename);

--- a/main/lsp/requests/prepare_rename.h
+++ b/main/lsp/requests/prepare_rename.h
@@ -11,7 +11,7 @@ class PrepareRenameTask final : public LSPRequestTask {
 public:
     PrepareRenameTask(const LSPConfiguration &config, MessageId id, std::unique_ptr<TextDocumentPositionParams> params);
 
-    std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerDelegate &typechecker) override;
+    std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerInterface &typechecker) override;
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/references.cc
+++ b/main/lsp/requests/references.cc
@@ -14,7 +14,7 @@ bool ReferencesTask::needsMultithreading(const LSPIndexer &indexer) const {
     return true;
 }
 
-unique_ptr<ResponseMessage> ReferencesTask::runRequest(LSPTypecheckerDelegate &typechecker) {
+unique_ptr<ResponseMessage> ReferencesTask::runRequest(LSPTypecheckerInterface &typechecker) {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentReferences);
     ShowOperation op(config, ShowOperation::Kind::References);
 

--- a/main/lsp/requests/references.h
+++ b/main/lsp/requests/references.h
@@ -11,7 +11,7 @@ class ReferencesTask final : public LSPRequestTask {
 public:
     ReferencesTask(const LSPConfiguration &config, MessageId id, std::unique_ptr<ReferenceParams> params);
 
-    std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerDelegate &typechecker) override;
+    std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerInterface &typechecker) override;
 
     bool needsMultithreading(const LSPIndexer &indexer) const override;
 };

--- a/main/lsp/requests/rename.cc
+++ b/main/lsp/requests/rename.cc
@@ -202,7 +202,7 @@ shared_ptr<AbstractRenamer> makeRenamer(const core::GlobalState &gs,
 RenameTask::RenameTask(const LSPConfiguration &config, MessageId id, unique_ptr<RenameParams> params)
     : LSPRequestTask(config, move(id), LSPMethod::TextDocumentRename), params(move(params)) {}
 
-unique_ptr<ResponseMessage> RenameTask::runRequest(LSPTypecheckerDelegate &typechecker) {
+unique_ptr<ResponseMessage> RenameTask::runRequest(LSPTypecheckerInterface &typechecker) {
     const core::GlobalState &gs = typechecker.state();
 
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentRename);

--- a/main/lsp/requests/rename.h
+++ b/main/lsp/requests/rename.h
@@ -12,7 +12,7 @@ class RenameTask final : public LSPRequestTask {
 public:
     RenameTask(const LSPConfiguration &config, MessageId id, std::unique_ptr<RenameParams> params);
 
-    std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerDelegate &typechecker) override;
+    std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerInterface &typechecker) override;
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/shutdown.cc
+++ b/main/lsp/requests/shutdown.cc
@@ -11,7 +11,7 @@ bool ShutdownTask::canPreempt(const LSPIndexer &indexer) const {
     return true;
 }
 
-unique_ptr<ResponseMessage> ShutdownTask::runRequest(LSPTypecheckerDelegate &ts) {
+unique_ptr<ResponseMessage> ShutdownTask::runRequest(LSPTypecheckerInterface &ts) {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::Shutdown);
     response->result = JSONNullObject();
     return response;

--- a/main/lsp/requests/shutdown.h
+++ b/main/lsp/requests/shutdown.h
@@ -11,7 +11,7 @@ public:
     bool canPreempt(const LSPIndexer &indexer) const override;
 
 protected:
-    std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerDelegate &ts) override;
+    std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerInterface &ts) override;
 };
 } // namespace sorbet::realmain::lsp
 

--- a/main/lsp/requests/signature_help.cc
+++ b/main/lsp/requests/signature_help.cc
@@ -54,7 +54,7 @@ SignatureHelpTask::SignatureHelpTask(const LSPConfiguration &config, MessageId i
                                      std::unique_ptr<TextDocumentPositionParams> params)
     : LSPRequestTask(config, move(id), LSPMethod::TextDocumentSignatureHelp), params(move(params)) {}
 
-unique_ptr<ResponseMessage> SignatureHelpTask::runRequest(LSPTypecheckerDelegate &typechecker) {
+unique_ptr<ResponseMessage> SignatureHelpTask::runRequest(LSPTypecheckerInterface &typechecker) {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentSignatureHelp);
     if (!config.opts.lspSignatureHelpEnabled) {
         response->error =

--- a/main/lsp/requests/signature_help.h
+++ b/main/lsp/requests/signature_help.h
@@ -11,7 +11,7 @@ class SignatureHelpTask final : public LSPRequestTask {
 public:
     SignatureHelpTask(const LSPConfiguration &config, MessageId id, std::unique_ptr<TextDocumentPositionParams> params);
 
-    std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerDelegate &typechecker) override;
+    std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerInterface &typechecker) override;
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/sorbet_error.cc
+++ b/main/lsp/requests/sorbet_error.cc
@@ -29,6 +29,6 @@ void SorbetErrorTask::preprocess(LSPPreprocessor &preprocessor) {
     }
 }
 
-void SorbetErrorTask::run(LSPTypecheckerDelegate &typechecker) {}
+void SorbetErrorTask::run(LSPTypecheckerInterface &typechecker) {}
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/sorbet_error.h
+++ b/main/lsp/requests/sorbet_error.h
@@ -17,7 +17,7 @@ public:
 
     void preprocess(LSPPreprocessor &preprocessor) override;
 
-    void run(LSPTypecheckerDelegate &typechecker) override;
+    void run(LSPTypecheckerInterface &typechecker) override;
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/sorbet_read_file.cc
+++ b/main/lsp/requests/sorbet_read_file.cc
@@ -9,7 +9,7 @@ SorbetReadFileTask::SorbetReadFileTask(const LSPConfiguration &config, MessageId
                                        std::unique_ptr<TextDocumentIdentifier> params)
     : LSPRequestTask(config, move(id), LSPMethod::SorbetReadFile), params(move(params)) {}
 
-unique_ptr<ResponseMessage> SorbetReadFileTask::runRequest(LSPTypecheckerDelegate &typechecker) {
+unique_ptr<ResponseMessage> SorbetReadFileTask::runRequest(LSPTypecheckerInterface &typechecker) {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::SorbetReadFile);
     auto fref = config.uri2FileRef(typechecker.state(), params->uri);
     if (fref.exists()) {

--- a/main/lsp/requests/sorbet_read_file.h
+++ b/main/lsp/requests/sorbet_read_file.h
@@ -11,7 +11,7 @@ class SorbetReadFileTask final : public LSPRequestTask {
 public:
     SorbetReadFileTask(const LSPConfiguration &config, MessageId id, std::unique_ptr<TextDocumentIdentifier> params);
 
-    std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerDelegate &typechecker) override;
+    std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerInterface &typechecker) override;
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/sorbet_show_symbol.cc
+++ b/main/lsp/requests/sorbet_show_symbol.cc
@@ -10,7 +10,7 @@ SorbetShowSymbolTask::SorbetShowSymbolTask(const LSPConfiguration &config, Messa
                                            std::unique_ptr<TextDocumentPositionParams> params)
     : LSPRequestTask(config, move(id), LSPMethod::SorbetShowSymbol), params(move(params)) {}
 
-unique_ptr<ResponseMessage> SorbetShowSymbolTask::runRequest(LSPTypecheckerDelegate &typechecker) {
+unique_ptr<ResponseMessage> SorbetShowSymbolTask::runRequest(LSPTypecheckerInterface &typechecker) {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::SorbetShowSymbol);
 
     const core::GlobalState &gs = typechecker.state();

--- a/main/lsp/requests/sorbet_show_symbol.h
+++ b/main/lsp/requests/sorbet_show_symbol.h
@@ -12,7 +12,7 @@ public:
     SorbetShowSymbolTask(const LSPConfiguration &config, MessageId id,
                          std::unique_ptr<TextDocumentPositionParams> params);
 
-    std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerDelegate &typechecker) override;
+    std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerInterface &typechecker) override;
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/type_definition.cc
+++ b/main/lsp/requests/type_definition.cc
@@ -86,7 +86,7 @@ TypeDefinitionTask::TypeDefinitionTask(const LSPConfiguration &config, MessageId
                                        std::unique_ptr<TextDocumentPositionParams> params)
     : LSPRequestTask(config, move(id), LSPMethod::TextDocumentTypeDefinition), params(move(params)) {}
 
-unique_ptr<ResponseMessage> TypeDefinitionTask::runRequest(LSPTypecheckerDelegate &typechecker) {
+unique_ptr<ResponseMessage> TypeDefinitionTask::runRequest(LSPTypecheckerInterface &typechecker) {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentTypeDefinition);
     const core::GlobalState &gs = typechecker.state();
     auto result = queryByLoc(typechecker, params->textDocument->uri, *params->position,

--- a/main/lsp/requests/type_definition.h
+++ b/main/lsp/requests/type_definition.h
@@ -12,7 +12,7 @@ public:
     TypeDefinitionTask(const LSPConfiguration &config, MessageId id,
                        std::unique_ptr<TextDocumentPositionParams> params);
 
-    std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerDelegate &typechecker) override;
+    std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerInterface &typechecker) override;
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/workspace_symbols.cc
+++ b/main/lsp/requests/workspace_symbols.cc
@@ -331,7 +331,7 @@ bool WorkspaceSymbolsTask::isDelayable() const {
     return true;
 }
 
-unique_ptr<ResponseMessage> WorkspaceSymbolsTask::runRequest(LSPTypecheckerDelegate &typechecker) {
+unique_ptr<ResponseMessage> WorkspaceSymbolsTask::runRequest(LSPTypecheckerInterface &typechecker) {
     Timer timeit(typechecker.state().tracer(), "LSPLoop::handleWorkspaceSymbols");
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::WorkspaceSymbol);
     ShowOperation op(config, ShowOperation::Kind::References);

--- a/main/lsp/requests/workspace_symbols.h
+++ b/main/lsp/requests/workspace_symbols.h
@@ -13,7 +13,7 @@ public:
 
     bool isDelayable() const override;
 
-    std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerDelegate &typechecker) override;
+    std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerInterface &typechecker) override;
 };
 
 } // namespace sorbet::realmain::lsp


### PR DESCRIPTION
This adds an interface class for the methods of `LSPTypecheckerDelegate`, with all methods marked virtual.


### Motivation
For now this is a functional no-op, but later on when serving requests from stale GlobalState, we'll need to expose somewhat different implementations of these methods.

It's worth noting that I'm not sure all the methods will be implementable from stale GlobalState. I think starting from that _assumption_ is probably the best thing to do, since every existing LSPTask depends on the interface exposed by `LSPTypecheckerDelegate`, but we may well want to tweak/refactor the interface down the line as we discover restrictions/limitations/caveats.


### Test plan
I think this should be an "if it compiles and the existing tests pass, everything is fine" situation.