### PR TITLE
Add ENV.to_hash

### DIFF
--- a/rbi/sorbet/sorbet.rbi
+++ b/rbi/sorbet/sorbet.rbi
@@ -348,6 +348,11 @@ class Sorbet::Private::Static::ENVClass
   def select!(&blk); end
 
   sig do
+    returns(T::Hash[String, T.nilable(String)])
+  end
+  def to_hash; end
+
+  sig do
     params(
         key: T::Hash[String, T.nilable(String)],
     )


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Similar to https://github.com/sorbet/sorbet/pull/3070, add a sig for `to_hash` methods of `ENV` to continue to address https://github.com/sorbet/sorbet/issues/2174

(`to_h` is inherited from `Enumerable`.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

Quick test instructions for this change:
```ruby
# sorbet/rbi/sorbet/sorbet.rbi
class Sorbet::Private::Static::ENVClass # monkey patch to test
  extend T::Generic
  include Enumerable

  sig do
    returns(T::Hash[String, T.nilable(String)])
  end
  def to_hash; end
end
# [`ENV`](https://docs.ruby-lang.org/en/2.6.0/ENV.html) is a hash-like accessor
# for environment variables.
::ENV = T.let(T.unsafe(nil), Sorbet::Private::Static::ENVClass)

# foo.rb
# typed: true
require 'sorbet-runtime'

class Main
  extend T::Sig

  sig { returns(T.nilable(String))}
  def self.main
    ENV.to_hash["foo"]
  end
end

Main.main
```

And run
```bash
srb tc foo.rb
No errors! Great job.
```

Without the `sorbet.rbi` monkey patch, the follow error is raised:

```
❯ srb tc foo.rb
./foo.rb:10: Method to_hash does not exist on Sorbet::Private::Static::ENVClass https://srb.help/7003
    10 |    ENV.to_hash["foo"]
                ^^^^^^^
  Got Sorbet::Private::Static::ENVClass originating from:
    https://github.com/sorbet/sorbet/tree/6e74dc3a09fc7baa4bb532921758f50d8195f872/rbi/sorbet/sorbet.rbi#L375:
     375 |::ENV = T.let(T.unsafe(nil), Sorbet::Private::Static::ENVClass)
          ^^^^^
  Autocorrect: Use `-a` to autocorrect
    ./foo.rb:10: Replace with rehash
    10 |    ENV.to_hash["foo"]
                ^^^^^^^

foo.rb:10: Method to_hash does not exist on Sorbet::Private::Static::ENVClass https://srb.help/7003
    10 |    ENV.to_hash["foo"]
                ^^^^^^^
  Got Sorbet::Private::Static::ENVClass originating from:
    https://github.com/sorbet/sorbet/tree/6e74dc3a09fc7baa4bb532921758f50d8195f872/rbi/sorbet/sorbet.rbi#L375:
     375 |::ENV = T.let(T.unsafe(nil), Sorbet::Private::Static::ENVClass)
          ^^^^^
  Autocorrect: Use `-a` to autocorrect
    foo.rb:10: Replace with rehash
    10 |    ENV.to_hash["foo"]
                ^^^^^^^
Errors: 2
```



