### PR TITLE
[LSP] Refactor code action tests

### DIFF
--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -2004,7 +2004,7 @@ SelectiveApplyCodeActionAssertions::SelectiveApplyCodeActionAssertions(std::stri
                                                                        std::unique_ptr<Range> &range, int assertionLine,
                                                                        std::vector<std::string> values,
                                                                        std::string_view assertionType)
-    : RangeAssertion(filename, range, assertionLine), assertionType(string(assertionType)), values(values){};
+    : RangeAssertion(filename, range, assertionLine), assertionType(assertionType), values(values){};
 
 std::optional<std::vector<std::string>>
 SelectiveApplyCodeActionAssertions::getValues(std::string_view type,

--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -71,6 +71,140 @@ string documentSymbolsToString(const variant<JSONNullObject, vector<unique_ptr<D
     }
 }
 
+void validateCodeActions(LSPWrapper &lspWrapper, Expectations &test, string fileUri, unique_ptr<Range> range,
+                         int &nextId, vector<CodeActionKind> &selectedCodeActionKinds,
+                         vector<shared_ptr<ApplyCodeActionAssertion>> &applyCodeActionAssertions,
+                         string codeActionDescription, bool assertAllChanges) {
+    auto isSelectedKind = [&selectedCodeActionKinds](CodeActionKind kind) {
+        return count(selectedCodeActionKinds.begin(), selectedCodeActionKinds.end(), kind) != 0;
+    };
+    vector<unique_ptr<Diagnostic>> diagnostics;
+
+    auto codeActionContext = make_unique<CodeActionContext>(move(diagnostics));
+    codeActionContext->only = selectedCodeActionKinds;
+
+    // Unfortunately there's no simpler way to copy the range (yet).
+    auto params = make_unique<CodeActionParams>(make_unique<TextDocumentIdentifier>(fileUri), range->copy(),
+                                                move(codeActionContext));
+    auto req = make_unique<RequestMessage>("2.0", nextId++, LSPMethod::TextDocumentCodeAction, move(params));
+    auto responses = getLSPResponsesFor(lspWrapper, make_unique<LSPMessage>(move(req)));
+    {
+        INFO("Did not receive exactly one response for a codeAction request.");
+        CHECK_EQ(responses.size(), 1);
+    }
+    if (responses.size() != 1) {
+        return;
+    }
+
+    auto &msg = responses.at(0);
+    CHECK(msg->isResponse());
+    if (!msg->isResponse()) {
+        return;
+    }
+
+    auto &response = msg->asResponse();
+    auto &receivedCodeActionResponse = get<variant<JSONNullObject, vector<unique_ptr<CodeAction>>>>(*response.result);
+    CHECK_FALSE(get_if<JSONNullObject>(&receivedCodeActionResponse));
+    if (get_if<JSONNullObject>(&receivedCodeActionResponse)) {
+        return;
+    }
+
+    UnorderedMap<string, unique_ptr<CodeAction>> receivedCodeActionsByTitle;
+    auto &receivedCodeActions = get<vector<unique_ptr<CodeAction>>>(receivedCodeActionResponse);
+    unique_ptr<CodeAction> sourceLevelCodeAction;
+    // One code action should be a 'source' level code action. Remove it.
+    if (!receivedCodeActions.empty() && isSelectedKind(CodeActionKind::Quickfix)) {
+        for (auto it = receivedCodeActions.begin(); it != receivedCodeActions.end();) {
+            if ((*it)->kind == CodeActionKind::SourceFixAllSorbet) {
+                INFO("Received multiple source-level code actions");
+                CHECK_EQ(sourceLevelCodeAction, nullptr);
+                sourceLevelCodeAction = move(*it);
+                // Remove from vector and continue
+                it = receivedCodeActions.erase(it);
+            } else {
+                it++;
+            }
+        }
+        INFO("Expected one source-level code action for code action request");
+        CHECK_NE(sourceLevelCodeAction, nullptr);
+    }
+
+    for (auto &codeAction : receivedCodeActions) {
+        if (!isSelectedKind(codeAction->kind.value())) {
+            continue;
+        }
+        // We send two identical "Apply all Sorbet autocorrects" code actions with different kinds: One is a
+        // Source, the other is a Quickfix. This logic strips out the quickfix.
+        if (sourceLevelCodeAction != nullptr && codeAction->title == sourceLevelCodeAction->title) {
+            continue;
+        }
+
+        bool codeActionTitleUnique =
+            receivedCodeActionsByTitle.find(codeAction->title) == receivedCodeActionsByTitle.end();
+        CHECK_MESSAGE(codeActionTitleUnique, "Found code action with duplicate title: " << codeAction->title);
+
+        if (codeActionTitleUnique) {
+            receivedCodeActionsByTitle[codeAction->title] = move(codeAction);
+        }
+    }
+
+    uint32_t receivedCodeActionsCount = receivedCodeActionsByTitle.size();
+    vector<shared_ptr<ApplyCodeActionAssertion>> matchedCodeActionAssertions;
+
+    // Test code action assertions matching the range of this error.
+    auto it = applyCodeActionAssertions.begin();
+    while (it != applyCodeActionAssertions.end()) {
+        auto codeActionAssertion = it->get();
+        if (!(range->start->cmp(*codeActionAssertion->range->start) <= 0 &&
+              range->end->cmp(*codeActionAssertion->range->end) >= 0)) {
+            ++it;
+            continue;
+        }
+
+        // Ensure we received a code action matching the assertion.
+        auto it2 = receivedCodeActionsByTitle.find(codeActionAssertion->title);
+        {
+            INFO(fmt::format(
+                "Did not receive code action matching assertion `{}` for error or selected code action `{}`...",
+                codeActionAssertion->toString(), codeActionDescription));
+            CHECK_NE(it2, receivedCodeActionsByTitle.end());
+        }
+
+        // Ensure that the received code action applies correctly.
+        if (it2 != receivedCodeActionsByTitle.end()) {
+            auto codeAction = move(it2->second);
+            if (assertAllChanges) {
+                codeActionAssertion->checkAll(test.sourceFileContents, lspWrapper, *codeAction.get());
+            } else {
+                codeActionAssertion->check(test.sourceFileContents, lspWrapper, *codeAction.get());
+            }
+
+            // Some bookkeeping to make surfacing errors re. extra/insufficient
+            // apply-code-action annotations easier.
+            receivedCodeActionsByTitle.erase(it2);
+
+            if (isSelectedKind(codeAction->kind.value())) {
+                (*it)->kind = codeAction->kind;
+                matchedCodeActionAssertions.emplace_back(*it);
+                it = applyCodeActionAssertions.erase(it);
+            }
+        } else {
+            ++it;
+        }
+    }
+
+    if (matchedCodeActionAssertions.size() > receivedCodeActionsCount) {
+        FAIL_CHECK(fmt::format("Found apply-code-action assertions without "
+                               "corresponding code actions from the server:\n{}",
+                               fmt::map_join(applyCodeActionAssertions.begin(), applyCodeActionAssertions.end(), ", ",
+                                             [](const auto &assertion) -> string { return assertion->toString(); })));
+    } else if (matchedCodeActionAssertions.size() < receivedCodeActionsCount) {
+        FAIL_CHECK(fmt::format("Received code actions without corresponding apply-code-action assertions:\n{}",
+                               fmt::map_join(receivedCodeActionsByTitle.begin(), receivedCodeActionsByTitle.end(), "\n",
+                                             [](const auto &action) -> string { return action.second->toJSON(); })));
+    }
+}
+
 void testQuickFixCodeActions(LSPWrapper &lspWrapper, Expectations &test, const vector<string> &filenames,
                              vector<shared_ptr<RangeAssertion>> &assertions, UnorderedMap<string, string> &testFileUris,
                              int &nextId) {
@@ -81,12 +215,21 @@ void testQuickFixCodeActions(LSPWrapper &lspWrapper, Expectations &test, const v
         }
     }
 
-    bool exhaustiveApplyCodeAction =
-        BooleanPropertyAssertion::getValue("exhaustive-apply-code-action", assertions).value_or(false);
-
-    if (applyCodeActionAssertionsByFilename.empty() && !exhaustiveApplyCodeAction) {
+    auto selectedCodeActions = SelectiveApplyCodeActionAssertions::getValues("selective-apply-code-action", assertions)
+                                   .value_or(vector<string>{});
+    if (applyCodeActionAssertionsByFilename.empty() && selectedCodeActions.empty()) {
         return;
     }
+
+    {
+        INFO("No code actions provided for the selective-apply-code-action assertion. Correct usage example "
+             "`selective-apply-code-action: quickfix, quickfix.refactor`");
+        CHECK(!selectedCodeActions.empty());
+    }
+
+    vector<CodeActionKind> selectedCodeActionKinds;
+    transform(selectedCodeActions.begin(), selectedCodeActions.end(), back_inserter(selectedCodeActionKinds),
+              getCodeActionKind);
 
     auto errors = RangeAssertion::getErrorAssertions(assertions);
     UnorderedMap<string, std::vector<std::shared_ptr<RangeAssertion>>> errorsByFilename;
@@ -96,126 +239,18 @@ void testQuickFixCodeActions(LSPWrapper &lspWrapper, Expectations &test, const v
 
     for (auto &filename : filenames) {
         auto applyCodeActionAssertions = applyCodeActionAssertionsByFilename[filename];
+        auto fileUri = testFileUris[filename];
 
         // Request code actions for each of this file's error.
         for (auto &error : errorsByFilename[filename]) {
-            vector<unique_ptr<Diagnostic>> diagnostics;
-            auto fileUri = testFileUris[filename];
-            // Unfortunately there's no simpler way to copy the range (yet).
-            auto params =
-                make_unique<CodeActionParams>(make_unique<TextDocumentIdentifier>(fileUri), error->range->copy(),
-                                              make_unique<CodeActionContext>(move(diagnostics)));
-            auto req = make_unique<RequestMessage>("2.0", nextId++, LSPMethod::TextDocumentCodeAction, move(params));
-            auto responses = getLSPResponsesFor(lspWrapper, make_unique<LSPMessage>(move(req)));
-            {
-                INFO("Did not receive exactly one response for a codeAction request.");
-                CHECK_EQ(responses.size(), 1);
-            }
-            if (responses.size() != 1) {
-                continue;
-            }
+            validateCodeActions(lspWrapper, test, fileUri, error->range->copy(), nextId, selectedCodeActionKinds,
+                                applyCodeActionAssertions, error->toString(), false);
+        }
 
-            auto &msg = responses.at(0);
-            CHECK(msg->isResponse());
-            if (!msg->isResponse()) {
-                continue;
-            }
-
-            auto &response = msg->asResponse();
-            REQUIRE_MESSAGE(response.result, "Code action request returned error: " << msg->toJSON());
-            auto &receivedCodeActionResponse =
-                get<variant<JSONNullObject, vector<unique_ptr<CodeAction>>>>(*response.result);
-            CHECK_FALSE(get_if<JSONNullObject>(&receivedCodeActionResponse));
-            if (get_if<JSONNullObject>(&receivedCodeActionResponse)) {
-                continue;
-            }
-
-            UnorderedMap<string, unique_ptr<CodeAction>> receivedCodeActionsByTitle;
-            auto &receivedCodeActions = get<vector<unique_ptr<CodeAction>>>(receivedCodeActionResponse);
-            unique_ptr<CodeAction> sourceLevelCodeAction;
-            // One code action should be a 'source' level code action. Remove it.
-            if (!receivedCodeActions.empty()) {
-                for (auto it = receivedCodeActions.begin(); it != receivedCodeActions.end();) {
-                    if ((*it)->kind == CodeActionKind::SourceFixAllSorbet) {
-                        INFO("Received multiple source-level code actions");
-                        CHECK_EQ(sourceLevelCodeAction, nullptr);
-                        sourceLevelCodeAction = move(*it);
-                        // Remove from vector and continue
-                        it = receivedCodeActions.erase(it);
-                    } else {
-                        it++;
-                    }
-                }
-                INFO("Expected one source-level code action for code action request");
-                CHECK_NE(sourceLevelCodeAction, nullptr);
-            }
-
-            for (auto &codeAction : receivedCodeActions) {
-                // We send two identical "Apply all Sorbet autocorrects" code actions with different kinds: One is a
-                // Source, the other is a Quickfix. This logic strips out the quickfix.
-                if (sourceLevelCodeAction != nullptr && codeAction->title == sourceLevelCodeAction->title) {
-                    continue;
-                }
-
-                bool codeActionTitleUnique =
-                    receivedCodeActionsByTitle.find(codeAction->title) == receivedCodeActionsByTitle.end();
-                CHECK_MESSAGE(codeActionTitleUnique, "Found code action with duplicate title: " << codeAction->title);
-
-                if (codeActionTitleUnique) {
-                    receivedCodeActionsByTitle[codeAction->title] = move(codeAction);
-                }
-            }
-
-            uint32_t receivedCodeActionsCount = receivedCodeActionsByTitle.size();
-            vector<shared_ptr<ApplyCodeActionAssertion>> matchedCodeActionAssertions;
-
-            // Test code action assertions matching the range of this error.
-            auto it = applyCodeActionAssertions.begin();
-            while (it != applyCodeActionAssertions.end()) {
-                auto codeActionAssertion = it->get();
-                if (!(error->range->start->cmp(*codeActionAssertion->range->start) <= 0 &&
-                      error->range->end->cmp(*codeActionAssertion->range->end) >= 0)) {
-                    ++it;
-                    continue;
-                }
-
-                // Ensure we received a code action matching the assertion.
-                auto it2 = receivedCodeActionsByTitle.find(codeActionAssertion->title);
-                {
-                    INFO(fmt::format("Did not receive code action matching assertion `{}` for error `{}`...",
-                                     codeActionAssertion->toString(), error->toString()));
-                    CHECK_NE(it2, receivedCodeActionsByTitle.end());
-                }
-
-                // Ensure that the received code action applies correctly.
-                if (it2 != receivedCodeActionsByTitle.end()) {
-                    auto codeAction = move(it2->second);
-                    codeActionAssertion->check(test.sourceFileContents, lspWrapper, *codeAction.get());
-
-                    // Some bookkeeping to make surfacing errors re. extra/insufficient
-                    // apply-code-action annotations easier.
-                    receivedCodeActionsByTitle.erase(it2);
-                    matchedCodeActionAssertions.emplace_back(*it);
-                    it = applyCodeActionAssertions.erase(it);
-                } else {
-                    ++it;
-                }
-            }
-
-            if (exhaustiveApplyCodeAction) {
-                if (matchedCodeActionAssertions.size() > receivedCodeActionsCount) {
-                    FAIL_CHECK(fmt::format(
-                        "Found apply-code-action assertions without "
-                        "corresponding code actions from the server:\n{}",
-                        fmt::map_join(applyCodeActionAssertions.begin(), applyCodeActionAssertions.end(), ", ",
-                                      [](const auto &assertion) -> string { return assertion->toString(); })));
-                } else if (matchedCodeActionAssertions.size() < receivedCodeActionsCount) {
-                    FAIL_CHECK(fmt::format(
-                        "Received code actions without corresponding apply-code-action assertions:\n{}",
-                        fmt::map_join(receivedCodeActionsByTitle.begin(), receivedCodeActionsByTitle.end(), "\n",
-                                      [](const auto &action) -> string { return action.second->toJSON(); })));
-                }
-            }
+        for (auto codeActionAssertion : applyCodeActionAssertions) {
+            validateCodeActions(lspWrapper, test, fileUri, codeActionAssertion->range->copy(), nextId,
+                                selectedCodeActionKinds, applyCodeActionAssertions, codeActionAssertion->toString(),
+                                true);
         }
 
         // We've already removed any code action assertions that matches a received code action assertion.

--- a/test/testdata/lsp/code_actions/loop_type_change.A.rbedited
+++ b/test/testdata/lsp/code_actions/loop_type_change.A.rbedited
@@ -1,5 +1,5 @@
 # typed: true
-# exhaustive-apply-code-action: true
+# selective-apply-code-action: quickfix
 
 x = T.let(nil, T.nilable(Integer))
 

--- a/test/testdata/lsp/code_actions/loop_type_change.rb
+++ b/test/testdata/lsp/code_actions/loop_type_change.rb
@@ -1,5 +1,5 @@
 # typed: true
-# exhaustive-apply-code-action: true
+# selective-apply-code-action: quickfix
 
 x = nil
 

--- a/test/testdata/lsp/code_actions/private.A.rbedited
+++ b/test/testdata/lsp/code_actions/private.A.rbedited
@@ -1,5 +1,5 @@
 # typed: false
-# exhaustive-apply-code-action: true
+# selective-apply-code-action: quickfix
 
 class A
   private def foo; end

--- a/test/testdata/lsp/code_actions/private.B.rbedited
+++ b/test/testdata/lsp/code_actions/private.B.rbedited
@@ -1,5 +1,5 @@
 # typed: false
-# exhaustive-apply-code-action: true
+# selective-apply-code-action: quickfix
 
 class A
   private def foo; end

--- a/test/testdata/lsp/code_actions/private.rb
+++ b/test/testdata/lsp/code_actions/private.rb
@@ -1,5 +1,5 @@
 # typed: false
-# exhaustive-apply-code-action: true
+# selective-apply-code-action: quickfix
 
 class A
   private def foo; end

--- a/test/testdata/lsp/code_actions/sig_missing__child.A.rbedited
+++ b/test/testdata/lsp/code_actions/sig_missing__child.A.rbedited
@@ -1,5 +1,5 @@
 # typed: strict
-# exhaustive-apply-code-action: true
+# selective-apply-code-action: quickfix
 
 require_relative './sig_missing__parent.rb'
 

--- a/test/testdata/lsp/code_actions/sig_missing__child.rb
+++ b/test/testdata/lsp/code_actions/sig_missing__child.rb
@@ -1,5 +1,5 @@
 # typed: strict
-# exhaustive-apply-code-action: true
+# selective-apply-code-action: quickfix
 
 require_relative './sig_missing__parent.rb'
 

--- a/test/testdata/lsp/code_actions/sig_missing__parent.A.rbedited
+++ b/test/testdata/lsp/code_actions/sig_missing__parent.A.rbedited
@@ -1,5 +1,5 @@
 # typed: strict
-# exhaustive-apply-code-action: true
+# selective-apply-code-action: quickfix
 
 class Foo
   extend T::Sig

--- a/test/testdata/lsp/code_actions/sig_missing__parent.rb
+++ b/test/testdata/lsp/code_actions/sig_missing__parent.rb
@@ -1,5 +1,5 @@
 # typed: strict
-# exhaustive-apply-code-action: true
+# selective-apply-code-action: quickfix
 
 class Foo
   extend T::Sig

--- a/test/testdata/lsp/code_actions/typo.A.rbedited
+++ b/test/testdata/lsp/code_actions/typo.A.rbedited
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # typed: true
-# exhaustive-apply-code-action: true
+# selective-apply-code-action: quickfix
 
 class Foo
   def bar(n); end

--- a/test/testdata/lsp/code_actions/typo.B.rbedited
+++ b/test/testdata/lsp/code_actions/typo.B.rbedited
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # typed: true
-# exhaustive-apply-code-action: true
+# selective-apply-code-action: quickfix
 
 class Foo
   def bar(n); end

--- a/test/testdata/lsp/code_actions/typo.C.rbedited
+++ b/test/testdata/lsp/code_actions/typo.C.rbedited
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # typed: true
-# exhaustive-apply-code-action: true
+# selective-apply-code-action: quickfix
 
 class Foo
   def bar(n); end

--- a/test/testdata/lsp/code_actions/typo.D.rbedited
+++ b/test/testdata/lsp/code_actions/typo.D.rbedited
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # typed: true
-# exhaustive-apply-code-action: true
+# selective-apply-code-action: quickfix
 
 class Foo
   def bar(n); end

--- a/test/testdata/lsp/code_actions/typo.rb
+++ b/test/testdata/lsp/code_actions/typo.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # typed: true
-# exhaustive-apply-code-action: true
+# selective-apply-code-action: quickfix
 
 class Foo
   def bar(n); end

--- a/test/testdata/lsp/missing_typed_sigil.A.rbedited
+++ b/test/testdata/lsp/missing_typed_sigil.A.rbedited
@@ -5,6 +5,8 @@
 # specially whitelisted.
 # !!!!
 
+# selective-apply-code-action: quickfix
+
 class Hello
   def something(x)
 

--- a/test/testdata/lsp/missing_typed_sigil.rb
+++ b/test/testdata/lsp/missing_typed_sigil.rb
@@ -5,6 +5,8 @@
 # specially whitelisted.
 # !!!!
 
+# selective-apply-code-action: quickfix
+
 class Hello
   def something(x)
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

The change replaces the `exhaustive-apply-code-action` assertion with the `selective-apply-code-action`. Previously, for the code action test you had to mark it with `exhaustive-apply-code-action` and it would assert all possible code actions are applied. Now you need to mark test with `selective-apply-code-action` and list all code actions you're looking for.

I've also added the `ApplyCodeActionAssertion::checkAll` method. It applies all edits in the code action and asserts the result after.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I need this refactoring for the extract method refactoring PR https://github.com/sorbet/sorbet/pull/5309

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
