### PR TITLE
Bump the compdb dependency

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,6 +4,10 @@ load("//third_party:externals.bzl", "register_sorbet_dependencies")
 
 register_sorbet_dependencies()
 
+load("@com_grail_bazel_compdb//:deps.bzl", "bazel_compdb_deps")
+
+bazel_compdb_deps()
+
 load("@com_grail_bazel_toolchain//toolchain:deps.bzl", "bazel_toolchain_dependencies")
 
 bazel_toolchain_dependencies()

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -161,15 +161,10 @@ def register_sorbet_dependencies():
     )
 
     http_archive(
-        name = "compdb",
-        urls = _github_public_urls("grailbio/bazel-compilation-database/archive/2cd8ed39ef726645615ba94fcd265d54b0f0de33.zip"),
-        sha256 = "94ae67d2047c8b57e0e569c3c21ff29e24934a795c8c7fa4b6397cbb9c106691",
-        build_file_content = (
-            """
-package(default_visibility = ["//visibility:public"])
-"""
-        ),
-        strip_prefix = "bazel-compilation-database-2cd8ed39ef726645615ba94fcd265d54b0f0de33",
+        name = "com_grail_bazel_compdb",
+        urls = _github_public_urls("grailbio/bazel-compilation-database/archive/6b9329e37295eab431f82af5fe24219865403e0f.zip"),
+        sha256 = "6cf0dc4b40023a26787cd7cdb629dccd26e2208c8a2f19e1dde4ca10c109c86c",
+        strip_prefix = "bazel-compilation-database-6b9329e37295eab431f82af5fe24219865403e0f",
     )
 
     # NOTE: we use the sorbet branch for development to keep our changes rebasable on grailio/bazel-toolchain

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -1,5 +1,6 @@
 load("//tools:clang.bzl", "clang_tool")
-load("@compdb//:aspects.bzl", "compilation_database")
+load("@com_grail_bazel_compdb//:defs.bzl", "compilation_database")
+load("@com_grail_bazel_output_base_util//:defs.bzl", "OUTPUT_BASE")
 
 clang_tool("clang-format")
 
@@ -10,6 +11,7 @@ clang_tool("opt")
 compilation_database(
     name = "compdb",
     testonly = True,
+    output_base = OUTPUT_BASE,
     targets = [
         # BEGIN compile_commands targets
         "//ast:ast",

--- a/tools/scripts/build_compilation_db.sh
+++ b/tools/scripts/build_compilation_db.sh
@@ -6,6 +6,4 @@ cd "$(dirname "$0")/../.."
 
 ./bazel build //tools:compdb --config=dbg
 
-execution_root="$(./bazel info execution_root)"
-
-sed "s|__EXEC_ROOT__|$execution_root|g" bazel-bin/tools/compile_commands.json > compile_commands.json
+cp bazel-bin/tools/compile_commands.json compile_commands.json


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
The newer version of the `@com_grail_bazel_compdb` package doesn't require us to use sed on the `compile_commands.json` file before it's usable. This PR bumps to a newer, but unreleased, version.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Simpler `compile_commands.json` generation.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
