### PR TITLE
Bump the VSCode extension

### DIFF
--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -4,7 +4,7 @@
   "description": "Ruby IDE features, powered by Sorbet.",
   "author": "Stripe Inc.",
   "license": "Apache-2.0",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "publisher": "sorbet",
   "icon": "icon.png",
   "repository": {


### PR DESCRIPTION
0.3.12 -> 0.3.13

It's a follow up for my previous PR: https://github.com/sorbet/sorbet/pull/5528
I forgot to actually increment the extension version


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
New extension release

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
