### PR TITLE
[LSP] Infrastructure for the "workspace/executeCommand" request

### DIFF
--- a/main/lsp/LSPPreprocessor.cc
+++ b/main/lsp/LSPPreprocessor.cc
@@ -211,6 +211,9 @@ unique_ptr<LSPTask> LSPPreprocessor::getTaskForMessage(LSPMessage &msg) {
                                                       move(get<unique_ptr<TextDocumentPositionParams>>(rawParams)));
             case LSPMethod::TextDocumentRename:
                 return make_unique<RenameTask>(*config, id, move(get<unique_ptr<RenameParams>>(rawParams)));
+            case LSPMethod::WorkspaceExecuteCommand:
+                return make_unique<ExecuteCommandTask>(*config, id,
+                                                       move(get<unique_ptr<ExecuteCommandParams>>(rawParams)));
             default:
                 return make_unique<SorbetErrorTask>(
                     *config,

--- a/main/lsp/LSPTask.cc
+++ b/main/lsp/LSPTask.cc
@@ -101,6 +101,9 @@ ResponseMessageStatus statusForResponse(const ResponseMessage &response) {
                     // sorbet/showSymbol
                     return holds_alternative<JSONNullObject>(res) ? ResponseMessageStatus::EmptyResult
                                                                   : ResponseMessageStatus::Succeeded;
+                } else if constexpr (is_same_v<T, variant<JSONNullObject, std::unique_ptr<ExecuteCommandResponse>>>) {
+                    // workspace/executeCommand
+                    return ResponseMessageStatus::Unknown;
                 } else {
                     static_assert(always_false_v<T>, "non-exhaustive visitor!");
                 }
@@ -190,6 +193,8 @@ ConstExprStr LSPTask::methodString() const {
             return "workspace.symbol";
         case LSPMethod::TextDocumentImplementation:
             return "textDocument.implementation";
+        case LSPMethod::WorkspaceExecuteCommand:
+            return "workspace.executeCommand";
     }
 }
 

--- a/main/lsp/requests/command.cc
+++ b/main/lsp/requests/command.cc
@@ -1,0 +1,20 @@
+#include "main/lsp/requests/command.h"
+#include "main/lsp/json_types.h"
+
+using namespace std;
+
+namespace sorbet::realmain::lsp {
+ExecuteCommandTask::ExecuteCommandTask(const LSPConfiguration &config, MessageId id,
+                                       unique_ptr<ExecuteCommandParams> params)
+
+    : LSPRequestTask(config, move(id), LSPMethod::WorkspaceExecuteCommand), params(move(params)) {}
+
+unique_ptr<ResponseMessage> ExecuteCommandTask::runRequest(LSPTypecheckerInterface &typechecker) {
+    auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::WorkspaceExecuteCommand);
+    auto result = make_unique<ExecuteCommandResponse>(JSONNullObject());
+    response->result = move(result);
+
+    return response;
+}
+
+} // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/command.h
+++ b/main/lsp/requests/command.h
@@ -1,0 +1,19 @@
+#ifndef SORBET_EXECUTE_COMMAND_H
+#define SORBET_EXECUTE_COMMAND_H
+
+#include "main/lsp/LSPTask.h"
+
+namespace sorbet::realmain::lsp {
+class ExecuteCommandParams;
+class ExecuteCommandTask final : public LSPRequestTask {
+    std::unique_ptr<ExecuteCommandParams> params;
+
+public:
+    ExecuteCommandTask(const LSPConfiguration &config, MessageId id, std::unique_ptr<ExecuteCommandParams> params);
+
+    std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerInterface &typechecker) override;
+};
+
+} // namespace sorbet::realmain::lsp
+
+#endif

--- a/main/lsp/requests/initialize.cc
+++ b/main/lsp/requests/initialize.cc
@@ -50,6 +50,9 @@ unique_ptr<ResponseMessage> InitializeTask::runRequest(LSPTypecheckerInterface &
     completionProvider->triggerCharacters = TRIGGER_CHARACTERS;
     serverCap->completionProvider = move(completionProvider);
 
+    auto commandProvider = make_unique<ExecuteCommandOptions>(vector<string>{});
+    serverCap->executeCommandProvider = move(commandProvider);
+
     response->result = make_unique<InitializeResult>(move(serverCap));
     return response;
 }

--- a/main/lsp/requests/requests.h
+++ b/main/lsp/requests/requests.h
@@ -2,6 +2,7 @@
 #define RUBY_TYPER_LSP_REQUESTS_REQUESTS_H
 
 #include "main/lsp/requests/code_action.h"
+#include "main/lsp/requests/command.h"
 #include "main/lsp/requests/completion.h"
 #include "main/lsp/requests/definition.h"
 #include "main/lsp/requests/document_formatting.h"

--- a/main/lsp/tools/make_lsp_types.cc
+++ b/main/lsp/tools/make_lsp_types.cc
@@ -61,6 +61,12 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
     shared_ptr<JSONType> JSONInt = make_shared<JSONIntType>();
     shared_ptr<JSONType> JSONDouble = make_shared<JSONDoubleType>();
     shared_ptr<JSONType> JSONString = make_shared<JSONStringType>();
+    // In the LSP specification JSONAny defined as
+    // `export type LSPAny = LSPObject | LSPArray | string | integer | uinteger | decimal | boolean | null;`
+    // https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#number
+    //
+    // We don't support LSPObject and LSPArray options yet
+    shared_ptr<JSONType> JSONAny = makeVariant({JSONNull, JSONBool, JSONInt, JSONDouble, JSONString});
 
     // Converted from https://microsoft.github.io/language-server-protocol/specification
     // Last updated on 11/14/18.
@@ -151,9 +157,10 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
 
     auto Command = makeObject("Command",
                               {
-                                  makeField("title", JSONString), makeField("command", JSONString),
+                                  makeField("title", JSONString),
+                                  makeField("command", JSONString),
                                   // Unused in Sorbet.
-                                  // makeField("arguments", makeOptional(makeArray(JSONAny))),
+                                  makeField("arguments", makeOptional(makeArray(JSONAny))),
                               },
                               classTypes);
 
@@ -779,8 +786,7 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
     auto ExecuteCommandParams = makeObject("ExecuteCommandParams",
                                            {
                                                makeField("command", JSONString),
-                                               // Unused in Sorbet.
-                                               // makeField("arguments", makeOptional(makeArray(JSONAny))),
+                                               makeField("arguments", makeOptional(makeArray(JSONAny))),
                                            },
                                            classTypes);
 
@@ -1362,6 +1368,7 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                                      "window/showMessage",
                                      "workspace/symbol",
                                      "textDocument/implementation",
+                                     "workspace/executeCommand",
                                  },
                                  enumTypes);
 
@@ -1388,7 +1395,13 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                                                 {"sorbet/error", SorbetErrorParams},
                                                 {"sorbet/readFile", TextDocumentIdentifier},
                                                 {"sorbet/showSymbol", TextDocumentPositionParams},
+                                                {"workspace/executeCommand", ExecuteCommandParams},
                                             });
+
+    auto ExecuteCommandResponse =
+        makeObject("ExecuteCommandResponse",
+                   {makeField("result", JSONAny), makeField("error", makeOptional(ResponseError))}, classTypes);
+
     auto RequestMessage =
         makeObject("RequestMessage",
                    {makeField("jsonrpc", JSONRPCConstant), makeField("id", makeVariant({JSONInt, JSONString})),
@@ -1424,6 +1437,12 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
             // Sorbet only sends CodeAction[].
             {"textDocument/codeAction", makeVariant({JSONNull, makeArray(CodeAction)})},
             // TODO: the following are more correct but I can only get the above to work.
+            //
+            // Workaround: the CodeAction interface has a command property,
+            // we can return empty list of edits and a command. In that case only the command would be executed
+            // If we would need more precise distinction between a Command and a CodeAction,
+            // we could introduce a discriminated union CodeActionOrCommand
+            //
             // {"textDocument/codeAction", makeVariant({JSONNull, makeArray(makeVariant({CodeAction, Command}))})},
             // {"textDocument/codeAction", makeVariant({JSONNull, makeArray(CodeAction), makeArray(Command)})},
             {"textDocument/implementation", makeVariant({JSONNull, makeArray(Location)})},
@@ -1431,6 +1450,7 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
             {"sorbet/error", SorbetErrorParams},
             {"sorbet/readFile", TextDocumentItem},
             {"sorbet/showSymbol", makeVariant({JSONNull, SymbolInformation})},
+            {"workspace/executeCommand", makeVariant({JSONNull, ExecuteCommandResponse})},
         });
     // N.B.: ResponseMessage.params must be optional, as it is not present when an error occurs.
     // N.B.: We add a 'requestMethod' field to response messages to make the discriminated union work.


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

The change scaffolds the infrastructure for the `workspace/executeCommand` request

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The `workspace/executeCommand` will be used in the extract method refactoring

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
