### PR TITLE
Report all package export dups

### DIFF
--- a/test/testdata/packager/dup-export/__package.rb
+++ b/test/testdata/packager/dup-export/__package.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class Foo::Bar < PackageSpec
+
+  export_for_test Foo::Bar::Exists
+#                 ^^^^^^^^^^^^^^^^ error: Duplicate export of `Foo::Bar::Exists`
+  export Foo::Bar::Exists
+
+  export Foo::Bar::Also
+  export Foo::Bar::Also
+#        ^^^^^^^^^^^^^^ error: Duplicate export of `Foo::Bar::Also`
+end

--- a/test/testdata/packager/dup-export/foo_bar.rb
+++ b/test/testdata/packager/dup-export/foo_bar.rb
@@ -1,0 +1,12 @@
+# typed: strict
+
+module Foo::Bar
+  class Exists
+    extend T::Sig
+
+    sig {void}
+    def self.hello; end
+  end
+
+  class Also; end
+end

--- a/test/testdata/packager/dup-export/other/__package.rb
+++ b/test/testdata/packager/dup-export/other/__package.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Other < PackageSpec
+  import Foo::Bar
+end

--- a/test/testdata/packager/dup-export/other/other.rb
+++ b/test/testdata/packager/dup-export/other/other.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Other::OtherClass
+  Foo::Bar::Exists
+end


### PR DESCRIPTION
There was a bug where we would not find all duplicate exports. Previously we were advancing the interator in a way that skipped comparisons between siblings (that can't prefix each other but can be dups). I also ensured that public exports are ranked ahead of export_for_test

### Motivation
Fix bug
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
