### PR TITLE
use `back_inserter` when calculating fast path method hashes

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -268,7 +268,7 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
                 // This will insert two entries into `changedMethodHashes` for each changed method, but they will get
                 // deduped later.
                 set_difference(oldMethodHashes.begin(), oldMethodHashes.end(), newMethodHashes.begin(),
-                               newMethodHashes.end(), inserter(changedMethodHashes, changedMethodHashes.begin()));
+                               newMethodHashes.end(), std::back_inserter(changedMethodHashes));
 
                 gs->replaceFile(fref, f);
                 // If file doesn't have a typed: sigil, then we need to ensure it's typechecked using typed: false.


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I think the usual expected number of inserts here is small...but we can still do the linear thing and not the accidentally quadratic thing.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
