### PR TITLE
Add `--no-build` flag to update_testdata_exp.sh

### DIFF
--- a/tools/scripts/update_testdata_exp.sh
+++ b/tools/scripts/update_testdata_exp.sh
@@ -44,12 +44,48 @@ passes=(
   minimized-rbi
 )
 
-./bazel build //main:sorbet //test:print_document_symbols -c opt
+usage() {
+  cat <<EOF
+$0 [options] [<file>...]
 
+Arguments
+  <file>      One or more *.rb files whose exp files to update.
+              Defaults to everything in test/testdata/
+
+Options
+  --no-build  Don't build anything, just reuse what was already built
+  -h, --help  Print this message
+EOF
+}
+
+BUILD=1
 if [ $# -eq 0 ]; then
   paths=(test/testdata)
 else
+  while true; do
+    case $1 in
+      --no-build)
+        BUILD=
+        shift
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      -*)
+        1>&2 echo "Unrecognized option '$1'"
+        1>&2 usage
+        exit 1
+        ;;
+      *)
+        break;
+    esac
+  done
   paths=("$@")
+fi
+
+if [ "$BUILD" != "" ]; then
+  ./bazel build //main:sorbet //test:print_document_symbols -c opt
 fi
 
 rb_src=()


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Faster to just use the Sorbet I've already built, even if it's a debug version,
for small changes.

(For runs that regenerate all testdata exp files, it's usually faster to build
an optimized version of sorbet and then update all the exp files).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tested manually