### PR TITLE
Fix runtime exception with unused optional and rest parameters.

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/signature.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature.rb
@@ -182,7 +182,10 @@ class T::Private::Methods::Signature
     arg_types = @arg_types
 
     if @has_rest
-      arg_types += [[@rest_name, @rest_type]] * (args_length - @arg_types.length)
+      rest_count = args_length - @arg_types.length
+      rest_count = 0 if rest_count.negative?
+
+      arg_types += [[@rest_name, @rest_type]] * rest_count
 
     elsif (args_length < @req_arg_count) || (args_length > @arg_types.length)
       expected_str = @req_arg_count.to_s

--- a/gems/sorbet-runtime/test/types/method_validation.rb
+++ b/gems/sorbet-runtime/test/types/method_validation.rb
@@ -520,6 +520,20 @@ module Opus::Types::Test
         assert_match(/\AParameter 'bar': Expected type String, got type Integer with value 2/, err.message)
       end
 
+      it 'handles splats with optional params' do
+        @mod.sig {params(bar: String, args: Integer).void}
+        def @mod.foo(bar='', *args); end
+
+        @mod.foo('hello')
+        @mod.foo('hello', 1, 2, 3)
+        @mod.foo
+
+        err = assert_raises(TypeError) do
+          @mod.foo(1)
+        end
+        assert_match(/\AParameter 'bar': Expected type String, got type Integer with value 1/, err.message)
+      end
+
       it 'handles keyrest' do
         @mod.sig {params(opts: Integer).void}
         def @mod.foo(**opts); end


### PR DESCRIPTION
This PR fixes an exception that occurs in sorbet-runtime when a method that accepts both optional and rest/splat parameters is called with neither.

### Motivation
Given a typed method definition such as:

```ruby
sig {params(x: Integer, rest: Integer).void}
def foo(x = 0, *rest)
end
```

If the method is called with no parameters, an ArgumentError will be raised at

https://github.com/sorbet/sorbet/blob/5897a44a70702ec323d5bf2681e9de5e98dfa454/gems/sorbet-runtime/lib/types/private/methods/signature.rb#L185

due to `(args_length - @arg_types.length)` being negative.

This PR constrains the above result to a minimum of zero, in which case nothing is added to `arg_types`.  

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
