### PR TITLE
avoid allocating unnecessarily in `<Magic>.<build-hash>`

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2034,16 +2034,18 @@ public:
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
         ENFORCE(args.args.size() % 2 == 0);
 
-        vector<TypePtr> keys;
-        vector<TypePtr> values;
-        keys.reserve(args.args.size() / 2);
-        values.reserve(args.args.size() / 2);
         for (int i = 0; i < args.args.size(); i += 2) {
             if (!isa_type<LiteralType>(args.args[i]->type)) {
                 res.returnType = Types::hashOfUntyped();
                 return;
             }
+        }
 
+        vector<TypePtr> keys;
+        vector<TypePtr> values;
+        keys.reserve(args.args.size() / 2);
+        values.reserve(args.args.size() / 2);
+        for (int i = 0; i < args.args.size(); i += 2) {
             keys.emplace_back(args.args[i]->type);
             values.emplace_back(args.args[i + 1]->type);
         }


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

No sense in making allocations for `keys` and `values` if it turns out that we can't make a `ShapeType`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
