### PR TITLE
fix flaky, time-dependent compiler oracle test

### DIFF
--- a/test/testdata/compiler/disabled/validate_exp_tests/test.rb
+++ b/test/testdata/compiler/disabled/validate_exp_tests/test.rb
@@ -8,7 +8,8 @@
 # that case to ensure that it's failing properly.
 
 # The oracle test needs to fail as well, but it's not the failure we're
-# interested in. Since the tests will never be run at the same time and their
-# output will be compared, it's sufficient to print out the current time to
-# guarantee a failure for the oracle test.
-puts Time.new
+# interested in. We used to compare the output of `Time.new`, but empirical
+# evidence says that sometimes the compiled version and the interpreted version
+# can print out the same time. Instead, we'll use this fancy compiler intrinsic
+# which is guaranteed to produce different output in each scenario.
+puts T::Private::Compiler.running_compiled?


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fewer spurious compiler test failures.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
