### PR TITLE
Add rename menu after the "Move method" refactoring

### DIFF
--- a/main/lsp/MoveMethod.h
+++ b/main/lsp/MoveMethod.h
@@ -12,6 +12,10 @@ std::vector<std::unique_ptr<TextDocumentEdit>> getMoveMethodEdits(const LSPConfi
                                                                   const core::lsp::MethodDefResponse &definition,
                                                                   LSPTypecheckerInterface &typechecker);
 
+std::unique_ptr<Position> getNewModuleLocation(const core::GlobalState &gs,
+                                               const core::lsp::MethodDefResponse &definition,
+                                               LSPTypecheckerInterface &typechecker);
+
 } // namespace sorbet::realmain::lsp
 
 #endif

--- a/main/lsp/ShowOperation.cc
+++ b/main/lsp/ShowOperation.cc
@@ -30,6 +30,8 @@ string_view kindToOperationName(ShowOperation::Kind kind) {
             return "SymbolSearch";
         case ShowOperation::Kind::Rename:
             return "Rename";
+        case ShowOperation::Kind::MoveMethod:
+            return "MoveMethod";
     }
 }
 
@@ -47,6 +49,8 @@ string_view kindToDescription(ShowOperation::Kind kind) {
             return "Workspace symbol search...";
         case ShowOperation::Kind::Rename:
             return "Renaming...";
+        case ShowOperation::Kind::MoveMethod:
+            return "Moving...";
     }
 }
 

--- a/main/lsp/ShowOperation.h
+++ b/main/lsp/ShowOperation.h
@@ -24,6 +24,7 @@ public:
         References,
         SymbolSearch,
         Rename,
+        MoveMethod,
     };
     ShowOperation(const LSPConfiguration &config, Kind kind);
     ~ShowOperation();

--- a/main/lsp/requests/code_action_resolve.cc
+++ b/main/lsp/requests/code_action_resolve.cc
@@ -1,6 +1,7 @@
 #include "main/lsp/requests/code_action_resolve.h"
 #include "main/lsp/LSPQuery.h"
 #include "main/lsp/MoveMethod.h"
+#include "main/lsp/ShowOperation.h"
 
 using namespace std;
 namespace sorbet::realmain::lsp {
@@ -26,6 +27,8 @@ unique_ptr<ResponseMessage> CodeActionResolveTask::runRequest(LSPTypecheckerInte
             make_unique<ResponseError>((int)LSPErrorCodes::InvalidRequest, "Invalid `codeAction/resolve` request");
         return response;
     }
+
+    ShowOperation op(config, ShowOperation::Kind::MoveMethod);
 
     for (const auto &resp : queryResult.responses) {
         if (const auto def = resp->isMethodDef()) {

--- a/main/lsp/tools/make_lsp_types.cc
+++ b/main/lsp/tools/make_lsp_types.cc
@@ -149,13 +149,28 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                    },
                    classTypes, {"std::unique_ptr<Diagnostic> copy() const;"});
 
-    auto Command = makeObject("Command",
-                              {
-                                  makeField("title", JSONString), makeField("command", JSONString),
-                                  // Unused in Sorbet.
-                                  // makeField("arguments", makeOptional(makeArray(JSONAny))),
-                              },
-                              classTypes);
+    auto TextDocumentIdentifier = makeObject("TextDocumentIdentifier",
+                                             {
+                                                 makeField("uri", JSONString),
+                                             },
+                                             classTypes);
+
+    auto TextDocumentPositionParams = makeObject("TextDocumentPositionParams",
+                                                 {
+                                                     makeField("textDocument", TextDocumentIdentifier),
+                                                     makeField("position", Position),
+                                                 },
+                                                 classTypes);
+    auto Command = makeObject(
+        "Command",
+        {
+            makeField("title", JSONString),
+            makeField("command", JSONString),
+            // the `arguments` field is declared as `LSPAny` in the LSP spec,
+            // but we use it only to call `sorbet.rename` so the type is limited to TextDocumentPositionParams
+            makeField("arguments", makeOptional(makeArray(TextDocumentPositionParams))),
+        },
+        classTypes);
 
     auto TextEdit = makeObject("TextEdit",
                                {
@@ -227,12 +242,6 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                                      makeField("documentChanges", makeOptional(makeArray(TextDocumentEdit)))},
                                     classTypes);
 
-    auto TextDocumentIdentifier = makeObject("TextDocumentIdentifier",
-                                             {
-                                                 makeField("uri", JSONString),
-                                             },
-                                             classTypes);
-
     auto TextDocumentItem = makeObject("TextDocumentItem",
                                        {
                                            makeField("uri", JSONString),
@@ -241,13 +250,6 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                                            makeField("text", JSONString),
                                        },
                                        classTypes);
-
-    auto TextDocumentPositionParams = makeObject("TextDocumentPositionParams",
-                                                 {
-                                                     makeField("textDocument", TextDocumentIdentifier),
-                                                     makeField("position", Position),
-                                                 },
-                                                 classTypes);
 
     auto DocumentFilter = makeObject("DocumentFilter",
                                      {

--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -4,7 +4,7 @@
   "description": "Ruby IDE features, powered by Sorbet.",
   "author": "Stripe Inc.",
   "license": "Apache-2.0",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "publisher": "sorbet",
   "icon": "icon.png",
   "repository": {

--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -76,6 +76,11 @@
         "command": "sorbet.copySymbolToClipboard",
         "title": "Copy Symbol to Clipboard",
         "category": "Sorbet"
+      },
+      {
+        "command": "sorbet.rename",
+        "title": "Rename Symbol",
+        "category": "Sorbet"
       }
     ],
     "configuration": {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation

The change adds a rename textfield after the refactoring have been applied. 
By the LSP spec, you can provide a command in the `CodeAction`, and it will be executed after all edits have been applied. 

```
export interface CodeAction {
	...
	
	/**
	 * A command this code action executes. If a code action
	 * provides an edit and a command, first the edit is
	 * executed and then the command.
	 */
	command?: Command;
}
```
I'm using this property of the code action to invoke the `sorbet.rename` command, which is also have been added in this change. The `sorbet.rename` commands calls the `editor.action.rename` command, which executes all needed requests to rename a symbol.

Unfortunately we can't call an `editor.action.rename` command directly, for more details please check here https://github.com/microsoft/vscode/issues/146767

https://user-images.githubusercontent.com/9540120/162059427-bf639cae-29c6-4dc4-930b-cc4894cc5a29.mov

The PR is best reviewed by commits


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
