### PR TITLE
use global variables more idiomatically in load/store codegen in the compiler

### DIFF
--- a/compiler/IREmitter/Payload.cc
+++ b/compiler/IREmitter/Payload.cc
@@ -110,9 +110,7 @@ llvm::Value *Payload::cPtrToRubyRegexp(CompilerState &cs, llvm::IRBuilderBase &b
     auto oldInsertPoint = builder.saveIP();
     builder.SetInsertPoint(cs.functionEntryInitializers);
     auto name = llvm::StringRef(str.data(), str.length());
-    auto global = builder.CreateLoad(
-        llvm::ConstantExpr::getInBoundsGetElementPtr(globalDeclaration->getValueType(), globalDeclaration, indices),
-        {"rubyRegexp_", name});
+    auto global = builder.CreateLoad(globalDeclaration, {"rubyRegexp_", name});
     builder.restoreIP(oldInsertPoint);
 
     // todo(perf): mark these as immutable with https://llvm.org/docs/LangRef.html#llvm-invariant-start-intrinsic
@@ -160,9 +158,7 @@ llvm::Value *Payload::cPtrToRubyString(CompilerState &cs, llvm::IRBuilderBase &b
     }));
 
     auto name = llvm::StringRef(str.data(), str.length());
-    auto global = builder.CreateLoad(
-        llvm::ConstantExpr::getInBoundsGetElementPtr(globalDeclaration->getValueType(), globalDeclaration, indices),
-        {"rubyStr_", name});
+    auto global = builder.CreateLoad(globalDeclaration, {"rubyStr_", name});
 
     // todo(perf): mark these as immutable with https://llvm.org/docs/LangRef.html#llvm-invariant-start-intrinsic
     return global;
@@ -208,9 +204,7 @@ llvm::Value *Payload::idIntern(CompilerState &cs, llvm::IRBuilderBase &builder, 
         return ret;
     }));
 
-    auto global = builder.CreateLoad(
-        llvm::ConstantExpr::getInBoundsGetElementPtr(globalDeclaration->getValueType(), globalDeclaration, indices),
-        {"rubyId_", name});
+    auto global = builder.CreateLoad(globalDeclaration, {"rubyId_", name});
 
     // todo(perf): mark these as immutable with https://llvm.org/docs/LangRef.html#llvm-invariant-start-intrinsic
     return global;
@@ -733,11 +727,7 @@ llvm::Value *allocateRubyStackFrames(CompilerState &cs, llvm::IRBuilderBase &bui
     }
 
     globalInitBuilder.SetInsertPoint(cs.functionEntryInitializers);
-    auto zero = llvm::ConstantInt::get(cs, llvm::APInt(64, 0));
-    llvm::Constant *indices[] = {zero};
-    auto global = globalInitBuilder.CreateLoad(
-        llvm::ConstantExpr::getInBoundsGetElementPtr(globalDeclaration->getValueType(), globalDeclaration, indices),
-        "stackFrame");
+    auto global = globalInitBuilder.CreateLoad(globalDeclaration, "stackFrame");
 
     // todo(perf): mark these as immutable with https://llvm.org/docs/LangRef.html#llvm-invariant-start-intrinsic
     return global;


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

LLVM's `GlobalVariable`s are represented by their address, so the current places where we do `getelemenptr var, 0` is the C equivalent of saying `&var[0]`.  We can do slightly less work and make the code a little clearer by using `var` directly.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.  No functional change intended.
