### PR TITLE
reduce the space required by empty generic argument lists on methods and classes

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1118,9 +1118,9 @@ TypeArgumentRef GlobalState::enterTypeArgument(Loc loc, MethodRef owner, NameRef
     flags.isTypeArgument = true;
 
     auto ownerScope = owner.dataAllowingNone(*this);
-    histogramInc("symbol_enter_by_name", ownerScope->typeArguments.size());
+    histogramInc("symbol_enter_by_name", ownerScope->typeArguments().size());
 
-    for (auto typeArg : ownerScope->typeArguments) {
+    for (auto typeArg : ownerScope->typeArguments()) {
         if (typeArg.dataAllowingNone(*this)->name == name) {
             ENFORCE(typeArg.dataAllowingNone(*this)->flags.hasFlags(flags), "existing symbol has wrong flags");
             counterInc("symbols.hit");
@@ -1129,8 +1129,8 @@ TypeArgumentRef GlobalState::enterTypeArgument(Loc loc, MethodRef owner, NameRef
     }
 
     ENFORCE(!symbolTableFrozen);
-    auto result = TypeArgumentRef(*this, typeArguments.size());
-    typeArguments.emplace_back();
+    auto result = TypeArgumentRef(*this, this->typeArguments.size());
+    this->typeArguments.emplace_back();
 
     TypeParameterData data = result.dataAllowingNone(*this);
     data->name = name;
@@ -1140,7 +1140,7 @@ TypeArgumentRef GlobalState::enterTypeArgument(Loc loc, MethodRef owner, NameRef
     DEBUG_ONLY(categoryCounterInc("symbols", "type_argument"));
     wasModified_ = true;
 
-    owner.dataAllowingNone(*this)->typeArguments.emplace_back(result);
+    owner.dataAllowingNone(*this)->getOrCreateTypeArguments().emplace_back(result);
     return result;
 }
 

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1094,7 +1094,7 @@ TypeMemberRef GlobalState::enterTypeMember(Loc loc, ClassOrModuleRef owner, Name
     DEBUG_ONLY(categoryCounterInc("symbols", "type_member"));
     wasModified_ = true;
 
-    auto &members = owner.dataAllowingNone(*this)->typeMembers();
+    auto &members = owner.dataAllowingNone(*this)->getOrCreateTypeMembers();
     if (!absl::c_linear_search(members, result)) {
         members.emplace_back(result);
     }

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1112,7 +1112,7 @@ bool Method::isPrintable(const GlobalState &gs) const {
         return true;
     }
 
-    for (auto typeParam : this->typeArguments) {
+    for (auto typeParam : this->typeArguments()) {
         if (typeParam.data(gs)->isPrintable(gs)) {
             return true;
         }
@@ -1286,9 +1286,10 @@ string MethodRef::toStringWithOptions(const GlobalState &gs, int tabs, bool show
                        fmt::map_join(methodFlags, "|", [](const auto &flag) { return flag; }));
     }
 
-    auto typeMembers = sym->typeArguments;
-    auto it = remove_if(typeMembers.begin(), typeMembers.end(),
-                        [&gs](auto &sym) -> bool { return sym.data(gs)->flags.isFixed; });
+    InlinedVector<TypeArgumentRef, 4> typeMembers;
+    typeMembers.assign(sym->typeArguments().begin(), sym->typeArguments().end());
+    auto it =
+        remove_if(typeMembers.begin(), typeMembers.end(), [&gs](auto &sym) -> bool { return sym.data(gs)->flags.isFixed; });
     typeMembers.erase(it, typeMembers.end());
     if (!typeMembers.empty()) {
         fmt::format_to(std::back_inserter(buf), "[{}]", fmt::map_join(typeMembers, ", ", [&](auto symb) {
@@ -1309,7 +1310,7 @@ string MethodRef::toStringWithOptions(const GlobalState &gs, int tabs, bool show
 
     ENFORCE(!absl::c_any_of(to_string(buf), [](char c) { return c == '\n'; }));
     fmt::format_to(std::back_inserter(buf), "\n");
-    for (auto ta : sym->typeArguments) {
+    for (auto ta : sym->typeArguments()) {
         ENFORCE_NO_TIMER(ta.exists());
 
         if (!showFull && !ta.data(gs)->isPrintable(gs)) {
@@ -2027,7 +2028,9 @@ Method Method::deepCopy(const GlobalState &to) const {
     result.resultType = this->resultType;
     result.name = NameRef(to, this->name);
     result.locs_ = this->locs_;
-    result.typeArguments = this->typeArguments;
+    if (this->typeArgs) {
+        result.typeArgs = std::make_unique<InlinedVector<TypeArgumentRef, 4>>(*this->typeArgs);
+    }
     result.arguments.reserve(this->arguments.size());
     for (auto &mem : this->arguments) {
         auto &store = result.arguments.emplace_back(mem.deepCopy());
@@ -2093,7 +2096,7 @@ void Method::sanityCheck(const GlobalState &gs) const {
     MethodRef current2 = const_cast<GlobalState &>(gs).enterMethodSymbol(this->loc(), this->owner, this->name);
 
     ENFORCE_NO_TIMER(current == current2);
-    for (auto &tp : typeArguments) {
+    for (auto &tp : typeArguments()) {
         ENFORCE_NO_TIMER(tp.data(gs)->name.exists(), name.toString(gs) + " has a member symbol without a name");
         ENFORCE_NO_TIMER(tp.exists(), name.toString(gs) + "." + tp.data(gs)->name.toString(gs) +
                                           " corresponds to a core::Symbols::noTypeArgument()");
@@ -2250,7 +2253,7 @@ uint32_t Method::hash(const GlobalState &gs) const {
         result = mix(result, type.hash(gs));
         result = mix(result, _hash(arg.name.shortName(gs)));
     }
-    for (const auto &e : typeArguments) {
+    for (const auto &e : typeArguments()) {
         if (e.exists()) {
             result = mix(result, _hash(e.data(gs)->name.shortName(gs)));
         }

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1191,8 +1191,8 @@ string ClassOrModuleRef::toStringWithOptions(const GlobalState &gs, int tabs, bo
     auto membersSpan = sym->typeMembers();
     InlinedVector<TypeMemberRef, 4> typeMembers;
     typeMembers.assign(membersSpan.begin(), membersSpan.end());
-    auto it =
-        remove_if(typeMembers.begin(), typeMembers.end(), [&gs](auto &sym) -> bool { return sym.data(gs)->flags.isFixed; });
+    auto it = remove_if(typeMembers.begin(), typeMembers.end(),
+                        [&gs](auto &sym) -> bool { return sym.data(gs)->flags.isFixed; });
     typeMembers.erase(it, typeMembers.end());
     if (!typeMembers.empty()) {
         fmt::format_to(std::back_inserter(buf), "[{}]", fmt::map_join(typeMembers, ", ", [&](auto symb) {
@@ -1288,8 +1288,8 @@ string MethodRef::toStringWithOptions(const GlobalState &gs, int tabs, bool show
 
     InlinedVector<TypeArgumentRef, 4> typeMembers;
     typeMembers.assign(sym->typeArguments().begin(), sym->typeArguments().end());
-    auto it =
-        remove_if(typeMembers.begin(), typeMembers.end(), [&gs](auto &sym) -> bool { return sym.data(gs)->flags.isFixed; });
+    auto it = remove_if(typeMembers.begin(), typeMembers.end(),
+                        [&gs](auto &sym) -> bool { return sym.data(gs)->flags.isFixed; });
     typeMembers.erase(it, typeMembers.end());
     if (!typeMembers.empty()) {
         fmt::format_to(std::back_inserter(buf), "[{}]", fmt::map_join(typeMembers, ", ", [&](auto symb) {

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -2227,11 +2227,9 @@ uint32_t ClassOrModule::hash(const GlobalState &gs) const {
             result = mix(result, _hash(e.data(gs)->name.shortName(gs)));
         }
     }
-    if (isClassOrModule()) {
-        for (const auto &e : typeMembers()) {
-            if (e.exists()) {
-                result = mix(result, _hash(e.data(gs)->name.shortName(gs)));
-            }
+    for (const auto &e : typeMembers()) {
+        if (e.exists()) {
+            result = mix(result, _hash(e.data(gs)->name.shortName(gs)));
         }
     }
 

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -375,12 +375,27 @@ public:
     // Add a placeholder for a mixin and return index in mixins()
     uint16_t addMixinPlaceholder(const GlobalState &gs);
 
-    inline InlinedVector<TypeMemberRef, 4> &typeMembers() {
-        return typeParams;
+    inline InlinedVector<TypeMemberRef, 4> &getOrCreateTypeMembers() {
+        ENFORCE(isClassOrModule());
+        if (typeParams) {
+            return *typeParams;
+        }
+        typeParams = std::make_unique<InlinedVector<TypeMemberRef, 4>>();
+        return *typeParams;
     }
 
-    inline const InlinedVector<TypeMemberRef, 4> &typeMembers() const {
-        return typeParams;
+    inline absl::Span<const TypeMemberRef> typeMembers() const {
+        ENFORCE(isClassOrModule());
+        if (typeParams) {
+            return *typeParams;
+        }
+        return {};
+    }
+
+    inline InlinedVector<TypeMemberRef, 4> &existingTypeMembers() {
+        ENFORCE(isClassOrModule());
+        ENFORCE(typeParams != nullptr);
+        return *typeParams;
     }
 
     // Return the number of type parameters that must be passed to instantiate
@@ -550,7 +565,7 @@ private:
 
     /** For Class or module - ordered type members of the class,
      */
-    InlinedVector<TypeMemberRef, 4> typeParams;
+    std::unique_ptr<InlinedVector<TypeMemberRef, 4>> typeParams;
     InlinedVector<Loc, 2> locs_;
 
     // Record a required ancestor for this class of module in a magic property

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -157,10 +157,30 @@ public:
     uint16_t intrinsicOffset = INVALID_INTRINSIC_OFFSET;
     TypePtr resultType;
     ArgumentsStore arguments;
-    InlinedVector<TypeArgumentRef, 4> typeArguments;
+
+    InlinedVector<TypeArgumentRef, 4> &getOrCreateTypeArguments() {
+        if (typeArgs) {
+            return *typeArgs;
+        }
+        typeArgs = std::make_unique<InlinedVector<TypeArgumentRef, 4>>();
+        return *typeArgs;
+    }
+
+    absl::Span<const TypeArgumentRef> typeArguments() const {
+        if (typeArgs) {
+            return *typeArgs;
+        }
+        return {};
+    }
+
+    InlinedVector<TypeArgumentRef, 4> &existingTypeArguments() {
+        ENFORCE(typeArgs != nullptr);
+        return *typeArgs;
+    }
 
 private:
     InlinedVector<Loc, 2> locs_;
+    std::unique_ptr<InlinedVector<TypeArgumentRef, 4>> typeArgs;
 };
 CheckSize(Method, 176, 8);
 

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -182,7 +182,7 @@ private:
     InlinedVector<Loc, 2> locs_;
     std::unique_ptr<InlinedVector<TypeArgumentRef, 4>> typeArgs;
 };
-CheckSize(Method, 176, 8);
+CheckSize(Method, 160, 8);
 
 // Contains a field or a static field
 class Field final {
@@ -605,7 +605,7 @@ private:
 
     void addMixinAt(ClassOrModuleRef sym, std::optional<uint16_t> index);
 };
-CheckSize(ClassOrModule, 152, 8);
+CheckSize(ClassOrModule, 136, 8);
 
 } // namespace sorbet::core
 #endif // SORBET_SYMBOLS_H

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -396,7 +396,6 @@ public:
     uint16_t addMixinPlaceholder(const GlobalState &gs);
 
     inline InlinedVector<TypeMemberRef, 4> &getOrCreateTypeMembers() {
-        ENFORCE(isClassOrModule());
         if (typeParams) {
             return *typeParams;
         }
@@ -405,7 +404,6 @@ public:
     }
 
     inline absl::Span<const TypeMemberRef> typeMembers() const {
-        ENFORCE(isClassOrModule());
         if (typeParams) {
             return *typeParams;
         }
@@ -413,7 +411,6 @@ public:
     }
 
     inline InlinedVector<TypeMemberRef, 4> &existingTypeMembers() {
-        ENFORCE(isClassOrModule());
         ENFORCE(typeParams != nullptr);
         return *typeParams;
     }

--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -147,7 +147,7 @@ com::stripe::rubytyper::Symbol Proto::toProto(const GlobalState &gs, SymbolRef s
             *symbolProto.add_children() = toProto(gs, pair.second, showFull);
         }
     } else if (sym.isMethod()) {
-        for (auto typeArg : sym.asMethodRef().data(gs)->typeArguments) {
+        for (auto typeArg : sym.asMethodRef().data(gs)->typeArguments()) {
             if (!typeArg.exists()) {
                 continue;
             }

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -601,11 +601,9 @@ void SerializerImpl::pickle(Pickler &p, const ClassOrModule &what) {
         p.putU4(s.id());
     }
 
-    if (what.isClassOrModule()) {
-        p.putU4(what.typeMembers().size());
-        for (auto s : what.typeMembers()) {
-            p.putU4(s.id());
-        }
+    p.putU4(what.typeMembers().size());
+    for (auto s : what.typeMembers()) {
+        p.putU4(s.id());
     }
 
     p.putU4(what.members().size());
@@ -645,15 +643,13 @@ ClassOrModule SerializerImpl::unpickleClassOrModule(UnPickler &p, const GlobalSt
         result.mixins_.emplace_back(ClassOrModuleRef::fromRaw(p.getU4()));
     }
 
-    if (result.isClassOrModule()) {
-        int typeParamsSize = p.getU4();
+    int typeParamsSize = p.getU4();
 
-        if (typeParamsSize != 0) {
-            auto &vec = result.getOrCreateTypeMembers();
-            vec.reserve(typeParamsSize);
-            for (int i = 0; i < typeParamsSize; i++) {
-                vec.emplace_back(TypeMemberRef::fromRaw(p.getU4()));
-            }
+    if (typeParamsSize != 0) {
+        auto &vec = result.getOrCreateTypeMembers();
+        vec.reserve(typeParamsSize);
+        for (int i = 0; i < typeParamsSize; i++) {
+            vec.emplace_back(TypeMemberRef::fromRaw(p.getU4()));
         }
     }
 

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -543,8 +543,8 @@ void SerializerImpl::pickle(Pickler &p, const Method &what) {
     p.putU4(what.name.rawId());
     p.putU4(what.rebind.id());
     p.putU4(what.flags.serialize());
-    p.putU4(what.typeArguments.size());
-    for (auto s : what.typeArguments) {
+    p.putU4(what.typeArguments().size());
+    for (auto s : what.typeArguments()) {
         p.putU4(s.id());
     }
     p.putU4(what.arguments.size());
@@ -571,9 +571,11 @@ Method SerializerImpl::unpickleMethod(UnPickler &p, const GlobalState *gs) {
     result.flags = flags;
 
     int typeParamsSize = p.getU4();
-    result.typeArguments.reserve(typeParamsSize);
-    for (int i = 0; i < typeParamsSize; i++) {
-        result.typeArguments.emplace_back(TypeArgumentRef::fromRaw(p.getU4()));
+    if (typeParamsSize != 0) {
+        auto &vec = result.getOrCreateTypeArguments();
+        for (int i = 0; i < typeParamsSize; i++) {
+            vec.emplace_back(TypeArgumentRef::fromRaw(p.getU4()));
+        }
     }
 
     int argsSize = p.getU4();

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -824,7 +824,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
     }
 
     if (data->flags.isGenericMethod) {
-        constr->defineDomain(gs, data->typeArguments);
+        constr->defineDomain(gs, data->typeArguments());
     }
     auto posArgs = args.numPosArgs;
     bool hasKwargs = absl::c_any_of(data->arguments, [](const auto &arg) { return arg.flags.isKeyword; });

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -509,7 +509,8 @@ InlinedVector<TypeMemberRef, 4> Types::alignBaseTypeArgs(const GlobalState &gs, 
 
     if (what == asIf || (asIf.data(gs)->isClass() && what.data(gs)->isClass() &&
                          asIf.data(gs)->typeMembers().size() == what.data(gs)->typeMembers().size())) {
-        currentAlignment = what.data(gs)->typeMembers();
+        auto members = what.data(gs)->typeMembers();
+        currentAlignment.assign(members.begin(), members.end());
     } else {
         currentAlignment.reserve(asIf.data(gs)->typeMembers().size());
         for (auto originalTp : asIf.data(gs)->typeMembers()) {

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -25,7 +25,7 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
     if (cfg->symbol.data(ctx)->flags.isGenericMethod) {
         _constr = make_unique<core::TypeConstraint>();
         constr = _constr.get();
-        for (core::SymbolRef typeArgument : cfg->symbol.data(ctx)->typeArguments) {
+        for (core::SymbolRef typeArgument : cfg->symbol.data(ctx)->typeArguments()) {
             constr->rememberIsSubtype(ctx, typeArgument.asTypeArgumentRef().data(ctx)->resultType,
                                       core::make_type<core::SelfTypeParam>(typeArgument));
         }

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1342,9 +1342,12 @@ class SymbolDefiner {
                 emitRedefinedConstantError(ctx, ctx.locAt(typeMember.nameLoc), oldSym, existingTypeMember);
             }
             // if we have more than one type member with the same name, then we have messed up somewhere
-            ENFORCE(absl::c_find_if(onSymbol.data(ctx)->typeMembers(), [&](auto mem) {
-                        return mem.data(ctx)->name == existingTypeMember.data(ctx)->name;
-                    }) != onSymbol.data(ctx)->typeMembers().end());
+            if (::sorbet::debug_mode) {
+                auto members = onSymbol.data(ctx)->typeMembers();
+                ENFORCE(absl::c_find_if(members, [&](auto mem) {
+                            return mem.data(ctx)->name == existingTypeMember.data(ctx)->name;
+                        }) != members.end());
+            }
             sym = existingTypeMember;
         } else {
             auto oldSym = onSymbol.data(ctx)->findMemberNoDealias(ctx, typeMember.name);

--- a/packager/rbi_gen.cc
+++ b/packager/rbi_gen.cc
@@ -271,7 +271,7 @@ private:
         if (sym->flags.isOverride) {
             flags.emplace_back("override");
         }
-        for (auto ta : method.data(gs)->typeArguments) {
+        for (auto ta : method.data(gs)->typeArguments()) {
             typeArguments.emplace_back(absl::StrCat(":", ta.data(gs)->name.show(gs)));
         }
         for (auto &argSym : method.data(gs)->arguments) {

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -128,7 +128,7 @@ void resolveTypeMembers(core::GlobalState &gs, core::ClassOrModuleRef sym,
                     }
                     ENFORCE(foundIdx < sym.data(gs)->typeMembers().size());
                     // quadratic
-                    swap(sym.data(gs)->typeMembers()[foundIdx], sym.data(gs)->typeMembers()[i]);
+                    swap(sym.data(gs)->existingTypeMembers()[foundIdx], sym.data(gs)->existingTypeMembers()[i]);
                 }
                 i++;
             }


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Generic parameters are fairly uncommon across methods and classes, but we make all methods and classes pay for their cost, size-wise, with a 24-byte `InlinedVector` in their respective symbols.  (It would be nice if we could at least reduce the inline storage cost--very few people need four generic parameters--but that's not possible due to restrictions in `InlinedVector` (?))

This PR implements the next best thing, which is lazily allocating the vectors storing those parameters.  It probably wants to wait for #5005, as some of the serialization code for `ClassOrModule` will be less messy after that PR.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
