### PR TITLE
Fix task move crash with async initialization

### DIFF
--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -179,6 +179,25 @@ void LSPIndexer::initialize(IndexerInitializationTask &task, std::unique_ptr<cor
     this->initialGS = std::move(initialGS);
 }
 
+bool LSPIndexer::canHandleTask(bool frontOfQueue, const LSPTask &task) const {
+    if (this->initialized) {
+        return true;
+    }
+
+    switch (task.method) {
+        case LSPMethod::Initialize:
+        case LSPMethod::Initialized:
+        case LSPMethod::SorbetIndexerInitialization:
+            return true;
+
+        case LSPMethod::SorbetFence:
+            return frontOfQueue;
+
+        default:
+            return false;
+    }
+}
+
 LSPFileUpdates LSPIndexer::commitEdit(SorbetWorkspaceEditParams &edit, WorkerPool &workers) {
     Timer timeit(config->logger, "LSPIndexer::commitEdit");
     LSPFileUpdates update;

--- a/main/lsp/LSPIndexer.h
+++ b/main/lsp/LSPIndexer.h
@@ -63,6 +63,11 @@ public:
     ~LSPIndexer();
 
     /**
+     * Returns `true` when the indexer is currently in a state where it can handle the request.
+     */
+    bool canHandleTask(bool frontOfQueue, const LSPTask &task) const;
+
+    /**
      * Determines if the given files can take the fast path relative to the latest committed edit.
      */
     bool canTakeFastPath(const std::vector<std::shared_ptr<core::File>> &changedFiles) const;

--- a/main/lsp/LSPPreprocessor.cc
+++ b/main/lsp/LSPPreprocessor.cc
@@ -2,6 +2,7 @@
 #include "absl/strings/match.h"
 #include "absl/strings/str_replace.h"
 #include "common/kvstore/KeyValueStore.h"
+#include "main/lsp/LSPIndexer.h"
 #include "main/lsp/LSPOutput.h"
 #include "main/lsp/json_types.h"
 #include "main/lsp/notifications/notifications.h"
@@ -71,8 +72,47 @@ absl::Mutex *TaskQueue::getMutex() {
     return &this->stateMutex;
 }
 
-bool TaskQueue::ready() const {
-    return this->terminated || (!this->paused && !this->pendingTasks.empty());
+namespace {
+
+class ReadyHandle final {
+    friend void TaskQueue::waitReady(const LSPIndexer &indexer);
+
+    const bool &terminated;
+    const bool &paused;
+    const std::deque<std::unique_ptr<LSPTask>> &pendingTasks;
+    const LSPIndexer &indexer;
+
+    ReadyHandle(const bool &terminated, const bool &paused, const std::deque<std::unique_ptr<LSPTask>> &pendingTasks,
+                const LSPIndexer &indexer)
+        : terminated{terminated}, paused{paused}, pendingTasks{pendingTasks}, indexer{indexer} {}
+
+public:
+    bool isReady() const {
+        if (this->terminated) {
+            return true;
+        }
+
+        if (this->paused) {
+            return false;
+        }
+
+        bool frontOfQueue = true;
+        for (auto &task : this->pendingTasks) {
+            if (this->indexer.canHandleTask(frontOfQueue, *task)) {
+                return true;
+            }
+            frontOfQueue = false;
+        }
+
+        return false;
+    }
+};
+
+} // namespace
+
+void TaskQueue::waitReady(const LSPIndexer &indexer) {
+    ReadyHandle handle{this->terminated, this->paused, this->pendingTasks, indexer};
+    this->stateMutex.Await(absl::Condition(&handle, &ReadyHandle::isReady));
 }
 
 LSPPreprocessor::LSPPreprocessor(shared_ptr<LSPConfiguration> config, shared_ptr<TaskQueue> taskQueue,

--- a/main/lsp/LSPPreprocessor.h
+++ b/main/lsp/LSPPreprocessor.h
@@ -8,6 +8,7 @@
 namespace sorbet::realmain::lsp {
 
 class LSPTask;
+class LSPIndexer;
 class SorbetWorkspaceEditParams;
 class DidChangeTextDocumentParams;
 class DidCloseTextDocumentParams;
@@ -69,7 +70,7 @@ public:
 
     absl::Mutex *getMutex() ABSL_LOCK_RETURNED(stateMutex);
 
-    bool ready() const ABSL_SHARED_LOCKS_REQUIRED(stateMutex);
+    void waitReady(const LSPIndexer &indexer) ABSL_SHARED_LOCKS_REQUIRED(stateMutex);
 };
 
 /**

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -25,7 +25,6 @@
 #include "main/lsp/UndoState.h"
 #include "main/lsp/json_types.h"
 #include "main/lsp/notifications/indexer_initialization.h"
-#include "main/lsp/notifications/sorbet_resume.h"
 #include "main/pipeline/pipeline.h"
 
 namespace sorbet::realmain::lsp {
@@ -162,7 +161,7 @@ void LSPTypechecker::initialize(TaskQueue &queue, std::unique_ptr<core::GlobalSt
         queue.tasks().push_front(std::move(initTask));
     }
 
-    config->logger->error("Resuming");
+    config->logger->info("Initialization complete");
 }
 
 bool LSPTypechecker::typecheck(LSPFileUpdates updates, WorkerPool &workers,
@@ -714,12 +713,6 @@ void LSPTypecheckerDelegate::initialize(InitializedTask &task, std::unique_ptr<c
     return typechecker.initialize(this->queue, std::move(gs), std::move(kvstore), this->workers);
 }
 
-void LSPTypecheckerDelegate::resumeTaskQueue(InitializedTask &task) {
-    absl::MutexLock lck{this->queue.getMutex()};
-    ENFORCE(this->queue.isPaused());
-    this->queue.resume();
-}
-
 void LSPTypecheckerDelegate::typecheckOnFastPath(LSPFileUpdates updates,
                                                  vector<unique_ptr<Timer>> diagnosticLatencyTimers) {
     if (!updates.canTakeFastPath) {
@@ -757,10 +750,6 @@ LSPStaleTypechecker::LSPStaleTypechecker(std::shared_ptr<const LSPConfiguration>
 void LSPStaleTypechecker::initialize(InitializedTask &task, std::unique_ptr<core::GlobalState> initialGS,
                                      std::unique_ptr<KeyValueStore> kvstore) {
     ENFORCE(false, "initialize not supported");
-}
-
-void LSPStaleTypechecker::resumeTaskQueue(InitializedTask &task) {
-    ENFORCE(false, "resumeTaskQueue not supported");
 }
 
 void LSPStaleTypechecker::typecheckOnFastPath(LSPFileUpdates updates,

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -167,11 +167,6 @@ public:
                             std::unique_ptr<KeyValueStore> kvstore) = 0;
 
     /**
-     * Resume processing of the task queue
-     */
-    virtual void resumeTaskQueue(InitializedTask &task) = 0;
-
-    /**
      * Typechecks the given input on the fast path. The edit *must* be a fast path edit!
      */
     virtual void typecheckOnFastPath(LSPFileUpdates updates,
@@ -233,8 +228,6 @@ public:
     void initialize(InitializedTask &task, std::unique_ptr<core::GlobalState> gs,
                     std::unique_ptr<KeyValueStore> kvstore) override;
 
-    void resumeTaskQueue(InitializedTask &task) override;
-
     void typecheckOnFastPath(LSPFileUpdates updates,
                              std::vector<std::unique_ptr<Timer>> diagnosticLatencyTimers) override;
 
@@ -282,8 +275,6 @@ public:
 
     void initialize(InitializedTask &task, std::unique_ptr<core::GlobalState> gs,
                     std::unique_ptr<KeyValueStore> kvstore) override;
-
-    void resumeTaskQueue(InitializedTask &task) override;
 
     void typecheckOnFastPath(LSPFileUpdates updates,
                              std::vector<std::unique_ptr<Timer>> diagnosticLatencyTimers) override;

--- a/main/lsp/notifications/initialized.cc
+++ b/main/lsp/notifications/initialized.cc
@@ -11,21 +11,15 @@ InitializedTask::InitializedTask(LSPConfiguration &config)
 
 void InitializedTask::preprocess(LSPPreprocessor &preprocessor) {
     mutableConfig.markInitialized();
-    this->preprocessor = &preprocessor;
 }
 
 void InitializedTask::index(LSPIndexer &indexer) {
-    // We need to pause during indexing so that nothing else will try to give work to the index thread while its state
-    // is being initialized in the typechecker.
-    preprocessor->pause();
-
     indexer.transferInitializeState(*this);
 }
 
 void InitializedTask::run(LSPTypecheckerInterface &typechecker) {
     ENFORCE(this->gs != nullptr);
     typechecker.initialize(*this, std::move(this->gs), std::move(this->kvstore));
-    typechecker.resumeTaskQueue(*this);
 }
 
 bool InitializedTask::needsMultithreading(const LSPIndexer &indexer) const {

--- a/main/lsp/notifications/initialized.h
+++ b/main/lsp/notifications/initialized.h
@@ -12,8 +12,6 @@ class KeyValueStore;
 namespace sorbet::realmain::lsp {
 class InitializedTask final : public LSPTask {
     LSPConfiguration &mutableConfig;
-    LSPFileUpdates updates;
-    LSPPreprocessor *preprocessor;
     std::unique_ptr<core::GlobalState> gs;
     std::unique_ptr<KeyValueStore> kvstore;
 

--- a/main/lsp/protocol.cc
+++ b/main/lsp/protocol.cc
@@ -221,7 +221,7 @@ optional<unique_ptr<core::GlobalState>> LSPLoop::runLSP(shared_ptr<LSPInput> inp
             {
                 absl::MutexLock lck(taskQueue->getMutex());
                 Timer timeit(logger, "idle");
-                taskQueue->getMutex()->Await(absl::Condition(taskQueue.get(), &TaskQueue::ready));
+                taskQueue->waitReady(indexer);
                 ENFORCE(!taskQueue->isPaused());
                 if (taskQueue->isTerminated()) {
                     if (taskQueue->getErrorCode() != 0) {
@@ -234,106 +234,122 @@ optional<unique_ptr<core::GlobalState>> LSPLoop::runLSP(shared_ptr<LSPInput> inp
                     }
                 }
 
+                // Find the first task that the indexer is able to handle
+                bool frontOfQueue = true;
+                auto it = absl::c_find_if(taskQueue->tasks(), [&frontOfQueue, &indexer = this->indexer](auto &task) {
+                    bool canHandle = indexer.canHandleTask(frontOfQueue, *task);
+                    frontOfQueue = false;
+                    return canHandle;
+                });
+
+                // taskQueue->waitReady ensures that there is a task to run if the queue isn't terminated.
+                ENFORCE(it != taskQueue->tasks().end());
+
                 // Before giving up the lock, check if the typechecker is running a slow path and if the task at the
                 // head of the queue can either operate on stale data (i.e., the GlobalState just prior to the change
                 // that required the slow path to run) or preempt the currently running slow path. (Note that we don't
                 // bother with either one in cases where we only need the indexer. TODO(aprocter): is that restriction
                 // actually appropriate for stale-data tasks?)
-                auto &frontTask = taskQueue->tasks().front();
+                auto &frontTask = *it;
 
-                // Note that running on stale data is an experimental feature, so we hide it behind the
-                // --enable-experimental-lsp-stale-state flag.
-                if (opts.lspStaleStateEnabled && frontTask->finalPhase() == LSPTask::Phase::RUN &&
-                    epochManager->getStatus().slowPathRunning && frontTask->canUseStaleData()) {
-                    logger->debug("Trying to run on stale data");
+                // TODO: currently we only support stale global state and preemption for tasks that sit at the front of
+                // the queue.
+                if (it == taskQueue->tasks().begin()) {
+                    // Note that running on stale data is an experimental feature, so we hide it behind the
+                    // --enable-experimental-lsp-stale-state flag.
+                    if (opts.lspStaleStateEnabled && frontTask->finalPhase() == LSPTask::Phase::RUN &&
+                        epochManager->getStatus().slowPathRunning && frontTask->canUseStaleData()) {
+                        logger->debug("Trying to run on stale data");
 
-                    frontTask = typecheckerCoord.syncRunOnStaleState(move(frontTask));
+                        frontTask = typecheckerCoord.syncRunOnStaleState(move(frontTask));
 
-                    // If the coordinator has consumed the task, we know it was able to run it on stale state. Pop it
-                    // and move on to the next task.
-                    if (frontTask == nullptr) {
-                        logger->debug("Succeeded in running on stale data");
-                        taskQueue->tasks().pop_front();
-                    }
-                    // If the coordinator has not consumed the task, that means it was not able to run it on stale
-                    // state, because no cancellationUndoState was present. There are (we think! see below) two
-                    // possibilities here:
-                    //
-                    //   1. by the time we acquired the cancellationUndoState lock, the typechecker had already
-                    //      finished the slow path and nulled out the cancellationUndoState; or
-                    //   2. (not sure if this case is actually possible!) we acquired the lock between the time
-                    //      slowPathRunning became true and the time that the typechecker actually initialized the
-                    //      cancellationUndoState.
-                    //
-                    // In case 1, we should be able to process the task as normal shortly, since slowPathRunning has
-                    // become (or is about to become) false.
-                    //
-                    // In case 2, we should be able to process the task on stale state once the typechecker initializes
-                    // cancellationUndoState.
-                    //
-                    // To handle both of these cases, we insert a short sleep before heading around for another turn of
-                    // the loop.
-                    //
-                    // TODO(aprocter): Investigate whether case 2 is actually possible, and consider if there's a
-                    // better way to handle all of this than sleep-and-retry.
-                    else {
-                        logger->debug("Failed to grab the stale state, will try again in 100ms");
-                        Timer::timedSleep(100ms, *logger, "stale_state.sleep");
-                    }
-
-                    continue;
-                }
-
-                // If the task can preempt, we may be able to schedule a preemption. Don't bother scheduling tasks to
-                // preempt that only need the indexer.
-                // N.B.: We check `canPreempt` last as it is mildly expensive for edits (it hashes the files)
-                if (frontTask->finalPhase() == LSPTask::Phase::RUN && epochManager->getStatus().slowPathRunning &&
-                    frontTask->canPreempt(indexer)) {
-                    absl::Notification finished;
-                    string methodStr = convertLSPMethodToString(frontTask->method);
-                    auto preemptTask = make_unique<LSPQueuePreemptionTask>(*config, finished, *taskQueue, indexer);
-                    auto scheduleToken = typecheckerCoord.trySchedulePreemption(move(preemptTask));
-
-                    if (scheduleToken != nullptr) {
-                        logger->debug("[Processing] Preempting slow path for task {}", methodStr);
-                        // Preemption scheduling success!
-                        // In this if statement **only**, `taskQueueMutex` protects all accesses to LSPIndexer. This is
-                        // needed to linearize the indexing of edits, which may happen in the typechecking thread if a
-                        // fast path edit preempts, with the `canPreempt` checks of edits in this thread.
-                        auto headOfQueueCanPreempt = [&indexer = this->indexer,
-                                                      &tasks = this->taskQueue->tasks()]() -> bool {
-                            // Await always holds taskQueueMutex when calling this function, but absl doesn't know that.
-                            return tasks.empty() || !tasks.front()->canPreempt(indexer);
-                        };
-                        // Wait until the head of the queue turns into a non-preemptible task to resume processing the
-                        // queue.
-                        taskQueue->getMutex()->Await(absl::Condition(&headOfQueueCanPreempt));
-
-                        // The queue is now empty or has a task that cannot preempt. There are two possibilities here:
-                        // 1) The scheduled work is now irrelevant because the task that was scheduled is now gone
-                        // (e.g., the request was canceled or, in the case of an edit, merged w/ a slow path edit)
-                        // 2) The scheduled work has already started (and may have finished).
-                        // Pessimistically assume 1) and try to cancel the scheduled preemption.
-                        if (!typecheckerCoord.tryCancelPreemption(scheduleToken)) {
-                            // Cancelation failed: 2) must be the case. Unlock the queue and wait until task finishes to
-                            // avoid races.
-                            taskQueue->getMutex()->Unlock();
-                            finished.WaitForNotification();
-                            taskQueue->getMutex()->Lock();
-                            logger->debug("[Processing] Preemption for task {} complete", methodStr);
-                        } else {
-                            logger->debug("[Processing] Canceled scheduled preemption for task {}", methodStr);
+                        // If the coordinator has consumed the task, we know it was able to run it on stale state. Pop
+                        // it and move on to the next task.
+                        if (frontTask == nullptr) {
+                            logger->debug("Succeeded in running on stale data");
+                            taskQueue->tasks().erase(it);
+                        }
+                        // If the coordinator has not consumed the task, that means it was not able to run it on stale
+                        // state, because no cancellationUndoState was present. There are (we think! see below) two
+                        // possibilities here:
+                        //
+                        //   1. by the time we acquired the cancellationUndoState lock, the typechecker had already
+                        //      finished the slow path and nulled out the cancellationUndoState; or
+                        //   2. (not sure if this case is actually possible!) we acquired the lock between the time
+                        //      slowPathRunning became true and the time that the typechecker actually initialized the
+                        //      cancellationUndoState.
+                        //
+                        // In case 1, we should be able to process the task as normal shortly, since slowPathRunning has
+                        // become (or is about to become) false.
+                        //
+                        // In case 2, we should be able to process the task on stale state once the typechecker
+                        // initializes cancellationUndoState.
+                        //
+                        // To handle both of these cases, we insert a short sleep before heading around for another turn
+                        // of the loop.
+                        //
+                        // TODO(aprocter): Investigate whether case 2 is actually possible, and consider if there's a
+                        // better way to handle all of this than sleep-and-retry.
+                        else {
+                            logger->debug("Failed to grab the stale state, will try again in 100ms");
+                            Timer::timedSleep(100ms, *logger, "stale_state.sleep");
                         }
 
-                        // At this point, we are guaranteed that the scheduled task has run or has been canceled.
                         continue;
                     }
-                    // If preemption scheduling failed, then the slow path probably finished just now. Continue as
-                    // normal.
+
+                    // If the task can preempt, we may be able to schedule a preemption. Don't bother scheduling tasks
+                    // to preempt that only need the indexer. N.B.: We check `canPreempt` last as it is mildly expensive
+                    // for edits (it hashes the files)
+                    if (frontTask->finalPhase() == LSPTask::Phase::RUN && epochManager->getStatus().slowPathRunning &&
+                        frontTask->canPreempt(indexer)) {
+                        absl::Notification finished;
+                        string methodStr = convertLSPMethodToString(frontTask->method);
+                        auto preemptTask = make_unique<LSPQueuePreemptionTask>(*config, finished, *taskQueue, indexer);
+                        auto scheduleToken = typecheckerCoord.trySchedulePreemption(move(preemptTask));
+
+                        if (scheduleToken != nullptr) {
+                            logger->debug("[Processing] Preempting slow path for task {}", methodStr);
+                            // Preemption scheduling success!
+                            // In this if statement **only**, `taskQueueMutex` protects all accesses to LSPIndexer. This
+                            // is needed to linearize the indexing of edits, which may happen in the typechecking thread
+                            // if a fast path edit preempts, with the `canPreempt` checks of edits in this thread.
+                            auto headOfQueueCanPreempt = [&indexer = this->indexer,
+                                                          &tasks = taskQueue->tasks()]() -> bool {
+                                // Await always holds taskQueueMutex when calling this function, but absl doesn't know
+                                // that.
+                                return tasks.empty() || !tasks.front()->canPreempt(indexer);
+                            };
+                            // Wait until the head of the queue turns into a non-preemptible task to resume processing
+                            // the queue.
+                            taskQueue->getMutex()->Await(absl::Condition(&headOfQueueCanPreempt));
+
+                            // The queue is now empty or has a task that cannot preempt. There are two possibilities
+                            // here: 1) The scheduled work is now irrelevant because the task that was scheduled is now
+                            // gone (e.g., the request was canceled or, in the case of an edit, merged w/ a slow path
+                            // edit) 2) The scheduled work has already started (and may have finished). Pessimistically
+                            // assume 1) and try to cancel the scheduled preemption.
+                            if (!typecheckerCoord.tryCancelPreemption(scheduleToken)) {
+                                // Cancelation failed: 2) must be the case. Unlock the queue and wait until task
+                                // finishes to avoid races.
+                                taskQueue->getMutex()->Unlock();
+                                finished.WaitForNotification();
+                                taskQueue->getMutex()->Lock();
+                                logger->debug("[Processing] Preemption for task {} complete", methodStr);
+                            } else {
+                                logger->debug("[Processing] Canceled scheduled preemption for task {}", methodStr);
+                            }
+
+                            // At this point, we are guaranteed that the scheduled task has run or has been canceled.
+                            continue;
+                        }
+                        // If preemption scheduling failed, then the slow path probably finished just now. Continue as
+                        // normal.
+                    }
                 }
 
-                task = move(taskQueue->tasks().front());
-                taskQueue->tasks().pop_front();
+                task = move(frontTask);
+                taskQueue->tasks().erase(it);
 
                 // Test only: Collect counters from other threads into this thread for reporting.
                 if (task->method == LSPMethod::GETCOUNTERS && !taskQueue->getCounters().hasNullCounters()) {

--- a/main/lsp/protocol.cc
+++ b/main/lsp/protocol.cc
@@ -234,122 +234,126 @@ optional<unique_ptr<core::GlobalState>> LSPLoop::runLSP(shared_ptr<LSPInput> inp
                     }
                 }
 
-                // Find the first task that the indexer is able to handle
-                bool frontOfQueue = true;
-                auto it = absl::c_find_if(taskQueue->tasks(), [&frontOfQueue, &indexer = this->indexer](auto &task) {
-                    bool canHandle = indexer.canHandleTask(frontOfQueue, *task);
-                    frontOfQueue = false;
-                    return canHandle;
-                });
+                {
+                    // Find the first task that the indexer is able to handle
+                    bool frontOfQueue = true;
+                    auto it =
+                        absl::c_find_if(taskQueue->tasks(), [&frontOfQueue, &indexer = this->indexer](auto &task) {
+                            bool canHandle = indexer.canHandleTask(frontOfQueue, *task);
+                            frontOfQueue = false;
+                            return canHandle;
+                        });
 
-                // taskQueue->waitReady ensures that there is a task to run if the queue isn't terminated.
-                ENFORCE(it != taskQueue->tasks().end());
+                    // taskQueue->waitReady ensures that there is a task to run if the queue isn't terminated.
+                    ENFORCE(it != taskQueue->tasks().end());
+
+                    if (it != taskQueue->tasks().begin()) {
+                        auto task = std::move(*it);
+                        taskQueue->tasks().erase(it);
+                        taskQueue->tasks().emplace_front(std::move(task));
+                    }
+                }
 
                 // Before giving up the lock, check if the typechecker is running a slow path and if the task at the
                 // head of the queue can either operate on stale data (i.e., the GlobalState just prior to the change
                 // that required the slow path to run) or preempt the currently running slow path. (Note that we don't
                 // bother with either one in cases where we only need the indexer. TODO(aprocter): is that restriction
                 // actually appropriate for stale-data tasks?)
-                auto &frontTask = *it;
+                auto &frontTask = taskQueue->tasks().front();
 
-                // TODO: currently we only support stale global state and preemption for tasks that sit at the front of
-                // the queue.
-                if (it == taskQueue->tasks().begin()) {
-                    // Note that running on stale data is an experimental feature, so we hide it behind the
-                    // --enable-experimental-lsp-stale-state flag.
-                    if (opts.lspStaleStateEnabled && frontTask->finalPhase() == LSPTask::Phase::RUN &&
-                        epochManager->getStatus().slowPathRunning && frontTask->canUseStaleData()) {
-                        logger->debug("Trying to run on stale data");
+                // Note that running on stale data is an experimental feature, so we hide it behind the
+                // --enable-experimental-lsp-stale-state flag.
+                if (opts.lspStaleStateEnabled && frontTask->finalPhase() == LSPTask::Phase::RUN &&
+                    epochManager->getStatus().slowPathRunning && frontTask->canUseStaleData()) {
+                    logger->debug("Trying to run on stale data");
 
-                        frontTask = typecheckerCoord.syncRunOnStaleState(move(frontTask));
+                    frontTask = typecheckerCoord.syncRunOnStaleState(move(frontTask));
 
-                        // If the coordinator has consumed the task, we know it was able to run it on stale state. Pop
-                        // it and move on to the next task.
-                        if (frontTask == nullptr) {
-                            logger->debug("Succeeded in running on stale data");
-                            taskQueue->tasks().erase(it);
-                        }
-                        // If the coordinator has not consumed the task, that means it was not able to run it on stale
-                        // state, because no cancellationUndoState was present. There are (we think! see below) two
-                        // possibilities here:
-                        //
-                        //   1. by the time we acquired the cancellationUndoState lock, the typechecker had already
-                        //      finished the slow path and nulled out the cancellationUndoState; or
-                        //   2. (not sure if this case is actually possible!) we acquired the lock between the time
-                        //      slowPathRunning became true and the time that the typechecker actually initialized the
-                        //      cancellationUndoState.
-                        //
-                        // In case 1, we should be able to process the task as normal shortly, since slowPathRunning has
-                        // become (or is about to become) false.
-                        //
-                        // In case 2, we should be able to process the task on stale state once the typechecker
-                        // initializes cancellationUndoState.
-                        //
-                        // To handle both of these cases, we insert a short sleep before heading around for another turn
-                        // of the loop.
-                        //
-                        // TODO(aprocter): Investigate whether case 2 is actually possible, and consider if there's a
-                        // better way to handle all of this than sleep-and-retry.
-                        else {
-                            logger->debug("Failed to grab the stale state, will try again in 100ms");
-                            Timer::timedSleep(100ms, *logger, "stale_state.sleep");
-                        }
-
-                        continue;
+                    // If the coordinator has consumed the task, we know it was able to run it on stale state. Pop it
+                    // and move on to the next task.
+                    if (frontTask == nullptr) {
+                        logger->debug("Succeeded in running on stale data");
+                        taskQueue->tasks().pop_front();
+                    }
+                    // If the coordinator has not consumed the task, that means it was not able to run it on stale
+                    // state, because no cancellationUndoState was present. There are (we think! see below) two
+                    // possibilities here:
+                    //
+                    //   1. by the time we acquired the cancellationUndoState lock, the typechecker had already
+                    //      finished the slow path and nulled out the cancellationUndoState; or
+                    //   2. (not sure if this case is actually possible!) we acquired the lock between the time
+                    //      slowPathRunning became true and the time that the typechecker actually initialized the
+                    //      cancellationUndoState.
+                    //
+                    // In case 1, we should be able to process the task as normal shortly, since slowPathRunning has
+                    // become (or is about to become) false.
+                    //
+                    // In case 2, we should be able to process the task on stale state once the typechecker initializes
+                    // cancellationUndoState.
+                    //
+                    // To handle both of these cases, we insert a short sleep before heading around for another turn of
+                    // the loop.
+                    //
+                    // TODO(aprocter): Investigate whether case 2 is actually possible, and consider if there's a
+                    // better way to handle all of this than sleep-and-retry.
+                    else {
+                        logger->debug("Failed to grab the stale state, will try again in 100ms");
+                        Timer::timedSleep(100ms, *logger, "stale_state.sleep");
                     }
 
-                    // If the task can preempt, we may be able to schedule a preemption. Don't bother scheduling tasks
-                    // to preempt that only need the indexer. N.B.: We check `canPreempt` last as it is mildly expensive
-                    // for edits (it hashes the files)
-                    if (frontTask->finalPhase() == LSPTask::Phase::RUN && epochManager->getStatus().slowPathRunning &&
-                        frontTask->canPreempt(indexer)) {
-                        absl::Notification finished;
-                        string methodStr = convertLSPMethodToString(frontTask->method);
-                        auto preemptTask = make_unique<LSPQueuePreemptionTask>(*config, finished, *taskQueue, indexer);
-                        auto scheduleToken = typecheckerCoord.trySchedulePreemption(move(preemptTask));
-
-                        if (scheduleToken != nullptr) {
-                            logger->debug("[Processing] Preempting slow path for task {}", methodStr);
-                            // Preemption scheduling success!
-                            // In this if statement **only**, `taskQueueMutex` protects all accesses to LSPIndexer. This
-                            // is needed to linearize the indexing of edits, which may happen in the typechecking thread
-                            // if a fast path edit preempts, with the `canPreempt` checks of edits in this thread.
-                            auto headOfQueueCanPreempt = [&indexer = this->indexer,
-                                                          &tasks = taskQueue->tasks()]() -> bool {
-                                // Await always holds taskQueueMutex when calling this function, but absl doesn't know
-                                // that.
-                                return tasks.empty() || !tasks.front()->canPreempt(indexer);
-                            };
-                            // Wait until the head of the queue turns into a non-preemptible task to resume processing
-                            // the queue.
-                            taskQueue->getMutex()->Await(absl::Condition(&headOfQueueCanPreempt));
-
-                            // The queue is now empty or has a task that cannot preempt. There are two possibilities
-                            // here: 1) The scheduled work is now irrelevant because the task that was scheduled is now
-                            // gone (e.g., the request was canceled or, in the case of an edit, merged w/ a slow path
-                            // edit) 2) The scheduled work has already started (and may have finished). Pessimistically
-                            // assume 1) and try to cancel the scheduled preemption.
-                            if (!typecheckerCoord.tryCancelPreemption(scheduleToken)) {
-                                // Cancelation failed: 2) must be the case. Unlock the queue and wait until task
-                                // finishes to avoid races.
-                                taskQueue->getMutex()->Unlock();
-                                finished.WaitForNotification();
-                                taskQueue->getMutex()->Lock();
-                                logger->debug("[Processing] Preemption for task {} complete", methodStr);
-                            } else {
-                                logger->debug("[Processing] Canceled scheduled preemption for task {}", methodStr);
-                            }
-
-                            // At this point, we are guaranteed that the scheduled task has run or has been canceled.
-                            continue;
-                        }
-                        // If preemption scheduling failed, then the slow path probably finished just now. Continue as
-                        // normal.
-                    }
+                    continue;
                 }
 
-                task = move(frontTask);
-                taskQueue->tasks().erase(it);
+                // If the task can preempt, we may be able to schedule a preemption. Don't bother scheduling tasks to
+                // preempt that only need the indexer.
+                // N.B.: We check `canPreempt` last as it is mildly expensive for edits (it hashes the files)
+                if (frontTask->finalPhase() == LSPTask::Phase::RUN && epochManager->getStatus().slowPathRunning &&
+                    frontTask->canPreempt(indexer)) {
+                    absl::Notification finished;
+                    string methodStr = convertLSPMethodToString(frontTask->method);
+                    auto preemptTask = make_unique<LSPQueuePreemptionTask>(*config, finished, *taskQueue, indexer);
+                    auto scheduleToken = typecheckerCoord.trySchedulePreemption(move(preemptTask));
+
+                    if (scheduleToken != nullptr) {
+                        logger->debug("[Processing] Preempting slow path for task {}", methodStr);
+                        // Preemption scheduling success!
+                        // In this if statement **only**, `taskQueueMutex` protects all accesses to LSPIndexer. This is
+                        // needed to linearize the indexing of edits, which may happen in the typechecking thread if a
+                        // fast path edit preempts, with the `canPreempt` checks of edits in this thread.
+                        auto headOfQueueCanPreempt = [&indexer = this->indexer,
+                                                      &tasks = this->taskQueue->tasks()]() -> bool {
+                            // Await always holds taskQueueMutex when calling this function, but absl doesn't know that.
+                            return tasks.empty() || !tasks.front()->canPreempt(indexer);
+                        };
+                        // Wait until the head of the queue turns into a non-preemptible task to resume processing the
+                        // queue.
+                        taskQueue->getMutex()->Await(absl::Condition(&headOfQueueCanPreempt));
+
+                        // The queue is now empty or has a task that cannot preempt. There are two possibilities here:
+                        // 1) The scheduled work is now irrelevant because the task that was scheduled is now gone
+                        // (e.g., the request was canceled or, in the case of an edit, merged w/ a slow path edit)
+                        // 2) The scheduled work has already started (and may have finished).
+                        // Pessimistically assume 1) and try to cancel the scheduled preemption.
+                        if (!typecheckerCoord.tryCancelPreemption(scheduleToken)) {
+                            // Cancelation failed: 2) must be the case. Unlock the queue and wait until task finishes to
+                            // avoid races.
+                            taskQueue->getMutex()->Unlock();
+                            finished.WaitForNotification();
+                            taskQueue->getMutex()->Lock();
+                            logger->debug("[Processing] Preemption for task {} complete", methodStr);
+                        } else {
+                            logger->debug("[Processing] Canceled scheduled preemption for task {}", methodStr);
+                        }
+
+                        // At this point, we are guaranteed that the scheduled task has run or has been canceled.
+                        continue;
+                    }
+                    // If preemption scheduling failed, then the slow path probably finished just now. Continue as
+                    // normal.
+                }
+
+                task = move(taskQueue->tasks().front());
+                taskQueue->tasks().pop_front();
 
                 // Test only: Collect counters from other threads into this thread for reporting.
                 if (task->method == LSPMethod::GETCOUNTERS && !taskQueue->getCounters().hasNullCounters()) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

- Revert "Revert "Don't pause the indexer during initialization (#5488)" (#5593)"
- Move the runnable task to the front of the queue instead of moving out of the reference and erasing the iterator.

All the relevant changes are in the second commit, and that commit greatly reduces the diff to master.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Fixing the nullptr crashes with the previous implementation in #5488.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
