### PR TITLE
Implement hover and (stubbed) codeAction on stale state

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -770,7 +770,7 @@ std::vector<std::unique_ptr<core::Error>> LSPStaleTypechecker::retypecheck(std::
 
 LSPQueryResult LSPStaleTypechecker::query(const core::lsp::Query &q,
                                           const std::vector<core::FileRef> &filesForQuery) const {
-    auto &gs = undoState.getEvictedGs();
+    const auto &gs = undoState.getEvictedGs();
 
     // We assume gs is a copy of initialGS, which has had the inferencer & resolver run.
     ENFORCE(gs->lspTypecheckCount > 0,
@@ -800,6 +800,7 @@ const ast::ParsedFile &LSPStaleTypechecker::getIndexed(core::FileRef fref) const
 }
 
 std::vector<ast::ParsedFile> LSPStaleTypechecker::getResolved(const std::vector<core::FileRef> &frefs) const {
+    const auto &gs = *(undoState.getEvictedGs());
     vector<ast::ParsedFile> updatedIndexed;
 
     for (auto fref : frefs) {
@@ -808,7 +809,8 @@ std::vector<ast::ParsedFile> LSPStaleTypechecker::getResolved(const std::vector<
             updatedIndexed.emplace_back(ast::ParsedFile{indexed.tree.deepCopy(), indexed.file});
         }
     }
-    return pipeline::incrementalResolve(*(undoState.getEvictedGs()), move(updatedIndexed), config->opts);
+
+    return pipeline::incrementalResolveWithoutStateMutation(gs, move(updatedIndexed), config->opts);
 }
 
 const core::GlobalState &LSPStaleTypechecker::state() const {

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -746,6 +746,9 @@ const core::GlobalState &LSPTypecheckerDelegate::state() const {
     return typechecker.state();
 }
 
+LSPStaleTypechecker::LSPStaleTypechecker(std::shared_ptr<const LSPConfiguration> config, UndoState &undoState)
+    : config(config), undoState(undoState), emptyWorkers(WorkerPool::create(0, undoState.getEvictedGs()->tracer())) {}
+
 void LSPStaleTypechecker::initialize(InitializedTask &task, std::unique_ptr<core::GlobalState> initialGS,
                                      std::unique_ptr<KeyValueStore> kvstore) {
     ENFORCE(false, "initialize not supported");
@@ -767,22 +770,49 @@ std::vector<std::unique_ptr<core::Error>> LSPStaleTypechecker::retypecheck(std::
 
 LSPQueryResult LSPStaleTypechecker::query(const core::lsp::Query &q,
                                           const std::vector<core::FileRef> &filesForQuery) const {
-    ENFORCE(false, "query not implemented");
-    return LSPQueryResult();
+    auto &gs = undoState.getEvictedGs();
+
+    // We assume gs is a copy of initialGS, which has had the inferencer & resolver run.
+    ENFORCE(gs->lspTypecheckCount > 0,
+            "Tried to run a query with a GlobalState object that never had inferencer and resolver runs.");
+
+    // Replace error queue with one that is owned by this thread.
+    auto queryCollector = make_shared<QueryCollector>();
+    gs->errorQueue = make_shared<core::ErrorQueue>(gs->errorQueue->logger, gs->errorQueue->tracer, queryCollector);
+
+    Timer timeit(config->logger, "query");
+    prodCategoryCounterInc("lsp.updates", "query");
+    ENFORCE(gs->errorQueue->isEmpty());
+    ENFORCE(gs->lspQuery.isEmpty());
+    gs->lspQuery = q;
+    auto resolved = getResolved(filesForQuery);
+    tryApplyDefLocSaver(*gs, resolved);
+    tryApplyLocalVarSaver(*gs, resolved);
+
+    pipeline::typecheck(gs, move(resolved), config->opts, *emptyWorkers, /*presorted*/ true);
+    gs->lspTypecheckCount++;
+    gs->lspQuery = core::lsp::Query::noQuery();
+    return LSPQueryResult{queryCollector->drainQueryResponses(), nullptr};
 }
 
 const ast::ParsedFile &LSPStaleTypechecker::getIndexed(core::FileRef fref) const {
-    ENFORCE(false, "getIndexed not implemented");
-    return *pf;
+    return undoState.getIndexed(fref);
 }
 
 std::vector<ast::ParsedFile> LSPStaleTypechecker::getResolved(const std::vector<core::FileRef> &frefs) const {
-    ENFORCE(false, "getResolved not implemented");
-    return {};
+    vector<ast::ParsedFile> updatedIndexed;
+
+    for (auto fref : frefs) {
+        auto &indexed = getIndexed(fref);
+        if (indexed.tree) {
+            updatedIndexed.emplace_back(ast::ParsedFile{indexed.tree.deepCopy(), indexed.file});
+        }
+    }
+    return pipeline::incrementalResolve(*(undoState.getEvictedGs()), move(updatedIndexed), config->opts);
 }
 
 const core::GlobalState &LSPStaleTypechecker::state() const {
-    return undoState.getEvictedGs();
+    return *(undoState.getEvictedGs());
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -210,13 +210,14 @@ public:
 };
 
 class LSPStaleTypechecker final : public LSPTypecheckerInterface {
+    std::shared_ptr<const LSPConfiguration> config;
     UndoState &undoState;
-
-    // Just so we have something to return from the stubbed functions after we ENFORCE(false)
-    ast::ParsedFile *pf;
+    // Using an WorkerPool with size 0 for all typechecker operations causes the work to run on the
+    // current thread (usually: the indexer thread).
+    std::unique_ptr<WorkerPool> emptyWorkers;
 
 public:
-    LSPStaleTypechecker(UndoState &undoState) : undoState(undoState), pf(nullptr) {}
+    LSPStaleTypechecker(std::shared_ptr<const LSPConfiguration> config, UndoState &undoState);
 
     // Delete copy constructor / assignment.
     LSPStaleTypechecker(LSPStaleTypechecker &) = delete;

--- a/main/lsp/LSPTypecheckerCoordinator.cc
+++ b/main/lsp/LSPTypecheckerCoordinator.cc
@@ -139,8 +139,9 @@ void LSPTypecheckerCoordinator::syncRun(unique_ptr<LSPTask> task) {
 }
 
 unique_ptr<LSPTask> LSPTypecheckerCoordinator::syncRunOnStaleState(unique_ptr<LSPTask> task) {
-    bool success = typechecker.tryRunOnStaleState([&task](UndoState &undoState) {
-        LSPStaleTypechecker typechecker(undoState);
+    auto config = this->config;
+    bool success = typechecker.tryRunOnStaleState([&task, &config](UndoState &undoState) {
+        LSPStaleTypechecker typechecker(config, undoState);
         task->run(typechecker);
     });
 

--- a/main/lsp/UndoState.cc
+++ b/main/lsp/UndoState.cc
@@ -33,8 +33,19 @@ void UndoState::restore(unique_ptr<core::GlobalState> &gs, vector<ast::ParsedFil
     gs = move(evictedGs);
 }
 
-const core::GlobalState &UndoState::getEvictedGs() const {
-    return *evictedGs;
+const std::unique_ptr<core::GlobalState> &UndoState::getEvictedGs() {
+    return evictedGs;
+}
+
+const ast::ParsedFile &UndoState::getIndexed(core::FileRef fref) const {
+    const auto id = fref.id();
+
+    auto treeEvictedIndexed = evictedIndexed.find(id);
+    if (treeEvictedIndexed != evictedIndexed.end()) {
+        return treeEvictedIndexed->second;
+    }
+
+    return dummyParsedFile;
 }
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/UndoState.h
+++ b/main/lsp/UndoState.h
@@ -19,6 +19,9 @@ class UndoState final {
     // Stores the index trees stored in `gs` that were evicted because the slow path operation replaced `gs`.
     UnorderedMap<int, ast::ParsedFile> evictedIndexedFinalGS;
 
+    // Dummy ParsedFile that we return when the file requested by getIndexed is not available.
+    ast::ParsedFile dummyParsedFile{nullptr, core::FileRef()};
+
 public:
     // Epoch of the running slow path
     const uint32_t epoch;
@@ -40,7 +43,12 @@ public:
     /**
      * Retrieves the evicted global state.
      */
-    const core::GlobalState &getEvictedGs() const;
+    const std::unique_ptr<core::GlobalState> &getEvictedGs();
+
+    /**
+     * Returns the indexed file
+     */
+    const ast::ParsedFile &getIndexed(core::FileRef fref) const;
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/code_action.cc
+++ b/main/lsp/requests/code_action.cc
@@ -50,6 +50,10 @@ unique_ptr<ResponseMessage> CodeActionTask::runRequest(LSPTypecheckerInterface &
 
     vector<unique_ptr<CodeAction>> result;
 
+    // TODO: In stale-state mode, we're returning an empty result here. The reason is that `hover` requests in vscode
+    // seem typically to be preceded by a `codeAction` request, and if we let that into the queue ahead of the `hover`
+    // request it would block otherwise; so we just stub out the result from `codeAction` for now. Eventually we will
+    // want to have proper support for this.
     if (typechecker.isStale()) {
         config.logger->debug("CodeActionTask running on stale, returning empty result");
         response->result = move(result);

--- a/main/lsp/wrapper.cc
+++ b/main/lsp/wrapper.cc
@@ -44,6 +44,10 @@ createGlobalStateAndOtherObjects(string_view rootPath, options::Options &options
     typeErrorsConsoleOut->set_pattern("%v");
     auto gs = make_unique<core::GlobalState>(make_shared<core::ErrorQueue>(*typeErrorsConsoleOut, *loggerOut));
 
+    if (options.sleepInSlowPath) {
+        gs->sleepInSlowPath = true;
+    }
+
     unique_ptr<const OwnedKeyValueStore> kvstore = cache::maybeCreateKeyValueStore(options);
     payload::createInitialGlobalState(gs, options, kvstore);
     setRequiredLSPOptions(*gs, options);

--- a/main/lsp/wrapper.cc
+++ b/main/lsp/wrapper.cc
@@ -44,10 +44,6 @@ createGlobalStateAndOtherObjects(string_view rootPath, options::Options &options
     typeErrorsConsoleOut->set_pattern("%v");
     auto gs = make_unique<core::GlobalState>(make_shared<core::ErrorQueue>(*typeErrorsConsoleOut, *loggerOut));
 
-    if (options.sleepInSlowPath) {
-        gs->sleepInSlowPath = true;
-    }
-
     unique_ptr<const OwnedKeyValueStore> kvstore = cache::maybeCreateKeyValueStore(options);
     payload::createInitialGlobalState(gs, options, kvstore);
     setRequiredLSPOptions(*gs, options);

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -30,6 +30,10 @@ ast::ParsedFilesOrCancelled resolve(std::unique_ptr<core::GlobalState> &gs, std:
 std::vector<ast::ParsedFile> incrementalResolve(core::GlobalState &gs, std::vector<ast::ParsedFile> what,
                                                 const options::Options &opts);
 
+std::vector<ast::ParsedFile> incrementalResolveWithoutStateMutation(const core::GlobalState &gs,
+                                                                    std::vector<ast::ParsedFile> what,
+                                                                    const options::Options &opts);
+
 ast::ParsedFilesOrCancelled name(core::GlobalState &gs, std::vector<ast::ParsedFile> what, const options::Options &opts,
                                  WorkerPool &workers);
 

--- a/test/lsp/ProtocolTest.cc
+++ b/test/lsp/ProtocolTest.cc
@@ -19,11 +19,13 @@ bool isTypecheckRun(const LSPMessage &msg) {
 }
 } // namespace
 
-void ProtocolTest::resetState() {
+void ProtocolTest::resetState(std::shared_ptr<realmain::options::Options> opts) {
     fs = make_shared<MockFileSystem>(rootPath);
     diagnostics.clear();
     sourceFileContents.clear();
-    auto opts = make_shared<realmain::options::Options>();
+    if (opts == nullptr) {
+        opts = make_shared<realmain::options::Options>();
+    }
     opts->disableWatchman = true;
     if (useCache) {
         // Only recreate the cacheDir if we haven't created one before.

--- a/test/lsp/ProtocolTest.h
+++ b/test/lsp/ProtocolTest.h
@@ -47,7 +47,7 @@ protected:
     ~ProtocolTest();
 
     /** Reset lspWrapper and other internal state. */
-    void resetState();
+    void resetState(std::shared_ptr<sorbet::realmain::options::Options> opts = nullptr);
 
     /** Get an absolute file URI for the given relative file path. */
     std::string getUri(std::string_view filePath);

--- a/test/lsp/multithreaded_protocol_test_corpus.cc
+++ b/test/lsp/multithreaded_protocol_test_corpus.cc
@@ -760,7 +760,8 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "HoverReturnsStaleInfoOneFile") {
     sendAsync(*changeFile("foo.rb",
                           "# typed: true\nclass Foo\nextend T::Sig\nsig{returns(Integer)}\ndef bar\n1\nend\nend", 2));
 
-    // Wait for typechecking to begin.
+    // Set slow-path blocking, and wait for typechecking to begin.
+    setSlowPathBlocked(true);
     {
         auto status = getTypecheckRunStatus(*readAsync());
         REQUIRE(status.has_value());
@@ -779,7 +780,8 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "HoverReturnsStaleInfoOneFile") {
         CHECK(absl::StrContains(hoverText->contents->value, "note: information may be stale"));
     }
 
-    // Wait for typechecking to finish.
+    // Unblock slow-path, and wait for typechecking to finish.
+    setSlowPathBlocked(false);
     {
         auto status = getTypecheckRunStatus(*readAsync());
         REQUIRE(status.has_value());
@@ -850,7 +852,8 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "HoverReturnsStaleInfoTwoFiles") {
     sendAsync(*changeFile("foo.rb",
                           "# typed: true\nclass Foo\nextend T::Sig\nsig{returns(Integer)}\ndef bar\n1\nend\nend", 2));
 
-    // Wait for typechecking to begin.
+    // Set slow-path blocking, and wait for typechecking to begin.
+    setSlowPathBlocked(true);
     {
         auto status = getTypecheckRunStatus(*readAsync());
         REQUIRE(status.has_value());
@@ -884,7 +887,8 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "HoverReturnsStaleInfoTwoFiles") {
         REQUIRE(holds_alternative<JSONNullObject>(*hoverResult));
     }
 
-    // Wait for typechecking to finish.
+    // Unblock slow-path, and wait for typechecking to finish.
+    setSlowPathBlocked(false);
     {
         auto status = getTypecheckRunStatus(*readAsync());
         REQUIRE(status.has_value());

--- a/test/lsp/multithreaded_protocol_test_corpus.cc
+++ b/test/lsp/multithreaded_protocol_test_corpus.cc
@@ -729,10 +729,9 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "StallInSlowPathWorks") {
 }
 
 TEST_CASE_FIXTURE(MultithreadedProtocolTest, "HoverReturnsStaleInfoOneFile") {
-    // Reset the options to enable stale state and sleep-in-slow-path.
+    // Reset the options to enable stale state.
     auto opts = make_shared<realmain::options::Options>();
     opts->lspStaleStateEnabled = true;
-    opts->sleepInSlowPath = true;
     resetState(opts);
 
     auto initOptions = make_unique<SorbetInitializationOptions>();
@@ -804,10 +803,9 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "HoverReturnsStaleInfoOneFile") {
 }
 
 TEST_CASE_FIXTURE(MultithreadedProtocolTest, "HoverReturnsStaleInfoTwoFiles") {
-    // Reset the options to enable stale state and sleep-in-slow-path.
+    // Reset the options to enable stale state.
     auto opts = make_shared<realmain::options::Options>();
     opts->lspStaleStateEnabled = true;
-    opts->sleepInSlowPath = true;
     resetState(opts);
 
     auto initOptions = make_unique<SorbetInitializationOptions>();

--- a/test/lsp/multithreaded_protocol_test_corpus.cc
+++ b/test/lsp/multithreaded_protocol_test_corpus.cc
@@ -728,4 +728,197 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "StallInSlowPathWorks") {
     }
 }
 
+TEST_CASE_FIXTURE(MultithreadedProtocolTest, "HoverReturnsStaleInfoOneFile") {
+    // Reset the options to enable stale state and sleep-in-slow-path.
+    auto opts = make_shared<realmain::options::Options>();
+    opts->lspStaleStateEnabled = true;
+    opts->sleepInSlowPath = true;
+    resetState(opts);
+
+    auto initOptions = make_unique<SorbetInitializationOptions>();
+    initOptions->enableTypecheckInfo = true;
+    assertDiagnostics(initializeLSP(true /* supportsMarkdown */, move(initOptions)), {});
+
+    // Set initial file contents for foo.rb.
+    assertDiagnostics(
+        send(*openFile("foo.rb",
+                       "# typed: true\nclass Foo\nextend T::Sig\nsig{returns(Integer)}\ndef foo\n1\nend\nend")),
+        {});
+
+    // Send a hover.
+    sendAsync(*hover("foo.rb", 4, 4));
+
+    // First response should be hover, and we do not expect the information to be stale.
+    {
+        auto response = readAsync();
+        REQUIRE(response->isResponse());
+        auto &hoverText =
+            get<unique_ptr<Hover>>(get<variant<JSONNullObject, unique_ptr<Hover>>>(*response->asResponse().result));
+        CHECK(!absl::StrContains(hoverText->contents->value, "note: information may be stale"));
+    }
+
+    // Make an edit, renaming Foo::foo to Foo::bar.
+    sendAsync(*changeFile("foo.rb",
+                          "# typed: true\nclass Foo\nextend T::Sig\nsig{returns(Integer)}\ndef bar\n1\nend\nend", 2));
+
+    // Wait for typechecking to begin.
+    {
+        auto status = getTypecheckRunStatus(*readAsync());
+        REQUIRE(status.has_value());
+        REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Started);
+    }
+
+    // Send a hover.
+    sendAsync(*hover("foo.rb", 4, 4));
+
+    // First response should be hover, and we do expect the information to be stale.
+    {
+        auto response = readAsync();
+        REQUIRE(response->isResponse());
+        auto &hoverText =
+            get<unique_ptr<Hover>>(get<variant<JSONNullObject, unique_ptr<Hover>>>(*response->asResponse().result));
+        CHECK(absl::StrContains(hoverText->contents->value, "note: information may be stale"));
+    }
+
+    // Wait for typechecking to finish.
+    {
+        auto status = getTypecheckRunStatus(*readAsync());
+        REQUIRE(status.has_value());
+        REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Ended);
+    }
+
+    // Send a hover.
+    sendAsync(*hover("foo.rb", 4, 4));
+
+    // First response should be hover, and we do not expect the information to be stale.
+    {
+        auto response = readAsync();
+        REQUIRE(response->isResponse());
+        auto &hoverText =
+            get<unique_ptr<Hover>>(get<variant<JSONNullObject, unique_ptr<Hover>>>(*response->asResponse().result));
+        CHECK(!absl::StrContains(hoverText->contents->value, "note: information may be stale"));
+    }
+
+    // Send a no-op to clear out the pipeline.
+    assertDiagnostics(send(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::SorbetFence, 20))), {});
+}
+
+TEST_CASE_FIXTURE(MultithreadedProtocolTest, "HoverReturnsStaleInfoTwoFiles") {
+    // Reset the options to enable stale state and sleep-in-slow-path.
+    auto opts = make_shared<realmain::options::Options>();
+    opts->lspStaleStateEnabled = true;
+    opts->sleepInSlowPath = true;
+    resetState(opts);
+
+    auto initOptions = make_unique<SorbetInitializationOptions>();
+    initOptions->enableTypecheckInfo = true;
+    assertDiagnostics(initializeLSP(true /* supportsMarkdown */, move(initOptions)), {});
+
+    // Set initial file contents for foo.rb and bar.rb.
+    assertDiagnostics(
+        send(*openFile("foo.rb",
+                       "# typed: true\nclass Foo\nextend T::Sig\nsig{returns(Integer)}\ndef foo\n1\nend\nend")),
+        {});
+    assertDiagnostics(
+        send(*openFile("bar.rb",
+                       "# typed: true\nclass Bar\nextend T::Sig\nsig{returns(Integer)}\ndef bar\n1\nend\nend")),
+        {});
+
+    // Send a hover in foo.rb.
+    sendAsync(*hover("foo.rb", 4, 4));
+
+    // First response should be hover, and we do not expect the information to be stale.
+    {
+        auto response = readAsync();
+        REQUIRE(response->isResponse());
+        auto &hoverText =
+            get<unique_ptr<Hover>>(get<variant<JSONNullObject, unique_ptr<Hover>>>(*response->asResponse().result));
+        CHECK(!absl::StrContains(hoverText->contents->value, "note: information may be stale"));
+    }
+
+    // Send a hover in bar.rb.
+    sendAsync(*hover("bar.rb", 4, 4));
+
+    // First response should be hover, and we do not expect the information to be stale.
+    {
+        auto response = readAsync();
+        REQUIRE(response->isResponse());
+        auto &hoverText =
+            get<unique_ptr<Hover>>(get<variant<JSONNullObject, unique_ptr<Hover>>>(*response->asResponse().result));
+        CHECK(!absl::StrContains(hoverText->contents->value, "note: information may be stale"));
+    }
+
+    // Make an edit, renaming Foo::foo to Foo::bar.
+    sendAsync(*changeFile("foo.rb",
+                          "# typed: true\nclass Foo\nextend T::Sig\nsig{returns(Integer)}\ndef bar\n1\nend\nend", 2));
+
+    // Wait for typechecking to begin.
+    {
+        auto status = getTypecheckRunStatus(*readAsync());
+        REQUIRE(status.has_value());
+        REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Started);
+    }
+
+    // Send a hover to foo.rb.
+    sendAsync(*hover("foo.rb", 4, 4));
+
+    // First response should be hover, and we do expect the information to be stale.
+    {
+        auto response = readAsync();
+        REQUIRE(response->isResponse());
+        auto &hoverText =
+            get<unique_ptr<Hover>>(get<variant<JSONNullObject, unique_ptr<Hover>>>(*response->asResponse().result));
+        CHECK(absl::StrContains(hoverText->contents->value, "note: information may be stale"));
+    }
+
+    // Send a hover to bar.rb.
+    sendAsync(*hover("bar.rb", 4, 4));
+
+    // We expect a null response from our hover on bar.rb. (NOTE: This is not ideal behavior, just what's expected with
+    // the current partial implementation.)
+    {
+        auto response = readAsync();
+        REQUIRE(response->isResponse());
+
+        auto hoverResult = get_if<variant<JSONNullObject, unique_ptr<Hover>>>(&(*response->asResponse().result));
+        REQUIRE(hoverResult != nullptr);
+
+        REQUIRE(holds_alternative<JSONNullObject>(*hoverResult));
+    }
+
+    // Wait for typechecking to finish.
+    {
+        auto status = getTypecheckRunStatus(*readAsync());
+        REQUIRE(status.has_value());
+        REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Ended);
+    }
+
+    // Send a hover to foo.rb.
+    sendAsync(*hover("foo.rb", 4, 4));
+
+    // First response should be hover, and we do not expect the information to be stale.
+    {
+        auto response = readAsync();
+        REQUIRE(response->isResponse());
+        auto &hoverText =
+            get<unique_ptr<Hover>>(get<variant<JSONNullObject, unique_ptr<Hover>>>(*response->asResponse().result));
+        CHECK(!absl::StrContains(hoverText->contents->value, "note: information may be stale"));
+    }
+
+    // Send a hover to bar.rb.
+    sendAsync(*hover("bar.rb", 4, 4));
+
+    // First response should be hover, and we do not expect the information to be stale.
+    {
+        auto response = readAsync();
+        REQUIRE(response->isResponse());
+        auto &hoverText =
+            get<unique_ptr<Hover>>(get<variant<JSONNullObject, unique_ptr<Hover>>>(*response->asResponse().result));
+        CHECK(!absl::StrContains(hoverText->contents->value, "note: information may be stale"));
+    }
+
+    // Send a no-op to clear out the pipeline.
+    assertDiagnostics(send(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::SorbetFence, 20))), {});
+}
+
 } // namespace sorbet::test::lsp


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
This implements a (beta, or let's even call it alpha) feature that allows `hover` queries to proceed even when slow-path typechecking is in progress. You have to opt into the feature with `--enable-experimental-lsp-stale-state`.


### Test plan
See included automated tests.