### PR TITLE
Resolve all instance variable warnings

### DIFF
--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -80,6 +80,7 @@ module T::Configuration
     T::Props::Private::DeserializerGenerator.respond_to?(:generate2)
   end
 
+  @use_vm_prop_serde = false
   # Whether to use VM-defined prop serialization/deserialization routines.
   #
   # The default is to use runtime codegen inside sorbet-runtime itself.
@@ -117,6 +118,7 @@ module T::Configuration
     T::Private::RuntimeLevels.default_checked_level = default_checked_level
   end
 
+  @inline_type_error_handler = nil
   # Set a handler to handle `TypeError`s raised by any in-line type assertions,
   # including `T.must`, `T.let`, `T.cast`, and `T.assert_type!`.
   #
@@ -164,6 +166,7 @@ module T::Configuration
     nil
   end
 
+  @sig_builder_error_handler = nil
   # Set a handler to handle errors that occur when the builder methods in the
   # body of a sig are executed. The sig builder methods are inside a proc so
   # that they can be lazily evaluated the first time the method being sig'd is
@@ -204,6 +207,7 @@ module T::Configuration
     nil
   end
 
+  @sig_validation_error_handler = nil
   # Set a handler to handle sig validation errors.
   #
   # Sig validation errors include things like abstract checks, override checks,
@@ -254,6 +258,7 @@ module T::Configuration
     nil
   end
 
+  @call_validation_error_handler = nil
   # Set a handler for type errors that result from calling a method.
   #
   # By default, errors from calling a method cause an exception to be raised.
@@ -300,6 +305,7 @@ module T::Configuration
     nil
   end
 
+  @log_info_handler = nil
   # Set a handler for logging
   #
   # @param [Lambda, Proc, Object, nil] value Proc that handles the error
@@ -331,6 +337,7 @@ module T::Configuration
     end
   end
 
+  @soft_assert_handler = nil
   # Set a handler for soft assertions
   #
   # These generally shouldn't stop execution of the program, but rather inform
@@ -365,6 +372,7 @@ module T::Configuration
     end
   end
 
+  @hard_assert_handler = nil
   # Set a handler for hard assertions
   #
   # These generally should stop execution of the program, and optionally inform
@@ -399,6 +407,7 @@ module T::Configuration
     end
   end
 
+  @scalar_types = nil
   # Set a list of class strings that are to be considered scalar.
   #   (pass nil to reset to default behavior)
   #
@@ -461,6 +470,7 @@ module T::Configuration
     @module_name_mangler = handler
   end
 
+  @sensitivity_and_pii_handler = nil
   # Set to a PII handler function. This will be called with the `sensitivity:`
   # annotations on things that use `T::Props` and can modify them ahead-of-time.
   #
@@ -490,6 +500,7 @@ module T::Configuration
     @redaction_handler
   end
 
+  @class_owner_finder = nil
   # Set to a function which can get the 'owner' of a class. This is
   # used in reporting deserialization errors
   #
@@ -523,6 +534,7 @@ module T::Configuration
     end
   end
 
+  @legacy_t_enum_migration_mode = false
   def self.enable_legacy_t_enum_migration_mode
     @legacy_t_enum_migration_mode = true
   end
@@ -543,6 +555,7 @@ module T::Configuration
     @prop_freeze_handler
   end
 
+  @sealed_violation_whitelist = nil
   # @param [Array] sealed_violation_whitelist An array of Regexp to validate
   #   whether inheriting /including a sealed module outside the defining module
   #   should be allowed. Useful to whitelist benign violations, like shim files

--- a/gems/sorbet-runtime/lib/types/enum.rb
+++ b/gems/sorbet-runtime/lib/types/enum.rb
@@ -286,14 +286,18 @@ class T::Enum
 
   sig {returns(T::Boolean)}
   def self.started_initializing?
-    @started_initializing = T.let(@started_initializing, T.nilable(T::Boolean))
-    @started_initializing ||= false
+    unless defined?(@started_initializing)
+      @started_initializing = T.let(false, T.nilable(T::Boolean))
+    end
+    T.must(@started_initializing)
   end
 
   sig {returns(T::Boolean)}
   def self.fully_initialized?
-    @fully_initialized = T.let(@fully_initialized, T.nilable(T::Boolean))
-    @fully_initialized ||= false
+    unless defined?(@fully_initialized)
+      @fully_initialized = T.let(false, T.nilable(T::Boolean))
+    end
+    T.must(@fully_initialized)
   end
 
   # Maintains the order in which values are defined
@@ -308,8 +312,8 @@ class T::Enum
   sig {params(blk: T.proc.void).void}
   def self.enums(&blk)
     raise "enums cannot be defined for T::Enum" if self == T::Enum
-    raise "Enum #{self} was already initialized" if @fully_initialized
-    raise "Enum #{self} is still initializing" if @started_initializing
+    raise "Enum #{self} was already initialized" if fully_initialized?
+    raise "Enum #{self} is still initializing" if started_initializing?
 
     @started_initializing = true
 

--- a/gems/sorbet-runtime/lib/types/private/abstract/data.rb
+++ b/gems/sorbet-runtime/lib/types/private/abstract/data.rb
@@ -12,7 +12,7 @@
 # modules that override the `hash` method with something completely broken.
 module T::Private::Abstract::Data
   def self.get(mod, key)
-    mod.instance_variable_get("@opus_abstract__#{key}")
+    mod.instance_variable_get("@opus_abstract__#{key}") if key?(mod, key)
   end
 
   def self.set(mod, key, value)

--- a/gems/sorbet-runtime/lib/types/private/sealed.rb
+++ b/gems/sorbet-runtime/lib/types/private/sealed.rb
@@ -70,7 +70,7 @@ module T::Private::Sealed
 
   def self.validate_inheritance(this_line, parent, child, verb)
     this_file = this_line&.split(':')&.first
-    decl_file = parent.instance_variable_get(:@sorbet_sealed_module_decl_file)
+    decl_file = parent.instance_variable_get(:@sorbet_sealed_module_decl_file) if sealed_module?(parent)
 
     if !this_file
       raise "Could not use backtrace to determine file for #{verb} child #{child}"

--- a/gems/sorbet-runtime/lib/types/props/constructor.rb
+++ b/gems/sorbet-runtime/lib/types/props/constructor.rb
@@ -20,7 +20,7 @@ module T::Props::Constructor::DecoratorMethods
     # Use `each_pair` rather than `count` because, as of Ruby 2.6, the latter delegates to Enumerator
     # and therefore allocates for each entry.
     result = 0
-    @props_without_defaults&.each_pair do |p, setter_proc|
+    props_without_defaults&.each_pair do |p, setter_proc|
       begin
         val = hash[p]
         instance.instance_exec(val, &setter_proc)

--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -155,7 +155,7 @@ class T::Props::Decorator
     .checked(:never)
   end
   def prop_get(instance, prop, rules=prop_rules(prop))
-    val = instance.instance_variable_get(rules[:accessor_key])
+    val = instance.instance_variable_get(rules[:accessor_key]) if instance.instance_variable_defined?(rules[:accessor_key])
     if !val.nil?
       val
     elsif (d = rules[:ifunset])
@@ -175,7 +175,7 @@ class T::Props::Decorator
     .checked(:never)
   end
   def prop_get_if_set(instance, prop, rules=prop_rules(prop))
-    instance.instance_variable_get(rules[:accessor_key])
+    instance.instance_variable_get(rules[:accessor_key]) if instance.instance_variable_defined?(rules[:accessor_key])
   end
   alias_method :get, :prop_get_if_set # Alias for backwards compatibility
 

--- a/gems/sorbet-runtime/lib/types/props/has_lazily_specialized_methods.rb
+++ b/gems/sorbet-runtime/lib/types/props/has_lazily_specialized_methods.rb
@@ -37,7 +37,7 @@ module T::Props
 
     sig {returns(T::Boolean)}
     def self.lazy_evaluation_enabled?
-      !@lazy_evaluation_disabled
+      !defined?(@lazy_evaluation_disabled) || !@lazy_evaluation_disabled
     end
 
     module DecoratorMethods
@@ -84,7 +84,7 @@ module T::Props
 
         cls = decorated_class
         if cls.method_defined?(name)
-          # Ruby doesn not emit "method redefined" warnings for aliased methods
+          # Ruby does not emit "method redefined" warnings for aliased methods
           # (more robust than undef_method that would create a small window in which the method doesn't exist)
           cls.send(:alias_method, name, name)
         end

--- a/gems/sorbet-runtime/lib/types/props/optional.rb
+++ b/gems/sorbet-runtime/lib/types/props/optional.rb
@@ -49,13 +49,13 @@ module T::Props::Optional::DecoratorMethods
     if default_setter
       @props_with_defaults ||= {}
       @props_with_defaults[prop] = default_setter
-      @props_without_defaults&.delete(prop) # Handle potential override
+      props_without_defaults&.delete(prop) # Handle potential override
 
       rules[DEFAULT_SETTER_RULE_KEY] = default_setter
     else
       @props_without_defaults ||= {}
       @props_without_defaults[prop] = rules.fetch(:setter_proc)
-      @props_with_defaults&.delete(prop) # Handle potential override
+      props_with_defaults&.delete(prop) # Handle potential override
     end
 
     super

--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -122,7 +122,7 @@ module T::Props::Serializable
     serialized = existing_hash
     new_val = self.class.from_hash(serialized.merge(recursive_stringify_keys(changed_props)))
     old_extra = self.instance_variable_get(:@_extra_props) if self.instance_variable_defined?(:@_extra_props)
-    new_extra = new_val.instance_variable_get(:@_extra_props) if self.instance_variable_defined?(:@_extra_props)
+    new_extra = new_val.instance_variable_get(:@_extra_props) if new_val.instance_variable_defined?(:@_extra_props)
     if old_extra != new_extra
       difference =
         if old_extra

--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -35,7 +35,7 @@ module T::Props::Serializable
       end
     end
 
-    h.merge!(@_extra_props) if @_extra_props
+    h.merge!(@_extra_props) if defined?(@_extra_props)
     h
   end
 
@@ -121,8 +121,8 @@ module T::Props::Serializable
   private def with_existing_hash(changed_props, existing_hash:)
     serialized = existing_hash
     new_val = self.class.from_hash(serialized.merge(recursive_stringify_keys(changed_props)))
-    old_extra = self.instance_variable_get(:@_extra_props)
-    new_extra = new_val.instance_variable_get(:@_extra_props)
+    old_extra = self.instance_variable_get(:@_extra_props) if self.instance_variable_defined?(:@_extra_props)
+    new_extra = new_val.instance_variable_get(:@_extra_props) if self.instance_variable_defined?(:@_extra_props)
     if old_extra != new_extra
       difference =
         if old_extra
@@ -137,7 +137,8 @@ module T::Props::Serializable
 
   # Asserts if this property is missing during strict serialize
   private def required_prop_missing_from_serialize(prop)
-    if @_required_props_missing_from_deserialize&.include?(prop)
+    if defined?(@_required_props_missing_from_deserialize) &&
+       @_required_props_missing_from_deserialize&.include?(prop)
       # If the prop was already missing during deserialization, that means the application
       # code already had to deal with a nil value, which means we wouldn't be accomplishing
       # much by raising here (other than causing an unnecessary breakage).
@@ -322,7 +323,11 @@ module T::Props::Serializable::DecoratorMethods
   private_constant :EMPTY_EXTRA_PROPS
 
   def extra_props(instance)
-    instance.instance_variable_get(:@_extra_props) || EMPTY_EXTRA_PROPS
+    if instance.instance_variable_defined?(:@_extra_props)
+      instance.instance_variable_get(:@_extra_props)
+    else
+      instance.instance_variable_set(:@_extra_props, EMPTY_EXTRA_PROPS)
+    end
   end
 
   # overrides T::Props::PrettyPrintable

--- a/gems/sorbet-runtime/lib/types/props/weak_constructor.rb
+++ b/gems/sorbet-runtime/lib/types/props/weak_constructor.rb
@@ -33,7 +33,7 @@ module T::Props::WeakConstructor::DecoratorMethods
     # Use `each_pair` rather than `count` because, as of Ruby 2.6, the latter delegates to Enumerator
     # and therefore allocates for each entry.
     result = 0
-    @props_without_defaults&.each_pair do |p, setter_proc|
+    props_without_defaults&.each_pair do |p, setter_proc|
       if hash.key?(p)
         instance.instance_exec(hash[p], &setter_proc)
         result += 1
@@ -54,7 +54,7 @@ module T::Props::WeakConstructor::DecoratorMethods
     # Use `each_pair` rather than `count` because, as of Ruby 2.6, the latter delegates to Enumerator
     # and therefore allocates for each entry.
     result = 0
-    @props_with_defaults&.each_pair do |p, default_struct|
+    props_with_defaults&.each_pair do |p, default_struct|
       if hash.key?(p)
         instance.instance_exec(hash[p], &default_struct.setter_proc)
         result += 1

--- a/website/docs/type-annotations.md
+++ b/website/docs/type-annotations.md
@@ -126,8 +126,10 @@ variables:
 module B
   sig {returns(String)}
   def current_user
-    @user = T.let(@user, T.nilable(String))
-    @user ||= ENV.fetch('USER')
+    unless defined?(@user)
+      @user = T.let(ENV.fetch('USER'), T.nilable(String))
+    end
+    T.must(@user)
   end
 end
 ```


### PR DESCRIPTION
This is a rebased version of @tomstuart's https://github.com/sorbet/sorbet/pull/3338, in turn, was a rebased version of @paracycle’s https://github.com/sorbet/sorbet/pull/3207, which appears to have gone stale. His original description is below.

---

This PR attempts to fix most of the Ruby warnings generated by `sorbet-runtime`. All the ones that can be identified by running the test suite are addressed, except for the ones that are dynamically triggered by the test suite itself.

Coincidentally, this investigation also lead to finding and fixing a memoization attempt using `||= false` which would be executed every time and defeat the aim to memoize the ivar.

### Motivation
Sorbet Runtime generates a lot of warnings like `warning: instance variable @foo not initialized` due to lazy initialization of various instance variables.

### Test plan
No extra automated tests, all the current ones pass.

Running the test suite using `RUBYOPT=-w bundle exec rake test` displays all the warnings that are generated during a test suite run.

There are still some `method redefinition` warnings left that this PR does not aim to fix.