### PR TITLE
[LSP] Fix non-alphanumeric characters in the module names

### DIFF
--- a/main/lsp/MoveMethod.cc
+++ b/main/lsp/MoveMethod.cc
@@ -65,6 +65,8 @@ string snakeToCamelCase(string_view name) {
     for (int i = 0; i < originalSize; i++) {
         if (name.at(i) == '_') {
             shouldCapitalize = true;
+        }
+        if (!isalnum(name.at(i))) {
             continue;
         }
         res += shouldCapitalize ? toupper(name[i]) : name[i];

--- a/test/testdata/lsp/code_actions/move_method/utf8_method_name.B.rbedited
+++ b/test/testdata/lsp/code_actions/move_method/utf8_method_name.B.rbedited
@@ -1,7 +1,9 @@
 # typed: strict
 # selective-apply-code-action: refactor.extract
+#
+# Test asserts that non-alphanumeric characters doesn't appear in the new module name
 
-module 😱Module
+module Module1
   extend T::Sig
   sig {void}
   def self.😱; end
@@ -14,9 +16,14 @@ module Foo
      # ^ apply-code-action: [A] Move method to a new module
 
      # ^ apply-code-action: [B] Move method to a new module
+
+  sig {void}
+  def self.method_with_?; end
+     # ^ apply-code-action: [C] Move method to a new module
+
 end
 
 
 Foo.ж
-😱Module.😱
-
+Module1.😱
+Foo.method_with_?

--- a/test/testdata/lsp/code_actions/move_method/utf8_method_name.C.rbedited
+++ b/test/testdata/lsp/code_actions/move_method/utf8_method_name.C.rbedited
@@ -3,27 +3,27 @@
 #
 # Test asserts that non-alphanumeric characters doesn't appear in the new module name
 
-module Module1
+module MethodWithModule
   extend T::Sig
   sig {void}
-  def self.ж; end
+  def self.method_with_?; end
 end
 
 module Foo
   extend T::Sig
+  sig {void}
+  def self.ж; end
      # ^ apply-code-action: [A] Move method to a new module
 
   sig {void}
   def self.😱; end
      # ^ apply-code-action: [B] Move method to a new module
 
-  sig {void}
-  def self.method_with_?; end
      # ^ apply-code-action: [C] Move method to a new module
 
 end
 
 
-Module1.ж
+Foo.ж
 Foo.😱
-Foo.method_with_?
+MethodWithModule.method_with_?

--- a/test/testdata/lsp/code_actions/move_method/utf8_method_name.rb
+++ b/test/testdata/lsp/code_actions/move_method/utf8_method_name.rb
@@ -1,5 +1,7 @@
 # typed: strict
 # selective-apply-code-action: refactor.extract
+#
+# Test asserts that non-alphanumeric characters doesn't appear in the new module name
 
 module Foo
   extend T::Sig
@@ -10,9 +12,14 @@ module Foo
   sig {void}
   def self.😱; end
      # ^ apply-code-action: [B] Move method to a new module
+
+  sig {void}
+  def self.method_with_?; end
+     # ^ apply-code-action: [C] Move method to a new module
+
 end
 
 
 Foo.ж
 Foo.😱
-
+Foo.method_with_?


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

The new module created after the "Move method" refactoring should only contain alphanumeric characters

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The use case like this
```ruby
module Foo
  sig {returns(T::Boolean)}
  def self.exists?
     # ^ apply-code-action: [A] Move method to a new module
    true
  end
end
```

will generate invalid module name

```ruby
module Exists?Module
            # ^ error: syntax error, unexpected constant, expecting `do' or '{' or '('
  sig {returns(T::Boolean)}
  def self.exists?
     # ^ apply-code-action: [A] Move method to a new module
    true
  end
end

module Foo
end
```

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
