### PR TITLE
Shard the generated lsp messages across multiple files

### DIFF
--- a/main/lsp/BUILD
+++ b/main/lsp/BUILD
@@ -111,10 +111,18 @@ genrule(
         "lsp_messages_enums_gen.h",
         "lsp_messages_enums_gen.cc",
     ],
-    cmd = "$(location :generate_lsp_messages) $(location lsp_messages_gen.h) $(location lsp_messages_gen.cc) \
-             $(location lsp_messages_enums_gen.h) $(location lsp_messages_enums_gen.cc) && \
-             $(location //tools:clang-format) -i $(location lsp_messages_gen.h) $(location lsp_messages_gen.cc) \
-             $(location lsp_messages_enums_gen.h) $(location lsp_messages_enums_gen.cc)",
+    cmd = """
+    set -euo pipefail
+
+    $(location :generate_lsp_messages) \
+        $(location lsp_messages_enums_gen.h) \
+        $(location lsp_messages_enums_gen.cc) \
+        $(location lsp_messages_gen.h) \
+        $(location lsp_messages_gen.cc)
+
+    $(location //tools:clang-format) -i $(location lsp_messages_gen.h) $(location lsp_messages_gen.cc) \
+        $(location lsp_messages_enums_gen.h) $(location lsp_messages_enums_gen.cc)
+    """,
     tools = [
         ":generate_lsp_messages",
         "//tools:clang-format",

--- a/main/lsp/BUILD
+++ b/main/lsp/BUILD
@@ -8,10 +8,7 @@ cc_library(
         "notifications/*.cc",
         "watchman/*.cc",
     ]) + [
-        "lsp_messages_gen.h",
-        "lsp_messages_gen.cc",
-        "lsp_messages_enums_gen.h",
-        "lsp_messages_enums_gen.cc",
+        ":lsp_messages",
         "LSPFileUpdates.h",
         "DefLocSaver.h",
         "watchman/WatchmanProcess.h",
@@ -103,14 +100,30 @@ cc_binary(
     ],
 )
 
+LSP_MESSAGES_SHARDS = [
+    "lsp_messages_gen_1.cc",
+    "lsp_messages_gen_2.cc",
+    "lsp_messages_gen_3.cc",
+    "lsp_messages_gen_4.cc",
+    "lsp_messages_gen_5.cc",
+]
+
+filegroup(
+    name = "lsp_messages",
+    srcs = [
+        "lsp_messages_gen.h",
+        "lsp_messages_enums_gen.h",
+        "lsp_messages_enums_gen.cc",
+    ] + LSP_MESSAGES_SHARDS,
+)
+
 genrule(
     name = "generate_lsp_messages_h",
     outs = [
-        "lsp_messages_gen.h",
-        "lsp_messages_gen.cc",
         "lsp_messages_enums_gen.h",
         "lsp_messages_enums_gen.cc",
-    ],
+        "lsp_messages_gen.h",
+    ] + LSP_MESSAGES_SHARDS,
     cmd = """
     set -euo pipefail
 
@@ -118,11 +131,14 @@ genrule(
         $(location lsp_messages_enums_gen.h) \
         $(location lsp_messages_enums_gen.cc) \
         $(location lsp_messages_gen.h) \
-        $(location lsp_messages_gen.cc)
+        {shards}
 
-    $(location //tools:clang-format) -i $(location lsp_messages_gen.h) $(location lsp_messages_gen.cc) \
-        $(location lsp_messages_enums_gen.h) $(location lsp_messages_enums_gen.cc)
-    """,
+    $(location //tools:clang-format) -i \
+        $(location lsp_messages_enums_gen.h) \
+        $(location lsp_messages_enums_gen.cc) \
+        $(location lsp_messages_gen.h) \
+        {shards}
+    """.format(shards = " ".join(["$(location {})".format(file) for file in LSP_MESSAGES_SHARDS])),
     tools = [
         ":generate_lsp_messages",
         "//tools:clang-format",


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
`main/lsp/lsp_messages_gen.cc` was taking a little over a minute to compile in CI. This PR splits it up into five files, taking it out of the critical path in CI.

| Before |
| --------- |
| ![before](https://user-images.githubusercontent.com/22708/162548727-0f0f3121-7d64-4046-8e6d-ac6bed827609.png) |

| After |
| --- |
| ![after](https://user-images.githubusercontent.com/22708/162548770-319b7619-84ec-4911-8b70-f95b0d6fedf1.png) |



### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Faster CI builds.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.


