### PR TITLE
Extract a TaskQueue class

### DIFF
--- a/main/lsp/LSPTask.h
+++ b/main/lsp/LSPTask.h
@@ -176,20 +176,19 @@ public:
 };
 
 class LSPIndexer;
-struct TaskQueueState;
+class TaskQueue;
 
 /**
  * Represents a preemption task. When run, it will run all tasks at the head of TaskQueueState that can preempt.
  */
 class LSPQueuePreemptionTask final : public LSPTask {
     absl::Notification &finished;
-    absl::Mutex &taskQueueMutex;
-    TaskQueueState &taskQueue GUARDED_BY(taskQueueMutex);
+    TaskQueue &taskQueue;
     LSPIndexer &indexer;
 
 public:
-    LSPQueuePreemptionTask(const LSPConfiguration &config, absl::Notification &finished, absl::Mutex &taskQueueMutex,
-                           TaskQueueState &taskQueue, LSPIndexer &indexer);
+    LSPQueuePreemptionTask(const LSPConfiguration &config, absl::Notification &finished, TaskQueue &taskQueue,
+                           LSPIndexer &indexer);
 
     void run(LSPTypecheckerInterface &tc) override;
 };

--- a/main/lsp/lsp.cc
+++ b/main/lsp/lsp.cc
@@ -17,8 +17,8 @@ namespace sorbet::realmain::lsp {
 
 LSPLoop::LSPLoop(std::unique_ptr<core::GlobalState> initialGS, WorkerPool &workers,
                  const std::shared_ptr<LSPConfiguration> &config, std::unique_ptr<KeyValueStore> kvstore)
-    : config(config), taskQueueMutex(make_shared<absl::Mutex>()), taskQueue(make_shared<TaskQueueState>()),
-      epochManager(initialGS->epochManager), preprocessor(config, taskQueueMutex, taskQueue),
+    : config(config), taskQueue(make_shared<TaskQueue>()), epochManager(initialGS->epochManager),
+      preprocessor(config, taskQueue),
       typecheckerCoord(config, make_shared<core::lsp::PreemptionTaskManager>(initialGS->epochManager), workers),
       indexer(config, move(initialGS), move(kvstore)), emptyWorkers(WorkerPool::create(0, *config->logger)),
       lastMetricUpdateTime(chrono::steady_clock::now()) {}

--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -31,9 +31,7 @@ class LSPLoop {
     /** Encapsulates the active configuration for the language server. */
     const std::shared_ptr<const LSPConfiguration> config;
     /** Protects outgoingQueue. */
-    const std::shared_ptr<absl::Mutex> taskQueueMutex;
-    /** Contains the output of LSPPreprocessor -- messages that have been converted into tasks. */
-    const std::shared_ptr<TaskQueueState> taskQueue GUARDED_BY(taskQueueMutex);
+    const std::shared_ptr<TaskQueue> taskQueue;
     const std::shared_ptr<core::lsp::TypecheckEpochManager> epochManager;
 
     /** The LSP preprocessor standardizes incoming messages and combines edits. */

--- a/main/lsp/request_dispatch.cc
+++ b/main/lsp/request_dispatch.cc
@@ -27,12 +27,13 @@ void LSPLoop::processRequests(vector<unique_ptr<LSPMessage>> messages) {
         preprocessor.preprocessAndEnqueue(move(message));
     }
     {
-        absl::MutexLock lck(taskQueueMutex.get());
-        ENFORCE(taskQueue->paused == false, "__PAUSE__ not supported in single-threaded mode.");
-        for (auto &task : taskQueue->pendingTasks) {
+        absl::MutexLock lck(taskQueue->getMutex());
+        ENFORCE(!taskQueue->isPaused(), "__PAUSE__ not supported in single-threaded mode.");
+        auto &tasks = taskQueue->tasks();
+        for (auto &task : taskQueue->tasks()) {
             runTask(move(task));
         }
-        taskQueue->pendingTasks.clear();
+        tasks.clear();
     }
 }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Extract a `TaskQueue` class from what was previously a pair of a mutex and the `TaskQueueState` struct. This is prework for moving the indexer thread's initialize behavior into the typechecker thread, as the typechecker will need a handle to the task queue to feed the results back through to the preprocessor thread.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Prework for reworking how `GlobalState` initialization happens.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
