### PR TITLE
reenable `ENFORCE` now that visibility is handled

### DIFF
--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1184,8 +1184,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                  *
                  * For now we can at least enforce a little consistency.
                  */
-                // ENFORCE(ctx.owner == i->method); TODO: re-enable when https://github.com/sorbet/sorbet/issues/904 is
-                // fixed
+                ENFORCE(ctx.owner == i.method);
 
                 auto argType = i.argument(ctx).argumentTypeAsSeenByImplementation(ctx, constr);
                 tp.type = std::move(argType);


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We fixed #904, so we can apparently turn on this `ENFORCE`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
