### PR TITLE
Fixup compdb sed command

### DIFF
--- a/tools/scripts/build_compilation_db.sh
+++ b/tools/scripts/build_compilation_db.sh
@@ -8,4 +8,4 @@ cd "$(dirname "$0")/../.."
 
 execution_root="$(./bazel info execution_root)"
 
-sed "s|__EXEC_ROOT__|$execution_root|" bazel-bin/tools/compile_commands.json > compile_commands.json
+sed "s|__EXEC_ROOT__|$execution_root|g" bazel-bin/tools/compile_commands.json > compile_commands.json


### PR DESCRIPTION
### Motivation
Upstream rewrote the compilation_commands.json generator in python, and it now outputs a single very large line of JSON, instead of one line per file. This breaks the sed command, only replacing the first one :(

### Test plan
Sorry, I broke this in #5480 where I clearly didn't test it enough 😬 