### PR TITLE
add a non-mutating incremental resolver interface

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3857,7 +3857,9 @@ ast::ParsedFilesOrCancelled Resolver::runIncrementalWithoutStateMutation(const c
     if (!result.hasResult()) {
         return result;
     }
-    sanityCheck(gs, result.result());
+    // The non-mutating resolver isn't ready for this check to be run yet, because e.g.
+    // it doesn't resolve UnresolvedConstantLit nodes.
+    // sanityCheck(gs, result.result());
     // This check is FAR too slow to run on large codebases, especially with sanitizers on.
     // But it can be super useful to uncomment when debugging certain issues.
     // ctx.state.sanityCheck();

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2903,7 +2903,9 @@ public:
         return tree;
     }
 
-    static vector<ast::ParsedFile> run(core::GlobalState &gs, vector<ast::ParsedFile> trees, WorkerPool &workers) {
+    template <typename StateType>
+    static vector<ast::ParsedFile> run(StateType &gs, vector<ast::ParsedFile> trees, WorkerPool &workers) {
+        static_assert(is_same_v<remove_const_t<StateType>, core::GlobalState>);
         Timer timeit(gs.tracer(), "resolver.type_params");
 
         auto inputq = make_shared<ConcurrentBoundedQueue<ast::ParsedFile>>(trees.size());

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3015,18 +3015,19 @@ public:
             bool progress = true;
             while (progress && !combinedTodoAssigns.empty()) {
                 progress = false;
-                auto it = std::remove_if(
-                    combinedTodoAssigns.begin(), combinedTodoAssigns.end(), [&](vector<ResolveAssignItem> &threadTodos) {
-                        auto origSize = threadTodos.size();
-                        auto threadTodoIt =
-                            std::remove_if(threadTodos.begin(), threadTodos.end(), [&](ResolveAssignItem &job) -> bool {
-                                core::MutableContext ctx(gs, core::Symbols::root(), job.file);
-                                return resolveJob(ctx, job, resolvedAttachedClasses);
-                            });
-                        threadTodos.erase(threadTodoIt, threadTodos.end());
-                        progress = progress || threadTodos.size() != origSize;
-                        return threadTodos.empty();
-                    });
+                auto it =
+                    std::remove_if(combinedTodoAssigns.begin(), combinedTodoAssigns.end(),
+                                   [&](vector<ResolveAssignItem> &threadTodos) {
+                                       auto origSize = threadTodos.size();
+                                       auto threadTodoIt = std::remove_if(
+                                           threadTodos.begin(), threadTodos.end(), [&](ResolveAssignItem &job) -> bool {
+                                               core::MutableContext ctx(gs, core::Symbols::root(), job.file);
+                                               return resolveJob(ctx, job, resolvedAttachedClasses);
+                                           });
+                                       threadTodos.erase(threadTodoIt, threadTodos.end());
+                                       progress = progress || threadTodos.size() != origSize;
+                                       return threadTodos.empty();
+                                   });
                 combinedTodoAssigns.erase(it, combinedTodoAssigns.end());
             }
 
@@ -3038,9 +3039,9 @@ public:
                 for (auto &threadTodos : combinedTodoAssigns) {
                     for (auto &job : threadTodos) {
                         if (job.lhs.isTypeMember()) {
-                            job.lhs.setResultType(gs, core::make_type<core::LambdaParam>(job.lhs.asTypeMemberRef(),
-                                                                                         core::Types::untypedUntracked(),
-                                                                                         core::Types::untypedUntracked()));
+                            job.lhs.setResultType(gs, core::make_type<core::LambdaParam>(
+                                                          job.lhs.asTypeMemberRef(), core::Types::untypedUntracked(),
+                                                          core::Types::untypedUntracked()));
                         } else {
                             job.lhs.setResultType(gs, core::Types::untypedUntracked());
                         }
@@ -3151,7 +3152,8 @@ private:
         }
     }
 
-    static void recordMethodInfoInSig(core::Context ctx, core::MethodRef method, ParsedSig &sig, const ast::MethodDef &mdef) {
+    static void recordMethodInfoInSig(core::Context ctx, core::MethodRef method, ParsedSig &sig,
+                                      const ast::MethodDef &mdef) {
         // Later passes are going to separate the sig and the method definition.
         // Record some information in the sig call itself so that we can reassociate
         // them later.
@@ -3690,8 +3692,7 @@ public:
 };
 
 template <typename StateType>
-ast::ParsedFilesOrCancelled resolveSigs(StateType &gs, vector<ast::ParsedFile> trees,
-                                        WorkerPool &workers) {
+ast::ParsedFilesOrCancelled resolveSigs(StateType &gs, vector<ast::ParsedFile> trees, WorkerPool &workers) {
     static_assert(is_same_v<remove_const_t<StateType>, core::GlobalState>);
     constexpr bool isConstStateType = is_const_v<StateType>;
 
@@ -3825,7 +3826,7 @@ void verifyLinearizationComputed(const core::GlobalState &gs) {
         ENFORCE_NO_TIMER(sym.data(gs)->isClassOrModuleLinearizationComputed(), "{}", sym.toString(gs));
     })
 }
-}
+} // namespace
 
 ast::ParsedFilesOrCancelled Resolver::runIncremental(core::GlobalState &gs, vector<ast::ParsedFile> trees) {
     auto workers = WorkerPool::create(0, gs.tracer());
@@ -3845,9 +3846,10 @@ ast::ParsedFilesOrCancelled Resolver::runIncremental(core::GlobalState &gs, vect
     return result;
 }
 
-ast::ParsedFilesOrCancelled Resolver::runIncrementalWithoutStateMutation(const core::GlobalState &gs, vector<ast::ParsedFile> trees) {
+ast::ParsedFilesOrCancelled Resolver::runIncrementalWithoutStateMutation(const core::GlobalState &gs,
+                                                                         vector<ast::ParsedFile> trees) {
     auto workers = WorkerPool::create(0, gs.tracer());
-    //trees = ResolveConstantsWalk::resolveConstants(gs, std::move(trees), *workers);
+    // trees = ResolveConstantsWalk::resolveConstants(gs, std::move(trees), *workers);
     // NOTE: Linearization does not need to be recomputed as we do not mutate mixins() during incremental resolve.
     verifyLinearizationComputed(gs);
     trees = ResolveTypeMembersAndFieldsWalk::run(gs, std::move(trees), *workers);

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3693,8 +3693,8 @@ public:
 
 template <typename StateType>
 ast::ParsedFilesOrCancelled resolveSigs(StateType &gs, vector<ast::ParsedFile> trees, WorkerPool &workers) {
-    static_assert(is_same_v<remove_const_t<StateType>, core::GlobalState>);
-    constexpr bool isConstStateType = is_const_v<StateType>;
+    static_assert(std::is_same_v<remove_const_t<StateType>, core::GlobalState>);
+    constexpr bool isConstStateType = std::is_const_v<StateType>;
 
     Timer timeit(gs.tracer(), "resolver.sigs_vars_and_flatten");
     auto inputq = make_shared<ConcurrentBoundedQueue<ast::ParsedFile>>(trees.size());

--- a/resolver/resolver.h
+++ b/resolver/resolver.h
@@ -18,6 +18,9 @@ public:
      * to find this) */
     static ast::ParsedFilesOrCancelled runIncremental(core::GlobalState &gs, std::vector<ast::ParsedFile> trees);
 
+    // Like the above, only skip all the steps that would require mutating global state.
+    static ast::ParsedFilesOrCancelled runIncrementalWithoutStateMutation(const core::GlobalState &gs, std::vector<ast::ParsedFile> trees);
+
     // used by autogen only
     static std::vector<ast::ParsedFile> runConstantResolution(core::GlobalState &gs, std::vector<ast::ParsedFile> trees,
                                                               WorkerPool &workers);

--- a/resolver/resolver.h
+++ b/resolver/resolver.h
@@ -19,7 +19,8 @@ public:
     static ast::ParsedFilesOrCancelled runIncremental(core::GlobalState &gs, std::vector<ast::ParsedFile> trees);
 
     // Like the above, only skip all the steps that would require mutating global state.
-    static ast::ParsedFilesOrCancelled runIncrementalWithoutStateMutation(const core::GlobalState &gs, std::vector<ast::ParsedFile> trees);
+    static ast::ParsedFilesOrCancelled runIncrementalWithoutStateMutation(const core::GlobalState &gs,
+                                                                          std::vector<ast::ParsedFile> trees);
 
     // used by autogen only
     static std::vector<ast::ParsedFile> runConstantResolution(core::GlobalState &gs, std::vector<ast::ParsedFile> trees,

--- a/resolver/resolver.h
+++ b/resolver/resolver.h
@@ -29,8 +29,6 @@ private:
     static void finalizeAncestors(core::GlobalState &gs);
     static void finalizeSymbols(core::GlobalState &gs);
     static void computeLinearization(core::GlobalState &gs);
-    static ast::ParsedFilesOrCancelled resolveSigs(core::GlobalState &gs, std::vector<ast::ParsedFile> trees,
-                                                   WorkerPool &workers);
     static void sanityCheck(const core::GlobalState &gs, std::vector<ast::ParsedFile> &trees);
 };
 

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -735,7 +735,6 @@ TEST_CASE("PerPhaseTest") { // NOLINT
         }
 
         move(resolver::Resolver::runIncrementalWithoutStateMutation(*gs, move(treesCopy)).result());
-        ENFORCE(!gs->hadCriticalError());
         errorQueue->flushAllErrors(*gs);
         errorCollector->drainErrors();
     }

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -726,6 +726,20 @@ TEST_CASE("PerPhaseTest") { // NOLINT
         }
     }
 
+    {
+        // Non-mutating resolver.  Note that non-mutating resolver leaves GlobalState
+        // alone, but modifies trees with abandon, so we need to copy here.
+        vector<ast::ParsedFile> treesCopy;
+        for (auto &tree : trees) {
+            treesCopy.emplace_back(ast::ParsedFile{tree.tree.deepCopy(), tree.file});
+        }
+
+        move(resolver::Resolver::runIncrementalWithoutStateMutation(*gs, move(treesCopy)).result());
+        ENFORCE(!gs->hadCriticalError());
+        errorQueue->flushAllErrors(*gs);
+        errorCollector->drainErrors();
+    }
+
     // resolver
     trees = move(resolver::Resolver::runIncremental(*gs, move(trees)).result());
 


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

When we're running queries on stale `GlobalState` (#5407), we may need to run resolver in a way that modifies the affected trees we're looking at, but deliberately does not modify the `GlobalState` we're using.  (We expect that either a) the new `GlobalState` resulting from a successful ongoing typecheck will replace it or b) mutating it for temporary changes, but then having to put it back without those changes if the ongoing typecheck is cancelled for some reason, is fraught with problems.)

This PR attempts to provide such an interface with a minimum of code duplication, leaning on templates and `if constexpr` to magically wall off mutating sections of the resolver.  This way the compiler will automatically flag misuses of `const GlobalState` in the templated function(s) and it should be relatively obvious how to proceed to satisfy the compiler.

What's not clear to me is how effective this version of the resolver is going to be, since the WIP being filed here shuts off quite a bit of the resolver, including things like resolving superclasses, etc.  But maybe the expectation is that the mutating incremental resolver wouldn't have found that many changes to make anyway...?

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Not sure how to test this.  Honestly this PR was just going to put the infrastructure in place; future PRs that actually call the non-mutating incremental resolver would need to figure out some sort of testing strategy.
