### PR TITLE
Do not set `EMPTY_EXTRA_PROPS` as `@_extra_props` value

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -324,9 +324,9 @@ module T::Props::Serializable::DecoratorMethods
 
   def extra_props(instance)
     if instance.instance_variable_defined?(:@_extra_props)
-      instance.instance_variable_get(:@_extra_props)
+      instance.instance_variable_get(:@_extra_props) || EMPTY_EXTRA_PROPS
     else
-      instance.instance_variable_set(:@_extra_props, EMPTY_EXTRA_PROPS)
+      EMPTY_EXTRA_PROPS
     end
   end
 

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -157,6 +157,12 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       str = obj.inspect
       assert_equal('<Opus::Types::Test::Props::SerializableTest::MySerializable foo={"age"=>7, "color"=>"red"}, name="Bob" @_extra_props=<not_a_prop="but_here_anyway">>', str)
     end
+
+    it 'inspects frozen structs' do
+      obj = a_serializable.freeze
+      str = obj.inspect
+      assert_equal('<Opus::Types::Test::Props::SerializableTest::MySerializable foo={"age"=>7, "color"=>"red"}, name="Bob">', str)
+    end
   end
 
   describe '.from_hash' do


### PR DESCRIPTION
### Motivation

Fix the difference in behavior introduced [here](https://github.com/sorbet/sorbet/pull/5482/files#diff-b6758eb606992ab00fd8e66aa0375c569648250f874bf6fb51fe402769e0e9cbL325-R330).

Without this fix, this code will raise:

```ruby
class MyStruct < T::Struct
  const :foo, String
end

puts MyStruct.new(foo: "foo").freeze.inspect
```

```
Traceback (most recent call last):
	16: from test.rb:7:in `<main>'
	15: from gems/sorbet-runtime/lib/types/props/pretty_printable.rb:9:in `inspect'
	14: from gems/sorbet-runtime/lib/types/private/methods/_methods.rb:270:in `block in _on_method_added'
	13: from gems/sorbet-runtime/lib/types/private/methods/call_validation.rb:161:in `validate_call'
	12: from gems/sorbet-runtime/lib/types/private/methods/call_validation.rb:161:in `bind_call'
	11: from gems/sorbet-runtime/lib/types/props/pretty_printable.rb:32:in `inspect_instance'
	10: from gems/sorbet-runtime/lib/types/props/serializable.rb:335:in `inspect_instance_components'
	 9: from gems/sorbet-runtime/lib/types/props/serializable.rb:329:in `extra_props'
	 8: from gems/sorbet-runtime/lib/types/props/serializable.rb:329:in `instance_variable_set'
	 7: from gems/sorbet-runtime/lib/types/props/pretty_printable.rb:9:in `inspect'
	 6: from gems/sorbet-runtime/lib/types/private/methods/call_validation.rb:90:in `block in create_validator_slow'
	 5: from gems/sorbet-runtime/lib/types/private/methods/call_validation.rb:161:in `validate_call'
	 4: from gems/sorbet-runtime/lib/types/private/methods/call_validation.rb:161:in `bind_call'
	 3: from gems/sorbet-runtime/lib/types/props/pretty_printable.rb:32:in `inspect_instance'
	 2: from gems/sorbet-runtime/lib/types/props/serializable.rb:335:in `inspect_instance_components'
	 1: from gems/sorbet-runtime/lib/types/props/serializable.rb:329:in `extra_props'
gems/sorbet-runtime/lib/types/props/serializable.rb:329:in `instance_variable_set': can't modify frozen #<Class:#<MyStruct:0x0000000142a49898>>:  ... (FrozenError)
```

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
