### PR TITLE
Position tests for stale-state hovers

### DIFF
--- a/main/lsp/LSPPreprocessor.cc
+++ b/main/lsp/LSPPreprocessor.cc
@@ -228,7 +228,7 @@ unique_ptr<LSPTask> LSPPreprocessor::getTaskForMessage(LSPMessage &msg) {
             case LSPMethod::Exit:
                 return make_unique<ExitTask>(*config, 0);
             case LSPMethod::SorbetFence:
-                return make_unique<SorbetFenceTask>(*config, get<int>(rawParams));
+                return make_unique<SorbetFenceTask>(*config, move(get<unique_ptr<SorbetFenceParams>>(rawParams)));
             case LSPMethod::PAUSE:
                 return make_unique<SorbetPauseTask>(*config);
             case LSPMethod::RESUME:

--- a/main/lsp/LSPTask.cc
+++ b/main/lsp/LSPTask.cc
@@ -95,6 +95,9 @@ ResponseMessageStatus statusForResponse(const ResponseMessage &response) {
                 } else if constexpr (is_same_v<T, unique_ptr<SorbetErrorParams>>) {
                     // sorbet/error
                     return ResponseMessageStatus::Unknown;
+                } else if constexpr (is_same_v<T, unique_ptr<SorbetFenceParams>>) {
+                    // sorbet/fence
+                    return ResponseMessageStatus::Unknown;
                 } else if constexpr (is_same_v<T, unique_ptr<TextDocumentItem>>) {
                     // sorbet/readFile
                     return ResponseMessageStatus::Unknown;

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -700,6 +700,11 @@ void LSPTypechecker::setSlowPathBlocked(bool blocked) {
     slowPathBlocked = blocked;
 }
 
+bool LSPTypechecker::isSlowPathBlocked() const {
+    absl::MutexLock lck(&slowPathBlockedMutex);
+    return slowPathBlocked;
+}
+
 LSPTypecheckerDelegate::LSPTypecheckerDelegate(TaskQueue &queue, WorkerPool &workers, LSPTypechecker &typechecker)
     : typechecker(typechecker), queue{queue}, workers(workers) {}
 

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -61,7 +61,7 @@ class LSPTypechecker final {
 
     /** Used in tests to force the slow path to block just after cancellation state has been set. */
     bool slowPathBlocked ABSL_GUARDED_BY(slowPathBlockedMutex) = false;
-    absl::Mutex slowPathBlockedMutex;
+    mutable absl::Mutex slowPathBlockedMutex;
 
     /** Conservatively reruns entire pipeline without caching any trees. Returns 'true' if committed, 'false' if
      * canceled. */
@@ -149,6 +149,9 @@ public:
      * this flag to `false` will immediately unblock any currently blocked slow paths.
      */
     void setSlowPathBlocked(bool blocked);
+
+    /** (For tests only) Checks if the `setSlowPathBlocked` flag is set. */
+    bool isSlowPathBlocked() const;
 };
 
 /**

--- a/main/lsp/LSPTypecheckerCoordinator.h
+++ b/main/lsp/LSPTypecheckerCoordinator.h
@@ -101,6 +101,11 @@ public:
     void setSlowPathBlocked(bool blocked) {
         typechecker.setSlowPathBlocked(blocked);
     }
+
+    /** (For tests only) Checks if the `setSlowPathBlocked` flag is set. */
+    bool isSlowPathBlocked() const {
+        return typechecker.isSlowPathBlocked();
+    }
 };
 } // namespace sorbet::realmain::lsp
 

--- a/main/lsp/lsp.h
+++ b/main/lsp/lsp.h
@@ -87,6 +87,11 @@ public:
     void setSlowPathBlocked(bool blocked) {
         typecheckerCoord.setSlowPathBlocked(blocked);
     }
+
+    /** (For tests only) Checks if the `setSlowPathBlocked` flag is set. */
+    bool isSlowPathBlocked() const {
+        return typecheckerCoord.isSlowPathBlocked();
+    }
 };
 
 // TODO(jvilk): Move to LSPTask.

--- a/main/lsp/notifications/sorbet_fence.h
+++ b/main/lsp/notifications/sorbet_fence.h
@@ -4,13 +4,16 @@
 #include "main/lsp/LSPTask.h"
 
 namespace sorbet::realmain::lsp {
+class SorbetFenceParams;
 class SorbetFenceTask final : public LSPTask {
-    int id;
+    std::unique_ptr<SorbetFenceParams> params;
 
 public:
-    SorbetFenceTask(const LSPConfiguration &config, int id);
+    SorbetFenceTask(const LSPConfiguration &config, std::unique_ptr<SorbetFenceParams> params);
 
     bool canPreempt(const LSPIndexer &indexer) const override;
+
+    bool canUseStaleData() const override;
 
     void run(LSPTypecheckerInterface &tc) override;
 };

--- a/main/lsp/tools/make_lsp_types.cc
+++ b/main/lsp/tools/make_lsp_types.cc
@@ -1280,6 +1280,12 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                                             makeField("message", JSONString),
                                         },
                                         classTypes);
+    auto SorbetFenceParams = makeObject("SorbetFenceParams",
+                                        {
+                                            makeField("id", JSONInt),
+                                            makeField("advanceIfStaleDataAvailable", JSONBool),
+                                        },
+                                        classTypes);
 
     /* Watchman JSON response objects */
     auto WatchmanQueryResponse = makeObject("WatchmanQueryResponse",
@@ -1387,6 +1393,7 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                                                 {"textDocument/formatting", DocumentFormattingParams},
                                                 {"workspace/symbol", WorkspaceSymbolParams},
                                                 {"sorbet/error", SorbetErrorParams},
+                                                {"sorbet/fence", SorbetFenceParams},
                                                 {"sorbet/readFile", TextDocumentIdentifier},
                                                 {"sorbet/showSymbol", TextDocumentPositionParams},
                                             });
@@ -1460,7 +1467,7 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                                                 {"sorbet/watchmanFileChange", WatchmanQueryResponse},
                                                 {"sorbet/showOperation", SorbetShowOperationParams},
                                                 {"sorbet/error", SorbetErrorParams},
-                                                {"sorbet/fence", JSONInt},
+                                                {"sorbet/fence", SorbetFenceParams},
                                                 {"sorbet/workspaceEdit", SorbetWorkspaceEditParams},
                                                 {"sorbet/typecheckRunInfo", SorbetTypecheckRunInfo},
                                             });

--- a/main/lsp/wrapper.cc
+++ b/main/lsp/wrapper.cc
@@ -193,6 +193,10 @@ void LSPWrapper::setSlowPathBlocked(bool blocked) {
     lspLoop->setSlowPathBlocked(blocked);
 }
 
+bool LSPWrapper::isSlowPathBlocked() const {
+    return lspLoop->isSlowPathBlocked();
+}
+
 const LSPConfiguration &LSPWrapper::config() const {
     return *config_;
 }

--- a/main/lsp/wrapper.h
+++ b/main/lsp/wrapper.h
@@ -84,6 +84,9 @@ public:
      * this flag to `false` will immediately unblock any currently blocked slow paths.
      */
     void setSlowPathBlocked(bool blocked);
+
+    /** (For tests only) Checks if the `setSlowPathBlocked` flag is set. */
+    bool isSlowPathBlocked() const;
 };
 
 class SingleThreadedLSPWrapper final : public LSPWrapper {

--- a/test/helpers/expectations.h
+++ b/test/helpers/expectations.h
@@ -12,6 +12,8 @@ struct Expectations {
     std::vector<std::string> sourceFiles;
     // version => [{originalFilename, versionFilePath}, ...]
     UnorderedMap<int, std::vector<std::pair<std::string, std::string>>> sourceLSPFileUpdates;
+    // version => [{originalFilename, versionFilePath}, ...]
+    UnorderedMap<int, std::vector<std::pair<std::string, std::string>>> staleLSPFileUpdates;
     // folder + sourceFile => file
     UnorderedMap<std::string, std::shared_ptr<core::File>> sourceFileContents;
     // expectations type => file => expectations for file

--- a/test/helpers/lsp.cc
+++ b/test/helpers/lsp.cc
@@ -471,9 +471,10 @@ vector<unique_ptr<LSPMessage>> getLSPResponsesFor(LSPWrapper &wrapper, vector<un
     } else if (auto mtWrapper = dynamic_cast<MultiThreadedLSPWrapper *>(&wrapper)) {
         // Fences are only used in tests. Use an ID that is likely to be unique to this method.
         const int fenceId = 909090;
+        bool advanceIfStaleDataAvailable = wrapper.isSlowPathBlocked();
         // Chase messages with a fence, and wait for a fence response.
-        messages.push_back(
-            make_unique<LSPMessage>(make_unique<NotificationMessage>("2.0", LSPMethod::SorbetFence, fenceId)));
+        messages.push_back(make_unique<LSPMessage>(make_unique<NotificationMessage>(
+            "2.0", LSPMethod::SorbetFence, std::make_unique<SorbetFenceParams>(fenceId, advanceIfStaleDataAvailable))));
         // ASSUMPTION: There are no other messages still being processed. This should be true if the tests are
         // disciplined. Also, even if they aren't, what should we do with stray messages? Passing them on seems most
         // correct.
@@ -492,7 +493,7 @@ vector<unique_ptr<LSPMessage>> getLSPResponsesFor(LSPWrapper &wrapper, vector<un
             }
 
             if (msg->isNotification() && msg->method() == LSPMethod::SorbetFence &&
-                get<int>(msg->asNotification().params) == fenceId) {
+                get<std::unique_ptr<SorbetFenceParams>>(msg->asNotification().params)->id == fenceId) {
                 break;
             }
             responses.push_back(move(msg));

--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -400,6 +400,12 @@ TEST_CASE("LSPTest") {
     /** Test expectations. */
     Expectations test = Expectations::getExpectations(singleTest);
 
+    /** Currently we cannot mix .rbupdate and .rbstaleupdate files, since the latter requires us to use a multithreaded
+        LSPWrapper and the former requires us to use a single-threaded LSPWrapper. */
+    bool haveSourceUpdates = test.sourceLSPFileUpdates.size() > 0;
+    bool haveStaleUpdates = test.staleLSPFileUpdates.size() > 0;
+    REQUIRE_MESSAGE(!(haveSourceUpdates && haveStaleUpdates), "Cannot mix .rbupdate and .rbstaleupdate files in test");
+
     /** All test assertions ordered by (filename, range, message). */
     std::vector<std::shared_ptr<RangeAssertion>> assertions = RangeAssertion::parseAssertions(test.sourceFileContents);
 
@@ -426,10 +432,16 @@ TEST_CASE("LSPTest") {
         }
         opts->disableWatchman = true;
 
-        // Set to a number that is reasonable large for tests, but small enough that we can have a test to handle this
-        // edge case. If you change this number, update the `lsp/fast_path/too_many_files` and `not_enough_files` tests.
-        opts->lspMaxFilesOnFastPath = 10;
-        lspWrapper = SingleThreadedLSPWrapper::create("", move(opts));
+        if (haveStaleUpdates) {
+            opts->lspStaleStateEnabled = true;
+            lspWrapper = MultiThreadedLSPWrapper::create("", move(opts));
+        } else {
+            // Set to a number that is reasonable large for tests, but small enough that we can have a test to handle
+            // this edge case. If you change this number, update the `lsp/fast_path/too_many_files` and
+            // `not_enough_files` tests.
+            opts->lspMaxFilesOnFastPath = 10;
+            lspWrapper = SingleThreadedLSPWrapper::create("", move(opts));
+        }
         lspWrapper->enableAllExperimentalFeatures();
     }
 
@@ -673,19 +685,23 @@ TEST_CASE("LSPTest") {
 
     // Fast path tests: Asserts that certain changes take the fast/slow path, and produce any expected diagnostics.
     {
-        // sourceLSPFileUpdates is unordered (and we can't use an ordered map unless we make its contents `const`)
+        // sourceLSPFileUpdates/staleLSPFileUpdates are unordered (and we can't use ordered maps unless we make their
+        // contents `const`)
         // Sort by version.
         vector<int> sortedUpdates;
         const int baseVersion = 4;
-        for (auto &update : test.sourceLSPFileUpdates) {
+
+        auto &testUpdates = haveStaleUpdates ? test.staleLSPFileUpdates : test.sourceLSPFileUpdates;
+
+        for (auto &update : testUpdates) {
             sortedUpdates.push_back(update.first);
         }
         fast_sort(sortedUpdates);
 
         // Apply updates in order.
         for (auto version : sortedUpdates) {
-            auto errorPrefix = fmt::format("[*.{}.rbupdate] ", version);
-            auto &updates = test.sourceLSPFileUpdates[version];
+            auto errorPrefix = fmt::format("[*.{}.{}] ", version, haveStaleUpdates ? "rbupdate" : "rbstaleupdate");
+            auto &updates = testUpdates[version];
             vector<unique_ptr<LSPMessage>> lspUpdates;
             UnorderedMap<std::string, std::shared_ptr<core::File>> updatesAndContents;
 
@@ -700,58 +716,142 @@ TEST_CASE("LSPTest") {
             auto assertions = RangeAssertion::parseAssertions(updatesAndContents);
             auto assertFastPath = FastPathAssertion::get(assertions);
             auto assertSlowPath = BooleanPropertyAssertion::getValue("assert-slow-path", assertions);
-            auto responses = getLSPResponsesFor(*lspWrapper, move(lspUpdates));
-            bool foundTypecheckRunInfo = false;
 
-            for (auto &r : responses) {
-                if (r->isNotification()) {
-                    if (r->method() == LSPMethod::SorbetTypecheckRunInfo) {
-                        auto &params = get<unique_ptr<SorbetTypecheckRunInfo>>(r->asNotification().params);
-                        // Ignore started messages. Note that cancelation messages cannot occur in test_corpus since
-                        // test_corpus only runs LSP in single-threaded mode.
-                        if (params->status == SorbetTypecheckRunStatus::Ended) {
-                            foundTypecheckRunInfo = true;
-                            if (assertSlowPath.value_or(false)) {
-                                INFO(errorPrefix << "Expected Sorbet to take slow path, but it took the fast path.");
+            // TODO(aprocter): There's probably more code duplication than necessary between the 'if' and the 'else'
+            // here.
+            if (haveStaleUpdates) {
+                // Wait for a fence, to clear out any pending slow-path operations.
+                (void)getLSPResponsesFor(*lspWrapper, std::vector<std::unique_ptr<LSPMessage>>{});
+
+                // Block the slow path, to force the edit tasks to operate on stale state.
+                lspWrapper->setSlowPathBlocked(true);
+
+                // Send the updates.
+                auto responses = getLSPResponsesFor(*lspWrapper, move(lspUpdates));
+
+                // Make sure we get the expected typecheck start message, and nothing unexpected in response to the
+                // edits.
+                bool foundTypecheckStart = false;
+
+                for (auto &r : responses) {
+                    if (r->isNotification()) {
+                        if (r->method() == LSPMethod::SorbetTypecheckRunInfo) {
+                            auto &params = get<unique_ptr<SorbetTypecheckRunInfo>>(r->asNotification().params);
+                            CHECK_EQ(params->status, SorbetTypecheckRunStatus::Started);
+                            if (params->status == SorbetTypecheckRunStatus::Started) {
+                                foundTypecheckStart = true;
+                                // For stale state, we must take the slow path.
+                                INFO(errorPrefix << "For stale state tests, we always expect Sorbet to take slow path, "
+                                                    "but it took the fast path.");
                                 CHECK_EQ(params->fastPath, false);
                             }
-                            if (assertFastPath.has_value()) {
-                                (*assertFastPath)->check(*params, test.folder, version, errorPrefix);
-                            }
+                        } else if (r->method() != LSPMethod::TextDocumentPublishDiagnostics) {
+                            FAIL_CHECK(errorPrefix
+                                       << fmt::format("Unexpected message response to file update of type {}:\n{}",
+                                                      convertLSPMethodToString(r->method()), r->toJSON()));
                         }
-                    } else if (r->method() != LSPMethod::TextDocumentPublishDiagnostics) {
+                    } else {
                         FAIL_CHECK(errorPrefix
-                                   << fmt::format("Unexpected message response to file update of type {}:\n{}",
-                                                  convertLSPMethodToString(r->method()), r->toJSON()));
+                                   << fmt::format("Unexpected message response to file update:\n{}", r->toJSON()));
                     }
-                } else {
-                    FAIL_CHECK(errorPrefix
-                               << fmt::format("Unexpected message response to file update:\n{}", r->toJSON()));
                 }
+
+                if (!foundTypecheckStart) {
+                    FAIL_CHECK(errorPrefix << "Sorbet did not send expected typechecking start.");
+                }
+
+                // Check any new HoverAssertions in the updates.
+                HoverAssertion::checkAll(assertions, updatesAndContents, *lspWrapper, nextId);
+
+                // Unblock the slow path.
+                lspWrapper->setSlowPathBlocked(false);
+
+                // Wait for a fence, to clear out the slow path we've just unblocked.
+                responses = getLSPResponsesFor(*lspWrapper, std::vector<std::unique_ptr<LSPMessage>>{});
+
+                // Make sure we get the expected end message for the unblocked slow path, and nothing else that's
+                // unexpected.
+                bool foundTypecheckEnd = false;
+
+                for (auto &r : responses) {
+                    if (r->isNotification()) {
+                        if (r->method() == LSPMethod::SorbetTypecheckRunInfo) {
+                            auto &params = get<unique_ptr<SorbetTypecheckRunInfo>>(r->asNotification().params);
+                            CHECK_EQ(params->status, SorbetTypecheckRunStatus::Ended);
+                            if (params->status == SorbetTypecheckRunStatus::Ended) {
+                                foundTypecheckEnd = true;
+                            }
+                            // We could check if the end message is for a slow path, but it's probably not necessary
+                            // since we already checked that we got a slow-path start message.
+                        } else {
+                            FAIL_CHECK(errorPrefix
+                                       << fmt::format("Unexpected message response to file update of type {}:\n{}",
+                                                      convertLSPMethodToString(r->method()), r->toJSON()));
+                        }
+                    } else {
+                        FAIL_CHECK(errorPrefix
+                                   << fmt::format("Unexpected message response to file update:\n{}", r->toJSON()));
+                    }
+                }
+
+                if (!foundTypecheckEnd) {
+                    FAIL_CHECK(errorPrefix << "Sorbet did not send expected typechecking end.");
+                }
+            } else {
+                auto responses = getLSPResponsesFor(*lspWrapper, move(lspUpdates));
+                bool foundTypecheckRunInfo = false;
+
+                for (auto &r : responses) {
+                    if (r->isNotification()) {
+                        if (r->method() == LSPMethod::SorbetTypecheckRunInfo) {
+                            auto &params = get<unique_ptr<SorbetTypecheckRunInfo>>(r->asNotification().params);
+                            // Ignore started messages. Note that cancelation messages cannot occur in test_corpus since
+                            // test_corpus only runs LSP in single-threaded mode.
+                            if (params->status == SorbetTypecheckRunStatus::Ended) {
+                                foundTypecheckRunInfo = true;
+                                if (assertSlowPath.value_or(false)) {
+                                    INFO(errorPrefix
+                                         << "Expected Sorbet to take slow path, but it took the fast path.");
+                                    CHECK_EQ(params->fastPath, false);
+                                }
+                                if (assertFastPath.has_value()) {
+                                    (*assertFastPath)->check(*params, test.folder, version, errorPrefix);
+                                }
+                            }
+                        } else if (r->method() != LSPMethod::TextDocumentPublishDiagnostics) {
+                            FAIL_CHECK(errorPrefix
+                                       << fmt::format("Unexpected message response to file update of type {}:\n{}",
+                                                      convertLSPMethodToString(r->method()), r->toJSON()));
+                        }
+                    } else {
+                        FAIL_CHECK(errorPrefix
+                                   << fmt::format("Unexpected message response to file update:\n{}", r->toJSON()));
+                    }
+                }
+
+                if (!foundTypecheckRunInfo) {
+                    FAIL_CHECK(errorPrefix << "Sorbet did not send expected typechecking metadata.");
+                }
+
+                updateDiagnostics(config, testFileUris, responses, diagnostics);
+
+                for (auto &update : updates) {
+                    auto originalFile = test.folder + update.first;
+                    auto updateFile = test.folder + update.second;
+                    testDocumentSymbols(*lspWrapper, test, nextId, testFileUris[originalFile], updateFile);
+                }
+
+                const bool passed = ErrorAssertion::checkAll(
+                    updatesAndContents, RangeAssertion::getErrorAssertions(assertions), diagnostics, errorPrefix);
+
+                if (!passed) {
+                    // Abort if an update fails its assertions, as subsequent updates will likely fail as well.
+                    break;
+                }
+
+                // Check any new HoverAssertions in the updates.
+                HoverAssertion::checkAll(assertions, updatesAndContents, *lspWrapper, nextId);
             }
-
-            if (!foundTypecheckRunInfo) {
-                FAIL_CHECK(errorPrefix << "Sorbet did not send expected typechecking metadata.");
-            }
-
-            updateDiagnostics(config, testFileUris, responses, diagnostics);
-
-            for (auto &update : updates) {
-                auto originalFile = test.folder + update.first;
-                auto updateFile = test.folder + update.second;
-                testDocumentSymbols(*lspWrapper, test, nextId, testFileUris[originalFile], updateFile);
-            }
-
-            const bool passed = ErrorAssertion::checkAll(
-                updatesAndContents, RangeAssertion::getErrorAssertions(assertions), diagnostics, errorPrefix);
-
-            if (!passed) {
-                // Abort if an update fails its assertions, as subsequent updates will likely fail as well.
-                break;
-            }
-
-            // Check any new HoverAssertions in the updates.
-            HoverAssertion::checkAll(assertions, updatesAndContents, *lspWrapper, nextId);
         }
     }
 

--- a/test/pipeline_test.bzl
+++ b/test/pipeline_test.bzl
@@ -180,6 +180,7 @@ def pipeline_tests(suite_name, all_paths, test_name_prefix, extra_args = [], tag
             data += [sentinel]
             data += native.glob(["{}.*.exp".format(prefix)])
             data += native.glob(["{}.*.rbupdate".format(prefix)])
+            data += native.glob(["{}.*.rbstaleupdate".format(prefix)])
             data += native.glob(["{}.*.rbedited".format(prefix)])
             data += native.glob(["{}.*.minimize.rbi".format(prefix)])
 

--- a/test/testdata/lsp/stale_state/simple_hover.1.rbstaleupdate
+++ b/test/testdata/lsp/stale_state/simple_hover.1.rbstaleupdate
@@ -1,0 +1,14 @@
+# typed: true
+
+class Foo
+  extend T::Sig
+
+  sig {returns(Integer)}
+  def bar
+    # ^ hover: ```ruby
+    # ^ hover: # note: information may be stale
+    # ^ hover: sig {returns(Integer)}
+    # ^ hover: def foo; end
+    42
+  end
+end

--- a/test/testdata/lsp/stale_state/simple_hover.rb
+++ b/test/testdata/lsp/stale_state/simple_hover.rb
@@ -1,0 +1,12 @@
+# typed: true
+
+class Foo
+  extend T::Sig
+
+  sig {returns(Integer)}
+  def foo
+    # ^ hover: sig {returns(Integer)}
+    # ^ hover: def foo; end
+    42
+  end
+end


### PR DESCRIPTION
(Stacked on #5469)

This adds support for `.rbstaleupdate` files to the `lsp_test_runner`.

WIP because there's some sloppy code duplication I think I can fix. But it seems to work on a simple example test!


### Motivation
We want to be able to test our new stale-state functionality without writing a bunch of protocol tests.


### Test plan
See included automated tests.
