### PR TITLE
de-duplicate protocol test definitions

### DIFF
--- a/test/lsp/BUILD
+++ b/test/lsp/BUILD
@@ -1,4 +1,4 @@
-load(":lsp_test.bzl", "lsp_test", "update_test")
+load(":lsp_test.bzl", "lsp_test", "update_test", "protocol_tests")
 
 sh_binary(
     name = "lsp_test_runner",
@@ -6,97 +6,12 @@ sh_binary(
     data = ["//main:sorbet"],
 )
 
-cc_test(
-    name = "protocol_test_corpus",
-    size = "medium",
-    srcs = [
-        "ProtocolTest.cc",
-        "ProtocolTest.h",
-        "protocol_test_corpus.cc",
-    ],
-    linkstatic = select({
-        "//tools/config:linkshared": 0,
-        "//conditions:default": 1,
-    }),
-    visibility = ["//tools:__pkg__"],
-    deps = [
-        "//core",
-        "//main/lsp",
-        "//payload",
-        "//test/helpers",
-        "@doctest",
-        "@doctest//:doctest_main",
-    ],
-)
-
-cc_test(
-    name = "cache_protocol_test_corpus",
-    size = "medium",
-    srcs = [
-        "ProtocolTest.cc",
-        "ProtocolTest.h",
-        "cache_protocol_test_corpus.cc",
-    ],
-    linkstatic = select({
-        "//tools/config:linkshared": 0,
-        "//conditions:default": 1,
-    }),
-    visibility = ["//tools:__pkg__"],
-    deps = [
-        "//core",
-        "//main/lsp",
-        "//payload",
-        "//test/helpers",
-        "@doctest",
-        "@doctest//:doctest_main",
-    ],
-)
-
-cc_test(
-    name = "multithreaded_protocol_test_corpus",
-    size = "medium",
-    srcs = [
-        "ProtocolTest.cc",
-        "ProtocolTest.h",
-        "multithreaded_protocol_test_corpus.cc",
-    ],
-    linkstatic = select({
-        "//tools/config:linkshared": 0,
-        "//conditions:default": 1,
-    }),
-    visibility = ["//tools:__pkg__"],
-    deps = [
-        "//core",
-        "//main/lsp",
-        "//payload",
-        "//test/helpers",
-        "@doctest",
-        "@doctest//:doctest_main",
-    ],
-)
-
-cc_test(
-    name = "watchman_test_corpus",
-    size = "medium",
-    srcs = [
-        "ProtocolTest.cc",
-        "ProtocolTest.h",
-        "watchman_test_corpus.cc",
-    ],
-    linkstatic = select({
-        "//tools/config:linkshared": 0,
-        "//conditions:default": 1,
-    }),
-    visibility = ["//tools:__pkg__"],
-    deps = [
-        "//core",
-        "//main/lsp",
-        "//payload",
-        "//test/helpers",
-        "@doctest",
-        "@doctest//:doctest_main",
-    ],
-)
+protocol_tests([
+  "protocol_test_corpus.cc",
+  "cache_protocol_test_corpus.cc",
+  "multithreaded_protocol_test_corpus.cc",
+  "watchman_test_corpus.cc",
+])
 
 test_suite(
     name = "lsp",

--- a/test/lsp/BUILD
+++ b/test/lsp/BUILD
@@ -7,10 +7,10 @@ sh_binary(
 )
 
 protocol_tests([
-  "protocol_test_corpus.cc",
-  "cache_protocol_test_corpus.cc",
-  "multithreaded_protocol_test_corpus.cc",
-  "watchman_test_corpus.cc",
+    "cache_protocol_test_corpus.cc",
+    "multithreaded_protocol_test_corpus.cc",
+    "protocol_test_corpus.cc",
+    "watchman_test_corpus.cc",
 ])
 
 test_suite(

--- a/test/lsp/BUILD
+++ b/test/lsp/BUILD
@@ -1,4 +1,4 @@
-load(":lsp_test.bzl", "lsp_test", "update_test", "protocol_tests")
+load(":lsp_test.bzl", "lsp_test", "protocol_tests", "update_test")
 
 sh_binary(
     name = "lsp_test_runner",

--- a/test/lsp/lsp_test.bzl
+++ b/test/lsp/lsp_test.bzl
@@ -1,3 +1,10 @@
+def basename(p):
+    return p.rpartition("/")[-1]
+
+def dropExtension(p):
+    "TODO: handle multiple . in name"
+    return p.partition(".")[0]
+
 def lsp_test(path):
     # path will be like `$name/$name.sh`
     words = path.split("/")
@@ -48,3 +55,26 @@ def update_test():
         tags = ["manual"],
         tests = update_rules,
     )
+
+_PROTOCOL_TEST_SRCS = ["ProtocolTest.cc", "ProtocolTest.h"]
+
+def protocol_tests(cc_files):
+    for cc_file in cc_files:
+        native.cc_test(
+            name = dropExtension(basename(cc_file)),
+            size = "medium",
+            srcs = _PROTOCOL_TEST_SRCS + [cc_file],
+            linkstatic = select({
+                "//tools/config:linkshared": 0,
+                "//conditions:default": 1,
+            }),
+            visibility = ["//tools:__pkg__"],
+            deps = [
+                "//core",
+                "//main/lsp",
+                "//payload",
+                "//test/helpers",
+                "@doctest",
+                "@doctest//:doctest_main",
+            ],
+        )

--- a/test/lsp/lsp_test.bzl
+++ b/test/lsp/lsp_test.bzl
@@ -62,7 +62,7 @@ def protocol_tests(cc_files):
     for cc_file in cc_files:
         native.cc_test(
             name = dropExtension(basename(cc_file)),
-            size = "medium",
+            timeout = "moderate",
             srcs = _PROTOCOL_TEST_SRCS + [cc_file],
             linkstatic = select({
                 "//tools/config:linkshared": 0,


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I would like to split up the protocol tests to make them run faster, and this is an easy first step to making that slightly easier.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
