### PR TITLE
Use callLocs in fewer error messages

### DIFF
--- a/core/Types.h
+++ b/core/Types.h
@@ -893,6 +893,24 @@ struct DispatchArgs {
     Loc argLoc(size_t i) const {
         return core::Loc(locs.file, locs.args[i]);
     }
+    Loc argsLoc() const {
+        if (!locs.args.empty()) {
+            return core::Loc(locs.file, locs.args.front().join(locs.args.back()));
+        }
+
+        if (this->block != nullptr) {
+            if (locs.fun.exists()) {
+                return funLoc().copyEndWithZeroLength();
+            }
+            return callLoc().copyEndWithZeroLength();
+        }
+
+        if (locs.fun.exists()) {
+            return core::Loc(locs.file, locs.fun.endPos(), locs.call.endPos());
+        }
+
+        return callLoc().copyEndWithZeroLength();
+    }
 
     DispatchArgs withSelfRef(const TypePtr &newSelfRef) const;
     DispatchArgs withThisRef(const TypePtr &newThisRef) const;

--- a/core/Types.h
+++ b/core/Types.h
@@ -911,6 +911,7 @@ struct DispatchArgs {
 
         return callLoc().copyEndWithZeroLength();
     }
+    Loc blockLoc(const GlobalState &gs) const;
 
     DispatchArgs withSelfRef(const TypePtr &newSelfRef) const;
     DispatchArgs withThisRef(const TypePtr &newThisRef) const;

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -602,9 +602,10 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
             // some cases, so we special-case it here as a last resort.
             auto result = DispatchResult(Types::untypedUntracked(), std::move(args.selfType), Symbols::noMethod());
             if (!args.args.empty() && !args.suppressErrors) {
-                if (auto e = gs.beginError(args.callLoc(), errors::Infer::MethodArgumentCountMismatch)) {
+                if (auto e = gs.beginError(args.argsLoc(), errors::Infer::MethodArgumentCountMismatch)) {
                     e.setHeader("Wrong number of arguments for constructor. Expected: `{}`, got: `{}`", 0,
                                 args.args.size());
+                    e.replaceWith("Delete args", args.argsLoc(), "");
                     result.main.errors.emplace_back(e.build());
                 }
             }

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1226,11 +1226,15 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
             auto file = data->loc().file();
             if (file.exists() && file.data(gs).strictLevel >= core::StrictLevel::Strict &&
                 bspec.isSyntheticBlockArgument()) {
-                // TODO(jez) Do we have a loc for the block itself, not the entire call?
-                if (auto e = gs.beginError(args.callLoc(), core::errors::Infer::TakesNoBlock)) {
+                auto blockLoc = args.blockLoc(gs);
+                if (auto e = gs.beginError(blockLoc, core::errors::Infer::TakesNoBlock)) {
                     e.setHeader("Method `{}` does not take a block", method.show(gs));
                     for (const auto loc : method.data(gs)->locs()) {
                         e.addErrorLine(loc, "`{}` defined here", method.show(gs));
+                    }
+
+                    if (blockLoc.exists()) {
+                        e.replaceWith("Remove block", blockLoc, "");
                     }
                 }
             }

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -981,7 +981,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
 
     if (pit != pend) {
         if (!(pit->flags.isKeyword || pit->flags.isDefault || pit->flags.isRepeated || pit->flags.isBlock)) {
-            if (auto e = gs.beginError(args.callLoc(), errors::Infer::MethodArgumentCountMismatch)) {
+            if (auto e = gs.beginError(args.argsLoc(), errors::Infer::MethodArgumentCountMismatch)) {
                 if (args.fullType.type != args.thisType) {
                     e.setHeader("Not enough arguments provided for method `{}` on `{}` component of `{}`. "
                                 "Expected: `{}`, got: `{}`",

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1298,7 +1298,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
         ENFORCE(data->arguments.back().flags.isBlock, "The last arg should be the block arg.");
         auto blockType = data->arguments.back().type;
         if (blockType && !core::Types::isSubType(gs, core::Types::nilClass(), blockType)) {
-            if (auto e = gs.beginError(args.callLoc(), errors::Infer::BlockNotPassed)) {
+            if (auto e = gs.beginError(args.callLoc().copyEndWithZeroLength(), errors::Infer::BlockNotPassed)) {
                 e.setHeader("`{}` requires a block parameter, but no block was passed", args.name.show(gs));
                 e.addErrorLine(method.data(gs)->loc(), "defined here");
                 result.main.errors.emplace_back(e.build());

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1789,7 +1789,7 @@ public:
         }
 
         if (args.numPosArgs != arity) {
-            if (auto e = gs.beginError(args.callLoc(), errors::Infer::GenericArgumentCountMismatch)) {
+            if (auto e = gs.beginError(args.argsLoc(), errors::Infer::GenericArgumentCountMismatch)) {
                 e.setHeader("Wrong number of type parameters for `{}`. Expected: `{}`, got: `{}`",
                             attachedClass.show(gs), arity, args.numPosArgs);
             }

--- a/test/cli/arity-messages/test.out
+++ b/test/cli/arity-messages/test.out
@@ -56,7 +56,7 @@ arity-messages.rb:12: Too many positional arguments provided for method `Object#
 
 arity-messages.rb:15: Not enough arguments provided for method `Object#quux`. Expected: `3`, got: `2` https://srb.help/7004
     15 |quux(2, z: 3)
-        ^^^^^^^^^^^^^
+             ^^^^^^^
     arity-messages.rb:14: `Object#quux` defined here
     14 |def quux(x, y, z); end
         ^^^^^^^^^^^^^^^^^
@@ -99,7 +99,7 @@ arity-messages.rb:24: Too many positional arguments provided for method `Object#
 
 arity-messages.rb:27: Not enough arguments provided for method `Object#pluto`. Expected: `1+`, got: `0` https://srb.help/7004
     27 |pluto
-        ^^^^^
+             ^
     arity-messages.rb:26: `Object#pluto` defined here
     26 |def pluto(x, *args); end
         ^^^^^^^^^^^^^^^^^^^

--- a/test/cli/autocorrect-case-meta-type/test.out
+++ b/test/cli/autocorrect-case-meta-type/test.out
@@ -21,7 +21,7 @@ autocorrect-case-meta-type.rb:12: Control flow could reach `T.absurd` because th
 
 autocorrect-case-meta-type.rb:16: Call to method `===` on `T::Array[Integer]` mistakes a type for a value https://srb.help/7030
     16 |T::Array[Integer].===(0)
-        ^^^^^^^^^^^^^^^^^^^^^^^^
+                          ^^^
   Note:
     It looks like you're trying to pattern match on a generic, which doesn't work at runtime
   Autocorrect: Done

--- a/test/cli/autocorrect-kwargs/test.out
+++ b/test/cli/autocorrect-kwargs/test.out
@@ -16,7 +16,7 @@ autocorrect-kwargs.rb:13: Keyword arguments given to `Array` https://srb.help/70
 
 autocorrect-kwargs.rb:13: Wrong number of type parameters for `Array`. Expected: `1`, got: `0` https://srb.help/7010
     13 |sig {returns(T::Array[foo: Integer])}
-                     ^^^^^^^^^^^^^^^^^^^^^^
+                              ^^^^^^^^^^^^
 
 autocorrect-kwargs.rb:21: `params` expects keyword arguments https://srb.help/5003
     21 |sig {params({a: Integer, b: String}).void}
@@ -52,7 +52,7 @@ autocorrect-kwargs.rb:13: Keyword arguments given to `Array` https://srb.help/70
 
 autocorrect-kwargs.rb:13: Wrong number of type parameters for `Array`. Expected: `1`, got: `0` https://srb.help/7010
     13 |sig {returns(T::Array[foo: Integer])}
-                     ^^^^^^^^^^^^^^^^^^^^^^
+                              ^^^^^^^^^^^^
 
 autocorrect-kwargs.rb:13: Unexpected bare `Symbol(:foo)` value found in type position https://srb.help/7009
     13 |sig {returns(T::Array[foo: Integer])}
@@ -68,7 +68,7 @@ autocorrect-kwargs.rb:18: Keyword arguments given to `Array` https://srb.help/70
 
 autocorrect-kwargs.rb:18: Wrong number of type parameters for `Array`. Expected: `1`, got: `0` https://srb.help/7010
     18 |foo = T::Array[foo: Integer, bar: String].new
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 autocorrect-kwargs.rb:18: Unexpected bare `Symbol(:foo)` value found in type position https://srb.help/7009
     18 |foo = T::Array[foo: Integer, bar: String].new

--- a/test/cli/autocorrect-requires-ancestor-block/test.out
+++ b/test/cli/autocorrect-requires-ancestor-block/test.out
@@ -38,7 +38,7 @@ autocorrect-requires-ancestor-block.rb:12: Too many arguments provided for metho
 
 autocorrect-requires-ancestor-block.rb:12: `requires_ancestor` requires a block parameter, but no block was passed https://srb.help/7021
     12 |  requires_ancestor RA1
-          ^^^^^^^^^^^^^^^^^^^^^
+                               ^
     https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#L110: defined here
      110 |  def requires_ancestor(&block); end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -56,7 +56,7 @@ autocorrect-requires-ancestor-block.rb:13: Too many arguments provided for metho
 
 autocorrect-requires-ancestor-block.rb:13: `requires_ancestor` requires a block parameter, but no block was passed https://srb.help/7021
     13 |  requires_ancestor RA2, RA3
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                    ^
     https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#L110: defined here
      110 |  def requires_ancestor(&block); end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/test/cli/autocorrect-strict/test.out
+++ b/test/cli/autocorrect-strict/test.out
@@ -18,7 +18,7 @@ autocorrect-strict.rb:13: Use `T::Array[...]`, not `Array[...]` to declare a typ
 
 autocorrect-strict.rb:3: `T.must` called on `Integer(3)`, which is never `nil` https://srb.help/7015
      3 |x = T.must(3)
-            ^^^^^^^^^
+                   ^
   Got `Integer(3)` originating from:
     autocorrect-strict.rb:3:
      3 |x = T.must(3)

--- a/test/cli/expected-got/test.out
+++ b/test/cli/expected-got/test.out
@@ -131,9 +131,9 @@ test/cli/expected-got/expected-got.rb:63: `T.cast` is useless because `Integer(1
     63 |T.cast(1, Integer)
                ^
 
-test/cli/expected-got/expected-got.rb:68: Can not call method `foo` on void type https://srb.help/7003
+test/cli/expected-got/expected-got.rb:68: Cannot call method `foo` on void type https://srb.help/7003
     68 |returns_void.foo
-        ^^^^^^^^^^^^^^^^
+                     ^^^
 
 test/cli/expected-got/expected-got.rb:73: Expected `T::Array[Integer]` but found `[Integer(1), Integer(2), T.nilable(Integer)]` for argument `xs` https://srb.help/7002
     73 |takes_int_array(xs)

--- a/test/cli/expected-got/test.out
+++ b/test/cli/expected-got/test.out
@@ -58,7 +58,7 @@ test/cli/expected-got/expected-got.rb:53: Control flow could reach `T.absurd` be
 
 test/cli/expected-got/expected-got.rb:30: `T.must` called on `Integer(0)`, which is never `nil` https://srb.help/7015
     30 |T.must(0)
-        ^^^^^^^^^
+               ^
   Got `Integer(0)` originating from:
     test/cli/expected-got/expected-got.rb:30:
     30 |T.must(0)

--- a/test/cli/no-valid-instantiation/test.out
+++ b/test/cli/no-valid-instantiation/test.out
@@ -1,6 +1,6 @@
 test/cli/no-valid-instantiation/no-valid-instantiation.rb:40: Could not find valid instantiation of type parameters for `Object#dispatch_call_fail` https://srb.help/7020
     40 |dispatch_call_fail(f, 0) # error: Could not find valid instantiation of type parameters
-        ^^^^^^^^^^^^^^^^^^^^^^^^
+        ^^^^^^^^^^^^^^^^^^
     test/cli/no-valid-instantiation/no-valid-instantiation.rb:26: `Object#dispatch_call_fail` defined here
     26 |def dispatch_call_fail(f, x)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/test/cli/suggest-class-new-not-singleton/test.out
+++ b/test/cli/suggest-class-new-not-singleton/test.out
@@ -1,6 +1,6 @@
 suggest-class-new-not-singleton.rb:3: Call to method `new` on `T.class_of(String)` mistakes a type for a value https://srb.help/7030
      3 |T.class_of(String).new
-        ^^^^^^^^^^^^^^^^^^^^^^
+                           ^^^
   Autocorrect: Done
     suggest-class-new-not-singleton.rb:3: Replaced with `String`
      3 |T.class_of(String).new
@@ -8,7 +8,7 @@ suggest-class-new-not-singleton.rb:3: Call to method `new` on `T.class_of(String
 
 suggest-class-new-not-singleton.rb:4: Call to method `new` on `T.class_of(Integer)` mistakes a type for a value https://srb.help/7030
      4 |T.class_of(Integer).new
-        ^^^^^^^^^^^^^^^^^^^^^^^
+                            ^^^
   Autocorrect: Done
     suggest-class-new-not-singleton.rb:4: Replaced with `Integer`
      4 |T.class_of(Integer).new
@@ -16,7 +16,7 @@ suggest-class-new-not-singleton.rb:4: Call to method `new` on `T.class_of(Intege
 
 suggest-class-new-not-singleton.rb:5: Call to method `new` on `T.class_of(T::Array)` mistakes a type for a value https://srb.help/7030
      5 |T.class_of(T::Array).new
-        ^^^^^^^^^^^^^^^^^^^^^^^^
+                             ^^^
   Autocorrect: Done
     suggest-class-new-not-singleton.rb:5: Replaced with `T::Array`
      5 |T.class_of(T::Array).new
@@ -24,7 +24,7 @@ suggest-class-new-not-singleton.rb:5: Call to method `new` on `T.class_of(T::Arr
 
 suggest-class-new-not-singleton.rb:6: Call to method `new` on `T.class_of(Array)` mistakes a type for a value https://srb.help/7030
      6 |T.class_of(T::Array[String]).new
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                     ^^^
   Autocorrect: Done
     suggest-class-new-not-singleton.rb:6: Replaced with `Array`
      6 |T.class_of(T::Array[String]).new
@@ -32,7 +32,7 @@ suggest-class-new-not-singleton.rb:6: Call to method `new` on `T.class_of(Array)
 
 suggest-class-new-not-singleton.rb:8: Call to method `new` on `T.class_of(String)` mistakes a type for a value https://srb.help/7030
      8 |x.new
-        ^^^^^
+          ^^^
   Autocorrect: Done
     suggest-class-new-not-singleton.rb:8: Replaced with `String`
      8 |x.new

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -235,6 +235,14 @@ int RangeAssertion::matches(string_view otherFilename, const Range &otherRange) 
             return cmp;
         }
     }
+    if (otherRange.start->cmp(*otherRange.end) == 0) {
+        // zero-width error message. Allow single `^` to match this
+        // (VS Code will still show a red squiggle for a diagnostic that is zero-width)
+        if (range->start->cmp(*otherRange.start) == 0 && range->end->line == otherRange.end->line &&
+            range->end->character - 1 == otherRange.end->character) {
+            return 0;
+        }
+    }
     return range->cmp(otherRange);
 }
 

--- a/test/testdata/core/fuzz_bad_subtyping.rb
+++ b/test/testdata/core/fuzz_bad_subtyping.rb
@@ -6,7 +6,8 @@ module MyEnumerable
   A = type_member
   sig {params(a: MyEnumerable[])}
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Malformed `sig`: No return type specified. Specify one with .returns()
-               # ^^^^^^^^^^^^^^ error-with-dupes: Wrong number of type parameters for `MyEnumerable`.
+  #              ^^^^^^^^^^^^^^ error: Wrong number of type parameters for `MyEnumerable`.
+  #                          ^^ error: Wrong number of type parameters for `MyEnumerable`.
   #    ^^^^^^ error: Method `params` does not exist on `T.class_of(MyEnumerable)`
 # ^^^ error: Method `sig` does not exist on `T.class_of(MyEnumerable)`
   def -(a) end

--- a/test/testdata/infer/arg_matching.rb
+++ b/test/testdata/infer/arg_matching.rb
@@ -42,15 +42,15 @@ class TestArgs
     # "too many arguments" and "missing keyword argument b"
     kwarg(1, 2)
     #        ^ error: Too many positional arguments provided for method `TestArgs#kwarg`. Expected: `1`, got: `2`
-  # ^^^^^^^^^^^ error: Missing required keyword argument `b` for method `TestArgs#kwarg`
+    #     ^^^^ error: Missing required keyword argument `b` for method `TestArgs#kwarg`
     kwarg(1)
-  # ^^^^^^^^ error: Missing required keyword argument `b`
+    #     ^ error: Missing required keyword argument `b`
 
     kwarg(1, b: 2)
     kwarg(1, b: 2, c: 3)
   # ^^^^^^^^^^^^^^^^^^^^ error: Unrecognized keyword argument `c`
     kwarg(1, {})
-  # ^^^^^^^^^^^^ error: Missing required keyword argument `b`
+    #     ^^^^^ error: Missing required keyword argument `b`
     kwarg(1, b: "hi")
     #           ^^^^ error: Expected `Integer` but found `String("hi")` for argument `b`
     kwarg(1, any)
@@ -107,9 +107,9 @@ class TestArgs
     # There's ambiguity here about whether to report `u` or `x` as
     # missing; We follow Ruby in complaining about `u`.
     optkw(u: 1)
-  # ^^^^^^^^^^^ error: Missing required keyword argument `u`
+    #     ^^^^ error: Missing required keyword argument `u`
     optkw(1, 2, 3)
-  # ^^^^^^^^^^^^^^ error: Missing required keyword argument `u` for method `TestArgs#optkw`
+    #     ^^^^^^^    error: Missing required keyword argument `u` for method `TestArgs#optkw`
     #           ^ error: Too many positional arguments provided for method `TestArgs#optkw`. Expected: `1..2`, got: `3`
   end
 end

--- a/test/testdata/infer/arg_matching.rb
+++ b/test/testdata/infer/arg_matching.rb
@@ -11,7 +11,8 @@ class TestArgs
   end
 
   def call_required
-    required(1) # error: Not enough arguments
+    required(1)
+    #        ^ error: Not enough arguments
     required(1, 2)
     required(1, 2, 3)
     #              ^ error: Expected: `2`, got: `3`

--- a/test/testdata/infer/attached_class_self_new.rb
+++ b/test/testdata/infer/attached_class_self_new.rb
@@ -27,7 +27,7 @@ class PosArgs
 
     # Not matching initialize
     T.reveal_type(self.new())
-                # ^^^^^^^^^^ error: Not enough arguments provided
+    #                     ^^ error: Not enough arguments provided
   # ^^^^^^^^^^^^^^^^^^^^^^^^^ error: Revealed type: `T.attached_class (of PosArgs)`
   end
 end

--- a/test/testdata/infer/attached_class_self_new.rb
+++ b/test/testdata/infer/attached_class_self_new.rb
@@ -60,7 +60,7 @@ class BlockArg
     T.reveal_type(self.new {|x| x + 1}) # error: Revealed type: `T.attached_class (of BlockArg)`
 
     T.reveal_type(self.new)
-                # ^^^^^^^^ error: `initialize` requires a block parameter
+    #                     ^ error: `initialize` requires a block parameter
   # ^^^^^^^^^^^^^^^^^^^^^^^ error: Revealed type: `T.attached_class (of BlockArg)`
   end
 end

--- a/test/testdata/infer/attached_class_self_new.rb
+++ b/test/testdata/infer/attached_class_self_new.rb
@@ -44,7 +44,7 @@ class NamedArgs
 
     # Not matching initialize
     T.reveal_type(self.new(x: 10))
-                # ^^^^^^^^^^^^^^^ error: Missing required keyword argument `y`
+    #                      ^^^^^ error: Missing required keyword argument `y`
   # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Revealed type: `T.attached_class (of NamedArgs)`
   end
 end

--- a/test/testdata/infer/autocorrect_no_block.rb
+++ b/test/testdata/infer/autocorrect_no_block.rb
@@ -1,0 +1,19 @@
+# typed: strict
+extend T::Sig
+
+sig {params(x: Integer).void}
+def takes_no_block(x: 0)
+end
+
+takes_no_block(x: 0) do end
+#                   ^^^^^^^ error: does not take a block
+takes_no_block do end
+#             ^^^^^^^ error: does not take a block
+takes_no_block{}
+#             ^^ error: does not take a block
+
+sig {params(xs: T::Array[Integer]).void}
+def example1(xs)
+  xs[0] {}
+  #    ^^^ error: does not take a block
+end

--- a/test/testdata/infer/autocorrect_no_block.rb.autocorrects.exp
+++ b/test/testdata/infer/autocorrect_no_block.rb.autocorrects.exp
@@ -1,0 +1,21 @@
+# -- test/testdata/infer/autocorrect_no_block.rb --
+# typed: strict
+extend T::Sig
+
+sig {params(x: Integer).void}
+def takes_no_block(x: 0)
+end
+
+takes_no_block(x: 0)
+#                   ^^^^^^^ error: does not take a block
+takes_no_block
+#             ^^^^^^^ error: does not take a block
+takes_no_block
+#             ^^ error: does not take a block
+
+sig {params(xs: T::Array[Integer]).void}
+def example1(xs)
+  xs[0]
+  #    ^^^ error: does not take a block
+end
+# ------------------------------

--- a/test/testdata/infer/block_parameter.rb
+++ b/test/testdata/infer/block_parameter.rb
@@ -17,7 +17,8 @@ end
 optional_block(1)
 optional_block(1) {}
 
-required_block(1) # error: `required_block` requires a block parameter, but no block was passed
+required_block(1)
+#                ^ error: `required_block` requires a block parameter, but no block was passed
 required_block(1) {}
 
 no_params()

--- a/test/testdata/infer/constructors.rb.autocorrects.exp
+++ b/test/testdata/infer/constructors.rb.autocorrects.exp
@@ -1,3 +1,4 @@
+# -- test/testdata/infer/constructors.rb --
 # typed: true
 class Foo1
 end
@@ -15,14 +16,14 @@ end
 class Bar
   def foo
     Foo1.new
-    Foo1.new(1)
+    Foo1.new()
     #        ^ error: Wrong number of arguments for constructor
     Foo2.new(1)
     Foo3.new(1, 2)
 
-    Foo1.new(1) {}
+    Foo1.new() {}
     #        ^ error: Wrong number of arguments for constructor
-    Foo1.new 1 do end
+    Foo1.new  do end
     #        ^ error: Wrong number of arguments for constructor
   end
 end
@@ -43,3 +44,4 @@ class InstanceMethod
     T.assert_type!(a.new, T.any(A, B))
   end
 end
+# ------------------------------

--- a/test/testdata/infer/funloc_errors.rb
+++ b/test/testdata/infer/funloc_errors.rb
@@ -1,0 +1,17 @@
+# typed: strict
+extend T::Sig
+
+sig {void}
+def returns_void; end
+
+returns_void.foo {puts 'hello'}
+#            ^^^ error: Cannot call method `foo` on void type
+
+T.proc.void.new {puts 'hello'}
+#           ^^^ error: Call to method `new` on `T.class_of(T.proc)` mistakes a type for a value
+
+T.nilable(Integer).new {puts 'hello'}
+#                  ^^^ error: Call to method `new` on `T.nilable(Integer)` mistakes a type for a value
+
+T::Array[Integer].map {|x| puts x}
+#                 ^^^ error: Call to method `map` on `T::Array[Integer]` mistakes a type for a value

--- a/test/testdata/infer/generics/arity_mismatch.rb
+++ b/test/testdata/infer/generics/arity_mismatch.rb
@@ -7,9 +7,11 @@ class Generic
 end
 
 def use_it
-  g1 = Generic[Integer].new # error: Wrong number of type parameters
+  g1 = Generic[Integer].new
+  #            ^^^^^^^ error: Wrong number of type parameters
   T.assert_type!(g1, Generic[Integer, T.untyped])
 
-  g2 = Generic[Integer, String, Object].new # error: Wrong number of type parameters
+  g2 = Generic[Integer, String, Object].new
+  #            ^^^^^^^^^^^^^^^^^^^^^^^ error: Wrong number of type parameters
   T.assert_type!(g2, Generic[Integer, String])
 end

--- a/test/testdata/infer/must_untyped.rb
+++ b/test/testdata/infer/must_untyped.rb
@@ -1,3 +1,4 @@
 # typed: strict
 
-T.must(T.unsafe(nil)) # error: `T.must` called on `T.untyped`, which is redundant
+T.must(T.unsafe(nil))
+#      ^^^^^^^^^^^^^ error: `T.must` called on `T.untyped`, which is redundant

--- a/test/testdata/lsp/completion/empty_parens.rb
+++ b/test/testdata/lsp/completion/empty_parens.rb
@@ -16,22 +16,26 @@ end
 
 sig {params(m: M, a: Integer, b: Integer).void}
 def AAA_example1(m, a, b)
-  AAA_example1() # error: Not enough arguments
+  AAA_example1()
+  #           ^^ error: Not enough arguments
   #            ^ completion: a, b, m, AAA_example1, ...
 
   # No locals here because !isPrivateOk 🙃
-  m.aaa_only_on_m() # error: Not enough arguments
+  m.aaa_only_on_m()
+  #              ^^ error: Not enough arguments
   #               ^ completion: aaa_only_on_m, ...
 
   # In addition to the above wonkiness, this case is even wonkier, because of
   # how we attempt to not show nonsensical completion request inside a method's
   # block.
 
-  AAA_example1() {} # error: Not enough arguments
+  AAA_example1() {}
+  #           ^ error: Not enough arguments
   #            ^ completion: (nothing)
   #               ^ completion: (nothing)
 
-  m.aaa_only_on_m() {} # error: Not enough arguments
+  m.aaa_only_on_m() {}
+  #              ^ error: Not enough arguments
   #               ^ completion: (nothing)
   #                  ^ completion: (nothing)
 end

--- a/test/testdata/lsp/completion/sig_non_self.A.rbedited
+++ b/test/testdata/lsp/completion/sig_non_self.A.rbedited
@@ -12,7 +12,8 @@ class A
   #                         ^ apply-completion: [A] item: 0
   def without_runtime; ''; end
 
-  Sorbet::Private::Static.sig # error: Not enough arguments
+  Sorbet::Private::Static.sig
+  #                          ^ error: Not enough arguments
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: no block
   #                          ^ apply-completion: [B] item: 0
   def private_static; :''; end
@@ -28,7 +29,8 @@ class Outer
     T::Sig::WithoutRuntime.sig # error: no block
     #                         ^ apply-completion: [C] item: 0
 
-    Sorbet::Private::Static.sig # error: Not enough arguments
+    Sorbet::Private::Static.sig
+    #                          ^ error: Not enough arguments
   # ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: no block
     #                          ^ apply-completion: [D] item: 0
   end

--- a/test/testdata/lsp/completion/sig_non_self.A.rbedited
+++ b/test/testdata/lsp/completion/sig_non_self.A.rbedited
@@ -14,7 +14,7 @@ class A
 
   Sorbet::Private::Static.sig
   #                          ^ error: Not enough arguments
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: no block
+  #                          ^ error: no block
   #                          ^ apply-completion: [B] item: 0
   def private_static; :''; end
 end
@@ -31,7 +31,7 @@ class Outer
 
     Sorbet::Private::Static.sig
     #                          ^ error: Not enough arguments
-  # ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: no block
+    #                          ^ error: no block
     #                          ^ apply-completion: [D] item: 0
   end
 

--- a/test/testdata/lsp/completion/sig_non_self.B.rbedited
+++ b/test/testdata/lsp/completion/sig_non_self.B.rbedited
@@ -14,7 +14,7 @@ class A
     ${2}
   end${0}
   #                          ^ error: Not enough arguments
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: no block
+  #                          ^ error: no block
   #                          ^ apply-completion: [B] item: 0
   def private_static; :''; end
 end
@@ -31,7 +31,7 @@ class Outer
 
     Sorbet::Private::Static.sig
     #                          ^ error: Not enough arguments
-  # ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: no block
+    #                          ^ error: no block
     #                          ^ apply-completion: [D] item: 0
   end
 

--- a/test/testdata/lsp/completion/sig_non_self.B.rbedited
+++ b/test/testdata/lsp/completion/sig_non_self.B.rbedited
@@ -12,7 +12,8 @@ class A
 
   Sorbet::Private::Static.sig(${1:T.untyped}) do
     ${2}
-  end${0} # error: Not enough arguments
+  end${0}
+  #                          ^ error: Not enough arguments
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: no block
   #                          ^ apply-completion: [B] item: 0
   def private_static; :''; end
@@ -28,7 +29,8 @@ class Outer
     T::Sig::WithoutRuntime.sig # error: no block
     #                         ^ apply-completion: [C] item: 0
 
-    Sorbet::Private::Static.sig # error: Not enough arguments
+    Sorbet::Private::Static.sig
+    #                          ^ error: Not enough arguments
   # ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: no block
     #                          ^ apply-completion: [D] item: 0
   end

--- a/test/testdata/lsp/completion/sig_non_self.C.rbedited
+++ b/test/testdata/lsp/completion/sig_non_self.C.rbedited
@@ -12,7 +12,7 @@ class A
 
   Sorbet::Private::Static.sig
   #                          ^ error: Not enough arguments
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: no block
+  #                          ^ error: no block
   #                          ^ apply-completion: [B] item: 0
   def private_static; :''; end
 end
@@ -31,7 +31,7 @@ class Outer
 
     Sorbet::Private::Static.sig
     #                          ^ error: Not enough arguments
-  # ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: no block
+    #                          ^ error: no block
     #                          ^ apply-completion: [D] item: 0
   end
 

--- a/test/testdata/lsp/completion/sig_non_self.C.rbedited
+++ b/test/testdata/lsp/completion/sig_non_self.C.rbedited
@@ -10,7 +10,8 @@ class A
   #                         ^ apply-completion: [A] item: 0
   def without_runtime; ''; end
 
-  Sorbet::Private::Static.sig # error: Not enough arguments
+  Sorbet::Private::Static.sig
+  #                          ^ error: Not enough arguments
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: no block
   #                          ^ apply-completion: [B] item: 0
   def private_static; :''; end
@@ -28,7 +29,8 @@ class Outer
     end${0} # error: no block
     #                         ^ apply-completion: [C] item: 0
 
-    Sorbet::Private::Static.sig # error: Not enough arguments
+    Sorbet::Private::Static.sig
+    #                          ^ error: Not enough arguments
   # ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: no block
     #                          ^ apply-completion: [D] item: 0
   end

--- a/test/testdata/lsp/completion/sig_non_self.D.rbedited
+++ b/test/testdata/lsp/completion/sig_non_self.D.rbedited
@@ -10,7 +10,8 @@ class A
   #                         ^ apply-completion: [A] item: 0
   def without_runtime; ''; end
 
-  Sorbet::Private::Static.sig # error: Not enough arguments
+  Sorbet::Private::Static.sig
+  #                          ^ error: Not enough arguments
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: no block
   #                          ^ apply-completion: [B] item: 0
   def private_static; :''; end
@@ -28,7 +29,8 @@ class Outer
 
     Sorbet::Private::Static.sig(${1:T.untyped}) do
       ${2}
-    end${0} # error: Not enough arguments
+    end${0}
+    #                          ^ error: Not enough arguments
   # ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: no block
     #                          ^ apply-completion: [D] item: 0
   end

--- a/test/testdata/lsp/completion/sig_non_self.D.rbedited
+++ b/test/testdata/lsp/completion/sig_non_self.D.rbedited
@@ -12,7 +12,7 @@ class A
 
   Sorbet::Private::Static.sig
   #                          ^ error: Not enough arguments
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: no block
+  #                          ^ error: no block
   #                          ^ apply-completion: [B] item: 0
   def private_static; :''; end
 end
@@ -31,7 +31,7 @@ class Outer
       ${2}
     end${0}
     #                          ^ error: Not enough arguments
-  # ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: no block
+    #                          ^ error: no block
     #                          ^ apply-completion: [D] item: 0
   end
 

--- a/test/testdata/lsp/completion/sig_non_self.rb
+++ b/test/testdata/lsp/completion/sig_non_self.rb
@@ -10,7 +10,8 @@ class A
   #                         ^ apply-completion: [A] item: 0
   def without_runtime; ''; end
 
-  Sorbet::Private::Static.sig # error: Not enough arguments
+  Sorbet::Private::Static.sig
+  #                          ^ error: Not enough arguments
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: no block
   #                          ^ apply-completion: [B] item: 0
   def private_static; :''; end
@@ -26,7 +27,8 @@ class Outer
     T::Sig::WithoutRuntime.sig # error: no block
     #                         ^ apply-completion: [C] item: 0
 
-    Sorbet::Private::Static.sig # error: Not enough arguments
+    Sorbet::Private::Static.sig
+    #                          ^ error: Not enough arguments
   # ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: no block
     #                          ^ apply-completion: [D] item: 0
   end

--- a/test/testdata/lsp/completion/sig_non_self.rb
+++ b/test/testdata/lsp/completion/sig_non_self.rb
@@ -12,7 +12,7 @@ class A
 
   Sorbet::Private::Static.sig
   #                          ^ error: Not enough arguments
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: no block
+  #                          ^ error: no block
   #                          ^ apply-completion: [B] item: 0
   def private_static; :''; end
 end
@@ -29,7 +29,7 @@ class Outer
 
     Sorbet::Private::Static.sig
     #                          ^ error: Not enough arguments
-  # ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: no block
+    #                          ^ error: no block
     #                          ^ apply-completion: [D] item: 0
   end
 

--- a/test/testdata/namer/alias_method.rb
+++ b/test/testdata/namer/alias_method.rb
@@ -7,7 +7,8 @@ module Alias
   alias_method :f_alias_1, :f
 
   alias_method # error: Not enough arguments provided for method `Module#alias_method`. Expected: `2`, got: `0`
-  alias_method :f # error: Not enough arguments provided for method `Module#alias_method`. Expected: `2`, got: `1`
+  alias_method :f
+  #            ^^ error: Not enough arguments provided for method `Module#alias_method`. Expected: `2`, got: `1`
   alias_method :f, 8 # error: Expected `Symbol` but found `Integer(8)` for argument `old_name`
   alias_method :bad_alias, :nonexistant_method
   #                        ^^^^^^^^^^^^^^^^^^^ error: Can't make method alias from `bad_alias` to non existing method `nonexistant_method`

--- a/test/testdata/namer/alias_method.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/alias_method.rb.symbol-table-raw.exp
@@ -1,17 +1,17 @@
 class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
-    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/alias_method.rb start=2:1 end=20:4}
+    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/alias_method.rb start=2:1 end=21:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/alias_method.rb start=??? end=???}
   module <C <U Alias>> < <C <U Sorbet>>::<C <U Private>>::<C <U Static>>::<C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/namer/alias_method.rb start=2:1 end=2:13}
-    method <C <U Alias>>#<U alias_user> (<blk>) @ Loc {file=test/testdata/namer/alias_method.rb start=15:3 end=15:17}
+    method <C <U Alias>>#<U alias_user> (<blk>) @ Loc {file=test/testdata/namer/alias_method.rb start=16:3 end=16:17}
       argument <blk><block> @ Loc {file=test/testdata/namer/alias_method.rb start=??? end=???}
-    method <C <U Alias>>#<U bad_alias> () -> AliasType { symbol = <C <U Sorbet>>::<C <U Private>>::<C <U Static>>#<U <bad-method-alias-stub>> } @ Loc {file=test/testdata/namer/alias_method.rb start=12:3 end=12:47}
+    method <C <U Alias>>#<U bad_alias> () -> AliasType { symbol = <C <U Sorbet>>::<C <U Private>>::<C <U Static>>#<U <bad-method-alias-stub>> } @ Loc {file=test/testdata/namer/alias_method.rb start=13:3 end=13:47}
     method <C <U Alias>>#<U f> (<blk>) @ Loc {file=test/testdata/namer/alias_method.rb start=3:3 end=3:8}
       argument <blk><block> @ Loc {file=test/testdata/namer/alias_method.rb start=??? end=???}
     method <C <U Alias>>#<U f_alias> () -> AliasType { symbol = <C <U Alias>>#<U f> } @ Loc {file=test/testdata/namer/alias_method.rb start=6:3 end=6:18}
     method <C <U Alias>>#<U f_alias_1> () -> AliasType { symbol = <C <U Alias>>#<U f> } @ Loc {file=test/testdata/namer/alias_method.rb start=7:3 end=7:30}
   class <S <C <U Alias>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> () @ Loc {file=test/testdata/namer/alias_method.rb start=2:8 end=2:13}
     type-member(+) <S <C <U Alias>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U Alias>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=Alias) @ Loc {file=test/testdata/namer/alias_method.rb start=2:8 end=2:13}
-    method <S <C <U Alias>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/alias_method.rb start=2:1 end=20:4}
+    method <S <C <U Alias>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/alias_method.rb start=2:1 end=21:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/alias_method.rb start=??? end=???}
 

--- a/test/testdata/namer/simple.rb
+++ b/test/testdata/namer/simple.rb
@@ -29,7 +29,7 @@ class Child < Parent
   #       ^ error: `include` must only contain constant literals
   #       ^ error: Expected `Module` but found `Integer(3)` for argument `arg0`
   include Mixin do; end
-# ^^^^^^^^^^^^^^^^^^^^^ error: Method `Module#include` does not take a block
+  #            ^^^^^^^^ error: Method `Module#include` does not take a block
 # ^^^^^^^^^^^^^^^^^^^^^ error: `include` can not be passed a block
   whatever.include OtherMixin # error: Method `whatever` does not exist on `T.class_of(Child)`
 end

--- a/test/testdata/packager/invalid_imports_and_exports/__package.rb
+++ b/test/testdata/packager/invalid_imports_and_exports/__package.rb
@@ -12,7 +12,7 @@ class A < PackageSpec
   import method
        # ^^^^^^ error: Argument to `import` must be a constant
        # ^^^^^^ error: Expected `T.class_of(PackageSpec)`
-       # ^^^^^^ error: Not enough arguments
+       #       ^ error: Not enough arguments
   import REFERENCE # error: Cannot find package `REFERENCE`
        # ^^^^^^^^^ error: Unable to resolve constant `REFERENCE`
   # Despite the above, this import should work.
@@ -23,7 +23,7 @@ class A < PackageSpec
   export 123 # error: Argument to `export` must be a constant
   export "hello" # error: Argument to `export` must be a constant
   export method # error: Argument to `export` must be a constant
-       # ^^^^^^ error: Not enough arguments
+       #       ^ error: Not enough arguments
   export A::REFERENCE # Works; it's a constant.
   export A::AClass
   export A::AModule

--- a/test/testdata/rbi/bundler.rb
+++ b/test/testdata/rbi/bundler.rb
@@ -6,11 +6,11 @@ Bundler.with_clean_env { true }
 Bundler.with_original_env { true }
 Bundler.with_unbundled_env { true }
 
-  Bundler.with_clean_env
-# ^^^^^^^^^^^^^^^^^^^^^^ error: `with_clean_env` requires a block parameter, but no block was passed
+Bundler.with_clean_env
+#                     ^ error: `with_clean_env` requires a block parameter, but no block was passed
 
-  Bundler.with_original_env
-# ^^^^^^^^^^^^^^^^^^^^^^^^^ error: `with_original_env` requires a block parameter, but no block was passed
+Bundler.with_original_env
+#                        ^ error: `with_original_env` requires a block parameter, but no block was passed
 
-  Bundler.with_unbundled_env
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `with_unbundled_env` requires a block parameter, but no block was passed
+Bundler.with_unbundled_env
+#                         ^ error: `with_unbundled_env` requires a block parameter, but no block was passed

--- a/test/testdata/rbi/t.rb
+++ b/test/testdata/rbi/t.rb
@@ -12,8 +12,10 @@ T.enum([:a, :b]) # error: Method `enum` does not exist on `T.class_of(T)`
 T.deprecated_enum([:a, :b])
 
 T.untyped
-T.any(String) # error: Not enough arguments provided for method `T.any`.
-T.all(String) # error: Not enough arguments provided for method `T.all`.
+T.any(String)
+#     ^^^^^^ error: Not enough arguments provided for method `T.any`.
+T.all(String)
+#     ^^^^^^ error: Not enough arguments provided for method `T.all`.
 T.any(String, Integer, Symbol)
 T.all(String, Integer, Symbol)
 

--- a/test/testdata/resolver/missing_type_combinator_args.rb
+++ b/test/testdata/resolver/missing_type_combinator_args.rb
@@ -5,8 +5,10 @@ T.cast(nil, T.nilable(Integer, Integer))
 T.cast(nil, T.any) # error: Not enough arguments provided for method
 T.cast(nil, T.all) # error: Not enough arguments provided for method
 T.must # error: Not enough arguments provided for method
-T.let(1) # error: Not enough arguments provided for method
+T.let(1)
+#     ^ error: Not enough arguments provided for method
 T.let(1, 2, 3) # error: Unsupported literal in type syntax
-T.reveal_type() # error: Not enough arguments provided for method
+T.reveal_type()
+#            ^^ error: Not enough arguments provided for method
 T.reveal_type(1, 2)
 #                ^ error: Too many arguments provided for method

--- a/test/testdata/resolver/redefinition_of_subclass_type_member.rb
+++ b/test/testdata/resolver/redefinition_of_subclass_type_member.rb
@@ -27,5 +27,5 @@ end
 class Bar < Foo # error: Type `V` declared by parent `Foo` must be re-declared in `Bar`
   K = Bar[String,String].new.foo('a', 2)
 # ^ error: Type variable `K` needs to be declared as `= type_member(SOMETHING)`
-    # ^^^^^^^^^^^^^^^^^^ error: Wrong number of type parameters
+  #       ^^^^^^^^^^^^^ error: Wrong number of type parameters
 end

--- a/test/testdata/resolver/requires_ancestor_calls_types.rb
+++ b/test/testdata/resolver/requires_ancestor_calls_types.rb
@@ -226,9 +226,9 @@ module Test10
 
     def m2
       T.attached_class.foo
-    # ^^^^^^^^^^^^^^^^^^^^ error: Call to method `foo` on `T.untyped` mistakes a type for a value
+      #                ^^^ error: Call to method `foo` on `T.untyped` mistakes a type for a value
       T.class_of(M2).foo
-    # ^^^^^^^^^^^^^^^^^^ error: Call to method `foo` on `T.class_of(Test10::M2)`
+      #              ^^^ error: Call to method `foo` on `T.class_of(Test10::M2)`
     end
   end
 end

--- a/test/testdata/resolver/requires_ancestor_errors.rb
+++ b/test/testdata/resolver/requires_ancestor_errors.rb
@@ -8,7 +8,8 @@ end
 module Helper2
   extend T::Helpers
 
-  requires_ancestor # error: `requires_ancestor` requires a block parameter, but no block was passed
+  requires_ancestor
+  #                ^ error: `requires_ancestor` requires a block parameter, but no block was passed
 end
 
 module Helper3
@@ -77,7 +78,7 @@ module Helper10
   extend T::Helpers
 
   requires_ancestor
-# ^^^^^^^^^^^^^^^^^ error: `requires_ancestor` requires a block parameter, but no block was passed
+  #                ^ error: `requires_ancestor` requires a block parameter, but no block was passed
 end
 
 module Helper11
@@ -86,7 +87,7 @@ module Helper11
   requires_ancestor (Kernel)
   #                  ^^^^^^ error: Too many arguments provided for method `T::Helpers#requires_ancestor`. Expected: `0`, got: `1`
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `requires_ancestor` only accepts a block
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `requires_ancestor` requires a block parameter, but no block was passed
+  #                         ^ error: `requires_ancestor` requires a block parameter, but no block was passed
 end
 
 module Helper12

--- a/test/testdata/resolver/sig_void.rb
+++ b/test/testdata/resolver/sig_void.rb
@@ -29,5 +29,5 @@ class Main
 end
 
 Main.new.foo
-Main.voider.bad # error: Can not call method `bad` on void type
-Main.voider.equal?(3) # error: Can not call method `equal?` on void type
+Main.voider.bad # error: Cannot call method `bad` on void type
+Main.voider.equal?(3) # error: Cannot call method `equal?` on void type

--- a/test/testdata/rewriter/def_delegator.rb
+++ b/test/testdata/rewriter/def_delegator.rb
@@ -69,7 +69,8 @@ class IgnoredUsages
   local = 0
   not_def_delegator :thing, :foo # error: Method `not_def_delegator` does not exist
   def_delegator # error: Not enough arguments provided for method `Forwardable#def_delegator`
-  def_delegator :thing # error: Not enough arguments provided for method `Forwardable#def_delegator`
+  def_delegator :thing
+  #             ^^^^^^ error: Not enough arguments provided for method `Forwardable#def_delegator`
   def_delegator :thing, :foo, :bar, :baz
   #                                 ^^^^ error: Too many arguments provided for method `Forwardable#def_delegator`
   def_delegator :thing, :foo, :bar, kwarg: :thing
@@ -82,8 +83,9 @@ class IgnoredUsages
   #                   ^^^^^^^^^^^^^^^ error: Expected `Symbol` but found `{Integer(0) => Symbol(:thing)}` for argument `method`
   def_delegator 234, :foo
   #             ^^^ error: Expected `T.any(Symbol, String)` but found `Integer(234)` for argument `accessor`
-  def_delegator :thing => :foo # error: Not enough arguments provided for method `Forwardable#def_delegator
-              # ^^^^^^^^^^^^^^ error: Expected `T.any(Symbol, String)` but found `{thing: Symbol(:foo)}` for argument `accessor`
+  def_delegator :thing => :foo
+  #             ^^^^^^^^^^^^^^ error: Not enough arguments provided for method `Forwardable#def_delegator
+  #             ^^^^^^^^^^^^^^ error: Expected `T.any(Symbol, String)` but found `{thing: Symbol(:foo)}` for argument `accessor`
 
 
   def_delegators # error: Not enough arguments provided for method `Forwardable#def_delegators`

--- a/test/testdata/rewriter/t_struct/normal.rb
+++ b/test/testdata/rewriter/t_struct/normal.rb
@@ -4,7 +4,8 @@ class Normal < T::Struct
   prop :foo, Integer
 end
 
-Normal.new # error: Missing required keyword argument `foo` for method `Normal#initialize`
+Normal.new
+#         ^ error: Missing required keyword argument `foo` for method `Normal#initialize`
 Normal.new(foo: "no")
 #               ^^^^ error: Expected `Integer` but found `String("no")` for argument `foo`
   Normal.new(foo: 3, bar: 4)

--- a/test/testdata/rewriter/t_struct/override.rb
+++ b/test/testdata/rewriter/t_struct/override.rb
@@ -14,7 +14,8 @@ class Override < T::Struct
   end
 end
 
-Override.new # error: Missing required keyword argument `foo` for method `Override#initialize`
+Override.new
+#           ^ error: Missing required keyword argument `foo` for method `Override#initialize`
 Override.new(foo: "no")
 #                 ^^^^ error: Expected `Integer` but found `String("no")` for argument `foo`
   Override.new(foo: 3, bar: 4)

--- a/test/testdata/rewriter/t_struct/root.rb
+++ b/test/testdata/rewriter/t_struct/root.rb
@@ -4,7 +4,8 @@ class Root < ::T::Struct
   prop :foo, Integer
 end
 
-Root.new # error: Missing required keyword argument `foo` for method `Root#initialize`
+Root.new
+#       ^ error: Missing required keyword argument `foo` for method `Root#initialize`
 Root.new(foo: "no")
 #             ^^^^ error: Expected `Integer` but found `String("no")` for argument `foo`
   Root.new(foo: 3, bar: 4)

--- a/test/testdata/rewriter/t_struct/some_default.rb
+++ b/test/testdata/rewriter/t_struct/some_default.rb
@@ -8,4 +8,5 @@ end
 SomeDefault.new(foo: 1)
 SomeDefault.new(foo: 2, bar: true)
 SomeDefault.new(foo: 3, bar: false)
-SomeDefault.new # error: Missing required keyword argument `foo` for method `SomeDefault#initialize`
+SomeDefault.new
+#              ^ error: Missing required keyword argument `foo` for method `SomeDefault#initialize`

--- a/test/testdata/union_method_arity_error.rb
+++ b/test/testdata/union_method_arity_error.rb
@@ -9,5 +9,4 @@ class B
 end
 
 a = T.let(A.new, T.any(A, B))
-  a.foo
-# ^^^^^ error: Not enough arguments provided for method `B#foo` on `B` component of `T.any(A, B)`. Expected: `1`, got: `0`
+  a.foo # error: Not enough arguments provided for method `B#foo` on `B` component of `T.any(A, B)`. Expected: `1`, got: `0`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The `args.callLocs()` contains the block argument, if one exists. Any time we
use this in an error message, it'll chunder across the whole screen, turning
large swaths of it red, obscuring other errors.

Even if there isn't a block, usually there's something more specific that we can
give.

This change searches for a bunch of places where `callLocs` is used and stops
using it.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Each commit is arguably an independent change, but given that they're so closely
related in spirit I've made only one PR.

You can review by commit to see the changes to tests next to the relevant change
to calls.cc