### PR TITLE
use the container form of `fmt::map_join`

### DIFF
--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -699,8 +699,7 @@ string ConstantLit::showRaw(const core::GlobalState &gs, int tabs) {
     if (resolutionScopes != nullptr && !resolutionScopes->empty()) {
         printTabs(buf, tabs + 1);
         fmt::format_to(std::back_inserter(buf), "resolutionScopes = [{}]\n",
-                       fmt::map_join(this->resolutionScopes->begin(), this->resolutionScopes->end(), ", ",
-                                     [&](auto sym) { return sym.showFullName(gs); }));
+                       fmt::map_join(*this->resolutionScopes, ", ", [&](auto sym) { return sym.showFullName(gs); }));
     }
     printTabs(buf, tabs);
 

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -187,16 +187,14 @@ ExpressionPtr mergeStrings(DesugarContext dctx, core::LocOffsets loc,
     if (stringsAccumulated.size() == 1) {
         return move(stringsAccumulated[0]);
     } else {
-        return MK::String(
-            loc,
-            dctx.ctx.state.enterNameUTF8(fmt::format(
-                "{}", fmt::map_join(stringsAccumulated.begin(), stringsAccumulated.end(), "", [&](const auto &expr) {
-                    if (isa_tree<EmptyTree>(expr)) {
-                        return ""sv;
-                    } else {
-                        return cast_tree<Literal>(expr)->asString(dctx.ctx).shortName(dctx.ctx);
-                    }
-                }))));
+        return MK::String(loc, dctx.ctx.state.enterNameUTF8(fmt::format(
+                                   "{}", fmt::map_join(stringsAccumulated, "", [&](const auto &expr) {
+                                       if (isa_tree<EmptyTree>(expr)) {
+                                           return ""sv;
+                                       } else {
+                                           return cast_tree<Literal>(expr)->asString(dctx.ctx).shortName(dctx.ctx);
+                                       }
+                                   }))));
     }
 }
 

--- a/cfg/CFG.cc
+++ b/cfg/CFG.cc
@@ -218,17 +218,16 @@ string CFG::toString(const core::GlobalState &gs) const {
         auto shape = basicBlock->id == 0 ? "invhouse" : basicBlock->id == 1 ? "parallelogram" : "rectangle";
         // whole block red if whole block is dead
         auto color = basicBlock->firstDeadInstructionIdx == 0 ? "red" : "black";
-        fmt::format_to(
-            std::back_inserter(buf),
-            "    \"bb{}_{}\" [\n"
-            "        shape = {};\n"
-            "        color = {};\n"
-            "        label = \"{}\\l\"\n"
-            "    ];\n\n"
-            "    \"bb{}_{}\" -> \"bb{}_{}\" [style=\"bold\"];\n",
-            symbolName, basicBlock->id, shape, color,
-            fmt::map_join(lines.begin(), lines.end(), "\\l", [](auto line) -> string { return absl::CEscape(line); }),
-            symbolName, basicBlock->id, symbolName, basicBlock->bexit.thenb->id);
+        fmt::format_to(std::back_inserter(buf),
+                       "    \"bb{}_{}\" [\n"
+                       "        shape = {};\n"
+                       "        color = {};\n"
+                       "        label = \"{}\\l\"\n"
+                       "    ];\n\n"
+                       "    \"bb{}_{}\" -> \"bb{}_{}\" [style=\"bold\"];\n",
+                       symbolName, basicBlock->id, shape, color,
+                       fmt::map_join(lines, "\\l", [](auto line) -> string { return absl::CEscape(line); }), symbolName,
+                       basicBlock->id, symbolName, basicBlock->bexit.thenb->id);
 
         if (basicBlock->bexit.thenb != basicBlock->bexit.elseb) {
             fmt::format_to(std::back_inserter(buf), "    \"bb{}_{}\" -> \"bb{}_{}\" [style=\"tapered\"];\n\n",
@@ -273,17 +272,16 @@ string CFG::showRaw(core::Context ctx) const {
         auto shape = basicBlock->id == 0 ? "invhouse" : basicBlock->id == 1 ? "parallelogram" : "rectangle";
         // whole block red if whole block is dead
         auto color = basicBlock->firstDeadInstructionIdx == 0 ? "red" : "black";
-        fmt::format_to(
-            std::back_inserter(buf),
-            "    \"bb{}_{}\" [\n"
-            "        shape = {};\n"
-            "        color = {};\n"
-            "        label = \"{}\\l\"\n"
-            "    ];\n\n"
-            "    \"bb{}_{}\" -> \"bb{}_{}\" [style=\"bold\"];\n",
-            symbolName, basicBlock->id, shape, color,
-            fmt::map_join(lines.begin(), lines.end(), "\\l", [](auto line) -> string { return absl::CEscape(line); }),
-            symbolName, basicBlock->id, symbolName, basicBlock->bexit.thenb->id);
+        fmt::format_to(std::back_inserter(buf),
+                       "    \"bb{}_{}\" [\n"
+                       "        shape = {};\n"
+                       "        color = {};\n"
+                       "        label = \"{}\\l\"\n"
+                       "    ];\n\n"
+                       "    \"bb{}_{}\" -> \"bb{}_{}\" [style=\"bold\"];\n",
+                       symbolName, basicBlock->id, shape, color,
+                       fmt::map_join(lines, "\\l", [](auto line) -> string { return absl::CEscape(line); }), symbolName,
+                       basicBlock->id, symbolName, basicBlock->bexit.thenb->id);
 
         if (basicBlock->bexit.thenb != basicBlock->bexit.elseb) {
             fmt::format_to(std::back_inserter(buf), "    \"bb{}_{}\" -> \"bb{}_{}\" [style=\"tapered\"];\n\n",
@@ -298,8 +296,7 @@ string BasicBlock::toString(const core::GlobalState &gs, const CFG &cfg) const {
     fmt::memory_buffer buf;
     fmt::format_to(std::back_inserter(buf), "block[id={}, rubyRegionId={}]({})\n", this->id, this->rubyRegionId,
                    fmt::map_join(
-                       this->args.begin(), this->args.end(),
-                       ", ", [&](const auto &arg) -> auto { return arg.toString(gs, cfg); }));
+                       this->args, ", ", [&](const auto &arg) -> auto { return arg.toString(gs, cfg); }));
 
     if (this->outerLoops > 0) {
         fmt::format_to(std::back_inserter(buf), "outerLoops: {}\n", this->outerLoops);
@@ -316,8 +313,7 @@ string BasicBlock::toTextualString(const core::GlobalState &gs, const CFG &cfg) 
     fmt::format_to(std::back_inserter(buf), "bb{}[rubyRegionId={}, firstDead={}]({}):\n", this->id, this->rubyRegionId,
                    this->firstDeadInstructionIdx,
                    fmt::map_join(
-                       this->args.begin(), this->args.end(),
-                       ", ", [&](const auto &arg) -> auto { return arg.toString(gs, cfg); }));
+                       this->args, ", ", [&](const auto &arg) -> auto { return arg.toString(gs, cfg); }));
 
     if (this->outerLoops > 0) {
         fmt::format_to(std::back_inserter(buf), "    # outerLoops: {}\n", this->outerLoops);
@@ -347,10 +343,9 @@ string BasicBlock::toTextualString(const core::GlobalState &gs, const CFG &cfg) 
 
 string BasicBlock::showRaw(const core::GlobalState &gs, const CFG &cfg) const {
     fmt::memory_buffer buf;
-    fmt::format_to(
-        std::back_inserter(buf), "block[id={}]({})\n", this->id,
-        fmt::map_join(
-            this->args.begin(), this->args.end(), ", ", [&](const auto &arg) -> auto { return arg.showRaw(gs, cfg); }));
+    fmt::format_to(std::back_inserter(buf), "block[id={}]({})\n", this->id,
+                   fmt::map_join(
+                       this->args, ", ", [&](const auto &arg) -> auto { return arg.showRaw(gs, cfg); }));
 
     if (this->outerLoops > 0) {
         fmt::format_to(std::back_inserter(buf), "outerLoops: {}\n", this->outerLoops);

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1029,8 +1029,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                                     e.setHeader(
                                         "Method `{}` on `{}` is package-private and cannot be called from package `{}`",
                                         it->main.method.data(ctx)->name.show(ctx), klass.show(ctx),
-                                        fmt::map_join(curPkgName.begin(), curPkgName.end(),
-                                                      "::", [&](const auto &nr) { return nr.show(ctx); }));
+                                        fmt::map_join(curPkgName, "::", [&](const auto &nr) { return nr.show(ctx); }));
                                     e.addErrorLine(it->main.method.data(ctx)->loc(), "Defined in `{}` here",
                                                    it->main.method.data(ctx)->owner.show(ctx));
                                 }

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -823,8 +823,7 @@ public:
                 errorDepth++;
                 if (auto e = ctx.beginError(constantLit->loc, core::errors::Packager::DefinitionPackageMismatch)) {
                     e.setHeader("Class or method definition must match enclosing package namespace `{}`",
-                                fmt::map_join(pkgName.begin(), pkgName.end(),
-                                              "::", [&](const auto &nr) { return nr.show(ctx); }));
+                                fmt::map_join(pkgName, "::", [&](const auto &nr) { return nr.show(ctx); }));
                     addPackageSuggestion(ctx, e);
                 }
             }
@@ -875,8 +874,7 @@ public:
                 errorDepth++;
                 if (auto e = ctx.beginError(lhs->loc, core::errors::Packager::DefinitionPackageMismatch)) {
                     e.setHeader("Constants may not be defined outside of the enclosing package namespace `{}`",
-                                fmt::map_join(pkgName.begin(), pkgName.end(),
-                                              "::", [&](const auto &nr) { return nr.show(ctx); }));
+                                fmt::map_join(pkgName, "::", [&](const auto &nr) { return nr.show(ctx); }));
                     addPackageSuggestion(ctx, e);
                 }
             }
@@ -939,7 +937,7 @@ public:
             if (auto e = ctx.beginError(loc, core::errors::Packager::DefinitionPackageMismatch)) {
                 e.setHeader(
                     "Class or method behavior may not be defined outside of the enclosing package namespace `{}`",
-                    fmt::map_join(pkgName.begin(), pkgName.end(), "::", [&](const auto &nr) { return nr.show(ctx); }));
+                    fmt::map_join(pkgName, "::", [&](const auto &nr) { return nr.show(ctx); }));
                 addPackageSuggestion(ctx, e);
             }
         }

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -384,7 +384,7 @@ vector<shared_ptr<RangeAssertion>> parseAssertionsForFile(const shared_ptr<core:
                                 "regular comment that just happens to be formatted like an assertion comment, you "
                                 "can add the label to `ignoredAssertionLabels`.",
                                 assertionType,
-                                fmt::map_join(assertionConstructors.begin(), assertionConstructors.end(), ", ",
+                                fmt::map_join(assertionConstructors, ", ",
                                               [](const auto &entry) -> string { return entry.first; })));
             }
         } else {
@@ -1160,7 +1160,7 @@ void CompletionAssertion::check(const UnorderedMap<string, shared_ptr<core::File
     string actualMessage =
         completionList->items.empty()
             ? "(nothing)"
-            : fmt::format("{}", fmt::map_join(completionList->items.begin(), completionList->items.end(), ", ",
+            : fmt::format("{}", fmt::map_join(completionList->items, ", ",
                                               [](const auto &item) -> string { return item->label; }));
 
     auto partial = absl::EndsWith(this->message, ", ...");

--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -67,8 +67,8 @@ string documentSymbolsToString(const variant<JSONNullObject, vector<unique_ptr<D
         return "null";
     } else {
         auto &symbols = get<vector<unique_ptr<DocumentSymbol>>>(symbolResult);
-        return fmt::format("{}", fmt::map_join(symbols.begin(), symbols.end(), ", ",
-                                               [](const auto &sym) -> string { return sym->toJSON(true); }));
+        return fmt::format("{}",
+                           fmt::map_join(symbols, ", ", [](const auto &sym) -> string { return sym->toJSON(true); }));
     }
 }
 
@@ -284,11 +284,11 @@ void validateCodeActions(LSPWrapper &lspWrapper, Expectations &test, string file
     if (matchedCodeActionAssertions.size() > receivedCodeActionsCount) {
         FAIL_CHECK(fmt::format("Found apply-code-action assertions without "
                                "corresponding code actions from the server:\n{}",
-                               fmt::map_join(applyCodeActionAssertions.begin(), applyCodeActionAssertions.end(), ", ",
+                               fmt::map_join(applyCodeActionAssertions, ", ",
                                              [](const auto &assertion) -> string { return assertion->toString(); })));
     } else if (matchedCodeActionAssertions.size() < receivedCodeActionsCount) {
         FAIL_CHECK(fmt::format("Received code actions without corresponding apply-code-action assertions:\n{}",
-                               fmt::map_join(receivedCodeActionsByTitle.begin(), receivedCodeActionsByTitle.end(), "\n",
+                               fmt::map_join(receivedCodeActionsByTitle, "\n",
                                              [](const auto &action) -> string { return action.second->toJSON(); })));
     }
 }
@@ -359,7 +359,7 @@ void testQuickFixCodeActions(LSPWrapper &lspWrapper, Expectations &test, const v
             // We've already removed any code action assertions that matches a received code action assertion.
             // Any remaining are therefore extraneous.
             INFO(fmt::format("Found extraneous apply-code-action assertions:\n{}",
-                             fmt::map_join(applyCodeActionAssertions.begin(), applyCodeActionAssertions.end(), "\n",
+                             fmt::map_join(applyCodeActionAssertions, "\n",
                                            [](const auto &assertion) -> string { return assertion->toString(); })));
             CHECK_EQ(applyCodeActionAssertions.size(), 0);
         } else {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

`common/formatting.h` contains a overload for `fmt::map_join` that accepts a container, and does the hard work of calling `.begin()` and `.end()` on that.  We should use that for in preference to the one that accepts a pair of iterators.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.  No functional change intended.
