### PR TITLE
Add public has_sig_block_for_method method

### DIFF
--- a/gems/sorbet-runtime/lib/types/utils.rb
+++ b/gems/sorbet-runtime/lib/types/utils.rb
@@ -2,7 +2,7 @@
 # typed: true
 
 module T::Utils
-  # Used to convert from a type specification to a `T::Types::Base`.
+  # Documented in rbi/sorbet/t.rbi
   def self.coerce(val)
     if val.is_a?(T::Private::Types::TypeAlias)
       val.aliased_type
@@ -27,10 +27,7 @@ module T::Utils
     end
   end
 
-  # Dynamically confirm that `value` is recursively a valid value of
-  # type `type`, including recursively through collections. Note that
-  # in some cases this runtime check can be very expensive, especially
-  # with large collections of objects.
+  # Documented in rbi/sorbet/t.rbi
   def self.check_type_recursive!(value, type)
     T::Private::Casts.cast_recursive(value, type, cast_method: "T.check_type_recursive!")
   end
@@ -48,18 +45,19 @@ module T::Utils
     end.uniq
   end
 
-  # Returns the signature for the `UnboundMethod`, or nil if it's not sig'd
-  #
-  # @example T::Utils.signature_for_method(x.method(:foo))
+  # Documented in rbi/sorbet/t.rbi
   def self.signature_for_method(method)
     T::Private::Methods.signature_for_method(method)
   end
 
-  # Returns the signature for the instance method on the supplied module, or nil if it's not found or not typed.
-  #
-  # @example T::Utils.signature_for_instance_method(MyClass, :my_method)
+  # Documented in rbi/sorbet/t.rbi
   def self.signature_for_instance_method(mod, method_name)
     T::Private::Methods.signature_for_method(mod.instance_method(method_name))
+  end
+
+  # Documented in rbi/sorbet/t.rbi
+  def self.has_sig_block_for_method(method)
+    T::Private::Methods.has_sig_block_for_method(method)
   end
 
   def self.wrap_method_with_call_validation_if_needed(mod, method_sig, original_method)

--- a/gems/sorbet-runtime/test/types/utils.rb
+++ b/gems/sorbet-runtime/test/types/utils.rb
@@ -64,5 +64,40 @@ module Opus::Types::Test
         assert_equal('Integer', sfm.return_type.name)
       end
     end
+
+    class ForHasSigBlockForMethod
+      extend T::Sig
+
+      sig {void}
+      def test1; end
+
+      sig {void}
+      def test2; end
+
+      T::Sig::WithoutRuntime.sig {void}
+      def test3; end
+    end
+
+    describe 'T::Utils.has_sig_block_for_method' do
+      it 'returns true if the method has a sig block pending' do
+        assert(T::Utils.has_sig_block_for_method(ForHasSigBlockForMethod.instance_method(:test1)))
+      end
+
+      it 'returns false if the method has already had its sig block forced' do
+        assert(T::Utils.has_sig_block_for_method(ForHasSigBlockForMethod.instance_method(:test2)))
+
+        # Another time, to assert that has_sig_block_for_method itself doesn't force it.
+        assert(T::Utils.has_sig_block_for_method(ForHasSigBlockForMethod.instance_method(:test2)))
+
+        # Force the sig block
+        ForHasSigBlockForMethod.new.test2
+
+        refute(T::Utils.has_sig_block_for_method(ForHasSigBlockForMethod.instance_method(:test2)))
+      end
+
+      it 'returns false if the method has no runtime sig wrapper' do
+        refute(T::Utils.has_sig_block_for_method(ForHasSigBlockForMethod.instance_method(:test3)))
+      end
+    end
   end
 end

--- a/rbi/sorbet/tprivate.rbi
+++ b/rbi/sorbet/tprivate.rbi
@@ -26,3 +26,58 @@ module T::Private::Compiler
   sig {returns(T.nilable(String))}
   def self.compiler_version; end
 end
+
+class T::Private::Methods::Signature
+  def method; end
+  def method_name; end
+  def arg_types; end
+  def kwarg_types; end
+  def block_type; end
+  def block_name; end
+  def rest_type; end
+  def rest_name; end
+  def keyrest_type; end
+  def keyrest_name; end
+  def bind; end
+  def return_type; end
+  def mode; end
+  def req_arg_count; end
+  def req_kwarg_names; end
+  def has_rest; end
+  def has_keyrest; end
+  def check_level; end
+  def parameters; end
+  def on_failure; end
+  def override_allow_incompatible; end
+  def defined_raw; end
+
+  def self.new_untyped(method:, mode: T.unsafe(nil), parameters: T.unsafe(nil)); end
+
+  def initialize(
+    method:,
+    method_name:,
+    raw_arg_types:,
+    raw_return_type:,
+    bind:,
+    mode:,
+    check_level:,
+    on_failure:,
+    parameters: method.parameters,
+    override_allow_incompatible: false,
+    defined_raw: false)
+  end
+
+  def as_alias(alias_name); end
+
+  def arg_count; end
+
+  def kwarg_names; end
+
+  def owner; end
+
+  def dsl_method; end
+
+  def each_args_value_type(args, &blk); end
+
+  def method_desc; end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

`T::Utils.signature_for_method` has the side effect of forcing the underlying
signature. If you want to do some logic that is conditional on whether a method
has a `sig` or not, you can get into a bad state where you accidentally force
the `sig` block to run earlier than it would have otherwise, which can cause
really hard to debug circular loading errors.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Added some tests.