### PR TITLE
take `Span<const T>` instead of `const InlinedVector<T, N> &` args

### DIFF
--- a/core/BUILD
+++ b/core/BUILD
@@ -36,6 +36,7 @@ cc_library(
         "//main/pipeline/semantic_extension:interface",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/synchronization",
+        "@com_google_absl//absl/types:span",
         "@rang",
     ],
 )

--- a/core/TypeConstraint.cc
+++ b/core/TypeConstraint.cc
@@ -11,7 +11,7 @@ bool TypeConstraint::isEmpty() const {
     return upperBounds.empty() && lowerBounds.empty();
 }
 
-void TypeConstraint::defineDomain(const GlobalState &gs, const InlinedVector<TypeArgumentRef, 4> &typeParams) {
+void TypeConstraint::defineDomain(const GlobalState &gs, absl::Span<const TypeArgumentRef> typeParams) {
     // ENFORCE(isEmpty()); // unfortunately this is false. See
     // test/testdata/infer/generic_methods/countraints_crosstalk.rb
     for (const auto &ta : typeParams) {

--- a/core/TypeConstraint.h
+++ b/core/TypeConstraint.h
@@ -1,6 +1,7 @@
 #ifndef SORBET_TYPECONSTRAINT_H
 #define SORBET_TYPECONSTRAINT_H
 
+#include "absl/types/span.h"
 #include "core/Context.h"
 #include "core/SymbolRef.h"
 #include "core/TypePtr.h"
@@ -23,7 +24,7 @@ public:
     TypeConstraint() = default;
     TypeConstraint(const TypeConstraint &) = delete;
     TypeConstraint(TypeConstraint &&) = default;
-    void defineDomain(const GlobalState &gs, const InlinedVector<TypeArgumentRef, 4> &typeParams);
+    void defineDomain(const GlobalState &gs, absl::Span<const TypeArgumentRef> typeParams);
     bool hasUpperBound(TypeArgumentRef forWhat) const;
     bool hasLowerBound(TypeArgumentRef forWhat) const;
     TypePtr findSolution(TypeArgumentRef forWhat) const;

--- a/core/TypePtr.cc
+++ b/core/TypePtr.cc
@@ -279,7 +279,7 @@ TypePtr TypePtr::_instantiate(const GlobalState &gs, const TypeConstraint &tc) c
 #undef _INSTANTIATE
 }
 
-TypePtr TypePtr::_instantiate(const GlobalState &gs, const InlinedVector<TypeMemberRef, 4> &params,
+TypePtr TypePtr::_instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
                               const std::vector<TypePtr> &targs) const {
     switch (tag()) {
         case Tag::BlamedUntyped:

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -1,5 +1,6 @@
 #ifndef SORBET_TYPEPTR_H
 #define SORBET_TYPEPTR_H
+#include "absl/types/span.h"
 #include "common/common.h"
 #include "core/NameRef.h"
 #include "core/ShowOptions.h"
@@ -306,7 +307,7 @@ public:
 
     TypePtr _instantiate(const GlobalState &gs, const TypeConstraint &tc) const;
 
-    TypePtr _instantiate(const GlobalState &gs, const InlinedVector<TypeMemberRef, 4> &params,
+    TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
                          const std::vector<TypePtr> &targs) const;
 
     // If this TypePtr `is_proxy_type`, returns its underlying type.

--- a/core/Types.h
+++ b/core/Types.h
@@ -142,8 +142,8 @@ public:
                                                              const std::vector<TypePtr> &targs, ClassOrModuleRef asIf);
     // Extract the return value type from a proc.
     static TypePtr getProcReturnType(const GlobalState &gs, const TypePtr &procType);
-    static TypePtr instantiate(const GlobalState &gs, const TypePtr &what,
-                               absl::Span<const TypeMemberRef> params, const std::vector<TypePtr> &targs);
+    static TypePtr instantiate(const GlobalState &gs, const TypePtr &what, absl::Span<const TypeMemberRef> params,
+                               const std::vector<TypePtr> &targs);
     /** Replace all type variables in `what` with their instantiations.
      * Requires that `tc` has already been solved.
      */

--- a/core/Types.h
+++ b/core/Types.h
@@ -2,6 +2,7 @@
 #define SORBET_TYPES_H
 
 #include "absl/base/casts.h"
+#include "absl/types/span.h"
 #include "common/Counters.h"
 #include "core/Context.h"
 #include "core/Error.h"
@@ -142,7 +143,7 @@ public:
     // Extract the return value type from a proc.
     static TypePtr getProcReturnType(const GlobalState &gs, const TypePtr &procType);
     static TypePtr instantiate(const GlobalState &gs, const TypePtr &what,
-                               const InlinedVector<TypeMemberRef, 4> &params, const std::vector<TypePtr> &targs);
+                               absl::Span<const TypeMemberRef> params, const std::vector<TypePtr> &targs);
     /** Replace all type variables in `what` with their instantiations.
      * Requires that `tc` has already been solved.
      */
@@ -391,7 +392,7 @@ public:
 
     void _sanityCheck(const GlobalState &gs) const;
 
-    TypePtr _instantiate(const GlobalState &gs, const InlinedVector<TypeMemberRef, 4> &params,
+    TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
                          const std::vector<TypePtr> &targs) const;
 };
 CheckSize(LambdaParam, 40, 8);
@@ -609,7 +610,7 @@ public:
     TypePtr getCallArguments(const GlobalState &gs, NameRef name) const;
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const;
     void _sanityCheck(const GlobalState &gs) const;
-    TypePtr _instantiate(const GlobalState &gs, const InlinedVector<TypeMemberRef, 4> &params,
+    TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
                          const std::vector<TypePtr> &targs) const;
     TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc) const;
     TypePtr _instantiate(const GlobalState &gs, const TypeConstraint &tc) const;
@@ -664,7 +665,7 @@ public:
     TypePtr getCallArguments(const GlobalState &gs, NameRef name) const;
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const;
     void _sanityCheck(const GlobalState &gs) const;
-    TypePtr _instantiate(const GlobalState &gs, const InlinedVector<TypeMemberRef, 4> &params,
+    TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
                          const std::vector<TypePtr> &targs) const;
     TypePtr _replaceSelfType(const GlobalState &gs, const TypePtr &receiver) const;
     TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc) const;
@@ -708,7 +709,7 @@ public:
     std::string showWithMoreInfo(const GlobalState &gs) const;
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
     void _sanityCheck(const GlobalState &gs) const;
-    TypePtr _instantiate(const GlobalState &gs, const InlinedVector<TypeMemberRef, 4> &params,
+    TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
                          const std::vector<TypePtr> &targs) const;
     TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc) const;
     TypePtr _instantiate(const GlobalState &gs, const TypeConstraint &tc) const;
@@ -734,7 +735,7 @@ public:
     std::string showWithMoreInfo(const GlobalState &gs) const;
     uint32_t hash(const GlobalState &gs) const;
     void _sanityCheck(const GlobalState &gs) const;
-    TypePtr _instantiate(const GlobalState &gs, const InlinedVector<TypeMemberRef, 4> &params,
+    TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
                          const std::vector<TypePtr> &targs) const;
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
     TypePtr _approximate(const GlobalState &gs, const TypeConstraint &tc) const;
@@ -761,7 +762,7 @@ public:
     uint32_t hash(const GlobalState &gs) const;
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
     void _sanityCheck(const GlobalState &gs) const;
-    TypePtr _instantiate(const GlobalState &gs, const InlinedVector<TypeMemberRef, 4> &params,
+    TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
                          const std::vector<TypePtr> &targs) const;
 
     TypePtr getCallArguments(const GlobalState &gs, NameRef name) const;

--- a/core/types/typemaps.cc
+++ b/core/types/typemaps.cc
@@ -8,7 +8,7 @@
 using namespace std;
 namespace sorbet::core {
 
-TypePtr Types::instantiate(const GlobalState &gs, const TypePtr &what, const InlinedVector<TypeMemberRef, 4> &params,
+TypePtr Types::instantiate(const GlobalState &gs, const TypePtr &what, absl::Span<const TypeMemberRef> params,
                            const vector<TypePtr> &targs) {
     ENFORCE(what != nullptr);
     auto t = what._instantiate(gs, params, targs);
@@ -119,7 +119,7 @@ optional<vector<TypePtr>> approximateElems(const vector<TypePtr> &elems, const G
 }
 } // anonymous namespace
 
-TypePtr TupleType::_instantiate(const GlobalState &gs, const InlinedVector<TypeMemberRef, 4> &params,
+TypePtr TupleType::_instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
                                 const vector<TypePtr> &targs) const {
     optional<vector<TypePtr>> newElems = instantiateElems(this->elems, gs, params, targs);
     if (!newElems) {
@@ -144,7 +144,7 @@ TypePtr TupleType::_approximate(const GlobalState &gs, const TypeConstraint &tc)
     return make_type<TupleType>(move(*newElems));
 };
 
-TypePtr ShapeType::_instantiate(const GlobalState &gs, const InlinedVector<TypeMemberRef, 4> &params,
+TypePtr ShapeType::_instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
                                 const vector<TypePtr> &targs) const {
     optional<vector<TypePtr>> newValues = instantiateElems(this->values, gs, params, targs);
     if (!newValues) {
@@ -169,7 +169,7 @@ TypePtr ShapeType::_approximate(const GlobalState &gs, const TypeConstraint &tc)
     return make_type<ShapeType>(this->keys, move(*newValues));
 }
 
-TypePtr OrType::_instantiate(const GlobalState &gs, const InlinedVector<TypeMemberRef, 4> &params,
+TypePtr OrType::_instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
                              const vector<TypePtr> &targs) const {
     auto left = this->left._instantiate(gs, params, targs);
     auto right = this->right._instantiate(gs, params, targs);
@@ -215,7 +215,7 @@ TypePtr OrType::_approximate(const GlobalState &gs, const TypeConstraint &tc) co
     return nullptr;
 }
 
-TypePtr AndType::_instantiate(const GlobalState &gs, const InlinedVector<TypeMemberRef, 4> &params,
+TypePtr AndType::_instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
                               const vector<TypePtr> &targs) const {
     auto left = this->left._instantiate(gs, params, targs);
     auto right = this->right._instantiate(gs, params, targs);
@@ -261,7 +261,7 @@ TypePtr AndType::_approximate(const GlobalState &gs, const TypeConstraint &tc) c
     return nullptr;
 }
 
-TypePtr AppliedType::_instantiate(const GlobalState &gs, const InlinedVector<TypeMemberRef, 4> &params,
+TypePtr AppliedType::_instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
                                   const vector<TypePtr> &targs) const {
     optional<vector<TypePtr>> newTargs = instantiateElems(this->targs, gs, params, targs);
     if (!newTargs) {
@@ -286,7 +286,7 @@ TypePtr AppliedType::_approximate(const GlobalState &gs, const TypeConstraint &t
     return make_type<AppliedType>(this->klass, move(*newTargs));
 }
 
-TypePtr LambdaParam::_instantiate(const GlobalState &gs, const InlinedVector<TypeMemberRef, 4> &params,
+TypePtr LambdaParam::_instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
                                   const vector<TypePtr> &targs) const {
     ENFORCE(params.size() == targs.size());
     for (auto &el : params) {


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Over in #5413, I had the idea to reduce the inlined storage for some `TypeArgumentRef`-storing and `TypeMemberRef`-storing vectors.  This turned out to be messier than necessary, because the types that are used for storage are also implicated in the argument types for various functions.

I think it would be cleaner if those various functions took `Span`, rather than dictating the particulars about what kind of storage the caller used.  And if those various functions took `Span`, that would make the original PR much more obvious in terms of its effects.

Hence, this PR.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.  No functional change intended.
