### PR TITLE
Adds type parameters to Kernel#Array

### DIFF
--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -695,7 +695,7 @@ module Kernel
       .returns(T::Array[T.type_parameter(:Elem)])
   end
   sig {params(x: NilClass).returns([])}
-  def Array(x); end
+  def Array(*x); end
 
   # Create a new
   # [`BigDecimal`](https://docs.ruby-lang.org/en/2.7.0/BigDecimal.html) object.

--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -688,10 +688,11 @@ module Kernel
   # Array(1)           #=> [1]
   # ```
   sig do
-    params(
-        x: BasicObject,
-    )
-    .returns(T::Array[T.untyped])
+    type_parameters(:Elem)
+      .params(
+        x: T.type_parameter(:Elem),
+      )
+      .returns(T::Array[T.type_parameter(:Elem)])
   end
   sig {params(x: NilClass).returns([])}
   def Array(x); end

--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -691,7 +691,7 @@ module Kernel
   sig do
     type_parameters(:Elem)
       .params(
-        x: T.any(T::Enumerable[T.type_parameter(:Elem)], T.type_parameter(:Elem))
+        x: T.any(T::Enumerable[T.type_parameter(:Elem)], T.type_parameter(:Elem), T.nilable(T.type_parameter(:Elem)))
       )
       .returns(T::Array[T.type_parameter(:Elem)])
   end

--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -687,21 +687,14 @@ module Kernel
   # Array(nil)         #=> []
   # Array(1)           #=> [1]
   # ```
+  sig { params(x: NilClass).returns(T::Array[T.untyped]) }
   sig do
     type_parameters(:Elem)
       .params(
-        x: T::Enumerable[T.type_parameter(:Elem)],
+        x: T.any(T::Enumerable[T.type_parameter(:Elem)], T.type_parameter(:Elem))
       )
       .returns(T::Array[T.type_parameter(:Elem)])
   end
-  sig do
-    type_parameters(:Elem)
-      .params(
-        x: T.type_parameter(:Elem),
-      )
-      .returns(T::Array[T.type_parameter(:Elem)])
-  end
-  sig {params(x: NilClass).returns([])}
   def Array(x); end
 
   # Create a new

--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -690,12 +690,19 @@ module Kernel
   sig do
     type_parameters(:Elem)
       .params(
+        x: T::Enumerable[T.type_parameter(:Elem)],
+      )
+      .returns(T::Array[T.type_parameter(:Elem)])
+  end
+  sig do
+    type_parameters(:Elem)
+      .params(
         x: T.type_parameter(:Elem),
       )
       .returns(T::Array[T.type_parameter(:Elem)])
   end
   sig {params(x: NilClass).returns([])}
-  def Array(*x); end
+  def Array(x); end
 
   # Create a new
   # [`BigDecimal`](https://docs.ruby-lang.org/en/2.7.0/BigDecimal.html) object.

--- a/test/cli/autocorrect-helpers/test.out
+++ b/test/cli/autocorrect-helpers/test.out
@@ -34,8 +34,8 @@ autocorrect-helpers.rb:16: Method `sealed!` does not exist on `T.class_of(S4)` h
     16 |  sealed!
         ^
   Did you mean:
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L2212: `Kernel#select`
-    2212 |  def select(read_array, write_array=nil, error_array=nil, timeout=nil); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L2213: `Kernel#select`
+    2213 |  def select(read_array, write_array=nil, error_array=nil, timeout=nil); end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 autocorrect-helpers.rb:20: Method `interface!` does not exist on `T.class_of(S5)` https://srb.help/7003
@@ -74,8 +74,8 @@ autocorrect-helpers.rb:26: Method `sealed!` does not exist on `T.class_of(S6)` h
     25 |  abstract!
         ^
   Did you mean:
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L2212: `Kernel#select`
-    2212 |  def select(read_array, write_array=nil, error_array=nil, timeout=nil); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L2213: `Kernel#select`
+    2213 |  def select(read_array, write_array=nil, error_array=nil, timeout=nil); end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 autocorrect-helpers.rb:30: Method `mixes_in_class_methods` does not exist on `T.class_of(S7)` https://srb.help/7003

--- a/test/cli/autocorrect/test.out
+++ b/test/cli/autocorrect/test.out
@@ -98,8 +98,8 @@ autocorrect.rb:12: Method `bar=` does not exist on `String` component of `T.nila
      3 |foo = T.let(nil, T.nilable(String))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Did you mean:
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L2717: `Kernel#warn`
-    2717 |  def warn(*msg); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L2718: `Kernel#warn`
+    2718 |  def warn(*msg); end
             ^^^^^^^^^^^^^^
 
 autocorrect.rb:12: Method `bar=` does not exist on `NilClass` component of `T.nilable(String)` https://srb.help/7003
@@ -142,8 +142,8 @@ autocorrect.rb:13: Method `bar=` does not exist on `String` component of `T.nila
      3 |foo = T.let(nil, T.nilable(String))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Did you mean:
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L2717: `Kernel#warn`
-    2717 |  def warn(*msg); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L2718: `Kernel#warn`
+    2718 |  def warn(*msg); end
             ^^^^^^^^^^^^^^
 
 autocorrect.rb:13: Method `bar=` does not exist on `NilClass` component of `T.nilable(String)` https://srb.help/7003
@@ -186,8 +186,8 @@ autocorrect.rb:14: Method `bar=` does not exist on `String` component of `T.nila
      3 |foo = T.let(nil, T.nilable(String))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Did you mean:
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L2717: `Kernel#warn`
-    2717 |  def warn(*msg); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L2718: `Kernel#warn`
+    2718 |  def warn(*msg); end
             ^^^^^^^^^^^^^^
 
 autocorrect.rb:14: Method `bar=` does not exist on `NilClass` component of `T.nilable(String)` https://srb.help/7003
@@ -230,8 +230,8 @@ autocorrect.rb:15: Method `bar=` does not exist on `String` component of `T.nila
      3 |foo = T.let(nil, T.nilable(String))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Did you mean:
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L2717: `Kernel#warn`
-    2717 |  def warn(*msg); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L2718: `Kernel#warn`
+    2718 |  def warn(*msg); end
             ^^^^^^^^^^^^^^
 
 autocorrect.rb:15: Method `bar=` does not exist on `NilClass` component of `T.nilable(String)` https://srb.help/7003

--- a/test/cli/cache-dsl/test.out
+++ b/test/cli/cache-dsl/test.out
@@ -7,8 +7,8 @@ test/cli/cache-dsl/attr_accessor.rb:7: Method `prop=` does not exist on `A` http
      6 |a = A.new
             ^^^^^
   Did you mean:
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L1783: `Kernel#proc`
-    1783 |  def proc(&blk); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L1784: `Kernel#proc`
+    1784 |  def proc(&blk); end
             ^^^^^^^^^^^^^^
 
 test/cli/cache-dsl/attr_accessor.rb:8: Method `prop` does not exist on `A` https://srb.help/7003
@@ -31,8 +31,8 @@ test/cli/cache-dsl/attr_accessor.rb:7: Method `prop=` does not exist on `A` http
      6 |a = A.new
             ^^^^^
   Did you mean:
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L1783: `Kernel#proc`
-    1783 |  def proc(&blk); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L1784: `Kernel#proc`
+    1784 |  def proc(&blk); end
             ^^^^^^^^^^^^^^
 
 test/cli/cache-dsl/attr_accessor.rb:8: Method `prop` does not exist on `A` https://srb.help/7003

--- a/test/cli/errors/test.out
+++ b/test/cli/errors/test.out
@@ -13,7 +13,7 @@ test/cli/errors/errors.rb:15: Expected `String` but found `Integer` for argument
     .. |    raise arg # raise is defined by stdlib
                   ^^^
   Expected `String` for argument `arg0` of method `Kernel#raise (overload.1)`:
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L2744:
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L2745:
     .. |        arg0: String,
                   ^^^^
   Got `Integer` originating from:
@@ -70,7 +70,7 @@ test/cli/errors/errors.rb:15: Expected `String` but found `Integer` for argument
     .. |    raise arg # raise is defined by stdlib
                   ^^^
   Expected `String` for argument `arg0` of method `Kernel#raise (overload.1)`:
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L2744:
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L2745:
     .. |        arg0: String,
                   ^^^^
   Got `Integer` originating from:
@@ -127,7 +127,7 @@ test/cli/errors/errors.rb:15: Expected `String` but found `Integer` for argument
     .. |    raise arg # raise is defined by stdlib
                   ^^^
   Expected `String` for argument `arg0` of method `Kernel#raise (overload.1)`:
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L2744:
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L2745:
     .. |        arg0: String,
                   ^^^^
   Got `Integer` originating from:

--- a/test/cli/incremental-resolver/test.out
+++ b/test/cli/incremental-resolver/test.out
@@ -121,8 +121,8 @@ test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:68: Method `void`
     68 |  sig {void}
                ^^^^
   Did you mean:
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L1560: `Kernel#load`
-    1560 |  def load(filename, arg0=T.unsafe(nil)); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L1561: `Kernel#load`
+    1561 |  def load(filename, arg0=T.unsafe(nil)); end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:69: Method `sig` does not exist on `T.class_of(<root>)` https://srb.help/7003
@@ -139,7 +139,7 @@ test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:69: Method `void`
     69 |  sig {void}
                ^^^^
   Did you mean:
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L1560: `Kernel#load`
-    1560 |  def load(filename, arg0=T.unsafe(nil)); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L1561: `Kernel#load`
+    1561 |  def load(filename, arg0=T.unsafe(nil)); end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Errors: 10

--- a/test/testdata/rbi/kernel_array.rb
+++ b/test/testdata/rbi/kernel_array.rb
@@ -20,3 +20,7 @@ T.reveal_type(Array('a'..'z')) # error: Revealed type: `T::Array[String]`
 T.reveal_type(Array(1..10)) # error: Revealed type: `T::Array[Integer]`
 
 T.reveal_type(Array([1, 'a', 3])) # error: Revealed type: `T::Array[T.any(Integer, String)]`
+
+maybe_x = T.let(nil, T.nilable(String))
+res = Array(maybe_x)
+T.reveal_type(res) # error: Revealed type: `T::Array[String]`

--- a/test/testdata/rbi/kernel_array.rb
+++ b/test/testdata/rbi/kernel_array.rb
@@ -3,4 +3,18 @@
 owners = T.let(1, T.untyped)
 T.reveal_type(Array(owners)) # error: Revealed type: `T::Array[T.untyped]`
 
-T.reveal_type(Array(10)) # error: Revealed type: `T::Array[T.untyped]`
+T.reveal_type(Array(10)) # error: Revealed type: `T::Array[Integer(10)]`
+
+T.reveal_type(Array(nil)) # error: Revealed type: `T::Array[T.untyped]`
+
+x = T.let('', T.any(String, T::Array[String]))
+T.reveal_type(Array(x)) # error: Revealed type: `T::Array[String]`
+
+y = T.let('', String)
+T.reveal_type(Array(y)) # error: Revealed type: `T::Array[String]`
+
+T.reveal_type(Array('a'..'z')) # error: Revealed type: `T::Array[String]`
+
+T.reveal_type(Array(1..10)) # error: Revealed type: `T::Array[Integer]`
+
+T.reveal_type(Array([1, 'a', 3])) # error: Revealed type: `T::Array[T.any(Integer, String)]`

--- a/test/testdata/rbi/kernel_array.rb
+++ b/test/testdata/rbi/kernel_array.rb
@@ -5,6 +5,8 @@ T.reveal_type(Array(owners)) # error: Revealed type: `T::Array[T.untyped]`
 
 T.reveal_type(Array(10)) # error: Revealed type: `T::Array[Integer(10)]`
 
+T.reveal_type(Array([10])) # error: Revealed type: `T::Array[Integer]`
+
 T.reveal_type(Array(nil)) # error: Revealed type: `T::Array[T.untyped]`
 
 x = T.let('', T.any(String, T::Array[String]))


### PR DESCRIPTION
The types were being erased by the signature when sorbet is actually
smart enough to infer the correct types. This may cause new type checks
to fail but should be correct.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
We were using `Array(x)` to collapse an input which was `T.any(String, T::Array[String])` into just an array of strings. However, it was erasing the type to `T::Array[T.untyped]`.

I was able to create a prototype [here](https://sorbet.run/#%23%20typed%3A%20strict%0A%0A%23%20your%20example%0AT.reveal_type%28T.let%28Array%28%22a%22%29%2C%20T%3A%3AArray%5BInteger%5D%29%29%0A%0A%23%20the%20kernel%20method%0AT.reveal_type%28Array%28%22a%22%29%29%0A%0Aextend%20T%3A%3ASig%0A%0Asig%20do%0A%20%20type_parameters%28%3Ain%29.params%28args%3A%20T.type_parameter%28%3Ain%29%29.returns%28T%3A%3AArray%5BT.type_parameter%28%3Ain%29%5D%29%0Aend%0Adef%20array%28*args%29%0A%20%20args%20%0Aend%0A%0A%23%20my%20parameterized%20value%0AT.reveal_type%28array%28%22a%22%29%29%0A%0A%23%20Let%20validation%0AT.let%28array%28%22a%22%29%2C%20T%3A%3AArray%5BInteger%5D%29%0AT.let%28array%28%22a%22%29%2C%20T%3A%3AArray%5BString%5D%29%0AT.let%28array%28%22a%22%2C%20123%29%2C%20T%3A%3AArray%5BT.untyped%5D%29%0AT.reveal_type%28array%28%22a%22%2C%20123%29%29).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Not sure how to test this but @jez said he would help out.
