### PR TITLE
Defer sorting resolver todo lists until it matters

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1582,16 +1582,7 @@ public:
             }
         }
 
-        // Note: `todo` does not need to be sorted. There are no ordering effects on error production.
-
-        fast_sort(todoAncestors, [](const auto &lhs, const auto &rhs) -> bool { return lhs.file < rhs.file; });
-        fast_sort(todoClassAliases, [](const auto &lhs, const auto &rhs) -> bool { return lhs.file < rhs.file; });
-        fast_sort(todoTypeAliases, [](const auto &lhs, const auto &rhs) -> bool { return lhs.file < rhs.file; });
-        fast_sort(todoClassMethods, [](const auto &lhs, const auto &rhs) -> bool { return lhs.file < rhs.file; });
-        fast_sort(todoRequiredAncestors, [](const auto &lhs, const auto &rhs) -> bool { return lhs.file < rhs.file; });
-
         ENFORCE(todoRequiredAncestors.empty() || gs.requiresAncestorEnabled);
-        fast_sort(trees, [](const auto &lhs, const auto &rhs) -> bool { return lhs.file < rhs.file; });
 
         Timer timeit1(gs.tracer(), "resolver.resolve_constants.fixed_point");
 
@@ -1719,6 +1710,14 @@ public:
          */
         fast_sort(todo,
                   [&gs](const auto &lhs, const auto &rhs) -> bool { return compareFiles(gs, lhs.file, rhs.file); });
+
+        fast_sort(todoAncestors, [](const auto &lhs, const auto &rhs) -> bool { return lhs.file < rhs.file; });
+        fast_sort(todoClassAliases, [](const auto &lhs, const auto &rhs) -> bool { return lhs.file < rhs.file; });
+        fast_sort(todoTypeAliases, [](const auto &lhs, const auto &rhs) -> bool { return lhs.file < rhs.file; });
+        fast_sort(todoClassMethods, [](const auto &lhs, const auto &rhs) -> bool { return lhs.file < rhs.file; });
+        fast_sort(todoRequiredAncestors, [](const auto &lhs, const auto &rhs) -> bool { return lhs.file < rhs.file; });
+
+        fast_sort(trees, [](const auto &lhs, const auto &rhs) -> bool { return lhs.file < rhs.file; });
 
         for (auto &todos : todo) {
             fast_sort(todos.items, [](const ResolutionItem &lhs, const ResolutionItem &rhs) -> bool {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

If `t` is number of TODO items and `e` is number of errors, this changes the
algorithm from

`O(t log(t))` → `O(e log(e))`

`t` scales with codebase size. `e` also scales with codebase size, but much
smaller, and only for builds that we don't expect to typecheck (branch builds).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Hopefully this has no changes, so existing tests should cover this.

~~I plan to test the perf impact on Stripe's codebase~~

Timings:
http://go/gist/jez/963ced6034405215ec5530f87ccf5075