### PR TITLE
Allow specifying `type_member` bounds lazily

### DIFF
--- a/gems/sorbet-runtime/lib/types/generic.rb
+++ b/gems/sorbet-runtime/lib/types/generic.rb
@@ -12,11 +12,13 @@ module T::Generic
     self
   end
 
-  def type_member(variance=:invariant, fixed: nil, lower: T.untyped, upper: BasicObject)
+  # TODO(jez) Remove these keyword arguments once it's a static error
+  def type_member(variance=:invariant, fixed: nil, lower: T.untyped, upper: BasicObject, &blk)
     T::Types::TypeMember.new(variance)
   end
 
-  def type_template(variance=:invariant, fixed: nil, lower: T.untyped, upper: BasicObject)
+  # TODO(jez) Remove these keyword arguments once it's a static error
+  def type_template(variance=:invariant, fixed: nil, lower: T.untyped, upper: BasicObject, &blk)
     T::Types::TypeTemplate.new(variance)
   end
 end

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -1439,6 +1439,16 @@ module Opus::Types::Test
       end
     end
 
+    class TestGeneric3
+      extend T::Sig
+      extend T::Generic
+
+      Elem = type_member {{fixed: Integer}}
+      sig {params(x: Elem).void}
+      def foo(x)
+      end
+    end
+
     class GenericSingleton
       extend T::Sig
       extend T::Generic

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -1445,8 +1445,7 @@ module Opus::Types::Test
 
       Elem = type_member {{fixed: Integer}}
       sig {params(x: Elem).void}
-      def foo(x)
-      end
+      def foo(x); end
     end
 
     class GenericSingleton

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1883,6 +1883,14 @@ public:
                                 case core::Names::upper().rawId():
                                     bounded = true;
                                     break;
+
+                                default:
+                                    if (auto e =
+                                            ctx.beginError(keyExpr.loc(), core::errors::Namer::InvalidTypeDefinition)) {
+                                        e.setHeader("Unknown key `{}` provided in block to `{}`",
+                                                    key->asSymbol(ctx).show(ctx), send->fun.show(ctx));
+                                    }
+                                    return tree;
                             }
                         }
                     } else {

--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -71,8 +71,8 @@ end
 module T::Generic
   include T::Helpers
 
-  def type_member(variance=:invariant, fixed: nil, lower: T.untyped, upper: BasicObject); end
-  def type_template(variance=:invariant, fixed: nil, lower: T.untyped, upper: BasicObject); end
+  def type_member(variance=:invariant, fixed: nil, lower: T.untyped, upper: BasicObject, &blk); end
+  def type_template(variance=:invariant, fixed: nil, lower: T.untyped, upper: BasicObject, &blk); end
   def [](*types); end
 end
 

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -39,13 +39,13 @@ ParsedSig TypeSyntax::parseSig(core::Context ctx, const ast::Send &sigSend, cons
     return result;
 }
 
-core::TypePtr TypeSyntax::getResultType(core::Context ctx, ast::ExpressionPtr &expr, const ParsedSig &sigBeingParsed,
-                                        TypeSyntaxArgs args) {
+core::TypePtr TypeSyntax::getResultType(core::Context ctx, const ast::ExpressionPtr &expr,
+                                        const ParsedSig &sigBeingParsed, TypeSyntaxArgs args) {
     return core::Types::unwrapSelfTypeParam(
         ctx, getResultTypeWithSelfTypeParams(ctx, expr, sigBeingParsed, args.withoutRebind()));
 }
 
-TypeSyntax::ResultType TypeSyntax::getResultTypeAndBind(core::Context ctx, ast::ExpressionPtr &expr,
+TypeSyntax::ResultType TypeSyntax::getResultTypeAndBind(core::Context ctx, const ast::ExpressionPtr &expr,
                                                         const ParsedSig &sigBeingParsed, TypeSyntaxArgs args) {
     auto result = getResultTypeAndBindWithSelfTypeParams(ctx, expr, sigBeingParsed, args);
     result.type = core::Types::unwrapSelfTypeParam(ctx, result.type);

--- a/resolver/type_syntax.h
+++ b/resolver/type_syntax.h
@@ -91,9 +91,9 @@ public:
         core::TypePtr type;
         core::ClassOrModuleRef rebind;
     };
-    static ResultType getResultTypeAndBind(core::Context ctx, ast::ExpressionPtr &expr, const ParsedSig &,
+    static ResultType getResultTypeAndBind(core::Context ctx, const ast::ExpressionPtr &expr, const ParsedSig &,
                                            TypeSyntaxArgs args);
-    static core::TypePtr getResultType(core::Context ctx, ast::ExpressionPtr &expr, const ParsedSig &,
+    static core::TypePtr getResultType(core::Context ctx, const ast::ExpressionPtr &expr, const ParsedSig &,
                                        TypeSyntaxArgs args);
 
     TypeSyntax() = delete;

--- a/test/testdata/infer/generics/type_member_bounds_block.rb
+++ b/test/testdata/infer/generics/type_member_bounds_block.rb
@@ -1,0 +1,27 @@
+# typed: true
+extend T::Sig
+
+class MyGenericUpper
+  extend T::Generic
+
+  Elem = type_member {{upper: Numeric}}
+end
+
+class MyGenericLower
+  extend T::Generic
+
+  Elem = type_member {{lower: Numeric}}
+end
+
+x = MyGenericUpper[String].new
+#                  ^^^^^^ error: `String` is not a subtype of upper bound of type member `::MyGenericUpper::Elem`
+T.reveal_type(x) # error: `MyGenericUpper[T.untyped]`
+x = MyGenericUpper[Integer].new
+T.reveal_type(x) # error: `MyGenericUpper[Integer]`
+
+x = MyGenericLower[Integer].new
+#                  ^^^^^^^ error: `Integer` is not a supertype of lower bound of type member `::MyGenericLower::Elem`
+T.reveal_type(x) # error: `MyGenericLower[T.untyped]`
+x = MyGenericLower[Numeric].new
+T.reveal_type(x) # error: `MyGenericLower[Numeric]`
+

--- a/test/testdata/resolver/type_member_block.rb
+++ b/test/testdata/resolver/type_member_block.rb
@@ -29,3 +29,9 @@ module IBox5
   X = type_member(:out) {x = 1; p(x); {upper: Integer}}
   #                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Block given to `type_member` must contain a single `Hash` literal
 end
+
+module IBox6
+  extend T::Generic
+  X = type_member(:out) {{unknown: Integer}}
+  #                       ^^^^^^^ error: Unknown key `unknown` provided in block to `type_member`
+end

--- a/test/testdata/resolver/type_member_block.rb
+++ b/test/testdata/resolver/type_member_block.rb
@@ -1,0 +1,31 @@
+# typed: true
+
+module IBox1
+  extend T::Generic
+  X = type_member(:out) {{upper: T.any(Integer, String)}}
+end
+
+module IBox2
+  extend T::Generic
+  X = type_member(:out) {{'upper' => T.any(Integer, String)}}
+  #                       ^^^^^^^ error: must have symbol keys
+end
+
+module IBox3
+  extend T::Generic
+  X = type_member(:out, fixed: Integer) {{upper: T.any(Integer, String)}}
+  #   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `type_member` must not have both keyword args and a block
+  #   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Type member is defined with bounds and `fixed`
+end
+
+module IBox4
+  extend T::Generic
+  X = type_member(:out) {nil}
+  #                      ^^^ error: Block given to `type_member` must contain a single `Hash` literal
+end
+
+module IBox5
+  extend T::Generic
+  X = type_member(:out) {x = 1; p(x); {upper: Integer}}
+  #                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Block given to `type_member` must contain a single `Hash` literal
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The types that show up in bounds are completely erased at runtime, so there's no
point not to make them lazy.

This should:

- potentially show load-time performance improvements
- prevent certain kinds of load-time cyclic references from happening

We will land a follow up change eventually to enforce the new syntax and add an
autocorrect.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.