### PR TITLE
Remove `type_parameters` from `T::Generic`

### DIFF
--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -71,9 +71,6 @@ end
 module T::Generic
   include T::Helpers
 
-  sig {params(params: T.untyped).returns(T::Private::Methods::DeclBuilder)}
-  def type_parameters(*params); end
-
   def type_member(variance=:invariant, fixed: nil, lower: T.untyped, upper: BasicObject); end
   def type_template(variance=:invariant, fixed: nil, lower: T.untyped, upper: BasicObject); end
   def [](*types); end

--- a/test/cli/autocorrect-requires-ancestor-block/test.out
+++ b/test/cli/autocorrect-requires-ancestor-block/test.out
@@ -28,8 +28,8 @@ autocorrect-requires-ancestor-block.rb:14: `requires_ancestor` only accepts a bl
 autocorrect-requires-ancestor-block.rb:12: Too many arguments provided for method `T::Helpers#requires_ancestor`. Expected: `0`, got: `1` https://srb.help/7004
     12 |  requires_ancestor RA1
                             ^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#L110: `requires_ancestor` defined here
-     110 |  def requires_ancestor(&block); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#L107: `requires_ancestor` defined here
+     107 |  def requires_ancestor(&block); end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
     autocorrect-requires-ancestor-block.rb:12: Deleted
@@ -39,15 +39,15 @@ autocorrect-requires-ancestor-block.rb:12: Too many arguments provided for metho
 autocorrect-requires-ancestor-block.rb:12: `requires_ancestor` requires a block parameter, but no block was passed https://srb.help/7021
     12 |  requires_ancestor RA1
                                ^
-    https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#L110: defined here
-     110 |  def requires_ancestor(&block); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#L107: defined here
+     107 |  def requires_ancestor(&block); end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 autocorrect-requires-ancestor-block.rb:13: Too many arguments provided for method `T::Helpers#requires_ancestor`. Expected: `0`, got: `2` https://srb.help/7004
     13 |  requires_ancestor RA2, RA3
                             ^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#L110: `requires_ancestor` defined here
-     110 |  def requires_ancestor(&block); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#L107: `requires_ancestor` defined here
+     107 |  def requires_ancestor(&block); end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
     autocorrect-requires-ancestor-block.rb:13: Deleted
@@ -57,15 +57,15 @@ autocorrect-requires-ancestor-block.rb:13: Too many arguments provided for metho
 autocorrect-requires-ancestor-block.rb:13: `requires_ancestor` requires a block parameter, but no block was passed https://srb.help/7021
     13 |  requires_ancestor RA2, RA3
                                     ^
-    https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#L110: defined here
-     110 |  def requires_ancestor(&block); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#L107: defined here
+     107 |  def requires_ancestor(&block); end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 autocorrect-requires-ancestor-block.rb:14: Too many arguments provided for method `T::Helpers#requires_ancestor`. Expected: `0`, got: `1` https://srb.help/7004
     14 |  requires_ancestor(RA4) { RA5 }
                             ^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#L110: `requires_ancestor` defined here
-     110 |  def requires_ancestor(&block); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#L107: `requires_ancestor` defined here
+     107 |  def requires_ancestor(&block); end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
     autocorrect-requires-ancestor-block.rb:14: Deleted


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This method doesn't actually exist on this class at runtime.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

test on Stripe's codebase