### PR TITLE
Fix crash in YieldLoadParams

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1443,7 +1443,7 @@ TypePtr getMethodArguments(const GlobalState &gs, ClassOrModuleRef klass, NameRe
     MethodRef method = klass.data(gs)->findMethodTransitive(gs, name);
 
     if (!method.exists()) {
-        return nullptr;
+        return core::Types::untypedUntracked();
     }
     auto data = method.data(gs);
 

--- a/test/testdata/infer/crash_yield_load_params.rb
+++ b/test/testdata/infer/crash_yield_load_params.rb
@@ -2,13 +2,13 @@
 
 module Left
   extend T::Sig
-  sig {params(blk: BasicObject).void}
+  sig {params(blk: BasicObject).returns(NilClass)}
   def foo(&blk); end
 end
 
 module Up
   extend T::Sig
-  sig {params(blk: BasicObject).void}
+  sig {params(blk: BasicObject).returns(NilClass)}
   def foo(&blk); end
 end
 
@@ -18,8 +18,8 @@ class Main
   sig {params(x: T.all(Left, Up)).void}
   def foo(x)
     res = x.foo do |y|
-      T.reveal_type(y)
+      T.reveal_type(y) # error: `T.untyped`
     end
-    res = T.reveal_type(res)
+    res = T.reveal_type(res) # error: `NilClass`
   end
 end

--- a/test/testdata/infer/crash_yield_load_params.rb
+++ b/test/testdata/infer/crash_yield_load_params.rb
@@ -1,0 +1,25 @@
+# typed: true
+
+module Left
+  extend T::Sig
+  sig {params(blk: BasicObject).void}
+  def foo(&blk); end
+end
+
+module Up
+  extend T::Sig
+  sig {params(blk: BasicObject).void}
+  def foo(&blk); end
+end
+
+class Main
+  extend T::Sig
+
+  sig {params(x: T.all(Left, Up)).void}
+  def foo(x)
+    res = x.foo do |y|
+      T.reveal_type(y)
+    end
+    res = T.reveal_type(res)
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We have a helper function called `getCallArguments` that takes types like:

    T.proc.params(arg0: Integer, arg1: Integer).void

into types like:

    [Integer, Integer]

There is a special case that when youc all `getCallArguments` on
`T.untyped`, it will return `T.untyped`. Unfortunately, if you call it on
something that is typed but isn't a valid `getCallArguments` target
(like `BasicObject`) it would return `nullptr` instead of `T.untyped` which
would cause crashes downstream.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I checked that this test case crashed before this change.