### PR TITLE
add `{Mutable,}Context::locAt` to replace `core::Loc{ctx.file, ...}`

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -268,7 +268,7 @@ ExpressionPtr validateRBIBody(DesugarContext dctx, ExpressionPtr body) {
         return body;
     }
 
-    auto loc = core::Loc(dctx.ctx.file, body.loc());
+    auto loc = dctx.ctx.locAt(body.loc());
     if (isa_tree<EmptyTree>(body)) {
         return body;
     } else if (isa_tree<Assign>(body)) {
@@ -598,7 +598,7 @@ public:
                 }
 
                 e.setHeader("Hash key `{}` is duplicated", nameRef.toString(gs));
-                e.addErrorLine(core::Loc(dctx.ctx.file, originalLoc), "First occurrence of `{}` hash key",
+                e.addErrorLine(dctx.ctx.locAt(originalLoc), "First occurrence of `{}` hash key",
                                nameRef.toString(gs));
             }
         }
@@ -1066,8 +1066,8 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
 
                     ExpressionPtr thenp;
                     if (lhsSend != nullptr && rhsSend != nullptr) {
-                        auto lhsSource = core::Loc(dctx.ctx.file, lhsSend->loc).source(dctx.ctx);
-                        auto rhsRecvSource = core::Loc(dctx.ctx.file, rhsSend->recv.loc()).source(dctx.ctx);
+                        auto lhsSource = dctx.ctx.locAt(lhsSend->loc).source(dctx.ctx);
+                        auto rhsRecvSource = dctx.ctx.locAt(rhsSend->recv.loc()).source(dctx.ctx);
                         if (lhsSource.has_value() && lhsSource == rhsRecvSource) {
                             // Have to use zero-width locs here so that these auto-generated things
                             // don't show up in e.g. completion requests.
@@ -1313,7 +1313,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                     // The arg loc for the synthetic variable created for the purpose of this safe navigation
                     // check is a bit of a hack. It's intentionally one character too short so that for
                     // completion requests it doesn't match `x&.|` (which would defeat completion requests.)
-                    if (core::Loc(dctx.ctx.file, ampersandLoc).source(dctx.ctx) == "&") {
+                    if (dctx.ctx.locAt(ampersandLoc).source(dctx.ctx) == "&") {
                         csendLoc = ampersandLoc;
                     }
                 }
@@ -1892,7 +1892,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                                                          core::errors::Desugar::UnnamedBlockParameter)) {
                             e.setHeader("Method `{}` uses `{}` but does not mention a block parameter",
                                         dctx.enclosingMethodName.show(dctx.ctx), "yield");
-                            e.addErrorLine(core::Loc(dctx.ctx.file, loc), "Arising from use of `{}` in method body",
+                            e.addErrorLine(dctx.ctx.locAt(loc), "Arising from use of `{}` in method body",
                                            "yield");
                         }
                     }
@@ -2099,7 +2099,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                 result = std::move(res);
             },
             [&](parser::LineLiteral *line) {
-                auto pos = core::Loc(dctx.ctx.file, loc).position(dctx.ctx);
+                auto pos = dctx.ctx.locAt(loc).position(dctx.ctx);
                 ENFORCE(pos.first.line == pos.second.line, "position corrupted");
                 auto res = MK::Int(loc, pos.first.line);
                 result = std::move(res);

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -598,8 +598,7 @@ public:
                 }
 
                 e.setHeader("Hash key `{}` is duplicated", nameRef.toString(gs));
-                e.addErrorLine(dctx.ctx.locAt(originalLoc), "First occurrence of `{}` hash key",
-                               nameRef.toString(gs));
+                e.addErrorLine(dctx.ctx.locAt(originalLoc), "First occurrence of `{}` hash key", nameRef.toString(gs));
             }
         }
     }
@@ -1892,8 +1891,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                                                          core::errors::Desugar::UnnamedBlockParameter)) {
                             e.setHeader("Method `{}` uses `{}` but does not mention a block parameter",
                                         dctx.enclosingMethodName.show(dctx.ctx), "yield");
-                            e.addErrorLine(dctx.ctx.locAt(loc), "Arising from use of `{}` in method body",
-                                           "yield");
+                            e.addErrorLine(dctx.ctx.locAt(loc), "Arising from use of `{}` in method body", "yield");
                         }
                     }
 

--- a/cfg/builder/builder_entry.cc
+++ b/cfg/builder/builder_entry.cc
@@ -91,7 +91,7 @@ unique_ptr<CFG> CFGBuilder::buildFor(core::Context ctx, ast::MethodDef &md) {
     core::LocOffsets rvLoc;
     if (cont->exprs.empty() || isa_instruction<LoadArg>(cont->exprs.back().value)) {
         auto beginAdjust = md.loc.endPos() - md.loc.beginPos() - 3;
-        auto endLoc = core::Loc(ctx.file, md.loc).adjust(ctx, beginAdjust, 0);
+        auto endLoc = ctx.locAt(md.loc).adjust(ctx, beginAdjust, 0);
         if (endLoc.source(ctx) == "end") {
             rvLoc = endLoc.offsets();
             res->implicitReturnLoc = rvLoc;

--- a/core/Context.cc
+++ b/core/Context.cc
@@ -70,6 +70,14 @@ MutableContext MutableContext::withOwner(SymbolRef sym) const {
     return MutableContext(state, sym, file);
 }
 
+Loc Context::locAt(LocOffsets offsets) const {
+    return Loc{this->file, offsets};
+}
+
+Loc MutableContext::locAt(LocOffsets offsets) const {
+    return Loc{this->file, offsets};
+}
+
 ErrorBuilder MutableContext::beginError(LocOffsets loc, ErrorClass what) const {
     return state.beginError(Loc(file, loc), what);
 }

--- a/core/Context.h
+++ b/core/Context.h
@@ -36,6 +36,8 @@ public:
     Context withOwner(SymbolRef sym) const;
     Context withFile(FileRef file) const;
 
+    Loc locAt(LocOffsets offset) const;
+
     void trace(std::string_view msg) const;
 };
 CheckSize(Context, 16, 8);
@@ -69,6 +71,8 @@ public:
     MutableContext withOwner(SymbolRef sym) const;
     MutableContext withFile(FileRef file) const;
     ErrorBuilder beginError(LocOffsets loc, ErrorClass what) const;
+
+    Loc locAt(LocOffsets offset) const;
 
     void trace(std::string_view msg) const;
 };

--- a/core/Loc.cc
+++ b/core/Loc.cc
@@ -171,10 +171,10 @@ string Loc::toStringWithTabs(const GlobalState &gs, int tabs) const {
 }
 
 string LocOffsets::showRaw(const Context ctx) const {
-    return Loc(ctx.file, *this).showRaw(ctx);
+    return ctx.locAt(*this).showRaw(ctx);
 }
 string LocOffsets::showRaw(const MutableContext ctx) const {
-    return Loc(ctx.file, *this).showRaw(ctx);
+    return ctx.locAt(*this).showRaw(ctx);
 }
 string LocOffsets::showRaw(const GlobalState &gs, const FileRef file) const {
     return Loc(file, *this).showRaw(gs);

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1069,10 +1069,9 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                         }
                     }
                     core::lsp::QueryResponse::pushQueryResponse(
-                        ctx,
-                        core::lsp::SendResponse(ctx.locAt(bind.loc), retainedResult, fun, send.isPrivateOk,
-                                                ctx.owner.asMethodRef(), ctx.locAt(send.receiverLoc),
-                                                ctx.locAt(send.funLoc), send.args.size()));
+                        ctx, core::lsp::SendResponse(ctx.locAt(bind.loc), retainedResult, fun, send.isPrivateOk,
+                                                     ctx.owner.asMethodRef(), ctx.locAt(send.receiverLoc),
+                                                     ctx.locAt(send.funLoc), send.args.size()));
                 }
                 if (send.link) {
                     // This should eventually become ENFORCEs but currently they are wrong
@@ -1094,9 +1093,9 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                 tp.origins = typeAndOrigin.origins;
 
                 if (lspQueryMatch && !bind.value->isSynthetic) {
-                    core::lsp::QueryResponse::pushQueryResponse(
-                        ctx, core::lsp::IdentResponse(ctx.locAt(bind.loc), i.what.data(inWhat), tp,
-                                                      ctx.owner.asMethodRef()));
+                    core::lsp::QueryResponse::pushQueryResponse(ctx, core::lsp::IdentResponse(ctx.locAt(bind.loc),
+                                                                                              i.what.data(inWhat), tp,
+                                                                                              ctx.owner.asMethodRef()));
                 }
 
                 ENFORCE(ctx.file.data(ctx).hasParseErrors() || !tp.origins.empty(),
@@ -1309,8 +1308,8 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                 tp.origins.emplace_back(ctx.locAt(bind.loc));
                 if (lspQueryMatch) {
                     core::lsp::QueryResponse::pushQueryResponse(
-                        ctx, core::lsp::IdentResponse(ctx.locAt(bind.loc), bind.bind.variable.data(inWhat),
-                                                      tp, ctx.owner.asMethodRef()));
+                        ctx, core::lsp::IdentResponse(ctx.locAt(bind.loc), bind.bind.variable.data(inWhat), tp,
+                                                      ctx.owner.asMethodRef()));
                 }
             },
             [&](cfg::Return &i) {
@@ -1380,8 +1379,8 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                 tp.origins.emplace_back(ctx.locAt(bind.loc));
 
                 if (lspQueryMatch) {
-                    core::lsp::QueryResponse::pushQueryResponse(
-                        ctx, core::lsp::LiteralResponse(ctx.locAt(bind.loc), tp));
+                    core::lsp::QueryResponse::pushQueryResponse(ctx,
+                                                                core::lsp::LiteralResponse(ctx.locAt(bind.loc), tp));
                 }
             },
             [&](cfg::TAbsurd &i) {
@@ -1470,8 +1469,8 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                                 (core::Loc{ctx.file, endPos, bind.loc.endPos()}.source(ctx) == suffix)) {
                                 const auto locWithoutTCast = core::Loc{ctx.file, beginPos, endPos};
                                 if (locWithoutTCast.exists()) {
-                                    e.replaceWith("Replace with `T.unsafe`", ctx.locAt(bind.loc),
-                                                  "T.unsafe({})", locWithoutTCast.source(ctx).value());
+                                    e.replaceWith("Replace with `T.unsafe`", ctx.locAt(bind.loc), "T.unsafe({})",
+                                                  locWithoutTCast.source(ctx).value());
                                 }
                             }
                         }

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -702,7 +702,7 @@ const Environment &Environment::withCond(core::Context ctx, const Environment &e
         return env;
     }
     copy.cloneFrom(env);
-    copy.assumeKnowledge(ctx, isTrue, env.bb->bexit.cond.variable, core::Loc(ctx.file, env.bb->bexit.loc), filter);
+    copy.assumeKnowledge(ctx, isTrue, env.bb->bexit.cond.variable, ctx.locAt(env.bb->bexit.loc), filter);
     return copy;
 }
 
@@ -951,7 +951,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
 
         bool checkFullyDefined = true;
         const core::lsp::Query &lspQuery = ctx.state.lspQuery;
-        bool lspQueryMatch = lspQuery.matchesLoc(core::Loc(ctx.file, bind.loc));
+        bool lspQueryMatch = lspQuery.matchesLoc(ctx.locAt(bind.loc));
 
         typecase(
             bind.value,
@@ -960,7 +960,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                 // hovering over the method or arguments (not the block)
                 auto locWithoutBlock = send.locWithoutBlock(bind.loc);
                 if (lspQueryMatch && locWithoutBlock.exists() && !locWithoutBlock.empty()) {
-                    lspQueryMatch = lspQuery.matchesLoc(core::Loc(ctx.file, locWithoutBlock));
+                    lspQueryMatch = lspQuery.matchesLoc(ctx.locAt(locWithoutBlock));
                 }
 
                 InlinedVector<const core::TypeAndOrigins *, 2> args;
@@ -1070,9 +1070,9 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                     }
                     core::lsp::QueryResponse::pushQueryResponse(
                         ctx,
-                        core::lsp::SendResponse(core::Loc(ctx.file, bind.loc), retainedResult, fun, send.isPrivateOk,
-                                                ctx.owner.asMethodRef(), core::Loc(ctx.file, send.receiverLoc),
-                                                core::Loc(ctx.file, send.funLoc), send.args.size()));
+                        core::lsp::SendResponse(ctx.locAt(bind.loc), retainedResult, fun, send.isPrivateOk,
+                                                ctx.owner.asMethodRef(), ctx.locAt(send.receiverLoc),
+                                                ctx.locAt(send.funLoc), send.args.size()));
                 }
                 if (send.link) {
                     // This should eventually become ENFORCEs but currently they are wrong
@@ -1086,7 +1086,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
 
                     send.link->result = move(retainedResult);
                 }
-                tp.origins.emplace_back(core::Loc(ctx.file, bind.loc));
+                tp.origins.emplace_back(ctx.locAt(bind.loc));
             },
             [&](cfg::Ident &i) {
                 const core::TypeAndOrigins &typeAndOrigin = getTypeAndOrigin(ctx, i.what);
@@ -1095,7 +1095,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
 
                 if (lspQueryMatch && !bind.value->isSynthetic) {
                     core::lsp::QueryResponse::pushQueryResponse(
-                        ctx, core::lsp::IdentResponse(core::Loc(ctx.file, bind.loc), i.what.data(inWhat), tp,
+                        ctx, core::lsp::IdentResponse(ctx.locAt(bind.loc), i.what.data(inWhat), tp,
                                                       ctx.owner.asMethodRef()));
                 }
 
@@ -1108,7 +1108,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                     auto singletonClass = symbol.asClassOrModuleRef().data(ctx)->lookupSingletonClass(ctx);
                     ENFORCE(singletonClass.exists(), "Every class should have a singleton class by now.");
                     tp.type = singletonClass.data(ctx)->externalType();
-                    tp.origins.emplace_back(core::Loc(ctx.file, bind.loc));
+                    tp.origins.emplace_back(ctx.locAt(bind.loc));
                 } else if (symbol.isField(ctx) ||
                            (symbol.isStaticField(ctx) &&
                             !symbol.asFieldRef().data(ctx)->flags.isStaticFieldTypeAlias) ||
@@ -1169,7 +1169,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                 } else {
                     type = i.link->result->returnType;
                 }
-                auto loc = core::Loc(ctx.file, bind.loc);
+                auto loc = ctx.locAt(bind.loc);
                 type = flatmapHack(ctx, main.receiver, type, i.link->fun, loc);
                 tp.type = std::move(type);
                 tp.origins.emplace_back(loc);
@@ -1190,7 +1190,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
 
                 auto argType = i.argument(ctx).argumentTypeAsSeenByImplementation(ctx, constr);
                 tp.type = std::move(argType);
-                tp.origins.emplace_back(core::Loc(ctx.file, bind.loc));
+                tp.origins.emplace_back(ctx.locAt(bind.loc));
             },
             [&](cfg::ArgPresent &i) {
                 // Return an unanalyzable boolean value that indicates whether or not arg was provided
@@ -1198,7 +1198,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                 ENFORCE(ctx.owner == i.method);
 
                 tp.type = core::Types::Boolean();
-                tp.origins.emplace_back(core::Loc(ctx.file, bind.loc));
+                tp.origins.emplace_back(ctx.locAt(bind.loc));
             },
             [&](cfg::LoadYieldParams &insn) {
                 ENFORCE(insn.link);
@@ -1249,13 +1249,13 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                 } else {
                     tp.type = params;
                 }
-                tp.origins.emplace_back(core::Loc(ctx.file, bind.loc));
+                tp.origins.emplace_back(ctx.locAt(bind.loc));
             },
             [&](cfg::YieldParamPresent &i) {
                 // Return an unanalyzable boolean value that indicates whether or not arg was provided
                 // It's unanalyzable because it varies by each individual call site.
                 tp.type = core::Types::Boolean();
-                tp.origins.emplace_back(core::Loc(ctx.file, bind.loc));
+                tp.origins.emplace_back(ctx.locAt(bind.loc));
             },
             [&](cfg::YieldLoadArg &i) {
                 // Mixing positional and rest args in blocks is not well supported.
@@ -1268,7 +1268,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                     } else {
                         tp.type = core::Types::untypedUntracked();
                     }
-                    tp.origins.emplace_back(core::Loc(ctx.file, bind.loc));
+                    tp.origins.emplace_back(ctx.locAt(bind.loc));
                     return;
                 }
 
@@ -1301,21 +1301,21 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                                                 recvType,
                                                 recvType.type,
                                                 block,
-                                                core::Loc(ctx.file, bind.loc),
+                                                ctx.locAt(bind.loc),
                                                 isPrivateOk,
                                                 suppressErrors};
                 auto dispatched = recvType.type.dispatchCall(ctx, dispatchArgs);
                 tp.type = dispatched.returnType;
-                tp.origins.emplace_back(core::Loc(ctx.file, bind.loc));
+                tp.origins.emplace_back(ctx.locAt(bind.loc));
                 if (lspQueryMatch) {
                     core::lsp::QueryResponse::pushQueryResponse(
-                        ctx, core::lsp::IdentResponse(core::Loc(ctx.file, bind.loc), bind.bind.variable.data(inWhat),
+                        ctx, core::lsp::IdentResponse(ctx.locAt(bind.loc), bind.bind.variable.data(inWhat),
                                                       tp, ctx.owner.asMethodRef()));
                 }
             },
             [&](cfg::Return &i) {
                 tp.type = core::Types::bottom();
-                tp.origins.emplace_back(core::Loc(ctx.file, bind.loc));
+                tp.origins.emplace_back(ctx.locAt(bind.loc));
 
                 const core::TypeAndOrigins &typeAndOrigin = getAndFillTypeAndOrigin(ctx, i.what);
                 if (core::Types::isSubType(ctx, core::Types::void_(), methodReturnType)) {
@@ -1333,7 +1333,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                         e.addErrorSection(typeAndOrigin.explainGot(ctx, ownerLoc));
                         core::TypeErrorDiagnostics::explainTypeMismatch(ctx, e, methodReturnType, typeAndOrigin.type);
                         if (i.whatLoc != inWhat.implicitReturnLoc) {
-                            auto replaceLoc = core::Loc(ctx.file, i.whatLoc);
+                            auto replaceLoc = ctx.locAt(i.whatLoc);
                             core::TypeErrorDiagnostics::maybeAutocorrect(ctx, e, replaceLoc, constr, methodReturnType,
                                                                          typeAndOrigin.type);
                         }
@@ -1373,15 +1373,15 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                 }
 
                 tp.type = core::Types::bottom();
-                tp.origins.emplace_back(core::Loc(ctx.file, bind.loc));
+                tp.origins.emplace_back(ctx.locAt(bind.loc));
             },
             [&](cfg::Literal &i) {
                 tp.type = i.value;
-                tp.origins.emplace_back(core::Loc(ctx.file, bind.loc));
+                tp.origins.emplace_back(ctx.locAt(bind.loc));
 
                 if (lspQueryMatch) {
                     core::lsp::QueryResponse::pushQueryResponse(
-                        ctx, core::lsp::LiteralResponse(core::Loc(ctx.file, bind.loc), tp));
+                        ctx, core::lsp::LiteralResponse(ctx.locAt(bind.loc), tp));
                 }
             },
             [&](cfg::TAbsurd &i) {
@@ -1398,11 +1398,11 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                 }
 
                 tp.type = core::Types::bottom();
-                tp.origins.emplace_back(core::Loc(ctx.file, bind.loc));
+                tp.origins.emplace_back(ctx.locAt(bind.loc));
             },
             [&](cfg::GetCurrentException &i) {
                 tp.type = core::Types::untypedUntracked();
-                tp.origins.emplace_back(core::Loc(ctx.file, bind.loc));
+                tp.origins.emplace_back(ctx.locAt(bind.loc));
             },
             [&](cfg::LoadSelf &l) {
                 ENFORCE(l.link);
@@ -1432,7 +1432,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                                                          klass.data(ctx)->selfTypeArgs(ctx));
 
                 tp.type = castType;
-                tp.origins.emplace_back(core::Loc(ctx.file, bind.loc));
+                tp.origins.emplace_back(ctx.locAt(bind.loc));
 
                 if (!hasType(ctx, bind.bind.variable)) {
                     noLoopChecking = true;
@@ -1470,7 +1470,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                                 (core::Loc{ctx.file, endPos, bind.loc.endPos()}.source(ctx) == suffix)) {
                                 const auto locWithoutTCast = core::Loc{ctx.file, beginPos, endPos};
                                 if (locWithoutTCast.exists()) {
-                                    e.replaceWith("Replace with `T.unsafe`", core::Loc(ctx.file, bind.loc),
+                                    e.replaceWith("Replace with `T.unsafe`", ctx.locAt(bind.loc),
                                                   "T.unsafe({})", locWithoutTCast.source(ctx).value());
                                 }
                             }
@@ -1521,7 +1521,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                                 e.addErrorSection(cur.explainExpected(ctx, "field defined here", ownerLoc));
                                 e.addErrorSection(tp.explainGot(ctx, ownerLoc));
                                 core::TypeErrorDiagnostics::explainTypeMismatch(ctx, e, cur.type, tp.type);
-                                auto replaceLoc = core::Loc(ctx.file, bind.loc);
+                                auto replaceLoc = ctx.locAt(bind.loc);
                                 // We are not processing a method call, so there is no constraint.
                                 auto &constr = core::TypeConstraint::EmptyFrozenConstraint;
                                 core::TypeErrorDiagnostics::maybeAutocorrect(ctx, e, replaceLoc, constr, cur.type,
@@ -1602,7 +1602,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
 
         clearKnowledge(ctx, bind.bind.variable, knowledgeFilter);
         if (auto *send = cfg::cast_instruction<cfg::Send>(bind.value)) {
-            updateKnowledge(ctx, bind.bind.variable, core::Loc(ctx.file, bind.loc), send, knowledgeFilter);
+            updateKnowledge(ctx, bind.bind.variable, ctx.locAt(bind.loc), send, knowledgeFilter);
         } else if (auto *i = cfg::cast_instruction<cfg::Ident>(bind.value)) {
             propagateKnowledge(ctx, bind.bind.variable, i->what, knowledgeFilter);
         }

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -169,10 +169,10 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
                             break;
                         } else if (unreachableInstruction == nullptr) {
                             unreachableInstruction = &expr.value;
-                            locForUnreachable = core::Loc(ctx.file, expr.loc);
+                            locForUnreachable = ctx.locAt(expr.loc);
                         } else {
                             // Expand the loc to cover the entire dead basic block
-                            locForUnreachable = locForUnreachable.join(core::Loc(ctx.file, expr.loc));
+                            locForUnreachable = locForUnreachable.join(ctx.locAt(expr.loc));
                         }
                     }
                 }
@@ -213,7 +213,7 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
                             }
 
                             auto alwaysWhat = prevBasicBlock->bexit.thenb->id == bb->id ? "falsy" : "truthy";
-                            auto bexitLoc = core::Loc(ctx.file, prevBasicBlock->bexit.loc);
+                            auto bexitLoc = ctx.locAt(prevBasicBlock->bexit.loc);
                             e.addErrorLine(bexitLoc, "This condition was always `{}` (`{}`)", alwaysWhat,
                                            cond.type.show(ctx));
 
@@ -257,7 +257,7 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
                 bind.bind.type.sanityCheck(ctx);
                 if (bind.bind.type.isBottom()) {
                     current.isDead = true;
-                    madeBlockDead = core::Loc(ctx.file, bind.loc);
+                    madeBlockDead = ctx.locAt(bind.loc);
                 }
                 if (current.isDead && bb->firstDeadInstructionIdx == -1) {
                     // this can also be result of evaluating an instruction, e.g. an always false hard_assert

--- a/main/autogen/data/msgpack.cc
+++ b/main/autogen/data/msgpack.cc
@@ -110,7 +110,7 @@ void MsgpackWriter::packReference(core::Context ctx, ParsedFile &pf, Reference &
     mpack_finish_array(&writer);
 
     // expression_range
-    auto expression_range = core::Loc(ctx.file, ref.definitionLoc).position(ctx);
+    auto expression_range = ctx.locAt(ref.definitionLoc).position(ctx);
     packRange(expression_range.first.line, expression_range.second.line);
     // expression_pos_range
     packRange(ref.loc.beginPos(), ref.loc.endPos());

--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -10,8 +10,7 @@ ast::ExpressionPtr DefLocSaver::postTransformMethodDef(core::Context ctx, ast::E
     auto &methodDef = ast::cast_tree_nonnull<ast::MethodDef>(tree);
 
     const core::lsp::Query &lspQuery = ctx.state.lspQuery;
-    bool lspQueryMatch =
-        lspQuery.matchesLoc(ctx.locAt(methodDef.declLoc)) || lspQuery.matchesSymbol(methodDef.symbol);
+    bool lspQueryMatch = lspQuery.matchesLoc(ctx.locAt(methodDef.declLoc)) || lspQuery.matchesSymbol(methodDef.symbol);
 
     if (lspQueryMatch) {
         // Query matches against the method definition as a whole.
@@ -33,8 +32,8 @@ ast::ExpressionPtr DefLocSaver::postTransformMethodDef(core::Context ctx, ast::E
                 tp.type = argType.type;
                 tp.origins.emplace_back(ctx.locAt(localExp->loc));
                 core::lsp::QueryResponse::pushQueryResponse(
-                    ctx, core::lsp::IdentResponse(ctx.locAt(localExp->loc), localExp->localVariable, tp,
-                                                  methodDef.symbol));
+                    ctx,
+                    core::lsp::IdentResponse(ctx.locAt(localExp->loc), localExp->localVariable, tp, methodDef.symbol));
                 return tree;
             }
         }
@@ -42,8 +41,7 @@ ast::ExpressionPtr DefLocSaver::postTransformMethodDef(core::Context ctx, ast::E
         tp.type = symbolData->resultType;
         tp.origins.emplace_back(ctx.locAt(methodDef.declLoc));
         core::lsp::QueryResponse::pushQueryResponse(
-            ctx,
-            core::lsp::MethodDefResponse(methodDef.symbol, ctx.locAt(methodDef.declLoc), methodDef.name, tp));
+            ctx, core::lsp::MethodDefResponse(methodDef.symbol, ctx.locAt(methodDef.declLoc), methodDef.name, tp));
     }
 
     return tree;

--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -11,7 +11,7 @@ ast::ExpressionPtr DefLocSaver::postTransformMethodDef(core::Context ctx, ast::E
 
     const core::lsp::Query &lspQuery = ctx.state.lspQuery;
     bool lspQueryMatch =
-        lspQuery.matchesLoc(core::Loc(ctx.file, methodDef.declLoc)) || lspQuery.matchesSymbol(methodDef.symbol);
+        lspQuery.matchesLoc(ctx.locAt(methodDef.declLoc)) || lspQuery.matchesSymbol(methodDef.symbol);
 
     if (lspQueryMatch) {
         // Query matches against the method definition as a whole.
@@ -29,21 +29,21 @@ ast::ExpressionPtr DefLocSaver::postTransformMethodDef(core::Context ctx, ast::E
             auto &argType = argTypes[i];
             auto *localExp = ast::MK::arg2Local(arg);
             // localExp should never be null, but guard against the possibility.
-            if (localExp && lspQuery.matchesLoc(core::Loc(ctx.file, localExp->loc))) {
+            if (localExp && lspQuery.matchesLoc(ctx.locAt(localExp->loc))) {
                 tp.type = argType.type;
-                tp.origins.emplace_back(core::Loc(ctx.file, localExp->loc));
+                tp.origins.emplace_back(ctx.locAt(localExp->loc));
                 core::lsp::QueryResponse::pushQueryResponse(
-                    ctx, core::lsp::IdentResponse(core::Loc(ctx.file, localExp->loc), localExp->localVariable, tp,
+                    ctx, core::lsp::IdentResponse(ctx.locAt(localExp->loc), localExp->localVariable, tp,
                                                   methodDef.symbol));
                 return tree;
             }
         }
 
         tp.type = symbolData->resultType;
-        tp.origins.emplace_back(core::Loc(ctx.file, methodDef.declLoc));
+        tp.origins.emplace_back(ctx.locAt(methodDef.declLoc));
         core::lsp::QueryResponse::pushQueryResponse(
             ctx,
-            core::lsp::MethodDefResponse(methodDef.symbol, core::Loc(ctx.file, methodDef.declLoc), methodDef.name, tp));
+            core::lsp::MethodDefResponse(methodDef.symbol, ctx.locAt(methodDef.declLoc), methodDef.name, tp));
     }
 
     return tree;
@@ -68,13 +68,13 @@ ast::ExpressionPtr DefLocSaver::postTransformUnresolvedIdent(core::Context ctx, 
         auto sym = klass.data(ctx)->findMemberTransitive(ctx, id.name);
         const core::lsp::Query &lspQuery = ctx.state.lspQuery;
         if (sym.exists() && sym.isFieldOrStaticField() &&
-            (lspQuery.matchesSymbol(sym) || lspQuery.matchesLoc(core::Loc(ctx.file, id.loc)))) {
+            (lspQuery.matchesSymbol(sym) || lspQuery.matchesLoc(ctx.locAt(id.loc)))) {
             auto field = sym.asFieldRef();
             core::TypeAndOrigins tp;
             tp.type = field.data(ctx)->resultType;
             tp.origins.emplace_back(field.data(ctx)->loc());
             core::lsp::QueryResponse::pushQueryResponse(
-                ctx, core::lsp::FieldResponse(field, core::Loc(ctx.file, id.loc), id.name, tp));
+                ctx, core::lsp::FieldResponse(field, ctx.locAt(id.loc), id.name, tp));
         }
     }
     return tree;
@@ -105,7 +105,7 @@ void matchesQuery(core::Context ctx, ast::ConstantLit *lit, const core::lsp::Que
     auto symbol = symbolBeforeDealias.dealias(ctx);
     while (lit && symbol.exists() && lit->original) {
         auto &unresolved = ast::cast_tree_nonnull<ast::UnresolvedConstantLit>(lit->original);
-        if (lspQuery.matchesLoc(core::Loc(ctx.file, lit->loc)) || lspQuery.matchesSymbol(symbol)) {
+        if (lspQuery.matchesLoc(ctx.locAt(lit->loc)) || lspQuery.matchesSymbol(symbol)) {
             // This basically approximates the cfg::Alias case from Environment::processBinding.
             core::TypeAndOrigins tp;
             tp.origins.emplace_back(symbol.loc(ctx));
@@ -125,7 +125,7 @@ void matchesQuery(core::Context ctx, ast::ConstantLit *lit, const core::lsp::Que
             }
 
             auto enclosingMethod = enclosingMethodFromContext(ctx);
-            auto resp = core::lsp::ConstantResponse(symbol, symbolBeforeDealias, core::Loc(ctx.file, lit->loc), scopes,
+            auto resp = core::lsp::ConstantResponse(symbol, symbolBeforeDealias, ctx.locAt(lit->loc), scopes,
                                                     unresolved.cnst, tp, enclosingMethod);
             core::lsp::QueryResponse::pushQueryResponse(ctx, resp);
         }

--- a/main/lsp/LocalVarFinder.cc
+++ b/main/lsp/LocalVarFinder.cc
@@ -10,7 +10,7 @@ ast::ExpressionPtr LocalVarFinder::preTransformBlock(core::Context ctx, ast::Exp
     ENFORCE(!methodStack.empty());
 
     auto &block = ast::cast_tree_nonnull<ast::Block>(tree);
-    auto loc = core::Loc{ctx.file, block.loc};
+    auto loc = ctx.locAt(block.loc);
 
     if (methodStack.back() != this->targetMethod) {
         return tree;

--- a/main/lsp/LocalVarSaver.cc
+++ b/main/lsp/LocalVarSaver.cc
@@ -31,8 +31,7 @@ ast::ExpressionPtr LocalVarSaver::postTransformBlock(core::Context ctx, ast::Exp
             if (lspQueryMatch) {
                 core::TypeAndOrigins tp;
                 core::lsp::QueryResponse::pushQueryResponse(
-                    ctx,
-                    core::lsp::IdentResponse(ctx.locAt(localExp->loc), localExp->localVariable, tp, method));
+                    ctx, core::lsp::IdentResponse(ctx.locAt(localExp->loc), localExp->localVariable, tp, method));
             }
         }
     }
@@ -68,8 +67,8 @@ ast::ExpressionPtr LocalVarSaver::postTransformMethodDef(core::Context ctx, ast:
                 // (Ditto)
                 core::TypeAndOrigins tp;
                 core::lsp::QueryResponse::pushQueryResponse(
-                    ctx, core::lsp::IdentResponse(ctx.locAt(localExp->loc), localExp->localVariable, tp,
-                                                  methodDef.symbol));
+                    ctx,
+                    core::lsp::IdentResponse(ctx.locAt(localExp->loc), localExp->localVariable, tp, methodDef.symbol));
             }
         }
     }

--- a/main/lsp/LocalVarSaver.cc
+++ b/main/lsp/LocalVarSaver.cc
@@ -32,7 +32,7 @@ ast::ExpressionPtr LocalVarSaver::postTransformBlock(core::Context ctx, ast::Exp
                 core::TypeAndOrigins tp;
                 core::lsp::QueryResponse::pushQueryResponse(
                     ctx,
-                    core::lsp::IdentResponse(core::Loc(ctx.file, localExp->loc), localExp->localVariable, tp, method));
+                    core::lsp::IdentResponse(ctx.locAt(localExp->loc), localExp->localVariable, tp, method));
             }
         }
     }
@@ -50,7 +50,7 @@ ast::ExpressionPtr LocalVarSaver::postTransformLocal(core::Context ctx, ast::Exp
         // Let the default constructor make tp.type an empty shared_ptr and tp.origins an empty vector
         core::TypeAndOrigins tp;
         core::lsp::QueryResponse::pushQueryResponse(
-            ctx, core::lsp::IdentResponse(core::Loc(ctx.file, local.loc), local.localVariable, tp, method));
+            ctx, core::lsp::IdentResponse(ctx.locAt(local.loc), local.localVariable, tp, method));
     }
 
     return tree;
@@ -68,7 +68,7 @@ ast::ExpressionPtr LocalVarSaver::postTransformMethodDef(core::Context ctx, ast:
                 // (Ditto)
                 core::TypeAndOrigins tp;
                 core::lsp::QueryResponse::pushQueryResponse(
-                    ctx, core::lsp::IdentResponse(core::Loc(ctx.file, localExp->loc), localExp->localVariable, tp,
+                    ctx, core::lsp::IdentResponse(ctx.locAt(localExp->loc), localExp->localVariable, tp,
                                                   methodDef.symbol));
             }
         }

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -813,8 +813,7 @@ class SymbolDefiner {
         // Mangle this one out of the way, and re-enter a symbol with this name as a class.
         auto scopeName = scope.name(ctx);
         ctx.state.mangleRenameSymbol(scope, scopeName);
-        auto scopeKlass =
-            ctx.state.enterClassSymbol(ctx.locAt(loc), scope.owner(ctx).asClassOrModuleRef(), scopeName);
+        auto scopeKlass = ctx.state.enterClassSymbol(ctx.locAt(loc), scope.owner(ctx).asClassOrModuleRef(), scopeName);
         scopeKlass.data(ctx)->singletonClass(ctx); // force singleton class into existance
         return scopeKlass;
     }
@@ -862,8 +861,7 @@ class SymbolDefiner {
         }
         // we know right now that pos >= arguments.size() because otherwise we would have hit the early return at the
         // beginning of this method
-        auto &argInfo =
-            ctx.state.enterMethodArgumentSymbol(ctx.locAt(parsedArg.loc), ctx.owner.asMethodRef(), name);
+        auto &argInfo = ctx.state.enterMethodArgumentSymbol(ctx.locAt(parsedArg.loc), ctx.owner.asMethodRef(), name);
         // if enterMethodArgumentSymbol did not emplace a new argument into the list, then it means it's reusing an
         // existing one, which means we've seen a repeated kwarg (as it treats identically named kwargs as
         // identical). We know that we need to match the arity of the function as written, so if we don't have as many
@@ -1224,8 +1222,8 @@ class SymbolDefiner {
             symbolData->setClassOrModuleSealed();
 
             auto classOfKlass = symbolData->singletonClass(ctx);
-            auto sealedSubclasses = ctx.state.enterMethodSymbol(ctx.locAt(mod.loc), classOfKlass,
-                                                                core::Names::sealedSubclasses());
+            auto sealedSubclasses =
+                ctx.state.enterMethodSymbol(ctx.locAt(mod.loc), classOfKlass, core::Names::sealedSubclasses());
             auto &blkArg =
                 ctx.state.enterMethodArgumentSymbol(core::Loc::none(), sealedSubclasses, core::Names::blkArg());
             blkArg.flags.isBlock = true;
@@ -1274,8 +1272,8 @@ class SymbolDefiner {
             ENFORCE(currSym.exists());
             auto renamedSym = ctx.state.findRenamedSymbol(scope, sym);
             if (renamedSym.exists()) {
-                emitRedefinedConstantError(ctx, ctx.locAt(staticField.asgnLoc),
-                                           renamedSym.name(ctx).show(ctx), renamedSym.loc(ctx));
+                emitRedefinedConstantError(ctx, ctx.locAt(staticField.asgnLoc), renamedSym.name(ctx).show(ctx),
+                                           renamedSym.loc(ctx));
             }
         }
         sym = ctx.state.enterStaticFieldSymbol(ctx.locAt(staticField.lhsLoc), scope, name);
@@ -1352,12 +1350,10 @@ class SymbolDefiner {
         } else {
             auto oldSym = onSymbol.data(ctx)->findMemberNoDealias(ctx, typeMember.name);
             if (oldSym.exists()) {
-                emitRedefinedConstantError(ctx, ctx.locAt(typeMember.nameLoc), oldSym.show(ctx),
-                                           oldSym.loc(ctx));
+                emitRedefinedConstantError(ctx, ctx.locAt(typeMember.nameLoc), oldSym.show(ctx), oldSym.loc(ctx));
                 ctx.state.mangleRenameSymbol(oldSym, oldSym.name(ctx));
             }
-            sym =
-                ctx.state.enterTypeMember(ctx.locAt(typeMember.asgnLoc), onSymbol, typeMember.name, variance);
+            sym = ctx.state.enterTypeMember(ctx.locAt(typeMember.asgnLoc), onSymbol, typeMember.name, variance);
 
             // The todo bounds will be fixed by the resolver in ResolveTypeParamsWalk.
             auto todo = core::make_type<core::ClassType>(core::Symbols::todo());
@@ -1366,14 +1362,13 @@ class SymbolDefiner {
             if (isTypeTemplate) {
                 auto context = ctx.owner.enclosingClass(ctx);
                 oldSym = context.data(ctx)->findMemberNoDealias(ctx, typeMember.name);
-                if (oldSym.exists() && !(oldSym.loc(ctx) == ctx.locAt(typeMember.asgnLoc) ||
-                                         oldSym.loc(ctx).isTombStoned(ctx))) {
+                if (oldSym.exists() &&
+                    !(oldSym.loc(ctx) == ctx.locAt(typeMember.asgnLoc) || oldSym.loc(ctx).isTombStoned(ctx))) {
                     emitRedefinedConstantError(ctx, ctx.locAt(typeMember.nameLoc), typeMember.name.show(ctx),
                                                oldSym.loc(ctx));
                     ctx.state.mangleRenameSymbol(oldSym, typeMember.name);
                 }
-                auto alias =
-                    ctx.state.enterStaticFieldSymbol(ctx.locAt(typeMember.asgnLoc), context, typeMember.name);
+                auto alias = ctx.state.enterStaticFieldSymbol(ctx.locAt(typeMember.asgnLoc), context, typeMember.name);
                 alias.data(ctx)->resultType = core::make_type<core::AliasType>(core::SymbolRef(sym));
             }
         }

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -814,7 +814,7 @@ class SymbolDefiner {
         auto scopeName = scope.name(ctx);
         ctx.state.mangleRenameSymbol(scope, scopeName);
         auto scopeKlass =
-            ctx.state.enterClassSymbol(core::Loc(ctx.file, loc), scope.owner(ctx).asClassOrModuleRef(), scopeName);
+            ctx.state.enterClassSymbol(ctx.locAt(loc), scope.owner(ctx).asClassOrModuleRef(), scopeName);
         scopeKlass.data(ctx)->singletonClass(ctx); // force singleton class into existance
         return scopeKlass;
     }
@@ -828,7 +828,7 @@ class SymbolDefiner {
         auto scope = ensureIsClass(ctx, ctx.owner, name, loc);
         core::SymbolRef existing = scope.data(ctx)->findMember(ctx, name);
         if (!existing.exists()) {
-            existing = ctx.state.enterClassSymbol(core::Loc(ctx.file, loc), scope, name);
+            existing = ctx.state.enterClassSymbol(ctx.locAt(loc), scope, name);
             existing.asClassOrModuleRef().data(ctx)->singletonClass(ctx); // force singleton class into existance
         }
 
@@ -839,7 +839,7 @@ class SymbolDefiner {
         if (pos < methodData->arguments.size()) {
             // TODO: check that flags match;
             if (parsedArg.loc.exists()) {
-                methodData->arguments[pos].loc = core::Loc(ctx.file, parsedArg.loc);
+                methodData->arguments[pos].loc = ctx.locAt(parsedArg.loc);
             }
             return;
         }
@@ -863,7 +863,7 @@ class SymbolDefiner {
         // we know right now that pos >= arguments.size() because otherwise we would have hit the early return at the
         // beginning of this method
         auto &argInfo =
-            ctx.state.enterMethodArgumentSymbol(core::Loc(ctx.file, parsedArg.loc), ctx.owner.asMethodRef(), name);
+            ctx.state.enterMethodArgumentSymbol(ctx.locAt(parsedArg.loc), ctx.owner.asMethodRef(), name);
         // if enterMethodArgumentSymbol did not emplace a new argument into the list, then it means it's reusing an
         // existing one, which means we've seen a repeated kwarg (as it treats identically named kwargs as
         // identical). We know that we need to match the arity of the function as written, so if we don't have as many
@@ -1029,7 +1029,7 @@ class SymbolDefiner {
         // enough in the file to see any other definition of `f`.
         auto &parsedArgs = method.parsedArgs;
         auto symTableSize = ctx.state.methodsUsed();
-        auto declLoc = core::Loc(ctx.file, method.declLoc);
+        auto declLoc = ctx.locAt(method.declLoc);
         auto sym = ctx.state.enterMethodSymbol(declLoc, owner, method.name);
         const bool isNewSymbol = symTableSize != ctx.state.methodsUsed();
         if (!isNewSymbol) {
@@ -1135,7 +1135,7 @@ class SymbolDefiner {
         ENFORCE(symbol.exists());
 
         const bool isModule = klass.classKind == ast::ClassDef::Kind::Module;
-        auto declLoc = core::Loc(ctx.file, klass.declLoc);
+        auto declLoc = ctx.locAt(klass.declLoc);
         if (!symbol.isClassOrModule()) {
             // we might have already mangled the class symbol, so see if we have a symbol that is a class already
             auto klassSymbol = ctx.state.lookupClassSymbol(symbol.owner(ctx).asClassOrModuleRef(), symbol.name(ctx));
@@ -1143,7 +1143,7 @@ class SymbolDefiner {
                 return klassSymbol;
             }
 
-            emitRedefinedConstantError(ctx, core::Loc(ctx.file, klass.loc), symbol.show(ctx), symbol.loc(ctx));
+            emitRedefinedConstantError(ctx, ctx.locAt(klass.loc), symbol.show(ctx), symbol.loc(ctx));
 
             auto origName = symbol.name(ctx);
             ctx.state.mangleRenameSymbol(symbol, symbol.name(ctx));
@@ -1173,7 +1173,7 @@ class SymbolDefiner {
             klassSymbol.data(ctx)->setIsModule(isModule);
             auto renamed = ctx.state.findRenamedSymbol(klassSymbol.data(ctx)->owner.asClassOrModuleRef(), symbol);
             if (renamed.exists()) {
-                emitRedefinedConstantError(ctx, core::Loc(ctx.file, klass.loc), symbol, renamed);
+                emitRedefinedConstantError(ctx, ctx.locAt(klass.loc), symbol, renamed);
             }
         }
         return klassSymbol;
@@ -1198,15 +1198,15 @@ class SymbolDefiner {
         // project) locs!
         if (symbol != core::Symbols::root() && symbol != core::Symbols::PackageRegistry() &&
             symbol.data(ctx)->owner != core::Symbols::PackageRegistry()) {
-            symbol.data(ctx)->addLoc(ctx, core::Loc(ctx.file, klass.declLoc));
+            symbol.data(ctx)->addLoc(ctx, ctx.locAt(klass.declLoc));
         }
         symbol.data(ctx)->singletonClass(ctx); // force singleton class into existence
 
         // make sure we've added a static init symbol so we have it ready for the flatten pass later
         if (symbol == core::Symbols::root()) {
-            ctx.state.staticInitForFile(core::Loc(ctx.file, klass.loc));
+            ctx.state.staticInitForFile(ctx.locAt(klass.loc));
         } else {
-            ctx.state.staticInitForClass(symbol, core::Loc(ctx.file, klass.loc));
+            ctx.state.staticInitForClass(symbol, ctx.locAt(klass.loc));
         }
 
         return symbol;
@@ -1224,7 +1224,7 @@ class SymbolDefiner {
             symbolData->setClassOrModuleSealed();
 
             auto classOfKlass = symbolData->singletonClass(ctx);
-            auto sealedSubclasses = ctx.state.enterMethodSymbol(core::Loc(ctx.file, mod.loc), classOfKlass,
+            auto sealedSubclasses = ctx.state.enterMethodSymbol(ctx.locAt(mod.loc), classOfKlass,
                                                                 core::Names::sealedSubclasses());
             auto &blkArg =
                 ctx.state.enterMethodArgumentSymbol(core::Loc::none(), sealedSubclasses, core::Names::blkArg());
@@ -1245,7 +1245,7 @@ class SymbolDefiner {
             if (!symbolData->isClassOrModuleModule()) {
                 if (auto e = ctx.beginError(mod.loc, core::errors::Namer::InterfaceClass)) {
                     e.setHeader("Classes can't be interfaces. Use `abstract!` instead of `interface!`");
-                    e.replaceWith("Change `interface!` to `abstract!`", core::Loc(ctx.file, mod.loc), "abstract!");
+                    e.replaceWith("Change `interface!` to `abstract!`", ctx.locAt(mod.loc), "abstract!");
                 }
             }
         }
@@ -1266,7 +1266,7 @@ class SymbolDefiner {
         auto currSym = ctx.state.lookupSymbol(scope, staticField.name);
         auto name = sym.exists() ? sym.data(ctx)->name : staticField.name;
         if (!sym.exists() && currSym.exists()) {
-            emitRedefinedConstantError(ctx, core::Loc(ctx.file, staticField.asgnLoc), staticField.name.show(ctx),
+            emitRedefinedConstantError(ctx, ctx.locAt(staticField.asgnLoc), staticField.name.show(ctx),
                                        currSym.loc(ctx));
             ctx.state.mangleRenameSymbol(currSym, currSym.name(ctx));
         }
@@ -1274,11 +1274,11 @@ class SymbolDefiner {
             ENFORCE(currSym.exists());
             auto renamedSym = ctx.state.findRenamedSymbol(scope, sym);
             if (renamedSym.exists()) {
-                emitRedefinedConstantError(ctx, core::Loc(ctx.file, staticField.asgnLoc),
+                emitRedefinedConstantError(ctx, ctx.locAt(staticField.asgnLoc),
                                            renamedSym.name(ctx).show(ctx), renamedSym.loc(ctx));
             }
         }
-        sym = ctx.state.enterStaticFieldSymbol(core::Loc(ctx.file, staticField.lhsLoc), scope, name);
+        sym = ctx.state.enterStaticFieldSymbol(ctx.locAt(staticField.lhsLoc), scope, name);
 
         if (staticField.isTypeAlias) {
             sym.data(ctx)->flags.isStaticFieldTypeAlias = true;
@@ -1333,7 +1333,7 @@ class SymbolDefiner {
                 if (auto e = ctx.state.beginError(existingTypeMember.data(ctx)->loc(),
                                                   core::errors::Namer::InvalidTypeDefinition)) {
                     e.setHeader("Duplicate type member `{}`", typeMember.name.show(ctx));
-                    e.addErrorLine(core::Loc(ctx.file, typeMember.asgnLoc), "Also defined here");
+                    e.addErrorLine(ctx.locAt(typeMember.asgnLoc), "Also defined here");
                 }
             }
 
@@ -1342,7 +1342,7 @@ class SymbolDefiner {
             // same error
             auto oldSym = ctx.state.findRenamedSymbol(onSymbol, existingTypeMember);
             if (oldSym.exists()) {
-                emitRedefinedConstantError(ctx, core::Loc(ctx.file, typeMember.nameLoc), oldSym, existingTypeMember);
+                emitRedefinedConstantError(ctx, ctx.locAt(typeMember.nameLoc), oldSym, existingTypeMember);
             }
             // if we have more than one type member with the same name, then we have messed up somewhere
             ENFORCE(absl::c_find_if(onSymbol.data(ctx)->typeMembers(), [&](auto mem) {
@@ -1352,12 +1352,12 @@ class SymbolDefiner {
         } else {
             auto oldSym = onSymbol.data(ctx)->findMemberNoDealias(ctx, typeMember.name);
             if (oldSym.exists()) {
-                emitRedefinedConstantError(ctx, core::Loc(ctx.file, typeMember.nameLoc), oldSym.show(ctx),
+                emitRedefinedConstantError(ctx, ctx.locAt(typeMember.nameLoc), oldSym.show(ctx),
                                            oldSym.loc(ctx));
                 ctx.state.mangleRenameSymbol(oldSym, oldSym.name(ctx));
             }
             sym =
-                ctx.state.enterTypeMember(core::Loc(ctx.file, typeMember.asgnLoc), onSymbol, typeMember.name, variance);
+                ctx.state.enterTypeMember(ctx.locAt(typeMember.asgnLoc), onSymbol, typeMember.name, variance);
 
             // The todo bounds will be fixed by the resolver in ResolveTypeParamsWalk.
             auto todo = core::make_type<core::ClassType>(core::Symbols::todo());
@@ -1366,14 +1366,14 @@ class SymbolDefiner {
             if (isTypeTemplate) {
                 auto context = ctx.owner.enclosingClass(ctx);
                 oldSym = context.data(ctx)->findMemberNoDealias(ctx, typeMember.name);
-                if (oldSym.exists() && !(oldSym.loc(ctx) == core::Loc(ctx.file, typeMember.asgnLoc) ||
+                if (oldSym.exists() && !(oldSym.loc(ctx) == ctx.locAt(typeMember.asgnLoc) ||
                                          oldSym.loc(ctx).isTombStoned(ctx))) {
-                    emitRedefinedConstantError(ctx, core::Loc(ctx.file, typeMember.nameLoc), typeMember.name.show(ctx),
+                    emitRedefinedConstantError(ctx, ctx.locAt(typeMember.nameLoc), typeMember.name.show(ctx),
                                                oldSym.loc(ctx));
                     ctx.state.mangleRenameSymbol(oldSym, typeMember.name);
                 }
                 auto alias =
-                    ctx.state.enterStaticFieldSymbol(core::Loc(ctx.file, typeMember.asgnLoc), context, typeMember.name);
+                    ctx.state.enterStaticFieldSymbol(ctx.locAt(typeMember.asgnLoc), context, typeMember.name);
                 alias.data(ctx)->resultType = core::make_type<core::AliasType>(core::SymbolRef(sym));
             }
         }
@@ -1678,7 +1678,7 @@ public:
             // TODO(dmitry) This won't find errors in fast-incremental mode.
             auto prevLoc = classBehaviorLocs.find(klass.symbol);
             if (prevLoc == classBehaviorLocs.end()) {
-                classBehaviorLocs[klass.symbol] = core::Loc(ctx.file, klass.declLoc);
+                classBehaviorLocs[klass.symbol] = ctx.locAt(klass.declLoc);
             } else if (prevLoc->second.file() != ctx.file &&
                        // Ignore packages, which have 'behavior defined in multiple files'.
                        klass.symbol.data(ctx)->owner != core::Symbols::PackageRegistry() &&

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -490,7 +490,7 @@ void checkPackageName(core::Context ctx, ast::UnresolvedConstantLit *constLit) {
 
                 e.addAutocorrect(core::AutocorrectSuggestion{
                     fmt::format("Replace `{}` with `{}`", constLit->cnst.shortName(ctx), replacement),
-                    {core::AutocorrectSuggestion::Edit{core::Loc(ctx.file, nameLoc), replacement}}});
+                    {core::AutocorrectSuggestion::Edit{ctx.locAt(nameLoc), replacement}}});
             }
         }
         constLit = ast::cast_tree<ast::UnresolvedConstantLit>(constLit->scope);
@@ -499,7 +499,7 @@ void checkPackageName(core::Context ctx, ast::UnresolvedConstantLit *constLit) {
 
 FullyQualifiedName getFullyQualifiedName(core::Context ctx, ast::UnresolvedConstantLit *constantLit) {
     FullyQualifiedName fqn;
-    fqn.loc = core::Loc(ctx.file, constantLit->loc);
+    fqn.loc = ctx.locAt(constantLit->loc);
     while (constantLit != nullptr) {
         fqn.parts.emplace_back(constantLit->cnst);
         constantLit = ast::cast_tree<ast::UnresolvedConstantLit>(constantLit->scope);
@@ -1108,7 +1108,7 @@ struct PackageInfoFinder {
                 ctx.state.freshNameUnique(core::UniqueNameKind::PackagerPrivate, utf8PrivateName, 1);
             info->privateMangledName = ctx.state.enterNameConstant(packagerPrivateName);
 
-            info->loc = core::Loc(ctx.file, classDef.loc);
+            info->loc = ctx.locAt(classDef.loc);
         } else {
             if (auto e = ctx.beginError(classDef.loc, core::errors::Packager::MultiplePackagesInOneFile)) {
                 e.setHeader("Package files can only declare one package");
@@ -1652,7 +1652,7 @@ private:
             // and the file processing order is consistent.
             e.setHeader("Conflicting import sources for `{}`",
                         fmt::map_join(nameParts, "::", [&](const auto &nr) { return nr.show(ctx); }));
-            e.addErrorLine(core::Loc(ctx.file, otherLoc), "Conflict from");
+            e.addErrorLine(ctx.locAt(otherLoc), "Conflict from");
         }
     }
 

--- a/resolver/CorrectTypeAlias.cc
+++ b/resolver/CorrectTypeAlias.cc
@@ -57,8 +57,8 @@ void CorrectTypeAlias::eagerToLazy(core::Context ctx, core::ErrorBuilder &e, ast
         if (ctx.locAt(send->loc).position(ctx).second.line == endLoc.position(ctx).second.line) {
             argSrc = indented(argSrc);
         }
-        e.replaceWith("Convert to lazy type alias", ctx.locAt(send->loc), "T.type_alias do\n{}\n{}end",
-                      argSrc, getIndent(ctx, ctx.locAt(send->loc)));
+        e.replaceWith("Convert to lazy type alias", ctx.locAt(send->loc), "T.type_alias do\n{}\n{}end", argSrc,
+                      getIndent(ctx, ctx.locAt(send->loc)));
     }
 }
 

--- a/resolver/CorrectTypeAlias.cc
+++ b/resolver/CorrectTypeAlias.cc
@@ -37,14 +37,14 @@ void CorrectTypeAlias::eagerToLazy(core::Context ctx, core::ErrorBuilder &e, ast
         return;
     }
 
-    auto [start, end] = core::Loc(ctx.file, send->loc).position(ctx);
+    auto [start, end] = ctx.locAt(send->loc).position(ctx);
 
     if (start.line == end.line) {
         if (wrapHash) {
-            e.replaceWith("Convert to lazy type alias", core::Loc(ctx.file, send->loc), "T.type_alias {{{{{}}}}}",
+            e.replaceWith("Convert to lazy type alias", ctx.locAt(send->loc), "T.type_alias {{{{{}}}}}",
                           argsLoc.source(ctx).value());
         } else {
-            e.replaceWith("Convert to lazy type alias", core::Loc(ctx.file, send->loc), "T.type_alias {{{}}}",
+            e.replaceWith("Convert to lazy type alias", ctx.locAt(send->loc), "T.type_alias {{{}}}",
                           argsLoc.source(ctx).value());
         }
     } else {
@@ -54,11 +54,11 @@ void CorrectTypeAlias::eagerToLazy(core::Context ctx, core::ErrorBuilder &e, ast
         if (wrapHash) {
             argSrc = fmt::format("{}{{\n{}\n{}}}", argIndent, indented(argSrc), argIndent);
         }
-        if (core::Loc(ctx.file, send->loc).position(ctx).second.line == endLoc.position(ctx).second.line) {
+        if (ctx.locAt(send->loc).position(ctx).second.line == endLoc.position(ctx).second.line) {
             argSrc = indented(argSrc);
         }
-        e.replaceWith("Convert to lazy type alias", core::Loc(ctx.file, send->loc), "T.type_alias do\n{}\n{}end",
-                      argSrc, getIndent(ctx, core::Loc(ctx.file, send->loc)));
+        e.replaceWith("Convert to lazy type alias", ctx.locAt(send->loc), "T.type_alias do\n{}\n{}end",
+                      argSrc, getIndent(ctx, ctx.locAt(send->loc)));
     }
 }
 

--- a/resolver/SuggestPackage.cc
+++ b/resolver/SuggestPackage.cc
@@ -252,7 +252,7 @@ private:
         for (auto suggestion : matches) {
             const auto replacement = suggestion.symbol.show(ctx);
             lines.emplace_back(core::ErrorLine::from(suggestion.symbol.loc(ctx), "Did you mean: `{}`?", replacement));
-            e.replaceWith(fmt::format("Replace with `{}`", replacement), core::Loc(ctx.file, unresolved.loc), "{}",
+            e.replaceWith(fmt::format("Replace with `{}`", replacement), ctx.locAt(unresolved.loc), "{}",
                           replacement);
         }
         e.addErrorSection(core::ErrorSection(lines));

--- a/resolver/SuggestPackage.cc
+++ b/resolver/SuggestPackage.cc
@@ -252,8 +252,7 @@ private:
         for (auto suggestion : matches) {
             const auto replacement = suggestion.symbol.show(ctx);
             lines.emplace_back(core::ErrorLine::from(suggestion.symbol.loc(ctx), "Did you mean: `{}`?", replacement));
-            e.replaceWith(fmt::format("Replace with `{}`", replacement), ctx.locAt(unresolved.loc), "{}",
-                          replacement);
+            e.replaceWith(fmt::format("Replace with `{}`", replacement), ctx.locAt(unresolved.loc), "{}", replacement);
         }
         e.addErrorSection(core::ErrorSection(lines));
     }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -612,7 +612,7 @@ private:
                     auto loc = resolvedField.data(ctx)->loc();
                     if (auto e = ctx.state.beginError(loc, core::errors::Resolver::RecursiveTypeAlias)) {
                         e.setHeader("Unable to resolve right hand side of type alias `{}`", resolved.show(ctx));
-                        e.addErrorLine(core::Loc(ctx.file, job.out->original.loc()), "Type alias used here");
+                        e.addErrorLine(ctx.locAt(job.out->original.loc()), "Type alias used here");
                     }
                     resolvedField.data(ctx)->resultType =
                         core::Types::untyped(ctx, resolved); // <<-- This is the reason this takes a MutableContext
@@ -2372,8 +2372,8 @@ class ResolveTypeMembersAndFieldsWalk {
         if (cast->cast != core::Names::let()) {
             if (auto e = ctx.beginError(cast->loc, core::errors::Resolver::ConstantAssertType)) {
                 e.setHeader("Use `{}` to specify the type of constants", "T.let");
-                auto rhsLoc = core::Loc(ctx.file, asgn.rhs.loc());
-                auto argSource = core::Loc(ctx.file, cast->arg.loc()).source(ctx).value();
+                auto rhsLoc = ctx.locAt(asgn.rhs.loc());
+                auto argSource = ctx.locAt(cast->arg.loc()).source(ctx).value();
                 e.replaceWith("Replace with `T.let`", rhsLoc, "T.let({}, {})", argSource, cast->type.show(ctx));
                 if (cast->cast == core::Names::cast()) {
                     e.addErrorNote("If you really want to use `{}`, assign to an intermediate variable first and then "
@@ -3594,7 +3594,7 @@ public:
             if (!ast::isa_tree<ast::EmptyTree>(mdef.rhs)) {
                 if (auto e = ctx.beginError(mdef.rhs.loc(), core::errors::Resolver::AbstractMethodWithBody)) {
                     e.setHeader("Abstract methods must not contain any code in their body");
-                    e.replaceWith("Delete the body", core::Loc(ctx.file, mdef.rhs.loc()), "");
+                    e.replaceWith("Delete the body", ctx.locAt(mdef.rhs.loc()), "");
                 }
 
                 mdef.rhs = ast::MK::EmptyTree();

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -443,7 +443,7 @@ private:
 
     static core::ClassOrModuleRef stubConstant(core::MutableContext ctx, core::ClassOrModuleRef owner,
                                                ast::ConstantLit *out, bool possibleGenericType) {
-        auto symbol = ctx.state.enterClassSymbol(core::Loc{ctx.file, out->loc}, owner,
+        auto symbol = ctx.state.enterClassSymbol(ctx.locAt(out->loc), owner,
                                                  ast::cast_tree<ast::UnresolvedConstantLit>(out->original)->cnst);
 
         auto data = symbol.data(ctx);
@@ -856,7 +856,7 @@ private:
                     e.setHeader("Reassigning a type alias is not allowed");
                 }
                 e.addErrorLine(rhsSym.loc(ctx), "Originally defined here");
-                auto rhsLoc = core::Loc{ctx.file, it.rhs->loc};
+                auto rhsLoc = ctx.locAt(it.rhs->loc);
                 if (rhsLoc.exists()) {
                     e.replaceWith("Declare as type alias", rhsLoc, "T.type_alias {{{}}}", rhsLoc.source(ctx).value());
                 }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -706,8 +706,8 @@ private:
                             const auto replacement = suggestion.symbol.show(ctx);
                             lines.emplace_back(
                                 core::ErrorLine::from(suggestion.symbol.loc(ctx), "Did you mean: `{}`?", replacement));
-                            e.replaceWith(fmt::format("Replace with `{}`", replacement),
-                                          ctx.locAt(job.out->loc), "{}", replacement);
+                            e.replaceWith(fmt::format("Replace with `{}`", replacement), ctx.locAt(job.out->loc), "{}",
+                                          replacement);
                         }
                         e.addErrorSection(core::ErrorSection(lines));
                     }
@@ -3439,8 +3439,7 @@ private:
                         if (!ctx.permitOverloadDefinitions(ctx.file)) {
                             if (auto e = ctx.beginError(lastSigs[0]->loc, core::errors::Resolver::OverloadNotAllowed)) {
                                 e.setHeader("Unused type annotation. No method def before next annotation");
-                                e.addErrorLine(ctx.locAt(send.loc),
-                                               "Type annotation that will be used instead");
+                                e.addErrorLine(ctx.locAt(send.loc), "Type annotation that will be used instead");
                             }
                         }
                     }
@@ -3568,8 +3567,8 @@ public:
             i++;
             core::MethodRef overloadSym;
             if (isOverloaded) {
-                overloadSym = ctx.state.enterNewMethodOverload(ctx.locAt(sig.loc), mdef.symbol, originalName,
-                                                               i, sig.argsToKeep);
+                overloadSym =
+                    ctx.state.enterNewMethodOverload(ctx.locAt(sig.loc), mdef.symbol, originalName, i, sig.argsToKeep);
                 overloadSym.data(ctx)->setMethodVisibility(mdef.symbol.data(ctx)->methodVisibility());
                 if (i != sigs.size() - 1) {
                     overloadSym.data(ctx)->flags.isOverloaded = true;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -707,7 +707,7 @@ private:
                             lines.emplace_back(
                                 core::ErrorLine::from(suggestion.symbol.loc(ctx), "Did you mean: `{}`?", replacement));
                             e.replaceWith(fmt::format("Replace with `{}`", replacement),
-                                          core::Loc(ctx.file, job.out->loc), "{}", replacement);
+                                          ctx.locAt(job.out->loc), "{}", replacement);
                         }
                         e.addErrorSection(core::ErrorSection(lines));
                     }
@@ -2344,7 +2344,7 @@ class ResolveTypeMembersAndFieldsWalk {
             return;
         }
 
-        auto alias = ctx.state.enterMethodSymbol(core::Loc(ctx.file, job.loc), job.owner, job.fromName);
+        auto alias = ctx.state.enterMethodSymbol(ctx.locAt(job.loc), job.owner, job.fromName);
         alias.data(ctx)->resultType = core::make_type<core::AliasType>(core::SymbolRef(toMethod));
     }
 
@@ -3286,7 +3286,7 @@ private:
                 if (auto e = ctx.state.beginError(arg.loc, core::errors::Resolver::BadParameterOrdering)) {
                     e.setHeader("Malformed `{}`. Required parameter `{}` must be declared before all the optional ones",
                                 "sig", treeArgName.show(ctx));
-                    e.addErrorLine(core::Loc(ctx.file, exprLoc), "Signature");
+                    e.addErrorLine(ctx.locAt(exprLoc), "Signature");
                 }
             }
 
@@ -3323,7 +3323,7 @@ private:
                     if (auto e = ctx.state.beginError(arg.loc, core::errors::Resolver::InvalidMethodSignature)) {
                         e.setHeader("Malformed `{}`. Type not specified for argument `{}`", "sig",
                                     treeArgName.show(ctx));
-                        e.addErrorLine(core::Loc(ctx.file, exprLoc), "Signature");
+                        e.addErrorLine(ctx.locAt(exprLoc), "Signature");
                     }
                 }
             }
@@ -3439,7 +3439,7 @@ private:
                         if (!ctx.permitOverloadDefinitions(ctx.file)) {
                             if (auto e = ctx.beginError(lastSigs[0]->loc, core::errors::Resolver::OverloadNotAllowed)) {
                                 e.setHeader("Unused type annotation. No method def before next annotation");
-                                e.addErrorLine(core::Loc(ctx.file, send.loc),
+                                e.addErrorLine(ctx.locAt(send.loc),
                                                "Type annotation that will be used instead");
                             }
                         }
@@ -3568,7 +3568,7 @@ public:
             i++;
             core::MethodRef overloadSym;
             if (isOverloaded) {
-                overloadSym = ctx.state.enterNewMethodOverload(core::Loc(ctx.file, sig.loc), mdef.symbol, originalName,
+                overloadSym = ctx.state.enterNewMethodOverload(ctx.locAt(sig.loc), mdef.symbol, originalName,
                                                                i, sig.argsToKeep);
                 overloadSym.data(ctx)->setMethodVisibility(mdef.symbol.data(ctx)->methodVisibility());
                 if (i != sigs.size() - 1) {

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -220,7 +220,7 @@ ParsedSig parseSigWithSelfTypeParams(core::Context ctx, const ast::Send &sigSend
                             }
                         }
                         typeArgSpec.type = core::make_type<core::TypeVar>(core::Symbols::todoTypeArgument());
-                        typeArgSpec.loc = core::Loc(ctx.file, arg.loc());
+                        typeArgSpec.loc = ctx.locAt(arg.loc());
                     } else {
                         if (auto e = ctx.beginError(arg.loc(), core::errors::Resolver::InvalidMethodSignature)) {
                             e.setHeader("Malformed `{}`: Type parameters are specified with symbols", "sig");
@@ -381,7 +381,7 @@ ParsedSig parseSigWithSelfTypeParams(core::Context ctx, const ast::Send &sigSend
                                 getResultTypeAndBindWithSelfTypeParams(ctx, value, *parent, args.withRebind());
                         }
 
-                        sig.argTypes.emplace_back(ParsedSig::ArgSpec{core::Loc(ctx.file, key.loc()), name,
+                        sig.argTypes.emplace_back(ParsedSig::ArgSpec{ctx.locAt(key.loc()), name,
                                                                      resultAndBind.type, resultAndBind.rebind});
                     }
                 }

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -159,7 +159,7 @@ void addMultiStatementSigAutocorrect(core::Context ctx, core::ErrorBuilder &e, c
         first = false;
     }
 
-    e.replaceWith("Use a chained sig builder", core::Loc{ctx.file, insseq->loc}, "{}", replacement);
+    e.replaceWith("Use a chained sig builder", ctx.locAt(insseq->loc), "{}", replacement);
 }
 
 ParsedSig parseSigWithSelfTypeParams(core::Context ctx, const ast::Send &sigSend, const ParsedSig *parent,
@@ -585,7 +585,7 @@ TypeSyntax::ResultType interpretTCombinator(core::Context ctx, const ast::Send &
                 if (arg != nullptr && arg->fun == core::Names::untyped() && !arg->hasPosArgs() && !arg->hasKwArgs()) {
                     if (auto e = ctx.beginError(send.loc, core::errors::Resolver::NilableUntyped)) {
                         e.setHeader("`{}` is the same as `{}`", "T.nilable(T.untyped)", "T.untyped");
-                        e.replaceWith("Replace with `T.untyped`", core::Loc{ctx.file, send.loc}, "T.untyped");
+                        e.replaceWith("Replace with `T.untyped`", ctx.locAt(send.loc), "T.untyped");
                     }
                 }
                 return result;
@@ -888,7 +888,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx,
                         // if we're already looking at `T::Array` instead.
                         auto typePrefix = isBuiltinGeneric ? "" : "T::";
 
-                        auto loc = core::Loc{ctx.file, i.loc};
+                        auto loc = ctx.locAt(i.loc);
                         if (auto locSource = loc.source(ctx)) {
                             if (klass == core::Symbols::Hash() || klass == core::Symbols::T_Hash()) {
                                 // Hash is special because it has arity 3 but you're only supposed to write the first 2

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -381,8 +381,8 @@ ParsedSig parseSigWithSelfTypeParams(core::Context ctx, const ast::Send &sigSend
                                 getResultTypeAndBindWithSelfTypeParams(ctx, value, *parent, args.withRebind());
                         }
 
-                        sig.argTypes.emplace_back(ParsedSig::ArgSpec{ctx.locAt(key.loc()), name,
-                                                                     resultAndBind.type, resultAndBind.rebind});
+                        sig.argTypes.emplace_back(
+                            ParsedSig::ArgSpec{ctx.locAt(key.loc()), name, resultAndBind.type, resultAndBind.rebind});
                     }
                 }
                 break;
@@ -503,8 +503,7 @@ ParsedSig parseSigWithSelfTypeParams(core::Context ctx, const ast::Send &sigSend
                 if (auto e = ctx.beginError(send->loc, core::errors::Resolver::InvalidMethodSignature)) {
                     reportedInvalidMethod = true;
                     e.setHeader("Malformed `{}`: `{}` is invalid in this context", "sig", send->fun.show(ctx));
-                    e.addErrorLine(ctx.locAt(send->loc),
-                                   "Consult https://sorbet.org/docs/sigs for signature syntax");
+                    e.addErrorLine(ctx.locAt(send->loc), "Consult https://sorbet.org/docs/sigs for signature syntax");
                 }
         }
         auto recv = ast::cast_tree<ast::Send>(send->recv);

--- a/rewriter/AttrReader.cc
+++ b/rewriter/AttrReader.cc
@@ -22,9 +22,9 @@ pair<core::NameRef, core::LocOffsets> getName(core::MutableContext ctx, ast::Exp
         if (lit->isSymbol(ctx)) {
             res = lit->asSymbol(ctx);
             loc = lit->loc;
-            ENFORCE(core::Loc(ctx.file, loc).exists());
-            ENFORCE(core::Loc(ctx.file, loc).source(ctx).value().size() > 1 &&
-                    core::Loc(ctx.file, loc).source(ctx).value()[0] == ':');
+            ENFORCE(ctx.locAt(loc).exists());
+            ENFORCE(ctx.locAt(loc).source(ctx).value().size() > 1 &&
+                    ctx.locAt(loc).source(ctx).value()[0] == ':');
             loc = core::LocOffsets{loc.beginPos() + 1, loc.endPos()};
         } else if (lit->isString(ctx)) {
             core::NameRef nameRef = lit->asString(ctx);

--- a/rewriter/AttrReader.cc
+++ b/rewriter/AttrReader.cc
@@ -23,8 +23,7 @@ pair<core::NameRef, core::LocOffsets> getName(core::MutableContext ctx, ast::Exp
             res = lit->asSymbol(ctx);
             loc = lit->loc;
             ENFORCE(ctx.locAt(loc).exists());
-            ENFORCE(ctx.locAt(loc).source(ctx).value().size() > 1 &&
-                    ctx.locAt(loc).source(ctx).value()[0] == ':');
+            ENFORCE(ctx.locAt(loc).source(ctx).value().size() > 1 && ctx.locAt(loc).source(ctx).value()[0] == ':');
             loc = core::LocOffsets{loc.beginPos() + 1, loc.endPos()};
         } else if (lit->isString(ctx)) {
             core::NameRef nameRef = lit->asString(ctx);

--- a/rewriter/DSLBuilder.cc
+++ b/rewriter/DSLBuilder.cc
@@ -50,8 +50,7 @@ vector<ast::ExpressionPtr> DSLBuilder::run(core::MutableContext ctx, ast::Send *
     name = sym->asSymbol(ctx);
 
     ENFORCE(ctx.locAt(sym->loc).exists());
-    ENFORCE(!ctx.locAt(sym->loc).source(ctx).value().empty() &&
-            ctx.locAt(sym->loc).source(ctx).value()[0] == ':');
+    ENFORCE(!ctx.locAt(sym->loc).source(ctx).value().empty() && ctx.locAt(sym->loc).source(ctx).value()[0] == ':');
     auto nameLoc = core::LocOffsets{sym->loc.beginPos() + 1, sym->loc.endPos()};
 
     type = ASTUtil::dupType(send->getPosArg(1));

--- a/rewriter/DSLBuilder.cc
+++ b/rewriter/DSLBuilder.cc
@@ -49,9 +49,9 @@ vector<ast::ExpressionPtr> DSLBuilder::run(core::MutableContext ctx, ast::Send *
     }
     name = sym->asSymbol(ctx);
 
-    ENFORCE(core::Loc(ctx.file, sym->loc).exists());
-    ENFORCE(!core::Loc(ctx.file, sym->loc).source(ctx).value().empty() &&
-            core::Loc(ctx.file, sym->loc).source(ctx).value()[0] == ':');
+    ENFORCE(ctx.locAt(sym->loc).exists());
+    ENFORCE(!ctx.locAt(sym->loc).source(ctx).value().empty() &&
+            ctx.locAt(sym->loc).source(ctx).value()[0] == ':');
     auto nameLoc = core::LocOffsets{sym->loc.beginPos() + 1, sym->loc.endPos()};
 
     type = ASTUtil::dupType(send->getPosArg(1));

--- a/rewriter/MixinEncryptedProp.cc
+++ b/rewriter/MixinEncryptedProp.cc
@@ -52,8 +52,7 @@ vector<ast::ExpressionPtr> MixinEncryptedProp::run(core::MutableContext ctx, ast
     }
     name = sym->asSymbol(ctx);
     ENFORCE(ctx.locAt(sym->loc).exists());
-    ENFORCE(ctx.locAt(sym->loc).source(ctx).value().size() > 1 &&
-            ctx.locAt(sym->loc).source(ctx).value()[0] == ':');
+    ENFORCE(ctx.locAt(sym->loc).source(ctx).value().size() > 1 && ctx.locAt(sym->loc).source(ctx).value()[0] == ':');
     auto nameLoc = core::LocOffsets{sym->loc.beginPos() + 1, sym->loc.endPos()};
     enc_name = name.prepend(ctx, "encrypted_");
 

--- a/rewriter/MixinEncryptedProp.cc
+++ b/rewriter/MixinEncryptedProp.cc
@@ -51,9 +51,9 @@ vector<ast::ExpressionPtr> MixinEncryptedProp::run(core::MutableContext ctx, ast
         return empty;
     }
     name = sym->asSymbol(ctx);
-    ENFORCE(core::Loc(ctx.file, sym->loc).exists());
-    ENFORCE(core::Loc(ctx.file, sym->loc).source(ctx).value().size() > 1 &&
-            core::Loc(ctx.file, sym->loc).source(ctx).value()[0] == ':');
+    ENFORCE(ctx.locAt(sym->loc).exists());
+    ENFORCE(ctx.locAt(sym->loc).source(ctx).value().size() > 1 &&
+            ctx.locAt(sym->loc).source(ctx).value()[0] == ':');
     auto nameLoc = core::LocOffsets{sym->loc.beginPos() + 1, sym->loc.endPos()};
     enc_name = name.prepend(ctx, "encrypted_");
 

--- a/rewriter/Private.cc
+++ b/rewriter/Private.cc
@@ -26,26 +26,26 @@ vector<ast::ExpressionPtr> Private::run(core::MutableContext ctx, ast::Send *sen
     if (send->fun == core::Names::private_() && mdef->flags.isSelfMethod) {
         if (auto e = ctx.beginError(send->loc, core::errors::Rewriter::PrivateMethodMismatch)) {
             e.setHeader("Use `{}` to define private class methods", "private_class_method");
-            auto replacementLoc = core::Loc{ctx.file, send->funLoc};
+            auto replacementLoc = ctx.locAt(send->funLoc);
             e.replaceWith("Replace with `private_class_method`", replacementLoc, "private_class_method");
         }
     } else if (send->fun == core::Names::privateClassMethod() && !mdef->flags.isSelfMethod) {
         if (auto e = ctx.beginError(send->loc, core::errors::Rewriter::PrivateMethodMismatch)) {
             e.setHeader("Use `{}` to define private instance methods", "private");
-            auto replacementLoc = core::Loc{ctx.file, send->funLoc};
+            auto replacementLoc = ctx.locAt(send->funLoc);
             e.replaceWith("Replace with `private`", replacementLoc, "private");
         }
     } else if (send->fun == core::Names::packagePrivate() && mdef->flags.isSelfMethod) {
         if (auto e = ctx.beginError(send->loc, core::errors::Rewriter::PrivateMethodMismatch)) {
             e.setHeader("Use `{}` to define package-private class methods", "package_private_class_method");
-            auto replacementLoc = core::Loc{ctx.file, send->funLoc};
+            auto replacementLoc = ctx.locAt(send->funLoc);
             e.replaceWith("Replace with `package_private_class_method`", replacementLoc,
                           "package_private_class_method");
         }
     } else if (send->fun == core::Names::packagePrivateClassMethod() && !mdef->flags.isSelfMethod) {
         if (auto e = ctx.beginError(send->loc, core::errors::Rewriter::PrivateMethodMismatch)) {
             e.setHeader("Use `{}` to define package-private instance methods", "package_private");
-            auto replacementLoc = core::Loc{ctx.file, send->funLoc};
+            auto replacementLoc = ctx.locAt(send->funLoc);
             e.replaceWith("Replace with `package_private`", replacementLoc, "package_private");
         }
     }

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -217,9 +217,9 @@ optional<PropInfo> parseProp(core::MutableContext ctx, const ast::Send *send) {
             return nullopt;
         }
         ret.name = sym->asSymbol(ctx);
-        ENFORCE(core::Loc(ctx.file, sym->loc).exists());
-        ENFORCE(!core::Loc(ctx.file, sym->loc).source(ctx).value().empty() &&
-                core::Loc(ctx.file, sym->loc).source(ctx).value()[0] == ':');
+        ENFORCE(ctx.locAt(sym->loc).exists());
+        ENFORCE(!ctx.locAt(sym->loc).source(ctx).value().empty() &&
+                ctx.locAt(sym->loc).source(ctx).value()[0] == ':');
         ret.nameLoc = core::LocOffsets{sym->loc.beginPos() + 1, sym->loc.endPos()};
     }
 

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -218,8 +218,7 @@ optional<PropInfo> parseProp(core::MutableContext ctx, const ast::Send *send) {
         }
         ret.name = sym->asSymbol(ctx);
         ENFORCE(ctx.locAt(sym->loc).exists());
-        ENFORCE(!ctx.locAt(sym->loc).source(ctx).value().empty() &&
-                ctx.locAt(sym->loc).source(ctx).value()[0] == ':');
+        ENFORCE(!ctx.locAt(sym->loc).source(ctx).value().empty() && ctx.locAt(sym->loc).source(ctx).value()[0] == ':');
         ret.nameLoc = core::LocOffsets{sym->loc.beginPos() + 1, sym->loc.endPos()};
     }
 

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -253,7 +253,7 @@ optional<PropInfo> parseProp(core::MutableContext ctx, const ast::Send *send) {
         auto loc = ret.type.loc();
         if (auto e = ctx.beginError(loc, core::errors::Rewriter::NilableUntyped)) {
             e.setHeader("`{}` is the same as `{}`", "T.nilable(T.untyped)", "T.untyped");
-            e.replaceWith("Use `T.untyped`", core::Loc{ctx.file, loc}, "T.untyped");
+            e.replaceWith("Use `T.untyped`", ctx.locAt(loc), "T.untyped");
 
             bool addDefault = true;
             if (rulesTree != nullptr) {

--- a/rewriter/Struct.cc
+++ b/rewriter/Struct.cc
@@ -127,7 +127,7 @@ vector<ast::ExpressionPtr> Struct::run(core::MutableContext ctx, ast::Assign *as
         }
 
         // TODO(jez) Use Loc::adjust here
-        if (symLoc.exists() && absl::StartsWith(core::Loc(ctx.file, symLoc).source(ctx).value(), ":")) {
+        if (symLoc.exists() && absl::StartsWith(ctx.locAt(symLoc).source(ctx).value(), ":")) {
             symLoc = core::LocOffsets{symLoc.beginPos() + 1, symLoc.endPos()};
         }
 

--- a/rewriter/TEnum.cc
+++ b/rewriter/TEnum.cc
@@ -52,7 +52,7 @@ ast::Send *asEnumsDo(ast::ExpressionPtr &stat) {
 vector<ast::ExpressionPtr> badConst(core::MutableContext ctx, core::LocOffsets headerLoc, core::LocOffsets line1Loc) {
     if (auto e = ctx.beginError(headerLoc, core::errors::Rewriter::TEnumConstNotEnumValue)) {
         e.setHeader("All constants defined on an `{}` must be unique instances of the enum", "T::Enum");
-        e.addErrorLine(core::Loc(ctx.file, line1Loc), "Enclosing definition here");
+        e.addErrorLine(ctx.locAt(line1Loc), "Enclosing definition here");
     }
     return {};
 }
@@ -112,7 +112,7 @@ vector<ast::ExpressionPtr> processStat(core::MutableContext ctx, ast::ClassDef *
         if (auto e = ctx.beginError(stat.loc(), core::errors::Rewriter::TEnumOutsideEnumsDo)) {
             e.setHeader("Definition of enum value `{}` must be within the `{}` block for this `{}`",
                         lhs->cnst.show(ctx), "enums do", "T::Enum");
-            e.addErrorLine(core::Loc(ctx.file, klass->declLoc), "Enclosing definition here");
+            e.addErrorLine(ctx.locAt(klass->declLoc), "Enclosing definition here");
         }
     }
 


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I think this is slightly easier to read--no `core::Loc` everywhere--with the possible downside that `ctx.locAt(thingLoc)` is kind of odd code.  But `loc` is kind of overloaded already to refer to `Loc` or `LocOffsets`, depending, so I don't feel too bad about this.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.  No functional change intended.
