### PR TITLE
give a type to `Enumerator::Lazy#lazy`

### DIFF
--- a/rbi/core/enumerator.rbi
+++ b/rbi/core/enumerator.rbi
@@ -726,6 +726,7 @@ class Enumerator::Lazy < Enumerator
   def grep_v(_); end
 
   # Returns self.
+  sig {returns(T.self_type)}
   def lazy; end
 
   # Like

--- a/test/cli/constant-fuzzy/test.out
+++ b/test/cli/constant-fuzzy/test.out
@@ -13,8 +13,8 @@ test/cli/constant-fuzzy/constant-fuzzy.rb:3: Unable to resolve constant `Yieldr`
     test/cli/constant-fuzzy/constant-fuzzy.rb:3: Replace with `Dir`
      3 |Yieldr.foo(Intege, Int)
         ^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/enumerator.rbi#L886: Did you mean: `Enumerator::Yielder`?
-     886 |class Enumerator::Yielder < Object
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/enumerator.rbi#L887: Did you mean: `Enumerator::Yielder`?
+     887 |class Enumerator::Yielder < Object
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/file.rbi#L33: Did you mean: `File`?
     33 |class File < IO

--- a/test/testdata/rbi/lazy_enumerator.rb
+++ b/test/testdata/rbi/lazy_enumerator.rb
@@ -20,6 +20,7 @@ T.assert_type!([1].lazy.flat_map{|i| [i + 1]}, T::Enumerator::Lazy[Integer])
 
 T.assert_type!([1].lazy.grep(1..10), T::Enumerator::Lazy[Integer])
 T.assert_type!([1].lazy.grep(1..10, &:to_s), T::Enumerator::Lazy[String])
+T.assert_type!([1].lazy.lazy, T::Enumerator::Lazy[Integer])
 T.assert_type!([1].lazy.map(&:to_s), T::Enumerator::Lazy[String])
 T.assert_type!([1].lazy.map, T::Enumerator::Lazy[Integer])
 T.assert_type!([1].lazy.reject(&:even?), T::Enumerator::Lazy[Integer])


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Less untyped.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

This change is needed to make a Sorbet bump on Stripe's codebase pass.