### PR TITLE
fix error prefix for stale state tests

### DIFF
--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -700,7 +700,7 @@ TEST_CASE("LSPTest") {
 
         // Apply updates in order.
         for (auto version : sortedUpdates) {
-            auto errorPrefix = fmt::format("[*.{}.{}] ", version, haveStaleUpdates ? "rbupdate" : "rbstaleupdate");
+            auto errorPrefix = fmt::format("[*.{}.{}] ", version, haveStaleUpdates ? "rbstaleupdate" : "rbupdate");
             auto &updates = testUpdates[version];
             vector<unique_ptr<LSPMessage>> lspUpdates;
             UnorderedMap<std::string, std::shared_ptr<core::File>> updatesAndContents;


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fix a thinko in the stale state testing.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
