### PR TITLE
Fix lazy type members

### DIFF
--- a/test/testdata/resolver/type_member_block.rb
+++ b/test/testdata/resolver/type_member_block.rb
@@ -1,4 +1,5 @@
 # typed: true
+extend T::Sig
 
 module IBox1
   extend T::Generic
@@ -34,4 +35,16 @@ module IBox6
   extend T::Generic
   X = type_member(:out) {{unknown: Integer}}
   #                       ^^^^^^^ error: Unknown key `unknown` provided in block to `type_member`
+end
+
+class IntBox
+  extend T::Sig
+  extend T::Generic
+
+  Elem = type_member {{fixed: Integer}}
+end
+
+sig {returns(IntBox)}
+def example1
+  IntBox.new
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Forgot to add enough tests in #5628 to discover this.

Exposed when I went to implement the autocorrect to convert all `type_member`s
to the new syntax.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.