### PR TITLE
use `= default` to define `TaskQueue::TaskQueue`

### DIFF
--- a/main/lsp/LSPPreprocessor.cc
+++ b/main/lsp/LSPPreprocessor.cc
@@ -27,8 +27,6 @@ string readFile(string_view path, const FileSystem &fs) {
 
 } // namespace
 
-TaskQueue::TaskQueue() : stateMutex{}, pendingTasks{}, terminated{false}, paused{false}, errorCode{0} {}
-
 bool TaskQueue::isTerminated() const {
     return this->terminated;
 }

--- a/main/lsp/LSPPreprocessor.h
+++ b/main/lsp/LSPPreprocessor.h
@@ -44,7 +44,7 @@ class TaskQueue final {
     CounterState counters GUARDED_BY(stateMutex);
 
 public:
-    TaskQueue();
+    TaskQueue() = default;
 
     TaskQueue(const TaskQueue &other) = delete;
     TaskQueue(TaskQueue &&other) = delete;


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


I noticed that `TaskQueue::TaskQueue` was using trivial values in its initializer-list...and then I saw that the definition of `TaskQueue` already had defaults for all the fields.  Let's just define things in a single place.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
