### PR TITLE
always pass `const DispatchArgs &` to `dispatchCall`-related functions

### DIFF
--- a/core/TypePtr.cc
+++ b/core/TypePtr.cc
@@ -347,7 +347,7 @@ bool TypePtr::derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const {
 #undef DERIVES_FROM
 }
 
-DispatchResult TypePtr::dispatchCall(const GlobalState &gs, DispatchArgs args) const {
+DispatchResult TypePtr::dispatchCall(const GlobalState &gs, const DispatchArgs &args) const {
 #define DISPATCH_CALL(T) return CALL_MEMBER_dispatchCall<const T>::call(cast_type_nonnull<T>(*this), gs, args);
     GENERATE_TAG_SWITCH(tag(), DISPATCH_CALL)
 #undef DISPATCH_CALL

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -330,7 +330,7 @@ public:
 
     uint32_t hash(const GlobalState &gs) const;
 
-    DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) const;
+    DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
 
     template <class T, class... Args> friend TypePtr make_type(Args &&...args);
     template <class To> friend To const *cast_type(const TypePtr &what);

--- a/core/Types.h
+++ b/core/Types.h
@@ -501,7 +501,7 @@ public:
     LiteralType(ClassOrModuleRef klass, NameRef val);
     TypePtr underlying(const GlobalState &gs) const;
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const;
-    DispatchResult dispatchCall(const GlobalState &gs, DispatchArgs args) const;
+    DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
     int64_t asInteger() const;
     double asFloat() const;
     core::NameRef asName(const core::GlobalState &gs) const;
@@ -880,6 +880,9 @@ struct DispatchArgs {
     // are cases where we call dispatchCall with no intention of showing the errors to the user. Producing those
     // unreported errors is expensive!
     bool suppressErrors;
+
+    DispatchArgs(const DispatchArgs &) = delete;
+    DispatchArgs &operator=(const DispatchArgs &) = delete;
 
     Loc callLoc() const {
         return core::Loc(locs.file, locs.call);

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -21,7 +21,7 @@ using namespace std;
 namespace sorbet::core {
 
 namespace {
-DispatchResult dispatchCallProxyType(const GlobalState &gs, TypePtr und, DispatchArgs args) {
+DispatchResult dispatchCallProxyType(const GlobalState &gs, TypePtr und, const DispatchArgs &args) {
     categoryCounterInc("dispatch_call", "proxytype");
     return und.dispatchCall(gs, args.withThisRef(und));
 }
@@ -49,7 +49,7 @@ bool TupleType::derivesFrom(const GlobalState &gs, core::ClassOrModuleRef klass)
     return underlying(gs).derivesFrom(gs, klass);
 }
 
-DispatchResult LiteralType::dispatchCall(const GlobalState &gs, DispatchArgs args) const {
+DispatchResult LiteralType::dispatchCall(const GlobalState &gs, const DispatchArgs &args) const {
     return dispatchCallProxyType(gs, underlying(gs), args);
 }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Consistency and epsilon performance improvements (we were copying `DispatchArgs` on every. single. `dispatchCall`.).

We already did something like this in #3640, but it didn't stick.  Let's try a little harder this time, with deleting the copy constructor for `DispatchArgs`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
