### PR TITLE
don't return completion results for untyped receivers

### DIFF
--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -204,6 +204,10 @@ SimilarMethodsByName similarMethodsForReceiver(const core::GlobalState &gs, cons
 // Walk a core::DispatchResult to find methods similar to `prefix` on any of its DispatchComponents' receivers.
 SimilarMethodsByName allSimilarMethods(const core::GlobalState &gs, core::DispatchResult &dispatchResult,
                                        string_view prefix) {
+    if (dispatchResult.main.receiver.isUntyped()) {
+        return SimilarMethodsByName{};
+    }
+
     auto result = similarMethodsForReceiver(gs, dispatchResult.main.receiver, prefix);
 
     for (auto &[methodName, similarMethods] : result) {
@@ -1115,11 +1119,6 @@ unique_ptr<ResponseMessage> CompletionTask::runRequest(LSPTypecheckerInterface &
     auto resp = move(queryResponses[0]);
 
     if (auto sendResp = resp->isSend()) {
-        if (sendResp->dispatchResult->main.receiver.isUntyped()) {
-            response->result = std::move(emptyResult);
-            return response;
-        }
-
         auto callerSideName = sendResp->callerSideName;
         auto prefix = (callerSideName == core::Names::methodNameMissing() || !sendResp->funLoc.contains(queryLoc))
                           ? ""

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -1115,6 +1115,11 @@ unique_ptr<ResponseMessage> CompletionTask::runRequest(LSPTypecheckerInterface &
     auto resp = move(queryResponses[0]);
 
     if (auto sendResp = resp->isSend()) {
+        if (sendResp->dispatchResult->main.receiver.isUntyped()) {
+            response->result = std::move(emptyResult);
+            return response;
+        }
+
         auto callerSideName = sendResp->callerSideName;
         auto prefix = (callerSideName == core::Names::methodNameMissing() || !sendResp->funLoc.contains(queryLoc))
                           ? ""

--- a/test/testdata/lsp/completion/untyped_receiver.rb
+++ b/test/testdata/lsp/completion/untyped_receiver.rb
@@ -1,0 +1,8 @@
+# typed: true
+extend T::Sig
+
+sig {params(x: T.untyped).void}
+def foo(x)
+  x.
+  # ^ completion: (nothing)
+end # error: unexpected token


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Fixes #5147.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

It's not actually obvious to me why we want this; it seems better to give a best-effort result.  I guess "best-effort result" in this context, though, is "everything", and that's not particularly helpful either.

This change does make it more obvious how we might insert a "hey, we couldn't find any completion results here" message for people, so they might be able to go and fix their code?

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
