### PR TITLE
add more location information to `cfg::Cast` for better autocorrects

### DIFF
--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -254,7 +254,8 @@ public:
     core::LocOffsets valueLoc;
     core::TypePtr type;
 
-    Cast(LocalRef value, core::LocOffsets valueLoc, const core::TypePtr &type, core::NameRef cast) : cast(cast), value(value), valueLoc(valueLoc), type(type) {
+    Cast(LocalRef value, core::LocOffsets valueLoc, const core::TypePtr &type, core::NameRef cast)
+        : cast(cast), value(value), valueLoc(valueLoc), type(type) {
         categoryCounterInc("cfg", "cast");
     }
 

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -251,16 +251,17 @@ INSN(Cast) : public Instruction {
 public:
     core::NameRef cast;
     VariableUseSite value;
+    core::LocOffsets valueLoc;
     core::TypePtr type;
 
-    Cast(LocalRef value, const core::TypePtr &type, core::NameRef cast) : cast(cast), value(value), type(type) {
+    Cast(LocalRef value, core::LocOffsets valueLoc, const core::TypePtr &type, core::NameRef cast) : cast(cast), value(value), valueLoc(valueLoc), type(type) {
         categoryCounterInc("cfg", "cast");
     }
 
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(Cast, 48, 8);
+CheckSize(Cast, 56, 8);
 
 INSN(TAbsurd) : public Instruction {
 public:

--- a/cfg/builder/builder_entry.cc
+++ b/cfg/builder/builder_entry.cc
@@ -33,7 +33,7 @@ unique_ptr<CFG> CFGBuilder::buildFor(core::Context ctx, ast::MethodDef &md) {
         }
         synthesizeExpr(
             entry, LocalRef::selfVariable(), core::LocOffsets::none(),
-            make_insn<Cast>(LocalRef::selfVariable(), selfClaz.data(ctx)->selfType(ctx), core::Names::cast()));
+            make_insn<Cast>(LocalRef::selfVariable(), core::LocOffsets::none(), selfClaz.data(ctx)->selfType(ctx), core::Names::cast()));
 
         BasicBlock *presentCont = entry;
         BasicBlock *defaultCont = nullptr;

--- a/cfg/builder/builder_entry.cc
+++ b/cfg/builder/builder_entry.cc
@@ -31,9 +31,9 @@ unique_ptr<CFG> CFGBuilder::buildFor(core::Context ctx, ast::MethodDef &md) {
         if (!selfClaz.exists()) {
             selfClaz = md.symbol.enclosingClass(ctx);
         }
-        synthesizeExpr(
-            entry, LocalRef::selfVariable(), core::LocOffsets::none(),
-            make_insn<Cast>(LocalRef::selfVariable(), core::LocOffsets::none(), selfClaz.data(ctx)->selfType(ctx), core::Names::cast()));
+        synthesizeExpr(entry, LocalRef::selfVariable(), core::LocOffsets::none(),
+                       make_insn<Cast>(LocalRef::selfVariable(), core::LocOffsets::none(),
+                                       selfClaz.data(ctx)->selfType(ctx), core::Names::cast()));
 
         BasicBlock *presentCont = entry;
         BasicBlock *defaultCont = nullptr;

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -170,7 +170,7 @@ tuple<LocalRef, BasicBlock *, BasicBlock *> CFGBuilder::walkDefault(CFGContext c
 
     if (argInfo.type != nullptr) {
         auto tmp = cctx.newTemporary(core::Names::castTemp());
-        synthesizeExpr(defaultNext, tmp, defLoc, make_insn<Cast>(result, argInfo.type, core::Names::let()));
+        synthesizeExpr(defaultNext, tmp, defLoc, make_insn<Cast>(result, core::LocOffsets::none(), argInfo.type, core::Names::let()));
         cctx.inWhat.minLoops[tmp.id()] = CFG::MIN_LOOP_LET;
     }
 
@@ -780,18 +780,19 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
 
             [&](ast::Cast &c) {
                 LocalRef tmp = cctx.newTemporary(core::Names::castTemp());
+                core::LocOffsets argLoc = c.arg.loc();
                 current = walk(cctx.withTarget(tmp), c.arg, current);
                 if (c.cast == core::Names::uncheckedLet()) {
                     current->exprs.emplace_back(cctx.target, c.loc, make_insn<Ident>(tmp));
                 } else if (c.cast == core::Names::bind()) {
                     if (c.arg.isSelfReference()) {
                         auto self = cctx.inWhat.enterLocal(core::LocalVariable::selfVariable());
-                        current->exprs.emplace_back(self, c.loc, make_insn<Cast>(tmp, c.type, core::Names::cast()));
+                        current->exprs.emplace_back(self, c.loc, make_insn<Cast>(tmp, argLoc, c.type, core::Names::cast()));
                         current->exprs.emplace_back(cctx.target, c.loc, make_insn<Ident>(self));
 
                         if (cctx.rescueScope) {
                             cctx.rescueScope->exprs.emplace_back(self, c.loc,
-                                                                 make_insn<Cast>(tmp, c.type, core::Names::cast()));
+                                                                 make_insn<Cast>(tmp, argLoc, c.type, core::Names::cast()));
                             cctx.rescueScope->exprs.emplace_back(cctx.target, c.loc, make_insn<Ident>(self));
                         }
                     } else {
@@ -800,7 +801,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                         }
                     }
                 } else {
-                    current->exprs.emplace_back(cctx.target, c.loc, make_insn<Cast>(tmp, c.type, c.cast));
+                    current->exprs.emplace_back(cctx.target, c.loc, make_insn<Cast>(tmp, argLoc, c.type, c.cast));
                 }
                 if (c.cast == core::Names::let()) {
                     cctx.inWhat.minLoops[cctx.target.id()] = CFG::MIN_LOOP_LET;

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -170,7 +170,8 @@ tuple<LocalRef, BasicBlock *, BasicBlock *> CFGBuilder::walkDefault(CFGContext c
 
     if (argInfo.type != nullptr) {
         auto tmp = cctx.newTemporary(core::Names::castTemp());
-        synthesizeExpr(defaultNext, tmp, defLoc, make_insn<Cast>(result, core::LocOffsets::none(), argInfo.type, core::Names::let()));
+        synthesizeExpr(defaultNext, tmp, defLoc,
+                       make_insn<Cast>(result, core::LocOffsets::none(), argInfo.type, core::Names::let()));
         cctx.inWhat.minLoops[tmp.id()] = CFG::MIN_LOOP_LET;
     }
 
@@ -787,12 +788,13 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                 } else if (c.cast == core::Names::bind()) {
                     if (c.arg.isSelfReference()) {
                         auto self = cctx.inWhat.enterLocal(core::LocalVariable::selfVariable());
-                        current->exprs.emplace_back(self, c.loc, make_insn<Cast>(tmp, argLoc, c.type, core::Names::cast()));
+                        current->exprs.emplace_back(self, c.loc,
+                                                    make_insn<Cast>(tmp, argLoc, c.type, core::Names::cast()));
                         current->exprs.emplace_back(cctx.target, c.loc, make_insn<Ident>(self));
 
                         if (cctx.rescueScope) {
-                            cctx.rescueScope->exprs.emplace_back(self, c.loc,
-                                                                 make_insn<Cast>(tmp, argLoc, c.type, core::Names::cast()));
+                            cctx.rescueScope->exprs.emplace_back(
+                                self, c.loc, make_insn<Cast>(tmp, argLoc, c.type, core::Names::cast()));
                             cctx.rescueScope->exprs.emplace_back(cctx.target, c.loc, make_insn<Ident>(self));
                         }
                     } else {

--- a/test/cli/autocorrect-cast-untyped/autocorrect-cast-untyped.rb
+++ b/test/cli/autocorrect-cast-untyped/autocorrect-cast-untyped.rb
@@ -4,8 +4,6 @@ T.cast(nil, T.untyped)
 
 _x = T.cast(nil, T.untyped)
 
-# ----- multi-line is not handled unless it matches an unlikely pattern -----
-
 T.cast(
   nil,
   T.untyped)

--- a/test/cli/autocorrect-cast-untyped/test.out
+++ b/test/cli/autocorrect-cast-untyped/test.out
@@ -14,36 +14,57 @@ autocorrect-cast-untyped.rb:5: Please use `T.unsafe` to cast to `T.untyped` http
      5 |_x = T.cast(nil, T.untyped)
              ^^^^^^^^^^^^^^^^^^^^^^
 
-autocorrect-cast-untyped.rb:9: Please use `T.unsafe` to cast to `T.untyped` https://srb.help/7015
-     9 |T.cast(
-    10 |  nil,
-    11 |  T.untyped)
-
-autocorrect-cast-untyped.rb:13: Please use `T.unsafe` to cast to `T.untyped` https://srb.help/7015
-    13 |_y = T.cast(
-    14 |  nil,
-    15 |  T.untyped)
-
-autocorrect-cast-untyped.rb:17: Please use `T.unsafe` to cast to `T.untyped` https://srb.help/7015
-    17 |T.cast(
-    18 |  nil,
-    19 |  T.untyped
-    20 |)
-
-autocorrect-cast-untyped.rb:22: Please use `T.unsafe` to cast to `T.untyped` https://srb.help/7015
-    22 |_z = T.cast(
-    23 |  nil,
-    24 |  T.untyped
-    25 |)
-
-autocorrect-cast-untyped.rb:27: Please use `T.unsafe` to cast to `T.untyped` https://srb.help/7015
-    27 |_w = T.cast(
-    28 |  nil, T.untyped)
+autocorrect-cast-untyped.rb:7: Please use `T.unsafe` to cast to `T.untyped` https://srb.help/7015
+     7 |T.cast(
+     8 |  nil,
+     9 |  T.untyped)
   Autocorrect: Done
-    autocorrect-cast-untyped.rb:27: Replaced with `T.unsafe(
-      nil)`
-    27 |_w = T.cast(
-    28 |  nil, T.untyped)
+    autocorrect-cast-untyped.rb:7: Replaced with `T.unsafe(nil)`
+     7 |T.cast(
+     8 |  nil,
+     9 |  T.untyped)
+
+autocorrect-cast-untyped.rb:11: Please use `T.unsafe` to cast to `T.untyped` https://srb.help/7015
+    11 |_y = T.cast(
+    12 |  nil,
+    13 |  T.untyped)
+  Autocorrect: Done
+    autocorrect-cast-untyped.rb:11: Replaced with `T.unsafe(nil)`
+    11 |_y = T.cast(
+    12 |  nil,
+    13 |  T.untyped)
+
+autocorrect-cast-untyped.rb:15: Please use `T.unsafe` to cast to `T.untyped` https://srb.help/7015
+    15 |T.cast(
+    16 |  nil,
+    17 |  T.untyped
+    18 |)
+  Autocorrect: Done
+    autocorrect-cast-untyped.rb:15: Replaced with `T.unsafe(nil)`
+    15 |T.cast(
+    16 |  nil,
+    17 |  T.untyped
+    18 |)
+
+autocorrect-cast-untyped.rb:20: Please use `T.unsafe` to cast to `T.untyped` https://srb.help/7015
+    20 |_z = T.cast(
+    21 |  nil,
+    22 |  T.untyped
+    23 |)
+  Autocorrect: Done
+    autocorrect-cast-untyped.rb:20: Replaced with `T.unsafe(nil)`
+    20 |_z = T.cast(
+    21 |  nil,
+    22 |  T.untyped
+    23 |)
+
+autocorrect-cast-untyped.rb:25: Please use `T.unsafe` to cast to `T.untyped` https://srb.help/7015
+    25 |_w = T.cast(
+    26 |  nil, T.untyped)
+  Autocorrect: Done
+    autocorrect-cast-untyped.rb:25: Replaced with `T.unsafe(nil)`
+    25 |_w = T.cast(
+    26 |  nil, T.untyped)
 Errors: 7
 
 --------------------------------------------------------------------------
@@ -54,25 +75,12 @@ T.unsafe(nil)
 
 _x = T.unsafe(nil)
 
-# ----- multi-line is not handled unless it matches an unlikely pattern -----
+T.unsafe(nil)
 
-T.cast(
-  nil,
-  T.untyped)
+_y = T.unsafe(nil)
 
-_y = T.cast(
-  nil,
-  T.untyped)
+T.unsafe(nil)
 
-T.cast(
-  nil,
-  T.untyped
-)
+_z = T.unsafe(nil)
 
-_z = T.cast(
-  nil,
-  T.untyped
-)
-
-_w = T.unsafe(
-  nil)
+_w = T.unsafe(nil)


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

#5236 becomes much easier once this bit of information is in place, and the range of things we can autocorrect is slightly better now.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
