### PR TITLE
move `isSynthetic` to be stored on `InstructionPtr`

### DIFF
--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -56,15 +56,13 @@ class Instruction;
 
 // When adding a new subtype, see if you need to add it to fillInBlockArguments
 class Instruction {
-public:
-    bool isSynthetic = false;
-
 protected:
     Instruction() = default;
     ~Instruction() = default;
 
 private:
     friend InstructionPtr;
+    bool isSynthetic = false;
 };
 
 #define INSN(name)                                                                  \
@@ -375,6 +373,14 @@ public:
         ENFORCE(ptr != 0);
 
         return static_cast<Tag>(ptr & TAG_MASK);
+    }
+
+    bool isSynthetic() const noexcept {
+        return this->get()->isSynthetic;
+    }
+
+    void setSynthetic() noexcept {
+        this->get()->isSynthetic = true;
     }
 
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -62,7 +62,6 @@ protected:
 
 private:
     friend InstructionPtr;
-    bool isSynthetic = false;
 };
 
 #define INSN(name)                                                                  \
@@ -90,7 +89,7 @@ public:
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(Alias, 16, 8);
+CheckSize(Alias, 8, 8);
 
 INSN(SolveConstraint) : public Instruction {
 public:
@@ -136,7 +135,7 @@ public:
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(Return, 40, 8);
+CheckSize(Return, 32, 8);
 
 INSN(BlockReturn) : public Instruction {
 public:
@@ -147,7 +146,7 @@ public:
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(BlockReturn, 48, 8);
+CheckSize(BlockReturn, 40, 8);
 
 INSN(LoadSelf) : public Instruction {
 public:
@@ -167,7 +166,7 @@ public:
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(Literal, 24, 8);
+CheckSize(Literal, 16, 8);
 
 INSN(GetCurrentException) : public Instruction {
 public:
@@ -219,7 +218,7 @@ public:
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(LoadYieldParams, 24, 8);
+CheckSize(LoadYieldParams, 16, 8);
 
 INSN(YieldParamPresent) : public Instruction {
 public:
@@ -274,14 +273,16 @@ public:
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(TAbsurd, 32, 8);
+CheckSize(TAbsurd, 24, 8);
 
 class InstructionPtr final {
     using tagged_storage = uint64_t;
 
-    static constexpr tagged_storage TAG_MASK = 0xffff;
-
-    static constexpr tagged_storage PTR_MASK = ~TAG_MASK;
+    static constexpr tagged_storage TAG_MASK = 0xff;
+    static constexpr tagged_storage FLAG_MASK = 0xff00;
+    static constexpr tagged_storage SYNTHETIC_FLAG = 0x0100;
+    static_assert((TAG_MASK & FLAG_MASK) == 0, "no bits should be shared between tags and flags");
+    static constexpr tagged_storage PTR_MASK = ~(FLAG_MASK | TAG_MASK);
 
     tagged_storage ptr;
 
@@ -376,11 +377,11 @@ public:
     }
 
     bool isSynthetic() const noexcept {
-        return this->get()->isSynthetic;
+        return (this->ptr & SYNTHETIC_FLAG) != 0;
     }
 
     void setSynthetic() noexcept {
-        this->get()->isSynthetic = true;
+        this->ptr |= SYNTHETIC_FLAG;
     }
 
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;

--- a/cfg/builder/builder_finalize.cc
+++ b/cfg/builder/builder_finalize.cc
@@ -204,7 +204,7 @@ void CFGBuilder::dealias(core::Context ctx, CFG &cfg) {
             }
 
             /* dealias */
-            if (!bind.value->isSynthetic) {
+            if (!bind.value.isSynthetic()) {
                 // we don't allow dealiasing values into synthetic instructions
                 // as otherwise it fools dead code analysis.
                 if (auto *v = cast_instruction<Ident>(bind.value)) {

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -112,7 +112,7 @@ void CFGBuilder::jumpToDead(BasicBlock *from, CFG &inWhat, core::LocOffsets loc)
 
 void CFGBuilder::synthesizeExpr(BasicBlock *bb, LocalRef var, core::LocOffsets loc, InstructionPtr inst) {
     auto &inserted = bb->exprs.emplace_back(var, loc, move(inst));
-    inserted.value->isSynthetic = true;
+    inserted.value.setSynthetic();
 }
 
 BasicBlock *CFGBuilder::walkHash(CFGContext cctx, ast::Hash &h, BasicBlock *current, core::NameRef method) {

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1095,7 +1095,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                 tp.type = typeAndOrigin.type;
                 tp.origins = typeAndOrigin.origins;
 
-                if (lspQueryMatch && !bind.value->isSynthetic) {
+                if (lspQueryMatch && !bind.value.isSynthetic()) {
                     core::lsp::QueryResponse::pushQueryResponse(ctx, core::lsp::IdentResponse(ctx.locAt(bind.loc),
                                                                                               i.what.data(inWhat), tp,
                                                                                               ctx.owner.asMethodRef()));
@@ -1455,7 +1455,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                             e.addErrorSection(ty.explainGot(ctx, ownerLoc));
                         }
                     }
-                } else if (!c.isSynthetic) {
+                } else if (!bind.value.isSynthetic()) {
                     if (castType.isUntyped()) {
                         if (auto e = ctx.beginError(bind.loc, core::errors::Infer::InvalidCast)) {
                             e.setHeader("Please use `{}` to cast to `{}`", "T.unsafe", "T.untyped");

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -145,7 +145,7 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
 
                 if (absl::c_any_of(bb->backEdges, [&](const auto &bb) { return !outEnvironments[bb->id].isDead; })) {
                     for (auto &expr : bb->exprs) {
-                        if (expr.value->isSynthetic) {
+                        if (expr.value.isSynthetic()) {
                             continue;
                         }
                         if (cfg::isa_instruction<cfg::TAbsurd>(expr.value)) {
@@ -263,7 +263,7 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
                     // this can also be result of evaluating an instruction, e.g. an always false hard_assert
                     bb->firstDeadInstructionIdx = i;
                 }
-            } else if (ctx.state.lspQuery.isEmpty() && current.isDead && !bind.value->isSynthetic) {
+            } else if (ctx.state.lspQuery.isEmpty() && current.isDead && !bind.value.isSynthetic()) {
                 if (auto e = ctx.beginError(bind.loc, core::errors::Infer::DeadBranchInferencer)) {
                     e.setHeader("This code is unreachable");
                     e.addErrorLine(madeBlockDead, "This expression always raises or can never be computed");


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This decreases the size of some frequently-used CFG instructions, notably `Alias` and `Literal`.

Unfortunately, I don't think we can take the logical next step without several contortions: we'd want to "inline" `Ident` similar to how `ClassType` is inlined into `TypePtr`.  It'd be a pretty nice savings if we could manage that.  (We could "inline" several other instructions as well, but `Ident` is by far and away the most frequently occuring instruction in Stripe's codebase.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
