### PR TITLE
Entirely skip sorbet.run in publish on branch builds

### DIFF
--- a/.buildkite/publish.sh
+++ b/.buildkite/publish.sh
@@ -35,29 +35,29 @@ rm -rf release
 rm -rf _out_
 buildkite-agent artifact download "_out_/**/*" .
 
-echo "--- releasing sorbet.run"
+if [ "$dryrun" = "" ]; then
+  echo "--- releasing sorbet.run"
 
-rm -rf sorbet.run
-git clone git@github.com:sorbet/sorbet.run.git --single-branch --branch master
-tar -xvf ./_out_/webasm/sorbet-wasm.tar ./sorbet-wasm.wasm ./sorbet-wasm.js
-mv sorbet-wasm.wasm sorbet.run/docs
-mv sorbet-wasm.js sorbet.run/docs
-pushd sorbet.run/docs
-git add sorbet-wasm.wasm sorbet-wasm.js
-dirty=
-git diff-index --quiet HEAD -- || dirty=1
-if [ "$dirty" != "" ]; then
-  echo "$BUILDKITE_COMMIT" > sha.html
-  git add sha.html
-  git commit -m "Updated site - $(date -u +%Y-%m-%dT%H:%M:%S%z)"
-  if [ "$dryrun" = "" ]; then
-      git push
+  rm -rf sorbet.run
+  git clone git@github.com:sorbet/sorbet.run.git --single-branch --branch master
+  tar -xvf ./_out_/webasm/sorbet-wasm.tar ./sorbet-wasm.wasm ./sorbet-wasm.js
+  mv sorbet-wasm.wasm sorbet.run/docs
+  mv sorbet-wasm.js sorbet.run/docs
+  pushd sorbet.run/docs
+  git add sorbet-wasm.wasm sorbet-wasm.js
+  dirty=
+  git diff-index --quiet HEAD -- || dirty=1
+  if [ "$dirty" != "" ]; then
+    echo "$BUILDKITE_COMMIT" > sha.html
+    git add sha.html
+    git commit -m "Updated site - $(date -u +%Y-%m-%dT%H:%M:%S%z)"
+    git push
+  else
+    echo "Nothing to update"
   fi
-else
-  echo "Nothing to update"
+  popd
+  rm -rf sorbet.run
 fi
-popd
-rm -rf sorbet.run
 
 echo "--- releasing sorbet.org"
 git fetch origin gh-pages


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This takes forever, because it has to clone sorbet.run, which has a ton
of binaries in it. Some numbers from a recent build:

- (98s) publish.sh job
  - (18s) cloning sorbet/sorbet itself, before running publish script
  - (53s) sorbet.run step of publish
  - (13s) vscode publish job

So half the time is just spent on sorbet.run nonsense.

On top of that, I can't remember it ever catching a legitimate bug. If
we ever need to make changes here, we can always tweak this code on a
branch build so that more of the steps run.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

CI