### PR TITLE
Allow renaming method to uppercase

### DIFF
--- a/main/lsp/requests/rename.cc
+++ b/main/lsp/requests/rename.cc
@@ -248,12 +248,6 @@ unique_ptr<ResponseMessage> RenameTask::runRequest(LSPTypecheckerInterface &type
             enrichResponse(response, renamer);
         }
     } else if (auto defResp = resp->isMethodDef()) {
-        if (isupper(params->newName[0])) {
-            response->error = make_unique<ResponseError>((int)LSPErrorCodes::InvalidRequest,
-                                                         "Method names must begin with an lowercase letter.");
-            return response;
-        }
-
         if (isValidRenameLocation(defResp->symbol, gs, response)) {
             renamer = makeRenamer(gs, config, defResp->symbol, params->newName);
             getRenameEdits(typechecker, renamer, defResp->symbol, params->newName);

--- a/test/testdata/lsp/rename/uppercase_method.A.rbedited
+++ b/test/testdata/lsp/rename/uppercase_method.A.rbedited
@@ -1,0 +1,15 @@
+# typed: true
+
+def ORIGIN(x = nil); end
+#   ^ apply-rename: [A] newName: ORIGIN
+
+ORIGIN()
+
+# This will technically turn into an error about "could not resolve constant"
+# but it seems easy enough for the user to look at those errors and add the
+# required parens on their own.
+ORIGIN
+
+# Crazily enough it doesn't even require parens to parse as a method name, it
+# just needs parens or any argument.
+ORIGIN 'foo'

--- a/test/testdata/lsp/rename/uppercase_method.rb
+++ b/test/testdata/lsp/rename/uppercase_method.rb
@@ -1,0 +1,15 @@
+# typed: true
+
+def origin(x = nil); end
+#   ^ apply-rename: [A] newName: ORIGIN
+
+origin()
+
+# This will technically turn into an error about "could not resolve constant"
+# but it seems easy enough for the user to look at those errors and add the
+# required parens on their own.
+origin
+
+# Crazily enough it doesn't even require parens to parse as a method name, it
+# just needs parens or any argument.
+origin 'foo'


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #5486


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

There are some slight gotchas here, but I think that the upsides are better than
the downsides, and we have tests.

We could consider a future implementation that goes so far as to detect the
places that will become errors and sticks a `()` onto the end to force Ruby to
parse the thing as a constant, but I'm fine leaving that for some future
improvement.