### PR TITLE
Allow user to dump internal payload files

### DIFF
--- a/main/options/options.h
+++ b/main/options/options.h
@@ -85,6 +85,7 @@ struct Printers {
     PrinterConfig AutogenSubclasses;
     PrinterConfig Packager;
     PrinterConfig MinimizeRBI;
+    PrinterConfig PayloadSources;
     // Ensure everything here is in PrinterConfig::printers().
 
     std::vector<std::reference_wrapper<PrinterConfig>> printers();

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -4,7 +4,6 @@
 #define FULL_BUILD_ONLY(X) X;
 #include "core/proto/proto.h" // has to be included first as it violates our poisons
 // intentional comment to stop from reformatting
-#include "absl/strings/str_split.h"
 #include "common/statsd/statsd.h"
 #include "common/web_tracer_framework/tracing.h"
 #include "main/autogen/autogen.h"
@@ -21,7 +20,9 @@
 #include "packager/rbi_gen.h"
 #endif
 
+#include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
+#include "absl/strings/str_split.h"
 #include "common/FileOps.h"
 #include "common/Timer.h"
 #include "common/sort.h"
@@ -500,6 +501,39 @@ int realmain(int argc, char *argv[]) {
     gs->suggestUnsafe = opts.suggestUnsafe;
 
     logger->trace("done building initial global state");
+
+    if (opts.print.PayloadSources.enabled) {
+        auto dumpDir = opts.print.PayloadSources.outputPath;
+        FileOps::ensureDir(dumpDir);
+
+        for (auto &payloadFile : gs->getFiles()) {
+            if (payloadFile == nullptr) {
+                continue;
+            }
+
+            auto payloadPath = payloadFile->path();
+            auto payloadPrefix = absl::StrCat(core::File::URL_PREFIX, "rbi/");
+            if (!absl::StartsWith(payloadPath, payloadPrefix)) {
+                // Skip files from `bazel-out/`
+                continue;
+            }
+
+            payloadPath.remove_prefix(payloadPrefix.size());
+
+            vector<string_view> parts = absl::StrSplit(payloadPath, "/");
+            auto dumpSubdir = dumpDir;
+            for (int i = 0; i < parts.size() - 1; i++) {
+                auto part = parts[i];
+                dumpSubdir = absl::StrCat(dumpSubdir, "/", part);
+                FileOps::ensureDir(dumpSubdir);
+            }
+
+            auto dumpPath = absl::StrCat(dumpDir, "/", payloadPath);
+            opts.fs->writeFile(dumpPath, payloadFile->source());
+        }
+
+        return returnCode;
+    }
 
     unique_ptr<core::GlobalState> gsForMinimize;
     if (!opts.minimizeRBI.empty()) {

--- a/test/cli/print-payload-sources/test.out
+++ b/test/cli/print-payload-sources/test.out
@@ -1,0 +1,13 @@
+You can't pass both `--print=payload-sources` and `--no-stdlib`.
+--------------------------------------------------------------------------
+You can't pass both `--print=payload-sources` and `-e`.
+--------------------------------------------------------------------------
+You can't pass both `--print=payload-sources` and paths to typecheck.
+--------------------------------------------------------------------------
+core/array.rbi:class Array < Object
+core/object.rbi:class Object < BasicObject
+stdlib/base64.rbi:module Base64
+--------------------------------------------------------------------------
+core/array.rbi:class Array < Object
+core/object.rbi:class Object < BasicObject
+stdlib/base64.rbi:module Base64

--- a/test/cli/print-payload-sources/test.sh
+++ b/test/cli/print-payload-sources/test.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+dir=$(mktemp -d)
+cleanup() {
+    rm -r "$dir"
+}
+trap cleanup EXIT
+
+dir_grep() {
+    grep -r "$1" "$2" | grep -o "\(core\|stdlib\).*"
+}
+
+# Can't use `--print=payload-sources` with `--no-stdlib`
+main/sorbet --silence-dev-message --print=payload-sources:$dir --no-stdlib 2>&1
+
+echo --------------------------------------------------------------------------
+
+# Can't use `--print=payload-sources` with `-e`
+main/sorbet --silence-dev-message --print=payload-sources:$dir -e "foo" 2>&1
+
+echo --------------------------------------------------------------------------
+
+# Can't use `--print=payload-sources` with arguments
+main/sorbet --silence-dev-message --print=payload-sources:$dir file.rb 2>&1
+
+echo --------------------------------------------------------------------------
+
+# Dump payload even if the directory exists
+main/sorbet --silence-dev-message --print=payload-sources:$dir
+dir_grep "class Array < Object" $dir
+dir_grep "class Object < BasicObject" $dir
+dir_grep "module Base64" $dir
+
+echo --------------------------------------------------------------------------
+
+# Dump payload even if the directory doesn't exist
+mkdir -p $dir/subdir1/subdir2
+main/sorbet --silence-dev-message --print=payload-sources:$dir/subdir1/subdir2
+dir_grep "class Array < Object" $dir/subdir1/subdir2
+dir_grep "class Object < BasicObject" $dir/subdir1/subdir2
+dir_grep "module Base64" $dir/subdir1/subdir2


### PR DESCRIPTION
### Motivation

For some tools it can be useful to know what is inside the payload embedded with Sorbet.

One could read the payload from Github but this payload might not be exactly corresponding to the one embedded in the version of Sorbet used.

This PR adds the `--print=payload-sources` option which writes the content of the payload in RBI files inside the specified directory:

```shell
$ sorbet --print=payload-sources=my-dir
```

### Test plan

See included automated tests.
