### PR TITLE
add stale-state tests for renaming constants

### DIFF
--- a/test/testdata/lsp/stale_state/rename_constant_def.1.rbstaleupdate
+++ b/test/testdata/lsp/stale_state/rename_constant_def.1.rbstaleupdate
@@ -1,0 +1,18 @@
+# typed: true
+
+class MyClass
+  extend T::Sig
+
+  # Choose something that's not going to get autocorrected.
+  # We renamed the def but not the use.
+  THE_INTEGER = T.let(1, Integer)
+# ^ hover: ```ruby
+# ^ hover: # note: information may be stale
+# ^ hover: Integer
+
+  sig {params(x: Integer).returns(Integer)}
+  def frob(x)
+    x + MY_CONSTANT
+      # ^ hover: null
+  end
+end

--- a/test/testdata/lsp/stale_state/rename_constant_def.rb
+++ b/test/testdata/lsp/stale_state/rename_constant_def.rb
@@ -1,0 +1,12 @@
+# typed: true
+
+class MyClass
+  extend T::Sig
+
+  A = T.let(1, Integer)
+
+  sig {params(x: Integer).returns(Integer)}
+  def frob(x)
+    x + A
+  end
+end

--- a/test/testdata/lsp/stale_state/rename_constant_use.1.rbstaleupdate
+++ b/test/testdata/lsp/stale_state/rename_constant_use.1.rbstaleupdate
@@ -1,0 +1,16 @@
+# typed: true
+
+class MyClass
+  extend T::Sig
+
+  # Oops, we didn't rename the definition
+  A = T.let(1, Integer)
+
+  sig {params(x: Integer).returns(Integer)}
+  def frob(x)
+    x + THE_INTEGER
+      # ^ hover: ```ruby
+      # ^ hover: # note: information may be stale
+      # ^ hover: A
+  end
+end

--- a/test/testdata/lsp/stale_state/rename_constant_use.rb
+++ b/test/testdata/lsp/stale_state/rename_constant_use.rb
@@ -1,0 +1,12 @@
+# typed: true
+
+class MyClass
+  extend T::Sig
+
+  A = T.let(1, Integer)
+
+  sig {params(x: Integer).returns(Integer)}
+  def frob(x)
+    x + A
+  end
+end


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I am getting asserts on the topmost commit, so I think some of the fixes from #5579 will need to land before these tests are ready to go.

Also getting some unhelpful assertions about taking the fast path unexpectedly in tests, so maybe need to consider what to do about that.  And it's hard to write partial-update-style tests, because the test harness has no way of dealing with error messages from stale-state typechecking, which seems bad.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. 