### PR TITLE
disable watchman in the LSP test runner

### DIFF
--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -424,6 +424,8 @@ TEST_CASE("LSPTest") {
             }
             opts->secondaryTestPackageNamespaces.emplace_back("Critic");
         }
+        opts->disableWatchman = true;
+
         // Set to a number that is reasonable large for tests, but small enough that we can have a test to handle this
         // edge case. If you change this number, update the `lsp/fast_path/too_many_files` and `not_enough_files` tests.
         opts->lspMaxFilesOnFastPath = 10;


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We're going to add a multi-threaded LSP case in #5545, which means that the multi-threaded LSP client is going to try to enable watchman.  This is going to fail (but maybe not if you have watchman on your machine?), and will lead to spurious notifications being sent back, which will trip `ENFORCE`s that check we don't receive messages during initialization.

We should just disable watchman regardless; these tests don't depend on watchman in any way and there are separate tests that *do* test watchman support.

cc @aprocter 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
