### PR TITLE
Check payload prefix against Sorbet SCM revision

### DIFF
--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -511,8 +511,10 @@ int realmain(int argc, char *argv[]) {
                 continue;
             }
 
+            auto payloadVersion = sorbet_is_release_build ? sorbet_build_scm_revision : "master";
             auto payloadPath = payloadFile->path();
-            auto payloadPrefix = absl::StrCat(core::File::URL_PREFIX, "rbi/");
+            auto payloadPrefix = absl::StrCat("https://github.com/sorbet/sorbet/tree/", payloadVersion, "/rbi/");
+
             if (!absl::StartsWith(payloadPath, payloadPrefix)) {
                 // Skip files from `bazel-out/`
                 continue;


### PR DESCRIPTION
### Motivation

When Sorbet runs in release build the payload prefix is _not_ based on `URL_PREFIX`.

Example in release build:

```
https://github.com/sorbet/sorbet/tree/32d144b7989158a1f3f67868dbd77cfda5deadc5/rbi/core/argf.rbi
```

vs. in debug build:

```
https://github.com/sorbet/sorbet/tree/master/rbi/core/argf.rbi
```

This results in all payload files [being ignored](https://github.com/Morriar/sorbet/blob/ad278ef9304130029e48e490f6cd70b8f9110d42/main/realmain.cc#L518-L520) when dumping the payload sources in release build. This PR changes the way we compute path prefix for payload files to take into account the SCM revision when in release build.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
