### PR TITLE
Remove newlines and excess whitespace from autocorrects

### DIFF
--- a/test/cli/arity-messages/test.out
+++ b/test/cli/arity-messages/test.out
@@ -8,7 +8,7 @@ arity-messages.rb:4: Too many positional arguments provided for method `Object#f
      4 |foo 1
             ^
   Autocorrect: Done
-    arity-messages.rb:4: Inserted `x: `
+    arity-messages.rb:4: Inserted `x:`
      4 |foo 1
             ^
 
@@ -26,7 +26,7 @@ arity-messages.rb:8: Too many positional arguments provided for method `Object#b
      8 |bar(5, x: 8)
             ^
   Autocorrect: Done
-    arity-messages.rb:8: Inserted `y: `
+    arity-messages.rb:8: Inserted `y:`
      8 |bar(5, x: 8)
             ^
 
@@ -50,7 +50,7 @@ arity-messages.rb:12: Too many positional arguments provided for method `Object#
     12 |baz 7
             ^
   Autocorrect: Done
-    arity-messages.rb:12: Inserted `x: `
+    arity-messages.rb:12: Inserted `x:`
     12 |baz 7
             ^
 
@@ -114,7 +114,7 @@ arity-messages.rb:30: Too many positional arguments provided for method `Object#
     30 |paperino(2, 3, z: 4)
                     ^
   Autocorrect: Done
-    arity-messages.rb:30: Inserted `y: `
+    arity-messages.rb:30: Inserted `y:`
     30 |paperino(2, 3, z: 4)
                     ^
 Errors: 12

--- a/test/cli/autocorrect-block-pass-curly-braces/test.out
+++ b/test/cli/autocorrect-block-pass-curly-braces/test.out
@@ -19,7 +19,7 @@ autocorrect-block-pass-curly-braces.rb:13: block pass should not be enclosed in 
     14 |                        : :cough)}
   Autocorrect: Done
     autocorrect-block-pass-curly-braces.rb:13: Replaced with `(&(T.unsafe(true) ? :sneeze
-                        : :cough))`
+                            : :cough))`
     13 |    h {&(T.unsafe(true) ? :sneeze
     14 |                        : :cough)}
 Errors: 3

--- a/test/cli/autocorrect-cast-untyped/test.out
+++ b/test/cli/autocorrect-cast-untyped/test.out
@@ -41,7 +41,7 @@ autocorrect-cast-untyped.rb:27: Please use `T.unsafe` to cast to `T.untyped` htt
     28 |  nil, T.untyped)
   Autocorrect: Done
     autocorrect-cast-untyped.rb:27: Replaced with `T.unsafe(
-  nil)`
+      nil)`
     27 |_w = T.cast(
     28 |  nil, T.untyped)
 Errors: 7

--- a/test/cli/autocorrect-helpers/test.out
+++ b/test/cli/autocorrect-helpers/test.out
@@ -2,8 +2,7 @@ autocorrect-helpers.rb:4: Method `interface!` does not exist on `T.class_of(S1)`
      4 |  interface!
           ^^^^^^^^^^
   Autocorrect: Done
-    autocorrect-helpers.rb:4: Inserted `  extend T::Helpers
-`
+    autocorrect-helpers.rb:4: Inserted `extend T::Helpers`
      4 |  interface!
         ^
 
@@ -11,8 +10,7 @@ autocorrect-helpers.rb:8: Method `abstract!` does not exist on `T.class_of(S2)` 
      8 |  abstract!
           ^^^^^^^^^
   Autocorrect: Done
-    autocorrect-helpers.rb:8: Inserted `  extend T::Helpers
-`
+    autocorrect-helpers.rb:8: Inserted `extend T::Helpers`
      8 |  abstract!
         ^
 
@@ -20,8 +18,7 @@ autocorrect-helpers.rb:12: Method `final!` does not exist on `T.class_of(S3)` ht
     12 |  final!
           ^^^^^^
   Autocorrect: Done
-    autocorrect-helpers.rb:12: Inserted `  extend T::Helpers
-`
+    autocorrect-helpers.rb:12: Inserted `extend T::Helpers`
     12 |  final!
         ^
 
@@ -29,8 +26,7 @@ autocorrect-helpers.rb:16: Method `sealed!` does not exist on `T.class_of(S4)` h
     16 |  sealed!
           ^^^^^^^
   Autocorrect: Done
-    autocorrect-helpers.rb:16: Inserted `  extend T::Helpers
-`
+    autocorrect-helpers.rb:16: Inserted `extend T::Helpers`
     16 |  sealed!
         ^
   Did you mean:
@@ -42,8 +38,7 @@ autocorrect-helpers.rb:20: Method `interface!` does not exist on `T.class_of(S5)
     20 |  interface!
           ^^^^^^^^^^
   Autocorrect: Done
-    autocorrect-helpers.rb:20: Inserted `  extend T::Helpers
-`
+    autocorrect-helpers.rb:20: Inserted `extend T::Helpers`
     20 |  interface!
         ^
 
@@ -51,8 +46,7 @@ autocorrect-helpers.rb:21: Method `final!` does not exist on `T.class_of(S5)` ht
     21 |  final!
           ^^^^^^
   Autocorrect: Done
-    autocorrect-helpers.rb:20: Inserted `  extend T::Helpers
-`
+    autocorrect-helpers.rb:20: Inserted `extend T::Helpers`
     20 |  interface!
         ^
 
@@ -60,8 +54,7 @@ autocorrect-helpers.rb:25: Method `abstract!` does not exist on `T.class_of(S6)`
     25 |  abstract!
           ^^^^^^^^^
   Autocorrect: Done
-    autocorrect-helpers.rb:25: Inserted `  extend T::Helpers
-`
+    autocorrect-helpers.rb:25: Inserted `extend T::Helpers`
     25 |  abstract!
         ^
 
@@ -69,8 +62,7 @@ autocorrect-helpers.rb:26: Method `sealed!` does not exist on `T.class_of(S6)` h
     26 |  sealed!
           ^^^^^^^
   Autocorrect: Done
-    autocorrect-helpers.rb:25: Inserted `  extend T::Helpers
-`
+    autocorrect-helpers.rb:25: Inserted `extend T::Helpers`
     25 |  abstract!
         ^
   Did you mean:
@@ -82,8 +74,7 @@ autocorrect-helpers.rb:30: Method `mixes_in_class_methods` does not exist on `T.
     30 |  mixes_in_class_methods(S1)
           ^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    autocorrect-helpers.rb:30: Inserted `  extend T::Helpers
-`
+    autocorrect-helpers.rb:30: Inserted `extend T::Helpers`
     30 |  mixes_in_class_methods(S1)
         ^
   Did you mean:

--- a/test/cli/autocorrect-kwargs-missing-comma/test.out
+++ b/test/cli/autocorrect-kwargs-missing-comma/test.out
@@ -2,7 +2,7 @@ autocorrect-kwargs-missing-comma.rb:4: missing "," between keyword args https://
      4 |  def example1(slug:, token:, merchant:request:)
                                                ^
   Autocorrect: Done
-    autocorrect-kwargs-missing-comma.rb:4: Inserted `, `
+    autocorrect-kwargs-missing-comma.rb:4: Inserted `,`
      4 |  def example1(slug:, token:, merchant:request:)
                                                ^
 
@@ -10,7 +10,7 @@ autocorrect-kwargs-missing-comma.rb:7: missing "," between keyword args https://
      7 |  def example2(merchant: request:)
                                 ^
   Autocorrect: Done
-    autocorrect-kwargs-missing-comma.rb:7: Replaced with `, `
+    autocorrect-kwargs-missing-comma.rb:7: Replaced with `,`
      7 |  def example2(merchant: request:)
                                 ^
 
@@ -18,7 +18,7 @@ autocorrect-kwargs-missing-comma.rb:10: missing "," between keyword args https:/
     10 |  def example3(merchant:request:)
                                 ^
   Autocorrect: Done
-    autocorrect-kwargs-missing-comma.rb:10: Inserted `, `
+    autocorrect-kwargs-missing-comma.rb:10: Inserted `,`
     10 |  def example3(merchant:request:)
                                 ^
 
@@ -26,7 +26,7 @@ autocorrect-kwargs-missing-comma.rb:14: missing "," between keyword args https:/
     14 |  def example4(merchant:request:, etc:)
                                 ^
   Autocorrect: Done
-    autocorrect-kwargs-missing-comma.rb:14: Inserted `, `
+    autocorrect-kwargs-missing-comma.rb:14: Inserted `,`
     14 |  def example4(merchant:request:, etc:)
                                 ^
 
@@ -34,7 +34,7 @@ autocorrect-kwargs-missing-comma.rb:18: missing "," between keyword args https:/
     18 |  def example5(merchant:request: etc:)
                                 ^
   Autocorrect: Done
-    autocorrect-kwargs-missing-comma.rb:18: Inserted `, `
+    autocorrect-kwargs-missing-comma.rb:18: Inserted `,`
     18 |  def example5(merchant:request: etc:)
                                 ^
 
@@ -42,7 +42,7 @@ autocorrect-kwargs-missing-comma.rb:18: missing "," between keyword args https:/
     18 |  def example5(merchant:request: etc:)
                                         ^
   Autocorrect: Done
-    autocorrect-kwargs-missing-comma.rb:18: Replaced with `, `
+    autocorrect-kwargs-missing-comma.rb:18: Replaced with `,`
     18 |  def example5(merchant:request: etc:)
                                         ^
 Errors: 6

--- a/test/cli/autocorrect-lazy-type-alias/test.out
+++ b/test/cli/autocorrect-lazy-type-alias/test.out
@@ -29,11 +29,11 @@ autocorrect-lazy-type-alias.rb:9: No block given to `T.type_alias` https://srb.h
     12 |    ))
   Autocorrect: Done
     autocorrect-lazy-type-alias.rb:9: Replaced with `T.type_alias do
-      T.any(
-        String,
-        Integer
-      )
-    end`
+          T.any(
+            String,
+            Integer
+          )
+        end`
      9 |    Multiline = T.type_alias(T.any(
     10 |      String,
     11 |      Integer
@@ -46,11 +46,11 @@ autocorrect-lazy-type-alias.rb:14: No block given to `T.type_alias` https://srb.
     17 |    )
   Autocorrect: Done
     autocorrect-lazy-type-alias.rb:14: Replaced with `T.type_alias do
-      {
-        foo: String,
-        bar: T.nilable(Integer)
-      }
-    end`
+          {
+            foo: String,
+            bar: T.nilable(Integer)
+          }
+        end`
     14 |    MyType = T.type_alias(
     15 |      foo: String,
     16 |      bar: T.nilable(Integer),

--- a/test/cli/autocorrect-requires-ancestor-block/test.out
+++ b/test/cli/autocorrect-requires-ancestor-block/test.out
@@ -15,7 +15,7 @@ autocorrect-requires-ancestor-block.rb:13: `requires_ancestor` only accepts a bl
     Use --isolate-error-code 5062 -a --typed true to auto-correct using the new syntax
   Autocorrect: Done
     autocorrect-requires-ancestor-block.rb:13: Replaced with `requires_ancestor { RA2 }
-  requires_ancestor { RA3 }`
+      requires_ancestor { RA3 }`
     13 |  requires_ancestor RA2, RA3
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/test/cli/autocorrect/test.out
+++ b/test/cli/autocorrect/test.out
@@ -2,9 +2,7 @@ autocorrect.rb:8: Method `sig` does not exist on `T.class_of(<root>)` https://sr
      8 |sig {params(a: String).void}
         ^^^
   Autocorrect: Done
-    autocorrect.rb:8: Inserted `extend T::Sig
-
-`
+    autocorrect.rb:8: Inserted `extend T::Sig`
      8 |sig {params(a: String).void}
         ^
 
@@ -16,9 +14,7 @@ autocorrect.rb:19: Method `sig` does not exist on `T.class_of(<root>)` https://s
     19 |sig {params(a: T.nilable(Integer)).void}
         ^^^
   Autocorrect: Done
-    autocorrect.rb:19: Inserted `extend T::Sig
-
-`
+    autocorrect.rb:19: Inserted `extend T::Sig`
     19 |sig {params(a: T.nilable(Integer)).void}
         ^
 

--- a/test/cli/autocorrect_array_plus/test.out
+++ b/test/cli/autocorrect_array_plus/test.out
@@ -121,7 +121,7 @@ autocorrect_array_plus.rb:18: Expected `T::Enumerable[Integer]` but found `T::Ar
   Note:
     If the desired behavior is to widen the type to `T::Array[T.any(Integer, String)]`, use `Array#concat` instead
   Autocorrect: Done
-    autocorrect_array_plus.rb:18: Replaced with ` = ints.concat(strings)`
+    autocorrect_array_plus.rb:18: Replaced with `= ints.concat(strings)`
     18 |ints += strings
             ^^^^^^^^^^^
 
@@ -139,7 +139,7 @@ autocorrect_array_plus.rb:19: Expected `T::Enumerable[Integer]` but found `T::Ar
   Note:
     If the desired behavior is to widen the type to `T::Array[T.any(Integer, String)]`, use `Array#concat` instead
   Autocorrect: Done
-    autocorrect_array_plus.rb:19: Replaced with ` = ints.concat(strings)`
+    autocorrect_array_plus.rb:19: Replaced with `= ints.concat(strings)`
     19 |ints += strings
             ^^^^^^^^^^^
 
@@ -157,7 +157,7 @@ autocorrect_array_plus.rb:20: Expected `T::Enumerable[Integer]` but found `T::Ar
   Note:
     If the desired behavior is to widen the type to `T::Array[T.any(Integer, String)]`, use `Array#concat` instead
   Autocorrect: Done
-    autocorrect_array_plus.rb:20: Replaced with ` = ints.concat(strings)`
+    autocorrect_array_plus.rb:20: Replaced with `= ints.concat(strings)`
     20 |ints += strings
             ^^^^^^^^^^^
 

--- a/test/cli/dash-e/test.out
+++ b/test/cli/dash-e/test.out
@@ -13,8 +13,7 @@ class ::<root> < ::Object ()
      2 |def foo; end
         ^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    -e:2: Insert `sig {returns(NilClass)}
-`
+    -e:2: Insert `sig {returns(NilClass)}`
      2 |def foo; end
         ^
 Errors: 1

--- a/test/cli/incremental-resolver/test.out
+++ b/test/cli/incremental-resolver/test.out
@@ -111,9 +111,7 @@ test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:68: Method `sig` 
     68 |  sig {void}
           ^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:68: Insert `  extend T::Sig
-
-`
+    test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:68: Insert `extend T::Sig`
     68 |  sig {void}
         ^
 
@@ -129,9 +127,7 @@ test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:69: Method `sig` 
     69 |  sig {void}
           ^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:69: Insert `  extend T::Sig
-
-`
+    test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:69: Insert `extend T::Sig`
     69 |  sig {void}
         ^
 

--- a/test/cli/isolate-error-code/test.out
+++ b/test/cli/isolate-error-code/test.out
@@ -2,12 +2,10 @@ test/cli/isolate-error-code/isolate-error-code.rb:6: This function does not have
      6 | def foo
          ^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/isolate-error-code/isolate-error-code.rb:6: Insert `sig {returns(Integer)}
- `
+    test/cli/isolate-error-code/isolate-error-code.rb:6: Insert `sig {returns(Integer)}`
      6 | def foo
          ^
-    test/cli/isolate-error-code/isolate-error-code.rb:6: Insert `  extend T::Sig
-`
+    test/cli/isolate-error-code/isolate-error-code.rb:6: Insert `extend T::Sig`
      6 | def foo
         ^
 Errors: 1
@@ -16,12 +14,10 @@ test/cli/isolate-error-code/isolate-error-code.rb:6: This function does not have
      6 | def foo
          ^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/isolate-error-code/isolate-error-code.rb:6: Insert `sig {returns(Integer)}
- `
+    test/cli/isolate-error-code/isolate-error-code.rb:6: Insert `sig {returns(Integer)}`
      6 | def foo
          ^
-    test/cli/isolate-error-code/isolate-error-code.rb:6: Insert `  extend T::Sig
-`
+    test/cli/isolate-error-code/isolate-error-code.rb:6: Insert `extend T::Sig`
      6 | def foo
         ^
 Errors: 1

--- a/test/cli/package-autocorrect-missing-import/test.out
+++ b/test/cli/package-autocorrect-missing-import/test.out
@@ -5,8 +5,7 @@ foo_class.rb:7: Unable to resolve constant `Bar` https://srb.help/5002
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    __package.rb:6: Inserted `
-  import Foo::Bar::OtherPackage`
+    __package.rb:6: Inserted `import Foo::Bar::OtherPackage`
      6 |  # import Foo::Bar::OtherPackage ## MISSING!
                                                      ^
 
@@ -17,8 +16,7 @@ foo_class.rb:8: Unable to resolve constant `Bar` https://srb.help/5002
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    __package.rb:6: Inserted `
-  import Foo::Bar::OtherPackage`
+    __package.rb:6: Inserted `import Foo::Bar::OtherPackage`
      6 |  # import Foo::Bar::OtherPackage ## MISSING!
                                                      ^
 
@@ -29,8 +27,7 @@ foo_class.rb:14: Unable to resolve constant `Bar` https://srb.help/5002
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    __package.rb:6: Inserted `
-  import Foo::Bar::OtherPackage`
+    __package.rb:6: Inserted `import Foo::Bar::OtherPackage`
      6 |  # import Foo::Bar::OtherPackage ## MISSING!
                                                      ^
 
@@ -41,8 +38,7 @@ foo_class.rb:15: Unable to resolve constant `Bar` https://srb.help/5002
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    __package.rb:6: Inserted `
-  import Foo::Bar::OtherPackage`
+    __package.rb:6: Inserted `import Foo::Bar::OtherPackage`
      6 |  # import Foo::Bar::OtherPackage ## MISSING!
                                                      ^
 
@@ -53,8 +49,7 @@ foo.test.rb:4: Unable to resolve constant `Bar` https://srb.help/5002
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    __package.rb:6: Inserted `
-  test_import Foo::Bar::OtherPackage`
+    __package.rb:6: Inserted `test_import Foo::Bar::OtherPackage`
      6 |  # import Foo::Bar::OtherPackage ## MISSING!
                                                      ^
 Errors: 5

--- a/test/cli/package-error-missing-export/test.out
+++ b/test/cli/package-error-missing-export/test.out
@@ -10,8 +10,7 @@ foo_class.rb:10: Unable to resolve constant `NotExported` https://srb.help/5002
   Note:
     Try running generate-packages.sh
   Autocorrect: Use `-a` to autocorrect
-    other/__package.rb:4: Insert `
-  export Foo::Bar::OtherPackage::NotExported`
+    other/__package.rb:4: Insert `export Foo::Bar::OtherPackage::NotExported`
      4 |  export Foo::Bar::OtherPackage::OtherClass
                                                    ^
 
@@ -27,8 +26,7 @@ foo_class.rb:11: Unable to resolve constant `NotExported` https://srb.help/5002
   Note:
     Try running generate-packages.sh
   Autocorrect: Use `-a` to autocorrect
-    other/__package.rb:4: Insert `
-  export Foo::Bar::OtherPackage::NotExported`
+    other/__package.rb:4: Insert `export Foo::Bar::OtherPackage::NotExported`
      4 |  export Foo::Bar::OtherPackage::OtherClass
                                                    ^
 
@@ -44,8 +42,7 @@ foo_class.rb:12: Unable to resolve constant `Inner` https://srb.help/5002
   Note:
     Try running generate-packages.sh
   Autocorrect: Use `-a` to autocorrect
-    other/__package.rb:4: Insert `
-  export Foo::Bar::OtherPackage::Inner`
+    other/__package.rb:4: Insert `export Foo::Bar::OtherPackage::Inner`
      4 |  export Foo::Bar::OtherPackage::OtherClass
                                                    ^
 
@@ -61,8 +58,7 @@ foo_class.rb:13: Unable to resolve constant `Inner` https://srb.help/5002
   Note:
     Try running generate-packages.sh
   Autocorrect: Use `-a` to autocorrect
-    other/__package.rb:4: Insert `
-  export Foo::Bar::OtherPackage::Inner`
+    other/__package.rb:4: Insert `export Foo::Bar::OtherPackage::Inner`
      4 |  export Foo::Bar::OtherPackage::OtherClass
                                                    ^
 Errors: 4

--- a/test/cli/package-error-missing-import/test.out
+++ b/test/cli/package-error-missing-import/test.out
@@ -5,8 +5,7 @@ foo_class.rb:7: Unable to resolve constant `Bar` https://srb.help/5002
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    __package.rb:6: Insert `
-  import Foo::Bar::OtherPackage`
+    __package.rb:6: Insert `import Foo::Bar::OtherPackage`
      6 |  # import Foo::Bar::OtherPackage ## MISSING!
                                                      ^
   Note:
@@ -19,8 +18,7 @@ foo_class.rb:8: Unable to resolve constant `Bar` https://srb.help/5002
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    __package.rb:6: Insert `
-  import Foo::Bar::OtherPackage`
+    __package.rb:6: Insert `import Foo::Bar::OtherPackage`
      6 |  # import Foo::Bar::OtherPackage ## MISSING!
                                                      ^
   Note:
@@ -33,8 +31,7 @@ foo_class.rb:14: Unable to resolve constant `Bar` https://srb.help/5002
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    __package.rb:6: Insert `
-  import Foo::Bar::OtherPackage`
+    __package.rb:6: Insert `import Foo::Bar::OtherPackage`
      6 |  # import Foo::Bar::OtherPackage ## MISSING!
                                                      ^
   Note:
@@ -47,8 +44,7 @@ foo.test.rb:4: Unable to resolve constant `Bar` https://srb.help/5002
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    __package.rb:6: Insert `
-  test_import Foo::Bar::OtherPackage`
+    __package.rb:6: Insert `test_import Foo::Bar::OtherPackage`
      6 |  # import Foo::Bar::OtherPackage ## MISSING!
                                                      ^
   Note:

--- a/test/cli/package-error-no-export-for-test/test.out
+++ b/test/cli/package-error-no-export-for-test/test.out
@@ -8,8 +8,7 @@ foo_bar/thing.test.rb:5: Unable to resolve constant `Thing` https://srb.help/500
      3 |class Foo::Bar::Exported
               ^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    foo_bar/__package.rb:4: Insert `
-  export_for_test Foo::Bar`
+    foo_bar/__package.rb:4: Insert `export_for_test Foo::Bar`
      4 |  export Foo::Bar::Exported
                                    ^
 
@@ -23,8 +22,7 @@ other/other.test.rb:5: Unable to resolve constant `Thing` https://srb.help/5002
      3 |class Foo::Bar::Thing
         ^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    foo_bar/__package.rb:4: Insert `
-  export Foo::Bar::Thing`
+    foo_bar/__package.rb:4: Insert `export Foo::Bar::Thing`
      4 |  export Foo::Bar::Exported
                                    ^
 Errors: 2

--- a/test/cli/print_generics/test.out
+++ b/test/cli/print_generics/test.out
@@ -2,8 +2,7 @@ test/cli/print_generics/print_generics.rb:5: This function does not have a `sig`
      5 |def foo(x)
         ^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/print_generics/print_generics.rb:5: Insert `sig {params(x: T.untyped).returns(T::Array[Integer])}
-`
+    test/cli/print_generics/print_generics.rb:5: Insert `sig {params(x: T.untyped).returns(T::Array[Integer])}`
      5 |def foo(x)
         ^
 
@@ -11,8 +10,7 @@ test/cli/print_generics/print_generics.rb:9: This function does not have a `sig`
      9 |def bar(x)
         ^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/print_generics/print_generics.rb:9: Insert `sig {params(x: T.untyped).returns(T::Hash[Symbol, Integer])}
-`
+    test/cli/print_generics/print_generics.rb:9: Insert `sig {params(x: T.untyped).returns(T::Hash[Symbol, Integer])}`
      9 |def bar(x)
         ^
 
@@ -20,8 +18,7 @@ test/cli/print_generics/print_generics.rb:13: This function does not have a `sig
     13 |def qux(x)
         ^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/print_generics/print_generics.rb:13: Insert `sig {params(x: T.untyped).returns(T::Enumerable[Integer])}
-`
+    test/cli/print_generics/print_generics.rb:13: Insert `sig {params(x: T.untyped).returns(T::Enumerable[Integer])}`
     13 |def qux(x)
         ^
 
@@ -29,8 +26,7 @@ test/cli/print_generics/print_generics.rb:17: This function does not have a `sig
     17 |def wub(x)
         ^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/print_generics/print_generics.rb:17: Insert `sig {params(x: T.untyped).returns(T::Range[Integer])}
-`
+    test/cli/print_generics/print_generics.rb:17: Insert `sig {params(x: T.untyped).returns(T::Range[Integer])}`
     17 |def wub(x)
         ^
 
@@ -38,8 +34,7 @@ test/cli/print_generics/print_generics.rb:21: This function does not have a `sig
     21 |def zan(x)
         ^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/print_generics/print_generics.rb:21: Insert `sig {params(x: T.untyped).returns(T::Set[Integer])}
-`
+    test/cli/print_generics/print_generics.rb:21: Insert `sig {params(x: T.untyped).returns(T::Set[Integer])}`
     21 |def zan(x)
         ^
 
@@ -47,8 +42,7 @@ test/cli/print_generics/print_generics.rb:25: This function does not have a `sig
     25 |def gaz(x)
         ^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    test/cli/print_generics/print_generics.rb:25: Insert `sig {params(x: T.untyped).returns(T::Enumerator[Integer])}
-`
+    test/cli/print_generics/print_generics.rb:25: Insert `sig {params(x: T.untyped).returns(T::Enumerator[Integer])}`
     25 |def gaz(x)
         ^
 Errors: 6

--- a/test/cli/simple-package/test.out
+++ b/test/cli/simple-package/test.out
@@ -17,8 +17,7 @@ foo/foo.rb:14: Unable to resolve constant `UnexportedClass` https://srb.help/500
     14 |  class UnexportedClass; end
           ^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
-    bar/__package.rb:9: Insert `
-  export Project::Bar::UnexportedClass`
+    bar/__package.rb:9: Insert `export Project::Bar::UnexportedClass`
      9 |  export Project::Bar::BarMethods
                                          ^
 Errors: 2

--- a/test/cli/suggest-sig-literal/test.out
+++ b/test/cli/suggest-sig-literal/test.out
@@ -2,8 +2,7 @@ suggest-sig-literal.rb:2: This function does not have a `sig` https://srb.help/7
      2 |def index_for_live(fields)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig-literal.rb:2: Inserted `sig {params(fields: T.untyped).returns(T::Array[T::Array[T.any(Symbol, Integer)]])}
-`
+    suggest-sig-literal.rb:2: Inserted `sig {params(fields: T.untyped).returns(T::Array[T::Array[T.any(Symbol, Integer)]])}`
      2 |def index_for_live(fields)
         ^
 Errors: 1

--- a/test/cli/suggest-sig/test.out
+++ b/test/cli/suggest-sig/test.out
@@ -36,8 +36,7 @@ suggest-sig.rb:5: This function does not have a `sig` https://srb.help/7017
      5 |def hazTwoArgs(a, b); 1; end;
         ^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:5: Inserted `sig {params(a: T.untyped, b: T.untyped).returns(Integer)}
-`
+    suggest-sig.rb:5: Inserted `sig {params(a: T.untyped, b: T.untyped).returns(Integer)}`
      5 |def hazTwoArgs(a, b); 1; end;
         ^
 
@@ -49,8 +48,7 @@ suggest-sig.rb:7: This function does not have a `sig` https://srb.help/7017
      7 |def baz
         ^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:7: Inserted `sig {returns(T.any(T::Array[T.untyped], String))}
-`
+    suggest-sig.rb:7: Inserted `sig {returns(T.any(T::Array[T.untyped], String))}`
      7 |def baz
         ^
 
@@ -58,8 +56,7 @@ suggest-sig.rb:18: This function does not have a `sig` https://srb.help/7017
     18 |def bla; give_me_void; end
         ^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:18: Inserted `sig {void}
-`
+    suggest-sig.rb:18: Inserted `sig {void}`
     18 |def bla; give_me_void; end
         ^
 
@@ -71,8 +68,7 @@ suggest-sig.rb:20: This function does not have a `sig` https://srb.help/7017
     20 |def bbq
         ^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:20: Inserted `sig {void}
-`
+    suggest-sig.rb:20: Inserted `sig {void}`
     20 |def bbq
         ^
 
@@ -84,8 +80,7 @@ suggest-sig.rb:30: This function does not have a `sig` https://srb.help/7017
     30 |def give_me_literal; 1; end;
         ^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:30: Inserted `sig {returns(Integer)}
-`
+    suggest-sig.rb:30: Inserted `sig {returns(Integer)}`
     30 |def give_me_literal; 1; end;
         ^
 
@@ -93,8 +88,7 @@ suggest-sig.rb:32: This function does not have a `sig` https://srb.help/7017
     32 |def give_me_literal_nested; [[1]]; end;
         ^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:32: Inserted `sig {returns(T::Array[T::Array[Integer]])}
-`
+    suggest-sig.rb:32: Inserted `sig {returns(T::Array[T::Array[Integer]])}`
     32 |def give_me_literal_nested; [[1]]; end;
         ^
 
@@ -102,8 +96,7 @@ suggest-sig.rb:34: This function does not have a `sig` https://srb.help/7017
     34 |private def root_private; end
                 ^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:34: Inserted `sig {returns(NilClass)}
-`
+    suggest-sig.rb:34: Inserted `sig {returns(NilClass)}`
     34 |private def root_private; end
         ^
 
@@ -111,8 +104,7 @@ suggest-sig.rb:36: This function does not have a `sig` https://srb.help/7017
     36 |protected def root_protected; end
                   ^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:36: Inserted `sig {returns(NilClass)}
-`
+    suggest-sig.rb:36: Inserted `sig {returns(NilClass)}`
     36 |protected def root_protected; end
         ^
 
@@ -120,8 +112,7 @@ suggest-sig.rb:46: This function does not have a `sig` https://srb.help/7017
     46 |def foo(a)
         ^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:46: Inserted `sig {params(a: Integer).returns(Integer)}
-`
+    suggest-sig.rb:46: Inserted `sig {params(a: Integer).returns(Integer)}`
     46 |def foo(a)
         ^
 
@@ -129,8 +120,7 @@ suggest-sig.rb:56: This function does not have a `sig` https://srb.help/7017
     56 |def fooCond(a, cond)
         ^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:56: Inserted `sig {params(a: T.any(Integer, String), cond: T.untyped).void}
-`
+    suggest-sig.rb:56: Inserted `sig {params(a: T.any(Integer, String), cond: T.untyped).void}`
     56 |def fooCond(a, cond)
         ^
 
@@ -138,8 +128,7 @@ suggest-sig.rb:64: This function does not have a `sig` https://srb.help/7017
     64 |def fooWhile(a, cond1, cond2)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:64: Inserted `sig {params(a: T.any(Integer, String), cond1: T.untyped, cond2: T.untyped).returns(NilClass)}
-`
+    suggest-sig.rb:64: Inserted `sig {params(a: T.any(Integer, String), cond1: T.untyped, cond2: T.untyped).returns(NilClass)}`
     64 |def fooWhile(a, cond1, cond2)
         ^
 
@@ -147,8 +136,7 @@ suggest-sig.rb:74: This function does not have a `sig` https://srb.help/7017
     74 |def takesBlock
         ^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:74: Inserted `sig {returns(Integer)}
-`
+    suggest-sig.rb:74: Inserted `sig {returns(Integer)}`
     74 |def takesBlock
         ^
 
@@ -156,8 +144,7 @@ suggest-sig.rb:79: This function does not have a `sig` https://srb.help/7017
     79 |def list_ints_or_empty_list
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:79: Inserted `sig {returns(T::Array[T.untyped])}
-`
+    suggest-sig.rb:79: Inserted `sig {returns(T::Array[T.untyped])}`
     79 |def list_ints_or_empty_list
         ^
 
@@ -207,8 +194,7 @@ suggest-sig.rb:84: This function does not have a `sig` https://srb.help/7017
     84 |def dead(x)
         ^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:84: Inserted `sig {params(x: Integer).void}
-`
+    suggest-sig.rb:84: Inserted `sig {params(x: Integer).void}`
     84 |def dead(x)
         ^
 
@@ -216,8 +202,7 @@ suggest-sig.rb:92: This function does not have a `sig` https://srb.help/7017
     92 |def with_block
         ^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:92: Inserted `sig {returns(NilClass)}
-`
+    suggest-sig.rb:92: Inserted `sig {returns(NilClass)}`
     92 |def with_block
         ^
 
@@ -233,8 +218,7 @@ suggest-sig.rb:118: This function does not have a `sig` https://srb.help/7017
      118 |def cantRun(a)
           ^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:118: Inserted `sig {params(a: T.untyped).returns(Integer)}
-`
+    suggest-sig.rb:118: Inserted `sig {params(a: T.untyped).returns(Integer)}`
      118 |def cantRun(a)
           ^
 
@@ -242,8 +226,7 @@ suggest-sig.rb:155: This function does not have a `sig` https://srb.help/7017
      155 |def explicitly_named_block_parameter(&blk)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:155: Inserted `sig {params(blk: T.untyped).returns(Integer)}
-`
+    suggest-sig.rb:155: Inserted `sig {params(blk: T.untyped).returns(Integer)}`
      155 |def explicitly_named_block_parameter(&blk)
           ^
 
@@ -275,8 +258,7 @@ suggest-sig.rb:41: This function does not have a `sig` https://srb.help/7017
     41 |  private def a_private; end
                   ^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:41: Inserted `sig {returns(NilClass)}
-  `
+    suggest-sig.rb:41: Inserted `sig {returns(NilClass)}`
     41 |  private def a_private; end
           ^
 
@@ -284,8 +266,7 @@ suggest-sig.rb:43: This function does not have a `sig` https://srb.help/7017
     43 |  protected def a_protected; end
                     ^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:43: Inserted `sig {returns(NilClass)}
-  `
+    suggest-sig.rb:43: Inserted `sig {returns(NilClass)}`
     43 |  protected def a_protected; end
           ^
 
@@ -309,12 +290,10 @@ suggest-sig.rb:112: This function does not have a `sig` https://srb.help/7017
      112 |  def self.load_account_business_profile(merchant)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:112: Inserted `sig {params(merchant: TestCarash::Merchant).returns(Integer)}
-  `
+    suggest-sig.rb:112: Inserted `sig {params(merchant: TestCarash::Merchant).returns(Integer)}`
      112 |  def self.load_account_business_profile(merchant)
             ^
-    suggest-sig.rb:105: Inserted `  extend T::Sig
-`
+    suggest-sig.rb:105: Inserted `extend T::Sig`
      105 |  class Merchant
           ^
 
@@ -322,8 +301,7 @@ suggest-sig.rb:108: Method `sig` does not exist on `T.class_of(TestCarash)` http
      108 |  sig {params(merchant: Merchant).void}
             ^^^
   Autocorrect: Done
-    suggest-sig.rb:105: Inserted `  extend T::Sig
-`
+    suggest-sig.rb:105: Inserted `extend T::Sig`
      105 |  class Merchant
           ^
 
@@ -335,8 +313,7 @@ suggest-sig.rb:166: This function does not have a `sig` https://srb.help/7017
      166 |  def self.test1(x:, y:)
             ^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:166: Inserted `sig {params(x: Integer, y: String).void}
-  `
+    suggest-sig.rb:166: Inserted `sig {params(x: Integer, y: String).void}`
      166 |  def self.test1(x:, y:)
             ^
 
@@ -344,8 +321,7 @@ suggest-sig.rb:170: This function does not have a `sig` https://srb.help/7017
      170 |  def self.test2(x:, y:)
             ^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:170: Inserted `sig {params(x: Integer, y: String).void}
-  `
+    suggest-sig.rb:170: Inserted `sig {params(x: Integer, y: String).void}`
      170 |  def self.test2(x:, y:)
             ^
 
@@ -353,8 +329,7 @@ suggest-sig.rb:174: This function does not have a `sig` https://srb.help/7017
      174 |  def self.test3(x:, y:)
             ^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:174: Inserted `sig {params(x: Integer, y: T.untyped).void}
-  `
+    suggest-sig.rb:174: Inserted `sig {params(x: Integer, y: T.untyped).void}`
      174 |  def self.test3(x:, y:)
             ^
 
@@ -362,8 +337,7 @@ suggest-sig.rb:186: This function does not have a `sig` https://srb.help/7017
      186 |  def self.test1(y)
             ^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:186: Inserted `sig {params(y: T.untyped).void}
-  `
+    suggest-sig.rb:186: Inserted `sig {params(y: T.untyped).void}`
      186 |  def self.test1(y)
             ^
 
@@ -371,8 +345,7 @@ suggest-sig.rb:191: This function does not have a `sig` https://srb.help/7017
      191 |  def self.test2(y)
             ^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:191: Inserted `sig {params(y: T.untyped).void}
-  `
+    suggest-sig.rb:191: Inserted `sig {params(y: T.untyped).void}`
      191 |  def self.test2(y)
             ^
 
@@ -380,8 +353,7 @@ suggest-sig.rb:204: This function does not have a `sig` https://srb.help/7017
      204 |  def returns_int; 42; end
             ^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig.rb:204: Inserted `sig(:final) {returns(Integer)}
-  `
+    suggest-sig.rb:204: Inserted `sig(:final) {returns(Integer)}`
      204 |  def returns_int; 42; end
             ^
 Errors: 47

--- a/test/cli/suggest-typed-true/test.out
+++ b/test/cli/suggest-typed-true/test.out
@@ -9,8 +9,7 @@ suggest-typed-true.rb:1: You could add `# typed: true` https://srb.help/7022
      1 |def true_func
         ^
   Autocorrect: Use `-a` to autocorrect
-    suggest-typed-true.rb:1: Insert `# typed: true
-`
+    suggest-typed-true.rb:1: Insert `# typed: true`
      1 |def true_func
         ^
 Errors: 1
@@ -19,8 +18,7 @@ suggest-typed-true.rb:1: You could add `# typed: true` https://srb.help/7022
      1 |def true_func
         ^
   Autocorrect: Use `-a` to autocorrect
-    suggest-typed-true.rb:1: Insert `# typed: true
-`
+    suggest-typed-true.rb:1: Insert `# typed: true`
      1 |def true_func
         ^
 Errors: 1
@@ -29,8 +27,7 @@ suggest-typed-ignore.rb:1: You could add `# typed: ignore` https://srb.help/7022
      1 |Foo
         ^
   Autocorrect: Done
-    suggest-typed-ignore.rb:1: Inserted `# typed: ignore
-`
+    suggest-typed-ignore.rb:1: Inserted `# typed: ignore`
      1 |Foo
         ^
 Errors: 1
@@ -42,8 +39,7 @@ suggest-typed-false.rb:1: You could add `# typed: false` https://srb.help/7022
      1 |false_func
         ^
   Autocorrect: Done
-    suggest-typed-false.rb:1: Inserted `# typed: false
-`
+    suggest-typed-false.rb:1: Inserted `# typed: false`
      1 |false_func
         ^
 Errors: 1
@@ -55,8 +51,7 @@ suggest-typed-true.rb:1: You could add `# typed: true` https://srb.help/7022
      1 |def true_func
         ^
   Autocorrect: Done
-    suggest-typed-true.rb:1: Inserted `# typed: true
-`
+    suggest-typed-true.rb:1: Inserted `# typed: true`
      1 |def true_func
         ^
 Errors: 1
@@ -69,8 +64,7 @@ suggest-typed-strict.rb:1: You could add `# typed: strict` https://srb.help/7022
      1 |extend T::Sig
         ^
   Autocorrect: Done
-    suggest-typed-strict.rb:1: Inserted `# typed: strict
-`
+    suggest-typed-strict.rb:1: Inserted `# typed: strict`
      1 |extend T::Sig
         ^
 Errors: 1
@@ -86,8 +80,7 @@ suggest-typed-strong.rb:1: You could add `# typed: strict` https://srb.help/7022
      1 |1
         ^
   Autocorrect: Done
-    suggest-typed-strong.rb:1: Inserted `# typed: strict
-`
+    suggest-typed-strong.rb:1: Inserted `# typed: strict`
      1 |1
         ^
 Errors: 1
@@ -99,8 +92,7 @@ empty.rb:1: You could add `# typed: strict` https://srb.help/7022
      1 |
         ^
   Autocorrect: Use `-a` to autocorrect
-    empty.rb:1: Insert `# typed: strict
-`
+    empty.rb:1: Insert `# typed: strict`
      1 |
         ^
 Errors: 1
@@ -109,8 +101,7 @@ suggest-typed-with-too-low.rb:2: You could add `# typed: strict` https://srb.hel
      2 |# typed: false
      3 |
   Autocorrect: Done
-    suggest-typed-with-too-low.rb:2: Replaced with `# typed: strict
-`
+    suggest-typed-with-too-low.rb:2: Replaced with `# typed: strict`
      2 |# typed: false
      3 |
 Errors: 1
@@ -131,8 +122,7 @@ suggest-typed-shabang.rb:2: You could add `# typed: true` https://srb.help/7022
      2 |def true_func
         ^
   Autocorrect: Done
-    suggest-typed-shabang.rb:2: Inserted `# typed: true
-`
+    suggest-typed-shabang.rb:2: Inserted `# typed: true`
      2 |def true_func
         ^
 Errors: 1

--- a/test/cli/suggest_initialize_sig/test.out
+++ b/test/cli/suggest_initialize_sig/test.out
@@ -13,9 +13,9 @@ test/cli/suggest_initialize_sig/suggest_initialize_sig.rb:16: The initialize met
     19 |    .returns(Integer)
   Autocorrect: Use `-a` to autocorrect
     test/cli/suggest_initialize_sig/suggest_initialize_sig.rb:16: Replace with `params(
-      x: Integer
-    )
-    .void`
+          x: Integer
+        )
+        .void`
     16 |    params(
     17 |      x: Integer
     18 |    )
@@ -28,9 +28,9 @@ test/cli/suggest_initialize_sig/suggest_initialize_sig.rb:30: The initialize met
     33 |    .returns(T::Array[T.any(String, T::Enum)])
   Autocorrect: Use `-a` to autocorrect
     test/cli/suggest_initialize_sig/suggest_initialize_sig.rb:30: Replace with `params(
-      x: T::Array[T.any(String, T::Enum)]
-    )
-    .void`
+          x: T::Array[T.any(String, T::Enum)]
+        )
+        .void`
     30 |    params(
     31 |      x: T::Array[T.any(String, T::Enum)]
     32 |    )
@@ -61,11 +61,11 @@ test/cli/suggest_initialize_sig/suggest_initialize_sig.rb:71: The initialize met
     76 |    .checked(:tests)
   Autocorrect: Use `-a` to autocorrect
     test/cli/suggest_initialize_sig/suggest_initialize_sig.rb:71: Replace with `params(
-      path: String,
-      key: String
-    )
-    .void
-    .checked(:tests)`
+          path: String,
+          key: String
+        )
+        .void
+        .checked(:tests)`
     71 |    params(
     72 |      path: String,
     73 |      key: String
@@ -81,10 +81,10 @@ test/cli/suggest_initialize_sig/suggest_initialize_sig.rb:86: The initialize met
     90 |    .returns(T.self_type).checked(:tests)
   Autocorrect: Use `-a` to autocorrect
     test/cli/suggest_initialize_sig/suggest_initialize_sig.rb:86: Replace with `params(
-      path: String,
-      key: String
-    )
-    .void.checked(:tests)`
+          path: String,
+          key: String
+        )
+        .void.checked(:tests)`
     86 |    params(
     87 |      path: String,
     88 |      key: String

--- a/test/cli/suggest_t_must/test.out
+++ b/test/cli/suggest_t_must/test.out
@@ -34,7 +34,7 @@ suggest_t_must.rb:8: Method `even?` does not exist on `NilClass` component of `T
      8 |T::Array[T.nilable(Integer)].new.map(&:even?)
                                               ^
   Autocorrect: Done
-    suggest_t_must.rb:8: Replaced with ` {|x| T.must(x).even?}`
+    suggest_t_must.rb:8: Replaced with `{|x| T.must(x).even?}`
      8 |T::Array[T.nilable(Integer)].new.map(&:even?)
                                             ^^^^^^^^^
 

--- a/test/cli/suggest_t_unsafe/test.out
+++ b/test/cli/suggest_t_unsafe/test.out
@@ -78,7 +78,7 @@ suggest_t_unsafe.rb:17: Method `even?` does not exist on `NilClass` component of
     17 |T::Array[T.nilable(Integer)].new.map(&:even?)
                                               ^
   Autocorrect: Done
-    suggest_t_unsafe.rb:17: Replaced with ` {|x| T.unsafe(x).even?}`
+    suggest_t_unsafe.rb:17: Replaced with `{|x| T.unsafe(x).even?}`
     17 |T::Array[T.nilable(Integer)].new.map(&:even?)
                                             ^^^^^^^^^
 Errors: 6
@@ -194,7 +194,7 @@ suggest_t_unsafe.rb:17: Method `even?` does not exist on `NilClass` component of
     17 |T::Array[T.nilable(Integer)].new.map(&:even?)
                                               ^
   Autocorrect: Done
-    suggest_t_unsafe.rb:17: Replaced with ` {|x| custom_wrapper(x).even?}`
+    suggest_t_unsafe.rb:17: Replaced with `{|x| custom_wrapper(x).even?}`
     17 |T::Array[T.nilable(Integer)].new.map(&:even?)
                                             ^^^^^^^^^
 Errors: 6

--- a/test/cli/type_argument_suggest_unsafe/test.out
+++ b/test/cli/type_argument_suggest_unsafe/test.out
@@ -30,7 +30,7 @@ type_argument_suggest_unsafe.rb:41: Call to method `foo` on unconstrained generi
     41 |  xs.map(&:foo) # error: Method `foo` does not exist on `Object#example4#U`
                   ^
   Autocorrect: Done
-    type_argument_suggest_unsafe.rb:41: Replaced with ` {|x| T.unsafe(x).foo}`
+    type_argument_suggest_unsafe.rb:41: Replaced with `{|x| T.unsafe(x).foo}`
     41 |  xs.map(&:foo) # error: Method `foo` does not exist on `Object#example4#U`
                 ^^^^^^^
 Errors: 3


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

When printing the messages into the terminal or into error messages in VS
Code, the extra whitespace is honestly more trouble than it's worth.

For a while I was pretty insistent that the autocorrect show you exactly
what it's going to do to your file, which mean showing the contents
unchanged. But honestly, people are just going to see that there's an
autocorrect and take it, and then undo the change if it turns out to have
not been a good one.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Exp file changes