### PR TITLE
Respect `--remove-path-prefix` flag in autogen msgpack output

### DIFF
--- a/main/autogen/data/msgpack.cc
+++ b/main/autogen/data/msgpack.cc
@@ -1,6 +1,7 @@
 // has to go first because it violates our poisons
 #include "mpack/mpack.h"
 
+#include "core/GlobalState.h"
 #include "main/autogen/data/definitions.h"
 #include "main/autogen/data/msgpack.h"
 
@@ -141,7 +142,7 @@ string MsgpackWriter::pack(core::Context ctx, ParsedFile &pf) {
     mpack_start_array(&writer, 6);
 
     mpack_write_true(&writer); // did_resolution
-    packString(pf.path);
+    packString(ctx.state.getPrintablePath(pf.path));
     mpack_write_u32(&writer, pf.cksum);
 
     // requires

--- a/test/cli/autogen-path-prefix/file_with_no_dot
+++ b/test/cli/autogen-path-prefix/file_with_no_dot
@@ -1,0 +1,10 @@
+# typed: true
+
+require_relative 'hotdog_generator'
+require_relative 'hotdog_consumer'
+
+puts 'This is indeed a ruby file'
+
+hotdogs = 5.times.flat_map { HotdogGenerator.make_hotdogs }
+
+HotdogConsumer.eat(hotdogs)

--- a/test/cli/autogen-path-prefix/hotdog_consumer.rb
+++ b/test/cli/autogen-path-prefix/hotdog_consumer.rb
@@ -1,0 +1,5 @@
+# typed: true
+
+module HotdogConsumer
+  def self.eat(hotdogs); end
+end

--- a/test/cli/autogen-path-prefix/hotdog_generator.rb
+++ b/test/cli/autogen-path-prefix/hotdog_generator.rb
@@ -1,0 +1,5 @@
+# typed: true
+
+module HotdogGenerator
+  def self.make_hotdogs; end
+end

--- a/test/cli/autogen-path-prefix/test.out
+++ b/test/cli/autogen-path-prefix/test.out
@@ -1,0 +1,66 @@
+--- autogen.txt start ---
+# ParsedFile: test/cli/autogen-path-prefix/file_with_no_dot
+requires: []
+## defs:
+[def id=0]
+ type=module
+ defines_behavior=0
+ is_empty=0
+## refs:
+[ref id=0]
+ scope=[]
+ name=[HotdogGenerator]
+ nesting=[]
+ resolved=[HotdogGenerator]
+ loc=autogen-path-prefix/file_with_no_dot:8
+ is_defining_ref=0
+[ref id=1]
+ scope=[]
+ name=[HotdogConsumer]
+ nesting=[]
+ resolved=[HotdogConsumer]
+ loc=autogen-path-prefix/file_with_no_dot:10
+ is_defining_ref=0
+# ParsedFile: test/cli/autogen-path-prefix/hotdog_consumer.rb
+requires: []
+## defs:
+[def id=0]
+ type=module
+ defines_behavior=0
+ is_empty=0
+[def id=1]
+ type=module
+ defines_behavior=1
+ is_empty=0
+ defining_ref=[HotdogConsumer]
+## refs:
+[ref id=0]
+ scope=[]
+ name=[HotdogConsumer]
+ nesting=[]
+ resolved=[HotdogConsumer]
+ loc=autogen-path-prefix/hotdog_consumer.rb:3
+ is_defining_ref=1
+# ParsedFile: test/cli/autogen-path-prefix/hotdog_generator.rb
+requires: []
+## defs:
+[def id=0]
+ type=module
+ defines_behavior=0
+ is_empty=0
+[def id=1]
+ type=module
+ defines_behavior=1
+ is_empty=0
+ defining_ref=[HotdogGenerator]
+## refs:
+[ref id=0]
+ scope=[]
+ name=[HotdogGenerator]
+ nesting=[]
+ resolved=[HotdogGenerator]
+ loc=autogen-path-prefix/hotdog_generator.rb:3
+ is_defining_ref=1
+--- autogen.txt end ---
+
+a545544be12108889c205854a8673f2f4189c396  autogen.msgpack

--- a/test/cli/autogen-path-prefix/test.sh
+++ b/test/cli/autogen-path-prefix/test.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -eu
+
+main/sorbet --silence-dev-message --stop-after namer --autogen-version=4 \
+  -p autogen:autogen.txt -p autogen-msgpack:autogen.msgpack \
+  --remove-path-prefix=test/cli/ \
+  test/cli/autogen-path-prefix \
+  test/cli/autogen-path-prefix/file_with_no_dot
+
+echo "--- autogen.txt start ---"
+cat autogen.txt
+echo "--- autogen.txt end ---"
+echo
+
+shasum autogen.msgpack
+


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Currently, pay-server manually generates a file list to pass to Sorbet, but we'd like to just pass the root directory and let Sorbet walk the directory tree itself, but doing this currently leaves the leading `./` in all msgpack output. This PR makes Sorbet respect the `--remove-path-prefix` option in the msgpack output when set.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests, and note that the `loc` values in the fixture correctly remove the path-prefix.
