### PR TITLE
use cwd from lspConfigs in vs code extension

### DIFF
--- a/vscode_extension/src/LanguageClient.ts
+++ b/vscode_extension/src/LanguageClient.ts
@@ -246,7 +246,7 @@ export default class SorbetLanguageClient implements ErrorHandler {
     ] = this._sorbetExtensionConfig.activeLspConfig!.command;
     this._outputChannel.appendLine(`    ${command} ${args.join(" ")}`);
     this._sorbetProcess = spawn(command, args, {
-      cwd: workspace.rootPath,
+      cwd: this._sorbetExtensionConfig.activeLspConfig!.cwd,
     });
     const onExit = (err?: NodeJS.ErrnoException) => {
       if (

--- a/vscode_extension/src/LanguageClient.ts
+++ b/vscode_extension/src/LanguageClient.ts
@@ -1,6 +1,5 @@
 import { ChildProcess, spawn } from "child_process";
 import {
-  workspace,
   commands,
   OutputChannel,
   window as vscodeWindow,


### PR DESCRIPTION
Sorbet is not currently respecting the cwd as defined in the `sorbet.lspConfigs`. It continues to reference the root no matter what you put as the cwd. This appears due to the fact that Sorbet is always passing in the `workspace.rootPath` when spawning the typecheck: https://github.com/sorbet/sorbet/blob/master/vscode_extension/src/LanguageClient.ts#L249.

### Motivation
See above

### Test plan
There don't seem to be any relevant tests for this part of the code and I'm unsure of how to test this specific change.