### PR TITLE
do less copying for `LSPStdout::rawWrite`

### DIFF
--- a/main/lsp/LSPMessage.cc
+++ b/main/lsp/LSPMessage.cc
@@ -222,4 +222,16 @@ string LSPMessage::toJSON(bool prettyPrint) const {
         Exception::raise("LSPMessage is not a request, notification, or a response.");
     }
 }
+
+rapidjson::StringBuffer LSPMessage::toJSONBuffer(bool prettyPrint) const {
+    if (isRequest()) {
+        return asRequest().toJSONBuffer(prettyPrint);
+    } else if (isNotification()) {
+        return asNotification().toJSONBuffer(prettyPrint);
+    } else if (isResponse()) {
+        return asResponse().toJSONBuffer(prettyPrint);
+    } else {
+        Exception::raise("LSPMessage is not a request, notification, or a response.");
+    }
+}
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/LSPMessage.cc
+++ b/main/lsp/LSPMessage.cc
@@ -212,15 +212,8 @@ LSPMethod LSPMessage::method() const {
 }
 
 string LSPMessage::toJSON(bool prettyPrint) const {
-    if (isRequest()) {
-        return asRequest().toJSON(prettyPrint);
-    } else if (isNotification()) {
-        return asNotification().toJSON(prettyPrint);
-    } else if (isResponse()) {
-        return asResponse().toJSON(prettyPrint);
-    } else {
-        Exception::raise("LSPMessage is not a request, notification, or a response.");
-    }
+    auto buffer = this->toJSONBuffer(prettyPrint);
+    return string(buffer.GetString(), buffer.GetLength());
 }
 
 rapidjson::StringBuffer LSPMessage::toJSONBuffer(bool prettyPrint) const {

--- a/main/lsp/LSPMessage.h
+++ b/main/lsp/LSPMessage.h
@@ -5,6 +5,7 @@
 #include "common/common.h"
 #include "main/lsp/json_enums.h"
 #include "rapidjson/document.h"
+#include "rapidjson/stringbuffer.h"
 #include <variant>
 
 namespace sorbet::realmain::lsp {
@@ -131,6 +132,8 @@ public:
      * Returns the message in JSON form.
      */
     std::string toJSON(bool prettyPrint = false) const;
+
+    rapidjson::StringBuffer toJSONBuffer(bool prettyPrint = false) const;
 };
 } // namespace sorbet::realmain::lsp
 

--- a/main/lsp/LSPOutput.cc
+++ b/main/lsp/LSPOutput.cc
@@ -51,10 +51,13 @@ void LSPOutput::write(unique_ptr<NotificationMessage> msg) {
 LSPStdout::LSPStdout(shared_ptr<spdlog::logger> &logger) : logger(logger) {}
 
 void LSPStdout::rawWrite(unique_ptr<LSPMessage> msg) {
-    auto json = msg->toJSON();
-    string outResult = fmt::format("Content-Length: {}\r\n\r\n{}", json.length(), json);
-    logger->debug("Write: {}\n", json);
-    cout << outResult << flush;
+    auto buffer = msg->toJSONBuffer();
+    auto length = buffer.GetLength();
+    auto view = string_view(buffer.GetString(), length);
+
+    string header = fmt::format("Content-Length: {}\r\n\r\n", length);
+    logger->debug("Write: {}\n", view);
+    cout << header << view << flush;
 }
 
 void LSPOutputToVector::rawWrite(unique_ptr<LSPMessage> msg) {

--- a/main/lsp/json_types.cc
+++ b/main/lsp/json_types.cc
@@ -81,9 +81,14 @@ InvalidTypeError::InvalidTypeError(string_view fieldName, string_view expectedTy
 const std::string JSONBaseType::defaultFieldName = "root";
 
 string JSONBaseType::toJSON(bool prettyPrint) const {
+    auto buffer = toJSONBuffer(prettyPrint);
+    return string(buffer.GetString(), buffer.GetLength());
+}
+
+rapidjson::StringBuffer JSONBaseType::toJSONBuffer(bool prettyPrint) const {
+    rapidjson::StringBuffer buffer;
     rapidjson::MemoryPoolAllocator<> alloc;
     auto v = toJSONValue(alloc);
-    rapidjson::StringBuffer buffer;
     if (!prettyPrint) {
         rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
         v->Accept(writer);
@@ -91,7 +96,7 @@ string JSONBaseType::toJSON(bool prettyPrint) const {
         rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(buffer);
         v->Accept(writer);
     }
-    return string(buffer.GetString(), buffer.GetLength());
+    return buffer;
 }
 
 // Object-specific helpers

--- a/main/lsp/json_types.cc
+++ b/main/lsp/json_types.cc
@@ -14,7 +14,7 @@ string stringify(const rapidjson::Value &value) {
     rapidjson::StringBuffer buffer;
     rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
     value.Accept(writer);
-    return buffer.GetString();
+    return string(buffer.GetString(), buffer.GetLength());
 }
 
 DeserializationError::DeserializationError(string_view message)
@@ -91,7 +91,7 @@ string JSONBaseType::toJSON(bool prettyPrint) const {
         rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(buffer);
         v->Accept(writer);
     }
-    return buffer.GetString();
+    return string(buffer.GetString(), buffer.GetLength());
 }
 
 // Object-specific helpers

--- a/main/lsp/json_types.h
+++ b/main/lsp/json_types.h
@@ -6,6 +6,7 @@
 #include "core/core.h"
 #include "main/lsp/json_enums.h"
 #include "rapidjson/document.h"
+#include "rapidjson/stringbuffer.h"
 
 #include <optional>
 #include <variant>
@@ -97,6 +98,8 @@ public:
      * Converts C++ object into a string containing a stringified JSON object.
      */
     std::string toJSON(bool prettyPrint = false) const;
+
+    rapidjson::StringBuffer toJSONBuffer(bool prettyPrint = false) const;
 
     /**
      * Converts C++ object into a RapidJSON JSON value owned by the given rapidjson allocator.


### PR DESCRIPTION
Building up JSON for LSP messages has a few problems when it comes to `LSPStdout::rawWrite` and `JSONBaseType::toJSON`:

* `JSONBaseType::toJSON` has enough information in the buffer it's building so that `std::string::string` doesn't have to call `strlen` to find the length of the string.
* Also in `toJSON`, we copy the entirety of the `StringBuffer` to convert it to a string, when nothing really needs the JSON as a `string`.
* Once we've converted it to a `string`, we copy *again* in `rawWrite` to format it into a string for output.  This step is really unnecessary, as we can just write the string to `cout` separately from the header.  Note that `rawWrite` is called under a lock, so there are no concerns about sending things as a single `write` call or similar; we'll be guaranteed to have completed all the `write` calls that we need before another thread gets a chance to write a message here.

We can fix the first thing fairly easily by calling `string`'s constructor directly.  We can fix the rest of the issues by adding a separate interface to directly build a `StringBuffer`, and then use that to construct `string_view`s for the actual output.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Looking for microseconds in the couch cushions.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
