### PR TITLE
Compatible with keyword argument Ruby 3.0

### DIFF
--- a/gems/sorbet/lib/gem-generator-tracepoint.rb
+++ b/gems/sorbet/lib/gem-generator-tracepoint.rb
@@ -40,7 +40,7 @@ module Sorbet::Private
       end
 
       FileUtils.rm_r(output_dir) if Dir.exist?(output_dir)
-      TracepointSerializer.new(trace_results).serialize(output_dir)
+      TracepointSerializer.new(**trace_results).serialize(output_dir)
     end
 
     def self.output_file


### PR DESCRIPTION
We encountered the same error in issue below.

https://github.com/sorbet/sorbet/issues/5332#issue-1144414552

### Motivation
We would like to make `srb init` works correctly.
(But there remains a few other errors even after this fix merged. ref: https://github.com/sorbet/sorbet/issues/5332#issue-1144414552)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
