### PR TITLE
shrink `TypePtr` to 8 bytes by using intrusive refcounting

### DIFF
--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -229,11 +229,11 @@ public:
     }
 
     static ExpressionPtr Symbol(core::LocOffsets loc, core::NameRef name) {
-        return make_expression<ast::Literal>(loc, core::make_type<core::LiteralType>(core::Symbols::Symbol(), name));
+        return make_expression<ast::Literal>(loc, core::make_type<core::NamedLiteralType>(core::Symbols::Symbol(), name));
     }
 
     static ExpressionPtr String(core::LocOffsets loc, core::NameRef value) {
-        return make_expression<ast::Literal>(loc, core::make_type<core::LiteralType>(core::Symbols::String(), value));
+        return make_expression<ast::Literal>(loc, core::make_type<core::NamedLiteralType>(core::Symbols::String(), value));
     }
 
     static ExpressionPtr Method(core::LocOffsets loc, core::LocOffsets declLoc, core::NameRef name,

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -229,11 +229,13 @@ public:
     }
 
     static ExpressionPtr Symbol(core::LocOffsets loc, core::NameRef name) {
-        return make_expression<ast::Literal>(loc, core::make_type<core::NamedLiteralType>(core::Symbols::Symbol(), name));
+        return make_expression<ast::Literal>(loc,
+                                             core::make_type<core::NamedLiteralType>(core::Symbols::Symbol(), name));
     }
 
     static ExpressionPtr String(core::LocOffsets loc, core::NameRef value) {
-        return make_expression<ast::Literal>(loc, core::make_type<core::NamedLiteralType>(core::Symbols::String(), value));
+        return make_expression<ast::Literal>(loc,
+                                             core::make_type<core::NamedLiteralType>(core::Symbols::String(), value));
     }
 
     static ExpressionPtr Method(core::LocOffsets loc, core::LocOffsets declLoc, core::NameRef name,

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -221,7 +221,7 @@ public:
     }
 
     static ExpressionPtr Int(core::LocOffsets loc, int64_t val) {
-        return make_expression<ast::Literal>(loc, core::make_type<core::LiteralType>(val));
+        return make_expression<ast::Literal>(loc, core::make_type<core::LiteralIntegerType>(val));
     }
 
     static ExpressionPtr Float(core::LocOffsets loc, double val) {

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -221,7 +221,7 @@ public:
     }
 
     static ExpressionPtr Int(core::LocOffsets loc, int64_t val) {
-        return make_expression<ast::Literal>(loc, core::make_type<core::LiteralIntegerType>(val));
+        return make_expression<ast::Literal>(loc, core::make_type<core::IntegerLiteralType>(val));
     }
 
     static ExpressionPtr Float(core::LocOffsets loc, double val) {

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -225,7 +225,7 @@ public:
     }
 
     static ExpressionPtr Float(core::LocOffsets loc, double val) {
-        return make_expression<ast::Literal>(loc, core::make_type<core::LiteralType>(val));
+        return make_expression<ast::Literal>(loc, core::make_type<core::FloatLiteralType>(val));
     }
 
     static ExpressionPtr Symbol(core::LocOffsets loc, core::NameRef name) {

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -1343,7 +1343,8 @@ core::NameRef Literal::asSymbol() const {
 
 bool Literal::isSymbol() const {
     return core::isa_type<core::NamedLiteralType>(value) &&
-           core::cast_type_nonnull<core::NamedLiteralType>(value).literalKind == core::NamedLiteralType::LiteralTypeKind::Symbol;
+           core::cast_type_nonnull<core::NamedLiteralType>(value).literalKind ==
+               core::NamedLiteralType::LiteralTypeKind::Symbol;
 }
 
 bool Literal::isNil(const core::GlobalState &gs) const {
@@ -1352,7 +1353,8 @@ bool Literal::isNil(const core::GlobalState &gs) const {
 
 bool Literal::isString() const {
     return core::isa_type<core::NamedLiteralType>(value) &&
-           core::cast_type_nonnull<core::NamedLiteralType>(value).literalKind == core::NamedLiteralType::LiteralTypeKind::String;
+           core::cast_type_nonnull<core::NamedLiteralType>(value).literalKind ==
+               core::NamedLiteralType::LiteralTypeKind::String;
 }
 
 bool Literal::isTrue(const core::GlobalState &gs) const {

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -812,6 +812,7 @@ string Literal::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     typecase(
         this->value, [&](const core::LiteralType &l) { res = l.showValue(gs); },
         [&](const core::LiteralIntegerType &i) { res = i.showValue(gs); },
+        [&](const core::FloatLiteralType &i) { res = i.showValue(gs); },
         [&](const core::ClassType &l) {
             if (l.symbol == core::Symbols::NilClass()) {
                 res = "nil";

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -810,7 +810,7 @@ string Literal::showRaw(const core::GlobalState &gs, int tabs) {
 string Literal::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     string res;
     typecase(
-        this->value, [&](const core::LiteralType &l) { res = l.showValue(gs); },
+        this->value, [&](const core::NamedLiteralType &l) { res = l.showValue(gs); },
         [&](const core::IntegerLiteralType &i) { res = i.showValue(gs); },
         [&](const core::FloatLiteralType &i) { res = i.showValue(gs); },
         [&](const core::ClassType &l) {
@@ -1329,21 +1329,21 @@ string Literal::nodeName() {
 
 core::NameRef Literal::asString() const {
     ENFORCE(isString());
-    auto t = core::cast_type_nonnull<core::LiteralType>(value);
+    auto t = core::cast_type_nonnull<core::NamedLiteralType>(value);
     core::NameRef res = t.asName();
     return res;
 }
 
 core::NameRef Literal::asSymbol() const {
     ENFORCE(isSymbol());
-    auto t = core::cast_type_nonnull<core::LiteralType>(value);
+    auto t = core::cast_type_nonnull<core::NamedLiteralType>(value);
     core::NameRef res = t.asName();
     return res;
 }
 
 bool Literal::isSymbol() const {
-    return core::isa_type<core::LiteralType>(value) &&
-           core::cast_type_nonnull<core::LiteralType>(value).literalKind == core::LiteralType::LiteralTypeKind::Symbol;
+    return core::isa_type<core::NamedLiteralType>(value) &&
+           core::cast_type_nonnull<core::NamedLiteralType>(value).literalKind == core::NamedLiteralType::LiteralTypeKind::Symbol;
 }
 
 bool Literal::isNil(const core::GlobalState &gs) const {
@@ -1351,8 +1351,8 @@ bool Literal::isNil(const core::GlobalState &gs) const {
 }
 
 bool Literal::isString() const {
-    return core::isa_type<core::LiteralType>(value) &&
-           core::cast_type_nonnull<core::LiteralType>(value).literalKind == core::LiteralType::LiteralTypeKind::String;
+    return core::isa_type<core::NamedLiteralType>(value) &&
+           core::cast_type_nonnull<core::NamedLiteralType>(value).literalKind == core::NamedLiteralType::LiteralTypeKind::String;
 }
 
 bool Literal::isTrue(const core::GlobalState &gs) const {

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -811,7 +811,7 @@ string Literal::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     string res;
     typecase(
         this->value, [&](const core::LiteralType &l) { res = l.showValue(gs); },
-        [&](const core::LiteralIntegerType &i) { res = i.showValue(gs); },
+        [&](const core::IntegerLiteralType &i) { res = i.showValue(gs); },
         [&](const core::FloatLiteralType &i) { res = i.showValue(gs); },
         [&](const core::ClassType &l) {
             if (l.symbol == core::Symbols::NilClass()) {

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -811,6 +811,7 @@ string Literal::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     string res;
     typecase(
         this->value, [&](const core::LiteralType &l) { res = l.showValue(gs); },
+        [&](const core::LiteralIntegerType &i) { res = i.showValue(gs); },
         [&](const core::ClassType &l) {
             if (l.symbol == core::Symbols::NilClass()) {
                 res = "nil";

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -964,7 +964,7 @@ public:
 
     void _sanityCheck();
 };
-CheckSize(Cast, 40, 8);
+CheckSize(Cast, 32, 8);
 
 EXPRESSION(Hash) {
 public:
@@ -1032,7 +1032,7 @@ public:
 
     void _sanityCheck();
 };
-CheckSize(Literal, 24, 8);
+CheckSize(Literal, 16, 8);
 
 EXPRESSION(UnresolvedConstantLit) {
 public:

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -770,8 +770,8 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                     }
 
                     auto kwargs = node2TreeImpl(dctx, std::move(kwArray));
-                    auto method =
-                        MK::Literal(loc, core::make_type<core::NamedLiteralType>(core::Symbols::Symbol(), send->method));
+                    auto method = MK::Literal(
+                        loc, core::make_type<core::NamedLiteralType>(core::Symbols::Symbol(), send->method));
 
                     if (auto *array = cast_tree<Array>(kwargs)) {
                         DuplicateHashKeyCheck::checkSendArgs(dctx, 0, array->elems);
@@ -872,8 +872,8 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                         res = MK::Send(loc, std::move(rec), send->method, send->methodLoc, numPosArgs, std::move(args),
                                        flags);
                     } else {
-                        auto method =
-                            MK::Literal(loc, core::make_type<core::NamedLiteralType>(core::Symbols::Symbol(), send->method));
+                        auto method = MK::Literal(
+                            loc, core::make_type<core::NamedLiteralType>(core::Symbols::Symbol(), send->method));
                         ExpressionPtr convertedBlock;
                         if (anonymousBlockPass) {
                             ENFORCE(block == nullptr, "encountered a block while processing an anonymous block pass");

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -332,7 +332,7 @@ ExpressionPtr symbol2Proc(DesugarContext dctx, ExpressionPtr expr) {
     ENFORCE(lit && lit->isSymbol());
 
     // &:foo => {|temp| temp.foo() }
-    core::NameRef name = core::cast_type_nonnull<core::LiteralType>(lit->value).asName();
+    core::NameRef name = core::cast_type_nonnull<core::NamedLiteralType>(lit->value).asName();
     // `temp` does not refer to any specific source text, so give it a 0-length Loc so LSP ignores it.
     auto zeroLengthLoc = loc.copyWithZeroLength();
     ExpressionPtr recv = MK::Local(zeroLengthLoc, temp);
@@ -771,7 +771,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
 
                     auto kwargs = node2TreeImpl(dctx, std::move(kwArray));
                     auto method =
-                        MK::Literal(loc, core::make_type<core::LiteralType>(core::Symbols::Symbol(), send->method));
+                        MK::Literal(loc, core::make_type<core::NamedLiteralType>(core::Symbols::Symbol(), send->method));
 
                     if (auto *array = cast_tree<Array>(kwargs)) {
                         DuplicateHashKeyCheck::checkSendArgs(dctx, 0, array->elems);
@@ -873,7 +873,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                                        flags);
                     } else {
                         auto method =
-                            MK::Literal(loc, core::make_type<core::LiteralType>(core::Symbols::Symbol(), send->method));
+                            MK::Literal(loc, core::make_type<core::NamedLiteralType>(core::Symbols::Symbol(), send->method));
                         ExpressionPtr convertedBlock;
                         if (anonymousBlockPass) {
                             ENFORCE(block == nullptr, "encountered a block while processing an anonymous block pass");

--- a/ast/substitute/Substitute.cc
+++ b/ast/substitute/Substitute.cc
@@ -90,7 +90,7 @@ public:
             auto nameRef = original.asString();
             auto newName = subst.substitute(nameRef);
             if (nameRef != newName) {
-                original.value = core::make_type<core::LiteralType>(core::Symbols::String(), newName);
+                original.value = core::make_type<core::NamedLiteralType>(core::Symbols::String(), newName);
             }
             return;
         }
@@ -98,7 +98,7 @@ public:
             auto nameRef = original.asSymbol();
             auto newName = subst.substitute(nameRef);
             if (newName != nameRef) {
-                original.value = core::make_type<core::LiteralType>(core::Symbols::Symbol(), newName);
+                original.value = core::make_type<core::NamedLiteralType>(core::Symbols::Symbol(), newName);
             }
             return;
         }

--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -163,6 +163,7 @@ string Literal::toString(const core::GlobalState &gs, const CFG &cfg) const {
     typecase(
         this->value, [&](const core::LiteralType &l) { res = l.showValue(gs); },
         [&](const core::LiteralIntegerType &i) { res = i.showValue(gs); },
+        [&](const core::FloatLiteralType &i) { res = i.showValue(gs); },
         [&](const core::ClassType &l) {
             if (l.symbol == core::Symbols::NilClass()) {
                 res = "nil";

--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -162,6 +162,7 @@ string Literal::toString(const core::GlobalState &gs, const CFG &cfg) const {
     string res;
     typecase(
         this->value, [&](const core::LiteralType &l) { res = l.showValue(gs); },
+        [&](const core::LiteralIntegerType &i) { res = i.showValue(gs); },
         [&](const core::ClassType &l) {
             if (l.symbol == core::Symbols::NilClass()) {
                 res = "nil";

--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -161,7 +161,7 @@ Literal::Literal(const core::TypePtr &value) : value(move(value)) {
 string Literal::toString(const core::GlobalState &gs, const CFG &cfg) const {
     string res;
     typecase(
-        this->value, [&](const core::LiteralType &l) { res = l.showValue(gs); },
+        this->value, [&](const core::NamedLiteralType &l) { res = l.showValue(gs); },
         [&](const core::IntegerLiteralType &i) { res = i.showValue(gs); },
         [&](const core::FloatLiteralType &i) { res = i.showValue(gs); },
         [&](const core::ClassType &l) {

--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -162,7 +162,7 @@ string Literal::toString(const core::GlobalState &gs, const CFG &cfg) const {
     string res;
     typecase(
         this->value, [&](const core::LiteralType &l) { res = l.showValue(gs); },
-        [&](const core::LiteralIntegerType &i) { res = i.showValue(gs); },
+        [&](const core::IntegerLiteralType &i) { res = i.showValue(gs); },
         [&](const core::FloatLiteralType &i) { res = i.showValue(gs); },
         [&](const core::ClassType &l) {
             if (l.symbol == core::Symbols::NilClass()) {

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -124,7 +124,7 @@ public:
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(Send, 144, 8);
+CheckSize(Send, 120, 8);
 
 INSN(Return) : public Instruction {
 public:
@@ -135,7 +135,7 @@ public:
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(Return, 32, 8);
+CheckSize(Return, 24, 8);
 
 INSN(BlockReturn) : public Instruction {
 public:
@@ -146,7 +146,7 @@ public:
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(BlockReturn, 40, 8);
+CheckSize(BlockReturn, 32, 8);
 
 INSN(LoadSelf) : public Instruction {
 public:
@@ -166,7 +166,7 @@ public:
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(Literal, 16, 8);
+CheckSize(Literal, 8, 8);
 
 INSN(GetCurrentException) : public Instruction {
 public:
@@ -245,7 +245,7 @@ public:
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(YieldLoadArg, 32, 8);
+CheckSize(YieldLoadArg, 24, 8);
 
 INSN(Cast) : public Instruction {
 public:
@@ -262,7 +262,7 @@ public:
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(Cast, 56, 8);
+CheckSize(Cast, 40, 8);
 
 INSN(TAbsurd) : public Instruction {
 public:
@@ -275,7 +275,7 @@ public:
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(TAbsurd, 24, 8);
+CheckSize(TAbsurd, 16, 8);
 
 class InstructionPtr final {
     using tagged_storage = uint64_t;

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -825,7 +825,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
             [&](ast::RuntimeMethodDefinition &rmd) {
                 current->exprs.emplace_back(
                     cctx.target, rmd.loc.copyWithZeroLength(),
-                    make_insn<Literal>(core::make_type<core::LiteralType>(core::Symbols::Symbol(), rmd.name)));
+                    make_insn<Literal>(core::make_type<core::NamedLiteralType>(core::Symbols::Symbol(), rmd.name)));
                 ret = current;
             },
 

--- a/compiler/IREmitter/IREmitterContext.cc
+++ b/compiler/IREmitter/IREmitterContext.cc
@@ -28,12 +28,12 @@ optional<string_view> isSymbol(const core::GlobalState &gs, const cfg::Instructi
         return std::nullopt;
     }
 
-    if (!core::isa_type<core::LiteralType>(liti->value)) {
+    if (!core::isa_type<core::NamedLiteralType>(liti->value)) {
         return std::nullopt;
     }
 
-    const auto &lit = core::cast_type_nonnull<core::LiteralType>(liti->value);
-    if (lit.literalKind != core::LiteralType::LiteralTypeKind::Symbol) {
+    const auto &lit = core::cast_type_nonnull<core::NamedLiteralType>(liti->value);
+    if (lit.literalKind != core::NamedLiteralType::LiteralTypeKind::Symbol) {
         return std::nullopt;
     }
 

--- a/compiler/IREmitter/IREmitterHelpers.cc
+++ b/compiler/IREmitter/IREmitterHelpers.cc
@@ -317,14 +317,15 @@ llvm::Value *IREmitterHelpers::emitLiteralish(CompilerState &cs, llvm::IRBuilder
     if (lit.derivesFrom(cs, core::Symbols::NilClass())) {
         return Payload::rubyNil(cs, builder);
     }
+    if (core::isa_type<core::LiteralIntegerType>(lit)) {
+        const auto &litInt = core::cast_type_nonnull<core::LiteralIntegerType>(lit);
+        auto *value = Payload::longToRubyValue(cs, builder, litInt.value);
+        Payload::assumeType(cs, builder, value, core::Symbols::Integer());
+        return value;
+    }
 
     auto litType = core::cast_type_nonnull<core::LiteralType>(lit);
     switch (litType.literalKind) {
-        case core::LiteralType::LiteralTypeKind::Integer: {
-            auto *value = Payload::longToRubyValue(cs, builder, litType.asInteger());
-            Payload::assumeType(cs, builder, value, core::Symbols::Integer());
-            return value;
-        }
         case core::LiteralType::LiteralTypeKind::Float: {
             auto *value = Payload::doubleToRubyValue(cs, builder, litType.asFloat());
             Payload::assumeType(cs, builder, value, core::Symbols::Float());

--- a/compiler/IREmitter/IREmitterHelpers.cc
+++ b/compiler/IREmitter/IREmitterHelpers.cc
@@ -317,8 +317,8 @@ llvm::Value *IREmitterHelpers::emitLiteralish(CompilerState &cs, llvm::IRBuilder
     if (lit.derivesFrom(cs, core::Symbols::NilClass())) {
         return Payload::rubyNil(cs, builder);
     }
-    if (core::isa_type<core::LiteralIntegerType>(lit)) {
-        const auto &litInt = core::cast_type_nonnull<core::LiteralIntegerType>(lit);
+    if (core::isa_type<core::IntegerLiteralType>(lit)) {
+        const auto &litInt = core::cast_type_nonnull<core::IntegerLiteralType>(lit);
         auto *value = Payload::longToRubyValue(cs, builder, litInt.value);
         Payload::assumeType(cs, builder, value, core::Symbols::Integer());
         return value;

--- a/compiler/IREmitter/IREmitterHelpers.cc
+++ b/compiler/IREmitter/IREmitterHelpers.cc
@@ -330,16 +330,16 @@ llvm::Value *IREmitterHelpers::emitLiteralish(CompilerState &cs, llvm::IRBuilder
         return value;
     }
 
-    auto litType = core::cast_type_nonnull<core::LiteralType>(lit);
+    auto litType = core::cast_type_nonnull<core::NamedLiteralType>(lit);
     switch (litType.literalKind) {
-        case core::LiteralType::LiteralTypeKind::Symbol: {
+        case core::NamedLiteralType::LiteralTypeKind::Symbol: {
             auto str = litType.asName().shortName(cs);
             auto rawId = Payload::idIntern(cs, builder, str);
             auto *value = builder.CreateCall(cs.getFunction("rb_id2sym"), {rawId}, "rawSym");
             Payload::assumeType(cs, builder, value, core::Symbols::Symbol());
             return value;
         }
-        case core::LiteralType::LiteralTypeKind::String: {
+        case core::NamedLiteralType::LiteralTypeKind::String: {
             auto str = litType.asName().shortName(cs);
             auto *value = Payload::cPtrToRubyString(cs, builder, str, true);
             Payload::assumeType(cs, builder, value, core::Symbols::String());

--- a/compiler/IREmitter/IREmitterHelpers.cc
+++ b/compiler/IREmitter/IREmitterHelpers.cc
@@ -323,14 +323,15 @@ llvm::Value *IREmitterHelpers::emitLiteralish(CompilerState &cs, llvm::IRBuilder
         Payload::assumeType(cs, builder, value, core::Symbols::Integer());
         return value;
     }
+    if (core::isa_type<core::FloatLiteralType>(lit)) {
+        const auto &litFloat = core::cast_type_nonnull<core::FloatLiteralType>(lit);
+        auto *value = Payload::doubleToRubyValue(cs, builder, litFloat.value);
+        Payload::assumeType(cs, builder, value, core::Symbols::Float());
+        return value;
+    }
 
     auto litType = core::cast_type_nonnull<core::LiteralType>(lit);
     switch (litType.literalKind) {
-        case core::LiteralType::LiteralTypeKind::Float: {
-            auto *value = Payload::doubleToRubyValue(cs, builder, litType.asFloat());
-            Payload::assumeType(cs, builder, value, core::Symbols::Float());
-            return value;
-        }
         case core::LiteralType::LiteralTypeKind::Symbol: {
             auto str = litType.asName().shortName(cs);
             auto rawId = Payload::idIntern(cs, builder, str);

--- a/compiler/IREmitter/IREmitterHelpers.h
+++ b/compiler/IREmitter/IREmitterHelpers.h
@@ -151,7 +151,7 @@ public:
     static void emitTypeTestForRestArg(CompilerState &gs, llvm::IRBuilderBase &builder, llvm::Value *value,
                                        const core::TypePtr &expectedType, std::string_view description);
 
-    // Return a value representing the literalish thing, which is either a LiteralType
+    // Return a value representing the literalish thing, which is either a NamedLiteralType
     // or a type representing nil, false, or true.
     static llvm::Value *emitLiteralish(CompilerState &gs, llvm::IRBuilderBase &builder,
                                        const core::TypePtr &literalish);

--- a/compiler/IREmitter/NameBasedIntrinsics.cc
+++ b/compiler/IREmitter/NameBasedIntrinsics.cc
@@ -279,6 +279,10 @@ public:
             return true;
         }
 
+        if (core::isa_type<core::LiteralIntegerType>(t)) {
+            return true;
+        }
+
         // IREmitterHelpers::emitLiteralish knows that its TypePtr argument is
         // restricted.  We have no such guarantees, so we have to be more defensive.
         if (t.hasUntyped()) {

--- a/compiler/IREmitter/NameBasedIntrinsics.cc
+++ b/compiler/IREmitter/NameBasedIntrinsics.cc
@@ -283,6 +283,10 @@ public:
             return true;
         }
 
+        if (core::isa_type<core::FloatLiteralType>(t)) {
+            return true;
+        }
+
         // IREmitterHelpers::emitLiteralish knows that its TypePtr argument is
         // restricted.  We have no such guarantees, so we have to be more defensive.
         if (t.hasUntyped()) {

--- a/compiler/IREmitter/NameBasedIntrinsics.cc
+++ b/compiler/IREmitter/NameBasedIntrinsics.cc
@@ -163,8 +163,8 @@ public:
         // TODO: this implementation generates code that is stupidly slow, we should be able to reuse instrinsics here
         // one day
         auto recv = send->args[0].variable;
-        auto lit = core::cast_type_nonnull<core::LiteralType>(send->args[1].type);
-        ENFORCE(lit.literalKind == core::LiteralType::LiteralTypeKind::Symbol);
+        auto lit = core::cast_type_nonnull<core::NamedLiteralType>(send->args[1].type);
+        ENFORCE(lit.literalKind == core::NamedLiteralType::LiteralTypeKind::Symbol);
         auto methodName = lit.asName();
 
         llvm::Value *blockHandler = prepareBlockHandler(mcctx, send->args[2]);
@@ -275,7 +275,7 @@ public:
 
     bool isLiteralish(CompilerState &cs, const core::TypePtr &t) const {
         // See IREmitterHelpers::emitLiteralish; we put the expected fast test first.
-        if (core::isa_type<core::LiteralType>(t)) {
+        if (core::isa_type<core::NamedLiteralType>(t)) {
             return true;
         }
 
@@ -473,8 +473,8 @@ public:
 
         auto [flags, splatArray] = prepareSplatArgs(mcctx, send->args[2], send->args[3]);
 
-        auto lit = core::cast_type_nonnull<core::LiteralType>(send->args[1].type);
-        ENFORCE(lit.literalKind == core::LiteralType::LiteralTypeKind::Symbol);
+        auto lit = core::cast_type_nonnull<core::NamedLiteralType>(send->args[1].type);
+        ENFORCE(lit.literalKind == core::NamedLiteralType::LiteralTypeKind::Symbol);
         auto methodName = lit.asName();
 
         // setup the inline cache
@@ -534,8 +534,8 @@ public:
         flags.blockarg = true;
         auto *blockHandler = prepareBlockHandler(mcctx, send->args[4]);
 
-        auto lit = core::cast_type_nonnull<core::LiteralType>(send->args[1].type);
-        ENFORCE(lit.literalKind == core::LiteralType::LiteralTypeKind::Symbol);
+        auto lit = core::cast_type_nonnull<core::NamedLiteralType>(send->args[1].type);
+        ENFORCE(lit.literalKind == core::NamedLiteralType::LiteralTypeKind::Symbol);
         auto methodName = lit.asName();
 
         // setup the inline cache
@@ -677,11 +677,11 @@ public:
         auto &cs = mcctx.cs;
         auto &builder = mcctx.builder;
         auto &var = mcctx.send->args[0].type;
-        if (!core::isa_type<core::LiteralType>(var)) {
+        if (!core::isa_type<core::NamedLiteralType>(var)) {
             return IREmitterHelpers::emitMethodCallViaRubyVM(mcctx);
         }
-        auto lit = core::cast_type_nonnull<core::LiteralType>(var);
-        if (lit.literalKind != core::LiteralType::LiteralTypeKind::Symbol) {
+        auto lit = core::cast_type_nonnull<core::NamedLiteralType>(var);
+        if (lit.literalKind != core::NamedLiteralType::LiteralTypeKind::Symbol) {
             return IREmitterHelpers::emitMethodCallViaRubyVM(mcctx);
         }
 
@@ -715,11 +715,11 @@ public:
         auto &cs = mcctx.cs;
         auto &builder = mcctx.builder;
         auto &var = mcctx.send->args[0].type;
-        if (!core::isa_type<core::LiteralType>(var)) {
+        if (!core::isa_type<core::NamedLiteralType>(var)) {
             return IREmitterHelpers::emitMethodCallViaRubyVM(mcctx);
         }
-        auto lit = core::cast_type_nonnull<core::LiteralType>(var);
-        if (lit.literalKind != core::LiteralType::LiteralTypeKind::Symbol) {
+        auto lit = core::cast_type_nonnull<core::NamedLiteralType>(var);
+        if (lit.literalKind != core::NamedLiteralType::LiteralTypeKind::Symbol) {
             return IREmitterHelpers::emitMethodCallViaRubyVM(mcctx);
         }
 

--- a/compiler/IREmitter/NameBasedIntrinsics.cc
+++ b/compiler/IREmitter/NameBasedIntrinsics.cc
@@ -279,7 +279,7 @@ public:
             return true;
         }
 
-        if (core::isa_type<core::LiteralIntegerType>(t)) {
+        if (core::isa_type<core::IntegerLiteralType>(t)) {
             return true;
         }
 

--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -688,14 +688,11 @@ public:
         auto options = 0;
         if (send->args.size() == 2) {
             auto &arg1 = send->args[1];
-            if (!core::isa_type<core::LiteralType>(arg1.type)) {
+            if (!core::isa_type<core::LiteralIntegerType>(arg1.type)) {
                 return IREmitterHelpers::emitMethodCallViaRubyVM(mcctx);
             }
-            auto literalOptions = core::cast_type_nonnull<core::LiteralType>(arg1.type);
-            if (literalOptions.literalKind != core::LiteralType::LiteralTypeKind::Integer) {
-                return IREmitterHelpers::emitMethodCallViaRubyVM(mcctx);
-            }
-            options = literalOptions.asInteger();
+            const auto &literalOptions = core::cast_type_nonnull<core::LiteralIntegerType>(arg1.type);
+            options = literalOptions.value;
         }
 
         auto &arg0 = send->args[0];

--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -688,10 +688,10 @@ public:
         auto options = 0;
         if (send->args.size() == 2) {
             auto &arg1 = send->args[1];
-            if (!core::isa_type<core::LiteralIntegerType>(arg1.type)) {
+            if (!core::isa_type<core::IntegerLiteralType>(arg1.type)) {
                 return IREmitterHelpers::emitMethodCallViaRubyVM(mcctx);
             }
-            const auto &literalOptions = core::cast_type_nonnull<core::LiteralIntegerType>(arg1.type);
+            const auto &literalOptions = core::cast_type_nonnull<core::IntegerLiteralType>(arg1.type);
             options = literalOptions.value;
         }
 

--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -472,14 +472,14 @@ public:
         }
 
         // Second arg: name of method to define
-        auto litName = core::cast_type_nonnull<core::LiteralType>(send->args[1].type);
-        ENFORCE(litName.literalKind == core::LiteralType::LiteralTypeKind::Symbol);
+        auto litName = core::cast_type_nonnull<core::NamedLiteralType>(send->args[1].type);
+        ENFORCE(litName.literalKind == core::NamedLiteralType::LiteralTypeKind::Symbol);
         auto funcNameRef = litName.asName();
         auto name = Payload::toCString(cs, funcNameRef.show(cs), builder);
 
         // Third arg: method kind (normal, attr_reader, or genericPropGetter)
-        auto litMethodKind = core::cast_type_nonnull<core::LiteralType>(send->args[2].type);
-        ENFORCE(litMethodKind.literalKind == core::LiteralType::LiteralTypeKind::Symbol);
+        auto litMethodKind = core::cast_type_nonnull<core::NamedLiteralType>(send->args[2].type);
+        ENFORCE(litMethodKind.literalKind == core::NamedLiteralType::LiteralTypeKind::Symbol);
         auto methodKind = litMethodKind.asName();
 
         auto lookupSym = isSelf ? ownerSym : ownerSym.data(cs)->attachedClass(cs);
@@ -696,12 +696,12 @@ public:
         }
 
         auto &arg0 = send->args[0];
-        if (!core::isa_type<core::LiteralType>(arg0.type)) {
+        if (!core::isa_type<core::NamedLiteralType>(arg0.type)) {
             return IREmitterHelpers::emitMethodCallViaRubyVM(mcctx);
         }
 
-        auto literal = core::cast_type_nonnull<core::LiteralType>(arg0.type);
-        if (literal.literalKind != core::LiteralType::LiteralTypeKind::String) {
+        auto literal = core::cast_type_nonnull<core::NamedLiteralType>(arg0.type);
+        if (literal.literalKind != core::NamedLiteralType::LiteralTypeKind::String) {
             return IREmitterHelpers::emitMethodCallViaRubyVM(mcctx);
         }
         auto &builder = mcctx.builder;

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -619,7 +619,7 @@ void GlobalState::initEmpty() {
     // Sorbet::Private::Static::VERSION
     field = enterStaticFieldSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), Names::Constants::VERSION());
     field.data(*this)->resultType =
-        make_type<LiteralType>(Symbols::String(), enterNameUTF8(sorbet_full_version_string));
+        make_type<NamedLiteralType>(Symbols::String(), enterNameUTF8(sorbet_full_version_string));
 
     // ::<ErrorNode>
     field = enterStaticFieldSymbol(Loc::none(), Symbols::root(), Names::Constants::ErrorNode());

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -183,7 +183,7 @@ private:
     InlinedVector<Loc, 2> locs_;
     std::unique_ptr<InlinedVector<TypeArgumentRef, 4>> typeArgs;
 };
-CheckSize(Method, 160, 8);
+CheckSize(Method, 136, 8);
 
 // Contains a field or a static field
 class Field final {
@@ -249,7 +249,7 @@ private:
 public:
     Flags flags;
 };
-CheckSize(Field, 64, 8);
+CheckSize(Field, 56, 8);
 
 class TypeParameter final {
     friend class serialize::SerializerImpl;
@@ -329,7 +329,7 @@ public:
 private:
     InlinedVector<Loc, 2> locs_;
 };
-CheckSize(TypeParameter, 64, 8);
+CheckSize(TypeParameter, 56, 8);
 
 class ClassOrModule final {
 public:
@@ -609,7 +609,7 @@ private:
 
     void addMixinAt(ClassOrModuleRef sym, std::optional<uint16_t> index);
 };
-CheckSize(ClassOrModule, 136, 8);
+CheckSize(ClassOrModule, 128, 8);
 
 } // namespace sorbet::core
 #endif // SORBET_SYMBOLS_H

--- a/core/TypePtr.cc
+++ b/core/TypePtr.cc
@@ -21,6 +21,7 @@ using namespace std;
         CASE_STATEMENT(CASE_BODY, SelfType)              \
         CASE_STATEMENT(CASE_BODY, LiteralType)           \
         CASE_STATEMENT(CASE_BODY, LiteralIntegerType)    \
+        CASE_STATEMENT(CASE_BODY, FloatLiteralType)      \
         CASE_STATEMENT(CASE_BODY, TypeVar)               \
         CASE_STATEMENT(CASE_BODY, OrType)                \
         CASE_STATEMENT(CASE_BODY, AndType)               \
@@ -115,6 +116,8 @@ int TypePtr::kind() const {
             return 12;
         case Tag::LiteralIntegerType:
             return 13;
+        case Tag::FloatLiteralType:
+            return 14;
     }
 }
 
@@ -137,6 +140,7 @@ bool TypePtr::isFullyDefined() const {
         case Tag::ClassType:
         case Tag::LiteralType:
         case Tag::LiteralIntegerType:
+        case Tag::FloatLiteralType:
         case Tag::AliasType:
         case Tag::SelfTypeParam:
         case Tag::MetaType: // MetaType: this is kinda true but kinda false. it's false for subtyping but true for
@@ -177,6 +181,7 @@ bool TypePtr::hasUntyped() const {
         case Tag::TypeVar:
         case Tag::LiteralType:
         case Tag::LiteralIntegerType:
+        case Tag::FloatLiteralType:
         case Tag::SelfType:
         case Tag::AliasType:
         case Tag::SelfTypeParam:
@@ -234,7 +239,8 @@ TypePtr TypePtr::getCallArguments(const GlobalState &gs, NameRef name) const {
         case Tag::TupleType:
         case Tag::ShapeType:
         case Tag::LiteralType:
-        case Tag::LiteralIntegerType: {
+        case Tag::LiteralIntegerType:
+        case Tag::FloatLiteralType: {
             return this->underlying(gs).getCallArguments(gs, name);
         }
         case Tag::OrType: {
@@ -298,6 +304,7 @@ TypePtr TypePtr::_instantiate(const GlobalState &gs, absl::Span<const TypeMember
         case Tag::TypeVar:
         case Tag::LiteralType:
         case Tag::LiteralIntegerType:
+        case Tag::FloatLiteralType:
         case Tag::SelfTypeParam:
         case Tag::SelfType:
             return nullptr;

--- a/core/TypePtr.cc
+++ b/core/TypePtr.cc
@@ -20,6 +20,7 @@ using namespace std;
         CASE_STATEMENT(CASE_BODY, AliasType)             \
         CASE_STATEMENT(CASE_BODY, SelfType)              \
         CASE_STATEMENT(CASE_BODY, LiteralType)           \
+        CASE_STATEMENT(CASE_BODY, LiteralIntegerType)    \
         CASE_STATEMENT(CASE_BODY, TypeVar)               \
         CASE_STATEMENT(CASE_BODY, OrType)                \
         CASE_STATEMENT(CASE_BODY, AndType)               \
@@ -112,6 +113,8 @@ int TypePtr::kind() const {
             return 11;
         case Tag::SelfType:
             return 12;
+        case Tag::LiteralIntegerType:
+            return 13;
     }
 }
 
@@ -133,6 +136,7 @@ bool TypePtr::isFullyDefined() const {
         case Tag::BlamedUntyped:
         case Tag::ClassType:
         case Tag::LiteralType:
+        case Tag::LiteralIntegerType:
         case Tag::AliasType:
         case Tag::SelfTypeParam:
         case Tag::MetaType: // MetaType: this is kinda true but kinda false. it's false for subtyping but true for
@@ -172,6 +176,7 @@ bool TypePtr::hasUntyped() const {
     switch (tag()) {
         case Tag::TypeVar:
         case Tag::LiteralType:
+        case Tag::LiteralIntegerType:
         case Tag::SelfType:
         case Tag::AliasType:
         case Tag::SelfTypeParam:
@@ -228,7 +233,8 @@ TypePtr TypePtr::getCallArguments(const GlobalState &gs, NameRef name) const {
         case Tag::MetaType:
         case Tag::TupleType:
         case Tag::ShapeType:
-        case Tag::LiteralType: {
+        case Tag::LiteralType:
+        case Tag::LiteralIntegerType: {
             return this->underlying(gs).getCallArguments(gs, name);
         }
         case Tag::OrType: {
@@ -291,6 +297,7 @@ TypePtr TypePtr::_instantiate(const GlobalState &gs, absl::Span<const TypeMember
         case Tag::ClassType:
         case Tag::TypeVar:
         case Tag::LiteralType:
+        case Tag::LiteralIntegerType:
         case Tag::SelfTypeParam:
         case Tag::SelfType:
             return nullptr;

--- a/core/TypePtr.cc
+++ b/core/TypePtr.cc
@@ -19,7 +19,7 @@ using namespace std;
         CASE_STATEMENT(CASE_BODY, SelfTypeParam)         \
         CASE_STATEMENT(CASE_BODY, AliasType)             \
         CASE_STATEMENT(CASE_BODY, SelfType)              \
-        CASE_STATEMENT(CASE_BODY, NamedLiteralType)           \
+        CASE_STATEMENT(CASE_BODY, NamedLiteralType)      \
         CASE_STATEMENT(CASE_BODY, IntegerLiteralType)    \
         CASE_STATEMENT(CASE_BODY, FloatLiteralType)      \
         CASE_STATEMENT(CASE_BODY, TypeVar)               \

--- a/core/TypePtr.cc
+++ b/core/TypePtr.cc
@@ -20,7 +20,7 @@ using namespace std;
         CASE_STATEMENT(CASE_BODY, AliasType)             \
         CASE_STATEMENT(CASE_BODY, SelfType)              \
         CASE_STATEMENT(CASE_BODY, LiteralType)           \
-        CASE_STATEMENT(CASE_BODY, LiteralIntegerType)    \
+        CASE_STATEMENT(CASE_BODY, IntegerLiteralType)    \
         CASE_STATEMENT(CASE_BODY, FloatLiteralType)      \
         CASE_STATEMENT(CASE_BODY, TypeVar)               \
         CASE_STATEMENT(CASE_BODY, OrType)                \
@@ -93,7 +93,7 @@ int TypePtr::kind() const {
         case Tag::UnresolvedClassType:
         case Tag::ClassType:
             return 2;
-        case Tag::LiteralIntegerType:
+        case Tag::IntegerLiteralType:
             return 3;
         case Tag::FloatLiteralType:
             return 4;
@@ -139,7 +139,7 @@ bool TypePtr::isFullyDefined() const {
         case Tag::BlamedUntyped:
         case Tag::ClassType:
         case Tag::LiteralType:
-        case Tag::LiteralIntegerType:
+        case Tag::IntegerLiteralType:
         case Tag::FloatLiteralType:
         case Tag::AliasType:
         case Tag::SelfTypeParam:
@@ -180,7 +180,7 @@ bool TypePtr::hasUntyped() const {
     switch (tag()) {
         case Tag::TypeVar:
         case Tag::LiteralType:
-        case Tag::LiteralIntegerType:
+        case Tag::IntegerLiteralType:
         case Tag::FloatLiteralType:
         case Tag::SelfType:
         case Tag::AliasType:
@@ -239,7 +239,7 @@ TypePtr TypePtr::getCallArguments(const GlobalState &gs, NameRef name) const {
         case Tag::TupleType:
         case Tag::ShapeType:
         case Tag::LiteralType:
-        case Tag::LiteralIntegerType:
+        case Tag::IntegerLiteralType:
         case Tag::FloatLiteralType: {
             return this->underlying(gs).getCallArguments(gs, name);
         }
@@ -303,7 +303,7 @@ TypePtr TypePtr::_instantiate(const GlobalState &gs, absl::Span<const TypeMember
         case Tag::ClassType:
         case Tag::TypeVar:
         case Tag::LiteralType:
-        case Tag::LiteralIntegerType:
+        case Tag::IntegerLiteralType:
         case Tag::FloatLiteralType:
         case Tag::SelfTypeParam:
         case Tag::SelfType:

--- a/core/TypePtr.cc
+++ b/core/TypePtr.cc
@@ -19,7 +19,7 @@ using namespace std;
         CASE_STATEMENT(CASE_BODY, SelfTypeParam)         \
         CASE_STATEMENT(CASE_BODY, AliasType)             \
         CASE_STATEMENT(CASE_BODY, SelfType)              \
-        CASE_STATEMENT(CASE_BODY, LiteralType)           \
+        CASE_STATEMENT(CASE_BODY, NamedLiteralType)           \
         CASE_STATEMENT(CASE_BODY, IntegerLiteralType)    \
         CASE_STATEMENT(CASE_BODY, FloatLiteralType)      \
         CASE_STATEMENT(CASE_BODY, TypeVar)               \
@@ -97,7 +97,7 @@ int TypePtr::kind() const {
             return 3;
         case Tag::FloatLiteralType:
             return 4;
-        case Tag::LiteralType:
+        case Tag::NamedLiteralType:
             return 5;
         case Tag::ShapeType:
             return 6;
@@ -138,7 +138,7 @@ bool TypePtr::isFullyDefined() const {
         case Tag::UnresolvedClassType:
         case Tag::BlamedUntyped:
         case Tag::ClassType:
-        case Tag::LiteralType:
+        case Tag::NamedLiteralType:
         case Tag::IntegerLiteralType:
         case Tag::FloatLiteralType:
         case Tag::AliasType:
@@ -179,7 +179,7 @@ bool TypePtr::isFullyDefined() const {
 bool TypePtr::hasUntyped() const {
     switch (tag()) {
         case Tag::TypeVar:
-        case Tag::LiteralType:
+        case Tag::NamedLiteralType:
         case Tag::IntegerLiteralType:
         case Tag::FloatLiteralType:
         case Tag::SelfType:
@@ -238,7 +238,7 @@ TypePtr TypePtr::getCallArguments(const GlobalState &gs, NameRef name) const {
         case Tag::MetaType:
         case Tag::TupleType:
         case Tag::ShapeType:
-        case Tag::LiteralType:
+        case Tag::NamedLiteralType:
         case Tag::IntegerLiteralType:
         case Tag::FloatLiteralType: {
             return this->underlying(gs).getCallArguments(gs, name);
@@ -302,7 +302,7 @@ TypePtr TypePtr::_instantiate(const GlobalState &gs, absl::Span<const TypeMember
         case Tag::UnresolvedClassType:
         case Tag::ClassType:
         case Tag::TypeVar:
-        case Tag::LiteralType:
+        case Tag::NamedLiteralType:
         case Tag::IntegerLiteralType:
         case Tag::FloatLiteralType:
         case Tag::SelfTypeParam:

--- a/core/TypePtr.cc
+++ b/core/TypePtr.cc
@@ -93,30 +93,30 @@ int TypePtr::kind() const {
         case Tag::UnresolvedClassType:
         case Tag::ClassType:
             return 2;
-        case Tag::LiteralType:
+        case Tag::LiteralIntegerType:
             return 3;
-        case Tag::ShapeType:
+        case Tag::FloatLiteralType:
             return 4;
-        case Tag::TupleType:
+        case Tag::LiteralType:
             return 5;
+        case Tag::ShapeType:
+            return 6;
+        case Tag::TupleType:
+            return 7;
         case Tag::LambdaParam:
         case Tag::SelfTypeParam:
-            return 6;
-        case Tag::MetaType:
-            return 7;
-        case Tag::TypeVar:
             return 8;
-        case Tag::AliasType:
+        case Tag::MetaType:
             return 9;
-        case Tag::OrType:
+        case Tag::TypeVar:
             return 10;
-        case Tag::AndType:
+        case Tag::AliasType:
             return 11;
-        case Tag::SelfType:
+        case Tag::OrType:
             return 12;
-        case Tag::LiteralIntegerType:
+        case Tag::AndType:
             return 13;
-        case Tag::FloatLiteralType:
+        case Tag::SelfType:
             return 14;
     }
 }

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -43,6 +43,7 @@ public:
         UnresolvedClassType,
         UnresolvedAppliedType,
         LiteralIntegerType,
+        FloatLiteralType,
     };
 
     // A mapping from type to its corresponding tag.

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -42,6 +42,7 @@ public:
         BlamedUntyped,
         UnresolvedClassType,
         UnresolvedAppliedType,
+        LiteralIntegerType,
     };
 
     // A mapping from type to its corresponding tag.

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -306,7 +306,7 @@ public:
     friend typename TypeToCastType<To, TypeToIsInlined<To>::value>::type cast_type_nonnull(const TypePtr &what);
     friend class TypePtrTestHelper;
 };
-CheckSize(TypePtr, 16, 8);
+CheckSize(TypePtr, 8, 8);
 } // namespace sorbet::core
 
 #endif

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -20,12 +20,12 @@ class Refcounted {
 
 public:
     void addref() {
-	this->counter.fetch_add(1);
+        this->counter.fetch_add(1);
     }
 
     uint32_t release() {
-	// fetch_sub returns value prior to subtract
-	return this->counter.fetch_sub(1) - 1;
+        // fetch_sub returns value prior to subtract
+        return this->counter.fetch_sub(1) - 1;
     }
 };
 

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -48,6 +48,8 @@ public:
         SelfTypeParam,
         AliasType,
         SelfType,
+        LiteralIntegerType,
+        FloatLiteralType,
         LiteralType,
         TypeVar,
         OrType,
@@ -59,8 +61,6 @@ public:
         BlamedUntyped,
         UnresolvedClassType,
         UnresolvedAppliedType,
-        LiteralIntegerType,
-        FloatLiteralType,
     };
 
     // A mapping from type to its corresponding tag.

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -140,7 +140,7 @@ private:
     }
 
     // Inlined TypePtr constructor
-    TypePtr(Tag tag, uint32_t value1, uint64_t value2) : value(value2), store(tagValue(tag, value1)) {}
+    TypePtr(Tag tag, uint64_t inlinedValue) : value(0), store(tagValue(tag, inlinedValue)) {}
 
     static void deleteTagged(Tag tag, void *ptr) noexcept;
 

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -50,7 +50,7 @@ public:
         SelfType,
         IntegerLiteralType,
         FloatLiteralType,
-        LiteralType,
+        NamedLiteralType,
         TypeVar,
         OrType,
         AndType,

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -48,7 +48,7 @@ public:
         SelfTypeParam,
         AliasType,
         SelfType,
-        LiteralIntegerType,
+        IntegerLiteralType,
         FloatLiteralType,
         LiteralType,
         TypeVar,

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -16,6 +16,7 @@ struct DispatchArgs;
 class NonRefcounted {};
 
 class Refcounted {
+    friend class TypePtrTestHelper;
     std::atomic<uint32_t> counter{0};
 
 public:

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -121,7 +121,7 @@ private:
         return val;
     }
 
-    static tagged_storage tagPtr(Tag tag, void *expr) {
+    static tagged_storage tagPtr(Tag tag, Refcounted *expr) {
         auto val = tagToMask(tag);
 
         auto maskedPtr = reinterpret_cast<tagged_storage>(expr) << 16;

--- a/core/Types.h
+++ b/core/Types.h
@@ -360,7 +360,7 @@ template <> inline ClassType cast_type_nonnull<ClassType>(const TypePtr &what) {
  * This is the type used to represent a use of a type_member or type_template in
  * a signature.
  */
-TYPE(LambdaParam) final {
+TYPE(LambdaParam) final : public Refcounted {
 public:
     TypeMemberRef definition;
 
@@ -528,7 +528,7 @@ template <> inline LiteralType cast_type_nonnull<LiteralType>(const TypePtr &wha
     }
 }
 
-TYPE(LiteralIntegerType) final {
+TYPE(LiteralIntegerType) final : public Refcounted {
 public:
     const int64_t value;
 
@@ -562,7 +562,7 @@ template <> inline TypePtr make_type<LiteralIntegerType, long long &>(long long 
     return make_type<LiteralIntegerType>(static_cast<int64_t>(val));
 }
 
-TYPE(FloatLiteralType) final {
+TYPE(FloatLiteralType) final : public Refcounted {
 public:
     const double value;
 
@@ -596,7 +596,7 @@ template <> inline TypePtr make_type<FloatLiteralType, float &&>(float &&val) {
  * TypeVars are the used for the type parameters of generic methods.
  * Note: These are mutated post-construction and cannot be inlined.
  */
-TYPE(TypeVar) final {
+TYPE(TypeVar) final : public Refcounted {
 public:
     TypeArgumentRef sym;
     TypeVar(TypeArgumentRef sym);
@@ -617,7 +617,7 @@ public:
 };
 CheckSize(TypeVar, 8, 8);
 
-TYPE(OrType) final {
+TYPE(OrType) final : public Refcounted {
 public:
     TypePtr left;
     TypePtr right;
@@ -673,7 +673,7 @@ private:
 };
 CheckSize(OrType, 32, 8);
 
-TYPE(AndType) final {
+TYPE(AndType) final : public Refcounted{
 public:
     TypePtr left;
     TypePtr right;
@@ -720,7 +720,7 @@ private:
 };
 CheckSize(AndType, 32, 8);
 
-TYPE(ShapeType) final {
+TYPE(ShapeType) final : public Refcounted {
 public:
     std::vector<TypePtr> keys; // TODO: store sorted by whatever
     std::vector<TypePtr> values;
@@ -751,7 +751,7 @@ public:
 };
 CheckSize(ShapeType, 48, 8);
 
-TYPE(TupleType) final {
+TYPE(TupleType) final : public Refcounted {
 private:
     TupleType() = delete;
 
@@ -783,7 +783,7 @@ public:
 };
 CheckSize(TupleType, 24, 8);
 
-TYPE(AppliedType) final {
+TYPE(AppliedType) final : public Refcounted {
 public:
     ClassOrModuleRef klass;
     std::vector<TypePtr> targs;
@@ -818,7 +818,7 @@ CheckSize(AppliedType, 32, 8);
 //
 // These are used within the inferencer in places where we need to track
 // user-written types in the source code.
-TYPE(MetaType) final {
+TYPE(MetaType) final : public Refcounted {
 public:
     TypePtr wrapped;
 
@@ -1011,7 +1011,7 @@ template <> inline BlamedUntyped cast_type_nonnull<BlamedUntyped>(const TypePtr 
     return BlamedUntyped(core::SymbolRef::fromRaw(what.inlinedValue()));
 }
 
-TYPE(UnresolvedClassType) final : public ClassType {
+TYPE(UnresolvedClassType) final : public Refcounted, public ClassType {
 public:
     const core::SymbolRef scope;
     const std::vector<core::NameRef> names;
@@ -1027,7 +1027,7 @@ public:
     uint32_t hash(const GlobalState &gs) const;
 };
 
-TYPE(UnresolvedAppliedType) final : public ClassType {
+TYPE(UnresolvedAppliedType) final : public Refcounted, public ClassType {
 public:
     const core::ClassOrModuleRef klass;
     const std::vector<TypePtr> targs;

--- a/core/Types.h
+++ b/core/Types.h
@@ -54,7 +54,7 @@ public:
     ArgInfo &operator=(ArgInfo &&) noexcept = default;
     ArgInfo deepCopy() const;
 };
-CheckSize(ArgInfo, 40, 8);
+CheckSize(ArgInfo, 32, 8);
 
 template <class T, class... Args> TypePtr make_type(Args &&...args) {
     static_assert(!TypePtr::TypeToIsInlined<T>::value, "Inlined types must specialize `make_type` for each combination "
@@ -386,7 +386,7 @@ public:
     TypePtr _instantiate(const GlobalState &gs, absl::Span<const TypeMemberRef> params,
                          const std::vector<TypePtr> &targs) const;
 };
-CheckSize(LambdaParam, 40, 8);
+CheckSize(LambdaParam, 24, 8);
 
 TYPE_INLINED(SelfTypeParam) final {
 public:
@@ -552,7 +552,7 @@ public:
     bool equals(const LiteralIntegerType &rhs) const;
     void _sanityCheck(const GlobalState &gs) const;
 };
-CheckSize(LiteralIntegerType, 8, 8);
+CheckSize(LiteralIntegerType, 16, 8);
 
 template <> inline TypePtr make_type<LiteralIntegerType, int64_t>(int64_t &&val) {
     return make_type<LiteralIntegerType>(absl::bit_cast<uint64_t>(val));
@@ -586,7 +586,7 @@ public:
     bool equals(const FloatLiteralType &rhs) const;
     void _sanityCheck(const GlobalState &gs) const;
 };
-CheckSize(FloatLiteralType, 8, 8);
+CheckSize(FloatLiteralType, 16, 8);
 
 template <> inline TypePtr make_type<FloatLiteralType, double &&>(double &&val) {
     return make_type<FloatLiteralType>(val);
@@ -675,7 +675,7 @@ private:
 
     static TypePtr make_shared(const TypePtr &left, const TypePtr &right);
 };
-CheckSize(OrType, 32, 8);
+CheckSize(OrType, 24, 8);
 
 TYPE(AndType) final : public Refcounted{
 public:
@@ -722,7 +722,7 @@ private:
 
     static TypePtr make_shared(const TypePtr &left, const TypePtr &right);
 };
-CheckSize(AndType, 32, 8);
+CheckSize(AndType, 24, 8);
 
 TYPE(ShapeType) final : public Refcounted {
 public:
@@ -753,7 +753,7 @@ public:
     std::optional<size_t> indexForKey(const LiteralIntegerType &lit) const;
     std::optional<size_t> indexForKey(const FloatLiteralType &lit) const;
 };
-CheckSize(ShapeType, 48, 8);
+CheckSize(ShapeType, 56, 8);
 
 TYPE(TupleType) final : public Refcounted {
 private:
@@ -785,7 +785,7 @@ public:
     TypePtr underlying(const GlobalState &gs) const;
     bool derivesFrom(const GlobalState &gs, core::ClassOrModuleRef klass) const;
 };
-CheckSize(TupleType, 24, 8);
+CheckSize(TupleType, 32, 8);
 
 TYPE(AppliedType) final : public Refcounted {
 public:
@@ -881,7 +881,7 @@ public:
     TypeAndOrigins &operator=(const TypeAndOrigins &) = default;
     TypeAndOrigins &operator=(TypeAndOrigins &&) = default;
 };
-CheckSize(TypeAndOrigins, 40, 8);
+CheckSize(TypeAndOrigins, 32, 8);
 
 struct CallLocs final {
     FileRef file;

--- a/core/Types.h
+++ b/core/Types.h
@@ -677,7 +677,7 @@ private:
 };
 CheckSize(OrType, 24, 8);
 
-TYPE(AndType) final : public Refcounted{
+TYPE(AndType) final : public Refcounted {
 public:
     TypePtr left;
     TypePtr right;

--- a/core/Types.h
+++ b/core/Types.h
@@ -485,7 +485,6 @@ TYPE_INLINED(LiteralType) final {
 public:
     enum class LiteralTypeKind : uint8_t { String, Symbol };
     const LiteralTypeKind literalKind;
-    LiteralType(double val);
     LiteralType(ClassOrModuleRef klass, NameRef val);
     TypePtr underlying(const GlobalState &gs) const;
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const;

--- a/core/Types.h
+++ b/core/Types.h
@@ -506,14 +506,18 @@ CheckSize(NamedLiteralType, 8, 8);
 
 // TODO(froydnj) it would be more work, but maybe it would be cleaner to split this
 // type into distinct types, rather than doing this manual tagging.
-template <> inline TypePtr make_type<NamedLiteralType, ClassOrModuleRef, NameRef &>(ClassOrModuleRef &&klass, NameRef &val) {
+template <>
+inline TypePtr make_type<NamedLiteralType, ClassOrModuleRef, NameRef &>(ClassOrModuleRef &&klass, NameRef &val) {
     NamedLiteralType type(klass, val);
-    return TypePtr(TypePtr::Tag::NamedLiteralType, (uint64_t(val.rawId()) << 8) | static_cast<uint64_t>(type.literalKind));
+    return TypePtr(TypePtr::Tag::NamedLiteralType,
+                   (uint64_t(val.rawId()) << 8) | static_cast<uint64_t>(type.literalKind));
 }
 
-template <> inline TypePtr make_type<NamedLiteralType, ClassOrModuleRef, NameRef>(ClassOrModuleRef &&klass, NameRef &&val) {
+template <>
+inline TypePtr make_type<NamedLiteralType, ClassOrModuleRef, NameRef>(ClassOrModuleRef &&klass, NameRef &&val) {
     NamedLiteralType type(klass, val);
-    return TypePtr(TypePtr::Tag::NamedLiteralType, (uint64_t(val.rawId()) << 8) | static_cast<uint64_t>(type.literalKind));
+    return TypePtr(TypePtr::Tag::NamedLiteralType,
+                   (uint64_t(val.rawId()) << 8) | static_cast<uint64_t>(type.literalKind));
 }
 
 template <> inline NamedLiteralType cast_type_nonnull<NamedLiteralType>(const TypePtr &what) {

--- a/core/Types.h
+++ b/core/Types.h
@@ -214,7 +214,7 @@ inline bool is_ground_type(const TypePtr &what) {
         case TypePtr::Tag::AndType:
             return true;
         case TypePtr::Tag::LiteralType:
-        case TypePtr::Tag::LiteralIntegerType:
+        case TypePtr::Tag::IntegerLiteralType:
         case TypePtr::Tag::FloatLiteralType:
         case TypePtr::Tag::ShapeType:
         case TypePtr::Tag::TupleType:
@@ -235,7 +235,7 @@ inline bool is_proxy_type(const TypePtr &what) {
     }
     switch (what.tag()) {
         case TypePtr::Tag::LiteralType:
-        case TypePtr::Tag::LiteralIntegerType:
+        case TypePtr::Tag::IntegerLiteralType:
         case TypePtr::Tag::FloatLiteralType:
         case TypePtr::Tag::ShapeType:
         case TypePtr::Tag::TupleType:
@@ -531,11 +531,11 @@ template <> inline LiteralType cast_type_nonnull<LiteralType>(const TypePtr &wha
     }
 }
 
-TYPE(LiteralIntegerType) final : public Refcounted {
+TYPE(IntegerLiteralType) final : public Refcounted {
 public:
     const int64_t value;
 
-    LiteralIntegerType(int64_t val);
+    IntegerLiteralType(int64_t val);
     TypePtr underlying(const GlobalState &gs) const;
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const;
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
@@ -548,21 +548,21 @@ public:
     std::string showValue(const GlobalState &gs) const;
     uint32_t hash(const GlobalState &gs) const;
 
-    bool equals(const LiteralIntegerType &rhs) const;
+    bool equals(const IntegerLiteralType &rhs) const;
     void _sanityCheck(const GlobalState &gs) const;
 };
-CheckSize(LiteralIntegerType, 16, 8);
+CheckSize(IntegerLiteralType, 16, 8);
 
-template <> inline TypePtr make_type<LiteralIntegerType, int64_t>(int64_t &&val) {
-    return make_type<LiteralIntegerType>(absl::bit_cast<uint64_t>(val));
+template <> inline TypePtr make_type<IntegerLiteralType, int64_t>(int64_t &&val) {
+    return make_type<IntegerLiteralType>(absl::bit_cast<uint64_t>(val));
 }
 
-template <> inline TypePtr make_type<LiteralIntegerType, long &>(long &val) {
-    return make_type<LiteralIntegerType>(static_cast<int64_t>(val));
+template <> inline TypePtr make_type<IntegerLiteralType, long &>(long &val) {
+    return make_type<IntegerLiteralType>(static_cast<int64_t>(val));
 }
 
-template <> inline TypePtr make_type<LiteralIntegerType, long long &>(long long &val) {
-    return make_type<LiteralIntegerType>(static_cast<int64_t>(val));
+template <> inline TypePtr make_type<IntegerLiteralType, long long &>(long long &val) {
+    return make_type<IntegerLiteralType>(static_cast<int64_t>(val));
 }
 
 TYPE(FloatLiteralType) final : public Refcounted {
@@ -749,7 +749,7 @@ public:
 
     std::optional<size_t> indexForKey(const TypePtr &t) const;
     std::optional<size_t> indexForKey(const LiteralType &lit) const;
-    std::optional<size_t> indexForKey(const LiteralIntegerType &lit) const;
+    std::optional<size_t> indexForKey(const IntegerLiteralType &lit) const;
     std::optional<size_t> indexForKey(const FloatLiteralType &lit) const;
 };
 CheckSize(ShapeType, 56, 8);

--- a/core/Types.h
+++ b/core/Types.h
@@ -478,9 +478,7 @@ template <> inline SelfType cast_type_nonnull<SelfType>(const TypePtr &what) {
 }
 
 TYPE_INLINED(NamedLiteralType) final {
-    union {
-        const NameRef name;
-    };
+    const NameRef name;
 
 public:
     enum class LiteralTypeKind : uint8_t { String, Symbol };

--- a/core/lsp/QueryResponse.h
+++ b/core/lsp/QueryResponse.h
@@ -39,7 +39,7 @@ public:
     const core::MethodRef enclosingMethod;
     const core::TypeAndOrigins retType;
 };
-CheckSize(IdentResponse, 64, 8);
+CheckSize(IdentResponse, 56, 8);
 
 class LiteralResponse final {
 public:
@@ -47,7 +47,7 @@ public:
     const core::Loc termLoc;
     const core::TypeAndOrigins retType;
 };
-CheckSize(LiteralResponse, 56, 8);
+CheckSize(LiteralResponse, 48, 8);
 
 class ConstantResponse final {
 public:
@@ -71,7 +71,7 @@ public:
     const core::MethodRef enclosingMethod;
     const core::TypeAndOrigins retType;
 };
-CheckSize(ConstantResponse, 96, 8);
+CheckSize(ConstantResponse, 88, 8);
 
 class FieldResponse final {
 public:
@@ -82,7 +82,7 @@ public:
     const core::NameRef name;
     const core::TypeAndOrigins retType;
 };
-CheckSize(FieldResponse, 64, 8);
+CheckSize(FieldResponse, 56, 8);
 
 class MethodDefResponse final {
 public:
@@ -93,7 +93,7 @@ public:
     const core::NameRef name;
     const core::TypeAndOrigins retType;
 };
-CheckSize(MethodDefResponse, 64, 8);
+CheckSize(MethodDefResponse, 56, 8);
 
 class EditResponse final {
 public:

--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -159,15 +159,15 @@ com::stripe::rubytyper::Symbol Proto::toProto(const GlobalState &gs, SymbolRef s
     return symbolProto;
 }
 
-com::stripe::rubytyper::Type::Literal Proto::toProto(const GlobalState &gs, const LiteralType &lit) {
+com::stripe::rubytyper::Type::Literal Proto::toProto(const GlobalState &gs, const NamedLiteralType &lit) {
     com::stripe::rubytyper::Type::Literal proto;
 
     switch (lit.literalKind) {
-        case LiteralType::LiteralTypeKind::String:
+        case NamedLiteralType::LiteralTypeKind::String:
             proto.set_kind(com::stripe::rubytyper::Type::Literal::STRING);
             proto.set_string(lit.asName().show(gs));
             break;
-        case LiteralType::LiteralTypeKind::Symbol:
+        case NamedLiteralType::LiteralTypeKind::Symbol:
             proto.set_kind(com::stripe::rubytyper::Type::Literal::SYMBOL);
             proto.set_symbol(lit.asName().show(gs));
             break;
@@ -221,7 +221,7 @@ com::stripe::rubytyper::Type Proto::toProto(const GlobalState &gs, const TypePtr
                 *proto.mutable_shape()->add_values() = toProto(gs, v);
             }
         },
-        [&](const LiteralType &t) {
+        [&](const NamedLiteralType &t) {
             proto.set_kind(com::stripe::rubytyper::Type::LITERAL);
             *proto.mutable_literal() = toProto(gs, t);
         },

--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -171,10 +171,6 @@ com::stripe::rubytyper::Type::Literal Proto::toProto(const GlobalState &gs, cons
             proto.set_kind(com::stripe::rubytyper::Type::Literal::SYMBOL);
             proto.set_symbol(lit.asName().show(gs));
             break;
-        case LiteralType::LiteralTypeKind::Float:
-            proto.set_kind(com::stripe::rubytyper::Type::Literal::FLOAT);
-            proto.set_float_(lit.asFloat());
-            break;
     }
     return proto;
 }
@@ -182,6 +178,12 @@ com::stripe::rubytyper::Type::Literal Proto::toProto(const GlobalState &gs, cons
 com::stripe::rubytyper::Type::LiteralInteger Proto::toProto(const GlobalState &gs, const LiteralIntegerType &lit) {
     com::stripe::rubytyper::Type::LiteralInteger proto;
     proto.set_integer(lit.value);
+    return proto;
+}
+
+com::stripe::rubytyper::Type::LiteralFloat Proto::toProto(const GlobalState &gs, const FloatLiteralType &lit) {
+    com::stripe::rubytyper::Type::LiteralFloat proto;
+    proto.set_float_(lit.value);
     return proto;
 }
 
@@ -226,6 +228,10 @@ com::stripe::rubytyper::Type Proto::toProto(const GlobalState &gs, const TypePtr
         [&](const LiteralIntegerType &t) {
             proto.set_kind(com::stripe::rubytyper::Type::LITERALINTEGER);
             *proto.mutable_literalinteger() = toProto(gs, t);
+        },
+        [&](const FloatLiteralType &t) {
+            proto.set_kind(com::stripe::rubytyper::Type::LITERALINTEGER);
+            *proto.mutable_literalfloat() = toProto(gs, t);
         },
         [&](const TupleType &t) {
             proto.set_kind(com::stripe::rubytyper::Type::TUPLE);

--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -175,7 +175,7 @@ com::stripe::rubytyper::Type::Literal Proto::toProto(const GlobalState &gs, cons
     return proto;
 }
 
-com::stripe::rubytyper::Type::LiteralInteger Proto::toProto(const GlobalState &gs, const LiteralIntegerType &lit) {
+com::stripe::rubytyper::Type::LiteralInteger Proto::toProto(const GlobalState &gs, const IntegerLiteralType &lit) {
     com::stripe::rubytyper::Type::LiteralInteger proto;
     proto.set_integer(lit.value);
     return proto;
@@ -225,7 +225,7 @@ com::stripe::rubytyper::Type Proto::toProto(const GlobalState &gs, const TypePtr
             proto.set_kind(com::stripe::rubytyper::Type::LITERAL);
             *proto.mutable_literal() = toProto(gs, t);
         },
-        [&](const LiteralIntegerType &t) {
+        [&](const IntegerLiteralType &t) {
             proto.set_kind(com::stripe::rubytyper::Type::LITERALINTEGER);
             *proto.mutable_literalinteger() = toProto(gs, t);
         },

--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -163,10 +163,6 @@ com::stripe::rubytyper::Type::Literal Proto::toProto(const GlobalState &gs, cons
     com::stripe::rubytyper::Type::Literal proto;
 
     switch (lit.literalKind) {
-        case LiteralType::LiteralTypeKind::Integer:
-            proto.set_kind(com::stripe::rubytyper::Type::Literal::INTEGER);
-            proto.set_integer(lit.asInteger());
-            break;
         case LiteralType::LiteralTypeKind::String:
             proto.set_kind(com::stripe::rubytyper::Type::Literal::STRING);
             proto.set_string(lit.asName().show(gs));
@@ -180,6 +176,12 @@ com::stripe::rubytyper::Type::Literal Proto::toProto(const GlobalState &gs, cons
             proto.set_float_(lit.asFloat());
             break;
     }
+    return proto;
+}
+
+com::stripe::rubytyper::Type::LiteralInteger Proto::toProto(const GlobalState &gs, const LiteralIntegerType &lit) {
+    com::stripe::rubytyper::Type::LiteralInteger proto;
+    proto.set_integer(lit.value);
     return proto;
 }
 
@@ -220,6 +222,10 @@ com::stripe::rubytyper::Type Proto::toProto(const GlobalState &gs, const TypePtr
         [&](const LiteralType &t) {
             proto.set_kind(com::stripe::rubytyper::Type::LITERAL);
             *proto.mutable_literal() = toProto(gs, t);
+        },
+        [&](const LiteralIntegerType &t) {
+            proto.set_kind(com::stripe::rubytyper::Type::LITERALINTEGER);
+            *proto.mutable_literalinteger() = toProto(gs, t);
         },
         [&](const TupleType &t) {
             proto.set_kind(com::stripe::rubytyper::Type::TUPLE);

--- a/core/proto/proto.h
+++ b/core/proto/proto.h
@@ -23,6 +23,7 @@ public:
     static com::stripe::rubytyper::Symbol toProto(const GlobalState &gs, SymbolRef sym, bool showFull);
 
     static com::stripe::rubytyper::Type::Literal toProto(const GlobalState &gs, const LiteralType &lit);
+    static com::stripe::rubytyper::Type::LiteralInteger toProto(const GlobalState &gs, const LiteralIntegerType &lit);
     static com::stripe::rubytyper::Type toProto(const GlobalState &gs, const TypePtr &typ);
 
     static com::stripe::rubytyper::Loc toProto(const GlobalState &gs, Loc loc);

--- a/core/proto/proto.h
+++ b/core/proto/proto.h
@@ -24,6 +24,7 @@ public:
 
     static com::stripe::rubytyper::Type::Literal toProto(const GlobalState &gs, const LiteralType &lit);
     static com::stripe::rubytyper::Type::LiteralInteger toProto(const GlobalState &gs, const LiteralIntegerType &lit);
+    static com::stripe::rubytyper::Type::LiteralFloat toProto(const GlobalState &gs, const FloatLiteralType &lit);
     static com::stripe::rubytyper::Type toProto(const GlobalState &gs, const TypePtr &typ);
 
     static com::stripe::rubytyper::Loc toProto(const GlobalState &gs, Loc loc);

--- a/core/proto/proto.h
+++ b/core/proto/proto.h
@@ -22,7 +22,7 @@ public:
     static com::stripe::rubytyper::Symbol::ArgumentInfo toProto(const GlobalState &gs, const ArgInfo &arg);
     static com::stripe::rubytyper::Symbol toProto(const GlobalState &gs, SymbolRef sym, bool showFull);
 
-    static com::stripe::rubytyper::Type::Literal toProto(const GlobalState &gs, const LiteralType &lit);
+    static com::stripe::rubytyper::Type::Literal toProto(const GlobalState &gs, const NamedLiteralType &lit);
     static com::stripe::rubytyper::Type::LiteralInteger toProto(const GlobalState &gs, const IntegerLiteralType &lit);
     static com::stripe::rubytyper::Type::LiteralFloat toProto(const GlobalState &gs, const FloatLiteralType &lit);
     static com::stripe::rubytyper::Type toProto(const GlobalState &gs, const TypePtr &typ);

--- a/core/proto/proto.h
+++ b/core/proto/proto.h
@@ -23,7 +23,7 @@ public:
     static com::stripe::rubytyper::Symbol toProto(const GlobalState &gs, SymbolRef sym, bool showFull);
 
     static com::stripe::rubytyper::Type::Literal toProto(const GlobalState &gs, const LiteralType &lit);
-    static com::stripe::rubytyper::Type::LiteralInteger toProto(const GlobalState &gs, const LiteralIntegerType &lit);
+    static com::stripe::rubytyper::Type::LiteralInteger toProto(const GlobalState &gs, const IntegerLiteralType &lit);
     static com::stripe::rubytyper::Type::LiteralFloat toProto(const GlobalState &gs, const FloatLiteralType &lit);
     static com::stripe::rubytyper::Type toProto(const GlobalState &gs, const TypePtr &typ);
 

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -367,8 +367,8 @@ void SerializerImpl::pickle(Pickler &p, const TypePtr &what) {
             }
             break;
         }
-        case TypePtr::Tag::LiteralIntegerType: {
-            auto &i = cast_type_nonnull<LiteralIntegerType>(what);
+        case TypePtr::Tag::IntegerLiteralType: {
+            auto &i = cast_type_nonnull<IntegerLiteralType>(what);
             p.putS8(i.value);
             break;
         }
@@ -465,8 +465,8 @@ TypePtr SerializerImpl::unpickleType(UnPickler &p, const GlobalState *gs) {
             }
             Exception::notImplemented();
         }
-        case TypePtr::Tag::LiteralIntegerType:
-            return make_type<LiteralIntegerType>(p.getS8());
+        case TypePtr::Tag::IntegerLiteralType:
+            return make_type<IntegerLiteralType>(p.getS8());
         case TypePtr::Tag::FloatLiteralType:
             return make_type<FloatLiteralType>(absl::bit_cast<double>(p.getS8()));
         case TypePtr::Tag::AndType:

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -360,9 +360,6 @@ void SerializerImpl::pickle(Pickler &p, const TypePtr &what) {
             auto c = cast_type_nonnull<LiteralType>(what);
             p.putU1((uint8_t)c.literalKind);
             switch (c.literalKind) {
-                case LiteralType::LiteralTypeKind::Float:
-                    p.putS8(absl::bit_cast<int64_t>(c.asFloat()));
-                    break;
                 case LiteralType::LiteralTypeKind::Symbol:
                 case LiteralType::LiteralTypeKind::String:
                     p.putS8(c.unsafeAsName().rawId());
@@ -373,6 +370,11 @@ void SerializerImpl::pickle(Pickler &p, const TypePtr &what) {
         case TypePtr::Tag::LiteralIntegerType: {
             auto &i = cast_type_nonnull<LiteralIntegerType>(what);
             p.putS8(i.value);
+            break;
+        }
+        case TypePtr::Tag::FloatLiteralType: {
+            auto &f = cast_type_nonnull<FloatLiteralType>(what);
+            p.putS8(absl::bit_cast<int64_t>(f.value));
             break;
         }
         case TypePtr::Tag::AndType: {
@@ -456,8 +458,6 @@ TypePtr SerializerImpl::unpickleType(UnPickler &p, const GlobalState *gs) {
             auto kind = (core::LiteralType::LiteralTypeKind)p.getU1();
             auto value = p.getS8();
             switch (kind) {
-                case LiteralType::LiteralTypeKind::Float:
-                    return make_type<LiteralType>(absl::bit_cast<double>(value));
                 case LiteralType::LiteralTypeKind::String:
                     return make_type<LiteralType>(Symbols::String(), NameRef::fromRawUnchecked(value));
                 case LiteralType::LiteralTypeKind::Symbol:
@@ -467,6 +467,8 @@ TypePtr SerializerImpl::unpickleType(UnPickler &p, const GlobalState *gs) {
         }
         case TypePtr::Tag::LiteralIntegerType:
             return make_type<LiteralIntegerType>(p.getS8());
+        case TypePtr::Tag::FloatLiteralType:
+            return make_type<FloatLiteralType>(absl::bit_cast<double>(p.getS8()));
         case TypePtr::Tag::AndType:
             return AndType::make_shared(unpickleType(p, gs), unpickleType(p, gs));
         case TypePtr::Tag::TupleType: {

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -356,12 +356,12 @@ void SerializerImpl::pickle(Pickler &p, const TypePtr &what) {
             pickle(p, o.right);
             break;
         }
-        case TypePtr::Tag::LiteralType: {
-            auto c = cast_type_nonnull<LiteralType>(what);
+        case TypePtr::Tag::NamedLiteralType: {
+            auto c = cast_type_nonnull<NamedLiteralType>(what);
             p.putU1((uint8_t)c.literalKind);
             switch (c.literalKind) {
-                case LiteralType::LiteralTypeKind::Symbol:
-                case LiteralType::LiteralTypeKind::String:
+                case NamedLiteralType::LiteralTypeKind::Symbol:
+                case NamedLiteralType::LiteralTypeKind::String:
                     p.putS8(c.unsafeAsName().rawId());
                     break;
             }
@@ -454,14 +454,14 @@ TypePtr SerializerImpl::unpickleType(UnPickler &p, const GlobalState *gs) {
             return make_type<ClassType>(ClassOrModuleRef::fromRaw(p.getU4()));
         case TypePtr::Tag::OrType:
             return OrType::make_shared(unpickleType(p, gs), unpickleType(p, gs));
-        case TypePtr::Tag::LiteralType: {
-            auto kind = (core::LiteralType::LiteralTypeKind)p.getU1();
+        case TypePtr::Tag::NamedLiteralType: {
+            auto kind = (core::NamedLiteralType::LiteralTypeKind)p.getU1();
             auto value = p.getS8();
             switch (kind) {
-                case LiteralType::LiteralTypeKind::String:
-                    return make_type<LiteralType>(Symbols::String(), NameRef::fromRawUnchecked(value));
-                case LiteralType::LiteralTypeKind::Symbol:
-                    return make_type<LiteralType>(Symbols::Symbol(), NameRef::fromRawUnchecked(value));
+                case NamedLiteralType::LiteralTypeKind::String:
+                    return make_type<NamedLiteralType>(Symbols::String(), NameRef::fromRawUnchecked(value));
+                case NamedLiteralType::LiteralTypeKind::Symbol:
+                    return make_type<NamedLiteralType>(Symbols::Symbol(), NameRef::fromRawUnchecked(value));
             }
             Exception::notImplemented();
         }

--- a/core/test/core_test.cc
+++ b/core/test/core_test.cc
@@ -308,7 +308,6 @@ TEST_SUITE("TypePtr") {
             CHECK_EQ(1, counter->load());
 
             // Moving should clear counter from ptrCopy and make it an empty TypePtr
-            CHECK_EQ(0, TypePtrTestHelper::value(ptrCopy));
             CHECK_EQ(0, TypePtrTestHelper::store(ptrCopy));
             CHECK_EQ(TypePtr(), ptrCopy);
 
@@ -348,10 +347,9 @@ TEST_SUITE("TypePtr") {
 
         for (auto values : valuesArray) {
             SUBCASE(fmt::format("{}, {}", values.first, values.second).c_str()) {
-                auto type = TypePtrTestHelper::createInlined(TypePtr::Tag::SelfType, values.first, values.second);
+                auto type = TypePtrTestHelper::createInlined(TypePtr::Tag::SelfType, values.first);
                 CHECK_EQ(TypePtr::Tag::SelfType, type.tag());
                 CHECK_EQ(values.first, TypePtrTestHelper::inlinedValue(type));
-                CHECK_EQ(values.second, TypePtrTestHelper::value(type));
             }
         }
     }

--- a/core/test/core_test.cc
+++ b/core/test/core_test.cc
@@ -249,15 +249,10 @@ class TypePtrTestHelper {
 public:
     static std::atomic<uint32_t> *counter(const TypePtr &ptr) {
         CHECK(ptr.containsPtr());
-        return ptr.counter;
+        return &ptr.get()->counter;
     }
 
-    static uint64_t value(const TypePtr &ptr) {
-        CHECK(!ptr.containsPtr());
-        return ptr.value;
-    }
-
-    static uint32_t inlinedValue(const TypePtr &ptr) {
+    static uint64_t inlinedValue(const TypePtr &ptr) {
         CHECK(!ptr.containsPtr());
         return ptr.inlinedValue();
     }
@@ -266,24 +261,24 @@ public:
         return ptr.store;
     }
 
-    static void *get(const TypePtr &ptr) {
+    static Refcounted *get(const TypePtr &ptr) {
         CHECK(ptr.containsPtr());
         return ptr.get();
     }
 
-    static TypePtr create(TypePtr::Tag tag, void *type) {
+    static TypePtr create(TypePtr::Tag tag, Refcounted *type) {
         return TypePtr(tag, type);
     }
 
-    static TypePtr createInlined(TypePtr::Tag tag, uint32_t inlinedValue, uint64_t value) {
-        return TypePtr(tag, inlinedValue, value);
+    static TypePtr createInlined(TypePtr::Tag tag, uint64_t inlinedValue) {
+        return TypePtr(tag, inlinedValue);
     }
 };
 
 TEST_SUITE("TypePtr") {
     TEST_CASE("Does not allocate a counter for null type") {
         TypePtr ptr;
-        CHECK_EQ(0, TypePtrTestHelper::value(ptr));
+        CHECK_EQ(0, TypePtrTestHelper::store(ptr));
     }
 
     TEST_CASE("Properly manages counter") {

--- a/core/test/core_test.cc
+++ b/core/test/core_test.cc
@@ -320,15 +320,6 @@ TEST_SUITE("TypePtr") {
     }
 
     TEST_CASE("Tagging works as expected") {
-        // This tag is < 8. Will be deleted / managed by TypePtr.
-        {
-            auto rawPtr = new SelfType();
-            auto ptr = TypePtrTestHelper::create(TypePtr::Tag::SelfType, rawPtr);
-            CHECK_EQ(TypePtr::Tag::SelfType, ptr.tag());
-            CHECK_EQ(rawPtr, TypePtrTestHelper::get(ptr));
-        }
-
-        // This tag is > 8
         {
             auto rawPtr = new UnresolvedClassType(Symbols::untyped(), {});
             auto ptr = TypePtrTestHelper::create(TypePtr::Tag::UnresolvedClassType, rawPtr);

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -41,6 +41,10 @@ bool LiteralType::derivesFrom(const GlobalState &gs, core::ClassOrModuleRef klas
     return underlying(gs).derivesFrom(gs, klass);
 }
 
+bool LiteralIntegerType::derivesFrom(const GlobalState &gs, core::ClassOrModuleRef klass) const {
+    return underlying(gs).derivesFrom(gs, klass);
+}
+
 bool ShapeType::derivesFrom(const GlobalState &gs, core::ClassOrModuleRef klass) const {
     return underlying(gs).derivesFrom(gs, klass);
 }
@@ -50,6 +54,10 @@ bool TupleType::derivesFrom(const GlobalState &gs, core::ClassOrModuleRef klass)
 }
 
 DispatchResult LiteralType::dispatchCall(const GlobalState &gs, const DispatchArgs &args) const {
+    return dispatchCallProxyType(gs, underlying(gs), args);
+}
+
+DispatchResult LiteralIntegerType::dispatchCall(const GlobalState &gs, const DispatchArgs &args) const {
     return dispatchCallProxyType(gs, underlying(gs), args);
 }
 
@@ -498,7 +506,7 @@ TypePtr unwrapType(const GlobalState &gs, Loc loc, const TypePtr &tp) {
             unwrappedElems.emplace_back(unwrapType(gs, loc, elem));
         }
         return make_type<TupleType>(move(unwrappedElems));
-    } else if (isa_type<LiteralType>(tp)) {
+    } else if (isa_type<LiteralType>(tp) || isa_type<LiteralIntegerType>(tp)) {
         if (auto e = gs.beginError(loc, errors::Infer::BareTypeUsage)) {
             e.setHeader("Unexpected bare `{}` value found in type position", tp.show(gs));
         }
@@ -1237,6 +1245,9 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                 ++kwit;
 
                 auto arg = absl::c_find_if(hash->keys, [&](const TypePtr &litType) {
+                        if (!isa_type<LiteralType>(litType)) {
+                            return false;
+                        }
                     auto lit = cast_type_nonnull<LiteralType>(litType);
                     auto underlying = lit.underlying(gs);
                     return cast_type_nonnull<ClassType>(underlying).symbol == Symbols::Symbol() &&
@@ -2090,7 +2101,8 @@ public:
         ENFORCE(args.args.size() % 2 == 0);
 
         for (int i = 0; i < args.args.size(); i += 2) {
-            if (!isa_type<LiteralType>(args.args[i]->type)) {
+            if (!isa_type<LiteralType>(args.args[i]->type) &&
+                !isa_type<LiteralIntegerType>(args.args[i]->type)) {
                 res.returnType = Types::hashOfUntyped();
                 return;
             }
@@ -2179,15 +2191,15 @@ public:
             return;
         }
         auto val = args.args.front()->type;
-        auto beforeLit = cast_type_nonnull<LiteralType>(args.args[1]->type);
-        auto afterLit = cast_type_nonnull<LiteralType>(args.args[2]->type);
-        if (!(beforeLit.underlying(gs).derivesFrom(gs, Symbols::Integer()) &&
-              afterLit.underlying(gs).derivesFrom(gs, Symbols::Integer()))) {
+        if (!(isa_type<LiteralIntegerType>(args.args[1]->type) &&
+              isa_type<LiteralIntegerType>(args.args[2]->type))) {
             res.returnType = Types::untypedUntracked();
             return;
         }
-        int before = (int)beforeLit.asInteger();
-        int after = (int)afterLit.asInteger();
+        auto &beforeLit = cast_type_nonnull<LiteralIntegerType>(args.args[1]->type);
+        auto &afterLit = cast_type_nonnull<LiteralIntegerType>(args.args[2]->type);
+        int before = (int)beforeLit.value;
+        int after = (int)afterLit.value;
         res.returnType = expandArray(gs, val, before + after);
     }
 } Magic_expandSplat;
@@ -2939,16 +2951,13 @@ public:
         if (args.args.size() == 1) {
             argType = args.args.front()->type;
         }
-        if (!isa_type<LiteralType>(argType)) {
+        if (!isa_type<LiteralIntegerType>(argType)) {
             return;
         }
 
-        auto lit = cast_type_nonnull<LiteralType>(argType);
-        if (!lit.underlying(gs).derivesFrom(gs, Symbols::Integer())) {
-            return;
-        }
+        auto &lit = cast_type_nonnull<LiteralIntegerType>(argType);
 
-        auto idx = lit.asInteger();
+        auto idx = lit.value;
         if (idx < 0) {
             idx = tuple->elems.size() + idx;
         }
@@ -3192,7 +3201,12 @@ public:
         auto values = shape->values;
         auto addShapeEntry = [&keys, &values](const TypePtr &keyType, const LiteralType &key, const TypePtr &value) {
             auto fnd =
-                absl::c_find_if(keys, [&key](auto &lit) { return key.equals(cast_type_nonnull<LiteralType>(lit)); });
+                absl::c_find_if(keys, [&key](auto &lit) {
+                        if (!isa_type<LiteralType>(lit)) {
+                            return false;
+                        }
+                        return key.equals(cast_type_nonnull<LiteralType>(lit));
+                    });
             if (fnd == keys.end()) {
                 keys.emplace_back(keyType);
                 values.emplace_back(value);
@@ -3219,6 +3233,9 @@ public:
         // then kwsplat
         if (kwsplat != nullptr) {
             for (auto &keyType : kwsplat->keys) {
+                if (!isa_type<LiteralType>(keyType)) {
+                    return;
+                }
                 auto key = cast_type_nonnull<LiteralType>(keyType);
                 addShapeEntry(keyType, key, kwsplat->values[&keyType - &kwsplat->keys.front()]);
             }
@@ -3460,18 +3477,17 @@ public:
             ENFORCE(args.locs.args.size() == 1, "Mismatch between args.size() and args.locs.args.size(): {}",
                     args.locs.args.size());
 
-            if (!isa_type<LiteralType>(argTyp)) {
+            if (!isa_type<LiteralIntegerType>(argTyp)) {
                 if (auto e = gs.beginError(args.argLoc(0), core::errors::Infer::ExpectedLiteralType)) {
                     e.setHeader("You must pass an Integer literal to specify a depth with Array#flatten");
                 }
                 return;
             }
 
-            auto lt = cast_type_nonnull<LiteralType>(argTyp);
-            ENFORCE(lt.literalKind == LiteralType::LiteralTypeKind::Integer, "depth arg must be an Integer literal");
+            auto &lt = cast_type_nonnull<LiteralIntegerType>(argTyp);
 
-            if (lt.asInteger() >= 0) {
-                depth = lt.asInteger();
+            if (lt.value >= 0) {
+                depth = lt.value;
             } else {
                 // Negative values behave like no depth was given
                 depth = MAX_DEPTH;

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -37,7 +37,7 @@ bool allComponentsPresent(DispatchResult &res) {
 }
 } // namespace
 
-bool LiteralType::derivesFrom(const GlobalState &gs, core::ClassOrModuleRef klass) const {
+bool NamedLiteralType::derivesFrom(const GlobalState &gs, core::ClassOrModuleRef klass) const {
     return underlying(gs).derivesFrom(gs, klass);
 }
 
@@ -57,7 +57,7 @@ bool TupleType::derivesFrom(const GlobalState &gs, core::ClassOrModuleRef klass)
     return underlying(gs).derivesFrom(gs, klass);
 }
 
-DispatchResult LiteralType::dispatchCall(const GlobalState &gs, const DispatchArgs &args) const {
+DispatchResult NamedLiteralType::dispatchCall(const GlobalState &gs, const DispatchArgs &args) const {
     return dispatchCallProxyType(gs, underlying(gs), args);
 }
 
@@ -514,7 +514,7 @@ TypePtr unwrapType(const GlobalState &gs, Loc loc, const TypePtr &tp) {
             unwrappedElems.emplace_back(unwrapType(gs, loc, elem));
         }
         return make_type<TupleType>(move(unwrappedElems));
-    } else if (isa_type<LiteralType>(tp) || isa_type<IntegerLiteralType>(tp) || isa_type<FloatLiteralType>(tp)) {
+    } else if (isa_type<NamedLiteralType>(tp) || isa_type<IntegerLiteralType>(tp) || isa_type<FloatLiteralType>(tp)) {
         if (auto e = gs.beginError(loc, errors::Infer::BareTypeUsage)) {
             e.setHeader("Unexpected bare `{}` value found in type position", tp.show(gs));
         }
@@ -657,11 +657,11 @@ const ShapeType *fromKwargsHash(const GlobalState &gs, const TypePtr &ty) {
     }
 
     if (!absl::c_all_of(hash->keys, [&gs](const auto &key) {
-            if (!isa_type<LiteralType>(key)) {
+            if (!isa_type<NamedLiteralType>(key)) {
                 return false;
             }
 
-            auto klass = cast_type_nonnull<LiteralType>(key).underlying(gs);
+            auto klass = cast_type_nonnull<NamedLiteralType>(key).underlying(gs);
             if (!isa_type<ClassType>(klass)) {
                 return false;
             }
@@ -984,8 +984,8 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
             while (kwit != kwend) {
                 // if the key isn't a symbol literal, break out as this is not a valid keyword
                 auto &key = *kwit++;
-                if (!isa_type<LiteralType>(key->type) ||
-                    cast_type_nonnull<LiteralType>(key->type).literalKind != LiteralType::LiteralTypeKind::Symbol) {
+                if (!isa_type<NamedLiteralType>(key->type) ||
+                    cast_type_nonnull<NamedLiteralType>(key->type).literalKind != NamedLiteralType::LiteralTypeKind::Symbol) {
                     // it's not possible to tell if this is hash will be used as kwargs yet, so we can't raise a useful
                     // error here.
 
@@ -1222,7 +1222,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                     break;
                 } else if (spec.flags.isRepeated) {
                     for (auto it = hash->keys.begin(); it != hash->keys.end(); ++it) {
-                        auto key = cast_type_nonnull<LiteralType>(*it);
+                        auto key = cast_type_nonnull<NamedLiteralType>(*it);
                         auto underlying = key.underlying(gs);
                         ClassOrModuleRef klass = cast_type_nonnull<ClassType>(underlying).symbol;
                         if (klass != Symbols::Symbol()) {
@@ -1253,10 +1253,10 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                 ++kwit;
 
                 auto arg = absl::c_find_if(hash->keys, [&](const TypePtr &litType) {
-                    if (!isa_type<LiteralType>(litType)) {
+                    if (!isa_type<NamedLiteralType>(litType)) {
                         return false;
                     }
-                    auto lit = cast_type_nonnull<LiteralType>(litType);
+                    auto lit = cast_type_nonnull<NamedLiteralType>(litType);
                     auto underlying = lit.underlying(gs);
                     return cast_type_nonnull<ClassType>(underlying).symbol == Symbols::Symbol() &&
                            lit.asName() == spec.name;
@@ -1309,7 +1309,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                 }
             }
             for (auto &keyType : hash->keys) {
-                auto key = cast_type_nonnull<LiteralType>(keyType);
+                auto key = cast_type_nonnull<NamedLiteralType>(keyType);
                 auto underlying = key.underlying(gs);
                 ClassOrModuleRef klass = cast_type_nonnull<ClassType>(underlying).symbol;
                 if (klass == Symbols::Symbol() && consumed.find(key.asName()) != consumed.end()) {
@@ -2109,7 +2109,7 @@ public:
         ENFORCE(args.args.size() % 2 == 0);
 
         for (int i = 0; i < args.args.size(); i += 2) {
-            if (!isa_type<LiteralType>(args.args[i]->type) && !isa_type<IntegerLiteralType>(args.args[i]->type) &&
+            if (!isa_type<NamedLiteralType>(args.args[i]->type) && !isa_type<IntegerLiteralType>(args.args[i]->type) &&
                 !isa_type<FloatLiteralType>(args.args[i]->type)) {
                 res.returnType = Types::hashOfUntyped();
                 return;
@@ -2269,10 +2269,10 @@ public:
             return;
         }
 
-        if (!isa_type<LiteralType>(args.args[1]->type)) {
+        if (!isa_type<NamedLiteralType>(args.args[1]->type)) {
             return;
         }
-        auto lit = cast_type_nonnull<LiteralType>(args.args[1]->type);
+        auto lit = cast_type_nonnull<NamedLiteralType>(args.args[1]->type);
         if (!lit.derivesFrom(gs, Symbols::Symbol())) {
             return;
         }
@@ -2518,10 +2518,10 @@ public:
             return;
         }
 
-        if (!isa_type<LiteralType>(args.args[1]->type)) {
+        if (!isa_type<NamedLiteralType>(args.args[1]->type)) {
             return;
         }
-        auto lit = cast_type_nonnull<LiteralType>(args.args[1]->type);
+        auto lit = cast_type_nonnull<NamedLiteralType>(args.args[1]->type);
         if (!lit.derivesFrom(gs, Symbols::Symbol())) {
             return;
         }
@@ -2588,10 +2588,10 @@ public:
             return;
         }
 
-        if (!isa_type<LiteralType>(args.args[1]->type)) {
+        if (!isa_type<NamedLiteralType>(args.args[1]->type)) {
             return;
         }
-        auto lit = cast_type_nonnull<LiteralType>(args.args[1]->type);
+        auto lit = cast_type_nonnull<NamedLiteralType>(args.args[1]->type);
         if (!lit.derivesFrom(gs, Symbols::Symbol())) {
             return;
         }
@@ -2764,10 +2764,10 @@ public:
         auto selfTy = *args.args[0];
         auto selfTyAndAnd = *args.args[1];
 
-        if (!isa_type<LiteralType>(args.args[2]->type)) {
+        if (!isa_type<NamedLiteralType>(args.args[2]->type)) {
             return;
         }
-        auto lit = cast_type_nonnull<LiteralType>(args.args[2]->type);
+        auto lit = cast_type_nonnull<NamedLiteralType>(args.args[2]->type);
         if (!lit.derivesFrom(gs, Symbols::Symbol())) {
             return;
         }
@@ -3132,7 +3132,7 @@ public:
         }
 
         auto &arg = args.args.front()->type;
-        if (!isa_type<LiteralType>(arg) && !isa_type<IntegerLiteralType>(arg) && !isa_type<FloatLiteralType>(arg)) {
+        if (!isa_type<NamedLiteralType>(arg) && !isa_type<IntegerLiteralType>(arg) && !isa_type<FloatLiteralType>(arg)) {
             return;
         }
 
@@ -3152,9 +3152,9 @@ public:
                                      args.fullType.origins2Explanations(gs, args.originForUninitialized)));
                     e.addErrorSection(actualType.explainGot(gs, args.originForUninitialized));
 
-                    if (args.fullType.origins.size() == 1 && isa_type<LiteralType>(arg)) {
-                        auto argLit = cast_type_nonnull<LiteralType>(arg);
-                        if (argLit.literalKind == LiteralType::LiteralTypeKind::Symbol) {
+                    if (args.fullType.origins.size() == 1 && isa_type<NamedLiteralType>(arg)) {
+                        auto argLit = cast_type_nonnull<NamedLiteralType>(arg);
+                        if (argLit.literalKind == NamedLiteralType::LiteralTypeKind::Symbol) {
                             auto key = argLit.asName();
                             auto loc = locOfValueForKey(gs, args.fullType.origins[0], key, expectedType);
 
@@ -3222,12 +3222,12 @@ public:
         // inlined keyword arguments first
         for (auto i = 0; i < numKwargs; i += 2) {
             auto &keyType = args.args[i]->type;
-            if (!isa_type<LiteralType>(keyType)) {
+            if (!isa_type<NamedLiteralType>(keyType)) {
                 return;
             }
 
-            auto key = cast_type_nonnull<LiteralType>(keyType);
-            if (key.literalKind != LiteralType::LiteralTypeKind::Symbol) {
+            auto key = cast_type_nonnull<NamedLiteralType>(keyType);
+            if (key.literalKind != NamedLiteralType::LiteralTypeKind::Symbol) {
                 return;
             }
 
@@ -3237,7 +3237,7 @@ public:
         // then kwsplat
         if (kwsplat != nullptr) {
             for (auto &keyType : kwsplat->keys) {
-                if (!isa_type<LiteralType>(keyType) && !isa_type<IntegerLiteralType>(keyType) &&
+                if (!isa_type<NamedLiteralType>(keyType) && !isa_type<IntegerLiteralType>(keyType) &&
                     !isa_type<FloatLiteralType>(keyType)) {
                     return;
                 }
@@ -3341,7 +3341,7 @@ class Magic_mergeHashValues : public IntrinsicMethod {
 
             // Guard shape construction on keys being valid, falling back on T::Hash[T.untyped, T.untyped] if it's
             // invalid.
-            if (!isa_type<LiteralType>(key->type)) {
+            if (!isa_type<NamedLiteralType>(key->type)) {
                 argType = Types::hashOfUntyped();
                 break;
             }

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -41,7 +41,7 @@ bool LiteralType::derivesFrom(const GlobalState &gs, core::ClassOrModuleRef klas
     return underlying(gs).derivesFrom(gs, klass);
 }
 
-bool LiteralIntegerType::derivesFrom(const GlobalState &gs, core::ClassOrModuleRef klass) const {
+bool IntegerLiteralType::derivesFrom(const GlobalState &gs, core::ClassOrModuleRef klass) const {
     return underlying(gs).derivesFrom(gs, klass);
 }
 
@@ -61,7 +61,7 @@ DispatchResult LiteralType::dispatchCall(const GlobalState &gs, const DispatchAr
     return dispatchCallProxyType(gs, underlying(gs), args);
 }
 
-DispatchResult LiteralIntegerType::dispatchCall(const GlobalState &gs, const DispatchArgs &args) const {
+DispatchResult IntegerLiteralType::dispatchCall(const GlobalState &gs, const DispatchArgs &args) const {
     return dispatchCallProxyType(gs, underlying(gs), args);
 }
 
@@ -514,7 +514,7 @@ TypePtr unwrapType(const GlobalState &gs, Loc loc, const TypePtr &tp) {
             unwrappedElems.emplace_back(unwrapType(gs, loc, elem));
         }
         return make_type<TupleType>(move(unwrappedElems));
-    } else if (isa_type<LiteralType>(tp) || isa_type<LiteralIntegerType>(tp) || isa_type<FloatLiteralType>(tp)) {
+    } else if (isa_type<LiteralType>(tp) || isa_type<IntegerLiteralType>(tp) || isa_type<FloatLiteralType>(tp)) {
         if (auto e = gs.beginError(loc, errors::Infer::BareTypeUsage)) {
             e.setHeader("Unexpected bare `{}` value found in type position", tp.show(gs));
         }
@@ -2109,7 +2109,7 @@ public:
         ENFORCE(args.args.size() % 2 == 0);
 
         for (int i = 0; i < args.args.size(); i += 2) {
-            if (!isa_type<LiteralType>(args.args[i]->type) && !isa_type<LiteralIntegerType>(args.args[i]->type) &&
+            if (!isa_type<LiteralType>(args.args[i]->type) && !isa_type<IntegerLiteralType>(args.args[i]->type) &&
                 !isa_type<FloatLiteralType>(args.args[i]->type)) {
                 res.returnType = Types::hashOfUntyped();
                 return;
@@ -2199,12 +2199,12 @@ public:
             return;
         }
         auto val = args.args.front()->type;
-        if (!(isa_type<LiteralIntegerType>(args.args[1]->type) && isa_type<LiteralIntegerType>(args.args[2]->type))) {
+        if (!(isa_type<IntegerLiteralType>(args.args[1]->type) && isa_type<IntegerLiteralType>(args.args[2]->type))) {
             res.returnType = Types::untypedUntracked();
             return;
         }
-        auto &beforeLit = cast_type_nonnull<LiteralIntegerType>(args.args[1]->type);
-        auto &afterLit = cast_type_nonnull<LiteralIntegerType>(args.args[2]->type);
+        auto &beforeLit = cast_type_nonnull<IntegerLiteralType>(args.args[1]->type);
+        auto &afterLit = cast_type_nonnull<IntegerLiteralType>(args.args[2]->type);
         int before = (int)beforeLit.value;
         int after = (int)afterLit.value;
         res.returnType = expandArray(gs, val, before + after);
@@ -2958,11 +2958,11 @@ public:
         if (args.args.size() == 1) {
             argType = args.args.front()->type;
         }
-        if (!isa_type<LiteralIntegerType>(argType)) {
+        if (!isa_type<IntegerLiteralType>(argType)) {
             return;
         }
 
-        auto &lit = cast_type_nonnull<LiteralIntegerType>(argType);
+        auto &lit = cast_type_nonnull<IntegerLiteralType>(argType);
 
         auto idx = lit.value;
         if (idx < 0) {
@@ -3132,7 +3132,7 @@ public:
         }
 
         auto &arg = args.args.front()->type;
-        if (!isa_type<LiteralType>(arg) && !isa_type<LiteralIntegerType>(arg) && !isa_type<FloatLiteralType>(arg)) {
+        if (!isa_type<LiteralType>(arg) && !isa_type<IntegerLiteralType>(arg) && !isa_type<FloatLiteralType>(arg)) {
             return;
         }
 
@@ -3237,7 +3237,7 @@ public:
         // then kwsplat
         if (kwsplat != nullptr) {
             for (auto &keyType : kwsplat->keys) {
-                if (!isa_type<LiteralType>(keyType) && !isa_type<LiteralIntegerType>(keyType) &&
+                if (!isa_type<LiteralType>(keyType) && !isa_type<IntegerLiteralType>(keyType) &&
                     !isa_type<FloatLiteralType>(keyType)) {
                     return;
                 }
@@ -3481,14 +3481,14 @@ public:
             ENFORCE(args.locs.args.size() == 1, "Mismatch between args.size() and args.locs.args.size(): {}",
                     args.locs.args.size());
 
-            if (!isa_type<LiteralIntegerType>(argTyp)) {
+            if (!isa_type<IntegerLiteralType>(argTyp)) {
                 if (auto e = gs.beginError(args.argLoc(0), core::errors::Infer::ExpectedLiteralType)) {
                     e.setHeader("You must pass an Integer literal to specify a depth with Array#flatten");
                 }
                 return;
             }
 
-            auto &lt = cast_type_nonnull<LiteralIntegerType>(argTyp);
+            auto &lt = cast_type_nonnull<IntegerLiteralType>(argTyp);
 
             if (lt.value >= 0) {
                 depth = lt.value;

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1253,9 +1253,9 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                 ++kwit;
 
                 auto arg = absl::c_find_if(hash->keys, [&](const TypePtr &litType) {
-                        if (!isa_type<LiteralType>(litType)) {
-                            return false;
-                        }
+                    if (!isa_type<LiteralType>(litType)) {
+                        return false;
+                    }
                     auto lit = cast_type_nonnull<LiteralType>(litType);
                     auto underlying = lit.underlying(gs);
                     return cast_type_nonnull<ClassType>(underlying).symbol == Symbols::Symbol() &&
@@ -2109,8 +2109,7 @@ public:
         ENFORCE(args.args.size() % 2 == 0);
 
         for (int i = 0; i < args.args.size(); i += 2) {
-            if (!isa_type<LiteralType>(args.args[i]->type) &&
-                !isa_type<LiteralIntegerType>(args.args[i]->type) &&
+            if (!isa_type<LiteralType>(args.args[i]->type) && !isa_type<LiteralIntegerType>(args.args[i]->type) &&
                 !isa_type<FloatLiteralType>(args.args[i]->type)) {
                 res.returnType = Types::hashOfUntyped();
                 return;
@@ -2200,8 +2199,7 @@ public:
             return;
         }
         auto val = args.args.front()->type;
-        if (!(isa_type<LiteralIntegerType>(args.args[1]->type) &&
-              isa_type<LiteralIntegerType>(args.args[2]->type))) {
+        if (!(isa_type<LiteralIntegerType>(args.args[1]->type) && isa_type<LiteralIntegerType>(args.args[2]->type))) {
             res.returnType = Types::untypedUntracked();
             return;
         }
@@ -3134,9 +3132,7 @@ public:
         }
 
         auto &arg = args.args.front()->type;
-        if (!isa_type<LiteralType>(arg) &&
-            !isa_type<LiteralIntegerType>(arg) &&
-            !isa_type<FloatLiteralType>(arg)) {
+        if (!isa_type<LiteralType>(arg) && !isa_type<LiteralIntegerType>(arg) && !isa_type<FloatLiteralType>(arg)) {
             return;
         }
 
@@ -3156,8 +3152,7 @@ public:
                                      args.fullType.origins2Explanations(gs, args.originForUninitialized)));
                     e.addErrorSection(actualType.explainGot(gs, args.originForUninitialized));
 
-                    if (args.fullType.origins.size() == 1 &&
-                        isa_type<LiteralType>(arg)) {
+                    if (args.fullType.origins.size() == 1 && isa_type<LiteralType>(arg)) {
                         auto argLit = cast_type_nonnull<LiteralType>(arg);
                         if (argLit.literalKind == LiteralType::LiteralTypeKind::Symbol) {
                             auto key = argLit.asName();
@@ -3242,8 +3237,7 @@ public:
         // then kwsplat
         if (kwsplat != nullptr) {
             for (auto &keyType : kwsplat->keys) {
-                if (!isa_type<LiteralType>(keyType) &&
-                    !isa_type<LiteralIntegerType>(keyType) &&
+                if (!isa_type<LiteralType>(keyType) && !isa_type<LiteralIntegerType>(keyType) &&
                     !isa_type<FloatLiteralType>(keyType)) {
                     return;
                 }

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -985,7 +985,8 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                 // if the key isn't a symbol literal, break out as this is not a valid keyword
                 auto &key = *kwit++;
                 if (!isa_type<NamedLiteralType>(key->type) ||
-                    cast_type_nonnull<NamedLiteralType>(key->type).literalKind != NamedLiteralType::LiteralTypeKind::Symbol) {
+                    cast_type_nonnull<NamedLiteralType>(key->type).literalKind !=
+                        NamedLiteralType::LiteralTypeKind::Symbol) {
                     // it's not possible to tell if this is hash will be used as kwargs yet, so we can't raise a useful
                     // error here.
 
@@ -3132,7 +3133,8 @@ public:
         }
 
         auto &arg = args.args.front()->type;
-        if (!isa_type<NamedLiteralType>(arg) && !isa_type<IntegerLiteralType>(arg) && !isa_type<FloatLiteralType>(arg)) {
+        if (!isa_type<NamedLiteralType>(arg) && !isa_type<IntegerLiteralType>(arg) &&
+            !isa_type<FloatLiteralType>(arg)) {
             return;
         }
 

--- a/core/types/hashing.cc
+++ b/core/types/hashing.cc
@@ -41,11 +41,22 @@ uint32_t LiteralType::hash(const GlobalState &gs) const {
         case LiteralType::LiteralTypeKind::Float:
             rawValue = absl::bit_cast<uint64_t>(asFloat());
             break;
-        case LiteralType::LiteralTypeKind::Integer:
-            rawValue = absl::bit_cast<uint64_t>(asInteger());
-            break;
     }
 
+    uint32_t topBits = static_cast<uint32_t>(rawValue >> 32);
+    uint32_t bottomBits = static_cast<uint32_t>(rawValue & 0xFFFFFFFF);
+    result = mix(result, topBits);
+    result = mix(result, bottomBits);
+    return result;
+}
+
+uint32_t LiteralIntegerType::hash(const GlobalState &gs) const {
+    uint32_t result = static_cast<uint32_t>(TypePtr::Tag::LiteralIntegerType);
+    auto underlying = this->underlying(gs);
+    ClassOrModuleRef undSymbol = cast_type_nonnull<ClassType>(underlying).symbol;
+    result = mix(result, undSymbol.id());
+
+    uint64_t rawValue = this->value;
     uint32_t topBits = static_cast<uint32_t>(rawValue >> 32);
     uint32_t bottomBits = static_cast<uint32_t>(rawValue & 0xFFFFFFFF);
     result = mix(result, topBits);

--- a/core/types/hashing.cc
+++ b/core/types/hashing.cc
@@ -33,16 +33,20 @@ uint32_t LiteralType::hash(const GlobalState &gs) const {
     ClassOrModuleRef undSymbol = cast_type_nonnull<ClassType>(underlying).symbol;
     result = mix(result, undSymbol.id());
 
-    uint64_t rawValue;
     switch (literalKind) {
         case LiteralType::LiteralTypeKind::String:
         case LiteralType::LiteralTypeKind::Symbol:
             return mix(result, _hash(asName().shortName(gs)));
-        case LiteralType::LiteralTypeKind::Float:
-            rawValue = absl::bit_cast<uint64_t>(asFloat());
-            break;
     }
+}
 
+uint32_t FloatLiteralType::hash(const GlobalState &gs) const {
+    uint32_t result = static_cast<uint32_t>(TypePtr::Tag::FloatLiteralType);
+    auto underlying = this->underlying(gs);
+    ClassOrModuleRef undSymbol = cast_type_nonnull<ClassType>(underlying).symbol;
+    result = mix(result, undSymbol.id());
+
+    uint64_t rawValue = absl::bit_cast<uint64_t>(this->value);
     uint32_t topBits = static_cast<uint32_t>(rawValue >> 32);
     uint32_t bottomBits = static_cast<uint32_t>(rawValue & 0xFFFFFFFF);
     result = mix(result, topBits);

--- a/core/types/hashing.cc
+++ b/core/types/hashing.cc
@@ -27,15 +27,15 @@ uint32_t UnresolvedAppliedType::hash(const GlobalState &gs) const {
     return result;
 }
 
-uint32_t LiteralType::hash(const GlobalState &gs) const {
-    uint32_t result = static_cast<uint32_t>(TypePtr::Tag::LiteralType);
+uint32_t NamedLiteralType::hash(const GlobalState &gs) const {
+    uint32_t result = static_cast<uint32_t>(TypePtr::Tag::NamedLiteralType);
     auto underlying = this->underlying(gs);
     ClassOrModuleRef undSymbol = cast_type_nonnull<ClassType>(underlying).symbol;
     result = mix(result, undSymbol.id());
 
     switch (literalKind) {
-        case LiteralType::LiteralTypeKind::String:
-        case LiteralType::LiteralTypeKind::Symbol:
+        case NamedLiteralType::LiteralTypeKind::String:
+        case NamedLiteralType::LiteralTypeKind::Symbol:
             return mix(result, _hash(asName().shortName(gs)));
     }
 }

--- a/core/types/hashing.cc
+++ b/core/types/hashing.cc
@@ -54,8 +54,8 @@ uint32_t FloatLiteralType::hash(const GlobalState &gs) const {
     return result;
 }
 
-uint32_t LiteralIntegerType::hash(const GlobalState &gs) const {
-    uint32_t result = static_cast<uint32_t>(TypePtr::Tag::LiteralIntegerType);
+uint32_t IntegerLiteralType::hash(const GlobalState &gs) const {
+    uint32_t result = static_cast<uint32_t>(TypePtr::Tag::IntegerLiteralType);
     auto underlying = this->underlying(gs);
     ClassOrModuleRef undSymbol = cast_type_nonnull<ClassType>(underlying).symbol;
     result = mix(result, undSymbol.id());

--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -100,11 +100,11 @@ string LiteralType::showValue(const GlobalState &gs) const {
     }
 }
 
-string LiteralIntegerType::toStringWithTabs(const GlobalState &gs, int tabs) const {
+string IntegerLiteralType::toStringWithTabs(const GlobalState &gs, int tabs) const {
     return fmt::format("{}({})", this->underlying(gs).toStringWithTabs(gs, tabs), showValue(gs));
 }
 
-string LiteralIntegerType::show(const GlobalState &gs, ShowOptions options) const {
+string IntegerLiteralType::show(const GlobalState &gs, ShowOptions options) const {
     if (options.showForRBI) {
         // RBI generator: Users type the class name, not `String("value")`.
         return fmt::format("{}", this->underlying(gs).show(gs, options));
@@ -113,7 +113,7 @@ string LiteralIntegerType::show(const GlobalState &gs, ShowOptions options) cons
     return fmt::format("{}({})", this->underlying(gs).show(gs, options), showValue(gs));
 }
 
-string LiteralIntegerType::showValue(const GlobalState &gs) const {
+string IntegerLiteralType::showValue(const GlobalState &gs) const {
     return to_string(this->value);
 }
 
@@ -199,8 +199,8 @@ string ShapeType::show(const GlobalState &gs, ShowOptions options) const {
             } else {
                 keyStr = options.showForRBI ? keyLiteral.showValue(gs) : keyLiteral.show(gs, options);
             }
-        } else if (isa_type<LiteralIntegerType>(key)) {
-            const auto &keyLiteral = cast_type_nonnull<LiteralIntegerType>(key);
+        } else if (isa_type<IntegerLiteralType>(key)) {
+            const auto &keyLiteral = cast_type_nonnull<IntegerLiteralType>(key);
             keyStr = options.showForRBI ? keyLiteral.showValue(gs) : keyLiteral.show(gs, options);
         } else {
             ENFORCE(isa_type<FloatLiteralType>(key));

--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -72,11 +72,11 @@ string UnresolvedAppliedType::show(const GlobalState &gs, ShowOptions options) c
                        resolvedString);
 }
 
-string LiteralType::toStringWithTabs(const GlobalState &gs, int tabs) const {
+string NamedLiteralType::toStringWithTabs(const GlobalState &gs, int tabs) const {
     return fmt::format("{}({})", this->underlying(gs).toStringWithTabs(gs, tabs), showValue(gs));
 }
 
-string LiteralType::show(const GlobalState &gs, ShowOptions options) const {
+string NamedLiteralType::show(const GlobalState &gs, ShowOptions options) const {
     if (options.showForRBI) {
         // RBI generator: Users type the class name, not `String("value")`.
         return fmt::format("{}", this->underlying(gs).show(gs, options));
@@ -85,11 +85,11 @@ string LiteralType::show(const GlobalState &gs, ShowOptions options) const {
     return fmt::format("{}({})", this->underlying(gs).show(gs, options), showValue(gs));
 }
 
-string LiteralType::showValue(const GlobalState &gs) const {
+string NamedLiteralType::showValue(const GlobalState &gs) const {
     switch (literalKind) {
-        case LiteralType::LiteralTypeKind::String:
+        case NamedLiteralType::LiteralTypeKind::String:
             return fmt::format("\"{}\"", absl::CEscape(asName().show(gs)));
-        case LiteralType::LiteralTypeKind::Symbol: {
+        case NamedLiteralType::LiteralTypeKind::Symbol: {
             auto shown = asName().show(gs);
             if (absl::StrContains(shown, " ")) {
                 return fmt::format(":\"{}\"", absl::CEscape(shown));
@@ -190,9 +190,9 @@ string ShapeType::show(const GlobalState &gs, ShowOptions options) const {
         string keyStr;
         string_view sepStr = " => ";
         // properties beginning with $ need to be printed as :$prop => type.
-        if (isa_type<LiteralType>(key)) {
-            const auto &keyLiteral = cast_type_nonnull<LiteralType>(key);
-            if (keyLiteral.literalKind == core::LiteralType::LiteralTypeKind::Symbol &&
+        if (isa_type<NamedLiteralType>(key)) {
+            const auto &keyLiteral = cast_type_nonnull<NamedLiteralType>(key);
+            if (keyLiteral.literalKind == core::NamedLiteralType::LiteralTypeKind::Symbol &&
                 !absl::StartsWith(keyLiteral.asName().shortName(gs), "$")) {
                 keyStr = keyLiteral.asName().show(gs);
                 sepStr = ": ";

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -438,7 +438,7 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                 },
                 [&](const LiteralIntegerType &l1) {
                     if (isa_type<LiteralIntegerType>(t2)) {
-                        auto l2 = cast_type_nonnull<LiteralIntegerType>(t2);
+                        auto &l2 = cast_type_nonnull<LiteralIntegerType>(t2);
                         if (l1.equals(l2)) {
                             result = t1;
                         } else {
@@ -450,7 +450,7 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                 },
                 [&](const FloatLiteralType &l1) {
                     if (isa_type<FloatLiteralType>(t2)) {
-                        auto l2 = cast_type_nonnull<FloatLiteralType>(t2);
+                        auto &l2 = cast_type_nonnull<FloatLiteralType>(t2);
                         if (l1.equals(l2)) {
                             result = t1;
                         } else {
@@ -803,7 +803,7 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                     }
                 },
                 [&](const LiteralIntegerType &l1) {
-                    auto l2 = cast_type_nonnull<LiteralIntegerType>(t2);
+                    auto &l2 = cast_type_nonnull<LiteralIntegerType>(t2);
                     if (l1.equals(l2)) {
                         result = t1;
                     } else {
@@ -811,7 +811,7 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                     }
                 },
                 [&](const FloatLiteralType &l1) {
-                    auto l2 = cast_type_nonnull<FloatLiteralType>(t2);
+                    auto &l2 = cast_type_nonnull<FloatLiteralType>(t2);
                     if (l1.equals(l2)) {
                         result = t1;
                     } else {
@@ -1284,7 +1284,7 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
                         return;
                     }
 
-                    auto l2 = cast_type_nonnull<LiteralIntegerType>(t2);
+                    auto &l2 = cast_type_nonnull<LiteralIntegerType>(t2);
                     result = l1.equals(l2);
                 },
                 [&](const FloatLiteralType &l1) {
@@ -1294,7 +1294,7 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
                         return;
                     }
 
-                    auto l2 = cast_type_nonnull<FloatLiteralType>(t2);
+                    auto &l2 = cast_type_nonnull<FloatLiteralType>(t2);
                     result = l1.equals(l2);
                 },
                 [&](const MetaType &m1) {

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -416,9 +416,9 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                         }
                     }
                 },
-                [&](const LiteralType &l1) {
-                    if (isa_type<LiteralType>(t2)) {
-                        auto l2 = cast_type_nonnull<LiteralType>(t2);
+                [&](const NamedLiteralType &l1) {
+                    if (isa_type<NamedLiteralType>(t2)) {
+                        auto l2 = cast_type_nonnull<NamedLiteralType>(t2);
                         auto underlyingL1 = l1.underlying(gs);
                         auto underlyingL2 = l2.underlying(gs);
                         auto class1 = cast_type_nonnull<ClassType>(underlyingL1);
@@ -786,8 +786,8 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                     }
 
                 },
-                [&](const LiteralType &l1) {
-                    auto l2 = cast_type_nonnull<LiteralType>(t2);
+                [&](const NamedLiteralType &l1) {
+                    auto l2 = cast_type_nonnull<NamedLiteralType>(t2);
                     auto underlyingL1 = l1.underlying(gs);
                     auto underlyingL2 = l2.underlying(gs);
                     auto class1 = cast_type_nonnull<ClassType>(underlyingL1);
@@ -1267,14 +1267,14 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
                         }
                     }
                 },
-                [&](const LiteralType &l1) {
-                    if (!isa_type<LiteralType>(t2)) {
+                [&](const NamedLiteralType &l1) {
+                    if (!isa_type<NamedLiteralType>(t2)) {
                         // is a literal a subtype of a different kind of proxy
                         result = false;
                         return;
                     }
 
-                    auto l2 = cast_type_nonnull<LiteralType>(t2);
+                    auto l2 = cast_type_nonnull<NamedLiteralType>(t2);
                     result = l1.equals(l2);
                 },
                 [&](const IntegerLiteralType &l1) {

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -436,9 +436,9 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                         result = lub(gs, l1.underlying(gs), t2.underlying(gs));
                     }
                 },
-                [&](const LiteralIntegerType &l1) {
-                    if (isa_type<LiteralIntegerType>(t2)) {
-                        auto &l2 = cast_type_nonnull<LiteralIntegerType>(t2);
+                [&](const IntegerLiteralType &l1) {
+                    if (isa_type<IntegerLiteralType>(t2)) {
+                        auto &l2 = cast_type_nonnull<IntegerLiteralType>(t2);
                         if (l1.equals(l2)) {
                             result = t1;
                         } else {
@@ -802,8 +802,8 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                         result = Types::bottom();
                     }
                 },
-                [&](const LiteralIntegerType &l1) {
-                    auto &l2 = cast_type_nonnull<LiteralIntegerType>(t2);
+                [&](const IntegerLiteralType &l1) {
+                    auto &l2 = cast_type_nonnull<IntegerLiteralType>(t2);
                     if (l1.equals(l2)) {
                         result = t1;
                     } else {
@@ -1277,14 +1277,14 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
                     auto l2 = cast_type_nonnull<LiteralType>(t2);
                     result = l1.equals(l2);
                 },
-                [&](const LiteralIntegerType &l1) {
-                    if (!isa_type<LiteralIntegerType>(t2)) {
+                [&](const IntegerLiteralType &l1) {
+                    if (!isa_type<IntegerLiteralType>(t2)) {
                         // is a literal a subtype of a different kind of proxy
                         result = false;
                         return;
                     }
 
-                    auto &l2 = cast_type_nonnull<LiteralIntegerType>(t2);
+                    auto &l2 = cast_type_nonnull<IntegerLiteralType>(t2);
                     result = l1.equals(l2);
                 },
                 [&](const FloatLiteralType &l1) {

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -261,6 +261,10 @@ TypePtr Types::dropLiteral(const GlobalState &gs, const TypePtr &tp) {
         auto &i = cast_type_nonnull<LiteralIntegerType>(tp);
         return i.underlying(gs);
     }
+    if (isa_type<FloatLiteralType>(tp)) {
+        auto &f = cast_type_nonnull<FloatLiteralType>(tp);
+        return f.underlying(gs);
+    }
     return tp;
 }
 
@@ -313,10 +317,6 @@ void sanityCheckProxyType(const GlobalState &gs, TypePtr underlying) {
 }
 } // namespace
 
-LiteralType::LiteralType(double val) : floatval(val), literalKind(LiteralTypeKind::Float) {
-    categoryCounterInc("types.allocated", "literaltype.double");
-}
-
 LiteralType::LiteralType(ClassOrModuleRef klass, NameRef val)
     : name(val), literalKind(klass == Symbols::String() ? LiteralTypeKind::String : LiteralTypeKind::Symbol) {
     if (klass == Symbols::String()) {
@@ -325,11 +325,6 @@ LiteralType::LiteralType(ClassOrModuleRef klass, NameRef val)
         categoryCounterInc("types.allocated", "literaltype.symbol");
     }
     ENFORCE(klass == Symbols::String() || klass == Symbols::Symbol());
-}
-
-double LiteralType::asFloat() const {
-    ENFORCE_NO_TIMER(literalKind == LiteralTypeKind::Float);
-    return floatval;
 }
 
 core::NameRef LiteralType::asName() const {
@@ -344,8 +339,6 @@ core::NameRef LiteralType::unsafeAsName() const {
 
 TypePtr LiteralType::underlying(const GlobalState &gs) const {
     switch (literalKind) {
-        case LiteralTypeKind::Float:
-            return Types::Float();
         case LiteralTypeKind::String:
             return Types::String();
         case LiteralTypeKind::Symbol:
@@ -360,6 +353,14 @@ LiteralIntegerType::LiteralIntegerType(int64_t val) : value(val) {
 
 TypePtr LiteralIntegerType::underlying(const GlobalState &gs) const {
     return Types::Integer();
+}
+
+FloatLiteralType::FloatLiteralType(double val) : value(val) {
+    categoryCounterInc("types.allocated", "floatliteraltype");
+}
+
+TypePtr FloatLiteralType::underlying(const GlobalState &gs) const {
+    return Types::Float();
 }
 
 TupleType::TupleType(vector<TypePtr> elements) : elems(move(elements)) {
@@ -380,8 +381,6 @@ bool LiteralType::equals(const LiteralType &rhs) const {
         return false;
     }
     switch (this->literalKind) {
-        case LiteralTypeKind::Float:
-            return this->floatval == rhs.floatval;
         case LiteralTypeKind::Symbol:
         case LiteralTypeKind::String:
             return this->name == rhs.name;
@@ -393,6 +392,14 @@ void LiteralIntegerType::_sanityCheck(const GlobalState &gs) const {
 }
 
 bool LiteralIntegerType::equals(const LiteralIntegerType &rhs) const {
+    return this->value == rhs.value;
+}
+
+void FloatLiteralType::_sanityCheck(const GlobalState &gs) const {
+    sanityCheckProxyType(gs, underlying(gs));
+}
+
+bool FloatLiteralType::equals(const FloatLiteralType &rhs) const {
     return this->value == rhs.value;
 }
 
@@ -409,7 +416,7 @@ void TupleType::_sanityCheck(const GlobalState &gs) const {
 }
 
 ShapeType::ShapeType(vector<TypePtr> keys, vector<TypePtr> values) : keys(move(keys)), values(move(values)) {
-    DEBUG_ONLY(for (auto &k : this->keys) { ENFORCE(isa_type<LiteralType>(k) || isa_type<LiteralIntegerType>(k)); };);
+    DEBUG_ONLY(for (auto &k : this->keys) { ENFORCE(isa_type<LiteralType>(k) || isa_type<LiteralIntegerType>(k) || isa_type<FloatLiteralType>(k)); };);
     categoryCounterInc("types.allocated", "shapetype");
     histogramInc("shapetype.keys", this->keys.size());
 }
@@ -425,6 +432,10 @@ std::optional<size_t> ShapeType::indexForKey(const TypePtr &t) const {
     }
     if (isa_type<LiteralIntegerType>(t)) {
         auto &lit = cast_type_nonnull<LiteralIntegerType>(t);
+        return this->indexForKey(lit);
+    }
+    if (isa_type<FloatLiteralType>(t)) {
+        auto &lit = cast_type_nonnull<FloatLiteralType>(t);
         return this->indexForKey(lit);
     }
     return std::nullopt;
@@ -450,6 +461,20 @@ std::optional<size_t> ShapeType::indexForKey(const LiteralIntegerType &lit) cons
                 return false;
             }
             const auto &candlit = cast_type_nonnull<LiteralIntegerType>(candidate);
+            return candlit.equals(lit);
+        });
+    if (fnd == this->keys.end()) {
+        return std::nullopt;
+    }
+    return std::distance(this->keys.begin(), fnd);
+}
+
+std::optional<size_t> ShapeType::indexForKey(const FloatLiteralType &lit) const {
+    auto fnd = absl::c_find_if(keys, [&](auto &candidate) -> bool {
+            if (!isa_type<FloatLiteralType>(candidate)) {
+                return false;
+            }
+            const auto &candlit = cast_type_nonnull<FloatLiteralType>(candidate);
             return candlit.equals(lit);
         });
     if (fnd == this->keys.end()) {
@@ -791,6 +816,7 @@ TypePtr Types::unwrapSelfTypeParam(Context ctx, const TypePtr &type) {
         [&](const LambdaParam &tv) { ret = type; }, [&](const SelfType &self) { ret = type; },
         [&](const LiteralType &lit) { ret = type; },
         [&](const LiteralIntegerType &i) { ret = type; },
+        [&](const FloatLiteralType &i) { ret = type; },
         [&](const AndType &andType) {
             ret = AndType::make_shared(unwrapSelfTypeParam(ctx, andType.left), unwrapSelfTypeParam(ctx, andType.right));
         },

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -257,8 +257,8 @@ TypePtr Types::dropLiteral(const GlobalState &gs, const TypePtr &tp) {
         auto a = cast_type_nonnull<LiteralType>(tp);
         return a.underlying(gs);
     }
-    if (isa_type<LiteralIntegerType>(tp)) {
-        auto &i = cast_type_nonnull<LiteralIntegerType>(tp);
+    if (isa_type<IntegerLiteralType>(tp)) {
+        auto &i = cast_type_nonnull<IntegerLiteralType>(tp);
         return i.underlying(gs);
     }
     if (isa_type<FloatLiteralType>(tp)) {
@@ -347,11 +347,11 @@ TypePtr LiteralType::underlying(const GlobalState &gs) const {
     Exception::raise("should never be reached");
 }
 
-LiteralIntegerType::LiteralIntegerType(int64_t val) : value(val) {
+IntegerLiteralType::IntegerLiteralType(int64_t val) : value(val) {
     categoryCounterInc("types.allocated", "literalintegertype");
 }
 
-TypePtr LiteralIntegerType::underlying(const GlobalState &gs) const {
+TypePtr IntegerLiteralType::underlying(const GlobalState &gs) const {
     return Types::Integer();
 }
 
@@ -387,11 +387,11 @@ bool LiteralType::equals(const LiteralType &rhs) const {
     }
 }
 
-void LiteralIntegerType::_sanityCheck(const GlobalState &gs) const {
+void IntegerLiteralType::_sanityCheck(const GlobalState &gs) const {
     sanityCheckProxyType(gs, underlying(gs));
 }
 
-bool LiteralIntegerType::equals(const LiteralIntegerType &rhs) const {
+bool IntegerLiteralType::equals(const IntegerLiteralType &rhs) const {
     return this->value == rhs.value;
 }
 
@@ -418,7 +418,7 @@ void TupleType::_sanityCheck(const GlobalState &gs) const {
 ShapeType::ShapeType(vector<TypePtr> keys, vector<TypePtr> values) : keys(move(keys)), values(move(values)) {
     DEBUG_ONLY(for (auto &k
                     : this->keys) {
-        ENFORCE(isa_type<LiteralType>(k) || isa_type<LiteralIntegerType>(k) || isa_type<FloatLiteralType>(k));
+        ENFORCE(isa_type<LiteralType>(k) || isa_type<IntegerLiteralType>(k) || isa_type<FloatLiteralType>(k));
     };);
     categoryCounterInc("types.allocated", "shapetype");
     histogramInc("shapetype.keys", this->keys.size());
@@ -433,8 +433,8 @@ std::optional<size_t> ShapeType::indexForKey(const TypePtr &t) const {
         const auto &lit = cast_type_nonnull<LiteralType>(t);
         return this->indexForKey(lit);
     }
-    if (isa_type<LiteralIntegerType>(t)) {
-        auto &lit = cast_type_nonnull<LiteralIntegerType>(t);
+    if (isa_type<IntegerLiteralType>(t)) {
+        auto &lit = cast_type_nonnull<IntegerLiteralType>(t);
         return this->indexForKey(lit);
     }
     if (isa_type<FloatLiteralType>(t)) {
@@ -458,12 +458,12 @@ std::optional<size_t> ShapeType::indexForKey(const LiteralType &lit) const {
     return std::distance(this->keys.begin(), fnd);
 }
 
-std::optional<size_t> ShapeType::indexForKey(const LiteralIntegerType &lit) const {
+std::optional<size_t> ShapeType::indexForKey(const IntegerLiteralType &lit) const {
     auto fnd = absl::c_find_if(keys, [&](auto &candidate) -> bool {
-        if (!isa_type<LiteralIntegerType>(candidate)) {
+        if (!isa_type<IntegerLiteralType>(candidate)) {
             return false;
         }
-        const auto &candlit = cast_type_nonnull<LiteralIntegerType>(candidate);
+        const auto &candlit = cast_type_nonnull<IntegerLiteralType>(candidate);
         return candlit.equals(lit);
     });
     if (fnd == this->keys.end()) {
@@ -817,7 +817,7 @@ TypePtr Types::unwrapSelfTypeParam(Context ctx, const TypePtr &type) {
     typecase(
         type, [&](const ClassType &klass) { ret = type; }, [&](const TypeVar &tv) { ret = type; },
         [&](const LambdaParam &tv) { ret = type; }, [&](const SelfType &self) { ret = type; },
-        [&](const LiteralType &lit) { ret = type; }, [&](const LiteralIntegerType &i) { ret = type; },
+        [&](const LiteralType &lit) { ret = type; }, [&](const IntegerLiteralType &i) { ret = type; },
         [&](const FloatLiteralType &i) { ret = type; },
         [&](const AndType &andType) {
             ret = AndType::make_shared(unwrapSelfTypeParam(ctx, andType.left), unwrapSelfTypeParam(ctx, andType.right));

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -416,7 +416,10 @@ void TupleType::_sanityCheck(const GlobalState &gs) const {
 }
 
 ShapeType::ShapeType(vector<TypePtr> keys, vector<TypePtr> values) : keys(move(keys)), values(move(values)) {
-    DEBUG_ONLY(for (auto &k : this->keys) { ENFORCE(isa_type<LiteralType>(k) || isa_type<LiteralIntegerType>(k) || isa_type<FloatLiteralType>(k)); };);
+    DEBUG_ONLY(for (auto &k
+                    : this->keys) {
+        ENFORCE(isa_type<LiteralType>(k) || isa_type<LiteralIntegerType>(k) || isa_type<FloatLiteralType>(k));
+    };);
     categoryCounterInc("types.allocated", "shapetype");
     histogramInc("shapetype.keys", this->keys.size());
 }
@@ -457,12 +460,12 @@ std::optional<size_t> ShapeType::indexForKey(const LiteralType &lit) const {
 
 std::optional<size_t> ShapeType::indexForKey(const LiteralIntegerType &lit) const {
     auto fnd = absl::c_find_if(keys, [&](auto &candidate) -> bool {
-            if (!isa_type<LiteralIntegerType>(candidate)) {
-                return false;
-            }
-            const auto &candlit = cast_type_nonnull<LiteralIntegerType>(candidate);
-            return candlit.equals(lit);
-        });
+        if (!isa_type<LiteralIntegerType>(candidate)) {
+            return false;
+        }
+        const auto &candlit = cast_type_nonnull<LiteralIntegerType>(candidate);
+        return candlit.equals(lit);
+    });
     if (fnd == this->keys.end()) {
         return std::nullopt;
     }
@@ -471,12 +474,12 @@ std::optional<size_t> ShapeType::indexForKey(const LiteralIntegerType &lit) cons
 
 std::optional<size_t> ShapeType::indexForKey(const FloatLiteralType &lit) const {
     auto fnd = absl::c_find_if(keys, [&](auto &candidate) -> bool {
-            if (!isa_type<FloatLiteralType>(candidate)) {
-                return false;
-            }
-            const auto &candlit = cast_type_nonnull<FloatLiteralType>(candidate);
-            return candlit.equals(lit);
-        });
+        if (!isa_type<FloatLiteralType>(candidate)) {
+            return false;
+        }
+        const auto &candlit = cast_type_nonnull<FloatLiteralType>(candidate);
+        return candlit.equals(lit);
+    });
     if (fnd == this->keys.end()) {
         return std::nullopt;
     }
@@ -814,8 +817,7 @@ TypePtr Types::unwrapSelfTypeParam(Context ctx, const TypePtr &type) {
     typecase(
         type, [&](const ClassType &klass) { ret = type; }, [&](const TypeVar &tv) { ret = type; },
         [&](const LambdaParam &tv) { ret = type; }, [&](const SelfType &self) { ret = type; },
-        [&](const LiteralType &lit) { ret = type; },
-        [&](const LiteralIntegerType &i) { ret = type; },
+        [&](const LiteralType &lit) { ret = type; }, [&](const LiteralIntegerType &i) { ret = type; },
         [&](const FloatLiteralType &i) { ret = type; },
         [&](const AndType &andType) {
             ret = AndType::make_shared(unwrapSelfTypeParam(ctx, andType.left), unwrapSelfTypeParam(ctx, andType.right));

--- a/definition_validator/variance.cc
+++ b/definition_validator/variance.cc
@@ -71,7 +71,7 @@ private:
         typecase(
             type, [&](const core::ClassType &klass) {},
 
-            [&](const core::LiteralType &lit) {},
+            [&](const core::NamedLiteralType &lit) {},
 
             [&](const core::SelfType &self) {},
 

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -142,9 +142,9 @@ void extractSendArgumentKnowledge(core::Context ctx, core::LocOffsets bindLoc, c
         // extract the keyword argument name when the send contains inlined keyword arguments
         optional<core::NameRef> keyword;
         if (inKwArgs) {
-            if (core::isa_type<core::LiteralType>(snd->args[i].type)) {
-                auto lit = core::cast_type_nonnull<core::LiteralType>(snd->args[i].type);
-                if (lit.literalKind == core::LiteralType::LiteralTypeKind::Symbol) {
+            if (core::isa_type<core::NamedLiteralType>(snd->args[i].type)) {
+                auto lit = core::cast_type_nonnull<core::NamedLiteralType>(snd->args[i].type);
+                if (lit.literalKind == core::NamedLiteralType::LiteralTypeKind::Symbol) {
                     keyword = lit.asName();
                 }
             }

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -920,7 +920,7 @@ core::TypePtr flatmapHack(core::Context ctx, const core::TypePtr &receiver, cons
     auto mapType = core::Types::arrayOf(ctx, returnType);
 
     const core::TypeAndOrigins recvType = {mapType, {loc}};
-    core::TypeAndOrigins arg{core::make_type<core::LiteralType>((int64_t)flattenDepth), recvType.origins};
+    core::TypeAndOrigins arg{core::make_type<core::LiteralIntegerType>((int64_t)flattenDepth), recvType.origins};
     InlinedVector<const core::TypeAndOrigins *, 2> args{&arg};
 
     InlinedVector<core::LocOffsets, 2> argLocs{loc.offsets()};
@@ -1275,7 +1275,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                 // Fetch the type for the argument out of the parameters for the block
                 // by simulating a blockParam[i] call.
                 const core::TypeAndOrigins &recvType = getAndFillTypeAndOrigin(ctx, i.yieldParam);
-                core::TypePtr argType = core::make_type<core::LiteralType>((int64_t)i.argId);
+                core::TypePtr argType = core::make_type<core::LiteralIntegerType>((int64_t)i.argId);
 
                 core::TypeAndOrigins arg;
                 arg.type = argType;

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -920,7 +920,7 @@ core::TypePtr flatmapHack(core::Context ctx, const core::TypePtr &receiver, cons
     auto mapType = core::Types::arrayOf(ctx, returnType);
 
     const core::TypeAndOrigins recvType = {mapType, {loc}};
-    core::TypeAndOrigins arg{core::make_type<core::LiteralIntegerType>((int64_t)flattenDepth), recvType.origins};
+    core::TypeAndOrigins arg{core::make_type<core::IntegerLiteralType>((int64_t)flattenDepth), recvType.origins};
     InlinedVector<const core::TypeAndOrigins *, 2> args{&arg};
 
     InlinedVector<core::LocOffsets, 2> argLocs{loc.offsets()};
@@ -1275,7 +1275,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                 // Fetch the type for the argument out of the parameters for the block
                 // by simulating a blockParam[i] call.
                 const core::TypeAndOrigins &recvType = getAndFillTypeAndOrigin(ctx, i.yieldParam);
-                core::TypePtr argType = core::make_type<core::LiteralIntegerType>((int64_t)i.argId);
+                core::TypePtr argType = core::make_type<core::IntegerLiteralType>((int64_t)i.argId);
 
                 core::TypeAndOrigins arg;
                 arg.type = argType;

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1060,8 +1060,8 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                 const bool isDesugarTripleEqSend = send.fun == core::Names::tripleEq() && send.funLoc.empty();
                 if (lspQueryMatch && !isDesugarTripleEqSend) {
                     auto fun = send.fun;
-                    if (fun == core::Names::checkAndAnd() && core::isa_type<core::LiteralType>(args[2]->type)) {
-                        auto lit = core::cast_type_nonnull<core::LiteralType>(args[2]->type);
+                    if (fun == core::Names::checkAndAnd() && core::isa_type<core::NamedLiteralType>(args[2]->type)) {
+                        auto lit = core::cast_type_nonnull<core::NamedLiteralType>(args[2]->type);
                         if (lit.derivesFrom(ctx, core::Symbols::Symbol())) {
                             fun = lit.asName();
                         }

--- a/infer/test/infer_test.cc
+++ b/infer/test/infer_test.cc
@@ -54,7 +54,7 @@ TEST_CASE("Infer") {
     gs.initEmpty();
 
     SUBCASE("LiteralsSubtyping") {
-        auto intLit = core::make_type<core::LiteralType>(int64_t(1));
+        auto intLit = core::make_type<core::LiteralIntegerType>(int64_t(1));
         auto intClass = core::make_type<core::ClassType>(core::Symbols::Integer());
         auto floatLit = core::make_type<core::LiteralType>(1.0f);
         auto floatClass = core::make_type<core::ClassType>(core::Symbols::Float());

--- a/infer/test/infer_test.cc
+++ b/infer/test/infer_test.cc
@@ -56,7 +56,7 @@ TEST_CASE("Infer") {
     SUBCASE("LiteralsSubtyping") {
         auto intLit = core::make_type<core::LiteralIntegerType>(int64_t(1));
         auto intClass = core::make_type<core::ClassType>(core::Symbols::Integer());
-        auto floatLit = core::make_type<core::LiteralType>(1.0f);
+        auto floatLit = core::make_type<core::FloatLiteralType>(1.0f);
         auto floatClass = core::make_type<core::ClassType>(core::Symbols::Float());
         auto trueLit = core::Types::trueClass();
         auto trueClass = core::make_type<core::ClassType>(core::Symbols::TrueClass());

--- a/infer/test/infer_test.cc
+++ b/infer/test/infer_test.cc
@@ -54,7 +54,7 @@ TEST_CASE("Infer") {
     gs.initEmpty();
 
     SUBCASE("LiteralsSubtyping") {
-        auto intLit = core::make_type<core::LiteralIntegerType>(int64_t(1));
+        auto intLit = core::make_type<core::IntegerLiteralType>(int64_t(1));
         auto intClass = core::make_type<core::ClassType>(core::Symbols::Integer());
         auto floatLit = core::make_type<core::FloatLiteralType>(1.0f);
         auto floatClass = core::make_type<core::ClassType>(core::Symbols::Float());

--- a/infer/test/infer_test.cc
+++ b/infer/test/infer_test.cc
@@ -60,7 +60,7 @@ TEST_CASE("Infer") {
         auto floatClass = core::make_type<core::ClassType>(core::Symbols::Float());
         auto trueLit = core::Types::trueClass();
         auto trueClass = core::make_type<core::ClassType>(core::Symbols::TrueClass());
-        auto stringLit = core::make_type<core::LiteralType>(core::Symbols::String(), core::Names::assignTemp());
+        auto stringLit = core::make_type<core::NamedLiteralType>(core::Symbols::String(), core::Names::assignTemp());
         auto stringClass = core::make_type<core::ClassType>(core::Symbols::String());
         REQUIRE(core::Types::isSubType(gs, intLit, intClass));
         REQUIRE(core::Types::isSubType(gs, floatLit, floatClass));

--- a/local_vars/local_vars.cc
+++ b/local_vars/local_vars.cc
@@ -293,7 +293,7 @@ class LocalNameInserter {
                 ENFORCE(kwArgsHash == nullptr, "Saw keyword arg after keyword splat");
 
                 kwArgKeyEntries.emplace_back(ast::MK::Literal(
-                    original.loc, core::make_type<core::LiteralType>(core::Symbols::Symbol(), arg.arg._name)));
+                    original.loc, core::make_type<core::NamedLiteralType>(core::Symbols::Symbol(), arg.arg._name)));
                 kwArgValueEntries.emplace_back(ast::make_expression<ast::Local>(original.loc, arg.arg));
             } else if (arg.flags.isKeywordSplat()) {
                 ENFORCE(kwArgsHash == nullptr, "Saw multiple keyword splats");
@@ -334,7 +334,7 @@ class LocalNameInserter {
         }
 
         auto method = ast::MK::Literal(
-            original.loc, core::make_type<core::LiteralType>(core::Symbols::Symbol(), core::Names::super()));
+            original.loc, core::make_type<core::NamedLiteralType>(core::Symbols::Symbol(), core::Names::super()));
 
         if (posArgsArray != nullptr) {
             // We wrap self with T.unsafe in order to get around the requirement for <call-with-splat> and

--- a/main/lsp/requests/type_definition.cc
+++ b/main/lsp/requests/type_definition.cc
@@ -52,7 +52,7 @@ vector<core::Loc> locsForType(const core::GlobalState &gs, const core::TypePtr &
                 result.emplace_back(loc);
             }
         },
-        [&](const core::LiteralType &_) {
+        [&](const core::NamedLiteralType &_) {
             // nothing
         },
         [&](const core::ShapeType &_) {

--- a/packager/rbi_gen.cc
+++ b/packager/rbi_gen.cc
@@ -437,7 +437,8 @@ private:
                 break;
             }
             case core::TypePtr::Tag::LiteralType:
-            case core::TypePtr::Tag::LiteralIntegerType: {
+            case core::TypePtr::Tag::LiteralIntegerType:
+            case core::TypePtr::Tag::FloatLiteralType: {
                 // No symbols here.
                 break;
             }

--- a/packager/rbi_gen.cc
+++ b/packager/rbi_gen.cc
@@ -436,7 +436,8 @@ private:
                 maybeEmit(classType.symbol);
                 break;
             }
-            case core::TypePtr::Tag::LiteralType: {
+            case core::TypePtr::Tag::LiteralType:
+            case core::TypePtr::Tag::LiteralIntegerType: {
                 // No symbols here.
                 break;
             }

--- a/packager/rbi_gen.cc
+++ b/packager/rbi_gen.cc
@@ -436,7 +436,7 @@ private:
                 maybeEmit(classType.symbol);
                 break;
             }
-            case core::TypePtr::Tag::LiteralType:
+            case core::TypePtr::Tag::NamedLiteralType:
             case core::TypePtr::Tag::IntegerLiteralType:
             case core::TypePtr::Tag::FloatLiteralType: {
                 // No symbols here.

--- a/packager/rbi_gen.cc
+++ b/packager/rbi_gen.cc
@@ -437,7 +437,7 @@ private:
                 break;
             }
             case core::TypePtr::Tag::LiteralType:
-            case core::TypePtr::Tag::LiteralIntegerType:
+            case core::TypePtr::Tag::IntegerLiteralType:
             case core::TypePtr::Tag::FloatLiteralType: {
                 // No symbols here.
                 break;

--- a/proto/Type.proto
+++ b/proto/Type.proto
@@ -20,6 +20,7 @@ message Type {
 
     message Literal {
         enum Kind {
+            // Unused, but kept for backwards compatibility (?)
             INTEGER = 0;
             STRING = 1;
             SYMBOL = 2;
@@ -43,6 +44,10 @@ message Type {
         repeated Type elems = 2;
     }
 
+    message LiteralInteger {
+        int64 integer = 1;
+    }
+
     enum Kind {
         // We only currently support simple types, because this is all we need
         // at this time. Others will show up as "UNKNOWN".
@@ -56,6 +61,8 @@ message Type {
         // skip a few
         OR = 10;
         AND = 11;
+        // skip some more
+        LITERALINTEGER = 13;
     }
 
     Kind kind = 1;
@@ -68,5 +75,6 @@ message Type {
         Shape shape = 104;
         Literal literal = 105;
         Tuple tuple = 106;
+        LiteralInteger literalinteger= 107;
     }
 }

--- a/proto/Type.proto
+++ b/proto/Type.proto
@@ -36,7 +36,6 @@ message Type {
             string string = 101;
             string symbol = 102;
             bool bool = 103;
-            float float = 104;
         }
     }
 
@@ -46,6 +45,10 @@ message Type {
 
     message LiteralInteger {
         int64 integer = 1;
+    }
+
+    message LiteralFloat {
+        float float = 1;
     }
 
     enum Kind {
@@ -63,6 +66,7 @@ message Type {
         AND = 11;
         // skip some more
         LITERALINTEGER = 13;
+        LITERALFLOAT = 14;
     }
 
     Kind kind = 1;
@@ -76,5 +80,6 @@ message Type {
         Literal literal = 105;
         Tuple tuple = 106;
         LiteralInteger literalinteger= 107;
+        LiteralFloat literalfloat = 108;
     }
 }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2454,15 +2454,15 @@ class ResolveTypeMembersAndFieldsWalk {
             return;
         }
 
-        if (!core::isa_type<core::LiteralType>(literalNode->value)) {
+        if (!core::isa_type<core::NamedLiteralType>(literalNode->value)) {
             if (auto e = ctx.beginError(stringLoc, core::errors::Resolver::LazyResolve)) {
                 e.setHeader("`{}` only accepts string literals", method);
             }
             return;
         }
 
-        auto literal = core::cast_type_nonnull<core::LiteralType>(literalNode->value);
-        if (literal.literalKind != core::LiteralType::LiteralTypeKind::String) {
+        auto literal = core::cast_type_nonnull<core::NamedLiteralType>(literalNode->value);
+        if (literal.literalKind != core::NamedLiteralType::LiteralTypeKind::String) {
             // Infer will report a type error
             return;
         }
@@ -2485,9 +2485,9 @@ class ResolveTypeMembersAndFieldsWalk {
                 return;
             }
 
-            if (!core::isa_type<core::LiteralType>(packageNode->value) ||
-                core::cast_type_nonnull<core::LiteralType>(packageNode->value).literalKind !=
-                    core::LiteralType::LiteralTypeKind::String) {
+            if (!core::isa_type<core::NamedLiteralType>(packageNode->value) ||
+                core::cast_type_nonnull<core::NamedLiteralType>(packageNode->value).literalKind !=
+                    core::NamedLiteralType::LiteralTypeKind::String) {
                 // Infer will report a type error
                 return;
             }
@@ -2527,7 +2527,7 @@ class ResolveTypeMembersAndFieldsWalk {
                 }
                 return;
             }
-            auto package = core::cast_type_nonnull<core::LiteralType>(packageType);
+            auto package = core::cast_type_nonnull<core::NamedLiteralType>(packageType);
             auto name = package.asName().shortName(ctx);
             vector<string> pkgParts = absl::StrSplit(name, "::");
             // add the initial empty string to mimic the leading `::`

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -1232,6 +1232,8 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx,
                 underlying = lit.value.underlying(ctx);
             } else if (core::isa_type<core::LiteralIntegerType>(lit.value)) {
                 underlying = lit.value.underlying(ctx);
+            } else if (core::isa_type<core::FloatLiteralType>(lit.value)) {
+                underlying = lit.value.underlying(ctx);
             } else {
                 underlying = lit.value;
             }

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -1227,7 +1227,14 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx,
             }
         },
         [&](const ast::Literal &lit) {
-            auto underlying = core::isa_type<core::LiteralType>(lit.value) ? lit.value.underlying(ctx) : lit.value;
+            core::TypePtr underlying;
+            if (core::isa_type<core::LiteralType>(lit.value)) {
+                underlying = lit.value.underlying(ctx);
+            } else if (core::isa_type<core::LiteralIntegerType>(lit.value)) {
+                underlying = lit.value.underlying(ctx);
+            } else {
+                underlying = lit.value;
+            }
             if (auto e = ctx.beginError(lit.loc, core::errors::Resolver::InvalidMethodSignature)) {
                 e.setHeader("Unsupported literal in type syntax", lit.value.show(ctx));
                 e.replaceWith("Replace with underlying type", ctx.locAt(lit.loc), "{}", underlying.show(ctx));

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -1230,7 +1230,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx,
             core::TypePtr underlying;
             if (core::isa_type<core::LiteralType>(lit.value)) {
                 underlying = lit.value.underlying(ctx);
-            } else if (core::isa_type<core::LiteralIntegerType>(lit.value)) {
+            } else if (core::isa_type<core::IntegerLiteralType>(lit.value)) {
                 underlying = lit.value.underlying(ctx);
             } else if (core::isa_type<core::FloatLiteralType>(lit.value)) {
                 underlying = lit.value.underlying(ctx);

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -63,8 +63,8 @@ core::TypePtr getResultLiteral(core::Context ctx, const ast::ExpressionPtr &expr
         expr,
         [&](const ast::Literal &lit) {
             result = lit.value;
-            if (core::isa_type<core::LiteralType>(result)) {
-                result = core::cast_type_nonnull<core::LiteralType>(result).underlying(ctx);
+            if (core::isa_type<core::NamedLiteralType>(result)) {
+                result = core::cast_type_nonnull<core::NamedLiteralType>(result).underlying(ctx);
             }
         },
         [&](const ast::ExpressionPtr &e) {
@@ -827,7 +827,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx,
                 auto val = getResultTypeWithSelfTypeParams(ctx, vtree, sigBeingParsed, args.withoutSelfType());
                 auto lit = ast::cast_tree<ast::Literal>(ktree);
                 if (lit && (lit->isSymbol() || lit->isString())) {
-                    ENFORCE(core::isa_type<core::LiteralType>(lit->value));
+                    ENFORCE(core::isa_type<core::NamedLiteralType>(lit->value));
                     keys.emplace_back(lit->value);
                     values.emplace_back(val);
                 } else {
@@ -1228,7 +1228,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx,
         },
         [&](const ast::Literal &lit) {
             core::TypePtr underlying;
-            if (core::isa_type<core::LiteralType>(lit.value)) {
+            if (core::isa_type<core::NamedLiteralType>(lit.value)) {
                 underlying = lit.value.underlying(ctx);
             } else if (core::isa_type<core::IntegerLiteralType>(lit.value)) {
                 underlying = lit.value.underlying(ctx);

--- a/rewriter/Rails.cc
+++ b/rewriter/Rails.cc
@@ -46,7 +46,7 @@ void Rails::run(core::MutableContext ctx, ast::ClassDef *cdef) {
     if (!core::isa_type<core::FloatLiteralType>(arg->value)) {
         return;
     }
-    auto f = core::cast_type_nonnull<core::FloatLiteralType>(arg->value);
+    auto &f = core::cast_type_nonnull<core::FloatLiteralType>(arg->value);
     char version[5];
     snprintf(version, sizeof(version), "V%.1f", f.value);
     absl::c_replace(version, '.', '_');

--- a/rewriter/Rails.cc
+++ b/rewriter/Rails.cc
@@ -43,12 +43,12 @@ void Rails::run(core::MutableContext ctx, ast::ClassDef *cdef) {
     if (!arg) {
         return;
     }
-    auto value = core::cast_type_nonnull<core::LiteralType>(arg->value);
-    if (value.literalKind != core::LiteralType::LiteralTypeKind::Float) {
+    if (!core::isa_type<core::FloatLiteralType>(arg->value)) {
         return;
     }
+    auto f = core::cast_type_nonnull<core::FloatLiteralType>(arg->value);
     char version[5];
-    snprintf(version, sizeof(version), "V%.1f", value.asFloat());
+    snprintf(version, sizeof(version), "V%.1f", f.value);
     absl::c_replace(version, '.', '_');
 
     cdef->ancestors.emplace_back(ast::MK::UnresolvedConstant(

--- a/rewriter/SelfNew.cc
+++ b/rewriter/SelfNew.cc
@@ -36,12 +36,12 @@ bool isSelfNewCallWithSplat(core::MutableContext ctx, ast::Send *send) {
         return false;
     }
 
-    if (!core::isa_type<core::LiteralType>(lit->value)) {
+    if (!core::isa_type<core::NamedLiteralType>(lit->value)) {
         return false;
     }
 
-    const auto &litType = core::cast_type_nonnull<core::LiteralType>(lit->value);
-    if (litType.literalKind != core::LiteralType::LiteralTypeKind::Symbol) {
+    const auto &litType = core::cast_type_nonnull<core::NamedLiteralType>(lit->value);
+    if (litType.literalKind != core::NamedLiteralType::LiteralTypeKind::Symbol) {
         return false;
     }
 

--- a/test/cli/expected-got/test.out
+++ b/test/cli/expected-got/test.out
@@ -22,14 +22,14 @@ test/cli/expected-got/expected-got.rb:12: Expected `Integer` but found `NilClass
     12 |  nil
           ^^^
 
-test/cli/expected-got/expected-got.rb:27: Expected `Integer` but found `T.any(String, Integer)` for argument `x` https://srb.help/7002
+test/cli/expected-got/expected-got.rb:27: Expected `Integer` but found `T.any(Integer, String)` for argument `x` https://srb.help/7002
     27 |  takes_integer(x)
                         ^
   Expected `Integer` for argument `x` of method `Object#takes_integer`:
     test/cli/expected-got/expected-got.rb:15:
     15 |sig {params(x: Integer).void}
                     ^
-  Got `T.any(String, Integer)` originating from:
+  Got `T.any(Integer, String)` originating from:
     test/cli/expected-got/expected-got.rb:22:
     22 |    x = ''
                 ^^

--- a/test/cli/suggest-constant-type/test.out
+++ b/test/cli/suggest-constant-type/test.out
@@ -30,7 +30,7 @@ suggest-constant-type.rb:13: Constants must have type annotations with `T.let` w
     13 |G = ["foo", 1, :symbol] # widens proxy types
             ^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-constant-type.rb:13: Replaced with `T.let(["foo", 1, :symbol], T::Array[T.any(String, Integer, Symbol)])`
+    suggest-constant-type.rb:13: Replaced with `T.let(["foo", 1, :symbol], T::Array[T.any(Integer, String, Symbol)])`
     13 |G = ["foo", 1, :symbol] # widens proxy types
             ^^^^^^^^^^^^^^^^^^^
 Errors: 5
@@ -49,4 +49,4 @@ C = B1 + 1 # does only a single iteration at a time
 E = F # doesn't do forward references
 F = 0
 
-G = T.let(["foo", 1, :symbol], T::Array[T.any(String, Integer, Symbol)]) # widens proxy types
+G = T.let(["foo", 1, :symbol], T::Array[T.any(Integer, String, Symbol)]) # widens proxy types

--- a/test/cli/suggest-sig-literal/test.out
+++ b/test/cli/suggest-sig-literal/test.out
@@ -2,7 +2,7 @@ suggest-sig-literal.rb:2: This function does not have a `sig` https://srb.help/7
      2 |def index_for_live(fields)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    suggest-sig-literal.rb:2: Inserted `sig {params(fields: T.untyped).returns(T::Array[T::Array[T.any(Symbol, Integer)]])}`
+    suggest-sig-literal.rb:2: Inserted `sig {params(fields: T.untyped).returns(T::Array[T::Array[T.any(Integer, Symbol)]])}`
      2 |def index_for_live(fields)
         ^
 Errors: 1
@@ -10,7 +10,7 @@ Errors: 1
 --------------------------------------------------------------------------
 
 # typed: strict
-sig {params(fields: T.untyped).returns(T::Array[T::Array[T.any(Symbol, Integer)]])}
+sig {params(fields: T.untyped).returns(T::Array[T::Array[T.any(Integer, Symbol)]])}
 def index_for_live(fields)
   [[:deleted_at, 1]] + fields
 end

--- a/test/testdata/infer/infer1.rb
+++ b/test/testdata/infer/infer1.rb
@@ -32,7 +32,7 @@ def baz6(cond)
  else
    b = "foo"
  end
- b = "foo".getbyte(b) # error: Expected `Integer` but found `T.any(Integer, String)` for argument `arg0`
+ b = "foo".getbyte(b) # error: Expected `Integer` but found `T.any(String, Integer)` for argument `arg0`
 end
 
 def baz7(cond)

--- a/test/testdata/infer/infer1.rb
+++ b/test/testdata/infer/infer1.rb
@@ -32,7 +32,7 @@ def baz6(cond)
  else
    b = "foo"
  end
- b = "foo".getbyte(b) # error: Expected `Integer` but found `T.any(String, Integer)` for argument `arg0`
+ b = "foo".getbyte(b) # error: Expected `Integer` but found `T.any(Integer, String)` for argument `arg0`
 end
 
 def baz7(cond)

--- a/test/testdata/infer/infer1.rb.cfg-text.exp
+++ b/test/testdata/infer/infer1.rb.cfg-text.exp
@@ -96,10 +96,10 @@ bb3[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb2(rubyRegionId=0)
 # - bb3(rubyRegionId=0)
-bb4[rubyRegionId=0, firstDead=5](b: T.any(Integer, String)):
-    <statTemp>$5: T.any(Integer, String) = b
+bb4[rubyRegionId=0, firstDead=5](b: T.any(String, Integer)):
+    <statTemp>$5: T.any(String, Integer) = b
     <statTemp>$6: Integer(1) = 1
-    b: T.untyped = <statTemp>$5: T.any(Integer, String).getbyte(<statTemp>$6: Integer(1))
+    b: T.untyped = <statTemp>$5: T.any(String, Integer).getbyte(<statTemp>$6: Integer(1))
     <returnMethodTemp>$2: T.untyped = b
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
@@ -133,10 +133,10 @@ bb3[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb2(rubyRegionId=0)
 # - bb3(rubyRegionId=0)
-bb4[rubyRegionId=0, firstDead=5](b: T.any(Integer, String)):
+bb4[rubyRegionId=0, firstDead=5](b: T.any(String, Integer)):
     <statTemp>$5: String("foo") = "foo"
-    <statTemp>$6: T.any(Integer, String) = b
-    b: T.nilable(Integer) = <statTemp>$5: String("foo").getbyte(<statTemp>$6: T.any(Integer, String))
+    <statTemp>$6: T.any(String, Integer) = b
+    b: T.nilable(Integer) = <statTemp>$5: String("foo").getbyte(<statTemp>$6: T.any(String, Integer))
     <returnMethodTemp>$2: T.nilable(Integer) = b
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(Integer)
     <unconditional> -> bb1

--- a/test/testdata/infer/infer1.rb.cfg-text.exp
+++ b/test/testdata/infer/infer1.rb.cfg-text.exp
@@ -96,10 +96,10 @@ bb3[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb2(rubyRegionId=0)
 # - bb3(rubyRegionId=0)
-bb4[rubyRegionId=0, firstDead=5](b: T.any(String, Integer)):
-    <statTemp>$5: T.any(String, Integer) = b
+bb4[rubyRegionId=0, firstDead=5](b: T.any(Integer, String)):
+    <statTemp>$5: T.any(Integer, String) = b
     <statTemp>$6: Integer(1) = 1
-    b: T.untyped = <statTemp>$5: T.any(String, Integer).getbyte(<statTemp>$6: Integer(1))
+    b: T.untyped = <statTemp>$5: T.any(Integer, String).getbyte(<statTemp>$6: Integer(1))
     <returnMethodTemp>$2: T.untyped = b
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
@@ -133,10 +133,10 @@ bb3[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb2(rubyRegionId=0)
 # - bb3(rubyRegionId=0)
-bb4[rubyRegionId=0, firstDead=5](b: T.any(String, Integer)):
+bb4[rubyRegionId=0, firstDead=5](b: T.any(Integer, String)):
     <statTemp>$5: String("foo") = "foo"
-    <statTemp>$6: T.any(String, Integer) = b
-    b: T.nilable(Integer) = <statTemp>$5: String("foo").getbyte(<statTemp>$6: T.any(String, Integer))
+    <statTemp>$6: T.any(Integer, String) = b
+    b: T.nilable(Integer) = <statTemp>$5: String("foo").getbyte(<statTemp>$6: T.any(Integer, String))
     <returnMethodTemp>$2: T.nilable(Integer) = b
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(Integer)
     <unconditional> -> bb1

--- a/test/testdata/rbi/kernel_array.rb
+++ b/test/testdata/rbi/kernel_array.rb
@@ -19,7 +19,7 @@ T.reveal_type(Array('a'..'z')) # error: Revealed type: `T::Array[String]`
 
 T.reveal_type(Array(1..10)) # error: Revealed type: `T::Array[Integer]`
 
-T.reveal_type(Array([1, 'a', 3])) # error: Revealed type: `T::Array[T.any(Integer, String)]`
+T.reveal_type(Array([1, 'a', 3])) # error: Revealed type: `T::Array[T.any(String, Integer)]`
 
 maybe_x = T.let(nil, T.nilable(String))
 res = Array(maybe_x)

--- a/test/testdata/rbi/kernel_array.rb
+++ b/test/testdata/rbi/kernel_array.rb
@@ -19,7 +19,7 @@ T.reveal_type(Array('a'..'z')) # error: Revealed type: `T::Array[String]`
 
 T.reveal_type(Array(1..10)) # error: Revealed type: `T::Array[Integer]`
 
-T.reveal_type(Array([1, 'a', 3])) # error: Revealed type: `T::Array[T.any(String, Integer)]`
+T.reveal_type(Array([1, 'a', 3])) # error: Revealed type: `T::Array[T.any(Integer, String)]`
 
 maybe_x = T.let(nil, T.nilable(String))
 res = Array(maybe_x)

--- a/test/testdata/rewriter/minitest_tables.rb
+++ b/test/testdata/rewriter/minitest_tables.rb
@@ -84,7 +84,7 @@ class MyTest
 
   test_each ["foo", 5, {x: false}] do |v|
     it "handles lists with several types" do
-      T.reveal_type(v) # error: Revealed type: `T.any(String, Integer, T::Hash[T.untyped, T.untyped])`
+      T.reveal_type(v) # error: Revealed type: `T.any(Integer, String, T::Hash[T.untyped, T.untyped])`
     end
   end
 


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

One small step to 8-byte `TypePtr`.  I kind of want to make 32-bit and 64-bit integer literals their own separate types, but one step at a time.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
