### PR TITLE
File.binwrite accepts a String or Pathname

### DIFF
--- a/rbi/core/io.rbi
+++ b/rbi/core/io.rbi
@@ -1844,7 +1844,7 @@ class IO < Object
   # (`"wb:ASCII-8BIT"`).
   sig do
     params(
-        name: String,
+        name: T.any(String, Pathname),
         arg0: String,
         offset: Integer,
         external_encoding: T.any(String, Encoding),


### PR DESCRIPTION
Fixes [this](https://sorbet.run/#%23%20typed%3A%20true%0A%0AFile.binwrite%28Pathname.new%28%22tmp%2Ftest.txt%22%29%2C%20%22hi%22%29).

Proof:

```ruby
2.7.3 :001 > File.binwrite(Pathname.new("tmp/test.txt"), "hi")
 => 2
2.7.3 :002 > File.read "tmp/test.txt"
 => "hi"
```
