### PR TITLE
Add nameBestEffortConst function

### DIFF
--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -685,6 +685,14 @@ vector<ast::ParsedFile> package(core::GlobalState &gs, vector<ast::ParsedFile> w
     return what;
 }
 
+ast::ParsedFilesOrCancelled nameBestEffortConst(const core::GlobalState &gs, vector<ast::ParsedFile> what,
+                                                const options::Options &opts, WorkerPool &workers) {
+    Timer timeit(gs.tracer(), "nameBestEffortConst");
+    auto result = namer::Namer::symbolizeTreesBestEffort(gs, move(what), workers);
+
+    return result;
+}
+
 ast::ParsedFilesOrCancelled name(core::GlobalState &gs, vector<ast::ParsedFile> what, const options::Options &opts,
                                  WorkerPool &workers) {
     Timer timeit(gs.tracer(), "name");

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -33,6 +33,9 @@ std::vector<ast::ParsedFile> incrementalResolve(core::GlobalState &gs, std::vect
 ast::ParsedFilesOrCancelled name(core::GlobalState &gs, std::vector<ast::ParsedFile> what, const options::Options &opts,
                                  WorkerPool &workers);
 
+ast::ParsedFilesOrCancelled nameBestEffortConst(const core::GlobalState &gs, std::vector<ast::ParsedFile> what,
+                                                const options::Options &opts, WorkerPool &workers);
+
 // Note: `cancelable` and `preemption task manager` are only applicable to LSP.
 // If `intentionallyLeakASTs` is `true`, typecheck will leak the ASTs rather than pay the cost of deleting them
 // properly, which is a significant speedup on large codebases.

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1959,6 +1959,24 @@ vector<ast::ParsedFile> symbolizeTrees(const core::GlobalState &gs, vector<ast::
 
 } // namespace
 
+// Designed to be "run as much of namer as is possible with a const GlobalState".
+//
+// The whole point of `defineSymbols` is to mutate GlobalState, so it clearly makes no sense to run.
+// And the whole point of `findSymbols` is to create the FoundDefinition vector that feeds into
+// defineSymbols, so that becomes not useful to run either.
+//
+// That leaves just symbolizeTrees.
+//
+// The "best effort" indicates that this is currently only used for the sake of serving LSP requests
+// with a potentially-stale GlobalState.
+ast::ParsedFilesOrCancelled Namer::symbolizeTreesBestEffort(const core::GlobalState &gs, vector<ast::ParsedFile> trees,
+                                                            WorkerPool &workers) {
+    // At the moment, we don't actually have to do anything more than symbolizeTrees.
+    // But symbolizeTrees is a "private" API, so we expose it in a function with a different name to
+    // make the interface clear.
+    return symbolizeTrees(gs, move(trees), workers);
+}
+
 ast::ParsedFilesOrCancelled Namer::run(core::GlobalState &gs, vector<ast::ParsedFile> trees, WorkerPool &workers) {
     auto foundDefs = findSymbols(gs, move(trees), workers);
     if (gs.epochManager->wasTypecheckingCanceled()) {

--- a/namer/namer.h
+++ b/namer/namer.h
@@ -11,6 +11,8 @@ namespace sorbet::namer {
 
 class Namer final {
 public:
+    static ast::ParsedFilesOrCancelled
+    symbolizeTreesBestEffort(const core::GlobalState &gs, std::vector<ast::ParsedFile> trees, WorkerPool &workers);
     static ast::ParsedFilesOrCancelled run(core::GlobalState &gs, std::vector<ast::ParsedFile> trees,
                                            WorkerPool &workers);
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -22,6 +22,7 @@ cc_binary(
         "//main/autogen",
         "//main/lsp",
         "//main/minimize",
+        "//main/pipeline",
         "//main/pipeline/semantic_extension:none",
         "//namer",
         "//packager",


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Alternative to #5470 that doesn't mess around with `Stub*` symbols.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Added a mode to run testdata test in a mode where we just assert that there are
no `ENFORCE` failures from running `nameBestEffortConst` on trees with an
otherwise empty GlobalState.