### PR TITLE
Add Hash.try_convert signature

### DIFF
--- a/gems/sorbet/test/hidden-method-finder/simple/sorbet_ruby_2_6_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/simple/sorbet_ruby_2_6_hidden.rbi.exp
@@ -2699,10 +2699,6 @@ class Hash
   include ::JSON::Ext::Generator::GeneratorMethods::Hash
 end
 
-class Hash
-  def self.try_convert(arg); end
-end
-
 class IO
   def nread(); end
 

--- a/gems/sorbet/test/hidden-method-finder/simple/sorbet_ruby_2_7_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/simple/sorbet_ruby_2_7_hidden.rbi.exp
@@ -2777,8 +2777,6 @@ class Hash
   def self.ruby2_keywords_hash(arg); end
 
   def self.ruby2_keywords_hash?(arg); end
-
-  def self.try_convert(arg); end
 end
 
 class IO

--- a/gems/sorbet/test/hidden-method-finder/thorough/sorbet_ruby_2_6_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/thorough/sorbet_ruby_2_6_hidden.rbi.exp
@@ -2717,10 +2717,6 @@ class Hash
   include ::JSON::Ext::Generator::GeneratorMethods::Hash
 end
 
-class Hash
-  def self.try_convert(arg); end
-end
-
 class IO
   def nread(); end
 

--- a/gems/sorbet/test/hidden-method-finder/thorough/sorbet_ruby_2_7_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/thorough/sorbet_ruby_2_7_hidden.rbi.exp
@@ -2795,8 +2795,6 @@ class Hash
   def self.ruby2_keywords_hash(arg); end
 
   def self.ruby2_keywords_hash?(arg); end
-
-  def self.try_convert(arg); end
 end
 
 class IO

--- a/rbi/core/hash.rbi
+++ b/rbi/core/hash.rbi
@@ -1401,6 +1401,21 @@ class Hash < Object
   end
   def transform_values!(&blk); end
 
+  # Attempts to convert a given object to a `Hash``. If *obj* is a `Hash``,
+  # *obj* is returned. If *obj* reponds to `to_hash`, the return of
+  # *obj.to_hash* is returned. Otherwise, `nil` is returned.
+  #
+  # ```ruby
+  # Hash.try_convert({ a: :b }) #=> { a: :b }
+  # Hash.try_convert(Object.new) #=> nil
+  # ```
+  #
+  # An exception is raised when `obj.to_hash` doesn't return a Hash.
+  sig do
+    params(obj: T.untyped).returns(T.nilable(T::Hash[T.untyped, T.untyped]))
+  end
+  def self.try_convert(obj); end
+
   # Adds the contents of the given hashes to the receiver.
   #
   # If no block is given, entries with duplicate keys are overwritten with the


### PR DESCRIPTION
Adds a signature for [`Hash.try_convert`](https://ruby-doc.org/core-3.1.1/Hash.html#method-c-try_convert). It seems this method is missing from Hash's default RBI.


### Motivation

While adding sorbet to some files, I noticed it didn't understand this method. It appears to have been a part of the standard lib [for awhile](https://ruby-doc.org/core-1.9.3/Hash.html#method-c-try_convert), so I think there's no harm in adding it. It is probably just a bit of an obscure method.


### Test plan

Reading the contributing doc and looking at other RBI PRs it looks like I don't need to write tests. Let me know if the signature and docs can be improved! 😄 
