### PR TITLE
Add (void) casts to silence a warning in clangd

### DIFF
--- a/main/lsp/request_dispatch.cc
+++ b/main/lsp/request_dispatch.cc
@@ -52,7 +52,7 @@ void LSPLoop::runTask(unique_ptr<LSPTask> task) {
     if (auto *dangerousTask = dynamic_cast<LSPDangerousTypecheckerTask *>(task.get())) {
         if (auto *editTask = dynamic_cast<SorbetWorkspaceEditTask *>(dangerousTask)) {
             unique_ptr<SorbetWorkspaceEditTask> edit(editTask);
-            task.release();
+            (void)task.release();
             if (edit->canTakeFastPath(indexer)) {
                 // Can run on fast path synchronously; it should complete quickly.
                 typecheckerCoord.syncRun(move(edit));
@@ -63,7 +63,7 @@ void LSPLoop::runTask(unique_ptr<LSPTask> task) {
             }
         } else if (auto *initializedTask = dynamic_cast<InitializedTask *>(dangerousTask)) {
             unique_ptr<InitializedTask> initialized(initializedTask);
-            task.release();
+            (void)task.release();
             typecheckerCoord.initialize(move(initialized));
         } else {
             // Must be a new type of dangerous task we don't know about.


### PR DESCRIPTION
There are a couple of places in `request_dispatch.cc` where we `release()` a `unique_ptr` without using its result, and this is intentional. On my machine at least, clangd complains that "the value returned by this function should be used", with a recommendation to cast to `void` to silence the warning.

Not sure why this doesn't break our build for `-Werror`, but I figured that applying the recommended fix makes sense here.


### Motivation
Just cutting down on noise in clangd.


### Test plan
Should be fine if the compiler's fine with it.
