### PR TITLE
wip: sorbet-runtime mode that tracks metaprogramming

### DIFF
--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -555,6 +555,15 @@ module T::Configuration
     @prop_freeze_handler
   end
 
+  @metaprogramming_location_tracking = false
+  def self.toggle_metaprogramming_location_tracking
+    @metaprogramming_location_tracking ^= true
+  end
+
+  def self.metaprogramming_location_tracking?
+    @metaprogramming_location_tracking
+  end
+
   @sealed_violation_whitelist = nil
   # @param [Array] sealed_violation_whitelist An array of Regexp to validate
   #   whether inheriting /including a sealed module outside the defining module

--- a/gems/sorbet-runtime/main.rb
+++ b/gems/sorbet-runtime/main.rb
@@ -1,0 +1,47 @@
+# typed: false
+require_relative './lib/sorbet-runtime'
+
+class Module
+  include T::Sig
+end
+
+original_method = T.let(nil, T.nilable(T::Private::ClassUtils::ReplacedMethod))
+original_method = T::Private::ClassUtils.replace_method(Module, :define_method) do |symbol, &blk|
+  T::Private::Methods.install_hooks(self)
+  original_method.bind(self).call(symbol, &blk)
+end
+
+original_singleton_method = T.let(nil, T.nilable(T::Private::ClassUtils::ReplacedMethod))
+original_singleton_method = T::Private::ClassUtils.replace_method(Kernel, :define_singleton_method) do |symbol, &blk|
+  T::Private::Methods.install_hooks(self)
+  original_singleton_method.bind(self).call(symbol, &blk)
+end
+
+T::Configuration.toggle_metaprogramming_location_tracking
+
+module MyDSL
+  def yikes
+    define_method(:yikes) {}
+  end
+
+  def big_yikes
+    define_singleton_method(:big_yikes) {}
+  end
+end
+
+class A
+  extend MyDSL
+
+  define_method(:bad1) {}
+  define_singleton_method(:bad2) {}
+
+  def good1; end
+  def self.good2; end
+
+  yikes
+  big_yikes
+
+end
+
+puts "Locs where DSL call triggered metaprogrammed methods:\n"
+pp(T::Private::Methods.metaprogrammed_methods)


### PR DESCRIPTION
note to future self:

- it might make more sense to keep this code out of sorbet-runtime? like
  for this to work you already had to monkey patch kernel and module...
  adding a method_added monkey patch is just one step away
- for attribution purposes, it's probably worth knowing what the method
  that's called on the reported line is. idk if it's easy to get that
  information from other frames in the backtrace, or whether we just let
  the user guess it by grepping the line


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.