### PR TITLE
Fix export_for_test misattribution bug

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -265,11 +265,12 @@ public:
         if (ctx.file.data(ctx).isPackagedTest()) {
             // In a test file first look to see in our own package to see if it's missing an `export_for_test`
             core::SymbolRef sym = findPrivateSymbol(ctx, scope, /* test */ false);
-            if (sym.exists() && sym.isClassOrModule()) {
+            if (sym.exists() && sym.isClassOrModule() && !sym.loc(ctx).file().isPackage()) {
                 res.emplace_back(MissingExportMatch{sym, this->mangledName()});
                 return res;
             }
         }
+
         for (auto &imported : importedPackageNames) {
             auto &info = ctx.state.packageDB().getPackageInfo(imported.name.mangledName);
             if (!info.exists()) {

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -265,7 +265,7 @@ public:
         if (ctx.file.data(ctx).isPackagedTest()) {
             // In a test file first look to see in our own package to see if it's missing an `export_for_test`
             core::SymbolRef sym = findPrivateSymbol(ctx, scope, /* test */ false);
-            if (sym.exists() && sym.isClassOrModule() && !sym.loc(ctx).file().isPackage()) {
+            if (sym.exists() && sym.isClassOrModule() && !sym.loc(ctx).file().data(ctx).isPackage()) {
                 res.emplace_back(MissingExportMatch{sym, this->mangledName()});
                 return res;
             }

--- a/test/cli/package-error-no-export-for-test/foo_bar/__package.rb
+++ b/test/cli/package-error-no-export-for-test/foo_bar/__package.rb
@@ -1,4 +1,5 @@
 # typed: strict
 
 class Foo::Bar < PackageSpec
+  export Foo::Bar::Exported
 end

--- a/test/cli/package-error-no-export-for-test/foo_bar/exported.rb
+++ b/test/cli/package-error-no-export-for-test/foo_bar/exported.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+class Foo::Bar::Exported
+end

--- a/test/cli/package-error-no-export-for-test/other/__package.rb
+++ b/test/cli/package-error-no-export-for-test/other/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class Other < PackageSpec
+  import Foo::Bar
+end

--- a/test/cli/package-error-no-export-for-test/other/other.test.rb
+++ b/test/cli/package-error-no-export-for-test/other/other.test.rb
@@ -1,0 +1,8 @@
+# typed: true
+
+class Test::Other
+  def aaa
+    Foo::Bar::Thing
+  end
+end
+

--- a/test/cli/package-error-no-export-for-test/test.out
+++ b/test/cli/package-error-no-export-for-test/test.out
@@ -3,13 +3,30 @@ foo_bar/thing.test.rb:5: Unable to resolve constant `Thing` https://srb.help/500
                 ^^^^^^^^^^^^^^^
     foo_bar/__package.rb:3: To expose this name to a package's own tests it must be exported. Do you need to `export_for_test Foo::Bar` in this package?
      3 |class Foo::Bar < PackageSpec
-     4 |end
-    foo_bar/thing.rb:3: Constant `Foo::Bar` is defined here:
-     3 |class Foo::Bar::Thing
+     4 |  export Foo::Bar::Exported
+     5 |end
+    foo_bar/exported.rb:3: Constant `Foo::Bar` is defined here:
+     3 |class Foo::Bar::Exported
               ^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    foo_bar/__package.rb:3: Insert `
+    foo_bar/__package.rb:4: Insert `
   export_for_test Foo::Bar`
+     4 |  export Foo::Bar::Exported
+                                   ^
+
+other/other.test.rb:5: Unable to resolve constant `Thing` https://srb.help/5002
+     5 |    Foo::Bar::Thing
+            ^^^^^^^^^^^^^^^
+    foo_bar/__package.rb:3: Do you need to `export Foo::Bar::Thing` in package `Foo::Bar`?
      3 |class Foo::Bar < PackageSpec
-                                    ^
-Errors: 1
+     4 |  export Foo::Bar::Exported
+     5 |end
+    foo_bar/thing.rb:3: Constant `Foo::Bar::Thing` is defined here:
+     3 |class Foo::Bar::Thing
+        ^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    foo_bar/__package.rb:4: Insert `
+  export Foo::Bar::Thing`
+     4 |  export Foo::Bar::Exported
+                                   ^
+Errors: 2


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Fixes an export misattribution bug in the case of `export_for_test` autocorrects that appears due to transitivity of imports.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
In `--stripe-packages` mode there is a bug wherein `export_for_test` autocorrect suggestions are misattributed to the wrong package. Consider the following:

```
  # foo/__package.rb
  class Opus::Foo < PackageSpec
    export Opus::Foo::A
  end
```

```
  # foo/a.rb
  class Opus::Foo::A
    # ...
   end
```

```
  # foo/unexported.rb
  class Opus::Foo::Unexported; end
```

```
  # bar/__package.rb
  class Opus::Bar < PackageSpec
     import Opus::Foo
  end
```

```
  # bar/b.test.rb
  class Test::Opus::Bar::B
      Opus::Foo::Unexported # <=== error
  end
```

Currently this would throw the following error:
```
    bar/__package.rb:3: To expose this name to a package's own tests it must be exported. Do you need to `export_for_test Opus::Foo` in this package?
     3 |class Opus::Bar < PackageSpec
     4 |  import Opus::Foo
     5 |end
    bar/__package.rb:4: Constant `Opus::Foo` is defined here:
     4 |  import Opus::Foo
```

The issue is that `Opus::Bar` contains the symbol `Opus::Foo` via an import, so the scope check finds `Opus::Foo` inside `Opus::Bar` and incorrectly attributes an export to it. The fix is simple -- ignore symbols that are "defined" in `__package.rb` files, as they are always going to be transitively imported.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Also tested on Stripe codebase.
