### PR TITLE
Also test immutableNamerResolver after mutable run

### DIFF
--- a/core/Error.cc
+++ b/core/Error.cc
@@ -41,7 +41,7 @@ string ErrorColors::replaceAll(string_view inWhat, string_view from, string_view
 }
 
 bool Error::isCritical() const {
-    return this->what.minLevel == StrictLevel::Internal;
+    return this->what == core::errors::Internal::InternalError;
 }
 
 string restoreColors(string_view formatted, rang::fg color) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Some notes:

- Has to run on the indexed trees (isn't idempotent, so can't run on
  already-resolved trees).
- This commit also changes Error::isCritical, because there are a
  handful of other errors in `core/errors/internal.h`: `WrongSigil`,
  `CyclicReferenceError`, and `FileNotFound`. Those three things are
  user errors. `InternalError` is what we raise when we're recovering
  from a thrown exception or something like that. That's the only thing
  we really care about being called "critical"


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

test-only change