### PR TITLE
Tidy up packager import suggestions

### DIFF
--- a/test/cli/package-autocorrect-missing-import/test.out
+++ b/test/cli/package-autocorrect-missing-import/test.out
@@ -1,57 +1,57 @@
 foo_class.rb:7: Unable to resolve constant `Bar` https://srb.help/5002
      7 |      Foo::Bar::OtherPackage::OtherClass # resolves via root
               ^^^^^^^^
-    other/__package.rb:3: Do you need to `import` package `Foo::Bar::OtherPackage`?
-     3 |class Foo::Bar::OtherPackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
     __package.rb:6: Inserted `import Foo::Bar::OtherPackage`
      6 |  # import Foo::Bar::OtherPackage ## MISSING!
                                                      ^
+    other/__package.rb:3: Defined here
+     3 |class Foo::Bar::OtherPackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 foo_class.rb:8: Unable to resolve constant `Bar` https://srb.help/5002
      8 |      Bar::OtherPackage::OtherClass # resolves via `module Foo`
               ^^^
-    other/__package.rb:3: Do you need to `import` package `Foo::Bar::OtherPackage`?
-     3 |class Foo::Bar::OtherPackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
     __package.rb:6: Inserted `import Foo::Bar::OtherPackage`
      6 |  # import Foo::Bar::OtherPackage ## MISSING!
                                                      ^
+    other/__package.rb:3: Defined here
+     3 |class Foo::Bar::OtherPackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 foo_class.rb:14: Unable to resolve constant `Bar` https://srb.help/5002
     14 |  Foo::Bar::OtherPackage::OtherClass # resolves via root
           ^^^^^^^^
-    other/__package.rb:3: Do you need to `import` package `Foo::Bar::OtherPackage`?
-     3 |class Foo::Bar::OtherPackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
     __package.rb:6: Inserted `import Foo::Bar::OtherPackage`
      6 |  # import Foo::Bar::OtherPackage ## MISSING!
                                                      ^
+    other/__package.rb:3: Defined here
+     3 |class Foo::Bar::OtherPackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 foo_class.rb:15: Unable to resolve constant `Bar` https://srb.help/5002
     15 |  Foo::Bar::MyClass::SUBCLASSES # resolves via root
           ^^^^^^^^
-    other/__package.rb:3: Do you need to `import` package `Foo::Bar::OtherPackage`?
-     3 |class Foo::Bar::OtherPackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
     __package.rb:6: Inserted `import Foo::Bar::OtherPackage`
      6 |  # import Foo::Bar::OtherPackage ## MISSING!
                                                      ^
+    other/__package.rb:3: Defined here
+     3 |class Foo::Bar::OtherPackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 foo.test.rb:4: Unable to resolve constant `Bar` https://srb.help/5002
      4 |  Test::Foo::Bar::OtherPackage::TestUtil
           ^^^^^^^^^^^^^^
-    other/__package.rb:3: Do you need to `test_import` package `Foo::Bar::OtherPackage`?
-     3 |class Foo::Bar::OtherPackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
     __package.rb:6: Inserted `test_import Foo::Bar::OtherPackage`
      6 |  # import Foo::Bar::OtherPackage ## MISSING!
                                                      ^
+    other/__package.rb:3: Defined here
+     3 |class Foo::Bar::OtherPackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Errors: 5
 
 --------------------------------------------------------------------------

--- a/test/cli/package-error-missing-export/test.out
+++ b/test/cli/package-error-missing-export/test.out
@@ -1,64 +1,52 @@
 foo_class.rb:10: Unable to resolve constant `NotExported` https://srb.help/5002
     10 |      Foo::Bar::OtherPackage::NotExported
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    other/__package.rb:3: Do you need to `export Foo::Bar::OtherPackage::NotExported` in package `Foo::Bar::OtherPackage`?
-     3 |class Foo::Bar::OtherPackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    other/other_class.rb:7: Constant `Foo::Bar::OtherPackage::NotExported` is defined here:
-     7 |  class NotExported
-          ^^^^^^^^^^^^^^^^^
-  Note:
-    Try running generate-packages.sh
   Autocorrect: Use `-a` to autocorrect
     other/__package.rb:4: Insert `export Foo::Bar::OtherPackage::NotExported`
      4 |  export Foo::Bar::OtherPackage::OtherClass
                                                    ^
+    other/other_class.rb:7: Defined here
+     7 |  class NotExported
+          ^^^^^^^^^^^^^^^^^
+  Note:
+    Try running generate-packages.sh
 
 foo_class.rb:11: Unable to resolve constant `NotExported` https://srb.help/5002
     11 |      Bar::OtherPackage::NotExported
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    other/__package.rb:3: Do you need to `export Foo::Bar::OtherPackage::NotExported` in package `Foo::Bar::OtherPackage`?
-     3 |class Foo::Bar::OtherPackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    other/other_class.rb:7: Constant `Foo::Bar::OtherPackage::NotExported` is defined here:
-     7 |  class NotExported
-          ^^^^^^^^^^^^^^^^^
-  Note:
-    Try running generate-packages.sh
   Autocorrect: Use `-a` to autocorrect
     other/__package.rb:4: Insert `export Foo::Bar::OtherPackage::NotExported`
      4 |  export Foo::Bar::OtherPackage::OtherClass
                                                    ^
+    other/other_class.rb:7: Defined here
+     7 |  class NotExported
+          ^^^^^^^^^^^^^^^^^
+  Note:
+    Try running generate-packages.sh
 
 foo_class.rb:12: Unable to resolve constant `Inner` https://srb.help/5002
     12 |      Foo::Bar::OtherPackage::Inner::AlsoNotExported
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    other/__package.rb:3: Do you need to `export Foo::Bar::OtherPackage::Inner` in package `Foo::Bar::OtherPackage`?
-     3 |class Foo::Bar::OtherPackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    other/other_class.rb:10: Constant `Foo::Bar::OtherPackage::Inner` is defined here:
-    10 |  class Inner::AlsoNotExported
-                ^^^^^
-  Note:
-    Try running generate-packages.sh
   Autocorrect: Use `-a` to autocorrect
     other/__package.rb:4: Insert `export Foo::Bar::OtherPackage::Inner`
      4 |  export Foo::Bar::OtherPackage::OtherClass
                                                    ^
+    other/other_class.rb:10: Defined here
+    10 |  class Inner::AlsoNotExported
+                ^^^^^
+  Note:
+    Try running generate-packages.sh
 
 foo_class.rb:13: Unable to resolve constant `Inner` https://srb.help/5002
     13 |      Bar::OtherPackage::Inner::AlsoNotExported
               ^^^^^^^^^^^^^^^^^^^^^^^^
-    other/__package.rb:3: Do you need to `export Foo::Bar::OtherPackage::Inner` in package `Foo::Bar::OtherPackage`?
-     3 |class Foo::Bar::OtherPackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    other/other_class.rb:10: Constant `Foo::Bar::OtherPackage::Inner` is defined here:
-    10 |  class Inner::AlsoNotExported
-                ^^^^^
-  Note:
-    Try running generate-packages.sh
   Autocorrect: Use `-a` to autocorrect
     other/__package.rb:4: Insert `export Foo::Bar::OtherPackage::Inner`
      4 |  export Foo::Bar::OtherPackage::OtherClass
                                                    ^
+    other/other_class.rb:10: Defined here
+    10 |  class Inner::AlsoNotExported
+                ^^^^^
+  Note:
+    Try running generate-packages.sh
 Errors: 4

--- a/test/cli/package-error-missing-import/test.out
+++ b/test/cli/package-error-missing-import/test.out
@@ -1,52 +1,52 @@
 foo_class.rb:7: Unable to resolve constant `Bar` https://srb.help/5002
      7 |      Foo::Bar::OtherPackage::OtherClass # resolves via root
               ^^^^^^^^
-    other/__package.rb:3: Do you need to `import` package `Foo::Bar::OtherPackage`?
-     3 |class Foo::Bar::OtherPackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
     __package.rb:6: Insert `import Foo::Bar::OtherPackage`
      6 |  # import Foo::Bar::OtherPackage ## MISSING!
                                                      ^
+    other/__package.rb:3: Defined here
+     3 |class Foo::Bar::OtherPackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Note:
     Try running generate-packages.sh
 
 foo_class.rb:8: Unable to resolve constant `Bar` https://srb.help/5002
      8 |      Bar::OtherPackage::OtherClass # resolves via `module Foo`
               ^^^
-    other/__package.rb:3: Do you need to `import` package `Foo::Bar::OtherPackage`?
-     3 |class Foo::Bar::OtherPackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
     __package.rb:6: Insert `import Foo::Bar::OtherPackage`
      6 |  # import Foo::Bar::OtherPackage ## MISSING!
                                                      ^
+    other/__package.rb:3: Defined here
+     3 |class Foo::Bar::OtherPackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Note:
     Try running generate-packages.sh
 
 foo_class.rb:14: Unable to resolve constant `Bar` https://srb.help/5002
     14 |  Foo::Bar::OtherPackage::OtherClass # resolves via root
           ^^^^^^^^
-    other/__package.rb:3: Do you need to `import` package `Foo::Bar::OtherPackage`?
-     3 |class Foo::Bar::OtherPackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
     __package.rb:6: Insert `import Foo::Bar::OtherPackage`
      6 |  # import Foo::Bar::OtherPackage ## MISSING!
                                                      ^
+    other/__package.rb:3: Defined here
+     3 |class Foo::Bar::OtherPackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Note:
     Try running generate-packages.sh
 
 foo.test.rb:4: Unable to resolve constant `Bar` https://srb.help/5002
      4 |  Test::Foo::Bar::OtherPackage::TestUtil
           ^^^^^^^^^^^^^^
-    other/__package.rb:3: Do you need to `test_import` package `Foo::Bar::OtherPackage`?
-     3 |class Foo::Bar::OtherPackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
     __package.rb:6: Insert `test_import Foo::Bar::OtherPackage`
      6 |  # import Foo::Bar::OtherPackage ## MISSING!
                                                      ^
+    other/__package.rb:3: Defined here
+     3 |class Foo::Bar::OtherPackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Note:
     Try running generate-packages.sh
 Errors: 4

--- a/test/cli/package-error-no-export-for-test/test.out
+++ b/test/cli/package-error-no-export-for-test/test.out
@@ -1,28 +1,22 @@
 foo_bar/thing.test.rb:5: Unable to resolve constant `Thing` https://srb.help/5002
      5 |    f = Foo::Bar::Thing.new
                 ^^^^^^^^^^^^^^^
-    foo_bar/__package.rb:3: To expose this name to a package's own tests it must be exported. Do you need to `export_for_test Foo::Bar` in this package?
-     3 |class Foo::Bar < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    foo_bar/exported.rb:3: Constant `Foo::Bar` is defined here:
-     3 |class Foo::Bar::Exported
-              ^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
     foo_bar/__package.rb:4: Insert `export_for_test Foo::Bar`
      4 |  export Foo::Bar::Exported
                                    ^
+    foo_bar/exported.rb:3: Defined here
+     3 |class Foo::Bar::Exported
+              ^^^^^^^^
 
 other/other.test.rb:5: Unable to resolve constant `Thing` https://srb.help/5002
      5 |    Foo::Bar::Thing
             ^^^^^^^^^^^^^^^
-    foo_bar/__package.rb:3: Do you need to `export Foo::Bar::Thing` in package `Foo::Bar`?
-     3 |class Foo::Bar < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    foo_bar/thing.rb:3: Constant `Foo::Bar::Thing` is defined here:
-     3 |class Foo::Bar::Thing
-        ^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
     foo_bar/__package.rb:4: Insert `export Foo::Bar::Thing`
      4 |  export Foo::Bar::Exported
                                    ^
+    foo_bar/thing.rb:3: Defined here
+     3 |class Foo::Bar::Thing
+        ^^^^^^^^^^^^^^^^^^^^^
 Errors: 2

--- a/test/cli/package-test-simple/test.out
+++ b/test/cli/package-test-simple/test.out
@@ -1,13 +1,13 @@
 main_lib/lib.rb:8: Unable to resolve constant `TestOnly` https://srb.help/5002
      8 |  Project::TestOnly::SomeHelper.new
           ^^^^^^^^^^^^^^^^^
-    test_only/__package.rb:5: Do you need to `import` package `Project::TestOnly`?
-     5 |class Project::TestOnly < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
     main_lib/__package.rb:7: Replace with `import Project::TestOnly`
      7 |  test_import Project::TestOnly
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    test_only/__package.rb:5: Defined here
+     5 |class Project::TestOnly < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Note:
     RUN SCRIPT HINT
 Errors: 1

--- a/test/cli/simple-package/test.out
+++ b/test/cli/simple-package/test.out
@@ -10,14 +10,11 @@ foo/foo.rb:13: Unable to resolve constant `BardClass` https://srb.help/5002
 foo/foo.rb:14: Unable to resolve constant `UnexportedClass` https://srb.help/5002
     14 |    Project::Bar::UnexportedClass
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    bar/__package.rb:5: Do you need to `export Project::Bar::UnexportedClass` in package `Project::Bar`?
-     5 |class Project::Bar < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    bar/bar.rb:14: Constant `Project::Bar::UnexportedClass` is defined here:
-    14 |  class UnexportedClass; end
-          ^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
     bar/__package.rb:9: Insert `export Project::Bar::UnexportedClass`
      9 |  export Project::Bar::BarMethods
                                          ^
+    bar/bar.rb:14: Defined here
+    14 |  class UnexportedClass; end
+          ^^^^^^^^^^^^^^^^^^^^^
 Errors: 2


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

- Some of the suggestions were redundant. In particular, if there was already an
  autocorrect, we don't need another `ErrorLine` saying the same thing.
- There was a lot of visual noise. Especially when the constant names and file
  names are huge, that distracts from the core message.

This should hopefully cut down on some of the chunder.

I was following this build as inspiration for what it looks like right now:

<http://go/builds/bui_LTKnw0Jy0zpU6h>

And this is what the same errors look like after these changes:

<http://go/builds/bui_LTNleqlT4v7Taf>


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

exp files