### PR TITLE
add explanation for mismatched `T.any` types in containers

### DIFF
--- a/core/TypeErrorDiagnostics.cc
+++ b/core/TypeErrorDiagnostics.cc
@@ -74,8 +74,7 @@ void TypeErrorDiagnostics::explainTypeMismatch(const GlobalState &gs, ErrorBuild
         }
         // We could extend this to multiple args, but the common cases are `T::Set`
         // and `T::Array`, so go with the simple code for now.
-        if (gotRef.targs.size() != expectedRef.targs.size() ||
-            gotRef.targs.size() != 1) {
+        if (gotRef.targs.size() != expectedRef.targs.size() || gotRef.targs.size() != 1) {
             return;
         }
 
@@ -94,9 +93,8 @@ void TypeErrorDiagnostics::explainTypeMismatch(const GlobalState &gs, ErrorBuild
         // TODO: should we just limit this to `T.class_of`-style types?
         vector<TypePtr> parts;
         flattenOrType(parts, cast_type_nonnull<OrType>(innerGot));
-        auto it = std::remove_if(parts.begin(), parts.end(), [&](auto &part) -> bool {
-                return core::Types::isSubType(gs, part, innerExpected);
-            });
+        auto it = std::remove_if(parts.begin(), parts.end(),
+                                 [&](auto &part) -> bool { return core::Types::isSubType(gs, part, innerExpected); });
         parts.erase(it, parts.end());
 
         for (auto &part : parts) {

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1450,6 +1450,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                         if (auto e = ctx.beginError(bind.loc, core::errors::Infer::CastTypeMismatch)) {
                             e.setHeader("Argument does not have asserted type `{}`", castType.show(ctx));
                             e.addErrorSection(ty.explainGot(ctx, ownerLoc));
+                            core::TypeErrorDiagnostics::explainTypeMismatch(ctx, e, castType, ty.type);
                         }
                     }
                 } else if (!c.isSynthetic) {

--- a/test/cli/big-any/big-any.rb
+++ b/test/cli/big-any/big-any.rb
@@ -1,0 +1,18 @@
+# typed: true
+
+class BaseClass; end
+
+class A < BaseClass; end
+class B < BaseClass; end
+class C < BaseClass; end
+class D < BaseClass; end
+class E < BaseClass; end
+class F < BaseClass; end
+class G < BaseClass; end
+class H < BaseClass; end
+class Not; end
+
+def f
+  x = T.let([A, B, C, D, E, F, G, H, Not].to_set.freeze, T::Set[T.class_of(BaseClass)])
+  return x
+end

--- a/test/cli/big-any/test.out
+++ b/test/cli/big-any/test.out
@@ -5,4 +5,6 @@ big-any.rb:16: Argument does not have asserted type `T::Set[T.class_of(BaseClass
     big-any.rb:16:
     16 |  x = T.let([A, B, C, D, E, F, G, H, Not].to_set.freeze, T::Set[T.class_of(BaseClass)])
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Note:
+    `T.class_of(Not)` is not a subtype of `T.class_of(BaseClass)`
 Errors: 1

--- a/test/cli/big-any/test.out
+++ b/test/cli/big-any/test.out
@@ -1,0 +1,8 @@
+big-any.rb:16: Argument does not have asserted type `T::Set[T.class_of(BaseClass)]` https://srb.help/7007
+    16 |  x = T.let([A, B, C, D, E, F, G, H, Not].to_set.freeze, T::Set[T.class_of(BaseClass)])
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Got `T::Set[T.any(T.class_of(A), T.class_of(B), T.class_of(C), T.class_of(D), T.class_of(E), T.class_of(F), T.class_of(G), T.class_of(H), T.class_of(Not))]` originating from:
+    big-any.rb:16:
+    16 |  x = T.let([A, B, C, D, E, F, G, H, Not].to_set.freeze, T::Set[T.class_of(BaseClass)])
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Errors: 1

--- a/test/cli/big-any/test.sh
+++ b/test/cli/big-any/test.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+main/sorbet --silence-dev-message --dir test/cli/big-any 2>&1


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

A similar case came up for a user at Stripe, where they had code similar to the added testcase, but some of their types were not quite right.  Sorbet obviously knew which types were not right, but was subsuming them all underneath a `T.any` and leaving the user to pick out which ones were wrong.

(There were also packaging-related problems, but I think we're going to try addressing those in a different PR.)

I am not 100% sure this is the right way to go: in particular, I think the error message might only be helpful in the `T.class_of` case highlighted by the added test.  We don't have location information for which subexpression is incorrectly typed, so we're relying on the user to be able to pick out which thing has the type that we're telling them about.

I think this also falls down if you have a tuple type where you wanted an array type, etc.  I suppose that could be a further refinement.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
