### PR TITLE
fix hover on `<Magic>.call-with-*`

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -744,7 +744,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                         argnodes.erase(fwdIt);
                     }
 
-                    auto array = make_unique<parser::Array>(loc, std::move(argnodes));
+                    auto array = make_unique<parser::Array>(locZeroLen, std::move(argnodes));
                     auto args = node2TreeImpl(dctx, std::move(array));
 
                     if (hasFwdArgs) {

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2226,7 +2226,7 @@ private:
                 dispatched.returnType = Types::instantiate(gs, dispatched.returnType, *(constr));
             }
         }
-        res.returnType = dispatched.returnType;
+        res = std::move(dispatched);
     }
 
 public:

--- a/test/testdata/infer/private_methods.rb
+++ b/test/testdata/infer/private_methods.rb
@@ -60,8 +60,9 @@ TestChild.new.using_symbol # error: Non-private call to private method `using_sy
 
 T.unsafe(Test.new).using_symbol
 
-# TODO: The following methods should also error out. They currently do not do that due to issues with the instrinsics.
+# TODO: The following call should also error out. It currently does not do that due to issues with the instrinsics.
 Test.new.splat_call(*T.unsafe(nil)) # Currently no Error, since T.unsafe makes Magic_callWithSplat#apply return prematurely due to the untyped argument.
+
 Test.new.splat_and_block_call(*[1, 'a'], &nil) # error: Non-private call to private method `splat_and_block_call` on `Test`
 Test.new.block_call(&nil) # error: Non-private call to private method `block_call` on `Test`
 

--- a/test/testdata/infer/private_methods.rb
+++ b/test/testdata/infer/private_methods.rb
@@ -62,8 +62,8 @@ T.unsafe(Test.new).using_symbol
 
 # TODO: The following methods should also error out. They currently do not do that due to issues with the instrinsics.
 Test.new.splat_call(*T.unsafe(nil)) # Currently no Error, since T.unsafe makes Magic_callWithSplat#apply return prematurely due to the untyped argument.
-Test.new.splat_and_block_call(*[1, 'a'], &nil) # Currently no Error, since the nil block makes Magic_callWithSplatAndBlock return prematurely.
-Test.new.block_call(&nil) # Currently no Error, since the nil block makes Magic_callWithBlock return prematurely.
+Test.new.splat_and_block_call(*[1, 'a'], &nil) # error: Non-private call to private method `splat_and_block_call` on `Test`
+Test.new.block_call(&nil) # error: Non-private call to private method `block_call` on `Test`
 
 Test.new.subsequent_visibility # error: Non-private call to private method `subsequent_visibility`
 Test.new.subsequent_visibility_attr_reader # error: Non-private call to private method `subsequent_visibility_attr_reader`

--- a/test/testdata/lsp/hover_call_block_splat.rb
+++ b/test/testdata/lsp/hover_call_block_splat.rb
@@ -1,0 +1,16 @@
+# typed: true
+
+module Foo
+  extend T::Sig
+
+  sig {params(blk: T.proc.void).void}
+  def foo(&blk); end
+
+  sig {params(blk: T.proc.void).void}
+  def baz(&blk)
+    foo(&blk)
+  # ^ hover: sig {params(blk: T.proc.void).void}
+    foo {}
+  # ^ hover: sig {params(blk: T.proc.void).void}
+  end
+end

--- a/test/testdata/lsp/hover_call_block_splat.rb
+++ b/test/testdata/lsp/hover_call_block_splat.rb
@@ -21,5 +21,6 @@ module Foo
   def call_splat_fun(x)
     splat_fun(*[x, x])
   # ^ hover: sig {params(args: Integer).void}
+  # ^ hover: def splat_fun(*args); end
   end
 end

--- a/test/testdata/lsp/hover_call_block_splat.rb
+++ b/test/testdata/lsp/hover_call_block_splat.rb
@@ -13,4 +13,13 @@ module Foo
     foo {}
   # ^ hover: sig {params(blk: T.proc.void).void}
   end
+
+  sig {params(args: Integer).void}
+  def splat_fun(*args); end
+
+  sig {params(x: Integer).void}
+  def call_splat_fun(x)
+    splat_fun(*[x, x])
+  # ^ hover: sig {params(args: Integer).void}
+  end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Fixes #4597.  You can see what the splat testcases look like at [this sorbet.run](https://sorbet.run/#%23%20typed%3A%20true%0A%0Amodule%20Foo%0A%20%20extend%20T%3A%3ASig%0A%0A%20%20sig%20{params(blk%3A%20T.proc.void).void}%0A%20%20def%20foo(%26blk)%3B%20end%0A%0A%20%20sig%20{params(blk%3A%20T.proc.void).void}%0A%20%20def%20baz(%26blk)%0A%20%20%20%20foo(%26blk)%0A%20%20%23%20^%20hover%3A%20sig%20{params(blk%3A%20T.proc.void).void}%0A%20%20%20%20foo%20{}%0A%20%20%23%20^%20hover%3A%20sig%20{params(blk%3A%20T.proc.void).void}%0A%20%20end%0A%0A%20%20sig%20{params(args%3A%20Integer).void}%0A%20%20def%20splat_fun(*args)%3B%20end%0A%0A%20%20sig%20{params(x%3A%20Integer).void}%0A%20%20def%20call_splat_fun(x)%0A%20%20%20%20splat_fun(*[x%2C%20x])%0A%20%20%23%20^%20hover%3A%20sig%20{params(args%3A%20Integer).void}%0A%20%20%20%20y%20%3D%20[x%2C%20x]%0A%20%20%20%20splat_fun(*y)%0A%20%20%23%20^%20hover%3A%20sig%20{params(args%3A%20Integer).void}%0A%20%20end%0Aend%0A); prior to this change, they show the type of the tuple being splatted, which seems suboptimal.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

As much as possible, we shouldn't let `<Magic>` bits leak through to LSP.  I think this code is sort of papering over the problem:

https://github.com/sorbet/sorbet/blob/5bd642cf5f4a3dc801da950bbb9647d3c43cc1ab/main/lsp/requests/hover.cc#L106-L110

I guess it's necessary for arrays and hashes to work as people expect, but it would probably be better to only permit certain functions to pass the check there.

I tried to cargo-cult the fix for `call-with*block` to `call-with-splat`, but I found that `call-with-splat` sort of does things half-heartedly in copying things over from the "real" dispatched call:

https://github.com/sorbet/sorbet/blob/5bd642cf5f4a3dc801da950bbb9647d3c43cc1ab/core/types/calls.cc#L2056-L2068

so the mostly right thing already happens (at least the `main` component is right, even if the secondary components are not).

I think the right thing to do there is something more akin to the fix made here for `call-with*block`, but as it is a separate issue (and requires some different testcase changes), I think I'll fix it someplace else.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.  I guess technically the `call-with*block` changes should really include some calls with `T.any`/`T.all` types, so we could write tests for dropping all the `DispatchResult`s on the floor.

I'm assuming that if the testcases check hover showing proper documentation, then jump-to-def etc. should also work just fine?