### PR TITLE
DefinitionResponse to MethodDefResponse

### DIFF
--- a/core/lsp/QueryResponse.cc
+++ b/core/lsp/QueryResponse.cc
@@ -37,7 +37,7 @@ const FieldResponse *QueryResponse::isField() const {
     return get_if<FieldResponse>(&response);
 }
 
-const MethodDefResponse *QueryResponse::isDefinition() const {
+const MethodDefResponse *QueryResponse::isMethodDef() const {
     return get_if<MethodDefResponse>(&response);
 }
 
@@ -56,7 +56,7 @@ core::Loc QueryResponse::getLoc() const {
         return constant->termLoc;
     } else if (auto field = isField()) {
         return field->termLoc;
-    } else if (auto def = isDefinition()) {
+    } else if (auto def = isMethodDef()) {
         return def->termLoc;
     } else if (auto edit = isEdit()) {
         return edit->loc;
@@ -76,7 +76,7 @@ core::TypePtr QueryResponse::getRetType() const {
         return constant->retType.type;
     } else if (auto field = isField()) {
         return field->retType.type;
-    } else if (auto def = isDefinition()) {
+    } else if (auto def = isMethodDef()) {
         return def->retType.type;
     } else {
         // Should never happen, as the above checks should be exhaustive.
@@ -93,7 +93,7 @@ const core::TypeAndOrigins &QueryResponse::getTypeAndOrigins() const {
         return constant->retType;
     } else if (auto field = isField()) {
         return field->retType;
-    } else if (auto def = isDefinition()) {
+    } else if (auto def = isMethodDef()) {
         return def->retType;
     } else {
         Exception::raise("QueryResponse is of type that does not have TypeAndOrigins.");

--- a/core/lsp/QueryResponse.cc
+++ b/core/lsp/QueryResponse.cc
@@ -37,8 +37,8 @@ const FieldResponse *QueryResponse::isField() const {
     return get_if<FieldResponse>(&response);
 }
 
-const DefinitionResponse *QueryResponse::isDefinition() const {
-    return get_if<DefinitionResponse>(&response);
+const MethodDefResponse *QueryResponse::isDefinition() const {
+    return get_if<MethodDefResponse>(&response);
 }
 
 const EditResponse *QueryResponse::isEdit() const {

--- a/core/lsp/QueryResponse.h
+++ b/core/lsp/QueryResponse.h
@@ -86,9 +86,9 @@ CheckSize(FieldResponse, 64, 8);
 
 class DefinitionResponse final {
 public:
-    DefinitionResponse(core::SymbolRef symbol, core::Loc termLoc, core::NameRef name, core::TypeAndOrigins retType)
+    DefinitionResponse(core::MethodRef symbol, core::Loc termLoc, core::NameRef name, core::TypeAndOrigins retType)
         : symbol(symbol), termLoc(termLoc), name(name), retType(std::move(retType)){};
-    const core::SymbolRef symbol;
+    const core::MethodRef symbol;
     const core::Loc termLoc;
     const core::NameRef name;
     const core::TypeAndOrigins retType;

--- a/core/lsp/QueryResponse.h
+++ b/core/lsp/QueryResponse.h
@@ -84,16 +84,16 @@ public:
 };
 CheckSize(FieldResponse, 64, 8);
 
-class DefinitionResponse final {
+class MethodDefResponse final {
 public:
-    DefinitionResponse(core::MethodRef symbol, core::Loc termLoc, core::NameRef name, core::TypeAndOrigins retType)
+    MethodDefResponse(core::MethodRef symbol, core::Loc termLoc, core::NameRef name, core::TypeAndOrigins retType)
         : symbol(symbol), termLoc(termLoc), name(name), retType(std::move(retType)){};
     const core::MethodRef symbol;
     const core::Loc termLoc;
     const core::NameRef name;
     const core::TypeAndOrigins retType;
 };
-CheckSize(DefinitionResponse, 64, 8);
+CheckSize(MethodDefResponse, 64, 8);
 
 class EditResponse final {
 public:
@@ -104,7 +104,7 @@ public:
 CheckSize(EditResponse, 40, 8);
 
 using QueryResponseVariant = std::variant<SendResponse, IdentResponse, LiteralResponse, ConstantResponse, FieldResponse,
-                                          DefinitionResponse, EditResponse>;
+                                          MethodDefResponse, EditResponse>;
 
 /**
  * Represents a response to a LSP query. Wraps a variant that contains one of several response types.
@@ -149,7 +149,7 @@ public:
     /**
      * Returns nullptr unless this is a Definition.
      */
-    const DefinitionResponse *isDefinition() const;
+    const MethodDefResponse *isDefinition() const;
 
     /**
      * Returns nullptr unless this is an Edit.

--- a/core/lsp/QueryResponse.h
+++ b/core/lsp/QueryResponse.h
@@ -149,7 +149,7 @@ public:
     /**
      * Returns nullptr unless this is a Definition.
      */
-    const MethodDefResponse *isDefinition() const;
+    const MethodDefResponse *isMethodDef() const;
 
     /**
      * Returns nullptr unless this is an Edit.

--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -42,8 +42,8 @@ ast::ExpressionPtr DefLocSaver::postTransformMethodDef(core::Context ctx, ast::E
         tp.type = symbolData->resultType;
         tp.origins.emplace_back(core::Loc(ctx.file, methodDef.declLoc));
         core::lsp::QueryResponse::pushQueryResponse(
-            ctx, core::lsp::DefinitionResponse(methodDef.symbol, core::Loc(ctx.file, methodDef.declLoc), methodDef.name,
-                                               tp));
+            ctx,
+            core::lsp::MethodDefResponse(methodDef.symbol, core::Loc(ctx.file, methodDef.declLoc), methodDef.name, tp));
     }
 
     return tree;

--- a/main/lsp/LSPTask.cc
+++ b/main/lsp/LSPTask.cc
@@ -377,7 +377,7 @@ LSPTask::filterAndDedup(const core::GlobalState &gs,
         if (loc.exists() && loc.file().exists()) {
             auto fileIsTyped = loc.file().data(gs).strictLevel >= core::StrictLevel::True;
             // If file is untyped, only support responses involving constants and definitions.
-            if (fileIsTyped || q->isConstant() || q->isField() || q->isDefinition()) {
+            if (fileIsTyped || q->isConstant() || q->isField() || q->isMethodDef()) {
                 responses.push_back(make_unique<core::lsp::QueryResponse>(*q));
             }
         }

--- a/main/lsp/QueryCollector.cc
+++ b/main/lsp/QueryCollector.cc
@@ -9,7 +9,7 @@ uint16_t getQueryResponseTypeSpecificity(const core::lsp::QueryResponse &q) {
     if (q.isEdit()) {
         // Only reported for autocomplete, and should take precedence over anything else reported
         return 8;
-    } else if (q.isDefinition()) {
+    } else if (q.isMethodDef()) {
         return 7;
     } else if (auto send = q.isSend()) {
         return 6;

--- a/main/lsp/requests/definition.cc
+++ b/main/lsp/requests/definition.cc
@@ -38,8 +38,8 @@ unique_ptr<ResponseMessage> DefinitionTask::runRequest(LSPTypecheckerInterface &
             for (auto &originLoc : retType.origins) {
                 addLocIfExists(gs, locations, originLoc);
             }
-        } else if (fileIsTyped && resp->isDefinition()) {
-            auto sym = resp->isDefinition()->symbol;
+        } else if (fileIsTyped && resp->isMethodDef()) {
+            auto sym = resp->isMethodDef()->symbol;
             for (auto loc : sym.data(gs)->locs()) {
                 addLocIfExists(gs, locations, loc);
             }

--- a/main/lsp/requests/definition.cc
+++ b/main/lsp/requests/definition.cc
@@ -40,7 +40,7 @@ unique_ptr<ResponseMessage> DefinitionTask::runRequest(LSPTypecheckerInterface &
             }
         } else if (fileIsTyped && resp->isDefinition()) {
             auto sym = resp->isDefinition()->symbol;
-            for (auto loc : sym.locs(gs)) {
+            for (auto loc : sym.data(gs)->locs()) {
                 addLocIfExists(gs, locations, loc);
             }
         } else if (fileIsTyped && resp->isSend()) {

--- a/main/lsp/requests/document_highlight.cc
+++ b/main/lsp/requests/document_highlight.cc
@@ -71,7 +71,7 @@ unique_ptr<ResponseMessage> DocumentHighlightTask::runRequest(LSPTypecheckerInte
                                                            getAccessorInfo(typechecker.state(), fieldResp->symbol),
                                                            fieldResp->symbol));
         } else if (auto defResp = resp->isDefinition()) {
-            if (fileIsTyped || defResp->symbol.isClassOrModule()) {
+            if (fileIsTyped) {
                 // This could be a `prop` or `attr_*`, which have multiple associated symbols.
                 response->result = getHighlights(
                     typechecker, getReferencesToAccessorInFile(typechecker, fref,

--- a/main/lsp/requests/document_highlight.cc
+++ b/main/lsp/requests/document_highlight.cc
@@ -70,7 +70,7 @@ unique_ptr<ResponseMessage> DocumentHighlightTask::runRequest(LSPTypecheckerInte
                 typechecker, getReferencesToAccessorInFile(typechecker, fref,
                                                            getAccessorInfo(typechecker.state(), fieldResp->symbol),
                                                            fieldResp->symbol));
-        } else if (auto defResp = resp->isDefinition()) {
+        } else if (auto defResp = resp->isMethodDef()) {
             if (fileIsTyped) {
                 // This could be a `prop` or `attr_*`, which have multiple associated symbols.
                 response->result = getHighlights(

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -82,7 +82,7 @@ unique_ptr<ResponseMessage> HoverTask::runRequest(LSPTypecheckerInterface &typec
                 documentationLocations.emplace_back(loc);
             }
         }
-    } else if (auto d = resp->isDefinition()) {
+    } else if (auto d = resp->isMethodDef()) {
         for (auto loc : d->symbol.data(gs)->locs()) {
             if (loc.exists()) {
                 documentationLocations.emplace_back(loc);
@@ -111,7 +111,7 @@ unique_ptr<ResponseMessage> HoverTask::runRequest(LSPTypecheckerInterface &typec
         } else {
             typeString = methodInfoString(gs, retType, *sendResp->dispatchResult, constraint);
         }
-    } else if (auto defResp = resp->isDefinition()) {
+    } else if (auto defResp = resp->isMethodDef()) {
         typeString = prettyTypeForMethod(gs, defResp->symbol, nullptr, defResp->retType.type, nullptr);
     } else if (auto constResp = resp->isConstant()) {
         typeString = prettyTypeForConstant(gs, constResp->symbol);

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -83,7 +83,7 @@ unique_ptr<ResponseMessage> HoverTask::runRequest(LSPTypecheckerInterface &typec
             }
         }
     } else if (auto d = resp->isDefinition()) {
-        for (auto loc : d->symbol.locs(gs)) {
+        for (auto loc : d->symbol.data(gs)->locs()) {
             if (loc.exists()) {
                 documentationLocations.emplace_back(loc);
             }
@@ -112,7 +112,7 @@ unique_ptr<ResponseMessage> HoverTask::runRequest(LSPTypecheckerInterface &typec
             typeString = methodInfoString(gs, retType, *sendResp->dispatchResult, constraint);
         }
     } else if (auto defResp = resp->isDefinition()) {
-        typeString = prettyTypeForMethod(gs, defResp->symbol.asMethodRef(), nullptr, defResp->retType.type, nullptr);
+        typeString = prettyTypeForMethod(gs, defResp->symbol, nullptr, defResp->retType.type, nullptr);
     } else if (auto constResp = resp->isConstant()) {
         typeString = prettyTypeForConstant(gs, constResp->symbol);
     } else {

--- a/main/lsp/requests/implementation.cc
+++ b/main/lsp/requests/implementation.cc
@@ -79,7 +79,7 @@ unique_ptr<ResponseMessage> ImplementationTask::runRequest(LSPTypecheckerInterfa
 
     vector<unique_ptr<Location>> result;
     auto queryResponse = move(queryResult.responses[0]);
-    if (auto def = queryResponse->isDefinition()) {
+    if (auto def = queryResponse->isMethodDef()) {
         // User called "Go to Implementation" from the abstract function definition
         core::SymbolRef maybeMethod = def->symbol;
         if (!maybeMethod.isMethod()) {

--- a/main/lsp/requests/prepare_rename.cc
+++ b/main/lsp/requests/prepare_rename.cc
@@ -74,11 +74,7 @@ unique_ptr<ResponseMessage> PrepareRenameTask::runRequest(LSPTypecheckerInterfac
     if (auto constResp = resp->isConstant()) {
         response->result = getPrepareRenameResult(gs, constResp->symbol);
     } else if (auto defResp = resp->isDefinition()) {
-        if (defResp->symbol.isClassOrModule()) {
-            response->result = getPrepareRenameResult(gs, defResp->symbol);
-        } else if (defResp->symbol.isMethod()) {
-            response->result = getPrepareRenameResult(gs, defResp->symbol);
-        }
+        response->result = getPrepareRenameResult(gs, defResp->symbol);
     } else if (auto sendResp = resp->isSend()) {
         response->result = getPrepareRenameResultForSend(gs, sendResp);
     }

--- a/main/lsp/requests/prepare_rename.cc
+++ b/main/lsp/requests/prepare_rename.cc
@@ -73,7 +73,7 @@ unique_ptr<ResponseMessage> PrepareRenameTask::runRequest(LSPTypecheckerInterfac
     // We support rename requests from constants, class definitions, and methods.
     if (auto constResp = resp->isConstant()) {
         response->result = getPrepareRenameResult(gs, constResp->symbol);
-    } else if (auto defResp = resp->isDefinition()) {
+    } else if (auto defResp = resp->isMethodDef()) {
         response->result = getPrepareRenameResult(gs, defResp->symbol);
     } else if (auto sendResp = resp->isSend()) {
         response->result = getPrepareRenameResultForSend(gs, sendResp);

--- a/main/lsp/requests/references.cc
+++ b/main/lsp/requests/references.cc
@@ -46,7 +46,7 @@ unique_ptr<ResponseMessage> ReferencesTask::runRequest(LSPTypecheckerInterface &
                 typechecker.state(),
                 getReferencesToAccessor(typechecker, getAccessorInfo(typechecker.state(), fieldResp->symbol),
                                         fieldResp->symbol));
-        } else if (auto defResp = resp->isDefinition()) {
+        } else if (auto defResp = resp->isMethodDef()) {
             if (fileIsTyped) {
                 // This could be a `prop` or `attr_*`, which have multiple associated symbols.
                 response->result = extractLocations(

--- a/main/lsp/requests/references.cc
+++ b/main/lsp/requests/references.cc
@@ -47,7 +47,7 @@ unique_ptr<ResponseMessage> ReferencesTask::runRequest(LSPTypecheckerInterface &
                 getReferencesToAccessor(typechecker, getAccessorInfo(typechecker.state(), fieldResp->symbol),
                                         fieldResp->symbol));
         } else if (auto defResp = resp->isDefinition()) {
-            if (fileIsTyped || defResp->symbol.isClassOrModule()) {
+            if (fileIsTyped) {
                 // This could be a `prop` or `attr_*`, which have multiple associated symbols.
                 response->result = extractLocations(
                     typechecker.state(),

--- a/main/lsp/requests/rename.cc
+++ b/main/lsp/requests/rename.cc
@@ -78,7 +78,7 @@ public:
         string newsrc;
         if (auto sendResp = response->isSend()) {
             newsrc = replaceMethodNameInSend(string(source.value()), sendResp);
-        } else if (auto defResp = response->isDefinition()) {
+        } else if (auto defResp = response->isMethodDef()) {
             newsrc = replaceMethodNameInDef(string(source.value()));
         } else {
             ENFORCE(0, "Unexpected query response type while renaming method");
@@ -247,7 +247,7 @@ unique_ptr<ResponseMessage> RenameTask::runRequest(LSPTypecheckerInterface &type
             getRenameEdits(typechecker, renamer, constResp->symbol, params->newName);
             enrichResponse(response, renamer);
         }
-    } else if (auto defResp = resp->isDefinition()) {
+    } else if (auto defResp = resp->isMethodDef()) {
         if (isupper(params->newName[0])) {
             response->error = make_unique<ResponseError>((int)LSPErrorCodes::InvalidRequest,
                                                          "Method names must begin with an lowercase letter.");

--- a/main/lsp/requests/rename.cc
+++ b/main/lsp/requests/rename.cc
@@ -248,24 +248,16 @@ unique_ptr<ResponseMessage> RenameTask::runRequest(LSPTypecheckerInterface &type
             enrichResponse(response, renamer);
         }
     } else if (auto defResp = resp->isDefinition()) {
-        if (defResp->symbol.isClassOrModule() && islower(params->newName[0])) {
-            response->error = make_unique<ResponseError>((int)LSPErrorCodes::InvalidRequest,
-                                                         "Class and Module names must begin with an uppercase letter.");
-            return response;
-        }
-
-        if (defResp->symbol.isMethod() && isupper(params->newName[0])) {
+        if (isupper(params->newName[0])) {
             response->error = make_unique<ResponseError>((int)LSPErrorCodes::InvalidRequest,
                                                          "Method names must begin with an lowercase letter.");
             return response;
         }
 
-        if (defResp->symbol.isClassOrModule() || defResp->symbol.isMethod()) {
-            if (isValidRenameLocation(defResp->symbol, gs, response)) {
-                renamer = makeRenamer(gs, config, defResp->symbol, params->newName);
-                getRenameEdits(typechecker, renamer, defResp->symbol, params->newName);
-                enrichResponse(response, renamer);
-            }
+        if (isValidRenameLocation(defResp->symbol, gs, response)) {
+            renamer = makeRenamer(gs, config, defResp->symbol, params->newName);
+            getRenameEdits(typechecker, renamer, defResp->symbol, params->newName);
+            enrichResponse(response, renamer);
         }
     } else if (auto sendResp = resp->isSend()) {
         // We don't need to handle dispatchResult->secondary here, because it will be checked in getRenameEdits.

--- a/main/lsp/requests/sorbet_show_symbol.cc
+++ b/main/lsp/requests/sorbet_show_symbol.cc
@@ -39,7 +39,7 @@ unique_ptr<ResponseMessage> SorbetShowSymbolTask::runRequest(LSPTypecheckerInter
         // Using symbolBeforeDealias instead of symbol here lets us show the name of the actual
         // constant under the user's cursor, not what it aliases to.
         sym = c->symbolBeforeDealias;
-    } else if (auto d = resp->isDefinition()) {
+    } else if (auto d = resp->isMethodDef()) {
         sym = d->symbol;
     } else if (auto f = resp->isField()) {
         sym = f->symbol;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

`DefLocSaver.cc` was only ever sending `DefinitionResponse` objects in response
to method definitions. That meant that a lot of code thinking that we had to
handle class or module definitions was actually dead, and that we couldn't take
advantage of the stricter typing that comes from using `MethodRef` instead of
`SymbolRef`.

The LSP response that is used for class definitions (when the location is on the
class name) is just a normal `ConstantResponse` (because there is a real
`ConstantLit` in the tree for `ClassDef` nodes).

If we want to introduce a specific query response for, e.g., hovering over he
`class` keyword specifically, we could do that, but my vote would be to
introduce a new `ClassDefResponse` class.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No behavior changes, so all tests should pass.