### PR TITLE
make `TypePtr` parameter passing more idiomatic in `TypeErrorDiagnostics`

### DIFF
--- a/core/TypeErrorDiagnostics.cc
+++ b/core/TypeErrorDiagnostics.cc
@@ -32,8 +32,8 @@ namespace {
 }
 } // namespace
 
-void TypeErrorDiagnostics::explainTypeMismatch(const GlobalState &gs, ErrorBuilder &e, const TypePtr expected,
-                                               const TypePtr got) {
+void TypeErrorDiagnostics::explainTypeMismatch(const GlobalState &gs, ErrorBuilder &e, const TypePtr &expected,
+                                               const TypePtr &got) {
     auto expectedSelfTypeParam = isa_type<SelfTypeParam>(expected);
     auto gotClassType = isa_type<ClassType>(got);
     if (expectedSelfTypeParam && gotClassType) {
@@ -56,7 +56,7 @@ void TypeErrorDiagnostics::explainTypeMismatch(const GlobalState &gs, ErrorBuild
 }
 
 void TypeErrorDiagnostics::maybeAutocorrect(const GlobalState &gs, ErrorBuilder &e, Loc loc, TypeConstraint &constr,
-                                            TypePtr expectedType, TypePtr actualType) {
+                                            const TypePtr &expectedType, const TypePtr &actualType) {
     if (!loc.exists()) {
         return;
     }

--- a/core/TypeErrorDiagnostics.h
+++ b/core/TypeErrorDiagnostics.h
@@ -17,9 +17,9 @@ public:
     //
     // Statefully accumulates the autocorrect directly onto the provided `ErrorBuilder`.
     static void maybeAutocorrect(const GlobalState &gs, ErrorBuilder &e, Loc loc, TypeConstraint &constr,
-                                 TypePtr expectedType, TypePtr actualType);
+                                 const TypePtr &expectedType, const TypePtr &actualType);
 
-    static void explainTypeMismatch(const GlobalState &gs, ErrorBuilder &e, const TypePtr expected, const TypePtr got);
+    static void explainTypeMismatch(const GlobalState &gs, ErrorBuilder &e, const TypePtr &expected, const TypePtr &got);
 };
 
 } // namespace sorbet::core

--- a/core/TypeErrorDiagnostics.h
+++ b/core/TypeErrorDiagnostics.h
@@ -19,7 +19,8 @@ public:
     static void maybeAutocorrect(const GlobalState &gs, ErrorBuilder &e, Loc loc, TypeConstraint &constr,
                                  const TypePtr &expectedType, const TypePtr &actualType);
 
-    static void explainTypeMismatch(const GlobalState &gs, ErrorBuilder &e, const TypePtr &expected, const TypePtr &got);
+    static void explainTypeMismatch(const GlobalState &gs, ErrorBuilder &e, const TypePtr &expected,
+                                    const TypePtr &got);
 };
 
 } // namespace sorbet::core


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Per the tin.  This is error code, so we don't really care about copying the `TypePtr`s, but still.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
