### PR TITLE
Non-mutating version of `resolveConstants`

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -585,6 +585,9 @@ void GlobalState::initEmpty() {
     enterMethodArgumentSymbol(Loc::none(), method, Names::args());
     ENFORCE(method == Symbols::todoMethod());
 
+    method = this->staticInitForClass(core::Symbols::root(), Loc::none());
+    ENFORCE(method == Symbols::rootStaticInit());
+
     klass = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::ResolvedSig());
     ENFORCE(klass == Symbols::Sorbet_Private_Static_ResolvedSig());
     klass = Symbols::Sorbet_Private_Static_ResolvedSig().data(*this)->singletonClass(*this);
@@ -2190,10 +2193,10 @@ MethodRef GlobalState::staticInitForClass(ClassOrModuleRef klass, Loc loc) {
     return sym;
 }
 
-MethodRef GlobalState::lookupStaticInitForClass(ClassOrModuleRef klass) const {
+MethodRef GlobalState::lookupStaticInitForClass(ClassOrModuleRef klass, bool allowMissing) const {
     auto classData = klass.data(*this);
     auto ref = classData->lookupSingletonClass(*this).data(*this)->findMethod(*this, core::Names::staticInit());
-    ENFORCE(ref.exists(), "looking up non-existent <static-init> for {}", klass.toString(*this));
+    ENFORCE(ref.exists() || allowMissing, "looking up non-existent <static-init> for {}", klass.toString(*this));
     return ref;
 }
 

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -835,6 +835,7 @@ void GlobalState::initEmpty() {
             Symbols::MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS);
 
     installIntrinsics();
+    computeLinearization();
 
     Symbols::top().data(*this)->resultType = Types::top();
     Symbols::bottom().data(*this)->resultType = Types::bottom();

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -139,7 +139,7 @@ public:
     MethodRef staticInitForClass(ClassOrModuleRef klass, Loc loc);
 
     MethodRef lookupStaticInitForFile(FileRef file) const;
-    MethodRef lookupStaticInitForClass(ClassOrModuleRef klass) const;
+    MethodRef lookupStaticInitForClass(ClassOrModuleRef klass, bool allowMissing = false) const;
 
     NameRef enterNameUTF8(std::string_view nm);
     NameRef lookupNameUTF8(std::string_view nm) const;

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -86,6 +86,7 @@ public:
 
     void initEmpty();
     void installIntrinsics();
+    void computeLinearization();
 
     // Expand symbol and name tables to the given lengths. Does nothing if the value is <= current capacity.
     void preallocateTables(uint32_t classAndModulesSize, uint32_t methodsSize, uint32_t fieldsSize,

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -954,6 +954,10 @@ public:
         return MethodRef::fromRaw(12);
     }
 
+    static MethodRef rootStaticInit() {
+        return MethodRef::fromRaw(13);
+    }
+
     static ClassOrModuleRef Sorbet_Private_Static_ResolvedSig() {
         return ClassOrModuleRef::fromRaw(85);
     }
@@ -1009,7 +1013,7 @@ public:
     }
 
     static constexpr int MAX_SYNTHETIC_CLASS_SYMBOLS = 207;
-    static constexpr int MAX_SYNTHETIC_METHOD_SYMBOLS = 45;
+    static constexpr int MAX_SYNTHETIC_METHOD_SYMBOLS = 46;
     static constexpr int MAX_SYNTHETIC_FIELD_SYMBOLS = 4;
     static constexpr int MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 4;
     static constexpr int MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 104;

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1648,6 +1648,14 @@ public:
         // NameDefiner should have forced this class's singleton class into existence.
         ENFORCE(klass.symbol.data(ctx)->lookupSingletonClass(ctx).exists());
 
+        auto allowMissing = true;
+        if (!ctx.state.lookupStaticInitForClass(klass.symbol, allowMissing).exists()) {
+            ENFORCE(this->bestEffort);
+            // Even though we found a symbol for this, we don't have a <static-init> for it, which is
+            // an invariant that namer must introduce (all ClassDef's have `<static-init>` methods).
+            return ast::MK::EmptyTree();
+        }
+
         for (auto &exp : klass.rhs) {
             addAncestor(ctx, klass, exp);
         }

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -259,121 +259,6 @@ void Resolver::finalizeAncestors(core::GlobalState &gs) {
     prodCounterAdd("types.input.methods.total", methodCount);
 }
 
-struct ParentLinearizationInformation {
-    const InlinedVector<core::ClassOrModuleRef, 4> &mixins;
-    core::ClassOrModuleRef superClass;
-    core::ClassOrModuleRef klass;
-    InlinedVector<core::ClassOrModuleRef, 4> fullLinearizationSlow(core::GlobalState &gs);
-};
-
-int maybeAddMixin(core::GlobalState &gs, core::ClassOrModuleRef forSym,
-                  InlinedVector<core::ClassOrModuleRef, 4> &mixinList, core::ClassOrModuleRef mixin,
-                  core::ClassOrModuleRef parent, int pos) {
-    if (forSym == mixin) {
-        Exception::raise("Loop in mixins");
-    }
-    if (parent.data(gs)->derivesFrom(gs, mixin)) {
-        return pos;
-    }
-    auto fnd = find(mixinList.begin(), mixinList.end(), mixin);
-    if (fnd != mixinList.end()) {
-        auto newPos = fnd - mixinList.begin();
-        if (newPos >= pos) {
-            return newPos + 1;
-        }
-        return pos;
-    } else {
-        mixinList.insert(mixinList.begin() + pos, mixin);
-        return pos + 1;
-    }
-}
-
-// ** This implements Dmitry's understanding of Ruby linerarization with an optimization that common
-// tails of class linearization aren't copied around.
-// In order to obtain Ruby-side ancestors, one would need to walk superclass chain and concatenate `mixins`.
-// The algorithm is harder to explain than to code, so just follow code & tests if `testdata/resolver/linearization`
-ParentLinearizationInformation computeClassLinearization(core::GlobalState &gs, core::ClassOrModuleRef ofClass) {
-    ENFORCE_NO_TIMER(ofClass.exists());
-    auto data = ofClass.data(gs);
-    if (!data->isClassOrModuleLinearizationComputed()) {
-        if (data->superClass().exists()) {
-            computeClassLinearization(gs, data->superClass());
-        }
-        InlinedVector<core::ClassOrModuleRef, 4> currentMixins = data->mixins();
-        InlinedVector<core::ClassOrModuleRef, 4> newMixins;
-        for (auto mixin : currentMixins) {
-            ENFORCE(mixin != core::Symbols::PlaceholderMixin(), "Resolver failed to replace all placeholders");
-            if (mixin == data->superClass()) {
-                continue;
-            }
-            if (mixin.data(gs)->superClass() == core::Symbols::StubSuperClass() ||
-                mixin.data(gs)->superClass() == core::Symbols::StubModule()) {
-                newMixins.emplace_back(mixin);
-                continue;
-            }
-            ParentLinearizationInformation mixinLinearization = computeClassLinearization(gs, mixin);
-
-            if (!mixin.data(gs)->isClassOrModuleModule()) {
-                // insert all transitive parents of class to bring methods back.
-                auto allMixins = mixinLinearization.fullLinearizationSlow(gs);
-                newMixins.insert(newMixins.begin(), allMixins.begin(), allMixins.end());
-            } else {
-                int pos = 0;
-                pos = maybeAddMixin(gs, ofClass, newMixins, mixin, data->superClass(), pos);
-                for (auto &mixinLinearizationComponent : mixinLinearization.mixins) {
-                    pos = maybeAddMixin(gs, ofClass, newMixins, mixinLinearizationComponent, data->superClass(), pos);
-                }
-            }
-        }
-        data->mixins() = std::move(newMixins);
-        data->setClassOrModuleLinearizationComputed();
-        if (debug_mode) {
-            for (auto oldMixin : currentMixins) {
-                ENFORCE(ofClass.data(gs)->derivesFrom(gs, oldMixin), "{} no longer derives from {}",
-                        ofClass.showFullName(gs), oldMixin.showFullName(gs));
-            }
-        }
-    }
-    ENFORCE_NO_TIMER(data->isClassOrModuleLinearizationComputed());
-    return ParentLinearizationInformation{data->mixins(), data->superClass(), ofClass};
-}
-
-void fullLinearizationSlowImpl(core::GlobalState &gs, const ParentLinearizationInformation &info,
-                               InlinedVector<core::ClassOrModuleRef, 4> &acc) {
-    ENFORCE(!absl::c_linear_search(acc, info.klass));
-    acc.emplace_back(info.klass);
-
-    for (auto m : info.mixins) {
-        if (!absl::c_linear_search(acc, m)) {
-            if (m.data(gs)->isClassOrModuleModule()) {
-                acc.emplace_back(m);
-            } else {
-                fullLinearizationSlowImpl(gs, computeClassLinearization(gs, m), acc);
-            }
-        }
-    }
-    if (info.superClass.exists()) {
-        if (!absl::c_linear_search(acc, info.superClass)) {
-            fullLinearizationSlowImpl(gs, computeClassLinearization(gs, info.superClass), acc);
-        }
-    }
-};
-InlinedVector<core::ClassOrModuleRef, 4> ParentLinearizationInformation::fullLinearizationSlow(core::GlobalState &gs) {
-    InlinedVector<core::ClassOrModuleRef, 4> res;
-    fullLinearizationSlowImpl(gs, *this, res);
-    return res;
-}
-
-void Resolver::computeLinearization(core::GlobalState &gs) {
-    Timer timer(gs.tracer(), "resolver.compute_linearization");
-
-    // TODO: this does not support `prepend`
-    for (int i = 1; i < gs.classAndModulesUsed(); ++i) {
-        const auto &ref = core::ClassOrModuleRef(gs, i);
-        computeClassLinearization(gs, ref);
-    }
-}
-
 void Resolver::finalizeSymbols(core::GlobalState &gs) {
     Timer timer(gs.tracer(), "resolver.finalize_resolution");
     // TODO(nelhage): Properly this first loop should go in finalizeAncestors,
@@ -411,7 +296,7 @@ void Resolver::finalizeSymbols(core::GlobalState &gs) {
         }
     }
 
-    computeLinearization(gs);
+    gs.computeLinearization();
 
     vector<vector<pair<core::TypeMemberRef, core::TypeMemberRef>>> typeAliases;
     typeAliases.resize(gs.classAndModulesUsed());

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -588,15 +588,15 @@ private:
         stubConstantSuffix(ctx, owner, suffix, possibleGenericType);
     }
 
-    // Mark type aliases as TODO items for a later pass, as all constants will have been stubbed out by then.
-    static void stubTypeAliasForRbiGeneration(core::MutableContext ctx, core::SymbolRef sym) {
-        sym.setResultType(ctx, core::make_type<core::ClassType>(core::Symbols::todo()));
-    }
-
     // We have failed to resolve the constant. We'll need to report the error and stub it so that we can proceed
-    static void constantResolutionFailed(core::MutableContext ctx, ResolutionItem &job, const ImportStubs &importStubs,
-                                         int &suggestionCount) {
+    template <typename StateType>
+    static void constantResolutionFailed(StateType &gs, core::FileRef file, ResolutionItem &job,
+                                         const ImportStubs &importStubs, int &suggestionCount) {
+        static_assert(is_same_v<remove_const_t<StateType>, core::GlobalState>);
+        constexpr bool isMutableStateType = !is_const_v<StateType>;
+
         auto &original = ast::cast_tree_nonnull<ast::UnresolvedConstantLit>(job.out->original);
+        core::Context ctx(gs, core::Symbols::root(), file);
 
         bool singlePackageRbiGeneration = ctx.state.singlePackageImports.has_value();
 
@@ -605,7 +605,11 @@ private:
             auto resolvedField = resolved.asFieldRef();
             if (resolvedField.data(ctx)->resultType == nullptr) {
                 if (singlePackageRbiGeneration) {
-                    stubTypeAliasForRbiGeneration(ctx, job.out->symbol);
+                    if constexpr (isMutableStateType) {
+                        job.out->symbol.setResultType(gs, core::make_type<core::ClassType>(core::Symbols::todo()));
+                    } else {
+                        ENFORCE(false, "Was not expecting non-mutating resolver and single package RBI generation");
+                    }
                 } else {
                     // This is actually a use-site error, but we limit ourselves to emitting it once by checking
                     // resultType
@@ -614,8 +618,13 @@ private:
                         e.setHeader("Unable to resolve right hand side of type alias `{}`", resolved.show(ctx));
                         e.addErrorLine(core::Loc(ctx.file, job.out->original.loc()), "Type alias used here");
                     }
-                    resolvedField.data(ctx)->resultType =
-                        core::Types::untyped(ctx, resolved); // <<-- This is the reason this takes a MutableContext
+
+                    if constexpr (isMutableStateType) {
+                        resolvedField.data(gs)->resultType = core::Types::untyped(ctx, resolved);
+                    } else {
+                        // Welp. We'll just report extra use-site errors possibly. But we don't care
+                        // about errors for the best-effort / non-mutating mode anyways.
+                    }
                 }
             }
             job.out->symbol = resolved;
@@ -630,8 +639,12 @@ private:
 
         // When generating rbis in single-package mode, we may need to invent a symbol at this point
         if (singlePackageRbiGeneration) {
-            stubForRbiGeneration(ctx.withOwner(job.scope->scope), importStubs, job.scope.get(), job.out,
-                                 job.possibleGenericType);
+            if constexpr (isMutableStateType) {
+                core::MutableContext ctx(gs, job.scope->scope, file);
+                stubForRbiGeneration(ctx, importStubs, job.scope.get(), job.out, job.possibleGenericType);
+            } else {
+                ENFORCE(false, "Was not expecting non-mutating resolver and single package RBI generation");
+            }
             return;
         }
 
@@ -1002,7 +1015,11 @@ private:
         return true;
     }
 
-    static void resolveClassMethodsJob(core::GlobalState &gs, const ClassMethodsResolutionItem &todo) {
+    template <typename StateType>
+    static void resolveClassMethodsJob(StateType &gs, const ClassMethodsResolutionItem &todo) {
+        static_assert(is_same_v<remove_const_t<StateType>, core::GlobalState>);
+        constexpr bool isMutableStateType = !is_const_v<StateType>;
+
         auto owner = todo.owner;
         auto send = todo.send;
         if (!owner.isClassOrModule() || !owner.asClassOrModuleRef().data(gs)->isClassOrModuleModule()) {
@@ -1065,30 +1082,36 @@ private:
                 continue;
             }
 
-            // Get the fake property holding the mixes
-            auto mixMethod = ownerKlass.data(gs)->findMethod(gs, core::Names::mixedInClassMethods());
-            if (!mixMethod.exists()) {
-                // We never stored a mixin in this symbol
-                // Create a the fake property that will hold the mixed in modules
-                mixMethod = gs.enterMethodSymbol(core::Loc{todo.file, send->loc}, ownerKlass,
-                                                 core::Names::mixedInClassMethods());
-                mixMethod.data(gs)->resultType = core::make_type<core::TupleType>(vector<core::TypePtr>{});
+            if constexpr (isMutableStateType) {
+                // Get the fake property holding the mixes
+                auto mixMethod = ownerKlass.data(gs)->findMethod(gs, core::Names::mixedInClassMethods());
+                if (!mixMethod.exists()) {
+                    // We never stored a mixin in this symbol
+                    // Create a the fake property that will hold the mixed in modules
+                    mixMethod = gs.enterMethodSymbol(core::Loc{todo.file, send->loc}, ownerKlass,
+                                                     core::Names::mixedInClassMethods());
+                    mixMethod.data(gs)->resultType = core::make_type<core::TupleType>(vector<core::TypePtr>{});
 
-                // Create a dummy block argument to satisfy sanitycheck during GlobalState::expandNames
-                auto &arg = gs.enterMethodArgumentSymbol(core::Loc::none(), mixMethod, core::Names::blkArg());
-                arg.flags.isBlock = true;
-            }
+                    // Create a dummy block argument to satisfy sanitycheck during GlobalState::expandNames
+                    auto &arg = gs.enterMethodArgumentSymbol(core::Loc::none(), mixMethod, core::Names::blkArg());
+                    arg.flags.isBlock = true;
+                }
 
-            auto type = core::make_type<core::ClassType>(id->symbol.asClassOrModuleRef());
-            auto &elems = (core::cast_type<core::TupleType>(mixMethod.data(gs)->resultType))->elems;
-            // Make sure we are not adding existing symbols to our tuple
-            if (absl::c_find(elems, type) == elems.end()) {
-                elems.emplace_back(type);
+                auto type = core::make_type<core::ClassType>(id->symbol.asClassOrModuleRef());
+                auto &elems = (core::cast_type<core::TupleType>(mixMethod.data(gs)->resultType))->elems;
+                // Make sure we are not adding existing symbols to our tuple
+                if (absl::c_find(elems, type) == elems.end()) {
+                    elems.emplace_back(type);
+                }
             }
         }
     }
 
-    static void resolveRequiredAncestorsJob(core::GlobalState &gs, const RequireAncestorResolutionItem &todo) {
+    template <typename StateType>
+    static void resolveRequiredAncestorsJob(StateType &gs, const RequireAncestorResolutionItem &todo) {
+        static_assert(is_same_v<remove_const_t<StateType>, core::GlobalState>);
+        constexpr bool isMutableStateType = !is_const_v<StateType>;
+
         auto owner = todo.owner;
         auto send = todo.send;
         auto loc = core::Loc(todo.file, send->loc);
@@ -1154,7 +1177,9 @@ private:
             return;
         }
 
-        owner.data(gs)->recordRequiredAncestor(gs, id->symbol.asClassOrModuleRef(), blockLoc);
+        if constexpr (isMutableStateType) {
+            owner.data(gs)->recordRequiredAncestor(gs, id->symbol.asClassOrModuleRef(), blockLoc);
+        }
     }
 
     static void tryRegisterSealedSubclass(core::MutableContext ctx, AncestorResolutionItem &job) {
@@ -1498,8 +1523,11 @@ public:
         vector<ast::ParsedFile> trees;
     };
 
-    static vector<ast::ParsedFile> resolveConstants(core::GlobalState &gs, vector<ast::ParsedFile> trees,
-                                                    WorkerPool &workers) {
+    template <typename StateType>
+    static vector<ast::ParsedFile> resolveConstants(StateType &gs, vector<ast::ParsedFile> trees, WorkerPool &workers) {
+        static_assert(is_same_v<remove_const_t<StateType>, core::GlobalState>);
+        constexpr bool isMutableStateType = !is_const_v<StateType>;
+
         Timer timeit(gs.tracer(), "resolver.resolve_constants");
         const core::GlobalState &igs = gs;
         auto resultq = make_shared<BlockingBoundedQueue<ResolveWalkResult>>(trees.size());
@@ -1598,80 +1626,84 @@ public:
         bool progress = true;
         bool first = true; // we need to run at least once to force class aliases and type aliases
 
-        while (progress && (first || !todo.empty() || !todoAncestors.empty())) {
-            first = false;
-            counterInc("resolve.constants.retries");
-            {
-                Timer timeit(gs.tracer(), "resolver.resolve_constants.fixed_point.ancestors");
-                // This is an optimization. The order should not matter semantically
-                // We try to resolve most ancestors second because this makes us much more likely to resolve
-                // everything else.
-                long retries = 0;
-                auto f = [&gs, &retries](ResolveItems<AncestorResolutionItem> &job) -> bool {
-                    core::MutableContext ctx(gs, core::Symbols::root(), job.file);
-                    const auto origSize = job.items.size();
-                    auto g = [&](AncestorResolutionItem &item) -> bool {
-                        auto resolved = resolveAncestorJob(ctx, item, false);
-                        if (resolved) {
-                            tryRegisterSealedSubclass(ctx, item);
-                        }
-                        return resolved;
+        // If the constant didn't immediately resolve during the initial treewalk, and we're not
+        // allowed to mutate GlobalState, it will never resolve. Let's just skip to the error phase.
+        if constexpr (isMutableStateType) {
+            while (progress && (first || !todo.empty() || !todoAncestors.empty())) {
+                first = false;
+                counterInc("resolve.constants.retries");
+                {
+                    Timer timeit(gs.tracer(), "resolver.resolve_constants.fixed_point.ancestors");
+                    // This is an optimization. The order should not matter semantically
+                    // We try to resolve most ancestors second because this makes us much more likely to resolve
+                    // everything else.
+                    long retries = 0;
+                    auto f = [&gs, &retries](ResolveItems<AncestorResolutionItem> &job) -> bool {
+                        core::MutableContext ctx(gs, core::Symbols::root(), job.file);
+                        const auto origSize = job.items.size();
+                        auto g = [&](AncestorResolutionItem &item) -> bool {
+                            auto resolved = resolveAncestorJob(ctx, item, false);
+                            if (resolved) {
+                                tryRegisterSealedSubclass(ctx, item);
+                            }
+                            return resolved;
+                        };
+                        auto fileIt = remove_if(job.items.begin(), job.items.end(), std::move(g));
+                        job.items.erase(fileIt, job.items.end());
+                        retries += origSize - job.items.size();
+                        return job.items.empty();
                     };
-                    auto fileIt = remove_if(job.items.begin(), job.items.end(), std::move(g));
-                    job.items.erase(fileIt, job.items.end());
-                    retries += origSize - job.items.size();
-                    return job.items.empty();
-                };
-                auto it = remove_if(todoAncestors.begin(), todoAncestors.end(), std::move(f));
-                todoAncestors.erase(it, todoAncestors.end());
-                categoryCounterAdd("resolve.constants.ancestor", "retry", retries);
-                progress = retries > 0;
-            }
-            {
-                Timer timeit(gs.tracer(), "resolver.resolve_constants.fixed_point.constants");
-                bool resolvedSomeConstants = resolveConstants(gs, todo, workers);
-                progress = progress || resolvedSomeConstants;
-            }
-            {
-                Timer timeit(gs.tracer(), "resolver.resolve_constants.fixed_point.class_aliases");
-                // This is an optimization. The order should not matter semantically
-                // This is done as a "pre-step" because the first iteration of this effectively ran in TreeMap.
-                // every item in todoClassAliases implicitly depends on an item in item in todo
-                // there would be no point in running the todoClassAliases step before todo
+                    auto it = remove_if(todoAncestors.begin(), todoAncestors.end(), std::move(f));
+                    todoAncestors.erase(it, todoAncestors.end());
+                    categoryCounterAdd("resolve.constants.ancestor", "retry", retries);
+                    progress = retries > 0;
+                }
+                {
+                    Timer timeit(gs.tracer(), "resolver.resolve_constants.fixed_point.constants");
+                    bool resolvedSomeConstants = resolveConstants(gs, todo, workers);
+                    progress = progress || resolvedSomeConstants;
+                }
+                {
+                    Timer timeit(gs.tracer(), "resolver.resolve_constants.fixed_point.class_aliases");
+                    // This is an optimization. The order should not matter semantically
+                    // This is done as a "pre-step" because the first iteration of this effectively ran in TreeMap.
+                    // every item in todoClassAliases implicitly depends on an item in item in todo
+                    // there would be no point in running the todoClassAliases step before todo
 
-                long retries = 0;
-                auto f = [&gs, &retries](ResolveItems<ClassAliasResolutionItem> &job) -> bool {
-                    core::MutableContext ctx(gs, core::Symbols::root(), job.file);
-                    auto origSize = job.items.size();
-                    auto g = [&](ClassAliasResolutionItem &item) -> bool {
-                        return resolveClassAliasJob(ctx, item);
+                    long retries = 0;
+                    auto f = [&gs, &retries](ResolveItems<ClassAliasResolutionItem> &job) -> bool {
+                        core::MutableContext ctx(gs, core::Symbols::root(), job.file);
+                        auto origSize = job.items.size();
+                        auto g = [&](ClassAliasResolutionItem &item) -> bool {
+                            return resolveClassAliasJob(ctx, item);
+                        };
+                        auto fileIt = remove_if(job.items.begin(), job.items.end(), std::move(g));
+                        job.items.erase(fileIt, job.items.end());
+                        retries += origSize - job.items.size();
+                        return job.items.empty();
                     };
-                    auto fileIt = remove_if(job.items.begin(), job.items.end(), std::move(g));
-                    job.items.erase(fileIt, job.items.end());
-                    retries += origSize - job.items.size();
-                    return job.items.empty();
-                };
-                auto it = remove_if(todoClassAliases.begin(), todoClassAliases.end(), std::move(f));
-                todoClassAliases.erase(it, todoClassAliases.end());
-                categoryCounterAdd("resolve.constants.aliases", "retry", retries);
-                progress = progress || retries > 0;
-            }
-            {
-                Timer timeit(gs.tracer(), "resolver.resolve_constants.fixed_point.type_aliases");
-                long retries = 0;
-                auto f = [&gs, &retries](ResolveItems<TypeAliasResolutionItem> &job) -> bool {
-                    core::MutableContext ctx(gs, core::Symbols::root(), job.file);
-                    auto origSize = job.items.size();
-                    auto g = [&](TypeAliasResolutionItem &item) -> bool { return resolveTypeAliasJob(ctx, item); };
-                    auto fileIt = remove_if(job.items.begin(), job.items.end(), std::move(g));
-                    job.items.erase(fileIt, job.items.end());
-                    retries += origSize - job.items.size();
-                    return job.items.empty();
-                };
-                auto it = remove_if(todoTypeAliases.begin(), todoTypeAliases.end(), std::move(f));
-                todoTypeAliases.erase(it, todoTypeAliases.end());
-                categoryCounterAdd("resolve.constants.typealiases", "retry", retries);
-                progress = progress || retries > 0;
+                    auto it = remove_if(todoClassAliases.begin(), todoClassAliases.end(), std::move(f));
+                    todoClassAliases.erase(it, todoClassAliases.end());
+                    categoryCounterAdd("resolve.constants.aliases", "retry", retries);
+                    progress = progress || retries > 0;
+                }
+                {
+                    Timer timeit(gs.tracer(), "resolver.resolve_constants.fixed_point.type_aliases");
+                    long retries = 0;
+                    auto f = [&gs, &retries](ResolveItems<TypeAliasResolutionItem> &job) -> bool {
+                        core::MutableContext ctx(gs, core::Symbols::root(), job.file);
+                        auto origSize = job.items.size();
+                        auto g = [&](TypeAliasResolutionItem &item) -> bool { return resolveTypeAliasJob(ctx, item); };
+                        auto fileIt = remove_if(job.items.begin(), job.items.end(), std::move(g));
+                        job.items.erase(fileIt, job.items.end());
+                        retries += origSize - job.items.size();
+                        return job.items.empty();
+                    };
+                    auto it = remove_if(todoTypeAliases.begin(), todoTypeAliases.end(), std::move(f));
+                    todoTypeAliases.erase(it, todoTypeAliases.end());
+                    categoryCounterAdd("resolve.constants.typealiases", "retry", retries);
+                    progress = progress || retries > 0;
+                }
             }
         }
 
@@ -1747,34 +1779,47 @@ public:
             ImportStubs importStubs;
             bool singlePackageRbiGeneration = gs.singlePackageImports.has_value();
             if (singlePackageRbiGeneration) {
-                importStubs = ImportStubs::make(gs);
+                if constexpr (isMutableStateType) {
+                    importStubs = ImportStubs::make(gs);
+                } else {
+                    ENFORCE(false, "Was not expecting non-mutating resolver and single package RBI generation");
+                }
             }
 
             // Only give suggestions for the first several constants, because fuzzy suggestions are expensive.
             int suggestionCount = 0;
             for (auto &job : todo) {
-                core::MutableContext ctx(gs, core::Symbols::root(), job.file);
                 for (auto &item : job.items) {
-                    constantResolutionFailed(ctx, item, importStubs, suggestionCount);
+                    constantResolutionFailed(gs, job.file, item, importStubs, suggestionCount);
                 }
             }
 
             if (singlePackageRbiGeneration) {
-                for (auto &job : todoClassAliases) {
-                    core::MutableContext ctx(gs, core::Symbols::root(), job.file);
-                    for (auto &item : job.items) {
-                        resolveClassAliasJob(ctx, item);
+                if constexpr (isMutableStateType) {
+                    for (auto &job : todoClassAliases) {
+                        core::MutableContext ctx(gs, core::Symbols::root(), job.file);
+                        for (auto &item : job.items) {
+                            resolveClassAliasJob(ctx, item);
+                        }
                     }
+
+                } else {
+                    ENFORCE(false, "Was not expecting non-mutating resolver and single package RBI generation");
                 }
             }
 
-            for (auto &job : todoAncestors) {
-                core::MutableContext ctx(gs, core::Symbols::root(), job.file);
-                for (auto &item : job.items) {
-                    auto resolved = resolveAncestorJob(ctx, item, true);
-                    if (!resolved) {
-                        resolved = resolveAncestorJob(ctx, item, true);
-                        ENFORCE(resolved);
+            if constexpr (isMutableStateType) {
+                // Only purpose of resolveAncestorJob is to mutate the symbol table, not the tree, so
+                // in non-mutating resolver mode we don't have to do anything (because we don't care
+                // about errors).
+                for (auto &job : todoAncestors) {
+                    core::MutableContext ctx(gs, core::Symbols::root(), job.file);
+                    for (auto &item : job.items) {
+                        auto resolved = resolveAncestorJob(ctx, item, true);
+                        if (!resolved) {
+                            resolved = resolveAncestorJob(ctx, item, true);
+                            ENFORCE(resolved);
+                        }
                     }
                 }
             }
@@ -3846,10 +3891,11 @@ ast::ParsedFilesOrCancelled Resolver::runIncremental(core::GlobalState &gs, vect
     return result;
 }
 
-ast::ParsedFilesOrCancelled Resolver::runIncrementalWithoutStateMutation(const core::GlobalState &gs,
-                                                                         vector<ast::ParsedFile> trees) {
+// TODO(jez) This is dupliicated with Resolver::runIncremental. Can we make them share more code?
+ast::ParsedFilesOrCancelled Resolver::runIncrementalBestEffort(const core::GlobalState &gs,
+                                                               vector<ast::ParsedFile> trees) {
     auto workers = WorkerPool::create(0, gs.tracer());
-    // trees = ResolveConstantsWalk::resolveConstants(gs, std::move(trees), *workers);
+    trees = ResolveConstantsWalk::resolveConstants(gs, std::move(trees), *workers);
     // NOTE: Linearization does not need to be recomputed as we do not mutate mixins() during incremental resolve.
     verifyLinearizationComputed(gs);
     trees = ResolveTypeMembersAndFieldsWalk::run(gs, std::move(trees), *workers);

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3873,7 +3873,10 @@ void verifyLinearizationComputed(const core::GlobalState &gs) {
 }
 } // namespace
 
-ast::ParsedFilesOrCancelled Resolver::runIncremental(core::GlobalState &gs, vector<ast::ParsedFile> trees) {
+template <typename StateType>
+ast::ParsedFilesOrCancelled Resolver::runIncremental(StateType &gs, vector<ast::ParsedFile> trees) {
+    static_assert(is_same_v<remove_const_t<StateType>, core::GlobalState>);
+
     auto workers = WorkerPool::create(0, gs.tracer());
     trees = ResolveConstantsWalk::resolveConstants(gs, std::move(trees), *workers);
     // NOTE: Linearization does not need to be recomputed as we do not mutate mixins() during incremental resolve.
@@ -3891,27 +3894,9 @@ ast::ParsedFilesOrCancelled Resolver::runIncremental(core::GlobalState &gs, vect
     return result;
 }
 
-// TODO(jez) This is dupliicated with Resolver::runIncremental. Can we make them share more code?
-ast::ParsedFilesOrCancelled Resolver::runIncrementalBestEffort(const core::GlobalState &gs,
-                                                               vector<ast::ParsedFile> trees) {
-    auto workers = WorkerPool::create(0, gs.tracer());
-    trees = ResolveConstantsWalk::resolveConstants(gs, std::move(trees), *workers);
-    // NOTE: Linearization does not need to be recomputed as we do not mutate mixins() during incremental resolve.
-    verifyLinearizationComputed(gs);
-    trees = ResolveTypeMembersAndFieldsWalk::run(gs, std::move(trees), *workers);
-    auto result = resolveSigs(gs, std::move(trees), *workers);
-    if (!result.hasResult()) {
-        return result;
-    }
-    // The non-mutating resolver isn't ready for this check to be run yet, because e.g.
-    // it doesn't resolve UnresolvedConstantLit nodes.
-    // sanityCheck(gs, result.result());
-    // This check is FAR too slow to run on large codebases, especially with sanitizers on.
-    // But it can be super useful to uncomment when debugging certain issues.
-    // ctx.state.sanityCheck();
-
-    return result;
-}
+template ast::ParsedFilesOrCancelled Resolver::runIncremental(core::GlobalState &gs, vector<ast::ParsedFile> trees);
+template ast::ParsedFilesOrCancelled Resolver::runIncremental(const core::GlobalState &gs,
+                                                              vector<ast::ParsedFile> trees);
 
 vector<ast::ParsedFile> Resolver::runConstantResolution(core::GlobalState &gs, vector<ast::ParsedFile> trees,
                                                         WorkerPool &workers) {

--- a/resolver/resolver.h
+++ b/resolver/resolver.h
@@ -13,14 +13,18 @@ public:
                                            WorkerPool &workers);
     Resolver() = delete;
 
-    /** Only runs tree passes, used for incremental changes that do not affect global state. Assumes that `run` was
-     * called on a tree that contains same definitions before (LSP uses heuristics that should only have false negatives
-     * to find this) */
-    static ast::ParsedFilesOrCancelled runIncremental(core::GlobalState &gs, std::vector<ast::ParsedFile> trees);
-
-    // Like the above, only skip all the steps that would require mutating global state.
-    static ast::ParsedFilesOrCancelled runIncrementalBestEffort(const core::GlobalState &gs,
-                                                                std::vector<ast::ParsedFile> trees);
+    /**
+     * Only runs tree passes, used for incremental changes that do not affect global state. Assumes
+     * that `run` was called on a tree that contains same definitions before (LSP uses heuristics
+     * that should only have false negatives to find this)
+     *
+     * Has two versions: one that requires a mutable GlobalState, and one that does a "best effort"
+     * mode with a constant GlobalState (for, e.g., serving stale LSP requests)
+     *
+     * These two versions are explicitly instantiated in resolver.cc
+     */
+    template <typename StateType>
+    static ast::ParsedFilesOrCancelled runIncremental(StateType &gs, std::vector<ast::ParsedFile> trees);
 
     // used by autogen only
     static std::vector<ast::ParsedFile> runConstantResolution(core::GlobalState &gs, std::vector<ast::ParsedFile> trees,

--- a/resolver/resolver.h
+++ b/resolver/resolver.h
@@ -19,8 +19,8 @@ public:
     static ast::ParsedFilesOrCancelled runIncremental(core::GlobalState &gs, std::vector<ast::ParsedFile> trees);
 
     // Like the above, only skip all the steps that would require mutating global state.
-    static ast::ParsedFilesOrCancelled runIncrementalWithoutStateMutation(const core::GlobalState &gs,
-                                                                          std::vector<ast::ParsedFile> trees);
+    static ast::ParsedFilesOrCancelled runIncrementalBestEffort(const core::GlobalState &gs,
+                                                                std::vector<ast::ParsedFile> trees);
 
     // used by autogen only
     static std::vector<ast::ParsedFile> runConstantResolution(core::GlobalState &gs, std::vector<ast::ParsedFile> trees,
@@ -29,7 +29,6 @@ public:
 private:
     static void finalizeAncestors(core::GlobalState &gs);
     static void finalizeSymbols(core::GlobalState &gs);
-    static void computeLinearization(core::GlobalState &gs);
     static void sanityCheck(const core::GlobalState &gs, std::vector<ast::ParsedFile> &trees);
 };
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This will allow us to make more progress on #5469 (LSP queries on stale state)


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This calls the immutable incremental resolver immediately after the immutable
namer and enables all ENFORCEs and sanityChecks, so that we can use our existing
test suite as a test of how well these modes work.