### PR TITLE
Immutable version of Packager::runIncremental

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -815,7 +815,7 @@ std::vector<ast::ParsedFile> LSPStaleTypechecker::getResolved(const std::vector<
         }
     }
 
-    return pipeline::incrementalResolveWithoutStateMutation(gs, move(updatedIndexed), config->opts);
+    return pipeline::incrementalResolveBestEffort(gs, move(updatedIndexed), config->opts);
 }
 
 const core::GlobalState &LSPStaleTypechecker::state() const {

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -306,7 +306,7 @@ vector<ast::ParsedFile> incrementalResolveWithoutStateMutation(const core::Globa
             Timer timeit(gs.tracer(), "incremental_resolve");
             gs.tracer().trace("Resolving (incremental pass)...");
 
-            auto result = sorbet::resolver::Resolver::runIncremental(gs, move(what));
+            auto result = sorbet::resolver::Resolver::runIncrementalBestEffort(gs, move(what));
             // incrementalResolve is not cancelable.
             ENFORCE(result.hasResult());
             what = move(result.result());

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -280,11 +280,10 @@ vector<ast::ParsedFile> incrementalResolveBestEffort(const core::GlobalState &gs
                                                      const options::Options &opts) {
     try {
 #ifndef SORBET_REALMAIN_MIN
-        // TODO: Figure out how to run the packager
-        // if (opts.stripePackages) {
-        //     Timer timeit(gs.tracer(), "incremental_packager");
-        //     what = packager::Packager::runIncremental(gs, move(what));
-        // }
+        if (opts.stripePackages) {
+            Timer timeit(gs.tracer(), "incremental_packager");
+            what = packager::Packager::runIncrementalBestEffort(gs, move(what));
+        }
 #endif
         {
             Timer timeit(gs.tracer(), "incremental_naming");

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -276,9 +276,8 @@ vector<ast::ParsedFile> incrementalResolve(core::GlobalState &gs, vector<ast::Pa
 }
 
 // TODO: Deduplicate implementation with incrementalResolve using is_const_v-ish tricks
-vector<ast::ParsedFile> incrementalResolveWithoutStateMutation(const core::GlobalState &gs,
-                                                               vector<ast::ParsedFile> what,
-                                                               const options::Options &opts) {
+vector<ast::ParsedFile> incrementalResolveBestEffort(const core::GlobalState &gs, vector<ast::ParsedFile> what,
+                                                     const options::Options &opts) {
     try {
 #ifndef SORBET_REALMAIN_MIN
         // TODO: Figure out how to run the packager

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -30,9 +30,9 @@ ast::ParsedFilesOrCancelled resolve(std::unique_ptr<core::GlobalState> &gs, std:
 std::vector<ast::ParsedFile> incrementalResolve(core::GlobalState &gs, std::vector<ast::ParsedFile> what,
                                                 const options::Options &opts);
 
-std::vector<ast::ParsedFile> incrementalResolveWithoutStateMutation(const core::GlobalState &gs,
-                                                                    std::vector<ast::ParsedFile> what,
-                                                                    const options::Options &opts);
+std::vector<ast::ParsedFile> incrementalResolveBestEffort(const core::GlobalState &gs,
+                                                          std::vector<ast::ParsedFile> what,
+                                                          const options::Options &opts);
 
 ast::ParsedFilesOrCancelled name(core::GlobalState &gs, std::vector<ast::ParsedFile> what, const options::Options &opts,
                                  WorkerPool &workers);

--- a/packager/packager.h
+++ b/packager/packager.h
@@ -84,6 +84,12 @@ public:
 
     // Run packager incrementally. Note: `files` must contain all packages files. Does not support package changes.
     static std::vector<ast::ParsedFile> runIncremental(core::GlobalState &gs, std::vector<ast::ParsedFile> files);
+    // Run packager incrementally, but withouut mutating GlobalState. This is used by LSP to serve
+    // certain kinds of requests using stale data. In this mode, if mutating GlobalState would have
+    // been required to make progress, the corresponding part of the tree that triggered the
+    // mutation is simply dropped.
+    static std::vector<ast::ParsedFile> runIncrementalBestEffort(const core::GlobalState &gs,
+                                                                 std::vector<ast::ParsedFile> files);
 
     // The structures created for `__package.rb` files from their imports are large and deep. This causes
     // performance problems with typechecking. Use to remove these modules while retaining the PackageSpec

--- a/resolver/resolver.h
+++ b/resolver/resolver.h
@@ -18,13 +18,17 @@ public:
      * that `run` was called on a tree that contains same definitions before (LSP uses heuristics
      * that should only have false negatives to find this)
      *
-     * Has two versions: one that requires a mutable GlobalState, and one that does a "best effort"
-     * mode with a constant GlobalState (for, e.g., serving stale LSP requests)
      *
      * These two versions are explicitly instantiated in resolver.cc
      */
-    template <typename StateType>
-    static ast::ParsedFilesOrCancelled runIncremental(StateType &gs, std::vector<ast::ParsedFile> trees);
+    static ast::ParsedFilesOrCancelled runIncremental(core::GlobalState &gs, std::vector<ast::ParsedFile> trees);
+
+    /**
+     * A version of runIncremental that does a "best effort" mode with a constant GlobalState
+     * (for, e.g., serving stale LSP requests)
+     */
+    static ast::ParsedFilesOrCancelled runIncrementalBestEffort(const core::GlobalState &gs,
+                                                                std::vector<ast::ParsedFile> trees);
 
     // used by autogen only
     static std::vector<ast::ParsedFile> runConstantResolution(core::GlobalState &gs, std::vector<ast::ParsedFile> trees,
@@ -33,7 +37,6 @@ public:
 private:
     static void finalizeAncestors(core::GlobalState &gs);
     static void finalizeSymbols(core::GlobalState &gs);
-    static void sanityCheck(const core::GlobalState &gs, std::vector<ast::ParsedFile> &trees);
 };
 
 } // namespace sorbet::resolver

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -185,7 +185,7 @@ void immutableNamerResolver(const core::GlobalState &gs, vector<ast::ParsedFile>
     trees = move(namer::Namer::symbolizeTreesBestEffort(gs, move(trees), workers).result());
     ENFORCE(!gs.hadCriticalError());
 
-    trees = move(resolver::Resolver::runIncremental(gs, move(trees)).result());
+    trees = move(resolver::Resolver::runIncrementalBestEffort(gs, move(trees)).result());
 
     // Also run the rest of the pipeline as normal, to make sure that things still work as expected.
 

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -179,7 +179,12 @@ public:
 };
 
 // Immutable namer + resolver mode, which is used by things like serving LSP requests from stale GlobalStates
-void immutableNamerResolver(const core::GlobalState &gs, vector<ast::ParsedFile> trees, WorkerPool &workers) {
+void immutableNamerResolver(const core::GlobalState &gs, vector<ast::ParsedFile> trees, WorkerPool &workers,
+                            bool enablePackager) {
+    if (enablePackager) {
+        trees = packager::Packager::runIncrementalBestEffort(gs, move(trees));
+    }
+
     // Non-mutating namer, before entering symbols into GlobalState
 
     trees = move(namer::Namer::symbolizeTreesBestEffort(gs, move(trees), workers).result());
@@ -349,6 +354,61 @@ TEST_CASE("PerPhaseTest") { // NOLINT
     }
 
     auto enablePackager = BooleanPropertyAssertion::getValue("enable-packager", assertions).value_or(false);
+
+    // Immutable namer + resolver will completely garble the trees (it's only the GlobalState
+    // that's immutable) so we have to make copies it can scratch on.
+    vector<ast::ParsedFile> indexedTreesCopy;
+
+    {
+        // Immutable namer + resolver (for stale GlobalState requests)
+
+        // Stashes any already-reported errors so we can check them later (we're going to toss all
+        // errors created at the end of this mode).
+        handler.drainErrors(*gs);
+
+        // This mode is not designed to run on files that Sorbet did not already know about. In LSP
+        // mode this constraint is satisfied naturally by way of the implementation. Here, we have
+        // to satisfy it by forcing the file-level `<static-init>` methods into existence first.
+        // This would mutate the rest of the pipeline, so for the sake of not polluting things
+        // downstream from us, we do it on a copy of GlobalState.
+        auto staleGS = gs->deepCopy();
+        {
+            core::UnfreezeNameTable nameTableAccess(*staleGS);
+            core::UnfreezeSymbolTable symbolTableAccess(*staleGS);
+            for (auto &tree : trees) {
+                staleGS->staticInitForFile(core::Loc(tree.file, tree.tree.loc()));
+            }
+
+            // Also, various later parts of Sorbet expect that the mutable resolver has run on the
+            // symbol table at least once (to compute things like externalTypes for classes). For
+            // the payload GlobalState this happens during the `--store-state` run.
+            //
+            // But for `# no-stdlib: true`, the initial empty GlobalState hasn't had resolver run on
+            // it once yet. In LSP mode with `--no-stdlib`, this would happen naturally as a part of
+            // initialization, but we need to run it manually here.
+            resolver::Resolver::run(*staleGS, {}, *workers);
+        }
+
+        // Immutable namer + resolver will completely garble the trees (it's only the GlobalState
+        // that's immutable) so we have to make copies it can scratch on.
+        vector<ast::ParsedFile> treesCopy;
+        for (auto &tree : trees) {
+            treesCopy.emplace_back(ast::ParsedFile{tree.tree.deepCopy(), tree.file});
+            // Also stash a copy to use for the run of immutable namer + resolver that will be
+            // tested after running mutable namer + resolver once.
+            indexedTreesCopy.emplace_back(ast::ParsedFile{tree.tree.deepCopy(), tree.file});
+        }
+
+        // Implemented in a helper function, so that only one GlobalState and list of trees is in scope.
+        immutableNamerResolver(*staleGS, std::move(treesCopy), *workers, enablePackager);
+
+        // Drop the errors that were produced as a result of this process.
+        // It's good to have the error-reporting code run (ensure that it doesn't ENFORCE), but we
+        // don't actually care what the errors are here, because LSP will never show them.
+        // (Even though we copied GlobalState, the error queues and collectors are shared with the original.)
+        handler.dropErrors(*gs);
+    }
+
     if (enablePackager) {
         vector<std::string> extraPackageFilesDirectoryPrefixes;
         vector<std::string> secondaryTestPackageNamespaces = {"Critic"};
@@ -449,60 +509,6 @@ TEST_CASE("PerPhaseTest") { // NOLINT
         }
     }
 
-    // Immutable namer + resolver will completely garble the trees (it's only the GlobalState
-    // that's immutable) so we have to make copies it can scratch on.
-    vector<ast::ParsedFile> indexedTreesCopy;
-
-    {
-        // Immutable namer + resolver (for stale GlobalState requests)
-
-        // Stashes any already-reported errors so we can check them later (we're going to toss all
-        // errors created at the end of this mode).
-        handler.drainErrors(*gs);
-
-        // This mode is not designed to run on files that Sorbet did not already know about. In LSP
-        // mode this constraint is satisfied naturally by way of the implementation. Here, we have
-        // to satisfy it by forcing the file-level `<static-init>` methods into existence first.
-        // This would mutate the rest of the pipeline, so for the sake of not polluting things
-        // downstream from us, we do it on a copy of GlobalState.
-        auto staleGS = gs->deepCopy();
-        {
-            core::UnfreezeNameTable nameTableAccess(*staleGS);
-            core::UnfreezeSymbolTable symbolTableAccess(*staleGS);
-            for (auto &tree : trees) {
-                staleGS->staticInitForFile(core::Loc(tree.file, tree.tree.loc()));
-            }
-
-            // Also, various later parts of Sorbet expect that the mutable resolver has run on the
-            // symbol table at least once (to compute things like externalTypes for classes). For
-            // the payload GlobalState this happens during the `--store-state` run.
-            //
-            // But for `# no-stdlib: true`, the initial empty GlobalState hasn't had resolver run on
-            // it once yet. In LSP mode with `--no-stdlib`, this would happen naturally as a part of
-            // initialization, but we need to run it manually here.
-            resolver::Resolver::run(*staleGS, {}, *workers);
-        }
-
-        // Immutable namer + resolver will completely garble the trees (it's only the GlobalState
-        // that's immutable) so we have to make copies it can scratch on.
-        vector<ast::ParsedFile> treesCopy;
-        for (auto &tree : trees) {
-            treesCopy.emplace_back(ast::ParsedFile{tree.tree.deepCopy(), tree.file});
-            // Also stash a copy to use for the run of immutable namer + resolver that will be
-            // tested after running mutable namer + resolver once.
-            indexedTreesCopy.emplace_back(ast::ParsedFile{tree.tree.deepCopy(), tree.file});
-        }
-
-        // Implemented in a helper function, so that only one GlobalState and list of trees is in scope.
-        immutableNamerResolver(*staleGS, std::move(treesCopy), *workers);
-
-        // Drop the errors that were produced as a result of this process.
-        // It's good to have the error-reporting code run (ensure that it doesn't ENFORCE), but we
-        // don't actually care what the errors are here, because LSP will never show them.
-        // (Even though we copied GlobalState, the error queues and collectors are shared with the original.)
-        handler.dropErrors(*gs);
-    }
-
     for (auto &tree : trees) {
         // Namer
         ast::ParsedFile namedTree;
@@ -567,7 +573,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
         // Immutable namer + resolver, after populating GlobalState (for stale GlobalState requests)
 
         handler.drainErrors(*gs);
-        immutableNamerResolver(*gs, std::move(indexedTreesCopy), *workers);
+        immutableNamerResolver(*gs, std::move(indexedTreesCopy), *workers, enablePackager);
         handler.dropErrors(*gs);
     }
 

--- a/test/testdata/packager/lsp_stale_state/bar/__package.rb
+++ b/test/testdata/packager/lsp_stale_state/bar/__package.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class Project::Bar < PackageSpec
+  import Project::Foo
+
+  export Project::Bar::Bar
+end

--- a/test/testdata/packager/lsp_stale_state/bar/bar.1.rbstaleupdate
+++ b/test/testdata/packager/lsp_stale_state/bar/bar.1.rbstaleupdate
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Project::Bar::Bar
+  extend T::Sig
+  sig {params(value: Integer).void}
+  def initialize(value)
+    @value = T.let(value, Integer)
+  end
+
+  puts(Project::Bar::Bar)
+  #                  ^ hover: T.class_of(Project::Bar::Bar)
+  #                  ^ hover: # note: information may be stale
+  puts(Project::Foo::Foo)
+  #                  ^ hover: T.class_of(Project::Foo::Foo)
+  #                  ^ hover: # note: information may be stale
+
+  X = 1
+end

--- a/test/testdata/packager/lsp_stale_state/bar/bar.rb
+++ b/test/testdata/packager/lsp_stale_state/bar/bar.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Project::Bar::Bar
+  extend T::Sig
+  sig {params(value: Integer).void}
+  def initialize(value)
+    @value = T.let(value, Integer)
+  end
+
+  puts(Project::Bar::Bar)
+  #                  ^ hover: T.class_of(Project::Bar::Bar)
+  #                  _________________________________________
+  puts(Project::Foo::Foo)
+  #                  ^ hover: T.class_of(Project::Foo::Foo)
+  #                  _________________________________________
+
+  # ___
+end

--- a/test/testdata/packager/lsp_stale_state/foo/__package.rb
+++ b/test/testdata/packager/lsp_stale_state/foo/__package.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Project::Foo < PackageSpec
+  import Project::Bar
+
+  export Project::Foo::Foo
+end

--- a/test/testdata/packager/lsp_stale_state/foo/foo.rb
+++ b/test/testdata/packager/lsp_stale_state/foo/foo.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Project::Foo::Foo
+  extend T::Sig
+  sig {params(value: Integer).void}
+  def initialize(value)
+    @value = T.let(value, Integer)
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Commit summary

- **Add a test that fails before these changes** (da637be99)


- **pre-work: Refactor Resolve::runIncremental into two explicit functions** (e016114d3)


- **pre-work: `...WithoutStateMutation` -> `...BestEffort`** (343d52a6d)


- **Immutable version of Packager::runIncremental** (ad505ab78)

  Honestly behaves like a hybrid of namer ("drop trees we don't want") and
  resolver ("use templates to do one thing or another conditionally").



### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Honestly behaves like a hybrid of namer ("drop trees we don't want") and
resolver ("use templates to do one thing or another conditionally").

For posterity's sake, here are those two previous PRs: #5498, #5532.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

- [x] @jez This is not tested yet.