### PR TITLE
Numeric classes produce nilable numbers when exception: false

### DIFF
--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -755,7 +755,7 @@ module Kernel
         digits: Integer,
         exception: T::Boolean
     )
-    .returns(BigDecimal)
+    .returns(T.nilable(BigDecimal))
   end
   def BigDecimal(initial, digits=0, exception: true); end
   ### As of 2.6, all these numeric conversion methods *can* return `nil` iff given the kwarg `exception: false`, which
@@ -805,7 +805,7 @@ module Kernel
         y: T.any(Numeric, String),
         exception: T::Boolean
     )
-    .returns(Complex)
+    .returns(T.nilable(Complex))
   end
   def Complex(x, y=T.unsafe(nil), exception: false); end
   ### As of 2.6, all these numeric conversion methods *can* return `nil` iff given the kwarg `exception: false`, which
@@ -837,7 +837,7 @@ module Kernel
         x: T.any(Numeric, String),
         exception: T::Boolean
     )
-    .returns(Float)
+    .returns(T.nilable(Float))
   end
   def Float(x, exception: true); end
   ### As of 2.6, all these numeric conversion methods *can* return `nil` iff given the kwarg `exception: false`, which
@@ -901,7 +901,7 @@ module Kernel
         base: Integer,
         exception: T::Boolean
     )
-    .returns(Integer)
+    .returns(T.nilable(Integer))
   end
   def Integer(arg, base=T.unsafe(nil), exception: true); end
   ### As of 2.6, all these numeric conversion methods *can* return `nil` iff given the kwarg `exception: false`, which
@@ -952,7 +952,7 @@ module Kernel
         y: T.any(Numeric, String),
         exception: T::Boolean
     )
-    .returns(Rational)
+    .returns(T.nilable(Rational))
   end
   def Rational(x, y=T.unsafe(nil), exception: true); end
   ### As of 2.6, all these numeric conversion methods *can* return `nil` iff given the kwarg `exception: false`, which


### PR DESCRIPTION
When exception: false is set on numeric types like Float, BigDecimal, etc... the return type can be nil.

```ruby
irb(main):002:0> Float('a', exception: false)
=> nil
```

### Motivation

The existing signatures are incorrect.

### Test plan

I did not include tests as this is simply making a signature correct.
