### PR TITLE
make the `const`ness of `GlobalState` more explicit during `typecheck`

### DIFF
--- a/core/lsp/PreemptionTaskManager.cc
+++ b/core/lsp/PreemptionTaskManager.cc
@@ -34,7 +34,7 @@ bool PreemptionTaskManager::trySchedulePreemptionTask(std::shared_ptr<Task> task
     return success;
 }
 
-bool PreemptionTaskManager::tryRunScheduledPreemptionTask(core::GlobalState &gs) {
+bool PreemptionTaskManager::tryRunScheduledPreemptionTask(const core::GlobalState &gs) {
     TypecheckEpochManager::assertConsistentThread(
         typecheckingThreadId, "PreemptionTaskManager::tryRunScheduledPreemptionTask", "typechecking thread");
     auto preemptTask = atomic_load(&this->preemptTask);

--- a/core/lsp/PreemptionTaskManager.h
+++ b/core/lsp/PreemptionTaskManager.h
@@ -31,7 +31,7 @@ public:
     // Run only from the typechecking thread.
     // Runs the scheduled preemption task, if any.
     // Handles running task with a fresh errorQueue, and restoring previous errorQueue when done.
-    bool tryRunScheduledPreemptionTask(core::GlobalState &gs);
+    bool tryRunScheduledPreemptionTask(const core::GlobalState &gs);
     // Run only from processing thread.
     // Tries to cancel the scheduled preemption task. Returns true if it succeeds.
     bool tryCancelScheduledPreemptionTask(std::shared_ptr<Task> &task);

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -324,7 +324,7 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
     ENFORCE(gs->lspQuery.isEmpty());
     auto resolved = pipeline::incrementalResolve(*gs, move(updatedIndexed), config->opts);
     auto sorted = sortParsedFiles(*gs, *errorReporter, move(resolved));
-    pipeline::typecheck(gs, move(sorted), config->opts, workers, /*presorted*/ true);
+    pipeline::typecheck(*gs, move(sorted), config->opts, workers, /*presorted*/ true);
     gs->lspTypecheckCount++;
 
     return subset;
@@ -503,7 +503,7 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates updates, WorkerPool &workers, bo
         }
 
         auto sorted = sortParsedFiles(*gs, *errorReporter, move(resolved));
-        pipeline::typecheck(gs, move(sorted), config->opts, workers, cancelable, preemptManager, /*presorted*/ true);
+        pipeline::typecheck(*gs, move(sorted), config->opts, workers, cancelable, preemptManager, /*presorted*/ true);
     });
 
     // Note: `gs` now holds the value of `finalGS`.
@@ -620,7 +620,7 @@ LSPQueryResult LSPTypechecker::query(const core::lsp::Query &q, const std::vecto
     tryApplyDefLocSaver(*gs, resolved);
     tryApplyLocalVarSaver(*gs, resolved);
 
-    pipeline::typecheck(gs, move(resolved), config->opts, workers, /*presorted*/ true);
+    pipeline::typecheck(*gs, move(resolved), config->opts, workers, /*presorted*/ true);
     gs->lspTypecheckCount++;
     gs->lspQuery = core::lsp::Query::noQuery();
     return LSPQueryResult{queryCollector->drainQueryResponses(), nullptr};
@@ -783,7 +783,7 @@ LSPQueryResult LSPStaleTypechecker::query(const core::lsp::Query &q,
     tryApplyDefLocSaver(*gs, resolved);
     tryApplyLocalVarSaver(*gs, resolved);
 
-    pipeline::typecheck(gs, move(resolved), config->opts, *emptyWorkers, /*presorted*/ true);
+    pipeline::typecheck(*gs, move(resolved), config->opts, *emptyWorkers, /*presorted*/ true);
     gs->lspTypecheckCount++;
     gs->lspQuery = core::lsp::Query::noQuery();
     return LSPQueryResult{queryCollector->drainQueryResponses(), nullptr};

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -1058,31 +1058,23 @@ ast::ParsedFilesOrCancelled resolve(unique_ptr<core::GlobalState> &gs, vector<as
     return ast::ParsedFilesOrCancelled(move(what));
 }
 
-void typecheck(const unique_ptr<core::GlobalState> &gs, vector<ast::ParsedFile> what, const options::Options &opts,
+void typecheck(const core::GlobalState &gs, vector<ast::ParsedFile> what, const options::Options &opts,
                WorkerPool &workers, bool cancelable,
-               optional<shared_ptr<core::lsp::PreemptionTaskManager>> preemptionManager, bool presorted,
-               bool intentionallyLeakASTs) {
-    return typecheck(reinterpret_cast<const unique_ptr<const core::GlobalState> &>(gs), move(what), opts, workers,
-                     cancelable, move(preemptionManager), presorted, intentionallyLeakASTs);
-}
-
-void typecheck(const unique_ptr<const core::GlobalState> &gs, vector<ast::ParsedFile> what,
-               const options::Options &opts, WorkerPool &workers, bool cancelable,
                optional<shared_ptr<core::lsp::PreemptionTaskManager>> preemptionManager, bool presorted,
                bool intentionallyLeakASTs) {
     // Unless the error queue had a critical error, only typecheck should flush errors to the client, otherwise we will
     // drop errors in LSP mode.
-    ENFORCE(gs->hadCriticalError() || gs->errorQueue->filesFlushedCount == 0);
+    ENFORCE(gs.hadCriticalError() || gs.errorQueue->filesFlushedCount == 0);
 
-    const auto &epochManager = *gs->epochManager;
+    const auto &epochManager = *gs.epochManager;
     // Record epoch at start of typechecking before any preemption occurs.
     const uint32_t epoch = epochManager.getStatus().epoch;
 
     {
-        Timer timeit(gs->tracer(), "typecheck");
+        Timer timeit(gs.tracer(), "typecheck");
         if (preemptionManager) {
             // Before kicking off typechecking, check if we need to preempt.
-            (*preemptionManager)->tryRunScheduledPreemptionTask(*gs);
+            (*preemptionManager)->tryRunScheduledPreemptionTask(gs);
         }
 
         shared_ptr<ConcurrentBoundedQueue<ast::ParsedFile>> fileq;
@@ -1093,12 +1085,11 @@ void typecheck(const unique_ptr<const core::GlobalState> &gs, vector<ast::Parsed
             outputq = make_shared<BlockingBoundedQueue<vector<core::FileRef>>>(what.size());
         }
 
-        const core::GlobalState &igs = *gs;
         if (!presorted) {
             // If files are not already sorted, we want to start typeckecking big files first because it helps with
             // better work distribution
             fast_sort(what, [&](const auto &lhs, const auto &rhs) -> bool {
-                return lhs.file.data(*gs).source().size() > rhs.file.data(*gs).source().size();
+                return lhs.file.data(gs).source().size() > rhs.file.data(gs).source().size();
             });
         }
 
@@ -1108,7 +1099,7 @@ void typecheck(const unique_ptr<const core::GlobalState> &gs, vector<ast::Parsed
 
         {
             ProgressIndicator cfgInferProgress(opts.showProgress, "CFG+Inference", what.size());
-            workers.multiplexJob("typecheck", [&igs, &opts, epoch, &epochManager, &preemptionManager, fileq, outputq,
+            workers.multiplexJob("typecheck", [&gs, &opts, epoch, &epochManager, &preemptionManager, fileq, outputq,
                                                cancelable, intentionallyLeakASTs]() {
                 vector<core::FileRef> processedFiles;
                 ast::ParsedFile job;
@@ -1129,18 +1120,18 @@ void typecheck(const unique_ptr<const core::GlobalState> &gs, vector<ast::Parsed
                             // [IDE] Also, don't do work if the file has changed under us since we began
                             // typechecking!
                             // TODO(jvilk): epoch is unlikely to overflow, but it is theoretically possible.
-                            const bool fileWasChanged = preemptionManager && job.file.data(igs).epoch > epoch;
+                            const bool fileWasChanged = preemptionManager && job.file.data(gs).epoch > epoch;
                             if (!isCanceled && !fileWasChanged) {
                                 core::FileRef file = job.file;
                                 try {
-                                    core::Context ctx(igs, core::Symbols::root(), file);
+                                    core::Context ctx(gs, core::Symbols::root(), file);
                                     auto file = job.file;
                                     typecheckOne(ctx, move(job), opts, intentionallyLeakASTs);
                                     processedFiles.emplace_back(file);
                                 } catch (SorbetException &) {
                                     Exception::failInFuzzer();
-                                    igs.tracer().error("Exception typing file: {} (backtrace is above)",
-                                                       file.data(igs).path());
+                                    gs.tracer().error("Exception typing file: {} (backtrace is above)",
+                                                      file.data(gs).path());
                                 }
                                 // Stream out errors
                                 outputq->push(move(processedFiles), processedByThread);
@@ -1156,18 +1147,18 @@ void typecheck(const unique_ptr<const core::GlobalState> &gs, vector<ast::Parsed
 
             vector<core::FileRef> files;
             {
-                for (auto result = outputq->wait_pop_timed(files, WorkerPool::BLOCK_INTERVAL(), gs->tracer());
+                for (auto result = outputq->wait_pop_timed(files, WorkerPool::BLOCK_INTERVAL(), gs.tracer());
                      !result.done();
-                     result = outputq->wait_pop_timed(files, WorkerPool::BLOCK_INTERVAL(), gs->tracer())) {
+                     result = outputq->wait_pop_timed(files, WorkerPool::BLOCK_INTERVAL(), gs.tracer())) {
                     if (result.gotItem()) {
                         for (auto &file : files) {
-                            gs->errorQueue->flushErrorsForFile(*gs, file);
+                            gs.errorQueue->flushErrorsForFile(gs, file);
                         }
                     }
                     cfgInferProgress.reportProgress(fileq->doneEstimate());
 
                     if (preemptionManager) {
-                        (*preemptionManager)->tryRunScheduledPreemptionTask(*gs);
+                        (*preemptionManager)->tryRunScheduledPreemptionTask(gs);
                     }
                 }
                 if (cancelable && epochManager.wasTypecheckingCanceled()) {
@@ -1190,12 +1181,12 @@ void typecheck(const unique_ptr<const core::GlobalState> &gs, vector<ast::Parsed
                 }
             }
         }
-        for (auto &extension : gs->semanticExtensions) {
-            extension->finishTypecheck(*gs);
+        for (auto &extension : gs.semanticExtensions) {
+            extension->finishTypecheck(gs);
         }
 
         // Error queue is re-used across runs, so reset the flush count to ignore files flushed during typecheck.
-        gs->errorQueue->filesFlushedCount = 0;
+        gs.errorQueue->filesFlushedCount = 0;
 
         return;
     }

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -1062,12 +1062,12 @@ void typecheck(const unique_ptr<core::GlobalState> &gs, vector<ast::ParsedFile> 
                WorkerPool &workers, bool cancelable,
                optional<shared_ptr<core::lsp::PreemptionTaskManager>> preemptionManager, bool presorted,
                bool intentionallyLeakASTs) {
-    return typecheck(reinterpret_cast<const unique_ptr<const core::GlobalState> &>(gs), move(what), opts, workers, cancelable, move(preemptionManager), presorted,
-                     intentionallyLeakASTs);
+    return typecheck(reinterpret_cast<const unique_ptr<const core::GlobalState> &>(gs), move(what), opts, workers,
+                     cancelable, move(preemptionManager), presorted, intentionallyLeakASTs);
 }
 
-void typecheck(const unique_ptr<const core::GlobalState> &gs, vector<ast::ParsedFile> what, const options::Options &opts,
-               WorkerPool &workers, bool cancelable,
+void typecheck(const unique_ptr<const core::GlobalState> &gs, vector<ast::ParsedFile> what,
+               const options::Options &opts, WorkerPool &workers, bool cancelable,
                optional<shared_ptr<core::lsp::PreemptionTaskManager>> preemptionManager, bool presorted,
                bool intentionallyLeakASTs) {
     // Unless the error queue had a critical error, only typecheck should flush errors to the client, otherwise we will

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -637,6 +637,7 @@ vector<ast::ParsedFile> index(core::GlobalState &gs, vector<core::FileRef> files
     return ret;
 }
 
+namespace {
 void typecheckOne(core::Context ctx, ast::ParsedFile resolved, const options::Options &opts,
                   bool intentionallyLeakASTs) {
     core::FileRef f = resolved.file;
@@ -714,6 +715,7 @@ void typecheckOne(core::Context ctx, ast::ParsedFile resolved, const options::Op
     }
     return;
 }
+} // namespace
 
 vector<ast::ParsedFile> package(core::GlobalState &gs, vector<ast::ParsedFile> what, const options::Options &opts,
                                 WorkerPool &workers) {

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -1062,6 +1062,14 @@ void typecheck(const unique_ptr<core::GlobalState> &gs, vector<ast::ParsedFile> 
                WorkerPool &workers, bool cancelable,
                optional<shared_ptr<core::lsp::PreemptionTaskManager>> preemptionManager, bool presorted,
                bool intentionallyLeakASTs) {
+    return typecheck(reinterpret_cast<const unique_ptr<const core::GlobalState> &>(gs), move(what), opts, workers, cancelable, move(preemptionManager), presorted,
+                     intentionallyLeakASTs);
+}
+
+void typecheck(const unique_ptr<const core::GlobalState> &gs, vector<ast::ParsedFile> what, const options::Options &opts,
+               WorkerPool &workers, bool cancelable,
+               optional<shared_ptr<core::lsp::PreemptionTaskManager>> preemptionManager, bool presorted,
+               bool intentionallyLeakASTs) {
     // Unless the error queue had a critical error, only typecheck should flush errors to the client, otherwise we will
     // drop errors in LSP mode.
     ENFORCE(gs->hadCriticalError() || gs->errorQueue->filesFlushedCount == 0);

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -48,6 +48,13 @@ void typecheck(const std::unique_ptr<core::GlobalState> &gs, std::vector<ast::Pa
                std::optional<std::shared_ptr<core::lsp::PreemptionTaskManager>> preemptionManager = std::nullopt,
                bool presorted = false, bool intentionallyLeakASTs = false);
 
+// Overload with more semantically correct types; the above forwards here for the
+// convenience of consumers that hold `unique_ptr<GlobalState>`.
+void typecheck(const std::unique_ptr<const core::GlobalState> &gs, std::vector<ast::ParsedFile> what,
+               const options::Options &opts, WorkerPool &workers, bool cancelable = false,
+               std::optional<std::shared_ptr<core::lsp::PreemptionTaskManager>> preemptionManager = std::nullopt,
+               bool presorted = false, bool intentionallyLeakASTs = false);
+
 core::StrictLevel decideStrictLevel(const core::GlobalState &gs, const core::FileRef file,
                                     const options::Options &opts);
 

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -43,15 +43,8 @@ ast::ParsedFilesOrCancelled nameBestEffortConst(const core::GlobalState &gs, std
 // Note: `cancelable` and `preemption task manager` are only applicable to LSP.
 // If `intentionallyLeakASTs` is `true`, typecheck will leak the ASTs rather than pay the cost of deleting them
 // properly, which is a significant speedup on large codebases.
-void typecheck(const std::unique_ptr<core::GlobalState> &gs, std::vector<ast::ParsedFile> what,
-               const options::Options &opts, WorkerPool &workers, bool cancelable = false,
-               std::optional<std::shared_ptr<core::lsp::PreemptionTaskManager>> preemptionManager = std::nullopt,
-               bool presorted = false, bool intentionallyLeakASTs = false);
-
-// Overload with more semantically correct types; the above forwards here for the
-// convenience of consumers that hold `unique_ptr<GlobalState>`.
-void typecheck(const std::unique_ptr<const core::GlobalState> &gs, std::vector<ast::ParsedFile> what,
-               const options::Options &opts, WorkerPool &workers, bool cancelable = false,
+void typecheck(const core::GlobalState &gs, std::vector<ast::ParsedFile> what, const options::Options &opts,
+               WorkerPool &workers, bool cancelable = false,
                std::optional<std::shared_ptr<core::lsp::PreemptionTaskManager>> preemptionManager = std::nullopt,
                bool presorted = false, bool intentionallyLeakASTs = false);
 

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -48,9 +48,6 @@ void typecheck(const std::unique_ptr<core::GlobalState> &gs, std::vector<ast::Pa
                std::optional<std::shared_ptr<core::lsp::PreemptionTaskManager>> preemptionManager = std::nullopt,
                bool presorted = false, bool intentionallyLeakASTs = false);
 
-void typecheckOne(core::Context ctx, ast::ParsedFile resolved, const options::Options &opts,
-                  bool intentionallyLeakASTs = false);
-
 core::StrictLevel decideStrictLevel(const core::GlobalState &gs, const core::FileRef file,
                                     const options::Options &opts);
 

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -722,7 +722,7 @@ int realmain(int argc, char *argv[]) {
 
             if (!opts.packageRBIGeneration) {
                 // we don't need to typecheck when generating rbis
-                pipeline::typecheck(gs, move(indexed), opts, *workers, /* cancelable */ false, nullopt,
+                pipeline::typecheck(*gs, move(indexed), opts, *workers, /* cancelable */ false, nullopt,
                                     /* presorted */ false, /* intentionallyLeakASTs */ !sorbet::emscripten_build);
             }
             if (gs->hadCriticalError()) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Some of the stale-state LSP work really wants to work with `const GlobalState`.  Despite not mutating `GlobalState`, `pipeline::typecheck` is typed in such a way that would lead you to believe that it does.  Let's fix `pipeline::typecheck`'s signature, and make other non-mutating code more obvious in the process.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
