### PR TITLE
Add a mechanism to block the slow path in tests

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -450,6 +450,13 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates updates, WorkerPool &workers, bo
             return;
         }
 
+        // Test-only hook: Stall for as long as `slowPathBlocked` is set.
+        {
+            absl::MutexLock lck(&slowPathBlockedMutex);
+            slowPathBlockedMutex.Await(absl::Condition(
+                +[](bool *slowPathBlocked) -> bool { return !*slowPathBlocked; }, &slowPathBlocked));
+        }
+
         ENFORCE(gs->lspQuery.isEmpty());
         if (gs->sleepInSlowPath) {
             Timer::timedSleep(3000ms, *logger, "slow_path.resolve.sleep");
@@ -686,6 +693,11 @@ bool LSPTypechecker::tryRunOnStaleState(std::function<void(UndoState &)> func) {
         func(*cancellationUndoState);
         return true;
     }
+}
+
+void LSPTypechecker::setSlowPathBlocked(bool blocked) {
+    absl::MutexLock lck(&slowPathBlockedMutex);
+    slowPathBlocked = blocked;
 }
 
 LSPTypecheckerDelegate::LSPTypecheckerDelegate(TaskQueue &queue, WorkerPool &workers, LSPTypechecker &typechecker)

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -59,6 +59,10 @@ class LSPTypechecker final {
 
     std::shared_ptr<ErrorReporter> errorReporter;
 
+    /** Used in tests to force the slow path to block just after cancellation state has been set. */
+    bool slowPathBlocked ABSL_GUARDED_BY(slowPathBlockedMutex) = false;
+    absl::Mutex slowPathBlockedMutex;
+
     /** Conservatively reruns entire pipeline without caching any trees. Returns 'true' if committed, 'false' if
      * canceled. */
     bool runSlowPath(LSPFileUpdates updates, WorkerPool &workers, bool cancelable);
@@ -139,6 +143,12 @@ public:
      * Tries to run the function on the stale undo state, acquiring a lock.
      */
     bool tryRunOnStaleState(std::function<void(UndoState &)> func);
+
+    /**
+     * (For tests only) Set a flag that forces the slow path to block indefinitely after saving undo state. Setting
+     * this flag to `false` will immediately unblock any currently blocked slow paths.
+     */
+    void setSlowPathBlocked(bool blocked);
 };
 
 /**

--- a/main/lsp/LSPTypecheckerCoordinator.h
+++ b/main/lsp/LSPTypecheckerCoordinator.h
@@ -93,6 +93,14 @@ public:
 
     /** Runs the typechecker in a dedicated thread. */
     std::unique_ptr<Joinable> startTypecheckerThread();
+
+    /**
+     * (For tests only) Set a flag that forces the slow path to block indefinitely after saving undo state. Setting
+     * this flag to `false` will immediately unblock any currently blocked slow paths.
+     */
+    void setSlowPathBlocked(bool blocked) {
+        typechecker.setSlowPathBlocked(blocked);
+    }
 };
 } // namespace sorbet::realmain::lsp
 

--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -79,6 +79,14 @@ public:
      * (For tests only) Retrieve the number of times typechecking has run.
      */
     int getTypecheckCount();
+
+    /**
+     * (For tests only) Set a flag that forces the slow path to block indefinitely after saving undo state. Setting
+     * this flag to `false` will immediately unblock any currently blocked slow paths.
+     */
+    void setSlowPathBlocked(bool blocked) {
+        typecheckerCoord.setSlowPathBlocked(blocked);
+    }
 };
 
 // TODO(jvilk): Move to LSPTask.

--- a/main/lsp/wrapper.cc
+++ b/main/lsp/wrapper.cc
@@ -189,6 +189,10 @@ int LSPWrapper::getTypecheckCount() {
     return lspLoop->getTypecheckCount();
 }
 
+void LSPWrapper::setSlowPathBlocked(bool blocked) {
+    lspLoop->setSlowPathBlocked(blocked);
+}
+
 const LSPConfiguration &LSPWrapper::config() const {
     return *config_;
 }

--- a/main/lsp/wrapper.h
+++ b/main/lsp/wrapper.h
@@ -78,6 +78,12 @@ public:
      * (For tests only) Retrieve the number of times typechecking has run.
      */
     int getTypecheckCount();
+
+    /**
+     * (For tests only) Set a flag that forces the slow path to block indefinitely after saving undo state. Setting
+     * this flag to `false` will immediately unblock any currently blocked slow paths.
+     */
+    void setSlowPathBlocked(bool blocked);
 };
 
 class SingleThreadedLSPWrapper final : public LSPWrapper {

--- a/test/lsp/ProtocolTest.h
+++ b/test/lsp/ProtocolTest.h
@@ -111,6 +111,14 @@ protected:
      * Request all counter metrics from the server. Used to assert that metrics are reporting correctly.
      */
     const CounterStateDatabase getCounters();
+
+    /**
+     * Set a flag that forces the slow path to block indefinitely after saving undo state. Setting this flag to `false`
+     * will immediately unblock any currently blocked slow paths.
+     */
+    void setSlowPathBlocked(bool blocked) {
+        lspWrapper->setSlowPathBlocked(blocked);
+    }
 };
 
 } // namespace sorbet::test::lsp

--- a/test/lsp/multithreaded_protocol_test_corpus.cc
+++ b/test/lsp/multithreaded_protocol_test_corpus.cc
@@ -675,4 +675,57 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "ErrorIntroducedInSlowPathPreemptio
     assertDiagnostics(send(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::SorbetFence, 20))), {});
 }
 
+TEST_CASE_FIXTURE(MultithreadedProtocolTest, "StallInSlowPathWorks") {
+    auto initOptions = make_unique<SorbetInitializationOptions>();
+    initOptions->enableTypecheckInfo = true;
+    assertDiagnostics(initializeLSP(true /* supportsMarkdown */, move(initOptions)), {});
+
+    // Create a simple file.
+    assertDiagnostics(send(*openFile("foo.rb", "")), {});
+    sendAsync(*changeFile("foo.rb", "# typed: true\nclass Foo\n  def foo\n  end\nend\n", 2));
+
+    // Wait for initial typechecking to start.
+    {
+        auto status = getTypecheckRunStatus(*readAsync());
+        REQUIRE(status.has_value());
+        REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Started);
+    }
+
+    // Wait for initial typechecking to finish.
+    {
+        auto status = getTypecheckRunStatus(*readAsync());
+        REQUIRE(status.has_value());
+        REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Ended);
+    }
+
+    // Turn on slow path blocking, and send an edit that is going to cause a slow path.
+    setSlowPathBlocked(true);
+    sendAsync(*changeFile("foo.rb", "# typed: true\nclass Foo\n  def bar\n  end\nend\n", 3, false, 0));
+
+    // Wait for typechecking to start.
+    {
+        auto status = getTypecheckRunStatus(*readAsync());
+        REQUIRE(status.has_value());
+        REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Started);
+    }
+
+    // We expect the slow path to be blocked, so we want to make sure that we _don't_ receive any messages within a
+    // pretty long time frame---let's say 2000ms.
+    {
+        auto &wrapper = dynamic_cast<MultiThreadedLSPWrapper &>(*lspWrapper);
+        auto msg = wrapper.read(2000);
+        REQUIRE(msg == nullptr);
+    }
+
+    // Unblock the slow path.
+    setSlowPathBlocked(false);
+
+    // The slow path should now be unblocked. Wait for typechecking to end.
+    {
+        auto status = getTypecheckRunStatus(*readAsync());
+        REQUIRE(status.has_value());
+        REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Ended);
+    }
+}
+
 } // namespace sorbet::test::lsp


### PR DESCRIPTION
For the stale-state feature we need a way to block slow paths programmatically in tests.


### Motivation
The immediate motivation is to get rid of reliance on (brittle, slow) sleeps in the protocol tests for #5469. We can also use this mechanism in the future to implement position assertion-style tests for stale-state queries.


### Test plan
See included automated tests.
