### PR TITLE
Drop procs.rbi file back to true

### DIFF
--- a/rbi/tools/generate_procs.cc
+++ b/rbi/tools/generate_procs.cc
@@ -45,7 +45,7 @@ void emitProc(ofstream &out, int arity) {
 
 int main(int argc, char **argv) {
     ofstream rb(argv[1], ios::trunc);
-    rb << "# typed: strict" << '\n';
+    rb << "# typed: true" << '\n';
     for (int arity = 0; arity <= MAX_PROC_ARITY; ++arity) {
         emitProc(rb, arity);
     }

--- a/test/cli/file-table-json/test.out
+++ b/test/cli/file-table-json/test.out
@@ -25,8 +25,8 @@
  "files": [
   {
    "path": "https://github.com/sorbet/sorbet/tree/master/bazel-out/host/bin/rbi/procs.rbi",
-   "sigil": "Strict",
-   "strict": "Strict",
+   "sigil": "True",
+   "strict": "True",
    "min_error_level": "Max"
   },
   {

--- a/test/testdata/rbi/proc.rb
+++ b/test/testdata/rbi/proc.rb
@@ -1,6 +1,22 @@
-# typed: true
+# typed: strict
+extend T::Sig
 
 -> (x) { x }[123]
 
 my_proc = Proc.new {}
 T.reveal_type(my_proc) # error: type: `Proc`
+
+sig {params(f: T.proc.params(x: Integer).void).void}
+def example(f)
+  f.call(0) do
+    puts 'hello'
+  end
+end
+
+f = ->(x, &blk) do
+  puts x
+  blk.call
+end
+
+example(f)
+#       ^ error: Expected `T.proc.params(arg0: Integer).void` but found `T.proc.params(arg0: T.untyped, arg1: T.untyped).returns(T.untyped)` for argument `f`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The changes in #5525 raced with a change in Stripe's codebase that caused it to
introduce problems. Blocks can take block arguments, and we don't do a great job
of modeling that right now. It used to be fine because we would just ignore the
error when passing blocks to a `.call` function on a proc type, because the
procs.rbi file was not `# typed: strict`

Eventually we might want to make it possible to declare proc types that take
blocks (and for that matter: keyword args) but I'm punting on that for today.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.