### PR TITLE
Initialize enabled on first launch

### DIFF
--- a/vscode_extension/.vscode/launch.json
+++ b/vscode_extension/.vscode/launch.json
@@ -21,10 +21,10 @@
             "runtimeExecutable": "${execPath}",
             "args": [
                 "--extensionDevelopmentPath=${workspaceFolder}",
-                "--extensionTestsPath=${workspaceFolder}/out/test"
+                "--extensionTestsPath=${workspaceFolder}/out/src/test"
             ],
             "outFiles": [
-                "${workspaceFolder}/out/test/**/*.js"
+                "${workspaceFolder}/out/src/test/**/*.js"
             ],
             "preLaunchTask": "watch"
         }

--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -4,7 +4,7 @@
   "description": "Ruby IDE features, powered by Sorbet.",
   "author": "Stripe Inc.",
   "license": "Apache-2.0",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "publisher": "sorbet",
   "icon": "icon.png",
   "repository": {

--- a/vscode_extension/src/test/config.test.ts
+++ b/vscode_extension/src/test/config.test.ts
@@ -61,6 +61,8 @@ class FakeWorkspaceConfiguration implements ISorbetWorkspaceContext {
   workspaceFolders() {
     return [{ uri: { fsPath: "/fake/path/to/project" } }] as WorkspaceFolder[];
   }
+
+  initializeEnabled(_enabled: boolean): void {}
 }
 
 const fooLspConfig = new SorbetLspConfig({

--- a/vscode_extension/src/test/config.test.ts
+++ b/vscode_extension/src/test/config.test.ts
@@ -7,6 +7,7 @@ import {
   ConfigurationChangeEvent,
   Uri,
   WorkspaceFolder,
+  extensions,
 } from "vscode";
 
 import * as fs from "fs";
@@ -22,13 +23,35 @@ import {
 class FakeWorkspaceConfiguration implements ISorbetWorkspaceContext {
   public _emitter = new EventEmitter<ConfigurationChangeEvent>();
   public backingStore: Map<String, any>;
+  public defaults: Map<String, any>;
   constructor(public properties: Iterable<[String, any]> = []) {
     this.backingStore = new Map<String, any>(properties);
+
+    const defaultProperties = extensions.getExtension(
+      "sorbet.sorbet-vscode-extension",
+    )!.packageJSON.contributes.configuration.properties;
+    const defaultValues: Iterable<[String, any]> = Object.keys(
+      defaultProperties,
+    ).map((settingName) => {
+      let value = defaultProperties[settingName].default;
+
+      if (
+        defaultProperties[settingName].type === "boolean" &&
+        value === undefined
+      ) {
+        value = false;
+      }
+
+      return [settingName.replace("sorbet.", ""), value];
+    });
+    this.defaults = new Map<String, any>(defaultValues);
   }
 
   get<T>(section: string, defaultValue: T): T {
     if (this.backingStore.has(section)) {
       return this.backingStore.get(section);
+    } else if (this.defaults.has(section)) {
+      return this.defaults.get(section);
     } else {
       return defaultValue;
     }
@@ -62,7 +85,13 @@ class FakeWorkspaceConfiguration implements ISorbetWorkspaceContext {
     return [{ uri: { fsPath: "/fake/path/to/project" } }] as WorkspaceFolder[];
   }
 
-  initializeEnabled(_enabled: boolean): void {}
+  initializeEnabled(enabled: boolean): void {
+    const stateEnabled = this.backingStore.get("enabled");
+
+    if (stateEnabled === undefined) {
+      this.update("enabled", enabled);
+    }
+  }
 }
 
 const fooLspConfig = new SorbetLspConfig({
@@ -219,10 +248,10 @@ suite("SorbetExtensionConfig", async () => {
         const workspaceConfig = new FakeWorkspaceConfiguration();
         const sorbetConfig = new SorbetExtensionConfig(workspaceConfig);
         assert.equal(sorbetConfig.enabled, false, "should not be enabled");
-        assert.equal(
+        assert.deepStrictEqual(
           sorbetConfig.selectedLspConfig,
-          undefined,
-          "no selected LSP config has been defined",
+          new SorbetLspConfig(workspaceConfig.defaults.get("lspConfigs")[0]),
+          "LSP configs should have been set to first default",
         );
         assert.equal(
           sorbetConfig.activeLspConfig,
@@ -242,7 +271,7 @@ suite("SorbetExtensionConfig", async () => {
         const workspaceConfig = new FakeWorkspaceConfiguration();
         const sorbetConfig = new SorbetExtensionConfig(workspaceConfig);
 
-        assert.equal(sorbetConfig.enabled, true, "should be enabled");
+        assert.strictEqual(sorbetConfig.enabled, true, "should be enabled");
         sinon.restore();
       });
     });


### PR DESCRIPTION
### Implementation

Initialize the `enabled` value based on whether the file `sorbet/config` exists only on first launch for a workspace.

Basically, since we know that `defaultValue` in the cached configuration is always `false`, we ignore it and check all of the other possible cached configurations (workspace, workspaceFolder, etc..). If they are all `undefined` and we haven't saved anything into the workspace state yet, then this is the first launch of Sorbet on that workspace and we can initialize the value of `enabled`.

I also fixed the path for the test folder in our launch configuration, so that we can run tests from inside VS Code.

### Motivation

Based on the [docs](https://code.visualstudio.com/api/references/vscode-api#WorkspaceConfiguration) and after inspecting in the debugger, the `defaultValue` stored in the cached configuration for `enabled` will always be `false` and cannot be `undefined`.

This means that when we invoke
```typescript
this._cachedSorbetConfiguration.get(section, defaultValue);
```
The `defaultValue` is always ignored, since `get` only takes it into account if the value of the setting is `undefined`. If you add a breakpoint here and test it out, you'll see that this invocation for the `enabled` flag always returns `false` no matter what the `defaultValue` is.

This means that the work to automatically enable the extension based on the `sorbet/config` file merged in #5345 does not do anything, since `defaultValue` is ignored.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests should cover it.