### PR TITLE
Add isOpenInClient bit on core::File

### DIFF
--- a/core/Files.cc
+++ b/core/Files.cc
@@ -169,7 +169,7 @@ bool isPackagePath(string_view path) {
 
 File::Flags::Flags(string_view path)
     : cached(false), hasParseErrors(false), isPackagedTest(isTestPath(path)), isPackageRBI(isPackageRBIPath(path)),
-      isPackage(isPackagePath(path)) {}
+      isPackage(isPackagePath(path)), isOpenInClient(false) {}
 
 File::File(string &&path_, string &&source_, Type sourceType, uint32_t epoch)
     : epoch(epoch), sourceType(sourceType), flags(File::Flags(path_)), path_(move(path_)), source_(move(source_)),
@@ -257,6 +257,14 @@ bool File::isPackage() const {
 
 void File::setIsPackage(bool isPackage) {
     this->flags.isPackage = isPackage;
+}
+
+bool File::isOpenInClient() const {
+    return this->flags.isOpenInClient;
+}
+
+void File::setIsOpenInClient(bool isOpenInClient) {
+    this->flags.isOpenInClient = isOpenInClient;
 }
 
 vector<int> &File::lineBreaks() const {

--- a/core/Files.h
+++ b/core/Files.h
@@ -93,6 +93,12 @@ public:
     bool isPackage() const;
     void setIsPackage(bool isPackage);
 
+    // Whether the file is open in the LSP client. (Always false if not running under LSP.)
+    bool isOpenInClient() const;
+    // Set whether the file is open in the LSP client. Should only be used by LSPPreprocessor when
+    // creating files using the set of openFiles.
+    void setIsOpenInClient(bool isOpenInClient);
+
     // flag accessors
     bool isPackagedTest() const;
 
@@ -132,6 +138,8 @@ private:
         bool isPackageRBI : 1;
         // if true, the file is a stripe package file
         bool isPackage : 1;
+        // Documented on public accessors
+        bool isOpenInClient : 1;
 
         Flags(std::string_view path);
     };

--- a/main/lsp/LSPPreprocessor.cc
+++ b/main/lsp/LSPPreprocessor.cc
@@ -364,6 +364,7 @@ LSPPreprocessor::canonicalizeEdits(uint32_t v, unique_ptr<DidChangeTextDocumentP
             auto fileType = core::File::Type::Normal;
             auto &slot = openFiles[localPath];
             auto file = make_shared<core::File>(move(localPath), move(fileContents), fileType, v);
+            file->setIsOpenInClient(true);
             edit->updates.push_back(file);
             slot = move(file);
         }
@@ -382,6 +383,7 @@ LSPPreprocessor::canonicalizeEdits(uint32_t v, unique_ptr<DidOpenTextDocumentPar
             auto fileType = core::File::Type::Normal;
             auto &slot = openFiles[localPath];
             auto file = make_shared<core::File>(move(localPath), move(openParams->textDocument->text), fileType, v);
+            file->setIsOpenInClient(true);
             edit->updates.push_back(file);
             slot = move(file);
         }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is currently unused, but we should be able to do this to power LSP
features for things that would otherwise be expensive to compute for
every file in a codebase. The use case that I have in mind right now is
visually distinguishing regions of a file that are `T.untyped`.

I can't currently think of other use cases for this boolean that could crop up
in the future that are actually bad and/or dangerous, so it seems fine to just
let it sit there for the time being.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Because this is unused, I've not added any tests. It's possible that the person
who first uses this feature in the future will need to fix bugs, but at least it
being here should be better than forgetting that this approach is possible.