### PR TITLE
structure C-level strings as a string table, rather than individual string constants

### DIFF
--- a/compiler/Core/CompilerState.cc
+++ b/compiler/Core/CompilerState.cc
@@ -24,8 +24,7 @@ CompilerState::CompilerState(const core::GlobalState &gs, llvm::LLVMContext &lct
                              StringTable &stringTable)
     : gs(gs), lctx(lctx), module(module), allocRubyIdsEntry(allocRubyIdsEntry),
       globalConstructorsEntry(globalConstructorsEntry), debug(debug), compileUnit(compileUnit),
-      functionEntryInitializers(nullptr), file(file), stringTable(stringTable) {
-}
+      functionEntryInitializers(nullptr), file(file), stringTable(stringTable) {}
 
 llvm::StructType *CompilerState::getValueType() {
     auto intType = llvm::Type::getInt64Ty(lctx);
@@ -61,8 +60,7 @@ llvm::Value *CompilerState::stringTableRef(std::string_view str) {
     const auto isConstant = false;
     auto *type = llvm::Type::getInt8PtrTy(this->lctx);
     llvm::Constant *initializer = llvm::ConstantPointerNull::get(type);
-    auto *global = new llvm::GlobalVariable(*this->module, type, isConstant,
-                                            llvm::GlobalVariable::InternalLinkage,
+    auto *global = new llvm::GlobalVariable(*this->module, type, isConstant, llvm::GlobalVariable::InternalLinkage,
                                             initializer, globalName);
     global->setUnnamedAddr(llvm::GlobalValue::UnnamedAddr::Global);
     global->setAlignment(llvm::MaybeAlign(8));
@@ -90,8 +88,7 @@ void StringTable::defineGlobalVariables(llvm::LLVMContext &lctx, llvm::Module &m
     const auto isConstant = true;
     const auto addNull = false;
     auto *initializer = llvm::ConstantDataArray::getString(lctx, tableInitializer, addNull);
-    auto *table = new llvm::GlobalVariable(module, arrayType, isConstant,
-                                           llvm::GlobalVariable::InternalLinkage,
+    auto *table = new llvm::GlobalVariable(module, arrayType, isConstant, llvm::GlobalVariable::InternalLinkage,
                                            initializer, "sorbet_moduleStringTable");
     table->setUnnamedAddr(llvm::GlobalValue::UnnamedAddr::Global);
     table->setAlignment(llvm::MaybeAlign(1));

--- a/compiler/Core/CompilerState.cc
+++ b/compiler/Core/CompilerState.cc
@@ -54,9 +54,7 @@ llvm::Value *CompilerState::stringTableRef(std::string_view str) {
 
     auto offset = this->stringTable.size;
     auto globalName = fmt::format("addr_str_{}", str);
-    // We will change the initializer later, but the variable itself is not
-    // modified at runtime.
-    const auto isConstant = true;
+    const auto isConstant = false;
     auto *type = llvm::Type::getInt8PtrTy(this->lctx);
     llvm::Constant *initializer = llvm::ConstantPointerNull::get(type);
     auto *global = new llvm::GlobalVariable(*this->module, type, isConstant,
@@ -95,6 +93,7 @@ void StringTable::defineGlobalVariables(llvm::LLVMContext &lctx, llvm::Module &m
         llvm::Constant *indices[] = {zero, index};
         auto *initializer = llvm::ConstantExpr::getInBoundsGetElementPtr(table->getValueType(), table, indices);
         var->setInitializer(initializer);
+        var->setConstant(true);
     }
 }
 

--- a/compiler/Core/CompilerState.cc
+++ b/compiler/Core/CompilerState.cc
@@ -7,6 +7,8 @@
 #include "llvm/Transforms/IPO.h"
 #include "llvm/Transforms/IPO/PassManagerBuilder.h"
 // ^^^ violate poisons
+#include "common/formatting.h"
+#include "common/sort.h"
 #include "compiler/Core/AbortCompilation.h"
 #include "compiler/Core/CompilerState.h"
 #include "compiler/Errors/Errors.h"
@@ -18,10 +20,12 @@ namespace sorbet::compiler {
 
 CompilerState::CompilerState(const core::GlobalState &gs, llvm::LLVMContext &lctx, llvm::Module *module,
                              llvm::DIBuilder *debug, llvm::DICompileUnit *compileUnit, core::FileRef file,
-                             llvm::BasicBlock *allocRubyIdsEntry, llvm::BasicBlock *globalConstructorsEntry)
+                             llvm::BasicBlock *allocRubyIdsEntry, llvm::BasicBlock *globalConstructorsEntry,
+                             StringTable &stringTable)
     : gs(gs), lctx(lctx), module(module), allocRubyIdsEntry(allocRubyIdsEntry),
       globalConstructorsEntry(globalConstructorsEntry), debug(debug), compileUnit(compileUnit),
-      functionEntryInitializers(nullptr), file(file) {}
+      functionEntryInitializers(nullptr), file(file), stringTable(stringTable) {
+}
 
 llvm::StructType *CompilerState::getValueType() {
     auto intType = llvm::Type::getInt64Ty(lctx);
@@ -30,6 +34,69 @@ llvm::StructType *CompilerState::getValueType() {
 
 void CompilerState::trace(string_view msg) const {
     gs.trace(msg);
+}
+
+llvm::Value *CompilerState::stringTableRef(llvm::IRBuilderBase &builder, std::string_view str) {
+    auto it = this->stringTable.table.find(str);
+
+    // We would like to return &sorbet_moduleStringTable[offset], but that would
+    // require knowing the length of the string table at this point (we would
+    // need to know the length to declare the global variable holding the string
+    // table properly).  So instead what we're going to do is return a
+    // (as-yet uninitialized) variable that would hold &sorbet_moduleStringTable[offset].
+    //
+    // Then, when we're finished compiling the module, we can declare the string
+    // table with the proper length (i.e. type) and go back and properly initialize
+    // all of the temporary variables we created along the way.
+    if (it != this->stringTable.table.end()) {
+        auto *var = it->second.addrVar;
+        return builder.CreateLoad(var);
+    }
+
+    auto offset = this->stringTable.size;
+    auto globalName = fmt::format("addr_str_{}", str);
+    // We will change the initializer later, but the variable itself is not
+    // modified at runtime.
+    const auto isConstant = true;
+    auto *type = llvm::Type::getInt8PtrTy(this->lctx);
+    llvm::Constant *initializer = llvm::ConstantPointerNull::get(type);
+    auto *global = new llvm::GlobalVariable(*this->module, type, isConstant,
+                                            llvm::GlobalVariable::InternalLinkage,
+                                            initializer, globalName);
+    global->setUnnamedAddr(llvm::GlobalValue::UnnamedAddr::Global);
+    global->setAlignment(llvm::MaybeAlign(8));
+    this->stringTable.table[str] = StringTable::StringTableEntry{offset, global};
+    this->stringTable.size += str.size();
+
+    return builder.CreateLoad(global);
+}
+
+void StringTable::defineGlobalVariables(llvm::LLVMContext &lctx, llvm::Module &module) {
+    vector<pair<string_view, StringTable::StringTableEntry>> tableElements;
+    tableElements.reserve(this->table.size());
+    absl::c_copy(this->table, std::back_inserter(tableElements));
+    fast_sort(tableElements, [](const auto &l, const auto &r) -> bool { return l.second.offset < r.second.offset; });
+    string tableInitializer = fmt::format("{}", fmt::map_join(tableElements, "", [&](const auto &e) -> std::string_view { return e.first; }));
+    ENFORCE(tableInitializer.size() == this->size);
+
+    auto *arrayType = llvm::ArrayType::get(llvm::Type::getInt8Ty(lctx), this->size);
+    const auto isConstant = true;
+    const auto addNull = false;
+    auto *initializer = llvm::ConstantDataArray::getString(lctx, tableInitializer, addNull);
+    auto *table = new llvm::GlobalVariable(module, arrayType, isConstant,
+                                           llvm::GlobalVariable::InternalLinkage,
+                                           initializer, "sorbet_moduleStringTable");
+    table->setUnnamedAddr(llvm::GlobalValue::UnnamedAddr::Global);
+    table->setAlignment(llvm::MaybeAlign(1));
+
+    for (auto &elem : tableElements) {
+        auto *var = elem.second.addrVar;
+        auto *zero = llvm::ConstantInt::get(lctx, llvm::APInt(64, 0));
+        auto *index = llvm::ConstantInt::get(lctx, llvm::APInt(64, elem.second.offset));
+        llvm::Constant *indices[] = {zero, index};
+        auto *initializer = llvm::ConstantExpr::getInBoundsGetElementPtr(table->getValueType(), table, indices);
+        var->setInitializer(initializer);
+    }
 }
 
 llvm::FunctionType *CompilerState::getRubyFFIType() {

--- a/compiler/Core/CompilerState.cc
+++ b/compiler/Core/CompilerState.cc
@@ -36,7 +36,7 @@ void CompilerState::trace(string_view msg) const {
     gs.trace(msg);
 }
 
-llvm::Value *CompilerState::stringTableRef(llvm::IRBuilderBase &builder, std::string_view str) {
+llvm::Value *CompilerState::stringTableRef(std::string_view str) {
     auto it = this->stringTable.table.find(str);
 
     // We would like to return &sorbet_moduleStringTable[offset], but that would
@@ -49,8 +49,7 @@ llvm::Value *CompilerState::stringTableRef(llvm::IRBuilderBase &builder, std::st
     // table with the proper length (i.e. type) and go back and properly initialize
     // all of the temporary variables we created along the way.
     if (it != this->stringTable.table.end()) {
-        auto *var = it->second.addrVar;
-        return builder.CreateLoad(var);
+        return it->second.addrVar;
     }
 
     auto offset = this->stringTable.size;
@@ -68,7 +67,7 @@ llvm::Value *CompilerState::stringTableRef(llvm::IRBuilderBase &builder, std::st
     this->stringTable.table[str] = StringTable::StringTableEntry{offset, global};
     this->stringTable.size += str.size();
 
-    return builder.CreateLoad(global);
+    return global;
 }
 
 void StringTable::defineGlobalVariables(llvm::LLVMContext &lctx, llvm::Module &module) {

--- a/compiler/Core/CompilerState.h
+++ b/compiler/Core/CompilerState.h
@@ -14,11 +14,11 @@ struct StringTable {
         llvm::GlobalVariable *addrVar = nullptr;
     };
 
-    UnorderedMap<std::string, StringTableEntry> table;
+    UnorderedMap<std::string, StringTableEntry> map;
     uint32_t size = 0;
 
     void clear() {
-        this->table.clear();
+        this->map.clear();
         this->size = 0;
     }
 

--- a/compiler/Core/CompilerState.h
+++ b/compiler/Core/CompilerState.h
@@ -52,7 +52,7 @@ public:
     core::FileRef file;
     StringTable &stringTable;
 
-    llvm::Value *stringTableRef(llvm::IRBuilderBase &builder, std::string_view str);
+    llvm::Value *stringTableRef(std::string_view str);
 
     // useful apis for getting common types
 

--- a/compiler/Core/ForwardDeclarations.h
+++ b/compiler/Core/ForwardDeclarations.h
@@ -8,6 +8,7 @@ class DIBuilder;
 class DICompileUnit;
 class Function;
 class FunctionType;
+class GlobalVariable;
 class IRBuilderBase;
 class LLVMContext;
 class Module;

--- a/compiler/IREmitter/Payload.cc
+++ b/compiler/IREmitter/Payload.cc
@@ -226,7 +226,7 @@ llvm::Value *Payload::getRubyConstant(CompilerState &cs, core::SymbolRef sym, ll
 }
 
 llvm::Value *Payload::toCString(CompilerState &cs, string_view str, llvm::IRBuilderBase &builder) {
-    return cs.stringTableRef(builder, str);
+    return builder.CreateLoad(cs.stringTableRef(str));
 }
 
 namespace {

--- a/compiler/IREmitter/Payload.cc
+++ b/compiler/IREmitter/Payload.cc
@@ -226,7 +226,16 @@ llvm::Value *Payload::getRubyConstant(CompilerState &cs, core::SymbolRef sym, ll
 }
 
 llvm::Value *Payload::toCString(CompilerState &cs, string_view str, llvm::IRBuilderBase &builder) {
-    return builder.CreateLoad(cs.stringTableRef(str));
+    // We know that this load will always return the same reference at runtime, but
+    // the actual contents of the string table reference won't be filled in until
+    // later (see the code in CompilerState for why).  But we want LLVM to know
+    // that the load always returns the same thing: such knowledge is important for
+    // transformations involving identical sorbet_i_getRuby{Class,Constant} calls
+    // and eliminating unnecessary type tests.  So mark the load as `!invariant.load`.
+    auto *load = builder.CreateLoad(cs.stringTableRef(str));
+    auto *MD = llvm::MDNode::get(cs, llvm::None);
+    load->setMetadata(llvm::LLVMContext::MD_invariant_load, MD);
+    return load;
 }
 
 namespace {

--- a/test/testdata/compiler/all_arguments.opt.ll.exp
+++ b/test/testdata/compiler/all_arguments.opt.ll.exp
@@ -83,37 +83,23 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_Object#14take_arguments" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @rubyIdPrecomputed_take_arguments = internal unnamed_addr global i64 0, align 8
-@str_take_arguments = private unnamed_addr constant [15 x i8] c"take_arguments\00", align 1
 @rubyStrFrozen_take_arguments = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/all_arguments.rb" = internal unnamed_addr global i64 0, align 8
-@"str_test/testdata/compiler/all_arguments.rb" = private unnamed_addr constant [40 x i8] c"test/testdata/compiler/all_arguments.rb\00", align 1
 @rubyIdPrecomputed_g = internal unnamed_addr global i64 0, align 8
-@str_g = private unnamed_addr constant [2 x i8] c"g\00", align 1
 @iseqEncodedArray = internal global [32 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @rubyIdPrecomputed_d = internal unnamed_addr global i64 0, align 8
-@str_d = private unnamed_addr constant [2 x i8] c"d\00", align 1
 @rubyIdPrecomputed_e = internal unnamed_addr global i64 0, align 8
-@str_e = private unnamed_addr constant [2 x i8] c"e\00", align 1
-@"str_<build-array>" = private unnamed_addr constant [14 x i8] c"<build-array>\00", align 1
 @ic_inspect = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_inspect = internal unnamed_addr global i64 0, align 8
-@str_inspect = private unnamed_addr constant [8 x i8] c"inspect\00", align 1
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
-@str_puts = private unnamed_addr constant [5 x i8] c"puts\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
-@str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
 @rubyIdPrecomputed_a = internal unnamed_addr global i64 0, align 8
-@str_a = private unnamed_addr constant [2 x i8] c"a\00", align 1
 @rubyIdPrecomputed_b = internal unnamed_addr global i64 0, align 8
-@str_b = private unnamed_addr constant [2 x i8] c"b\00", align 1
 @rubyIdPrecomputed_c = internal unnamed_addr global i64 0, align 8
-@str_c = private unnamed_addr constant [2 x i8] c"c\00", align 1
 @rubyIdPrecomputed_f = internal unnamed_addr global i64 0, align 8
-@str_f = private unnamed_addr constant [2 x i8] c"f\00", align 1
 @ic_take_arguments = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_take_arguments.1 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_take_arguments.2 = internal global %struct.FunctionInlineCache zeroinitializer
@@ -129,7 +115,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ic_take_arguments.12 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_take_arguments.13 = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_baz = internal unnamed_addr global i64 0, align 8
-@str_baz = private unnamed_addr constant [4 x i8] c"baz\00", align 1
 @ic_take_arguments.14 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_take_arguments.15 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_take_arguments.16 = internal global %struct.FunctionInlineCache zeroinitializer
@@ -137,6 +122,7 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ic_take_arguments.18 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_take_arguments.19 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_take_arguments.20 = internal global %struct.FunctionInlineCache zeroinitializer
+@sorbet_moduleStringTable = internal unnamed_addr constant [138 x i8] c"take_arguments\00test/testdata/compiler/all_arguments.rb\00g\00d\00e\00<build-array>\00inspect\00puts\00<top (required)>\00normal\00Object\00a\00b\00c\00f\00baz\00master\00", align 1
 @rb_cObject = external local_unnamed_addr constant i64
 
 ; Function Attrs: nounwind readnone willreturn
@@ -486,36 +472,36 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %19)
   %20 = bitcast i64* %keywords154.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %20)
-  %21 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @str_take_arguments, i64 0, i64 0), i64 noundef 14) #11
+  %21 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 14) #11
   store i64 %21, i64* @rubyIdPrecomputed_take_arguments, align 8
-  %22 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_g, i64 0, i64 0), i64 noundef 1) #11
+  %22 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 55), i64 noundef 1) #11
   store i64 %22, i64* @rubyIdPrecomputed_g, align 8
-  %23 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_d, i64 0, i64 0), i64 noundef 1) #11
+  %23 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 57), i64 noundef 1) #11
   store i64 %23, i64* @rubyIdPrecomputed_d, align 8
-  %24 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_e, i64 0, i64 0), i64 noundef 1) #11
+  %24 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 59), i64 noundef 1) #11
   store i64 %24, i64* @rubyIdPrecomputed_e, align 8
-  %25 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_<build-array>", i64 0, i64 0), i64 noundef 13) #11
-  %26 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_inspect, i64 0, i64 0), i64 noundef 7) #11
+  %25 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 61), i64 noundef 13) #11
+  %26 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 75), i64 noundef 7) #11
   store i64 %26, i64* @rubyIdPrecomputed_inspect, align 8
-  %27 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #11
+  %27 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 83), i64 noundef 4) #11
   store i64 %27, i64* @rubyIdPrecomputed_puts, align 8
-  %28 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
+  %28 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 88), i64 noundef 16) #11
   store i64 %28, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %29 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #11
-  %30 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_a, i64 0, i64 0), i64 noundef 1) #11
+  %29 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 105), i64 noundef 6) #11
+  %30 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 119), i64 noundef 1) #11
   store i64 %30, i64* @rubyIdPrecomputed_a, align 8
-  %31 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_b, i64 0, i64 0), i64 noundef 1) #11
+  %31 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 121), i64 noundef 1) #11
   store i64 %31, i64* @rubyIdPrecomputed_b, align 8
-  %32 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_c, i64 0, i64 0), i64 noundef 1) #11
+  %32 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 123), i64 noundef 1) #11
   store i64 %32, i64* @rubyIdPrecomputed_c, align 8
-  %33 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_f, i64 0, i64 0), i64 noundef 1) #11
+  %33 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 125), i64 noundef 1) #11
   store i64 %33, i64* @rubyIdPrecomputed_f, align 8
-  %34 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_baz, i64 0, i64 0), i64 noundef 3) #11
+  %34 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 127), i64 noundef 3) #11
   store i64 %34, i64* @rubyIdPrecomputed_baz, align 8
-  %35 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @str_take_arguments, i64 0, i64 0), i64 noundef 14) #11
+  %35 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 14) #11
   tail call void @rb_gc_register_mark_object(i64 %35) #11
   store i64 %35, i64* @rubyStrFrozen_take_arguments, align 8
-  %36 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([40 x i8], [40 x i8]* @"str_test/testdata/compiler/all_arguments.rb", i64 0, i64 0), i64 noundef 39) #11
+  %36 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 15), i64 noundef 39) #11
   tail call void @rb_gc_register_mark_object(i64 %36) #11
   store i64 %36, i64* @"rubyStrFrozen_test/testdata/compiler/all_arguments.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 32)
@@ -533,7 +519,7 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_inspect, i64 %rubyId_inspect.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !29
   %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !36
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !36
-  %39 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
+  %39 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 88), i64 noundef 16) #11
   call void @rb_gc_register_mark_object(i64 %39) #11
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/all_arguments.rb.i163.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/all_arguments.rb", align 8
@@ -851,7 +837,7 @@ entry:
   %164 = getelementptr inbounds i8, i8* %119, i64 56, !dbg !37
   %165 = bitcast i8* %164 to i8**, !dbg !37
   store i8* %163, i8** %165, align 8, !dbg !37, !tbaa !88
-  call void @sorbet_vm_define_method(i64 %118, i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @str_take_arguments, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#14take_arguments", i8* nonnull %119, %struct.rb_iseq_struct* %stackFrame386.i, i1 noundef zeroext false) #11, !dbg !37
+  call void @sorbet_vm_define_method(i64 %118, i8* noundef getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#14take_arguments", i8* nonnull %119, %struct.rb_iseq_struct* %stackFrame386.i, i1 noundef zeroext false) #11, !dbg !37
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %117, align 8, !dbg !37, !tbaa !14
   %166 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !39
   %167 = load i64*, i64** %166, align 8, !dbg !39

--- a/test/testdata/compiler/block_arg_expand.opt.ll.exp
+++ b/test/testdata/compiler/block_arg_expand.opt.ll.exp
@@ -90,49 +90,37 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
 @"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/block_arg_expand.rb" = internal unnamed_addr global i64 0, align 8
-@"str_test/testdata/compiler/block_arg_expand.rb" = private unnamed_addr constant [43 x i8] c"test/testdata/compiler/block_arg_expand.rb\00", align 1
 @"rubyIdPrecomputed_<block-call>" = internal unnamed_addr global i64 0, align 8
-@"str_<block-call>" = private unnamed_addr constant [13 x i8] c"<block-call>\00", align 1
 @iseqEncodedArray = internal global [32 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_block in <top (required)>" = internal unnamed_addr global i64 0, align 8
-@"str_block in <top (required)>" = private unnamed_addr constant [26 x i8] c"block in <top (required)>\00", align 1
 @"rubyStrFrozen_block in <top (required)>" = internal unnamed_addr global i64 0, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_2" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_3" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_4" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_5" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"str_<build-array>" = private unnamed_addr constant [14 x i8] c"<build-array>\00", align 1
 @rubyIdPrecomputed_each = internal unnamed_addr global i64 0, align 8
-@str_each = private unnamed_addr constant [5 x i8] c"each\00", align 1
 @"func_<root>.17<static-init>$153$block_1_ifunc" = internal unnamed_addr global i64 0
-@str_T.let = private unnamed_addr constant [6 x i8] c"T.let\00", align 1
-@str_Integer = private unnamed_addr constant [8 x i8] c"Integer\00", align 1
 @"rubyIdPrecomputed_+" = internal unnamed_addr global i64 0, align 8
-@"str_+" = private unnamed_addr constant [2 x i8] c"+\00", align 1
 @"ic_+" = internal global %struct.FunctionInlineCache zeroinitializer
 @"func_<root>.17<static-init>$153$block_2_ifunc" = internal unnamed_addr global i64 0
 @ic_p = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_p = internal unnamed_addr global i64 0, align 8
-@str_p = private unnamed_addr constant [2 x i8] c"p\00", align 1
 @"func_<root>.17<static-init>$153$block_3_ifunc" = internal unnamed_addr global i64 0
 @rubyIdPrecomputed_x = internal unnamed_addr global i64 0, align 8
-@str_x = private unnamed_addr constant [2 x i8] c"x\00", align 1
 @ic_p.5 = internal global %struct.FunctionInlineCache zeroinitializer
 @"func_<root>.17<static-init>$153$block_4_ifunc" = internal unnamed_addr global i64 0
 @rubyIdPrecomputed_default = internal unnamed_addr global i64 0, align 8
-@str_default = private unnamed_addr constant [8 x i8] c"default\00", align 1
 @rubyIdPrecomputed_something = internal unnamed_addr global i64 0, align 8
-@str_something = private unnamed_addr constant [10 x i8] c"something\00", align 1
 @ic_p.8 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_p.9 = internal global %struct.FunctionInlineCache zeroinitializer
 @"func_<root>.17<static-init>$153$block_5_ifunc" = internal unnamed_addr global i64 0
 @ic_p.12 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_p.13 = internal global %struct.FunctionInlineCache zeroinitializer
+@sorbet_moduleStringTable = internal unnamed_addr constant [163 x i8] c"<top (required)>\00test/testdata/compiler/block_arg_expand.rb\00<block-call>\00block in <top (required)>\00<build-array>\00each\00T.let\00Integer\00+\00p\00x\00default\00something\00master\00", align 1
 
 ; Function Attrs: nounwind readnone willreturn
 declare i64 @rb_id2sym(i64) local_unnamed_addr #0
@@ -769,29 +757,29 @@ entry:
   %callArgs.i = alloca [3 x i64], align 8
   %locals.i.i = alloca i64, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #13
+  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([163 x i8], [163 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #13
   store i64 %8, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @"str_<block-call>", i64 0, i64 0), i64 noundef 12) #13
+  %9 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @sorbet_moduleStringTable, i64 0, i64 60), i64 noundef 12) #13
   store i64 %9, i64* @"rubyIdPrecomputed_<block-call>", align 8
-  %10 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #13
+  %10 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @sorbet_moduleStringTable, i64 0, i64 73), i64 noundef 25) #13
   store i64 %10, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
-  %11 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_<build-array>", i64 0, i64 0), i64 noundef 13) #13
-  %12 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_each, i64 0, i64 0), i64 noundef 4) #13
+  %11 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @sorbet_moduleStringTable, i64 0, i64 99), i64 noundef 13) #13
+  %12 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @sorbet_moduleStringTable, i64 0, i64 113), i64 noundef 4) #13
   store i64 %12, i64* @rubyIdPrecomputed_each, align 8
-  %13 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_+", i64 0, i64 0), i64 noundef 1) #13
+  %13 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @sorbet_moduleStringTable, i64 0, i64 132), i64 noundef 1) #13
   store i64 %13, i64* @"rubyIdPrecomputed_+", align 8
-  %14 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_p, i64 0, i64 0), i64 noundef 1) #13
+  %14 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @sorbet_moduleStringTable, i64 0, i64 134), i64 noundef 1) #13
   store i64 %14, i64* @rubyIdPrecomputed_p, align 8
-  %15 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_x, i64 0, i64 0), i64 noundef 1) #13
+  %15 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @sorbet_moduleStringTable, i64 0, i64 136), i64 noundef 1) #13
   store i64 %15, i64* @rubyIdPrecomputed_x, align 8
-  %16 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_default, i64 0, i64 0), i64 noundef 7) #13
+  %16 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @sorbet_moduleStringTable, i64 0, i64 138), i64 noundef 7) #13
   store i64 %16, i64* @rubyIdPrecomputed_default, align 8
-  %17 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @str_something, i64 0, i64 0), i64 noundef 9) #13
+  %17 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @sorbet_moduleStringTable, i64 0, i64 146), i64 noundef 9) #13
   store i64 %17, i64* @rubyIdPrecomputed_something, align 8
-  %18 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #13
+  %18 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([163 x i8], [163 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #13
   tail call void @rb_gc_register_mark_object(i64 %18) #13
   store i64 %18, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %19 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([43 x i8], [43 x i8]* @"str_test/testdata/compiler/block_arg_expand.rb", i64 0, i64 0), i64 noundef 42) #13
+  %19 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 42) #13
   tail call void @rb_gc_register_mark_object(i64 %19) #13
   store i64 %19, i64* @"rubyStrFrozen_test/testdata/compiler/block_arg_expand.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 32)
@@ -805,7 +793,7 @@ entry:
   %21 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i.i, i32 noundef 1, i32 noundef 3)
   store %struct.rb_iseq_struct* %21, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %20)
-  %22 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #13
+  %22 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @sorbet_moduleStringTable, i64 0, i64 73), i64 noundef 25) #13
   call void @rb_gc_register_mark_object(i64 %22) #13
   store i64 %22, i64* @"rubyStrFrozen_block in <top (required)>", align 8
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
@@ -1539,7 +1527,7 @@ declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) 
 ; Function Attrs: cold minsize noreturn ssp
 define internal fastcc void @"func_<root>.17<static-init>$153$block_1.cold.1"(i64 %el2.sroa.0.0) unnamed_addr #11 !dbg !132 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %el2.sroa.0.0, i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_T.let, i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #17, !dbg !134
+  tail call void @sorbet_cast_failure(i64 %el2.sroa.0.0, i8* getelementptr inbounds ([163 x i8], [163 x i8]* @sorbet_moduleStringTable, i64 0, i64 118), i8* getelementptr inbounds ([163 x i8], [163 x i8]* @sorbet_moduleStringTable, i64 0, i64 124)) #17, !dbg !134
   unreachable, !dbg !134
 }
 

--- a/test/testdata/compiler/block_args.opt.ll.exp
+++ b/test/testdata/compiler/block_args.opt.ll.exp
@@ -91,25 +91,19 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
 @"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/block_args.rb" = internal unnamed_addr global i64 0, align 8
-@"str_test/testdata/compiler/block_args.rb" = private unnamed_addr constant [37 x i8] c"test/testdata/compiler/block_args.rb\00", align 1
 @iseqEncodedArray = internal global [5 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_block in <top (required)>" = internal unnamed_addr global i64 0, align 8
-@"str_block in <top (required)>" = private unnamed_addr constant [26 x i8] c"block in <top (required)>\00", align 1
-@"str_<build-array>" = private unnamed_addr constant [14 x i8] c"<build-array>\00", align 1
 @rubyIdPrecomputed_map = internal unnamed_addr global i64 0, align 8
-@str_map = private unnamed_addr constant [4 x i8] c"map\00", align 1
 @"func_<root>.17<static-init>$153$block_1_ifunc" = internal unnamed_addr global i64 0
 @"rubyIdPrecomputed_+" = internal unnamed_addr global i64 0, align 8
-@"str_+" = private unnamed_addr constant [2 x i8] c"+\00", align 1
 @"ic_+" = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
-@str_puts = private unnamed_addr constant [5 x i8] c"puts\00", align 1
+@sorbet_moduleStringTable = internal unnamed_addr constant [112 x i8] c"<top (required)>\00test/testdata/compiler/block_args.rb\00block in <top (required)>\00<build-array>\00map\00+\00puts\00master\00", align 1
 
 declare i64 @rb_ary_push(i64, i64) local_unnamed_addr #0
 
@@ -288,21 +282,21 @@ entry:
   %callArgs.i = alloca [3 x i64], align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
+  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([112 x i8], [112 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #11
   store i64 %2, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #11
+  %3 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([112 x i8], [112 x i8]* @sorbet_moduleStringTable, i64 0, i64 54), i64 noundef 25) #11
   store i64 %3, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
-  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_<build-array>", i64 0, i64 0), i64 noundef 13) #11
-  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_map, i64 0, i64 0), i64 noundef 3) #11
+  %4 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([112 x i8], [112 x i8]* @sorbet_moduleStringTable, i64 0, i64 80), i64 noundef 13) #11
+  %5 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([112 x i8], [112 x i8]* @sorbet_moduleStringTable, i64 0, i64 94), i64 noundef 3) #11
   store i64 %5, i64* @rubyIdPrecomputed_map, align 8
-  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_+", i64 0, i64 0), i64 noundef 1) #11
+  %6 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([112 x i8], [112 x i8]* @sorbet_moduleStringTable, i64 0, i64 98), i64 noundef 1) #11
   store i64 %6, i64* @"rubyIdPrecomputed_+", align 8
-  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #11
+  %7 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([112 x i8], [112 x i8]* @sorbet_moduleStringTable, i64 0, i64 100), i64 noundef 4) #11
   store i64 %7, i64* @rubyIdPrecomputed_puts, align 8
-  %8 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
+  %8 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([112 x i8], [112 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #11
   tail call void @rb_gc_register_mark_object(i64 %8) #11
   store i64 %8, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %9 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([37 x i8], [37 x i8]* @"str_test/testdata/compiler/block_args.rb", i64 0, i64 0), i64 noundef 36) #11
+  %9 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([112 x i8], [112 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 36) #11
   tail call void @rb_gc_register_mark_object(i64 %9) #11
   store i64 %9, i64* @"rubyStrFrozen_test/testdata/compiler/block_args.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 5)
@@ -311,7 +305,7 @@ entry:
   %"rubyStr_test/testdata/compiler/block_args.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_args.rb", align 8
   %10 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_args.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 3)
   store %struct.rb_iseq_struct* %10, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %11 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #11
+  %11 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([112 x i8], [112 x i8]* @sorbet_moduleStringTable, i64 0, i64 54), i64 noundef 25) #11
   call void @rb_gc_register_mark_object(i64 %11) #11
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
   %"rubyId_block in <top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8

--- a/test/testdata/compiler/block_no_args.opt.ll.exp
+++ b/test/testdata/compiler/block_no_args.opt.ll.exp
@@ -84,22 +84,17 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
 @"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/block_no_args.rb" = internal unnamed_addr global i64 0, align 8
-@"str_test/testdata/compiler/block_no_args.rb" = private unnamed_addr constant [40 x i8] c"test/testdata/compiler/block_no_args.rb\00", align 1
 @iseqEncodedArray = internal global [7 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_block in <top (required)>" = internal unnamed_addr global i64 0, align 8
-@"str_block in <top (required)>" = private unnamed_addr constant [26 x i8] c"block in <top (required)>\00", align 1
-@str_times = private unnamed_addr constant [6 x i8] c"times\00", align 1
 @"func_<root>.17<static-init>$153$block_1_ifunc" = internal unnamed_addr global i64 0
 @rubyStrFrozen_hi = internal unnamed_addr global i64 0, align 8
-@str_hi = private unnamed_addr constant [3 x i8] c"hi\00", align 1
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
-@str_puts = private unnamed_addr constant [5 x i8] c"puts\00", align 1
+@sorbet_moduleStringTable = internal unnamed_addr constant [111 x i8] c"<top (required)>\00test/testdata/compiler/block_no_args.rb\00block in <top (required)>\00times\00hi\00puts\00Kernel\00master\00", align 1
 @rb_mKernel = external local_unnamed_addr constant i64
 
 declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
@@ -184,17 +179,17 @@ define void @Init_block_no_args() local_unnamed_addr #4 {
 entry:
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #7
+  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([111 x i8], [111 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #7
   store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #7
+  %1 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([111 x i8], [111 x i8]* @sorbet_moduleStringTable, i64 0, i64 57), i64 noundef 25) #7
   store i64 %1, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
-  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_times, i64 0, i64 0), i64 noundef 5) #7
-  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #7
+  %2 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([111 x i8], [111 x i8]* @sorbet_moduleStringTable, i64 0, i64 83), i64 noundef 5) #7
+  %3 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([111 x i8], [111 x i8]* @sorbet_moduleStringTable, i64 0, i64 92), i64 noundef 4) #7
   store i64 %3, i64* @rubyIdPrecomputed_puts, align 8
-  %4 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #7
+  %4 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([111 x i8], [111 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #7
   tail call void @rb_gc_register_mark_object(i64 %4) #7
   store i64 %4, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %5 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([40 x i8], [40 x i8]* @"str_test/testdata/compiler/block_no_args.rb", i64 0, i64 0), i64 noundef 39) #7
+  %5 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([111 x i8], [111 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 39) #7
   tail call void @rb_gc_register_mark_object(i64 %5) #7
   store i64 %5, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 7)
@@ -203,7 +198,7 @@ entry:
   %"rubyStr_test/testdata/compiler/block_no_args.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args.rb", align 8
   %6 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_no_args.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %6, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %7 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #7
+  %7 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([111 x i8], [111 x i8]* @sorbet_moduleStringTable, i64 0, i64 57), i64 noundef 25) #7
   call void @rb_gc_register_mark_object(i64 %7) #7
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
   %"rubyId_block in <top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
@@ -214,7 +209,7 @@ entry:
   %10 = ptrtoint %struct.vm_ifunc* %9 to i64
   %11 = call i64 @sorbet_globalConstRegister(i64 %10)
   store i64 %11, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8
-  %12 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_hi, i64 0, i64 0), i64 noundef 2) #7
+  %12 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([111 x i8], [111 x i8]* @sorbet_moduleStringTable, i64 0, i64 89), i64 noundef 2) #7
   call void @rb_gc_register_mark_object(i64 %12) #7
   store i64 %12, i64* @rubyStrFrozen_hi, align 8
   %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !26

--- a/test/testdata/compiler/block_no_args_capture.opt.ll.exp
+++ b/test/testdata/compiler/block_no_args_capture.opt.ll.exp
@@ -85,25 +85,19 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
 @"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/block_no_args_capture.rb" = internal unnamed_addr global i64 0, align 8
-@"str_test/testdata/compiler/block_no_args_capture.rb" = private unnamed_addr constant [48 x i8] c"test/testdata/compiler/block_no_args_capture.rb\00", align 1
 @rubyIdPrecomputed_s = internal unnamed_addr global i64 0, align 8
-@str_s = private unnamed_addr constant [2 x i8] c"s\00", align 1
 @iseqEncodedArray = internal global [8 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_block in <top (required)>" = internal unnamed_addr global i64 0, align 8
-@"str_block in <top (required)>" = private unnamed_addr constant [26 x i8] c"block in <top (required)>\00", align 1
 @rubyStrFrozen_hi = internal unnamed_addr global i64 0, align 8
-@str_hi = private unnamed_addr constant [3 x i8] c"hi\00", align 1
 @rubyIdPrecomputed_times = internal unnamed_addr global i64 0, align 8
-@str_times = private unnamed_addr constant [6 x i8] c"times\00", align 1
 @"func_<root>.17<static-init>$153$block_1_ifunc" = internal unnamed_addr global i64 0
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
-@str_puts = private unnamed_addr constant [5 x i8] c"puts\00", align 1
+@sorbet_moduleStringTable = internal unnamed_addr constant [121 x i8] c"<top (required)>\00test/testdata/compiler/block_no_args_capture.rb\00s\00block in <top (required)>\00hi\00times\00puts\00Kernel\00master\00", align 1
 @rb_mKernel = external local_unnamed_addr constant i64
 
 declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
@@ -202,20 +196,20 @@ entry:
   %0 = alloca %struct.sorbet_inlineIntrinsicEnv, align 8
   %locals.i.i = alloca i64, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #9
+  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([121 x i8], [121 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #9
   store i64 %1, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_s, i64 0, i64 0), i64 noundef 1) #9
+  %2 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([121 x i8], [121 x i8]* @sorbet_moduleStringTable, i64 0, i64 65), i64 noundef 1) #9
   store i64 %2, i64* @rubyIdPrecomputed_s, align 8
-  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #9
+  %3 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([121 x i8], [121 x i8]* @sorbet_moduleStringTable, i64 0, i64 67), i64 noundef 25) #9
   store i64 %3, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
-  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_times, i64 0, i64 0), i64 noundef 5) #9
+  %4 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([121 x i8], [121 x i8]* @sorbet_moduleStringTable, i64 0, i64 96), i64 noundef 5) #9
   store i64 %4, i64* @rubyIdPrecomputed_times, align 8
-  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #9
+  %5 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([121 x i8], [121 x i8]* @sorbet_moduleStringTable, i64 0, i64 102), i64 noundef 4) #9
   store i64 %5, i64* @rubyIdPrecomputed_puts, align 8
-  %6 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #9
+  %6 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([121 x i8], [121 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #9
   tail call void @rb_gc_register_mark_object(i64 %6) #9
   store i64 %6, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %7 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([48 x i8], [48 x i8]* @"str_test/testdata/compiler/block_no_args_capture.rb", i64 0, i64 0), i64 noundef 47) #9
+  %7 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([121 x i8], [121 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 47) #9
   tail call void @rb_gc_register_mark_object(i64 %7) #9
   store i64 %7, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args_capture.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 8)
@@ -229,14 +223,14 @@ entry:
   %9 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_no_args_capture.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i.i, i32 noundef 1, i32 noundef 2)
   store %struct.rb_iseq_struct* %9, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %8)
-  %10 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #9
+  %10 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([121 x i8], [121 x i8]* @sorbet_moduleStringTable, i64 0, i64 67), i64 noundef 25) #9
   call void @rb_gc_register_mark_object(i64 %10) #9
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
   %"rubyId_block in <top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
   %"rubyStr_test/testdata/compiler/block_no_args_capture.rb.i2.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args_capture.rb", align 8
   %11 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %10, i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_no_args_capture.rb.i2.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %11, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1", align 8
-  %12 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_hi, i64 0, i64 0), i64 noundef 2) #9
+  %12 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([121 x i8], [121 x i8]* @sorbet_moduleStringTable, i64 0, i64 93), i64 noundef 2) #9
   call void @rb_gc_register_mark_object(i64 %12) #9
   store i64 %12, i64* @rubyStrFrozen_hi, align 8
   %13 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_1", i8* noundef null, i32 noundef 0, i32 noundef 0) #9

--- a/test/testdata/compiler/block_no_args_captures_constant.opt.ll.exp
+++ b/test/testdata/compiler/block_no_args_captures_constant.opt.ll.exp
@@ -86,29 +86,21 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_Object#3foo" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @rubyIdPrecomputed_foo = internal unnamed_addr global i64 0, align 8
-@str_foo = private unnamed_addr constant [4 x i8] c"foo\00", align 1
 @rubyStrFrozen_foo = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/block_no_args_captures_constant.rb" = internal unnamed_addr global i64 0, align 8
-@"str_test/testdata/compiler/block_no_args_captures_constant.rb" = private unnamed_addr constant [58 x i8] c"test/testdata/compiler/block_no_args_captures_constant.rb\00", align 1
 @iseqEncodedArray = internal global [13 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @"stackFramePrecomputed_func_Object#3foo$block_1" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_block in foo" = internal unnamed_addr global i64 0, align 8
-@"str_block in foo" = private unnamed_addr constant [13 x i8] c"block in foo\00", align 1
-@str_A = private unnamed_addr constant [2 x i8] c"A\00", align 1
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
-@str_puts = private unnamed_addr constant [5 x i8] c"puts\00", align 1
-@str_times = private unnamed_addr constant [6 x i8] c"times\00", align 1
 @"func_Object#3foo$block_1_ifunc" = internal unnamed_addr global i64 0
 @ic_puts.1 = internal global %struct.FunctionInlineCache zeroinitializer
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
 @rubyStrFrozen_hi = internal unnamed_addr global i64 0, align 8
-@str_hi = private unnamed_addr constant [3 x i8] c"hi\00", align 1
-@str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
 @ic_foo = internal global %struct.FunctionInlineCache zeroinitializer
+@sorbet_moduleStringTable = internal unnamed_addr constant [136 x i8] c"foo\00test/testdata/compiler/block_no_args_captures_constant.rb\00block in foo\00A\00puts\00Kernel\00times\00<top (required)>\00hi\00Object\00normal\00master\00", align 1
 @guard_epoch_A = linkonce local_unnamed_addr global i64 0
 @guarded_const_A = linkonce local_unnamed_addr global i64 0
 @rb_mKernel = external local_unnamed_addr constant i64
@@ -333,20 +325,20 @@ entry:
   %locals.i7.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #12
+  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 3) #12
   store i64 %0, i64* @rubyIdPrecomputed_foo, align 8
-  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @"str_block in foo", i64 0, i64 0), i64 noundef 12) #12
+  %1 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i64 0, i64 62), i64 noundef 12) #12
   store i64 %1, i64* @"rubyIdPrecomputed_block in foo", align 8
-  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #12
+  %2 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i64 0, i64 77), i64 noundef 4) #12
   store i64 %2, i64* @rubyIdPrecomputed_puts, align 8
-  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_times, i64 0, i64 0), i64 noundef 5) #12
-  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #12
+  %3 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i64 0, i64 89), i64 noundef 5) #12
+  %4 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i64 0, i64 95), i64 noundef 16) #12
   store i64 %4, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #12
-  %6 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #12
+  %5 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i64 0, i64 122), i64 noundef 6) #12
+  %6 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 3) #12
   tail call void @rb_gc_register_mark_object(i64 %6) #12
   store i64 %6, i64* @rubyStrFrozen_foo, align 8
-  %7 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([58 x i8], [58 x i8]* @"str_test/testdata/compiler/block_no_args_captures_constant.rb", i64 0, i64 0), i64 noundef 57) #12
+  %7 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i64 0, i64 4), i64 noundef 57) #12
   tail call void @rb_gc_register_mark_object(i64 %7) #12
   store i64 %7, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args_captures_constant.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 13)
@@ -355,7 +347,7 @@ entry:
   %"rubyStr_test/testdata/compiler/block_no_args_captures_constant.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args_captures_constant.rb", align 8
   %8 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_foo.i.i, i64 %rubyId_foo.i.i, i64 %"rubyStr_test/testdata/compiler/block_no_args_captures_constant.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %8, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8
-  %9 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @"str_block in foo", i64 0, i64 0), i64 noundef 12) #12
+  %9 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i64 0, i64 62), i64 noundef 12) #12
   call void @rb_gc_register_mark_object(i64 %9) #12
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8
   %"rubyId_block in foo.i.i" = load i64, i64* @"rubyIdPrecomputed_block in foo", align 8
@@ -370,13 +362,13 @@ entry:
   store i64 %13, i64* @"func_Object#3foo$block_1_ifunc", align 8
   %rubyId_puts2.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !49
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts2.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !49
-  %14 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #12
+  %14 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i64 0, i64 95), i64 noundef 16) #12
   call void @rb_gc_register_mark_object(i64 %14) #12
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/block_no_args_captures_constant.rb.i6.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args_captures_constant.rb", align 8
   %15 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %14, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_no_args_captures_constant.rb.i6.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i7.i, i32 noundef 0, i32 noundef 4)
   store %struct.rb_iseq_struct* %15, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %16 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_hi, i64 0, i64 0), i64 noundef 2) #12
+  %16 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i64 0, i64 112), i64 noundef 2) #12
   call void @rb_gc_register_mark_object(i64 %16) #12
   store i64 %16, i64* @rubyStrFrozen_hi, align 8
   %rubyId_foo.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !50
@@ -400,7 +392,7 @@ entry:
   store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %28, align 8, !dbg !60, !tbaa !14
   %rubyStr_hi.i = load i64, i64* @rubyStrFrozen_hi, align 8, !dbg !61
   %29 = load i64, i64* @rb_cObject, align 8, !dbg !61
-  %30 = call i64 @sorbet_setConstant(i64 %29, i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 noundef 1, i64 %rubyStr_hi.i) #12, !dbg !61
+  %30 = call i64 @sorbet_setConstant(i64 %29, i8* getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i64 0, i64 75), i64 noundef 1, i64 %rubyStr_hi.i) #12, !dbg !61
   store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %28, align 8, !dbg !61, !tbaa !14
   %stackFrame12.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8, !dbg !62
   %31 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #13, !dbg !62
@@ -410,7 +402,7 @@ entry:
   store i16 %34, i16* %32, align 8, !dbg !62
   %35 = getelementptr inbounds i8, i8* %31, i64 4, !dbg !62
   call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %35, i8 0, i64 28, i1 false) #12, !dbg !62
-  call void @sorbet_vm_define_method(i64 %29, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#3foo", i8* nonnull %31, %struct.rb_iseq_struct* %stackFrame12.i, i1 noundef zeroext false) #12, !dbg !62
+  call void @sorbet_vm_define_method(i64 %29, i8* noundef getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#3foo", i8* nonnull %31, %struct.rb_iseq_struct* %stackFrame12.i, i1 noundef zeroext false) #12, !dbg !62
   store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %28, align 8, !dbg !62, !tbaa !14
   %36 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %22, i64 0, i32 1, !dbg !50
   %37 = load i64*, i64** %36, align 8, !dbg !50
@@ -432,7 +424,7 @@ declare void @llvm.assume(i1 noundef) #9
 
 ; Function Attrs: ssp
 define linkonce void @const_recompute_A() local_unnamed_addr #5 {
-  %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 1)
+  %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i64 0, i64 75), i64 1)
   store i64 %1, i64* @guarded_const_A, align 8
   %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !20
   store i64 %2, i64* @guard_epoch_A, align 8

--- a/test/testdata/compiler/block_type_checking.opt.ll.exp
+++ b/test/testdata/compiler/block_type_checking.opt.ll.exp
@@ -87,60 +87,38 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
 @"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb" = internal unnamed_addr global i64 0, align 8
-@"str_test/testdata/compiler/block_type_checking.rb" = private unnamed_addr constant [46 x i8] c"test/testdata/compiler/block_type_checking.rb\00", align 1
 @iseqEncodedArray = internal global [19 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_block in <top (required)>" = internal unnamed_addr global i64 0, align 8
-@"str_block in <top (required)>" = private unnamed_addr constant [26 x i8] c"block in <top (required)>\00", align 1
-@str_Foo = private unnamed_addr constant [4 x i8] c"Foo\00", align 1
 @ic_new = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_new = internal unnamed_addr global i64 0, align 8
-@str_new = private unnamed_addr constant [4 x i8] c"new\00", align 1
 @ic_initialize = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_initialize = internal unnamed_addr global i64 0, align 8
-@str_initialize = private unnamed_addr constant [11 x i8] c"initialize\00", align 1
 @ic_bar = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_bar = internal unnamed_addr global i64 0, align 8
-@str_bar = private unnamed_addr constant [4 x i8] c"bar\00", align 1
 @"func_<root>.17<static-init>$153$block_1_ifunc" = internal unnamed_addr global i64 0
 @ic_p = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_p = internal unnamed_addr global i64 0, align 8
-@str_p = private unnamed_addr constant [2 x i8] c"p\00", align 1
 @"stackFramePrecomputed_func_Foo#3bar" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"str_Parameter 'x'" = private unnamed_addr constant [14 x i8] c"Parameter 'x'\00", align 1
-@str_Integer = private unnamed_addr constant [8 x i8] c"Integer\00", align 1
-@"str_+" = private unnamed_addr constant [2 x i8] c"+\00", align 1
-@"str_Return value" = private unnamed_addr constant [13 x i8] c"Return value\00", align 1
 @"stackFramePrecomputed_func_Foo.13<static-init>" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<class:Foo>" = internal unnamed_addr global i64 0, align 8
-@"str_<class:Foo>" = private unnamed_addr constant [12 x i8] c"<class:Foo>\00", align 1
 @"stackFramePrecomputed_func_Foo.13<static-init>$block_1" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_block in <class:Foo>" = internal unnamed_addr global i64 0, align 8
-@"str_block in <class:Foo>" = private unnamed_addr constant [21 x i8] c"block in <class:Foo>\00", align 1
 @rubyIdPrecomputed_x = internal unnamed_addr global i64 0, align 8
-@str_x = private unnamed_addr constant [2 x i8] c"x\00", align 1
 @rubyIdPrecomputed_blk = internal unnamed_addr global i64 0, align 8
-@str_blk = private unnamed_addr constant [4 x i8] c"blk\00", align 1
 @ic_proc = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_proc = internal unnamed_addr global i64 0, align 8
-@str_proc = private unnamed_addr constant [5 x i8] c"proc\00", align 1
-@str_T = private unnamed_addr constant [2 x i8] c"T\00", align 1
 @ic_returns = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_returns = internal unnamed_addr global i64 0, align 8
-@str_returns = private unnamed_addr constant [8 x i8] c"returns\00", align 1
 @ic_params = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_params = internal unnamed_addr global i64 0, align 8
-@str_params = private unnamed_addr constant [7 x i8] c"params\00", align 1
 @ic_returns.1 = internal global %struct.FunctionInlineCache zeroinitializer
-@"str_T::Sig" = private unnamed_addr constant [7 x i8] c"T::Sig\00", align 1
 @ic_extend = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_extend = internal unnamed_addr global i64 0, align 8
-@str_extend = private unnamed_addr constant [7 x i8] c"extend\00", align 1
-@str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
+@sorbet_moduleStringTable = internal unnamed_addr constant [247 x i8] c"<top (required)>\00test/testdata/compiler/block_type_checking.rb\00block in <top (required)>\00Foo\00Object\00new\00initialize\00bar\00p\00master\00Parameter 'x'\00Integer\00+\00Return value\00<class:Foo>\00block in <class:Foo>\00x\00blk\00proc\00T\00returns\00params\00T::Sig\00extend\00normal\00", align 1
 @rb_cObject = external local_unnamed_addr constant i64
 @"guard_epoch_T::Sig" = linkonce local_unnamed_addr global i64 0
 @"guarded_const_T::Sig" = linkonce local_unnamed_addr global i64 0
@@ -273,40 +251,40 @@ entry:
   %realpath = tail call i64 @sorbet_readRealpath()
   %0 = bitcast i64* %keywords.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %0)
-  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #17
+  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #17
   store i64 %1, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #17
+  %2 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 63), i64 noundef 25) #17
   store i64 %2, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
-  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_new, i64 0, i64 0), i64 noundef 3) #17
+  %3 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 100), i64 noundef 3) #17
   store i64 %3, i64* @rubyIdPrecomputed_new, align 8
-  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 noundef 10) #17
+  %4 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 104), i64 noundef 10) #17
   store i64 %4, i64* @rubyIdPrecomputed_initialize, align 8
-  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_bar, i64 0, i64 0), i64 noundef 3) #17
+  %5 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 115), i64 noundef 3) #17
   store i64 %5, i64* @rubyIdPrecomputed_bar, align 8
-  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_p, i64 0, i64 0), i64 noundef 1) #17
+  %6 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 119), i64 noundef 1) #17
   store i64 %6, i64* @rubyIdPrecomputed_p, align 8
-  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_+", i64 0, i64 0), i64 noundef 1) #17
-  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([12 x i8], [12 x i8]* @"str_<class:Foo>", i64 0, i64 0), i64 noundef 11) #17
+  %7 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 150), i64 noundef 1) #17
+  %8 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 165), i64 noundef 11) #17
   store i64 %8, i64* @"rubyIdPrecomputed_<class:Foo>", align 8
-  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([21 x i8], [21 x i8]* @"str_block in <class:Foo>", i64 0, i64 0), i64 noundef 20) #17
+  %9 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 177), i64 noundef 20) #17
   store i64 %9, i64* @"rubyIdPrecomputed_block in <class:Foo>", align 8
-  %10 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_x, i64 0, i64 0), i64 noundef 1) #17
+  %10 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 198), i64 noundef 1) #17
   store i64 %10, i64* @rubyIdPrecomputed_x, align 8
-  %11 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_blk, i64 0, i64 0), i64 noundef 3) #17
+  %11 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 200), i64 noundef 3) #17
   store i64 %11, i64* @rubyIdPrecomputed_blk, align 8
-  %12 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_proc, i64 0, i64 0), i64 noundef 4) #17
+  %12 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 204), i64 noundef 4) #17
   store i64 %12, i64* @rubyIdPrecomputed_proc, align 8
-  %13 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_returns, i64 0, i64 0), i64 noundef 7) #17
+  %13 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 211), i64 noundef 7) #17
   store i64 %13, i64* @rubyIdPrecomputed_returns, align 8
-  %14 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_params, i64 0, i64 0), i64 noundef 6) #17
+  %14 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 219), i64 noundef 6) #17
   store i64 %14, i64* @rubyIdPrecomputed_params, align 8
-  %15 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_extend, i64 0, i64 0), i64 noundef 6) #17
+  %15 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 233), i64 noundef 6) #17
   store i64 %15, i64* @rubyIdPrecomputed_extend, align 8
-  %16 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #17
-  %17 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #17
+  %16 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 240), i64 noundef 6) #17
+  %17 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #17
   tail call void @rb_gc_register_mark_object(i64 %17) #17
   store i64 %17, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %18 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([46 x i8], [46 x i8]* @"str_test/testdata/compiler/block_type_checking.rb", i64 0, i64 0), i64 noundef 45) #17
+  %18 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 45) #17
   tail call void @rb_gc_register_mark_object(i64 %18) #17
   store i64 %18, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 19)
@@ -315,7 +293,7 @@ entry:
   %"rubyStr_test/testdata/compiler/block_type_checking.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
   %19 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %19, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %20 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #17
+  %20 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 63), i64 noundef 25) #17
   call void @rb_gc_register_mark_object(i64 %20) #17
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
   %"rubyId_block in <top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
@@ -334,19 +312,19 @@ entry:
   store i64 %24, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8
   %rubyId_p.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !32
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !32
-  %25 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_bar, i64 0, i64 0), i64 noundef 3) #17
+  %25 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 115), i64 noundef 3) #17
   call void @rb_gc_register_mark_object(i64 %25) #17
   %rubyId_bar.i.i = load i64, i64* @rubyIdPrecomputed_bar, align 8
   %"rubyStr_test/testdata/compiler/block_type_checking.rb.i15.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
   %26 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %25, i64 %rubyId_bar.i.i, i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i15.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 9, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i16.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %26, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo#3bar", align 8
-  %27 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([12 x i8], [12 x i8]* @"str_<class:Foo>", i64 0, i64 0), i64 noundef 11) #17
+  %27 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 165), i64 noundef 11) #17
   call void @rb_gc_register_mark_object(i64 %27) #17
   %"rubyId_<class:Foo>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:Foo>", align 8
   %"rubyStr_test/testdata/compiler/block_type_checking.rb.i17.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
   %28 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %27, i64 %"rubyId_<class:Foo>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i17.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i18.i, i32 noundef 0, i32 noundef 4)
   store %struct.rb_iseq_struct* %28, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>", align 8
-  %29 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([21 x i8], [21 x i8]* @"str_block in <class:Foo>", i64 0, i64 0), i64 noundef 20) #17
+  %29 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 177), i64 noundef 20) #17
   call void @rb_gc_register_mark_object(i64 %29) #17
   %stackFrame.i19.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>", align 8
   %"rubyId_block in <class:Foo>.i.i" = load i64, i64* @"rubyIdPrecomputed_block in <class:Foo>", align 8
@@ -389,7 +367,7 @@ entry:
   %45 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %39, i64 0, i32 0
   store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %45, align 8, !dbg !44, !tbaa !15
   %46 = load i64, i64* @rb_cObject, align 8, !dbg !45
-  %47 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_Foo, i64 0, i64 0), i64 %46) #17, !dbg !45
+  %47 = call i64 @rb_define_class(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 89), i64 %46) #17, !dbg !45
   %48 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %47) #17, !dbg !45
   %49 = bitcast i64* %positional_table.i.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %49) #17
@@ -478,7 +456,7 @@ entry:
   %91 = getelementptr inbounds i8, i8* %77, i64 32, !dbg !26
   %92 = bitcast i8* %91 to i8**, !dbg !26
   store i8* %90, i8** %92, align 8, !dbg !26, !tbaa !56
-  call void @sorbet_vm_define_method(i64 %74, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_bar, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Foo#3bar", i8* nonnull %77, %struct.rb_iseq_struct* %stackFrame42.i.i, i1 noundef zeroext false) #17, !dbg !26
+  call void @sorbet_vm_define_method(i64 %74, i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 115), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Foo#3bar", i8* nonnull %77, %struct.rb_iseq_struct* %stackFrame42.i.i, i1 noundef zeroext false) #17, !dbg !26
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %49) #17
   call void @sorbet_popFrame() #17, !dbg !45
   store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 15), i64** %45, align 8, !dbg !45, !tbaa !15
@@ -730,14 +708,14 @@ declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
 define internal fastcc void @"func_Foo#3bar.cold.1"(i64 %0) unnamed_addr #14 !dbg !82 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %0, i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @"str_Return value", i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #20
+  tail call void @sorbet_cast_failure(i64 %0, i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 152), i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 142)) #20
   unreachable
 }
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
 define internal fastcc void @"func_Foo#3bar.cold.2"(i64 %rawArg_x) unnamed_addr #14 !dbg !84 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %rawArg_x, i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_Parameter 'x'", i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #20, !dbg !85
+  tail call void @sorbet_cast_failure(i64 %rawArg_x, i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 128), i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 142)) #20, !dbg !85
   unreachable, !dbg !85
 }
 
@@ -746,7 +724,7 @@ declare void @llvm.assume(i1 noundef) #15
 
 ; Function Attrs: ssp
 define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #12 {
-  %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([7 x i8], [7 x i8]* @"str_T::Sig", i64 0, i64 0), i64 6)
+  %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 226), i64 6)
   store i64 %1, i64* @"guarded_const_T::Sig", align 8
   %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !49
   store i64 %2, i64* @"guard_epoch_T::Sig", align 8
@@ -755,7 +733,7 @@ define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #12 {
 
 ; Function Attrs: ssp
 define linkonce void @const_recompute_Foo() local_unnamed_addr #12 {
-  %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @str_Foo, i64 0, i64 0), i64 3)
+  %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 89), i64 3)
   store i64 %1, i64* @guarded_const_Foo, align 8
   %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !49
   store i64 %2, i64* @guard_epoch_Foo, align 8
@@ -764,7 +742,7 @@ define linkonce void @const_recompute_Foo() local_unnamed_addr #12 {
 
 ; Function Attrs: ssp
 define linkonce void @const_recompute_T() local_unnamed_addr #12 {
-  %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @str_T, i64 0, i64 0), i64 1)
+  %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 209), i64 1)
   store i64 %1, i64* @guarded_const_T, align 8
   %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !49
   store i64 %2, i64* @guard_epoch_T, align 8

--- a/test/testdata/compiler/boolean_ops.opt.ll.exp
+++ b/test/testdata/compiler/boolean_ops.opt.ll.exp
@@ -82,19 +82,15 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
 @"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/boolean_ops.rb" = internal unnamed_addr global i64 0, align 8
-@"str_test/testdata/compiler/boolean_ops.rb" = private unnamed_addr constant [38 x i8] c"test/testdata/compiler/boolean_ops.rb\00", align 1
 @iseqEncodedArray = internal global [6 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
-@"str_>" = private unnamed_addr constant [2 x i8] c">\00", align 1
 @"ic_!" = internal global %struct.FunctionInlineCache zeroinitializer
 @"rubyIdPrecomputed_!" = internal unnamed_addr global i64 0, align 8
-@"str_!" = private unnamed_addr constant [2 x i8] c"!\00", align 1
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
-@str_puts = private unnamed_addr constant [5 x i8] c"puts\00", align 1
+@sorbet_moduleStringTable = internal unnamed_addr constant [71 x i8] c"<top (required)>\00test/testdata/compiler/boolean_ops.rb\00>\00!\00puts\00master\00", align 1
 
 declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
 
@@ -143,17 +139,17 @@ define void @Init_boolean_ops() local_unnamed_addr #4 {
 entry:
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #6
+  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([71 x i8], [71 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #6
   store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_>", i64 0, i64 0), i64 noundef 1) #6
-  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_!", i64 0, i64 0), i64 noundef 1) #6
+  %1 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([71 x i8], [71 x i8]* @sorbet_moduleStringTable, i64 0, i64 55), i64 noundef 1) #6
+  %2 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([71 x i8], [71 x i8]* @sorbet_moduleStringTable, i64 0, i64 57), i64 noundef 1) #6
   store i64 %2, i64* @"rubyIdPrecomputed_!", align 8
-  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #6
+  %3 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([71 x i8], [71 x i8]* @sorbet_moduleStringTable, i64 0, i64 59), i64 noundef 4) #6
   store i64 %3, i64* @rubyIdPrecomputed_puts, align 8
-  %4 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #6
+  %4 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([71 x i8], [71 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #6
   tail call void @rb_gc_register_mark_object(i64 %4) #6
   store i64 %4, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %5 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([38 x i8], [38 x i8]* @"str_test/testdata/compiler/boolean_ops.rb", i64 0, i64 0), i64 noundef 37) #6
+  %5 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([71 x i8], [71 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 37) #6
   tail call void @rb_gc_register_mark_object(i64 %5) #6
   store i64 %5, i64* @"rubyStrFrozen_test/testdata/compiler/boolean_ops.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([6 x i64], [6 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 6)

--- a/test/testdata/compiler/casts.opt.ll.exp
+++ b/test/testdata/compiler/casts.opt.ll.exp
@@ -83,50 +83,33 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_Object#6fooAll" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @rubyIdPrecomputed_fooAll = internal unnamed_addr global i64 0, align 8
-@str_fooAll = private unnamed_addr constant [7 x i8] c"fooAll\00", align 1
 @rubyStrFrozen_fooAll = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/casts.rb" = internal unnamed_addr global i64 0, align 8
-@"str_test/testdata/compiler/casts.rb" = private unnamed_addr constant [32 x i8] c"test/testdata/compiler/casts.rb\00", align 1
 @iseqEncodedArray = internal global [30 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
-@str_Kernel = private unnamed_addr constant [7 x i8] c"Kernel\00", align 1
-@str_T.cast = private unnamed_addr constant [7 x i8] c"T.cast\00", align 1
 @"stackFramePrecomputed_func_Object#7fooAny1" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @rubyIdPrecomputed_fooAny1 = internal unnamed_addr global i64 0, align 8
-@str_fooAny1 = private unnamed_addr constant [8 x i8] c"fooAny1\00", align 1
-@"str_T.any(Integer, Float)" = private unnamed_addr constant [22 x i8] c"T.any(Integer, Float)\00", align 1
 @"stackFramePrecomputed_func_Object#7fooAny2" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @rubyIdPrecomputed_fooAny2 = internal unnamed_addr global i64 0, align 8
-@str_fooAny2 = private unnamed_addr constant [8 x i8] c"fooAny2\00", align 1
-@"str_T.any(Float, Integer)" = private unnamed_addr constant [22 x i8] c"T.any(Float, Integer)\00", align 1
 @"stackFramePrecomputed_func_Object#6fooInt" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @rubyIdPrecomputed_fooInt = internal unnamed_addr global i64 0, align 8
-@str_fooInt = private unnamed_addr constant [7 x i8] c"fooInt\00", align 1
-@str_Integer = private unnamed_addr constant [8 x i8] c"Integer\00", align 1
-@"str_+" = private unnamed_addr constant [2 x i8] c"+\00", align 1
 @"stackFramePrecomputed_func_Object#8fooArray" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @rubyIdPrecomputed_fooArray = internal unnamed_addr global i64 0, align 8
-@str_fooArray = private unnamed_addr constant [9 x i8] c"fooArray\00", align 1
-@"str_T::Array[Integer]" = private unnamed_addr constant [18 x i8] c"T::Array[Integer]\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
-@str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
 @rubyIdPrecomputed_arg = internal unnamed_addr global i64 0, align 8
-@str_arg = private unnamed_addr constant [4 x i8] c"arg\00", align 1
 @ic_fooInt = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
-@str_puts = private unnamed_addr constant [5 x i8] c"puts\00", align 1
 @ic_fooAny1 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.1 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_fooAny2 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.2 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_fooAll = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.3 = internal global %struct.FunctionInlineCache zeroinitializer
-@"str_<build-array>" = private unnamed_addr constant [14 x i8] c"<build-array>\00", align 1
 @ic_fooArray = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.4 = internal global %struct.FunctionInlineCache zeroinitializer
+@sorbet_moduleStringTable = internal unnamed_addr constant [218 x i8] c"fooAll\00test/testdata/compiler/casts.rb\00Kernel\00T.cast\00fooAny1\00T.any(Integer, Float)\00fooAny2\00T.any(Float, Integer)\00fooInt\00Integer\00+\00fooArray\00T::Array[Integer]\00<top (required)>\00normal\00Object\00arg\00puts\00<build-array>\00master\00", align 1
 @rb_mKernel = external local_unnamed_addr constant i64
 @rb_cObject = external local_unnamed_addr constant i64
 
@@ -503,29 +486,29 @@ entry:
   %locals.i25.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_fooAll, i64 0, i64 0), i64 noundef 6) #17
+  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 6) #17
   store i64 %0, i64* @rubyIdPrecomputed_fooAll, align 8
-  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_fooAny1, i64 0, i64 0), i64 noundef 7) #17
+  %1 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 53), i64 noundef 7) #17
   store i64 %1, i64* @rubyIdPrecomputed_fooAny1, align 8
-  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_fooAny2, i64 0, i64 0), i64 noundef 7) #17
+  %2 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 83), i64 noundef 7) #17
   store i64 %2, i64* @rubyIdPrecomputed_fooAny2, align 8
-  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_fooInt, i64 0, i64 0), i64 noundef 6) #17
+  %3 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 113), i64 noundef 6) #17
   store i64 %3, i64* @rubyIdPrecomputed_fooInt, align 8
-  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_+", i64 0, i64 0), i64 noundef 1) #17
-  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_fooArray, i64 0, i64 0), i64 noundef 8) #17
+  %4 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 128), i64 noundef 1) #17
+  %5 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 130), i64 noundef 8) #17
   store i64 %5, i64* @rubyIdPrecomputed_fooArray, align 8
-  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #17
+  %6 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 157), i64 noundef 16) #17
   store i64 %6, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #17
-  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_arg, i64 0, i64 0), i64 noundef 3) #17
+  %7 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 174), i64 noundef 6) #17
+  %8 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 188), i64 noundef 3) #17
   store i64 %8, i64* @rubyIdPrecomputed_arg, align 8
-  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #17
+  %9 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 192), i64 noundef 4) #17
   store i64 %9, i64* @rubyIdPrecomputed_puts, align 8
-  %10 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_<build-array>", i64 0, i64 0), i64 noundef 13) #17
-  %11 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_fooAll, i64 0, i64 0), i64 noundef 6) #17
+  %10 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 197), i64 noundef 13) #17
+  %11 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 6) #17
   tail call void @rb_gc_register_mark_object(i64 %11) #17
   store i64 %11, i64* @rubyStrFrozen_fooAll, align 8
-  %12 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([32 x i8], [32 x i8]* @"str_test/testdata/compiler/casts.rb", i64 0, i64 0), i64 noundef 31) #17
+  %12 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 7), i64 noundef 31) #17
   tail call void @rb_gc_register_mark_object(i64 %12) #17
   store i64 %12, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 30)
@@ -534,31 +517,31 @@ entry:
   %"rubyStr_test/testdata/compiler/casts.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
   %13 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_fooAll.i.i, i64 %rubyId_fooAll.i.i, i64 %"rubyStr_test/testdata/compiler/casts.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 0)
   store %struct.rb_iseq_struct* %13, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#6fooAll", align 8
-  %14 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_fooAny1, i64 0, i64 0), i64 noundef 7) #17
+  %14 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 53), i64 noundef 7) #17
   call void @rb_gc_register_mark_object(i64 %14) #17
   %rubyId_fooAny1.i.i = load i64, i64* @rubyIdPrecomputed_fooAny1, align 8
   %"rubyStr_test/testdata/compiler/casts.rb.i24.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
   %15 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %14, i64 %rubyId_fooAny1.i.i, i64 %"rubyStr_test/testdata/compiler/casts.rb.i24.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 9, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i25.i, i32 noundef 0, i32 noundef 0)
   store %struct.rb_iseq_struct* %15, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#7fooAny1", align 8
-  %16 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_fooAny2, i64 0, i64 0), i64 noundef 7) #17
+  %16 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 83), i64 noundef 7) #17
   call void @rb_gc_register_mark_object(i64 %16) #17
   %rubyId_fooAny2.i.i = load i64, i64* @rubyIdPrecomputed_fooAny2, align 8
   %"rubyStr_test/testdata/compiler/casts.rb.i26.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
   %17 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %16, i64 %rubyId_fooAny2.i.i, i64 %"rubyStr_test/testdata/compiler/casts.rb.i26.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 13, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i27.i, i32 noundef 0, i32 noundef 0)
   store %struct.rb_iseq_struct* %17, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#7fooAny2", align 8
-  %18 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_fooInt, i64 0, i64 0), i64 noundef 6) #17
+  %18 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 113), i64 noundef 6) #17
   call void @rb_gc_register_mark_object(i64 %18) #17
   %rubyId_fooInt.i.i = load i64, i64* @rubyIdPrecomputed_fooInt, align 8
   %"rubyStr_test/testdata/compiler/casts.rb.i28.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
   %19 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %18, i64 %rubyId_fooInt.i.i, i64 %"rubyStr_test/testdata/compiler/casts.rb.i28.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 17, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i29.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %19, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#6fooInt", align 8
-  %20 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_fooArray, i64 0, i64 0), i64 noundef 8) #17
+  %20 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 130), i64 noundef 8) #17
   call void @rb_gc_register_mark_object(i64 %20) #17
   %rubyId_fooArray.i.i = load i64, i64* @rubyIdPrecomputed_fooArray, align 8
   %"rubyStr_test/testdata/compiler/casts.rb.i30.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
   %21 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %20, i64 %rubyId_fooArray.i.i, i64 %"rubyStr_test/testdata/compiler/casts.rb.i30.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 21, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i31.i, i32 noundef 0, i32 noundef 0)
   store %struct.rb_iseq_struct* %21, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#8fooArray", align 8
-  %22 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #17
+  %22 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 157), i64 noundef 16) #17
   call void @rb_gc_register_mark_object(i64 %22) #17
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/casts.rb.i32.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
@@ -637,7 +620,7 @@ entry:
   %55 = getelementptr inbounds i8, i8* %44, i64 32, !dbg !49
   %56 = bitcast i8* %55 to i8**, !dbg !49
   store i8* %54, i8** %56, align 8, !dbg !49, !tbaa !83
-  call void @sorbet_vm_define_method(i64 %43, i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_fooAll, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#6fooAll", i8* nonnull %44, %struct.rb_iseq_struct* %stackFrame73.i, i1 noundef zeroext false) #17, !dbg !49
+  call void @sorbet_vm_define_method(i64 %43, i8* noundef getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#6fooAll", i8* nonnull %44, %struct.rb_iseq_struct* %stackFrame73.i, i1 noundef zeroext false) #17, !dbg !49
   store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %42, align 8, !dbg !49, !tbaa !14
   %stackFrame82.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#7fooAny1", align 8, !dbg !51
   %57 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !51
@@ -661,7 +644,7 @@ entry:
   %68 = getelementptr inbounds i8, i8* %57, i64 32, !dbg !51
   %69 = bitcast i8* %68 to i8**, !dbg !51
   store i8* %67, i8** %69, align 8, !dbg !51, !tbaa !83
-  call void @sorbet_vm_define_method(i64 %43, i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_fooAny1, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#7fooAny1", i8* nonnull %57, %struct.rb_iseq_struct* %stackFrame82.i, i1 noundef zeroext false) #17, !dbg !51
+  call void @sorbet_vm_define_method(i64 %43, i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 53), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#7fooAny1", i8* nonnull %57, %struct.rb_iseq_struct* %stackFrame82.i, i1 noundef zeroext false) #17, !dbg !51
   store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %42, align 8, !dbg !51, !tbaa !14
   %stackFrame94.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#7fooAny2", align 8, !dbg !52
   %70 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !52
@@ -685,7 +668,7 @@ entry:
   %81 = getelementptr inbounds i8, i8* %70, i64 32, !dbg !52
   %82 = bitcast i8* %81 to i8**, !dbg !52
   store i8* %80, i8** %82, align 8, !dbg !52, !tbaa !83
-  call void @sorbet_vm_define_method(i64 %43, i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_fooAny2, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#7fooAny2", i8* nonnull %70, %struct.rb_iseq_struct* %stackFrame94.i, i1 noundef zeroext false) #17, !dbg !52
+  call void @sorbet_vm_define_method(i64 %43, i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 83), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#7fooAny2", i8* nonnull %70, %struct.rb_iseq_struct* %stackFrame94.i, i1 noundef zeroext false) #17, !dbg !52
   store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %42, align 8, !dbg !52, !tbaa !14
   %stackFrame106.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#6fooInt", align 8, !dbg !53
   %83 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !53
@@ -709,7 +692,7 @@ entry:
   %94 = getelementptr inbounds i8, i8* %83, i64 32, !dbg !53
   %95 = bitcast i8* %94 to i8**, !dbg !53
   store i8* %93, i8** %95, align 8, !dbg !53, !tbaa !83
-  call void @sorbet_vm_define_method(i64 %43, i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_fooInt, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#6fooInt", i8* nonnull %83, %struct.rb_iseq_struct* %stackFrame106.i, i1 noundef zeroext false) #17, !dbg !53
+  call void @sorbet_vm_define_method(i64 %43, i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 113), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#6fooInt", i8* nonnull %83, %struct.rb_iseq_struct* %stackFrame106.i, i1 noundef zeroext false) #17, !dbg !53
   store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %42, align 8, !dbg !53, !tbaa !14
   %stackFrame118.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#8fooArray", align 8, !dbg !54
   %96 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !54
@@ -733,7 +716,7 @@ entry:
   %107 = getelementptr inbounds i8, i8* %96, i64 32, !dbg !54
   %108 = bitcast i8* %107 to i8**, !dbg !54
   store i8* %106, i8** %108, align 8, !dbg !54, !tbaa !83
-  call void @sorbet_vm_define_method(i64 %43, i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_fooArray, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#8fooArray", i8* nonnull %96, %struct.rb_iseq_struct* %stackFrame118.i, i1 noundef zeroext false) #17, !dbg !54
+  call void @sorbet_vm_define_method(i64 %43, i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 130), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#8fooArray", i8* nonnull %96, %struct.rb_iseq_struct* %stackFrame118.i, i1 noundef zeroext false) #17, !dbg !54
   store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %42, align 8, !dbg !54, !tbaa !14
   %109 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 1, !dbg !55
   %110 = load i64*, i64** %109, align 8, !dbg !55
@@ -844,35 +827,35 @@ declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #7
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
 define internal fastcc void @"func_Object#6fooAll.cold.1"(i64 %rawArg_arg) unnamed_addr #12 !dbg !88 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %rawArg_arg, i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_T.cast, i64 0, i64 0), i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_Kernel, i64 0, i64 0)) #14, !dbg !90
+  tail call void @sorbet_cast_failure(i64 %rawArg_arg, i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 46), i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 39)) #14, !dbg !90
   unreachable, !dbg !90
 }
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
 define internal fastcc void @"func_Object#7fooAny1.cold.1"(i64 %rawArg_arg) unnamed_addr #12 !dbg !91 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %rawArg_arg, i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_T.cast, i64 0, i64 0), i8* noundef getelementptr inbounds ([22 x i8], [22 x i8]* @"str_T.any(Integer, Float)", i64 0, i64 0)) #14, !dbg !92
+  tail call void @sorbet_cast_failure(i64 %rawArg_arg, i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 46), i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 61)) #14, !dbg !92
   unreachable, !dbg !92
 }
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
 define internal fastcc void @"func_Object#7fooAny2.cold.1"(i64 %rawArg_arg) unnamed_addr #12 !dbg !93 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %rawArg_arg, i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_T.cast, i64 0, i64 0), i8* noundef getelementptr inbounds ([22 x i8], [22 x i8]* @"str_T.any(Float, Integer)", i64 0, i64 0)) #14, !dbg !94
+  tail call void @sorbet_cast_failure(i64 %rawArg_arg, i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 46), i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 91)) #14, !dbg !94
   unreachable, !dbg !94
 }
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
 define internal fastcc void @"func_Object#6fooInt.cold.1"(i64 %rawArg_arg) unnamed_addr #12 !dbg !95 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %rawArg_arg, i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_T.cast, i64 0, i64 0), i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Integer, i64 0, i64 0)) #14, !dbg !96
+  tail call void @sorbet_cast_failure(i64 %rawArg_arg, i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 46), i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 120)) #14, !dbg !96
   unreachable, !dbg !96
 }
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
 define internal fastcc void @"func_Object#8fooArray.cold.1"(i64 %rawArg_arg) unnamed_addr #12 !dbg !97 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %rawArg_arg, i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_T.cast, i64 0, i64 0), i8* noundef getelementptr inbounds ([18 x i8], [18 x i8]* @"str_T::Array[Integer]", i64 0, i64 0)) #14, !dbg !98
+  tail call void @sorbet_cast_failure(i64 %rawArg_arg, i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 46), i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 139)) #14, !dbg !98
   unreachable, !dbg !98
 }
 

--- a/test/testdata/compiler/class.opt.ll.exp
+++ b/test/testdata/compiler/class.opt.ll.exp
@@ -78,27 +78,20 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
 @"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/class.rb" = internal unnamed_addr global i64 0, align 8
-@"str_test/testdata/compiler/class.rb" = private unnamed_addr constant [32 x i8] c"test/testdata/compiler/class.rb\00", align 1
 @iseqEncodedArray = internal global [10 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
-@str_Foo = private unnamed_addr constant [4 x i8] c"Foo\00", align 1
-@str_Baz = private unnamed_addr constant [4 x i8] c"Baz\00", align 1
 @"stackFramePrecomputed_func_Foo.13<static-init>" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<module:Foo>" = internal unnamed_addr global i64 0, align 8
-@"str_<module:Foo>" = private unnamed_addr constant [13 x i8] c"<module:Foo>\00", align 1
 @"rubyStrFrozen_<module:Foo>" = internal unnamed_addr global i64 0, align 8
-@str_Bar = private unnamed_addr constant [4 x i8] c"Bar\00", align 1
 @"stackFramePrecomputed_func_Foo::Bar.13<static-init>" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<class:Foo::Bar>" = internal unnamed_addr global i64 0, align 8
-@"str_<class:Foo::Bar>" = private unnamed_addr constant [17 x i8] c"<class:Foo::Bar>\00", align 1
 @"rubyStrFrozen_<class:Foo::Bar>" = internal unnamed_addr global i64 0, align 8
 @"stackFramePrecomputed_func_Baz.13<static-init>" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<class:Baz>" = internal unnamed_addr global i64 0, align 8
-@"str_<class:Baz>" = private unnamed_addr constant [12 x i8] c"<class:Baz>\00", align 1
 @"rubyStrFrozen_<class:Baz>" = internal unnamed_addr global i64 0, align 8
+@sorbet_moduleStringTable = internal unnamed_addr constant [117 x i8] c"<top (required)>\00test/testdata/compiler/class.rb\00Foo\00Baz\00Object\00master\00<module:Foo>\00Bar\00<class:Foo::Bar>\00<class:Baz>\00", align 1
 @guard_epoch_Foo = linkonce local_unnamed_addr global i64 0
 @guarded_const_Foo = linkonce local_unnamed_addr global i64 0
 @rb_cObject = external local_unnamed_addr constant i64
@@ -180,7 +173,7 @@ entryInitializers:
 ; Function Attrs: nounwind ssp
 define internal fastcc void @"Constr_rubyIdPrecomputed_<top (required)>"() unnamed_addr #4 {
 constr:
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #8
+  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([117 x i8], [117 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #8
   store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   ret void
 }
@@ -188,7 +181,7 @@ constr:
 ; Function Attrs: nounwind ssp
 define internal fastcc void @"Constr_rubyStrFrozen_<top (required)>"() unnamed_addr #4 {
 constr:
-  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #8
+  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([117 x i8], [117 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #8
   tail call void @rb_gc_register_mark_object(i64 %0) #8
   store i64 %0, i64* @"rubyStrFrozen_<top (required)>", align 8
   ret void
@@ -197,7 +190,7 @@ constr:
 ; Function Attrs: nounwind ssp
 define internal fastcc void @"Constr_rubyStrFrozen_test/testdata/compiler/class.rb"() unnamed_addr #4 {
 constr:
-  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([32 x i8], [32 x i8]* @"str_test/testdata/compiler/class.rb", i64 0, i64 0), i64 noundef 31) #8
+  %0 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([117 x i8], [117 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 31) #8
   tail call void @rb_gc_register_mark_object(i64 %0) #8
   store i64 %0, i64* @"rubyStrFrozen_test/testdata/compiler/class.rb", align 8
   ret void
@@ -222,7 +215,7 @@ entry:
   tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame.i) #8
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
   store i64* getelementptr inbounds ([10 x i64], [10 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %8, align 8, !dbg !19, !tbaa !10
-  %9 = tail call i64 @rb_define_module(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_Foo, i64 0, i64 0)) #8, !dbg !24
+  %9 = tail call i64 @rb_define_module(i8* getelementptr inbounds ([117 x i8], [117 x i8]* @sorbet_moduleStringTable, i64 0, i64 49)) #8, !dbg !24
   %10 = tail call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %9) #8, !dbg !24
   %stackFrame.i1.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>", align 8
   %11 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !10
@@ -254,7 +247,7 @@ entry:
   %guardUpdated = icmp eq i64 %25, %26, !dbg !28
   tail call void @llvm.assume(i1 %guardUpdated), !dbg !28
   %27 = load i64, i64* @rb_cObject, align 8, !dbg !28
-  %28 = tail call i64 @rb_define_class_under(i64 %24, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_Bar, i64 0, i64 0), i64 %27) #8, !dbg !28
+  %28 = tail call i64 @rb_define_class_under(i64 %24, i8* getelementptr inbounds ([117 x i8], [117 x i8]* @sorbet_moduleStringTable, i64 0, i64 84), i64 %27) #8, !dbg !28
   %29 = tail call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %28) #8, !dbg !28
   %stackFrame.i.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo::Bar.13<static-init>", align 8
   %30 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !10
@@ -273,7 +266,7 @@ entry:
   tail call void @sorbet_popFrame() #8, !dbg !28
   tail call void @sorbet_popFrame() #8, !dbg !24
   store i64* getelementptr inbounds ([10 x i64], [10 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !dbg !24, !tbaa !10
-  %39 = tail call i64 @rb_define_class(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_Baz, i64 0, i64 0), i64 %27) #8, !dbg !35
+  %39 = tail call i64 @rb_define_class(i8* getelementptr inbounds ([117 x i8], [117 x i8]* @sorbet_moduleStringTable, i64 0, i64 53), i64 %27) #8, !dbg !35
   %40 = tail call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %39) #8, !dbg !35
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Baz.13<static-init>", align 8
   %41 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !10
@@ -308,7 +301,7 @@ entryInitializers:
 ; Function Attrs: nounwind ssp
 define internal fastcc void @"Constr_rubyIdPrecomputed_<module:Foo>"() unnamed_addr #4 {
 constr:
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @"str_<module:Foo>", i64 0, i64 0), i64 noundef 12) #8
+  %0 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([117 x i8], [117 x i8]* @sorbet_moduleStringTable, i64 0, i64 71), i64 noundef 12) #8
   store i64 %0, i64* @"rubyIdPrecomputed_<module:Foo>", align 8
   ret void
 }
@@ -316,7 +309,7 @@ constr:
 ; Function Attrs: nounwind ssp
 define internal fastcc void @"Constr_rubyStrFrozen_<module:Foo>"() unnamed_addr #4 {
 constr:
-  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @"str_<module:Foo>", i64 0, i64 0), i64 noundef 12) #8
+  %0 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([117 x i8], [117 x i8]* @sorbet_moduleStringTable, i64 0, i64 71), i64 noundef 12) #8
   tail call void @rb_gc_register_mark_object(i64 %0) #8
   store i64 %0, i64* @"rubyStrFrozen_<module:Foo>", align 8
   ret void
@@ -337,7 +330,7 @@ entryInitializers:
 ; Function Attrs: nounwind ssp
 define internal fastcc void @"Constr_rubyIdPrecomputed_<class:Foo::Bar>"() unnamed_addr #4 {
 constr:
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<class:Foo::Bar>", i64 0, i64 0), i64 noundef 16) #8
+  %0 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([117 x i8], [117 x i8]* @sorbet_moduleStringTable, i64 0, i64 88), i64 noundef 16) #8
   store i64 %0, i64* @"rubyIdPrecomputed_<class:Foo::Bar>", align 8
   ret void
 }
@@ -345,7 +338,7 @@ constr:
 ; Function Attrs: nounwind ssp
 define internal fastcc void @"Constr_rubyStrFrozen_<class:Foo::Bar>"() unnamed_addr #4 {
 constr:
-  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<class:Foo::Bar>", i64 0, i64 0), i64 noundef 16) #8
+  %0 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([117 x i8], [117 x i8]* @sorbet_moduleStringTable, i64 0, i64 88), i64 noundef 16) #8
   tail call void @rb_gc_register_mark_object(i64 %0) #8
   store i64 %0, i64* @"rubyStrFrozen_<class:Foo::Bar>", align 8
   ret void
@@ -366,7 +359,7 @@ entryInitializers:
 ; Function Attrs: nounwind ssp
 define internal fastcc void @"Constr_rubyIdPrecomputed_<class:Baz>"() unnamed_addr #4 {
 constr:
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([12 x i8], [12 x i8]* @"str_<class:Baz>", i64 0, i64 0), i64 noundef 11) #8
+  %0 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([117 x i8], [117 x i8]* @sorbet_moduleStringTable, i64 0, i64 105), i64 noundef 11) #8
   store i64 %0, i64* @"rubyIdPrecomputed_<class:Baz>", align 8
   ret void
 }
@@ -374,7 +367,7 @@ constr:
 ; Function Attrs: nounwind ssp
 define internal fastcc void @"Constr_rubyStrFrozen_<class:Baz>"() unnamed_addr #4 {
 constr:
-  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([12 x i8], [12 x i8]* @"str_<class:Baz>", i64 0, i64 0), i64 noundef 11) #8
+  %0 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([117 x i8], [117 x i8]* @sorbet_moduleStringTable, i64 0, i64 105), i64 noundef 11) #8
   tail call void @rb_gc_register_mark_object(i64 %0) #8
   store i64 %0, i64* @"rubyStrFrozen_<class:Baz>", align 8
   ret void
@@ -385,7 +378,7 @@ declare void @llvm.assume(i1 noundef) #6
 
 ; Function Attrs: ssp
 define linkonce void @const_recompute_Foo() local_unnamed_addr #3 {
-  %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @str_Foo, i64 0, i64 0), i64 3)
+  %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([117 x i8], [117 x i8]* @sorbet_moduleStringTable, i64 0, i64 49), i64 3)
   store i64 %1, i64* @guarded_const_Foo, align 8
   %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !29
   store i64 %2, i64* @guard_epoch_Foo, align 8

--- a/test/testdata/compiler/classfields.opt.ll.exp
+++ b/test/testdata/compiler/classfields.opt.ll.exp
@@ -83,44 +83,33 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
 @"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/classfields.rb" = internal unnamed_addr global i64 0, align 8
-@"str_test/testdata/compiler/classfields.rb" = private unnamed_addr constant [38 x i8] c"test/testdata/compiler/classfields.rb\00", align 1
 @iseqEncodedArray = internal global [29 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
-@str_B = private unnamed_addr constant [2 x i8] c"B\00", align 1
 @ic_new = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_new = internal unnamed_addr global i64 0, align 8
-@str_new = private unnamed_addr constant [4 x i8] c"new\00", align 1
 @ic_initialize = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_initialize = internal unnamed_addr global i64 0, align 8
-@str_initialize = private unnamed_addr constant [11 x i8] c"initialize\00", align 1
 @ic_write = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_write = internal unnamed_addr global i64 0, align 8
-@str_write = private unnamed_addr constant [6 x i8] c"write\00", align 1
 @ic_read = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_read = internal unnamed_addr global i64 0, align 8
-@str_read = private unnamed_addr constant [5 x i8] c"read\00", align 1
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
-@str_puts = private unnamed_addr constant [5 x i8] c"puts\00", align 1
 @ic_new.1 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_initialize.2 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_read.3 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.4 = internal global %struct.FunctionInlineCache zeroinitializer
 @"stackFramePrecomputed_func_B#5write" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_@@f" = internal unnamed_addr global i64 0, align 8
-@"str_@@f" = private unnamed_addr constant [4 x i8] c"@@f\00", align 1
 @"stackFramePrecomputed_func_B#4read" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @rubyStrFrozen_read = internal unnamed_addr global i64 0, align 8
 @stackFramePrecomputed_func_B.4read = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"stackFramePrecomputed_func_B.13<static-init>" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<class:B>" = internal unnamed_addr global i64 0, align 8
-@"str_<class:B>" = private unnamed_addr constant [10 x i8] c"<class:B>\00", align 1
-@str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
 @rubyIdPrecomputed_a = internal unnamed_addr global i64 0, align 8
-@str_a = private unnamed_addr constant [2 x i8] c"a\00", align 1
+@sorbet_moduleStringTable = internal unnamed_addr constant [125 x i8] c"<top (required)>\00test/testdata/compiler/classfields.rb\00B\00Object\00new\00initialize\00write\00read\00puts\00master\00@@f\00<class:B>\00normal\00a\00", align 1
 @rb_cObject = external local_unnamed_addr constant i64
 @guard_epoch_B = linkonce local_unnamed_addr global i64 0
 @guarded_const_B = linkonce local_unnamed_addr global i64 0
@@ -204,29 +193,29 @@ entry:
   %locals.i17.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
+  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #11
   store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_new, i64 0, i64 0), i64 noundef 3) #11
+  %1 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 64), i64 noundef 3) #11
   store i64 %1, i64* @rubyIdPrecomputed_new, align 8
-  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 noundef 10) #11
+  %2 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 68), i64 noundef 10) #11
   store i64 %2, i64* @rubyIdPrecomputed_initialize, align 8
-  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_write, i64 0, i64 0), i64 noundef 5) #11
+  %3 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 79), i64 noundef 5) #11
   store i64 %3, i64* @rubyIdPrecomputed_write, align 8
-  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_read, i64 0, i64 0), i64 noundef 4) #11
+  %4 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 85), i64 noundef 4) #11
   store i64 %4, i64* @rubyIdPrecomputed_read, align 8
-  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #11
+  %5 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 90), i64 noundef 4) #11
   store i64 %5, i64* @rubyIdPrecomputed_puts, align 8
-  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @"str_@@f", i64 0, i64 0), i64 noundef 3) #11
+  %6 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 102), i64 noundef 3) #11
   store i64 %6, i64* @"rubyIdPrecomputed_@@f", align 8
-  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:B>", i64 0, i64 0), i64 noundef 9) #11
+  %7 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 106), i64 noundef 9) #11
   store i64 %7, i64* @"rubyIdPrecomputed_<class:B>", align 8
-  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #11
-  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_a, i64 0, i64 0), i64 noundef 1) #11
+  %8 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 116), i64 noundef 6) #11
+  %9 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 123), i64 noundef 1) #11
   store i64 %9, i64* @rubyIdPrecomputed_a, align 8
-  %10 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
+  %10 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #11
   tail call void @rb_gc_register_mark_object(i64 %10) #11
   store i64 %10, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %11 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([38 x i8], [38 x i8]* @"str_test/testdata/compiler/classfields.rb", i64 0, i64 0), i64 noundef 37) #11
+  %11 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 37) #11
   tail call void @rb_gc_register_mark_object(i64 %11) #11
   store i64 %11, i64* @"rubyStrFrozen_test/testdata/compiler/classfields.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 29)
@@ -253,13 +242,13 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_read.3, i64 %rubyId_read11.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !20
   %rubyId_puts13.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !21
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.4, i64 %rubyId_puts13.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !21
-  %13 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_write, i64 0, i64 0), i64 noundef 5) #11
+  %13 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 79), i64 noundef 5) #11
   call void @rb_gc_register_mark_object(i64 %13) #11
   %rubyId_write.i.i = load i64, i64* @rubyIdPrecomputed_write, align 8
   %"rubyStr_test/testdata/compiler/classfields.rb.i16.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/classfields.rb", align 8
   %14 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %13, i64 %rubyId_write.i.i, i64 %"rubyStr_test/testdata/compiler/classfields.rb.i16.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 7, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i17.i, i32 noundef 0, i32 noundef 0)
   store %struct.rb_iseq_struct* %14, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B#5write", align 8
-  %15 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_read, i64 0, i64 0), i64 noundef 4) #11
+  %15 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 85), i64 noundef 4) #11
   call void @rb_gc_register_mark_object(i64 %15) #11
   store i64 %15, i64* @rubyStrFrozen_read, align 8
   %rubyId_read.i.i = load i64, i64* @rubyIdPrecomputed_read, align 8
@@ -271,7 +260,7 @@ entry:
   %"rubyStr_test/testdata/compiler/classfields.rb.i22.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/classfields.rb", align 8
   %17 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_read.i21.i, i64 %rubyId_read.i20.i, i64 %"rubyStr_test/testdata/compiler/classfields.rb.i22.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 19, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i23.i, i32 noundef 0, i32 noundef 0)
   store %struct.rb_iseq_struct* %17, %struct.rb_iseq_struct** @stackFramePrecomputed_func_B.4read, align 8
-  %18 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:B>", i64 0, i64 0), i64 noundef 9) #11
+  %18 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 106), i64 noundef 9) #11
   call void @rb_gc_register_mark_object(i64 %18) #11
   %"rubyId_<class:B>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:B>", align 8
   %"rubyStr_test/testdata/compiler/classfields.rb.i24.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/classfields.rb", align 8
@@ -295,7 +284,7 @@ entry:
   %31 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 0
   store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %31, align 8, !dbg !40, !tbaa !22
   %32 = load i64, i64* @rb_cObject, align 8, !dbg !41
-  %33 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_B, i64 0, i64 0), i64 %32) #11, !dbg !41
+  %33 = call i64 @rb_define_class(i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 55), i64 %32) #11, !dbg !41
   %34 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %33) #11, !dbg !41
   %35 = bitcast i64* %positional_table.i.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %35) #11
@@ -350,7 +339,7 @@ entry:
   %63 = getelementptr inbounds i8, i8* %52, i64 32, !dbg !10
   %64 = bitcast i8* %63 to i8**, !dbg !10
   store i8* %62, i8** %64, align 8, !dbg !10, !tbaa !49
-  call void @sorbet_vm_define_method(i64 %49, i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_write, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_B#5write", i8* nonnull %52, %struct.rb_iseq_struct* %stackFrame25.i.i, i1 noundef zeroext false) #11, !dbg !10
+  call void @sorbet_vm_define_method(i64 %49, i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 79), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_B#5write", i8* nonnull %52, %struct.rb_iseq_struct* %stackFrame25.i.i, i1 noundef zeroext false) #11, !dbg !10
   store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %44, align 8, !dbg !10, !tbaa !22
   %stackFrame34.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B#4read", align 8, !dbg !50
   %65 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !50
@@ -360,7 +349,7 @@ entry:
   store i16 %68, i16* %66, align 8, !dbg !50
   %69 = getelementptr inbounds i8, i8* %65, i64 4, !dbg !50
   call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %69, i8 0, i64 28, i1 false) #11, !dbg !50
-  call void @sorbet_vm_define_method(i64 %49, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_read, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_B#4read", i8* nonnull %65, %struct.rb_iseq_struct* %stackFrame34.i.i, i1 noundef zeroext false) #11, !dbg !50
+  call void @sorbet_vm_define_method(i64 %49, i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 85), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_B#4read", i8* nonnull %65, %struct.rb_iseq_struct* %stackFrame34.i.i, i1 noundef zeroext false) #11, !dbg !50
   store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %44, align 8, !dbg !50, !tbaa !22
   %stackFrame44.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_B.4read, align 8, !dbg !51
   %70 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !51
@@ -370,7 +359,7 @@ entry:
   store i16 %73, i16* %71, align 8, !dbg !51
   %74 = getelementptr inbounds i8, i8* %70, i64 4, !dbg !51
   call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %74, i8 0, i64 28, i1 false) #11, !dbg !51
-  call void @sorbet_vm_define_method(i64 %49, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_read, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_B.4read, i8* nonnull %70, %struct.rb_iseq_struct* %stackFrame44.i.i, i1 noundef zeroext true) #11, !dbg !51
+  call void @sorbet_vm_define_method(i64 %49, i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 85), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_B.4read, i8* nonnull %70, %struct.rb_iseq_struct* %stackFrame44.i.i, i1 noundef zeroext true) #11, !dbg !51
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %35) #11
   call void @sorbet_popFrame() #11, !dbg !41
   store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %31, align 8, !dbg !41, !tbaa !22
@@ -578,7 +567,7 @@ declare void @llvm.assume(i1 noundef) #8
 
 ; Function Attrs: ssp
 define linkonce void @const_recompute_B() local_unnamed_addr #9 {
-  %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @str_B, i64 0, i64 0), i64 1)
+  %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 55), i64 1)
   store i64 %1, i64* @guarded_const_B, align 8
   %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !43
   store i64 %2, i64* @guard_epoch_B, align 8

--- a/test/testdata/compiler/constant_cache.opt.ll.exp
+++ b/test/testdata/compiler/constant_cache.opt.ll.exp
@@ -83,27 +83,21 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_Object#3foo" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @rubyIdPrecomputed_foo = internal unnamed_addr global i64 0, align 8
-@str_foo = private unnamed_addr constant [4 x i8] c"foo\00", align 1
 @rubyStrFrozen_foo = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/constant_cache.rb" = internal unnamed_addr global i64 0, align 8
-@"str_test/testdata/compiler/constant_cache.rb" = private unnamed_addr constant [41 x i8] c"test/testdata/compiler/constant_cache.rb\00", align 1
 @iseqEncodedArray = internal global [13 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
-@str_A = private unnamed_addr constant [2 x i8] c"A\00", align 1
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
-@str_puts = private unnamed_addr constant [5 x i8] c"puts\00", align 1
 @ic_puts.1 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.2 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.3 = internal global %struct.FunctionInlineCache zeroinitializer
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
-@str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
 @ic_foo = internal global %struct.FunctionInlineCache zeroinitializer
 @"stackFramePrecomputed_func_A.13<static-init>" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<class:A>" = internal unnamed_addr global i64 0, align 8
-@"str_<class:A>" = private unnamed_addr constant [10 x i8] c"<class:A>\00", align 1
+@sorbet_moduleStringTable = internal unnamed_addr constant [100 x i8] c"foo\00test/testdata/compiler/constant_cache.rb\00A\00puts\00<top (required)>\00Object\00normal\00master\00<class:A>\00", align 1
 @guard_epoch_A = linkonce local_unnamed_addr global i64 0
 @guarded_const_A = linkonce local_unnamed_addr global i64 0
 @rb_cObject = external local_unnamed_addr constant i64
@@ -233,19 +227,19 @@ entry:
   %locals.i13.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #11
+  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 3) #11
   store i64 %0, i64* @rubyIdPrecomputed_foo, align 8
-  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #11
+  %1 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 47), i64 noundef 4) #11
   store i64 %1, i64* @rubyIdPrecomputed_puts, align 8
-  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
+  %2 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 52), i64 noundef 16) #11
   store i64 %2, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #11
-  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #11
+  %3 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 76), i64 noundef 6) #11
+  %4 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 90), i64 noundef 9) #11
   store i64 %4, i64* @"rubyIdPrecomputed_<class:A>", align 8
-  %5 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #11
+  %5 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 3) #11
   tail call void @rb_gc_register_mark_object(i64 %5) #11
   store i64 %5, i64* @rubyStrFrozen_foo, align 8
-  %6 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([41 x i8], [41 x i8]* @"str_test/testdata/compiler/constant_cache.rb", i64 0, i64 0), i64 noundef 40) #11
+  %6 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 4), i64 noundef 40) #11
   tail call void @rb_gc_register_mark_object(i64 %6) #11
   store i64 %6, i64* @"rubyStrFrozen_test/testdata/compiler/constant_cache.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 13)
@@ -262,7 +256,7 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts4.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !24
   %rubyId_puts7.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !25
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts7.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !25
-  %8 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
+  %8 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 52), i64 noundef 16) #11
   call void @rb_gc_register_mark_object(i64 %8) #11
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/constant_cache.rb.i12.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/constant_cache.rb", align 8
@@ -270,7 +264,7 @@ entry:
   store %struct.rb_iseq_struct* %9, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
   %rubyId_foo.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !26
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !26
-  %10 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #11
+  %10 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 90), i64 noundef 9) #11
   call void @rb_gc_register_mark_object(i64 %10) #11
   %"rubyId_<class:A>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:A>", align 8
   %"rubyStr_test/testdata/compiler/constant_cache.rb.i14.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/constant_cache.rb", align 8
@@ -294,7 +288,7 @@ entry:
   %23 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 0
   store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %23, align 8, !dbg !43, !tbaa !14
   %24 = load i64, i64* @rb_cObject, align 8, !dbg !44
-  %25 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 %24) #11, !dbg !44
+  %25 = call i64 @rb_define_class(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 45), i64 %24) #11, !dbg !44
   %26 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %25) #11, !dbg !44
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
   %27 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
@@ -320,7 +314,7 @@ entry:
   store i16 %39, i16* %37, align 8, !dbg !48
   %40 = getelementptr inbounds i8, i8* %36, i64 4, !dbg !48
   call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %40, i8 0, i64 28, i1 false) #11, !dbg !48
-  call void @sorbet_vm_define_method(i64 %24, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#3foo", i8* nonnull %36, %struct.rb_iseq_struct* %stackFrame21.i, i1 noundef zeroext false) #11, !dbg !48
+  call void @sorbet_vm_define_method(i64 %24, i8* noundef getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#3foo", i8* nonnull %36, %struct.rb_iseq_struct* %stackFrame21.i, i1 noundef zeroext false) #11, !dbg !48
   store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %23, align 8, !dbg !48, !tbaa !14
   %41 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 1, !dbg !26
   %42 = load i64*, i64** %41, align 8, !dbg !26
@@ -339,7 +333,7 @@ declare void @llvm.assume(i1 noundef) #7
 
 ; Function Attrs: ssp
 define linkonce void @const_recompute_A() local_unnamed_addr #8 {
-  %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 1)
+  %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 45), i64 1)
   store i64 %1, i64* @guarded_const_A, align 8
   %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !20
   store i64 %2, i64* @guard_epoch_A, align 8

--- a/test/testdata/compiler/custom_plus.opt.ll.exp
+++ b/test/testdata/compiler/custom_plus.opt.ll.exp
@@ -83,46 +83,32 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_Object#8delegate" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @rubyIdPrecomputed_delegate = internal unnamed_addr global i64 0, align 8
-@str_delegate = private unnamed_addr constant [9 x i8] c"delegate\00", align 1
 @rubyStrFrozen_delegate = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/custom_plus.rb" = internal unnamed_addr global i64 0, align 8
-@"str_test/testdata/compiler/custom_plus.rb" = private unnamed_addr constant [38 x i8] c"test/testdata/compiler/custom_plus.rb\00", align 1
 @iseqEncodedArray = internal global [23 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @"ic_+" = internal global %struct.FunctionInlineCache zeroinitializer
 @"rubyIdPrecomputed_+" = internal unnamed_addr global i64 0, align 8
-@"str_+" = private unnamed_addr constant [2 x i8] c"+\00", align 1
 @"ic_==" = internal global %struct.FunctionInlineCache zeroinitializer
 @"rubyIdPrecomputed_==" = internal unnamed_addr global i64 0, align 8
-@"str_==" = private unnamed_addr constant [3 x i8] c"==\00", align 1
 @rubyStrFrozen_ok = internal unnamed_addr global i64 0, align 8
-@str_ok = private unnamed_addr constant [3 x i8] c"ok\00", align 1
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
-@str_puts = private unnamed_addr constant [5 x i8] c"puts\00", align 1
 @rubyStrFrozen_fail = internal unnamed_addr global i64 0, align 8
-@str_fail = private unnamed_addr constant [5 x i8] c"fail\00", align 1
 @ic_puts.1 = internal global %struct.FunctionInlineCache zeroinitializer
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
-@str_A = private unnamed_addr constant [2 x i8] c"A\00", align 1
 @ic_new = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_new = internal unnamed_addr global i64 0, align 8
-@str_new = private unnamed_addr constant [4 x i8] c"new\00", align 1
 @ic_initialize = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_initialize = internal unnamed_addr global i64 0, align 8
-@str_initialize = private unnamed_addr constant [11 x i8] c"initialize\00", align 1
-@str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
 @rubyIdPrecomputed_a = internal unnamed_addr global i64 0, align 8
-@str_a = private unnamed_addr constant [2 x i8] c"a\00", align 1
 @ic_delegate = internal global %struct.FunctionInlineCache zeroinitializer
 @"stackFramePrecomputed_func_A#1+" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"stackFramePrecomputed_func_A.13<static-init>" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<class:A>" = internal unnamed_addr global i64 0, align 8
-@"str_<class:A>" = private unnamed_addr constant [10 x i8] c"<class:A>\00", align 1
 @rubyIdPrecomputed_b = internal unnamed_addr global i64 0, align 8
-@str_b = private unnamed_addr constant [2 x i8] c"b\00", align 1
+@sorbet_moduleStringTable = internal unnamed_addr constant [134 x i8] c"delegate\00test/testdata/compiler/custom_plus.rb\00+\00==\00ok\00puts\00fail\00<top (required)>\00A\00Object\00new\00initialize\00normal\00a\00master\00<class:A>\00b\00", align 1
 @rb_cObject = external local_unnamed_addr constant i64
 @guard_epoch_A = linkonce local_unnamed_addr global i64 0
 @guarded_const_A = linkonce local_unnamed_addr global i64 0
@@ -253,7 +239,7 @@ functionEntryInitializers:
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
   store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %8, align 8, !dbg !32, !tbaa !14
   %9 = load i64, i64* @rb_cObject, align 8, !dbg !33
-  %10 = tail call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 %9) #11, !dbg !33
+  %10 = tail call i64 @rb_define_class(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 82), i64 %9) #11, !dbg !33
   %11 = tail call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %10) #11, !dbg !33
   %12 = bitcast i64* %positional_table.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %12)
@@ -308,7 +294,7 @@ functionEntryInitializers:
   %40 = getelementptr inbounds i8, i8* %29, i64 32, !dbg !22
   %41 = bitcast i8* %40 to i8**, !dbg !22
   store i8* %39, i8** %41, align 8, !dbg !22, !tbaa !42
-  tail call void @sorbet_vm_define_method(i64 %26, i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_+", i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_A#1+", i8* nonnull %29, %struct.rb_iseq_struct* %stackFrame7.i, i1 noundef zeroext false) #11, !dbg !22
+  tail call void @sorbet_vm_define_method(i64 %26, i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 47), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_A#1+", i8* nonnull %29, %struct.rb_iseq_struct* %stackFrame7.i, i1 noundef zeroext false) #11, !dbg !22
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %12)
   tail call void @sorbet_popFrame() #11, !dbg !33
   store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %8, align 8, !dbg !33, !tbaa !14
@@ -362,7 +348,7 @@ afterNew:                                         ; preds = %fastNew, %slowNew
   %65 = getelementptr inbounds i8, i8* %52, i64 32, !dbg !44
   %66 = bitcast i8* %65 to i8**, !dbg !44
   store i8* %63, i8** %66, align 8, !dbg !44, !tbaa !42
-  tail call void @sorbet_vm_define_method(i64 %9, i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_delegate, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#8delegate", i8* nonnull %52, %struct.rb_iseq_struct* %stackFrame28, i1 noundef zeroext false) #11, !dbg !44
+  tail call void @sorbet_vm_define_method(i64 %9, i8* noundef getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#8delegate", i8* nonnull %52, %struct.rb_iseq_struct* %stackFrame28, i1 noundef zeroext false) #11, !dbg !44
   store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %8, align 8, !dbg !44, !tbaa !14
   %67 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !45
   %68 = load i64*, i64** %67, align 8, !dbg !45
@@ -383,31 +369,31 @@ entry:
   %locals.i12.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_delegate, i64 0, i64 0), i64 noundef 8) #11
+  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 8) #11
   store i64 %0, i64* @rubyIdPrecomputed_delegate, align 8
-  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_+", i64 0, i64 0), i64 noundef 1) #11
+  %1 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 47), i64 noundef 1) #11
   store i64 %1, i64* @"rubyIdPrecomputed_+", align 8
-  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @"str_==", i64 0, i64 0), i64 noundef 2) #11
+  %2 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 49), i64 noundef 2) #11
   store i64 %2, i64* @"rubyIdPrecomputed_==", align 8
-  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #11
+  %3 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 55), i64 noundef 4) #11
   store i64 %3, i64* @rubyIdPrecomputed_puts, align 8
-  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
+  %4 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 65), i64 noundef 16) #11
   store i64 %4, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_new, i64 0, i64 0), i64 noundef 3) #11
+  %5 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 91), i64 noundef 3) #11
   store i64 %5, i64* @rubyIdPrecomputed_new, align 8
-  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 noundef 10) #11
+  %6 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 95), i64 noundef 10) #11
   store i64 %6, i64* @rubyIdPrecomputed_initialize, align 8
-  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #11
-  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_a, i64 0, i64 0), i64 noundef 1) #11
+  %7 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 106), i64 noundef 6) #11
+  %8 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 113), i64 noundef 1) #11
   store i64 %8, i64* @rubyIdPrecomputed_a, align 8
-  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #11
+  %9 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 122), i64 noundef 9) #11
   store i64 %9, i64* @"rubyIdPrecomputed_<class:A>", align 8
-  %10 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_b, i64 0, i64 0), i64 noundef 1) #11
+  %10 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 132), i64 noundef 1) #11
   store i64 %10, i64* @rubyIdPrecomputed_b, align 8
-  %11 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_delegate, i64 0, i64 0), i64 noundef 8) #11
+  %11 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 8) #11
   tail call void @rb_gc_register_mark_object(i64 %11) #11
   store i64 %11, i64* @rubyStrFrozen_delegate, align 8
-  %12 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([38 x i8], [38 x i8]* @"str_test/testdata/compiler/custom_plus.rb", i64 0, i64 0), i64 noundef 37) #11
+  %12 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 9), i64 noundef 37) #11
   tail call void @rb_gc_register_mark_object(i64 %12) #11
   store i64 %12, i64* @"rubyStrFrozen_test/testdata/compiler/custom_plus.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 23)
@@ -420,17 +406,17 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_+", i64 %"rubyId_+.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
   %"rubyId_==.i" = load i64, i64* @"rubyIdPrecomputed_==", align 8, !dbg !19
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_==", i64 %"rubyId_==.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
-  %14 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_ok, i64 0, i64 0), i64 noundef 2) #11
+  %14 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 52), i64 noundef 2) #11
   call void @rb_gc_register_mark_object(i64 %14) #11
   store i64 %14, i64* @rubyStrFrozen_ok, align 8
   %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !46
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !46
-  %15 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_fail, i64 0, i64 0), i64 noundef 4) #11
+  %15 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 60), i64 noundef 4) #11
   call void @rb_gc_register_mark_object(i64 %15) #11
   store i64 %15, i64* @rubyStrFrozen_fail, align 8
   %rubyId_puts3.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !47
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts3.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !47
-  %16 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
+  %16 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 65), i64 noundef 16) #11
   call void @rb_gc_register_mark_object(i64 %16) #11
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/custom_plus.rb.i11.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/custom_plus.rb", align 8
@@ -442,13 +428,13 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 %rubyId_initialize.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !43
   %rubyId_delegate.i = load i64, i64* @rubyIdPrecomputed_delegate, align 8, !dbg !45
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_delegate, i64 %rubyId_delegate.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !45
-  %18 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_+", i64 0, i64 0), i64 noundef 1) #11
+  %18 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 47), i64 noundef 1) #11
   call void @rb_gc_register_mark_object(i64 %18) #11
   %"rubyId_+.i.i" = load i64, i64* @"rubyIdPrecomputed_+", align 8
   %"rubyStr_test/testdata/compiler/custom_plus.rb.i13.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/custom_plus.rb", align 8
   %19 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %18, i64 %"rubyId_+.i.i", i64 %"rubyStr_test/testdata/compiler/custom_plus.rb.i13.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 7, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i14.i, i32 noundef 0, i32 noundef 0)
   store %struct.rb_iseq_struct* %19, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#1+", align 8
-  %20 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #11
+  %20 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 122), i64 noundef 9) #11
   call void @rb_gc_register_mark_object(i64 %20) #11
   %"rubyId_<class:A>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:A>", align 8
   %"rubyStr_test/testdata/compiler/custom_plus.rb.i15.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/custom_plus.rb", align 8
@@ -491,7 +477,7 @@ declare void @llvm.assume(i1 noundef) #8
 
 ; Function Attrs: ssp
 define linkonce void @const_recompute_A() local_unnamed_addr #6 {
-  %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 1)
+  %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 82), i64 1)
   store i64 %1, i64* @guarded_const_A, align 8
   %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !35
   store i64 %2, i64* @guard_epoch_A, align 8

--- a/test/testdata/compiler/direct_call.opt.ll.exp
+++ b/test/testdata/compiler/direct_call.opt.ll.exp
@@ -82,24 +82,19 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_Object#3foo" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @rubyIdPrecomputed_foo = internal unnamed_addr global i64 0, align 8
-@str_foo = private unnamed_addr constant [4 x i8] c"foo\00", align 1
 @rubyStrFrozen_foo = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/direct_call.rb" = internal unnamed_addr global i64 0, align 8
-@"str_test/testdata/compiler/direct_call.rb" = private unnamed_addr constant [38 x i8] c"test/testdata/compiler/direct_call.rb\00", align 1
 @iseqEncodedArray = internal global [13 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @"stackFramePrecomputed_func_Object#3bar" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @rubyIdPrecomputed_bar = internal unnamed_addr global i64 0, align 8
-@str_bar = private unnamed_addr constant [4 x i8] c"bar\00", align 1
 @ic_foo = internal global %struct.FunctionInlineCache zeroinitializer
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
-@str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
 @ic_bar = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
-@str_puts = private unnamed_addr constant [5 x i8] c"puts\00", align 1
+@sorbet_moduleStringTable = internal unnamed_addr constant [89 x i8] c"foo\00test/testdata/compiler/direct_call.rb\00bar\00<top (required)>\00normal\00Object\00puts\00master\00", align 1
 @rb_cObject = external local_unnamed_addr constant i64
 
 ; Function Attrs: noreturn
@@ -192,19 +187,19 @@ entry:
   %locals.i6.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #9
+  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([89 x i8], [89 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 3) #9
   store i64 %0, i64* @rubyIdPrecomputed_foo, align 8
-  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_bar, i64 0, i64 0), i64 noundef 3) #9
+  %1 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([89 x i8], [89 x i8]* @sorbet_moduleStringTable, i64 0, i64 42), i64 noundef 3) #9
   store i64 %1, i64* @rubyIdPrecomputed_bar, align 8
-  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #9
+  %2 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([89 x i8], [89 x i8]* @sorbet_moduleStringTable, i64 0, i64 46), i64 noundef 16) #9
   store i64 %2, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #9
-  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #9
+  %3 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([89 x i8], [89 x i8]* @sorbet_moduleStringTable, i64 0, i64 63), i64 noundef 6) #9
+  %4 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([89 x i8], [89 x i8]* @sorbet_moduleStringTable, i64 0, i64 77), i64 noundef 4) #9
   store i64 %4, i64* @rubyIdPrecomputed_puts, align 8
-  %5 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #9
+  %5 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([89 x i8], [89 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 3) #9
   tail call void @rb_gc_register_mark_object(i64 %5) #9
   store i64 %5, i64* @rubyStrFrozen_foo, align 8
-  %6 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([38 x i8], [38 x i8]* @"str_test/testdata/compiler/direct_call.rb", i64 0, i64 0), i64 noundef 37) #9
+  %6 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([89 x i8], [89 x i8]* @sorbet_moduleStringTable, i64 0, i64 4), i64 noundef 37) #9
   tail call void @rb_gc_register_mark_object(i64 %6) #9
   store i64 %6, i64* @"rubyStrFrozen_test/testdata/compiler/direct_call.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 13)
@@ -213,7 +208,7 @@ entry:
   %"rubyStr_test/testdata/compiler/direct_call.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/direct_call.rb", align 8
   %7 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_foo.i.i, i64 %rubyId_foo.i.i, i64 %"rubyStr_test/testdata/compiler/direct_call.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 0)
   store %struct.rb_iseq_struct* %7, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8
-  %8 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_bar, i64 0, i64 0), i64 noundef 3) #9
+  %8 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([89 x i8], [89 x i8]* @sorbet_moduleStringTable, i64 0, i64 42), i64 noundef 3) #9
   call void @rb_gc_register_mark_object(i64 %8) #9
   %rubyId_bar.i.i = load i64, i64* @rubyIdPrecomputed_bar, align 8
   %"rubyStr_test/testdata/compiler/direct_call.rb.i5.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/direct_call.rb", align 8
@@ -221,7 +216,7 @@ entry:
   store %struct.rb_iseq_struct* %9, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3bar", align 8
   %rubyId_foo.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !22
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !22
-  %10 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #9
+  %10 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([89 x i8], [89 x i8]* @sorbet_moduleStringTable, i64 0, i64 46), i64 noundef 16) #9
   call void @rb_gc_register_mark_object(i64 %10) #9
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/direct_call.rb.i7.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/direct_call.rb", align 8
@@ -257,7 +252,7 @@ entry:
   store i16 %28, i16* %26, align 8, !dbg !43
   %29 = getelementptr inbounds i8, i8* %25, i64 4, !dbg !43
   call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %29, i8 0, i64 28, i1 false) #9, !dbg !43
-  call void @sorbet_vm_define_method(i64 %24, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#3foo", i8* nonnull %25, %struct.rb_iseq_struct* %stackFrame21.i, i1 noundef zeroext false) #9, !dbg !43
+  call void @sorbet_vm_define_method(i64 %24, i8* noundef getelementptr inbounds ([89 x i8], [89 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#3foo", i8* nonnull %25, %struct.rb_iseq_struct* %stackFrame21.i, i1 noundef zeroext false) #9, !dbg !43
   store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %23, align 8, !dbg !43, !tbaa !14
   %stackFrame30.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3bar", align 8, !dbg !44
   %30 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #10, !dbg !44
@@ -267,7 +262,7 @@ entry:
   store i16 %33, i16* %31, align 8, !dbg !44
   %34 = getelementptr inbounds i8, i8* %30, i64 4, !dbg !44
   call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %34, i8 0, i64 28, i1 false) #9, !dbg !44
-  call void @sorbet_vm_define_method(i64 %24, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_bar, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#3bar", i8* nonnull %30, %struct.rb_iseq_struct* %stackFrame30.i, i1 noundef zeroext false) #9, !dbg !44
+  call void @sorbet_vm_define_method(i64 %24, i8* getelementptr inbounds ([89 x i8], [89 x i8]* @sorbet_moduleStringTable, i64 0, i64 42), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#3bar", i8* nonnull %30, %struct.rb_iseq_struct* %stackFrame30.i, i1 noundef zeroext false) #9, !dbg !44
   store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %23, align 8, !dbg !44, !tbaa !14
   %35 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 1, !dbg !23
   %36 = load i64*, i64** %35, align 8, !dbg !23

--- a/test/testdata/compiler/exceptions/basic.opt.ll.exp
+++ b/test/testdata/compiler/exceptions/basic.opt.ll.exp
@@ -84,66 +84,45 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
 @"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/exceptions/basic.rb" = internal unnamed_addr global i64 0, align 8
-@"str_test/testdata/compiler/exceptions/basic.rb" = private unnamed_addr constant [43 x i8] c"test/testdata/compiler/exceptions/basic.rb\00", align 1
 @iseqEncodedArray = internal global [28 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
-@str_A = private unnamed_addr constant [2 x i8] c"A\00", align 1
 @"rubyStrFrozen_=== no-raise ===" = internal unnamed_addr global i64 0, align 8
-@"str_=== no-raise ===" = private unnamed_addr constant [17 x i8] c"=== no-raise ===\00", align 1
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
-@str_puts = private unnamed_addr constant [5 x i8] c"puts\00", align 1
 @ic_test = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_test = internal unnamed_addr global i64 0, align 8
-@str_test = private unnamed_addr constant [5 x i8] c"test\00", align 1
 @"rubyStrFrozen_=== raise ===" = internal unnamed_addr global i64 0, align 8
-@"str_=== raise ===" = private unnamed_addr constant [14 x i8] c"=== raise ===\00", align 1
 @ic_puts.1 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_test.2 = internal global %struct.FunctionInlineCache zeroinitializer
 @stackFramePrecomputed_func_A.4test = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<exceptionValue>" = internal unnamed_addr global i64 0, align 8
-@"str_<exceptionValue>" = private unnamed_addr constant [17 x i8] c"<exceptionValue>\00", align 1
 @rubyIdPrecomputed_x = internal unnamed_addr global i64 0, align 8
-@str_x = private unnamed_addr constant [2 x i8] c"x\00", align 1
 @"rubyIdPrecomputed_<returnMethodTemp>" = internal unnamed_addr global i64 0, align 8
-@"str_<returnMethodTemp>" = private unnamed_addr constant [19 x i8] c"<returnMethodTemp>\00", align 1
 @"rubyIdPrecomputed_<magic>" = internal unnamed_addr global i64 0, align 8
-@"str_<magic>" = private unnamed_addr constant [8 x i8] c"<magic>\00", align 1
 @"rubyIdPrecomputed_<gotoDeadTemp>" = internal unnamed_addr global i64 0, align 8
-@"str_<gotoDeadTemp>" = private unnamed_addr constant [15 x i8] c"<gotoDeadTemp>\00", align 1
 @"stackFramePrecomputed_func_A.4test$block_2" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_rescue in test" = internal unnamed_addr global i64 0, align 8
-@"str_rescue in test" = private unnamed_addr constant [15 x i8] c"rescue in test\00", align 1
 @"stackFramePrecomputed_func_A.4test$block_3" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_ensure in test" = internal unnamed_addr global i64 0, align 8
-@"str_ensure in test" = private unnamed_addr constant [15 x i8] c"ensure in test\00", align 1
 @"<retry-singleton>" = internal unnamed_addr global i64 0
 @rubyStrFrozen_begin = internal unnamed_addr global i64 0, align 8
-@str_begin = private unnamed_addr constant [6 x i8] c"begin\00", align 1
 @ic_puts.3 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.4 = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyStrFrozen_foo = internal unnamed_addr global i64 0, align 8
-@str_foo = private unnamed_addr constant [4 x i8] c"foo\00", align 1
 @ic_raise = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_raise = internal unnamed_addr global i64 0, align 8
-@str_raise = private unnamed_addr constant [6 x i8] c"raise\00", align 1
 @"ic_is_a?" = internal global %struct.FunctionInlineCache zeroinitializer
 @"rubyIdPrecomputed_is_a?" = internal unnamed_addr global i64 0, align 8
-@"str_is_a?" = private unnamed_addr constant [6 x i8] c"is_a?\00", align 1
 @ic_puts.5 = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyStrFrozen_else = internal unnamed_addr global i64 0, align 8
-@str_else = private unnamed_addr constant [5 x i8] c"else\00", align 1
 @ic_puts.6 = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyStrFrozen_ensure = internal unnamed_addr global i64 0, align 8
-@str_ensure = private unnamed_addr constant [7 x i8] c"ensure\00", align 1
 @ic_puts.7 = internal global %struct.FunctionInlineCache zeroinitializer
 @"stackFramePrecomputed_func_A.13<static-init>" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<class:A>" = internal unnamed_addr global i64 0, align 8
-@"str_<class:A>" = private unnamed_addr constant [10 x i8] c"<class:A>\00", align 1
-@str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
+@sorbet_moduleStringTable = internal unnamed_addr constant [273 x i8] c"<top (required)>\00test/testdata/compiler/exceptions/basic.rb\00A\00Object\00=== no-raise ===\00puts\00test\00=== raise ===\00master\00<exceptionValue>\00x\00<returnMethodTemp>\00<magic>\00<gotoDeadTemp>\00rescue in test\00ensure in test\00begin\00foo\00raise\00StandardError\00is_a?\00else\00ensure\00<class:A>\00normal\00", align 1
 @rb_cObject = external local_unnamed_addr constant i64
 @guard_epoch_A = linkonce local_unnamed_addr global i64 0
 @guarded_const_A = linkonce local_unnamed_addr global i64 0
@@ -228,37 +207,37 @@ entry:
   %locals.i26.i = alloca i64, i32 5, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
+  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #11
   store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #11
+  %1 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 86), i64 noundef 4) #11
   store i64 %1, i64* @rubyIdPrecomputed_puts, align 8
-  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_test, i64 0, i64 0), i64 noundef 4) #11
+  %2 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 91), i64 noundef 4) #11
   store i64 %2, i64* @rubyIdPrecomputed_test, align 8
-  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<exceptionValue>", i64 0, i64 0), i64 noundef 16) #11
+  %3 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 117), i64 noundef 16) #11
   store i64 %3, i64* @"rubyIdPrecomputed_<exceptionValue>", align 8
-  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_x, i64 0, i64 0), i64 noundef 1) #11
+  %4 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 134), i64 noundef 1) #11
   store i64 %4, i64* @rubyIdPrecomputed_x, align 8
-  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([19 x i8], [19 x i8]* @"str_<returnMethodTemp>", i64 0, i64 0), i64 noundef 18) #11
+  %5 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 136), i64 noundef 18) #11
   store i64 %5, i64* @"rubyIdPrecomputed_<returnMethodTemp>", align 8
-  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @"str_<magic>", i64 0, i64 0), i64 noundef 7) #11
+  %6 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 155), i64 noundef 7) #11
   store i64 %6, i64* @"rubyIdPrecomputed_<magic>", align 8
-  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @"str_<gotoDeadTemp>", i64 0, i64 0), i64 noundef 14) #11
+  %7 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 163), i64 noundef 14) #11
   store i64 %7, i64* @"rubyIdPrecomputed_<gotoDeadTemp>", align 8
-  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @"str_rescue in test", i64 0, i64 0), i64 noundef 14) #11
+  %8 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 178), i64 noundef 14) #11
   store i64 %8, i64* @"rubyIdPrecomputed_rescue in test", align 8
-  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @"str_ensure in test", i64 0, i64 0), i64 noundef 14) #11
+  %9 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 193), i64 noundef 14) #11
   store i64 %9, i64* @"rubyIdPrecomputed_ensure in test", align 8
-  %10 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_raise, i64 0, i64 0), i64 noundef 5) #11
+  %10 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 218), i64 noundef 5) #11
   store i64 %10, i64* @rubyIdPrecomputed_raise, align 8
-  %11 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @"str_is_a?", i64 0, i64 0), i64 noundef 5) #11
+  %11 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 238), i64 noundef 5) #11
   store i64 %11, i64* @"rubyIdPrecomputed_is_a?", align 8
-  %12 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #11
+  %12 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 256), i64 noundef 9) #11
   store i64 %12, i64* @"rubyIdPrecomputed_<class:A>", align 8
-  %13 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #11
-  %14 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
+  %13 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 266), i64 noundef 6) #11
+  %14 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #11
   tail call void @rb_gc_register_mark_object(i64 %14) #11
   store i64 %14, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %15 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([43 x i8], [43 x i8]* @"str_test/testdata/compiler/exceptions/basic.rb", i64 0, i64 0), i64 noundef 42) #11
+  %15 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 42) #11
   tail call void @rb_gc_register_mark_object(i64 %15) #11
   store i64 %15, i64* @"rubyStrFrozen_test/testdata/compiler/exceptions/basic.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 28)
@@ -267,21 +246,21 @@ entry:
   %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/exceptions/basic.rb", align 8
   %16 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %16, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %17 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_=== no-raise ===", i64 0, i64 0), i64 noundef 16) #11
+  %17 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 69), i64 noundef 16) #11
   call void @rb_gc_register_mark_object(i64 %17) #11
   store i64 %17, i64* @"rubyStrFrozen_=== no-raise ===", align 8
   %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !17
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !17
   %rubyId_test.i = load i64, i64* @rubyIdPrecomputed_test, align 8, !dbg !18
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test, i64 %rubyId_test.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !18
-  %18 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_=== raise ===", i64 0, i64 0), i64 noundef 13) #11
+  %18 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 96), i64 noundef 13) #11
   call void @rb_gc_register_mark_object(i64 %18) #11
   store i64 %18, i64* @"rubyStrFrozen_=== raise ===", align 8
   %rubyId_puts2.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !19
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts2.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
   %rubyId_test5.i = load i64, i64* @rubyIdPrecomputed_test, align 8, !dbg !20
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test.2, i64 %rubyId_test5.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !20
-  %19 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_test, i64 0, i64 0), i64 noundef 4) #11
+  %19 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 91), i64 noundef 4) #11
   call void @rb_gc_register_mark_object(i64 %19) #11
   %20 = bitcast i64* %locals.i26.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 40, i8* nonnull %20)
@@ -304,14 +283,14 @@ entry:
   %25 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %19, i64 %rubyId_test.i.i, i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i25.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i26.i, i32 noundef 5, i32 noundef 2)
   store %struct.rb_iseq_struct* %25, %struct.rb_iseq_struct** @stackFramePrecomputed_func_A.4test, align 8
   call void @llvm.lifetime.end.p0i8(i64 40, i8* nonnull %20)
-  %26 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @"str_rescue in test", i64 0, i64 0), i64 noundef 14) #11
+  %26 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 178), i64 noundef 14) #11
   call void @rb_gc_register_mark_object(i64 %26) #11
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_A.4test, align 8
   %"rubyId_rescue in test.i.i" = load i64, i64* @"rubyIdPrecomputed_rescue in test", align 8
   %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i27.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/exceptions/basic.rb", align 8
   %27 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %26, i64 %"rubyId_rescue in test.i.i", i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i27.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 4, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %27, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.4test$block_2", align 8
-  %28 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @"str_ensure in test", i64 0, i64 0), i64 noundef 14) #11
+  %28 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 193), i64 noundef 14) #11
   call void @rb_gc_register_mark_object(i64 %28) #11
   %stackFrame.i28.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_A.4test, align 8
   %"rubyId_ensure in test.i.i" = load i64, i64* @"rubyIdPrecomputed_ensure in test", align 8
@@ -320,14 +299,14 @@ entry:
   store %struct.rb_iseq_struct* %29, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.4test$block_3", align 8
   %30 = call i64 @sorbet_getConstant(i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @sorbet_getTRetry.retry, i64 0, i64 0), i64 noundef 25) #11
   store i64 %30, i64* @"<retry-singleton>", align 8
-  %31 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_begin, i64 0, i64 0), i64 noundef 5) #11
+  %31 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 208), i64 noundef 5) #11
   call void @rb_gc_register_mark_object(i64 %31) #11
   store i64 %31, i64* @rubyStrFrozen_begin, align 8
   %rubyId_puts7.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !21
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts7.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !21
   %rubyId_puts10.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !24
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.4, i64 %rubyId_puts10.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !24
-  %32 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #11
+  %32 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 214), i64 noundef 3) #11
   call void @rb_gc_register_mark_object(i64 %32) #11
   store i64 %32, i64* @rubyStrFrozen_foo, align 8
   %rubyId_raise.i = load i64, i64* @rubyIdPrecomputed_raise, align 8, !dbg !25
@@ -336,17 +315,17 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_is_a?", i64 %"rubyId_is_a?.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !26
   %rubyId_puts16.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !28
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.5, i64 %rubyId_puts16.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !28
-  %33 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_else, i64 0, i64 0), i64 noundef 4) #11
+  %33 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 244), i64 noundef 4) #11
   call void @rb_gc_register_mark_object(i64 %33) #11
   store i64 %33, i64* @rubyStrFrozen_else, align 8
   %rubyId_puts19.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !29
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.6, i64 %rubyId_puts19.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !29
-  %34 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_ensure, i64 0, i64 0), i64 noundef 6) #11
+  %34 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 249), i64 noundef 6) #11
   call void @rb_gc_register_mark_object(i64 %34) #11
   store i64 %34, i64* @rubyStrFrozen_ensure, align 8
   %rubyId_puts22.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !31
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.7, i64 %rubyId_puts22.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !31
-  %35 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #11
+  %35 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 256), i64 noundef 9) #11
   call void @rb_gc_register_mark_object(i64 %35) #11
   %"rubyId_<class:A>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:A>", align 8
   %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i30.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/exceptions/basic.rb", align 8
@@ -370,7 +349,7 @@ entry:
   %48 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %42, i64 0, i32 0
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %48, align 8, !dbg !51, !tbaa !33
   %49 = load i64, i64* @rb_cObject, align 8, !dbg !52
-  %50 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 %49) #11, !dbg !52
+  %50 = call i64 @rb_define_class(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 60), i64 %49) #11, !dbg !52
   %51 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %50) #11, !dbg !52
   %52 = bitcast i64* %positional_table.i.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %52) #11
@@ -425,7 +404,7 @@ entry:
   %80 = getelementptr inbounds i8, i8* %69, i64 32, !dbg !10
   %81 = bitcast i8* %80 to i8**, !dbg !10
   store i8* %79, i8** %81, align 8, !dbg !10, !tbaa !60
-  call void @sorbet_vm_define_method(i64 %66, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_test, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_A.4test, i8* nonnull %69, %struct.rb_iseq_struct* %stackFrame7.i.i, i1 noundef zeroext true) #11, !dbg !10
+  call void @sorbet_vm_define_method(i64 %66, i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 91), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_A.4test, i8* nonnull %69, %struct.rb_iseq_struct* %stackFrame7.i.i, i1 noundef zeroext true) #11, !dbg !10
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %52) #11
   call void @sorbet_popFrame() #11, !dbg !52
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %48, align 8, !dbg !52, !tbaa !33
@@ -789,7 +768,7 @@ declare void @llvm.assume(i1 noundef) #9
 
 ; Function Attrs: ssp
 define linkonce void @const_recompute_A() local_unnamed_addr #7 {
-  %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 1)
+  %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 60), i64 1)
   store i64 %1, i64* @guarded_const_A, align 8
   %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !54
   store i64 %2, i64* @guard_epoch_A, align 8

--- a/test/testdata/compiler/float-intrinsics.opt.ll.exp
+++ b/test/testdata/compiler/float-intrinsics.opt.ll.exp
@@ -84,58 +84,36 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_Object#4plus" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @rubyIdPrecomputed_plus = internal unnamed_addr global i64 0, align 8
-@str_plus = private unnamed_addr constant [5 x i8] c"plus\00", align 1
 @rubyStrFrozen_plus = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb" = internal unnamed_addr global i64 0, align 8
-@"str_test/testdata/compiler/float-intrinsics.rb" = private unnamed_addr constant [43 x i8] c"test/testdata/compiler/float-intrinsics.rb\00", align 1
 @iseqEncodedArray = internal global [49 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
-@"str_Parameter 'x'" = private unnamed_addr constant [14 x i8] c"Parameter 'x'\00", align 1
-@str_Float = private unnamed_addr constant [6 x i8] c"Float\00", align 1
-@"str_+" = private unnamed_addr constant [2 x i8] c"+\00", align 1
-@"str_Return value" = private unnamed_addr constant [13 x i8] c"Return value\00", align 1
 @"stackFramePrecomputed_func_Object#5minus" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @rubyIdPrecomputed_minus = internal unnamed_addr global i64 0, align 8
-@str_minus = private unnamed_addr constant [6 x i8] c"minus\00", align 1
 @ic_- = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_- = internal unnamed_addr global i64 0, align 8
-@str_- = private unnamed_addr constant [2 x i8] c"-\00", align 1
 @"stackFramePrecomputed_func_Object#2lt" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @rubyIdPrecomputed_lt = internal unnamed_addr global i64 0, align 8
-@str_lt = private unnamed_addr constant [3 x i8] c"lt\00", align 1
-@"str_<" = private unnamed_addr constant [2 x i8] c"<\00", align 1
-@"str_T::Boolean" = private unnamed_addr constant [11 x i8] c"T::Boolean\00", align 1
 @"stackFramePrecomputed_func_Object#3lte" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @rubyIdPrecomputed_lte = internal unnamed_addr global i64 0, align 8
-@str_lte = private unnamed_addr constant [4 x i8] c"lte\00", align 1
-@"str_<=" = private unnamed_addr constant [3 x i8] c"<=\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
 @"rubyIdPrecomputed_<block-call>" = internal unnamed_addr global i64 0, align 8
-@"str_<block-call>" = private unnamed_addr constant [13 x i8] c"<block-call>\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_block in <top (required)>" = internal unnamed_addr global i64 0, align 8
-@"str_block in <top (required)>" = private unnamed_addr constant [26 x i8] c"block in <top (required)>\00", align 1
 @"rubyStrFrozen_block in <top (required)>" = internal unnamed_addr global i64 0, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_2" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_3" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_4" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @rubyIdPrecomputed_x = internal unnamed_addr global i64 0, align 8
-@str_x = private unnamed_addr constant [2 x i8] c"x\00", align 1
 @rubyIdPrecomputed_y = internal unnamed_addr global i64 0, align 8
-@str_y = private unnamed_addr constant [2 x i8] c"y\00", align 1
 @ic_untyped = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_untyped = internal unnamed_addr global i64 0, align 8
-@str_untyped = private unnamed_addr constant [8 x i8] c"untyped\00", align 1
-@str_T = private unnamed_addr constant [2 x i8] c"T\00", align 1
 @ic_params = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_params = internal unnamed_addr global i64 0, align 8
-@str_params = private unnamed_addr constant [7 x i8] c"params\00", align 1
 @ic_untyped.1 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_returns = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_returns = internal unnamed_addr global i64 0, align 8
-@str_returns = private unnamed_addr constant [8 x i8] c"returns\00", align 1
 @ic_untyped.2 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_params.3 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_untyped.4 = internal global %struct.FunctionInlineCache zeroinitializer
@@ -146,15 +124,11 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ic_untyped.9 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_params.10 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_returns.11 = internal global %struct.FunctionInlineCache zeroinitializer
-@"str_T::Sig" = private unnamed_addr constant [7 x i8] c"T::Sig\00", align 1
 @ic_extend = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_extend = internal unnamed_addr global i64 0, align 8
-@str_extend = private unnamed_addr constant [7 x i8] c"extend\00", align 1
-@str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
 @ic_plus = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_p = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_p = internal unnamed_addr global i64 0, align 8
-@str_p = private unnamed_addr constant [2 x i8] c"p\00", align 1
 @ic_minus = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_p.12 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_lt = internal global %struct.FunctionInlineCache zeroinitializer
@@ -170,45 +144,38 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ic_plus.21 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_p.22 = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyStrFrozen_8.9 = internal unnamed_addr global i64 0, align 8
-@str_8.9 = private unnamed_addr constant [4 x i8] c"8.9\00", align 1
 @ic_Rational = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_Rational = internal unnamed_addr global i64 0, align 8
-@str_Rational = private unnamed_addr constant [9 x i8] c"Rational\00", align 1
 @ic_plus.23 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_p.24 = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyStrFrozen_5 = internal unnamed_addr global i64 0, align 8
-@str_5 = private unnamed_addr constant [2 x i8] c"5\00", align 1
 @ic_Complex = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_Complex = internal unnamed_addr global i64 0, align 8
-@str_Complex = private unnamed_addr constant [8 x i8] c"Complex\00", align 1
 @ic_plus.25 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_p.26 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_minus.27 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_p.28 = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyStrFrozen_15.4 = internal unnamed_addr global i64 0, align 8
-@str_15.4 = private unnamed_addr constant [5 x i8] c"15.4\00", align 1
 @ic_Rational.29 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_minus.30 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_p.31 = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyStrFrozen_18 = internal unnamed_addr global i64 0, align 8
-@str_18 = private unnamed_addr constant [3 x i8] c"18\00", align 1
 @ic_Complex.32 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_minus.33 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_p.34 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_lt.35 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_p.36 = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyStrFrozen_25.4 = internal unnamed_addr global i64 0, align 8
-@str_25.4 = private unnamed_addr constant [5 x i8] c"25.4\00", align 1
 @ic_Rational.37 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_lt.38 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_p.39 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_lte.40 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_p.41 = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyStrFrozen_5.923 = internal unnamed_addr global i64 0, align 8
-@str_5.923 = private unnamed_addr constant [6 x i8] c"5.923\00", align 1
 @ic_Rational.42 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_lte.43 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_p.44 = internal global %struct.FunctionInlineCache zeroinitializer
+@sorbet_moduleStringTable = internal unnamed_addr constant [309 x i8] c"plus\00test/testdata/compiler/float-intrinsics.rb\00Parameter 'x'\00Float\00Parameter 'y'\00T.untyped\00+\00Return value\00minus\00-\00lt\00<\00T::Boolean\00lte\00<=\00<top (required)>\00<block-call>\00block in <top (required)>\00x\00y\00untyped\00T\00params\00returns\00T::Sig\00extend\00normal\00Object\00p\008.9\00Rational\00Kernel\005\00Complex\0015.4\0018\0025.4\005.923\00master\00", align 1
 @guard_epoch_T = linkonce local_unnamed_addr global i64 0
 @guarded_const_T = linkonce local_unnamed_addr global i64 0
 @rb_cFloat = external local_unnamed_addr constant i64
@@ -880,48 +847,48 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %2)
   %3 = bitcast i64* %keywords38.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %3)
-  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_plus, i64 0, i64 0), i64 noundef 4) #17
+  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 4) #17
   store i64 %4, i64* @rubyIdPrecomputed_plus, align 8
-  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_+", i64 0, i64 0), i64 noundef 1) #17
-  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_minus, i64 0, i64 0), i64 noundef 5) #17
+  %5 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 92), i64 noundef 1) #17
+  %6 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 107), i64 noundef 5) #17
   store i64 %6, i64* @rubyIdPrecomputed_minus, align 8
-  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_-, i64 0, i64 0), i64 noundef 1) #17
+  %7 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 113), i64 noundef 1) #17
   store i64 %7, i64* @rubyIdPrecomputed_-, align 8
-  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_lt, i64 0, i64 0), i64 noundef 2) #17
+  %8 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 115), i64 noundef 2) #17
   store i64 %8, i64* @rubyIdPrecomputed_lt, align 8
-  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_<", i64 0, i64 0), i64 noundef 1) #17
-  %10 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_lte, i64 0, i64 0), i64 noundef 3) #17
+  %9 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 118), i64 noundef 1) #17
+  %10 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 131), i64 noundef 3) #17
   store i64 %10, i64* @rubyIdPrecomputed_lte, align 8
-  %11 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @"str_<=", i64 0, i64 0), i64 noundef 2) #17
-  %12 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #17
+  %11 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 135), i64 noundef 2) #17
+  %12 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 138), i64 noundef 16) #17
   store i64 %12, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %13 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @"str_<block-call>", i64 0, i64 0), i64 noundef 12) #17
+  %13 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 155), i64 noundef 12) #17
   store i64 %13, i64* @"rubyIdPrecomputed_<block-call>", align 8
-  %14 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #17
+  %14 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 168), i64 noundef 25) #17
   store i64 %14, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
-  %15 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_x, i64 0, i64 0), i64 noundef 1) #17
+  %15 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 194), i64 noundef 1) #17
   store i64 %15, i64* @rubyIdPrecomputed_x, align 8
-  %16 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_y, i64 0, i64 0), i64 noundef 1) #17
+  %16 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 196), i64 noundef 1) #17
   store i64 %16, i64* @rubyIdPrecomputed_y, align 8
-  %17 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_untyped, i64 0, i64 0), i64 noundef 7) #17
+  %17 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 198), i64 noundef 7) #17
   store i64 %17, i64* @rubyIdPrecomputed_untyped, align 8
-  %18 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_params, i64 0, i64 0), i64 noundef 6) #17
+  %18 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 208), i64 noundef 6) #17
   store i64 %18, i64* @rubyIdPrecomputed_params, align 8
-  %19 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_returns, i64 0, i64 0), i64 noundef 7) #17
+  %19 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 215), i64 noundef 7) #17
   store i64 %19, i64* @rubyIdPrecomputed_returns, align 8
-  %20 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_extend, i64 0, i64 0), i64 noundef 6) #17
+  %20 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 230), i64 noundef 6) #17
   store i64 %20, i64* @rubyIdPrecomputed_extend, align 8
-  %21 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #17
-  %22 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_p, i64 0, i64 0), i64 noundef 1) #17
+  %21 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 237), i64 noundef 6) #17
+  %22 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 251), i64 noundef 1) #17
   store i64 %22, i64* @rubyIdPrecomputed_p, align 8
-  %23 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([9 x i8], [9 x i8]* @str_Rational, i64 0, i64 0), i64 noundef 8) #17
+  %23 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 257), i64 noundef 8) #17
   store i64 %23, i64* @rubyIdPrecomputed_Rational, align 8
-  %24 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_Complex, i64 0, i64 0), i64 noundef 7) #17
+  %24 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 275), i64 noundef 7) #17
   store i64 %24, i64* @rubyIdPrecomputed_Complex, align 8
-  %25 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_plus, i64 0, i64 0), i64 noundef 4) #17
+  %25 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 4) #17
   tail call void @rb_gc_register_mark_object(i64 %25) #17
   store i64 %25, i64* @rubyStrFrozen_plus, align 8
-  %26 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([43 x i8], [43 x i8]* @"str_test/testdata/compiler/float-intrinsics.rb", i64 0, i64 0), i64 noundef 42) #17
+  %26 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 5), i64 noundef 42) #17
   tail call void @rb_gc_register_mark_object(i64 %26) #17
   store i64 %26, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 49)
@@ -930,7 +897,7 @@ entry:
   %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
   %27 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_plus.i.i, i64 %rubyId_plus.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %27, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#4plus", align 8
-  %28 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_minus, i64 0, i64 0), i64 noundef 5) #17
+  %28 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 107), i64 noundef 5) #17
   call void @rb_gc_register_mark_object(i64 %28) #17
   %rubyId_minus.i.i = load i64, i64* @rubyIdPrecomputed_minus, align 8
   %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i156.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
@@ -938,19 +905,19 @@ entry:
   store %struct.rb_iseq_struct* %29, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#5minus", align 8
   %rubyId_-.i = load i64, i64* @rubyIdPrecomputed_-, align 8, !dbg !37
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_-, i64 %rubyId_-.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !37
-  %30 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_lt, i64 0, i64 0), i64 noundef 2) #17
+  %30 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 115), i64 noundef 2) #17
   call void @rb_gc_register_mark_object(i64 %30) #17
   %rubyId_lt.i.i = load i64, i64* @rubyIdPrecomputed_lt, align 8
   %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i158.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
   %31 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %30, i64 %rubyId_lt.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i158.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 18, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i159.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %31, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#2lt", align 8
-  %32 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_lte, i64 0, i64 0), i64 noundef 3) #17
+  %32 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 131), i64 noundef 3) #17
   call void @rb_gc_register_mark_object(i64 %32) #17
   %rubyId_lte.i.i = load i64, i64* @rubyIdPrecomputed_lte, align 8
   %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i160.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
   %33 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %32, i64 %rubyId_lte.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i160.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 23, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i161.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %33, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3lte", align 8
-  %34 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #17
+  %34 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 138), i64 noundef 16) #17
   call void @rb_gc_register_mark_object(i64 %34) #17
   %35 = bitcast i64* %locals.i163.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %35)
@@ -961,7 +928,7 @@ entry:
   %36 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %34, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i162.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i163.i, i32 noundef 1, i32 noundef 4)
   store %struct.rb_iseq_struct* %36, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %35)
-  %37 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([26 x i8], [26 x i8]* @"str_block in <top (required)>", i64 0, i64 0), i64 noundef 25) #17
+  %37 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 168), i64 noundef 25) #17
   call void @rb_gc_register_mark_object(i64 %37) #17
   store i64 %37, i64* @"rubyStrFrozen_block in <top (required)>", align 8
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
@@ -1077,7 +1044,7 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus.21, i64 %rubyId_plus86.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !103
   %rubyId_p89.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !104
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.22, i64 %rubyId_p89.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !104
-  %54 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_8.9, i64 0, i64 0), i64 noundef 3) #17
+  %54 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 253), i64 noundef 3) #17
   call void @rb_gc_register_mark_object(i64 %54) #17
   store i64 %54, i64* @rubyStrFrozen_8.9, align 8
   %rubyId_Rational.i = load i64, i64* @rubyIdPrecomputed_Rational, align 8, !dbg !105
@@ -1086,7 +1053,7 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus.23, i64 %rubyId_plus93.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !106
   %rubyId_p96.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !107
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.24, i64 %rubyId_p96.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !107
-  %55 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_5, i64 0, i64 0), i64 noundef 1) #17
+  %55 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 273), i64 noundef 1) #17
   call void @rb_gc_register_mark_object(i64 %55) #17
   store i64 %55, i64* @rubyStrFrozen_5, align 8
   %rubyId_Complex.i = load i64, i64* @rubyIdPrecomputed_Complex, align 8, !dbg !108
@@ -1099,7 +1066,7 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus.27, i64 %rubyId_minus106.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !111
   %rubyId_p109.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !112
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.28, i64 %rubyId_p109.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !112
-  %56 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_15.4, i64 0, i64 0), i64 noundef 4) #17
+  %56 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 283), i64 noundef 4) #17
   call void @rb_gc_register_mark_object(i64 %56) #17
   store i64 %56, i64* @rubyStrFrozen_15.4, align 8
   %rubyId_Rational112.i = load i64, i64* @rubyIdPrecomputed_Rational, align 8, !dbg !113
@@ -1108,7 +1075,7 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus.30, i64 %rubyId_minus114.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !114
   %rubyId_p117.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !115
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.31, i64 %rubyId_p117.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !115
-  %57 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_18, i64 0, i64 0), i64 noundef 2) #17
+  %57 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 288), i64 noundef 2) #17
   call void @rb_gc_register_mark_object(i64 %57) #17
   store i64 %57, i64* @rubyStrFrozen_18, align 8
   %rubyId_Complex120.i = load i64, i64* @rubyIdPrecomputed_Complex, align 8, !dbg !116
@@ -1121,7 +1088,7 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt.35, i64 %rubyId_lt128.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !119
   %rubyId_p131.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !120
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.36, i64 %rubyId_p131.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !120
-  %58 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_25.4, i64 0, i64 0), i64 noundef 4) #17
+  %58 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 291), i64 noundef 4) #17
   call void @rb_gc_register_mark_object(i64 %58) #17
   store i64 %58, i64* @rubyStrFrozen_25.4, align 8
   %rubyId_Rational134.i = load i64, i64* @rubyIdPrecomputed_Rational, align 8, !dbg !121
@@ -1134,7 +1101,7 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.40, i64 %rubyId_lte142.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !124
   %rubyId_p145.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !125
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.41, i64 %rubyId_p145.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !125
-  %59 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_5.923, i64 0, i64 0), i64 noundef 5) #17
+  %59 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 296), i64 noundef 5) #17
   call void @rb_gc_register_mark_object(i64 %59) #17
   store i64 %59, i64* @rubyStrFrozen_5.923, align 8
   %rubyId_Rational148.i = load i64, i64* @rubyIdPrecomputed_Rational, align 8, !dbg !126
@@ -1238,7 +1205,7 @@ entry:
   %100 = getelementptr inbounds i8, i8* %88, i64 32, !dbg !84
   %101 = bitcast i8* %100 to i8**, !dbg !84
   store i8* %99, i8** %101, align 8, !dbg !84, !tbaa !146
-  call void @sorbet_vm_define_method(i64 %87, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_plus, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#4plus", i8* nonnull %88, %struct.rb_iseq_struct* %stackFrame308.i, i1 noundef zeroext false) #17, !dbg !84
+  call void @sorbet_vm_define_method(i64 %87, i8* noundef getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#4plus", i8* nonnull %88, %struct.rb_iseq_struct* %stackFrame308.i, i1 noundef zeroext false) #17, !dbg !84
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %75, align 8, !dbg !84, !tbaa !14
   %stackFrame318.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#5minus", align 8, !dbg !85
   %102 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #19, !dbg !85
@@ -1265,7 +1232,7 @@ entry:
   %114 = getelementptr inbounds i8, i8* %102, i64 32, !dbg !85
   %115 = bitcast i8* %114 to i8**, !dbg !85
   store i8* %113, i8** %115, align 8, !dbg !85, !tbaa !146
-  call void @sorbet_vm_define_method(i64 %87, i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_minus, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#5minus", i8* nonnull %102, %struct.rb_iseq_struct* %stackFrame318.i, i1 noundef zeroext false) #17, !dbg !85
+  call void @sorbet_vm_define_method(i64 %87, i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 107), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#5minus", i8* nonnull %102, %struct.rb_iseq_struct* %stackFrame318.i, i1 noundef zeroext false) #17, !dbg !85
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %75, align 8, !dbg !85, !tbaa !14
   %stackFrame332.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#2lt", align 8, !dbg !86
   %116 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #19, !dbg !86
@@ -1292,7 +1259,7 @@ entry:
   %128 = getelementptr inbounds i8, i8* %116, i64 32, !dbg !86
   %129 = bitcast i8* %128 to i8**, !dbg !86
   store i8* %127, i8** %129, align 8, !dbg !86, !tbaa !146
-  call void @sorbet_vm_define_method(i64 %87, i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_lt, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#2lt", i8* nonnull %116, %struct.rb_iseq_struct* %stackFrame332.i, i1 noundef zeroext false) #17, !dbg !86
+  call void @sorbet_vm_define_method(i64 %87, i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 115), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#2lt", i8* nonnull %116, %struct.rb_iseq_struct* %stackFrame332.i, i1 noundef zeroext false) #17, !dbg !86
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %75, align 8, !dbg !86, !tbaa !14
   %stackFrame346.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3lte", align 8, !dbg !87
   %130 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #19, !dbg !87
@@ -1319,7 +1286,7 @@ entry:
   %142 = getelementptr inbounds i8, i8* %130, i64 32, !dbg !87
   %143 = bitcast i8* %142 to i8**, !dbg !87
   store i8* %141, i8** %143, align 8, !dbg !87, !tbaa !146
-  call void @sorbet_vm_define_method(i64 %87, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_lte, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#3lte", i8* nonnull %130, %struct.rb_iseq_struct* %stackFrame346.i, i1 noundef zeroext false) #17, !dbg !87
+  call void @sorbet_vm_define_method(i64 %87, i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 131), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#3lte", i8* nonnull %130, %struct.rb_iseq_struct* %stackFrame346.i, i1 noundef zeroext false) #17, !dbg !87
   store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %75, align 8, !dbg !87, !tbaa !14
   %144 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !89
   %145 = load i64*, i64** %144, align 8, !dbg !89
@@ -1724,14 +1691,14 @@ declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
 define internal fastcc void @"func_Object#2lt.cold.1"(i64 %0) unnamed_addr #12 !dbg !147 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %0, i8* noundef getelementptr inbounds ([13 x i8], [13 x i8]* @"str_Return value", i64 0, i64 0), i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @"str_T::Boolean", i64 0, i64 0)) #15
+  tail call void @sorbet_cast_failure(i64 %0, i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 94), i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 120)) #15
   unreachable
 }
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
 define internal fastcc void @"func_Object#2lt.cold.3"(i64 %rawArg_x) unnamed_addr #12 !dbg !149 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %rawArg_x, i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_Parameter 'x'", i64 0, i64 0), i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_Float, i64 0, i64 0)) #15, !dbg !150
+  tail call void @sorbet_cast_failure(i64 %rawArg_x, i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 48), i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 62)) #15, !dbg !150
   unreachable, !dbg !150
 }
 
@@ -1740,7 +1707,7 @@ declare void @llvm.assume(i1 noundef) #13
 
 ; Function Attrs: ssp
 define linkonce void @const_recompute_T() local_unnamed_addr #8 {
-  %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @str_T, i64 0, i64 0), i64 1)
+  %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 206), i64 1)
   store i64 %1, i64* @guarded_const_T, align 8
   %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !65
   store i64 %2, i64* @guard_epoch_T, align 8
@@ -1749,7 +1716,7 @@ define linkonce void @const_recompute_T() local_unnamed_addr #8 {
 
 ; Function Attrs: ssp
 define linkonce void @"const_recompute_T::Boolean"() local_unnamed_addr #8 {
-  %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"str_T::Boolean", i64 0, i64 0), i64 10)
+  %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 120), i64 10)
   store i64 %1, i64* @"guarded_const_T::Boolean", align 8
   %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !65
   store i64 %2, i64* @"guard_epoch_T::Boolean", align 8
@@ -1758,7 +1725,7 @@ define linkonce void @"const_recompute_T::Boolean"() local_unnamed_addr #8 {
 
 ; Function Attrs: ssp
 define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #8 {
-  %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([7 x i8], [7 x i8]* @"str_T::Sig", i64 0, i64 0), i64 6)
+  %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 223), i64 6)
   store i64 %1, i64* @"guarded_const_T::Sig", align 8
   %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !65
   store i64 %2, i64* @"guard_epoch_T::Sig", align 8

--- a/test/testdata/compiler/globalfields.opt.ll.exp
+++ b/test/testdata/compiler/globalfields.opt.ll.exp
@@ -85,44 +85,31 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
 @"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/globalfields.rb" = internal unnamed_addr global i64 0, align 8
-@"str_test/testdata/compiler/globalfields.rb" = private unnamed_addr constant [39 x i8] c"test/testdata/compiler/globalfields.rb\00", align 1
 @iseqEncodedArray = internal global [20 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
-@str_A = private unnamed_addr constant [2 x i8] c"A\00", align 1
 @ic_new = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_new = internal unnamed_addr global i64 0, align 8
-@str_new = private unnamed_addr constant [4 x i8] c"new\00", align 1
 @ic_initialize = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_initialize = internal unnamed_addr global i64 0, align 8
-@str_initialize = private unnamed_addr constant [11 x i8] c"initialize\00", align 1
 @ic_read = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_read = internal unnamed_addr global i64 0, align 8
-@str_read = private unnamed_addr constant [5 x i8] c"read\00", align 1
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
-@str_puts = private unnamed_addr constant [5 x i8] c"puts\00", align 1
 @rubyStrFrozen_value = internal unnamed_addr global i64 0, align 8
-@str_value = private unnamed_addr constant [6 x i8] c"value\00", align 1
 @ic_write = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_write = internal unnamed_addr global i64 0, align 8
-@str_write = private unnamed_addr constant [6 x i8] c"write\00", align 1
 @ic_read.1 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.2 = internal global %struct.FunctionInlineCache zeroinitializer
 @"rubyIdPrecomputed_$f" = internal unnamed_addr global i64 0, align 8
-@"str_$f" = private unnamed_addr constant [3 x i8] c"$f\00", align 1
 @ic_puts.3 = internal global %struct.FunctionInlineCache zeroinitializer
-@str_F = private unnamed_addr constant [2 x i8] c"F\00", align 1
 @"stackFramePrecomputed_func_A#5write" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"stackFramePrecomputed_func_A#4read" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"stackFramePrecomputed_func_A.13<static-init>" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<class:A>" = internal unnamed_addr global i64 0, align 8
-@"str_<class:A>" = private unnamed_addr constant [10 x i8] c"<class:A>\00", align 1
-@str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
 @rubyIdPrecomputed_v = internal unnamed_addr global i64 0, align 8
-@str_v = private unnamed_addr constant [2 x i8] c"v\00", align 1
+@sorbet_moduleStringTable = internal unnamed_addr constant [133 x i8] c"<top (required)>\00test/testdata/compiler/globalfields.rb\00A\00Object\00new\00initialize\00read\00puts\00value\00write\00$f\00F\00master\00<class:A>\00normal\00v\00", align 1
 @rb_cObject = external local_unnamed_addr constant i64
 @guard_epoch_A = linkonce local_unnamed_addr global i64 0
 @guarded_const_A = linkonce local_unnamed_addr global i64 0
@@ -209,29 +196,29 @@ entry:
   %locals.i15.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
+  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #11
   store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_new, i64 0, i64 0), i64 noundef 3) #11
+  %1 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 65), i64 noundef 3) #11
   store i64 %1, i64* @rubyIdPrecomputed_new, align 8
-  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 noundef 10) #11
+  %2 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 69), i64 noundef 10) #11
   store i64 %2, i64* @rubyIdPrecomputed_initialize, align 8
-  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_read, i64 0, i64 0), i64 noundef 4) #11
+  %3 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 80), i64 noundef 4) #11
   store i64 %3, i64* @rubyIdPrecomputed_read, align 8
-  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #11
+  %4 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 85), i64 noundef 4) #11
   store i64 %4, i64* @rubyIdPrecomputed_puts, align 8
-  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_write, i64 0, i64 0), i64 noundef 5) #11
+  %5 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 96), i64 noundef 5) #11
   store i64 %5, i64* @rubyIdPrecomputed_write, align 8
-  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @"str_$f", i64 0, i64 0), i64 noundef 2) #11
+  %6 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 102), i64 noundef 2) #11
   store i64 %6, i64* @"rubyIdPrecomputed_$f", align 8
-  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #11
+  %7 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 114), i64 noundef 9) #11
   store i64 %7, i64* @"rubyIdPrecomputed_<class:A>", align 8
-  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #11
-  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_v, i64 0, i64 0), i64 noundef 1) #11
+  %8 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 124), i64 noundef 6) #11
+  %9 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 131), i64 noundef 1) #11
   store i64 %9, i64* @rubyIdPrecomputed_v, align 8
-  %10 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
+  %10 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #11
   tail call void @rb_gc_register_mark_object(i64 %10) #11
   store i64 %10, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %11 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([39 x i8], [39 x i8]* @"str_test/testdata/compiler/globalfields.rb", i64 0, i64 0), i64 noundef 38) #11
+  %11 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 38) #11
   tail call void @rb_gc_register_mark_object(i64 %11) #11
   store i64 %11, i64* @"rubyStrFrozen_test/testdata/compiler/globalfields.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 20)
@@ -248,7 +235,7 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_read, i64 %rubyId_read.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !18
   %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !19
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
-  %13 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_value, i64 0, i64 0), i64 noundef 5) #11
+  %13 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 90), i64 noundef 5) #11
   call void @rb_gc_register_mark_object(i64 %13) #11
   store i64 %13, i64* @rubyStrFrozen_value, align 8
   %rubyId_write.i = load i64, i64* @rubyIdPrecomputed_write, align 8, !dbg !20
@@ -259,19 +246,19 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts8.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !22
   %rubyId_puts11.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !23
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts11.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !23
-  %14 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_write, i64 0, i64 0), i64 noundef 5) #11
+  %14 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 96), i64 noundef 5) #11
   call void @rb_gc_register_mark_object(i64 %14) #11
   %rubyId_write.i.i = load i64, i64* @rubyIdPrecomputed_write, align 8
   %"rubyStr_test/testdata/compiler/globalfields.rb.i14.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/globalfields.rb", align 8
   %15 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %14, i64 %rubyId_write.i.i, i64 %"rubyStr_test/testdata/compiler/globalfields.rb.i14.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i15.i, i32 noundef 0, i32 noundef 0)
   store %struct.rb_iseq_struct* %15, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#5write", align 8
-  %16 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_read, i64 0, i64 0), i64 noundef 4) #11
+  %16 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 80), i64 noundef 4) #11
   call void @rb_gc_register_mark_object(i64 %16) #11
   %rubyId_read.i.i = load i64, i64* @rubyIdPrecomputed_read, align 8
   %"rubyStr_test/testdata/compiler/globalfields.rb.i16.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/globalfields.rb", align 8
   %17 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %16, i64 %rubyId_read.i.i, i64 %"rubyStr_test/testdata/compiler/globalfields.rb.i16.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 9, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i17.i, i32 noundef 0, i32 noundef 0)
   store %struct.rb_iseq_struct* %17, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#4read", align 8
-  %18 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #11
+  %18 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 114), i64 noundef 9) #11
   call void @rb_gc_register_mark_object(i64 %18) #11
   %"rubyId_<class:A>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:A>", align 8
   %"rubyStr_test/testdata/compiler/globalfields.rb.i18.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/globalfields.rb", align 8
@@ -295,7 +282,7 @@ entry:
   %31 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 0
   store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %31, align 8, !dbg !42, !tbaa !24
   %32 = load i64, i64* @rb_cObject, align 8, !dbg !43
-  %33 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 %32) #11, !dbg !43
+  %33 = call i64 @rb_define_class(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 56), i64 %32) #11, !dbg !43
   %34 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %33) #11, !dbg !43
   %35 = bitcast i64* %positional_table.i.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %35) #11
@@ -350,7 +337,7 @@ entry:
   %63 = getelementptr inbounds i8, i8* %52, i64 32, !dbg !10
   %64 = bitcast i8* %63 to i8**, !dbg !10
   store i8* %62, i8** %64, align 8, !dbg !10, !tbaa !51
-  call void @sorbet_vm_define_method(i64 %49, i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_write, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_A#5write", i8* nonnull %52, %struct.rb_iseq_struct* %stackFrame17.i.i, i1 noundef zeroext false) #11, !dbg !10
+  call void @sorbet_vm_define_method(i64 %49, i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 96), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_A#5write", i8* nonnull %52, %struct.rb_iseq_struct* %stackFrame17.i.i, i1 noundef zeroext false) #11, !dbg !10
   store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %44, align 8, !dbg !10, !tbaa !24
   %stackFrame26.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#4read", align 8, !dbg !52
   %65 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !52
@@ -360,7 +347,7 @@ entry:
   store i16 %68, i16* %66, align 8, !dbg !52
   %69 = getelementptr inbounds i8, i8* %65, i64 4, !dbg !52
   call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %69, i8 0, i64 28, i1 false) #11, !dbg !52
-  call void @sorbet_vm_define_method(i64 %49, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_read, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_A#4read", i8* nonnull %65, %struct.rb_iseq_struct* %stackFrame26.i.i, i1 noundef zeroext false) #11, !dbg !52
+  call void @sorbet_vm_define_method(i64 %49, i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 80), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_A#4read", i8* nonnull %65, %struct.rb_iseq_struct* %stackFrame26.i.i, i1 noundef zeroext false) #11, !dbg !52
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %35) #11
   call void @sorbet_popFrame() #11, !dbg !43
   store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %31, align 8, !dbg !43, !tbaa !24
@@ -441,7 +428,7 @@ fastNew.i:                                        ; preds = %48
   store i64* %103, i64** %100, align 8, !dbg !23
   %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.3, i64 0), !dbg !23
   store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %31, align 8, !dbg !23, !tbaa !24
-  %104 = call i64 @sorbet_setConstant(i64 %32, i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_F, i64 0, i64 0), i64 noundef 1, i64 noundef 3) #11, !dbg !54
+  %104 = call i64 @sorbet_setConstant(i64 %32, i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 105), i64 noundef 1, i64 noundef 3) #11, !dbg !54
   ret void
 }
 
@@ -499,7 +486,7 @@ declare void @llvm.assume(i1 noundef) #8
 
 ; Function Attrs: ssp
 define linkonce void @const_recompute_A() local_unnamed_addr #9 {
-  %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 1)
+  %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 56), i64 1)
   store i64 %1, i64* @guarded_const_A, align 8
   %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !45
   store i64 %2, i64* @guard_epoch_A, align 8

--- a/test/testdata/compiler/hello.opt.ll.exp
+++ b/test/testdata/compiler/hello.opt.ll.exp
@@ -82,17 +82,14 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
 @"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/hello.rb" = internal unnamed_addr global i64 0, align 8
-@"str_test/testdata/compiler/hello.rb" = private unnamed_addr constant [32 x i8] c"test/testdata/compiler/hello.rb\00", align 1
 @iseqEncodedArray = internal global [5 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @"rubyStrFrozen_hello world" = internal unnamed_addr global i64 0, align 8
-@"str_hello world" = private unnamed_addr constant [12 x i8] c"hello world\00", align 1
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
-@str_puts = private unnamed_addr constant [5 x i8] c"puts\00", align 1
+@sorbet_moduleStringTable = internal unnamed_addr constant [73 x i8] c"<top (required)>\00test/testdata/compiler/hello.rb\00hello world\00puts\00master\00", align 1
 
 declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
 
@@ -134,14 +131,14 @@ define void @Init_hello() local_unnamed_addr #3 {
 entry:
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #5
+  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([73 x i8], [73 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #5
   store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #5
+  %1 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([73 x i8], [73 x i8]* @sorbet_moduleStringTable, i64 0, i64 61), i64 noundef 4) #5
   store i64 %1, i64* @rubyIdPrecomputed_puts, align 8
-  %2 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #5
+  %2 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([73 x i8], [73 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #5
   tail call void @rb_gc_register_mark_object(i64 %2) #5
   store i64 %2, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %3 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([32 x i8], [32 x i8]* @"str_test/testdata/compiler/hello.rb", i64 0, i64 0), i64 noundef 31) #5
+  %3 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([73 x i8], [73 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 31) #5
   tail call void @rb_gc_register_mark_object(i64 %3) #5
   store i64 %3, i64* @"rubyStrFrozen_test/testdata/compiler/hello.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 5)
@@ -150,7 +147,7 @@ entry:
   %"rubyStr_test/testdata/compiler/hello.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/hello.rb", align 8
   %4 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/hello.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %4, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %5 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([12 x i8], [12 x i8]* @"str_hello world", i64 0, i64 0), i64 noundef 11) #5
+  %5 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([73 x i8], [73 x i8]* @sorbet_moduleStringTable, i64 0, i64 49), i64 noundef 11) #5
   call void @rb_gc_register_mark_object(i64 %5) #5
   store i64 %5, i64* @"rubyStrFrozen_hello world", align 8
   %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !10

--- a/test/testdata/compiler/intrinsics/bang.opt.ll.exp
+++ b/test/testdata/compiler/intrinsics/bang.opt.ll.exp
@@ -82,29 +82,19 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
 @"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb" = internal unnamed_addr global i64 0, align 8
-@"str_test/testdata/compiler/intrinsics/bang.rb" = private unnamed_addr constant [42 x i8] c"test/testdata/compiler/intrinsics/bang.rb\00", align 1
 @iseqEncodedArray = internal global [23 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
-@str_Bad = private unnamed_addr constant [4 x i8] c"Bad\00", align 1
-@str_Main = private unnamed_addr constant [5 x i8] c"Main\00", align 1
 @ic_test = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_test = internal unnamed_addr global i64 0, align 8
-@str_test = private unnamed_addr constant [5 x i8] c"test\00", align 1
 @"stackFramePrecomputed_func_Bad#1!" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_!" = internal unnamed_addr global i64 0, align 8
-@"str_!" = private unnamed_addr constant [2 x i8] c"!\00", align 1
 @"rubyStrFrozen_bad bang overload" = internal unnamed_addr global i64 0, align 8
-@"str_bad bang overload" = private unnamed_addr constant [18 x i8] c"bad bang overload\00", align 1
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
-@str_puts = private unnamed_addr constant [5 x i8] c"puts\00", align 1
 @"stackFramePrecomputed_func_Bad.13<static-init>" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<class:Bad>" = internal unnamed_addr global i64 0, align 8
-@"str_<class:Bad>" = private unnamed_addr constant [12 x i8] c"<class:Bad>\00", align 1
-@str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
 @stackFramePrecomputed_func_Main.4test = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"ic_!" = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.1 = internal global %struct.FunctionInlineCache zeroinitializer
@@ -113,20 +103,17 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @"ic_!.4" = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.5 = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyStrFrozen_hello = internal unnamed_addr global i64 0, align 8
-@str_hello = private unnamed_addr constant [6 x i8] c"hello\00", align 1
 @"ic_!.6" = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.7 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_new = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_new = internal unnamed_addr global i64 0, align 8
-@str_new = private unnamed_addr constant [4 x i8] c"new\00", align 1
 @ic_initialize = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_initialize = internal unnamed_addr global i64 0, align 8
-@str_initialize = private unnamed_addr constant [11 x i8] c"initialize\00", align 1
 @"ic_!.8" = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.9 = internal global %struct.FunctionInlineCache zeroinitializer
 @"stackFramePrecomputed_func_Main.13<static-init>" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<module:Main>" = internal unnamed_addr global i64 0, align 8
-@"str_<module:Main>" = private unnamed_addr constant [14 x i8] c"<module:Main>\00", align 1
+@sorbet_moduleStringTable = internal unnamed_addr constant [166 x i8] c"<top (required)>\00test/testdata/compiler/intrinsics/bang.rb\00Bad\00Object\00Main\00test\00master\00!\00bad bang overload\00puts\00<class:Bad>\00normal\00hello\00new\00initialize\00<module:Main>\00", align 1
 @rb_cObject = external local_unnamed_addr constant i64
 @guard_epoch_Bad = linkonce local_unnamed_addr global i64 0
 @guarded_const_Bad = linkonce local_unnamed_addr global i64 0
@@ -199,27 +186,27 @@ entry:
   %locals.i30.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #10
+  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #10
   store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_test, i64 0, i64 0), i64 noundef 4) #10
+  %1 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 75), i64 noundef 4) #10
   store i64 %1, i64* @rubyIdPrecomputed_test, align 8
-  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_!", i64 0, i64 0), i64 noundef 1) #10
+  %2 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 87), i64 noundef 1) #10
   store i64 %2, i64* @"rubyIdPrecomputed_!", align 8
-  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #10
+  %3 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 107), i64 noundef 4) #10
   store i64 %3, i64* @rubyIdPrecomputed_puts, align 8
-  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([12 x i8], [12 x i8]* @"str_<class:Bad>", i64 0, i64 0), i64 noundef 11) #10
+  %4 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 112), i64 noundef 11) #10
   store i64 %4, i64* @"rubyIdPrecomputed_<class:Bad>", align 8
-  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #10
-  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_new, i64 0, i64 0), i64 noundef 3) #10
+  %5 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 124), i64 noundef 6) #10
+  %6 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 137), i64 noundef 3) #10
   store i64 %6, i64* @rubyIdPrecomputed_new, align 8
-  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 noundef 10) #10
+  %7 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 141), i64 noundef 10) #10
   store i64 %7, i64* @rubyIdPrecomputed_initialize, align 8
-  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_<module:Main>", i64 0, i64 0), i64 noundef 13) #10
+  %8 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 152), i64 noundef 13) #10
   store i64 %8, i64* @"rubyIdPrecomputed_<module:Main>", align 8
-  %9 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #10
+  %9 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #10
   tail call void @rb_gc_register_mark_object(i64 %9) #10
   store i64 %9, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %10 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([42 x i8], [42 x i8]* @"str_test/testdata/compiler/intrinsics/bang.rb", i64 0, i64 0), i64 noundef 41) #10
+  %10 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 41) #10
   tail call void @rb_gc_register_mark_object(i64 %10) #10
   store i64 %10, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 23)
@@ -230,24 +217,24 @@ entry:
   store %struct.rb_iseq_struct* %11, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
   %rubyId_test.i = load i64, i64* @rubyIdPrecomputed_test, align 8, !dbg !10
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test, i64 %rubyId_test.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !10
-  %12 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_!", i64 0, i64 0), i64 noundef 1) #10
+  %12 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 87), i64 noundef 1) #10
   call void @rb_gc_register_mark_object(i64 %12) #10
   %"rubyId_!.i.i" = load i64, i64* @"rubyIdPrecomputed_!", align 8
   %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i29.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
   %13 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %12, i64 %"rubyId_!.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i29.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i30.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %13, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad#1!", align 8
-  %14 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([18 x i8], [18 x i8]* @"str_bad bang overload", i64 0, i64 0), i64 noundef 17) #10
+  %14 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 89), i64 noundef 17) #10
   call void @rb_gc_register_mark_object(i64 %14) #10
   store i64 %14, i64* @"rubyStrFrozen_bad bang overload", align 8
   %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !15
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
-  %15 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([12 x i8], [12 x i8]* @"str_<class:Bad>", i64 0, i64 0), i64 noundef 11) #10
+  %15 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 112), i64 noundef 11) #10
   call void @rb_gc_register_mark_object(i64 %15) #10
   %"rubyId_<class:Bad>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:Bad>", align 8
   %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i31.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
   %16 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %15, i64 %"rubyId_<class:Bad>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i31.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i32.i, i32 noundef 0, i32 noundef 4)
   store %struct.rb_iseq_struct* %16, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad.13<static-init>", align 8
-  %17 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_test, i64 0, i64 0), i64 noundef 4) #10
+  %17 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 75), i64 noundef 4) #10
   call void @rb_gc_register_mark_object(i64 %17) #10
   %rubyId_test.i.i = load i64, i64* @rubyIdPrecomputed_test, align 8
   %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i33.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
@@ -265,7 +252,7 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_!.4", i64 %"rubyId_!11.i", i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !22
   %rubyId_puts13.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !23
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.5, i64 %rubyId_puts13.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !23
-  %19 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_hello, i64 0, i64 0), i64 noundef 5) #10
+  %19 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 131), i64 noundef 5) #10
   call void @rb_gc_register_mark_object(i64 %19) #10
   store i64 %19, i64* @rubyStrFrozen_hello, align 8
   %"rubyId_!16.i" = load i64, i64* @"rubyIdPrecomputed_!", align 8, !dbg !24
@@ -280,7 +267,7 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_!.8", i64 %"rubyId_!24.i", i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !27
   %rubyId_puts26.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !28
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.9, i64 %rubyId_puts26.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !28
-  %20 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_<module:Main>", i64 0, i64 0), i64 noundef 13) #10
+  %20 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 152), i64 noundef 13) #10
   call void @rb_gc_register_mark_object(i64 %20) #10
   %"rubyId_<module:Main>.i.i" = load i64, i64* @"rubyIdPrecomputed_<module:Main>", align 8
   %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i35.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
@@ -301,7 +288,7 @@ entry:
   %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 0
   store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %30, align 8, !dbg !38, !tbaa !29
   %31 = load i64, i64* @rb_cObject, align 8, !dbg !39
-  %32 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_Bad, i64 0, i64 0), i64 %31) #10, !dbg !39
+  %32 = call i64 @rb_define_class(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 59), i64 %31) #10, !dbg !39
   %33 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %32) #10, !dbg !39
   %stackFrame.i1.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad.13<static-init>", align 8
   %34 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !29
@@ -340,10 +327,10 @@ entry:
   store i16 %53, i16* %51, align 8, !dbg !43
   %54 = getelementptr inbounds i8, i8* %50, i64 4, !dbg !43
   call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %54, i8 0, i64 28, i1 false) #10, !dbg !43
-  call void @sorbet_vm_define_method(i64 %47, i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @"str_!", i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Bad#1!", i8* nonnull %50, %struct.rb_iseq_struct* %stackFrame7.i2.i, i1 noundef zeroext false) #10, !dbg !43
+  call void @sorbet_vm_define_method(i64 %47, i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 87), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Bad#1!", i8* nonnull %50, %struct.rb_iseq_struct* %stackFrame7.i2.i, i1 noundef zeroext false) #10, !dbg !43
   call void @sorbet_popFrame() #10, !dbg !39
   store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %30, align 8, !dbg !39, !tbaa !29
-  %55 = call i64 @rb_define_module(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_Main, i64 0, i64 0)) #10, !dbg !47
+  %55 = call i64 @rb_define_module(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 70)) #10, !dbg !47
   %56 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %55) #10, !dbg !47
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Main.13<static-init>", align 8
   %57 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !29
@@ -382,7 +369,7 @@ entry:
   store i16 %76, i16* %74, align 8, !dbg !51
   %77 = getelementptr inbounds i8, i8* %73, i64 4, !dbg !51
   call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %77, i8 0, i64 28, i1 false) #10, !dbg !51
-  call void @sorbet_vm_define_method(i64 %70, i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_test, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_Main.4test, i8* nonnull %73, %struct.rb_iseq_struct* %stackFrame7.i.i, i1 noundef zeroext true) #10, !dbg !51
+  call void @sorbet_vm_define_method(i64 %70, i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 75), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_Main.4test, i8* nonnull %73, %struct.rb_iseq_struct* %stackFrame7.i.i, i1 noundef zeroext true) #10, !dbg !51
   call void @sorbet_popFrame() #10, !dbg !47
   store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %30, align 8, !dbg !47, !tbaa !29
   %78 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !10
@@ -535,7 +522,7 @@ declare void @llvm.assume(i1 noundef) #7
 
 ; Function Attrs: ssp
 define linkonce void @const_recompute_Bad() local_unnamed_addr #8 {
-  %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @str_Bad, i64 0, i64 0), i64 3)
+  %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 59), i64 3)
   store i64 %1, i64* @guarded_const_Bad, align 8
   %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !44
   store i64 %2, i64* @guard_epoch_Bad, align 8
@@ -544,7 +531,7 @@ define linkonce void @const_recompute_Bad() local_unnamed_addr #8 {
 
 ; Function Attrs: ssp
 define linkonce void @const_recompute_Main() local_unnamed_addr #8 {
-  %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @str_Main, i64 0, i64 0), i64 4)
+  %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 70), i64 4)
   store i64 %1, i64* @guarded_const_Main, align 8
   %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !44
   store i64 %2, i64* @guard_epoch_Main, align 8

--- a/test/testdata/compiler/intrinsics/t_must.opt.ll.exp
+++ b/test/testdata/compiler/intrinsics/t_must.opt.ll.exp
@@ -85,64 +85,44 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
 @"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb" = internal unnamed_addr global i64 0, align 8
-@"str_test/testdata/compiler/intrinsics/t_must.rb" = private unnamed_addr constant [44 x i8] c"test/testdata/compiler/intrinsics/t_must.rb\00", align 1
 @iseqEncodedArray = internal global [28 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
-@str_Test = private unnamed_addr constant [5 x i8] c"Test\00", align 1
 @ic_test_known_nil = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_test_known_nil = internal unnamed_addr global i64 0, align 8
-@str_test_known_nil = private unnamed_addr constant [15 x i8] c"test_known_nil\00", align 1
 @ic_test_nilable_arg = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_test_nilable_arg = internal unnamed_addr global i64 0, align 8
-@str_test_nilable_arg = private unnamed_addr constant [17 x i8] c"test_nilable_arg\00", align 1
 @ic_test_nilable_arg.1 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_test_nilable_arg.2 = internal global %struct.FunctionInlineCache zeroinitializer
 @stackFramePrecomputed_func_Test.14test_known_nil = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<exceptionValue>" = internal unnamed_addr global i64 0, align 8
-@"str_<exceptionValue>" = private unnamed_addr constant [17 x i8] c"<exceptionValue>\00", align 1
 @"rubyIdPrecomputed_<magic>" = internal unnamed_addr global i64 0, align 8
-@"str_<magic>" = private unnamed_addr constant [8 x i8] c"<magic>\00", align 1
 @"rubyIdPrecomputed_<returnMethodTemp>" = internal unnamed_addr global i64 0, align 8
-@"str_<returnMethodTemp>" = private unnamed_addr constant [19 x i8] c"<returnMethodTemp>\00", align 1
 @"rubyIdPrecomputed_<gotoDeadTemp>" = internal unnamed_addr global i64 0, align 8
-@"str_<gotoDeadTemp>" = private unnamed_addr constant [15 x i8] c"<gotoDeadTemp>\00", align 1
 @"stackFramePrecomputed_func_Test.14test_known_nil$block_2" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_rescue in test_known_nil" = internal unnamed_addr global i64 0, align 8
-@"str_rescue in test_known_nil" = private unnamed_addr constant [25 x i8] c"rescue in test_known_nil\00", align 1
 @"stackFramePrecomputed_func_Test.14test_known_nil$block_3" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_ensure in test_known_nil" = internal unnamed_addr global i64 0, align 8
-@"str_ensure in test_known_nil" = private unnamed_addr constant [25 x i8] c"ensure in test_known_nil\00", align 1
 @"<retry-singleton>" = internal unnamed_addr global i64 0
-@str_must = private unnamed_addr constant [5 x i8] c"must\00", align 1
 @"ic_is_a?" = internal global %struct.FunctionInlineCache zeroinitializer
 @"rubyIdPrecomputed_is_a?" = internal unnamed_addr global i64 0, align 8
-@"str_is_a?" = private unnamed_addr constant [6 x i8] c"is_a?\00", align 1
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
-@str_puts = private unnamed_addr constant [5 x i8] c"puts\00", align 1
 @stackFramePrecomputed_func_Test.16test_nilable_arg = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @rubyIdPrecomputed_arg = internal unnamed_addr global i64 0, align 8
-@str_arg = private unnamed_addr constant [4 x i8] c"arg\00", align 1
 @"stackFramePrecomputed_func_Test.16test_nilable_arg$block_2" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_rescue in test_nilable_arg" = internal unnamed_addr global i64 0, align 8
-@"str_rescue in test_nilable_arg" = private unnamed_addr constant [27 x i8] c"rescue in test_nilable_arg\00", align 1
 @"stackFramePrecomputed_func_Test.16test_nilable_arg$block_3" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_ensure in test_nilable_arg" = internal unnamed_addr global i64 0, align 8
-@"str_ensure in test_nilable_arg" = private unnamed_addr constant [27 x i8] c"ensure in test_nilable_arg\00", align 1
 @"rubyStrFrozen_ wasn't nil" = internal unnamed_addr global i64 0, align 8
-@"str_ wasn't nil" = private unnamed_addr constant [12 x i8] c" wasn't nil\00", align 1
 @"rubyIdPrecomputed_<string-interpolate>" = internal unnamed_addr global i64 0, align 8
-@"str_<string-interpolate>" = private unnamed_addr constant [21 x i8] c"<string-interpolate>\00", align 1
 @ic_puts.3 = internal global %struct.FunctionInlineCache zeroinitializer
 @"ic_is_a?.4" = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.5 = internal global %struct.FunctionInlineCache zeroinitializer
 @"stackFramePrecomputed_func_Test.13<static-init>" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<module:Test>" = internal unnamed_addr global i64 0, align 8
-@"str_<module:Test>" = private unnamed_addr constant [14 x i8] c"<module:Test>\00", align 1
-@str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
+@sorbet_moduleStringTable = internal unnamed_addr constant [358 x i8] c"<top (required)>\00test/testdata/compiler/intrinsics/t_must.rb\00Test\00test_known_nil\00test_nilable_arg\00master\00<exceptionValue>\00<magic>\00<returnMethodTemp>\00<gotoDeadTemp>\00rescue in test_known_nil\00ensure in test_known_nil\00T\00must\00StandardError\00is_a?\00puts\00arg\00rescue in test_nilable_arg\00ensure in test_nilable_arg\00 wasn't nil\00<string-interpolate>\00<module:Test>\00normal\00", align 1
 @guard_epoch_Test = linkonce local_unnamed_addr global i64 0
 @guarded_const_Test = linkonce local_unnamed_addr global i64 0
 @rb_eStandardError = external local_unnamed_addr constant i64
@@ -234,44 +214,44 @@ entry:
   %locals.i17.i = alloca i64, i32 4, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #14
+  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #14
   store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @str_test_known_nil, i64 0, i64 0), i64 noundef 14) #14
+  %1 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 66), i64 noundef 14) #14
   store i64 %1, i64* @rubyIdPrecomputed_test_known_nil, align 8
-  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @str_test_nilable_arg, i64 0, i64 0), i64 noundef 16) #14
+  %2 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 81), i64 noundef 16) #14
   store i64 %2, i64* @rubyIdPrecomputed_test_nilable_arg, align 8
-  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<exceptionValue>", i64 0, i64 0), i64 noundef 16) #14
+  %3 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 105), i64 noundef 16) #14
   store i64 %3, i64* @"rubyIdPrecomputed_<exceptionValue>", align 8
-  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @"str_<magic>", i64 0, i64 0), i64 noundef 7) #14
+  %4 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 122), i64 noundef 7) #14
   store i64 %4, i64* @"rubyIdPrecomputed_<magic>", align 8
-  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([19 x i8], [19 x i8]* @"str_<returnMethodTemp>", i64 0, i64 0), i64 noundef 18) #14
+  %5 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 130), i64 noundef 18) #14
   store i64 %5, i64* @"rubyIdPrecomputed_<returnMethodTemp>", align 8
-  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @"str_<gotoDeadTemp>", i64 0, i64 0), i64 noundef 14) #14
+  %6 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 149), i64 noundef 14) #14
   store i64 %6, i64* @"rubyIdPrecomputed_<gotoDeadTemp>", align 8
-  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @"str_rescue in test_known_nil", i64 0, i64 0), i64 noundef 24) #14
+  %7 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 164), i64 noundef 24) #14
   store i64 %7, i64* @"rubyIdPrecomputed_rescue in test_known_nil", align 8
-  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @"str_ensure in test_known_nil", i64 0, i64 0), i64 noundef 24) #14
+  %8 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 189), i64 noundef 24) #14
   store i64 %8, i64* @"rubyIdPrecomputed_ensure in test_known_nil", align 8
-  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_must, i64 0, i64 0), i64 noundef 4) #14
-  %10 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @"str_is_a?", i64 0, i64 0), i64 noundef 5) #14
+  %9 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 216), i64 noundef 4) #14
+  %10 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 235), i64 noundef 5) #14
   store i64 %10, i64* @"rubyIdPrecomputed_is_a?", align 8
-  %11 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #14
+  %11 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 241), i64 noundef 4) #14
   store i64 %11, i64* @rubyIdPrecomputed_puts, align 8
-  %12 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_arg, i64 0, i64 0), i64 noundef 3) #14
+  %12 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 246), i64 noundef 3) #14
   store i64 %12, i64* @rubyIdPrecomputed_arg, align 8
-  %13 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([27 x i8], [27 x i8]* @"str_rescue in test_nilable_arg", i64 0, i64 0), i64 noundef 26) #14
+  %13 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 250), i64 noundef 26) #14
   store i64 %13, i64* @"rubyIdPrecomputed_rescue in test_nilable_arg", align 8
-  %14 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([27 x i8], [27 x i8]* @"str_ensure in test_nilable_arg", i64 0, i64 0), i64 noundef 26) #14
+  %14 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 277), i64 noundef 26) #14
   store i64 %14, i64* @"rubyIdPrecomputed_ensure in test_nilable_arg", align 8
-  %15 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([21 x i8], [21 x i8]* @"str_<string-interpolate>", i64 0, i64 0), i64 noundef 20) #14
+  %15 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 316), i64 noundef 20) #14
   store i64 %15, i64* @"rubyIdPrecomputed_<string-interpolate>", align 8
-  %16 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_<module:Test>", i64 0, i64 0), i64 noundef 13) #14
+  %16 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 337), i64 noundef 13) #14
   store i64 %16, i64* @"rubyIdPrecomputed_<module:Test>", align 8
-  %17 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #14
-  %18 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #14
+  %17 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 351), i64 noundef 6) #14
+  %18 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #14
   tail call void @rb_gc_register_mark_object(i64 %18) #14
   store i64 %18, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %19 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([44 x i8], [44 x i8]* @"str_test/testdata/compiler/intrinsics/t_must.rb", i64 0, i64 0), i64 noundef 43) #14
+  %19 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 43) #14
   tail call void @rb_gc_register_mark_object(i64 %19) #14
   store i64 %19, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 28)
@@ -288,7 +268,7 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test_nilable_arg.1, i64 %rubyId_test_nilable_arg2.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
   %rubyId_test_nilable_arg4.i = load i64, i64* @rubyIdPrecomputed_test_nilable_arg, align 8, !dbg !20
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test_nilable_arg.2, i64 %rubyId_test_nilable_arg4.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !20
-  %21 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @str_test_known_nil, i64 0, i64 0), i64 noundef 14) #14
+  %21 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 66), i64 noundef 14) #14
   call void @rb_gc_register_mark_object(i64 %21) #14
   %22 = bitcast i64* %locals.i17.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 32, i8* nonnull %22)
@@ -308,14 +288,14 @@ entry:
   %26 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %21, i64 %rubyId_test_known_nil.i.i, i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i16.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i17.i, i32 noundef 4, i32 noundef 2)
   store %struct.rb_iseq_struct* %26, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.14test_known_nil, align 8
   call void @llvm.lifetime.end.p0i8(i64 32, i8* nonnull %22)
-  %27 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @"str_rescue in test_known_nil", i64 0, i64 0), i64 noundef 24) #14
+  %27 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 164), i64 noundef 24) #14
   call void @rb_gc_register_mark_object(i64 %27) #14
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.14test_known_nil, align 8
   %"rubyId_rescue in test_known_nil.i.i" = load i64, i64* @"rubyIdPrecomputed_rescue in test_known_nil", align 8
   %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i18.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
   %28 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %27, i64 %"rubyId_rescue in test_known_nil.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i18.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 4, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %28, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.14test_known_nil$block_2", align 8
-  %29 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @"str_ensure in test_known_nil", i64 0, i64 0), i64 noundef 24) #14
+  %29 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 189), i64 noundef 24) #14
   call void @rb_gc_register_mark_object(i64 %29) #14
   %stackFrame.i19.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.14test_known_nil, align 8
   %"rubyId_ensure in test_known_nil.i.i" = load i64, i64* @"rubyIdPrecomputed_ensure in test_known_nil", align 8
@@ -328,7 +308,7 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_is_a?", i64 %"rubyId_is_a?.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !21
   %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !24
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !24
-  %32 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @str_test_nilable_arg, i64 0, i64 0), i64 noundef 16) #14
+  %32 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 81), i64 noundef 16) #14
   call void @rb_gc_register_mark_object(i64 %32) #14
   %33 = bitcast i64* %locals.i22.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 40, i8* nonnull %33)
@@ -351,21 +331,21 @@ entry:
   %38 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %32, i64 %rubyId_test_nilable_arg.i.i, i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i21.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 14, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i22.i, i32 noundef 5, i32 noundef 3)
   store %struct.rb_iseq_struct* %38, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.16test_nilable_arg, align 8
   call void @llvm.lifetime.end.p0i8(i64 40, i8* nonnull %33)
-  %39 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([27 x i8], [27 x i8]* @"str_rescue in test_nilable_arg", i64 0, i64 0), i64 noundef 26) #14
+  %39 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 250), i64 noundef 26) #14
   call void @rb_gc_register_mark_object(i64 %39) #14
   %stackFrame.i27.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.16test_nilable_arg, align 8
   %"rubyId_rescue in test_nilable_arg.i.i" = load i64, i64* @"rubyIdPrecomputed_rescue in test_nilable_arg", align 8
   %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i28.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
   %40 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %39, i64 %"rubyId_rescue in test_nilable_arg.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i28.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i27.i, i32 noundef 4, i32 noundef 14, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
   store %struct.rb_iseq_struct* %40, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.16test_nilable_arg$block_2", align 8
-  %41 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([27 x i8], [27 x i8]* @"str_ensure in test_nilable_arg", i64 0, i64 0), i64 noundef 26) #14
+  %41 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 277), i64 noundef 26) #14
   call void @rb_gc_register_mark_object(i64 %41) #14
   %stackFrame.i29.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.16test_nilable_arg, align 8
   %"rubyId_ensure in test_nilable_arg.i.i" = load i64, i64* @"rubyIdPrecomputed_ensure in test_nilable_arg", align 8
   %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i30.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
   %42 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %41, i64 %"rubyId_ensure in test_nilable_arg.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i30.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i29.i, i32 noundef 5, i32 noundef 14, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
   store %struct.rb_iseq_struct* %42, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.16test_nilable_arg$block_3", align 8
-  %43 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([12 x i8], [12 x i8]* @"str_ wasn't nil", i64 0, i64 0), i64 noundef 11) #14
+  %43 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 304), i64 noundef 11) #14
   call void @rb_gc_register_mark_object(i64 %43) #14
   store i64 %43, i64* @"rubyStrFrozen_ wasn't nil", align 8
   %rubyId_puts8.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !25
@@ -374,7 +354,7 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_is_a?.4", i64 %"rubyId_is_a?11.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !28
   %rubyId_puts13.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !30
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.5, i64 %rubyId_puts13.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !30
-  %44 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_<module:Test>", i64 0, i64 0), i64 noundef 13) #14
+  %44 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 337), i64 noundef 13) #14
   call void @rb_gc_register_mark_object(i64 %44) #14
   %"rubyId_<module:Test>.i.i" = load i64, i64* @"rubyIdPrecomputed_<module:Test>", align 8
   %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i31.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
@@ -394,7 +374,7 @@ entry:
   call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %46, %struct.rb_control_frame_struct* %48, %struct.rb_iseq_struct* %stackFrame.i) #14
   %54 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %48, i64 0, i32 0
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %54, align 8, !dbg !40, !tbaa !31
-  %55 = call i64 @rb_define_module(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_Test, i64 0, i64 0)) #14, !dbg !41
+  %55 = call i64 @rb_define_module(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 61)) #14, !dbg !41
   %56 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %55) #14, !dbg !41
   %57 = bitcast i64* %positional_table.i.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %57) #14
@@ -435,7 +415,7 @@ entry:
   store i16 %77, i16* %75, align 8, !dbg !43
   %78 = getelementptr inbounds i8, i8* %74, i64 4, !dbg !43
   call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %78, i8 0, i64 28, i1 false) #14, !dbg !43
-  call void @sorbet_vm_define_method(i64 %71, i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @str_test_known_nil, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_Test.14test_known_nil, i8* nonnull %74, %struct.rb_iseq_struct* %stackFrame17.i.i, i1 noundef zeroext true) #14, !dbg !43
+  call void @sorbet_vm_define_method(i64 %71, i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 66), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_Test.14test_known_nil, i8* nonnull %74, %struct.rb_iseq_struct* %stackFrame17.i.i, i1 noundef zeroext true) #14, !dbg !43
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %66, align 8, !dbg !43, !tbaa !31
   %stackFrame26.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.16test_nilable_arg, align 8, !dbg !10
   %79 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #15, !dbg !10
@@ -459,7 +439,7 @@ entry:
   %90 = getelementptr inbounds i8, i8* %79, i64 32, !dbg !10
   %91 = bitcast i8* %90 to i8**, !dbg !10
   store i8* %89, i8** %91, align 8, !dbg !10, !tbaa !51
-  call void @sorbet_vm_define_method(i64 %71, i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @str_test_nilable_arg, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_Test.16test_nilable_arg, i8* nonnull %79, %struct.rb_iseq_struct* %stackFrame26.i.i, i1 noundef zeroext true) #14, !dbg !10
+  call void @sorbet_vm_define_method(i64 %71, i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 81), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_Test.16test_nilable_arg, i8* nonnull %79, %struct.rb_iseq_struct* %stackFrame26.i.i, i1 noundef zeroext true) #14, !dbg !10
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %57) #14
   call void @sorbet_popFrame() #14, !dbg !41
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %54, align 8, !dbg !41, !tbaa !31
@@ -975,7 +955,7 @@ declare void @llvm.assume(i1 noundef) #12
 
 ; Function Attrs: ssp
 define linkonce void @const_recompute_Test() local_unnamed_addr #9 {
-  %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @str_Test, i64 0, i64 0), i64 4)
+  %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 61), i64 4)
   store i64 %1, i64* @guarded_const_Test, align 8
   %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !44
   store i64 %2, i64* @guard_epoch_Test, align 8

--- a/test/testdata/compiler/literal_hash.opt.ll.exp
+++ b/test/testdata/compiler/literal_hash.opt.ll.exp
@@ -82,46 +82,29 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
 @"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/literal_hash.rb" = internal unnamed_addr global i64 0, align 8
-@"str_test/testdata/compiler/literal_hash.rb" = private unnamed_addr constant [39 x i8] c"test/testdata/compiler/literal_hash.rb\00", align 1
 @iseqEncodedArray = internal global [15 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @rubyStrFrozen_foo = internal unnamed_addr global i64 0, align 8
-@str_foo = private unnamed_addr constant [4 x i8] c"foo\00", align 1
 @rubyStrFrozen_bar = internal unnamed_addr global i64 0, align 8
-@str_bar = private unnamed_addr constant [4 x i8] c"bar\00", align 1
 @rubyStrFrozen_baz = internal unnamed_addr global i64 0, align 8
-@str_baz = private unnamed_addr constant [4 x i8] c"baz\00", align 1
 @rubyStrFrozen_quux = internal unnamed_addr global i64 0, align 8
-@str_quux = private unnamed_addr constant [5 x i8] c"quux\00", align 1
 @rubyStrFrozen_wat = internal unnamed_addr global i64 0, align 8
-@str_wat = private unnamed_addr constant [4 x i8] c"wat\00", align 1
 @rubyStrFrozen_how = internal unnamed_addr global i64 0, align 8
-@str_how = private unnamed_addr constant [4 x i8] c"how\00", align 1
 @rubyStrFrozen_unknown = internal unnamed_addr global i64 0, align 8
-@str_unknown = private unnamed_addr constant [8 x i8] c"unknown\00", align 1
 @rubyIdPrecomputed_do = internal unnamed_addr global i64 0, align 8
-@str_do = private unnamed_addr constant [3 x i8] c"do\00", align 1
-@str_magic = private unnamed_addr constant [6 x i8] c"magic\00", align 1
 @ruby_hashLiteral1 = internal unnamed_addr global i64 0, align 8
-@str_one = private unnamed_addr constant [4 x i8] c"one\00", align 1
 @ruby_hashLiteral2 = internal unnamed_addr global i64 0, align 8
-@str_two = private unnamed_addr constant [4 x i8] c"two\00", align 1
 @ruby_hashLiteral3 = internal unnamed_addr global i64 0, align 8
-@str_true = private unnamed_addr constant [5 x i8] c"true\00", align 1
 @ruby_hashLiteral4 = internal unnamed_addr global i64 0, align 8
-@str_false = private unnamed_addr constant [6 x i8] c"false\00", align 1
 @ruby_hashLiteral5 = internal unnamed_addr global i64 0, align 8
-@str_nil = private unnamed_addr constant [4 x i8] c"nil\00", align 1
 @ruby_hashLiteral6 = internal unnamed_addr global i64 0, align 8
 @rubyIdPrecomputed_symbol = internal unnamed_addr global i64 0, align 8
-@str_symbol = private unnamed_addr constant [7 x i8] c"symbol\00", align 1
 @ruby_hashLiteral7 = internal unnamed_addr global i64 0, align 8
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
-@str_puts = private unnamed_addr constant [5 x i8] c"puts\00", align 1
+@sorbet_moduleStringTable = internal unnamed_addr constant [140 x i8] c"<top (required)>\00test/testdata/compiler/literal_hash.rb\00foo\00bar\00baz\00quux\00wat\00how\00unknown\00do\00magic\00one\00two\00true\00false\00nil\00symbol\00puts\00master\00", align 1
 
 ; Function Attrs: nounwind readnone willreturn
 declare i64 @rb_id2sym(i64) local_unnamed_addr #0
@@ -176,18 +159,18 @@ entry:
   %argArray.i.i = alloca [14 x i64], align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #7
+  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #7
   store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @str_do, i64 0, i64 0), i64 noundef 2) #7
+  %1 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 89), i64 noundef 2) #7
   store i64 %1, i64* @rubyIdPrecomputed_do, align 8
-  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_symbol, i64 0, i64 0), i64 noundef 6) #7
+  %2 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 121), i64 noundef 6) #7
   store i64 %2, i64* @rubyIdPrecomputed_symbol, align 8
-  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #7
+  %3 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 128), i64 noundef 4) #7
   store i64 %3, i64* @rubyIdPrecomputed_puts, align 8
-  %4 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #7
+  %4 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #7
   tail call void @rb_gc_register_mark_object(i64 %4) #7
   store i64 %4, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %5 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([39 x i8], [39 x i8]* @"str_test/testdata/compiler/literal_hash.rb", i64 0, i64 0), i64 noundef 38) #7
+  %5 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 38) #7
   tail call void @rb_gc_register_mark_object(i64 %5) #7
   store i64 %5, i64* @"rubyStrFrozen_test/testdata/compiler/literal_hash.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 15)
@@ -196,28 +179,28 @@ entry:
   %"rubyStr_test/testdata/compiler/literal_hash.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/literal_hash.rb", align 8
   %6 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/literal_hash.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 15)
   store %struct.rb_iseq_struct* %6, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %7 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #7
+  %7 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 56), i64 noundef 3) #7
   call void @rb_gc_register_mark_object(i64 %7) #7
   store i64 %7, i64* @rubyStrFrozen_foo, align 8
-  %8 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_bar, i64 0, i64 0), i64 noundef 3) #7
+  %8 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 60), i64 noundef 3) #7
   call void @rb_gc_register_mark_object(i64 %8) #7
   store i64 %8, i64* @rubyStrFrozen_bar, align 8
-  %9 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_baz, i64 0, i64 0), i64 noundef 3) #7
+  %9 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 64), i64 noundef 3) #7
   call void @rb_gc_register_mark_object(i64 %9) #7
   store i64 %9, i64* @rubyStrFrozen_baz, align 8
-  %10 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_quux, i64 0, i64 0), i64 noundef 4) #7
+  %10 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 68), i64 noundef 4) #7
   call void @rb_gc_register_mark_object(i64 %10) #7
   store i64 %10, i64* @rubyStrFrozen_quux, align 8
-  %11 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_wat, i64 0, i64 0), i64 noundef 3) #7
+  %11 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 73), i64 noundef 3) #7
   call void @rb_gc_register_mark_object(i64 %11) #7
   store i64 %11, i64* @rubyStrFrozen_wat, align 8
-  %12 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_how, i64 0, i64 0), i64 noundef 3) #7
+  %12 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 77), i64 noundef 3) #7
   call void @rb_gc_register_mark_object(i64 %12) #7
   store i64 %12, i64* @rubyStrFrozen_how, align 8
-  %13 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_unknown, i64 0, i64 0), i64 noundef 7) #7
+  %13 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 81), i64 noundef 7) #7
   call void @rb_gc_register_mark_object(i64 %13) #7
   store i64 %13, i64* @rubyStrFrozen_unknown, align 8
-  %14 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_magic, i64 0, i64 0), i64 noundef 5) #7
+  %14 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 92), i64 noundef 5) #7
   call void @rb_gc_register_mark_object(i64 %14) #7
   %15 = bitcast [14 x i64]* %argArray.i.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 112, i8* nonnull %15)
@@ -263,7 +246,7 @@ entry:
   %17 = call i64 @sorbet_globalConstRegister(i64 %16) #7
   store i64 %17, i64* @ruby_hashLiteral1, align 8
   call void @llvm.lifetime.end.p0i8(i64 112, i8* nonnull %15)
-  %18 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_one, i64 0, i64 0), i64 noundef 3) #7
+  %18 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 98), i64 noundef 3) #7
   call void @rb_gc_register_mark_object(i64 %18) #7
   %19 = bitcast [2 x i64]* %argArray.i1.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %19)
@@ -276,7 +259,7 @@ entry:
   %21 = call i64 @sorbet_globalConstRegister(i64 %20) #7
   store i64 %21, i64* @ruby_hashLiteral2, align 8
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %19)
-  %22 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_two, i64 0, i64 0), i64 noundef 3) #7
+  %22 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 102), i64 noundef 3) #7
   call void @rb_gc_register_mark_object(i64 %22) #7
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %19)
   store i64 2, i64* %hashArgs0Addr.i2.i, align 8
@@ -286,7 +269,7 @@ entry:
   %24 = call i64 @sorbet_globalConstRegister(i64 %23) #7
   store i64 %24, i64* @ruby_hashLiteral3, align 8
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %19)
-  %25 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_true, i64 0, i64 0), i64 noundef 4) #7
+  %25 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 106), i64 noundef 4) #7
   call void @rb_gc_register_mark_object(i64 %25) #7
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %19)
   store i64 20, i64* %hashArgs0Addr.i2.i, align 8
@@ -296,7 +279,7 @@ entry:
   %27 = call i64 @sorbet_globalConstRegister(i64 %26) #7
   store i64 %27, i64* @ruby_hashLiteral4, align 8
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %19)
-  %28 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([6 x i8], [6 x i8]* @str_false, i64 0, i64 0), i64 noundef 5) #7
+  %28 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 111), i64 noundef 5) #7
   call void @rb_gc_register_mark_object(i64 %28) #7
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %19)
   store i64 0, i64* %hashArgs0Addr.i2.i, align 8
@@ -306,7 +289,7 @@ entry:
   %30 = call i64 @sorbet_globalConstRegister(i64 %29) #7
   store i64 %30, i64* @ruby_hashLiteral5, align 8
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %19)
-  %31 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_nil, i64 0, i64 0), i64 noundef 3) #7
+  %31 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 117), i64 noundef 3) #7
   call void @rb_gc_register_mark_object(i64 %31) #7
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %19)
   store i64 8, i64* %hashArgs0Addr.i2.i, align 8
@@ -316,7 +299,7 @@ entry:
   %33 = call i64 @sorbet_globalConstRegister(i64 %32) #7
   store i64 %33, i64* @ruby_hashLiteral6, align 8
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %19)
-  %34 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_symbol, i64 0, i64 0), i64 noundef 6) #7
+  %34 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 121), i64 noundef 6) #7
   call void @rb_gc_register_mark_object(i64 %34) #7
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %19)
   %rubyId_symbol.i.i = load i64, i64* @rubyIdPrecomputed_symbol, align 8

--- a/test/testdata/compiler/literals.opt.ll.exp
+++ b/test/testdata/compiler/literals.opt.ll.exp
@@ -82,25 +82,21 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
 @"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/literals.rb" = internal unnamed_addr global i64 0, align 8
-@"str_test/testdata/compiler/literals.rb" = private unnamed_addr constant [35 x i8] c"test/testdata/compiler/literals.rb\00", align 1
 @iseqEncodedArray = internal global [11 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
-@str_puts = private unnamed_addr constant [5 x i8] c"puts\00", align 1
 @ic_puts.1 = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyStrFrozen_str = internal unnamed_addr global i64 0, align 8
-@str_str = private unnamed_addr constant [4 x i8] c"str\00", align 1
 @ic_puts.2 = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_sym = internal unnamed_addr global i64 0, align 8
-@str_sym = private unnamed_addr constant [4 x i8] c"sym\00", align 1
 @ic_puts.3 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.4 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.5 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.6 = internal global %struct.FunctionInlineCache zeroinitializer
+@sorbet_moduleStringTable = internal unnamed_addr constant [72 x i8] c"<top (required)>\00test/testdata/compiler/literals.rb\00puts\00str\00sym\00master\00", align 1
 
 ; Function Attrs: nounwind readnone willreturn
 declare i64 @rb_id2sym(i64) local_unnamed_addr #0
@@ -145,16 +141,16 @@ define void @Init_literals() local_unnamed_addr #4 {
 entry:
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #6
+  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([72 x i8], [72 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #6
   store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #6
+  %1 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([72 x i8], [72 x i8]* @sorbet_moduleStringTable, i64 0, i64 52), i64 noundef 4) #6
   store i64 %1, i64* @rubyIdPrecomputed_puts, align 8
-  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_sym, i64 0, i64 0), i64 noundef 3) #6
+  %2 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([72 x i8], [72 x i8]* @sorbet_moduleStringTable, i64 0, i64 61), i64 noundef 3) #6
   store i64 %2, i64* @rubyIdPrecomputed_sym, align 8
-  %3 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #6
+  %3 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([72 x i8], [72 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #6
   tail call void @rb_gc_register_mark_object(i64 %3) #6
   store i64 %3, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %4 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([35 x i8], [35 x i8]* @"str_test/testdata/compiler/literals.rb", i64 0, i64 0), i64 noundef 34) #6
+  %4 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([72 x i8], [72 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 34) #6
   tail call void @rb_gc_register_mark_object(i64 %4) #6
   store i64 %4, i64* @"rubyStrFrozen_test/testdata/compiler/literals.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 11)
@@ -167,7 +163,7 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !10
   %rubyId_puts1.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !15
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts1.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
-  %6 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_str, i64 0, i64 0), i64 noundef 3) #6
+  %6 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([72 x i8], [72 x i8]* @sorbet_moduleStringTable, i64 0, i64 57), i64 noundef 3) #6
   call void @rb_gc_register_mark_object(i64 %6) #6
   store i64 %6, i64* @rubyStrFrozen_str, align 8
   %rubyId_puts4.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !16

--- a/test/testdata/compiler/method.rb
+++ b/test/testdata/compiler/method.rb
@@ -13,5 +13,6 @@ end
 hello("sorbet")
 
 # INITIAL-LABEL: define internal i64 @"func_<root>.17<static-init>
-# INITIAL: call void @sorbet_defineMethod({{.*@str_hello}}
+# INITIAL: [[VAR:%[a-zA-Z0-9_]+]] = load i8*, i8** @addr_str_hello{{.*}}
+# INITIAL: call void @sorbet_defineMethod({{.*}}[[VAR]]
 # INITIAL{LITERAL}: }

--- a/test/testdata/compiler/repeated_casts.opt.ll.exp
+++ b/test/testdata/compiler/repeated_casts.opt.ll.exp
@@ -82,28 +82,20 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_Object#10doubleCast" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @rubyIdPrecomputed_doubleCast = internal unnamed_addr global i64 0, align 8
-@str_doubleCast = private unnamed_addr constant [11 x i8] c"doubleCast\00", align 1
 @rubyStrFrozen_doubleCast = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/repeated_casts.rb" = internal unnamed_addr global i64 0, align 8
-@"str_test/testdata/compiler/repeated_casts.rb" = private unnamed_addr constant [41 x i8] c"test/testdata/compiler/repeated_casts.rb\00", align 1
 @iseqEncodedArray = internal global [12 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
-@str_A = private unnamed_addr constant [2 x i8] c"A\00", align 1
-@str_T.cast = private unnamed_addr constant [7 x i8] c"T.cast\00", align 1
 @ic_foo = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_foo = internal unnamed_addr global i64 0, align 8
-@str_foo = private unnamed_addr constant [4 x i8] c"foo\00", align 1
 @ic_foo.1 = internal global %struct.FunctionInlineCache zeroinitializer
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
-@str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
 @rubyIdPrecomputed_a = internal unnamed_addr global i64 0, align 8
-@str_a = private unnamed_addr constant [2 x i8] c"a\00", align 1
 @"stackFramePrecomputed_func_A#3foo" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"stackFramePrecomputed_func_A.13<static-init>" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<class:A>" = internal unnamed_addr global i64 0, align 8
-@"str_<class:A>" = private unnamed_addr constant [10 x i8] c"<class:A>\00", align 1
+@sorbet_moduleStringTable = internal unnamed_addr constant [115 x i8] c"doubleCast\00test/testdata/compiler/repeated_casts.rb\00A\00T.cast\00foo\00<top (required)>\00Object\00normal\00a\00master\00<class:A>\00", align 1
 @guard_epoch_A = linkonce local_unnamed_addr global i64 0
 @guarded_const_A = linkonce local_unnamed_addr global i64 0
 @rb_cObject = external local_unnamed_addr constant i64
@@ -243,21 +235,21 @@ entry:
   %locals.i4.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_doubleCast, i64 0, i64 0), i64 noundef 10) #16
+  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 10) #16
   store i64 %0, i64* @rubyIdPrecomputed_doubleCast, align 8
-  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #16
+  %1 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 61), i64 noundef 3) #16
   store i64 %1, i64* @rubyIdPrecomputed_foo, align 8
-  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #16
+  %2 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 65), i64 noundef 16) #16
   store i64 %2, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #16
-  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_a, i64 0, i64 0), i64 noundef 1) #16
+  %3 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 89), i64 noundef 6) #16
+  %4 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 96), i64 noundef 1) #16
   store i64 %4, i64* @rubyIdPrecomputed_a, align 8
-  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #16
+  %5 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 105), i64 noundef 9) #16
   store i64 %5, i64* @"rubyIdPrecomputed_<class:A>", align 8
-  %6 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_doubleCast, i64 0, i64 0), i64 noundef 10) #16
+  %6 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 10) #16
   tail call void @rb_gc_register_mark_object(i64 %6) #16
   store i64 %6, i64* @rubyStrFrozen_doubleCast, align 8
-  %7 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([41 x i8], [41 x i8]* @"str_test/testdata/compiler/repeated_casts.rb", i64 0, i64 0), i64 noundef 40) #16
+  %7 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 11), i64 noundef 40) #16
   tail call void @rb_gc_register_mark_object(i64 %7) #16
   store i64 %7, i64* @"rubyStrFrozen_test/testdata/compiler/repeated_casts.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 12)
@@ -270,19 +262,19 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !19
   %rubyId_foo1.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !24
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo.1, i64 %rubyId_foo1.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !24
-  %9 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #16
+  %9 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 65), i64 noundef 16) #16
   call void @rb_gc_register_mark_object(i64 %9) #16
   %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/repeated_casts.rb.i3.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/repeated_casts.rb", align 8
   %10 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %9, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/repeated_casts.rb.i3.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i4.i, i32 noundef 0, i32 noundef 4)
   store %struct.rb_iseq_struct* %10, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %11 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #16
+  %11 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 61), i64 noundef 3) #16
   call void @rb_gc_register_mark_object(i64 %11) #16
   %rubyId_foo.i.i = load i64, i64* @rubyIdPrecomputed_foo, align 8
   %"rubyStr_test/testdata/compiler/repeated_casts.rb.i5.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/repeated_casts.rb", align 8
   %12 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %11, i64 %rubyId_foo.i.i, i64 %"rubyStr_test/testdata/compiler/repeated_casts.rb.i5.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i6.i, i32 noundef 0, i32 noundef 0)
   store %struct.rb_iseq_struct* %12, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#3foo", align 8
-  %13 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #16
+  %13 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 105), i64 noundef 9) #16
   call void @rb_gc_register_mark_object(i64 %13) #16
   %"rubyId_<class:A>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:A>", align 8
   %"rubyStr_test/testdata/compiler/repeated_casts.rb.i7.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/repeated_casts.rb", align 8
@@ -305,7 +297,7 @@ entry:
   %24 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 0
   store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %24, align 8, !dbg !34, !tbaa !14
   %25 = load i64, i64* @rb_cObject, align 8, !dbg !35
-  %26 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 %25) #16, !dbg !35
+  %26 = call i64 @rb_define_class(i8* getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 52), i64 %25) #16, !dbg !35
   %27 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %26) #16, !dbg !35
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
   %28 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
@@ -344,7 +336,7 @@ entry:
   store i16 %47, i16* %45, align 8, !dbg !39
   %48 = getelementptr inbounds i8, i8* %44, i64 4, !dbg !39
   call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %48, i8 0, i64 28, i1 false) #16, !dbg !39
-  call void @sorbet_vm_define_method(i64 %41, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_A#3foo", i8* nonnull %44, %struct.rb_iseq_struct* %stackFrame7.i.i, i1 noundef zeroext false) #16, !dbg !39
+  call void @sorbet_vm_define_method(i64 %41, i8* getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 61), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_A#3foo", i8* nonnull %44, %struct.rb_iseq_struct* %stackFrame7.i.i, i1 noundef zeroext false) #16, !dbg !39
   call void @sorbet_popFrame() #16, !dbg !35
   store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %24, align 8, !dbg !35, !tbaa !14
   %stackFrame19.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#10doubleCast", align 8, !dbg !25
@@ -369,7 +361,7 @@ entry:
   %60 = getelementptr inbounds i8, i8* %49, i64 32, !dbg !25
   %61 = bitcast i8* %60 to i8**, !dbg !25
   store i8* %59, i8** %61, align 8, !dbg !25, !tbaa !44
-  call void @sorbet_vm_define_method(i64 %25, i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_doubleCast, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#10doubleCast", i8* nonnull %49, %struct.rb_iseq_struct* %stackFrame19.i, i1 noundef zeroext false) #16, !dbg !25
+  call void @sorbet_vm_define_method(i64 %25, i8* noundef getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#10doubleCast", i8* nonnull %49, %struct.rb_iseq_struct* %stackFrame19.i, i1 noundef zeroext false) #16, !dbg !25
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %18)
   ret void
 }
@@ -397,7 +389,7 @@ declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
 define internal fastcc void @"func_Object#10doubleCast.cold.1"(i64 %rawArg_a) unnamed_addr #10 !dbg !49 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %rawArg_a, i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_T.cast, i64 0, i64 0), i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0)) #14, !dbg !51
+  tail call void @sorbet_cast_failure(i64 %rawArg_a, i8* getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 54), i8* getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 52)) #14, !dbg !51
   unreachable, !dbg !51
 }
 
@@ -406,7 +398,7 @@ declare void @llvm.assume(i1 noundef) #11
 
 ; Function Attrs: ssp
 define linkonce void @const_recompute_A() local_unnamed_addr #12 {
-  %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 1)
+  %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 52), i64 1)
   store i64 %1, i64* @guarded_const_A, align 8
   %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !20
   store i64 %2, i64* @guard_epoch_A, align 8

--- a/test/testdata/compiler/send_with_block_param.opt.ll.exp
+++ b/test/testdata/compiler/send_with_block_param.opt.ll.exp
@@ -84,21 +84,16 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
 @"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/send_with_block_param.rb" = internal unnamed_addr global i64 0, align 8
-@"str_test/testdata/compiler/send_with_block_param.rb" = private unnamed_addr constant [48 x i8] c"test/testdata/compiler/send_with_block_param.rb\00", align 1
 @iseqEncodedArray = internal global [7 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @ruby_hashLiteral1 = internal unnamed_addr global i64 0, align 8
-@str_unsafe = private unnamed_addr constant [7 x i8] c"unsafe\00", align 1
-@"str_<build-array>" = private unnamed_addr constant [14 x i8] c"<build-array>\00", align 1
 @rubyIdPrecomputed_map = internal unnamed_addr global i64 0, align 8
-@str_map = private unnamed_addr constant [4 x i8] c"map\00", align 1
 @ic_map = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
-@str_puts = private unnamed_addr constant [5 x i8] c"puts\00", align 1
+@sorbet_moduleStringTable = internal unnamed_addr constant [104 x i8] c"<top (required)>\00test/testdata/compiler/send_with_block_param.rb\00T\00unsafe\00<build-array>\00map\00puts\00master\00", align 1
 
 declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
 
@@ -159,18 +154,18 @@ entry:
   %argArray.i.i = alloca [2 x i64], align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #7
+  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([104 x i8], [104 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #7
   store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_unsafe, i64 0, i64 0), i64 noundef 6) #7
-  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_<build-array>", i64 0, i64 0), i64 noundef 13) #7
-  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_map, i64 0, i64 0), i64 noundef 3) #7
+  %1 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([104 x i8], [104 x i8]* @sorbet_moduleStringTable, i64 0, i64 67), i64 noundef 6) #7
+  %2 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([104 x i8], [104 x i8]* @sorbet_moduleStringTable, i64 0, i64 74), i64 noundef 13) #7
+  %3 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([104 x i8], [104 x i8]* @sorbet_moduleStringTable, i64 0, i64 88), i64 noundef 3) #7
   store i64 %3, i64* @rubyIdPrecomputed_map, align 8
-  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #7
+  %4 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([104 x i8], [104 x i8]* @sorbet_moduleStringTable, i64 0, i64 92), i64 noundef 4) #7
   store i64 %4, i64* @rubyIdPrecomputed_puts, align 8
-  %5 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #7
+  %5 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([104 x i8], [104 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #7
   tail call void @rb_gc_register_mark_object(i64 %5) #7
   store i64 %5, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %6 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([48 x i8], [48 x i8]* @"str_test/testdata/compiler/send_with_block_param.rb", i64 0, i64 0), i64 noundef 47) #7
+  %6 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([104 x i8], [104 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 47) #7
   tail call void @rb_gc_register_mark_object(i64 %6) #7
   store i64 %6, i64* @"rubyStrFrozen_test/testdata/compiler/send_with_block_param.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 7)

--- a/test/testdata/compiler/sig_rewriter.opt.ll.exp
+++ b/test/testdata/compiler/sig_rewriter.opt.ll.exp
@@ -83,40 +83,28 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
 @"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb" = internal unnamed_addr global i64 0, align 8
-@"str_test/testdata/compiler/sig_rewriter.rb" = private unnamed_addr constant [39 x i8] c"test/testdata/compiler/sig_rewriter.rb\00", align 1
 @iseqEncodedArray = internal global [14 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
-@str_A = private unnamed_addr constant [2 x i8] c"A\00", align 1
 @ic_new = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_new = internal unnamed_addr global i64 0, align 8
-@str_new = private unnamed_addr constant [4 x i8] c"new\00", align 1
 @ic_initialize = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_initialize = internal unnamed_addr global i64 0, align 8
-@str_initialize = private unnamed_addr constant [11 x i8] c"initialize\00", align 1
 @ic_foo = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_foo = internal unnamed_addr global i64 0, align 8
-@str_foo = private unnamed_addr constant [4 x i8] c"foo\00", align 1
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
-@str_puts = private unnamed_addr constant [5 x i8] c"puts\00", align 1
 @"stackFramePrecomputed_func_A#3foo" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"stackFramePrecomputed_func_A.13<static-init>" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<class:A>" = internal unnamed_addr global i64 0, align 8
-@"str_<class:A>" = private unnamed_addr constant [10 x i8] c"<class:A>\00", align 1
 @"stackFramePrecomputed_func_A.13<static-init>$block_1" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_block in <class:A>" = internal unnamed_addr global i64 0, align 8
-@"str_block in <class:A>" = private unnamed_addr constant [19 x i8] c"block in <class:A>\00", align 1
 @ic_returns = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_returns = internal unnamed_addr global i64 0, align 8
-@str_returns = private unnamed_addr constant [8 x i8] c"returns\00", align 1
-@"str_T::Sig" = private unnamed_addr constant [7 x i8] c"T::Sig\00", align 1
 @ic_extend = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_extend = internal unnamed_addr global i64 0, align 8
-@str_extend = private unnamed_addr constant [7 x i8] c"extend\00", align 1
-@str_normal = private unnamed_addr constant [7 x i8] c"normal\00", align 1
+@sorbet_moduleStringTable = internal unnamed_addr constant [175 x i8] c"<top (required)>\00test/testdata/compiler/sig_rewriter.rb\00A\00Object\00new\00initialize\00foo\00puts\00master\00Return value\00Integer\00<class:A>\00block in <class:A>\00returns\00T::Sig\00extend\00normal\00", align 1
 @rb_cObject = external local_unnamed_addr constant i64
 @"guard_epoch_T::Sig" = linkonce local_unnamed_addr global i64 0
 @"guarded_const_T::Sig" = linkonce local_unnamed_addr global i64 0
@@ -189,29 +177,29 @@ entry:
   %locals.i10.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
+  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #11
   store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_new, i64 0, i64 0), i64 noundef 3) #11
+  %1 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 65), i64 noundef 3) #11
   store i64 %1, i64* @rubyIdPrecomputed_new, align 8
-  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([11 x i8], [11 x i8]* @str_initialize, i64 0, i64 0), i64 noundef 10) #11
+  %2 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 69), i64 noundef 10) #11
   store i64 %2, i64* @rubyIdPrecomputed_initialize, align 8
-  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #11
+  %3 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 80), i64 noundef 3) #11
   store i64 %3, i64* @rubyIdPrecomputed_foo, align 8
-  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #11
+  %4 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 84), i64 noundef 4) #11
   store i64 %4, i64* @rubyIdPrecomputed_puts, align 8
-  %5 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #11
+  %5 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 117), i64 noundef 9) #11
   store i64 %5, i64* @"rubyIdPrecomputed_<class:A>", align 8
-  %6 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([19 x i8], [19 x i8]* @"str_block in <class:A>", i64 0, i64 0), i64 noundef 18) #11
+  %6 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 127), i64 noundef 18) #11
   store i64 %6, i64* @"rubyIdPrecomputed_block in <class:A>", align 8
-  %7 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @str_returns, i64 0, i64 0), i64 noundef 7) #11
+  %7 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 146), i64 noundef 7) #11
   store i64 %7, i64* @rubyIdPrecomputed_returns, align 8
-  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_extend, i64 0, i64 0), i64 noundef 6) #11
+  %8 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 161), i64 noundef 6) #11
   store i64 %8, i64* @rubyIdPrecomputed_extend, align 8
-  %9 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_normal, i64 0, i64 0), i64 noundef 6) #11
-  %10 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #11
+  %9 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 168), i64 noundef 6) #11
+  %10 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #11
   tail call void @rb_gc_register_mark_object(i64 %10) #11
   store i64 %10, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %11 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([39 x i8], [39 x i8]* @"str_test/testdata/compiler/sig_rewriter.rb", i64 0, i64 0), i64 noundef 38) #11
+  %11 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 38) #11
   tail call void @rb_gc_register_mark_object(i64 %11) #11
   store i64 %11, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 14)
@@ -228,19 +216,19 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !10
   %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !15
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
-  %13 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 noundef 3) #11
+  %13 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 80), i64 noundef 3) #11
   call void @rb_gc_register_mark_object(i64 %13) #11
   %rubyId_foo.i.i = load i64, i64* @rubyIdPrecomputed_foo, align 8
   %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i9.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
   %14 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %13, i64 %rubyId_foo.i.i, i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i9.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i10.i, i32 noundef 0, i32 noundef 0)
   store %struct.rb_iseq_struct* %14, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#3foo", align 8
-  %15 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([10 x i8], [10 x i8]* @"str_<class:A>", i64 0, i64 0), i64 noundef 9) #11
+  %15 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 117), i64 noundef 9) #11
   call void @rb_gc_register_mark_object(i64 %15) #11
   %"rubyId_<class:A>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:A>", align 8
   %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i11.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
   %16 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %15, i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i11.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i12.i, i32 noundef 0, i32 noundef 4)
   store %struct.rb_iseq_struct* %16, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %17 = call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([19 x i8], [19 x i8]* @"str_block in <class:A>", i64 0, i64 0), i64 noundef 18) #11
+  %17 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 127), i64 noundef 18) #11
   call void @rb_gc_register_mark_object(i64 %17) #11
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
   %"rubyId_block in <class:A>.i.i" = load i64, i64* @"rubyIdPrecomputed_block in <class:A>", align 8
@@ -269,7 +257,7 @@ entry:
   %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 0
   store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %30, align 8, !dbg !38, !tbaa !20
   %31 = load i64, i64* @rb_cObject, align 8, !dbg !39
-  %32 = call i64 @rb_define_class(i8* noundef getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 %31) #11, !dbg !39
+  %32 = call i64 @rb_define_class(i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 56), i64 %31) #11, !dbg !39
   %33 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %32) #11, !dbg !39
   %stackFrame.i.i1 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
   %34 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !20
@@ -336,7 +324,7 @@ entry:
   store i16 %64, i16* %62, align 8, !dbg !46
   %65 = getelementptr inbounds i8, i8* %61, i64 4, !dbg !46
   call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %65, i8 0, i64 28, i1 false) #11, !dbg !46
-  call void @sorbet_vm_define_method(i64 %58, i8* noundef getelementptr inbounds ([4 x i8], [4 x i8]* @str_foo, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_A#3foo", i8* nonnull %61, %struct.rb_iseq_struct* %stackFrame42.i.i, i1 noundef zeroext false) #11, !dbg !46
+  call void @sorbet_vm_define_method(i64 %58, i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 80), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_A#3foo", i8* nonnull %61, %struct.rb_iseq_struct* %stackFrame42.i.i, i1 noundef zeroext false) #11, !dbg !46
   call void @sorbet_popFrame() #11, !dbg !39
   store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %30, align 8, !dbg !39, !tbaa !20
   %66 = call i64 @sorbet_maybeAllocateObjectFastPath(i64 %58, %struct.FunctionInlineCache* noundef @ic_new) #11, !dbg !10
@@ -435,7 +423,7 @@ declare void @llvm.assume(i1 noundef) #9
 
 ; Function Attrs: ssp
 define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #7 {
-  %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([7 x i8], [7 x i8]* @"str_T::Sig", i64 0, i64 0), i64 6)
+  %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 154), i64 6)
   store i64 %1, i64* @"guarded_const_T::Sig", align 8
   %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !44
   store i64 %2, i64* @"guard_epoch_T::Sig", align 8
@@ -444,7 +432,7 @@ define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #7 {
 
 ; Function Attrs: ssp
 define linkonce void @const_recompute_A() local_unnamed_addr #7 {
-  %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @str_A, i64 0, i64 0), i64 1)
+  %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 56), i64 1)
   store i64 %1, i64* @guarded_const_A, align 8
   %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !44
   store i64 %2, i64* @guard_epoch_A, align 8

--- a/test/testdata/compiler/splat_assign.opt.ll.exp
+++ b/test/testdata/compiler/splat_assign.opt.ll.exp
@@ -82,20 +82,15 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
 @"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/splat_assign.rb" = internal unnamed_addr global i64 0, align 8
-@"str_test/testdata/compiler/splat_assign.rb" = private unnamed_addr constant [39 x i8] c"test/testdata/compiler/splat_assign.rb\00", align 1
 @iseqEncodedArray = internal global [13 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
-@"str_<build-array>" = private unnamed_addr constant [14 x i8] c"<build-array>\00", align 1
-@"str_<expand-splat>" = private unnamed_addr constant [15 x i8] c"<expand-splat>\00", align 1
-@"str_[]" = private unnamed_addr constant [3 x i8] c"[]\00", align 1
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
-@str_puts = private unnamed_addr constant [5 x i8] c"puts\00", align 1
 @ic_puts.6 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.10 = internal global %struct.FunctionInlineCache zeroinitializer
+@sorbet_moduleStringTable = internal unnamed_addr constant [100 x i8] c"<top (required)>\00test/testdata/compiler/splat_assign.rb\00<build-array>\00<expand-splat>\00[]\00puts\00master\00", align 1
 
 declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
 
@@ -151,17 +146,17 @@ entry:
   %callArgs.i = alloca [8 x i64], align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #7
+  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #7
   store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([14 x i8], [14 x i8]* @"str_<build-array>", i64 0, i64 0), i64 noundef 13) #7
-  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([15 x i8], [15 x i8]* @"str_<expand-splat>", i64 0, i64 0), i64 noundef 14) #7
-  %3 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([3 x i8], [3 x i8]* @"str_[]", i64 0, i64 0), i64 noundef 2) #7
-  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #7
+  %1 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 56), i64 noundef 13) #7
+  %2 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 70), i64 noundef 14) #7
+  %3 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 85), i64 noundef 2) #7
+  %4 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 88), i64 noundef 4) #7
   store i64 %4, i64* @rubyIdPrecomputed_puts, align 8
-  %5 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #7
+  %5 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #7
   tail call void @rb_gc_register_mark_object(i64 %5) #7
   store i64 %5, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %6 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([39 x i8], [39 x i8]* @"str_test/testdata/compiler/splat_assign.rb", i64 0, i64 0), i64 noundef 38) #7
+  %6 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 38) #7
   tail call void @rb_gc_register_mark_object(i64 %6) #7
   store i64 %6, i64* @"rubyStrFrozen_test/testdata/compiler/splat_assign.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 13)

--- a/test/testdata/compiler/static_method.rb
+++ b/test/testdata/compiler/static_method.rb
@@ -11,5 +11,6 @@ end
 puts Foo.bar
 
 # INITIAL-LABEL: define internal i64 @"func_Foo.13<static-init>
-# INITIAL: call void @sorbet_defineMethodSingleton({{.*@str_bar}}
+# INITIAL: [[VAR:%[a-zA-Z0-9_]+]] = load i8*, i8** @addr_str_bar{{.*}}
+# INITIAL: call void @sorbet_defineMethodSingleton({{.*}}[[VAR]]
 # INITIAL{LITERAL}: }

--- a/test/testdata/compiler/unsafe.opt.ll.exp
+++ b/test/testdata/compiler/unsafe.opt.ll.exp
@@ -82,16 +82,13 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"str_<top (required)>" = private unnamed_addr constant [17 x i8] c"<top (required)>\00", align 1
 @"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/unsafe.rb" = internal unnamed_addr global i64 0, align 8
-@"str_test/testdata/compiler/unsafe.rb" = private unnamed_addr constant [33 x i8] c"test/testdata/compiler/unsafe.rb\00", align 1
 @iseqEncodedArray = internal global [5 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
-@str_unsafe = private unnamed_addr constant [7 x i8] c"unsafe\00", align 1
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
-@str_puts = private unnamed_addr constant [5 x i8] c"puts\00", align 1
+@sorbet_moduleStringTable = internal unnamed_addr constant [71 x i8] c"<top (required)>\00test/testdata/compiler/unsafe.rb\00T\00unsafe\00puts\00master\00", align 1
 
 declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
 
@@ -138,15 +135,15 @@ define void @Init_unsafe() local_unnamed_addr #4 {
 entry:
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #6
+  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([71 x i8], [71 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #6
   store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([7 x i8], [7 x i8]* @str_unsafe, i64 0, i64 0), i64 noundef 6) #6
-  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([5 x i8], [5 x i8]* @str_puts, i64 0, i64 0), i64 noundef 4) #6
+  %1 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([71 x i8], [71 x i8]* @sorbet_moduleStringTable, i64 0, i64 52), i64 noundef 6) #6
+  %2 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([71 x i8], [71 x i8]* @sorbet_moduleStringTable, i64 0, i64 59), i64 noundef 4) #6
   store i64 %2, i64* @rubyIdPrecomputed_puts, align 8
-  %3 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([17 x i8], [17 x i8]* @"str_<top (required)>", i64 0, i64 0), i64 noundef 16) #6
+  %3 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([71 x i8], [71 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #6
   tail call void @rb_gc_register_mark_object(i64 %3) #6
   store i64 %3, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %4 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([33 x i8], [33 x i8]* @"str_test/testdata/compiler/unsafe.rb", i64 0, i64 0), i64 noundef 32) #6
+  %4 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([71 x i8], [71 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 32) #6
   tail call void @rb_gc_register_mark_object(i64 %4) #6
   store i64 %4, i64* @"rubyStrFrozen_test/testdata/compiler/unsafe.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 5)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This change lays some groundwork for not generating code for interning individual IDs in each compiled module.  Instead, once we have this string table, we can generate a table for IDs that looks something like (C++ code):

```c++
// In the compiled module:
static const size_t numIDs = ...;
static struct IDDescriptor {
  uint32_t offset;
  uint32_t length;
} idDescriptors[numIDs] = {...};

static ID idTable[numIDs];

// sorbet_moduleStringTable defined via CompilerState

// Later, in initialization of the module.  One call for all IDs instead of
// N calls for N IDs.
sorbet_intern_ids(idTable, idDescriptors, numIDs, sorbet_moduleStringTable);

// In the VM payload:
void sorbet_intern_ids(ID *idTable, const IDDescriptor *idDescriptors, size_t numIDs, const char *stringTable) {
  for (size_t i = 0; i < numIDs; ++i) {
    const IDDescriptor &desc = idDescriptors[i];
    idTable[i] = rb_intern(&stringTable[desc.offset], desc.length);
  }
}
```

which creates a lot less IR for LLVM to optimize in the actual compiled module.

And we can do the same thing for Ruby-level strings, which also cuts down on the amount of LLVM IR we generate.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.  The only complication here is that certain calls will no longer see the string constant, but rather some address in the string table, so a few filecheck assertions need to be updated (see `method.rb` and `static_method.rb`).