### PR TITLE
Only run checkExpectations once

### DIFF
--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -128,8 +128,8 @@ public:
         }
     }
 
-    void checkExpectations(string prefix = "") {
-        for (auto &gotPhase : got) {
+    void checkExpectations(string prefix = "") const {
+        for (const auto &gotPhase : got) {
             auto expectation = test.expectations.find(gotPhase.first);
             REQUIRE_MESSAGE(expectation != test.expectations.end(),
                             prefix << "missing expectation for " << gotPhase.first);
@@ -686,35 +686,6 @@ TEST_CASE("PerPhaseTest") { // NOLINT
         extension->finishTypecheck(*gs);
     }
 
-    handler.checkExpectations();
-
-    if (test.expectations.contains("symbol-table")) {
-        string table = gs->toString() + '\n';
-        CHECK_EQ_DIFF(handler.got["symbol-table"], table, "symbol-table should not be mutated by CFG+inference");
-    }
-
-    if (test.expectations.contains("symbol-table-raw")) {
-        string table = gs->showRaw() + '\n';
-        CHECK_EQ_DIFF(handler.got["symbol-table-raw"], table,
-                      "symbol-table-raw should not be mutated by CFG+inference");
-    }
-
-    // Check warnings and errors
-    {
-        map<string, vector<unique_ptr<Diagnostic>>> diagnostics;
-        for (auto &error : handler.errors) {
-            if (error->isSilenced) {
-                continue;
-            }
-            auto diag = errorToDiagnostic(*gs, *error);
-            ENFORCE(diag != nullptr, "Error was given no valid location - '{}'", error->toString(*gs));
-
-            auto path = error->loc.file().data(*gs).path();
-            diagnostics[string(path.begin(), path.end())].push_back(std::move(diag));
-        }
-        ErrorAssertion::checkAll(test.sourceFileContents, RangeAssertion::getErrorAssertions(assertions), diagnostics);
-    }
-
     // Check autocorrects
     {
         auto autocorrects = vector<core::AutocorrectSuggestion>{};
@@ -755,6 +726,33 @@ TEST_CASE("PerPhaseTest") { // NOLINT
     }
 
     handler.checkExpectations();
+
+    if (test.expectations.contains("symbol-table")) {
+        string table = gs->toString() + '\n';
+        CHECK_EQ_DIFF(handler.got["symbol-table"], table, "symbol-table should not be mutated by CFG+inference");
+    }
+
+    if (test.expectations.contains("symbol-table-raw")) {
+        string table = gs->showRaw() + '\n';
+        CHECK_EQ_DIFF(handler.got["symbol-table-raw"], table,
+                      "symbol-table-raw should not be mutated by CFG+inference");
+    }
+
+    // Check warnings and errors
+    {
+        map<string, vector<unique_ptr<Diagnostic>>> diagnostics;
+        for (auto &error : handler.errors) {
+            if (error->isSilenced) {
+                continue;
+            }
+            auto diag = errorToDiagnostic(*gs, *error);
+            ENFORCE(diag != nullptr, "Error was given no valid location - '{}'", error->toString(*gs));
+
+            auto path = error->loc.file().data(*gs).path();
+            diagnostics[string(path.begin(), path.end())].push_back(std::move(diag));
+        }
+        ErrorAssertion::checkAll(test.sourceFileContents, RangeAssertion::getErrorAssertions(assertions), diagnostics);
+    }
 
     // Allow later phases to have errors that we didn't test for
     errorQueue->flushAllErrors(*gs);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

checkExpectations will check **all** expectations. We were running it
twice for every exp kind except the `autocorrects` exp kind.

The diff is weird (it shows me as moving the "check warnings and errors"
code down below), but in my head this was moving the "Check
autocorrects" section up.

If we move things around like this, then by the time we get to
checkExpectations the first time, the autocorrects expectations will be
populated, so we don't have to run checkExpectations as second time.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

test-only change. i verified that failures in autocorrect exp files are still
checked.