### PR TITLE
Process --extra-package-... flags for rbi-generation

### DIFF
--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -878,10 +878,6 @@ void readOptions(Options &opts,
         opts.stripeMode = raw["stripe-mode"].as<bool>();
         opts.stripePackages = raw["stripe-packages"].as<bool>();
         if (raw.count("extra-package-files-directory-prefix")) {
-            if (!opts.stripePackages) {
-                logger->error("--extra-package-files-directory-prefix can only be specified in --stripe-packages mode");
-                throw EarlyReturnWithCode(1);
-            }
             for (const string &dirName : raw["extra-package-files-directory-prefix"].as<vector<string>>()) {
                 if (dirName.back() != '/') {
                     logger->error(

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -583,6 +583,13 @@ int realmain(int argc, char *argv[]) {
             // seconds.
             auto packageFileRefs = pipeline::reserveFiles(gs, packageFiles);
             auto packages = pipeline::index(*gs, packageFileRefs, opts, *workers, nullptr);
+            {
+                core::UnfreezeNameTable unfreezeToEnterPackagerOptionsGS(*gs);
+                core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = gs->unfreezePackages();
+                gs->setPackagerOptions(opts.secondaryTestPackageNamespaces, opts.extraPackageFilesDirectoryPrefixes,
+                                       opts.stripePackagesHint);
+            }
+
             packages = packager::Packager::findPackages(*gs, *workers, move(packages));
 
             if (!opts.singlePackage.empty()) {

--- a/test/cli/rbi-gen-single/family/__package.rb
+++ b/test/cli/rbi-gen-single/family/__package.rb
@@ -6,6 +6,7 @@ class Family < PackageSpec
   import Family::Bart
   test_import Util::Testing
 
+  export Family::Belcher
   export Family::Simpsons
   export Test::Family::TestFamily
 

--- a/test/cli/rbi-gen-single/other/Family/belcher.rb
+++ b/test/cli/rbi-gen-single/other/Family/belcher.rb
@@ -1,0 +1,10 @@
+# typed: true
+
+module Family
+
+  # This class exists outside of the top-level family tree, but is present in
+  # that package via the use of `--extra-package-files-directory-prefix`.
+  class Belcher
+  end
+
+end

--- a/test/cli/rbi-gen-single/test.out
+++ b/test/cli/rbi-gen-single/test.out
@@ -17,6 +17,8 @@ Family::Simpsons::RelativeBart = Family::Bart::Character
 Family::Simpsons::MaybeBartFull = T.type_alias {T.nilable(Family::Bart::Character)}
 Family::Simpsons::MaybeBart = T.type_alias {T.nilable(Family::Bart::Character)}
 Family::Simpsons::FullyQualifiedBart = Family::Bart::Character
+class Family::Belcher
+end
 -- RBI Deps (Family)
 {"packageRefs":["Family::Bart"], "rbiRefs":[]}
 -- Test Private RBI (Family)

--- a/test/cli/rbi-gen-single/test.sh
+++ b/test/cli/rbi-gen-single/test.sh
@@ -13,6 +13,7 @@ echo "-- sanity-checking package with --stripe-packages"
 "$sorbet" --silence-dev-message \
   --stripe-packages \
   --dump-package-info="$rbis/package-info.json" \
+  --extra-package-files-directory-prefix="${test_path}/other/" \
   "$test_path"
 
 show_output() {
@@ -35,6 +36,7 @@ find . -name __package.rb | sort | while read -r package; do
   "$sorbet" --silence-dev-message \
     --ignore=__package.rb \
     --package-rbi-output="$rbis" \
+    --extra-package-files-directory-prefix="${test_path}/other/" \
     --single-package="$name" "$test_path"
 
   show_output "$name" "RBI"                   "package.rbi"


### PR DESCRIPTION
The `--extra-package-files-directory-prefix` flag gives additional context to the packageDB that we need to associate rbis and generated files with a package for single-package rbi generation. This PR removes the restriction that it only be provided in `--stripe-packages` mode, and uses it to setup the global state before initializing the packageDB when generating rbis.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Stabilizing rbi generation.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
