### PR TITLE
Fix path issues with openssl config

### DIFF
--- a/third_party/openssl/darwin.BUILD
+++ b/third_party/openssl/darwin.BUILD
@@ -7,7 +7,8 @@ cc_import(
 cc_library(
     name = "ssl",
     hdrs = glob(["include/openssl/**/*.h"]),
-    includes = ["include/openssl"],
+    # "include" is added to the includes as openssl is installed in /usr/local/opt/openssl on darwin.
+    includes = ["include"],
     visibility = ["//visibility:public"],
     deps = [":ssl-import"],
 )
@@ -21,7 +22,8 @@ cc_import(
 cc_library(
     name = "crypto",
     hdrs = glob(["include/openssl/**/*.h"]),
-    includes = ["include/openssl"],
+    # "include" is added to the includes as openssl is installed in /usr/local/opt/openssl on darwin.
+    includes = ["include"],
     visibility = ["//visibility:public"],
     deps = [":crypto-import"],
 )

--- a/third_party/openssl/darwin.BUILD
+++ b/third_party/openssl/darwin.BUILD
@@ -7,7 +7,7 @@ cc_import(
 cc_library(
     name = "ssl",
     hdrs = glob(["include/openssl/**/*.h"]),
-    includes = ["include"],
+    includes = ["include/openssl"],
     visibility = ["//visibility:public"],
     deps = [":ssl-import"],
 )
@@ -21,7 +21,7 @@ cc_import(
 cc_library(
     name = "crypto",
     hdrs = glob(["include/openssl/**/*.h"]),
-    includes = ["include"],
+    includes = ["include/openssl"],
     visibility = ["//visibility:public"],
     deps = [":crypto-import"],
 )

--- a/third_party/openssl/linux.BUILD
+++ b/third_party/openssl/linux.BUILD
@@ -4,10 +4,9 @@ cc_import(
     visibility = ["//visibility:private"],
 )
 
+# No headers are exported, as /usr/include is already part of the system include path.
 cc_library(
     name = "ssl",
-    hdrs = glob(["include/openssl/**/*.h"]),
-    includes = ["include/openssl"],
     visibility = ["//visibility:public"],
     deps = [":ssl-import"],
 )
@@ -18,10 +17,9 @@ cc_import(
     visibility = ["//visibility:private"],
 )
 
+# No headers are exported, as /usr/include is already part of the system include path.
 cc_library(
     name = "crypto",
-    hdrs = glob(["include/openssl/**/*.h"]),
-    includes = ["include/openssl"],
     visibility = ["//visibility:public"],
     deps = [":crypto-import"],
 )

--- a/third_party/openssl/linux.BUILD
+++ b/third_party/openssl/linux.BUILD
@@ -7,7 +7,7 @@ cc_import(
 cc_library(
     name = "ssl",
     hdrs = glob(["include/openssl/**/*.h"]),
-    includes = ["include"],
+    includes = ["include/openssl"],
     visibility = ["//visibility:public"],
     deps = [":ssl-import"],
 )
@@ -21,7 +21,7 @@ cc_import(
 cc_library(
     name = "crypto",
     hdrs = glob(["include/openssl/**/*.h"]),
-    includes = ["include"],
+    includes = ["include/openssl"],
     visibility = ["//visibility:public"],
     deps = [":crypto-import"],
 )


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
To avoid accidentally passing `-isystem /usr/include` when building ruby, don't add any includes in the linux openssl import. This works because the openssl headers are installed in `/usr/include` which is a system include path and doesn't need to be explicitly added.

Without this change, ruby-3.0.3 fails to build, as we end up adding `-isystem /usr/include` through some roundabout symlinking. This wasn't a problem for ruby 2.7 and lower, as the only c++ headers included didn't use `#include_next` to monkey patch headers like `math.h`. However ruby-3 detects when some headers are compiled with a c++ compiler and includes the c++ variant which wraps the c header using `#include_next`. There's more discussion here: https://stackoverflow.com/a/37218954/12027039

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Pre-work for building ruby-3 in sorbet's CI.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I ran the snapshot tests locally to ensure that they work on osx.