### PR TITLE
add a LSP testcase for hovering an undefined constant

### DIFF
--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -214,7 +214,9 @@ string prettyTypeForConstant(const core::GlobalState &gs, core::SymbolRef consta
     ENFORCE(constant == constant.dealias(gs));
 
     core::TypePtr result;
-    if (constant.isClassOrModule()) {
+    if (constant == core::Symbols::StubModule()) {
+        result = core::Types::untyped(gs, constant);
+    } else if (constant.isClassOrModule()) {
         auto targetClass = constant.asClassOrModuleRef();
         if (!targetClass.data(gs)->attachedClass(gs).exists()) {
             targetClass = targetClass.data(gs)->lookupSingletonClass(gs);

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -213,10 +213,12 @@ string prettyTypeForConstant(const core::GlobalState &gs, core::SymbolRef consta
     // We should understand where dealias calls go.
     ENFORCE(constant == constant.dealias(gs));
 
-    core::TypePtr result;
     if (constant == core::Symbols::StubModule()) {
-        result = core::Types::untyped(gs, constant);
-    } else if (constant.isClassOrModule()) {
+        return "This constant is not defined";
+    }
+
+    core::TypePtr result;
+    if (constant.isClassOrModule()) {
         auto targetClass = constant.asClassOrModuleRef();
         if (!targetClass.data(gs)->attachedClass(gs).exists()) {
             targetClass = targetClass.data(gs)->lookupSingletonClass(gs);

--- a/test/testdata/lsp/hover_undefined_constant.rb
+++ b/test/testdata/lsp/hover_undefined_constant.rb
@@ -1,0 +1,8 @@
+# typed: true
+
+class MyClass
+  def foo(x)
+    x + THE_CONSTANT # error: Unable to resolve constant
+      # ^ hover: T.class_of(Sorbet::Private::Static::StubModule)
+  end
+end

--- a/test/testdata/lsp/hover_undefined_constant.rb
+++ b/test/testdata/lsp/hover_undefined_constant.rb
@@ -3,6 +3,6 @@
 class MyClass
   def foo(x)
     x + THE_CONSTANT # error: Unable to resolve constant
-      # ^ hover: T.class_of(Sorbet::Private::Static::StubModule)
+      # ^ hover: T.untyped
   end
 end

--- a/test/testdata/lsp/hover_undefined_constant.rb
+++ b/test/testdata/lsp/hover_undefined_constant.rb
@@ -3,6 +3,6 @@
 class MyClass
   def foo(x)
     x + THE_CONSTANT # error: Unable to resolve constant
-      # ^ hover: T.untyped
+      # ^ hover: This constant is not defined
   end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I don't know that this is really the behavior we *want* for this (`Sorbet::Private::*` symbols shouldn't leak out via LSP), but responses like this came up while thinking up tests for stale state, so we might as well capture today's behavior.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
