### PR TITLE
Flatten virtual package module into a series of casgns

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1722,7 +1722,7 @@ private:
             return;
         }
 
-        // Use the loc from the import in the module name and declaration to get the
+        // Use the loc from the import in the assignment name and declaration to get the
         // following jump to definition behavior in the case of enumerated imports:
         // imported constant: `Foo::Bar::Baz` from package `Foo::Bar`
         //                     ^^^^^^^^       jump to the import statement

--- a/test/cli/packager_suggest_nested/consumer_auth/__package.rb
+++ b/test/cli/packager_suggest_nested/consumer_auth/__package.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Project::ConsumerAuth < PackageSpec
+  import Project::ConsumerAuth::Data
+end

--- a/test/cli/packager_suggest_nested/consumer_auth/data/__package.rb
+++ b/test/cli/packager_suggest_nested/consumer_auth/data/__package.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Project::ConsumerAuth::Data < PackageSpec
+  export Project::ConsumerAuth::Data::IdentifierStruct
+end

--- a/test/cli/packager_suggest_nested/consumer_auth/data/identifier_struct.rb
+++ b/test/cli/packager_suggest_nested/consumer_auth/data/identifier_struct.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Project::ConsumerAuth::Data
+  class IdentifierStruct
+  end
+end

--- a/test/cli/packager_suggest_nested/consumer_auth/identity_type.rb
+++ b/test/cli/packager_suggest_nested/consumer_auth/identity_type.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Project::ConsumerAuth
+  class IdentifierType
+  end
+end

--- a/test/cli/packager_suggest_nested/test.out
+++ b/test/cli/packager_suggest_nested/test.out
@@ -1,0 +1,1 @@
+No errors! Great job.

--- a/test/cli/packager_suggest_nested/test.sh
+++ b/test/cli/packager_suggest_nested/test.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+main/sorbet --silence-dev-message --stripe-packages test/cli/packager_suggest_nested/ 2>&1

--- a/test/testdata/packager/deeply_nested_packages/pass.package-tree.exp
+++ b/test/testdata/packager/deeply_nested_packages/pass.package-tree.exp
@@ -9,33 +9,21 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Package_Package_Private$1>::<C Package><<C <todo sym>>> < ()
-      <emptyTree>::<C Subpackage> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage>
-    end
+    <emptyTree>::<C Package_Package_Private$1>::<C Package>::<C Subpackage> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage>
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Package_Package_Private$1>::<C Package><<C <todo sym>>> < ()
-      <emptyTree>::<C InnerClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package_Private$1>::<C Package>::<C InnerClass>
-    end
+    <emptyTree>::<C Package_Package_Private$1>::<C Package>::<C InnerClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package_Private$1>::<C Package>::<C InnerClass>
 
-    module <emptyTree>::<C Package_Package_Private$1>::<C Package><<C <todo sym>>> < ()
-      <emptyTree>::<C PackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package_Private$1>::<C Package>::<C PackageClass>
-    end
+    <emptyTree>::<C Package_Package_Private$1>::<C Package>::<C PackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package_Private$1>::<C Package>::<C PackageClass>
 
-    module <emptyTree>::<C Package_Package_Private$1>::<C Package><<C <todo sym>>> < ()
-      <emptyTree>::<C Subpackage> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage>
-    end
+    <emptyTree>::<C Package_Package_Private$1>::<C Package>::<C Subpackage> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage>
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Package_Package$1>::<C Package><<C <todo sym>>> < ()
-      <emptyTree>::<C InnerClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package_Private$1>::<C Package>::<C InnerClass>
-    end
+    <emptyTree>::<C Package_Package$1>::<C Package>::<C InnerClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package_Private$1>::<C Package>::<C InnerClass>
 
-    module <emptyTree>::<C Package_Package$1>::<C Package><<C <todo sym>>> < ()
-      <emptyTree>::<C PackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package_Private$1>::<C Package>::<C PackageClass>
-    end
+    <emptyTree>::<C Package_Package$1>::<C Package>::<C PackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package_Private$1>::<C Package>::<C PackageClass>
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
@@ -75,33 +63,21 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Package_Subpackage_Package_Private$1>::<C Package><<C <todo sym>>> < ()
-      <emptyTree>::<C InnerClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>::<C InnerClass>
-    end
+    <emptyTree>::<C Package_Subpackage_Package_Private$1>::<C Package>::<C InnerClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>::<C InnerClass>
 
-    module <emptyTree>::<C Package_Subpackage_Package_Private$1>::<C Package><<C <todo sym>>> < ()
-      <emptyTree>::<C PackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>::<C PackageClass>
-    end
+    <emptyTree>::<C Package_Subpackage_Package_Private$1>::<C Package>::<C PackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>::<C PackageClass>
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Package_Subpackage_Package_Private$1>::<C Package><<C <todo sym>>> < ()
-      <emptyTree>::<C InnerClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>::<C InnerClass>
-    end
+    <emptyTree>::<C Package_Subpackage_Package_Private$1>::<C Package>::<C InnerClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>::<C InnerClass>
 
-    module <emptyTree>::<C Package_Subpackage_Package_Private$1>::<C Package><<C <todo sym>>> < ()
-      <emptyTree>::<C PackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>::<C PackageClass>
-    end
+    <emptyTree>::<C Package_Subpackage_Package_Private$1>::<C Package>::<C PackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>::<C PackageClass>
 
-    module <emptyTree>::<C Package_Subpackage_Package_Private$1>::<C Package>::<C Subpackage><<C <todo sym>>> < ()
-      <emptyTree>::<C SubpackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package_Private$1>::<C Package>::<C Subpackage>::<C SubpackageClass>
-    end
+    <emptyTree>::<C Package_Subpackage_Package_Private$1>::<C Package>::<C Subpackage>::<C SubpackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package_Private$1>::<C Package>::<C Subpackage>::<C SubpackageClass>
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage><<C <todo sym>>> < ()
-      <emptyTree>::<C SubpackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package_Private$1>::<C Package>::<C Subpackage>::<C SubpackageClass>
-    end
+    <emptyTree>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage>::<C SubpackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package_Private$1>::<C Package>::<C Subpackage>::<C SubpackageClass>
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()

--- a/test/testdata/packager/export_for_test/pass.package-tree.exp
+++ b/test/testdata/packager/export_for_test/pass.package-tree.exp
@@ -32,53 +32,31 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Opus_Foo_Package_Private$1>::<C Opus>::<C Foo><<C <todo sym>>> < ()
-      <emptyTree>::<C Bar> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Bar_Package$1>::<C Opus>::<C Foo>::<C Bar>
-    end
+    <emptyTree>::<C Opus_Foo_Package_Private$1>::<C Opus>::<C Foo>::<C Bar> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Bar_Package$1>::<C Opus>::<C Foo>::<C Bar>
 
-    module <emptyTree>::<C Opus_Foo_Package_Private$1>::<C Opus><<C <todo sym>>> < ()
-      <emptyTree>::<C Util> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Util_Package$1>::<C Opus>::<C Util>
-    end
+    <emptyTree>::<C Opus_Foo_Package_Private$1>::<C Opus>::<C Util> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Util_Package$1>::<C Opus>::<C Util>
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Opus_Foo_Package_Private$1>::<C Opus>::<C Foo><<C <todo sym>>> < ()
-      <emptyTree>::<C Bar> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Bar_Package$1>::<C Opus>::<C Foo>::<C Bar>
-    end
+    <emptyTree>::<C Opus_Foo_Package_Private$1>::<C Opus>::<C Foo>::<C Bar> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Bar_Package$1>::<C Opus>::<C Foo>::<C Bar>
 
-    module <emptyTree>::<C Opus_Foo_Package_Private$1>::<C Opus>::<C Foo><<C <todo sym>>> < ()
-      <emptyTree>::<C FooClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Package_Private$1>::<C Opus>::<C Foo>::<C FooClass>
-    end
+    <emptyTree>::<C Opus_Foo_Package_Private$1>::<C Opus>::<C Foo>::<C FooClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Package_Private$1>::<C Opus>::<C Foo>::<C FooClass>
 
-    module <emptyTree>::<C Opus_Foo_Package_Private$1>::<C Opus>::<C Foo>::<C Private><<C <todo sym>>> < ()
-      <emptyTree>::<C ImplDetail> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Package_Private$1>::<C Opus>::<C Foo>::<C Private>::<C ImplDetail>
-    end
+    <emptyTree>::<C Opus_Foo_Package_Private$1>::<C Opus>::<C Foo>::<C Private>::<C ImplDetail> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Package_Private$1>::<C Opus>::<C Foo>::<C Private>::<C ImplDetail>
 
-    module <emptyTree>::<C Opus_Foo_Package_Private$1>::<C Opus><<C <todo sym>>> < ()
-      <emptyTree>::<C TestImported> = <emptyTree>::<C <PackageRegistry>>::<C Opus_TestImported_Package$1>::<C Opus>::<C TestImported>
-    end
+    <emptyTree>::<C Opus_Foo_Package_Private$1>::<C Opus>::<C TestImported> = <emptyTree>::<C <PackageRegistry>>::<C Opus_TestImported_Package$1>::<C Opus>::<C TestImported>
 
-    module <emptyTree>::<C Opus_Foo_Package_Private$1>::<C Opus><<C <todo sym>>> < ()
-      <emptyTree>::<C Util> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Util_Package$1>::<C Opus>::<C Util>
-    end
+    <emptyTree>::<C Opus_Foo_Package_Private$1>::<C Opus>::<C Util> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Util_Package$1>::<C Opus>::<C Util>
 
-    module <emptyTree>::<C Opus_Foo_Package_Private$1>::<C Test>::<C Opus>::<C Foo><<C <todo sym>>> < ()
-      <emptyTree>::<C Bar> = <emptyTree>::<C <PackageTests>>::<C Opus_Foo_Bar_Package$1>::<C Test>::<C Opus>::<C Foo>::<C Bar>
-    end
+    <emptyTree>::<C Opus_Foo_Package_Private$1>::<C Test>::<C Opus>::<C Foo>::<C Bar> = <emptyTree>::<C <PackageTests>>::<C Opus_Foo_Bar_Package$1>::<C Test>::<C Opus>::<C Foo>::<C Bar>
 
-    module <emptyTree>::<C Opus_Foo_Package_Private$1>::<C Test>::<C Opus><<C <todo sym>>> < ()
-      <emptyTree>::<C TestImported> = <emptyTree>::<C <PackageTests>>::<C Opus_TestImported_Package$1>::<C Test>::<C Opus>::<C TestImported>
-    end
+    <emptyTree>::<C Opus_Foo_Package_Private$1>::<C Test>::<C Opus>::<C TestImported> = <emptyTree>::<C <PackageTests>>::<C Opus_TestImported_Package$1>::<C Test>::<C Opus>::<C TestImported>
 
-    module <emptyTree>::<C Opus_Foo_Package_Private$1>::<C Test>::<C Opus><<C <todo sym>>> < ()
-      <emptyTree>::<C Util> = <emptyTree>::<C <PackageTests>>::<C Opus_Util_Package$1>::<C Test>::<C Opus>::<C Util>
-    end
+    <emptyTree>::<C Opus_Foo_Package_Private$1>::<C Test>::<C Opus>::<C Util> = <emptyTree>::<C <PackageTests>>::<C Opus_Util_Package$1>::<C Test>::<C Opus>::<C Util>
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Opus_Foo_Package$1>::<C Opus>::<C Foo><<C <todo sym>>> < ()
-      <emptyTree>::<C FooClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Package_Private$1>::<C Opus>::<C Foo>::<C FooClass>
-    end
+    <emptyTree>::<C Opus_Foo_Package$1>::<C Opus>::<C Foo>::<C FooClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Package_Private$1>::<C Opus>::<C Foo>::<C FooClass>
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
@@ -96,21 +74,15 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Opus_Foo_Bar_Package_Private$1>::<C Opus>::<C Foo>::<C Bar><<C <todo sym>>> < ()
-      <emptyTree>::<C BarClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Bar_Package_Private$1>::<C Opus>::<C Foo>::<C Bar>::<C BarClass>
-    end
+    <emptyTree>::<C Opus_Foo_Bar_Package_Private$1>::<C Opus>::<C Foo>::<C Bar>::<C BarClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Bar_Package_Private$1>::<C Opus>::<C Foo>::<C Bar>::<C BarClass>
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Opus_Foo_Bar_Package$1>::<C Opus>::<C Foo>::<C Bar><<C <todo sym>>> < ()
-      <emptyTree>::<C BarClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Bar_Package_Private$1>::<C Opus>::<C Foo>::<C Bar>::<C BarClass>
-    end
+    <emptyTree>::<C Opus_Foo_Bar_Package$1>::<C Opus>::<C Foo>::<C Bar>::<C BarClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Foo_Bar_Package_Private$1>::<C Opus>::<C Foo>::<C Bar>::<C BarClass>
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Opus_Foo_Bar_Package$1>::<C Test>::<C Opus>::<C Foo>::<C Bar><<C <todo sym>>> < ()
-      <emptyTree>::<C BarClassTest> = <emptyTree>::<C <PackageTests>>::<C Opus_Foo_Bar_Package_Private$1>::<C Test>::<C Opus>::<C Foo>::<C Bar>::<C BarClassTest>
-    end
+    <emptyTree>::<C Opus_Foo_Bar_Package$1>::<C Test>::<C Opus>::<C Foo>::<C Bar>::<C BarClassTest> = <emptyTree>::<C <PackageTests>>::<C Opus_Foo_Bar_Package_Private$1>::<C Test>::<C Opus>::<C Foo>::<C Bar>::<C BarClassTest>
   end
 end
 # -- test/testdata/packager/export_for_test/foo/bar/bar.rb --
@@ -218,21 +190,15 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Opus_TestImported_Package_Private$1>::<C Opus>::<C TestImported><<C <todo sym>>> < ()
-      <emptyTree>::<C TIClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_TestImported_Package_Private$1>::<C Opus>::<C TestImported>::<C TIClass>
-    end
+    <emptyTree>::<C Opus_TestImported_Package_Private$1>::<C Opus>::<C TestImported>::<C TIClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_TestImported_Package_Private$1>::<C Opus>::<C TestImported>::<C TIClass>
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Opus_TestImported_Package$1>::<C Opus>::<C TestImported><<C <todo sym>>> < ()
-      <emptyTree>::<C TIClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_TestImported_Package_Private$1>::<C Opus>::<C TestImported>::<C TIClass>
-    end
+    <emptyTree>::<C Opus_TestImported_Package$1>::<C Opus>::<C TestImported>::<C TIClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_TestImported_Package_Private$1>::<C Opus>::<C TestImported>::<C TIClass>
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Opus_TestImported_Package$1>::<C Test>::<C Opus>::<C TestImported><<C <todo sym>>> < ()
-      <emptyTree>::<C TITestClass> = <emptyTree>::<C <PackageTests>>::<C Opus_TestImported_Package_Private$1>::<C Test>::<C Opus>::<C TestImported>::<C TITestClass>
-    end
+    <emptyTree>::<C Opus_TestImported_Package$1>::<C Test>::<C Opus>::<C TestImported>::<C TITestClass> = <emptyTree>::<C <PackageTests>>::<C Opus_TestImported_Package_Private$1>::<C Test>::<C Opus>::<C TestImported>::<C TITestClass>
   end
 end
 # -- test/testdata/packager/export_for_test/test_imported/test_imported.rb --
@@ -269,29 +235,19 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Opus_Util_Package_Private$1>::<C Opus>::<C Util><<C <todo sym>>> < ()
-      <emptyTree>::<C Nesting> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Util_Package_Private$1>::<C Opus>::<C Util>::<C Nesting>
-    end
+    <emptyTree>::<C Opus_Util_Package_Private$1>::<C Opus>::<C Util>::<C Nesting> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Util_Package_Private$1>::<C Opus>::<C Util>::<C Nesting>
 
-    module <emptyTree>::<C Opus_Util_Package_Private$1>::<C Opus>::<C Util><<C <todo sym>>> < ()
-      <emptyTree>::<C UtilClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Util_Package_Private$1>::<C Opus>::<C Util>::<C UtilClass>
-    end
+    <emptyTree>::<C Opus_Util_Package_Private$1>::<C Opus>::<C Util>::<C UtilClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Util_Package_Private$1>::<C Opus>::<C Util>::<C UtilClass>
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Opus_Util_Package$1>::<C Opus>::<C Util>::<C Nesting><<C <todo sym>>> < ()
-      <emptyTree>::<C Public> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Util_Package_Private$1>::<C Opus>::<C Util>::<C Nesting>::<C Public>
-    end
+    <emptyTree>::<C Opus_Util_Package$1>::<C Opus>::<C Util>::<C Nesting>::<C Public> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Util_Package_Private$1>::<C Opus>::<C Util>::<C Nesting>::<C Public>
 
-    module <emptyTree>::<C Opus_Util_Package$1>::<C Opus>::<C Util><<C <todo sym>>> < ()
-      <emptyTree>::<C UtilClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Util_Package_Private$1>::<C Opus>::<C Util>::<C UtilClass>
-    end
+    <emptyTree>::<C Opus_Util_Package$1>::<C Opus>::<C Util>::<C UtilClass> = <emptyTree>::<C <PackageRegistry>>::<C Opus_Util_Package_Private$1>::<C Opus>::<C Util>::<C UtilClass>
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Opus_Util_Package$1>::<C Test>::<C Opus>::<C Util><<C <todo sym>>> < ()
-      <emptyTree>::<C TestUtil> = <emptyTree>::<C <PackageTests>>::<C Opus_Util_Package_Private$1>::<C Test>::<C Opus>::<C Util>::<C TestUtil>
-    end
+    <emptyTree>::<C Opus_Util_Package$1>::<C Test>::<C Opus>::<C Util>::<C TestUtil> = <emptyTree>::<C <PackageTests>>::<C Opus_Util_Package_Private$1>::<C Test>::<C Opus>::<C Util>::<C TestUtil>
   end
 end
 # -- test/testdata/packager/export_for_test/util/util.rb --

--- a/test/testdata/packager/export_imported/pass.package-tree.exp
+++ b/test/testdata/packager/export_imported/pass.package-tree.exp
@@ -7,21 +7,15 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C A_Package_Private$1><<C <todo sym>>> < ()
-      <emptyTree>::<C B> = <emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>
-    end
+    <emptyTree>::<C A_Package_Private$1>::<C B> = <emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C A_Package_Private$1><<C <todo sym>>> < ()
-      <emptyTree>::<C B> = <emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>
-    end
+    <emptyTree>::<C A_Package_Private$1>::<C B> = <emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C A_Package$1>::<C B><<C <todo sym>>> < ()
-      <emptyTree>::<C BClass> = <emptyTree>::<C <PackageRegistry>>::<C A_Package_Private$1>::<C B>::<C BClass>
-    end
+    <emptyTree>::<C A_Package$1>::<C B>::<C BClass> = <emptyTree>::<C <PackageRegistry>>::<C A_Package_Private$1>::<C B>::<C BClass>
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
@@ -37,15 +31,11 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C B_Package_Private$1>::<C B><<C <todo sym>>> < ()
-      <emptyTree>::<C BClass> = <emptyTree>::<C <PackageRegistry>>::<C B_Package_Private$1>::<C B>::<C BClass>
-    end
+    <emptyTree>::<C B_Package_Private$1>::<C B>::<C BClass> = <emptyTree>::<C <PackageRegistry>>::<C B_Package_Private$1>::<C B>::<C BClass>
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C B_Package$1>::<C B><<C <todo sym>>> < ()
-      <emptyTree>::<C BClass> = <emptyTree>::<C <PackageRegistry>>::<C B_Package_Private$1>::<C B>::<C BClass>
-    end
+    <emptyTree>::<C B_Package$1>::<C B>::<C BClass> = <emptyTree>::<C <PackageRegistry>>::<C B_Package_Private$1>::<C B>::<C BClass>
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()

--- a/test/testdata/packager/extra_package_paths/pass.package-tree.exp
+++ b/test/testdata/packager/extra_package_paths/pass.package-tree.exp
@@ -7,23 +7,15 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Project_Bar_Package_Private$1>::<C Project>::<C Baz><<C <todo sym>>> < ()
-      <emptyTree>::<C Package> = <emptyTree>::<C <PackageRegistry>>::<C Project_Baz_Package_Package$1>::<C Project>::<C Baz>::<C Package>
-    end
+    <emptyTree>::<C Project_Bar_Package_Private$1>::<C Project>::<C Baz>::<C Package> = <emptyTree>::<C <PackageRegistry>>::<C Project_Baz_Package_Package$1>::<C Project>::<C Baz>::<C Package>
 
-    module <emptyTree>::<C Project_Bar_Package_Private$1>::<C Project><<C <todo sym>>> < ()
-      <emptyTree>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>
-    end
+    <emptyTree>::<C Project_Bar_Package_Private$1>::<C Project>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Project_Bar_Package_Private$1>::<C Project>::<C Baz><<C <todo sym>>> < ()
-      <emptyTree>::<C Package> = <emptyTree>::<C <PackageRegistry>>::<C Project_Baz_Package_Package$1>::<C Project>::<C Baz>::<C Package>
-    end
+    <emptyTree>::<C Project_Bar_Package_Private$1>::<C Project>::<C Baz>::<C Package> = <emptyTree>::<C <PackageRegistry>>::<C Project_Baz_Package_Package$1>::<C Project>::<C Baz>::<C Package>
 
-    module <emptyTree>::<C Project_Bar_Package_Private$1>::<C Project><<C <todo sym>>> < ()
-      <emptyTree>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>
-    end
+    <emptyTree>::<C Project_Bar_Package_Private$1>::<C Project>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
@@ -70,15 +62,11 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Project_Baz_Package_Package_Private$1>::<C Project>::<C Baz>::<C Package><<C <todo sym>>> < ()
-      <emptyTree>::<C C> = <emptyTree>::<C <PackageRegistry>>::<C Project_Baz_Package_Package_Private$1>::<C Project>::<C Baz>::<C Package>::<C C>
-    end
+    <emptyTree>::<C Project_Baz_Package_Package_Private$1>::<C Project>::<C Baz>::<C Package>::<C C> = <emptyTree>::<C <PackageRegistry>>::<C Project_Baz_Package_Package_Private$1>::<C Project>::<C Baz>::<C Package>::<C C>
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Project_Baz_Package_Package$1>::<C Project>::<C Baz>::<C Package><<C <todo sym>>> < ()
-      <emptyTree>::<C C> = <emptyTree>::<C <PackageRegistry>>::<C Project_Baz_Package_Package_Private$1>::<C Project>::<C Baz>::<C Package>::<C C>
-    end
+    <emptyTree>::<C Project_Baz_Package_Package$1>::<C Project>::<C Baz>::<C Package>::<C C> = <emptyTree>::<C <PackageRegistry>>::<C Project_Baz_Package_Package_Private$1>::<C Project>::<C Baz>::<C Package>::<C C>
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
@@ -132,15 +120,11 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Project_Foo_Package_Private$1>::<C Project>::<C Foo><<C <todo sym>>> < ()
-      <emptyTree>::<C B> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package_Private$1>::<C Project>::<C Foo>::<C B>
-    end
+    <emptyTree>::<C Project_Foo_Package_Private$1>::<C Project>::<C Foo>::<C B> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package_Private$1>::<C Project>::<C Foo>::<C B>
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Project_Foo_Package$1>::<C Project>::<C Foo><<C <todo sym>>> < ()
-      <emptyTree>::<C B> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package_Private$1>::<C Project>::<C Foo>::<C B>
-    end
+    <emptyTree>::<C Project_Foo_Package$1>::<C Project>::<C Foo>::<C B> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package_Private$1>::<C Project>::<C Foo>::<C B>
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()

--- a/test/testdata/packager/import_subpackage/pass.package-tree.exp
+++ b/test/testdata/packager/import_subpackage/pass.package-tree.exp
@@ -5,15 +5,11 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Root_Package_Private$1>::<C Root><<C <todo sym>>> < ()
-      <emptyTree>::<C B> = <emptyTree>::<C <PackageRegistry>>::<C Root_B_Package$1>::<C Root>::<C B>
-    end
+    <emptyTree>::<C Root_Package_Private$1>::<C Root>::<C B> = <emptyTree>::<C <PackageRegistry>>::<C Root_B_Package$1>::<C Root>::<C B>
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Root_Package_Private$1>::<C Root><<C <todo sym>>> < ()
-      <emptyTree>::<C B> = <emptyTree>::<C <PackageRegistry>>::<C Root_B_Package$1>::<C Root>::<C B>
-    end
+    <emptyTree>::<C Root_Package_Private$1>::<C Root>::<C B> = <emptyTree>::<C <PackageRegistry>>::<C Root_B_Package$1>::<C Root>::<C B>
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
@@ -32,15 +28,11 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Root_B_Package_Private$1>::<C Root>::<C B><<C <todo sym>>> < ()
-      <emptyTree>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Root_B_Package_Private$1>::<C Root>::<C B>::<C Foo>
-    end
+    <emptyTree>::<C Root_B_Package_Private$1>::<C Root>::<C B>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Root_B_Package_Private$1>::<C Root>::<C B>::<C Foo>
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Root_B_Package$1>::<C Root>::<C B><<C <todo sym>>> < ()
-      <emptyTree>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Root_B_Package_Private$1>::<C Root>::<C B>::<C Foo>
-    end
+    <emptyTree>::<C Root_B_Package$1>::<C Root>::<C B>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Root_B_Package_Private$1>::<C Root>::<C B>::<C Foo>
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()

--- a/test/testdata/packager/invalid_imports_and_exports/pass.package-tree.exp
+++ b/test/testdata/packager/invalid_imports_and_exports/pass.package-tree.exp
@@ -27,41 +27,25 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C A_Package_Private$1><<C <todo sym>>> < ()
-      <emptyTree>::<C B> = <emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>
-    end
+    <emptyTree>::<C A_Package_Private$1>::<C B> = <emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C A_Package_Private$1>::<C A><<C <todo sym>>> < ()
-      <emptyTree>::<C AClass> = <emptyTree>::<C <PackageRegistry>>::<C A_Package_Private$1>::<C A>::<C AClass>
-    end
+    <emptyTree>::<C A_Package_Private$1>::<C A>::<C AClass> = <emptyTree>::<C <PackageRegistry>>::<C A_Package_Private$1>::<C A>::<C AClass>
 
-    module <emptyTree>::<C A_Package_Private$1>::<C A><<C <todo sym>>> < ()
-      <emptyTree>::<C AModule> = <emptyTree>::<C <PackageRegistry>>::<C A_Package_Private$1>::<C A>::<C AModule>
-    end
+    <emptyTree>::<C A_Package_Private$1>::<C A>::<C AModule> = <emptyTree>::<C <PackageRegistry>>::<C A_Package_Private$1>::<C A>::<C AModule>
 
-    module <emptyTree>::<C A_Package_Private$1>::<C A><<C <todo sym>>> < ()
-      <emptyTree>::<C REFERENCE> = <emptyTree>::<C <PackageRegistry>>::<C A_Package_Private$1>::<C A>::<C REFERENCE>
-    end
+    <emptyTree>::<C A_Package_Private$1>::<C A>::<C REFERENCE> = <emptyTree>::<C <PackageRegistry>>::<C A_Package_Private$1>::<C A>::<C REFERENCE>
 
-    module <emptyTree>::<C A_Package_Private$1><<C <todo sym>>> < ()
-      <emptyTree>::<C B> = <emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>
-    end
+    <emptyTree>::<C A_Package_Private$1>::<C B> = <emptyTree>::<C <PackageRegistry>>::<C B_Package$1>::<C B>
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C A_Package$1>::<C A><<C <todo sym>>> < ()
-      <emptyTree>::<C AClass> = <emptyTree>::<C <PackageRegistry>>::<C A_Package_Private$1>::<C A>::<C AClass>
-    end
+    <emptyTree>::<C A_Package$1>::<C A>::<C AClass> = <emptyTree>::<C <PackageRegistry>>::<C A_Package_Private$1>::<C A>::<C AClass>
 
-    module <emptyTree>::<C A_Package$1>::<C A><<C <todo sym>>> < ()
-      <emptyTree>::<C AModule> = <emptyTree>::<C <PackageRegistry>>::<C A_Package_Private$1>::<C A>::<C AModule>
-    end
+    <emptyTree>::<C A_Package$1>::<C A>::<C AModule> = <emptyTree>::<C <PackageRegistry>>::<C A_Package_Private$1>::<C A>::<C AModule>
 
-    module <emptyTree>::<C A_Package$1>::<C A><<C <todo sym>>> < ()
-      <emptyTree>::<C REFERENCE> = <emptyTree>::<C <PackageRegistry>>::<C A_Package_Private$1>::<C A>::<C REFERENCE>
-    end
+    <emptyTree>::<C A_Package$1>::<C A>::<C REFERENCE> = <emptyTree>::<C <PackageRegistry>>::<C A_Package_Private$1>::<C A>::<C REFERENCE>
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
@@ -117,33 +101,21 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C B_Package_Private$1><<C <todo sym>>> < ()
-      <emptyTree>::<C A> = <emptyTree>::<C <PackageRegistry>>::<C A_Package$1>::<C A>
-    end
+    <emptyTree>::<C B_Package_Private$1>::<C A> = <emptyTree>::<C <PackageRegistry>>::<C A_Package$1>::<C A>
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C B_Package_Private$1><<C <todo sym>>> < ()
-      <emptyTree>::<C A> = <emptyTree>::<C <PackageRegistry>>::<C A_Package$1>::<C A>
-    end
+    <emptyTree>::<C B_Package_Private$1>::<C A> = <emptyTree>::<C <PackageRegistry>>::<C A_Package$1>::<C A>
 
-    module <emptyTree>::<C B_Package_Private$1>::<C B><<C <todo sym>>> < ()
-      <emptyTree>::<C BClass> = <emptyTree>::<C <PackageRegistry>>::<C B_Package_Private$1>::<C B>::<C BClass>
-    end
+    <emptyTree>::<C B_Package_Private$1>::<C B>::<C BClass> = <emptyTree>::<C <PackageRegistry>>::<C B_Package_Private$1>::<C B>::<C BClass>
 
-    module <emptyTree>::<C B_Package_Private$1>::<C B><<C <todo sym>>> < ()
-      <emptyTree>::<C BModule> = <emptyTree>::<C <PackageRegistry>>::<C B_Package_Private$1>::<C B>::<C BModule>
-    end
+    <emptyTree>::<C B_Package_Private$1>::<C B>::<C BModule> = <emptyTree>::<C <PackageRegistry>>::<C B_Package_Private$1>::<C B>::<C BModule>
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C B_Package$1>::<C B><<C <todo sym>>> < ()
-      <emptyTree>::<C BClass> = <emptyTree>::<C <PackageRegistry>>::<C B_Package_Private$1>::<C B>::<C BClass>
-    end
+    <emptyTree>::<C B_Package$1>::<C B>::<C BClass> = <emptyTree>::<C <PackageRegistry>>::<C B_Package_Private$1>::<C B>::<C BClass>
 
-    module <emptyTree>::<C B_Package$1>::<C B><<C <todo sym>>> < ()
-      <emptyTree>::<C BModule> = <emptyTree>::<C <PackageRegistry>>::<C B_Package_Private$1>::<C B>::<C BModule>
-    end
+    <emptyTree>::<C B_Package$1>::<C B>::<C BModule> = <emptyTree>::<C <PackageRegistry>>::<C B_Package_Private$1>::<C B>::<C BModule>
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()

--- a/test/testdata/packager/nested_inner_namespaces/pass.package-tree.exp
+++ b/test/testdata/packager/nested_inner_namespaces/pass.package-tree.exp
@@ -5,15 +5,11 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C RootPackage_Package_Private$1>::<C RootPackage><<C <todo sym>>> < ()
-      <emptyTree>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo>
-    end
+    <emptyTree>::<C RootPackage_Package_Private$1>::<C RootPackage>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo>
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C RootPackage_Package_Private$1>::<C RootPackage><<C <todo sym>>> < ()
-      <emptyTree>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo>
-    end
+    <emptyTree>::<C RootPackage_Package_Private$1>::<C RootPackage>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo>
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
@@ -62,31 +58,19 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C RootPackage_Foo_Package_Private$1>::<C RootPackage>::<C Foo>::<C Bar><<C <todo sym>>> < ()
-      <emptyTree>::<C Baz> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package_Private$1>::<C RootPackage>::<C Foo>::<C Bar>::<C Baz>
-    end
+    <emptyTree>::<C RootPackage_Foo_Package_Private$1>::<C RootPackage>::<C Foo>::<C Bar>::<C Baz> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package_Private$1>::<C RootPackage>::<C Foo>::<C Bar>::<C Baz>
 
-    module <emptyTree>::<C RootPackage_Foo_Package_Private$1>::<C RootPackage>::<C Foo>::<C Bar><<C <todo sym>>> < ()
-      <emptyTree>::<C Constant> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package_Private$1>::<C RootPackage>::<C Foo>::<C Bar>::<C Constant>
-    end
+    <emptyTree>::<C RootPackage_Foo_Package_Private$1>::<C RootPackage>::<C Foo>::<C Bar>::<C Constant> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package_Private$1>::<C RootPackage>::<C Foo>::<C Bar>::<C Constant>
 
-    module <emptyTree>::<C RootPackage_Foo_Package_Private$1>::<C RootPackage>::<C Foo><<C <todo sym>>> < ()
-      <emptyTree>::<C Constant> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package_Private$1>::<C RootPackage>::<C Foo>::<C Constant>
-    end
+    <emptyTree>::<C RootPackage_Foo_Package_Private$1>::<C RootPackage>::<C Foo>::<C Constant> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package_Private$1>::<C RootPackage>::<C Foo>::<C Constant>
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo>::<C Bar><<C <todo sym>>> < ()
-      <emptyTree>::<C Baz> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package_Private$1>::<C RootPackage>::<C Foo>::<C Bar>::<C Baz>
-    end
+    <emptyTree>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo>::<C Bar>::<C Baz> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package_Private$1>::<C RootPackage>::<C Foo>::<C Bar>::<C Baz>
 
-    module <emptyTree>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo>::<C Bar><<C <todo sym>>> < ()
-      <emptyTree>::<C Constant> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package_Private$1>::<C RootPackage>::<C Foo>::<C Bar>::<C Constant>
-    end
+    <emptyTree>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo>::<C Bar>::<C Constant> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package_Private$1>::<C RootPackage>::<C Foo>::<C Bar>::<C Constant>
 
-    module <emptyTree>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo><<C <todo sym>>> < ()
-      <emptyTree>::<C Constant> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package_Private$1>::<C RootPackage>::<C Foo>::<C Constant>
-    end
+    <emptyTree>::<C RootPackage_Foo_Package$1>::<C RootPackage>::<C Foo>::<C Constant> = <emptyTree>::<C <PackageRegistry>>::<C RootPackage_Foo_Package_Private$1>::<C RootPackage>::<C Foo>::<C Constant>
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()

--- a/test/testdata/packager/nested_packages/pass.package-tree.exp
+++ b/test/testdata/packager/nested_packages/pass.package-tree.exp
@@ -7,25 +7,17 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Package_Package_Private$1>::<C Package><<C <todo sym>>> < ()
-      <emptyTree>::<C Subpackage> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage>
-    end
+    <emptyTree>::<C Package_Package_Private$1>::<C Package>::<C Subpackage> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage>
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Package_Package_Private$1>::<C Package><<C <todo sym>>> < ()
-      <emptyTree>::<C PackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package_Private$1>::<C Package>::<C PackageClass>
-    end
+    <emptyTree>::<C Package_Package_Private$1>::<C Package>::<C PackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package_Private$1>::<C Package>::<C PackageClass>
 
-    module <emptyTree>::<C Package_Package_Private$1>::<C Package><<C <todo sym>>> < ()
-      <emptyTree>::<C Subpackage> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage>
-    end
+    <emptyTree>::<C Package_Package_Private$1>::<C Package>::<C Subpackage> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage>
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Package_Package$1>::<C Package><<C <todo sym>>> < ()
-      <emptyTree>::<C PackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package_Private$1>::<C Package>::<C PackageClass>
-    end
+    <emptyTree>::<C Package_Package$1>::<C Package>::<C PackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package_Private$1>::<C Package>::<C PackageClass>
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
@@ -58,25 +50,17 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Package_Subpackage_Package_Private$1>::<C Package><<C <todo sym>>> < ()
-      <emptyTree>::<C PackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>::<C PackageClass>
-    end
+    <emptyTree>::<C Package_Subpackage_Package_Private$1>::<C Package>::<C PackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>::<C PackageClass>
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Package_Subpackage_Package_Private$1>::<C Package><<C <todo sym>>> < ()
-      <emptyTree>::<C PackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>::<C PackageClass>
-    end
+    <emptyTree>::<C Package_Subpackage_Package_Private$1>::<C Package>::<C PackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Package$1>::<C Package>::<C PackageClass>
 
-    module <emptyTree>::<C Package_Subpackage_Package_Private$1>::<C Package>::<C Subpackage><<C <todo sym>>> < ()
-      <emptyTree>::<C SubpackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package_Private$1>::<C Package>::<C Subpackage>::<C SubpackageClass>
-    end
+    <emptyTree>::<C Package_Subpackage_Package_Private$1>::<C Package>::<C Subpackage>::<C SubpackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package_Private$1>::<C Package>::<C Subpackage>::<C SubpackageClass>
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage><<C <todo sym>>> < ()
-      <emptyTree>::<C SubpackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package_Private$1>::<C Package>::<C Subpackage>::<C SubpackageClass>
-    end
+    <emptyTree>::<C Package_Subpackage_Package$1>::<C Package>::<C Subpackage>::<C SubpackageClass> = <emptyTree>::<C <PackageRegistry>>::<C Package_Subpackage_Package_Private$1>::<C Package>::<C Subpackage>::<C SubpackageClass>
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()

--- a/test/testdata/packager/simple_package/pass.flatten-tree.exp
+++ b/test/testdata/packager/simple_package/pass.flatten-tree.exp
@@ -211,80 +211,26 @@ begin
   end
   module ::<PackageRegistry><<C <PackageRegistry>>> < ()
     def self.<static-init>(<blk>)
-      begin
-        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Bar_Package_Private::Project)
-        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Bar_Package_Private::Project)
-        <emptyTree>
-      end
-    end
-  end
-  module ::<PackageRegistry>::Project_Bar_Package_Private::Project<<C Project>> < ()
-    def self.<static-init>(<blk>)
       ::<PackageRegistry>::Project_Bar_Package_Private::Project::Foo = ::<PackageRegistry>::Project_Foo_Package::Project::Foo
     end
   end
   module ::<PackageTests><<C <PackageTests>>> < ()
     def self.<static-init>(<blk>)
       begin
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageTests>::Project_Bar_Package_Private::Project::Bar)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>::Project_Bar_Package_Private::Project::Bar)
-          <emptyTree>
-        end
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageTests>::Project_Bar_Package_Private::Project::Bar)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>::Project_Bar_Package_Private::Project::Bar)
-          <emptyTree>
-        end
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageTests>::Project_Bar_Package_Private::Project)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>::Project_Bar_Package_Private::Project)
-          <emptyTree>
-        end
+        ::<PackageTests>::Project_Bar_Package_Private::Project::Bar::Bar = ::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar
+        ::<PackageTests>::Project_Bar_Package_Private::Project::Bar::CallsFoo = ::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::CallsFoo
+        ::<PackageTests>::Project_Bar_Package_Private::Project::Foo = ::<PackageRegistry>::Project_Foo_Package::Project::Foo
         <emptyTree>
       end
-    end
-  end
-  module ::<PackageTests>::Project_Bar_Package_Private::Project::Bar<<C Bar>> < ()
-    def self.<static-init>(<blk>)
-      ::<PackageTests>::Project_Bar_Package_Private::Project::Bar::Bar = ::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar
-    end
-  end
-  module ::<PackageTests>::Project_Bar_Package_Private::Project::Bar<<C Bar>> < ()
-    def self.<static-init>(<blk>)
-      ::<PackageTests>::Project_Bar_Package_Private::Project::Bar::CallsFoo = ::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::CallsFoo
-    end
-  end
-  module ::<PackageTests>::Project_Bar_Package_Private::Project<<C Project>> < ()
-    def self.<static-init>(<blk>)
-      ::<PackageTests>::Project_Bar_Package_Private::Project::Foo = ::<PackageRegistry>::Project_Foo_Package::Project::Foo
     end
   end
   module ::<PackageRegistry><<C <PackageRegistry>>> < ()
     def self.<static-init>(<blk>)
       begin
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Bar_Package::Project::Bar)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Bar_Package::Project::Bar)
-          <emptyTree>
-        end
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Bar_Package::Project::Bar)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Bar_Package::Project::Bar)
-          <emptyTree>
-        end
+        ::<PackageRegistry>::Project_Bar_Package::Project::Bar::Bar = ::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar
+        ::<PackageRegistry>::Project_Bar_Package::Project::Bar::CallsFoo = ::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::CallsFoo
         <emptyTree>
       end
-    end
-  end
-  module ::<PackageRegistry>::Project_Bar_Package::Project::Bar<<C Bar>> < ()
-    def self.<static-init>(<blk>)
-      ::<PackageRegistry>::Project_Bar_Package::Project::Bar::Bar = ::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::Bar
-    end
-  end
-  module ::<PackageRegistry>::Project_Bar_Package::Project::Bar<<C Bar>> < ()
-    def self.<static-init>(<blk>)
-      ::<PackageRegistry>::Project_Bar_Package::Project::Bar::CallsFoo = ::<PackageRegistry>::Project_Bar_Package_Private::Project::Bar::CallsFoo
     end
   end
   module ::<PackageTests><<C <PackageTests>>> < ()
@@ -341,80 +287,26 @@ begin
   end
   module ::<PackageRegistry><<C <PackageRegistry>>> < ()
     def self.<static-init>(<blk>)
-      begin
-        ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Foo_Package_Private::Project)
-        ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Foo_Package_Private::Project)
-        <emptyTree>
-      end
-    end
-  end
-  module ::<PackageRegistry>::Project_Foo_Package_Private::Project<<C Project>> < ()
-    def self.<static-init>(<blk>)
       ::<PackageRegistry>::Project_Foo_Package_Private::Project::Bar = ::<PackageRegistry>::Project_Bar_Package::Project::Bar
     end
   end
   module ::<PackageTests><<C <PackageTests>>> < ()
     def self.<static-init>(<blk>)
       begin
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageTests>::Project_Foo_Package_Private::Project)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>::Project_Foo_Package_Private::Project)
-          <emptyTree>
-        end
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageTests>::Project_Foo_Package_Private::Project::Foo)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>::Project_Foo_Package_Private::Project::Foo)
-          <emptyTree>
-        end
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageTests>::Project_Foo_Package_Private::Project::Foo)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageTests>::Project_Foo_Package_Private::Project::Foo)
-          <emptyTree>
-        end
+        ::<PackageTests>::Project_Foo_Package_Private::Project::Bar = ::<PackageRegistry>::Project_Bar_Package::Project::Bar
+        ::<PackageTests>::Project_Foo_Package_Private::Project::Foo::CallsBar = ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::CallsBar
+        ::<PackageTests>::Project_Foo_Package_Private::Project::Foo::Foo = ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo
         <emptyTree>
       end
-    end
-  end
-  module ::<PackageTests>::Project_Foo_Package_Private::Project<<C Project>> < ()
-    def self.<static-init>(<blk>)
-      ::<PackageTests>::Project_Foo_Package_Private::Project::Bar = ::<PackageRegistry>::Project_Bar_Package::Project::Bar
-    end
-  end
-  module ::<PackageTests>::Project_Foo_Package_Private::Project::Foo<<C Foo>> < ()
-    def self.<static-init>(<blk>)
-      ::<PackageTests>::Project_Foo_Package_Private::Project::Foo::CallsBar = ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::CallsBar
-    end
-  end
-  module ::<PackageTests>::Project_Foo_Package_Private::Project::Foo<<C Foo>> < ()
-    def self.<static-init>(<blk>)
-      ::<PackageTests>::Project_Foo_Package_Private::Project::Foo::Foo = ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo
     end
   end
   module ::<PackageRegistry><<C <PackageRegistry>>> < ()
     def self.<static-init>(<blk>)
       begin
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Foo_Package::Project::Foo)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Foo_Package::Project::Foo)
-          <emptyTree>
-        end
-        begin
-          ::<Magic>.<define-top-class-or-module>(::<PackageRegistry>::Project_Foo_Package::Project::Foo)
-          ::Sorbet::Private::Static.keep_for_ide(::<PackageRegistry>::Project_Foo_Package::Project::Foo)
-          <emptyTree>
-        end
+        ::<PackageRegistry>::Project_Foo_Package::Project::Foo::CallsBar = ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::CallsBar
+        ::<PackageRegistry>::Project_Foo_Package::Project::Foo::Foo = ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo
         <emptyTree>
       end
-    end
-  end
-  module ::<PackageRegistry>::Project_Foo_Package::Project::Foo<<C Foo>> < ()
-    def self.<static-init>(<blk>)
-      ::<PackageRegistry>::Project_Foo_Package::Project::Foo::CallsBar = ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::CallsBar
-    end
-  end
-  module ::<PackageRegistry>::Project_Foo_Package::Project::Foo<<C Foo>> < ()
-    def self.<static-init>(<blk>)
-      ::<PackageRegistry>::Project_Foo_Package::Project::Foo::Foo = ::<PackageRegistry>::Project_Foo_Package_Private::Project::Foo::Foo
     end
   end
   module ::<PackageTests><<C <PackageTests>>> < ()

--- a/test/testdata/packager/simple_package/pass.package-tree.exp
+++ b/test/testdata/packager/simple_package/pass.package-tree.exp
@@ -9,33 +9,21 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Project_Bar_Package_Private$1>::<C Project><<C <todo sym>>> < ()
-      <emptyTree>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>
-    end
+    <emptyTree>::<C Project_Bar_Package_Private$1>::<C Project>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Project_Bar_Package_Private$1>::<C Project>::<C Bar><<C <todo sym>>> < ()
-      <emptyTree>::<C Bar> = <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package_Private$1>::<C Project>::<C Bar>::<C Bar>
-    end
+    <emptyTree>::<C Project_Bar_Package_Private$1>::<C Project>::<C Bar>::<C Bar> = <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package_Private$1>::<C Project>::<C Bar>::<C Bar>
 
-    module <emptyTree>::<C Project_Bar_Package_Private$1>::<C Project>::<C Bar><<C <todo sym>>> < ()
-      <emptyTree>::<C CallsFoo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package_Private$1>::<C Project>::<C Bar>::<C CallsFoo>
-    end
+    <emptyTree>::<C Project_Bar_Package_Private$1>::<C Project>::<C Bar>::<C CallsFoo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package_Private$1>::<C Project>::<C Bar>::<C CallsFoo>
 
-    module <emptyTree>::<C Project_Bar_Package_Private$1>::<C Project><<C <todo sym>>> < ()
-      <emptyTree>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>
-    end
+    <emptyTree>::<C Project_Bar_Package_Private$1>::<C Project>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package$1>::<C Project>::<C Foo>
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Project_Bar_Package$1>::<C Project>::<C Bar><<C <todo sym>>> < ()
-      <emptyTree>::<C Bar> = <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package_Private$1>::<C Project>::<C Bar>::<C Bar>
-    end
+    <emptyTree>::<C Project_Bar_Package$1>::<C Project>::<C Bar>::<C Bar> = <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package_Private$1>::<C Project>::<C Bar>::<C Bar>
 
-    module <emptyTree>::<C Project_Bar_Package$1>::<C Project>::<C Bar><<C <todo sym>>> < ()
-      <emptyTree>::<C CallsFoo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package_Private$1>::<C Project>::<C Bar>::<C CallsFoo>
-    end
+    <emptyTree>::<C Project_Bar_Package$1>::<C Project>::<C Bar>::<C CallsFoo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package_Private$1>::<C Project>::<C Bar>::<C CallsFoo>
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
@@ -98,33 +86,21 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Project_Foo_Package_Private$1>::<C Project><<C <todo sym>>> < ()
-      <emptyTree>::<C Bar> = <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package$1>::<C Project>::<C Bar>
-    end
+    <emptyTree>::<C Project_Foo_Package_Private$1>::<C Project>::<C Bar> = <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package$1>::<C Project>::<C Bar>
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Project_Foo_Package_Private$1>::<C Project><<C <todo sym>>> < ()
-      <emptyTree>::<C Bar> = <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package$1>::<C Project>::<C Bar>
-    end
+    <emptyTree>::<C Project_Foo_Package_Private$1>::<C Project>::<C Bar> = <emptyTree>::<C <PackageRegistry>>::<C Project_Bar_Package$1>::<C Project>::<C Bar>
 
-    module <emptyTree>::<C Project_Foo_Package_Private$1>::<C Project>::<C Foo><<C <todo sym>>> < ()
-      <emptyTree>::<C CallsBar> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package_Private$1>::<C Project>::<C Foo>::<C CallsBar>
-    end
+    <emptyTree>::<C Project_Foo_Package_Private$1>::<C Project>::<C Foo>::<C CallsBar> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package_Private$1>::<C Project>::<C Foo>::<C CallsBar>
 
-    module <emptyTree>::<C Project_Foo_Package_Private$1>::<C Project>::<C Foo><<C <todo sym>>> < ()
-      <emptyTree>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package_Private$1>::<C Project>::<C Foo>::<C Foo>
-    end
+    <emptyTree>::<C Project_Foo_Package_Private$1>::<C Project>::<C Foo>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package_Private$1>::<C Project>::<C Foo>::<C Foo>
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Project_Foo_Package$1>::<C Project>::<C Foo><<C <todo sym>>> < ()
-      <emptyTree>::<C CallsBar> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package_Private$1>::<C Project>::<C Foo>::<C CallsBar>
-    end
+    <emptyTree>::<C Project_Foo_Package$1>::<C Project>::<C Foo>::<C CallsBar> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package_Private$1>::<C Project>::<C Foo>::<C CallsBar>
 
-    module <emptyTree>::<C Project_Foo_Package$1>::<C Project>::<C Foo><<C <todo sym>>> < ()
-      <emptyTree>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package_Private$1>::<C Project>::<C Foo>::<C Foo>
-    end
+    <emptyTree>::<C Project_Foo_Package$1>::<C Project>::<C Foo>::<C Foo> = <emptyTree>::<C <PackageRegistry>>::<C Project_Foo_Package_Private$1>::<C Project>::<C Foo>::<C Foo>
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()

--- a/test/testdata/packager/simple_test_import/pass.package-tree.exp
+++ b/test/testdata/packager/simple_test_import/pass.package-tree.exp
@@ -9,27 +9,17 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Project_MainLib_Package_Private$1>::<C Project><<C <todo sym>>> < ()
-      <emptyTree>::<C Util> = <emptyTree>::<C <PackageRegistry>>::<C Project_Util_Package$1>::<C Project>::<C Util>
-    end
+    <emptyTree>::<C Project_MainLib_Package_Private$1>::<C Project>::<C Util> = <emptyTree>::<C <PackageRegistry>>::<C Project_Util_Package$1>::<C Project>::<C Util>
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Project_MainLib_Package_Private$1>::<C Project>::<C MainLib><<C <todo sym>>> < ()
-      <emptyTree>::<C Lib> = <emptyTree>::<C <PackageRegistry>>::<C Project_MainLib_Package_Private$1>::<C Project>::<C MainLib>::<C Lib>
-    end
+    <emptyTree>::<C Project_MainLib_Package_Private$1>::<C Project>::<C MainLib>::<C Lib> = <emptyTree>::<C <PackageRegistry>>::<C Project_MainLib_Package_Private$1>::<C Project>::<C MainLib>::<C Lib>
 
-    module <emptyTree>::<C Project_MainLib_Package_Private$1>::<C Project><<C <todo sym>>> < ()
-      <emptyTree>::<C TestOnly> = <emptyTree>::<C <PackageRegistry>>::<C Project_TestOnly_Package$1>::<C Project>::<C TestOnly>
-    end
+    <emptyTree>::<C Project_MainLib_Package_Private$1>::<C Project>::<C TestOnly> = <emptyTree>::<C <PackageRegistry>>::<C Project_TestOnly_Package$1>::<C Project>::<C TestOnly>
 
-    module <emptyTree>::<C Project_MainLib_Package_Private$1>::<C Project><<C <todo sym>>> < ()
-      <emptyTree>::<C Util> = <emptyTree>::<C <PackageRegistry>>::<C Project_Util_Package$1>::<C Project>::<C Util>
-    end
+    <emptyTree>::<C Project_MainLib_Package_Private$1>::<C Project>::<C Util> = <emptyTree>::<C <PackageRegistry>>::<C Project_Util_Package$1>::<C Project>::<C Util>
 
-    module <emptyTree>::<C Project_MainLib_Package_Private$1>::<C Test>::<C Project><<C <todo sym>>> < ()
-      <emptyTree>::<C Util> = <emptyTree>::<C <PackageTests>>::<C Project_Util_Package$1>::<C Test>::<C Project>::<C Util>
-    end
+    <emptyTree>::<C Project_MainLib_Package_Private$1>::<C Test>::<C Project>::<C Util> = <emptyTree>::<C <PackageTests>>::<C Project_Util_Package$1>::<C Test>::<C Project>::<C Util>
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
@@ -78,15 +68,11 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Project_TestOnly_Package_Private$1>::<C Project>::<C TestOnly><<C <todo sym>>> < ()
-      <emptyTree>::<C SomeHelper> = <emptyTree>::<C <PackageRegistry>>::<C Project_TestOnly_Package_Private$1>::<C Project>::<C TestOnly>::<C SomeHelper>
-    end
+    <emptyTree>::<C Project_TestOnly_Package_Private$1>::<C Project>::<C TestOnly>::<C SomeHelper> = <emptyTree>::<C <PackageRegistry>>::<C Project_TestOnly_Package_Private$1>::<C Project>::<C TestOnly>::<C SomeHelper>
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Project_TestOnly_Package$1>::<C Project>::<C TestOnly><<C <todo sym>>> < ()
-      <emptyTree>::<C SomeHelper> = <emptyTree>::<C <PackageRegistry>>::<C Project_TestOnly_Package_Private$1>::<C Project>::<C TestOnly>::<C SomeHelper>
-    end
+    <emptyTree>::<C Project_TestOnly_Package$1>::<C Project>::<C TestOnly>::<C SomeHelper> = <emptyTree>::<C <PackageRegistry>>::<C Project_TestOnly_Package_Private$1>::<C Project>::<C TestOnly>::<C SomeHelper>
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
@@ -111,21 +97,15 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Project_Util_Package_Private$1>::<C Project>::<C Util><<C <todo sym>>> < ()
-      <emptyTree>::<C MyUtil> = <emptyTree>::<C <PackageRegistry>>::<C Project_Util_Package_Private$1>::<C Project>::<C Util>::<C MyUtil>
-    end
+    <emptyTree>::<C Project_Util_Package_Private$1>::<C Project>::<C Util>::<C MyUtil> = <emptyTree>::<C <PackageRegistry>>::<C Project_Util_Package_Private$1>::<C Project>::<C Util>::<C MyUtil>
   end
 
   module <emptyTree>::<C <PackageRegistry>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Project_Util_Package$1>::<C Project>::<C Util><<C <todo sym>>> < ()
-      <emptyTree>::<C MyUtil> = <emptyTree>::<C <PackageRegistry>>::<C Project_Util_Package_Private$1>::<C Project>::<C Util>::<C MyUtil>
-    end
+    <emptyTree>::<C Project_Util_Package$1>::<C Project>::<C Util>::<C MyUtil> = <emptyTree>::<C <PackageRegistry>>::<C Project_Util_Package_Private$1>::<C Project>::<C Util>::<C MyUtil>
   end
 
   module <emptyTree>::<C <PackageTests>><<C <todo sym>>> < ()
-    module <emptyTree>::<C Project_Util_Package$1>::<C Test>::<C Project>::<C Util><<C <todo sym>>> < ()
-      <emptyTree>::<C UtilHelper> = <emptyTree>::<C <PackageTests>>::<C Project_Util_Package_Private$1>::<C Test>::<C Project>::<C Util>::<C UtilHelper>
-    end
+    <emptyTree>::<C Project_Util_Package$1>::<C Test>::<C Project>::<C Util>::<C UtilHelper> = <emptyTree>::<C <PackageTests>>::<C Project_Util_Package_Private$1>::<C Test>::<C Project>::<C Util>::<C UtilHelper>
   end
 end
 # -- test/testdata/packager/simple_test_import/util/my_util.rb --


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Changes the structure of the AST rewrite that is performed by the packager. Essentially, we remove all intermediate module declarations and replace them with fully-qualified casgns.

For details, see: [before](https://sorbet.run/#%23%20assume%0A%23%20%3Cpackage%20Project%3A%3AFoo%3E%0A%23%20class%20Project%3A%3AFoo%20%3C%20PackageSpec%0A%23%20%20%20import%20Project%3A%3AFoo%3A%3ABar%0A%23%20end%0A%23%0A%23%20class%20Project%3A%3AFoo%0A%23%20%20%20Project%3A%3AFoo%3A%3ABar%0A%23%20end%0A%23%20%0A%23%20%3Cpackage%20Project%3A%3AFoo%3A%3ABar%3E%0A%23%20class%20Project%3A%3AFoo%3A%3ABar%20%3C%20PackageSpec%0A%23%20%20%20export%20Project%3A%3AFoo%3A%3ABar%0A%23%20end%0A%23%0A%23%20class%20Project%3A%3AFoo%3A%3ABar%3B%20end%0A%23%0A%23%20Translates%20to%3A%0A%0Amodule%20PkgRegistry%0A%20%20module%20PkgProjectFoo%0A%20%20%20%20%23%20virtual%20module%20%2B%20alias%0A%20%20%20%20module%20Project%3A%3AFoo%0A%20%20%20%20%20%20Bar%20%3D%20PkgProjectFooBar%3A%3AProject%3A%3AFoo%3A%3ABar%0A%20%20%20%20end%0A%0A%20%20%20%20class%20Project%3A%3AFoo%0A%20%20%20%20%20%20Project%3A%3AFoo%3A%3ABar%0A%20%20%20%20end%0A%20%20end%0A%0A%20%20module%20PkgProjectFooBar%0A%20%20%20%20class%20Project%3A%3AFoo%3A%3ABar%3B%20end%0A%20%20end%0Aend) and [after](https://sorbet.run/#%23%20assume%0A%23%20%3Cpackage%20Project%3A%3AFoo%3E%0A%23%20class%20Project%3A%3AFoo%20%3C%20PackageSpec%0A%23%20%20%20import%20Project%3A%3AFoo%3A%3ABar%0A%23%20end%0A%23%0A%23%20class%20Project%3A%3AFoo%0A%23%20%20%20Project%3A%3AFoo%3A%3ABar%0A%23%20end%0A%23%20%0A%23%20%3Cpackage%20Project%3A%3AFoo%3A%3ABar%3E%0A%23%20class%20Project%3A%3AFoo%3A%3ABar%20%3C%20PackageSpec%0A%23%20%20%20export%20Project%3A%3AFoo%3A%3ABar%0A%23%20end%0A%23%0A%23%20class%20Project%3A%3AFoo%3A%3ABar%3B%20end%0A%23%0A%23%20Translates%20to%3A%0A%0Amodule%20PkgRegistry%0A%20%20%23%20virtual%20alias%0A%20%20PkgProjectFoo%3A%3AProject%3A%3AFoo%3A%3ABar%20%3D%20PkgProjectFooBar%3A%3AProject%3A%3AFoo%3A%3ABar%0A%0A%20%20module%20PkgProjectFoo%0A%20%20%20%20class%20Project%3A%3AFoo%0A%20%20%20%20%20%20Project%3A%3AFoo%3A%3ABar%0A%20%20%20%20end%0A%20%20end%0A%0A%20%20module%20PkgProjectFooBar%0A%20%20%20%20class%20Project%3A%3AFoo%3A%3ABar%3B%20end%0A%20%20end%0Aend)

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
`--stripe-packages` mode currently works poorly when a package namespace also corresponds to a class in the actual codebase (as opposed to a module). Essentially, it breaks when a nested-package is imported by a parent package that is also a class. Therefore, we replace module declarations with fully qualified casgns -- that way we do not redeclare any modules.

As a side effect, this change also leads to a **~12%** memory improvement in type-checking the Stripe codebase.

Runtime changes perhaps not statistically significant.
**BEFORE**
<img width="388" alt="before_casgn_1" src="https://user-images.githubusercontent.com/83986377/163725031-471ff42d-c647-4de7-9299-d88e4ce83d86.png">
<img width="675" alt="before_casgn_2" src="https://user-images.githubusercontent.com/83986377/163725032-92ca4c60-c484-4c00-a41b-4a0a4cccf222.png">
<img width="1034" alt="before_casgn_3" src="https://user-images.githubusercontent.com/83986377/163725033-e58e60fa-c69d-4499-a012-142d388db1ae.png">

**AFTER**
<img width="450" alt="after_casgn_1" src="https://user-images.githubusercontent.com/83986377/163725043-a0c7a248-0e52-4c47-a633-ee17a0a17b75.png">
<img width="559" alt="after_casgn_2" src="https://user-images.githubusercontent.com/83986377/163725048-dc0c85dc-064d-4bac-919f-bb91285905af.png">
<img width="670" alt="after_casgn_3" src="https://user-images.githubusercontent.com/83986377/163725049-9a1d1eee-bd7a-4818-801e-64517e18928e.png">

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
Tested on Stripe codebase.