### PR TITLE
Write a modification timestamp to track if autoloader generation modifies any files

### DIFF
--- a/test/cli/autogen-autoloader/test.sh
+++ b/test/cli/autogen-autoloader/test.sh
@@ -16,7 +16,7 @@ main/sorbet --silence-dev-message --stop-after=namer -p autogen-autoloader:outpu
   test/cli/autogen-autoloader/{foo,bar,bar2,errors}.rb \
   test/cli/autogen-autoloader/scripts/baz.rb 2>&1
 
-for file in $(find output -type f | sort); do
+for file in $(find output -type f | sort | grep -v "_mtime_stamp"); do
   printf "\n--- %s\n" "$file"
   cat "$file"
 done
@@ -41,7 +41,7 @@ main/sorbet --silence-dev-message --stop-after=namer \
   --autogen-autoloader-modules=Foo \
   test/cli/autogen-autoloader/inplace.rb
 
-find inplace-output | sort
+find inplace-output | sort | grep -v "_mtime_stamp"
 
 echo
 echo "--- strip-prefixes and root rename"

--- a/test/cli/autogen-pkg-autoloader/test.sh
+++ b/test/cli/autogen-pkg-autoloader/test.sh
@@ -25,7 +25,7 @@ mkdir output
   test/cli/autogen-pkg-autoloader/nested/*.rb \
   test/cli/autogen-pkg-autoloader/scripts/baz.rb 2>&1
 
-for file in $(find output -type f | sort); do
+for file in $(find output -type f | sort | grep -v "_mtime_stamp"); do
   printf "\n--- %s\n" "$file"
   cat "$file"
 done


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Writes a very simple modification timestamp that updates if the autoloader generation modifies any files.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
In the Stripe development environment, we use the full autoloader tree as an input to a local Bazel build system. However, there is a lot of overhead associated with diff-ing the entire autoloader tree to see if something changed. It's a lot easier to diff a single file. Hence, we write a timestamp in case any files change.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->
Tested on Stripe codebase.

See included automated tests.