### PR TITLE
store IDs in a single table for compiled modules

### DIFF
--- a/compiler/Core/CompilerState.cc
+++ b/compiler/Core/CompilerState.cc
@@ -86,6 +86,25 @@ llvm::Value *CompilerState::stringTableRef(std::string_view str) {
     return entry.addrVar;
 }
 
+llvm::Value *CompilerState::idTableRef(std::string_view str) {
+    auto it = this->idTable.map.find(str);
+
+    if (it != this->idTable.map.end()) {
+        return it->second.addrVar;
+    }
+
+    auto entry = this->insertIntoStringTable(str);
+    auto offset = static_cast<uint32_t>(this->idTable.map.size());
+    auto globalName = fmt::format("addr_id_{}", str);
+    // TODO(froydnj): IDs are 32 bits, but Payload.cc was declaring them as 64?
+    auto *type = llvm::Type::getInt64PtrTy(this->lctx);
+    auto *global = declareNullptrPlaceholder(*this->module, type, globalName);
+    auto strSize = static_cast<uint32_t>(str.size());
+    this->idTable.map[str] = IDTable::IDTableEntry{offset, entry.offset, strSize, global};
+
+    return global;
+}
+
 void StringTable::defineGlobalVariables(llvm::LLVMContext &lctx, llvm::Module &module) {
     vector<pair<string_view, StringTable::StringTableEntry>> tableElements;
     tableElements.reserve(this->map.size());
@@ -117,6 +136,70 @@ void StringTable::defineGlobalVariables(llvm::LLVMContext &lctx, llvm::Module &m
         var->setInitializer(initializer);
         var->setConstant(true);
     }
+}
+
+void IDTable::defineGlobalVariables(llvm::LLVMContext &lctx, llvm::Module &module, llvm::IRBuilderBase &builder) {
+    vector <pair<string_view, IDTable::IDTableEntry>> tableElements;
+    tableElements.reserve(this->map.size());
+    absl::c_copy(this->map, std::back_inserter(tableElements));
+    fast_sort(tableElements, [](const auto &l, const auto &r) -> bool { return l.second.offset < r.second.offset; });
+
+    llvm::GlobalVariable *table;
+
+    {
+        auto *arrayType = llvm::ArrayType::get(llvm::Type::getInt64Ty(lctx), this->map.size());
+        const auto isConstant = false;
+        auto *initializer = llvm::ConstantAggregateZero::get(arrayType);
+        table = new llvm::GlobalVariable(module, arrayType, isConstant, llvm::GlobalVariable::InternalLinkage,
+                                         initializer, "sorbet_moduleIDTable");
+        table->setUnnamedAddr(llvm::GlobalValue::UnnamedAddr::Global);
+        table->setAlignment(llvm::MaybeAlign(8));
+    }
+
+    // Fill in all the addr vars that we indirected through.
+    for (auto &elem : tableElements) {
+        auto *var = elem.second.addrVar;
+        auto *zero = llvm::ConstantInt::get(lctx, llvm::APInt(64, 0));
+        auto *index = llvm::ConstantInt::get(lctx, llvm::APInt(64, elem.second.offset));
+        llvm::Constant *indices[] = {zero, index};
+        auto *initializer = llvm::ConstantExpr::getInBoundsGetElementPtr(table->getValueType(), table, indices);
+        var->setInitializer(initializer);
+        var->setConstant(true);
+    }
+
+    // Descriptors for the runtime initialization of members of the above.
+    // These types are known to the runtime.
+    auto *func = module.getFunction("sorbet_vm_intern_ids");
+    ENFORCE(func != nullptr);
+    auto *descOffsetTy = llvm::Type::getInt32Ty(lctx);
+    auto *descLengthTy = descOffsetTy;
+    auto *structType = llvm::dyn_cast<llvm::StructType>(func->getType()->getElementType()->getFunctionParamType(1)->getPointerElementType());
+    ENFORCE(structType != nullptr);
+    auto *arrayType = llvm::ArrayType::get(structType, this->map.size());
+    const auto isConstant = true;
+    std::vector<llvm::Constant *> descsConstants;
+    descsConstants.reserve(this->map.size());
+
+    for (auto &elem : tableElements) {
+        auto *offset = llvm::ConstantInt::get(descOffsetTy, elem.second.stringTableOffset);
+        auto *length = llvm::ConstantInt::get(descLengthTy, elem.second.stringLength);
+        auto *desc = llvm::ConstantStruct::get(structType, offset, length);
+        descsConstants.push_back(desc);
+    }
+
+    auto *initializer = llvm::ConstantArray::get(arrayType, descsConstants);
+    auto *descTable = new llvm::GlobalVariable(module, arrayType, isConstant, llvm::GlobalVariable::InternalLinkage,
+                                               initializer, "sorbet_moduleIDDescriptors");
+    descTable->setUnnamedAddr(llvm::GlobalValue::UnnamedAddr::Global);
+    descTable->setAlignment(llvm::MaybeAlign(8));
+
+    // Call into the runtime to initialize everything.
+    const auto allowInternal = true;
+    auto *stringTable = module.getGlobalVariable("sorbet_moduleStringTable", allowInternal);
+    ENFORCE(stringTable != nullptr);
+    builder.CreateCall(func, {builder.CreateConstGEP2_32(nullptr, table, 0, 0),
+                              builder.CreateConstGEP2_32(nullptr, descTable, 0, 0), llvm::ConstantInt::get(llvm::Type::getInt32Ty(lctx), this->map.size()),
+                              builder.CreateConstGEP2_32(nullptr, stringTable, 0, 0)});
 }
 
 llvm::FunctionType *CompilerState::getRubyFFIType() {

--- a/compiler/Core/CompilerState.cc
+++ b/compiler/Core/CompilerState.cc
@@ -21,10 +21,10 @@ namespace sorbet::compiler {
 CompilerState::CompilerState(const core::GlobalState &gs, llvm::LLVMContext &lctx, llvm::Module *module,
                              llvm::DIBuilder *debug, llvm::DICompileUnit *compileUnit, core::FileRef file,
                              llvm::BasicBlock *allocRubyIdsEntry, llvm::BasicBlock *globalConstructorsEntry,
-                             StringTable &stringTable)
+                             StringTable &stringTable, IDTable &idTable)
     : gs(gs), lctx(lctx), module(module), allocRubyIdsEntry(allocRubyIdsEntry),
       globalConstructorsEntry(globalConstructorsEntry), debug(debug), compileUnit(compileUnit),
-      functionEntryInitializers(nullptr), file(file), stringTable(stringTable) {}
+      functionEntryInitializers(nullptr), file(file), stringTable(stringTable), idTable(idTable) {}
 
 llvm::StructType *CompilerState::getValueType() {
     auto intType = llvm::Type::getInt64Ty(lctx);

--- a/compiler/Core/CompilerState.h
+++ b/compiler/Core/CompilerState.h
@@ -25,6 +25,23 @@ struct StringTable {
     void defineGlobalVariables(llvm::LLVMContext &lctx, llvm::Module &module);
 };
 
+struct IDTable {
+    struct IDTableEntry {
+        uint32_t offset;
+        uint32_t stringTableOffset = 0;
+        uint32_t stringLength = 0;
+        llvm::GlobalVariable *addrVar = nullptr;
+    };
+
+    UnorderedMap<std::string, IDTableEntry> map;
+
+    void clear() {
+        this->map.clear();
+    }
+
+    void defineGlobalVariables(llvm::LLVMContext &lctx, llvm::Module &module);
+};
+
 // Like GlobalState, but for the Sorbet Compiler.
 class CompilerState {
 public:

--- a/compiler/Core/CompilerState.h
+++ b/compiler/Core/CompilerState.h
@@ -70,6 +70,10 @@ public:
     StringTable &stringTable;
     IDTable &idTable;
 
+private:
+    StringTable::StringTableEntry insertIntoStringTable(std::string_view str);
+
+public:
     llvm::Value *stringTableRef(std::string_view str);
 
     // useful apis for getting common types

--- a/compiler/Core/CompilerState.h
+++ b/compiler/Core/CompilerState.h
@@ -39,7 +39,7 @@ struct IDTable {
         this->map.clear();
     }
 
-    void defineGlobalVariables(llvm::LLVMContext &lctx, llvm::Module &module);
+    void defineGlobalVariables(llvm::LLVMContext &lctx, llvm::Module &module, llvm::IRBuilderBase &builder);
 };
 
 // Like GlobalState, but for the Sorbet Compiler.
@@ -48,7 +48,7 @@ public:
     // Things created and managed ouside of us (by either Sorbet or plugin_injector)
     CompilerState(const core::GlobalState &gs, llvm::LLVMContext &lctx, llvm::Module *, llvm::DIBuilder *,
                   llvm::DICompileUnit *, core::FileRef, llvm::BasicBlock *allocRubyIdsEntry,
-                  llvm::BasicBlock *globalConstructorsEntry, StringTable &stringTable);
+                  llvm::BasicBlock *globalConstructorsEntry, StringTable &stringTable, IDTable &idTable);
 
     const core::GlobalState &gs;
     llvm::LLVMContext &lctx;
@@ -68,6 +68,7 @@ public:
 
     core::FileRef file;
     StringTable &stringTable;
+    IDTable &idTable;
 
     llvm::Value *stringTableRef(std::string_view str);
 

--- a/compiler/Core/CompilerState.h
+++ b/compiler/Core/CompilerState.h
@@ -75,6 +75,7 @@ private:
 
 public:
     llvm::Value *stringTableRef(std::string_view str);
+    llvm::Value *idTableRef(std::string_view str);
 
     // useful apis for getting common types
 

--- a/compiler/IREmitter/Payload/codegen-payload.c
+++ b/compiler/IREmitter/Payload/codegen-payload.c
@@ -168,6 +168,15 @@ SORBET_ALIVE(void, sorbet_vm_define_method,
 SORBET_ALIVE(void, sorbet_vm_define_prop_getter,
              (VALUE klass, const char *name, rb_sorbet_func_t methodPtr, void *paramp, rb_iseq_t *iseq));
 
+// The layout of this struct is known to the compiler.
+struct IDDescriptor {
+    unsigned int offset;
+    unsigned int length;
+};
+
+SORBET_ALIVE(void, sorbet_vm_intern_ids,
+             (ID *idTable, struct IDDescriptor *idDescriptors, unsigned int numIDs, const char *stringTable));
+
 SORBET_ALIVE(VALUE, sorbet_maybeAllocateObjectFastPath, (VALUE recv, struct FunctionInlineCache *newCache));
 SORBET_ALIVE(VALUE, sorbet_vm_instance_variable_get,
              (struct FunctionInlineCache * getCache, struct iseq_inline_iv_cache_entry *varCache,

--- a/compiler/IREmitter/Payload/codegen-payload.c
+++ b/compiler/IREmitter/Payload/codegen-payload.c
@@ -175,7 +175,7 @@ struct IDDescriptor {
 };
 
 SORBET_ALIVE(void, sorbet_vm_intern_ids,
-             (ID *idTable, struct IDDescriptor *idDescriptors, unsigned int numIDs, const char *stringTable));
+             (ID * idTable, struct IDDescriptor *idDescriptors, unsigned int numIDs, const char *stringTable));
 
 SORBET_ALIVE(VALUE, sorbet_maybeAllocateObjectFastPath, (VALUE recv, struct FunctionInlineCache *newCache));
 SORBET_ALIVE(VALUE, sorbet_vm_instance_variable_get,

--- a/compiler/IREmitter/Payload/vm-payload.c
+++ b/compiler/IREmitter/Payload/vm-payload.c
@@ -535,3 +535,16 @@ void sorbet_vm_define_prop_getter(VALUE klass, const char *name, rb_sorbet_func_
     const bool isSelf = false;
     sorbet_vm_define_method(klass, name, methodPtr, paramp, iseq, isSelf);
 }
+
+// The layout of this struct is known to the compiler.
+struct IDDescriptor {
+    unsigned int offset;
+    unsigned int length;
+};
+
+void sorbet_vm_intern_ids(ID *idTable, struct IDDescriptor *idDescriptors, size_t numIDs, const char *stringTable) {
+    for (size_t i = 0; i < numIDs; ++i) {
+        const struct IDDescriptor *desc = &idDescriptors[i];
+        idTable[i] = rb_intern2(&stringTable[desc->offset], desc->length);
+    }
+}

--- a/test/testdata/compiler/all_arguments.opt.ll.exp
+++ b/test/testdata/compiler/all_arguments.opt.ll.exp
@@ -82,24 +82,13 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_Object#14take_arguments" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@rubyIdPrecomputed_take_arguments = internal unnamed_addr global i64 0, align 8
 @rubyStrFrozen_take_arguments = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/all_arguments.rb" = internal unnamed_addr global i64 0, align 8
-@rubyIdPrecomputed_g = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [32 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
-@rubyIdPrecomputed_d = internal unnamed_addr global i64 0, align 8
-@rubyIdPrecomputed_e = internal unnamed_addr global i64 0, align 8
 @ic_inspect = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_inspect = internal unnamed_addr global i64 0, align 8
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@rubyIdPrecomputed_a = internal unnamed_addr global i64 0, align 8
-@rubyIdPrecomputed_b = internal unnamed_addr global i64 0, align 8
-@rubyIdPrecomputed_c = internal unnamed_addr global i64 0, align 8
-@rubyIdPrecomputed_f = internal unnamed_addr global i64 0, align 8
 @ic_take_arguments = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_take_arguments.1 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_take_arguments.2 = internal global %struct.FunctionInlineCache zeroinitializer
@@ -114,7 +103,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ic_take_arguments.11 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_take_arguments.12 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_take_arguments.13 = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_baz = internal unnamed_addr global i64 0, align 8
 @ic_take_arguments.14 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_take_arguments.15 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_take_arguments.16 = internal global %struct.FunctionInlineCache zeroinitializer
@@ -123,6 +111,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ic_take_arguments.19 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_take_arguments.20 = internal global %struct.FunctionInlineCache zeroinitializer
 @sorbet_moduleStringTable = internal unnamed_addr constant [138 x i8] c"take_arguments\00test/testdata/compiler/all_arguments.rb\00g\00d\00e\00<build-array>\00inspect\00puts\00<top (required)>\00normal\00Object\00a\00b\00c\00f\00baz\00master\00", align 1
+@sorbet_moduleIDTable = internal unnamed_addr global [14 x i64] zeroinitializer, align 8
+@sorbet_moduleIDDescriptors = internal unnamed_addr constant [14 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 14 }, %struct.rb_code_position_struct { i32 55, i32 1 }, %struct.rb_code_position_struct { i32 57, i32 1 }, %struct.rb_code_position_struct { i32 59, i32 1 }, %struct.rb_code_position_struct { i32 61, i32 13 }, %struct.rb_code_position_struct { i32 75, i32 7 }, %struct.rb_code_position_struct { i32 83, i32 4 }, %struct.rb_code_position_struct { i32 88, i32 16 }, %struct.rb_code_position_struct { i32 105, i32 6 }, %struct.rb_code_position_struct { i32 119, i32 1 }, %struct.rb_code_position_struct { i32 121, i32 1 }, %struct.rb_code_position_struct { i32 123, i32 1 }, %struct.rb_code_position_struct { i32 125, i32 1 }, %struct.rb_code_position_struct { i32 127, i32 3 }], align 8
 @rb_cObject = external local_unnamed_addr constant i64
 
 ; Function Attrs: nounwind readnone willreturn
@@ -152,13 +142,13 @@ declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %
 
 declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #2
 
+declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #2
+
 declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #2
 
 declare i32 @rb_block_given_p() local_unnamed_addr #2
 
 declare i64 @rb_block_proc() local_unnamed_addr #2
-
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #2
 
 declare i64 @rb_ary_new_from_values(i64, i64*) local_unnamed_addr #2
 
@@ -264,7 +254,7 @@ sorbet_readRestArgs.exit:                         ; preds = %fillFromDefaultBloc
   %"<argPresent>.sroa.0.083" = phi i64 [ %"<argPresent>.sroa.0.084", %fillFromDefaultBlockDone1.thread ], [ 20, %20 ]
   %b.sroa.0.181 = phi i64 [ %b.sroa.0.182, %fillFromDefaultBlockDone1.thread ], [ %rawArg_b, %20 ]
   %25 = phi i64 [ %19, %fillFromDefaultBlockDone1.thread ], [ %24, %20 ], !dbg !16
-  %rubyId_d = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !16
+  %rubyId_d = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !16, !invariant.load !5
   %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_d), !dbg !16
   %26 = icmp eq i64 %29, 52, !dbg !16
   br i1 %26, label %kwArgContinue, label %sorbet_removeKWArg.exit74, !dbg !16
@@ -275,7 +265,7 @@ sorbet_removeKWArg.exit74:                        ; preds = %sorbet_readRestArgs
   br i1 %28, label %kwArgContinue, label %kwArgContinue.thread, !dbg !16
 
 kwArgContinue.thread:                             ; preds = %sorbet_removeKWArg.exit74
-  %rubyId_e87 = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !16
+  %rubyId_e87 = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !16, !invariant.load !5
   %rawSym2088 = tail call i64 @rb_id2sym(i64 %rubyId_e87), !dbg !16
   br label %sorbet_removeKWArg.exit.thread, !dbg !16
 
@@ -316,7 +306,7 @@ sorbet_writeLocal.exit:                           ; preds = %41, %43
 
 kwArgContinue:                                    ; preds = %sorbet_readRestArgs.exit, %sorbet_removeKWArg.exit74
   %44 = tail call i64 @sorbet_addMissingKWArg(i64 noundef 52, i64 %rawSym), !dbg !16
-  %rubyId_e = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !16
+  %rubyId_e = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !16, !invariant.load !5
   %rawSym20 = tail call i64 @rb_id2sym(i64 %rubyId_e), !dbg !16
   br i1 %26, label %sorbet_removeKWArg.exit, label %sorbet_removeKWArg.exit.thread, !dbg !16
 
@@ -472,248 +462,124 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %19)
   %20 = bitcast i64* %keywords154.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %20)
-  %21 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 14) #11
-  store i64 %21, i64* @rubyIdPrecomputed_take_arguments, align 8
-  %22 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 55), i64 noundef 1) #11
-  store i64 %22, i64* @rubyIdPrecomputed_g, align 8
-  %23 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 57), i64 noundef 1) #11
-  store i64 %23, i64* @rubyIdPrecomputed_d, align 8
-  %24 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 59), i64 noundef 1) #11
-  store i64 %24, i64* @rubyIdPrecomputed_e, align 8
-  %25 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 61), i64 noundef 13) #11
-  %26 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 75), i64 noundef 7) #11
-  store i64 %26, i64* @rubyIdPrecomputed_inspect, align 8
-  %27 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 83), i64 noundef 4) #11
-  store i64 %27, i64* @rubyIdPrecomputed_puts, align 8
-  %28 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 88), i64 noundef 16) #11
-  store i64 %28, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %29 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 105), i64 noundef 6) #11
-  %30 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 119), i64 noundef 1) #11
-  store i64 %30, i64* @rubyIdPrecomputed_a, align 8
-  %31 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 121), i64 noundef 1) #11
-  store i64 %31, i64* @rubyIdPrecomputed_b, align 8
-  %32 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 123), i64 noundef 1) #11
-  store i64 %32, i64* @rubyIdPrecomputed_c, align 8
-  %33 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 125), i64 noundef 1) #11
-  store i64 %33, i64* @rubyIdPrecomputed_f, align 8
-  %34 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 127), i64 noundef 3) #11
-  store i64 %34, i64* @rubyIdPrecomputed_baz, align 8
-  %35 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 14) #11
-  tail call void @rb_gc_register_mark_object(i64 %35) #11
-  store i64 %35, i64* @rubyStrFrozen_take_arguments, align 8
-  %36 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 15), i64 noundef 39) #11
-  tail call void @rb_gc_register_mark_object(i64 %36) #11
-  store i64 %36, i64* @"rubyStrFrozen_test/testdata/compiler/all_arguments.rb", align 8
+  tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([14 x %struct.rb_code_position_struct], [14 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 14, i8* noundef getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
+  %21 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 14) #11
+  tail call void @rb_gc_register_mark_object(i64 %21) #11
+  store i64 %21, i64* @rubyStrFrozen_take_arguments, align 8
+  %22 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 15), i64 noundef 39) #11
+  tail call void @rb_gc_register_mark_object(i64 %22) #11
+  store i64 %22, i64* @"rubyStrFrozen_test/testdata/compiler/all_arguments.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 32)
-  %37 = bitcast i64* %locals.i.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %37)
-  %rubyId_take_arguments.i.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8
+  %23 = bitcast i64* %locals.i.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %23)
+  %rubyId_take_arguments.i.i = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
   %rubyStr_take_arguments.i.i = load i64, i64* @rubyStrFrozen_take_arguments, align 8
   %"rubyStr_test/testdata/compiler/all_arguments.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/all_arguments.rb", align 8
-  %rubyId_g.i.i = load i64, i64* @rubyIdPrecomputed_g, align 8
+  %rubyId_g.i.i = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !invariant.load !5
   store i64 %rubyId_g.i.i, i64* %locals.i.i, align 8
-  %38 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_take_arguments.i.i, i64 %rubyId_take_arguments.i.i, i64 %"rubyStr_test/testdata/compiler/all_arguments.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i.i, i32 noundef 1, i32 noundef 8)
-  store %struct.rb_iseq_struct* %38, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#14take_arguments", align 8
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %37)
-  %rubyId_inspect.i = load i64, i64* @rubyIdPrecomputed_inspect, align 8, !dbg !29
+  %24 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_take_arguments.i.i, i64 %rubyId_take_arguments.i.i, i64 %"rubyStr_test/testdata/compiler/all_arguments.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i.i, i32 noundef 1, i32 noundef 8)
+  store %struct.rb_iseq_struct* %24, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#14take_arguments", align 8
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %23)
+  %rubyId_inspect.i = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 5), align 8, !dbg !29, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_inspect, i64 %rubyId_inspect.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !29
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !36
+  %rubyId_puts.i = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 6), align 8, !dbg !36, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !36
-  %39 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 88), i64 noundef 16) #11
-  call void @rb_gc_register_mark_object(i64 %39) #11
-  %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
+  %25 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 88), i64 noundef 16) #11
+  call void @rb_gc_register_mark_object(i64 %25) #11
+  %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 7), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/all_arguments.rb.i163.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/all_arguments.rb", align 8
-  %40 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %39, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/all_arguments.rb.i163.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i164.i, i32 noundef 0, i32 noundef 11)
-  store %struct.rb_iseq_struct* %40, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %rubyId_take_arguments.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !39
-  %rubyId_d.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !39
-  %41 = call i64 @rb_id2sym(i64 %rubyId_d.i) #13, !dbg !39
-  store i64 %41, i64* %keywords.i, align 8, !dbg !39
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments, i64 %rubyId_take_arguments.i, i32 noundef 68, i32 noundef 8, i32 noundef 1, i64* noundef nonnull align 8 %keywords.i), !dbg !39
-  %rubyId_take_arguments3.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !40
-  %rubyId_d5.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !40
-  %42 = call i64 @rb_id2sym(i64 %rubyId_d5.i) #13, !dbg !40
-  store i64 %42, i64* %keywords4.i, align 8, !dbg !40
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.1, i64 %rubyId_take_arguments3.i, i32 noundef 68, i32 noundef 7, i32 noundef 1, i64* noundef nonnull align 8 %keywords4.i), !dbg !40
-  %rubyId_take_arguments9.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !41
-  %rubyId_d11.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !41
-  %43 = call i64 @rb_id2sym(i64 %rubyId_d11.i) #13, !dbg !41
-  store i64 %43, i64* %keywords10.i, align 8, !dbg !41
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.2, i64 %rubyId_take_arguments9.i, i32 noundef 68, i32 noundef 6, i32 noundef 1, i64* noundef nonnull align 8 %keywords10.i), !dbg !41
-  %rubyId_take_arguments15.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !42
-  %rubyId_d17.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !42
-  %44 = call i64 @rb_id2sym(i64 %rubyId_d17.i) #13, !dbg !42
-  store i64 %44, i64* %keywords16.i, align 8, !dbg !42
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.3, i64 %rubyId_take_arguments15.i, i32 noundef 68, i32 noundef 5, i32 noundef 1, i64* noundef nonnull align 8 %keywords16.i), !dbg !42
-  %rubyId_take_arguments21.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !43
-  %rubyId_d23.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !43
-  %45 = call i64 @rb_id2sym(i64 %rubyId_d23.i) #13, !dbg !43
-  store i64 %45, i64* %keywords22.i, align 8, !dbg !43
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.4, i64 %rubyId_take_arguments21.i, i32 noundef 68, i32 noundef 4, i32 noundef 1, i64* noundef nonnull align 8 %keywords22.i), !dbg !43
-  %rubyId_take_arguments27.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !44
-  %rubyId_d29.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !44
-  %46 = call i64 @rb_id2sym(i64 %rubyId_d29.i) #13, !dbg !44
-  store i64 %46, i64* %keywords28.i, align 8, !dbg !44
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.5, i64 %rubyId_take_arguments27.i, i32 noundef 68, i32 noundef 3, i32 noundef 1, i64* noundef nonnull align 8 %keywords28.i), !dbg !44
-  %rubyId_take_arguments33.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !45
-  %rubyId_d35.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !45
-  %47 = call i64 @rb_id2sym(i64 %rubyId_d35.i) #13, !dbg !45
-  store i64 %47, i64* %keywords34.i, align 8, !dbg !45
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.6, i64 %rubyId_take_arguments33.i, i32 noundef 68, i32 noundef 2, i32 noundef 1, i64* noundef nonnull align 8 %keywords34.i), !dbg !45
-  %rubyId_take_arguments39.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !46
-  %rubyId_d41.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !46
-  %48 = call i64 @rb_id2sym(i64 %rubyId_d41.i) #13, !dbg !46
-  store i64 %48, i64* %keywords40.i, align 8, !dbg !46
-  %rubyId_e.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !46
-  %49 = call i64 @rb_id2sym(i64 %rubyId_e.i) #13, !dbg !46
-  %50 = getelementptr i64, i64* %keywords40.i, i32 1, !dbg !46
-  store i64 %49, i64* %50, align 8, !dbg !46
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.7, i64 %rubyId_take_arguments39.i, i32 noundef 68, i32 noundef 9, i32 noundef 2, i64* noundef nonnull align 8 %keywords40.i), !dbg !46
-  %rubyId_take_arguments46.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !47
-  %rubyId_d48.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !47
-  %51 = call i64 @rb_id2sym(i64 %rubyId_d48.i) #13, !dbg !47
-  store i64 %51, i64* %keywords47.i, align 8, !dbg !47
-  %rubyId_e50.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !47
-  %52 = call i64 @rb_id2sym(i64 %rubyId_e50.i) #13, !dbg !47
-  %53 = getelementptr i64, i64* %keywords47.i, i32 1, !dbg !47
-  store i64 %52, i64* %53, align 8, !dbg !47
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.8, i64 %rubyId_take_arguments46.i, i32 noundef 68, i32 noundef 8, i32 noundef 2, i64* noundef nonnull align 8 %keywords47.i), !dbg !47
-  %rubyId_take_arguments54.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !48
-  %rubyId_d56.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !48
-  %54 = call i64 @rb_id2sym(i64 %rubyId_d56.i) #13, !dbg !48
-  store i64 %54, i64* %keywords55.i, align 8, !dbg !48
-  %rubyId_e58.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !48
-  %55 = call i64 @rb_id2sym(i64 %rubyId_e58.i) #13, !dbg !48
-  %56 = getelementptr i64, i64* %keywords55.i, i32 1, !dbg !48
-  store i64 %55, i64* %56, align 8, !dbg !48
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.9, i64 %rubyId_take_arguments54.i, i32 noundef 68, i32 noundef 7, i32 noundef 2, i64* noundef nonnull align 8 %keywords55.i), !dbg !48
-  %rubyId_take_arguments62.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !49
-  %rubyId_d64.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !49
-  %57 = call i64 @rb_id2sym(i64 %rubyId_d64.i) #13, !dbg !49
-  store i64 %57, i64* %keywords63.i, align 8, !dbg !49
-  %rubyId_e66.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !49
-  %58 = call i64 @rb_id2sym(i64 %rubyId_e66.i) #13, !dbg !49
-  %59 = getelementptr i64, i64* %keywords63.i, i32 1, !dbg !49
-  store i64 %58, i64* %59, align 8, !dbg !49
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.10, i64 %rubyId_take_arguments62.i, i32 noundef 68, i32 noundef 6, i32 noundef 2, i64* noundef nonnull align 8 %keywords63.i), !dbg !49
-  %rubyId_take_arguments70.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !50
-  %rubyId_d72.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !50
-  %60 = call i64 @rb_id2sym(i64 %rubyId_d72.i) #13, !dbg !50
-  store i64 %60, i64* %keywords71.i, align 8, !dbg !50
-  %rubyId_e74.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !50
-  %61 = call i64 @rb_id2sym(i64 %rubyId_e74.i) #13, !dbg !50
-  %62 = getelementptr i64, i64* %keywords71.i, i32 1, !dbg !50
-  store i64 %61, i64* %62, align 8, !dbg !50
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.11, i64 %rubyId_take_arguments70.i, i32 noundef 68, i32 noundef 5, i32 noundef 2, i64* noundef nonnull align 8 %keywords71.i), !dbg !50
-  %rubyId_take_arguments78.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !51
-  %rubyId_d80.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !51
-  %63 = call i64 @rb_id2sym(i64 %rubyId_d80.i) #13, !dbg !51
-  store i64 %63, i64* %keywords79.i, align 8, !dbg !51
-  %rubyId_e82.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !51
-  %64 = call i64 @rb_id2sym(i64 %rubyId_e82.i) #13, !dbg !51
-  %65 = getelementptr i64, i64* %keywords79.i, i32 1, !dbg !51
-  store i64 %64, i64* %65, align 8, !dbg !51
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.12, i64 %rubyId_take_arguments78.i, i32 noundef 68, i32 noundef 4, i32 noundef 2, i64* noundef nonnull align 8 %keywords79.i), !dbg !51
-  %rubyId_take_arguments86.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !52
-  %rubyId_d88.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !52
-  %66 = call i64 @rb_id2sym(i64 %rubyId_d88.i) #13, !dbg !52
-  store i64 %66, i64* %keywords87.i, align 8, !dbg !52
-  %rubyId_e90.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !52
-  %67 = call i64 @rb_id2sym(i64 %rubyId_e90.i) #13, !dbg !52
-  %68 = getelementptr i64, i64* %keywords87.i, i32 1, !dbg !52
-  store i64 %67, i64* %68, align 8, !dbg !52
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.13, i64 %rubyId_take_arguments86.i, i32 noundef 68, i32 noundef 3, i32 noundef 2, i64* noundef nonnull align 8 %keywords87.i), !dbg !52
-  %rubyId_take_arguments94.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !53
-  %rubyId_d96.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !53
-  %69 = call i64 @rb_id2sym(i64 %rubyId_d96.i) #13, !dbg !53
-  store i64 %69, i64* %keywords95.i, align 8, !dbg !53
-  %rubyId_e98.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !53
-  %70 = call i64 @rb_id2sym(i64 %rubyId_e98.i) #13, !dbg !53
-  %71 = getelementptr i64, i64* %keywords95.i, i32 1, !dbg !53
-  store i64 %70, i64* %71, align 8, !dbg !53
-  %rubyId_baz.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !53
-  %72 = call i64 @rb_id2sym(i64 %rubyId_baz.i) #13, !dbg !53
-  %73 = getelementptr i64, i64* %keywords95.i, i32 2, !dbg !53
-  store i64 %72, i64* %73, align 8, !dbg !53
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.14, i64 %rubyId_take_arguments94.i, i32 noundef 68, i32 noundef 10, i32 noundef 3, i64* noundef nonnull align 8 %keywords95.i), !dbg !53
-  %rubyId_take_arguments103.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !54
-  %rubyId_d105.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !54
-  %74 = call i64 @rb_id2sym(i64 %rubyId_d105.i) #13, !dbg !54
-  store i64 %74, i64* %keywords104.i, align 8, !dbg !54
-  %rubyId_e107.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !54
-  %75 = call i64 @rb_id2sym(i64 %rubyId_e107.i) #13, !dbg !54
-  %76 = getelementptr i64, i64* %keywords104.i, i32 1, !dbg !54
-  store i64 %75, i64* %76, align 8, !dbg !54
-  %rubyId_baz109.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !54
-  %77 = call i64 @rb_id2sym(i64 %rubyId_baz109.i) #13, !dbg !54
-  %78 = getelementptr i64, i64* %keywords104.i, i32 2, !dbg !54
-  store i64 %77, i64* %78, align 8, !dbg !54
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.15, i64 %rubyId_take_arguments103.i, i32 noundef 68, i32 noundef 9, i32 noundef 3, i64* noundef nonnull align 8 %keywords104.i), !dbg !54
-  %rubyId_take_arguments113.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !55
-  %rubyId_d115.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !55
-  %79 = call i64 @rb_id2sym(i64 %rubyId_d115.i) #13, !dbg !55
-  store i64 %79, i64* %keywords114.i, align 8, !dbg !55
-  %rubyId_e117.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !55
-  %80 = call i64 @rb_id2sym(i64 %rubyId_e117.i) #13, !dbg !55
-  %81 = getelementptr i64, i64* %keywords114.i, i32 1, !dbg !55
-  store i64 %80, i64* %81, align 8, !dbg !55
-  %rubyId_baz119.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !55
-  %82 = call i64 @rb_id2sym(i64 %rubyId_baz119.i) #13, !dbg !55
-  %83 = getelementptr i64, i64* %keywords114.i, i32 2, !dbg !55
-  store i64 %82, i64* %83, align 8, !dbg !55
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.16, i64 %rubyId_take_arguments113.i, i32 noundef 68, i32 noundef 8, i32 noundef 3, i64* noundef nonnull align 8 %keywords114.i), !dbg !55
-  %rubyId_take_arguments123.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !56
-  %rubyId_d125.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !56
-  %84 = call i64 @rb_id2sym(i64 %rubyId_d125.i) #13, !dbg !56
-  store i64 %84, i64* %keywords124.i, align 8, !dbg !56
-  %rubyId_e127.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !56
-  %85 = call i64 @rb_id2sym(i64 %rubyId_e127.i) #13, !dbg !56
-  %86 = getelementptr i64, i64* %keywords124.i, i32 1, !dbg !56
-  store i64 %85, i64* %86, align 8, !dbg !56
-  %rubyId_baz129.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !56
-  %87 = call i64 @rb_id2sym(i64 %rubyId_baz129.i) #13, !dbg !56
-  %88 = getelementptr i64, i64* %keywords124.i, i32 2, !dbg !56
-  store i64 %87, i64* %88, align 8, !dbg !56
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.17, i64 %rubyId_take_arguments123.i, i32 noundef 68, i32 noundef 7, i32 noundef 3, i64* noundef nonnull align 8 %keywords124.i), !dbg !56
-  %rubyId_take_arguments133.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !57
-  %rubyId_d135.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !57
-  %89 = call i64 @rb_id2sym(i64 %rubyId_d135.i) #13, !dbg !57
-  store i64 %89, i64* %keywords134.i, align 8, !dbg !57
-  %rubyId_e137.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !57
-  %90 = call i64 @rb_id2sym(i64 %rubyId_e137.i) #13, !dbg !57
-  %91 = getelementptr i64, i64* %keywords134.i, i32 1, !dbg !57
-  store i64 %90, i64* %91, align 8, !dbg !57
-  %rubyId_baz139.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !57
-  %92 = call i64 @rb_id2sym(i64 %rubyId_baz139.i) #13, !dbg !57
-  %93 = getelementptr i64, i64* %keywords134.i, i32 2, !dbg !57
-  store i64 %92, i64* %93, align 8, !dbg !57
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.18, i64 %rubyId_take_arguments133.i, i32 noundef 68, i32 noundef 6, i32 noundef 3, i64* noundef nonnull align 8 %keywords134.i), !dbg !57
-  %rubyId_take_arguments143.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !58
-  %rubyId_d145.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !58
-  %94 = call i64 @rb_id2sym(i64 %rubyId_d145.i) #13, !dbg !58
-  store i64 %94, i64* %keywords144.i, align 8, !dbg !58
-  %rubyId_e147.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !58
-  %95 = call i64 @rb_id2sym(i64 %rubyId_e147.i) #13, !dbg !58
-  %96 = getelementptr i64, i64* %keywords144.i, i32 1, !dbg !58
-  store i64 %95, i64* %96, align 8, !dbg !58
-  %rubyId_baz149.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !58
-  %97 = call i64 @rb_id2sym(i64 %rubyId_baz149.i) #13, !dbg !58
-  %98 = getelementptr i64, i64* %keywords144.i, i32 2, !dbg !58
-  store i64 %97, i64* %98, align 8, !dbg !58
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.19, i64 %rubyId_take_arguments143.i, i32 noundef 68, i32 noundef 5, i32 noundef 3, i64* noundef nonnull align 8 %keywords144.i), !dbg !58
-  %rubyId_take_arguments153.i = load i64, i64* @rubyIdPrecomputed_take_arguments, align 8, !dbg !59
-  %rubyId_d155.i = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !59
-  %99 = call i64 @rb_id2sym(i64 %rubyId_d155.i) #13, !dbg !59
-  store i64 %99, i64* %keywords154.i, align 8, !dbg !59
-  %rubyId_e157.i = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !59
-  %100 = call i64 @rb_id2sym(i64 %rubyId_e157.i) #13, !dbg !59
-  %101 = getelementptr i64, i64* %keywords154.i, i32 1, !dbg !59
-  store i64 %100, i64* %101, align 8, !dbg !59
-  %rubyId_baz159.i = load i64, i64* @rubyIdPrecomputed_baz, align 8, !dbg !59
-  %102 = call i64 @rb_id2sym(i64 %rubyId_baz159.i) #13, !dbg !59
-  %103 = getelementptr i64, i64* %keywords154.i, i32 2, !dbg !59
-  store i64 %102, i64* %103, align 8, !dbg !59
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.20, i64 %rubyId_take_arguments153.i, i32 noundef 68, i32 noundef 4, i32 noundef 3, i64* noundef nonnull align 8 %keywords154.i), !dbg !59
+  %26 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %25, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/all_arguments.rb.i163.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i164.i, i32 noundef 0, i32 noundef 11)
+  store %struct.rb_iseq_struct* %26, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %rubyId_d.i = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !39, !invariant.load !5
+  %27 = call i64 @rb_id2sym(i64 %rubyId_d.i) #13, !dbg !39
+  store i64 %27, i64* %keywords.i, align 8, !dbg !39
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 8, i32 noundef 1, i64* noundef nonnull align 8 %keywords.i), !dbg !39
+  store i64 %27, i64* %keywords4.i, align 8, !dbg !40
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.1, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 7, i32 noundef 1, i64* noundef nonnull align 8 %keywords4.i), !dbg !40
+  store i64 %27, i64* %keywords10.i, align 8, !dbg !41
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.2, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 6, i32 noundef 1, i64* noundef nonnull align 8 %keywords10.i), !dbg !41
+  store i64 %27, i64* %keywords16.i, align 8, !dbg !42
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.3, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 5, i32 noundef 1, i64* noundef nonnull align 8 %keywords16.i), !dbg !42
+  store i64 %27, i64* %keywords22.i, align 8, !dbg !43
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.4, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 4, i32 noundef 1, i64* noundef nonnull align 8 %keywords22.i), !dbg !43
+  store i64 %27, i64* %keywords28.i, align 8, !dbg !44
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.5, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 3, i32 noundef 1, i64* noundef nonnull align 8 %keywords28.i), !dbg !44
+  store i64 %27, i64* %keywords34.i, align 8, !dbg !45
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.6, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 2, i32 noundef 1, i64* noundef nonnull align 8 %keywords34.i), !dbg !45
+  store i64 %27, i64* %keywords40.i, align 8, !dbg !46
+  %rubyId_e.i = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !46, !invariant.load !5
+  %28 = call i64 @rb_id2sym(i64 %rubyId_e.i) #13, !dbg !46
+  %29 = getelementptr i64, i64* %keywords40.i, i32 1, !dbg !46
+  store i64 %28, i64* %29, align 8, !dbg !46
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.7, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 9, i32 noundef 2, i64* noundef nonnull align 8 %keywords40.i), !dbg !46
+  store i64 %27, i64* %keywords47.i, align 8, !dbg !47
+  %30 = getelementptr i64, i64* %keywords47.i, i32 1, !dbg !47
+  store i64 %28, i64* %30, align 8, !dbg !47
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.8, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 8, i32 noundef 2, i64* noundef nonnull align 8 %keywords47.i), !dbg !47
+  store i64 %27, i64* %keywords55.i, align 8, !dbg !48
+  %31 = getelementptr i64, i64* %keywords55.i, i32 1, !dbg !48
+  store i64 %28, i64* %31, align 8, !dbg !48
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.9, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 7, i32 noundef 2, i64* noundef nonnull align 8 %keywords55.i), !dbg !48
+  store i64 %27, i64* %keywords63.i, align 8, !dbg !49
+  %32 = getelementptr i64, i64* %keywords63.i, i32 1, !dbg !49
+  store i64 %28, i64* %32, align 8, !dbg !49
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.10, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 6, i32 noundef 2, i64* noundef nonnull align 8 %keywords63.i), !dbg !49
+  store i64 %27, i64* %keywords71.i, align 8, !dbg !50
+  %33 = getelementptr i64, i64* %keywords71.i, i32 1, !dbg !50
+  store i64 %28, i64* %33, align 8, !dbg !50
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.11, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 5, i32 noundef 2, i64* noundef nonnull align 8 %keywords71.i), !dbg !50
+  store i64 %27, i64* %keywords79.i, align 8, !dbg !51
+  %34 = getelementptr i64, i64* %keywords79.i, i32 1, !dbg !51
+  store i64 %28, i64* %34, align 8, !dbg !51
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.12, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 4, i32 noundef 2, i64* noundef nonnull align 8 %keywords79.i), !dbg !51
+  store i64 %27, i64* %keywords87.i, align 8, !dbg !52
+  %35 = getelementptr i64, i64* %keywords87.i, i32 1, !dbg !52
+  store i64 %28, i64* %35, align 8, !dbg !52
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.13, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 3, i32 noundef 2, i64* noundef nonnull align 8 %keywords87.i), !dbg !52
+  store i64 %27, i64* %keywords95.i, align 8, !dbg !53
+  %36 = getelementptr i64, i64* %keywords95.i, i32 1, !dbg !53
+  store i64 %28, i64* %36, align 8, !dbg !53
+  %rubyId_baz.i = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 13), align 8, !dbg !53, !invariant.load !5
+  %37 = call i64 @rb_id2sym(i64 %rubyId_baz.i) #13, !dbg !53
+  %38 = getelementptr i64, i64* %keywords95.i, i32 2, !dbg !53
+  store i64 %37, i64* %38, align 8, !dbg !53
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.14, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 10, i32 noundef 3, i64* noundef nonnull align 8 %keywords95.i), !dbg !53
+  store i64 %27, i64* %keywords104.i, align 8, !dbg !54
+  %39 = getelementptr i64, i64* %keywords104.i, i32 1, !dbg !54
+  store i64 %28, i64* %39, align 8, !dbg !54
+  %40 = getelementptr i64, i64* %keywords104.i, i32 2, !dbg !54
+  store i64 %37, i64* %40, align 8, !dbg !54
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.15, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 9, i32 noundef 3, i64* noundef nonnull align 8 %keywords104.i), !dbg !54
+  store i64 %27, i64* %keywords114.i, align 8, !dbg !55
+  %41 = getelementptr i64, i64* %keywords114.i, i32 1, !dbg !55
+  store i64 %28, i64* %41, align 8, !dbg !55
+  %42 = getelementptr i64, i64* %keywords114.i, i32 2, !dbg !55
+  store i64 %37, i64* %42, align 8, !dbg !55
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.16, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 8, i32 noundef 3, i64* noundef nonnull align 8 %keywords114.i), !dbg !55
+  store i64 %27, i64* %keywords124.i, align 8, !dbg !56
+  %43 = getelementptr i64, i64* %keywords124.i, i32 1, !dbg !56
+  store i64 %28, i64* %43, align 8, !dbg !56
+  %44 = getelementptr i64, i64* %keywords124.i, i32 2, !dbg !56
+  store i64 %37, i64* %44, align 8, !dbg !56
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.17, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 7, i32 noundef 3, i64* noundef nonnull align 8 %keywords124.i), !dbg !56
+  store i64 %27, i64* %keywords134.i, align 8, !dbg !57
+  %45 = getelementptr i64, i64* %keywords134.i, i32 1, !dbg !57
+  store i64 %28, i64* %45, align 8, !dbg !57
+  %46 = getelementptr i64, i64* %keywords134.i, i32 2, !dbg !57
+  store i64 %37, i64* %46, align 8, !dbg !57
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.18, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 6, i32 noundef 3, i64* noundef nonnull align 8 %keywords134.i), !dbg !57
+  store i64 %27, i64* %keywords144.i, align 8, !dbg !58
+  %47 = getelementptr i64, i64* %keywords144.i, i32 1, !dbg !58
+  store i64 %28, i64* %47, align 8, !dbg !58
+  %48 = getelementptr i64, i64* %keywords144.i, i32 2, !dbg !58
+  store i64 %37, i64* %48, align 8, !dbg !58
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.19, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 5, i32 noundef 3, i64* noundef nonnull align 8 %keywords144.i), !dbg !58
+  store i64 %27, i64* %keywords154.i, align 8, !dbg !59
+  %49 = getelementptr i64, i64* %keywords154.i, i32 1, !dbg !59
+  store i64 %28, i64* %49, align 8, !dbg !59
+  %50 = getelementptr i64, i64* %keywords154.i, i32 2, !dbg !59
+  store i64 %37, i64* %50, align 8, !dbg !59
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.20, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 4, i32 noundef 3, i64* noundef nonnull align 8 %keywords154.i), !dbg !59
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %0)
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %2)
@@ -735,474 +601,469 @@ entry:
   call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %18)
   call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %19)
   call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %20)
-  %104 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
-  %105 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %104, i64 0, i32 18
-  %106 = load i64, i64* %105, align 8, !tbaa !60
-  %107 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %108 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %107, i64 0, i32 2
-  %109 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %108, align 8, !tbaa !70
-  %110 = bitcast i64* %positional_table.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 32, i8* nonnull %110)
-  %111 = bitcast i64* %keyword_table.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %111)
+  %51 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
+  %52 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %51, i64 0, i32 18
+  %53 = load i64, i64* %52, align 8, !tbaa !60
+  %54 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %55 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %54, i64 0, i32 2
+  %56 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %55, align 8, !tbaa !70
+  %57 = bitcast i64* %positional_table.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 32, i8* nonnull %57)
+  %58 = bitcast i64* %keyword_table.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %58)
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %112 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %112, align 8, !tbaa !73
-  %113 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 4
-  %114 = load i64*, i64** %113, align 8, !tbaa !20
-  %115 = load i64, i64* %114, align 8, !tbaa !6
-  %116 = and i64 %115, -33
-  store i64 %116, i64* %114, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %107, %struct.rb_control_frame_struct* %109, %struct.rb_iseq_struct* %stackFrame.i) #11
-  %117 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 0
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %117, align 8, !dbg !74, !tbaa !14
-  %118 = load i64, i64* @rb_cObject, align 8, !dbg !37
+  %59 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %59, align 8, !tbaa !73
+  %60 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 4
+  %61 = load i64*, i64** %60, align 8, !tbaa !20
+  %62 = load i64, i64* %61, align 8, !tbaa !6
+  %63 = and i64 %62, -33
+  store i64 %63, i64* %61, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %54, %struct.rb_control_frame_struct* %56, %struct.rb_iseq_struct* %stackFrame.i) #11
+  %64 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 0
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %64, align 8, !dbg !74, !tbaa !14
+  %65 = load i64, i64* @rb_cObject, align 8, !dbg !37
   %stackFrame386.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#14take_arguments", align 8, !dbg !37
-  %119 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #14, !dbg !37
-  %120 = bitcast i8* %119 to i16*, !dbg !37
-  %121 = load i16, i16* %120, align 8, !dbg !37
-  %122 = and i16 %121, -384, !dbg !37
-  %123 = or i16 %122, 119, !dbg !37
-  store i16 %123, i16* %120, align 8, !dbg !37
-  %124 = getelementptr inbounds i8, i8* %119, i64 8, !dbg !37
-  %125 = bitcast i8* %124 to i32*, !dbg !37
-  %126 = getelementptr inbounds i8, i8* %119, i64 12, !dbg !37
-  %127 = bitcast i8* %126 to i32*, !dbg !37
-  %128 = getelementptr inbounds i8, i8* %119, i64 16, !dbg !37
-  %129 = getelementptr inbounds i8, i8* %119, i64 20, !dbg !37
-  %130 = bitcast i8* %129 to i32*, !dbg !37
-  store i32 0, i32* %130, align 4, !dbg !37, !tbaa !75
-  %131 = getelementptr inbounds i8, i8* %119, i64 24, !dbg !37
-  %132 = bitcast i8* %131 to i32*, !dbg !37
-  store i32 0, i32* %132, align 8, !dbg !37, !tbaa !78
-  %133 = getelementptr inbounds i8, i8* %119, i64 28, !dbg !37
-  %134 = bitcast i8* %133 to i32*, !dbg !37
-  store i32 3, i32* %134, align 4, !dbg !37, !tbaa !79
-  %135 = getelementptr inbounds i8, i8* %119, i64 4, !dbg !37
-  %136 = bitcast i8* %135 to i32*, !dbg !37
-  %137 = bitcast i32* %136 to <4 x i32>*, !dbg !37
-  store <4 x i32> <i32 7, i32 1, i32 1, i32 2>, <4 x i32>* %137, align 4, !dbg !37, !tbaa !80
-  %rubyId_a.i = load i64, i64* @rubyIdPrecomputed_a, align 8, !dbg !37
-  store i64 %rubyId_a.i, i64* %positional_table.i, align 8, !dbg !37
-  %rubyId_b.i = load i64, i64* @rubyIdPrecomputed_b, align 8, !dbg !37
-  %138 = getelementptr i64, i64* %positional_table.i, i32 1, !dbg !37
-  store i64 %rubyId_b.i, i64* %138, align 8, !dbg !37
-  %rubyId_c.i = load i64, i64* @rubyIdPrecomputed_c, align 8, !dbg !37
-  %139 = getelementptr i64, i64* %positional_table.i, i32 2, !dbg !37
-  store i64 %rubyId_c.i, i64* %139, align 8, !dbg !37
-  %rubyId_g.i = load i64, i64* @rubyIdPrecomputed_g, align 8, !dbg !37
-  %140 = getelementptr i64, i64* %positional_table.i, i32 3, !dbg !37
-  store i64 %rubyId_g.i, i64* %140, align 8, !dbg !37
-  %141 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 4, i64 noundef 8) #14, !dbg !37
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %141, i8* nocapture noundef nonnull readonly align 8 dereferenceable(24) %110, i64 noundef 32, i1 noundef false) #11, !dbg !37
-  %142 = getelementptr inbounds i8, i8* %119, i64 32, !dbg !37
-  %143 = bitcast i8* %142 to i8**, !dbg !37
-  store i8* %141, i8** %143, align 8, !dbg !37, !tbaa !81
-  %rubyId_d.i1 = load i64, i64* @rubyIdPrecomputed_d, align 8, !dbg !37
-  store i64 %rubyId_d.i1, i64* %keyword_table.i, align 8, !dbg !37
-  %rubyId_e.i2 = load i64, i64* @rubyIdPrecomputed_e, align 8, !dbg !37
-  %144 = getelementptr i64, i64* %keyword_table.i, i32 1, !dbg !37
-  store i64 %rubyId_e.i2, i64* %144, align 8, !dbg !37
-  %rubyId_f.i = load i64, i64* @rubyIdPrecomputed_f, align 8, !dbg !37
-  %145 = getelementptr i64, i64* %keyword_table.i, i32 2, !dbg !37
-  store i64 %rubyId_f.i, i64* %145, align 8, !dbg !37
-  %146 = getelementptr inbounds i8, i8* %119, i64 40, !dbg !37
-  %147 = bitcast i8* %146 to i32*, !dbg !37
-  store i32 2, i32* %147, align 8, !dbg !37, !tbaa !82
-  %148 = getelementptr inbounds i8, i8* %119, i64 44, !dbg !37
-  %149 = bitcast i8* %148 to i32*, !dbg !37
-  store i32 1, i32* %149, align 4, !dbg !37, !tbaa !83
-  %150 = load i32, i32* %125, align 8, !dbg !37, !tbaa !84
-  %151 = load i32, i32* %127, align 4, !dbg !37, !tbaa !85
-  %152 = add i32 %150, 2, !dbg !37
-  %153 = add i32 %152, %151, !dbg !37
-  %154 = getelementptr inbounds i8, i8* %119, i64 48, !dbg !37
-  %155 = bitcast i8* %154 to i32*, !dbg !37
-  store i32 %153, i32* %155, align 8, !dbg !37, !tbaa !86
-  %156 = load i16, i16* %120, align 8, !dbg !37
-  %157 = and i16 %156, 32, !dbg !37
-  %158 = icmp eq i16 %157, 0, !dbg !37
-  br i1 %158, label %"func_<root>.17<static-init>$153.exit", label %159, !dbg !37
+  %66 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #14, !dbg !37
+  %67 = bitcast i8* %66 to i16*, !dbg !37
+  %68 = load i16, i16* %67, align 8, !dbg !37
+  %69 = and i16 %68, -384, !dbg !37
+  %70 = or i16 %69, 119, !dbg !37
+  store i16 %70, i16* %67, align 8, !dbg !37
+  %71 = getelementptr inbounds i8, i8* %66, i64 8, !dbg !37
+  %72 = bitcast i8* %71 to i32*, !dbg !37
+  %73 = getelementptr inbounds i8, i8* %66, i64 12, !dbg !37
+  %74 = bitcast i8* %73 to i32*, !dbg !37
+  %75 = getelementptr inbounds i8, i8* %66, i64 16, !dbg !37
+  %76 = getelementptr inbounds i8, i8* %66, i64 20, !dbg !37
+  %77 = bitcast i8* %76 to i32*, !dbg !37
+  store i32 0, i32* %77, align 4, !dbg !37, !tbaa !75
+  %78 = getelementptr inbounds i8, i8* %66, i64 24, !dbg !37
+  %79 = bitcast i8* %78 to i32*, !dbg !37
+  store i32 0, i32* %79, align 8, !dbg !37, !tbaa !78
+  %80 = getelementptr inbounds i8, i8* %66, i64 28, !dbg !37
+  %81 = bitcast i8* %80 to i32*, !dbg !37
+  store i32 3, i32* %81, align 4, !dbg !37, !tbaa !79
+  %82 = getelementptr inbounds i8, i8* %66, i64 4, !dbg !37
+  %83 = bitcast i8* %82 to i32*, !dbg !37
+  %84 = bitcast i32* %83 to <4 x i32>*, !dbg !37
+  store <4 x i32> <i32 7, i32 1, i32 1, i32 2>, <4 x i32>* %84, align 4, !dbg !37, !tbaa !80
+  %85 = load <2 x i64>, <2 x i64>* bitcast (i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 9) to <2 x i64>*), align 8, !dbg !37, !invariant.load !5
+  %86 = bitcast i64* %positional_table.i to <2 x i64>*, !dbg !37
+  store <2 x i64> %85, <2 x i64>* %86, align 8, !dbg !37
+  %rubyId_c.i = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 11), align 8, !dbg !37, !invariant.load !5
+  %87 = getelementptr i64, i64* %positional_table.i, i32 2, !dbg !37
+  store i64 %rubyId_c.i, i64* %87, align 8, !dbg !37
+  %88 = getelementptr i64, i64* %positional_table.i, i32 3, !dbg !37
+  store i64 %rubyId_g.i.i, i64* %88, align 8, !dbg !37
+  %89 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 4, i64 noundef 8) #14, !dbg !37
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %89, i8* nocapture noundef nonnull readonly align 8 dereferenceable(24) %57, i64 noundef 32, i1 noundef false) #11, !dbg !37
+  %90 = getelementptr inbounds i8, i8* %66, i64 32, !dbg !37
+  %91 = bitcast i8* %90 to i8**, !dbg !37
+  store i8* %89, i8** %91, align 8, !dbg !37, !tbaa !81
+  store i64 %rubyId_d.i, i64* %keyword_table.i, align 8, !dbg !37
+  %92 = getelementptr i64, i64* %keyword_table.i, i32 1, !dbg !37
+  store i64 %rubyId_e.i, i64* %92, align 8, !dbg !37
+  %rubyId_f.i = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 12), align 8, !dbg !37, !invariant.load !5
+  %93 = getelementptr i64, i64* %keyword_table.i, i32 2, !dbg !37
+  store i64 %rubyId_f.i, i64* %93, align 8, !dbg !37
+  %94 = getelementptr inbounds i8, i8* %66, i64 40, !dbg !37
+  %95 = bitcast i8* %94 to i32*, !dbg !37
+  store i32 2, i32* %95, align 8, !dbg !37, !tbaa !82
+  %96 = getelementptr inbounds i8, i8* %66, i64 44, !dbg !37
+  %97 = bitcast i8* %96 to i32*, !dbg !37
+  store i32 1, i32* %97, align 4, !dbg !37, !tbaa !83
+  %98 = load i32, i32* %72, align 8, !dbg !37, !tbaa !84
+  %99 = load i32, i32* %74, align 4, !dbg !37, !tbaa !85
+  %100 = add i32 %98, 2, !dbg !37
+  %101 = add i32 %100, %99, !dbg !37
+  %102 = getelementptr inbounds i8, i8* %66, i64 48, !dbg !37
+  %103 = bitcast i8* %102 to i32*, !dbg !37
+  store i32 %101, i32* %103, align 8, !dbg !37, !tbaa !86
+  %104 = load i16, i16* %67, align 8, !dbg !37
+  %105 = and i16 %104, 32, !dbg !37
+  %106 = icmp eq i16 %105, 0, !dbg !37
+  br i1 %106, label %"func_<root>.17<static-init>$153.exit", label %107, !dbg !37
 
-159:                                              ; preds = %entry
-  %160 = add nsw i32 %153, 1, !dbg !37
-  %161 = getelementptr inbounds i8, i8* %119, i64 52, !dbg !37
-  %162 = bitcast i8* %161 to i32*, !dbg !37
-  store i32 %160, i32* %162, align 4, !dbg !37, !tbaa !87
+107:                                              ; preds = %entry
+  %108 = add nsw i32 %101, 1, !dbg !37
+  %109 = getelementptr inbounds i8, i8* %66, i64 52, !dbg !37
+  %110 = bitcast i8* %109 to i32*, !dbg !37
+  store i32 %108, i32* %110, align 4, !dbg !37, !tbaa !87
   br label %"func_<root>.17<static-init>$153.exit", !dbg !37
 
-"func_<root>.17<static-init>$153.exit":           ; preds = %entry, %159
-  %163 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 3, i64 noundef 8) #14, !dbg !37
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %163, i8* nocapture noundef nonnull readonly align 8 dereferenceable(24) %111, i64 noundef 24, i1 noundef false) #11, !dbg !37
-  %164 = getelementptr inbounds i8, i8* %119, i64 56, !dbg !37
-  %165 = bitcast i8* %164 to i8**, !dbg !37
-  store i8* %163, i8** %165, align 8, !dbg !37, !tbaa !88
-  call void @sorbet_vm_define_method(i64 %118, i8* noundef getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#14take_arguments", i8* nonnull %119, %struct.rb_iseq_struct* %stackFrame386.i, i1 noundef zeroext false) #11, !dbg !37
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %117, align 8, !dbg !37, !tbaa !14
-  %166 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !39
-  %167 = load i64*, i64** %166, align 8, !dbg !39
-  store i64 %106, i64* %167, align 8, !dbg !39, !tbaa !6
-  %168 = getelementptr inbounds i64, i64* %167, i64 1, !dbg !39
-  %169 = getelementptr inbounds i64, i64* %168, i64 1, !dbg !39
-  %170 = getelementptr inbounds i64, i64* %169, i64 1, !dbg !39
-  %171 = getelementptr inbounds i64, i64* %170, i64 1, !dbg !39
-  %172 = bitcast i64* %168 to <4 x i64>*, !dbg !39
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %172, align 8, !dbg !39, !tbaa !6
-  %173 = getelementptr inbounds i64, i64* %171, i64 1, !dbg !39
-  %174 = getelementptr inbounds i64, i64* %173, i64 1, !dbg !39
-  %175 = bitcast i64* %173 to <2 x i64>*, !dbg !39
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %175, align 8, !dbg !39, !tbaa !6
-  %176 = getelementptr inbounds i64, i64* %174, i64 1, !dbg !39
-  store i64 -13, i64* %176, align 8, !dbg !39, !tbaa !6
-  %177 = getelementptr inbounds i64, i64* %176, i64 1, !dbg !39
-  store i64 -15, i64* %177, align 8, !dbg !39, !tbaa !6
-  %178 = getelementptr inbounds i64, i64* %177, i64 1, !dbg !39
-  store i64* %178, i64** %166, align 8, !dbg !39
+"func_<root>.17<static-init>$153.exit":           ; preds = %entry, %107
+  %111 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 3, i64 noundef 8) #14, !dbg !37
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %111, i8* nocapture noundef nonnull readonly align 8 dereferenceable(24) %58, i64 noundef 24, i1 noundef false) #11, !dbg !37
+  %112 = getelementptr inbounds i8, i8* %66, i64 56, !dbg !37
+  %113 = bitcast i8* %112 to i8**, !dbg !37
+  store i8* %111, i8** %113, align 8, !dbg !37, !tbaa !88
+  call void @sorbet_vm_define_method(i64 %65, i8* noundef getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#14take_arguments", i8* nonnull %66, %struct.rb_iseq_struct* %stackFrame386.i, i1 noundef zeroext false) #11, !dbg !37
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %64, align 8, !dbg !37, !tbaa !14
+  %114 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 1, !dbg !39
+  %115 = load i64*, i64** %114, align 8, !dbg !39
+  store i64 %53, i64* %115, align 8, !dbg !39, !tbaa !6
+  %116 = getelementptr inbounds i64, i64* %115, i64 1, !dbg !39
+  %117 = getelementptr inbounds i64, i64* %116, i64 1, !dbg !39
+  %118 = getelementptr inbounds i64, i64* %117, i64 1, !dbg !39
+  %119 = getelementptr inbounds i64, i64* %118, i64 1, !dbg !39
+  %120 = bitcast i64* %116 to <4 x i64>*, !dbg !39
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %120, align 8, !dbg !39, !tbaa !6
+  %121 = getelementptr inbounds i64, i64* %119, i64 1, !dbg !39
+  %122 = getelementptr inbounds i64, i64* %121, i64 1, !dbg !39
+  %123 = bitcast i64* %121 to <2 x i64>*, !dbg !39
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %123, align 8, !dbg !39, !tbaa !6
+  %124 = getelementptr inbounds i64, i64* %122, i64 1, !dbg !39
+  store i64 -13, i64* %124, align 8, !dbg !39, !tbaa !6
+  %125 = getelementptr inbounds i64, i64* %124, i64 1, !dbg !39
+  store i64 -15, i64* %125, align 8, !dbg !39, !tbaa !6
+  %126 = getelementptr inbounds i64, i64* %125, i64 1, !dbg !39
+  store i64* %126, i64** %114, align 8, !dbg !39
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments, i64 0), !dbg !39
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %117, align 8, !dbg !39, !tbaa !14
-  %179 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !40
-  %180 = load i64*, i64** %179, align 8, !dbg !40
-  store i64 %106, i64* %180, align 8, !dbg !40, !tbaa !6
-  %181 = getelementptr inbounds i64, i64* %180, i64 1, !dbg !40
-  %182 = getelementptr inbounds i64, i64* %181, i64 1, !dbg !40
-  %183 = getelementptr inbounds i64, i64* %182, i64 1, !dbg !40
-  %184 = getelementptr inbounds i64, i64* %183, i64 1, !dbg !40
-  %185 = bitcast i64* %181 to <4 x i64>*, !dbg !40
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %185, align 8, !dbg !40, !tbaa !6
-  %186 = getelementptr inbounds i64, i64* %184, i64 1, !dbg !40
-  %187 = getelementptr inbounds i64, i64* %186, i64 1, !dbg !40
-  %188 = bitcast i64* %186 to <2 x i64>*, !dbg !40
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %188, align 8, !dbg !40, !tbaa !6
-  %189 = getelementptr inbounds i64, i64* %187, i64 1, !dbg !40
-  store i64 -15, i64* %189, align 8, !dbg !40, !tbaa !6
-  %190 = getelementptr inbounds i64, i64* %189, i64 1, !dbg !40
-  store i64* %190, i64** %179, align 8, !dbg !40
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %64, align 8, !dbg !39, !tbaa !14
+  %127 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 1, !dbg !40
+  %128 = load i64*, i64** %127, align 8, !dbg !40
+  store i64 %53, i64* %128, align 8, !dbg !40, !tbaa !6
+  %129 = getelementptr inbounds i64, i64* %128, i64 1, !dbg !40
+  %130 = getelementptr inbounds i64, i64* %129, i64 1, !dbg !40
+  %131 = getelementptr inbounds i64, i64* %130, i64 1, !dbg !40
+  %132 = getelementptr inbounds i64, i64* %131, i64 1, !dbg !40
+  %133 = bitcast i64* %129 to <4 x i64>*, !dbg !40
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %133, align 8, !dbg !40, !tbaa !6
+  %134 = getelementptr inbounds i64, i64* %132, i64 1, !dbg !40
+  %135 = getelementptr inbounds i64, i64* %134, i64 1, !dbg !40
+  %136 = bitcast i64* %134 to <2 x i64>*, !dbg !40
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %136, align 8, !dbg !40, !tbaa !6
+  %137 = getelementptr inbounds i64, i64* %135, i64 1, !dbg !40
+  store i64 -15, i64* %137, align 8, !dbg !40, !tbaa !6
+  %138 = getelementptr inbounds i64, i64* %137, i64 1, !dbg !40
+  store i64* %138, i64** %127, align 8, !dbg !40
   %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.1, i64 0), !dbg !40
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %117, align 8, !dbg !40, !tbaa !14
-  %191 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !41
-  %192 = load i64*, i64** %191, align 8, !dbg !41
-  store i64 %106, i64* %192, align 8, !dbg !41, !tbaa !6
-  %193 = getelementptr inbounds i64, i64* %192, i64 1, !dbg !41
-  %194 = getelementptr inbounds i64, i64* %193, i64 1, !dbg !41
-  %195 = getelementptr inbounds i64, i64* %194, i64 1, !dbg !41
-  %196 = getelementptr inbounds i64, i64* %195, i64 1, !dbg !41
-  %197 = bitcast i64* %193 to <4 x i64>*, !dbg !41
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %197, align 8, !dbg !41, !tbaa !6
-  %198 = getelementptr inbounds i64, i64* %196, i64 1, !dbg !41
-  %199 = getelementptr inbounds i64, i64* %198, i64 1, !dbg !41
-  %200 = bitcast i64* %198 to <2 x i64>*, !dbg !41
-  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %200, align 8, !dbg !41, !tbaa !6
-  %201 = getelementptr inbounds i64, i64* %199, i64 1, !dbg !41
-  store i64* %201, i64** %191, align 8, !dbg !41
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %64, align 8, !dbg !40, !tbaa !14
+  %139 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 1, !dbg !41
+  %140 = load i64*, i64** %139, align 8, !dbg !41
+  store i64 %53, i64* %140, align 8, !dbg !41, !tbaa !6
+  %141 = getelementptr inbounds i64, i64* %140, i64 1, !dbg !41
+  %142 = getelementptr inbounds i64, i64* %141, i64 1, !dbg !41
+  %143 = getelementptr inbounds i64, i64* %142, i64 1, !dbg !41
+  %144 = getelementptr inbounds i64, i64* %143, i64 1, !dbg !41
+  %145 = bitcast i64* %141 to <4 x i64>*, !dbg !41
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %145, align 8, !dbg !41, !tbaa !6
+  %146 = getelementptr inbounds i64, i64* %144, i64 1, !dbg !41
+  %147 = getelementptr inbounds i64, i64* %146, i64 1, !dbg !41
+  %148 = bitcast i64* %146 to <2 x i64>*, !dbg !41
+  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %148, align 8, !dbg !41, !tbaa !6
+  %149 = getelementptr inbounds i64, i64* %147, i64 1, !dbg !41
+  store i64* %149, i64** %139, align 8, !dbg !41
   %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.2, i64 0), !dbg !41
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %117, align 8, !dbg !41, !tbaa !14
-  %202 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !42
-  %203 = load i64*, i64** %202, align 8, !dbg !42
-  store i64 %106, i64* %203, align 8, !dbg !42, !tbaa !6
-  %204 = getelementptr inbounds i64, i64* %203, i64 1, !dbg !42
-  %205 = getelementptr inbounds i64, i64* %204, i64 1, !dbg !42
-  %206 = getelementptr inbounds i64, i64* %205, i64 1, !dbg !42
-  %207 = getelementptr inbounds i64, i64* %206, i64 1, !dbg !42
-  %208 = bitcast i64* %204 to <4 x i64>*, !dbg !42
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %208, align 8, !dbg !42, !tbaa !6
-  %209 = getelementptr inbounds i64, i64* %207, i64 1, !dbg !42
-  store i64 -15, i64* %209, align 8, !dbg !42, !tbaa !6
-  %210 = getelementptr inbounds i64, i64* %209, i64 1, !dbg !42
-  store i64* %210, i64** %202, align 8, !dbg !42
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %64, align 8, !dbg !41, !tbaa !14
+  %150 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 1, !dbg !42
+  %151 = load i64*, i64** %150, align 8, !dbg !42
+  store i64 %53, i64* %151, align 8, !dbg !42, !tbaa !6
+  %152 = getelementptr inbounds i64, i64* %151, i64 1, !dbg !42
+  %153 = getelementptr inbounds i64, i64* %152, i64 1, !dbg !42
+  %154 = getelementptr inbounds i64, i64* %153, i64 1, !dbg !42
+  %155 = getelementptr inbounds i64, i64* %154, i64 1, !dbg !42
+  %156 = bitcast i64* %152 to <4 x i64>*, !dbg !42
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %156, align 8, !dbg !42, !tbaa !6
+  %157 = getelementptr inbounds i64, i64* %155, i64 1, !dbg !42
+  store i64 -15, i64* %157, align 8, !dbg !42, !tbaa !6
+  %158 = getelementptr inbounds i64, i64* %157, i64 1, !dbg !42
+  store i64* %158, i64** %150, align 8, !dbg !42
   %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.3, i64 0), !dbg !42
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %117, align 8, !dbg !42, !tbaa !14
-  %211 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !43
-  %212 = load i64*, i64** %211, align 8, !dbg !43
-  store i64 %106, i64* %212, align 8, !dbg !43, !tbaa !6
-  %213 = getelementptr inbounds i64, i64* %212, i64 1, !dbg !43
-  %214 = getelementptr inbounds i64, i64* %213, i64 1, !dbg !43
-  %215 = getelementptr inbounds i64, i64* %214, i64 1, !dbg !43
-  %216 = getelementptr inbounds i64, i64* %215, i64 1, !dbg !43
-  %217 = bitcast i64* %213 to <4 x i64>*, !dbg !43
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %217, align 8, !dbg !43, !tbaa !6
-  %218 = getelementptr inbounds i64, i64* %216, i64 1, !dbg !43
-  store i64* %218, i64** %211, align 8, !dbg !43
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %64, align 8, !dbg !42, !tbaa !14
+  %159 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 1, !dbg !43
+  %160 = load i64*, i64** %159, align 8, !dbg !43
+  store i64 %53, i64* %160, align 8, !dbg !43, !tbaa !6
+  %161 = getelementptr inbounds i64, i64* %160, i64 1, !dbg !43
+  %162 = getelementptr inbounds i64, i64* %161, i64 1, !dbg !43
+  %163 = getelementptr inbounds i64, i64* %162, i64 1, !dbg !43
+  %164 = getelementptr inbounds i64, i64* %163, i64 1, !dbg !43
+  %165 = bitcast i64* %161 to <4 x i64>*, !dbg !43
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %165, align 8, !dbg !43, !tbaa !6
+  %166 = getelementptr inbounds i64, i64* %164, i64 1, !dbg !43
+  store i64* %166, i64** %159, align 8, !dbg !43
   %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.4, i64 0), !dbg !43
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %117, align 8, !dbg !43, !tbaa !14
-  %219 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !44
-  %220 = load i64*, i64** %219, align 8, !dbg !44
-  store i64 %106, i64* %220, align 8, !dbg !44, !tbaa !6
-  %221 = getelementptr inbounds i64, i64* %220, i64 1, !dbg !44
-  %222 = getelementptr inbounds i64, i64* %221, i64 1, !dbg !44
-  %223 = bitcast i64* %221 to <2 x i64>*, !dbg !44
-  store <2 x i64> <i64 -1, i64 -3>, <2 x i64>* %223, align 8, !dbg !44, !tbaa !6
-  %224 = getelementptr inbounds i64, i64* %222, i64 1, !dbg !44
-  store i64 -15, i64* %224, align 8, !dbg !44, !tbaa !6
-  %225 = getelementptr inbounds i64, i64* %224, i64 1, !dbg !44
-  store i64* %225, i64** %219, align 8, !dbg !44
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %64, align 8, !dbg !43, !tbaa !14
+  %167 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 1, !dbg !44
+  %168 = load i64*, i64** %167, align 8, !dbg !44
+  store i64 %53, i64* %168, align 8, !dbg !44, !tbaa !6
+  %169 = getelementptr inbounds i64, i64* %168, i64 1, !dbg !44
+  %170 = getelementptr inbounds i64, i64* %169, i64 1, !dbg !44
+  %171 = bitcast i64* %169 to <2 x i64>*, !dbg !44
+  store <2 x i64> <i64 -1, i64 -3>, <2 x i64>* %171, align 8, !dbg !44, !tbaa !6
+  %172 = getelementptr inbounds i64, i64* %170, i64 1, !dbg !44
+  store i64 -15, i64* %172, align 8, !dbg !44, !tbaa !6
+  %173 = getelementptr inbounds i64, i64* %172, i64 1, !dbg !44
+  store i64* %173, i64** %167, align 8, !dbg !44
   %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.5, i64 0), !dbg !44
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %117, align 8, !dbg !44, !tbaa !14
-  %226 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !45
-  %227 = load i64*, i64** %226, align 8, !dbg !45
-  store i64 %106, i64* %227, align 8, !dbg !45, !tbaa !6
-  %228 = getelementptr inbounds i64, i64* %227, i64 1, !dbg !45
-  %229 = getelementptr inbounds i64, i64* %228, i64 1, !dbg !45
-  %230 = bitcast i64* %228 to <2 x i64>*, !dbg !45
-  store <2 x i64> <i64 -1, i64 -15>, <2 x i64>* %230, align 8, !dbg !45, !tbaa !6
-  %231 = getelementptr inbounds i64, i64* %229, i64 1, !dbg !45
-  store i64* %231, i64** %226, align 8, !dbg !45
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %64, align 8, !dbg !44, !tbaa !14
+  %174 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 1, !dbg !45
+  %175 = load i64*, i64** %174, align 8, !dbg !45
+  store i64 %53, i64* %175, align 8, !dbg !45, !tbaa !6
+  %176 = getelementptr inbounds i64, i64* %175, i64 1, !dbg !45
+  %177 = getelementptr inbounds i64, i64* %176, i64 1, !dbg !45
+  %178 = bitcast i64* %176 to <2 x i64>*, !dbg !45
+  store <2 x i64> <i64 -1, i64 -15>, <2 x i64>* %178, align 8, !dbg !45, !tbaa !6
+  %179 = getelementptr inbounds i64, i64* %177, i64 1, !dbg !45
+  store i64* %179, i64** %174, align 8, !dbg !45
   %send14 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.6, i64 0), !dbg !45
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %117, align 8, !dbg !45, !tbaa !14
-  %232 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !46
-  %233 = load i64*, i64** %232, align 8, !dbg !46
-  store i64 %106, i64* %233, align 8, !dbg !46, !tbaa !6
-  %234 = getelementptr inbounds i64, i64* %233, i64 1, !dbg !46
-  %235 = getelementptr inbounds i64, i64* %234, i64 1, !dbg !46
-  %236 = getelementptr inbounds i64, i64* %235, i64 1, !dbg !46
-  %237 = getelementptr inbounds i64, i64* %236, i64 1, !dbg !46
-  %238 = bitcast i64* %234 to <4 x i64>*, !dbg !46
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %238, align 8, !dbg !46, !tbaa !6
-  %239 = getelementptr inbounds i64, i64* %237, i64 1, !dbg !46
-  %240 = getelementptr inbounds i64, i64* %239, i64 1, !dbg !46
-  %241 = bitcast i64* %239 to <2 x i64>*, !dbg !46
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %241, align 8, !dbg !46, !tbaa !6
-  %242 = getelementptr inbounds i64, i64* %240, i64 1, !dbg !46
-  store i64 -13, i64* %242, align 8, !dbg !46, !tbaa !6
-  %243 = getelementptr inbounds i64, i64* %242, i64 1, !dbg !46
-  store i64 -15, i64* %243, align 8, !dbg !46, !tbaa !6
-  %244 = getelementptr inbounds i64, i64* %243, i64 1, !dbg !46
-  store i64 -17, i64* %244, align 8, !dbg !46, !tbaa !6
-  %245 = getelementptr inbounds i64, i64* %244, i64 1, !dbg !46
-  store i64* %245, i64** %232, align 8, !dbg !46
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %64, align 8, !dbg !45, !tbaa !14
+  %180 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 1, !dbg !46
+  %181 = load i64*, i64** %180, align 8, !dbg !46
+  store i64 %53, i64* %181, align 8, !dbg !46, !tbaa !6
+  %182 = getelementptr inbounds i64, i64* %181, i64 1, !dbg !46
+  %183 = getelementptr inbounds i64, i64* %182, i64 1, !dbg !46
+  %184 = getelementptr inbounds i64, i64* %183, i64 1, !dbg !46
+  %185 = getelementptr inbounds i64, i64* %184, i64 1, !dbg !46
+  %186 = bitcast i64* %182 to <4 x i64>*, !dbg !46
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %186, align 8, !dbg !46, !tbaa !6
+  %187 = getelementptr inbounds i64, i64* %185, i64 1, !dbg !46
+  %188 = getelementptr inbounds i64, i64* %187, i64 1, !dbg !46
+  %189 = bitcast i64* %187 to <2 x i64>*, !dbg !46
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %189, align 8, !dbg !46, !tbaa !6
+  %190 = getelementptr inbounds i64, i64* %188, i64 1, !dbg !46
+  store i64 -13, i64* %190, align 8, !dbg !46, !tbaa !6
+  %191 = getelementptr inbounds i64, i64* %190, i64 1, !dbg !46
+  store i64 -15, i64* %191, align 8, !dbg !46, !tbaa !6
+  %192 = getelementptr inbounds i64, i64* %191, i64 1, !dbg !46
+  store i64 -17, i64* %192, align 8, !dbg !46, !tbaa !6
+  %193 = getelementptr inbounds i64, i64* %192, i64 1, !dbg !46
+  store i64* %193, i64** %180, align 8, !dbg !46
   %send16 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.7, i64 0), !dbg !46
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %117, align 8, !dbg !46, !tbaa !14
-  %246 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !47
-  %247 = load i64*, i64** %246, align 8, !dbg !47
-  store i64 %106, i64* %247, align 8, !dbg !47, !tbaa !6
-  %248 = getelementptr inbounds i64, i64* %247, i64 1, !dbg !47
-  %249 = getelementptr inbounds i64, i64* %248, i64 1, !dbg !47
-  %250 = getelementptr inbounds i64, i64* %249, i64 1, !dbg !47
-  %251 = getelementptr inbounds i64, i64* %250, i64 1, !dbg !47
-  %252 = bitcast i64* %248 to <4 x i64>*, !dbg !47
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %252, align 8, !dbg !47, !tbaa !6
-  %253 = getelementptr inbounds i64, i64* %251, i64 1, !dbg !47
-  %254 = getelementptr inbounds i64, i64* %253, i64 1, !dbg !47
-  %255 = bitcast i64* %253 to <2 x i64>*, !dbg !47
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %255, align 8, !dbg !47, !tbaa !6
-  %256 = getelementptr inbounds i64, i64* %254, i64 1, !dbg !47
-  store i64 -15, i64* %256, align 8, !dbg !47, !tbaa !6
-  %257 = getelementptr inbounds i64, i64* %256, i64 1, !dbg !47
-  store i64 -17, i64* %257, align 8, !dbg !47, !tbaa !6
-  %258 = getelementptr inbounds i64, i64* %257, i64 1, !dbg !47
-  store i64* %258, i64** %246, align 8, !dbg !47
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %64, align 8, !dbg !46, !tbaa !14
+  %194 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 1, !dbg !47
+  %195 = load i64*, i64** %194, align 8, !dbg !47
+  store i64 %53, i64* %195, align 8, !dbg !47, !tbaa !6
+  %196 = getelementptr inbounds i64, i64* %195, i64 1, !dbg !47
+  %197 = getelementptr inbounds i64, i64* %196, i64 1, !dbg !47
+  %198 = getelementptr inbounds i64, i64* %197, i64 1, !dbg !47
+  %199 = getelementptr inbounds i64, i64* %198, i64 1, !dbg !47
+  %200 = bitcast i64* %196 to <4 x i64>*, !dbg !47
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %200, align 8, !dbg !47, !tbaa !6
+  %201 = getelementptr inbounds i64, i64* %199, i64 1, !dbg !47
+  %202 = getelementptr inbounds i64, i64* %201, i64 1, !dbg !47
+  %203 = bitcast i64* %201 to <2 x i64>*, !dbg !47
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %203, align 8, !dbg !47, !tbaa !6
+  %204 = getelementptr inbounds i64, i64* %202, i64 1, !dbg !47
+  store i64 -15, i64* %204, align 8, !dbg !47, !tbaa !6
+  %205 = getelementptr inbounds i64, i64* %204, i64 1, !dbg !47
+  store i64 -17, i64* %205, align 8, !dbg !47, !tbaa !6
+  %206 = getelementptr inbounds i64, i64* %205, i64 1, !dbg !47
+  store i64* %206, i64** %194, align 8, !dbg !47
   %send18 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.8, i64 0), !dbg !47
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %117, align 8, !dbg !47, !tbaa !14
-  %259 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !48
-  %260 = load i64*, i64** %259, align 8, !dbg !48
-  store i64 %106, i64* %260, align 8, !dbg !48, !tbaa !6
-  %261 = getelementptr inbounds i64, i64* %260, i64 1, !dbg !48
-  %262 = getelementptr inbounds i64, i64* %261, i64 1, !dbg !48
-  %263 = getelementptr inbounds i64, i64* %262, i64 1, !dbg !48
-  %264 = getelementptr inbounds i64, i64* %263, i64 1, !dbg !48
-  %265 = bitcast i64* %261 to <4 x i64>*, !dbg !48
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %265, align 8, !dbg !48, !tbaa !6
-  %266 = getelementptr inbounds i64, i64* %264, i64 1, !dbg !48
-  %267 = getelementptr inbounds i64, i64* %266, i64 1, !dbg !48
-  %268 = bitcast i64* %266 to <2 x i64>*, !dbg !48
-  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %268, align 8, !dbg !48, !tbaa !6
-  %269 = getelementptr inbounds i64, i64* %267, i64 1, !dbg !48
-  store i64 -17, i64* %269, align 8, !dbg !48, !tbaa !6
-  %270 = getelementptr inbounds i64, i64* %269, i64 1, !dbg !48
-  store i64* %270, i64** %259, align 8, !dbg !48
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %64, align 8, !dbg !47, !tbaa !14
+  %207 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 1, !dbg !48
+  %208 = load i64*, i64** %207, align 8, !dbg !48
+  store i64 %53, i64* %208, align 8, !dbg !48, !tbaa !6
+  %209 = getelementptr inbounds i64, i64* %208, i64 1, !dbg !48
+  %210 = getelementptr inbounds i64, i64* %209, i64 1, !dbg !48
+  %211 = getelementptr inbounds i64, i64* %210, i64 1, !dbg !48
+  %212 = getelementptr inbounds i64, i64* %211, i64 1, !dbg !48
+  %213 = bitcast i64* %209 to <4 x i64>*, !dbg !48
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %213, align 8, !dbg !48, !tbaa !6
+  %214 = getelementptr inbounds i64, i64* %212, i64 1, !dbg !48
+  %215 = getelementptr inbounds i64, i64* %214, i64 1, !dbg !48
+  %216 = bitcast i64* %214 to <2 x i64>*, !dbg !48
+  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %216, align 8, !dbg !48, !tbaa !6
+  %217 = getelementptr inbounds i64, i64* %215, i64 1, !dbg !48
+  store i64 -17, i64* %217, align 8, !dbg !48, !tbaa !6
+  %218 = getelementptr inbounds i64, i64* %217, i64 1, !dbg !48
+  store i64* %218, i64** %207, align 8, !dbg !48
   %send20 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.9, i64 0), !dbg !48
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %117, align 8, !dbg !48, !tbaa !14
-  %271 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !49
-  %272 = load i64*, i64** %271, align 8, !dbg !49
-  store i64 %106, i64* %272, align 8, !dbg !49, !tbaa !6
-  %273 = getelementptr inbounds i64, i64* %272, i64 1, !dbg !49
-  %274 = getelementptr inbounds i64, i64* %273, i64 1, !dbg !49
-  %275 = getelementptr inbounds i64, i64* %274, i64 1, !dbg !49
-  %276 = getelementptr inbounds i64, i64* %275, i64 1, !dbg !49
-  %277 = bitcast i64* %273 to <4 x i64>*, !dbg !49
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %277, align 8, !dbg !49, !tbaa !6
-  %278 = getelementptr inbounds i64, i64* %276, i64 1, !dbg !49
-  %279 = getelementptr inbounds i64, i64* %278, i64 1, !dbg !49
-  %280 = bitcast i64* %278 to <2 x i64>*, !dbg !49
-  store <2 x i64> <i64 -15, i64 -17>, <2 x i64>* %280, align 8, !dbg !49, !tbaa !6
-  %281 = getelementptr inbounds i64, i64* %279, i64 1, !dbg !49
-  store i64* %281, i64** %271, align 8, !dbg !49
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %64, align 8, !dbg !48, !tbaa !14
+  %219 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 1, !dbg !49
+  %220 = load i64*, i64** %219, align 8, !dbg !49
+  store i64 %53, i64* %220, align 8, !dbg !49, !tbaa !6
+  %221 = getelementptr inbounds i64, i64* %220, i64 1, !dbg !49
+  %222 = getelementptr inbounds i64, i64* %221, i64 1, !dbg !49
+  %223 = getelementptr inbounds i64, i64* %222, i64 1, !dbg !49
+  %224 = getelementptr inbounds i64, i64* %223, i64 1, !dbg !49
+  %225 = bitcast i64* %221 to <4 x i64>*, !dbg !49
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %225, align 8, !dbg !49, !tbaa !6
+  %226 = getelementptr inbounds i64, i64* %224, i64 1, !dbg !49
+  %227 = getelementptr inbounds i64, i64* %226, i64 1, !dbg !49
+  %228 = bitcast i64* %226 to <2 x i64>*, !dbg !49
+  store <2 x i64> <i64 -15, i64 -17>, <2 x i64>* %228, align 8, !dbg !49, !tbaa !6
+  %229 = getelementptr inbounds i64, i64* %227, i64 1, !dbg !49
+  store i64* %229, i64** %219, align 8, !dbg !49
   %send22 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.10, i64 0), !dbg !49
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 20), i64** %117, align 8, !dbg !49, !tbaa !14
-  %282 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !50
-  %283 = load i64*, i64** %282, align 8, !dbg !50
-  store i64 %106, i64* %283, align 8, !dbg !50, !tbaa !6
-  %284 = getelementptr inbounds i64, i64* %283, i64 1, !dbg !50
-  %285 = getelementptr inbounds i64, i64* %284, i64 1, !dbg !50
-  %286 = getelementptr inbounds i64, i64* %285, i64 1, !dbg !50
-  %287 = getelementptr inbounds i64, i64* %286, i64 1, !dbg !50
-  %288 = bitcast i64* %284 to <4 x i64>*, !dbg !50
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %288, align 8, !dbg !50, !tbaa !6
-  %289 = getelementptr inbounds i64, i64* %287, i64 1, !dbg !50
-  store i64 -17, i64* %289, align 8, !dbg !50, !tbaa !6
-  %290 = getelementptr inbounds i64, i64* %289, i64 1, !dbg !50
-  store i64* %290, i64** %282, align 8, !dbg !50
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 20), i64** %64, align 8, !dbg !49, !tbaa !14
+  %230 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 1, !dbg !50
+  %231 = load i64*, i64** %230, align 8, !dbg !50
+  store i64 %53, i64* %231, align 8, !dbg !50, !tbaa !6
+  %232 = getelementptr inbounds i64, i64* %231, i64 1, !dbg !50
+  %233 = getelementptr inbounds i64, i64* %232, i64 1, !dbg !50
+  %234 = getelementptr inbounds i64, i64* %233, i64 1, !dbg !50
+  %235 = getelementptr inbounds i64, i64* %234, i64 1, !dbg !50
+  %236 = bitcast i64* %232 to <4 x i64>*, !dbg !50
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %236, align 8, !dbg !50, !tbaa !6
+  %237 = getelementptr inbounds i64, i64* %235, i64 1, !dbg !50
+  store i64 -17, i64* %237, align 8, !dbg !50, !tbaa !6
+  %238 = getelementptr inbounds i64, i64* %237, i64 1, !dbg !50
+  store i64* %238, i64** %230, align 8, !dbg !50
   %send24 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.11, i64 0), !dbg !50
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %117, align 8, !dbg !50, !tbaa !14
-  %291 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !51
-  %292 = load i64*, i64** %291, align 8, !dbg !51
-  store i64 %106, i64* %292, align 8, !dbg !51, !tbaa !6
-  %293 = getelementptr inbounds i64, i64* %292, i64 1, !dbg !51
-  %294 = getelementptr inbounds i64, i64* %293, i64 1, !dbg !51
-  %295 = getelementptr inbounds i64, i64* %294, i64 1, !dbg !51
-  %296 = getelementptr inbounds i64, i64* %295, i64 1, !dbg !51
-  %297 = bitcast i64* %293 to <4 x i64>*, !dbg !51
-  store <4 x i64> <i64 -1, i64 -3, i64 -15, i64 -17>, <4 x i64>* %297, align 8, !dbg !51, !tbaa !6
-  %298 = getelementptr inbounds i64, i64* %296, i64 1, !dbg !51
-  store i64* %298, i64** %291, align 8, !dbg !51
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %64, align 8, !dbg !50, !tbaa !14
+  %239 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 1, !dbg !51
+  %240 = load i64*, i64** %239, align 8, !dbg !51
+  store i64 %53, i64* %240, align 8, !dbg !51, !tbaa !6
+  %241 = getelementptr inbounds i64, i64* %240, i64 1, !dbg !51
+  %242 = getelementptr inbounds i64, i64* %241, i64 1, !dbg !51
+  %243 = getelementptr inbounds i64, i64* %242, i64 1, !dbg !51
+  %244 = getelementptr inbounds i64, i64* %243, i64 1, !dbg !51
+  %245 = bitcast i64* %241 to <4 x i64>*, !dbg !51
+  store <4 x i64> <i64 -1, i64 -3, i64 -15, i64 -17>, <4 x i64>* %245, align 8, !dbg !51, !tbaa !6
+  %246 = getelementptr inbounds i64, i64* %244, i64 1, !dbg !51
+  store i64* %246, i64** %239, align 8, !dbg !51
   %send26 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.12, i64 0), !dbg !51
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %117, align 8, !dbg !51, !tbaa !14
-  %299 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !52
-  %300 = load i64*, i64** %299, align 8, !dbg !52
-  store i64 %106, i64* %300, align 8, !dbg !52, !tbaa !6
-  %301 = getelementptr inbounds i64, i64* %300, i64 1, !dbg !52
-  %302 = getelementptr inbounds i64, i64* %301, i64 1, !dbg !52
-  %303 = bitcast i64* %301 to <2 x i64>*, !dbg !52
-  store <2 x i64> <i64 -1, i64 -15>, <2 x i64>* %303, align 8, !dbg !52, !tbaa !6
-  %304 = getelementptr inbounds i64, i64* %302, i64 1, !dbg !52
-  store i64 -17, i64* %304, align 8, !dbg !52, !tbaa !6
-  %305 = getelementptr inbounds i64, i64* %304, i64 1, !dbg !52
-  store i64* %305, i64** %299, align 8, !dbg !52
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %64, align 8, !dbg !51, !tbaa !14
+  %247 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 1, !dbg !52
+  %248 = load i64*, i64** %247, align 8, !dbg !52
+  store i64 %53, i64* %248, align 8, !dbg !52, !tbaa !6
+  %249 = getelementptr inbounds i64, i64* %248, i64 1, !dbg !52
+  %250 = getelementptr inbounds i64, i64* %249, i64 1, !dbg !52
+  %251 = bitcast i64* %249 to <2 x i64>*, !dbg !52
+  store <2 x i64> <i64 -1, i64 -15>, <2 x i64>* %251, align 8, !dbg !52, !tbaa !6
+  %252 = getelementptr inbounds i64, i64* %250, i64 1, !dbg !52
+  store i64 -17, i64* %252, align 8, !dbg !52, !tbaa !6
+  %253 = getelementptr inbounds i64, i64* %252, i64 1, !dbg !52
+  store i64* %253, i64** %247, align 8, !dbg !52
   %send28 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.13, i64 0), !dbg !52
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %117, align 8, !dbg !52, !tbaa !14
-  %306 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !53
-  %307 = load i64*, i64** %306, align 8, !dbg !53
-  store i64 %106, i64* %307, align 8, !dbg !53, !tbaa !6
-  %308 = getelementptr inbounds i64, i64* %307, i64 1, !dbg !53
-  %309 = getelementptr inbounds i64, i64* %308, i64 1, !dbg !53
-  %310 = getelementptr inbounds i64, i64* %309, i64 1, !dbg !53
-  %311 = getelementptr inbounds i64, i64* %310, i64 1, !dbg !53
-  %312 = bitcast i64* %308 to <4 x i64>*, !dbg !53
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %312, align 8, !dbg !53, !tbaa !6
-  %313 = getelementptr inbounds i64, i64* %311, i64 1, !dbg !53
-  %314 = getelementptr inbounds i64, i64* %313, i64 1, !dbg !53
-  %315 = bitcast i64* %313 to <2 x i64>*, !dbg !53
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %315, align 8, !dbg !53, !tbaa !6
-  %316 = getelementptr inbounds i64, i64* %314, i64 1, !dbg !53
-  store i64 -13, i64* %316, align 8, !dbg !53, !tbaa !6
-  %317 = getelementptr inbounds i64, i64* %316, i64 1, !dbg !53
-  store i64 -15, i64* %317, align 8, !dbg !53, !tbaa !6
-  %318 = getelementptr inbounds i64, i64* %317, i64 1, !dbg !53
-  store i64 -17, i64* %318, align 8, !dbg !53, !tbaa !6
-  %319 = getelementptr inbounds i64, i64* %318, i64 1, !dbg !53
-  store i64 -19, i64* %319, align 8, !dbg !53, !tbaa !6
-  %320 = getelementptr inbounds i64, i64* %319, i64 1, !dbg !53
-  store i64* %320, i64** %306, align 8, !dbg !53
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %64, align 8, !dbg !52, !tbaa !14
+  %254 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 1, !dbg !53
+  %255 = load i64*, i64** %254, align 8, !dbg !53
+  store i64 %53, i64* %255, align 8, !dbg !53, !tbaa !6
+  %256 = getelementptr inbounds i64, i64* %255, i64 1, !dbg !53
+  %257 = getelementptr inbounds i64, i64* %256, i64 1, !dbg !53
+  %258 = getelementptr inbounds i64, i64* %257, i64 1, !dbg !53
+  %259 = getelementptr inbounds i64, i64* %258, i64 1, !dbg !53
+  %260 = bitcast i64* %256 to <4 x i64>*, !dbg !53
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %260, align 8, !dbg !53, !tbaa !6
+  %261 = getelementptr inbounds i64, i64* %259, i64 1, !dbg !53
+  %262 = getelementptr inbounds i64, i64* %261, i64 1, !dbg !53
+  %263 = bitcast i64* %261 to <2 x i64>*, !dbg !53
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %263, align 8, !dbg !53, !tbaa !6
+  %264 = getelementptr inbounds i64, i64* %262, i64 1, !dbg !53
+  store i64 -13, i64* %264, align 8, !dbg !53, !tbaa !6
+  %265 = getelementptr inbounds i64, i64* %264, i64 1, !dbg !53
+  store i64 -15, i64* %265, align 8, !dbg !53, !tbaa !6
+  %266 = getelementptr inbounds i64, i64* %265, i64 1, !dbg !53
+  store i64 -17, i64* %266, align 8, !dbg !53, !tbaa !6
+  %267 = getelementptr inbounds i64, i64* %266, i64 1, !dbg !53
+  store i64 -19, i64* %267, align 8, !dbg !53, !tbaa !6
+  %268 = getelementptr inbounds i64, i64* %267, i64 1, !dbg !53
+  store i64* %268, i64** %254, align 8, !dbg !53
   %send30 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.14, i64 0), !dbg !53
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %117, align 8, !dbg !53, !tbaa !14
-  %321 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !54
-  %322 = load i64*, i64** %321, align 8, !dbg !54
-  store i64 %106, i64* %322, align 8, !dbg !54, !tbaa !6
-  %323 = getelementptr inbounds i64, i64* %322, i64 1, !dbg !54
-  %324 = getelementptr inbounds i64, i64* %323, i64 1, !dbg !54
-  %325 = getelementptr inbounds i64, i64* %324, i64 1, !dbg !54
-  %326 = getelementptr inbounds i64, i64* %325, i64 1, !dbg !54
-  %327 = bitcast i64* %323 to <4 x i64>*, !dbg !54
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %327, align 8, !dbg !54, !tbaa !6
-  %328 = getelementptr inbounds i64, i64* %326, i64 1, !dbg !54
-  %329 = getelementptr inbounds i64, i64* %328, i64 1, !dbg !54
-  %330 = bitcast i64* %328 to <2 x i64>*, !dbg !54
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %330, align 8, !dbg !54, !tbaa !6
-  %331 = getelementptr inbounds i64, i64* %329, i64 1, !dbg !54
-  store i64 -15, i64* %331, align 8, !dbg !54, !tbaa !6
-  %332 = getelementptr inbounds i64, i64* %331, i64 1, !dbg !54
-  store i64 -17, i64* %332, align 8, !dbg !54, !tbaa !6
-  %333 = getelementptr inbounds i64, i64* %332, i64 1, !dbg !54
-  store i64 -19, i64* %333, align 8, !dbg !54, !tbaa !6
-  %334 = getelementptr inbounds i64, i64* %333, i64 1, !dbg !54
-  store i64* %334, i64** %321, align 8, !dbg !54
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %64, align 8, !dbg !53, !tbaa !14
+  %269 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 1, !dbg !54
+  %270 = load i64*, i64** %269, align 8, !dbg !54
+  store i64 %53, i64* %270, align 8, !dbg !54, !tbaa !6
+  %271 = getelementptr inbounds i64, i64* %270, i64 1, !dbg !54
+  %272 = getelementptr inbounds i64, i64* %271, i64 1, !dbg !54
+  %273 = getelementptr inbounds i64, i64* %272, i64 1, !dbg !54
+  %274 = getelementptr inbounds i64, i64* %273, i64 1, !dbg !54
+  %275 = bitcast i64* %271 to <4 x i64>*, !dbg !54
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %275, align 8, !dbg !54, !tbaa !6
+  %276 = getelementptr inbounds i64, i64* %274, i64 1, !dbg !54
+  %277 = getelementptr inbounds i64, i64* %276, i64 1, !dbg !54
+  %278 = bitcast i64* %276 to <2 x i64>*, !dbg !54
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %278, align 8, !dbg !54, !tbaa !6
+  %279 = getelementptr inbounds i64, i64* %277, i64 1, !dbg !54
+  store i64 -15, i64* %279, align 8, !dbg !54, !tbaa !6
+  %280 = getelementptr inbounds i64, i64* %279, i64 1, !dbg !54
+  store i64 -17, i64* %280, align 8, !dbg !54, !tbaa !6
+  %281 = getelementptr inbounds i64, i64* %280, i64 1, !dbg !54
+  store i64 -19, i64* %281, align 8, !dbg !54, !tbaa !6
+  %282 = getelementptr inbounds i64, i64* %281, i64 1, !dbg !54
+  store i64* %282, i64** %269, align 8, !dbg !54
   %send32 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.15, i64 0), !dbg !54
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %117, align 8, !dbg !54, !tbaa !14
-  %335 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !55
-  %336 = load i64*, i64** %335, align 8, !dbg !55
-  store i64 %106, i64* %336, align 8, !dbg !55, !tbaa !6
-  %337 = getelementptr inbounds i64, i64* %336, i64 1, !dbg !55
-  %338 = getelementptr inbounds i64, i64* %337, i64 1, !dbg !55
-  %339 = getelementptr inbounds i64, i64* %338, i64 1, !dbg !55
-  %340 = getelementptr inbounds i64, i64* %339, i64 1, !dbg !55
-  %341 = bitcast i64* %337 to <4 x i64>*, !dbg !55
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %341, align 8, !dbg !55, !tbaa !6
-  %342 = getelementptr inbounds i64, i64* %340, i64 1, !dbg !55
-  %343 = getelementptr inbounds i64, i64* %342, i64 1, !dbg !55
-  %344 = bitcast i64* %342 to <2 x i64>*, !dbg !55
-  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %344, align 8, !dbg !55, !tbaa !6
-  %345 = getelementptr inbounds i64, i64* %343, i64 1, !dbg !55
-  store i64 -17, i64* %345, align 8, !dbg !55, !tbaa !6
-  %346 = getelementptr inbounds i64, i64* %345, i64 1, !dbg !55
-  store i64 -19, i64* %346, align 8, !dbg !55, !tbaa !6
-  %347 = getelementptr inbounds i64, i64* %346, i64 1, !dbg !55
-  store i64* %347, i64** %335, align 8, !dbg !55
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %64, align 8, !dbg !54, !tbaa !14
+  %283 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 1, !dbg !55
+  %284 = load i64*, i64** %283, align 8, !dbg !55
+  store i64 %53, i64* %284, align 8, !dbg !55, !tbaa !6
+  %285 = getelementptr inbounds i64, i64* %284, i64 1, !dbg !55
+  %286 = getelementptr inbounds i64, i64* %285, i64 1, !dbg !55
+  %287 = getelementptr inbounds i64, i64* %286, i64 1, !dbg !55
+  %288 = getelementptr inbounds i64, i64* %287, i64 1, !dbg !55
+  %289 = bitcast i64* %285 to <4 x i64>*, !dbg !55
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %289, align 8, !dbg !55, !tbaa !6
+  %290 = getelementptr inbounds i64, i64* %288, i64 1, !dbg !55
+  %291 = getelementptr inbounds i64, i64* %290, i64 1, !dbg !55
+  %292 = bitcast i64* %290 to <2 x i64>*, !dbg !55
+  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %292, align 8, !dbg !55, !tbaa !6
+  %293 = getelementptr inbounds i64, i64* %291, i64 1, !dbg !55
+  store i64 -17, i64* %293, align 8, !dbg !55, !tbaa !6
+  %294 = getelementptr inbounds i64, i64* %293, i64 1, !dbg !55
+  store i64 -19, i64* %294, align 8, !dbg !55, !tbaa !6
+  %295 = getelementptr inbounds i64, i64* %294, i64 1, !dbg !55
+  store i64* %295, i64** %283, align 8, !dbg !55
   %send34 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.16, i64 0), !dbg !55
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %117, align 8, !dbg !55, !tbaa !14
-  %348 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !56
-  %349 = load i64*, i64** %348, align 8, !dbg !56
-  store i64 %106, i64* %349, align 8, !dbg !56, !tbaa !6
-  %350 = getelementptr inbounds i64, i64* %349, i64 1, !dbg !56
-  %351 = getelementptr inbounds i64, i64* %350, i64 1, !dbg !56
-  %352 = getelementptr inbounds i64, i64* %351, i64 1, !dbg !56
-  %353 = getelementptr inbounds i64, i64* %352, i64 1, !dbg !56
-  %354 = bitcast i64* %350 to <4 x i64>*, !dbg !56
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %354, align 8, !dbg !56, !tbaa !6
-  %355 = getelementptr inbounds i64, i64* %353, i64 1, !dbg !56
-  %356 = getelementptr inbounds i64, i64* %355, i64 1, !dbg !56
-  %357 = bitcast i64* %355 to <2 x i64>*, !dbg !56
-  store <2 x i64> <i64 -15, i64 -17>, <2 x i64>* %357, align 8, !dbg !56, !tbaa !6
-  %358 = getelementptr inbounds i64, i64* %356, i64 1, !dbg !56
-  store i64 -19, i64* %358, align 8, !dbg !56, !tbaa !6
-  %359 = getelementptr inbounds i64, i64* %358, i64 1, !dbg !56
-  store i64* %359, i64** %348, align 8, !dbg !56
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %64, align 8, !dbg !55, !tbaa !14
+  %296 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 1, !dbg !56
+  %297 = load i64*, i64** %296, align 8, !dbg !56
+  store i64 %53, i64* %297, align 8, !dbg !56, !tbaa !6
+  %298 = getelementptr inbounds i64, i64* %297, i64 1, !dbg !56
+  %299 = getelementptr inbounds i64, i64* %298, i64 1, !dbg !56
+  %300 = getelementptr inbounds i64, i64* %299, i64 1, !dbg !56
+  %301 = getelementptr inbounds i64, i64* %300, i64 1, !dbg !56
+  %302 = bitcast i64* %298 to <4 x i64>*, !dbg !56
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %302, align 8, !dbg !56, !tbaa !6
+  %303 = getelementptr inbounds i64, i64* %301, i64 1, !dbg !56
+  %304 = getelementptr inbounds i64, i64* %303, i64 1, !dbg !56
+  %305 = bitcast i64* %303 to <2 x i64>*, !dbg !56
+  store <2 x i64> <i64 -15, i64 -17>, <2 x i64>* %305, align 8, !dbg !56, !tbaa !6
+  %306 = getelementptr inbounds i64, i64* %304, i64 1, !dbg !56
+  store i64 -19, i64* %306, align 8, !dbg !56, !tbaa !6
+  %307 = getelementptr inbounds i64, i64* %306, i64 1, !dbg !56
+  store i64* %307, i64** %296, align 8, !dbg !56
   %send36 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.17, i64 0), !dbg !56
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %117, align 8, !dbg !56, !tbaa !14
-  %360 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !57
-  %361 = load i64*, i64** %360, align 8, !dbg !57
-  store i64 %106, i64* %361, align 8, !dbg !57, !tbaa !6
-  %362 = getelementptr inbounds i64, i64* %361, i64 1, !dbg !57
-  %363 = getelementptr inbounds i64, i64* %362, i64 1, !dbg !57
-  %364 = getelementptr inbounds i64, i64* %363, i64 1, !dbg !57
-  %365 = getelementptr inbounds i64, i64* %364, i64 1, !dbg !57
-  %366 = bitcast i64* %362 to <4 x i64>*, !dbg !57
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %366, align 8, !dbg !57, !tbaa !6
-  %367 = getelementptr inbounds i64, i64* %365, i64 1, !dbg !57
-  %368 = getelementptr inbounds i64, i64* %367, i64 1, !dbg !57
-  %369 = bitcast i64* %367 to <2 x i64>*, !dbg !57
-  store <2 x i64> <i64 -17, i64 -19>, <2 x i64>* %369, align 8, !dbg !57, !tbaa !6
-  %370 = getelementptr inbounds i64, i64* %368, i64 1, !dbg !57
-  store i64* %370, i64** %360, align 8, !dbg !57
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %64, align 8, !dbg !56, !tbaa !14
+  %308 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 1, !dbg !57
+  %309 = load i64*, i64** %308, align 8, !dbg !57
+  store i64 %53, i64* %309, align 8, !dbg !57, !tbaa !6
+  %310 = getelementptr inbounds i64, i64* %309, i64 1, !dbg !57
+  %311 = getelementptr inbounds i64, i64* %310, i64 1, !dbg !57
+  %312 = getelementptr inbounds i64, i64* %311, i64 1, !dbg !57
+  %313 = getelementptr inbounds i64, i64* %312, i64 1, !dbg !57
+  %314 = bitcast i64* %310 to <4 x i64>*, !dbg !57
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %314, align 8, !dbg !57, !tbaa !6
+  %315 = getelementptr inbounds i64, i64* %313, i64 1, !dbg !57
+  %316 = getelementptr inbounds i64, i64* %315, i64 1, !dbg !57
+  %317 = bitcast i64* %315 to <2 x i64>*, !dbg !57
+  store <2 x i64> <i64 -17, i64 -19>, <2 x i64>* %317, align 8, !dbg !57, !tbaa !6
+  %318 = getelementptr inbounds i64, i64* %316, i64 1, !dbg !57
+  store i64* %318, i64** %308, align 8, !dbg !57
   %send38 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.18, i64 0), !dbg !57
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 29), i64** %117, align 8, !dbg !57, !tbaa !14
-  %371 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !58
-  %372 = load i64*, i64** %371, align 8, !dbg !58
-  store i64 %106, i64* %372, align 8, !dbg !58, !tbaa !6
-  %373 = getelementptr inbounds i64, i64* %372, i64 1, !dbg !58
-  %374 = getelementptr inbounds i64, i64* %373, i64 1, !dbg !58
-  %375 = getelementptr inbounds i64, i64* %374, i64 1, !dbg !58
-  %376 = getelementptr inbounds i64, i64* %375, i64 1, !dbg !58
-  %377 = bitcast i64* %373 to <4 x i64>*, !dbg !58
-  store <4 x i64> <i64 -1, i64 -3, i64 -15, i64 -17>, <4 x i64>* %377, align 8, !dbg !58, !tbaa !6
-  %378 = getelementptr inbounds i64, i64* %376, i64 1, !dbg !58
-  store i64 -19, i64* %378, align 8, !dbg !58, !tbaa !6
-  %379 = getelementptr inbounds i64, i64* %378, i64 1, !dbg !58
-  store i64* %379, i64** %371, align 8, !dbg !58
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 29), i64** %64, align 8, !dbg !57, !tbaa !14
+  %319 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 1, !dbg !58
+  %320 = load i64*, i64** %319, align 8, !dbg !58
+  store i64 %53, i64* %320, align 8, !dbg !58, !tbaa !6
+  %321 = getelementptr inbounds i64, i64* %320, i64 1, !dbg !58
+  %322 = getelementptr inbounds i64, i64* %321, i64 1, !dbg !58
+  %323 = getelementptr inbounds i64, i64* %322, i64 1, !dbg !58
+  %324 = getelementptr inbounds i64, i64* %323, i64 1, !dbg !58
+  %325 = bitcast i64* %321 to <4 x i64>*, !dbg !58
+  store <4 x i64> <i64 -1, i64 -3, i64 -15, i64 -17>, <4 x i64>* %325, align 8, !dbg !58, !tbaa !6
+  %326 = getelementptr inbounds i64, i64* %324, i64 1, !dbg !58
+  store i64 -19, i64* %326, align 8, !dbg !58, !tbaa !6
+  %327 = getelementptr inbounds i64, i64* %326, i64 1, !dbg !58
+  store i64* %327, i64** %319, align 8, !dbg !58
   %send40 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.19, i64 0), !dbg !58
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 30), i64** %117, align 8, !dbg !58, !tbaa !14
-  %380 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %109, i64 0, i32 1, !dbg !59
-  %381 = load i64*, i64** %380, align 8, !dbg !59
-  store i64 %106, i64* %381, align 8, !dbg !59, !tbaa !6
-  %382 = getelementptr inbounds i64, i64* %381, i64 1, !dbg !59
-  %383 = getelementptr inbounds i64, i64* %382, i64 1, !dbg !59
-  %384 = getelementptr inbounds i64, i64* %383, i64 1, !dbg !59
-  %385 = getelementptr inbounds i64, i64* %384, i64 1, !dbg !59
-  %386 = bitcast i64* %382 to <4 x i64>*, !dbg !59
-  store <4 x i64> <i64 -1, i64 -15, i64 -17, i64 -19>, <4 x i64>* %386, align 8, !dbg !59, !tbaa !6
-  %387 = getelementptr inbounds i64, i64* %385, i64 1, !dbg !59
-  store i64* %387, i64** %380, align 8, !dbg !59
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 30), i64** %64, align 8, !dbg !58, !tbaa !14
+  %328 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 1, !dbg !59
+  %329 = load i64*, i64** %328, align 8, !dbg !59
+  store i64 %53, i64* %329, align 8, !dbg !59, !tbaa !6
+  %330 = getelementptr inbounds i64, i64* %329, i64 1, !dbg !59
+  %331 = getelementptr inbounds i64, i64* %330, i64 1, !dbg !59
+  %332 = getelementptr inbounds i64, i64* %331, i64 1, !dbg !59
+  %333 = getelementptr inbounds i64, i64* %332, i64 1, !dbg !59
+  %334 = bitcast i64* %330 to <4 x i64>*, !dbg !59
+  store <4 x i64> <i64 -1, i64 -15, i64 -17, i64 -19>, <4 x i64>* %334, align 8, !dbg !59, !tbaa !6
+  %335 = getelementptr inbounds i64, i64* %333, i64 1, !dbg !59
+  store i64* %335, i64** %328, align 8, !dbg !59
   %send42 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.20, i64 0), !dbg !59
-  call void @llvm.lifetime.end.p0i8(i64 32, i8* nonnull %110)
-  call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %111)
+  call void @llvm.lifetime.end.p0i8(i64 32, i8* nonnull %57)
+  call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %58)
   ret void
 }
 

--- a/test/testdata/compiler/block_arg_expand.opt.ll.exp
+++ b/test/testdata/compiler/block_arg_expand.opt.ll.exp
@@ -89,38 +89,31 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/block_arg_expand.rb" = internal unnamed_addr global i64 0, align 8
-@"rubyIdPrecomputed_<block-call>" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [32 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_block in <top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_block in <top (required)>" = internal unnamed_addr global i64 0, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_2" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_3" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_4" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_5" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@rubyIdPrecomputed_each = internal unnamed_addr global i64 0, align 8
 @"func_<root>.17<static-init>$153$block_1_ifunc" = internal unnamed_addr global i64 0
-@"rubyIdPrecomputed_+" = internal unnamed_addr global i64 0, align 8
 @"ic_+" = internal global %struct.FunctionInlineCache zeroinitializer
 @"func_<root>.17<static-init>$153$block_2_ifunc" = internal unnamed_addr global i64 0
 @ic_p = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_p = internal unnamed_addr global i64 0, align 8
 @"func_<root>.17<static-init>$153$block_3_ifunc" = internal unnamed_addr global i64 0
-@rubyIdPrecomputed_x = internal unnamed_addr global i64 0, align 8
 @ic_p.5 = internal global %struct.FunctionInlineCache zeroinitializer
 @"func_<root>.17<static-init>$153$block_4_ifunc" = internal unnamed_addr global i64 0
-@rubyIdPrecomputed_default = internal unnamed_addr global i64 0, align 8
-@rubyIdPrecomputed_something = internal unnamed_addr global i64 0, align 8
 @ic_p.8 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_p.9 = internal global %struct.FunctionInlineCache zeroinitializer
 @"func_<root>.17<static-init>$153$block_5_ifunc" = internal unnamed_addr global i64 0
 @ic_p.12 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_p.13 = internal global %struct.FunctionInlineCache zeroinitializer
 @sorbet_moduleStringTable = internal unnamed_addr constant [163 x i8] c"<top (required)>\00test/testdata/compiler/block_arg_expand.rb\00<block-call>\00block in <top (required)>\00<build-array>\00each\00T.let\00Integer\00+\00p\00x\00default\00something\00master\00", align 1
+@sorbet_moduleIDTable = internal unnamed_addr global [10 x i64] zeroinitializer, align 8
+@sorbet_moduleIDDescriptors = internal unnamed_addr constant [10 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 60, i32 12 }, %struct.rb_code_position_struct { i32 73, i32 25 }, %struct.rb_code_position_struct { i32 99, i32 13 }, %struct.rb_code_position_struct { i32 113, i32 4 }, %struct.rb_code_position_struct { i32 132, i32 1 }, %struct.rb_code_position_struct { i32 134, i32 1 }, %struct.rb_code_position_struct { i32 136, i32 1 }, %struct.rb_code_position_struct { i32 138, i32 7 }, %struct.rb_code_position_struct { i32 146, i32 9 }], align 8
 
 ; Function Attrs: nounwind readnone willreturn
 declare i64 @rb_id2sym(i64) local_unnamed_addr #0
@@ -150,6 +143,8 @@ declare i64 @sorbet_globalConstRegister(i64) local_unnamed_addr #2
 
 declare %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64) local_unnamed_addr #2
 
+declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #2
+
 declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #2
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
@@ -157,8 +152,6 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #3
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #3
-
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #2
 
 declare void @rb_ary_detransient(i64) local_unnamed_addr #2
 
@@ -463,7 +456,7 @@ BB14:                                             ; preds = %functionEntryInitia
 
 BB15:                                             ; preds = %functionEntryInitializers
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %10, align 8, !tbaa !15
-  %rubyId_x = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !50
+  %rubyId_x = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 7), align 8, !dbg !50, !invariant.load !5
   %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_x) #16, !dbg !50
   br label %BB16, !dbg !50
 
@@ -505,7 +498,7 @@ functionEntryInitializers:
 
 BB23.thread:                                      ; preds = %fillRequiredArgs
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %10, align 8, !tbaa !15
-  %rubyId_default = load i64, i64* @rubyIdPrecomputed_default, align 8, !dbg !56
+  %rubyId_default = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 8), align 8, !dbg !56, !invariant.load !5
   %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_default) #16, !dbg !56
   br label %BB25, !dbg !57
 
@@ -523,7 +516,7 @@ BB24:                                             ; preds = %fillFromArgBlock0
 BB25:                                             ; preds = %BB23.thread62, %BB23.thread
   %x.sroa.0.061 = phi i64 [ %rawSym, %BB23.thread ], [ %x.sroa.0.2.ph.ph, %BB23.thread62 ]
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %10, align 8, !tbaa !15
-  %rubyId_something = load i64, i64* @rubyIdPrecomputed_something, align 8, !dbg !58
+  %rubyId_something = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 9), align 8, !dbg !58, !invariant.load !5
   %rawSym16 = tail call i64 @rb_id2sym(i64 %rubyId_something) #16, !dbg !58
   br label %BB26, !dbg !58
 
@@ -648,7 +641,7 @@ BB31:                                             ; preds = %fillFromArgBlock0
 BB32:                                             ; preds = %argArrayExpandArrayTest, %sorbet_isa_Array.exit, %fillRequiredArgs, %fillFromArgBlock0
   %x.sroa.0.1.ph = phi i64 [ 8, %fillRequiredArgs ], [ %rawArg_x, %fillFromArgBlock0 ], [ %arg1_maybeExpandToFullArgs, %sorbet_isa_Array.exit ], [ %arg1_maybeExpandToFullArgs, %argArrayExpandArrayTest ]
   store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %10, align 8, !tbaa !15
-  %rubyId_something = load i64, i64* @rubyIdPrecomputed_something, align 8, !dbg !66
+  %rubyId_something = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 9), align 8, !dbg !66, !invariant.load !5
   %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_something) #16, !dbg !66
   br label %BB33, !dbg !66
 
@@ -757,767 +750,736 @@ entry:
   %callArgs.i = alloca [3 x i64], align 8
   %locals.i.i = alloca i64, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %8 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([163 x i8], [163 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #13
-  store i64 %8, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %9 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @sorbet_moduleStringTable, i64 0, i64 60), i64 noundef 12) #13
-  store i64 %9, i64* @"rubyIdPrecomputed_<block-call>", align 8
-  %10 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @sorbet_moduleStringTable, i64 0, i64 73), i64 noundef 25) #13
-  store i64 %10, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
-  %11 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @sorbet_moduleStringTable, i64 0, i64 99), i64 noundef 13) #13
-  %12 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @sorbet_moduleStringTable, i64 0, i64 113), i64 noundef 4) #13
-  store i64 %12, i64* @rubyIdPrecomputed_each, align 8
-  %13 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @sorbet_moduleStringTable, i64 0, i64 132), i64 noundef 1) #13
-  store i64 %13, i64* @"rubyIdPrecomputed_+", align 8
-  %14 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @sorbet_moduleStringTable, i64 0, i64 134), i64 noundef 1) #13
-  store i64 %14, i64* @rubyIdPrecomputed_p, align 8
-  %15 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @sorbet_moduleStringTable, i64 0, i64 136), i64 noundef 1) #13
-  store i64 %15, i64* @rubyIdPrecomputed_x, align 8
-  %16 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @sorbet_moduleStringTable, i64 0, i64 138), i64 noundef 7) #13
-  store i64 %16, i64* @rubyIdPrecomputed_default, align 8
-  %17 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @sorbet_moduleStringTable, i64 0, i64 146), i64 noundef 9) #13
-  store i64 %17, i64* @rubyIdPrecomputed_something, align 8
-  %18 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([163 x i8], [163 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #13
-  tail call void @rb_gc_register_mark_object(i64 %18) #13
-  store i64 %18, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %19 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 42) #13
-  tail call void @rb_gc_register_mark_object(i64 %19) #13
-  store i64 %19, i64* @"rubyStrFrozen_test/testdata/compiler/block_arg_expand.rb", align 8
+  tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([10 x %struct.rb_code_position_struct], [10 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 10, i8* noundef getelementptr inbounds ([163 x i8], [163 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
+  %8 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([163 x i8], [163 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #13
+  tail call void @rb_gc_register_mark_object(i64 %8) #13
+  store i64 %8, i64* @"rubyStrFrozen_<top (required)>", align 8
+  %9 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 42) #13
+  tail call void @rb_gc_register_mark_object(i64 %9) #13
+  store i64 %9, i64* @"rubyStrFrozen_test/testdata/compiler/block_arg_expand.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 32)
-  %20 = bitcast i64* %locals.i.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %20)
-  %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
+  %10 = bitcast i64* %locals.i.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %10)
+  %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
   %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_arg_expand.rb", align 8
-  %"rubyId_<block-call>.i.i" = load i64, i64* @"rubyIdPrecomputed_<block-call>", align 8
+  %"rubyId_<block-call>.i.i" = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !invariant.load !5
   store i64 %"rubyId_<block-call>.i.i", i64* %locals.i.i, align 8
-  %21 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i.i, i32 noundef 1, i32 noundef 3)
-  store %struct.rb_iseq_struct* %21, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %20)
-  %22 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @sorbet_moduleStringTable, i64 0, i64 73), i64 noundef 25) #13
-  call void @rb_gc_register_mark_object(i64 %22) #13
-  store i64 %22, i64* @"rubyStrFrozen_block in <top (required)>", align 8
+  %11 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i.i, i32 noundef 1, i32 noundef 3)
+  store %struct.rb_iseq_struct* %11, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %10)
+  %12 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @sorbet_moduleStringTable, i64 0, i64 73), i64 noundef 25) #13
+  call void @rb_gc_register_mark_object(i64 %12) #13
+  store i64 %12, i64* @"rubyStrFrozen_block in <top (required)>", align 8
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %"rubyId_block in <top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
+  %"rubyId_block in <top (required)>.i.i" = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i26.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_arg_expand.rb", align 8
-  %23 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %22, i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i26.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
-  store %struct.rb_iseq_struct* %23, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1", align 8
+  %13 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %12, i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i26.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
+  store %struct.rb_iseq_struct* %13, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1", align 8
   %stackFrame.i27.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %"rubyId_block in <top (required)>.i28.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
   %"rubyStr_block in <top (required)>.i29.i" = load i64, i64* @"rubyStrFrozen_block in <top (required)>", align 8
   %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i30.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_arg_expand.rb", align 8
-  %24 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i29.i", i64 %"rubyId_block in <top (required)>.i28.i", i64 %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i30.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i27.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
-  store %struct.rb_iseq_struct* %24, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_2", align 8
+  %14 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i29.i", i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i30.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i27.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
+  store %struct.rb_iseq_struct* %14, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_2", align 8
   %stackFrame.i31.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %"rubyId_block in <top (required)>.i32.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
   %"rubyStr_block in <top (required)>.i33.i" = load i64, i64* @"rubyStrFrozen_block in <top (required)>", align 8
   %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i34.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_arg_expand.rb", align 8
-  %25 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i33.i", i64 %"rubyId_block in <top (required)>.i32.i", i64 %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i34.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i31.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
-  store %struct.rb_iseq_struct* %25, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_3", align 8
+  %15 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i33.i", i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i34.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i31.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
+  store %struct.rb_iseq_struct* %15, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_3", align 8
   %stackFrame.i35.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %"rubyId_block in <top (required)>.i36.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
   %"rubyStr_block in <top (required)>.i37.i" = load i64, i64* @"rubyStrFrozen_block in <top (required)>", align 8
   %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i38.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_arg_expand.rb", align 8
-  %26 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i37.i", i64 %"rubyId_block in <top (required)>.i36.i", i64 %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i38.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i35.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
-  store %struct.rb_iseq_struct* %26, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_4", align 8
+  %16 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i37.i", i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i38.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i35.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
+  store %struct.rb_iseq_struct* %16, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_4", align 8
   %stackFrame.i39.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %"rubyId_block in <top (required)>.i40.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
   %"rubyStr_block in <top (required)>.i41.i" = load i64, i64* @"rubyStrFrozen_block in <top (required)>", align 8
   %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i42.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_arg_expand.rb", align 8
-  %27 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i41.i", i64 %"rubyId_block in <top (required)>.i40.i", i64 %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i42.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i39.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
-  store %struct.rb_iseq_struct* %27, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_5", align 8
-  %28 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_1", i8* noundef null, i32 noundef 2, i32 noundef 2) #13
-  %29 = ptrtoint %struct.vm_ifunc* %28 to i64
-  %30 = call i64 @sorbet_globalConstRegister(i64 %29)
-  store i64 %30, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8
-  %"rubyId_+.i" = load i64, i64* @"rubyIdPrecomputed_+", align 8, !dbg !30
+  %17 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i41.i", i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i42.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i39.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
+  store %struct.rb_iseq_struct* %17, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_5", align 8
+  %18 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_1", i8* noundef null, i32 noundef 2, i32 noundef 2) #13
+  %19 = ptrtoint %struct.vm_ifunc* %18 to i64
+  %20 = call i64 @sorbet_globalConstRegister(i64 %19)
+  store i64 %20, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8
+  %"rubyId_+.i" = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 5), align 8, !dbg !30, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_+", i64 %"rubyId_+.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !30
-  %31 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_2", i8* noundef null, i32 noundef 1, i32 noundef 1) #13
-  %32 = ptrtoint %struct.vm_ifunc* %31 to i64
-  %33 = call i64 @sorbet_globalConstRegister(i64 %32)
-  store i64 %33, i64* @"func_<root>.17<static-init>$153$block_2_ifunc", align 8
-  %rubyId_p.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !45
+  %21 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_2", i8* noundef null, i32 noundef 1, i32 noundef 1) #13
+  %22 = ptrtoint %struct.vm_ifunc* %21 to i64
+  %23 = call i64 @sorbet_globalConstRegister(i64 %22)
+  store i64 %23, i64* @"func_<root>.17<static-init>$153$block_2_ifunc", align 8
+  %rubyId_p.i = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 6), align 8, !dbg !45, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !45
-  %34 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_3", i8* noundef null, i32 noundef 0, i32 noundef 1) #13
-  %35 = ptrtoint %struct.vm_ifunc* %34 to i64
-  %36 = call i64 @sorbet_globalConstRegister(i64 %35)
-  store i64 %36, i64* @"func_<root>.17<static-init>$153$block_3_ifunc", align 8
-  %rubyId_p7.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !52
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.5, i64 %rubyId_p7.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !52
-  %37 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_4", i8* noundef null, i32 noundef 0, i32 noundef 2) #13
-  %38 = ptrtoint %struct.vm_ifunc* %37 to i64
-  %39 = call i64 @sorbet_globalConstRegister(i64 %38)
-  store i64 %39, i64* @"func_<root>.17<static-init>$153$block_4_ifunc", align 8
-  %rubyId_p12.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !60
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.8, i64 %rubyId_p12.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !60
-  %rubyId_p15.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !61
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.9, i64 %rubyId_p15.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !61
-  %40 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_5", i8* noundef null, i32 noundef 1, i32 noundef 2) #13
-  %41 = ptrtoint %struct.vm_ifunc* %40 to i64
-  %42 = call i64 @sorbet_globalConstRegister(i64 %41)
-  store i64 %42, i64* @"func_<root>.17<static-init>$153$block_5_ifunc", align 8
-  %rubyId_p20.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !68
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.12, i64 %rubyId_p20.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !68
-  %rubyId_p23.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !69
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.13, i64 %rubyId_p23.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !69
-  %43 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
-  %44 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %43, i64 0, i32 2
-  %45 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %44, align 8, !tbaa !17
-  %46 = bitcast [3 x i64]* %callArgs.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %46)
+  %24 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_3", i8* noundef null, i32 noundef 0, i32 noundef 1) #13
+  %25 = ptrtoint %struct.vm_ifunc* %24 to i64
+  %26 = call i64 @sorbet_globalConstRegister(i64 %25)
+  store i64 %26, i64* @"func_<root>.17<static-init>$153$block_3_ifunc", align 8
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.5, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !52
+  %27 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_4", i8* noundef null, i32 noundef 0, i32 noundef 2) #13
+  %28 = ptrtoint %struct.vm_ifunc* %27 to i64
+  %29 = call i64 @sorbet_globalConstRegister(i64 %28)
+  store i64 %29, i64* @"func_<root>.17<static-init>$153$block_4_ifunc", align 8
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.8, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !60
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.9, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !61
+  %30 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_5", i8* noundef null, i32 noundef 1, i32 noundef 2) #13
+  %31 = ptrtoint %struct.vm_ifunc* %30 to i64
+  %32 = call i64 @sorbet_globalConstRegister(i64 %31)
+  store i64 %32, i64* @"func_<root>.17<static-init>$153$block_5_ifunc", align 8
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.12, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !68
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.13, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !69
+  %33 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
+  %34 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %33, i64 0, i32 2
+  %35 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %34, align 8, !tbaa !17
+  %36 = bitcast [3 x i64]* %callArgs.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %36)
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %47 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %44, align 8, !tbaa !17
-  %48 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %47, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %48, align 8, !tbaa !21
-  %49 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %47, i64 0, i32 4
-  %50 = load i64*, i64** %49, align 8, !tbaa !23
-  %51 = load i64, i64* %50, align 8, !tbaa !6
-  %52 = and i64 %51, -33
-  store i64 %52, i64* %50, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %43, %struct.rb_control_frame_struct* %47, %struct.rb_iseq_struct* %stackFrame.i) #13
-  %53 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %45, i64 0, i32 0
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %53, align 8, !dbg !71, !tbaa !15
+  %37 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %34, align 8, !tbaa !17
+  %38 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %38, align 8, !tbaa !21
+  %39 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 4
+  %40 = load i64*, i64** %39, align 8, !tbaa !23
+  %41 = load i64, i64* %40, align 8, !tbaa !6
+  %42 = and i64 %41, -33
+  store i64 %42, i64* %40, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %33, %struct.rb_control_frame_struct* %37, %struct.rb_iseq_struct* %stackFrame.i) #13
+  %43 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %35, i64 0, i32 0
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %43, align 8, !dbg !71, !tbaa !15
   %callArgs0Addr.i = getelementptr [3 x i64], [3 x i64]* %callArgs.i, i64 0, i64 0, !dbg !72
-  %54 = bitcast i64* %callArgs0Addr.i to <2 x i64>*, !dbg !72
-  store <2 x i64> <i64 3, i64 5>, <2 x i64>* %54, align 8, !dbg !72
+  %44 = bitcast i64* %callArgs0Addr.i to <2 x i64>*, !dbg !72
+  store <2 x i64> <i64 3, i64 5>, <2 x i64>* %44, align 8, !dbg !72
   call void @llvm.experimental.noalias.scope.decl(metadata !73) #13, !dbg !72
-  %55 = call i64 @rb_ary_new_from_values(i64 noundef 2, i64* noundef nonnull align 8 %callArgs0Addr.i) #13, !dbg !72
-  store i64 %55, i64* %callArgs0Addr.i, align 8, !dbg !76
+  %45 = call i64 @rb_ary_new_from_values(i64 noundef 2, i64* noundef nonnull align 8 %callArgs0Addr.i) #13, !dbg !72
+  store i64 %45, i64* %callArgs0Addr.i, align 8, !dbg !76
   call void @llvm.experimental.noalias.scope.decl(metadata !77) #13, !dbg !76
-  %56 = call i64 @rb_ary_new_from_values(i64 noundef 1, i64* noundef nonnull %callArgs0Addr.i) #13, !dbg !76
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %53, align 8, !dbg !76, !tbaa !15
-  %rubyId_each.i = load i64, i64* @rubyIdPrecomputed_each, align 8, !dbg !80
-  %57 = load i64, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8, !dbg !80
-  %58 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %57) #13, !dbg !80
-  %59 = bitcast %struct.sorbet_inlineIntrinsicEnv* %6 to i8*, !dbg !80
-  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %59) #13, !dbg !80
-  %60 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %6, i64 0, i32 0, !dbg !80
-  store i64 %56, i64* %60, align 8, !dbg !80, !tbaa !81
-  %61 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %6, i64 0, i32 1, !dbg !80
-  store i64 %rubyId_each.i, i64* %61, align 8, !dbg !80, !tbaa !83
-  %62 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %6, i64 0, i32 2, !dbg !80
-  store i32 0, i32* %62, align 8, !dbg !80, !tbaa !84
-  %63 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %6, i64 0, i32 3, !dbg !80
-  %64 = bitcast i64** %63 to i8*, !dbg !80
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %64, i8 0, i64 16, i1 false) #13, !dbg !80
-  %65 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !80, !tbaa !15
-  %66 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %65, i64 0, i32 2, !dbg !80
-  %67 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %66, align 8, !dbg !80, !tbaa !17
-  %68 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %67, i64 0, i32 3, !dbg !80
-  %69 = bitcast i64* %68 to %struct.rb_captured_block*, !dbg !80
-  %70 = getelementptr inbounds i64, i64* %68, i64 2, !dbg !80
-  %71 = bitcast i64* %70 to %struct.vm_ifunc**, !dbg !80
-  store %struct.vm_ifunc* %58, %struct.vm_ifunc** %71, align 8, !dbg !80, !tbaa !27
+  %46 = call i64 @rb_ary_new_from_values(i64 noundef 1, i64* noundef nonnull %callArgs0Addr.i) #13, !dbg !76
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %43, align 8, !dbg !76, !tbaa !15
+  %rubyId_each.i = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !dbg !80, !invariant.load !5
+  %47 = load i64, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8, !dbg !80
+  %48 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %47) #13, !dbg !80
+  %49 = bitcast %struct.sorbet_inlineIntrinsicEnv* %6 to i8*, !dbg !80
+  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %49) #13, !dbg !80
+  %50 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %6, i64 0, i32 0, !dbg !80
+  store i64 %46, i64* %50, align 8, !dbg !80, !tbaa !81
+  %51 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %6, i64 0, i32 1, !dbg !80
+  store i64 %rubyId_each.i, i64* %51, align 8, !dbg !80, !tbaa !83
+  %52 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %6, i64 0, i32 2, !dbg !80
+  store i32 0, i32* %52, align 8, !dbg !80, !tbaa !84
+  %53 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %6, i64 0, i32 3, !dbg !80
+  %54 = bitcast i64** %53 to i8*, !dbg !80
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %54, i8 0, i64 16, i1 false) #13, !dbg !80
+  %55 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !80, !tbaa !15
+  %56 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %55, i64 0, i32 2, !dbg !80
+  %57 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %56, align 8, !dbg !80, !tbaa !17
+  %58 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %57, i64 0, i32 3, !dbg !80
+  %59 = bitcast i64* %58 to %struct.rb_captured_block*, !dbg !80
+  %60 = getelementptr inbounds i64, i64* %58, i64 2, !dbg !80
+  %61 = bitcast i64* %60 to %struct.vm_ifunc**, !dbg !80
+  store %struct.vm_ifunc* %48, %struct.vm_ifunc** %61, align 8, !dbg !80, !tbaa !27
   call void @llvm.experimental.noalias.scope.decl(metadata !85) #13, !dbg !80
-  %72 = ptrtoint %struct.rb_captured_block* %69 to i64, !dbg !80
-  %73 = or i64 %72, 3, !dbg !80
-  %74 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %65, i64 0, i32 17, !dbg !80
-  %75 = and i64 %73, -4, !dbg !88
-  %76 = inttoptr i64 %75 to %struct.rb_captured_block*, !dbg !88
-  store i64 0, i64* %74, align 8, !dbg !88, !tbaa !90
-  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %76) #13, !dbg !88
-  %77 = inttoptr i64 %56 to %struct.iseq_inline_iv_cache_entry*, !dbg !88
-  %78 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %77, i64 0, i32 0, !dbg !88
-  %79 = load i64, i64* %78, align 8, !dbg !88, !tbaa !25
-  %80 = and i64 %79, 8192, !dbg !88
-  %81 = icmp eq i64 %80, 0, !dbg !88
-  br i1 %81, label %85, label %82, !dbg !88
+  %62 = ptrtoint %struct.rb_captured_block* %59 to i64, !dbg !80
+  %63 = or i64 %62, 3, !dbg !80
+  %64 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %55, i64 0, i32 17, !dbg !80
+  %65 = and i64 %63, -4, !dbg !88
+  %66 = inttoptr i64 %65 to %struct.rb_captured_block*, !dbg !88
+  store i64 0, i64* %64, align 8, !dbg !88, !tbaa !90
+  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %66) #13, !dbg !88
+  %67 = inttoptr i64 %46 to %struct.iseq_inline_iv_cache_entry*, !dbg !88
+  %68 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %67, i64 0, i32 0, !dbg !88
+  %69 = load i64, i64* %68, align 8, !dbg !88, !tbaa !25
+  %70 = and i64 %69, 8192, !dbg !88
+  %71 = icmp eq i64 %70, 0, !dbg !88
+  br i1 %71, label %75, label %72, !dbg !88
 
-82:                                               ; preds = %entry
-  %83 = lshr i64 %79, 15, !dbg !88
-  %84 = and i64 %83, 3, !dbg !88
+72:                                               ; preds = %entry
+  %73 = lshr i64 %69, 15, !dbg !88
+  %74 = and i64 %73, 3, !dbg !88
   br label %rb_array_len.exit1.i3.i, !dbg !88
 
-85:                                               ; preds = %entry
-  %86 = inttoptr i64 %56 to %struct.RArray*, !dbg !88
-  %87 = getelementptr inbounds %struct.RArray, %struct.RArray* %86, i64 0, i32 1, i32 0, i32 0, !dbg !88
-  %88 = load i64, i64* %87, align 8, !dbg !88, !tbaa !27
+75:                                               ; preds = %entry
+  %76 = inttoptr i64 %46 to %struct.RArray*, !dbg !88
+  %77 = getelementptr inbounds %struct.RArray, %struct.RArray* %76, i64 0, i32 1, i32 0, i32 0, !dbg !88
+  %78 = load i64, i64* %77, align 8, !dbg !88, !tbaa !27
   br label %rb_array_len.exit1.i3.i, !dbg !88
 
-rb_array_len.exit1.i3.i:                          ; preds = %85, %82
-  %89 = phi i64 [ %84, %82 ], [ %88, %85 ], !dbg !88
-  %90 = icmp sgt i64 %89, 0, !dbg !88
-  br i1 %90, label %91, label %forward_sorbet_rb_array_each_withBlock.exit.i, !dbg !88
+rb_array_len.exit1.i3.i:                          ; preds = %75, %72
+  %79 = phi i64 [ %74, %72 ], [ %78, %75 ], !dbg !88
+  %80 = icmp sgt i64 %79, 0, !dbg !88
+  br i1 %80, label %81, label %forward_sorbet_rb_array_each_withBlock.exit.i, !dbg !88
 
-91:                                               ; preds = %rb_array_len.exit1.i3.i
-  %92 = bitcast i64* %1 to i8*, !dbg !88
-  %93 = inttoptr i64 %56 to %struct.RArray*, !dbg !80
-  %94 = getelementptr inbounds %struct.RArray, %struct.RArray* %93, i64 0, i32 1, i32 0, i32 0, !dbg !80
-  %95 = getelementptr inbounds %struct.RArray, %struct.RArray* %93, i64 0, i32 1, i32 0, i32 2, !dbg !80
-  br label %96, !dbg !88
+81:                                               ; preds = %rb_array_len.exit1.i3.i
+  %82 = bitcast i64* %1 to i8*, !dbg !88
+  %83 = inttoptr i64 %46 to %struct.RArray*, !dbg !80
+  %84 = getelementptr inbounds %struct.RArray, %struct.RArray* %83, i64 0, i32 1, i32 0, i32 0, !dbg !80
+  %85 = getelementptr inbounds %struct.RArray, %struct.RArray* %83, i64 0, i32 1, i32 0, i32 2, !dbg !80
+  br label %86, !dbg !88
 
-96:                                               ; preds = %rb_array_len.exit.i5.i, %91
-  %97 = phi i64 [ 0, %91 ], [ %107, %rb_array_len.exit.i5.i ], !dbg !88
-  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 dereferenceable(8) %92) #13, !dbg !88
-  %98 = load i64, i64* %78, align 8, !dbg !88, !tbaa !25
-  %99 = and i64 %98, 8192, !dbg !88
-  %100 = icmp eq i64 %99, 0, !dbg !88
-  br i1 %100, label %101, label %rb_array_const_ptr_transient.exit.i4.i, !dbg !88
+86:                                               ; preds = %rb_array_len.exit.i5.i, %81
+  %87 = phi i64 [ 0, %81 ], [ %97, %rb_array_len.exit.i5.i ], !dbg !88
+  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 dereferenceable(8) %82) #13, !dbg !88
+  %88 = load i64, i64* %68, align 8, !dbg !88, !tbaa !25
+  %89 = and i64 %88, 8192, !dbg !88
+  %90 = icmp eq i64 %89, 0, !dbg !88
+  br i1 %90, label %91, label %rb_array_const_ptr_transient.exit.i4.i, !dbg !88
 
-101:                                              ; preds = %96
-  %102 = load i64*, i64** %95, align 8, !dbg !88, !tbaa !27
+91:                                               ; preds = %86
+  %92 = load i64*, i64** %85, align 8, !dbg !88, !tbaa !27
   br label %rb_array_const_ptr_transient.exit.i4.i, !dbg !88
 
-rb_array_const_ptr_transient.exit.i4.i:           ; preds = %101, %96
-  %103 = phi i64* [ %102, %101 ], [ %94, %96 ], !dbg !88
-  %104 = getelementptr inbounds i64, i64* %103, i64 %97, !dbg !88
-  %105 = load i64, i64* %104, align 8, !dbg !88, !tbaa !6
-  store i64 %105, i64* %1, align 8, !dbg !88, !tbaa !6
-  %106 = call i64 @"func_<root>.17<static-init>$153$block_1"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %1, i64 undef) #13, !dbg !88
-  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %92) #13, !dbg !88
-  %107 = add nuw nsw i64 %97, 1, !dbg !88
-  %108 = load i64, i64* %78, align 8, !dbg !88, !tbaa !25
-  %109 = and i64 %108, 8192, !dbg !88
-  %110 = icmp eq i64 %109, 0, !dbg !88
-  br i1 %110, label %114, label %111, !dbg !88
+rb_array_const_ptr_transient.exit.i4.i:           ; preds = %91, %86
+  %93 = phi i64* [ %92, %91 ], [ %84, %86 ], !dbg !88
+  %94 = getelementptr inbounds i64, i64* %93, i64 %87, !dbg !88
+  %95 = load i64, i64* %94, align 8, !dbg !88, !tbaa !6
+  store i64 %95, i64* %1, align 8, !dbg !88, !tbaa !6
+  %96 = call i64 @"func_<root>.17<static-init>$153$block_1"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %1, i64 undef) #13, !dbg !88
+  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %82) #13, !dbg !88
+  %97 = add nuw nsw i64 %87, 1, !dbg !88
+  %98 = load i64, i64* %68, align 8, !dbg !88, !tbaa !25
+  %99 = and i64 %98, 8192, !dbg !88
+  %100 = icmp eq i64 %99, 0, !dbg !88
+  br i1 %100, label %104, label %101, !dbg !88
 
-111:                                              ; preds = %rb_array_const_ptr_transient.exit.i4.i
-  %112 = lshr i64 %108, 15, !dbg !88
-  %113 = and i64 %112, 3, !dbg !88
+101:                                              ; preds = %rb_array_const_ptr_transient.exit.i4.i
+  %102 = lshr i64 %98, 15, !dbg !88
+  %103 = and i64 %102, 3, !dbg !88
   br label %rb_array_len.exit.i5.i, !dbg !88
 
-114:                                              ; preds = %rb_array_const_ptr_transient.exit.i4.i
-  %115 = load i64, i64* %94, align 8, !dbg !88, !tbaa !27
+104:                                              ; preds = %rb_array_const_ptr_transient.exit.i4.i
+  %105 = load i64, i64* %84, align 8, !dbg !88, !tbaa !27
   br label %rb_array_len.exit.i5.i, !dbg !88
 
-rb_array_len.exit.i5.i:                           ; preds = %114, %111
-  %116 = phi i64 [ %113, %111 ], [ %115, %114 ], !dbg !88
-  %117 = icmp sgt i64 %116, %107, !dbg !88
-  br i1 %117, label %96, label %forward_sorbet_rb_array_each_withBlock.exit.i, !dbg !88, !llvm.loop !91
+rb_array_len.exit.i5.i:                           ; preds = %104, %101
+  %106 = phi i64 [ %103, %101 ], [ %105, %104 ], !dbg !88
+  %107 = icmp sgt i64 %106, %97, !dbg !88
+  br i1 %107, label %86, label %forward_sorbet_rb_array_each_withBlock.exit.i, !dbg !88, !llvm.loop !91
 
 forward_sorbet_rb_array_each_withBlock.exit.i:    ; preds = %rb_array_len.exit.i5.i, %rb_array_len.exit1.i3.i
   call void @sorbet_popFrame() #13, !dbg !88
-  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %59) #13, !dbg !80
-  %118 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !80, !tbaa !15
-  %119 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %118, i64 0, i32 5, !dbg !80
-  %120 = load i32, i32* %119, align 8, !dbg !80, !tbaa !37
-  %121 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %118, i64 0, i32 6, !dbg !80
-  %122 = load i32, i32* %121, align 4, !dbg !80, !tbaa !38
-  %123 = xor i32 %122, -1, !dbg !80
-  %124 = and i32 %123, %120, !dbg !80
-  %125 = icmp eq i32 %124, 0, !dbg !80
-  br i1 %125, label %rb_check_arity.1.exit.i8.i, label %126, !dbg !80, !prof !31
+  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %49) #13, !dbg !80
+  %108 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !80, !tbaa !15
+  %109 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %108, i64 0, i32 5, !dbg !80
+  %110 = load i32, i32* %109, align 8, !dbg !80, !tbaa !37
+  %111 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %108, i64 0, i32 6, !dbg !80
+  %112 = load i32, i32* %111, align 4, !dbg !80, !tbaa !38
+  %113 = xor i32 %112, -1, !dbg !80
+  %114 = and i32 %113, %110, !dbg !80
+  %115 = icmp eq i32 %114, 0, !dbg !80
+  br i1 %115, label %rb_check_arity.1.exit.i8.i, label %116, !dbg !80, !prof !31
 
-126:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.exit.i
-  %127 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %118, i64 0, i32 8, !dbg !80
-  %128 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %127, align 8, !dbg !80, !tbaa !39
-  %129 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %128, i32 noundef 0) #13, !dbg !80
+116:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.exit.i
+  %117 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %108, i64 0, i32 8, !dbg !80
+  %118 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %117, align 8, !dbg !80, !tbaa !39
+  %119 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %118, i32 noundef 0) #13, !dbg !80
   br label %rb_check_arity.1.exit.i8.i, !dbg !80
 
-rb_check_arity.1.exit.i8.i:                       ; preds = %126, %forward_sorbet_rb_array_each_withBlock.exit.i
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %53, align 8, !dbg !80, !tbaa !15
-  %rubyId_each65.i = load i64, i64* @rubyIdPrecomputed_each, align 8, !dbg !93
-  %130 = load i64, i64* @"func_<root>.17<static-init>$153$block_2_ifunc", align 8, !dbg !93
-  %131 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %130) #13, !dbg !93
-  %132 = bitcast %struct.sorbet_inlineIntrinsicEnv* %5 to i8*, !dbg !93
-  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %132) #13, !dbg !93
-  %133 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %5, i64 0, i32 0, !dbg !93
-  store i64 %56, i64* %133, align 8, !dbg !93, !tbaa !81
-  %134 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %5, i64 0, i32 1, !dbg !93
-  store i64 %rubyId_each65.i, i64* %134, align 8, !dbg !93, !tbaa !83
-  %135 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %5, i64 0, i32 2, !dbg !93
-  store i32 0, i32* %135, align 8, !dbg !93, !tbaa !84
-  %136 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %5, i64 0, i32 3, !dbg !93
-  %137 = bitcast i64** %136 to i8*, !dbg !93
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %137, i8 0, i64 16, i1 false) #13, !dbg !93
-  %138 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !93, !tbaa !15
-  %139 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %138, i64 0, i32 2, !dbg !93
-  %140 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %139, align 8, !dbg !93, !tbaa !17
-  %141 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %140, i64 0, i32 3, !dbg !93
-  %142 = bitcast i64* %141 to %struct.rb_captured_block*, !dbg !93
-  %143 = getelementptr inbounds i64, i64* %141, i64 2, !dbg !93
-  %144 = bitcast i64* %143 to %struct.vm_ifunc**, !dbg !93
-  store %struct.vm_ifunc* %131, %struct.vm_ifunc** %144, align 8, !dbg !93, !tbaa !27
+rb_check_arity.1.exit.i8.i:                       ; preds = %116, %forward_sorbet_rb_array_each_withBlock.exit.i
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %43, align 8, !dbg !80, !tbaa !15
+  %120 = load i64, i64* @"func_<root>.17<static-init>$153$block_2_ifunc", align 8, !dbg !93
+  %121 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %120) #13, !dbg !93
+  %122 = bitcast %struct.sorbet_inlineIntrinsicEnv* %5 to i8*, !dbg !93
+  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %122) #13, !dbg !93
+  %123 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %5, i64 0, i32 0, !dbg !93
+  store i64 %46, i64* %123, align 8, !dbg !93, !tbaa !81
+  %124 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %5, i64 0, i32 1, !dbg !93
+  store i64 %rubyId_each.i, i64* %124, align 8, !dbg !93, !tbaa !83
+  %125 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %5, i64 0, i32 2, !dbg !93
+  store i32 0, i32* %125, align 8, !dbg !93, !tbaa !84
+  %126 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %5, i64 0, i32 3, !dbg !93
+  %127 = bitcast i64** %126 to i8*, !dbg !93
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %127, i8 0, i64 16, i1 false) #13, !dbg !93
+  %128 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !93, !tbaa !15
+  %129 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %128, i64 0, i32 2, !dbg !93
+  %130 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %129, align 8, !dbg !93, !tbaa !17
+  %131 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %130, i64 0, i32 3, !dbg !93
+  %132 = bitcast i64* %131 to %struct.rb_captured_block*, !dbg !93
+  %133 = getelementptr inbounds i64, i64* %131, i64 2, !dbg !93
+  %134 = bitcast i64* %133 to %struct.vm_ifunc**, !dbg !93
+  store %struct.vm_ifunc* %121, %struct.vm_ifunc** %134, align 8, !dbg !93, !tbaa !27
   call void @llvm.experimental.noalias.scope.decl(metadata !94) #13, !dbg !93
-  %145 = ptrtoint %struct.rb_captured_block* %142 to i64, !dbg !93
-  %146 = or i64 %145, 3, !dbg !93
-  %147 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %138, i64 0, i32 17, !dbg !93
-  %148 = and i64 %146, -4, !dbg !97
-  %149 = inttoptr i64 %148 to %struct.rb_captured_block*, !dbg !97
-  store i64 0, i64* %147, align 8, !dbg !97, !tbaa !90
-  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %149) #13, !dbg !97
-  %150 = load i64, i64* %78, align 8, !dbg !97, !tbaa !25
-  %151 = and i64 %150, 8192, !dbg !97
-  %152 = icmp eq i64 %151, 0, !dbg !97
-  br i1 %152, label %156, label %153, !dbg !97
+  %135 = ptrtoint %struct.rb_captured_block* %132 to i64, !dbg !93
+  %136 = or i64 %135, 3, !dbg !93
+  %137 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %128, i64 0, i32 17, !dbg !93
+  %138 = and i64 %136, -4, !dbg !97
+  %139 = inttoptr i64 %138 to %struct.rb_captured_block*, !dbg !97
+  store i64 0, i64* %137, align 8, !dbg !97, !tbaa !90
+  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %139) #13, !dbg !97
+  %140 = load i64, i64* %68, align 8, !dbg !97, !tbaa !25
+  %141 = and i64 %140, 8192, !dbg !97
+  %142 = icmp eq i64 %141, 0, !dbg !97
+  br i1 %142, label %146, label %143, !dbg !97
 
-153:                                              ; preds = %rb_check_arity.1.exit.i8.i
-  %154 = lshr i64 %150, 15, !dbg !97
-  %155 = and i64 %154, 3, !dbg !97
+143:                                              ; preds = %rb_check_arity.1.exit.i8.i
+  %144 = lshr i64 %140, 15, !dbg !97
+  %145 = and i64 %144, 3, !dbg !97
   br label %rb_array_len.exit1.i9.i, !dbg !97
 
-156:                                              ; preds = %rb_check_arity.1.exit.i8.i
-  %157 = inttoptr i64 %56 to %struct.RArray*, !dbg !97
-  %158 = getelementptr inbounds %struct.RArray, %struct.RArray* %157, i64 0, i32 1, i32 0, i32 0, !dbg !97
-  %159 = load i64, i64* %158, align 8, !dbg !97, !tbaa !27
+146:                                              ; preds = %rb_check_arity.1.exit.i8.i
+  %147 = inttoptr i64 %46 to %struct.RArray*, !dbg !97
+  %148 = getelementptr inbounds %struct.RArray, %struct.RArray* %147, i64 0, i32 1, i32 0, i32 0, !dbg !97
+  %149 = load i64, i64* %148, align 8, !dbg !97, !tbaa !27
   br label %rb_array_len.exit1.i9.i, !dbg !97
 
-rb_array_len.exit1.i9.i:                          ; preds = %156, %153
-  %160 = phi i64 [ %155, %153 ], [ %159, %156 ], !dbg !97
-  %161 = icmp sgt i64 %160, 0, !dbg !97
-  br i1 %161, label %162, label %forward_sorbet_rb_array_each_withBlock.1.exit.i, !dbg !97
+rb_array_len.exit1.i9.i:                          ; preds = %146, %143
+  %150 = phi i64 [ %145, %143 ], [ %149, %146 ], !dbg !97
+  %151 = icmp sgt i64 %150, 0, !dbg !97
+  br i1 %151, label %152, label %forward_sorbet_rb_array_each_withBlock.1.exit.i, !dbg !97
 
-162:                                              ; preds = %rb_array_len.exit1.i9.i
-  %163 = inttoptr i64 %56 to %struct.RArray*, !dbg !93
-  %164 = getelementptr inbounds %struct.RArray, %struct.RArray* %163, i64 0, i32 1, i32 0, i32 0, !dbg !93
-  %165 = getelementptr inbounds %struct.RArray, %struct.RArray* %163, i64 0, i32 1, i32 0, i32 2, !dbg !93
-  br label %166, !dbg !97
+152:                                              ; preds = %rb_array_len.exit1.i9.i
+  %153 = inttoptr i64 %46 to %struct.RArray*, !dbg !93
+  %154 = getelementptr inbounds %struct.RArray, %struct.RArray* %153, i64 0, i32 1, i32 0, i32 0, !dbg !93
+  %155 = getelementptr inbounds %struct.RArray, %struct.RArray* %153, i64 0, i32 1, i32 0, i32 2, !dbg !93
+  br label %156, !dbg !97
 
-166:                                              ; preds = %rb_array_len.exit.i11.i, %162
-  %167 = phi i64 [ 0, %162 ], [ %191, %rb_array_len.exit.i11.i ], !dbg !97
-  %168 = load i64, i64* %78, align 8, !dbg !97, !tbaa !25
-  %169 = and i64 %168, 8192, !dbg !97
-  %170 = icmp eq i64 %169, 0, !dbg !97
-  br i1 %170, label %171, label %rb_array_const_ptr_transient.exit.i10.i, !dbg !97
+156:                                              ; preds = %rb_array_len.exit.i11.i, %152
+  %157 = phi i64 [ 0, %152 ], [ %181, %rb_array_len.exit.i11.i ], !dbg !97
+  %158 = load i64, i64* %68, align 8, !dbg !97, !tbaa !25
+  %159 = and i64 %158, 8192, !dbg !97
+  %160 = icmp eq i64 %159, 0, !dbg !97
+  br i1 %160, label %161, label %rb_array_const_ptr_transient.exit.i10.i, !dbg !97
 
-171:                                              ; preds = %166
-  %172 = load i64*, i64** %165, align 8, !dbg !97, !tbaa !27
+161:                                              ; preds = %156
+  %162 = load i64*, i64** %155, align 8, !dbg !97, !tbaa !27
   br label %rb_array_const_ptr_transient.exit.i10.i, !dbg !97
 
-rb_array_const_ptr_transient.exit.i10.i:          ; preds = %171, %166
-  %173 = phi i64* [ %172, %171 ], [ %164, %166 ], !dbg !97
-  %174 = getelementptr inbounds i64, i64* %173, i64 %167, !dbg !97
-  %175 = load i64, i64* %174, align 8, !dbg !97, !tbaa !6
+rb_array_const_ptr_transient.exit.i10.i:          ; preds = %161, %156
+  %163 = phi i64* [ %162, %161 ], [ %154, %156 ], !dbg !97
+  %164 = getelementptr inbounds i64, i64* %163, i64 %157, !dbg !97
+  %165 = load i64, i64* %164, align 8, !dbg !97, !tbaa !6
   call void @llvm.experimental.noalias.scope.decl(metadata !99) #13, !dbg !97
-  %176 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !93, !tbaa !15, !noalias !99
-  %177 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %176, i64 0, i32 2, !dbg !93
-  %178 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %177, align 8, !dbg !93, !tbaa !17, !noalias !99
-  %179 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %178, i64 0, i32 3, !dbg !93
-  %180 = load i64, i64* %179, align 8, !dbg !93, !tbaa !42, !noalias !99
+  %166 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !93, !tbaa !15, !noalias !99
+  %167 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %166, i64 0, i32 2, !dbg !93
+  %168 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %167, align 8, !dbg !93, !tbaa !17, !noalias !99
+  %169 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %168, i64 0, i32 3, !dbg !93
+  %170 = load i64, i64* %169, align 8, !dbg !93, !tbaa !42, !noalias !99
   %stackFrame.i.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_2", align 8, !dbg !93, !noalias !99
-  %181 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %178, i64 0, i32 2, !dbg !93
-  store %struct.rb_iseq_struct* %stackFrame.i.i.i, %struct.rb_iseq_struct** %181, align 8, !dbg !93, !tbaa !21, !noalias !99
-  %182 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %178, i64 0, i32 4, !dbg !93
-  %183 = load i64*, i64** %182, align 8, !dbg !93, !tbaa !23, !noalias !99
-  %184 = load i64, i64* %183, align 8, !dbg !93, !tbaa !6, !noalias !99
-  %185 = and i64 %184, -129, !dbg !93
-  store i64 %185, i64* %183, align 8, !dbg !93, !tbaa !6, !noalias !99
-  %186 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %178, i64 0, i32 0, !dbg !93
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %186, align 8, !dbg !102, !tbaa !15, !noalias !99
-  %187 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %178, i64 0, i32 1, !dbg !104
-  %188 = load i64*, i64** %187, align 8, !dbg !104
-  store i64 %180, i64* %188, align 8, !dbg !104, !tbaa !6
-  %189 = getelementptr inbounds i64, i64* %188, i64 1, !dbg !104
-  store i64 %175, i64* %189, align 8, !dbg !104, !tbaa !6
-  %190 = getelementptr inbounds i64, i64* %189, i64 1, !dbg !104
-  store i64* %190, i64** %187, align 8, !dbg !104
+  %171 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %168, i64 0, i32 2, !dbg !93
+  store %struct.rb_iseq_struct* %stackFrame.i.i.i, %struct.rb_iseq_struct** %171, align 8, !dbg !93, !tbaa !21, !noalias !99
+  %172 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %168, i64 0, i32 4, !dbg !93
+  %173 = load i64*, i64** %172, align 8, !dbg !93, !tbaa !23, !noalias !99
+  %174 = load i64, i64* %173, align 8, !dbg !93, !tbaa !6, !noalias !99
+  %175 = and i64 %174, -129, !dbg !93
+  store i64 %175, i64* %173, align 8, !dbg !93, !tbaa !6, !noalias !99
+  %176 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %168, i64 0, i32 0, !dbg !93
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %176, align 8, !dbg !102, !tbaa !15, !noalias !99
+  %177 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %168, i64 0, i32 1, !dbg !104
+  %178 = load i64*, i64** %177, align 8, !dbg !104
+  store i64 %170, i64* %178, align 8, !dbg !104, !tbaa !6
+  %179 = getelementptr inbounds i64, i64* %178, i64 1, !dbg !104
+  store i64 %165, i64* %179, align 8, !dbg !104, !tbaa !6
+  %180 = getelementptr inbounds i64, i64* %179, i64 1, !dbg !104
+  store i64* %180, i64** %177, align 8, !dbg !104
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p, i64 0), !dbg !104
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %186, align 8, !dbg !104, !tbaa !15, !noalias !99
-  %191 = add nuw nsw i64 %167, 1, !dbg !97
-  %192 = load i64, i64* %78, align 8, !dbg !97, !tbaa !25
-  %193 = and i64 %192, 8192, !dbg !97
-  %194 = icmp eq i64 %193, 0, !dbg !97
-  br i1 %194, label %198, label %195, !dbg !97
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %176, align 8, !dbg !104, !tbaa !15, !noalias !99
+  %181 = add nuw nsw i64 %157, 1, !dbg !97
+  %182 = load i64, i64* %68, align 8, !dbg !97, !tbaa !25
+  %183 = and i64 %182, 8192, !dbg !97
+  %184 = icmp eq i64 %183, 0, !dbg !97
+  br i1 %184, label %188, label %185, !dbg !97
 
-195:                                              ; preds = %rb_array_const_ptr_transient.exit.i10.i
-  %196 = lshr i64 %192, 15, !dbg !97
-  %197 = and i64 %196, 3, !dbg !97
+185:                                              ; preds = %rb_array_const_ptr_transient.exit.i10.i
+  %186 = lshr i64 %182, 15, !dbg !97
+  %187 = and i64 %186, 3, !dbg !97
   br label %rb_array_len.exit.i11.i, !dbg !97
 
-198:                                              ; preds = %rb_array_const_ptr_transient.exit.i10.i
-  %199 = load i64, i64* %164, align 8, !dbg !97, !tbaa !27
+188:                                              ; preds = %rb_array_const_ptr_transient.exit.i10.i
+  %189 = load i64, i64* %154, align 8, !dbg !97, !tbaa !27
   br label %rb_array_len.exit.i11.i, !dbg !97
 
-rb_array_len.exit.i11.i:                          ; preds = %198, %195
-  %200 = phi i64 [ %197, %195 ], [ %199, %198 ], !dbg !97
-  %201 = icmp sgt i64 %200, %191, !dbg !97
-  br i1 %201, label %166, label %forward_sorbet_rb_array_each_withBlock.1.exit.i, !dbg !97, !llvm.loop !105
+rb_array_len.exit.i11.i:                          ; preds = %188, %185
+  %190 = phi i64 [ %187, %185 ], [ %189, %188 ], !dbg !97
+  %191 = icmp sgt i64 %190, %181, !dbg !97
+  br i1 %191, label %156, label %forward_sorbet_rb_array_each_withBlock.1.exit.i, !dbg !97, !llvm.loop !105
 
 forward_sorbet_rb_array_each_withBlock.1.exit.i:  ; preds = %rb_array_len.exit.i11.i, %rb_array_len.exit1.i9.i
   call void @sorbet_popFrame() #13, !dbg !97
-  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %132) #13, !dbg !93
-  %202 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !93, !tbaa !15
-  %203 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %202, i64 0, i32 5, !dbg !93
-  %204 = load i32, i32* %203, align 8, !dbg !93, !tbaa !37
-  %205 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %202, i64 0, i32 6, !dbg !93
-  %206 = load i32, i32* %205, align 4, !dbg !93, !tbaa !38
-  %207 = xor i32 %206, -1, !dbg !93
-  %208 = and i32 %207, %204, !dbg !93
-  %209 = icmp eq i32 %208, 0, !dbg !93
-  br i1 %209, label %rb_check_arity.1.exit.i14.i, label %210, !dbg !93, !prof !31
+  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %122) #13, !dbg !93
+  %192 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !93, !tbaa !15
+  %193 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %192, i64 0, i32 5, !dbg !93
+  %194 = load i32, i32* %193, align 8, !dbg !93, !tbaa !37
+  %195 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %192, i64 0, i32 6, !dbg !93
+  %196 = load i32, i32* %195, align 4, !dbg !93, !tbaa !38
+  %197 = xor i32 %196, -1, !dbg !93
+  %198 = and i32 %197, %194, !dbg !93
+  %199 = icmp eq i32 %198, 0, !dbg !93
+  br i1 %199, label %rb_check_arity.1.exit.i14.i, label %200, !dbg !93, !prof !31
 
-210:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.1.exit.i
-  %211 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %202, i64 0, i32 8, !dbg !93
-  %212 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %211, align 8, !dbg !93, !tbaa !39
-  %213 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %212, i32 noundef 0) #13, !dbg !93
+200:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.1.exit.i
+  %201 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %192, i64 0, i32 8, !dbg !93
+  %202 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %201, align 8, !dbg !93, !tbaa !39
+  %203 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %202, i32 noundef 0) #13, !dbg !93
   br label %rb_check_arity.1.exit.i14.i, !dbg !93
 
-rb_check_arity.1.exit.i14.i:                      ; preds = %210, %forward_sorbet_rb_array_each_withBlock.1.exit.i
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %53, align 8, !dbg !93, !tbaa !15
-  %rubyId_each77.i = load i64, i64* @rubyIdPrecomputed_each, align 8, !dbg !106
-  %214 = load i64, i64* @"func_<root>.17<static-init>$153$block_3_ifunc", align 8, !dbg !106
-  %215 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %214) #13, !dbg !106
-  %216 = bitcast %struct.sorbet_inlineIntrinsicEnv* %4 to i8*, !dbg !106
-  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %216) #13, !dbg !106
-  %217 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %4, i64 0, i32 0, !dbg !106
-  store i64 %56, i64* %217, align 8, !dbg !106, !tbaa !81
-  %218 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %4, i64 0, i32 1, !dbg !106
-  store i64 %rubyId_each77.i, i64* %218, align 8, !dbg !106, !tbaa !83
-  %219 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %4, i64 0, i32 2, !dbg !106
-  store i32 0, i32* %219, align 8, !dbg !106, !tbaa !84
-  %220 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %4, i64 0, i32 3, !dbg !106
-  %221 = bitcast i64** %220 to i8*, !dbg !106
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %221, i8 0, i64 16, i1 false) #13, !dbg !106
-  %222 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !106, !tbaa !15
-  %223 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %222, i64 0, i32 2, !dbg !106
-  %224 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %223, align 8, !dbg !106, !tbaa !17
-  %225 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %224, i64 0, i32 3, !dbg !106
-  %226 = bitcast i64* %225 to %struct.rb_captured_block*, !dbg !106
-  %227 = getelementptr inbounds i64, i64* %225, i64 2, !dbg !106
-  %228 = bitcast i64* %227 to %struct.vm_ifunc**, !dbg !106
-  store %struct.vm_ifunc* %215, %struct.vm_ifunc** %228, align 8, !dbg !106, !tbaa !27
+rb_check_arity.1.exit.i14.i:                      ; preds = %200, %forward_sorbet_rb_array_each_withBlock.1.exit.i
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %43, align 8, !dbg !93, !tbaa !15
+  %204 = load i64, i64* @"func_<root>.17<static-init>$153$block_3_ifunc", align 8, !dbg !106
+  %205 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %204) #13, !dbg !106
+  %206 = bitcast %struct.sorbet_inlineIntrinsicEnv* %4 to i8*, !dbg !106
+  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %206) #13, !dbg !106
+  %207 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %4, i64 0, i32 0, !dbg !106
+  store i64 %46, i64* %207, align 8, !dbg !106, !tbaa !81
+  %208 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %4, i64 0, i32 1, !dbg !106
+  store i64 %rubyId_each.i, i64* %208, align 8, !dbg !106, !tbaa !83
+  %209 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %4, i64 0, i32 2, !dbg !106
+  store i32 0, i32* %209, align 8, !dbg !106, !tbaa !84
+  %210 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %4, i64 0, i32 3, !dbg !106
+  %211 = bitcast i64** %210 to i8*, !dbg !106
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %211, i8 0, i64 16, i1 false) #13, !dbg !106
+  %212 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !106, !tbaa !15
+  %213 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %212, i64 0, i32 2, !dbg !106
+  %214 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %213, align 8, !dbg !106, !tbaa !17
+  %215 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %214, i64 0, i32 3, !dbg !106
+  %216 = bitcast i64* %215 to %struct.rb_captured_block*, !dbg !106
+  %217 = getelementptr inbounds i64, i64* %215, i64 2, !dbg !106
+  %218 = bitcast i64* %217 to %struct.vm_ifunc**, !dbg !106
+  store %struct.vm_ifunc* %205, %struct.vm_ifunc** %218, align 8, !dbg !106, !tbaa !27
   call void @llvm.experimental.noalias.scope.decl(metadata !107) #13, !dbg !106
-  %229 = ptrtoint %struct.rb_captured_block* %226 to i64, !dbg !106
-  %230 = or i64 %229, 3, !dbg !106
-  %231 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %222, i64 0, i32 17, !dbg !106
-  %232 = and i64 %230, -4, !dbg !110
-  %233 = inttoptr i64 %232 to %struct.rb_captured_block*, !dbg !110
-  store i64 0, i64* %231, align 8, !dbg !110, !tbaa !90
-  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %233) #13, !dbg !110
-  %234 = load i64, i64* %78, align 8, !dbg !110, !tbaa !25
-  %235 = and i64 %234, 8192, !dbg !110
-  %236 = icmp eq i64 %235, 0, !dbg !110
-  br i1 %236, label %240, label %237, !dbg !110
+  %219 = ptrtoint %struct.rb_captured_block* %216 to i64, !dbg !106
+  %220 = or i64 %219, 3, !dbg !106
+  %221 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %212, i64 0, i32 17, !dbg !106
+  %222 = and i64 %220, -4, !dbg !110
+  %223 = inttoptr i64 %222 to %struct.rb_captured_block*, !dbg !110
+  store i64 0, i64* %221, align 8, !dbg !110, !tbaa !90
+  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %223) #13, !dbg !110
+  %224 = load i64, i64* %68, align 8, !dbg !110, !tbaa !25
+  %225 = and i64 %224, 8192, !dbg !110
+  %226 = icmp eq i64 %225, 0, !dbg !110
+  br i1 %226, label %230, label %227, !dbg !110
 
-237:                                              ; preds = %rb_check_arity.1.exit.i14.i
-  %238 = lshr i64 %234, 15, !dbg !110
-  %239 = and i64 %238, 3, !dbg !110
+227:                                              ; preds = %rb_check_arity.1.exit.i14.i
+  %228 = lshr i64 %224, 15, !dbg !110
+  %229 = and i64 %228, 3, !dbg !110
   br label %rb_array_len.exit1.i15.i, !dbg !110
 
-240:                                              ; preds = %rb_check_arity.1.exit.i14.i
-  %241 = inttoptr i64 %56 to %struct.RArray*, !dbg !110
-  %242 = getelementptr inbounds %struct.RArray, %struct.RArray* %241, i64 0, i32 1, i32 0, i32 0, !dbg !110
-  %243 = load i64, i64* %242, align 8, !dbg !110, !tbaa !27
+230:                                              ; preds = %rb_check_arity.1.exit.i14.i
+  %231 = inttoptr i64 %46 to %struct.RArray*, !dbg !110
+  %232 = getelementptr inbounds %struct.RArray, %struct.RArray* %231, i64 0, i32 1, i32 0, i32 0, !dbg !110
+  %233 = load i64, i64* %232, align 8, !dbg !110, !tbaa !27
   br label %rb_array_len.exit1.i15.i, !dbg !110
 
-rb_array_len.exit1.i15.i:                         ; preds = %240, %237
-  %244 = phi i64 [ %239, %237 ], [ %243, %240 ], !dbg !110
-  %245 = icmp sgt i64 %244, 0, !dbg !110
-  br i1 %245, label %246, label %forward_sorbet_rb_array_each_withBlock.3.exit.i, !dbg !110
+rb_array_len.exit1.i15.i:                         ; preds = %230, %227
+  %234 = phi i64 [ %229, %227 ], [ %233, %230 ], !dbg !110
+  %235 = icmp sgt i64 %234, 0, !dbg !110
+  br i1 %235, label %236, label %forward_sorbet_rb_array_each_withBlock.3.exit.i, !dbg !110
 
-246:                                              ; preds = %rb_array_len.exit1.i15.i
-  %247 = inttoptr i64 %56 to %struct.RArray*, !dbg !106
-  %248 = getelementptr inbounds %struct.RArray, %struct.RArray* %247, i64 0, i32 1, i32 0, i32 0, !dbg !106
-  %249 = getelementptr inbounds %struct.RArray, %struct.RArray* %247, i64 0, i32 1, i32 0, i32 2, !dbg !106
-  br label %250, !dbg !110
+236:                                              ; preds = %rb_array_len.exit1.i15.i
+  %237 = inttoptr i64 %46 to %struct.RArray*, !dbg !106
+  %238 = getelementptr inbounds %struct.RArray, %struct.RArray* %237, i64 0, i32 1, i32 0, i32 0, !dbg !106
+  %239 = getelementptr inbounds %struct.RArray, %struct.RArray* %237, i64 0, i32 1, i32 0, i32 2, !dbg !106
+  br label %240, !dbg !110
 
-250:                                              ; preds = %rb_array_len.exit.i18.i, %246
-  %251 = phi i64 [ 0, %246 ], [ %275, %rb_array_len.exit.i18.i ], !dbg !110
-  %252 = load i64, i64* %78, align 8, !dbg !110, !tbaa !25
-  %253 = and i64 %252, 8192, !dbg !110
-  %254 = icmp eq i64 %253, 0, !dbg !110
-  br i1 %254, label %255, label %rb_array_const_ptr_transient.exit.i17.i, !dbg !110
+240:                                              ; preds = %rb_array_len.exit.i18.i, %236
+  %241 = phi i64 [ 0, %236 ], [ %265, %rb_array_len.exit.i18.i ], !dbg !110
+  %242 = load i64, i64* %68, align 8, !dbg !110, !tbaa !25
+  %243 = and i64 %242, 8192, !dbg !110
+  %244 = icmp eq i64 %243, 0, !dbg !110
+  br i1 %244, label %245, label %rb_array_const_ptr_transient.exit.i17.i, !dbg !110
 
-255:                                              ; preds = %250
-  %256 = load i64*, i64** %249, align 8, !dbg !110, !tbaa !27
+245:                                              ; preds = %240
+  %246 = load i64*, i64** %239, align 8, !dbg !110, !tbaa !27
   br label %rb_array_const_ptr_transient.exit.i17.i, !dbg !110
 
-rb_array_const_ptr_transient.exit.i17.i:          ; preds = %255, %250
-  %257 = phi i64* [ %256, %255 ], [ %248, %250 ], !dbg !110
-  %258 = getelementptr inbounds i64, i64* %257, i64 %251, !dbg !110
-  %259 = load i64, i64* %258, align 8, !dbg !110, !tbaa !6
+rb_array_const_ptr_transient.exit.i17.i:          ; preds = %245, %240
+  %247 = phi i64* [ %246, %245 ], [ %238, %240 ], !dbg !110
+  %248 = getelementptr inbounds i64, i64* %247, i64 %241, !dbg !110
+  %249 = load i64, i64* %248, align 8, !dbg !110, !tbaa !6
   call void @llvm.experimental.noalias.scope.decl(metadata !112) #13, !dbg !110
-  %260 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !106, !tbaa !15, !noalias !112
-  %261 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %260, i64 0, i32 2, !dbg !106
-  %262 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %261, align 8, !dbg !106, !tbaa !17, !noalias !112
-  %263 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %262, i64 0, i32 3, !dbg !106
-  %264 = load i64, i64* %263, align 8, !dbg !106, !tbaa !42, !noalias !112
+  %250 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !106, !tbaa !15, !noalias !112
+  %251 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %250, i64 0, i32 2, !dbg !106
+  %252 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %251, align 8, !dbg !106, !tbaa !17, !noalias !112
+  %253 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %252, i64 0, i32 3, !dbg !106
+  %254 = load i64, i64* %253, align 8, !dbg !106, !tbaa !42, !noalias !112
   %stackFrame.i.i16.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_3", align 8, !dbg !106, !noalias !112
-  %265 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %262, i64 0, i32 2, !dbg !106
-  store %struct.rb_iseq_struct* %stackFrame.i.i16.i, %struct.rb_iseq_struct** %265, align 8, !dbg !106, !tbaa !21, !noalias !112
-  %266 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %262, i64 0, i32 4, !dbg !106
-  %267 = load i64*, i64** %266, align 8, !dbg !106, !tbaa !23, !noalias !112
-  %268 = load i64, i64* %267, align 8, !dbg !106, !tbaa !6, !noalias !112
-  %269 = and i64 %268, -129, !dbg !106
-  store i64 %269, i64* %267, align 8, !dbg !106, !tbaa !6, !noalias !112
-  %270 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %262, i64 0, i32 0, !dbg !106
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %270, align 8, !dbg !106, !tbaa !15, !noalias !112
-  %271 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %262, i64 0, i32 1, !dbg !115
-  %272 = load i64*, i64** %271, align 8, !dbg !115
-  store i64 %264, i64* %272, align 8, !dbg !115, !tbaa !6
-  %273 = getelementptr inbounds i64, i64* %272, i64 1, !dbg !115
-  store i64 %259, i64* %273, align 8, !dbg !115, !tbaa !6
-  %274 = getelementptr inbounds i64, i64* %273, i64 1, !dbg !115
-  store i64* %274, i64** %271, align 8, !dbg !115
+  %255 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %252, i64 0, i32 2, !dbg !106
+  store %struct.rb_iseq_struct* %stackFrame.i.i16.i, %struct.rb_iseq_struct** %255, align 8, !dbg !106, !tbaa !21, !noalias !112
+  %256 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %252, i64 0, i32 4, !dbg !106
+  %257 = load i64*, i64** %256, align 8, !dbg !106, !tbaa !23, !noalias !112
+  %258 = load i64, i64* %257, align 8, !dbg !106, !tbaa !6, !noalias !112
+  %259 = and i64 %258, -129, !dbg !106
+  store i64 %259, i64* %257, align 8, !dbg !106, !tbaa !6, !noalias !112
+  %260 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %252, i64 0, i32 0, !dbg !106
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %260, align 8, !dbg !106, !tbaa !15, !noalias !112
+  %261 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %252, i64 0, i32 1, !dbg !115
+  %262 = load i64*, i64** %261, align 8, !dbg !115
+  store i64 %254, i64* %262, align 8, !dbg !115, !tbaa !6
+  %263 = getelementptr inbounds i64, i64* %262, i64 1, !dbg !115
+  store i64 %249, i64* %263, align 8, !dbg !115, !tbaa !6
+  %264 = getelementptr inbounds i64, i64* %263, i64 1, !dbg !115
+  store i64* %264, i64** %261, align 8, !dbg !115
   %send14 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.5, i64 0), !dbg !115
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %270, align 8, !dbg !115, !tbaa !15, !noalias !112
-  %275 = add nuw nsw i64 %251, 1, !dbg !110
-  %276 = load i64, i64* %78, align 8, !dbg !110, !tbaa !25
-  %277 = and i64 %276, 8192, !dbg !110
-  %278 = icmp eq i64 %277, 0, !dbg !110
-  br i1 %278, label %282, label %279, !dbg !110
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %260, align 8, !dbg !115, !tbaa !15, !noalias !112
+  %265 = add nuw nsw i64 %241, 1, !dbg !110
+  %266 = load i64, i64* %68, align 8, !dbg !110, !tbaa !25
+  %267 = and i64 %266, 8192, !dbg !110
+  %268 = icmp eq i64 %267, 0, !dbg !110
+  br i1 %268, label %272, label %269, !dbg !110
 
-279:                                              ; preds = %rb_array_const_ptr_transient.exit.i17.i
-  %280 = lshr i64 %276, 15, !dbg !110
-  %281 = and i64 %280, 3, !dbg !110
+269:                                              ; preds = %rb_array_const_ptr_transient.exit.i17.i
+  %270 = lshr i64 %266, 15, !dbg !110
+  %271 = and i64 %270, 3, !dbg !110
   br label %rb_array_len.exit.i18.i, !dbg !110
 
-282:                                              ; preds = %rb_array_const_ptr_transient.exit.i17.i
-  %283 = load i64, i64* %248, align 8, !dbg !110, !tbaa !27
+272:                                              ; preds = %rb_array_const_ptr_transient.exit.i17.i
+  %273 = load i64, i64* %238, align 8, !dbg !110, !tbaa !27
   br label %rb_array_len.exit.i18.i, !dbg !110
 
-rb_array_len.exit.i18.i:                          ; preds = %282, %279
-  %284 = phi i64 [ %281, %279 ], [ %283, %282 ], !dbg !110
-  %285 = icmp sgt i64 %284, %275, !dbg !110
-  br i1 %285, label %250, label %forward_sorbet_rb_array_each_withBlock.3.exit.i, !dbg !110, !llvm.loop !117
+rb_array_len.exit.i18.i:                          ; preds = %272, %269
+  %274 = phi i64 [ %271, %269 ], [ %273, %272 ], !dbg !110
+  %275 = icmp sgt i64 %274, %265, !dbg !110
+  br i1 %275, label %240, label %forward_sorbet_rb_array_each_withBlock.3.exit.i, !dbg !110, !llvm.loop !117
 
 forward_sorbet_rb_array_each_withBlock.3.exit.i:  ; preds = %rb_array_len.exit.i18.i, %rb_array_len.exit1.i15.i
   call void @sorbet_popFrame() #13, !dbg !110
-  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %216) #13, !dbg !106
-  %286 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !106, !tbaa !15
-  %287 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %286, i64 0, i32 5, !dbg !106
-  %288 = load i32, i32* %287, align 8, !dbg !106, !tbaa !37
-  %289 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %286, i64 0, i32 6, !dbg !106
-  %290 = load i32, i32* %289, align 4, !dbg !106, !tbaa !38
-  %291 = xor i32 %290, -1, !dbg !106
-  %292 = and i32 %291, %288, !dbg !106
-  %293 = icmp eq i32 %292, 0, !dbg !106
-  br i1 %293, label %rb_check_arity.1.exit.i21.i, label %294, !dbg !106, !prof !31
+  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %206) #13, !dbg !106
+  %276 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !106, !tbaa !15
+  %277 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %276, i64 0, i32 5, !dbg !106
+  %278 = load i32, i32* %277, align 8, !dbg !106, !tbaa !37
+  %279 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %276, i64 0, i32 6, !dbg !106
+  %280 = load i32, i32* %279, align 4, !dbg !106, !tbaa !38
+  %281 = xor i32 %280, -1, !dbg !106
+  %282 = and i32 %281, %278, !dbg !106
+  %283 = icmp eq i32 %282, 0, !dbg !106
+  br i1 %283, label %rb_check_arity.1.exit.i21.i, label %284, !dbg !106, !prof !31
 
-294:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.3.exit.i
-  %295 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %286, i64 0, i32 8, !dbg !106
-  %296 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %295, align 8, !dbg !106, !tbaa !39
-  %297 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %296, i32 noundef 0) #13, !dbg !106
+284:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.3.exit.i
+  %285 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %276, i64 0, i32 8, !dbg !106
+  %286 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %285, align 8, !dbg !106, !tbaa !39
+  %287 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %286, i32 noundef 0) #13, !dbg !106
   br label %rb_check_arity.1.exit.i21.i, !dbg !106
 
-rb_check_arity.1.exit.i21.i:                      ; preds = %294, %forward_sorbet_rb_array_each_withBlock.3.exit.i
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %53, align 8, !dbg !106, !tbaa !15
-  %rubyId_each89.i = load i64, i64* @rubyIdPrecomputed_each, align 8, !dbg !118
-  %298 = load i64, i64* @"func_<root>.17<static-init>$153$block_4_ifunc", align 8, !dbg !118
-  %299 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %298) #13, !dbg !118
-  %300 = bitcast %struct.sorbet_inlineIntrinsicEnv* %3 to i8*, !dbg !118
-  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %300) #13, !dbg !118
-  %301 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %3, i64 0, i32 0, !dbg !118
-  store i64 %56, i64* %301, align 8, !dbg !118, !tbaa !81
-  %302 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %3, i64 0, i32 1, !dbg !118
-  store i64 %rubyId_each89.i, i64* %302, align 8, !dbg !118, !tbaa !83
-  %303 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %3, i64 0, i32 2, !dbg !118
-  store i32 0, i32* %303, align 8, !dbg !118, !tbaa !84
-  %304 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %3, i64 0, i32 3, !dbg !118
-  %305 = bitcast i64** %304 to i8*, !dbg !118
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %305, i8 0, i64 16, i1 false) #13, !dbg !118
-  %306 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !118, !tbaa !15
-  %307 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %306, i64 0, i32 2, !dbg !118
-  %308 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %307, align 8, !dbg !118, !tbaa !17
-  %309 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %308, i64 0, i32 3, !dbg !118
-  %310 = bitcast i64* %309 to %struct.rb_captured_block*, !dbg !118
-  %311 = getelementptr inbounds i64, i64* %309, i64 2, !dbg !118
-  %312 = bitcast i64* %311 to %struct.vm_ifunc**, !dbg !118
-  store %struct.vm_ifunc* %299, %struct.vm_ifunc** %312, align 8, !dbg !118, !tbaa !27
+rb_check_arity.1.exit.i21.i:                      ; preds = %284, %forward_sorbet_rb_array_each_withBlock.3.exit.i
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %43, align 8, !dbg !106, !tbaa !15
+  %288 = load i64, i64* @"func_<root>.17<static-init>$153$block_4_ifunc", align 8, !dbg !118
+  %289 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %288) #13, !dbg !118
+  %290 = bitcast %struct.sorbet_inlineIntrinsicEnv* %3 to i8*, !dbg !118
+  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %290) #13, !dbg !118
+  %291 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %3, i64 0, i32 0, !dbg !118
+  store i64 %46, i64* %291, align 8, !dbg !118, !tbaa !81
+  %292 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %3, i64 0, i32 1, !dbg !118
+  store i64 %rubyId_each.i, i64* %292, align 8, !dbg !118, !tbaa !83
+  %293 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %3, i64 0, i32 2, !dbg !118
+  store i32 0, i32* %293, align 8, !dbg !118, !tbaa !84
+  %294 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %3, i64 0, i32 3, !dbg !118
+  %295 = bitcast i64** %294 to i8*, !dbg !118
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %295, i8 0, i64 16, i1 false) #13, !dbg !118
+  %296 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !118, !tbaa !15
+  %297 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %296, i64 0, i32 2, !dbg !118
+  %298 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %297, align 8, !dbg !118, !tbaa !17
+  %299 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %298, i64 0, i32 3, !dbg !118
+  %300 = bitcast i64* %299 to %struct.rb_captured_block*, !dbg !118
+  %301 = getelementptr inbounds i64, i64* %299, i64 2, !dbg !118
+  %302 = bitcast i64* %301 to %struct.vm_ifunc**, !dbg !118
+  store %struct.vm_ifunc* %289, %struct.vm_ifunc** %302, align 8, !dbg !118, !tbaa !27
   call void @llvm.experimental.noalias.scope.decl(metadata !119) #13, !dbg !118
-  %313 = ptrtoint %struct.rb_captured_block* %310 to i64, !dbg !118
-  %314 = or i64 %313, 3, !dbg !118
-  %315 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %306, i64 0, i32 17, !dbg !118
-  %316 = and i64 %314, -4, !dbg !122
-  %317 = inttoptr i64 %316 to %struct.rb_captured_block*, !dbg !122
-  store i64 0, i64* %315, align 8, !dbg !122, !tbaa !90
-  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %317) #13, !dbg !122
-  %318 = load i64, i64* %78, align 8, !dbg !122, !tbaa !25
-  %319 = and i64 %318, 8192, !dbg !122
-  %320 = icmp eq i64 %319, 0, !dbg !122
-  br i1 %320, label %324, label %321, !dbg !122
+  %303 = ptrtoint %struct.rb_captured_block* %300 to i64, !dbg !118
+  %304 = or i64 %303, 3, !dbg !118
+  %305 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %296, i64 0, i32 17, !dbg !118
+  %306 = and i64 %304, -4, !dbg !122
+  %307 = inttoptr i64 %306 to %struct.rb_captured_block*, !dbg !122
+  store i64 0, i64* %305, align 8, !dbg !122, !tbaa !90
+  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %307) #13, !dbg !122
+  %308 = load i64, i64* %68, align 8, !dbg !122, !tbaa !25
+  %309 = and i64 %308, 8192, !dbg !122
+  %310 = icmp eq i64 %309, 0, !dbg !122
+  br i1 %310, label %314, label %311, !dbg !122
 
-321:                                              ; preds = %rb_check_arity.1.exit.i21.i
-  %322 = lshr i64 %318, 15, !dbg !122
-  %323 = and i64 %322, 3, !dbg !122
+311:                                              ; preds = %rb_check_arity.1.exit.i21.i
+  %312 = lshr i64 %308, 15, !dbg !122
+  %313 = and i64 %312, 3, !dbg !122
   br label %rb_array_len.exit1.i22.i, !dbg !122
 
-324:                                              ; preds = %rb_check_arity.1.exit.i21.i
-  %325 = inttoptr i64 %56 to %struct.RArray*, !dbg !122
-  %326 = getelementptr inbounds %struct.RArray, %struct.RArray* %325, i64 0, i32 1, i32 0, i32 0, !dbg !122
-  %327 = load i64, i64* %326, align 8, !dbg !122, !tbaa !27
+314:                                              ; preds = %rb_check_arity.1.exit.i21.i
+  %315 = inttoptr i64 %46 to %struct.RArray*, !dbg !122
+  %316 = getelementptr inbounds %struct.RArray, %struct.RArray* %315, i64 0, i32 1, i32 0, i32 0, !dbg !122
+  %317 = load i64, i64* %316, align 8, !dbg !122, !tbaa !27
   br label %rb_array_len.exit1.i22.i, !dbg !122
 
-rb_array_len.exit1.i22.i:                         ; preds = %324, %321
-  %328 = phi i64 [ %323, %321 ], [ %327, %324 ], !dbg !122
-  %329 = icmp sgt i64 %328, 0, !dbg !122
-  br i1 %329, label %330, label %forward_sorbet_rb_array_each_withBlock.6.exit.i, !dbg !122
+rb_array_len.exit1.i22.i:                         ; preds = %314, %311
+  %318 = phi i64 [ %313, %311 ], [ %317, %314 ], !dbg !122
+  %319 = icmp sgt i64 %318, 0, !dbg !122
+  br i1 %319, label %320, label %forward_sorbet_rb_array_each_withBlock.6.exit.i, !dbg !122
 
-330:                                              ; preds = %rb_array_len.exit1.i22.i
-  %331 = bitcast i64* %0 to i8*, !dbg !122
-  %332 = inttoptr i64 %56 to %struct.RArray*, !dbg !118
-  %333 = getelementptr inbounds %struct.RArray, %struct.RArray* %332, i64 0, i32 1, i32 0, i32 0, !dbg !118
-  %334 = getelementptr inbounds %struct.RArray, %struct.RArray* %332, i64 0, i32 1, i32 0, i32 2, !dbg !118
-  br label %335, !dbg !122
+320:                                              ; preds = %rb_array_len.exit1.i22.i
+  %321 = bitcast i64* %0 to i8*, !dbg !122
+  %322 = inttoptr i64 %46 to %struct.RArray*, !dbg !118
+  %323 = getelementptr inbounds %struct.RArray, %struct.RArray* %322, i64 0, i32 1, i32 0, i32 0, !dbg !118
+  %324 = getelementptr inbounds %struct.RArray, %struct.RArray* %322, i64 0, i32 1, i32 0, i32 2, !dbg !118
+  br label %325, !dbg !122
 
-335:                                              ; preds = %rb_array_len.exit.i24.i, %330
-  %336 = phi i64 [ 0, %330 ], [ %346, %rb_array_len.exit.i24.i ], !dbg !122
-  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 dereferenceable(8) %331) #13, !dbg !122
-  %337 = load i64, i64* %78, align 8, !dbg !122, !tbaa !25
-  %338 = and i64 %337, 8192, !dbg !122
-  %339 = icmp eq i64 %338, 0, !dbg !122
-  br i1 %339, label %340, label %rb_array_const_ptr_transient.exit.i23.i, !dbg !122
+325:                                              ; preds = %rb_array_len.exit.i24.i, %320
+  %326 = phi i64 [ 0, %320 ], [ %336, %rb_array_len.exit.i24.i ], !dbg !122
+  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 dereferenceable(8) %321) #13, !dbg !122
+  %327 = load i64, i64* %68, align 8, !dbg !122, !tbaa !25
+  %328 = and i64 %327, 8192, !dbg !122
+  %329 = icmp eq i64 %328, 0, !dbg !122
+  br i1 %329, label %330, label %rb_array_const_ptr_transient.exit.i23.i, !dbg !122
 
-340:                                              ; preds = %335
-  %341 = load i64*, i64** %334, align 8, !dbg !122, !tbaa !27
+330:                                              ; preds = %325
+  %331 = load i64*, i64** %324, align 8, !dbg !122, !tbaa !27
   br label %rb_array_const_ptr_transient.exit.i23.i, !dbg !122
 
-rb_array_const_ptr_transient.exit.i23.i:          ; preds = %340, %335
-  %342 = phi i64* [ %341, %340 ], [ %333, %335 ], !dbg !122
-  %343 = getelementptr inbounds i64, i64* %342, i64 %336, !dbg !122
-  %344 = load i64, i64* %343, align 8, !dbg !122, !tbaa !6
-  store i64 %344, i64* %0, align 8, !dbg !122, !tbaa !6
-  %345 = call i64 @"func_<root>.17<static-init>$153$block_4"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %0, i64 undef) #13, !dbg !122
-  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %331) #13, !dbg !122
-  %346 = add nuw nsw i64 %336, 1, !dbg !122
-  %347 = load i64, i64* %78, align 8, !dbg !122, !tbaa !25
-  %348 = and i64 %347, 8192, !dbg !122
-  %349 = icmp eq i64 %348, 0, !dbg !122
-  br i1 %349, label %353, label %350, !dbg !122
+rb_array_const_ptr_transient.exit.i23.i:          ; preds = %330, %325
+  %332 = phi i64* [ %331, %330 ], [ %323, %325 ], !dbg !122
+  %333 = getelementptr inbounds i64, i64* %332, i64 %326, !dbg !122
+  %334 = load i64, i64* %333, align 8, !dbg !122, !tbaa !6
+  store i64 %334, i64* %0, align 8, !dbg !122, !tbaa !6
+  %335 = call i64 @"func_<root>.17<static-init>$153$block_4"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %0, i64 undef) #13, !dbg !122
+  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %321) #13, !dbg !122
+  %336 = add nuw nsw i64 %326, 1, !dbg !122
+  %337 = load i64, i64* %68, align 8, !dbg !122, !tbaa !25
+  %338 = and i64 %337, 8192, !dbg !122
+  %339 = icmp eq i64 %338, 0, !dbg !122
+  br i1 %339, label %343, label %340, !dbg !122
 
-350:                                              ; preds = %rb_array_const_ptr_transient.exit.i23.i
-  %351 = lshr i64 %347, 15, !dbg !122
-  %352 = and i64 %351, 3, !dbg !122
+340:                                              ; preds = %rb_array_const_ptr_transient.exit.i23.i
+  %341 = lshr i64 %337, 15, !dbg !122
+  %342 = and i64 %341, 3, !dbg !122
   br label %rb_array_len.exit.i24.i, !dbg !122
 
-353:                                              ; preds = %rb_array_const_ptr_transient.exit.i23.i
-  %354 = load i64, i64* %333, align 8, !dbg !122, !tbaa !27
+343:                                              ; preds = %rb_array_const_ptr_transient.exit.i23.i
+  %344 = load i64, i64* %323, align 8, !dbg !122, !tbaa !27
   br label %rb_array_len.exit.i24.i, !dbg !122
 
-rb_array_len.exit.i24.i:                          ; preds = %353, %350
-  %355 = phi i64 [ %352, %350 ], [ %354, %353 ], !dbg !122
-  %356 = icmp sgt i64 %355, %346, !dbg !122
-  br i1 %356, label %335, label %forward_sorbet_rb_array_each_withBlock.6.exit.i, !dbg !122, !llvm.loop !124
+rb_array_len.exit.i24.i:                          ; preds = %343, %340
+  %345 = phi i64 [ %342, %340 ], [ %344, %343 ], !dbg !122
+  %346 = icmp sgt i64 %345, %336, !dbg !122
+  br i1 %346, label %325, label %forward_sorbet_rb_array_each_withBlock.6.exit.i, !dbg !122, !llvm.loop !124
 
 forward_sorbet_rb_array_each_withBlock.6.exit.i:  ; preds = %rb_array_len.exit.i24.i, %rb_array_len.exit1.i22.i
   call void @sorbet_popFrame() #13, !dbg !122
-  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %300) #13, !dbg !118
-  %357 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !118, !tbaa !15
-  %358 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %357, i64 0, i32 5, !dbg !118
-  %359 = load i32, i32* %358, align 8, !dbg !118, !tbaa !37
-  %360 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %357, i64 0, i32 6, !dbg !118
-  %361 = load i32, i32* %360, align 4, !dbg !118, !tbaa !38
-  %362 = xor i32 %361, -1, !dbg !118
-  %363 = and i32 %362, %359, !dbg !118
-  %364 = icmp eq i32 %363, 0, !dbg !118
-  br i1 %364, label %rb_check_arity.1.exit.i.i, label %365, !dbg !118, !prof !31
+  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %290) #13, !dbg !118
+  %347 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !118, !tbaa !15
+  %348 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %347, i64 0, i32 5, !dbg !118
+  %349 = load i32, i32* %348, align 8, !dbg !118, !tbaa !37
+  %350 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %347, i64 0, i32 6, !dbg !118
+  %351 = load i32, i32* %350, align 4, !dbg !118, !tbaa !38
+  %352 = xor i32 %351, -1, !dbg !118
+  %353 = and i32 %352, %349, !dbg !118
+  %354 = icmp eq i32 %353, 0, !dbg !118
+  br i1 %354, label %rb_check_arity.1.exit.i.i, label %355, !dbg !118, !prof !31
 
-365:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.6.exit.i
-  %366 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %357, i64 0, i32 8, !dbg !118
-  %367 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %366, align 8, !dbg !118, !tbaa !39
-  %368 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %367, i32 noundef 0) #13, !dbg !118
+355:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.6.exit.i
+  %356 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %347, i64 0, i32 8, !dbg !118
+  %357 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %356, align 8, !dbg !118, !tbaa !39
+  %358 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %357, i32 noundef 0) #13, !dbg !118
   br label %rb_check_arity.1.exit.i.i, !dbg !118
 
-rb_check_arity.1.exit.i.i:                        ; preds = %365, %forward_sorbet_rb_array_each_withBlock.6.exit.i
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %53, align 8, !dbg !118, !tbaa !15
-  %rubyId_each101.i = load i64, i64* @rubyIdPrecomputed_each, align 8, !dbg !125
-  %369 = load i64, i64* @"func_<root>.17<static-init>$153$block_5_ifunc", align 8, !dbg !125
-  %370 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %369) #13, !dbg !125
-  %371 = bitcast %struct.sorbet_inlineIntrinsicEnv* %7 to i8*, !dbg !125
-  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %371) #13, !dbg !125
-  %372 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %7, i64 0, i32 0, !dbg !125
-  store i64 %56, i64* %372, align 8, !dbg !125, !tbaa !81
-  %373 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %7, i64 0, i32 1, !dbg !125
-  store i64 %rubyId_each101.i, i64* %373, align 8, !dbg !125, !tbaa !83
-  %374 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %7, i64 0, i32 2, !dbg !125
-  store i32 0, i32* %374, align 8, !dbg !125, !tbaa !84
-  %375 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %7, i64 0, i32 3, !dbg !125
-  %376 = bitcast i64** %375 to i8*, !dbg !125
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %376, i8 0, i64 16, i1 false) #13, !dbg !125
-  %377 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !125, !tbaa !15
-  %378 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %377, i64 0, i32 2, !dbg !125
-  %379 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %378, align 8, !dbg !125, !tbaa !17
-  %380 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %379, i64 0, i32 3, !dbg !125
-  %381 = bitcast i64* %380 to %struct.rb_captured_block*, !dbg !125
-  %382 = getelementptr inbounds i64, i64* %380, i64 2, !dbg !125
-  %383 = bitcast i64* %382 to %struct.vm_ifunc**, !dbg !125
-  store %struct.vm_ifunc* %370, %struct.vm_ifunc** %383, align 8, !dbg !125, !tbaa !27
+rb_check_arity.1.exit.i.i:                        ; preds = %355, %forward_sorbet_rb_array_each_withBlock.6.exit.i
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %43, align 8, !dbg !118, !tbaa !15
+  %359 = load i64, i64* @"func_<root>.17<static-init>$153$block_5_ifunc", align 8, !dbg !125
+  %360 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %359) #13, !dbg !125
+  %361 = bitcast %struct.sorbet_inlineIntrinsicEnv* %7 to i8*, !dbg !125
+  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %361) #13, !dbg !125
+  %362 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %7, i64 0, i32 0, !dbg !125
+  store i64 %46, i64* %362, align 8, !dbg !125, !tbaa !81
+  %363 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %7, i64 0, i32 1, !dbg !125
+  store i64 %rubyId_each.i, i64* %363, align 8, !dbg !125, !tbaa !83
+  %364 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %7, i64 0, i32 2, !dbg !125
+  store i32 0, i32* %364, align 8, !dbg !125, !tbaa !84
+  %365 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %7, i64 0, i32 3, !dbg !125
+  %366 = bitcast i64** %365 to i8*, !dbg !125
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %366, i8 0, i64 16, i1 false) #13, !dbg !125
+  %367 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !125, !tbaa !15
+  %368 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %367, i64 0, i32 2, !dbg !125
+  %369 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %368, align 8, !dbg !125, !tbaa !17
+  %370 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %369, i64 0, i32 3, !dbg !125
+  %371 = bitcast i64* %370 to %struct.rb_captured_block*, !dbg !125
+  %372 = getelementptr inbounds i64, i64* %370, i64 2, !dbg !125
+  %373 = bitcast i64* %372 to %struct.vm_ifunc**, !dbg !125
+  store %struct.vm_ifunc* %360, %struct.vm_ifunc** %373, align 8, !dbg !125, !tbaa !27
   call void @llvm.experimental.noalias.scope.decl(metadata !126) #13, !dbg !125
-  %384 = ptrtoint %struct.rb_captured_block* %381 to i64, !dbg !125
-  %385 = or i64 %384, 3, !dbg !125
-  %386 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %377, i64 0, i32 17, !dbg !125
-  %387 = and i64 %385, -4, !dbg !129
-  %388 = inttoptr i64 %387 to %struct.rb_captured_block*, !dbg !129
-  store i64 0, i64* %386, align 8, !dbg !129, !tbaa !90
-  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %388) #13, !dbg !129
-  %389 = load i64, i64* %78, align 8, !dbg !129, !tbaa !25
-  %390 = and i64 %389, 8192, !dbg !129
-  %391 = icmp eq i64 %390, 0, !dbg !129
-  br i1 %391, label %395, label %392, !dbg !129
+  %374 = ptrtoint %struct.rb_captured_block* %371 to i64, !dbg !125
+  %375 = or i64 %374, 3, !dbg !125
+  %376 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %367, i64 0, i32 17, !dbg !125
+  %377 = and i64 %375, -4, !dbg !129
+  %378 = inttoptr i64 %377 to %struct.rb_captured_block*, !dbg !129
+  store i64 0, i64* %376, align 8, !dbg !129, !tbaa !90
+  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %378) #13, !dbg !129
+  %379 = load i64, i64* %68, align 8, !dbg !129, !tbaa !25
+  %380 = and i64 %379, 8192, !dbg !129
+  %381 = icmp eq i64 %380, 0, !dbg !129
+  br i1 %381, label %385, label %382, !dbg !129
 
-392:                                              ; preds = %rb_check_arity.1.exit.i.i
-  %393 = lshr i64 %389, 15, !dbg !129
-  %394 = and i64 %393, 3, !dbg !129
+382:                                              ; preds = %rb_check_arity.1.exit.i.i
+  %383 = lshr i64 %379, 15, !dbg !129
+  %384 = and i64 %383, 3, !dbg !129
   br label %rb_array_len.exit1.i.i, !dbg !129
 
-395:                                              ; preds = %rb_check_arity.1.exit.i.i
-  %396 = inttoptr i64 %56 to %struct.RArray*, !dbg !129
-  %397 = getelementptr inbounds %struct.RArray, %struct.RArray* %396, i64 0, i32 1, i32 0, i32 0, !dbg !129
-  %398 = load i64, i64* %397, align 8, !dbg !129, !tbaa !27
+385:                                              ; preds = %rb_check_arity.1.exit.i.i
+  %386 = inttoptr i64 %46 to %struct.RArray*, !dbg !129
+  %387 = getelementptr inbounds %struct.RArray, %struct.RArray* %386, i64 0, i32 1, i32 0, i32 0, !dbg !129
+  %388 = load i64, i64* %387, align 8, !dbg !129, !tbaa !27
   br label %rb_array_len.exit1.i.i, !dbg !129
 
-rb_array_len.exit1.i.i:                           ; preds = %395, %392
-  %399 = phi i64 [ %394, %392 ], [ %398, %395 ], !dbg !129
-  %400 = icmp sgt i64 %399, 0, !dbg !129
-  br i1 %400, label %401, label %forward_sorbet_rb_array_each_withBlock.10.exit.i, !dbg !129
+rb_array_len.exit1.i.i:                           ; preds = %385, %382
+  %389 = phi i64 [ %384, %382 ], [ %388, %385 ], !dbg !129
+  %390 = icmp sgt i64 %389, 0, !dbg !129
+  br i1 %390, label %391, label %forward_sorbet_rb_array_each_withBlock.10.exit.i, !dbg !129
 
-401:                                              ; preds = %rb_array_len.exit1.i.i
-  %402 = bitcast i64* %2 to i8*, !dbg !129
-  %403 = inttoptr i64 %56 to %struct.RArray*, !dbg !125
-  %404 = getelementptr inbounds %struct.RArray, %struct.RArray* %403, i64 0, i32 1, i32 0, i32 0, !dbg !125
-  %405 = getelementptr inbounds %struct.RArray, %struct.RArray* %403, i64 0, i32 1, i32 0, i32 2, !dbg !125
-  br label %406, !dbg !129
+391:                                              ; preds = %rb_array_len.exit1.i.i
+  %392 = bitcast i64* %2 to i8*, !dbg !129
+  %393 = inttoptr i64 %46 to %struct.RArray*, !dbg !125
+  %394 = getelementptr inbounds %struct.RArray, %struct.RArray* %393, i64 0, i32 1, i32 0, i32 0, !dbg !125
+  %395 = getelementptr inbounds %struct.RArray, %struct.RArray* %393, i64 0, i32 1, i32 0, i32 2, !dbg !125
+  br label %396, !dbg !129
 
-406:                                              ; preds = %rb_array_len.exit.i.i, %401
-  %407 = phi i64 [ 0, %401 ], [ %417, %rb_array_len.exit.i.i ], !dbg !129
-  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 dereferenceable(8) %402) #13, !dbg !129
-  %408 = load i64, i64* %78, align 8, !dbg !129, !tbaa !25
-  %409 = and i64 %408, 8192, !dbg !129
-  %410 = icmp eq i64 %409, 0, !dbg !129
-  br i1 %410, label %411, label %rb_array_const_ptr_transient.exit.i.i, !dbg !129
+396:                                              ; preds = %rb_array_len.exit.i.i, %391
+  %397 = phi i64 [ 0, %391 ], [ %407, %rb_array_len.exit.i.i ], !dbg !129
+  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 dereferenceable(8) %392) #13, !dbg !129
+  %398 = load i64, i64* %68, align 8, !dbg !129, !tbaa !25
+  %399 = and i64 %398, 8192, !dbg !129
+  %400 = icmp eq i64 %399, 0, !dbg !129
+  br i1 %400, label %401, label %rb_array_const_ptr_transient.exit.i.i, !dbg !129
 
-411:                                              ; preds = %406
-  %412 = load i64*, i64** %405, align 8, !dbg !129, !tbaa !27
+401:                                              ; preds = %396
+  %402 = load i64*, i64** %395, align 8, !dbg !129, !tbaa !27
   br label %rb_array_const_ptr_transient.exit.i.i, !dbg !129
 
-rb_array_const_ptr_transient.exit.i.i:            ; preds = %411, %406
-  %413 = phi i64* [ %412, %411 ], [ %404, %406 ], !dbg !129
-  %414 = getelementptr inbounds i64, i64* %413, i64 %407, !dbg !129
-  %415 = load i64, i64* %414, align 8, !dbg !129, !tbaa !6
-  store i64 %415, i64* %2, align 8, !dbg !129, !tbaa !6
-  %416 = call i64 @"func_<root>.17<static-init>$153$block_5"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %2, i64 undef) #13, !dbg !129
-  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %402) #13, !dbg !129
-  %417 = add nuw nsw i64 %407, 1, !dbg !129
-  %418 = load i64, i64* %78, align 8, !dbg !129, !tbaa !25
-  %419 = and i64 %418, 8192, !dbg !129
-  %420 = icmp eq i64 %419, 0, !dbg !129
-  br i1 %420, label %424, label %421, !dbg !129
+rb_array_const_ptr_transient.exit.i.i:            ; preds = %401, %396
+  %403 = phi i64* [ %402, %401 ], [ %394, %396 ], !dbg !129
+  %404 = getelementptr inbounds i64, i64* %403, i64 %397, !dbg !129
+  %405 = load i64, i64* %404, align 8, !dbg !129, !tbaa !6
+  store i64 %405, i64* %2, align 8, !dbg !129, !tbaa !6
+  %406 = call i64 @"func_<root>.17<static-init>$153$block_5"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %2, i64 undef) #13, !dbg !129
+  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %392) #13, !dbg !129
+  %407 = add nuw nsw i64 %397, 1, !dbg !129
+  %408 = load i64, i64* %68, align 8, !dbg !129, !tbaa !25
+  %409 = and i64 %408, 8192, !dbg !129
+  %410 = icmp eq i64 %409, 0, !dbg !129
+  br i1 %410, label %414, label %411, !dbg !129
 
-421:                                              ; preds = %rb_array_const_ptr_transient.exit.i.i
-  %422 = lshr i64 %418, 15, !dbg !129
-  %423 = and i64 %422, 3, !dbg !129
+411:                                              ; preds = %rb_array_const_ptr_transient.exit.i.i
+  %412 = lshr i64 %408, 15, !dbg !129
+  %413 = and i64 %412, 3, !dbg !129
   br label %rb_array_len.exit.i.i, !dbg !129
 
-424:                                              ; preds = %rb_array_const_ptr_transient.exit.i.i
-  %425 = load i64, i64* %404, align 8, !dbg !129, !tbaa !27
+414:                                              ; preds = %rb_array_const_ptr_transient.exit.i.i
+  %415 = load i64, i64* %394, align 8, !dbg !129, !tbaa !27
   br label %rb_array_len.exit.i.i, !dbg !129
 
-rb_array_len.exit.i.i:                            ; preds = %424, %421
-  %426 = phi i64 [ %423, %421 ], [ %425, %424 ], !dbg !129
-  %427 = icmp sgt i64 %426, %417, !dbg !129
-  br i1 %427, label %406, label %forward_sorbet_rb_array_each_withBlock.10.exit.i, !dbg !129, !llvm.loop !131
+rb_array_len.exit.i.i:                            ; preds = %414, %411
+  %416 = phi i64 [ %413, %411 ], [ %415, %414 ], !dbg !129
+  %417 = icmp sgt i64 %416, %407, !dbg !129
+  br i1 %417, label %396, label %forward_sorbet_rb_array_each_withBlock.10.exit.i, !dbg !129, !llvm.loop !131
 
 forward_sorbet_rb_array_each_withBlock.10.exit.i: ; preds = %rb_array_len.exit.i.i, %rb_array_len.exit1.i.i
   call void @sorbet_popFrame() #13, !dbg !129
-  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %371) #13, !dbg !125
-  %428 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !125, !tbaa !15
-  %429 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %428, i64 0, i32 5, !dbg !125
-  %430 = load i32, i32* %429, align 8, !dbg !125, !tbaa !37
-  %431 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %428, i64 0, i32 6, !dbg !125
-  %432 = load i32, i32* %431, align 4, !dbg !125, !tbaa !38
-  %433 = xor i32 %432, -1, !dbg !125
-  %434 = and i32 %433, %430, !dbg !125
-  %435 = icmp eq i32 %434, 0, !dbg !125
-  br i1 %435, label %"func_<root>.17<static-init>$153.exit", label %436, !dbg !125, !prof !31
+  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %361) #13, !dbg !125
+  %418 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !125, !tbaa !15
+  %419 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %418, i64 0, i32 5, !dbg !125
+  %420 = load i32, i32* %419, align 8, !dbg !125, !tbaa !37
+  %421 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %418, i64 0, i32 6, !dbg !125
+  %422 = load i32, i32* %421, align 4, !dbg !125, !tbaa !38
+  %423 = xor i32 %422, -1, !dbg !125
+  %424 = and i32 %423, %420, !dbg !125
+  %425 = icmp eq i32 %424, 0, !dbg !125
+  br i1 %425, label %"func_<root>.17<static-init>$153.exit", label %426, !dbg !125, !prof !31
 
-436:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.10.exit.i
-  %437 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %428, i64 0, i32 8, !dbg !125
-  %438 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %437, align 8, !dbg !125, !tbaa !39
-  %439 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %438, i32 noundef 0) #13, !dbg !125
+426:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.10.exit.i
+  %427 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %418, i64 0, i32 8, !dbg !125
+  %428 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %427, align 8, !dbg !125, !tbaa !39
+  %429 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %428, i32 noundef 0) #13, !dbg !125
   br label %"func_<root>.17<static-init>$153.exit", !dbg !125
 
-"func_<root>.17<static-init>$153.exit":           ; preds = %forward_sorbet_rb_array_each_withBlock.10.exit.i, %436
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %53, align 8, !tbaa !15
-  call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %46)
+"func_<root>.17<static-init>$153.exit":           ; preds = %forward_sorbet_rb_array_each_withBlock.10.exit.i, %426
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %43, align 8, !tbaa !15
+  call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %36)
   ret void
 }
 

--- a/test/testdata/compiler/block_args.opt.ll.exp
+++ b/test/testdata/compiler/block_args.opt.ll.exp
@@ -90,20 +90,17 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/block_args.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [5 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_block in <top (required)>" = internal unnamed_addr global i64 0, align 8
-@rubyIdPrecomputed_map = internal unnamed_addr global i64 0, align 8
 @"func_<root>.17<static-init>$153$block_1_ifunc" = internal unnamed_addr global i64 0
-@"rubyIdPrecomputed_+" = internal unnamed_addr global i64 0, align 8
 @"ic_+" = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
 @sorbet_moduleStringTable = internal unnamed_addr constant [112 x i8] c"<top (required)>\00test/testdata/compiler/block_args.rb\00block in <top (required)>\00<build-array>\00map\00+\00puts\00master\00", align 1
+@sorbet_moduleIDTable = internal unnamed_addr global [6 x i64] zeroinitializer, align 8
+@sorbet_moduleIDDescriptors = internal unnamed_addr constant [6 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 54, i32 25 }, %struct.rb_code_position_struct { i32 80, i32 13 }, %struct.rb_code_position_struct { i32 94, i32 3 }, %struct.rb_code_position_struct { i32 98, i32 1 }, %struct.rb_code_position_struct { i32 100, i32 4 }], align 8
 
 declare i64 @rb_ary_push(i64, i64) local_unnamed_addr #0
 
@@ -129,6 +126,8 @@ declare i64 @sorbet_globalConstRegister(i64) local_unnamed_addr #0
 
 declare %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64) local_unnamed_addr #0
 
+declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #0
+
 declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
@@ -136,8 +135,6 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #1
-
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #0
 
 declare i64 @rb_ary_new_capa(i64) local_unnamed_addr #0
 
@@ -282,218 +279,208 @@ entry:
   %callArgs.i = alloca [3 x i64], align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %2 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([112 x i8], [112 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #11
-  store i64 %2, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %3 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([112 x i8], [112 x i8]* @sorbet_moduleStringTable, i64 0, i64 54), i64 noundef 25) #11
-  store i64 %3, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
-  %4 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([112 x i8], [112 x i8]* @sorbet_moduleStringTable, i64 0, i64 80), i64 noundef 13) #11
-  %5 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([112 x i8], [112 x i8]* @sorbet_moduleStringTable, i64 0, i64 94), i64 noundef 3) #11
-  store i64 %5, i64* @rubyIdPrecomputed_map, align 8
-  %6 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([112 x i8], [112 x i8]* @sorbet_moduleStringTable, i64 0, i64 98), i64 noundef 1) #11
-  store i64 %6, i64* @"rubyIdPrecomputed_+", align 8
-  %7 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([112 x i8], [112 x i8]* @sorbet_moduleStringTable, i64 0, i64 100), i64 noundef 4) #11
-  store i64 %7, i64* @rubyIdPrecomputed_puts, align 8
-  %8 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([112 x i8], [112 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #11
-  tail call void @rb_gc_register_mark_object(i64 %8) #11
-  store i64 %8, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %9 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([112 x i8], [112 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 36) #11
-  tail call void @rb_gc_register_mark_object(i64 %9) #11
-  store i64 %9, i64* @"rubyStrFrozen_test/testdata/compiler/block_args.rb", align 8
+  tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([6 x %struct.rb_code_position_struct], [6 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 6, i8* noundef getelementptr inbounds ([112 x i8], [112 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
+  %2 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([112 x i8], [112 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #11
+  tail call void @rb_gc_register_mark_object(i64 %2) #11
+  store i64 %2, i64* @"rubyStrFrozen_<top (required)>", align 8
+  %3 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([112 x i8], [112 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 36) #11
+  tail call void @rb_gc_register_mark_object(i64 %3) #11
+  store i64 %3, i64* @"rubyStrFrozen_test/testdata/compiler/block_args.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 5)
-  %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
+  %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
   %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/block_args.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_args.rb", align 8
-  %10 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_args.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 3)
-  store %struct.rb_iseq_struct* %10, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %11 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([112 x i8], [112 x i8]* @sorbet_moduleStringTable, i64 0, i64 54), i64 noundef 25) #11
-  call void @rb_gc_register_mark_object(i64 %11) #11
+  %4 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_args.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 3)
+  store %struct.rb_iseq_struct* %4, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %5 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([112 x i8], [112 x i8]* @sorbet_moduleStringTable, i64 0, i64 54), i64 noundef 25) #11
+  call void @rb_gc_register_mark_object(i64 %5) #11
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %"rubyId_block in <top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
+  %"rubyId_block in <top (required)>.i.i" = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/block_args.rb.i3.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_args.rb", align 8
-  %12 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %11, i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_args.rb.i3.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
-  store %struct.rb_iseq_struct* %12, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1", align 8
-  %13 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_1", i8* noundef null, i32 noundef 1, i32 noundef 1) #11
-  %14 = ptrtoint %struct.vm_ifunc* %13 to i64
-  %15 = call i64 @sorbet_globalConstRegister(i64 %14)
-  store i64 %15, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8
-  %"rubyId_+.i" = load i64, i64* @"rubyIdPrecomputed_+", align 8, !dbg !26
+  %6 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %5, i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_args.rb.i3.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
+  store %struct.rb_iseq_struct* %6, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1", align 8
+  %7 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_1", i8* noundef null, i32 noundef 1, i32 noundef 1) #11
+  %8 = ptrtoint %struct.vm_ifunc* %7 to i64
+  %9 = call i64 @sorbet_globalConstRegister(i64 %8)
+  store i64 %9, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8
+  %"rubyId_+.i" = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !dbg !26, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_+", i64 %"rubyId_+.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !26
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !38
+  %rubyId_puts.i = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleIDTable, i64 0, i64 5), align 8, !dbg !38, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !38
-  %16 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !15
-  %17 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %16, i64 0, i32 18
-  %18 = load i64, i64* %17, align 8, !tbaa !39
-  %19 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
-  %20 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %19, i64 0, i32 2
-  %21 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %20, align 8, !tbaa !17
-  %22 = bitcast [3 x i64]* %callArgs.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %22)
+  %10 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !15
+  %11 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %10, i64 0, i32 18
+  %12 = load i64, i64* %11, align 8, !tbaa !39
+  %13 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
+  %14 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %13, i64 0, i32 2
+  %15 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %14, align 8, !tbaa !17
+  %16 = bitcast [3 x i64]* %callArgs.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %16)
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %23 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %20, align 8, !tbaa !17
-  %24 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %24, align 8, !tbaa !21
-  %25 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 4
-  %26 = load i64*, i64** %25, align 8, !tbaa !23
-  %27 = load i64, i64* %26, align 8, !tbaa !6
-  %28 = and i64 %27, -33
-  store i64 %28, i64* %26, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %19, %struct.rb_control_frame_struct* %23, %struct.rb_iseq_struct* %stackFrame.i) #11
-  %29 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %21, i64 0, i32 0
-  store i64* getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %29, align 8, !dbg !48, !tbaa !15
+  %17 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %14, align 8, !tbaa !17
+  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %18, align 8, !tbaa !21
+  %19 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 4
+  %20 = load i64*, i64** %19, align 8, !tbaa !23
+  %21 = load i64, i64* %20, align 8, !tbaa !6
+  %22 = and i64 %21, -33
+  store i64 %22, i64* %20, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %13, %struct.rb_control_frame_struct* %17, %struct.rb_iseq_struct* %stackFrame.i) #11
+  %23 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 0
+  store i64* getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %23, align 8, !dbg !48, !tbaa !15
   %callArgs0Addr.i = getelementptr [3 x i64], [3 x i64]* %callArgs.i, i64 0, i64 0, !dbg !49
-  %30 = bitcast i64* %callArgs0Addr.i to <2 x i64>*, !dbg !49
-  store <2 x i64> <i64 3, i64 5>, <2 x i64>* %30, align 8, !dbg !49
+  %24 = bitcast i64* %callArgs0Addr.i to <2 x i64>*, !dbg !49
+  store <2 x i64> <i64 3, i64 5>, <2 x i64>* %24, align 8, !dbg !49
   call void @llvm.experimental.noalias.scope.decl(metadata !50) #11, !dbg !49
-  %31 = call i64 @rb_ary_new_from_values(i64 noundef 2, i64* noundef nonnull align 8 %callArgs0Addr.i) #11, !dbg !49
-  %rubyId_map.i = load i64, i64* @rubyIdPrecomputed_map, align 8, !dbg !49
-  %32 = load i64, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8, !dbg !49
-  %33 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %32) #11, !dbg !49
-  %34 = bitcast %struct.sorbet_inlineIntrinsicEnv* %1 to i8*, !dbg !49
-  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %34) #11, !dbg !49
-  %35 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %1, i64 0, i32 0, !dbg !49
-  store i64 %31, i64* %35, align 8, !dbg !49, !tbaa !53
-  %36 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %1, i64 0, i32 1, !dbg !49
-  store i64 %rubyId_map.i, i64* %36, align 8, !dbg !49, !tbaa !55
-  %37 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %1, i64 0, i32 2, !dbg !49
-  store i32 0, i32* %37, align 8, !dbg !49, !tbaa !56
-  %38 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %1, i64 0, i32 3, !dbg !49
-  %39 = bitcast i64** %38 to i8*, !dbg !49
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %39, i8 0, i64 16, i1 false) #11, !dbg !49
-  %40 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !49, !tbaa !15
-  %41 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %40, i64 0, i32 2, !dbg !49
-  %42 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %41, align 8, !dbg !49, !tbaa !17
-  %43 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %42, i64 0, i32 3, !dbg !49
-  %44 = bitcast i64* %43 to %struct.rb_captured_block*, !dbg !49
-  %45 = getelementptr inbounds i64, i64* %43, i64 2, !dbg !49
-  %46 = bitcast i64* %45 to %struct.vm_ifunc**, !dbg !49
-  store %struct.vm_ifunc* %33, %struct.vm_ifunc** %46, align 8, !dbg !49, !tbaa !57
+  %25 = call i64 @rb_ary_new_from_values(i64 noundef 2, i64* noundef nonnull align 8 %callArgs0Addr.i) #11, !dbg !49
+  %rubyId_map.i = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !49, !invariant.load !5
+  %26 = load i64, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8, !dbg !49
+  %27 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %26) #11, !dbg !49
+  %28 = bitcast %struct.sorbet_inlineIntrinsicEnv* %1 to i8*, !dbg !49
+  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %28) #11, !dbg !49
+  %29 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %1, i64 0, i32 0, !dbg !49
+  store i64 %25, i64* %29, align 8, !dbg !49, !tbaa !53
+  %30 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %1, i64 0, i32 1, !dbg !49
+  store i64 %rubyId_map.i, i64* %30, align 8, !dbg !49, !tbaa !55
+  %31 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %1, i64 0, i32 2, !dbg !49
+  store i32 0, i32* %31, align 8, !dbg !49, !tbaa !56
+  %32 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %1, i64 0, i32 3, !dbg !49
+  %33 = bitcast i64** %32 to i8*, !dbg !49
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %33, i8 0, i64 16, i1 false) #11, !dbg !49
+  %34 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !49, !tbaa !15
+  %35 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %34, i64 0, i32 2, !dbg !49
+  %36 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %35, align 8, !dbg !49, !tbaa !17
+  %37 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 3, !dbg !49
+  %38 = bitcast i64* %37 to %struct.rb_captured_block*, !dbg !49
+  %39 = getelementptr inbounds i64, i64* %37, i64 2, !dbg !49
+  %40 = bitcast i64* %39 to %struct.vm_ifunc**, !dbg !49
+  store %struct.vm_ifunc* %27, %struct.vm_ifunc** %40, align 8, !dbg !49, !tbaa !57
   call void @llvm.experimental.noalias.scope.decl(metadata !58) #11, !dbg !49
-  %47 = ptrtoint %struct.rb_captured_block* %44 to i64, !dbg !49
-  %48 = or i64 %47, 3, !dbg !49
-  %49 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %40, i64 0, i32 17, !dbg !49
-  %50 = and i64 %48, -4, !dbg !61
-  %51 = inttoptr i64 %50 to %struct.rb_captured_block*, !dbg !61
-  store i64 0, i64* %49, align 8, !dbg !61, !tbaa !63
-  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %51) #11, !dbg !61
-  %52 = inttoptr i64 %31 to %struct.iseq_inline_iv_cache_entry*, !dbg !61
-  %53 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %52, i64 0, i32 0, !dbg !61
-  %54 = load i64, i64* %53, align 8, !dbg !61, !tbaa !27
-  %55 = and i64 %54, 8192, !dbg !61
-  %56 = icmp eq i64 %55, 0, !dbg !61
-  br i1 %56, label %60, label %57, !dbg !61
+  %41 = ptrtoint %struct.rb_captured_block* %38 to i64, !dbg !49
+  %42 = or i64 %41, 3, !dbg !49
+  %43 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %34, i64 0, i32 17, !dbg !49
+  %44 = and i64 %42, -4, !dbg !61
+  %45 = inttoptr i64 %44 to %struct.rb_captured_block*, !dbg !61
+  store i64 0, i64* %43, align 8, !dbg !61, !tbaa !63
+  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %45) #11, !dbg !61
+  %46 = inttoptr i64 %25 to %struct.iseq_inline_iv_cache_entry*, !dbg !61
+  %47 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %46, i64 0, i32 0, !dbg !61
+  %48 = load i64, i64* %47, align 8, !dbg !61, !tbaa !27
+  %49 = and i64 %48, 8192, !dbg !61
+  %50 = icmp eq i64 %49, 0, !dbg !61
+  br i1 %50, label %54, label %51, !dbg !61
 
-57:                                               ; preds = %entry
-  %58 = lshr i64 %54, 15, !dbg !61
-  %59 = and i64 %58, 3, !dbg !61
+51:                                               ; preds = %entry
+  %52 = lshr i64 %48, 15, !dbg !61
+  %53 = and i64 %52, 3, !dbg !61
   br label %rb_array_len.exit2.i.i, !dbg !61
 
-60:                                               ; preds = %entry
-  %61 = inttoptr i64 %31 to %struct.RArray*, !dbg !61
-  %62 = getelementptr inbounds %struct.RArray, %struct.RArray* %61, i64 0, i32 1, i32 0, i32 0, !dbg !61
-  %63 = load i64, i64* %62, align 8, !dbg !61, !tbaa !57
+54:                                               ; preds = %entry
+  %55 = inttoptr i64 %25 to %struct.RArray*, !dbg !61
+  %56 = getelementptr inbounds %struct.RArray, %struct.RArray* %55, i64 0, i32 1, i32 0, i32 0, !dbg !61
+  %57 = load i64, i64* %56, align 8, !dbg !61, !tbaa !57
   br label %rb_array_len.exit2.i.i, !dbg !61
 
-rb_array_len.exit2.i.i:                           ; preds = %60, %57
-  %64 = phi i64 [ %59, %57 ], [ %63, %60 ], !dbg !61
-  %65 = call i64 @rb_ary_new_capa(i64 %64) #11, !dbg !61
-  %66 = load i64, i64* %53, align 8, !dbg !61, !tbaa !27
-  %67 = and i64 %66, 8192, !dbg !61
-  %68 = icmp eq i64 %67, 0, !dbg !61
-  br i1 %68, label %72, label %69, !dbg !61
+rb_array_len.exit2.i.i:                           ; preds = %54, %51
+  %58 = phi i64 [ %53, %51 ], [ %57, %54 ], !dbg !61
+  %59 = call i64 @rb_ary_new_capa(i64 %58) #11, !dbg !61
+  %60 = load i64, i64* %47, align 8, !dbg !61, !tbaa !27
+  %61 = and i64 %60, 8192, !dbg !61
+  %62 = icmp eq i64 %61, 0, !dbg !61
+  br i1 %62, label %66, label %63, !dbg !61
 
-69:                                               ; preds = %rb_array_len.exit2.i.i
-  %70 = lshr i64 %66, 15, !dbg !61
-  %71 = and i64 %70, 3, !dbg !61
+63:                                               ; preds = %rb_array_len.exit2.i.i
+  %64 = lshr i64 %60, 15, !dbg !61
+  %65 = and i64 %64, 3, !dbg !61
   br label %rb_array_len.exit1.i.i, !dbg !61
 
-72:                                               ; preds = %rb_array_len.exit2.i.i
-  %73 = inttoptr i64 %31 to %struct.RArray*, !dbg !61
-  %74 = getelementptr inbounds %struct.RArray, %struct.RArray* %73, i64 0, i32 1, i32 0, i32 0, !dbg !61
-  %75 = load i64, i64* %74, align 8, !dbg !61, !tbaa !57
+66:                                               ; preds = %rb_array_len.exit2.i.i
+  %67 = inttoptr i64 %25 to %struct.RArray*, !dbg !61
+  %68 = getelementptr inbounds %struct.RArray, %struct.RArray* %67, i64 0, i32 1, i32 0, i32 0, !dbg !61
+  %69 = load i64, i64* %68, align 8, !dbg !61, !tbaa !57
   br label %rb_array_len.exit1.i.i, !dbg !61
 
-rb_array_len.exit1.i.i:                           ; preds = %72, %69
-  %76 = phi i64 [ %71, %69 ], [ %75, %72 ], !dbg !61
-  %77 = icmp sgt i64 %76, 0, !dbg !61
-  br i1 %77, label %78, label %forward_sorbet_rb_array_collect_withBlock.exit.i, !dbg !61
+rb_array_len.exit1.i.i:                           ; preds = %66, %63
+  %70 = phi i64 [ %65, %63 ], [ %69, %66 ], !dbg !61
+  %71 = icmp sgt i64 %70, 0, !dbg !61
+  br i1 %71, label %72, label %forward_sorbet_rb_array_collect_withBlock.exit.i, !dbg !61
 
-78:                                               ; preds = %rb_array_len.exit1.i.i
-  %79 = bitcast i64* %0 to i8*, !dbg !61
-  %80 = inttoptr i64 %31 to %struct.RArray*, !dbg !49
-  %81 = getelementptr inbounds %struct.RArray, %struct.RArray* %80, i64 0, i32 1, i32 0, i32 0, !dbg !49
-  %82 = getelementptr inbounds %struct.RArray, %struct.RArray* %80, i64 0, i32 1, i32 0, i32 2, !dbg !49
-  br label %83, !dbg !61
+72:                                               ; preds = %rb_array_len.exit1.i.i
+  %73 = bitcast i64* %0 to i8*, !dbg !61
+  %74 = inttoptr i64 %25 to %struct.RArray*, !dbg !49
+  %75 = getelementptr inbounds %struct.RArray, %struct.RArray* %74, i64 0, i32 1, i32 0, i32 0, !dbg !49
+  %76 = getelementptr inbounds %struct.RArray, %struct.RArray* %74, i64 0, i32 1, i32 0, i32 2, !dbg !49
+  br label %77, !dbg !61
 
-83:                                               ; preds = %rb_array_len.exit.i.i, %78
-  %84 = phi i64 [ 0, %78 ], [ %95, %rb_array_len.exit.i.i ], !dbg !61
-  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 dereferenceable(8) %79) #11, !dbg !61
-  %85 = load i64, i64* %53, align 8, !dbg !61, !tbaa !27
-  %86 = and i64 %85, 8192, !dbg !61
-  %87 = icmp eq i64 %86, 0, !dbg !61
-  br i1 %87, label %88, label %rb_array_const_ptr_transient.exit.i.i, !dbg !61
+77:                                               ; preds = %rb_array_len.exit.i.i, %72
+  %78 = phi i64 [ 0, %72 ], [ %89, %rb_array_len.exit.i.i ], !dbg !61
+  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 dereferenceable(8) %73) #11, !dbg !61
+  %79 = load i64, i64* %47, align 8, !dbg !61, !tbaa !27
+  %80 = and i64 %79, 8192, !dbg !61
+  %81 = icmp eq i64 %80, 0, !dbg !61
+  br i1 %81, label %82, label %rb_array_const_ptr_transient.exit.i.i, !dbg !61
 
-88:                                               ; preds = %83
-  %89 = load i64*, i64** %82, align 8, !dbg !61, !tbaa !57
+82:                                               ; preds = %77
+  %83 = load i64*, i64** %76, align 8, !dbg !61, !tbaa !57
   br label %rb_array_const_ptr_transient.exit.i.i, !dbg !61
 
-rb_array_const_ptr_transient.exit.i.i:            ; preds = %88, %83
-  %90 = phi i64* [ %89, %88 ], [ %81, %83 ], !dbg !61
-  %91 = getelementptr inbounds i64, i64* %90, i64 %84, !dbg !61
-  %92 = load i64, i64* %91, align 8, !dbg !61, !tbaa !6
-  store i64 %92, i64* %0, align 8, !dbg !61, !tbaa !6
-  %93 = call i64 @"func_<root>.17<static-init>$153$block_1"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %0, i64 undef) #11, !dbg !61
-  %94 = call i64 @rb_ary_push(i64 %65, i64 %93) #11, !dbg !61
-  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %79) #11, !dbg !61
-  %95 = add nuw nsw i64 %84, 1, !dbg !61
-  %96 = load i64, i64* %53, align 8, !dbg !61, !tbaa !27
-  %97 = and i64 %96, 8192, !dbg !61
-  %98 = icmp eq i64 %97, 0, !dbg !61
-  br i1 %98, label %102, label %99, !dbg !61
+rb_array_const_ptr_transient.exit.i.i:            ; preds = %82, %77
+  %84 = phi i64* [ %83, %82 ], [ %75, %77 ], !dbg !61
+  %85 = getelementptr inbounds i64, i64* %84, i64 %78, !dbg !61
+  %86 = load i64, i64* %85, align 8, !dbg !61, !tbaa !6
+  store i64 %86, i64* %0, align 8, !dbg !61, !tbaa !6
+  %87 = call i64 @"func_<root>.17<static-init>$153$block_1"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %0, i64 undef) #11, !dbg !61
+  %88 = call i64 @rb_ary_push(i64 %59, i64 %87) #11, !dbg !61
+  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %73) #11, !dbg !61
+  %89 = add nuw nsw i64 %78, 1, !dbg !61
+  %90 = load i64, i64* %47, align 8, !dbg !61, !tbaa !27
+  %91 = and i64 %90, 8192, !dbg !61
+  %92 = icmp eq i64 %91, 0, !dbg !61
+  br i1 %92, label %96, label %93, !dbg !61
 
-99:                                               ; preds = %rb_array_const_ptr_transient.exit.i.i
-  %100 = lshr i64 %96, 15, !dbg !61
-  %101 = and i64 %100, 3, !dbg !61
+93:                                               ; preds = %rb_array_const_ptr_transient.exit.i.i
+  %94 = lshr i64 %90, 15, !dbg !61
+  %95 = and i64 %94, 3, !dbg !61
   br label %rb_array_len.exit.i.i, !dbg !61
 
-102:                                              ; preds = %rb_array_const_ptr_transient.exit.i.i
-  %103 = load i64, i64* %81, align 8, !dbg !61, !tbaa !57
+96:                                               ; preds = %rb_array_const_ptr_transient.exit.i.i
+  %97 = load i64, i64* %75, align 8, !dbg !61, !tbaa !57
   br label %rb_array_len.exit.i.i, !dbg !61
 
-rb_array_len.exit.i.i:                            ; preds = %102, %99
-  %104 = phi i64 [ %101, %99 ], [ %103, %102 ], !dbg !61
-  %105 = icmp slt i64 %95, %104, !dbg !61
-  br i1 %105, label %83, label %forward_sorbet_rb_array_collect_withBlock.exit.i, !dbg !61, !llvm.loop !64
+rb_array_len.exit.i.i:                            ; preds = %96, %93
+  %98 = phi i64 [ %95, %93 ], [ %97, %96 ], !dbg !61
+  %99 = icmp slt i64 %89, %98, !dbg !61
+  br i1 %99, label %77, label %forward_sorbet_rb_array_collect_withBlock.exit.i, !dbg !61, !llvm.loop !64
 
 forward_sorbet_rb_array_collect_withBlock.exit.i: ; preds = %rb_array_len.exit.i.i, %rb_array_len.exit1.i.i
   call void @sorbet_popFrame() #11, !dbg !61
-  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %34) #11, !dbg !49
-  %106 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !49, !tbaa !15
-  %107 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %106, i64 0, i32 5, !dbg !49
-  %108 = load i32, i32* %107, align 8, !dbg !49, !tbaa !35
-  %109 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %106, i64 0, i32 6, !dbg !49
-  %110 = load i32, i32* %109, align 4, !dbg !49, !tbaa !36
-  %111 = xor i32 %110, -1, !dbg !49
-  %112 = and i32 %111, %108, !dbg !49
-  %113 = icmp eq i32 %112, 0, !dbg !49
-  br i1 %113, label %"func_<root>.17<static-init>$153.exit", label %114, !dbg !49, !prof !29
+  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %28) #11, !dbg !49
+  %100 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !49, !tbaa !15
+  %101 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %100, i64 0, i32 5, !dbg !49
+  %102 = load i32, i32* %101, align 8, !dbg !49, !tbaa !35
+  %103 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %100, i64 0, i32 6, !dbg !49
+  %104 = load i32, i32* %103, align 4, !dbg !49, !tbaa !36
+  %105 = xor i32 %104, -1, !dbg !49
+  %106 = and i32 %105, %102, !dbg !49
+  %107 = icmp eq i32 %106, 0, !dbg !49
+  br i1 %107, label %"func_<root>.17<static-init>$153.exit", label %108, !dbg !49, !prof !29
 
-114:                                              ; preds = %forward_sorbet_rb_array_collect_withBlock.exit.i
-  %115 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %106, i64 0, i32 8, !dbg !49
-  %116 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %115, align 8, !dbg !49, !tbaa !37
-  %117 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %116, i32 noundef 0) #11, !dbg !49
+108:                                              ; preds = %forward_sorbet_rb_array_collect_withBlock.exit.i
+  %109 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %100, i64 0, i32 8, !dbg !49
+  %110 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %109, align 8, !dbg !49, !tbaa !37
+  %111 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %110, i32 noundef 0) #11, !dbg !49
   br label %"func_<root>.17<static-init>$153.exit", !dbg !49
 
-"func_<root>.17<static-init>$153.exit":           ; preds = %forward_sorbet_rb_array_collect_withBlock.exit.i, %114
-  store i64* getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %29, align 8, !tbaa !15
-  %118 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %21, i64 0, i32 1, !dbg !38
-  %119 = load i64*, i64** %118, align 8, !dbg !38
-  store i64 %18, i64* %119, align 8, !dbg !38, !tbaa !6
-  %120 = getelementptr inbounds i64, i64* %119, i64 1, !dbg !38
-  store i64 %65, i64* %120, align 8, !dbg !38, !tbaa !6
-  %121 = getelementptr inbounds i64, i64* %120, i64 1, !dbg !38
-  store i64* %121, i64** %118, align 8, !dbg !38
+"func_<root>.17<static-init>$153.exit":           ; preds = %forward_sorbet_rb_array_collect_withBlock.exit.i, %108
+  store i64* getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %23, align 8, !tbaa !15
+  %112 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 1, !dbg !38
+  %113 = load i64*, i64** %112, align 8, !dbg !38
+  store i64 %12, i64* %113, align 8, !dbg !38, !tbaa !6
+  %114 = getelementptr inbounds i64, i64* %113, i64 1, !dbg !38
+  store i64 %59, i64* %114, align 8, !dbg !38, !tbaa !6
+  %115 = getelementptr inbounds i64, i64* %114, i64 1, !dbg !38
+  store i64* %115, i64** %112, align 8, !dbg !38
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !38
-  call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %22)
+  call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %16)
   ret void
 }
 

--- a/test/testdata/compiler/block_no_args.opt.ll.exp
+++ b/test/testdata/compiler/block_no_args.opt.ll.exp
@@ -83,18 +83,17 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/block_no_args.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [7 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_block in <top (required)>" = internal unnamed_addr global i64 0, align 8
 @"func_<root>.17<static-init>$153$block_1_ifunc" = internal unnamed_addr global i64 0
 @rubyStrFrozen_hi = internal unnamed_addr global i64 0, align 8
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
 @sorbet_moduleStringTable = internal unnamed_addr constant [111 x i8] c"<top (required)>\00test/testdata/compiler/block_no_args.rb\00block in <top (required)>\00times\00hi\00puts\00Kernel\00master\00", align 1
+@sorbet_moduleIDTable = internal unnamed_addr global [4 x i64] zeroinitializer, align 8
+@sorbet_moduleIDDescriptors = internal unnamed_addr constant [4 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 57, i32 25 }, %struct.rb_code_position_struct { i32 83, i32 5 }, %struct.rb_code_position_struct { i32 92, i32 4 }], align 8
 @rb_mKernel = external local_unnamed_addr constant i64
 
 declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
@@ -117,9 +116,9 @@ declare i64 @sorbet_globalConstRegister(i64) local_unnamed_addr #0
 
 declare %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64) local_unnamed_addr #0
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
+declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #0
 
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #0
+declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
 
 declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
 
@@ -179,125 +178,119 @@ define void @Init_block_no_args() local_unnamed_addr #4 {
 entry:
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([111 x i8], [111 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #7
-  store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %1 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([111 x i8], [111 x i8]* @sorbet_moduleStringTable, i64 0, i64 57), i64 noundef 25) #7
-  store i64 %1, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
-  %2 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([111 x i8], [111 x i8]* @sorbet_moduleStringTable, i64 0, i64 83), i64 noundef 5) #7
-  %3 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([111 x i8], [111 x i8]* @sorbet_moduleStringTable, i64 0, i64 92), i64 noundef 4) #7
-  store i64 %3, i64* @rubyIdPrecomputed_puts, align 8
-  %4 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([111 x i8], [111 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #7
-  tail call void @rb_gc_register_mark_object(i64 %4) #7
-  store i64 %4, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %5 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([111 x i8], [111 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 39) #7
-  tail call void @rb_gc_register_mark_object(i64 %5) #7
-  store i64 %5, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args.rb", align 8
+  tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([4 x %struct.rb_code_position_struct], [4 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 4, i8* noundef getelementptr inbounds ([111 x i8], [111 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
+  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([111 x i8], [111 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #7
+  tail call void @rb_gc_register_mark_object(i64 %0) #7
+  store i64 %0, i64* @"rubyStrFrozen_<top (required)>", align 8
+  %1 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([111 x i8], [111 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 39) #7
+  tail call void @rb_gc_register_mark_object(i64 %1) #7
+  store i64 %1, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 7)
-  %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
+  %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
   %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/block_no_args.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args.rb", align 8
-  %6 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_no_args.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %6, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %7 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([111 x i8], [111 x i8]* @sorbet_moduleStringTable, i64 0, i64 57), i64 noundef 25) #7
-  call void @rb_gc_register_mark_object(i64 %7) #7
+  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_no_args.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %3 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([111 x i8], [111 x i8]* @sorbet_moduleStringTable, i64 0, i64 57), i64 noundef 25) #7
+  call void @rb_gc_register_mark_object(i64 %3) #7
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %"rubyId_block in <top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
+  %"rubyId_block in <top (required)>.i.i" = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/block_no_args.rb.i2.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args.rb", align 8
-  %8 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %7, i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_no_args.rb.i2.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %8, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1", align 8
-  %9 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_1", i8* noundef null, i32 noundef 0, i32 noundef 0) #7
-  %10 = ptrtoint %struct.vm_ifunc* %9 to i64
-  %11 = call i64 @sorbet_globalConstRegister(i64 %10)
-  store i64 %11, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8
-  %12 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([111 x i8], [111 x i8]* @sorbet_moduleStringTable, i64 0, i64 89), i64 noundef 2) #7
-  call void @rb_gc_register_mark_object(i64 %12) #7
-  store i64 %12, i64* @rubyStrFrozen_hi, align 8
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !26
+  %4 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %3, i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_no_args.rb.i2.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %4, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1", align 8
+  %5 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_1", i8* noundef null, i32 noundef 0, i32 noundef 0) #7
+  %6 = ptrtoint %struct.vm_ifunc* %5 to i64
+  %7 = call i64 @sorbet_globalConstRegister(i64 %6)
+  store i64 %7, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8
+  %8 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([111 x i8], [111 x i8]* @sorbet_moduleStringTable, i64 0, i64 89), i64 noundef 2) #7
+  call void @rb_gc_register_mark_object(i64 %8) #7
+  store i64 %8, i64* @rubyStrFrozen_hi, align 8
+  %rubyId_puts.i = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !26, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !26
-  %13 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
-  %14 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %13, i64 0, i32 2
-  %15 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %14, align 8, !tbaa !17
+  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
+  %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 2
+  %11 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %10, align 8, !tbaa !17
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %16 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %16, align 8, !tbaa !21
-  %17 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 4
-  %18 = load i64*, i64** %17, align 8, !tbaa !23
-  %19 = load i64, i64* %18, align 8, !tbaa !6
-  %20 = and i64 %19, -33
-  store i64 %20, i64* %18, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %13, %struct.rb_control_frame_struct* %15, %struct.rb_iseq_struct* %stackFrame.i) #7
-  %21 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 0
-  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %21, align 8, !dbg !27, !tbaa !15
-  %22 = load i64, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8, !dbg !28
-  %23 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %22) #7, !dbg !28
-  %24 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !28, !tbaa !15
-  %25 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %24, i64 0, i32 2, !dbg !28
-  %26 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %25, align 8, !dbg !28, !tbaa !17
-  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 3, !dbg !28
-  %28 = bitcast i64* %27 to %struct.rb_captured_block*, !dbg !28
-  %29 = getelementptr inbounds i64, i64* %27, i64 2, !dbg !28
-  %30 = bitcast i64* %29 to %struct.vm_ifunc**, !dbg !28
-  store %struct.vm_ifunc* %23, %struct.vm_ifunc** %30, align 8, !dbg !28, !tbaa !29
+  %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %12, align 8, !tbaa !21
+  %13 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 4
+  %14 = load i64*, i64** %13, align 8, !tbaa !23
+  %15 = load i64, i64* %14, align 8, !tbaa !6
+  %16 = and i64 %15, -33
+  store i64 %16, i64* %14, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %9, %struct.rb_control_frame_struct* %11, %struct.rb_iseq_struct* %stackFrame.i) #7
+  %17 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 0
+  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %17, align 8, !dbg !27, !tbaa !15
+  %18 = load i64, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8, !dbg !28
+  %19 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %18) #7, !dbg !28
+  %20 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !28, !tbaa !15
+  %21 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %20, i64 0, i32 2, !dbg !28
+  %22 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %21, align 8, !dbg !28, !tbaa !17
+  %23 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %22, i64 0, i32 3, !dbg !28
+  %24 = bitcast i64* %23 to %struct.rb_captured_block*, !dbg !28
+  %25 = getelementptr inbounds i64, i64* %23, i64 2, !dbg !28
+  %26 = bitcast i64* %25 to %struct.vm_ifunc**, !dbg !28
+  store %struct.vm_ifunc* %19, %struct.vm_ifunc** %26, align 8, !dbg !28, !tbaa !29
   call void @llvm.experimental.noalias.scope.decl(metadata !30) #7, !dbg !28
-  %31 = ptrtoint %struct.rb_captured_block* %28 to i64, !dbg !28
-  %32 = or i64 %31, 3, !dbg !28
-  %33 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %24, i64 0, i32 17, !dbg !28
-  %34 = and i64 %32, -4, !dbg !33
-  %35 = inttoptr i64 %34 to %struct.rb_captured_block*, !dbg !33
-  store i64 0, i64* %33, align 8, !dbg !33, !tbaa !35
-  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %35) #7, !dbg !33
-  %36 = load i64, i64* @rb_mKernel, align 8, !dbg !28
-  br label %37, !dbg !33
+  %27 = ptrtoint %struct.rb_captured_block* %24 to i64, !dbg !28
+  %28 = or i64 %27, 3, !dbg !28
+  %29 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %20, i64 0, i32 17, !dbg !28
+  %30 = and i64 %28, -4, !dbg !33
+  %31 = inttoptr i64 %30 to %struct.rb_captured_block*, !dbg !33
+  store i64 0, i64* %29, align 8, !dbg !33, !tbaa !35
+  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %31) #7, !dbg !33
+  %32 = load i64, i64* @rb_mKernel, align 8, !dbg !28
+  br label %33, !dbg !33
 
-37:                                               ; preds = %37, %entry
-  %38 = phi i64 [ 0, %entry ], [ %52, %37 ], !dbg !33
-  %39 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !28, !tbaa !15
-  %40 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %39, i64 0, i32 2, !dbg !28
-  %41 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %40, align 8, !dbg !28, !tbaa !17
+33:                                               ; preds = %33, %entry
+  %34 = phi i64 [ 0, %entry ], [ %48, %33 ], !dbg !33
+  %35 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !28, !tbaa !15
+  %36 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %35, i64 0, i32 2, !dbg !28
+  %37 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %36, align 8, !dbg !28, !tbaa !17
   %stackFrame.i1.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1", align 8, !dbg !28
-  %42 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 2, !dbg !28
-  store %struct.rb_iseq_struct* %stackFrame.i1.i.i, %struct.rb_iseq_struct** %42, align 8, !dbg !28, !tbaa !21
-  %43 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 4, !dbg !28
-  %44 = load i64*, i64** %43, align 8, !dbg !28, !tbaa !23
-  %45 = load i64, i64* %44, align 8, !dbg !28, !tbaa !6
-  %46 = and i64 %45, -129, !dbg !28
-  store i64 %46, i64* %44, align 8, !dbg !28, !tbaa !6
-  %47 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 0, !dbg !28
-  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %47, align 8, !dbg !36, !tbaa !15
+  %38 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 2, !dbg !28
+  store %struct.rb_iseq_struct* %stackFrame.i1.i.i, %struct.rb_iseq_struct** %38, align 8, !dbg !28, !tbaa !21
+  %39 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 4, !dbg !28
+  %40 = load i64*, i64** %39, align 8, !dbg !28, !tbaa !23
+  %41 = load i64, i64* %40, align 8, !dbg !28, !tbaa !6
+  %42 = and i64 %41, -129, !dbg !28
+  store i64 %42, i64* %40, align 8, !dbg !28, !tbaa !6
+  %43 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 0, !dbg !28
+  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %43, align 8, !dbg !36, !tbaa !15
   %rubyStr_hi.i2.i.i = load i64, i64* @rubyStrFrozen_hi, align 8, !dbg !38
-  %48 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %41, i64 0, i32 1, !dbg !39
-  %49 = load i64*, i64** %48, align 8, !dbg !39
-  store i64 %36, i64* %49, align 8, !dbg !39, !tbaa !6
-  %50 = getelementptr inbounds i64, i64* %49, i64 1, !dbg !39
-  store i64 %rubyStr_hi.i2.i.i, i64* %50, align 8, !dbg !39, !tbaa !6
-  %51 = getelementptr inbounds i64, i64* %50, i64 1, !dbg !39
-  store i64* %51, i64** %48, align 8, !dbg !39
+  %44 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 1, !dbg !39
+  %45 = load i64*, i64** %44, align 8, !dbg !39
+  store i64 %32, i64* %45, align 8, !dbg !39, !tbaa !6
+  %46 = getelementptr inbounds i64, i64* %45, i64 1, !dbg !39
+  store i64 %rubyStr_hi.i2.i.i, i64* %46, align 8, !dbg !39, !tbaa !6
+  %47 = getelementptr inbounds i64, i64* %46, i64 1, !dbg !39
+  store i64* %47, i64** %44, align 8, !dbg !39
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !39
-  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %47, align 8, !dbg !39, !tbaa !15
-  %52 = add nuw nsw i64 %38, 1, !dbg !33
-  %53 = icmp eq i64 %52, 10, !dbg !33
-  br i1 %53, label %forward_sorbet_rb_int_dotimes_withBlock.exit.i, label %37, !dbg !33, !llvm.loop !40
+  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %43, align 8, !dbg !39, !tbaa !15
+  %48 = add nuw nsw i64 %34, 1, !dbg !33
+  %49 = icmp eq i64 %48, 10, !dbg !33
+  br i1 %49, label %forward_sorbet_rb_int_dotimes_withBlock.exit.i, label %33, !dbg !33, !llvm.loop !40
 
-forward_sorbet_rb_int_dotimes_withBlock.exit.i:   ; preds = %37
+forward_sorbet_rb_int_dotimes_withBlock.exit.i:   ; preds = %33
   call void @sorbet_popFrame() #7, !dbg !33
-  %54 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !28, !tbaa !15
-  %55 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %54, i64 0, i32 5, !dbg !28
-  %56 = load i32, i32* %55, align 8, !dbg !28, !tbaa !42
-  %57 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %54, i64 0, i32 6, !dbg !28
-  %58 = load i32, i32* %57, align 4, !dbg !28, !tbaa !43
-  %59 = xor i32 %58, -1, !dbg !28
-  %60 = and i32 %59, %56, !dbg !28
-  %61 = icmp eq i32 %60, 0, !dbg !28
-  br i1 %61, label %"func_<root>.17<static-init>$153.exit", label %62, !dbg !28, !prof !44
+  %50 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !28, !tbaa !15
+  %51 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %50, i64 0, i32 5, !dbg !28
+  %52 = load i32, i32* %51, align 8, !dbg !28, !tbaa !42
+  %53 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %50, i64 0, i32 6, !dbg !28
+  %54 = load i32, i32* %53, align 4, !dbg !28, !tbaa !43
+  %55 = xor i32 %54, -1, !dbg !28
+  %56 = and i32 %55, %52, !dbg !28
+  %57 = icmp eq i32 %56, 0, !dbg !28
+  br i1 %57, label %"func_<root>.17<static-init>$153.exit", label %58, !dbg !28, !prof !44
 
-62:                                               ; preds = %forward_sorbet_rb_int_dotimes_withBlock.exit.i
-  %63 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %54, i64 0, i32 8, !dbg !28
-  %64 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %63, align 8, !dbg !28, !tbaa !45
-  %65 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %64, i32 noundef 0) #7, !dbg !28
+58:                                               ; preds = %forward_sorbet_rb_int_dotimes_withBlock.exit.i
+  %59 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %50, i64 0, i32 8, !dbg !28
+  %60 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %59, align 8, !dbg !28, !tbaa !45
+  %61 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %60, i32 noundef 0) #7, !dbg !28
   br label %"func_<root>.17<static-init>$153.exit", !dbg !28
 
-"func_<root>.17<static-init>$153.exit":           ; preds = %forward_sorbet_rb_int_dotimes_withBlock.exit.i, %62
-  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %21, align 8, !tbaa !15
+"func_<root>.17<static-init>$153.exit":           ; preds = %forward_sorbet_rb_int_dotimes_withBlock.exit.i, %58
+  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %17, align 8, !tbaa !15
   ret void
 }
 

--- a/test/testdata/compiler/block_no_args_capture.opt.ll.exp
+++ b/test/testdata/compiler/block_no_args_capture.opt.ll.exp
@@ -84,20 +84,17 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/block_no_args_capture.rb" = internal unnamed_addr global i64 0, align 8
-@rubyIdPrecomputed_s = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [8 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_block in <top (required)>" = internal unnamed_addr global i64 0, align 8
 @rubyStrFrozen_hi = internal unnamed_addr global i64 0, align 8
-@rubyIdPrecomputed_times = internal unnamed_addr global i64 0, align 8
 @"func_<root>.17<static-init>$153$block_1_ifunc" = internal unnamed_addr global i64 0
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
 @sorbet_moduleStringTable = internal unnamed_addr constant [121 x i8] c"<top (required)>\00test/testdata/compiler/block_no_args_capture.rb\00s\00block in <top (required)>\00hi\00times\00puts\00Kernel\00master\00", align 1
+@sorbet_moduleIDTable = internal unnamed_addr global [5 x i64] zeroinitializer, align 8
+@sorbet_moduleIDDescriptors = internal unnamed_addr constant [5 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 65, i32 1 }, %struct.rb_code_position_struct { i32 67, i32 25 }, %struct.rb_code_position_struct { i32 96, i32 5 }, %struct.rb_code_position_struct { i32 102, i32 4 }], align 8
 @rb_mKernel = external local_unnamed_addr constant i64
 
 declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
@@ -122,6 +119,8 @@ declare i64 @sorbet_globalConstRegister(i64) local_unnamed_addr #0
 
 declare %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64) local_unnamed_addr #0
 
+declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #0
+
 declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
@@ -129,8 +128,6 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #1
-
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #0
 
 declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
 
@@ -196,169 +193,160 @@ entry:
   %0 = alloca %struct.sorbet_inlineIntrinsicEnv, align 8
   %locals.i.i = alloca i64, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([121 x i8], [121 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #9
-  store i64 %1, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %2 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([121 x i8], [121 x i8]* @sorbet_moduleStringTable, i64 0, i64 65), i64 noundef 1) #9
-  store i64 %2, i64* @rubyIdPrecomputed_s, align 8
-  %3 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([121 x i8], [121 x i8]* @sorbet_moduleStringTable, i64 0, i64 67), i64 noundef 25) #9
-  store i64 %3, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
-  %4 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([121 x i8], [121 x i8]* @sorbet_moduleStringTable, i64 0, i64 96), i64 noundef 5) #9
-  store i64 %4, i64* @rubyIdPrecomputed_times, align 8
-  %5 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([121 x i8], [121 x i8]* @sorbet_moduleStringTable, i64 0, i64 102), i64 noundef 4) #9
-  store i64 %5, i64* @rubyIdPrecomputed_puts, align 8
-  %6 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([121 x i8], [121 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #9
-  tail call void @rb_gc_register_mark_object(i64 %6) #9
-  store i64 %6, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %7 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([121 x i8], [121 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 47) #9
-  tail call void @rb_gc_register_mark_object(i64 %7) #9
-  store i64 %7, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args_capture.rb", align 8
+  tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([5 x %struct.rb_code_position_struct], [5 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 5, i8* noundef getelementptr inbounds ([121 x i8], [121 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
+  %1 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([121 x i8], [121 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #9
+  tail call void @rb_gc_register_mark_object(i64 %1) #9
+  store i64 %1, i64* @"rubyStrFrozen_<top (required)>", align 8
+  %2 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([121 x i8], [121 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 47) #9
+  tail call void @rb_gc_register_mark_object(i64 %2) #9
+  store i64 %2, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args_capture.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 8)
-  %8 = bitcast i64* %locals.i.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %8)
-  %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
+  %3 = bitcast i64* %locals.i.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %3)
+  %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
   %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/block_no_args_capture.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args_capture.rb", align 8
-  %rubyId_s.i.i = load i64, i64* @rubyIdPrecomputed_s, align 8
+  %rubyId_s.i.i = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !invariant.load !5
   store i64 %rubyId_s.i.i, i64* %locals.i.i, align 8
-  %9 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_no_args_capture.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i.i, i32 noundef 1, i32 noundef 2)
-  store %struct.rb_iseq_struct* %9, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %8)
-  %10 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([121 x i8], [121 x i8]* @sorbet_moduleStringTable, i64 0, i64 67), i64 noundef 25) #9
-  call void @rb_gc_register_mark_object(i64 %10) #9
+  %4 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_no_args_capture.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i.i, i32 noundef 1, i32 noundef 2)
+  store %struct.rb_iseq_struct* %4, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %3)
+  %5 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([121 x i8], [121 x i8]* @sorbet_moduleStringTable, i64 0, i64 67), i64 noundef 25) #9
+  call void @rb_gc_register_mark_object(i64 %5) #9
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %"rubyId_block in <top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
+  %"rubyId_block in <top (required)>.i.i" = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/block_no_args_capture.rb.i2.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args_capture.rb", align 8
-  %11 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %10, i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_no_args_capture.rb.i2.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %11, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1", align 8
-  %12 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([121 x i8], [121 x i8]* @sorbet_moduleStringTable, i64 0, i64 93), i64 noundef 2) #9
-  call void @rb_gc_register_mark_object(i64 %12) #9
-  store i64 %12, i64* @rubyStrFrozen_hi, align 8
-  %13 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_1", i8* noundef null, i32 noundef 0, i32 noundef 0) #9
-  %14 = ptrtoint %struct.vm_ifunc* %13 to i64
-  %15 = call i64 @sorbet_globalConstRegister(i64 %14)
-  store i64 %15, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !24
+  %6 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %5, i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_no_args_capture.rb.i2.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %6, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1", align 8
+  %7 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([121 x i8], [121 x i8]* @sorbet_moduleStringTable, i64 0, i64 93), i64 noundef 2) #9
+  call void @rb_gc_register_mark_object(i64 %7) #9
+  store i64 %7, i64* @rubyStrFrozen_hi, align 8
+  %8 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_1", i8* noundef null, i32 noundef 0, i32 noundef 0) #9
+  %9 = ptrtoint %struct.vm_ifunc* %8 to i64
+  %10 = call i64 @sorbet_globalConstRegister(i64 %9)
+  store i64 %10, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8
+  %rubyId_puts.i = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !dbg !24, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !24
-  %16 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
-  %17 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 2
-  %18 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %17, align 8, !tbaa !17
+  %11 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
+  %12 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %11, i64 0, i32 2
+  %13 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %12, align 8, !tbaa !17
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %19 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %19, align 8, !tbaa !21
-  %20 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 4
-  %21 = load i64*, i64** %20, align 8, !tbaa !25
-  %22 = load i64, i64* %21, align 8, !tbaa !6
-  %23 = and i64 %22, -33
-  store i64 %23, i64* %21, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %16, %struct.rb_control_frame_struct* %18, %struct.rb_iseq_struct* %stackFrame.i) #9
-  %24 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 0
-  store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %24, align 8, !dbg !26, !tbaa !15
+  %14 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %13, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %14, align 8, !tbaa !21
+  %15 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %13, i64 0, i32 4
+  %16 = load i64*, i64** %15, align 8, !tbaa !25
+  %17 = load i64, i64* %16, align 8, !tbaa !6
+  %18 = and i64 %17, -33
+  store i64 %18, i64* %16, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %11, %struct.rb_control_frame_struct* %13, %struct.rb_iseq_struct* %stackFrame.i) #9
+  %19 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %13, i64 0, i32 0
+  store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %19, align 8, !dbg !26, !tbaa !15
   %rubyStr_hi.i = load i64, i64* @rubyStrFrozen_hi, align 8, !dbg !27
-  %25 = load i64*, i64** %20, align 8, !dbg !27, !tbaa !25
-  %26 = load i64, i64* %25, align 8, !dbg !27, !tbaa !6
-  %27 = and i64 %26, 8, !dbg !27
-  %28 = icmp eq i64 %27, 0, !dbg !27
-  br i1 %28, label %29, label %31, !dbg !27, !prof !28
+  %20 = load i64*, i64** %15, align 8, !dbg !27, !tbaa !25
+  %21 = load i64, i64* %20, align 8, !dbg !27, !tbaa !6
+  %22 = and i64 %21, 8, !dbg !27
+  %23 = icmp eq i64 %22, 0, !dbg !27
+  br i1 %23, label %24, label %26, !dbg !27, !prof !28
 
-29:                                               ; preds = %entry
-  %30 = getelementptr inbounds i64, i64* %25, i64 -3, !dbg !27
-  store i64 %rubyStr_hi.i, i64* %30, align 8, !dbg !27, !tbaa !6
-  br label %32, !dbg !27
+24:                                               ; preds = %entry
+  %25 = getelementptr inbounds i64, i64* %20, i64 -3, !dbg !27
+  store i64 %rubyStr_hi.i, i64* %25, align 8, !dbg !27, !tbaa !6
+  br label %27, !dbg !27
 
-31:                                               ; preds = %entry
-  call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %25, i32 noundef -3, i64 %rubyStr_hi.i) #9, !dbg !27
-  br label %32, !dbg !27
+26:                                               ; preds = %entry
+  call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %20, i32 noundef -3, i64 %rubyStr_hi.i) #9, !dbg !27
+  br label %27, !dbg !27
 
-32:                                               ; preds = %31, %29
-  store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %24, align 8, !dbg !27, !tbaa !15
-  %rubyId_times.i = load i64, i64* @rubyIdPrecomputed_times, align 8, !dbg !29
-  %33 = load i64, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8, !dbg !29
-  %34 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %33) #9, !dbg !29
-  %35 = bitcast %struct.sorbet_inlineIntrinsicEnv* %0 to i8*, !dbg !29
-  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %35) #9, !dbg !29
-  %36 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %0, i64 0, i32 0, !dbg !29
-  store i64 21, i64* %36, align 8, !dbg !29, !tbaa !30
-  %37 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %0, i64 0, i32 1, !dbg !29
-  store i64 %rubyId_times.i, i64* %37, align 8, !dbg !29, !tbaa !32
-  %38 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %0, i64 0, i32 2, !dbg !29
-  store i32 0, i32* %38, align 8, !dbg !29, !tbaa !33
-  %39 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %0, i64 0, i32 3, !dbg !29
-  %40 = bitcast i64** %39 to i8*, !dbg !29
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %40, i8 0, i64 16, i1 false) #9, !dbg !29
-  %41 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !29, !tbaa !15
-  %42 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %41, i64 0, i32 2, !dbg !29
-  %43 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %42, align 8, !dbg !29, !tbaa !17
-  %44 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %43, i64 0, i32 3, !dbg !29
-  %45 = bitcast i64* %44 to %struct.rb_captured_block*, !dbg !29
-  %46 = getelementptr inbounds i64, i64* %44, i64 2, !dbg !29
-  %47 = bitcast i64* %46 to %struct.vm_ifunc**, !dbg !29
-  store %struct.vm_ifunc* %34, %struct.vm_ifunc** %47, align 8, !dbg !29, !tbaa !34
+27:                                               ; preds = %26, %24
+  store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %19, align 8, !dbg !27, !tbaa !15
+  %rubyId_times.i = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !29, !invariant.load !5
+  %28 = load i64, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8, !dbg !29
+  %29 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %28) #9, !dbg !29
+  %30 = bitcast %struct.sorbet_inlineIntrinsicEnv* %0 to i8*, !dbg !29
+  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %30) #9, !dbg !29
+  %31 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %0, i64 0, i32 0, !dbg !29
+  store i64 21, i64* %31, align 8, !dbg !29, !tbaa !30
+  %32 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %0, i64 0, i32 1, !dbg !29
+  store i64 %rubyId_times.i, i64* %32, align 8, !dbg !29, !tbaa !32
+  %33 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %0, i64 0, i32 2, !dbg !29
+  store i32 0, i32* %33, align 8, !dbg !29, !tbaa !33
+  %34 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %0, i64 0, i32 3, !dbg !29
+  %35 = bitcast i64** %34 to i8*, !dbg !29
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %35, i8 0, i64 16, i1 false) #9, !dbg !29
+  %36 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !29, !tbaa !15
+  %37 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %36, i64 0, i32 2, !dbg !29
+  %38 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %37, align 8, !dbg !29, !tbaa !17
+  %39 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 3, !dbg !29
+  %40 = bitcast i64* %39 to %struct.rb_captured_block*, !dbg !29
+  %41 = getelementptr inbounds i64, i64* %39, i64 2, !dbg !29
+  %42 = bitcast i64* %41 to %struct.vm_ifunc**, !dbg !29
+  store %struct.vm_ifunc* %29, %struct.vm_ifunc** %42, align 8, !dbg !29, !tbaa !34
   call void @llvm.experimental.noalias.scope.decl(metadata !35) #9, !dbg !29
-  %48 = ptrtoint %struct.rb_captured_block* %45 to i64, !dbg !29
-  %49 = or i64 %48, 3, !dbg !29
-  %50 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %41, i64 0, i32 17, !dbg !29
-  %51 = and i64 %49, -4, !dbg !38
-  %52 = inttoptr i64 %51 to %struct.rb_captured_block*, !dbg !38
-  store i64 0, i64* %50, align 8, !dbg !38, !tbaa !40
-  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %52) #9, !dbg !38
-  %53 = load i64, i64* @rb_mKernel, align 8, !dbg !29
-  br label %54, !dbg !38
+  %43 = ptrtoint %struct.rb_captured_block* %40 to i64, !dbg !29
+  %44 = or i64 %43, 3, !dbg !29
+  %45 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %36, i64 0, i32 17, !dbg !29
+  %46 = and i64 %44, -4, !dbg !38
+  %47 = inttoptr i64 %46 to %struct.rb_captured_block*, !dbg !38
+  store i64 0, i64* %45, align 8, !dbg !38, !tbaa !40
+  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %47) #9, !dbg !38
+  %48 = load i64, i64* @rb_mKernel, align 8, !dbg !29
+  br label %49, !dbg !38
 
-54:                                               ; preds = %54, %32
-  %55 = phi i64 [ 0, %32 ], [ %75, %54 ], !dbg !38
-  %56 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !29, !tbaa !15
-  %57 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %56, i64 0, i32 2, !dbg !29
-  %58 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %57, align 8, !dbg !29, !tbaa !17
+49:                                               ; preds = %49, %27
+  %50 = phi i64 [ 0, %27 ], [ %70, %49 ], !dbg !38
+  %51 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !29, !tbaa !15
+  %52 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %51, i64 0, i32 2, !dbg !29
+  %53 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %52, align 8, !dbg !29, !tbaa !17
   %stackFrame.i1.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1", align 8, !dbg !29
-  %59 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %58, i64 0, i32 2, !dbg !29
-  store %struct.rb_iseq_struct* %stackFrame.i1.i.i, %struct.rb_iseq_struct** %59, align 8, !dbg !29, !tbaa !21
-  %60 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %58, i64 0, i32 4, !dbg !29
-  %61 = load i64*, i64** %60, align 8, !dbg !29
-  %62 = load i64, i64* %61, align 8, !dbg !29, !tbaa !6
-  %63 = and i64 %62, -129, !dbg !29
-  store i64 %63, i64* %61, align 8, !dbg !29, !tbaa !6
-  %64 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %58, i64 0, i32 0, !dbg !29
-  store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %64, align 8, !dbg !41, !tbaa !15
-  %65 = getelementptr inbounds i64, i64* %61, i64 -1, !dbg !43
-  %66 = load i64, i64* %65, align 8, !dbg !43, !tbaa !6
-  %67 = and i64 %66, -4, !dbg !43
-  %68 = inttoptr i64 %67 to i64*, !dbg !43
-  %69 = getelementptr inbounds i64, i64* %68, i64 -3, !dbg !43
-  %70 = load i64, i64* %69, align 8, !dbg !43, !tbaa !6
-  %71 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %58, i64 0, i32 1, !dbg !43
-  %72 = load i64*, i64** %71, align 8, !dbg !43
-  store i64 %53, i64* %72, align 8, !dbg !43, !tbaa !6
-  %73 = getelementptr inbounds i64, i64* %72, i64 1, !dbg !43
-  store i64 %70, i64* %73, align 8, !dbg !43, !tbaa !6
-  %74 = getelementptr inbounds i64, i64* %73, i64 1, !dbg !43
-  store i64* %74, i64** %71, align 8, !dbg !43
+  %54 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 2, !dbg !29
+  store %struct.rb_iseq_struct* %stackFrame.i1.i.i, %struct.rb_iseq_struct** %54, align 8, !dbg !29, !tbaa !21
+  %55 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 4, !dbg !29
+  %56 = load i64*, i64** %55, align 8, !dbg !29
+  %57 = load i64, i64* %56, align 8, !dbg !29, !tbaa !6
+  %58 = and i64 %57, -129, !dbg !29
+  store i64 %58, i64* %56, align 8, !dbg !29, !tbaa !6
+  %59 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 0, !dbg !29
+  store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %59, align 8, !dbg !41, !tbaa !15
+  %60 = getelementptr inbounds i64, i64* %56, i64 -1, !dbg !43
+  %61 = load i64, i64* %60, align 8, !dbg !43, !tbaa !6
+  %62 = and i64 %61, -4, !dbg !43
+  %63 = inttoptr i64 %62 to i64*, !dbg !43
+  %64 = getelementptr inbounds i64, i64* %63, i64 -3, !dbg !43
+  %65 = load i64, i64* %64, align 8, !dbg !43, !tbaa !6
+  %66 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !43
+  %67 = load i64*, i64** %66, align 8, !dbg !43
+  store i64 %48, i64* %67, align 8, !dbg !43, !tbaa !6
+  %68 = getelementptr inbounds i64, i64* %67, i64 1, !dbg !43
+  store i64 %65, i64* %68, align 8, !dbg !43, !tbaa !6
+  %69 = getelementptr inbounds i64, i64* %68, i64 1, !dbg !43
+  store i64* %69, i64** %66, align 8, !dbg !43
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !43
-  store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %64, align 8, !dbg !43, !tbaa !15
-  %75 = add nuw nsw i64 %55, 1, !dbg !38
-  %76 = icmp eq i64 %75, 10, !dbg !38
-  br i1 %76, label %forward_sorbet_rb_int_dotimes_withBlock.exit.i, label %54, !dbg !38, !llvm.loop !44
+  store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %59, align 8, !dbg !43, !tbaa !15
+  %70 = add nuw nsw i64 %50, 1, !dbg !38
+  %71 = icmp eq i64 %70, 10, !dbg !38
+  br i1 %71, label %forward_sorbet_rb_int_dotimes_withBlock.exit.i, label %49, !dbg !38, !llvm.loop !44
 
-forward_sorbet_rb_int_dotimes_withBlock.exit.i:   ; preds = %54
+forward_sorbet_rb_int_dotimes_withBlock.exit.i:   ; preds = %49
   call void @sorbet_popFrame() #9, !dbg !38
-  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %35) #9, !dbg !29
-  %77 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !29, !tbaa !15
-  %78 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %77, i64 0, i32 5, !dbg !29
-  %79 = load i32, i32* %78, align 8, !dbg !29, !tbaa !46
-  %80 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %77, i64 0, i32 6, !dbg !29
-  %81 = load i32, i32* %80, align 4, !dbg !29, !tbaa !47
-  %82 = xor i32 %81, -1, !dbg !29
-  %83 = and i32 %82, %79, !dbg !29
-  %84 = icmp eq i32 %83, 0, !dbg !29
-  br i1 %84, label %"func_<root>.17<static-init>$153.exit", label %85, !dbg !29, !prof !28
+  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %30) #9, !dbg !29
+  %72 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !29, !tbaa !15
+  %73 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %72, i64 0, i32 5, !dbg !29
+  %74 = load i32, i32* %73, align 8, !dbg !29, !tbaa !46
+  %75 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %72, i64 0, i32 6, !dbg !29
+  %76 = load i32, i32* %75, align 4, !dbg !29, !tbaa !47
+  %77 = xor i32 %76, -1, !dbg !29
+  %78 = and i32 %77, %74, !dbg !29
+  %79 = icmp eq i32 %78, 0, !dbg !29
+  br i1 %79, label %"func_<root>.17<static-init>$153.exit", label %80, !dbg !29, !prof !28
 
-85:                                               ; preds = %forward_sorbet_rb_int_dotimes_withBlock.exit.i
-  %86 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %77, i64 0, i32 8, !dbg !29
-  %87 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %86, align 8, !dbg !29, !tbaa !48
-  %88 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %87, i32 noundef 0) #9, !dbg !29
+80:                                               ; preds = %forward_sorbet_rb_int_dotimes_withBlock.exit.i
+  %81 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %72, i64 0, i32 8, !dbg !29
+  %82 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %81, align 8, !dbg !29, !tbaa !48
+  %83 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %82, i32 noundef 0) #9, !dbg !29
   br label %"func_<root>.17<static-init>$153.exit", !dbg !29
 
-"func_<root>.17<static-init>$153.exit":           ; preds = %forward_sorbet_rb_int_dotimes_withBlock.exit.i, %85
-  store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %24, align 8, !tbaa !15
+"func_<root>.17<static-init>$153.exit":           ; preds = %forward_sorbet_rb_int_dotimes_withBlock.exit.i, %80
+  store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %19, align 8, !tbaa !15
   ret void
 }
 

--- a/test/testdata/compiler/block_no_args_captures_constant.opt.ll.exp
+++ b/test/testdata/compiler/block_no_args_captures_constant.opt.ll.exp
@@ -85,22 +85,20 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_Object#3foo" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@rubyIdPrecomputed_foo = internal unnamed_addr global i64 0, align 8
 @rubyStrFrozen_foo = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/block_no_args_captures_constant.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [13 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @"stackFramePrecomputed_func_Object#3foo$block_1" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_block in foo" = internal unnamed_addr global i64 0, align 8
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
 @"func_Object#3foo$block_1_ifunc" = internal unnamed_addr global i64 0
 @ic_puts.1 = internal global %struct.FunctionInlineCache zeroinitializer
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @rubyStrFrozen_hi = internal unnamed_addr global i64 0, align 8
 @ic_foo = internal global %struct.FunctionInlineCache zeroinitializer
 @sorbet_moduleStringTable = internal unnamed_addr constant [136 x i8] c"foo\00test/testdata/compiler/block_no_args_captures_constant.rb\00block in foo\00A\00puts\00Kernel\00times\00<top (required)>\00hi\00Object\00normal\00master\00", align 1
+@sorbet_moduleIDTable = internal unnamed_addr global [6 x i64] zeroinitializer, align 8
+@sorbet_moduleIDDescriptors = internal unnamed_addr constant [6 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 3 }, %struct.rb_code_position_struct { i32 62, i32 12 }, %struct.rb_code_position_struct { i32 77, i32 4 }, %struct.rb_code_position_struct { i32 89, i32 5 }, %struct.rb_code_position_struct { i32 95, i32 16 }, %struct.rb_code_position_struct { i32 122, i32 6 }], align 8
 @guard_epoch_A = linkonce local_unnamed_addr global i64 0
 @guarded_const_A = linkonce local_unnamed_addr global i64 0
 @rb_mKernel = external local_unnamed_addr constant i64
@@ -135,9 +133,9 @@ declare %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64) local_unnamed_addr 
 
 declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #1
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #1
+declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #1
 
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #1
+declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #1
 
 declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #1
 
@@ -325,90 +323,79 @@ entry:
   %locals.i7.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 3) #12
-  store i64 %0, i64* @rubyIdPrecomputed_foo, align 8
-  %1 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i64 0, i64 62), i64 noundef 12) #12
-  store i64 %1, i64* @"rubyIdPrecomputed_block in foo", align 8
-  %2 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i64 0, i64 77), i64 noundef 4) #12
-  store i64 %2, i64* @rubyIdPrecomputed_puts, align 8
-  %3 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i64 0, i64 89), i64 noundef 5) #12
-  %4 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i64 0, i64 95), i64 noundef 16) #12
-  store i64 %4, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %5 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i64 0, i64 122), i64 noundef 6) #12
-  %6 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 3) #12
-  tail call void @rb_gc_register_mark_object(i64 %6) #12
-  store i64 %6, i64* @rubyStrFrozen_foo, align 8
-  %7 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i64 0, i64 4), i64 noundef 57) #12
-  tail call void @rb_gc_register_mark_object(i64 %7) #12
-  store i64 %7, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args_captures_constant.rb", align 8
+  tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([6 x %struct.rb_code_position_struct], [6 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 6, i8* noundef getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
+  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 3) #12
+  tail call void @rb_gc_register_mark_object(i64 %0) #12
+  store i64 %0, i64* @rubyStrFrozen_foo, align 8
+  %1 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i64 0, i64 4), i64 noundef 57) #12
+  tail call void @rb_gc_register_mark_object(i64 %1) #12
+  store i64 %1, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args_captures_constant.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 13)
-  %rubyId_foo.i.i = load i64, i64* @rubyIdPrecomputed_foo, align 8
+  %rubyId_foo.i.i = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
   %rubyStr_foo.i.i = load i64, i64* @rubyStrFrozen_foo, align 8
   %"rubyStr_test/testdata/compiler/block_no_args_captures_constant.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args_captures_constant.rb", align 8
-  %8 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_foo.i.i, i64 %rubyId_foo.i.i, i64 %"rubyStr_test/testdata/compiler/block_no_args_captures_constant.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %8, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8
-  %9 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i64 0, i64 62), i64 noundef 12) #12
-  call void @rb_gc_register_mark_object(i64 %9) #12
+  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_foo.i.i, i64 %rubyId_foo.i.i, i64 %"rubyStr_test/testdata/compiler/block_no_args_captures_constant.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8
+  %3 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i64 0, i64 62), i64 noundef 12) #12
+  call void @rb_gc_register_mark_object(i64 %3) #12
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8
-  %"rubyId_block in foo.i.i" = load i64, i64* @"rubyIdPrecomputed_block in foo", align 8
+  %"rubyId_block in foo.i.i" = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/block_no_args_captures_constant.rb.i5.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args_captures_constant.rb", align 8
-  %10 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %9, i64 %"rubyId_block in foo.i.i", i64 %"rubyStr_test/testdata/compiler/block_no_args_captures_constant.rb.i5.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %10, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo$block_1", align 8
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !19
+  %4 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %3, i64 %"rubyId_block in foo.i.i", i64 %"rubyStr_test/testdata/compiler/block_no_args_captures_constant.rb.i5.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %4, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo$block_1", align 8
+  %rubyId_puts.i = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !19, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
-  %11 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_Object#3foo$block_1", i8* noundef null, i32 noundef 0, i32 noundef 0) #12
-  %12 = ptrtoint %struct.vm_ifunc* %11 to i64
-  %13 = call i64 @sorbet_globalConstRegister(i64 %12)
-  store i64 %13, i64* @"func_Object#3foo$block_1_ifunc", align 8
-  %rubyId_puts2.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !49
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts2.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !49
-  %14 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i64 0, i64 95), i64 noundef 16) #12
-  call void @rb_gc_register_mark_object(i64 %14) #12
-  %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
+  %5 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_Object#3foo$block_1", i8* noundef null, i32 noundef 0, i32 noundef 0) #12
+  %6 = ptrtoint %struct.vm_ifunc* %5 to i64
+  %7 = call i64 @sorbet_globalConstRegister(i64 %6)
+  store i64 %7, i64* @"func_Object#3foo$block_1_ifunc", align 8
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !49
+  %8 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i64 0, i64 95), i64 noundef 16) #12
+  call void @rb_gc_register_mark_object(i64 %8) #12
+  %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/block_no_args_captures_constant.rb.i6.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args_captures_constant.rb", align 8
-  %15 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %14, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_no_args_captures_constant.rb.i6.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i7.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %15, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %16 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i64 0, i64 112), i64 noundef 2) #12
-  call void @rb_gc_register_mark_object(i64 %16) #12
-  store i64 %16, i64* @rubyStrFrozen_hi, align 8
-  %rubyId_foo.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !50
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !50
-  %17 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
-  %18 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %17, i64 0, i32 18
-  %19 = load i64, i64* %18, align 8, !tbaa !52
-  %20 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %21 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %20, i64 0, i32 2
-  %22 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %21, align 8, !tbaa !24
+  %9 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %8, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_no_args_captures_constant.rb.i6.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i7.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %9, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %10 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i64 0, i64 112), i64 noundef 2) #12
+  call void @rb_gc_register_mark_object(i64 %10) #12
+  store i64 %10, i64* @rubyStrFrozen_hi, align 8
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !50
+  %11 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
+  %12 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %11, i64 0, i32 18
+  %13 = load i64, i64* %12, align 8, !tbaa !52
+  %14 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %15 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %14, i64 0, i32 2
+  %16 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %15, align 8, !tbaa !24
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %23 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %22, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %23, align 8, !tbaa !35
-  %24 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %22, i64 0, i32 4
-  %25 = load i64*, i64** %24, align 8, !tbaa !37
-  %26 = load i64, i64* %25, align 8, !tbaa !6
-  %27 = and i64 %26, -33
-  store i64 %27, i64* %25, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %20, %struct.rb_control_frame_struct* %22, %struct.rb_iseq_struct* %stackFrame.i) #12
-  %28 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %22, i64 0, i32 0
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %28, align 8, !dbg !60, !tbaa !14
+  %17 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %16, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %17, align 8, !tbaa !35
+  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %16, i64 0, i32 4
+  %19 = load i64*, i64** %18, align 8, !tbaa !37
+  %20 = load i64, i64* %19, align 8, !tbaa !6
+  %21 = and i64 %20, -33
+  store i64 %21, i64* %19, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %14, %struct.rb_control_frame_struct* %16, %struct.rb_iseq_struct* %stackFrame.i) #12
+  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %16, i64 0, i32 0
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %22, align 8, !dbg !60, !tbaa !14
   %rubyStr_hi.i = load i64, i64* @rubyStrFrozen_hi, align 8, !dbg !61
-  %29 = load i64, i64* @rb_cObject, align 8, !dbg !61
-  %30 = call i64 @sorbet_setConstant(i64 %29, i8* getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i64 0, i64 75), i64 noundef 1, i64 %rubyStr_hi.i) #12, !dbg !61
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %28, align 8, !dbg !61, !tbaa !14
+  %23 = load i64, i64* @rb_cObject, align 8, !dbg !61
+  %24 = call i64 @sorbet_setConstant(i64 %23, i8* getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i64 0, i64 75), i64 noundef 1, i64 %rubyStr_hi.i) #12, !dbg !61
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %22, align 8, !dbg !61, !tbaa !14
   %stackFrame12.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8, !dbg !62
-  %31 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #13, !dbg !62
-  %32 = bitcast i8* %31 to i16*, !dbg !62
-  %33 = load i16, i16* %32, align 8, !dbg !62
-  %34 = and i16 %33, -384, !dbg !62
-  store i16 %34, i16* %32, align 8, !dbg !62
-  %35 = getelementptr inbounds i8, i8* %31, i64 4, !dbg !62
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %35, i8 0, i64 28, i1 false) #12, !dbg !62
-  call void @sorbet_vm_define_method(i64 %29, i8* noundef getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#3foo", i8* nonnull %31, %struct.rb_iseq_struct* %stackFrame12.i, i1 noundef zeroext false) #12, !dbg !62
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %28, align 8, !dbg !62, !tbaa !14
-  %36 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %22, i64 0, i32 1, !dbg !50
-  %37 = load i64*, i64** %36, align 8, !dbg !50
-  store i64 %19, i64* %37, align 8, !dbg !50, !tbaa !6
-  %38 = getelementptr inbounds i64, i64* %37, i64 1, !dbg !50
-  store i64* %38, i64** %36, align 8, !dbg !50
+  %25 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #13, !dbg !62
+  %26 = bitcast i8* %25 to i16*, !dbg !62
+  %27 = load i16, i16* %26, align 8, !dbg !62
+  %28 = and i16 %27, -384, !dbg !62
+  store i16 %28, i16* %26, align 8, !dbg !62
+  %29 = getelementptr inbounds i8, i8* %25, i64 4, !dbg !62
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %29, i8 0, i64 28, i1 false) #12, !dbg !62
+  call void @sorbet_vm_define_method(i64 %23, i8* noundef getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#3foo", i8* nonnull %25, %struct.rb_iseq_struct* %stackFrame12.i, i1 noundef zeroext false) #12, !dbg !62
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %22, align 8, !dbg !62, !tbaa !14
+  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %16, i64 0, i32 1, !dbg !50
+  %31 = load i64*, i64** %30, align 8, !dbg !50
+  store i64 %13, i64* %31, align 8, !dbg !50, !tbaa !6
+  %32 = getelementptr inbounds i64, i64* %31, i64 1, !dbg !50
+  store i64* %32, i64** %30, align 8, !dbg !50
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo, i64 0), !dbg !50
   ret void
 }

--- a/test/testdata/compiler/block_type_checking.opt.ll.exp
+++ b/test/testdata/compiler/block_type_checking.opt.ll.exp
@@ -86,39 +86,27 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [19 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_block in <top (required)>" = internal unnamed_addr global i64 0, align 8
 @ic_new = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_new = internal unnamed_addr global i64 0, align 8
 @ic_initialize = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_initialize = internal unnamed_addr global i64 0, align 8
 @ic_bar = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_bar = internal unnamed_addr global i64 0, align 8
 @"func_<root>.17<static-init>$153$block_1_ifunc" = internal unnamed_addr global i64 0
 @ic_p = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_p = internal unnamed_addr global i64 0, align 8
 @"stackFramePrecomputed_func_Foo#3bar" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"stackFramePrecomputed_func_Foo.13<static-init>" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_<class:Foo>" = internal unnamed_addr global i64 0, align 8
 @"stackFramePrecomputed_func_Foo.13<static-init>$block_1" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_block in <class:Foo>" = internal unnamed_addr global i64 0, align 8
-@rubyIdPrecomputed_x = internal unnamed_addr global i64 0, align 8
-@rubyIdPrecomputed_blk = internal unnamed_addr global i64 0, align 8
 @ic_proc = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_proc = internal unnamed_addr global i64 0, align 8
 @ic_returns = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_returns = internal unnamed_addr global i64 0, align 8
 @ic_params = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_params = internal unnamed_addr global i64 0, align 8
 @ic_returns.1 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_extend = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_extend = internal unnamed_addr global i64 0, align 8
 @sorbet_moduleStringTable = internal unnamed_addr constant [247 x i8] c"<top (required)>\00test/testdata/compiler/block_type_checking.rb\00block in <top (required)>\00Foo\00Object\00new\00initialize\00bar\00p\00master\00Parameter 'x'\00Integer\00+\00Return value\00<class:Foo>\00block in <class:Foo>\00x\00blk\00proc\00T\00returns\00params\00T::Sig\00extend\00normal\00", align 1
+@sorbet_moduleIDTable = internal unnamed_addr global [16 x i64] zeroinitializer, align 8
+@sorbet_moduleIDDescriptors = internal unnamed_addr constant [16 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 63, i32 25 }, %struct.rb_code_position_struct { i32 100, i32 3 }, %struct.rb_code_position_struct { i32 104, i32 10 }, %struct.rb_code_position_struct { i32 115, i32 3 }, %struct.rb_code_position_struct { i32 119, i32 1 }, %struct.rb_code_position_struct { i32 150, i32 1 }, %struct.rb_code_position_struct { i32 165, i32 11 }, %struct.rb_code_position_struct { i32 177, i32 20 }, %struct.rb_code_position_struct { i32 198, i32 1 }, %struct.rb_code_position_struct { i32 200, i32 3 }, %struct.rb_code_position_struct { i32 204, i32 4 }, %struct.rb_code_position_struct { i32 211, i32 7 }, %struct.rb_code_position_struct { i32 219, i32 6 }, %struct.rb_code_position_struct { i32 233, i32 6 }, %struct.rb_code_position_struct { i32 240, i32 6 }], align 8
 @rb_cObject = external local_unnamed_addr constant i64
 @"guard_epoch_T::Sig" = linkonce local_unnamed_addr global i64 0
 @"guarded_const_T::Sig" = linkonce local_unnamed_addr global i64 0
@@ -165,6 +153,8 @@ declare void @sorbet_vm_register_sig(i64, i64, i64, i64, i64 (i64, i64, i32, i64
 
 declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #3
 
+declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #3
+
 declare i64 @sorbet_maybeAllocateObjectFastPath(i64, %struct.FunctionInlineCache*) local_unnamed_addr #3
 
 declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #3
@@ -178,8 +168,6 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #4
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #4
-
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #3
 
 declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #3
 
@@ -251,271 +239,237 @@ entry:
   %realpath = tail call i64 @sorbet_readRealpath()
   %0 = bitcast i64* %keywords.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %0)
-  %1 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #17
-  store i64 %1, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %2 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 63), i64 noundef 25) #17
-  store i64 %2, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
-  %3 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 100), i64 noundef 3) #17
-  store i64 %3, i64* @rubyIdPrecomputed_new, align 8
-  %4 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 104), i64 noundef 10) #17
-  store i64 %4, i64* @rubyIdPrecomputed_initialize, align 8
-  %5 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 115), i64 noundef 3) #17
-  store i64 %5, i64* @rubyIdPrecomputed_bar, align 8
-  %6 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 119), i64 noundef 1) #17
-  store i64 %6, i64* @rubyIdPrecomputed_p, align 8
-  %7 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 150), i64 noundef 1) #17
-  %8 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 165), i64 noundef 11) #17
-  store i64 %8, i64* @"rubyIdPrecomputed_<class:Foo>", align 8
-  %9 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 177), i64 noundef 20) #17
-  store i64 %9, i64* @"rubyIdPrecomputed_block in <class:Foo>", align 8
-  %10 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 198), i64 noundef 1) #17
-  store i64 %10, i64* @rubyIdPrecomputed_x, align 8
-  %11 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 200), i64 noundef 3) #17
-  store i64 %11, i64* @rubyIdPrecomputed_blk, align 8
-  %12 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 204), i64 noundef 4) #17
-  store i64 %12, i64* @rubyIdPrecomputed_proc, align 8
-  %13 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 211), i64 noundef 7) #17
-  store i64 %13, i64* @rubyIdPrecomputed_returns, align 8
-  %14 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 219), i64 noundef 6) #17
-  store i64 %14, i64* @rubyIdPrecomputed_params, align 8
-  %15 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 233), i64 noundef 6) #17
-  store i64 %15, i64* @rubyIdPrecomputed_extend, align 8
-  %16 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 240), i64 noundef 6) #17
-  %17 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #17
-  tail call void @rb_gc_register_mark_object(i64 %17) #17
-  store i64 %17, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %18 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 45) #17
-  tail call void @rb_gc_register_mark_object(i64 %18) #17
-  store i64 %18, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
+  tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([16 x %struct.rb_code_position_struct], [16 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 16, i8* noundef getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
+  %1 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #17
+  tail call void @rb_gc_register_mark_object(i64 %1) #17
+  store i64 %1, i64* @"rubyStrFrozen_<top (required)>", align 8
+  %2 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 45) #17
+  tail call void @rb_gc_register_mark_object(i64 %2) #17
+  store i64 %2, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 19)
-  %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
+  %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
   %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/block_type_checking.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
-  %19 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %19, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %20 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 63), i64 noundef 25) #17
-  call void @rb_gc_register_mark_object(i64 %20) #17
+  %3 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %3, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %4 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 63), i64 noundef 25) #17
+  call void @rb_gc_register_mark_object(i64 %4) #17
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %"rubyId_block in <top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
+  %"rubyId_block in <top (required)>.i.i" = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/block_type_checking.rb.i14.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
-  %21 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %20, i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i14.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %21, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1", align 8
-  %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !31
+  %5 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %4, i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i14.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %5, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1", align 8
+  %rubyId_new.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !31, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !31
-  %rubyId_initialize.i = load i64, i64* @rubyIdPrecomputed_initialize, align 8, !dbg !31
+  %rubyId_initialize.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !31, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 %rubyId_initialize.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !31
-  %rubyId_bar.i = load i64, i64* @rubyIdPrecomputed_bar, align 8, !dbg !31
+  %rubyId_bar.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !dbg !31, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_bar, i64 %rubyId_bar.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !31
-  %22 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_1", i8* noundef null, i32 noundef 0, i32 noundef 0) #17
-  %23 = ptrtoint %struct.vm_ifunc* %22 to i64
-  %24 = call i64 @sorbet_globalConstRegister(i64 %23)
-  store i64 %24, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8
-  %rubyId_p.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !32
+  %6 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_1", i8* noundef null, i32 noundef 0, i32 noundef 0) #17
+  %7 = ptrtoint %struct.vm_ifunc* %6 to i64
+  %8 = call i64 @sorbet_globalConstRegister(i64 %7)
+  store i64 %8, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8
+  %rubyId_p.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 5), align 8, !dbg !32, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !32
-  %25 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 115), i64 noundef 3) #17
-  call void @rb_gc_register_mark_object(i64 %25) #17
-  %rubyId_bar.i.i = load i64, i64* @rubyIdPrecomputed_bar, align 8
+  %9 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 115), i64 noundef 3) #17
+  call void @rb_gc_register_mark_object(i64 %9) #17
   %"rubyStr_test/testdata/compiler/block_type_checking.rb.i15.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
-  %26 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %25, i64 %rubyId_bar.i.i, i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i15.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 9, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i16.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %26, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo#3bar", align 8
-  %27 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 165), i64 noundef 11) #17
-  call void @rb_gc_register_mark_object(i64 %27) #17
-  %"rubyId_<class:Foo>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:Foo>", align 8
+  %10 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %9, i64 %rubyId_bar.i, i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i15.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 9, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i16.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %10, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo#3bar", align 8
+  %11 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 165), i64 noundef 11) #17
+  call void @rb_gc_register_mark_object(i64 %11) #17
+  %"rubyId_<class:Foo>.i.i" = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 7), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/block_type_checking.rb.i17.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
-  %28 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %27, i64 %"rubyId_<class:Foo>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i17.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i18.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %28, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>", align 8
-  %29 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 177), i64 noundef 20) #17
-  call void @rb_gc_register_mark_object(i64 %29) #17
+  %12 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %11, i64 %"rubyId_<class:Foo>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i17.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i18.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %12, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>", align 8
+  %13 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 177), i64 noundef 20) #17
+  call void @rb_gc_register_mark_object(i64 %13) #17
   %stackFrame.i19.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>", align 8
-  %"rubyId_block in <class:Foo>.i.i" = load i64, i64* @"rubyIdPrecomputed_block in <class:Foo>", align 8
+  %"rubyId_block in <class:Foo>.i.i" = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 8), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/block_type_checking.rb.i20.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
-  %30 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %29, i64 %"rubyId_block in <class:Foo>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i20.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i19.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %30, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>$block_1", align 8
-  %rubyId_proc.i = load i64, i64* @rubyIdPrecomputed_proc, align 8, !dbg !33
+  %14 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %13, i64 %"rubyId_block in <class:Foo>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i20.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i19.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %14, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>$block_1", align 8
+  %rubyId_proc.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 11), align 8, !dbg !33, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_proc, i64 %rubyId_proc.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !33
-  %rubyId_returns.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !33
+  %rubyId_returns.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 12), align 8, !dbg !33, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !33
-  %rubyId_params.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !29
-  %rubyId_x.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !29
-  %31 = call i64 @rb_id2sym(i64 %rubyId_x.i) #18, !dbg !29
-  store i64 %31, i64* %keywords.i, align 8, !dbg !29
-  %rubyId_blk.i = load i64, i64* @rubyIdPrecomputed_blk, align 8, !dbg !29
-  %32 = call i64 @rb_id2sym(i64 %rubyId_blk.i) #18, !dbg !29
-  %33 = getelementptr i64, i64* %keywords.i, i32 1, !dbg !29
-  store i64 %32, i64* %33, align 8, !dbg !29
+  %rubyId_params.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 13), align 8, !dbg !29, !invariant.load !5
+  %rubyId_x.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 9), align 8, !dbg !29, !invariant.load !5
+  %15 = call i64 @rb_id2sym(i64 %rubyId_x.i) #18, !dbg !29
+  store i64 %15, i64* %keywords.i, align 8, !dbg !29
+  %rubyId_blk.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 10), align 8, !dbg !29, !invariant.load !5
+  %16 = call i64 @rb_id2sym(i64 %rubyId_blk.i) #18, !dbg !29
+  %17 = getelementptr i64, i64* %keywords.i, i32 1, !dbg !29
+  store i64 %16, i64* %17, align 8, !dbg !29
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull align 8 %keywords.i), !dbg !29
-  %rubyId_returns10.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !29
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.1, i64 %rubyId_returns10.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !29
-  %rubyId_extend.i = load i64, i64* @rubyIdPrecomputed_extend, align 8, !dbg !34
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.1, i64 %rubyId_returns.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !29
+  %rubyId_extend.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 14), align 8, !dbg !34, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !34
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %0)
-  %34 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !15
-  %35 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %34, i64 0, i32 18
-  %36 = load i64, i64* %35, align 8, !tbaa !35
-  %37 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
-  %38 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %37, i64 0, i32 2
-  %39 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %38, align 8, !tbaa !17
+  %18 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !15
+  %19 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %18, i64 0, i32 18
+  %20 = load i64, i64* %19, align 8, !tbaa !35
+  %21 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
+  %22 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 2
+  %23 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %22, align 8, !tbaa !17
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %40 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %39, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %40, align 8, !tbaa !21
-  %41 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %39, i64 0, i32 4
-  %42 = load i64*, i64** %41, align 8, !tbaa !23
-  %43 = load i64, i64* %42, align 8, !tbaa !6
-  %44 = and i64 %43, -33
-  store i64 %44, i64* %42, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %37, %struct.rb_control_frame_struct* %39, %struct.rb_iseq_struct* %stackFrame.i) #17
-  %45 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %39, i64 0, i32 0
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %45, align 8, !dbg !44, !tbaa !15
-  %46 = load i64, i64* @rb_cObject, align 8, !dbg !45
-  %47 = call i64 @rb_define_class(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 89), i64 %46) #17, !dbg !45
-  %48 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %47) #17, !dbg !45
-  %49 = bitcast i64* %positional_table.i.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %49) #17
+  %24 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %24, align 8, !tbaa !21
+  %25 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 4
+  %26 = load i64*, i64** %25, align 8, !tbaa !23
+  %27 = load i64, i64* %26, align 8, !tbaa !6
+  %28 = and i64 %27, -33
+  store i64 %28, i64* %26, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %21, %struct.rb_control_frame_struct* %23, %struct.rb_iseq_struct* %stackFrame.i) #17
+  %29 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 0
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %29, align 8, !dbg !44, !tbaa !15
+  %30 = load i64, i64* @rb_cObject, align 8, !dbg !45
+  %31 = call i64 @rb_define_class(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 89), i64 %30) #17, !dbg !45
+  %32 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %31) #17, !dbg !45
+  %33 = bitcast i64* %positional_table.i.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %33) #17
   %stackFrame.i.i1 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>", align 8
-  %50 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
-  %51 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %50, i64 0, i32 2
-  %52 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %51, align 8, !tbaa !17
-  %53 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %52, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i.i1, %struct.rb_iseq_struct** %53, align 8, !tbaa !21
-  %54 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %52, i64 0, i32 4
-  %55 = load i64*, i64** %54, align 8, !tbaa !23
-  %56 = load i64, i64* %55, align 8, !tbaa !6
-  %57 = and i64 %56, -33
-  store i64 %57, i64* %55, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %50, %struct.rb_control_frame_struct* %52, %struct.rb_iseq_struct* %stackFrame.i.i1) #17
-  %58 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %48, i64 0, i32 0
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %58, align 8, !dbg !46, !tbaa !15
-  %rubyId_bar.i.i2 = load i64, i64* @rubyIdPrecomputed_bar, align 8, !dbg !47
-  %rawSym.i.i = call i64 @rb_id2sym(i64 %rubyId_bar.i.i2) #17, !dbg !47
-  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym.i.i, i64 %47, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_Foo.13<static-init>L62$block_1") #17, !dbg !47
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %58, align 8, !dbg !47, !tbaa !15
-  %59 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !48
-  %60 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !48, !tbaa !49
-  %needTakeSlowPath = icmp ne i64 %59, %60, !dbg !48
-  br i1 %needTakeSlowPath, label %61, label %62, !dbg !48, !prof !50
+  %34 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
+  %35 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %34, i64 0, i32 2
+  %36 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %35, align 8, !tbaa !17
+  %37 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i.i1, %struct.rb_iseq_struct** %37, align 8, !tbaa !21
+  %38 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 4
+  %39 = load i64*, i64** %38, align 8, !tbaa !23
+  %40 = load i64, i64* %39, align 8, !tbaa !6
+  %41 = and i64 %40, -33
+  store i64 %41, i64* %39, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %34, %struct.rb_control_frame_struct* %36, %struct.rb_iseq_struct* %stackFrame.i.i1) #17
+  %42 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 0
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %42, align 8, !dbg !46, !tbaa !15
+  %rawSym.i.i = call i64 @rb_id2sym(i64 %rubyId_bar.i) #17, !dbg !47
+  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym.i.i, i64 %31, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_Foo.13<static-init>L62$block_1") #17, !dbg !47
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %42, align 8, !dbg !47, !tbaa !15
+  %43 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !48
+  %44 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !48, !tbaa !49
+  %needTakeSlowPath = icmp ne i64 %43, %44, !dbg !48
+  br i1 %needTakeSlowPath, label %45, label %46, !dbg !48, !prof !50
 
-61:                                               ; preds = %entry
+45:                                               ; preds = %entry
   call void @"const_recompute_T::Sig"(), !dbg !48
-  br label %62, !dbg !48
+  br label %46, !dbg !48
 
-62:                                               ; preds = %entry, %61
-  %63 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !48
-  %64 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !48
-  %65 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !48, !tbaa !49
-  %guardUpdated = icmp eq i64 %64, %65, !dbg !48
+46:                                               ; preds = %entry, %45
+  %47 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !48
+  %48 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !48
+  %49 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !48, !tbaa !49
+  %guardUpdated = icmp eq i64 %48, %49, !dbg !48
   call void @llvm.assume(i1 %guardUpdated), !dbg !48
-  %66 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %48, i64 0, i32 1, !dbg !48
-  %67 = load i64*, i64** %66, align 8, !dbg !48
-  store i64 %47, i64* %67, align 8, !dbg !48, !tbaa !6
-  %68 = getelementptr inbounds i64, i64* %67, i64 1, !dbg !48
-  store i64 %63, i64* %68, align 8, !dbg !48, !tbaa !6
-  %69 = getelementptr inbounds i64, i64* %68, i64 1, !dbg !48
-  store i64* %69, i64** %66, align 8, !dbg !48
+  %50 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 1, !dbg !48
+  %51 = load i64*, i64** %50, align 8, !dbg !48
+  store i64 %31, i64* %51, align 8, !dbg !48, !tbaa !6
+  %52 = getelementptr inbounds i64, i64* %51, i64 1, !dbg !48
+  store i64 %47, i64* %52, align 8, !dbg !48, !tbaa !6
+  %53 = getelementptr inbounds i64, i64* %52, i64 1, !dbg !48
+  store i64* %53, i64** %50, align 8, !dbg !48
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !48
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %58, align 8, !dbg !48, !tbaa !15
-  %70 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !26
-  %71 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !26, !tbaa !49
-  %needTakeSlowPath3 = icmp ne i64 %70, %71, !dbg !26
-  br i1 %needTakeSlowPath3, label %72, label %73, !dbg !26, !prof !50
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %42, align 8, !dbg !48, !tbaa !15
+  %54 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !26
+  %55 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !26, !tbaa !49
+  %needTakeSlowPath2 = icmp ne i64 %54, %55, !dbg !26
+  br i1 %needTakeSlowPath2, label %56, label %57, !dbg !26, !prof !50
 
-72:                                               ; preds = %62
+56:                                               ; preds = %46
   call void @const_recompute_Foo(), !dbg !26
-  br label %73, !dbg !26
+  br label %57, !dbg !26
 
-73:                                               ; preds = %62, %72
-  %74 = load i64, i64* @guarded_const_Foo, align 8, !dbg !26
-  %75 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !26
-  %76 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !26, !tbaa !49
-  %guardUpdated4 = icmp eq i64 %75, %76, !dbg !26
-  call void @llvm.assume(i1 %guardUpdated4), !dbg !26
+57:                                               ; preds = %46, %56
+  %58 = load i64, i64* @guarded_const_Foo, align 8, !dbg !26
+  %59 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !26
+  %60 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !26, !tbaa !49
+  %guardUpdated3 = icmp eq i64 %59, %60, !dbg !26
+  call void @llvm.assume(i1 %guardUpdated3), !dbg !26
   %stackFrame42.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo#3bar", align 8, !dbg !26
-  %77 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #19, !dbg !26
-  %78 = bitcast i8* %77 to i16*, !dbg !26
-  %79 = load i16, i16* %78, align 8, !dbg !26
-  %80 = and i16 %79, -384, !dbg !26
-  %81 = or i16 %80, 65, !dbg !26
-  store i16 %81, i16* %78, align 8, !dbg !26
-  %82 = getelementptr inbounds i8, i8* %77, i64 8, !dbg !26
-  %83 = bitcast i8* %82 to i32*, !dbg !26
-  store i32 1, i32* %83, align 8, !dbg !26, !tbaa !51
-  %84 = getelementptr inbounds i8, i8* %77, i64 12, !dbg !26
-  %85 = getelementptr inbounds i8, i8* %77, i64 28, !dbg !26
-  %86 = bitcast i8* %85 to i32*, !dbg !26
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %84, i8 0, i64 16, i1 false) #17, !dbg !26
-  store i32 1, i32* %86, align 4, !dbg !26, !tbaa !54
-  %87 = getelementptr inbounds i8, i8* %77, i64 4, !dbg !26
-  %88 = bitcast i8* %87 to i32*, !dbg !26
-  store i32 2, i32* %88, align 4, !dbg !26, !tbaa !55
-  %rubyId_x.i.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !26
-  store i64 %rubyId_x.i.i, i64* %positional_table.i.i, align 8, !dbg !26
-  %rubyId_blk.i.i = load i64, i64* @rubyIdPrecomputed_blk, align 8, !dbg !26
-  %89 = getelementptr i64, i64* %positional_table.i.i, i32 1, !dbg !26
-  store i64 %rubyId_blk.i.i, i64* %89, align 8, !dbg !26
-  %90 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #19, !dbg !26
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %90, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %49, i64 noundef 16, i1 noundef false) #17, !dbg !26
-  %91 = getelementptr inbounds i8, i8* %77, i64 32, !dbg !26
-  %92 = bitcast i8* %91 to i8**, !dbg !26
-  store i8* %90, i8** %92, align 8, !dbg !26, !tbaa !56
-  call void @sorbet_vm_define_method(i64 %74, i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 115), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Foo#3bar", i8* nonnull %77, %struct.rb_iseq_struct* %stackFrame42.i.i, i1 noundef zeroext false) #17, !dbg !26
-  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %49) #17
+  %61 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #19, !dbg !26
+  %62 = bitcast i8* %61 to i16*, !dbg !26
+  %63 = load i16, i16* %62, align 8, !dbg !26
+  %64 = and i16 %63, -384, !dbg !26
+  %65 = or i16 %64, 65, !dbg !26
+  store i16 %65, i16* %62, align 8, !dbg !26
+  %66 = getelementptr inbounds i8, i8* %61, i64 8, !dbg !26
+  %67 = bitcast i8* %66 to i32*, !dbg !26
+  store i32 1, i32* %67, align 8, !dbg !26, !tbaa !51
+  %68 = getelementptr inbounds i8, i8* %61, i64 12, !dbg !26
+  %69 = getelementptr inbounds i8, i8* %61, i64 28, !dbg !26
+  %70 = bitcast i8* %69 to i32*, !dbg !26
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %68, i8 0, i64 16, i1 false) #17, !dbg !26
+  store i32 1, i32* %70, align 4, !dbg !26, !tbaa !54
+  %71 = getelementptr inbounds i8, i8* %61, i64 4, !dbg !26
+  %72 = bitcast i8* %71 to i32*, !dbg !26
+  store i32 2, i32* %72, align 4, !dbg !26, !tbaa !55
+  store i64 %rubyId_x.i, i64* %positional_table.i.i, align 8, !dbg !26
+  %73 = getelementptr i64, i64* %positional_table.i.i, i32 1, !dbg !26
+  store i64 %rubyId_blk.i, i64* %73, align 8, !dbg !26
+  %74 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #19, !dbg !26
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %74, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %33, i64 noundef 16, i1 noundef false) #17, !dbg !26
+  %75 = getelementptr inbounds i8, i8* %61, i64 32, !dbg !26
+  %76 = bitcast i8* %75 to i8**, !dbg !26
+  store i8* %74, i8** %76, align 8, !dbg !26, !tbaa !56
+  call void @sorbet_vm_define_method(i64 %58, i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 115), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Foo#3bar", i8* nonnull %61, %struct.rb_iseq_struct* %stackFrame42.i.i, i1 noundef zeroext false) #17, !dbg !26
+  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %33) #17
   call void @sorbet_popFrame() #17, !dbg !45
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 15), i64** %45, align 8, !dbg !45, !tbaa !15
-  %93 = call i64 @sorbet_maybeAllocateObjectFastPath(i64 %74, %struct.FunctionInlineCache* noundef @ic_new) #17, !dbg !31
-  %94 = icmp eq i64 %93, 52, !dbg !31
-  br i1 %94, label %slowNew.i, label %fastNew.i, !dbg !31
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 15), i64** %29, align 8, !dbg !45, !tbaa !15
+  %77 = call i64 @sorbet_maybeAllocateObjectFastPath(i64 %58, %struct.FunctionInlineCache* noundef @ic_new) #17, !dbg !31
+  %78 = icmp eq i64 %77, 52, !dbg !31
+  br i1 %78, label %slowNew.i, label %fastNew.i, !dbg !31
 
-slowNew.i:                                        ; preds = %73
-  %95 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %39, i64 0, i32 1, !dbg !31
-  %96 = load i64*, i64** %95, align 8, !dbg !31
-  store i64 %74, i64* %96, align 8, !dbg !31, !tbaa !6
-  %97 = getelementptr inbounds i64, i64* %96, i64 1, !dbg !31
-  store i64* %97, i64** %95, align 8, !dbg !31
-  %98 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_new, i64 noundef 0) #17, !dbg !31
+slowNew.i:                                        ; preds = %57
+  %79 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 1, !dbg !31
+  %80 = load i64*, i64** %79, align 8, !dbg !31
+  store i64 %58, i64* %80, align 8, !dbg !31, !tbaa !6
+  %81 = getelementptr inbounds i64, i64* %80, i64 1, !dbg !31
+  store i64* %81, i64** %79, align 8, !dbg !31
+  %82 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_new, i64 noundef 0) #17, !dbg !31
   br label %"func_<root>.17<static-init>$153.exit", !dbg !31
 
-fastNew.i:                                        ; preds = %73
-  %99 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %39, i64 0, i32 1, !dbg !31
-  %100 = load i64*, i64** %99, align 8, !dbg !31
-  store i64 %93, i64* %100, align 8, !dbg !31, !tbaa !6
-  %101 = getelementptr inbounds i64, i64* %100, i64 1, !dbg !31
-  store i64* %101, i64** %99, align 8, !dbg !31
-  %102 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 noundef 0) #17, !dbg !31
+fastNew.i:                                        ; preds = %57
+  %83 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 1, !dbg !31
+  %84 = load i64*, i64** %83, align 8, !dbg !31
+  store i64 %77, i64* %84, align 8, !dbg !31, !tbaa !6
+  %85 = getelementptr inbounds i64, i64* %84, i64 1, !dbg !31
+  store i64* %85, i64** %83, align 8, !dbg !31
+  %86 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 noundef 0) #17, !dbg !31
   br label %"func_<root>.17<static-init>$153.exit", !dbg !31
 
 "func_<root>.17<static-init>$153.exit":           ; preds = %slowNew.i, %fastNew.i
-  %initializedObject.i = phi i64 [ %98, %slowNew.i ], [ %93, %fastNew.i ], !dbg !31
-  %103 = load i64, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8, !dbg !31
-  %104 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %103) #17, !dbg !31
-  %105 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %39, i64 0, i32 1, !dbg !31
-  %106 = load i64*, i64** %105, align 8, !dbg !31
-  store i64 %initializedObject.i, i64* %106, align 8, !dbg !31, !tbaa !6
-  %107 = getelementptr inbounds i64, i64* %106, i64 1, !dbg !31
-  store i64 11, i64* %107, align 8, !dbg !31, !tbaa !6
-  %108 = getelementptr inbounds i64, i64* %107, i64 1, !dbg !31
-  store i64* %108, i64** %105, align 8, !dbg !31
-  %109 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !31, !tbaa !15
-  %110 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %109, i64 0, i32 2, !dbg !31
-  %111 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %110, align 8, !dbg !31, !tbaa !17
-  %112 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %111, i64 0, i32 3, !dbg !31
-  %113 = bitcast i64* %112 to %struct.rb_captured_block*, !dbg !31
-  %114 = getelementptr inbounds i64, i64* %112, i64 2, !dbg !31
-  %115 = bitcast i64* %114 to %struct.vm_ifunc**, !dbg !31
-  store %struct.vm_ifunc* %104, %struct.vm_ifunc** %115, align 8, !dbg !31, !tbaa !57
-  %116 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %109, i64 0, i32 17, !dbg !31
-  store i64 0, i64* %116, align 8, !dbg !31, !tbaa !58
+  %initializedObject.i = phi i64 [ %82, %slowNew.i ], [ %77, %fastNew.i ], !dbg !31
+  %87 = load i64, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8, !dbg !31
+  %88 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %87) #17, !dbg !31
+  %89 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 1, !dbg !31
+  %90 = load i64*, i64** %89, align 8, !dbg !31
+  store i64 %initializedObject.i, i64* %90, align 8, !dbg !31, !tbaa !6
+  %91 = getelementptr inbounds i64, i64* %90, i64 1, !dbg !31
+  store i64 11, i64* %91, align 8, !dbg !31, !tbaa !6
+  %92 = getelementptr inbounds i64, i64* %91, i64 1, !dbg !31
+  store i64* %92, i64** %89, align 8, !dbg !31
+  %93 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !31, !tbaa !15
+  %94 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %93, i64 0, i32 2, !dbg !31
+  %95 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %94, align 8, !dbg !31, !tbaa !17
+  %96 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %95, i64 0, i32 3, !dbg !31
+  %97 = bitcast i64* %96 to %struct.rb_captured_block*, !dbg !31
+  %98 = getelementptr inbounds i64, i64* %96, i64 2, !dbg !31
+  %99 = bitcast i64* %98 to %struct.vm_ifunc**, !dbg !31
+  store %struct.vm_ifunc* %88, %struct.vm_ifunc** %99, align 8, !dbg !31, !tbaa !57
+  %100 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %93, i64 0, i32 17, !dbg !31
+  store i64 0, i64* %100, align 8, !dbg !31, !tbaa !58
   call void @llvm.experimental.noalias.scope.decl(metadata !59) #17, !dbg !31
-  %117 = ptrtoint %struct.rb_captured_block* %113 to i64, !dbg !31
-  %118 = or i64 %117, 3, !dbg !31
-  %119 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_bar, i64 %118) #17, !dbg !31
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %45, align 8, !dbg !31, !tbaa !15
-  %120 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %39, i64 0, i32 1, !dbg !32
-  %121 = load i64*, i64** %120, align 8, !dbg !32
-  store i64 %36, i64* %121, align 8, !dbg !32, !tbaa !6
-  %122 = getelementptr inbounds i64, i64* %121, i64 1, !dbg !32
-  store i64 %119, i64* %122, align 8, !dbg !32, !tbaa !6
-  %123 = getelementptr inbounds i64, i64* %122, i64 1, !dbg !32
-  store i64* %123, i64** %120, align 8, !dbg !32
-  %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p, i64 0), !dbg !32
+  %101 = ptrtoint %struct.rb_captured_block* %97 to i64, !dbg !31
+  %102 = or i64 %101, 3, !dbg !31
+  %103 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_bar, i64 %102) #17, !dbg !31
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %29, align 8, !dbg !31, !tbaa !15
+  %104 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 1, !dbg !32
+  %105 = load i64*, i64** %104, align 8, !dbg !32
+  store i64 %20, i64* %105, align 8, !dbg !32, !tbaa !6
+  %106 = getelementptr inbounds i64, i64* %105, i64 1, !dbg !32
+  store i64 %103, i64* %106, align 8, !dbg !32, !tbaa !6
+  %107 = getelementptr inbounds i64, i64* %106, i64 1, !dbg !32
+  store i64* %107, i64** %104, align 8, !dbg !32
+  %send5 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p, i64 0), !dbg !32
   ret void
 }
 

--- a/test/testdata/compiler/boolean_ops.opt.ll.exp
+++ b/test/testdata/compiler/boolean_ops.opt.ll.exp
@@ -81,16 +81,15 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/boolean_ops.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [6 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @"ic_!" = internal global %struct.FunctionInlineCache zeroinitializer
-@"rubyIdPrecomputed_!" = internal unnamed_addr global i64 0, align 8
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
 @sorbet_moduleStringTable = internal unnamed_addr constant [71 x i8] c"<top (required)>\00test/testdata/compiler/boolean_ops.rb\00>\00!\00puts\00master\00", align 1
+@sorbet_moduleIDTable = internal unnamed_addr global [4 x i64] zeroinitializer, align 8
+@sorbet_moduleIDDescriptors = internal unnamed_addr constant [4 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 55, i32 1 }, %struct.rb_code_position_struct { i32 57, i32 1 }, %struct.rb_code_position_struct { i32 59, i32 4 }], align 8
 
 declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
 
@@ -104,11 +103,11 @@ declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_u
 
 declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #0
 
+declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #0
+
 declare i64 @sorbet_vm_bang(%struct.FunctionInlineCache*, %struct.rb_control_frame_struct*, i64) local_unnamed_addr #0
 
 declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
-
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #0
 
 declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
 
@@ -139,72 +138,66 @@ define void @Init_boolean_ops() local_unnamed_addr #4 {
 entry:
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([71 x i8], [71 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #6
-  store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %1 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([71 x i8], [71 x i8]* @sorbet_moduleStringTable, i64 0, i64 55), i64 noundef 1) #6
-  %2 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([71 x i8], [71 x i8]* @sorbet_moduleStringTable, i64 0, i64 57), i64 noundef 1) #6
-  store i64 %2, i64* @"rubyIdPrecomputed_!", align 8
-  %3 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([71 x i8], [71 x i8]* @sorbet_moduleStringTable, i64 0, i64 59), i64 noundef 4) #6
-  store i64 %3, i64* @rubyIdPrecomputed_puts, align 8
-  %4 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([71 x i8], [71 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #6
-  tail call void @rb_gc_register_mark_object(i64 %4) #6
-  store i64 %4, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %5 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([71 x i8], [71 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 37) #6
-  tail call void @rb_gc_register_mark_object(i64 %5) #6
-  store i64 %5, i64* @"rubyStrFrozen_test/testdata/compiler/boolean_ops.rb", align 8
+  tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([4 x %struct.rb_code_position_struct], [4 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 4, i8* noundef getelementptr inbounds ([71 x i8], [71 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
+  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([71 x i8], [71 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #6
+  tail call void @rb_gc_register_mark_object(i64 %0) #6
+  store i64 %0, i64* @"rubyStrFrozen_<top (required)>", align 8
+  %1 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([71 x i8], [71 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 37) #6
+  tail call void @rb_gc_register_mark_object(i64 %1) #6
+  store i64 %1, i64* @"rubyStrFrozen_test/testdata/compiler/boolean_ops.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([6 x i64], [6 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 6)
-  %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
+  %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
   %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/boolean_ops.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/boolean_ops.rb", align 8
-  %6 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/boolean_ops.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %6, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %"rubyId_!.i" = load i64, i64* @"rubyIdPrecomputed_!", align 8, !dbg !10
+  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/boolean_ops.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %"rubyId_!.i" = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !10, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_!", i64 %"rubyId_!.i", i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !10
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !15
+  %rubyId_puts.i = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !15, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
-  %7 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !16
-  %8 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %7, i64 0, i32 18
-  %9 = load i64, i64* %8, align 8, !tbaa !18
-  %10 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !16
-  %11 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %10, i64 0, i32 2
-  %12 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %11, align 8, !tbaa !28
+  %3 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !16
+  %4 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %3, i64 0, i32 18
+  %5 = load i64, i64* %4, align 8, !tbaa !18
+  %6 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !16
+  %7 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %6, i64 0, i32 2
+  %8 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %7, align 8, !tbaa !28
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %13 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %13, align 8, !tbaa !31
-  %14 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 4
-  %15 = load i64*, i64** %14, align 8, !tbaa !33
-  %16 = load i64, i64* %15, align 8, !tbaa !6
-  %17 = and i64 %16, -33
-  store i64 %17, i64* %15, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %10, %struct.rb_control_frame_struct* %12, %struct.rb_iseq_struct* %stackFrame.i) #6
-  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 0
-  store i64* getelementptr inbounds ([6 x i64], [6 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %18, align 8, !dbg !34, !tbaa !16
+  %9 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %8, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %9, align 8, !tbaa !31
+  %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %8, i64 0, i32 4
+  %11 = load i64*, i64** %10, align 8, !tbaa !33
+  %12 = load i64, i64* %11, align 8, !tbaa !6
+  %13 = and i64 %12, -33
+  store i64 %13, i64* %11, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %6, %struct.rb_control_frame_struct* %8, %struct.rb_iseq_struct* %stackFrame.i) #6
+  %14 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %8, i64 0, i32 0
+  store i64* getelementptr inbounds ([6 x i64], [6 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %14, align 8, !dbg !34, !tbaa !16
   call void @llvm.experimental.noalias.scope.decl(metadata !35) #6, !dbg !38
-  %19 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !38, !tbaa !16
-  %20 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %19, i64 0, i32 5, !dbg !38
-  %21 = load i32, i32* %20, align 8, !dbg !38, !tbaa !39
-  %22 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %19, i64 0, i32 6, !dbg !38
-  %23 = load i32, i32* %22, align 4, !dbg !38, !tbaa !40
-  %24 = xor i32 %23, -1, !dbg !38
-  %25 = and i32 %24, %21, !dbg !38
-  %26 = icmp eq i32 %25, 0, !dbg !38
-  br i1 %26, label %"func_<root>.17<static-init>$153.exit", label %27, !dbg !38, !prof !41
+  %15 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !38, !tbaa !16
+  %16 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %15, i64 0, i32 5, !dbg !38
+  %17 = load i32, i32* %16, align 8, !dbg !38, !tbaa !39
+  %18 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %15, i64 0, i32 6, !dbg !38
+  %19 = load i32, i32* %18, align 4, !dbg !38, !tbaa !40
+  %20 = xor i32 %19, -1, !dbg !38
+  %21 = and i32 %20, %17, !dbg !38
+  %22 = icmp eq i32 %21, 0, !dbg !38
+  br i1 %22, label %"func_<root>.17<static-init>$153.exit", label %23, !dbg !38, !prof !41
 
-27:                                               ; preds = %entry
-  %28 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %19, i64 0, i32 8, !dbg !38
-  %29 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %28, align 8, !dbg !38, !tbaa !42
-  %30 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %29, i32 noundef 0) #6, !dbg !38
+23:                                               ; preds = %entry
+  %24 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %15, i64 0, i32 8, !dbg !38
+  %25 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %24, align 8, !dbg !38, !tbaa !42
+  %26 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %25, i32 noundef 0) #6, !dbg !38
   br label %"func_<root>.17<static-init>$153.exit", !dbg !38
 
-"func_<root>.17<static-init>$153.exit":           ; preds = %entry, %27
-  %31 = call i64 @sorbet_vm_bang(%struct.FunctionInlineCache* noundef @"ic_!", %struct.rb_control_frame_struct* nonnull %12, i64 noundef 0) #6, !dbg !10
-  %32 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 1, !dbg !15
-  %33 = load i64*, i64** %32, align 8, !dbg !15
-  store i64 %9, i64* %33, align 8, !dbg !15, !tbaa !6
-  %34 = getelementptr inbounds i64, i64* %33, i64 1, !dbg !15
-  store i64 %31, i64* %34, align 8, !dbg !15, !tbaa !6
-  %35 = getelementptr inbounds i64, i64* %34, i64 1, !dbg !15
-  store i64* %35, i64** %32, align 8, !dbg !15
+"func_<root>.17<static-init>$153.exit":           ; preds = %entry, %23
+  %27 = call i64 @sorbet_vm_bang(%struct.FunctionInlineCache* noundef @"ic_!", %struct.rb_control_frame_struct* nonnull %8, i64 noundef 0) #6, !dbg !10
+  %28 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %8, i64 0, i32 1, !dbg !15
+  %29 = load i64*, i64** %28, align 8, !dbg !15
+  store i64 %5, i64* %29, align 8, !dbg !15, !tbaa !6
+  %30 = getelementptr inbounds i64, i64* %29, i64 1, !dbg !15
+  store i64 %27, i64* %30, align 8, !dbg !15, !tbaa !6
+  %31 = getelementptr inbounds i64, i64* %30, i64 1, !dbg !15
+  store i64* %31, i64** %28, align 8, !dbg !15
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !15
   ret void
 }

--- a/test/testdata/compiler/casts.opt.ll.exp
+++ b/test/testdata/compiler/casts.opt.ll.exp
@@ -82,25 +82,17 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_Object#6fooAll" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@rubyIdPrecomputed_fooAll = internal unnamed_addr global i64 0, align 8
 @rubyStrFrozen_fooAll = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/casts.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [30 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @"stackFramePrecomputed_func_Object#7fooAny1" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@rubyIdPrecomputed_fooAny1 = internal unnamed_addr global i64 0, align 8
 @"stackFramePrecomputed_func_Object#7fooAny2" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@rubyIdPrecomputed_fooAny2 = internal unnamed_addr global i64 0, align 8
 @"stackFramePrecomputed_func_Object#6fooInt" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@rubyIdPrecomputed_fooInt = internal unnamed_addr global i64 0, align 8
 @"stackFramePrecomputed_func_Object#8fooArray" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@rubyIdPrecomputed_fooArray = internal unnamed_addr global i64 0, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@rubyIdPrecomputed_arg = internal unnamed_addr global i64 0, align 8
 @ic_fooInt = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
 @ic_fooAny1 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.1 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_fooAny2 = internal global %struct.FunctionInlineCache zeroinitializer
@@ -110,6 +102,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ic_fooArray = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.4 = internal global %struct.FunctionInlineCache zeroinitializer
 @sorbet_moduleStringTable = internal unnamed_addr constant [218 x i8] c"fooAll\00test/testdata/compiler/casts.rb\00Kernel\00T.cast\00fooAny1\00T.any(Integer, Float)\00fooAny2\00T.any(Float, Integer)\00fooInt\00Integer\00+\00fooArray\00T::Array[Integer]\00<top (required)>\00normal\00Object\00arg\00puts\00<build-array>\00master\00", align 1
+@sorbet_moduleIDTable = internal unnamed_addr global [11 x i64] zeroinitializer, align 8
+@sorbet_moduleIDDescriptors = internal unnamed_addr constant [11 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 6 }, %struct.rb_code_position_struct { i32 53, i32 7 }, %struct.rb_code_position_struct { i32 83, i32 7 }, %struct.rb_code_position_struct { i32 113, i32 6 }, %struct.rb_code_position_struct { i32 128, i32 1 }, %struct.rb_code_position_struct { i32 130, i32 8 }, %struct.rb_code_position_struct { i32 157, i32 16 }, %struct.rb_code_position_struct { i32 174, i32 6 }, %struct.rb_code_position_struct { i32 188, i32 3 }, %struct.rb_code_position_struct { i32 192, i32 4 }, %struct.rb_code_position_struct { i32 197, i32 13 }], align 8
 @rb_mKernel = external local_unnamed_addr constant i64
 @rb_cObject = external local_unnamed_addr constant i64
 
@@ -138,9 +132,9 @@ declare i64 @sorbet_rb_int_plus_slowpath(i64, i64) local_unnamed_addr #3
 
 declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #3
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #3
+declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #3
 
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #3
+declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #3
 
 declare i64 @rb_ary_new_from_values(i64, i64*) local_unnamed_addr #3
 
@@ -486,332 +480,301 @@ entry:
   %locals.i25.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 6) #17
-  store i64 %0, i64* @rubyIdPrecomputed_fooAll, align 8
-  %1 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 53), i64 noundef 7) #17
-  store i64 %1, i64* @rubyIdPrecomputed_fooAny1, align 8
-  %2 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 83), i64 noundef 7) #17
-  store i64 %2, i64* @rubyIdPrecomputed_fooAny2, align 8
-  %3 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 113), i64 noundef 6) #17
-  store i64 %3, i64* @rubyIdPrecomputed_fooInt, align 8
-  %4 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 128), i64 noundef 1) #17
-  %5 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 130), i64 noundef 8) #17
-  store i64 %5, i64* @rubyIdPrecomputed_fooArray, align 8
-  %6 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 157), i64 noundef 16) #17
-  store i64 %6, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %7 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 174), i64 noundef 6) #17
-  %8 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 188), i64 noundef 3) #17
-  store i64 %8, i64* @rubyIdPrecomputed_arg, align 8
-  %9 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 192), i64 noundef 4) #17
-  store i64 %9, i64* @rubyIdPrecomputed_puts, align 8
-  %10 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 197), i64 noundef 13) #17
-  %11 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 6) #17
-  tail call void @rb_gc_register_mark_object(i64 %11) #17
-  store i64 %11, i64* @rubyStrFrozen_fooAll, align 8
-  %12 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 7), i64 noundef 31) #17
-  tail call void @rb_gc_register_mark_object(i64 %12) #17
-  store i64 %12, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
+  tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([11 x %struct.rb_code_position_struct], [11 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 11, i8* noundef getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
+  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 6) #17
+  tail call void @rb_gc_register_mark_object(i64 %0) #17
+  store i64 %0, i64* @rubyStrFrozen_fooAll, align 8
+  %1 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 7), i64 noundef 31) #17
+  tail call void @rb_gc_register_mark_object(i64 %1) #17
+  store i64 %1, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 30)
-  %rubyId_fooAll.i.i = load i64, i64* @rubyIdPrecomputed_fooAll, align 8
+  %rubyId_fooAll.i.i = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
   %rubyStr_fooAll.i.i = load i64, i64* @rubyStrFrozen_fooAll, align 8
   %"rubyStr_test/testdata/compiler/casts.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
-  %13 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_fooAll.i.i, i64 %rubyId_fooAll.i.i, i64 %"rubyStr_test/testdata/compiler/casts.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %13, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#6fooAll", align 8
-  %14 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 53), i64 noundef 7) #17
-  call void @rb_gc_register_mark_object(i64 %14) #17
-  %rubyId_fooAny1.i.i = load i64, i64* @rubyIdPrecomputed_fooAny1, align 8
+  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_fooAll.i.i, i64 %rubyId_fooAll.i.i, i64 %"rubyStr_test/testdata/compiler/casts.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#6fooAll", align 8
+  %3 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 53), i64 noundef 7) #17
+  call void @rb_gc_register_mark_object(i64 %3) #17
+  %rubyId_fooAny1.i.i = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/casts.rb.i24.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
-  %15 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %14, i64 %rubyId_fooAny1.i.i, i64 %"rubyStr_test/testdata/compiler/casts.rb.i24.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 9, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i25.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %15, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#7fooAny1", align 8
-  %16 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 83), i64 noundef 7) #17
-  call void @rb_gc_register_mark_object(i64 %16) #17
-  %rubyId_fooAny2.i.i = load i64, i64* @rubyIdPrecomputed_fooAny2, align 8
+  %4 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %3, i64 %rubyId_fooAny1.i.i, i64 %"rubyStr_test/testdata/compiler/casts.rb.i24.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 9, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i25.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %4, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#7fooAny1", align 8
+  %5 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 83), i64 noundef 7) #17
+  call void @rb_gc_register_mark_object(i64 %5) #17
+  %rubyId_fooAny2.i.i = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/casts.rb.i26.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
-  %17 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %16, i64 %rubyId_fooAny2.i.i, i64 %"rubyStr_test/testdata/compiler/casts.rb.i26.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 13, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i27.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %17, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#7fooAny2", align 8
-  %18 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 113), i64 noundef 6) #17
-  call void @rb_gc_register_mark_object(i64 %18) #17
-  %rubyId_fooInt.i.i = load i64, i64* @rubyIdPrecomputed_fooInt, align 8
+  %6 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %5, i64 %rubyId_fooAny2.i.i, i64 %"rubyStr_test/testdata/compiler/casts.rb.i26.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 13, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i27.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %6, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#7fooAny2", align 8
+  %7 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 113), i64 noundef 6) #17
+  call void @rb_gc_register_mark_object(i64 %7) #17
+  %rubyId_fooInt.i.i = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/casts.rb.i28.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
-  %19 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %18, i64 %rubyId_fooInt.i.i, i64 %"rubyStr_test/testdata/compiler/casts.rb.i28.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 17, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i29.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %19, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#6fooInt", align 8
-  %20 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 130), i64 noundef 8) #17
-  call void @rb_gc_register_mark_object(i64 %20) #17
-  %rubyId_fooArray.i.i = load i64, i64* @rubyIdPrecomputed_fooArray, align 8
+  %8 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %7, i64 %rubyId_fooInt.i.i, i64 %"rubyStr_test/testdata/compiler/casts.rb.i28.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 17, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i29.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %8, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#6fooInt", align 8
+  %9 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 130), i64 noundef 8) #17
+  call void @rb_gc_register_mark_object(i64 %9) #17
+  %rubyId_fooArray.i.i = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 5), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/casts.rb.i30.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
-  %21 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %20, i64 %rubyId_fooArray.i.i, i64 %"rubyStr_test/testdata/compiler/casts.rb.i30.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 21, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i31.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %21, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#8fooArray", align 8
-  %22 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 157), i64 noundef 16) #17
-  call void @rb_gc_register_mark_object(i64 %22) #17
-  %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
+  %10 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %9, i64 %rubyId_fooArray.i.i, i64 %"rubyStr_test/testdata/compiler/casts.rb.i30.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 21, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i31.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %10, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#8fooArray", align 8
+  %11 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 157), i64 noundef 16) #17
+  call void @rb_gc_register_mark_object(i64 %11) #17
+  %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 6), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/casts.rb.i32.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
-  %23 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %22, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/casts.rb.i32.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i33.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %23, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %rubyId_fooInt.i = load i64, i64* @rubyIdPrecomputed_fooInt, align 8, !dbg !55
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooInt, i64 %rubyId_fooInt.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !55
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !56
+  %12 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %11, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/casts.rb.i32.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i33.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %12, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooInt, i64 %rubyId_fooInt.i.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !55
+  %rubyId_puts.i = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 9), align 8, !dbg !56, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !56
-  %rubyId_fooAny1.i = load i64, i64* @rubyIdPrecomputed_fooAny1, align 8, !dbg !57
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooAny1, i64 %rubyId_fooAny1.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !57
-  %rubyId_puts6.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !58
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts6.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !58
-  %rubyId_fooAny2.i = load i64, i64* @rubyIdPrecomputed_fooAny2, align 8, !dbg !59
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooAny2, i64 %rubyId_fooAny2.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !59
-  %rubyId_puts11.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !60
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts11.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !60
-  %rubyId_fooAll.i = load i64, i64* @rubyIdPrecomputed_fooAll, align 8, !dbg !61
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooAll, i64 %rubyId_fooAll.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !61
-  %rubyId_puts16.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !62
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts16.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !62
-  %rubyId_fooArray.i = load i64, i64* @rubyIdPrecomputed_fooArray, align 8, !dbg !63
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooArray, i64 %rubyId_fooArray.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !63
-  %rubyId_puts21.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !64
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.4, i64 %rubyId_puts21.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !64
-  %24 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
-  %25 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %24, i64 0, i32 18
-  %26 = load i64, i64* %25, align 8, !tbaa !65
-  %27 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %28 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %27, i64 0, i32 2
-  %29 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %28, align 8, !tbaa !74
-  %30 = bitcast [4 x i64]* %callArgs.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 32, i8* nonnull %30)
-  %31 = bitcast i64* %positional_table.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %31)
-  %32 = bitcast i64* %positional_table84.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %32)
-  %33 = bitcast i64* %positional_table96.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %33)
-  %34 = bitcast i64* %positional_table108.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %34)
-  %35 = bitcast i64* %positional_table120.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %35)
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooAny1, i64 %rubyId_fooAny1.i.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !57
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !58
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooAny2, i64 %rubyId_fooAny2.i.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !59
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !60
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooAll, i64 %rubyId_fooAll.i.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !61
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !62
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooArray, i64 %rubyId_fooArray.i.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !63
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.4, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !64
+  %13 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
+  %14 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %13, i64 0, i32 18
+  %15 = load i64, i64* %14, align 8, !tbaa !65
+  %16 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %17 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 2
+  %18 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %17, align 8, !tbaa !74
+  %19 = bitcast [4 x i64]* %callArgs.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 32, i8* nonnull %19)
+  %20 = bitcast i64* %positional_table.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %20)
+  %21 = bitcast i64* %positional_table84.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %21)
+  %22 = bitcast i64* %positional_table96.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %22)
+  %23 = bitcast i64* %positional_table108.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %23)
+  %24 = bitcast i64* %positional_table120.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %24)
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %36 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %28, align 8, !tbaa !74
-  %37 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %37, align 8, !tbaa !75
-  %38 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 4
-  %39 = load i64*, i64** %38, align 8, !tbaa !77
-  %40 = load i64, i64* %39, align 8, !tbaa !6
-  %41 = and i64 %40, -33
-  store i64 %41, i64* %39, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %27, %struct.rb_control_frame_struct* %36, %struct.rb_iseq_struct* %stackFrame.i) #17
-  %42 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 0
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %42, align 8, !dbg !78, !tbaa !14
-  %43 = load i64, i64* @rb_cObject, align 8, !dbg !49
+  %25 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %17, align 8, !tbaa !74
+  %26 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %26, align 8, !tbaa !75
+  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 4
+  %28 = load i64*, i64** %27, align 8, !tbaa !77
+  %29 = load i64, i64* %28, align 8, !tbaa !6
+  %30 = and i64 %29, -33
+  store i64 %30, i64* %28, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %16, %struct.rb_control_frame_struct* %25, %struct.rb_iseq_struct* %stackFrame.i) #17
+  %31 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 0
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %31, align 8, !dbg !78, !tbaa !14
+  %32 = load i64, i64* @rb_cObject, align 8, !dbg !49
   %stackFrame73.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#6fooAll", align 8, !dbg !49
-  %44 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !49
-  %45 = bitcast i8* %44 to i16*, !dbg !49
-  %46 = load i16, i16* %45, align 8, !dbg !49
-  %47 = and i16 %46, -384, !dbg !49
-  %48 = or i16 %47, 1, !dbg !49
-  store i16 %48, i16* %45, align 8, !dbg !49
-  %49 = getelementptr inbounds i8, i8* %44, i64 8, !dbg !49
-  %50 = bitcast i8* %49 to i32*, !dbg !49
-  store i32 1, i32* %50, align 8, !dbg !49, !tbaa !79
-  %51 = getelementptr inbounds i8, i8* %44, i64 12, !dbg !49
-  %52 = getelementptr inbounds i8, i8* %44, i64 4, !dbg !49
-  %53 = bitcast i8* %52 to i32*, !dbg !49
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %51, i8 0, i64 20, i1 false) #17, !dbg !49
-  store i32 1, i32* %53, align 4, !dbg !49, !tbaa !82
-  %rubyId_arg.i = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !49
+  %33 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !49
+  %34 = bitcast i8* %33 to i16*, !dbg !49
+  %35 = load i16, i16* %34, align 8, !dbg !49
+  %36 = and i16 %35, -384, !dbg !49
+  %37 = or i16 %36, 1, !dbg !49
+  store i16 %37, i16* %34, align 8, !dbg !49
+  %38 = getelementptr inbounds i8, i8* %33, i64 8, !dbg !49
+  %39 = bitcast i8* %38 to i32*, !dbg !49
+  store i32 1, i32* %39, align 8, !dbg !49, !tbaa !79
+  %40 = getelementptr inbounds i8, i8* %33, i64 12, !dbg !49
+  %41 = getelementptr inbounds i8, i8* %33, i64 4, !dbg !49
+  %42 = bitcast i8* %41 to i32*, !dbg !49
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %40, i8 0, i64 20, i1 false) #17, !dbg !49
+  store i32 1, i32* %42, align 4, !dbg !49, !tbaa !82
+  %rubyId_arg.i = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 8), align 8, !dbg !49, !invariant.load !5
   store i64 %rubyId_arg.i, i64* %positional_table.i, align 8, !dbg !49
-  %54 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !49
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %54, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %31, i64 noundef 8, i1 noundef false) #17, !dbg !49
-  %55 = getelementptr inbounds i8, i8* %44, i64 32, !dbg !49
-  %56 = bitcast i8* %55 to i8**, !dbg !49
-  store i8* %54, i8** %56, align 8, !dbg !49, !tbaa !83
-  call void @sorbet_vm_define_method(i64 %43, i8* noundef getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#6fooAll", i8* nonnull %44, %struct.rb_iseq_struct* %stackFrame73.i, i1 noundef zeroext false) #17, !dbg !49
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %42, align 8, !dbg !49, !tbaa !14
+  %43 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !49
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %43, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %20, i64 noundef 8, i1 noundef false) #17, !dbg !49
+  %44 = getelementptr inbounds i8, i8* %33, i64 32, !dbg !49
+  %45 = bitcast i8* %44 to i8**, !dbg !49
+  store i8* %43, i8** %45, align 8, !dbg !49, !tbaa !83
+  call void @sorbet_vm_define_method(i64 %32, i8* noundef getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#6fooAll", i8* nonnull %33, %struct.rb_iseq_struct* %stackFrame73.i, i1 noundef zeroext false) #17, !dbg !49
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %31, align 8, !dbg !49, !tbaa !14
   %stackFrame82.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#7fooAny1", align 8, !dbg !51
-  %57 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !51
-  %58 = bitcast i8* %57 to i16*, !dbg !51
-  %59 = load i16, i16* %58, align 8, !dbg !51
-  %60 = and i16 %59, -384, !dbg !51
-  %61 = or i16 %60, 1, !dbg !51
-  store i16 %61, i16* %58, align 8, !dbg !51
-  %62 = getelementptr inbounds i8, i8* %57, i64 8, !dbg !51
-  %63 = bitcast i8* %62 to i32*, !dbg !51
-  store i32 1, i32* %63, align 8, !dbg !51, !tbaa !79
-  %64 = getelementptr inbounds i8, i8* %57, i64 12, !dbg !51
-  %65 = getelementptr inbounds i8, i8* %57, i64 4, !dbg !51
-  %66 = bitcast i8* %65 to i32*, !dbg !51
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %64, i8 0, i64 20, i1 false) #17, !dbg !51
-  store i32 1, i32* %66, align 4, !dbg !51, !tbaa !82
-  %rubyId_arg85.i = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !51
-  store i64 %rubyId_arg85.i, i64* %positional_table84.i, align 8, !dbg !51
-  %67 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !51
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %67, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %32, i64 noundef 8, i1 noundef false) #17, !dbg !51
-  %68 = getelementptr inbounds i8, i8* %57, i64 32, !dbg !51
-  %69 = bitcast i8* %68 to i8**, !dbg !51
-  store i8* %67, i8** %69, align 8, !dbg !51, !tbaa !83
-  call void @sorbet_vm_define_method(i64 %43, i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 53), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#7fooAny1", i8* nonnull %57, %struct.rb_iseq_struct* %stackFrame82.i, i1 noundef zeroext false) #17, !dbg !51
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %42, align 8, !dbg !51, !tbaa !14
+  %46 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !51
+  %47 = bitcast i8* %46 to i16*, !dbg !51
+  %48 = load i16, i16* %47, align 8, !dbg !51
+  %49 = and i16 %48, -384, !dbg !51
+  %50 = or i16 %49, 1, !dbg !51
+  store i16 %50, i16* %47, align 8, !dbg !51
+  %51 = getelementptr inbounds i8, i8* %46, i64 8, !dbg !51
+  %52 = bitcast i8* %51 to i32*, !dbg !51
+  store i32 1, i32* %52, align 8, !dbg !51, !tbaa !79
+  %53 = getelementptr inbounds i8, i8* %46, i64 12, !dbg !51
+  %54 = getelementptr inbounds i8, i8* %46, i64 4, !dbg !51
+  %55 = bitcast i8* %54 to i32*, !dbg !51
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %53, i8 0, i64 20, i1 false) #17, !dbg !51
+  store i32 1, i32* %55, align 4, !dbg !51, !tbaa !82
+  store i64 %rubyId_arg.i, i64* %positional_table84.i, align 8, !dbg !51
+  %56 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !51
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %56, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %21, i64 noundef 8, i1 noundef false) #17, !dbg !51
+  %57 = getelementptr inbounds i8, i8* %46, i64 32, !dbg !51
+  %58 = bitcast i8* %57 to i8**, !dbg !51
+  store i8* %56, i8** %58, align 8, !dbg !51, !tbaa !83
+  call void @sorbet_vm_define_method(i64 %32, i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 53), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#7fooAny1", i8* nonnull %46, %struct.rb_iseq_struct* %stackFrame82.i, i1 noundef zeroext false) #17, !dbg !51
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %31, align 8, !dbg !51, !tbaa !14
   %stackFrame94.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#7fooAny2", align 8, !dbg !52
-  %70 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !52
-  %71 = bitcast i8* %70 to i16*, !dbg !52
-  %72 = load i16, i16* %71, align 8, !dbg !52
-  %73 = and i16 %72, -384, !dbg !52
-  %74 = or i16 %73, 1, !dbg !52
-  store i16 %74, i16* %71, align 8, !dbg !52
-  %75 = getelementptr inbounds i8, i8* %70, i64 8, !dbg !52
-  %76 = bitcast i8* %75 to i32*, !dbg !52
-  store i32 1, i32* %76, align 8, !dbg !52, !tbaa !79
-  %77 = getelementptr inbounds i8, i8* %70, i64 12, !dbg !52
-  %78 = getelementptr inbounds i8, i8* %70, i64 4, !dbg !52
-  %79 = bitcast i8* %78 to i32*, !dbg !52
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %77, i8 0, i64 20, i1 false) #17, !dbg !52
-  store i32 1, i32* %79, align 4, !dbg !52, !tbaa !82
-  %rubyId_arg97.i = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !52
-  store i64 %rubyId_arg97.i, i64* %positional_table96.i, align 8, !dbg !52
-  %80 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !52
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %80, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %33, i64 noundef 8, i1 noundef false) #17, !dbg !52
-  %81 = getelementptr inbounds i8, i8* %70, i64 32, !dbg !52
-  %82 = bitcast i8* %81 to i8**, !dbg !52
-  store i8* %80, i8** %82, align 8, !dbg !52, !tbaa !83
-  call void @sorbet_vm_define_method(i64 %43, i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 83), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#7fooAny2", i8* nonnull %70, %struct.rb_iseq_struct* %stackFrame94.i, i1 noundef zeroext false) #17, !dbg !52
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %42, align 8, !dbg !52, !tbaa !14
+  %59 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !52
+  %60 = bitcast i8* %59 to i16*, !dbg !52
+  %61 = load i16, i16* %60, align 8, !dbg !52
+  %62 = and i16 %61, -384, !dbg !52
+  %63 = or i16 %62, 1, !dbg !52
+  store i16 %63, i16* %60, align 8, !dbg !52
+  %64 = getelementptr inbounds i8, i8* %59, i64 8, !dbg !52
+  %65 = bitcast i8* %64 to i32*, !dbg !52
+  store i32 1, i32* %65, align 8, !dbg !52, !tbaa !79
+  %66 = getelementptr inbounds i8, i8* %59, i64 12, !dbg !52
+  %67 = getelementptr inbounds i8, i8* %59, i64 4, !dbg !52
+  %68 = bitcast i8* %67 to i32*, !dbg !52
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %66, i8 0, i64 20, i1 false) #17, !dbg !52
+  store i32 1, i32* %68, align 4, !dbg !52, !tbaa !82
+  store i64 %rubyId_arg.i, i64* %positional_table96.i, align 8, !dbg !52
+  %69 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !52
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %69, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %22, i64 noundef 8, i1 noundef false) #17, !dbg !52
+  %70 = getelementptr inbounds i8, i8* %59, i64 32, !dbg !52
+  %71 = bitcast i8* %70 to i8**, !dbg !52
+  store i8* %69, i8** %71, align 8, !dbg !52, !tbaa !83
+  call void @sorbet_vm_define_method(i64 %32, i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 83), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#7fooAny2", i8* nonnull %59, %struct.rb_iseq_struct* %stackFrame94.i, i1 noundef zeroext false) #17, !dbg !52
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %31, align 8, !dbg !52, !tbaa !14
   %stackFrame106.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#6fooInt", align 8, !dbg !53
-  %83 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !53
-  %84 = bitcast i8* %83 to i16*, !dbg !53
-  %85 = load i16, i16* %84, align 8, !dbg !53
-  %86 = and i16 %85, -384, !dbg !53
-  %87 = or i16 %86, 1, !dbg !53
-  store i16 %87, i16* %84, align 8, !dbg !53
-  %88 = getelementptr inbounds i8, i8* %83, i64 8, !dbg !53
-  %89 = bitcast i8* %88 to i32*, !dbg !53
-  store i32 1, i32* %89, align 8, !dbg !53, !tbaa !79
-  %90 = getelementptr inbounds i8, i8* %83, i64 12, !dbg !53
-  %91 = getelementptr inbounds i8, i8* %83, i64 4, !dbg !53
-  %92 = bitcast i8* %91 to i32*, !dbg !53
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %90, i8 0, i64 20, i1 false) #17, !dbg !53
-  store i32 1, i32* %92, align 4, !dbg !53, !tbaa !82
-  %rubyId_arg109.i = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !53
-  store i64 %rubyId_arg109.i, i64* %positional_table108.i, align 8, !dbg !53
-  %93 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !53
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %93, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %34, i64 noundef 8, i1 noundef false) #17, !dbg !53
-  %94 = getelementptr inbounds i8, i8* %83, i64 32, !dbg !53
-  %95 = bitcast i8* %94 to i8**, !dbg !53
-  store i8* %93, i8** %95, align 8, !dbg !53, !tbaa !83
-  call void @sorbet_vm_define_method(i64 %43, i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 113), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#6fooInt", i8* nonnull %83, %struct.rb_iseq_struct* %stackFrame106.i, i1 noundef zeroext false) #17, !dbg !53
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %42, align 8, !dbg !53, !tbaa !14
+  %72 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !53
+  %73 = bitcast i8* %72 to i16*, !dbg !53
+  %74 = load i16, i16* %73, align 8, !dbg !53
+  %75 = and i16 %74, -384, !dbg !53
+  %76 = or i16 %75, 1, !dbg !53
+  store i16 %76, i16* %73, align 8, !dbg !53
+  %77 = getelementptr inbounds i8, i8* %72, i64 8, !dbg !53
+  %78 = bitcast i8* %77 to i32*, !dbg !53
+  store i32 1, i32* %78, align 8, !dbg !53, !tbaa !79
+  %79 = getelementptr inbounds i8, i8* %72, i64 12, !dbg !53
+  %80 = getelementptr inbounds i8, i8* %72, i64 4, !dbg !53
+  %81 = bitcast i8* %80 to i32*, !dbg !53
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %79, i8 0, i64 20, i1 false) #17, !dbg !53
+  store i32 1, i32* %81, align 4, !dbg !53, !tbaa !82
+  store i64 %rubyId_arg.i, i64* %positional_table108.i, align 8, !dbg !53
+  %82 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !53
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %82, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %23, i64 noundef 8, i1 noundef false) #17, !dbg !53
+  %83 = getelementptr inbounds i8, i8* %72, i64 32, !dbg !53
+  %84 = bitcast i8* %83 to i8**, !dbg !53
+  store i8* %82, i8** %84, align 8, !dbg !53, !tbaa !83
+  call void @sorbet_vm_define_method(i64 %32, i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 113), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#6fooInt", i8* nonnull %72, %struct.rb_iseq_struct* %stackFrame106.i, i1 noundef zeroext false) #17, !dbg !53
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %31, align 8, !dbg !53, !tbaa !14
   %stackFrame118.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#8fooArray", align 8, !dbg !54
-  %96 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !54
-  %97 = bitcast i8* %96 to i16*, !dbg !54
-  %98 = load i16, i16* %97, align 8, !dbg !54
-  %99 = and i16 %98, -384, !dbg !54
-  %100 = or i16 %99, 1, !dbg !54
-  store i16 %100, i16* %97, align 8, !dbg !54
-  %101 = getelementptr inbounds i8, i8* %96, i64 8, !dbg !54
-  %102 = bitcast i8* %101 to i32*, !dbg !54
-  store i32 1, i32* %102, align 8, !dbg !54, !tbaa !79
-  %103 = getelementptr inbounds i8, i8* %96, i64 12, !dbg !54
-  %104 = getelementptr inbounds i8, i8* %96, i64 4, !dbg !54
-  %105 = bitcast i8* %104 to i32*, !dbg !54
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %103, i8 0, i64 20, i1 false) #17, !dbg !54
-  store i32 1, i32* %105, align 4, !dbg !54, !tbaa !82
-  %rubyId_arg121.i = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !54
-  store i64 %rubyId_arg121.i, i64* %positional_table120.i, align 8, !dbg !54
-  %106 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !54
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %106, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %35, i64 noundef 8, i1 noundef false) #17, !dbg !54
-  %107 = getelementptr inbounds i8, i8* %96, i64 32, !dbg !54
-  %108 = bitcast i8* %107 to i8**, !dbg !54
-  store i8* %106, i8** %108, align 8, !dbg !54, !tbaa !83
-  call void @sorbet_vm_define_method(i64 %43, i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 130), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#8fooArray", i8* nonnull %96, %struct.rb_iseq_struct* %stackFrame118.i, i1 noundef zeroext false) #17, !dbg !54
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %42, align 8, !dbg !54, !tbaa !14
-  %109 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 1, !dbg !55
-  %110 = load i64*, i64** %109, align 8, !dbg !55
-  store i64 %26, i64* %110, align 8, !dbg !55, !tbaa !6
-  %111 = getelementptr inbounds i64, i64* %110, i64 1, !dbg !55
-  store i64 5, i64* %111, align 8, !dbg !55, !tbaa !6
-  %112 = getelementptr inbounds i64, i64* %111, i64 1, !dbg !55
-  store i64* %112, i64** %109, align 8, !dbg !55
+  %85 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !54
+  %86 = bitcast i8* %85 to i16*, !dbg !54
+  %87 = load i16, i16* %86, align 8, !dbg !54
+  %88 = and i16 %87, -384, !dbg !54
+  %89 = or i16 %88, 1, !dbg !54
+  store i16 %89, i16* %86, align 8, !dbg !54
+  %90 = getelementptr inbounds i8, i8* %85, i64 8, !dbg !54
+  %91 = bitcast i8* %90 to i32*, !dbg !54
+  store i32 1, i32* %91, align 8, !dbg !54, !tbaa !79
+  %92 = getelementptr inbounds i8, i8* %85, i64 12, !dbg !54
+  %93 = getelementptr inbounds i8, i8* %85, i64 4, !dbg !54
+  %94 = bitcast i8* %93 to i32*, !dbg !54
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %92, i8 0, i64 20, i1 false) #17, !dbg !54
+  store i32 1, i32* %94, align 4, !dbg !54, !tbaa !82
+  store i64 %rubyId_arg.i, i64* %positional_table120.i, align 8, !dbg !54
+  %95 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !54
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %95, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %24, i64 noundef 8, i1 noundef false) #17, !dbg !54
+  %96 = getelementptr inbounds i8, i8* %85, i64 32, !dbg !54
+  %97 = bitcast i8* %96 to i8**, !dbg !54
+  store i8* %95, i8** %97, align 8, !dbg !54, !tbaa !83
+  call void @sorbet_vm_define_method(i64 %32, i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 130), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#8fooArray", i8* nonnull %85, %struct.rb_iseq_struct* %stackFrame118.i, i1 noundef zeroext false) #17, !dbg !54
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %31, align 8, !dbg !54, !tbaa !14
+  %98 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 1, !dbg !55
+  %99 = load i64*, i64** %98, align 8, !dbg !55
+  store i64 %15, i64* %99, align 8, !dbg !55, !tbaa !6
+  %100 = getelementptr inbounds i64, i64* %99, i64 1, !dbg !55
+  store i64 5, i64* %100, align 8, !dbg !55, !tbaa !6
+  %101 = getelementptr inbounds i64, i64* %100, i64 1, !dbg !55
+  store i64* %101, i64** %98, align 8, !dbg !55
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_fooInt, i64 0), !dbg !55
-  %113 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 1, !dbg !56
-  %114 = load i64*, i64** %113, align 8, !dbg !56
-  store i64 %26, i64* %114, align 8, !dbg !56, !tbaa !6
-  %115 = getelementptr inbounds i64, i64* %114, i64 1, !dbg !56
-  store i64 %send, i64* %115, align 8, !dbg !56, !tbaa !6
-  %116 = getelementptr inbounds i64, i64* %115, i64 1, !dbg !56
-  store i64* %116, i64** %113, align 8, !dbg !56
+  %102 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 1, !dbg !56
+  %103 = load i64*, i64** %102, align 8, !dbg !56
+  store i64 %15, i64* %103, align 8, !dbg !56, !tbaa !6
+  %104 = getelementptr inbounds i64, i64* %103, i64 1, !dbg !56
+  store i64 %send, i64* %104, align 8, !dbg !56, !tbaa !6
+  %105 = getelementptr inbounds i64, i64* %104, i64 1, !dbg !56
+  store i64* %105, i64** %102, align 8, !dbg !56
   %send2 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !56
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %42, align 8, !dbg !56, !tbaa !14
-  %117 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 1, !dbg !57
-  %118 = load i64*, i64** %117, align 8, !dbg !57
-  store i64 %26, i64* %118, align 8, !dbg !57, !tbaa !6
-  %119 = getelementptr inbounds i64, i64* %118, i64 1, !dbg !57
-  store i64 5, i64* %119, align 8, !dbg !57, !tbaa !6
-  %120 = getelementptr inbounds i64, i64* %119, i64 1, !dbg !57
-  store i64* %120, i64** %117, align 8, !dbg !57
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %31, align 8, !dbg !56, !tbaa !14
+  %106 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 1, !dbg !57
+  %107 = load i64*, i64** %106, align 8, !dbg !57
+  store i64 %15, i64* %107, align 8, !dbg !57, !tbaa !6
+  %108 = getelementptr inbounds i64, i64* %107, i64 1, !dbg !57
+  store i64 5, i64* %108, align 8, !dbg !57, !tbaa !6
+  %109 = getelementptr inbounds i64, i64* %108, i64 1, !dbg !57
+  store i64* %109, i64** %106, align 8, !dbg !57
   %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_fooAny1, i64 0), !dbg !57
-  %121 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 1, !dbg !58
-  %122 = load i64*, i64** %121, align 8, !dbg !58
-  store i64 %26, i64* %122, align 8, !dbg !58, !tbaa !6
-  %123 = getelementptr inbounds i64, i64* %122, i64 1, !dbg !58
-  store i64 %send4, i64* %123, align 8, !dbg !58, !tbaa !6
-  %124 = getelementptr inbounds i64, i64* %123, i64 1, !dbg !58
-  store i64* %124, i64** %121, align 8, !dbg !58
+  %110 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 1, !dbg !58
+  %111 = load i64*, i64** %110, align 8, !dbg !58
+  store i64 %15, i64* %111, align 8, !dbg !58, !tbaa !6
+  %112 = getelementptr inbounds i64, i64* %111, i64 1, !dbg !58
+  store i64 %send4, i64* %112, align 8, !dbg !58, !tbaa !6
+  %113 = getelementptr inbounds i64, i64* %112, i64 1, !dbg !58
+  store i64* %113, i64** %110, align 8, !dbg !58
   %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.1, i64 0), !dbg !58
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %42, align 8, !dbg !58, !tbaa !14
-  %125 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 1, !dbg !59
-  %126 = load i64*, i64** %125, align 8, !dbg !59
-  store i64 %26, i64* %126, align 8, !dbg !59, !tbaa !6
-  %127 = getelementptr inbounds i64, i64* %126, i64 1, !dbg !59
-  store i64 5, i64* %127, align 8, !dbg !59, !tbaa !6
-  %128 = getelementptr inbounds i64, i64* %127, i64 1, !dbg !59
-  store i64* %128, i64** %125, align 8, !dbg !59
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %31, align 8, !dbg !58, !tbaa !14
+  %114 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 1, !dbg !59
+  %115 = load i64*, i64** %114, align 8, !dbg !59
+  store i64 %15, i64* %115, align 8, !dbg !59, !tbaa !6
+  %116 = getelementptr inbounds i64, i64* %115, i64 1, !dbg !59
+  store i64 5, i64* %116, align 8, !dbg !59, !tbaa !6
+  %117 = getelementptr inbounds i64, i64* %116, i64 1, !dbg !59
+  store i64* %117, i64** %114, align 8, !dbg !59
   %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_fooAny2, i64 0), !dbg !59
-  %129 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 1, !dbg !60
-  %130 = load i64*, i64** %129, align 8, !dbg !60
-  store i64 %26, i64* %130, align 8, !dbg !60, !tbaa !6
-  %131 = getelementptr inbounds i64, i64* %130, i64 1, !dbg !60
-  store i64 %send8, i64* %131, align 8, !dbg !60, !tbaa !6
-  %132 = getelementptr inbounds i64, i64* %131, i64 1, !dbg !60
-  store i64* %132, i64** %129, align 8, !dbg !60
+  %118 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 1, !dbg !60
+  %119 = load i64*, i64** %118, align 8, !dbg !60
+  store i64 %15, i64* %119, align 8, !dbg !60, !tbaa !6
+  %120 = getelementptr inbounds i64, i64* %119, i64 1, !dbg !60
+  store i64 %send8, i64* %120, align 8, !dbg !60, !tbaa !6
+  %121 = getelementptr inbounds i64, i64* %120, i64 1, !dbg !60
+  store i64* %121, i64** %118, align 8, !dbg !60
   %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.2, i64 0), !dbg !60
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %42, align 8, !dbg !60, !tbaa !14
-  %133 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 1, !dbg !61
-  %134 = load i64*, i64** %133, align 8, !dbg !61
-  store i64 %26, i64* %134, align 8, !dbg !61, !tbaa !6
-  %135 = getelementptr inbounds i64, i64* %134, i64 1, !dbg !61
-  store i64 5, i64* %135, align 8, !dbg !61, !tbaa !6
-  %136 = getelementptr inbounds i64, i64* %135, i64 1, !dbg !61
-  store i64* %136, i64** %133, align 8, !dbg !61
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %31, align 8, !dbg !60, !tbaa !14
+  %122 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 1, !dbg !61
+  %123 = load i64*, i64** %122, align 8, !dbg !61
+  store i64 %15, i64* %123, align 8, !dbg !61, !tbaa !6
+  %124 = getelementptr inbounds i64, i64* %123, i64 1, !dbg !61
+  store i64 5, i64* %124, align 8, !dbg !61, !tbaa !6
+  %125 = getelementptr inbounds i64, i64* %124, i64 1, !dbg !61
+  store i64* %125, i64** %122, align 8, !dbg !61
   %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_fooAll, i64 0), !dbg !61
-  %137 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 1, !dbg !62
-  %138 = load i64*, i64** %137, align 8, !dbg !62
-  store i64 %26, i64* %138, align 8, !dbg !62, !tbaa !6
-  %139 = getelementptr inbounds i64, i64* %138, i64 1, !dbg !62
-  store i64 %send12, i64* %139, align 8, !dbg !62, !tbaa !6
-  %140 = getelementptr inbounds i64, i64* %139, i64 1, !dbg !62
-  store i64* %140, i64** %137, align 8, !dbg !62
+  %126 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 1, !dbg !62
+  %127 = load i64*, i64** %126, align 8, !dbg !62
+  store i64 %15, i64* %127, align 8, !dbg !62, !tbaa !6
+  %128 = getelementptr inbounds i64, i64* %127, i64 1, !dbg !62
+  store i64 %send12, i64* %128, align 8, !dbg !62, !tbaa !6
+  %129 = getelementptr inbounds i64, i64* %128, i64 1, !dbg !62
+  store i64* %129, i64** %126, align 8, !dbg !62
   %send14 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.3, i64 0), !dbg !62
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 29), i64** %42, align 8, !dbg !62, !tbaa !14
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 29), i64** %31, align 8, !dbg !62, !tbaa !14
   %callArgs0Addr.i = getelementptr [4 x i64], [4 x i64]* %callArgs.i, i64 0, i64 0, !dbg !84
   store i64 5, i64* %callArgs0Addr.i, align 8, !dbg !84
   call void @llvm.experimental.noalias.scope.decl(metadata !85) #17, !dbg !84
-  %141 = call i64 @rb_ary_new_from_values(i64 noundef 1, i64* noundef nonnull align 8 %callArgs0Addr.i) #17, !dbg !84
-  %142 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 1, !dbg !63
-  %143 = load i64*, i64** %142, align 8, !dbg !63
-  store i64 %26, i64* %143, align 8, !dbg !63, !tbaa !6
-  %144 = getelementptr inbounds i64, i64* %143, i64 1, !dbg !63
-  store i64 %141, i64* %144, align 8, !dbg !63, !tbaa !6
-  %145 = getelementptr inbounds i64, i64* %144, i64 1, !dbg !63
-  store i64* %145, i64** %142, align 8, !dbg !63
+  %130 = call i64 @rb_ary_new_from_values(i64 noundef 1, i64* noundef nonnull align 8 %callArgs0Addr.i) #17, !dbg !84
+  %131 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 1, !dbg !63
+  %132 = load i64*, i64** %131, align 8, !dbg !63
+  store i64 %15, i64* %132, align 8, !dbg !63, !tbaa !6
+  %133 = getelementptr inbounds i64, i64* %132, i64 1, !dbg !63
+  store i64 %130, i64* %133, align 8, !dbg !63, !tbaa !6
+  %134 = getelementptr inbounds i64, i64* %133, i64 1, !dbg !63
+  store i64* %134, i64** %131, align 8, !dbg !63
   %send16 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_fooArray, i64 0), !dbg !63
-  %146 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 1, !dbg !64
-  %147 = load i64*, i64** %146, align 8, !dbg !64
-  store i64 %26, i64* %147, align 8, !dbg !64, !tbaa !6
-  %148 = getelementptr inbounds i64, i64* %147, i64 1, !dbg !64
-  store i64 %send16, i64* %148, align 8, !dbg !64, !tbaa !6
-  %149 = getelementptr inbounds i64, i64* %148, i64 1, !dbg !64
-  store i64* %149, i64** %146, align 8, !dbg !64
+  %135 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 1, !dbg !64
+  %136 = load i64*, i64** %135, align 8, !dbg !64
+  store i64 %15, i64* %136, align 8, !dbg !64, !tbaa !6
+  %137 = getelementptr inbounds i64, i64* %136, i64 1, !dbg !64
+  store i64 %send16, i64* %137, align 8, !dbg !64, !tbaa !6
+  %138 = getelementptr inbounds i64, i64* %137, i64 1, !dbg !64
+  store i64* %138, i64** %135, align 8, !dbg !64
   %send18 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.4, i64 0), !dbg !64
-  call void @llvm.lifetime.end.p0i8(i64 32, i8* nonnull %30)
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %31)
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %32)
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %33)
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %34)
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %35)
+  call void @llvm.lifetime.end.p0i8(i64 32, i8* nonnull %19)
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %20)
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %21)
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %22)
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %23)
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %24)
   ret void
 }
 

--- a/test/testdata/compiler/class.opt.ll.exp
+++ b/test/testdata/compiler/class.opt.ll.exp
@@ -77,21 +77,19 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/class.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [10 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @"stackFramePrecomputed_func_Foo.13<static-init>" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_<module:Foo>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_<module:Foo>" = internal unnamed_addr global i64 0, align 8
 @"stackFramePrecomputed_func_Foo::Bar.13<static-init>" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_<class:Foo::Bar>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_<class:Foo::Bar>" = internal unnamed_addr global i64 0, align 8
 @"stackFramePrecomputed_func_Baz.13<static-init>" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_<class:Baz>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_<class:Baz>" = internal unnamed_addr global i64 0, align 8
 @sorbet_moduleStringTable = internal unnamed_addr constant [117 x i8] c"<top (required)>\00test/testdata/compiler/class.rb\00Foo\00Baz\00Object\00master\00<module:Foo>\00Bar\00<class:Foo::Bar>\00<class:Baz>\00", align 1
+@sorbet_moduleIDTable = internal unnamed_addr global [4 x i64] zeroinitializer, align 8
+@sorbet_moduleIDDescriptors = internal unnamed_addr constant [4 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 71, i32 12 }, %struct.rb_code_position_struct { i32 88, i32 16 }, %struct.rb_code_position_struct { i32 105, i32 11 }], align 8
 @guard_epoch_Foo = linkonce local_unnamed_addr global i64 0
 @guarded_const_Foo = linkonce local_unnamed_addr global i64 0
 @rb_cObject = external local_unnamed_addr constant i64
@@ -110,6 +108,8 @@ declare void @sorbet_popFrame() local_unnamed_addr #0
 
 declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #0
 
+declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #0
+
 declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
 
 declare i64 @rb_define_module(i8*) local_unnamed_addr #0
@@ -117,8 +117,6 @@ declare i64 @rb_define_module(i8*) local_unnamed_addr #0
 declare i64 @rb_define_class(i8*, i64) local_unnamed_addr #0
 
 declare i64 @rb_define_class_under(i64, i8*, i64) local_unnamed_addr #0
-
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #0
 
 declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
 
@@ -141,10 +139,7 @@ define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #2 {
 
 define internal fastcc void @sorbet_globalConstructors(i64 %realpath) unnamed_addr {
 allocRubyIds:
-  tail call fastcc void @"Constr_rubyIdPrecomputed_<top (required)>"() #8
-  tail call fastcc void @"Constr_rubyIdPrecomputed_<module:Foo>"() #8
-  tail call fastcc void @"Constr_rubyIdPrecomputed_<class:Foo::Bar>"() #8
-  tail call fastcc void @"Constr_rubyIdPrecomputed_<class:Baz>"() #8
+  tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([4 x %struct.rb_code_position_struct], [4 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 4, i8* noundef getelementptr inbounds ([117 x i8], [117 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
   tail call fastcc void @"Constr_rubyStrFrozen_<top (required)>"() #8
   tail call fastcc void @"Constr_rubyStrFrozen_test/testdata/compiler/class.rb"() #8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([10 x i64], [10 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 10)
@@ -161,20 +156,12 @@ allocRubyIds:
 ; Function Attrs: ssp
 define internal fastcc void @"Constr_stackFramePrecomputed_func_<root>.17<static-init>$153"(i64 %realpath) unnamed_addr #3 {
 entryInitializers:
-  %"rubyId_<top (required)>" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
+  %"rubyId_<top (required)>" = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
   %"rubyStr_<top (required)>" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/class.rb" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/class.rb", align 8
   %locals = alloca i64, i32 0, align 8
   %0 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>", i64 %"rubyId_<top (required)>", i64 %"rubyStr_test/testdata/compiler/class.rb", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %0, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  ret void
-}
-
-; Function Attrs: nounwind ssp
-define internal fastcc void @"Constr_rubyIdPrecomputed_<top (required)>"() unnamed_addr #4 {
-constr:
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([117 x i8], [117 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #8
-  store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
   ret void
 }
 
@@ -289,20 +276,12 @@ entry:
 ; Function Attrs: ssp
 define internal fastcc void @"Constr_stackFramePrecomputed_func_Foo.13<static-init>"(i64 %realpath) unnamed_addr #3 {
 entryInitializers:
-  %"rubyId_<module:Foo>" = load i64, i64* @"rubyIdPrecomputed_<module:Foo>", align 8
+  %"rubyId_<module:Foo>" = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !invariant.load !5
   %"rubyStr_<module:Foo>" = load i64, i64* @"rubyStrFrozen_<module:Foo>", align 8
   %"rubyStr_test/testdata/compiler/class.rb" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/class.rb", align 8
   %locals = alloca i64, i32 0, align 8
   %0 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<module:Foo>", i64 %"rubyId_<module:Foo>", i64 %"rubyStr_test/testdata/compiler/class.rb", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %0, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>", align 8
-  ret void
-}
-
-; Function Attrs: nounwind ssp
-define internal fastcc void @"Constr_rubyIdPrecomputed_<module:Foo>"() unnamed_addr #4 {
-constr:
-  %0 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([117 x i8], [117 x i8]* @sorbet_moduleStringTable, i64 0, i64 71), i64 noundef 12) #8
-  store i64 %0, i64* @"rubyIdPrecomputed_<module:Foo>", align 8
   ret void
 }
 
@@ -318,20 +297,12 @@ constr:
 ; Function Attrs: ssp
 define internal fastcc void @"Constr_stackFramePrecomputed_func_Foo::Bar.13<static-init>"(i64 %realpath) unnamed_addr #3 {
 entryInitializers:
-  %"rubyId_<class:Foo::Bar>" = load i64, i64* @"rubyIdPrecomputed_<class:Foo::Bar>", align 8
+  %"rubyId_<class:Foo::Bar>" = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !invariant.load !5
   %"rubyStr_<class:Foo::Bar>" = load i64, i64* @"rubyStrFrozen_<class:Foo::Bar>", align 8
   %"rubyStr_test/testdata/compiler/class.rb" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/class.rb", align 8
   %locals = alloca i64, i32 0, align 8
   %0 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<class:Foo::Bar>", i64 %"rubyId_<class:Foo::Bar>", i64 %"rubyStr_test/testdata/compiler/class.rb", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals, i32 noundef 0, i32 noundef 0)
   store %struct.rb_iseq_struct* %0, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo::Bar.13<static-init>", align 8
-  ret void
-}
-
-; Function Attrs: nounwind ssp
-define internal fastcc void @"Constr_rubyIdPrecomputed_<class:Foo::Bar>"() unnamed_addr #4 {
-constr:
-  %0 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([117 x i8], [117 x i8]* @sorbet_moduleStringTable, i64 0, i64 88), i64 noundef 16) #8
-  store i64 %0, i64* @"rubyIdPrecomputed_<class:Foo::Bar>", align 8
   ret void
 }
 
@@ -347,20 +318,12 @@ constr:
 ; Function Attrs: ssp
 define internal fastcc void @"Constr_stackFramePrecomputed_func_Baz.13<static-init>"(i64 %realpath) unnamed_addr #3 {
 entryInitializers:
-  %"rubyId_<class:Baz>" = load i64, i64* @"rubyIdPrecomputed_<class:Baz>", align 8
+  %"rubyId_<class:Baz>" = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !invariant.load !5
   %"rubyStr_<class:Baz>" = load i64, i64* @"rubyStrFrozen_<class:Baz>", align 8
   %"rubyStr_test/testdata/compiler/class.rb" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/class.rb", align 8
   %locals = alloca i64, i32 0, align 8
   %0 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<class:Baz>", i64 %"rubyId_<class:Baz>", i64 %"rubyStr_test/testdata/compiler/class.rb", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals, i32 noundef 0, i32 noundef 0)
   store %struct.rb_iseq_struct* %0, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Baz.13<static-init>", align 8
-  ret void
-}
-
-; Function Attrs: nounwind ssp
-define internal fastcc void @"Constr_rubyIdPrecomputed_<class:Baz>"() unnamed_addr #4 {
-constr:
-  %0 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([117 x i8], [117 x i8]* @sorbet_moduleStringTable, i64 0, i64 105), i64 noundef 11) #8
-  store i64 %0, i64* @"rubyIdPrecomputed_<class:Baz>", align 8
   ret void
 }
 

--- a/test/testdata/compiler/classfields.opt.ll.exp
+++ b/test/testdata/compiler/classfields.opt.ll.exp
@@ -82,34 +82,27 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/classfields.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [29 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @ic_new = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_new = internal unnamed_addr global i64 0, align 8
 @ic_initialize = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_initialize = internal unnamed_addr global i64 0, align 8
 @ic_write = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_write = internal unnamed_addr global i64 0, align 8
 @ic_read = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_read = internal unnamed_addr global i64 0, align 8
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
 @ic_new.1 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_initialize.2 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_read.3 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.4 = internal global %struct.FunctionInlineCache zeroinitializer
 @"stackFramePrecomputed_func_B#5write" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_@@f" = internal unnamed_addr global i64 0, align 8
 @"stackFramePrecomputed_func_B#4read" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @rubyStrFrozen_read = internal unnamed_addr global i64 0, align 8
 @stackFramePrecomputed_func_B.4read = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"stackFramePrecomputed_func_B.13<static-init>" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_<class:B>" = internal unnamed_addr global i64 0, align 8
-@rubyIdPrecomputed_a = internal unnamed_addr global i64 0, align 8
 @sorbet_moduleStringTable = internal unnamed_addr constant [125 x i8] c"<top (required)>\00test/testdata/compiler/classfields.rb\00B\00Object\00new\00initialize\00write\00read\00puts\00master\00@@f\00<class:B>\00normal\00a\00", align 1
+@sorbet_moduleIDTable = internal unnamed_addr global [10 x i64] zeroinitializer, align 8
+@sorbet_moduleIDDescriptors = internal unnamed_addr constant [10 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 64, i32 3 }, %struct.rb_code_position_struct { i32 68, i32 10 }, %struct.rb_code_position_struct { i32 79, i32 5 }, %struct.rb_code_position_struct { i32 85, i32 4 }, %struct.rb_code_position_struct { i32 90, i32 4 }, %struct.rb_code_position_struct { i32 102, i32 3 }, %struct.rb_code_position_struct { i32 106, i32 9 }, %struct.rb_code_position_struct { i32 116, i32 6 }, %struct.rb_code_position_struct { i32 123, i32 1 }], align 8
 @rb_cObject = external local_unnamed_addr constant i64
 @guard_epoch_B = linkonce local_unnamed_addr global i64 0
 @guarded_const_B = linkonce local_unnamed_addr global i64 0
@@ -137,6 +130,8 @@ declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %
 
 declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #1
 
+declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #1
+
 declare i64 @sorbet_maybeAllocateObjectFastPath(i64, %struct.FunctionInlineCache*) local_unnamed_addr #1
 
 declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #1
@@ -152,8 +147,6 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #2
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #2
-
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #1
 
 declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #1
 
@@ -193,261 +186,236 @@ entry:
   %locals.i17.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #11
-  store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %1 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 64), i64 noundef 3) #11
-  store i64 %1, i64* @rubyIdPrecomputed_new, align 8
-  %2 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 68), i64 noundef 10) #11
-  store i64 %2, i64* @rubyIdPrecomputed_initialize, align 8
-  %3 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 79), i64 noundef 5) #11
-  store i64 %3, i64* @rubyIdPrecomputed_write, align 8
-  %4 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 85), i64 noundef 4) #11
-  store i64 %4, i64* @rubyIdPrecomputed_read, align 8
-  %5 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 90), i64 noundef 4) #11
-  store i64 %5, i64* @rubyIdPrecomputed_puts, align 8
-  %6 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 102), i64 noundef 3) #11
-  store i64 %6, i64* @"rubyIdPrecomputed_@@f", align 8
-  %7 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 106), i64 noundef 9) #11
-  store i64 %7, i64* @"rubyIdPrecomputed_<class:B>", align 8
-  %8 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 116), i64 noundef 6) #11
-  %9 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 123), i64 noundef 1) #11
-  store i64 %9, i64* @rubyIdPrecomputed_a, align 8
-  %10 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #11
-  tail call void @rb_gc_register_mark_object(i64 %10) #11
-  store i64 %10, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %11 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 37) #11
-  tail call void @rb_gc_register_mark_object(i64 %11) #11
-  store i64 %11, i64* @"rubyStrFrozen_test/testdata/compiler/classfields.rb", align 8
+  tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([10 x %struct.rb_code_position_struct], [10 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 10, i8* noundef getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
+  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #11
+  tail call void @rb_gc_register_mark_object(i64 %0) #11
+  store i64 %0, i64* @"rubyStrFrozen_<top (required)>", align 8
+  %1 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 37) #11
+  tail call void @rb_gc_register_mark_object(i64 %1) #11
+  store i64 %1, i64* @"rubyStrFrozen_test/testdata/compiler/classfields.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 29)
-  %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
+  %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
   %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/classfields.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/classfields.rb", align 8
-  %12 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/classfields.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %12, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !17
+  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/classfields.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %rubyId_new.i = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !dbg !17, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !17
-  %rubyId_initialize.i = load i64, i64* @rubyIdPrecomputed_initialize, align 8, !dbg !17
+  %rubyId_initialize.i = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !17, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 %rubyId_initialize.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !17
-  %rubyId_write.i = load i64, i64* @rubyIdPrecomputed_write, align 8, !dbg !17
+  %rubyId_write.i = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !17, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_write, i64 %rubyId_write.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !17
-  %rubyId_read.i = load i64, i64* @rubyIdPrecomputed_read, align 8, !dbg !18
+  %rubyId_read.i = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !dbg !18, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_read, i64 %rubyId_read.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !18
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !19
+  %rubyId_puts.i = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 5), align 8, !dbg !19, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
-  %rubyId_new6.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !20
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new.1, i64 %rubyId_new6.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !20
-  %rubyId_initialize8.i = load i64, i64* @rubyIdPrecomputed_initialize, align 8, !dbg !20
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_initialize.2, i64 %rubyId_initialize8.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !20
-  %rubyId_read11.i = load i64, i64* @rubyIdPrecomputed_read, align 8, !dbg !20
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_read.3, i64 %rubyId_read11.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !20
-  %rubyId_puts13.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !21
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.4, i64 %rubyId_puts13.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !21
-  %13 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 79), i64 noundef 5) #11
-  call void @rb_gc_register_mark_object(i64 %13) #11
-  %rubyId_write.i.i = load i64, i64* @rubyIdPrecomputed_write, align 8
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new.1, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !20
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_initialize.2, i64 %rubyId_initialize.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !20
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_read.3, i64 %rubyId_read.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !20
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.4, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !21
+  %3 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 79), i64 noundef 5) #11
+  call void @rb_gc_register_mark_object(i64 %3) #11
   %"rubyStr_test/testdata/compiler/classfields.rb.i16.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/classfields.rb", align 8
-  %14 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %13, i64 %rubyId_write.i.i, i64 %"rubyStr_test/testdata/compiler/classfields.rb.i16.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 7, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i17.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %14, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B#5write", align 8
-  %15 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 85), i64 noundef 4) #11
-  call void @rb_gc_register_mark_object(i64 %15) #11
-  store i64 %15, i64* @rubyStrFrozen_read, align 8
-  %rubyId_read.i.i = load i64, i64* @rubyIdPrecomputed_read, align 8
+  %4 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %3, i64 %rubyId_write.i, i64 %"rubyStr_test/testdata/compiler/classfields.rb.i16.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 7, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i17.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %4, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B#5write", align 8
+  %5 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 85), i64 noundef 4) #11
+  call void @rb_gc_register_mark_object(i64 %5) #11
+  store i64 %5, i64* @rubyStrFrozen_read, align 8
   %"rubyStr_test/testdata/compiler/classfields.rb.i18.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/classfields.rb", align 8
-  %16 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %15, i64 %rubyId_read.i.i, i64 %"rubyStr_test/testdata/compiler/classfields.rb.i18.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 16, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i19.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %16, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B#4read", align 8
-  %rubyId_read.i20.i = load i64, i64* @rubyIdPrecomputed_read, align 8
+  %6 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %5, i64 %rubyId_read.i, i64 %"rubyStr_test/testdata/compiler/classfields.rb.i18.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 16, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i19.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %6, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B#4read", align 8
   %rubyStr_read.i21.i = load i64, i64* @rubyStrFrozen_read, align 8
   %"rubyStr_test/testdata/compiler/classfields.rb.i22.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/classfields.rb", align 8
-  %17 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_read.i21.i, i64 %rubyId_read.i20.i, i64 %"rubyStr_test/testdata/compiler/classfields.rb.i22.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 19, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i23.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %17, %struct.rb_iseq_struct** @stackFramePrecomputed_func_B.4read, align 8
-  %18 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 106), i64 noundef 9) #11
-  call void @rb_gc_register_mark_object(i64 %18) #11
-  %"rubyId_<class:B>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:B>", align 8
+  %7 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_read.i21.i, i64 %rubyId_read.i, i64 %"rubyStr_test/testdata/compiler/classfields.rb.i22.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 19, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i23.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %7, %struct.rb_iseq_struct** @stackFramePrecomputed_func_B.4read, align 8
+  %8 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 106), i64 noundef 9) #11
+  call void @rb_gc_register_mark_object(i64 %8) #11
+  %"rubyId_<class:B>.i.i" = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 7), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/classfields.rb.i24.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/classfields.rb", align 8
-  %19 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %18, i64 %"rubyId_<class:B>.i.i", i64 %"rubyStr_test/testdata/compiler/classfields.rb.i24.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i25.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %19, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B.13<static-init>", align 8
-  %20 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !22
-  %21 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %20, i64 0, i32 18
-  %22 = load i64, i64* %21, align 8, !tbaa !24
-  %23 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !22
-  %24 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %23, i64 0, i32 2
-  %25 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %24, align 8, !tbaa !34
+  %9 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %8, i64 %"rubyId_<class:B>.i.i", i64 %"rubyStr_test/testdata/compiler/classfields.rb.i24.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i25.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %9, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B.13<static-init>", align 8
+  %10 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !22
+  %11 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %10, i64 0, i32 18
+  %12 = load i64, i64* %11, align 8, !tbaa !24
+  %13 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !22
+  %14 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %13, i64 0, i32 2
+  %15 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %14, align 8, !tbaa !34
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %26 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %26, align 8, !tbaa !37
-  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 4
-  %28 = load i64*, i64** %27, align 8, !tbaa !39
-  %29 = load i64, i64* %28, align 8, !tbaa !6
-  %30 = and i64 %29, -33
-  store i64 %30, i64* %28, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %23, %struct.rb_control_frame_struct* %25, %struct.rb_iseq_struct* %stackFrame.i) #11
-  %31 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 0
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %31, align 8, !dbg !40, !tbaa !22
-  %32 = load i64, i64* @rb_cObject, align 8, !dbg !41
-  %33 = call i64 @rb_define_class(i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 55), i64 %32) #11, !dbg !41
-  %34 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %33) #11, !dbg !41
-  %35 = bitcast i64* %positional_table.i.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %35) #11
+  %16 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %16, align 8, !tbaa !37
+  %17 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 4
+  %18 = load i64*, i64** %17, align 8, !tbaa !39
+  %19 = load i64, i64* %18, align 8, !tbaa !6
+  %20 = and i64 %19, -33
+  store i64 %20, i64* %18, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %13, %struct.rb_control_frame_struct* %15, %struct.rb_iseq_struct* %stackFrame.i) #11
+  %21 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 0
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %21, align 8, !dbg !40, !tbaa !22
+  %22 = load i64, i64* @rb_cObject, align 8, !dbg !41
+  %23 = call i64 @rb_define_class(i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 55), i64 %22) #11, !dbg !41
+  %24 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %23) #11, !dbg !41
+  %25 = bitcast i64* %positional_table.i.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %25) #11
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B.13<static-init>", align 8
-  %36 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !22
-  %37 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %36, i64 0, i32 2
-  %38 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %37, align 8, !tbaa !34
-  %39 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %39, align 8, !tbaa !37
-  %40 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 4
-  %41 = load i64*, i64** %40, align 8, !tbaa !39
-  %42 = load i64, i64* %41, align 8, !tbaa !6
-  %43 = and i64 %42, -33
-  store i64 %43, i64* %41, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %36, %struct.rb_control_frame_struct* %38, %struct.rb_iseq_struct* %stackFrame.i.i) #11
-  %44 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %34, i64 0, i32 0
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %44, align 8, !dbg !42, !tbaa !22
-  %45 = load i64, i64* @guard_epoch_B, align 8, !dbg !10
-  %46 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !43
-  %needTakeSlowPath = icmp ne i64 %45, %46, !dbg !10
-  br i1 %needTakeSlowPath, label %47, label %48, !dbg !10, !prof !44
+  %26 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !22
+  %27 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %26, i64 0, i32 2
+  %28 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %27, align 8, !tbaa !34
+  %29 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %28, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %29, align 8, !tbaa !37
+  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %28, i64 0, i32 4
+  %31 = load i64*, i64** %30, align 8, !tbaa !39
+  %32 = load i64, i64* %31, align 8, !tbaa !6
+  %33 = and i64 %32, -33
+  store i64 %33, i64* %31, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %26, %struct.rb_control_frame_struct* %28, %struct.rb_iseq_struct* %stackFrame.i.i) #11
+  %34 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 0
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %34, align 8, !dbg !42, !tbaa !22
+  %35 = load i64, i64* @guard_epoch_B, align 8, !dbg !10
+  %36 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !43
+  %needTakeSlowPath = icmp ne i64 %35, %36, !dbg !10
+  br i1 %needTakeSlowPath, label %37, label %38, !dbg !10, !prof !44
 
-47:                                               ; preds = %entry
+37:                                               ; preds = %entry
   call void @const_recompute_B(), !dbg !10
-  br label %48, !dbg !10
+  br label %38, !dbg !10
 
-48:                                               ; preds = %entry, %47
-  %49 = load i64, i64* @guarded_const_B, align 8, !dbg !10
-  %50 = load i64, i64* @guard_epoch_B, align 8, !dbg !10
-  %51 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !43
-  %guardUpdated = icmp eq i64 %50, %51, !dbg !10
+38:                                               ; preds = %entry, %37
+  %39 = load i64, i64* @guarded_const_B, align 8, !dbg !10
+  %40 = load i64, i64* @guard_epoch_B, align 8, !dbg !10
+  %41 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !43
+  %guardUpdated = icmp eq i64 %40, %41, !dbg !10
   call void @llvm.assume(i1 %guardUpdated), !dbg !10
   %stackFrame25.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B#5write", align 8, !dbg !10
-  %52 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !10
-  %53 = bitcast i8* %52 to i16*, !dbg !10
-  %54 = load i16, i16* %53, align 8, !dbg !10
-  %55 = and i16 %54, -384, !dbg !10
-  %56 = or i16 %55, 1, !dbg !10
-  store i16 %56, i16* %53, align 8, !dbg !10
-  %57 = getelementptr inbounds i8, i8* %52, i64 8, !dbg !10
-  %58 = bitcast i8* %57 to i32*, !dbg !10
-  store i32 1, i32* %58, align 8, !dbg !10, !tbaa !45
-  %59 = getelementptr inbounds i8, i8* %52, i64 12, !dbg !10
-  %60 = getelementptr inbounds i8, i8* %52, i64 4, !dbg !10
-  %61 = bitcast i8* %60 to i32*, !dbg !10
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %59, i8 0, i64 20, i1 false) #11, !dbg !10
-  store i32 1, i32* %61, align 4, !dbg !10, !tbaa !48
-  %rubyId_a.i.i = load i64, i64* @rubyIdPrecomputed_a, align 8, !dbg !10
+  %42 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !10
+  %43 = bitcast i8* %42 to i16*, !dbg !10
+  %44 = load i16, i16* %43, align 8, !dbg !10
+  %45 = and i16 %44, -384, !dbg !10
+  %46 = or i16 %45, 1, !dbg !10
+  store i16 %46, i16* %43, align 8, !dbg !10
+  %47 = getelementptr inbounds i8, i8* %42, i64 8, !dbg !10
+  %48 = bitcast i8* %47 to i32*, !dbg !10
+  store i32 1, i32* %48, align 8, !dbg !10, !tbaa !45
+  %49 = getelementptr inbounds i8, i8* %42, i64 12, !dbg !10
+  %50 = getelementptr inbounds i8, i8* %42, i64 4, !dbg !10
+  %51 = bitcast i8* %50 to i32*, !dbg !10
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %49, i8 0, i64 20, i1 false) #11, !dbg !10
+  store i32 1, i32* %51, align 4, !dbg !10, !tbaa !48
+  %rubyId_a.i.i = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 9), align 8, !dbg !10, !invariant.load !5
   store i64 %rubyId_a.i.i, i64* %positional_table.i.i, align 8, !dbg !10
-  %62 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !10
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %62, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %35, i64 noundef 8, i1 noundef false) #11, !dbg !10
-  %63 = getelementptr inbounds i8, i8* %52, i64 32, !dbg !10
-  %64 = bitcast i8* %63 to i8**, !dbg !10
-  store i8* %62, i8** %64, align 8, !dbg !10, !tbaa !49
-  call void @sorbet_vm_define_method(i64 %49, i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 79), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_B#5write", i8* nonnull %52, %struct.rb_iseq_struct* %stackFrame25.i.i, i1 noundef zeroext false) #11, !dbg !10
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %44, align 8, !dbg !10, !tbaa !22
+  %52 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !10
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %52, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %25, i64 noundef 8, i1 noundef false) #11, !dbg !10
+  %53 = getelementptr inbounds i8, i8* %42, i64 32, !dbg !10
+  %54 = bitcast i8* %53 to i8**, !dbg !10
+  store i8* %52, i8** %54, align 8, !dbg !10, !tbaa !49
+  call void @sorbet_vm_define_method(i64 %39, i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 79), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_B#5write", i8* nonnull %42, %struct.rb_iseq_struct* %stackFrame25.i.i, i1 noundef zeroext false) #11, !dbg !10
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %34, align 8, !dbg !10, !tbaa !22
   %stackFrame34.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B#4read", align 8, !dbg !50
-  %65 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !50
-  %66 = bitcast i8* %65 to i16*, !dbg !50
-  %67 = load i16, i16* %66, align 8, !dbg !50
-  %68 = and i16 %67, -384, !dbg !50
-  store i16 %68, i16* %66, align 8, !dbg !50
-  %69 = getelementptr inbounds i8, i8* %65, i64 4, !dbg !50
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %69, i8 0, i64 28, i1 false) #11, !dbg !50
-  call void @sorbet_vm_define_method(i64 %49, i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 85), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_B#4read", i8* nonnull %65, %struct.rb_iseq_struct* %stackFrame34.i.i, i1 noundef zeroext false) #11, !dbg !50
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %44, align 8, !dbg !50, !tbaa !22
+  %55 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !50
+  %56 = bitcast i8* %55 to i16*, !dbg !50
+  %57 = load i16, i16* %56, align 8, !dbg !50
+  %58 = and i16 %57, -384, !dbg !50
+  store i16 %58, i16* %56, align 8, !dbg !50
+  %59 = getelementptr inbounds i8, i8* %55, i64 4, !dbg !50
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %59, i8 0, i64 28, i1 false) #11, !dbg !50
+  call void @sorbet_vm_define_method(i64 %39, i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 85), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_B#4read", i8* nonnull %55, %struct.rb_iseq_struct* %stackFrame34.i.i, i1 noundef zeroext false) #11, !dbg !50
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %34, align 8, !dbg !50, !tbaa !22
   %stackFrame44.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_B.4read, align 8, !dbg !51
-  %70 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !51
-  %71 = bitcast i8* %70 to i16*, !dbg !51
-  %72 = load i16, i16* %71, align 8, !dbg !51
-  %73 = and i16 %72, -384, !dbg !51
-  store i16 %73, i16* %71, align 8, !dbg !51
-  %74 = getelementptr inbounds i8, i8* %70, i64 4, !dbg !51
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %74, i8 0, i64 28, i1 false) #11, !dbg !51
-  call void @sorbet_vm_define_method(i64 %49, i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 85), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_B.4read, i8* nonnull %70, %struct.rb_iseq_struct* %stackFrame44.i.i, i1 noundef zeroext true) #11, !dbg !51
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %35) #11
+  %60 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !51
+  %61 = bitcast i8* %60 to i16*, !dbg !51
+  %62 = load i16, i16* %61, align 8, !dbg !51
+  %63 = and i16 %62, -384, !dbg !51
+  store i16 %63, i16* %61, align 8, !dbg !51
+  %64 = getelementptr inbounds i8, i8* %60, i64 4, !dbg !51
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %64, i8 0, i64 28, i1 false) #11, !dbg !51
+  call void @sorbet_vm_define_method(i64 %39, i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 85), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_B.4read, i8* nonnull %60, %struct.rb_iseq_struct* %stackFrame44.i.i, i1 noundef zeroext true) #11, !dbg !51
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %25) #11
   call void @sorbet_popFrame() #11, !dbg !41
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %31, align 8, !dbg !41, !tbaa !22
-  %75 = call i64 @sorbet_maybeAllocateObjectFastPath(i64 %49, %struct.FunctionInlineCache* noundef @ic_new) #11, !dbg !17
-  %76 = icmp eq i64 %75, 52, !dbg !17
-  br i1 %76, label %slowNew.i, label %fastNew.i, !dbg !17
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %21, align 8, !dbg !41, !tbaa !22
+  %65 = call i64 @sorbet_maybeAllocateObjectFastPath(i64 %39, %struct.FunctionInlineCache* noundef @ic_new) #11, !dbg !17
+  %66 = icmp eq i64 %65, 52, !dbg !17
+  br i1 %66, label %slowNew.i, label %fastNew.i, !dbg !17
 
-slowNew.i:                                        ; preds = %48
-  %77 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !17
-  %78 = load i64*, i64** %77, align 8, !dbg !17
-  store i64 %49, i64* %78, align 8, !dbg !17, !tbaa !6
-  %79 = getelementptr inbounds i64, i64* %78, i64 1, !dbg !17
-  store i64* %79, i64** %77, align 8, !dbg !17
-  %80 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_new, i64 noundef 0) #11, !dbg !17
+slowNew.i:                                        ; preds = %38
+  %67 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 1, !dbg !17
+  %68 = load i64*, i64** %67, align 8, !dbg !17
+  store i64 %39, i64* %68, align 8, !dbg !17, !tbaa !6
+  %69 = getelementptr inbounds i64, i64* %68, i64 1, !dbg !17
+  store i64* %69, i64** %67, align 8, !dbg !17
+  %70 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_new, i64 noundef 0) #11, !dbg !17
   br label %afterNew.i, !dbg !17
 
-fastNew.i:                                        ; preds = %48
-  %81 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !17
-  %82 = load i64*, i64** %81, align 8, !dbg !17
-  store i64 %75, i64* %82, align 8, !dbg !17, !tbaa !6
-  %83 = getelementptr inbounds i64, i64* %82, i64 1, !dbg !17
-  store i64* %83, i64** %81, align 8, !dbg !17
-  %84 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 noundef 0) #11, !dbg !17
+fastNew.i:                                        ; preds = %38
+  %71 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 1, !dbg !17
+  %72 = load i64*, i64** %71, align 8, !dbg !17
+  store i64 %65, i64* %72, align 8, !dbg !17, !tbaa !6
+  %73 = getelementptr inbounds i64, i64* %72, i64 1, !dbg !17
+  store i64* %73, i64** %71, align 8, !dbg !17
+  %74 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 noundef 0) #11, !dbg !17
   br label %afterNew.i, !dbg !17
 
 afterNew.i:                                       ; preds = %fastNew.i, %slowNew.i
-  %initializedObject.i = phi i64 [ %80, %slowNew.i ], [ %75, %fastNew.i ], !dbg !17
-  %85 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !17
-  %86 = load i64*, i64** %85, align 8, !dbg !17
-  store i64 %initializedObject.i, i64* %86, align 8, !dbg !17, !tbaa !6
-  %87 = getelementptr inbounds i64, i64* %86, i64 1, !dbg !17
-  store i64 3, i64* %87, align 8, !dbg !17, !tbaa !6
-  %88 = getelementptr inbounds i64, i64* %87, i64 1, !dbg !17
-  store i64* %88, i64** %85, align 8, !dbg !17
+  %initializedObject.i = phi i64 [ %70, %slowNew.i ], [ %65, %fastNew.i ], !dbg !17
+  %75 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 1, !dbg !17
+  %76 = load i64*, i64** %75, align 8, !dbg !17
+  store i64 %initializedObject.i, i64* %76, align 8, !dbg !17, !tbaa !6
+  %77 = getelementptr inbounds i64, i64* %76, i64 1, !dbg !17
+  store i64 3, i64* %77, align 8, !dbg !17, !tbaa !6
+  %78 = getelementptr inbounds i64, i64* %77, i64 1, !dbg !17
+  store i64* %78, i64** %75, align 8, !dbg !17
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_write, i64 0), !dbg !17
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %31, align 8, !dbg !17, !tbaa !22
-  %89 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !18
-  %90 = load i64*, i64** %89, align 8, !dbg !18
-  store i64 %49, i64* %90, align 8, !dbg !18, !tbaa !6
-  %91 = getelementptr inbounds i64, i64* %90, i64 1, !dbg !18
-  store i64* %91, i64** %89, align 8, !dbg !18
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %21, align 8, !dbg !17, !tbaa !22
+  %79 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 1, !dbg !18
+  %80 = load i64*, i64** %79, align 8, !dbg !18
+  store i64 %39, i64* %80, align 8, !dbg !18, !tbaa !6
+  %81 = getelementptr inbounds i64, i64* %80, i64 1, !dbg !18
+  store i64* %81, i64** %79, align 8, !dbg !18
   %send5 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_read, i64 0), !dbg !18
-  %92 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !19
-  %93 = load i64*, i64** %92, align 8, !dbg !19
-  store i64 %22, i64* %93, align 8, !dbg !19, !tbaa !6
-  %94 = getelementptr inbounds i64, i64* %93, i64 1, !dbg !19
-  store i64 %send5, i64* %94, align 8, !dbg !19, !tbaa !6
-  %95 = getelementptr inbounds i64, i64* %94, i64 1, !dbg !19
-  store i64* %95, i64** %92, align 8, !dbg !19
+  %82 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 1, !dbg !19
+  %83 = load i64*, i64** %82, align 8, !dbg !19
+  store i64 %12, i64* %83, align 8, !dbg !19, !tbaa !6
+  %84 = getelementptr inbounds i64, i64* %83, i64 1, !dbg !19
+  store i64 %send5, i64* %84, align 8, !dbg !19, !tbaa !6
+  %85 = getelementptr inbounds i64, i64* %84, i64 1, !dbg !19
+  store i64* %85, i64** %82, align 8, !dbg !19
   %send7 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !19
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %31, align 8, !dbg !19, !tbaa !22
-  %96 = call i64 @sorbet_maybeAllocateObjectFastPath(i64 %49, %struct.FunctionInlineCache* noundef @ic_new.1) #11, !dbg !20
-  %97 = icmp eq i64 %96, 52, !dbg !20
-  br i1 %97, label %slowNew50.i, label %fastNew51.i, !dbg !20
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %21, align 8, !dbg !19, !tbaa !22
+  %86 = call i64 @sorbet_maybeAllocateObjectFastPath(i64 %39, %struct.FunctionInlineCache* noundef @ic_new.1) #11, !dbg !20
+  %87 = icmp eq i64 %86, 52, !dbg !20
+  br i1 %87, label %slowNew50.i, label %fastNew51.i, !dbg !20
 
 slowNew50.i:                                      ; preds = %afterNew.i
-  %98 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !20
-  %99 = load i64*, i64** %98, align 8, !dbg !20
-  store i64 %49, i64* %99, align 8, !dbg !20, !tbaa !6
-  %100 = getelementptr inbounds i64, i64* %99, i64 1, !dbg !20
-  store i64* %100, i64** %98, align 8, !dbg !20
-  %101 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_new.1, i64 noundef 0) #11, !dbg !20
+  %88 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 1, !dbg !20
+  %89 = load i64*, i64** %88, align 8, !dbg !20
+  store i64 %39, i64* %89, align 8, !dbg !20, !tbaa !6
+  %90 = getelementptr inbounds i64, i64* %89, i64 1, !dbg !20
+  store i64* %90, i64** %88, align 8, !dbg !20
+  %91 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_new.1, i64 noundef 0) #11, !dbg !20
   br label %"func_<root>.17<static-init>$153.exit", !dbg !20
 
 fastNew51.i:                                      ; preds = %afterNew.i
-  %102 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !20
-  %103 = load i64*, i64** %102, align 8, !dbg !20
-  store i64 %96, i64* %103, align 8, !dbg !20, !tbaa !6
-  %104 = getelementptr inbounds i64, i64* %103, i64 1, !dbg !20
-  store i64* %104, i64** %102, align 8, !dbg !20
-  %105 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_initialize.2, i64 noundef 0) #11, !dbg !20
+  %92 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 1, !dbg !20
+  %93 = load i64*, i64** %92, align 8, !dbg !20
+  store i64 %86, i64* %93, align 8, !dbg !20, !tbaa !6
+  %94 = getelementptr inbounds i64, i64* %93, i64 1, !dbg !20
+  store i64* %94, i64** %92, align 8, !dbg !20
+  %95 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_initialize.2, i64 noundef 0) #11, !dbg !20
   br label %"func_<root>.17<static-init>$153.exit", !dbg !20
 
 "func_<root>.17<static-init>$153.exit":           ; preds = %slowNew50.i, %fastNew51.i
-  %initializedObject56.i = phi i64 [ %101, %slowNew50.i ], [ %96, %fastNew51.i ], !dbg !20
-  %106 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !20
-  %107 = load i64*, i64** %106, align 8, !dbg !20
-  store i64 %initializedObject56.i, i64* %107, align 8, !dbg !20, !tbaa !6
-  %108 = getelementptr inbounds i64, i64* %107, i64 1, !dbg !20
-  store i64* %108, i64** %106, align 8, !dbg !20
+  %initializedObject56.i = phi i64 [ %91, %slowNew50.i ], [ %86, %fastNew51.i ], !dbg !20
+  %96 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 1, !dbg !20
+  %97 = load i64*, i64** %96, align 8, !dbg !20
+  store i64 %initializedObject56.i, i64* %97, align 8, !dbg !20, !tbaa !6
+  %98 = getelementptr inbounds i64, i64* %97, i64 1, !dbg !20
+  store i64* %98, i64** %96, align 8, !dbg !20
   %send9 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_read.3, i64 0), !dbg !20
-  %109 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !21
-  %110 = load i64*, i64** %109, align 8, !dbg !21
-  store i64 %22, i64* %110, align 8, !dbg !21, !tbaa !6
-  %111 = getelementptr inbounds i64, i64* %110, i64 1, !dbg !21
-  store i64 %send9, i64* %111, align 8, !dbg !21, !tbaa !6
-  %112 = getelementptr inbounds i64, i64* %111, i64 1, !dbg !21
-  store i64* %112, i64** %109, align 8, !dbg !21
+  %99 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 1, !dbg !21
+  %100 = load i64*, i64** %99, align 8, !dbg !21
+  store i64 %12, i64* %100, align 8, !dbg !21, !tbaa !6
+  %101 = getelementptr inbounds i64, i64* %100, i64 1, !dbg !21
+  store i64 %send9, i64* %101, align 8, !dbg !21, !tbaa !6
+  %102 = getelementptr inbounds i64, i64* %101, i64 1, !dbg !21
+  store i64* %102, i64** %99, align 8, !dbg !21
   %send11 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.4, i64 0), !dbg !21
   ret void
 }
@@ -484,10 +452,9 @@ fillRequiredArgs:                                 ; preds = %functionEntryInitia
   %7 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !56, !tbaa !43
   %guardUpdated = icmp eq i64 %6, %7, !dbg !56
   tail call void @llvm.assume(i1 %guardUpdated), !dbg !56
-  %"rubyId_@@f" = load i64, i64* @"rubyIdPrecomputed_@@f", align 8, !dbg !56
+  %"rubyId_@@f" = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 6), align 8, !dbg !56, !invariant.load !5
   tail call void @rb_cvar_set(i64 %5, i64 %"rubyId_@@f", i64 %rawArg_a) #11, !dbg !56
-  %"rubyId_@@f6" = load i64, i64* @"rubyIdPrecomputed_@@f", align 8, !dbg !57
-  %8 = tail call i64 @rb_cvar_get(i64 %5, i64 %"rubyId_@@f6") #11, !dbg !57
+  %8 = tail call i64 @rb_cvar_get(i64 %5, i64 %"rubyId_@@f") #11, !dbg !57
   ret i64 %8
 }
 
@@ -520,7 +487,7 @@ fillRequiredArgs:                                 ; preds = %functionEntryInitia
   %7 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !62, !tbaa !43
   %guardUpdated = icmp eq i64 %6, %7, !dbg !62
   tail call void @llvm.assume(i1 %guardUpdated), !dbg !62
-  %"rubyId_@@f" = load i64, i64* @"rubyIdPrecomputed_@@f", align 8, !dbg !62
+  %"rubyId_@@f" = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 6), align 8, !dbg !62, !invariant.load !5
   %8 = tail call i64 @rb_cvar_get(i64 %5, i64 %"rubyId_@@f") #11, !dbg !62
   ret i64 %8
 }
@@ -554,7 +521,7 @@ fillRequiredArgs:                                 ; preds = %functionEntryInitia
   %7 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !66, !tbaa !43
   %guardUpdated = icmp eq i64 %6, %7, !dbg !66
   tail call void @llvm.assume(i1 %guardUpdated), !dbg !66
-  %"rubyId_@@f" = load i64, i64* @"rubyIdPrecomputed_@@f", align 8, !dbg !66
+  %"rubyId_@@f" = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 6), align 8, !dbg !66, !invariant.load !5
   %8 = tail call i64 @rb_cvar_get(i64 %5, i64 %"rubyId_@@f") #11, !dbg !66
   ret i64 %8
 }

--- a/test/testdata/compiler/constant_cache.opt.ll.exp
+++ b/test/testdata/compiler/constant_cache.opt.ll.exp
@@ -82,22 +82,20 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_Object#3foo" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@rubyIdPrecomputed_foo = internal unnamed_addr global i64 0, align 8
 @rubyStrFrozen_foo = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/constant_cache.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [13 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
 @ic_puts.1 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.2 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.3 = internal global %struct.FunctionInlineCache zeroinitializer
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @ic_foo = internal global %struct.FunctionInlineCache zeroinitializer
 @"stackFramePrecomputed_func_A.13<static-init>" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_<class:A>" = internal unnamed_addr global i64 0, align 8
 @sorbet_moduleStringTable = internal unnamed_addr constant [100 x i8] c"foo\00test/testdata/compiler/constant_cache.rb\00A\00puts\00<top (required)>\00Object\00normal\00master\00<class:A>\00", align 1
+@sorbet_moduleIDTable = internal unnamed_addr global [5 x i64] zeroinitializer, align 8
+@sorbet_moduleIDDescriptors = internal unnamed_addr constant [5 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 3 }, %struct.rb_code_position_struct { i32 47, i32 4 }, %struct.rb_code_position_struct { i32 52, i32 16 }, %struct.rb_code_position_struct { i32 76, i32 6 }, %struct.rb_code_position_struct { i32 90, i32 9 }], align 8
 @guard_epoch_A = linkonce local_unnamed_addr global i64 0
 @guarded_const_A = linkonce local_unnamed_addr global i64 0
 @rb_cObject = external local_unnamed_addr constant i64
@@ -125,11 +123,11 @@ declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %
 
 declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #1
 
+declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #1
+
 declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #1
 
 declare i64 @rb_define_class(i8*, i64) local_unnamed_addr #1
-
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #1
 
 declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #1
 
@@ -227,100 +225,88 @@ entry:
   %locals.i13.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 3) #11
-  store i64 %0, i64* @rubyIdPrecomputed_foo, align 8
-  %1 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 47), i64 noundef 4) #11
-  store i64 %1, i64* @rubyIdPrecomputed_puts, align 8
-  %2 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 52), i64 noundef 16) #11
-  store i64 %2, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %3 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 76), i64 noundef 6) #11
-  %4 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 90), i64 noundef 9) #11
-  store i64 %4, i64* @"rubyIdPrecomputed_<class:A>", align 8
-  %5 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 3) #11
-  tail call void @rb_gc_register_mark_object(i64 %5) #11
-  store i64 %5, i64* @rubyStrFrozen_foo, align 8
-  %6 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 4), i64 noundef 40) #11
-  tail call void @rb_gc_register_mark_object(i64 %6) #11
-  store i64 %6, i64* @"rubyStrFrozen_test/testdata/compiler/constant_cache.rb", align 8
+  tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([5 x %struct.rb_code_position_struct], [5 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 5, i8* noundef getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
+  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 3) #11
+  tail call void @rb_gc_register_mark_object(i64 %0) #11
+  store i64 %0, i64* @rubyStrFrozen_foo, align 8
+  %1 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 4), i64 noundef 40) #11
+  tail call void @rb_gc_register_mark_object(i64 %1) #11
+  store i64 %1, i64* @"rubyStrFrozen_test/testdata/compiler/constant_cache.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 13)
-  %rubyId_foo.i.i = load i64, i64* @rubyIdPrecomputed_foo, align 8
+  %rubyId_foo.i.i = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
   %rubyStr_foo.i.i = load i64, i64* @rubyStrFrozen_foo, align 8
   %"rubyStr_test/testdata/compiler/constant_cache.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/constant_cache.rb", align 8
-  %7 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_foo.i.i, i64 %rubyId_foo.i.i, i64 %"rubyStr_test/testdata/compiler/constant_cache.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %7, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !19
+  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_foo.i.i, i64 %rubyId_foo.i.i, i64 %"rubyStr_test/testdata/compiler/constant_cache.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8
+  %rubyId_puts.i = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !dbg !19, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
-  %rubyId_puts1.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !23
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts1.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !23
-  %rubyId_puts4.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !24
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts4.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !24
-  %rubyId_puts7.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !25
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts7.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !25
-  %8 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 52), i64 noundef 16) #11
-  call void @rb_gc_register_mark_object(i64 %8) #11
-  %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !23
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !24
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !25
+  %3 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 52), i64 noundef 16) #11
+  call void @rb_gc_register_mark_object(i64 %3) #11
+  %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/constant_cache.rb.i12.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/constant_cache.rb", align 8
-  %9 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %8, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/constant_cache.rb.i12.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i13.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %9, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %rubyId_foo.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !26
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !26
-  %10 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 90), i64 noundef 9) #11
-  call void @rb_gc_register_mark_object(i64 %10) #11
-  %"rubyId_<class:A>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:A>", align 8
+  %4 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %3, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/constant_cache.rb.i12.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i13.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %4, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !26
+  %5 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 90), i64 noundef 9) #11
+  call void @rb_gc_register_mark_object(i64 %5) #11
+  %"rubyId_<class:A>.i.i" = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/constant_cache.rb.i14.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/constant_cache.rb", align 8
-  %11 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %10, i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/constant_cache.rb.i14.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i15.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %11, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %12 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
-  %13 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %12, i64 0, i32 18
-  %14 = load i64, i64* %13, align 8, !tbaa !28
-  %15 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %16 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %15, i64 0, i32 2
-  %17 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %16, align 8, !tbaa !37
+  %6 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %5, i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/constant_cache.rb.i14.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i15.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %6, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
+  %7 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
+  %8 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %7, i64 0, i32 18
+  %9 = load i64, i64* %8, align 8, !tbaa !28
+  %10 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %11 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %10, i64 0, i32 2
+  %12 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %11, align 8, !tbaa !37
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %18, align 8, !tbaa !40
-  %19 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 4
-  %20 = load i64*, i64** %19, align 8, !tbaa !42
-  %21 = load i64, i64* %20, align 8, !tbaa !6
-  %22 = and i64 %21, -33
-  store i64 %22, i64* %20, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %15, %struct.rb_control_frame_struct* %17, %struct.rb_iseq_struct* %stackFrame.i) #11
-  %23 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 0
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %23, align 8, !dbg !43, !tbaa !14
-  %24 = load i64, i64* @rb_cObject, align 8, !dbg !44
-  %25 = call i64 @rb_define_class(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 45), i64 %24) #11, !dbg !44
-  %26 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %25) #11, !dbg !44
+  %13 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %13, align 8, !tbaa !40
+  %14 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 4
+  %15 = load i64*, i64** %14, align 8, !tbaa !42
+  %16 = load i64, i64* %15, align 8, !tbaa !6
+  %17 = and i64 %16, -33
+  store i64 %17, i64* %15, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %10, %struct.rb_control_frame_struct* %12, %struct.rb_iseq_struct* %stackFrame.i) #11
+  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 0
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %18, align 8, !dbg !43, !tbaa !14
+  %19 = load i64, i64* @rb_cObject, align 8, !dbg !44
+  %20 = call i64 @rb_define_class(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 45), i64 %19) #11, !dbg !44
+  %21 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %20) #11, !dbg !44
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %27 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %28 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %27, i64 0, i32 2
-  %29 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %28, align 8, !tbaa !37
-  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %30, align 8, !tbaa !40
-  %31 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 4
-  %32 = load i64*, i64** %31, align 8, !tbaa !42
-  %33 = load i64, i64* %32, align 8, !tbaa !6
-  %34 = and i64 %33, -33
-  store i64 %34, i64* %32, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %27, %struct.rb_control_frame_struct* %29, %struct.rb_iseq_struct* %stackFrame.i.i) #11
-  %35 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 0
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %35, align 8, !dbg !45, !tbaa !14
+  %22 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %23 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %22, i64 0, i32 2
+  %24 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %23, align 8, !tbaa !37
+  %25 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %25, align 8, !tbaa !40
+  %26 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 4
+  %27 = load i64*, i64** %26, align 8, !tbaa !42
+  %28 = load i64, i64* %27, align 8, !tbaa !6
+  %29 = and i64 %28, -33
+  store i64 %29, i64* %27, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %22, %struct.rb_control_frame_struct* %24, %struct.rb_iseq_struct* %stackFrame.i.i) #11
+  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %21, i64 0, i32 0
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %30, align 8, !dbg !45, !tbaa !14
   call void @sorbet_popFrame() #11, !dbg !44
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %23, align 8, !dbg !44, !tbaa !14
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %18, align 8, !dbg !44, !tbaa !14
   %stackFrame21.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8, !dbg !48
-  %36 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !48
-  %37 = bitcast i8* %36 to i16*, !dbg !48
-  %38 = load i16, i16* %37, align 8, !dbg !48
-  %39 = and i16 %38, -384, !dbg !48
-  store i16 %39, i16* %37, align 8, !dbg !48
-  %40 = getelementptr inbounds i8, i8* %36, i64 4, !dbg !48
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %40, i8 0, i64 28, i1 false) #11, !dbg !48
-  call void @sorbet_vm_define_method(i64 %24, i8* noundef getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#3foo", i8* nonnull %36, %struct.rb_iseq_struct* %stackFrame21.i, i1 noundef zeroext false) #11, !dbg !48
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %23, align 8, !dbg !48, !tbaa !14
-  %41 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 1, !dbg !26
-  %42 = load i64*, i64** %41, align 8, !dbg !26
-  store i64 %14, i64* %42, align 8, !dbg !26, !tbaa !6
-  %43 = getelementptr inbounds i64, i64* %42, i64 1, !dbg !26
-  store i64* %43, i64** %41, align 8, !dbg !26
+  %31 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !48
+  %32 = bitcast i8* %31 to i16*, !dbg !48
+  %33 = load i16, i16* %32, align 8, !dbg !48
+  %34 = and i16 %33, -384, !dbg !48
+  store i16 %34, i16* %32, align 8, !dbg !48
+  %35 = getelementptr inbounds i8, i8* %31, i64 4, !dbg !48
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %35, i8 0, i64 28, i1 false) #11, !dbg !48
+  call void @sorbet_vm_define_method(i64 %19, i8* noundef getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#3foo", i8* nonnull %31, %struct.rb_iseq_struct* %stackFrame21.i, i1 noundef zeroext false) #11, !dbg !48
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %18, align 8, !dbg !48, !tbaa !14
+  %36 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 1, !dbg !26
+  %37 = load i64*, i64** %36, align 8, !dbg !26
+  store i64 %9, i64* %37, align 8, !dbg !26, !tbaa !6
+  %38 = getelementptr inbounds i64, i64* %37, i64 1, !dbg !26
+  store i64* %38, i64** %36, align 8, !dbg !26
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo, i64 0), !dbg !26
   ret void
 }

--- a/test/testdata/compiler/custom_plus.opt.ll.exp
+++ b/test/testdata/compiler/custom_plus.opt.ll.exp
@@ -82,33 +82,25 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_Object#8delegate" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@rubyIdPrecomputed_delegate = internal unnamed_addr global i64 0, align 8
 @rubyStrFrozen_delegate = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/custom_plus.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [23 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @"ic_+" = internal global %struct.FunctionInlineCache zeroinitializer
-@"rubyIdPrecomputed_+" = internal unnamed_addr global i64 0, align 8
 @"ic_==" = internal global %struct.FunctionInlineCache zeroinitializer
-@"rubyIdPrecomputed_==" = internal unnamed_addr global i64 0, align 8
 @rubyStrFrozen_ok = internal unnamed_addr global i64 0, align 8
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
 @rubyStrFrozen_fail = internal unnamed_addr global i64 0, align 8
 @ic_puts.1 = internal global %struct.FunctionInlineCache zeroinitializer
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @ic_new = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_new = internal unnamed_addr global i64 0, align 8
 @ic_initialize = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_initialize = internal unnamed_addr global i64 0, align 8
-@rubyIdPrecomputed_a = internal unnamed_addr global i64 0, align 8
 @ic_delegate = internal global %struct.FunctionInlineCache zeroinitializer
 @"stackFramePrecomputed_func_A#1+" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"stackFramePrecomputed_func_A.13<static-init>" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_<class:A>" = internal unnamed_addr global i64 0, align 8
-@rubyIdPrecomputed_b = internal unnamed_addr global i64 0, align 8
 @sorbet_moduleStringTable = internal unnamed_addr constant [134 x i8] c"delegate\00test/testdata/compiler/custom_plus.rb\00+\00==\00ok\00puts\00fail\00<top (required)>\00A\00Object\00new\00initialize\00normal\00a\00master\00<class:A>\00b\00", align 1
+@sorbet_moduleIDTable = internal unnamed_addr global [11 x i64] zeroinitializer, align 8
+@sorbet_moduleIDDescriptors = internal unnamed_addr constant [11 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 8 }, %struct.rb_code_position_struct { i32 47, i32 1 }, %struct.rb_code_position_struct { i32 49, i32 2 }, %struct.rb_code_position_struct { i32 55, i32 4 }, %struct.rb_code_position_struct { i32 65, i32 16 }, %struct.rb_code_position_struct { i32 91, i32 3 }, %struct.rb_code_position_struct { i32 95, i32 10 }, %struct.rb_code_position_struct { i32 106, i32 6 }, %struct.rb_code_position_struct { i32 113, i32 1 }, %struct.rb_code_position_struct { i32 122, i32 9 }, %struct.rb_code_position_struct { i32 132, i32 1 }], align 8
 @rb_cObject = external local_unnamed_addr constant i64
 @guard_epoch_A = linkonce local_unnamed_addr global i64 0
 @guarded_const_A = linkonce local_unnamed_addr global i64 0
@@ -136,6 +128,8 @@ declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %
 
 declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #1
 
+declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #1
+
 declare i64 @sorbet_maybeAllocateObjectFastPath(i64, %struct.FunctionInlineCache*) local_unnamed_addr #1
 
 declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #1
@@ -151,8 +145,6 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #2
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #2
-
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #1
 
 declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #1
 
@@ -287,7 +279,7 @@ functionEntryInitializers:
   %38 = bitcast i8* %37 to i32*, !dbg !22
   tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %36, i8 0, i64 20, i1 false) #11, !dbg !22
   store i32 1, i32* %38, align 4, !dbg !22, !tbaa !41
-  %rubyId_b.i = load i64, i64* @rubyIdPrecomputed_b, align 8, !dbg !22
+  %rubyId_b.i = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 10), align 8, !dbg !22, !invariant.load !5
   store i64 %rubyId_b.i, i64* %positional_table.i, align 8, !dbg !22
   %39 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !22
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %39, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %12, i64 noundef 8, i1 noundef false) #11, !dbg !22
@@ -340,7 +332,7 @@ afterNew:                                         ; preds = %fastNew, %slowNew
   tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %59, i8 0, i64 20, i1 false), !dbg !44
   store i32 1, i32* %62, align 4, !dbg !44, !tbaa !41
   %positional_table = alloca i64, align 8, !dbg !44
-  %rubyId_a = load i64, i64* @rubyIdPrecomputed_a, align 8, !dbg !44
+  %rubyId_a = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 8), align 8, !dbg !44, !invariant.load !5
   store i64 %rubyId_a, i64* %positional_table, align 8, !dbg !44
   %63 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !44
   %64 = bitcast i64* %positional_table to i8*, !dbg !44
@@ -369,84 +361,61 @@ entry:
   %locals.i12.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 8) #11
-  store i64 %0, i64* @rubyIdPrecomputed_delegate, align 8
-  %1 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 47), i64 noundef 1) #11
-  store i64 %1, i64* @"rubyIdPrecomputed_+", align 8
-  %2 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 49), i64 noundef 2) #11
-  store i64 %2, i64* @"rubyIdPrecomputed_==", align 8
-  %3 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 55), i64 noundef 4) #11
-  store i64 %3, i64* @rubyIdPrecomputed_puts, align 8
-  %4 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 65), i64 noundef 16) #11
-  store i64 %4, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %5 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 91), i64 noundef 3) #11
-  store i64 %5, i64* @rubyIdPrecomputed_new, align 8
-  %6 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 95), i64 noundef 10) #11
-  store i64 %6, i64* @rubyIdPrecomputed_initialize, align 8
-  %7 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 106), i64 noundef 6) #11
-  %8 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 113), i64 noundef 1) #11
-  store i64 %8, i64* @rubyIdPrecomputed_a, align 8
-  %9 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 122), i64 noundef 9) #11
-  store i64 %9, i64* @"rubyIdPrecomputed_<class:A>", align 8
-  %10 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 132), i64 noundef 1) #11
-  store i64 %10, i64* @rubyIdPrecomputed_b, align 8
-  %11 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 8) #11
-  tail call void @rb_gc_register_mark_object(i64 %11) #11
-  store i64 %11, i64* @rubyStrFrozen_delegate, align 8
-  %12 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 9), i64 noundef 37) #11
-  tail call void @rb_gc_register_mark_object(i64 %12) #11
-  store i64 %12, i64* @"rubyStrFrozen_test/testdata/compiler/custom_plus.rb", align 8
+  tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([11 x %struct.rb_code_position_struct], [11 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 11, i8* noundef getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
+  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 8) #11
+  tail call void @rb_gc_register_mark_object(i64 %0) #11
+  store i64 %0, i64* @rubyStrFrozen_delegate, align 8
+  %1 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 9), i64 noundef 37) #11
+  tail call void @rb_gc_register_mark_object(i64 %1) #11
+  store i64 %1, i64* @"rubyStrFrozen_test/testdata/compiler/custom_plus.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 23)
-  %rubyId_delegate.i.i = load i64, i64* @rubyIdPrecomputed_delegate, align 8
+  %rubyId_delegate.i.i = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
   %rubyStr_delegate.i.i = load i64, i64* @rubyStrFrozen_delegate, align 8
   %"rubyStr_test/testdata/compiler/custom_plus.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/custom_plus.rb", align 8
-  %13 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_delegate.i.i, i64 %rubyId_delegate.i.i, i64 %"rubyStr_test/testdata/compiler/custom_plus.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 14, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %13, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#8delegate", align 8
-  %"rubyId_+.i" = load i64, i64* @"rubyIdPrecomputed_+", align 8, !dbg !19
+  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_delegate.i.i, i64 %rubyId_delegate.i.i, i64 %"rubyStr_test/testdata/compiler/custom_plus.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 14, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#8delegate", align 8
+  %"rubyId_+.i" = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !dbg !19, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_+", i64 %"rubyId_+.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
-  %"rubyId_==.i" = load i64, i64* @"rubyIdPrecomputed_==", align 8, !dbg !19
+  %"rubyId_==.i" = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !19, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_==", i64 %"rubyId_==.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
-  %14 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 52), i64 noundef 2) #11
-  call void @rb_gc_register_mark_object(i64 %14) #11
-  store i64 %14, i64* @rubyStrFrozen_ok, align 8
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !46
+  %3 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 52), i64 noundef 2) #11
+  call void @rb_gc_register_mark_object(i64 %3) #11
+  store i64 %3, i64* @rubyStrFrozen_ok, align 8
+  %rubyId_puts.i = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !46, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !46
-  %15 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 60), i64 noundef 4) #11
-  call void @rb_gc_register_mark_object(i64 %15) #11
-  store i64 %15, i64* @rubyStrFrozen_fail, align 8
-  %rubyId_puts3.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !47
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts3.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !47
-  %16 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 65), i64 noundef 16) #11
-  call void @rb_gc_register_mark_object(i64 %16) #11
-  %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
+  %4 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 60), i64 noundef 4) #11
+  call void @rb_gc_register_mark_object(i64 %4) #11
+  store i64 %4, i64* @rubyStrFrozen_fail, align 8
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !47
+  %5 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 65), i64 noundef 16) #11
+  call void @rb_gc_register_mark_object(i64 %5) #11
+  %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/custom_plus.rb.i11.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/custom_plus.rb", align 8
-  %17 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %16, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/custom_plus.rb.i11.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i12.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %17, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !43
+  %6 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %5, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/custom_plus.rb.i11.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i12.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %6, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %rubyId_new.i = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 5), align 8, !dbg !43, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !43
-  %rubyId_initialize.i = load i64, i64* @rubyIdPrecomputed_initialize, align 8, !dbg !43
+  %rubyId_initialize.i = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 6), align 8, !dbg !43, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 %rubyId_initialize.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !43
-  %rubyId_delegate.i = load i64, i64* @rubyIdPrecomputed_delegate, align 8, !dbg !45
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_delegate, i64 %rubyId_delegate.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !45
-  %18 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 47), i64 noundef 1) #11
-  call void @rb_gc_register_mark_object(i64 %18) #11
-  %"rubyId_+.i.i" = load i64, i64* @"rubyIdPrecomputed_+", align 8
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_delegate, i64 %rubyId_delegate.i.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !45
+  %7 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 47), i64 noundef 1) #11
+  call void @rb_gc_register_mark_object(i64 %7) #11
   %"rubyStr_test/testdata/compiler/custom_plus.rb.i13.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/custom_plus.rb", align 8
-  %19 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %18, i64 %"rubyId_+.i.i", i64 %"rubyStr_test/testdata/compiler/custom_plus.rb.i13.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 7, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i14.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %19, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#1+", align 8
-  %20 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 122), i64 noundef 9) #11
-  call void @rb_gc_register_mark_object(i64 %20) #11
-  %"rubyId_<class:A>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:A>", align 8
+  %8 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %7, i64 %"rubyId_+.i", i64 %"rubyStr_test/testdata/compiler/custom_plus.rb.i13.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 7, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i14.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %8, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#1+", align 8
+  %9 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 122), i64 noundef 9) #11
+  call void @rb_gc_register_mark_object(i64 %9) #11
+  %"rubyId_<class:A>.i.i" = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 9), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/custom_plus.rb.i15.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/custom_plus.rb", align 8
-  %21 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %20, i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/custom_plus.rb.i15.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i16.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %21, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %22 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
-  %23 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %22, i64 0, i32 18
-  %24 = load i64, i64* %23, align 8, !tbaa !48
-  %25 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %26 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %25, i64 0, i32 2
-  %27 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %26, align 8, !tbaa !25
-  call fastcc void @"func_<root>.17<static-init>$153"(i64 %24, %struct.rb_control_frame_struct* %27) #11
+  %10 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %9, i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/custom_plus.rb.i15.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i16.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %10, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
+  %11 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
+  %12 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %11, i64 0, i32 18
+  %13 = load i64, i64* %12, align 8, !tbaa !48
+  %14 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %15 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %14, i64 0, i32 2
+  %16 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %15, align 8, !tbaa !25
+  call fastcc void @"func_<root>.17<static-init>$153"(i64 %13, %struct.rb_control_frame_struct* %16) #11
   ret void
 }
 

--- a/test/testdata/compiler/direct_call.opt.ll.exp
+++ b/test/testdata/compiler/direct_call.opt.ll.exp
@@ -81,20 +81,18 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_Object#3foo" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@rubyIdPrecomputed_foo = internal unnamed_addr global i64 0, align 8
 @rubyStrFrozen_foo = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/direct_call.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [13 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @"stackFramePrecomputed_func_Object#3bar" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@rubyIdPrecomputed_bar = internal unnamed_addr global i64 0, align 8
 @ic_foo = internal global %struct.FunctionInlineCache zeroinitializer
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @ic_bar = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
 @sorbet_moduleStringTable = internal unnamed_addr constant [89 x i8] c"foo\00test/testdata/compiler/direct_call.rb\00bar\00<top (required)>\00normal\00Object\00puts\00master\00", align 1
+@sorbet_moduleIDTable = internal unnamed_addr global [5 x i64] zeroinitializer, align 8
+@sorbet_moduleIDDescriptors = internal unnamed_addr constant [5 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 3 }, %struct.rb_code_position_struct { i32 42, i32 3 }, %struct.rb_code_position_struct { i32 46, i32 16 }, %struct.rb_code_position_struct { i32 63, i32 6 }, %struct.rb_code_position_struct { i32 77, i32 4 }], align 8
 @rb_cObject = external local_unnamed_addr constant i64
 
 ; Function Attrs: noreturn
@@ -114,9 +112,9 @@ declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %
 
 declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #1
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #1
+declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #1
 
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #1
+declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #1
 
 declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #1
 
@@ -187,96 +185,86 @@ entry:
   %locals.i6.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([89 x i8], [89 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 3) #9
-  store i64 %0, i64* @rubyIdPrecomputed_foo, align 8
-  %1 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([89 x i8], [89 x i8]* @sorbet_moduleStringTable, i64 0, i64 42), i64 noundef 3) #9
-  store i64 %1, i64* @rubyIdPrecomputed_bar, align 8
-  %2 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([89 x i8], [89 x i8]* @sorbet_moduleStringTable, i64 0, i64 46), i64 noundef 16) #9
-  store i64 %2, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %3 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([89 x i8], [89 x i8]* @sorbet_moduleStringTable, i64 0, i64 63), i64 noundef 6) #9
-  %4 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([89 x i8], [89 x i8]* @sorbet_moduleStringTable, i64 0, i64 77), i64 noundef 4) #9
-  store i64 %4, i64* @rubyIdPrecomputed_puts, align 8
-  %5 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([89 x i8], [89 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 3) #9
-  tail call void @rb_gc_register_mark_object(i64 %5) #9
-  store i64 %5, i64* @rubyStrFrozen_foo, align 8
-  %6 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([89 x i8], [89 x i8]* @sorbet_moduleStringTable, i64 0, i64 4), i64 noundef 37) #9
-  tail call void @rb_gc_register_mark_object(i64 %6) #9
-  store i64 %6, i64* @"rubyStrFrozen_test/testdata/compiler/direct_call.rb", align 8
+  tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([5 x %struct.rb_code_position_struct], [5 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 5, i8* noundef getelementptr inbounds ([89 x i8], [89 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
+  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([89 x i8], [89 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 3) #9
+  tail call void @rb_gc_register_mark_object(i64 %0) #9
+  store i64 %0, i64* @rubyStrFrozen_foo, align 8
+  %1 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([89 x i8], [89 x i8]* @sorbet_moduleStringTable, i64 0, i64 4), i64 noundef 37) #9
+  tail call void @rb_gc_register_mark_object(i64 %1) #9
+  store i64 %1, i64* @"rubyStrFrozen_test/testdata/compiler/direct_call.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 13)
-  %rubyId_foo.i.i = load i64, i64* @rubyIdPrecomputed_foo, align 8
+  %rubyId_foo.i.i = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
   %rubyStr_foo.i.i = load i64, i64* @rubyStrFrozen_foo, align 8
   %"rubyStr_test/testdata/compiler/direct_call.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/direct_call.rb", align 8
-  %7 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_foo.i.i, i64 %rubyId_foo.i.i, i64 %"rubyStr_test/testdata/compiler/direct_call.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %7, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8
-  %8 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([89 x i8], [89 x i8]* @sorbet_moduleStringTable, i64 0, i64 42), i64 noundef 3) #9
-  call void @rb_gc_register_mark_object(i64 %8) #9
-  %rubyId_bar.i.i = load i64, i64* @rubyIdPrecomputed_bar, align 8
+  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_foo.i.i, i64 %rubyId_foo.i.i, i64 %"rubyStr_test/testdata/compiler/direct_call.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8
+  %3 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([89 x i8], [89 x i8]* @sorbet_moduleStringTable, i64 0, i64 42), i64 noundef 3) #9
+  call void @rb_gc_register_mark_object(i64 %3) #9
+  %rubyId_bar.i.i = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/direct_call.rb.i5.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/direct_call.rb", align 8
-  %9 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %8, i64 %rubyId_bar.i.i, i64 %"rubyStr_test/testdata/compiler/direct_call.rb.i5.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i6.i, i32 noundef 0, i32 noundef 1)
-  store %struct.rb_iseq_struct* %9, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3bar", align 8
-  %rubyId_foo.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !22
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !22
-  %10 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([89 x i8], [89 x i8]* @sorbet_moduleStringTable, i64 0, i64 46), i64 noundef 16) #9
-  call void @rb_gc_register_mark_object(i64 %10) #9
-  %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
+  %4 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %3, i64 %rubyId_bar.i.i, i64 %"rubyStr_test/testdata/compiler/direct_call.rb.i5.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i6.i, i32 noundef 0, i32 noundef 1)
+  store %struct.rb_iseq_struct* %4, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3bar", align 8
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !22
+  %5 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([89 x i8], [89 x i8]* @sorbet_moduleStringTable, i64 0, i64 46), i64 noundef 16) #9
+  call void @rb_gc_register_mark_object(i64 %5) #9
+  %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/direct_call.rb.i7.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/direct_call.rb", align 8
-  %11 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %10, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/direct_call.rb.i7.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i8.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %11, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %rubyId_bar.i = load i64, i64* @rubyIdPrecomputed_bar, align 8, !dbg !23
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_bar, i64 %rubyId_bar.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !23
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !25
+  %6 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %5, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/direct_call.rb.i7.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i8.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %6, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_bar, i64 %rubyId_bar.i.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !23
+  %rubyId_puts.i = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !dbg !25, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !25
-  %12 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
-  %13 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %12, i64 0, i32 18
-  %14 = load i64, i64* %13, align 8, !tbaa !26
-  %15 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %16 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %15, i64 0, i32 2
-  %17 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %16, align 8, !tbaa !36
+  %7 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
+  %8 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %7, i64 0, i32 18
+  %9 = load i64, i64* %8, align 8, !tbaa !26
+  %10 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %11 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %10, i64 0, i32 2
+  %12 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %11, align 8, !tbaa !36
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %18, align 8, !tbaa !39
-  %19 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 4
-  %20 = load i64*, i64** %19, align 8, !tbaa !41
-  %21 = load i64, i64* %20, align 8, !tbaa !6
-  %22 = and i64 %21, -33
-  store i64 %22, i64* %20, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %15, %struct.rb_control_frame_struct* %17, %struct.rb_iseq_struct* %stackFrame.i) #9
-  %23 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 0
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %23, align 8, !dbg !42, !tbaa !14
-  %24 = load i64, i64* @rb_cObject, align 8, !dbg !43
+  %13 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %13, align 8, !tbaa !39
+  %14 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 4
+  %15 = load i64*, i64** %14, align 8, !tbaa !41
+  %16 = load i64, i64* %15, align 8, !tbaa !6
+  %17 = and i64 %16, -33
+  store i64 %17, i64* %15, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %10, %struct.rb_control_frame_struct* %12, %struct.rb_iseq_struct* %stackFrame.i) #9
+  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 0
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %18, align 8, !dbg !42, !tbaa !14
+  %19 = load i64, i64* @rb_cObject, align 8, !dbg !43
   %stackFrame21.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8, !dbg !43
-  %25 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #10, !dbg !43
-  %26 = bitcast i8* %25 to i16*, !dbg !43
-  %27 = load i16, i16* %26, align 8, !dbg !43
-  %28 = and i16 %27, -384, !dbg !43
-  store i16 %28, i16* %26, align 8, !dbg !43
-  %29 = getelementptr inbounds i8, i8* %25, i64 4, !dbg !43
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %29, i8 0, i64 28, i1 false) #9, !dbg !43
-  call void @sorbet_vm_define_method(i64 %24, i8* noundef getelementptr inbounds ([89 x i8], [89 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#3foo", i8* nonnull %25, %struct.rb_iseq_struct* %stackFrame21.i, i1 noundef zeroext false) #9, !dbg !43
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %23, align 8, !dbg !43, !tbaa !14
+  %20 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #10, !dbg !43
+  %21 = bitcast i8* %20 to i16*, !dbg !43
+  %22 = load i16, i16* %21, align 8, !dbg !43
+  %23 = and i16 %22, -384, !dbg !43
+  store i16 %23, i16* %21, align 8, !dbg !43
+  %24 = getelementptr inbounds i8, i8* %20, i64 4, !dbg !43
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %24, i8 0, i64 28, i1 false) #9, !dbg !43
+  call void @sorbet_vm_define_method(i64 %19, i8* noundef getelementptr inbounds ([89 x i8], [89 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#3foo", i8* nonnull %20, %struct.rb_iseq_struct* %stackFrame21.i, i1 noundef zeroext false) #9, !dbg !43
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %18, align 8, !dbg !43, !tbaa !14
   %stackFrame30.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3bar", align 8, !dbg !44
-  %30 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #10, !dbg !44
-  %31 = bitcast i8* %30 to i16*, !dbg !44
-  %32 = load i16, i16* %31, align 8, !dbg !44
-  %33 = and i16 %32, -384, !dbg !44
-  store i16 %33, i16* %31, align 8, !dbg !44
-  %34 = getelementptr inbounds i8, i8* %30, i64 4, !dbg !44
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %34, i8 0, i64 28, i1 false) #9, !dbg !44
-  call void @sorbet_vm_define_method(i64 %24, i8* getelementptr inbounds ([89 x i8], [89 x i8]* @sorbet_moduleStringTable, i64 0, i64 42), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#3bar", i8* nonnull %30, %struct.rb_iseq_struct* %stackFrame30.i, i1 noundef zeroext false) #9, !dbg !44
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %23, align 8, !dbg !44, !tbaa !14
-  %35 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 1, !dbg !23
-  %36 = load i64*, i64** %35, align 8, !dbg !23
-  store i64 %14, i64* %36, align 8, !dbg !23, !tbaa !6
-  %37 = getelementptr inbounds i64, i64* %36, i64 1, !dbg !23
-  store i64* %37, i64** %35, align 8, !dbg !23
+  %25 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #10, !dbg !44
+  %26 = bitcast i8* %25 to i16*, !dbg !44
+  %27 = load i16, i16* %26, align 8, !dbg !44
+  %28 = and i16 %27, -384, !dbg !44
+  store i16 %28, i16* %26, align 8, !dbg !44
+  %29 = getelementptr inbounds i8, i8* %25, i64 4, !dbg !44
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %29, i8 0, i64 28, i1 false) #9, !dbg !44
+  call void @sorbet_vm_define_method(i64 %19, i8* getelementptr inbounds ([89 x i8], [89 x i8]* @sorbet_moduleStringTable, i64 0, i64 42), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#3bar", i8* nonnull %25, %struct.rb_iseq_struct* %stackFrame30.i, i1 noundef zeroext false) #9, !dbg !44
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %18, align 8, !dbg !44, !tbaa !14
+  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 1, !dbg !23
+  %31 = load i64*, i64** %30, align 8, !dbg !23
+  store i64 %9, i64* %31, align 8, !dbg !23, !tbaa !6
+  %32 = getelementptr inbounds i64, i64* %31, i64 1, !dbg !23
+  store i64* %32, i64** %30, align 8, !dbg !23
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_bar, i64 0), !dbg !23
-  %38 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 1, !dbg !25
-  %39 = load i64*, i64** %38, align 8, !dbg !25
-  store i64 %14, i64* %39, align 8, !dbg !25, !tbaa !6
-  %40 = getelementptr inbounds i64, i64* %39, i64 1, !dbg !25
-  store i64 %send, i64* %40, align 8, !dbg !25, !tbaa !6
-  %41 = getelementptr inbounds i64, i64* %40, i64 1, !dbg !25
-  store i64* %41, i64** %38, align 8, !dbg !25
+  %33 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 1, !dbg !25
+  %34 = load i64*, i64** %33, align 8, !dbg !25
+  store i64 %9, i64* %34, align 8, !dbg !25, !tbaa !6
+  %35 = getelementptr inbounds i64, i64* %34, i64 1, !dbg !25
+  store i64 %send, i64* %35, align 8, !dbg !25, !tbaa !6
+  %36 = getelementptr inbounds i64, i64* %35, i64 1, !dbg !25
+  store i64* %36, i64** %33, align 8, !dbg !25
   %send2 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !25
   ret void
 }

--- a/test/testdata/compiler/exceptions/basic.opt.ll.exp
+++ b/test/testdata/compiler/exceptions/basic.opt.ll.exp
@@ -83,46 +83,35 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/exceptions/basic.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [28 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @"rubyStrFrozen_=== no-raise ===" = internal unnamed_addr global i64 0, align 8
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
 @ic_test = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_test = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_=== raise ===" = internal unnamed_addr global i64 0, align 8
 @ic_puts.1 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_test.2 = internal global %struct.FunctionInlineCache zeroinitializer
 @stackFramePrecomputed_func_A.4test = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_<exceptionValue>" = internal unnamed_addr global i64 0, align 8
-@rubyIdPrecomputed_x = internal unnamed_addr global i64 0, align 8
-@"rubyIdPrecomputed_<returnMethodTemp>" = internal unnamed_addr global i64 0, align 8
-@"rubyIdPrecomputed_<magic>" = internal unnamed_addr global i64 0, align 8
-@"rubyIdPrecomputed_<gotoDeadTemp>" = internal unnamed_addr global i64 0, align 8
 @"stackFramePrecomputed_func_A.4test$block_2" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_rescue in test" = internal unnamed_addr global i64 0, align 8
 @"stackFramePrecomputed_func_A.4test$block_3" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_ensure in test" = internal unnamed_addr global i64 0, align 8
 @"<retry-singleton>" = internal unnamed_addr global i64 0
 @rubyStrFrozen_begin = internal unnamed_addr global i64 0, align 8
 @ic_puts.3 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.4 = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyStrFrozen_foo = internal unnamed_addr global i64 0, align 8
 @ic_raise = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_raise = internal unnamed_addr global i64 0, align 8
 @"ic_is_a?" = internal global %struct.FunctionInlineCache zeroinitializer
-@"rubyIdPrecomputed_is_a?" = internal unnamed_addr global i64 0, align 8
 @ic_puts.5 = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyStrFrozen_else = internal unnamed_addr global i64 0, align 8
 @ic_puts.6 = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyStrFrozen_ensure = internal unnamed_addr global i64 0, align 8
 @ic_puts.7 = internal global %struct.FunctionInlineCache zeroinitializer
 @"stackFramePrecomputed_func_A.13<static-init>" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_<class:A>" = internal unnamed_addr global i64 0, align 8
 @sorbet_moduleStringTable = internal unnamed_addr constant [273 x i8] c"<top (required)>\00test/testdata/compiler/exceptions/basic.rb\00A\00Object\00=== no-raise ===\00puts\00test\00=== raise ===\00master\00<exceptionValue>\00x\00<returnMethodTemp>\00<magic>\00<gotoDeadTemp>\00rescue in test\00ensure in test\00begin\00foo\00raise\00StandardError\00is_a?\00else\00ensure\00<class:A>\00normal\00", align 1
+@sorbet_moduleIDTable = internal unnamed_addr global [14 x i64] zeroinitializer, align 8
+@sorbet_moduleIDDescriptors = internal unnamed_addr constant [14 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 86, i32 4 }, %struct.rb_code_position_struct { i32 91, i32 4 }, %struct.rb_code_position_struct { i32 117, i32 16 }, %struct.rb_code_position_struct { i32 134, i32 1 }, %struct.rb_code_position_struct { i32 136, i32 18 }, %struct.rb_code_position_struct { i32 155, i32 7 }, %struct.rb_code_position_struct { i32 163, i32 14 }, %struct.rb_code_position_struct { i32 178, i32 14 }, %struct.rb_code_position_struct { i32 193, i32 14 }, %struct.rb_code_position_struct { i32 218, i32 5 }, %struct.rb_code_position_struct { i32 238, i32 5 }, %struct.rb_code_position_struct { i32 256, i32 9 }, %struct.rb_code_position_struct { i32 266, i32 6 }], align 8
 @rb_cObject = external local_unnamed_addr constant i64
 @guard_epoch_A = linkonce local_unnamed_addr global i64 0
 @guarded_const_A = linkonce local_unnamed_addr global i64 0
@@ -155,6 +144,8 @@ declare void @sorbet_setExceptionStackFrame(%struct.rb_execution_context_struct*
 
 declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #1
 
+declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #1
+
 declare i64 @sorbet_vm_isa_p(%struct.FunctionInlineCache*, %struct.rb_control_frame_struct*, i64, i64) local_unnamed_addr #1
 
 declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #1
@@ -168,8 +159,6 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #2
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #2
-
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #1
 
 declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #1
 
@@ -207,243 +196,201 @@ entry:
   %locals.i26.i = alloca i64, i32 5, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #11
-  store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %1 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 86), i64 noundef 4) #11
-  store i64 %1, i64* @rubyIdPrecomputed_puts, align 8
-  %2 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 91), i64 noundef 4) #11
-  store i64 %2, i64* @rubyIdPrecomputed_test, align 8
-  %3 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 117), i64 noundef 16) #11
-  store i64 %3, i64* @"rubyIdPrecomputed_<exceptionValue>", align 8
-  %4 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 134), i64 noundef 1) #11
-  store i64 %4, i64* @rubyIdPrecomputed_x, align 8
-  %5 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 136), i64 noundef 18) #11
-  store i64 %5, i64* @"rubyIdPrecomputed_<returnMethodTemp>", align 8
-  %6 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 155), i64 noundef 7) #11
-  store i64 %6, i64* @"rubyIdPrecomputed_<magic>", align 8
-  %7 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 163), i64 noundef 14) #11
-  store i64 %7, i64* @"rubyIdPrecomputed_<gotoDeadTemp>", align 8
-  %8 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 178), i64 noundef 14) #11
-  store i64 %8, i64* @"rubyIdPrecomputed_rescue in test", align 8
-  %9 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 193), i64 noundef 14) #11
-  store i64 %9, i64* @"rubyIdPrecomputed_ensure in test", align 8
-  %10 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 218), i64 noundef 5) #11
-  store i64 %10, i64* @rubyIdPrecomputed_raise, align 8
-  %11 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 238), i64 noundef 5) #11
-  store i64 %11, i64* @"rubyIdPrecomputed_is_a?", align 8
-  %12 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 256), i64 noundef 9) #11
-  store i64 %12, i64* @"rubyIdPrecomputed_<class:A>", align 8
-  %13 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 266), i64 noundef 6) #11
-  %14 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #11
-  tail call void @rb_gc_register_mark_object(i64 %14) #11
-  store i64 %14, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %15 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 42) #11
-  tail call void @rb_gc_register_mark_object(i64 %15) #11
-  store i64 %15, i64* @"rubyStrFrozen_test/testdata/compiler/exceptions/basic.rb", align 8
+  tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([14 x %struct.rb_code_position_struct], [14 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 14, i8* noundef getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
+  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #11
+  tail call void @rb_gc_register_mark_object(i64 %0) #11
+  store i64 %0, i64* @"rubyStrFrozen_<top (required)>", align 8
+  %1 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 42) #11
+  tail call void @rb_gc_register_mark_object(i64 %1) #11
+  store i64 %1, i64* @"rubyStrFrozen_test/testdata/compiler/exceptions/basic.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 28)
-  %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
+  %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
   %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/exceptions/basic.rb", align 8
-  %16 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %16, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %17 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 69), i64 noundef 16) #11
-  call void @rb_gc_register_mark_object(i64 %17) #11
-  store i64 %17, i64* @"rubyStrFrozen_=== no-raise ===", align 8
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !17
+  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %3 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 69), i64 noundef 16) #11
+  call void @rb_gc_register_mark_object(i64 %3) #11
+  store i64 %3, i64* @"rubyStrFrozen_=== no-raise ===", align 8
+  %rubyId_puts.i = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !dbg !17, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !17
-  %rubyId_test.i = load i64, i64* @rubyIdPrecomputed_test, align 8, !dbg !18
+  %rubyId_test.i = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !18, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test, i64 %rubyId_test.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !18
-  %18 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 96), i64 noundef 13) #11
-  call void @rb_gc_register_mark_object(i64 %18) #11
-  store i64 %18, i64* @"rubyStrFrozen_=== raise ===", align 8
-  %rubyId_puts2.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !19
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts2.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
-  %rubyId_test5.i = load i64, i64* @rubyIdPrecomputed_test, align 8, !dbg !20
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test.2, i64 %rubyId_test5.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !20
-  %19 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 91), i64 noundef 4) #11
-  call void @rb_gc_register_mark_object(i64 %19) #11
-  %20 = bitcast i64* %locals.i26.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 40, i8* nonnull %20)
-  %rubyId_test.i.i = load i64, i64* @rubyIdPrecomputed_test, align 8
+  %4 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 96), i64 noundef 13) #11
+  call void @rb_gc_register_mark_object(i64 %4) #11
+  store i64 %4, i64* @"rubyStrFrozen_=== raise ===", align 8
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test.2, i64 %rubyId_test.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !20
+  %5 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 91), i64 noundef 4) #11
+  call void @rb_gc_register_mark_object(i64 %5) #11
+  %6 = bitcast i64* %locals.i26.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 40, i8* nonnull %6)
   %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i25.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/exceptions/basic.rb", align 8
-  %"rubyId_<exceptionValue>.i.i" = load i64, i64* @"rubyIdPrecomputed_<exceptionValue>", align 8
-  store i64 %"rubyId_<exceptionValue>.i.i", i64* %locals.i26.i, align 8
-  %rubyId_x.i.i = load i64, i64* @rubyIdPrecomputed_x, align 8
-  %21 = getelementptr i64, i64* %locals.i26.i, i32 1
-  store i64 %rubyId_x.i.i, i64* %21, align 8
-  %"rubyId_<returnMethodTemp>.i.i" = load i64, i64* @"rubyIdPrecomputed_<returnMethodTemp>", align 8
-  %22 = getelementptr i64, i64* %locals.i26.i, i32 2
-  store i64 %"rubyId_<returnMethodTemp>.i.i", i64* %22, align 8
-  %"rubyId_<magic>.i.i" = load i64, i64* @"rubyIdPrecomputed_<magic>", align 8
-  %23 = getelementptr i64, i64* %locals.i26.i, i32 3
-  store i64 %"rubyId_<magic>.i.i", i64* %23, align 8
-  %"rubyId_<gotoDeadTemp>.i.i" = load i64, i64* @"rubyIdPrecomputed_<gotoDeadTemp>", align 8
-  %24 = getelementptr i64, i64* %locals.i26.i, i32 4
-  store i64 %"rubyId_<gotoDeadTemp>.i.i", i64* %24, align 8
-  %25 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %19, i64 %rubyId_test.i.i, i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i25.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i26.i, i32 noundef 5, i32 noundef 2)
-  store %struct.rb_iseq_struct* %25, %struct.rb_iseq_struct** @stackFramePrecomputed_func_A.4test, align 8
-  call void @llvm.lifetime.end.p0i8(i64 40, i8* nonnull %20)
-  %26 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 178), i64 noundef 14) #11
-  call void @rb_gc_register_mark_object(i64 %26) #11
+  %7 = load <4 x i64>, <4 x i64>* bitcast (i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 3) to <4 x i64>*), align 8, !invariant.load !5
+  %8 = bitcast i64* %locals.i26.i to <4 x i64>*
+  store <4 x i64> %7, <4 x i64>* %8, align 8
+  %"rubyId_<gotoDeadTemp>.i.i" = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 7), align 8, !invariant.load !5
+  %9 = getelementptr i64, i64* %locals.i26.i, i32 4
+  store i64 %"rubyId_<gotoDeadTemp>.i.i", i64* %9, align 8
+  %10 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %5, i64 %rubyId_test.i, i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i25.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i26.i, i32 noundef 5, i32 noundef 2)
+  store %struct.rb_iseq_struct* %10, %struct.rb_iseq_struct** @stackFramePrecomputed_func_A.4test, align 8
+  call void @llvm.lifetime.end.p0i8(i64 40, i8* nonnull %6)
+  %11 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 178), i64 noundef 14) #11
+  call void @rb_gc_register_mark_object(i64 %11) #11
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_A.4test, align 8
-  %"rubyId_rescue in test.i.i" = load i64, i64* @"rubyIdPrecomputed_rescue in test", align 8
+  %"rubyId_rescue in test.i.i" = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 8), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i27.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/exceptions/basic.rb", align 8
-  %27 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %26, i64 %"rubyId_rescue in test.i.i", i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i27.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 4, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %27, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.4test$block_2", align 8
-  %28 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 193), i64 noundef 14) #11
-  call void @rb_gc_register_mark_object(i64 %28) #11
+  %12 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %11, i64 %"rubyId_rescue in test.i.i", i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i27.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 4, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %12, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.4test$block_2", align 8
+  %13 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 193), i64 noundef 14) #11
+  call void @rb_gc_register_mark_object(i64 %13) #11
   %stackFrame.i28.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_A.4test, align 8
-  %"rubyId_ensure in test.i.i" = load i64, i64* @"rubyIdPrecomputed_ensure in test", align 8
+  %"rubyId_ensure in test.i.i" = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 9), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i29.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/exceptions/basic.rb", align 8
-  %29 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %28, i64 %"rubyId_ensure in test.i.i", i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i29.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i28.i, i32 noundef 5, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %29, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.4test$block_3", align 8
-  %30 = call i64 @sorbet_getConstant(i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @sorbet_getTRetry.retry, i64 0, i64 0), i64 noundef 25) #11
-  store i64 %30, i64* @"<retry-singleton>", align 8
-  %31 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 208), i64 noundef 5) #11
-  call void @rb_gc_register_mark_object(i64 %31) #11
-  store i64 %31, i64* @rubyStrFrozen_begin, align 8
-  %rubyId_puts7.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !21
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts7.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !21
-  %rubyId_puts10.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !24
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.4, i64 %rubyId_puts10.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !24
-  %32 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 214), i64 noundef 3) #11
-  call void @rb_gc_register_mark_object(i64 %32) #11
-  store i64 %32, i64* @rubyStrFrozen_foo, align 8
-  %rubyId_raise.i = load i64, i64* @rubyIdPrecomputed_raise, align 8, !dbg !25
+  %14 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %13, i64 %"rubyId_ensure in test.i.i", i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i29.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i28.i, i32 noundef 5, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %14, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.4test$block_3", align 8
+  %15 = call i64 @sorbet_getConstant(i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @sorbet_getTRetry.retry, i64 0, i64 0), i64 noundef 25) #11
+  store i64 %15, i64* @"<retry-singleton>", align 8
+  %16 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 208), i64 noundef 5) #11
+  call void @rb_gc_register_mark_object(i64 %16) #11
+  store i64 %16, i64* @rubyStrFrozen_begin, align 8
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !21
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.4, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !24
+  %17 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 214), i64 noundef 3) #11
+  call void @rb_gc_register_mark_object(i64 %17) #11
+  store i64 %17, i64* @rubyStrFrozen_foo, align 8
+  %rubyId_raise.i = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 10), align 8, !dbg !25, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_raise, i64 %rubyId_raise.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !25
-  %"rubyId_is_a?.i" = load i64, i64* @"rubyIdPrecomputed_is_a?", align 8, !dbg !26
+  %"rubyId_is_a?.i" = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 11), align 8, !dbg !26, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_is_a?", i64 %"rubyId_is_a?.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !26
-  %rubyId_puts16.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !28
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.5, i64 %rubyId_puts16.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !28
-  %33 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 244), i64 noundef 4) #11
-  call void @rb_gc_register_mark_object(i64 %33) #11
-  store i64 %33, i64* @rubyStrFrozen_else, align 8
-  %rubyId_puts19.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !29
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.6, i64 %rubyId_puts19.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !29
-  %34 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 249), i64 noundef 6) #11
-  call void @rb_gc_register_mark_object(i64 %34) #11
-  store i64 %34, i64* @rubyStrFrozen_ensure, align 8
-  %rubyId_puts22.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !31
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.7, i64 %rubyId_puts22.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !31
-  %35 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 256), i64 noundef 9) #11
-  call void @rb_gc_register_mark_object(i64 %35) #11
-  %"rubyId_<class:A>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:A>", align 8
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.5, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !28
+  %18 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 244), i64 noundef 4) #11
+  call void @rb_gc_register_mark_object(i64 %18) #11
+  store i64 %18, i64* @rubyStrFrozen_else, align 8
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.6, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !29
+  %19 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 249), i64 noundef 6) #11
+  call void @rb_gc_register_mark_object(i64 %19) #11
+  store i64 %19, i64* @rubyStrFrozen_ensure, align 8
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.7, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !31
+  %20 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 256), i64 noundef 9) #11
+  call void @rb_gc_register_mark_object(i64 %20) #11
+  %"rubyId_<class:A>.i.i" = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 12), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i30.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/exceptions/basic.rb", align 8
-  %36 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %35, i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i30.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i31.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %36, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %37 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !33
-  %38 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %37, i64 0, i32 18
-  %39 = load i64, i64* %38, align 8, !tbaa !35
-  %40 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !33
-  %41 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %40, i64 0, i32 2
-  %42 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %41, align 8, !tbaa !45
+  %21 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %20, i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i30.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i31.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %21, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
+  %22 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !33
+  %23 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %22, i64 0, i32 18
+  %24 = load i64, i64* %23, align 8, !tbaa !35
+  %25 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !33
+  %26 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %25, i64 0, i32 2
+  %27 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %26, align 8, !tbaa !45
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %43 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %42, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %43, align 8, !tbaa !48
-  %44 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %42, i64 0, i32 4
-  %45 = load i64*, i64** %44, align 8, !tbaa !50
-  %46 = load i64, i64* %45, align 8, !tbaa !6
-  %47 = and i64 %46, -33
-  store i64 %47, i64* %45, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %40, %struct.rb_control_frame_struct* %42, %struct.rb_iseq_struct* %stackFrame.i) #11
-  %48 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %42, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %48, align 8, !dbg !51, !tbaa !33
-  %49 = load i64, i64* @rb_cObject, align 8, !dbg !52
-  %50 = call i64 @rb_define_class(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 60), i64 %49) #11, !dbg !52
-  %51 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %50) #11, !dbg !52
-  %52 = bitcast i64* %positional_table.i.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %52) #11
+  %28 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %27, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %28, align 8, !tbaa !48
+  %29 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %27, i64 0, i32 4
+  %30 = load i64*, i64** %29, align 8, !tbaa !50
+  %31 = load i64, i64* %30, align 8, !tbaa !6
+  %32 = and i64 %31, -33
+  store i64 %32, i64* %30, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %25, %struct.rb_control_frame_struct* %27, %struct.rb_iseq_struct* %stackFrame.i) #11
+  %33 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %27, i64 0, i32 0
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %33, align 8, !dbg !51, !tbaa !33
+  %34 = load i64, i64* @rb_cObject, align 8, !dbg !52
+  %35 = call i64 @rb_define_class(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 60), i64 %34) #11, !dbg !52
+  %36 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %35) #11, !dbg !52
+  %37 = bitcast i64* %positional_table.i.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %37) #11
   %stackFrame.i.i1 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %53 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !33
-  %54 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %53, i64 0, i32 2
-  %55 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %54, align 8, !tbaa !45
-  %56 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %55, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i.i1, %struct.rb_iseq_struct** %56, align 8, !tbaa !48
-  %57 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %55, i64 0, i32 4
-  %58 = load i64*, i64** %57, align 8, !tbaa !50
-  %59 = load i64, i64* %58, align 8, !tbaa !6
-  %60 = and i64 %59, -33
-  store i64 %60, i64* %58, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %53, %struct.rb_control_frame_struct* %55, %struct.rb_iseq_struct* %stackFrame.i.i1) #11
-  %61 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %51, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %61, align 8, !dbg !53, !tbaa !33
-  %62 = load i64, i64* @guard_epoch_A, align 8, !dbg !10
-  %63 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !54
-  %needTakeSlowPath = icmp ne i64 %62, %63, !dbg !10
-  br i1 %needTakeSlowPath, label %64, label %65, !dbg !10, !prof !55
+  %38 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !33
+  %39 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %38, i64 0, i32 2
+  %40 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %39, align 8, !tbaa !45
+  %41 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %40, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i.i1, %struct.rb_iseq_struct** %41, align 8, !tbaa !48
+  %42 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %40, i64 0, i32 4
+  %43 = load i64*, i64** %42, align 8, !tbaa !50
+  %44 = load i64, i64* %43, align 8, !tbaa !6
+  %45 = and i64 %44, -33
+  store i64 %45, i64* %43, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %38, %struct.rb_control_frame_struct* %40, %struct.rb_iseq_struct* %stackFrame.i.i1) #11
+  %46 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 0
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %46, align 8, !dbg !53, !tbaa !33
+  %47 = load i64, i64* @guard_epoch_A, align 8, !dbg !10
+  %48 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !54
+  %needTakeSlowPath = icmp ne i64 %47, %48, !dbg !10
+  br i1 %needTakeSlowPath, label %49, label %50, !dbg !10, !prof !55
 
-64:                                               ; preds = %entry
+49:                                               ; preds = %entry
   call void @const_recompute_A(), !dbg !10
-  br label %65, !dbg !10
+  br label %50, !dbg !10
 
-65:                                               ; preds = %entry, %64
-  %66 = load i64, i64* @guarded_const_A, align 8, !dbg !10
-  %67 = load i64, i64* @guard_epoch_A, align 8, !dbg !10
-  %68 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !54
-  %guardUpdated = icmp eq i64 %67, %68, !dbg !10
+50:                                               ; preds = %entry, %49
+  %51 = load i64, i64* @guarded_const_A, align 8, !dbg !10
+  %52 = load i64, i64* @guard_epoch_A, align 8, !dbg !10
+  %53 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !54
+  %guardUpdated = icmp eq i64 %52, %53, !dbg !10
   call void @llvm.assume(i1 %guardUpdated), !dbg !10
   %stackFrame7.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_A.4test, align 8, !dbg !10
-  %69 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !10
-  %70 = bitcast i8* %69 to i16*, !dbg !10
-  %71 = load i16, i16* %70, align 8, !dbg !10
-  %72 = and i16 %71, -384, !dbg !10
-  %73 = or i16 %72, 1, !dbg !10
-  store i16 %73, i16* %70, align 8, !dbg !10
-  %74 = getelementptr inbounds i8, i8* %69, i64 8, !dbg !10
-  %75 = bitcast i8* %74 to i32*, !dbg !10
-  store i32 1, i32* %75, align 8, !dbg !10, !tbaa !56
-  %76 = getelementptr inbounds i8, i8* %69, i64 12, !dbg !10
-  %77 = getelementptr inbounds i8, i8* %69, i64 4, !dbg !10
-  %78 = bitcast i8* %77 to i32*, !dbg !10
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %76, i8 0, i64 20, i1 false) #11, !dbg !10
-  store i32 1, i32* %78, align 4, !dbg !10, !tbaa !59
-  %rubyId_x.i.i2 = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !10
-  store i64 %rubyId_x.i.i2, i64* %positional_table.i.i, align 8, !dbg !10
-  %79 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !10
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %79, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %52, i64 noundef 8, i1 noundef false) #11, !dbg !10
-  %80 = getelementptr inbounds i8, i8* %69, i64 32, !dbg !10
-  %81 = bitcast i8* %80 to i8**, !dbg !10
-  store i8* %79, i8** %81, align 8, !dbg !10, !tbaa !60
-  call void @sorbet_vm_define_method(i64 %66, i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 91), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_A.4test, i8* nonnull %69, %struct.rb_iseq_struct* %stackFrame7.i.i, i1 noundef zeroext true) #11, !dbg !10
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %52) #11
+  %54 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !10
+  %55 = bitcast i8* %54 to i16*, !dbg !10
+  %56 = load i16, i16* %55, align 8, !dbg !10
+  %57 = and i16 %56, -384, !dbg !10
+  %58 = or i16 %57, 1, !dbg !10
+  store i16 %58, i16* %55, align 8, !dbg !10
+  %59 = getelementptr inbounds i8, i8* %54, i64 8, !dbg !10
+  %60 = bitcast i8* %59 to i32*, !dbg !10
+  store i32 1, i32* %60, align 8, !dbg !10, !tbaa !56
+  %61 = getelementptr inbounds i8, i8* %54, i64 12, !dbg !10
+  %62 = getelementptr inbounds i8, i8* %54, i64 4, !dbg !10
+  %63 = bitcast i8* %62 to i32*, !dbg !10
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %61, i8 0, i64 20, i1 false) #11, !dbg !10
+  store i32 1, i32* %63, align 4, !dbg !10, !tbaa !59
+  %64 = extractelement <4 x i64> %7, i32 1, !dbg !10
+  store i64 %64, i64* %positional_table.i.i, align 8, !dbg !10
+  %65 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !10
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %65, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %37, i64 noundef 8, i1 noundef false) #11, !dbg !10
+  %66 = getelementptr inbounds i8, i8* %54, i64 32, !dbg !10
+  %67 = bitcast i8* %66 to i8**, !dbg !10
+  store i8* %65, i8** %67, align 8, !dbg !10, !tbaa !60
+  call void @sorbet_vm_define_method(i64 %51, i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 91), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_A.4test, i8* nonnull %54, %struct.rb_iseq_struct* %stackFrame7.i.i, i1 noundef zeroext true) #11, !dbg !10
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %37) #11
   call void @sorbet_popFrame() #11, !dbg !52
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %48, align 8, !dbg !52, !tbaa !33
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %33, align 8, !dbg !52, !tbaa !33
   %"rubyStr_=== no-raise ===.i" = load i64, i64* @"rubyStrFrozen_=== no-raise ===", align 8, !dbg !61
-  %82 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %42, i64 0, i32 1, !dbg !17
-  %83 = load i64*, i64** %82, align 8, !dbg !17
-  store i64 %39, i64* %83, align 8, !dbg !17, !tbaa !6
-  %84 = getelementptr inbounds i64, i64* %83, i64 1, !dbg !17
-  store i64 %"rubyStr_=== no-raise ===.i", i64* %84, align 8, !dbg !17, !tbaa !6
-  %85 = getelementptr inbounds i64, i64* %84, i64 1, !dbg !17
-  store i64* %85, i64** %82, align 8, !dbg !17
+  %68 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %27, i64 0, i32 1, !dbg !17
+  %69 = load i64*, i64** %68, align 8, !dbg !17
+  store i64 %24, i64* %69, align 8, !dbg !17, !tbaa !6
+  %70 = getelementptr inbounds i64, i64* %69, i64 1, !dbg !17
+  store i64 %"rubyStr_=== no-raise ===.i", i64* %70, align 8, !dbg !17, !tbaa !6
+  %71 = getelementptr inbounds i64, i64* %70, i64 1, !dbg !17
+  store i64* %71, i64** %68, align 8, !dbg !17
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !17
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %48, align 8, !dbg !17, !tbaa !33
-  %86 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %42, i64 0, i32 1, !dbg !18
-  %87 = load i64*, i64** %86, align 8, !dbg !18
-  store i64 %66, i64* %87, align 8, !dbg !18, !tbaa !6
-  %88 = getelementptr inbounds i64, i64* %87, i64 1, !dbg !18
-  store i64 0, i64* %88, align 8, !dbg !18, !tbaa !6
-  %89 = getelementptr inbounds i64, i64* %88, i64 1, !dbg !18
-  store i64* %89, i64** %86, align 8, !dbg !18
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %33, align 8, !dbg !17, !tbaa !33
+  %72 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %27, i64 0, i32 1, !dbg !18
+  %73 = load i64*, i64** %72, align 8, !dbg !18
+  store i64 %51, i64* %73, align 8, !dbg !18, !tbaa !6
+  %74 = getelementptr inbounds i64, i64* %73, i64 1, !dbg !18
+  store i64 0, i64* %74, align 8, !dbg !18, !tbaa !6
+  %75 = getelementptr inbounds i64, i64* %74, i64 1, !dbg !18
+  store i64* %75, i64** %72, align 8, !dbg !18
   %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test, i64 0), !dbg !18
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %48, align 8, !dbg !18, !tbaa !33
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %33, align 8, !dbg !18, !tbaa !33
   %"rubyStr_=== raise ===.i" = load i64, i64* @"rubyStrFrozen_=== raise ===", align 8, !dbg !62
-  %90 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %42, i64 0, i32 1, !dbg !19
-  %91 = load i64*, i64** %90, align 8, !dbg !19
-  store i64 %39, i64* %91, align 8, !dbg !19, !tbaa !6
-  %92 = getelementptr inbounds i64, i64* %91, i64 1, !dbg !19
-  store i64 %"rubyStr_=== raise ===.i", i64* %92, align 8, !dbg !19, !tbaa !6
-  %93 = getelementptr inbounds i64, i64* %92, i64 1, !dbg !19
-  store i64* %93, i64** %90, align 8, !dbg !19
+  %76 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %27, i64 0, i32 1, !dbg !19
+  %77 = load i64*, i64** %76, align 8, !dbg !19
+  store i64 %24, i64* %77, align 8, !dbg !19, !tbaa !6
+  %78 = getelementptr inbounds i64, i64* %77, i64 1, !dbg !19
+  store i64 %"rubyStr_=== raise ===.i", i64* %78, align 8, !dbg !19, !tbaa !6
+  %79 = getelementptr inbounds i64, i64* %78, i64 1, !dbg !19
+  store i64* %79, i64** %76, align 8, !dbg !19
   %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.1, i64 0), !dbg !19
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %48, align 8, !dbg !19, !tbaa !33
-  %94 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %42, i64 0, i32 1, !dbg !20
-  %95 = load i64*, i64** %94, align 8, !dbg !20
-  store i64 %66, i64* %95, align 8, !dbg !20, !tbaa !6
-  %96 = getelementptr inbounds i64, i64* %95, i64 1, !dbg !20
-  store i64 20, i64* %96, align 8, !dbg !20, !tbaa !6
-  %97 = getelementptr inbounds i64, i64* %96, i64 1, !dbg !20
-  store i64* %97, i64** %94, align 8, !dbg !20
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %33, align 8, !dbg !19, !tbaa !33
+  %80 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %27, i64 0, i32 1, !dbg !20
+  %81 = load i64*, i64** %80, align 8, !dbg !20
+  store i64 %51, i64* %81, align 8, !dbg !20, !tbaa !6
+  %82 = getelementptr inbounds i64, i64* %81, i64 1, !dbg !20
+  store i64 20, i64* %82, align 8, !dbg !20, !tbaa !6
+  %83 = getelementptr inbounds i64, i64* %82, i64 1, !dbg !20
+  store i64* %83, i64** %80, align 8, !dbg !20
   %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test.2, i64 0), !dbg !20
   ret void
 }

--- a/test/testdata/compiler/float-intrinsics.opt.ll.exp
+++ b/test/testdata/compiler/float-intrinsics.opt.ll.exp
@@ -83,37 +83,24 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_Object#4plus" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@rubyIdPrecomputed_plus = internal unnamed_addr global i64 0, align 8
 @rubyStrFrozen_plus = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [49 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @"stackFramePrecomputed_func_Object#5minus" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@rubyIdPrecomputed_minus = internal unnamed_addr global i64 0, align 8
 @ic_- = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_- = internal unnamed_addr global i64 0, align 8
 @"stackFramePrecomputed_func_Object#2lt" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@rubyIdPrecomputed_lt = internal unnamed_addr global i64 0, align 8
 @"stackFramePrecomputed_func_Object#3lte" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@rubyIdPrecomputed_lte = internal unnamed_addr global i64 0, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"rubyIdPrecomputed_<block-call>" = internal unnamed_addr global i64 0, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_block in <top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_block in <top (required)>" = internal unnamed_addr global i64 0, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_2" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_3" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_4" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@rubyIdPrecomputed_x = internal unnamed_addr global i64 0, align 8
-@rubyIdPrecomputed_y = internal unnamed_addr global i64 0, align 8
 @ic_untyped = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_untyped = internal unnamed_addr global i64 0, align 8
 @ic_params = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_params = internal unnamed_addr global i64 0, align 8
 @ic_untyped.1 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_returns = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_returns = internal unnamed_addr global i64 0, align 8
 @ic_untyped.2 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_params.3 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_untyped.4 = internal global %struct.FunctionInlineCache zeroinitializer
@@ -125,10 +112,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ic_params.10 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_returns.11 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_extend = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_extend = internal unnamed_addr global i64 0, align 8
 @ic_plus = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_p = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_p = internal unnamed_addr global i64 0, align 8
 @ic_minus = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_p.12 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_lt = internal global %struct.FunctionInlineCache zeroinitializer
@@ -145,12 +130,10 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ic_p.22 = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyStrFrozen_8.9 = internal unnamed_addr global i64 0, align 8
 @ic_Rational = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_Rational = internal unnamed_addr global i64 0, align 8
 @ic_plus.23 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_p.24 = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyStrFrozen_5 = internal unnamed_addr global i64 0, align 8
 @ic_Complex = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_Complex = internal unnamed_addr global i64 0, align 8
 @ic_plus.25 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_p.26 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_minus.27 = internal global %struct.FunctionInlineCache zeroinitializer
@@ -176,6 +159,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ic_lte.43 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_p.44 = internal global %struct.FunctionInlineCache zeroinitializer
 @sorbet_moduleStringTable = internal unnamed_addr constant [309 x i8] c"plus\00test/testdata/compiler/float-intrinsics.rb\00Parameter 'x'\00Float\00Parameter 'y'\00T.untyped\00+\00Return value\00minus\00-\00lt\00<\00T::Boolean\00lte\00<=\00<top (required)>\00<block-call>\00block in <top (required)>\00x\00y\00untyped\00T\00params\00returns\00T::Sig\00extend\00normal\00Object\00p\008.9\00Rational\00Kernel\005\00Complex\0015.4\0018\0025.4\005.923\00master\00", align 1
+@sorbet_moduleIDTable = internal unnamed_addr global [21 x i64] zeroinitializer, align 8
+@sorbet_moduleIDDescriptors = internal unnamed_addr constant [21 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 4 }, %struct.rb_code_position_struct { i32 92, i32 1 }, %struct.rb_code_position_struct { i32 107, i32 5 }, %struct.rb_code_position_struct { i32 113, i32 1 }, %struct.rb_code_position_struct { i32 115, i32 2 }, %struct.rb_code_position_struct { i32 118, i32 1 }, %struct.rb_code_position_struct { i32 131, i32 3 }, %struct.rb_code_position_struct { i32 135, i32 2 }, %struct.rb_code_position_struct { i32 138, i32 16 }, %struct.rb_code_position_struct { i32 155, i32 12 }, %struct.rb_code_position_struct { i32 168, i32 25 }, %struct.rb_code_position_struct { i32 194, i32 1 }, %struct.rb_code_position_struct { i32 196, i32 1 }, %struct.rb_code_position_struct { i32 198, i32 7 }, %struct.rb_code_position_struct { i32 208, i32 6 }, %struct.rb_code_position_struct { i32 215, i32 7 }, %struct.rb_code_position_struct { i32 230, i32 6 }, %struct.rb_code_position_struct { i32 237, i32 6 }, %struct.rb_code_position_struct { i32 251, i32 1 }, %struct.rb_code_position_struct { i32 257, i32 8 }, %struct.rb_code_position_struct { i32 275, i32 7 }], align 8
 @guard_epoch_T = linkonce local_unnamed_addr global i64 0
 @guarded_const_T = linkonce local_unnamed_addr global i64 0
 @rb_cFloat = external local_unnamed_addr constant i64
@@ -219,9 +204,9 @@ declare void @sorbet_vm_register_sig(i64, i64, i64, i64, i64 (i64, i64, i32, i64
 
 declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #0
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
+declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #0
 
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #0
+declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
 
 declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
 
@@ -847,832 +832,720 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %2)
   %3 = bitcast i64* %keywords38.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %3)
-  %4 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 4) #17
-  store i64 %4, i64* @rubyIdPrecomputed_plus, align 8
-  %5 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 92), i64 noundef 1) #17
-  %6 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 107), i64 noundef 5) #17
-  store i64 %6, i64* @rubyIdPrecomputed_minus, align 8
-  %7 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 113), i64 noundef 1) #17
-  store i64 %7, i64* @rubyIdPrecomputed_-, align 8
-  %8 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 115), i64 noundef 2) #17
-  store i64 %8, i64* @rubyIdPrecomputed_lt, align 8
-  %9 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 118), i64 noundef 1) #17
-  %10 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 131), i64 noundef 3) #17
-  store i64 %10, i64* @rubyIdPrecomputed_lte, align 8
-  %11 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 135), i64 noundef 2) #17
-  %12 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 138), i64 noundef 16) #17
-  store i64 %12, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %13 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 155), i64 noundef 12) #17
-  store i64 %13, i64* @"rubyIdPrecomputed_<block-call>", align 8
-  %14 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 168), i64 noundef 25) #17
-  store i64 %14, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
-  %15 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 194), i64 noundef 1) #17
-  store i64 %15, i64* @rubyIdPrecomputed_x, align 8
-  %16 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 196), i64 noundef 1) #17
-  store i64 %16, i64* @rubyIdPrecomputed_y, align 8
-  %17 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 198), i64 noundef 7) #17
-  store i64 %17, i64* @rubyIdPrecomputed_untyped, align 8
-  %18 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 208), i64 noundef 6) #17
-  store i64 %18, i64* @rubyIdPrecomputed_params, align 8
-  %19 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 215), i64 noundef 7) #17
-  store i64 %19, i64* @rubyIdPrecomputed_returns, align 8
-  %20 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 230), i64 noundef 6) #17
-  store i64 %20, i64* @rubyIdPrecomputed_extend, align 8
-  %21 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 237), i64 noundef 6) #17
-  %22 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 251), i64 noundef 1) #17
-  store i64 %22, i64* @rubyIdPrecomputed_p, align 8
-  %23 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 257), i64 noundef 8) #17
-  store i64 %23, i64* @rubyIdPrecomputed_Rational, align 8
-  %24 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 275), i64 noundef 7) #17
-  store i64 %24, i64* @rubyIdPrecomputed_Complex, align 8
-  %25 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 4) #17
-  tail call void @rb_gc_register_mark_object(i64 %25) #17
-  store i64 %25, i64* @rubyStrFrozen_plus, align 8
-  %26 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 5), i64 noundef 42) #17
-  tail call void @rb_gc_register_mark_object(i64 %26) #17
-  store i64 %26, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
+  tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([21 x %struct.rb_code_position_struct], [21 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 21, i8* noundef getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
+  %4 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 4) #17
+  tail call void @rb_gc_register_mark_object(i64 %4) #17
+  store i64 %4, i64* @rubyStrFrozen_plus, align 8
+  %5 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 5), i64 noundef 42) #17
+  tail call void @rb_gc_register_mark_object(i64 %5) #17
+  store i64 %5, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 49)
-  %rubyId_plus.i.i = load i64, i64* @rubyIdPrecomputed_plus, align 8
+  %rubyId_plus.i.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
   %rubyStr_plus.i.i = load i64, i64* @rubyStrFrozen_plus, align 8
   %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
-  %27 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_plus.i.i, i64 %rubyId_plus.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %27, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#4plus", align 8
-  %28 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 107), i64 noundef 5) #17
-  call void @rb_gc_register_mark_object(i64 %28) #17
-  %rubyId_minus.i.i = load i64, i64* @rubyIdPrecomputed_minus, align 8
+  %6 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_plus.i.i, i64 %rubyId_plus.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %6, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#4plus", align 8
+  %7 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 107), i64 noundef 5) #17
+  call void @rb_gc_register_mark_object(i64 %7) #17
+  %rubyId_minus.i.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i156.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
-  %29 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %28, i64 %rubyId_minus.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i156.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 13, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i157.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %29, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#5minus", align 8
-  %rubyId_-.i = load i64, i64* @rubyIdPrecomputed_-, align 8, !dbg !37
+  %8 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %7, i64 %rubyId_minus.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i156.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 13, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i157.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %8, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#5minus", align 8
+  %rubyId_-.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !37, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_-, i64 %rubyId_-.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !37
-  %30 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 115), i64 noundef 2) #17
-  call void @rb_gc_register_mark_object(i64 %30) #17
-  %rubyId_lt.i.i = load i64, i64* @rubyIdPrecomputed_lt, align 8
+  %9 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 115), i64 noundef 2) #17
+  call void @rb_gc_register_mark_object(i64 %9) #17
+  %rubyId_lt.i.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i158.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
-  %31 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %30, i64 %rubyId_lt.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i158.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 18, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i159.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %31, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#2lt", align 8
-  %32 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 131), i64 noundef 3) #17
-  call void @rb_gc_register_mark_object(i64 %32) #17
-  %rubyId_lte.i.i = load i64, i64* @rubyIdPrecomputed_lte, align 8
+  %10 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %9, i64 %rubyId_lt.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i158.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 18, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i159.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %10, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#2lt", align 8
+  %11 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 131), i64 noundef 3) #17
+  call void @rb_gc_register_mark_object(i64 %11) #17
+  %rubyId_lte.i.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 6), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i160.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
-  %33 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %32, i64 %rubyId_lte.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i160.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 23, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i161.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %33, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3lte", align 8
-  %34 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 138), i64 noundef 16) #17
-  call void @rb_gc_register_mark_object(i64 %34) #17
-  %35 = bitcast i64* %locals.i163.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %35)
-  %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
+  %12 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %11, i64 %rubyId_lte.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i160.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 23, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i161.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %12, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3lte", align 8
+  %13 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 138), i64 noundef 16) #17
+  call void @rb_gc_register_mark_object(i64 %13) #17
+  %14 = bitcast i64* %locals.i163.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %14)
+  %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 8), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i162.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
-  %"rubyId_<block-call>.i.i" = load i64, i64* @"rubyIdPrecomputed_<block-call>", align 8
+  %"rubyId_<block-call>.i.i" = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 9), align 8, !invariant.load !5
   store i64 %"rubyId_<block-call>.i.i", i64* %locals.i163.i, align 8
-  %36 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %34, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i162.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i163.i, i32 noundef 1, i32 noundef 4)
-  store %struct.rb_iseq_struct* %36, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %35)
-  %37 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 168), i64 noundef 25) #17
-  call void @rb_gc_register_mark_object(i64 %37) #17
-  store i64 %37, i64* @"rubyStrFrozen_block in <top (required)>", align 8
+  %15 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %13, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i162.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i163.i, i32 noundef 1, i32 noundef 4)
+  store %struct.rb_iseq_struct* %15, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %14)
+  %16 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 168), i64 noundef 25) #17
+  call void @rb_gc_register_mark_object(i64 %16) #17
+  store i64 %16, i64* @"rubyStrFrozen_block in <top (required)>", align 8
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %"rubyId_block in <top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
+  %"rubyId_block in <top (required)>.i.i" = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 10), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i164.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
-  %38 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %37, i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i164.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %38, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1", align 8
+  %17 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %16, i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i164.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %17, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1", align 8
   %stackFrame.i165.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %"rubyId_block in <top (required)>.i166.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
   %"rubyStr_block in <top (required)>.i167.i" = load i64, i64* @"rubyStrFrozen_block in <top (required)>", align 8
   %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i168.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
-  %39 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i167.i", i64 %"rubyId_block in <top (required)>.i166.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i168.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i165.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %39, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_2", align 8
+  %18 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i167.i", i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i168.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i165.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %18, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_2", align 8
   %stackFrame.i169.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %"rubyId_block in <top (required)>.i170.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
   %"rubyStr_block in <top (required)>.i171.i" = load i64, i64* @"rubyStrFrozen_block in <top (required)>", align 8
   %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i172.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
-  %40 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i171.i", i64 %"rubyId_block in <top (required)>.i170.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i172.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i169.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %40, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_3", align 8
+  %19 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i171.i", i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i172.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i169.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %19, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_3", align 8
   %stackFrame.i173.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %"rubyId_block in <top (required)>.i174.i" = load i64, i64* @"rubyIdPrecomputed_block in <top (required)>", align 8
   %"rubyStr_block in <top (required)>.i175.i" = load i64, i64* @"rubyStrFrozen_block in <top (required)>", align 8
   %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i176.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
-  %41 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i175.i", i64 %"rubyId_block in <top (required)>.i174.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i176.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i173.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %41, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_4", align 8
-  %rubyId_untyped.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !64
+  %20 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i175.i", i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i176.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i173.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %20, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_4", align 8
+  %rubyId_untyped.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 13), align 8, !dbg !64, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped, i64 %rubyId_untyped.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !64
-  %rubyId_params.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !68
-  %rubyId_x.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !68
-  %42 = call i64 @rb_id2sym(i64 %rubyId_x.i) #18, !dbg !68
-  store i64 %42, i64* %keywords.i, align 8, !dbg !68
-  %rubyId_y.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !68
-  %43 = call i64 @rb_id2sym(i64 %rubyId_y.i) #18, !dbg !68
-  %44 = getelementptr i64, i64* %keywords.i, i32 1, !dbg !68
-  store i64 %43, i64* %44, align 8, !dbg !68
+  %rubyId_params.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 14), align 8, !dbg !68, !invariant.load !5
+  %rubyId_x.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 11), align 8, !dbg !68, !invariant.load !5
+  %21 = call i64 @rb_id2sym(i64 %rubyId_x.i) #18, !dbg !68
+  store i64 %21, i64* %keywords.i, align 8, !dbg !68
+  %rubyId_y.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 12), align 8, !dbg !68, !invariant.load !5
+  %22 = call i64 @rb_id2sym(i64 %rubyId_y.i) #18, !dbg !68
+  %23 = getelementptr i64, i64* %keywords.i, i32 1, !dbg !68
+  store i64 %22, i64* %23, align 8, !dbg !68
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull align 8 %keywords.i), !dbg !68
-  %rubyId_untyped6.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !69
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.1, i64 %rubyId_untyped6.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !69
-  %rubyId_returns.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !68
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.1, i64 %rubyId_untyped.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !69
+  %rubyId_returns.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 15), align 8, !dbg !68, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !68
-  %rubyId_untyped9.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !72
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.2, i64 %rubyId_untyped9.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !72
-  %rubyId_params11.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !73
-  %rubyId_x13.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !73
-  %45 = call i64 @rb_id2sym(i64 %rubyId_x13.i) #18, !dbg !73
-  store i64 %45, i64* %keywords12.i, align 8, !dbg !73
-  %rubyId_y15.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !73
-  %46 = call i64 @rb_id2sym(i64 %rubyId_y15.i) #18, !dbg !73
-  %47 = getelementptr i64, i64* %keywords12.i, i32 1, !dbg !73
-  store i64 %46, i64* %47, align 8, !dbg !73
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params.3, i64 %rubyId_params11.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull align 8 %keywords12.i), !dbg !73
-  %rubyId_untyped19.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !74
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.4, i64 %rubyId_untyped19.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !74
-  %rubyId_returns21.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !73
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.5, i64 %rubyId_returns21.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !73
-  %rubyId_untyped23.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !77
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.6, i64 %rubyId_untyped23.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !77
-  %rubyId_params25.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !78
-  %rubyId_x27.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !78
-  %48 = call i64 @rb_id2sym(i64 %rubyId_x27.i) #18, !dbg !78
-  store i64 %48, i64* %keywords26.i, align 8, !dbg !78
-  %rubyId_y29.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !78
-  %49 = call i64 @rb_id2sym(i64 %rubyId_y29.i) #18, !dbg !78
-  %50 = getelementptr i64, i64* %keywords26.i, i32 1, !dbg !78
-  store i64 %49, i64* %50, align 8, !dbg !78
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params.7, i64 %rubyId_params25.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull align 8 %keywords26.i), !dbg !78
-  %rubyId_returns33.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !78
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.8, i64 %rubyId_returns33.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !78
-  %rubyId_untyped35.i = load i64, i64* @rubyIdPrecomputed_untyped, align 8, !dbg !81
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.9, i64 %rubyId_untyped35.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !81
-  %rubyId_params37.i = load i64, i64* @rubyIdPrecomputed_params, align 8, !dbg !82
-  %rubyId_x39.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !82
-  %51 = call i64 @rb_id2sym(i64 %rubyId_x39.i) #18, !dbg !82
-  store i64 %51, i64* %keywords38.i, align 8, !dbg !82
-  %rubyId_y41.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !82
-  %52 = call i64 @rb_id2sym(i64 %rubyId_y41.i) #18, !dbg !82
-  %53 = getelementptr i64, i64* %keywords38.i, i32 1, !dbg !82
-  store i64 %52, i64* %53, align 8, !dbg !82
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params.10, i64 %rubyId_params37.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull align 8 %keywords38.i), !dbg !82
-  %rubyId_returns45.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !82
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.11, i64 %rubyId_returns45.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !82
-  %rubyId_extend.i = load i64, i64* @rubyIdPrecomputed_extend, align 8, !dbg !88
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.2, i64 %rubyId_untyped.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !72
+  store i64 %21, i64* %keywords12.i, align 8, !dbg !73
+  %24 = getelementptr i64, i64* %keywords12.i, i32 1, !dbg !73
+  store i64 %22, i64* %24, align 8, !dbg !73
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params.3, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull align 8 %keywords12.i), !dbg !73
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.4, i64 %rubyId_untyped.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !74
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.5, i64 %rubyId_returns.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !73
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.6, i64 %rubyId_untyped.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !77
+  store i64 %21, i64* %keywords26.i, align 8, !dbg !78
+  %25 = getelementptr i64, i64* %keywords26.i, i32 1, !dbg !78
+  store i64 %22, i64* %25, align 8, !dbg !78
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params.7, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull align 8 %keywords26.i), !dbg !78
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.8, i64 %rubyId_returns.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !78
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.9, i64 %rubyId_untyped.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !81
+  store i64 %21, i64* %keywords38.i, align 8, !dbg !82
+  %26 = getelementptr i64, i64* %keywords38.i, i32 1, !dbg !82
+  store i64 %22, i64* %26, align 8, !dbg !82
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params.10, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull align 8 %keywords38.i), !dbg !82
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.11, i64 %rubyId_returns.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !82
+  %rubyId_extend.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 16), align 8, !dbg !88, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !88
-  %rubyId_plus.i = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !89
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus, i64 %rubyId_plus.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !89
-  %rubyId_p.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !90
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus, i64 %rubyId_plus.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !89
+  %rubyId_p.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 18), align 8, !dbg !90, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !90
-  %rubyId_minus.i = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !91
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus, i64 %rubyId_minus.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !91
-  %rubyId_p55.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !92
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.12, i64 %rubyId_p55.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !92
-  %rubyId_lt.i = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !93
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt, i64 %rubyId_lt.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !93
-  %rubyId_p60.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !94
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.13, i64 %rubyId_p60.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !94
-  %rubyId_lt63.i = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !95
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt.14, i64 %rubyId_lt63.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !95
-  %rubyId_p66.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !96
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.15, i64 %rubyId_p66.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !96
-  %rubyId_lte.i = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !97
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte, i64 %rubyId_lte.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !97
-  %rubyId_p71.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !98
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.16, i64 %rubyId_p71.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !98
-  %rubyId_lte74.i = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !99
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.17, i64 %rubyId_lte74.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !99
-  %rubyId_p77.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !100
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.18, i64 %rubyId_p77.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !100
-  %rubyId_lte80.i = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !101
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.19, i64 %rubyId_lte80.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !101
-  %rubyId_p83.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !102
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.20, i64 %rubyId_p83.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !102
-  %rubyId_plus86.i = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !103
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus.21, i64 %rubyId_plus86.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !103
-  %rubyId_p89.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !104
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.22, i64 %rubyId_p89.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !104
-  %54 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 253), i64 noundef 3) #17
-  call void @rb_gc_register_mark_object(i64 %54) #17
-  store i64 %54, i64* @rubyStrFrozen_8.9, align 8
-  %rubyId_Rational.i = load i64, i64* @rubyIdPrecomputed_Rational, align 8, !dbg !105
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus, i64 %rubyId_minus.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !91
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.12, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !92
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt, i64 %rubyId_lt.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !93
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.13, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !94
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt.14, i64 %rubyId_lt.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !95
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.15, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !96
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte, i64 %rubyId_lte.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !97
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.16, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !98
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.17, i64 %rubyId_lte.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !99
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.18, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !100
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.19, i64 %rubyId_lte.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !101
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.20, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !102
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus.21, i64 %rubyId_plus.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !103
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.22, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !104
+  %27 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 253), i64 noundef 3) #17
+  call void @rb_gc_register_mark_object(i64 %27) #17
+  store i64 %27, i64* @rubyStrFrozen_8.9, align 8
+  %rubyId_Rational.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 19), align 8, !dbg !105, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational, i64 %rubyId_Rational.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !105
-  %rubyId_plus93.i = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !106
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus.23, i64 %rubyId_plus93.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !106
-  %rubyId_p96.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !107
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.24, i64 %rubyId_p96.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !107
-  %55 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 273), i64 noundef 1) #17
-  call void @rb_gc_register_mark_object(i64 %55) #17
-  store i64 %55, i64* @rubyStrFrozen_5, align 8
-  %rubyId_Complex.i = load i64, i64* @rubyIdPrecomputed_Complex, align 8, !dbg !108
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus.23, i64 %rubyId_plus.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !106
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.24, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !107
+  %28 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 273), i64 noundef 1) #17
+  call void @rb_gc_register_mark_object(i64 %28) #17
+  store i64 %28, i64* @rubyStrFrozen_5, align 8
+  %rubyId_Complex.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 20), align 8, !dbg !108, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Complex, i64 %rubyId_Complex.i, i32 noundef 16, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !108
-  %rubyId_plus100.i = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !109
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus.25, i64 %rubyId_plus100.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !109
-  %rubyId_p103.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !110
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.26, i64 %rubyId_p103.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !110
-  %rubyId_minus106.i = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !111
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus.27, i64 %rubyId_minus106.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !111
-  %rubyId_p109.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !112
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.28, i64 %rubyId_p109.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !112
-  %56 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 283), i64 noundef 4) #17
-  call void @rb_gc_register_mark_object(i64 %56) #17
-  store i64 %56, i64* @rubyStrFrozen_15.4, align 8
-  %rubyId_Rational112.i = load i64, i64* @rubyIdPrecomputed_Rational, align 8, !dbg !113
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational.29, i64 %rubyId_Rational112.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !113
-  %rubyId_minus114.i = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !114
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus.30, i64 %rubyId_minus114.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !114
-  %rubyId_p117.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !115
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.31, i64 %rubyId_p117.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !115
-  %57 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 288), i64 noundef 2) #17
-  call void @rb_gc_register_mark_object(i64 %57) #17
-  store i64 %57, i64* @rubyStrFrozen_18, align 8
-  %rubyId_Complex120.i = load i64, i64* @rubyIdPrecomputed_Complex, align 8, !dbg !116
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Complex.32, i64 %rubyId_Complex120.i, i32 noundef 16, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !116
-  %rubyId_minus122.i = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !117
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus.33, i64 %rubyId_minus122.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !117
-  %rubyId_p125.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !118
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.34, i64 %rubyId_p125.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !118
-  %rubyId_lt128.i = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !119
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt.35, i64 %rubyId_lt128.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !119
-  %rubyId_p131.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !120
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.36, i64 %rubyId_p131.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !120
-  %58 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 291), i64 noundef 4) #17
-  call void @rb_gc_register_mark_object(i64 %58) #17
-  store i64 %58, i64* @rubyStrFrozen_25.4, align 8
-  %rubyId_Rational134.i = load i64, i64* @rubyIdPrecomputed_Rational, align 8, !dbg !121
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational.37, i64 %rubyId_Rational134.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !121
-  %rubyId_lt136.i = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !122
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt.38, i64 %rubyId_lt136.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !122
-  %rubyId_p139.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !123
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.39, i64 %rubyId_p139.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !123
-  %rubyId_lte142.i = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !124
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.40, i64 %rubyId_lte142.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !124
-  %rubyId_p145.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !125
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.41, i64 %rubyId_p145.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !125
-  %59 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 296), i64 noundef 5) #17
-  call void @rb_gc_register_mark_object(i64 %59) #17
-  store i64 %59, i64* @rubyStrFrozen_5.923, align 8
-  %rubyId_Rational148.i = load i64, i64* @rubyIdPrecomputed_Rational, align 8, !dbg !126
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational.42, i64 %rubyId_Rational148.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !126
-  %rubyId_lte150.i = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !127
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.43, i64 %rubyId_lte150.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !127
-  %rubyId_p153.i = load i64, i64* @rubyIdPrecomputed_p, align 8, !dbg !128
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.44, i64 %rubyId_p153.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !128
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus.25, i64 %rubyId_plus.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !109
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.26, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !110
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus.27, i64 %rubyId_minus.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !111
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.28, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !112
+  %29 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 283), i64 noundef 4) #17
+  call void @rb_gc_register_mark_object(i64 %29) #17
+  store i64 %29, i64* @rubyStrFrozen_15.4, align 8
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational.29, i64 %rubyId_Rational.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !113
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus.30, i64 %rubyId_minus.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !114
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.31, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !115
+  %30 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 288), i64 noundef 2) #17
+  call void @rb_gc_register_mark_object(i64 %30) #17
+  store i64 %30, i64* @rubyStrFrozen_18, align 8
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Complex.32, i64 %rubyId_Complex.i, i32 noundef 16, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !116
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus.33, i64 %rubyId_minus.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !117
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.34, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !118
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt.35, i64 %rubyId_lt.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !119
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.36, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !120
+  %31 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 291), i64 noundef 4) #17
+  call void @rb_gc_register_mark_object(i64 %31) #17
+  store i64 %31, i64* @rubyStrFrozen_25.4, align 8
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational.37, i64 %rubyId_Rational.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !121
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt.38, i64 %rubyId_lt.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !122
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.39, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !123
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.40, i64 %rubyId_lte.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !124
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.41, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !125
+  %32 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 296), i64 noundef 5) #17
+  call void @rb_gc_register_mark_object(i64 %32) #17
+  store i64 %32, i64* @rubyStrFrozen_5.923, align 8
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational.42, i64 %rubyId_Rational.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !126
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.43, i64 %rubyId_lte.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !127
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.44, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !128
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %0)
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %3)
-  %60 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
-  %61 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %60, i64 0, i32 18
-  %62 = load i64, i64* %61, align 8, !tbaa !129
-  %63 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %64 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %63, i64 0, i32 2
-  %65 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %64, align 8, !tbaa !59
-  %66 = bitcast i64* %positional_table.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %66)
-  %67 = bitcast i64* %positional_table320.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %67)
-  %68 = bitcast i64* %positional_table334.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %68)
-  %69 = bitcast i64* %positional_table348.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %69)
+  %33 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
+  %34 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %33, i64 0, i32 18
+  %35 = load i64, i64* %34, align 8, !tbaa !129
+  %36 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %37 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %36, i64 0, i32 2
+  %38 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %37, align 8, !tbaa !59
+  %39 = bitcast i64* %positional_table.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %39)
+  %40 = bitcast i64* %positional_table320.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %40)
+  %41 = bitcast i64* %positional_table334.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %41)
+  %42 = bitcast i64* %positional_table348.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %42)
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %70 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %70, align 8, !tbaa !62
-  %71 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 4
-  %72 = load i64*, i64** %71, align 8, !tbaa !63
-  %73 = load i64, i64* %72, align 8, !tbaa !6
-  %74 = and i64 %73, -33
-  store i64 %74, i64* %72, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %63, %struct.rb_control_frame_struct* %65, %struct.rb_iseq_struct* %stackFrame.i) #17
-  %75 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 0
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %75, align 8, !dbg !137, !tbaa !14
-  %rubyId_plus.i1 = load i64, i64* @rubyIdPrecomputed_plus, align 8, !dbg !138
-  %rawSym.i = call i64 @rb_id2sym(i64 %rubyId_plus.i1) #17, !dbg !138
-  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym.i, i64 %62, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_1") #17, !dbg !138
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %75, align 8, !dbg !138, !tbaa !14
-  %rubyId_minus.i2 = load i64, i64* @rubyIdPrecomputed_minus, align 8, !dbg !139
-  %rawSym257.i = call i64 @rb_id2sym(i64 %rubyId_minus.i2) #17, !dbg !139
-  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym257.i, i64 %62, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_2") #17, !dbg !139
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %75, align 8, !dbg !139, !tbaa !14
-  %rubyId_lt.i3 = load i64, i64* @rubyIdPrecomputed_lt, align 8, !dbg !140
-  %rawSym271.i = call i64 @rb_id2sym(i64 %rubyId_lt.i3) #17, !dbg !140
-  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym271.i, i64 %62, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_3") #17, !dbg !140
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %75, align 8, !dbg !140, !tbaa !14
-  %rubyId_lte.i4 = load i64, i64* @rubyIdPrecomputed_lte, align 8, !dbg !141
-  %rawSym285.i = call i64 @rb_id2sym(i64 %rubyId_lte.i4) #17, !dbg !141
-  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym285.i, i64 %62, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_4") #17, !dbg !141
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %75, align 8, !dbg !141, !tbaa !14
-  %76 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !88
-  %77 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !88, !tbaa !65
-  %needTakeSlowPath = icmp ne i64 %76, %77, !dbg !88
-  br i1 %needTakeSlowPath, label %78, label %79, !dbg !88, !prof !67
+  %43 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %43, align 8, !tbaa !62
+  %44 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 4
+  %45 = load i64*, i64** %44, align 8, !tbaa !63
+  %46 = load i64, i64* %45, align 8, !tbaa !6
+  %47 = and i64 %46, -33
+  store i64 %47, i64* %45, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %36, %struct.rb_control_frame_struct* %38, %struct.rb_iseq_struct* %stackFrame.i) #17
+  %48 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 0
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %48, align 8, !dbg !137, !tbaa !14
+  %rawSym.i = call i64 @rb_id2sym(i64 %rubyId_plus.i.i) #17, !dbg !138
+  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym.i, i64 %35, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_1") #17, !dbg !138
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %48, align 8, !dbg !138, !tbaa !14
+  %rawSym257.i = call i64 @rb_id2sym(i64 %rubyId_minus.i.i) #17, !dbg !139
+  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym257.i, i64 %35, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_2") #17, !dbg !139
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %48, align 8, !dbg !139, !tbaa !14
+  %rawSym271.i = call i64 @rb_id2sym(i64 %rubyId_lt.i.i) #17, !dbg !140
+  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym271.i, i64 %35, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_3") #17, !dbg !140
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %48, align 8, !dbg !140, !tbaa !14
+  %rawSym285.i = call i64 @rb_id2sym(i64 %rubyId_lte.i.i) #17, !dbg !141
+  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym285.i, i64 %35, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_4") #17, !dbg !141
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %48, align 8, !dbg !141, !tbaa !14
+  %49 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !88
+  %50 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !88, !tbaa !65
+  %needTakeSlowPath = icmp ne i64 %49, %50, !dbg !88
+  br i1 %needTakeSlowPath, label %51, label %52, !dbg !88, !prof !67
 
-78:                                               ; preds = %entry
+51:                                               ; preds = %entry
   call void @"const_recompute_T::Sig"(), !dbg !88
-  br label %79, !dbg !88
+  br label %52, !dbg !88
 
-79:                                               ; preds = %entry, %78
-  %80 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !88
-  %81 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !88
-  %82 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !88, !tbaa !65
-  %guardUpdated = icmp eq i64 %81, %82, !dbg !88
+52:                                               ; preds = %entry, %51
+  %53 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !88
+  %54 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !88
+  %55 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !88, !tbaa !65
+  %guardUpdated = icmp eq i64 %54, %55, !dbg !88
   call void @llvm.assume(i1 %guardUpdated), !dbg !88
-  %83 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !88
-  %84 = load i64*, i64** %83, align 8, !dbg !88
-  store i64 %62, i64* %84, align 8, !dbg !88, !tbaa !6
-  %85 = getelementptr inbounds i64, i64* %84, i64 1, !dbg !88
-  store i64 %80, i64* %85, align 8, !dbg !88, !tbaa !6
-  %86 = getelementptr inbounds i64, i64* %85, i64 1, !dbg !88
-  store i64* %86, i64** %83, align 8, !dbg !88
+  %56 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !88
+  %57 = load i64*, i64** %56, align 8, !dbg !88
+  store i64 %35, i64* %57, align 8, !dbg !88, !tbaa !6
+  %58 = getelementptr inbounds i64, i64* %57, i64 1, !dbg !88
+  store i64 %53, i64* %58, align 8, !dbg !88, !tbaa !6
+  %59 = getelementptr inbounds i64, i64* %58, i64 1, !dbg !88
+  store i64* %59, i64** %56, align 8, !dbg !88
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !88
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %75, align 8, !dbg !88, !tbaa !14
-  %87 = load i64, i64* @rb_cObject, align 8, !dbg !84
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %48, align 8, !dbg !88, !tbaa !14
+  %60 = load i64, i64* @rb_cObject, align 8, !dbg !84
   %stackFrame308.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#4plus", align 8, !dbg !84
-  %88 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #19, !dbg !84
-  %89 = bitcast i8* %88 to i16*, !dbg !84
-  %90 = load i16, i16* %89, align 8, !dbg !84
-  %91 = and i16 %90, -384, !dbg !84
-  %92 = or i16 %91, 1, !dbg !84
-  store i16 %92, i16* %89, align 8, !dbg !84
-  %93 = getelementptr inbounds i8, i8* %88, i64 8, !dbg !84
-  %94 = bitcast i8* %93 to i32*, !dbg !84
-  store i32 2, i32* %94, align 8, !dbg !84, !tbaa !142
-  %95 = getelementptr inbounds i8, i8* %88, i64 12, !dbg !84
-  %96 = getelementptr inbounds i8, i8* %88, i64 4, !dbg !84
-  %97 = bitcast i8* %96 to i32*, !dbg !84
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %95, i8 0, i64 20, i1 false) #17, !dbg !84
-  store i32 2, i32* %97, align 4, !dbg !84, !tbaa !145
-  %rubyId_x.i5 = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !84
-  store i64 %rubyId_x.i5, i64* %positional_table.i, align 8, !dbg !84
-  %rubyId_y.i6 = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !84
-  %98 = getelementptr i64, i64* %positional_table.i, i32 1, !dbg !84
-  store i64 %rubyId_y.i6, i64* %98, align 8, !dbg !84
-  %99 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #19, !dbg !84
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %99, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %66, i64 noundef 16, i1 noundef false) #17, !dbg !84
-  %100 = getelementptr inbounds i8, i8* %88, i64 32, !dbg !84
-  %101 = bitcast i8* %100 to i8**, !dbg !84
-  store i8* %99, i8** %101, align 8, !dbg !84, !tbaa !146
-  call void @sorbet_vm_define_method(i64 %87, i8* noundef getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#4plus", i8* nonnull %88, %struct.rb_iseq_struct* %stackFrame308.i, i1 noundef zeroext false) #17, !dbg !84
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %75, align 8, !dbg !84, !tbaa !14
+  %61 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #19, !dbg !84
+  %62 = bitcast i8* %61 to i16*, !dbg !84
+  %63 = load i16, i16* %62, align 8, !dbg !84
+  %64 = and i16 %63, -384, !dbg !84
+  %65 = or i16 %64, 1, !dbg !84
+  store i16 %65, i16* %62, align 8, !dbg !84
+  %66 = getelementptr inbounds i8, i8* %61, i64 8, !dbg !84
+  %67 = bitcast i8* %66 to i32*, !dbg !84
+  store i32 2, i32* %67, align 8, !dbg !84, !tbaa !142
+  %68 = getelementptr inbounds i8, i8* %61, i64 12, !dbg !84
+  %69 = getelementptr inbounds i8, i8* %61, i64 4, !dbg !84
+  %70 = bitcast i8* %69 to i32*, !dbg !84
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %68, i8 0, i64 20, i1 false) #17, !dbg !84
+  store i32 2, i32* %70, align 4, !dbg !84, !tbaa !145
+  store i64 %rubyId_x.i, i64* %positional_table.i, align 8, !dbg !84
+  %71 = getelementptr i64, i64* %positional_table.i, i32 1, !dbg !84
+  store i64 %rubyId_y.i, i64* %71, align 8, !dbg !84
+  %72 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #19, !dbg !84
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %72, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %39, i64 noundef 16, i1 noundef false) #17, !dbg !84
+  %73 = getelementptr inbounds i8, i8* %61, i64 32, !dbg !84
+  %74 = bitcast i8* %73 to i8**, !dbg !84
+  store i8* %72, i8** %74, align 8, !dbg !84, !tbaa !146
+  call void @sorbet_vm_define_method(i64 %60, i8* noundef getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#4plus", i8* nonnull %61, %struct.rb_iseq_struct* %stackFrame308.i, i1 noundef zeroext false) #17, !dbg !84
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %48, align 8, !dbg !84, !tbaa !14
   %stackFrame318.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#5minus", align 8, !dbg !85
-  %102 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #19, !dbg !85
-  %103 = bitcast i8* %102 to i16*, !dbg !85
-  %104 = load i16, i16* %103, align 8, !dbg !85
-  %105 = and i16 %104, -384, !dbg !85
-  %106 = or i16 %105, 1, !dbg !85
-  store i16 %106, i16* %103, align 8, !dbg !85
-  %107 = getelementptr inbounds i8, i8* %102, i64 8, !dbg !85
-  %108 = bitcast i8* %107 to i32*, !dbg !85
-  store i32 2, i32* %108, align 8, !dbg !85, !tbaa !142
-  %109 = getelementptr inbounds i8, i8* %102, i64 12, !dbg !85
-  %110 = getelementptr inbounds i8, i8* %102, i64 4, !dbg !85
-  %111 = bitcast i8* %110 to i32*, !dbg !85
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %109, i8 0, i64 20, i1 false) #17, !dbg !85
-  store i32 2, i32* %111, align 4, !dbg !85, !tbaa !145
-  %rubyId_x321.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !85
-  store i64 %rubyId_x321.i, i64* %positional_table320.i, align 8, !dbg !85
-  %rubyId_y322.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !85
-  %112 = getelementptr i64, i64* %positional_table320.i, i32 1, !dbg !85
-  store i64 %rubyId_y322.i, i64* %112, align 8, !dbg !85
-  %113 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #19, !dbg !85
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %113, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %67, i64 noundef 16, i1 noundef false) #17, !dbg !85
-  %114 = getelementptr inbounds i8, i8* %102, i64 32, !dbg !85
-  %115 = bitcast i8* %114 to i8**, !dbg !85
-  store i8* %113, i8** %115, align 8, !dbg !85, !tbaa !146
-  call void @sorbet_vm_define_method(i64 %87, i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 107), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#5minus", i8* nonnull %102, %struct.rb_iseq_struct* %stackFrame318.i, i1 noundef zeroext false) #17, !dbg !85
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %75, align 8, !dbg !85, !tbaa !14
+  %75 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #19, !dbg !85
+  %76 = bitcast i8* %75 to i16*, !dbg !85
+  %77 = load i16, i16* %76, align 8, !dbg !85
+  %78 = and i16 %77, -384, !dbg !85
+  %79 = or i16 %78, 1, !dbg !85
+  store i16 %79, i16* %76, align 8, !dbg !85
+  %80 = getelementptr inbounds i8, i8* %75, i64 8, !dbg !85
+  %81 = bitcast i8* %80 to i32*, !dbg !85
+  store i32 2, i32* %81, align 8, !dbg !85, !tbaa !142
+  %82 = getelementptr inbounds i8, i8* %75, i64 12, !dbg !85
+  %83 = getelementptr inbounds i8, i8* %75, i64 4, !dbg !85
+  %84 = bitcast i8* %83 to i32*, !dbg !85
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %82, i8 0, i64 20, i1 false) #17, !dbg !85
+  store i32 2, i32* %84, align 4, !dbg !85, !tbaa !145
+  store i64 %rubyId_x.i, i64* %positional_table320.i, align 8, !dbg !85
+  %85 = getelementptr i64, i64* %positional_table320.i, i32 1, !dbg !85
+  store i64 %rubyId_y.i, i64* %85, align 8, !dbg !85
+  %86 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #19, !dbg !85
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %86, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %40, i64 noundef 16, i1 noundef false) #17, !dbg !85
+  %87 = getelementptr inbounds i8, i8* %75, i64 32, !dbg !85
+  %88 = bitcast i8* %87 to i8**, !dbg !85
+  store i8* %86, i8** %88, align 8, !dbg !85, !tbaa !146
+  call void @sorbet_vm_define_method(i64 %60, i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 107), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#5minus", i8* nonnull %75, %struct.rb_iseq_struct* %stackFrame318.i, i1 noundef zeroext false) #17, !dbg !85
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %48, align 8, !dbg !85, !tbaa !14
   %stackFrame332.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#2lt", align 8, !dbg !86
-  %116 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #19, !dbg !86
-  %117 = bitcast i8* %116 to i16*, !dbg !86
-  %118 = load i16, i16* %117, align 8, !dbg !86
-  %119 = and i16 %118, -384, !dbg !86
-  %120 = or i16 %119, 1, !dbg !86
-  store i16 %120, i16* %117, align 8, !dbg !86
-  %121 = getelementptr inbounds i8, i8* %116, i64 8, !dbg !86
-  %122 = bitcast i8* %121 to i32*, !dbg !86
-  store i32 2, i32* %122, align 8, !dbg !86, !tbaa !142
-  %123 = getelementptr inbounds i8, i8* %116, i64 12, !dbg !86
-  %124 = getelementptr inbounds i8, i8* %116, i64 4, !dbg !86
-  %125 = bitcast i8* %124 to i32*, !dbg !86
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %123, i8 0, i64 20, i1 false) #17, !dbg !86
-  store i32 2, i32* %125, align 4, !dbg !86, !tbaa !145
-  %rubyId_x335.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !86
-  store i64 %rubyId_x335.i, i64* %positional_table334.i, align 8, !dbg !86
-  %rubyId_y336.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !86
-  %126 = getelementptr i64, i64* %positional_table334.i, i32 1, !dbg !86
-  store i64 %rubyId_y336.i, i64* %126, align 8, !dbg !86
-  %127 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #19, !dbg !86
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %127, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %68, i64 noundef 16, i1 noundef false) #17, !dbg !86
-  %128 = getelementptr inbounds i8, i8* %116, i64 32, !dbg !86
-  %129 = bitcast i8* %128 to i8**, !dbg !86
-  store i8* %127, i8** %129, align 8, !dbg !86, !tbaa !146
-  call void @sorbet_vm_define_method(i64 %87, i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 115), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#2lt", i8* nonnull %116, %struct.rb_iseq_struct* %stackFrame332.i, i1 noundef zeroext false) #17, !dbg !86
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %75, align 8, !dbg !86, !tbaa !14
+  %89 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #19, !dbg !86
+  %90 = bitcast i8* %89 to i16*, !dbg !86
+  %91 = load i16, i16* %90, align 8, !dbg !86
+  %92 = and i16 %91, -384, !dbg !86
+  %93 = or i16 %92, 1, !dbg !86
+  store i16 %93, i16* %90, align 8, !dbg !86
+  %94 = getelementptr inbounds i8, i8* %89, i64 8, !dbg !86
+  %95 = bitcast i8* %94 to i32*, !dbg !86
+  store i32 2, i32* %95, align 8, !dbg !86, !tbaa !142
+  %96 = getelementptr inbounds i8, i8* %89, i64 12, !dbg !86
+  %97 = getelementptr inbounds i8, i8* %89, i64 4, !dbg !86
+  %98 = bitcast i8* %97 to i32*, !dbg !86
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %96, i8 0, i64 20, i1 false) #17, !dbg !86
+  store i32 2, i32* %98, align 4, !dbg !86, !tbaa !145
+  store i64 %rubyId_x.i, i64* %positional_table334.i, align 8, !dbg !86
+  %99 = getelementptr i64, i64* %positional_table334.i, i32 1, !dbg !86
+  store i64 %rubyId_y.i, i64* %99, align 8, !dbg !86
+  %100 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #19, !dbg !86
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %100, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %41, i64 noundef 16, i1 noundef false) #17, !dbg !86
+  %101 = getelementptr inbounds i8, i8* %89, i64 32, !dbg !86
+  %102 = bitcast i8* %101 to i8**, !dbg !86
+  store i8* %100, i8** %102, align 8, !dbg !86, !tbaa !146
+  call void @sorbet_vm_define_method(i64 %60, i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 115), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#2lt", i8* nonnull %89, %struct.rb_iseq_struct* %stackFrame332.i, i1 noundef zeroext false) #17, !dbg !86
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %48, align 8, !dbg !86, !tbaa !14
   %stackFrame346.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3lte", align 8, !dbg !87
-  %130 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #19, !dbg !87
-  %131 = bitcast i8* %130 to i16*, !dbg !87
-  %132 = load i16, i16* %131, align 8, !dbg !87
-  %133 = and i16 %132, -384, !dbg !87
-  %134 = or i16 %133, 1, !dbg !87
-  store i16 %134, i16* %131, align 8, !dbg !87
-  %135 = getelementptr inbounds i8, i8* %130, i64 8, !dbg !87
-  %136 = bitcast i8* %135 to i32*, !dbg !87
-  store i32 2, i32* %136, align 8, !dbg !87, !tbaa !142
-  %137 = getelementptr inbounds i8, i8* %130, i64 12, !dbg !87
-  %138 = getelementptr inbounds i8, i8* %130, i64 4, !dbg !87
-  %139 = bitcast i8* %138 to i32*, !dbg !87
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %137, i8 0, i64 20, i1 false) #17, !dbg !87
-  store i32 2, i32* %139, align 4, !dbg !87, !tbaa !145
-  %rubyId_x349.i = load i64, i64* @rubyIdPrecomputed_x, align 8, !dbg !87
-  store i64 %rubyId_x349.i, i64* %positional_table348.i, align 8, !dbg !87
-  %rubyId_y350.i = load i64, i64* @rubyIdPrecomputed_y, align 8, !dbg !87
-  %140 = getelementptr i64, i64* %positional_table348.i, i32 1, !dbg !87
-  store i64 %rubyId_y350.i, i64* %140, align 8, !dbg !87
-  %141 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #19, !dbg !87
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %141, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %69, i64 noundef 16, i1 noundef false) #17, !dbg !87
-  %142 = getelementptr inbounds i8, i8* %130, i64 32, !dbg !87
-  %143 = bitcast i8* %142 to i8**, !dbg !87
-  store i8* %141, i8** %143, align 8, !dbg !87, !tbaa !146
-  call void @sorbet_vm_define_method(i64 %87, i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 131), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#3lte", i8* nonnull %130, %struct.rb_iseq_struct* %stackFrame346.i, i1 noundef zeroext false) #17, !dbg !87
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %75, align 8, !dbg !87, !tbaa !14
-  %144 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !89
-  %145 = load i64*, i64** %144, align 8, !dbg !89
-  store i64 %62, i64* %145, align 8, !dbg !89, !tbaa !6
-  %146 = getelementptr inbounds i64, i64* %145, i64 1, !dbg !89
-  %147 = getelementptr inbounds i64, i64* %146, i64 1, !dbg !89
-  %148 = bitcast i64* %146 to <2 x i64>*, !dbg !89
-  store <2 x i64> <i64 45035996273704962, i64 54043195528445954>, <2 x i64>* %148, align 8, !dbg !89, !tbaa !6
-  %149 = getelementptr inbounds i64, i64* %147, i64 1, !dbg !89
-  store i64* %149, i64** %144, align 8, !dbg !89
-  %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus, i64 0), !dbg !89
-  %150 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !90
-  %151 = load i64*, i64** %150, align 8, !dbg !90
-  store i64 %62, i64* %151, align 8, !dbg !90, !tbaa !6
-  %152 = getelementptr inbounds i64, i64* %151, i64 1, !dbg !90
-  store i64 %send8, i64* %152, align 8, !dbg !90, !tbaa !6
-  %153 = getelementptr inbounds i64, i64* %152, i64 1, !dbg !90
-  store i64* %153, i64** %150, align 8, !dbg !90
-  %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p, i64 0), !dbg !90
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %75, align 8, !dbg !90, !tbaa !14
-  %154 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !91
-  %155 = load i64*, i64** %154, align 8, !dbg !91
-  store i64 %62, i64* %155, align 8, !dbg !91, !tbaa !6
-  %156 = getelementptr inbounds i64, i64* %155, i64 1, !dbg !91
-  %157 = getelementptr inbounds i64, i64* %156, i64 1, !dbg !91
-  %158 = bitcast i64* %156 to <2 x i64>*, !dbg !91
-  store <2 x i64> <i64 146704757861593906, i64 194442913911721170>, <2 x i64>* %158, align 8, !dbg !91, !tbaa !6
-  %159 = getelementptr inbounds i64, i64* %157, i64 1, !dbg !91
-  store i64* %159, i64** %154, align 8, !dbg !91
-  %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus, i64 0), !dbg !91
-  %160 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !92
-  %161 = load i64*, i64** %160, align 8, !dbg !92
-  store i64 %62, i64* %161, align 8, !dbg !92, !tbaa !6
-  %162 = getelementptr inbounds i64, i64* %161, i64 1, !dbg !92
-  store i64 %send12, i64* %162, align 8, !dbg !92, !tbaa !6
-  %163 = getelementptr inbounds i64, i64* %162, i64 1, !dbg !92
-  store i64* %163, i64** %160, align 8, !dbg !92
-  %send14 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.12, i64 0), !dbg !92
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 29), i64** %75, align 8, !dbg !92, !tbaa !14
-  %164 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !93
-  %165 = load i64*, i64** %164, align 8, !dbg !93
-  store i64 %62, i64* %165, align 8, !dbg !93, !tbaa !6
-  %166 = getelementptr inbounds i64, i64* %165, i64 1, !dbg !93
-  %167 = getelementptr inbounds i64, i64* %166, i64 1, !dbg !93
-  %168 = bitcast i64* %166 to <2 x i64>*, !dbg !93
-  store <2 x i64> <i64 193204424014194282, i64 53142475602971858>, <2 x i64>* %168, align 8, !dbg !93, !tbaa !6
-  %169 = getelementptr inbounds i64, i64* %167, i64 1, !dbg !93
-  store i64* %169, i64** %164, align 8, !dbg !93
-  %send16 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt, i64 0), !dbg !93
-  %170 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !94
-  %171 = load i64*, i64** %170, align 8, !dbg !94
-  store i64 %62, i64* %171, align 8, !dbg !94, !tbaa !6
-  %172 = getelementptr inbounds i64, i64* %171, i64 1, !dbg !94
-  store i64 %send16, i64* %172, align 8, !dbg !94, !tbaa !6
-  %173 = getelementptr inbounds i64, i64* %172, i64 1, !dbg !94
-  store i64* %173, i64** %170, align 8, !dbg !94
-  %send18 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.13, i64 0), !dbg !94
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 30), i64** %75, align 8, !dbg !94, !tbaa !14
-  %174 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !95
-  %175 = load i64*, i64** %174, align 8, !dbg !95
-  store i64 %62, i64* %175, align 8, !dbg !95, !tbaa !6
-  %176 = getelementptr inbounds i64, i64* %175, i64 1, !dbg !95
-  %177 = getelementptr inbounds i64, i64* %176, i64 1, !dbg !95
-  %178 = bitcast i64* %176 to <2 x i64>*, !dbg !95
-  store <2 x i64> <i64 61248954932238746, i64 133982088914272258>, <2 x i64>* %178, align 8, !dbg !95, !tbaa !6
-  %179 = getelementptr inbounds i64, i64* %177, i64 1, !dbg !95
-  store i64* %179, i64** %174, align 8, !dbg !95
-  %send20 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt.14, i64 0), !dbg !95
-  %180 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !96
-  %181 = load i64*, i64** %180, align 8, !dbg !96
-  store i64 %62, i64* %181, align 8, !dbg !96, !tbaa !6
-  %182 = getelementptr inbounds i64, i64* %181, i64 1, !dbg !96
-  store i64 %send20, i64* %182, align 8, !dbg !96, !tbaa !6
-  %183 = getelementptr inbounds i64, i64* %182, i64 1, !dbg !96
-  store i64* %183, i64** %180, align 8, !dbg !96
-  %send22 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.15, i64 0), !dbg !96
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 31), i64** %75, align 8, !dbg !96, !tbaa !14
-  %184 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !97
-  %185 = load i64*, i64** %184, align 8, !dbg !97
-  store i64 %62, i64* %185, align 8, !dbg !97, !tbaa !6
-  %186 = getelementptr inbounds i64, i64* %185, i64 1, !dbg !97
-  %187 = getelementptr inbounds i64, i64* %186, i64 1, !dbg !97
-  %188 = bitcast i64* %186 to <2 x i64>*, !dbg !97
-  store <2 x i64> <i64 180200280090161970, i64 155261597153597850>, <2 x i64>* %188, align 8, !dbg !97, !tbaa !6
-  %189 = getelementptr inbounds i64, i64* %187, i64 1, !dbg !97
-  store i64* %189, i64** %184, align 8, !dbg !97
-  %send24 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte, i64 0), !dbg !97
-  %190 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !98
-  %191 = load i64*, i64** %190, align 8, !dbg !98
-  store i64 %62, i64* %191, align 8, !dbg !98, !tbaa !6
-  %192 = getelementptr inbounds i64, i64* %191, i64 1, !dbg !98
-  store i64 %send24, i64* %192, align 8, !dbg !98, !tbaa !6
-  %193 = getelementptr inbounds i64, i64* %192, i64 1, !dbg !98
-  store i64* %193, i64** %190, align 8, !dbg !98
-  %send26 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.16, i64 0), !dbg !98
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 32), i64** %75, align 8, !dbg !98, !tbaa !14
-  %194 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !99
-  %195 = load i64*, i64** %194, align 8, !dbg !99
-  store i64 %62, i64* %195, align 8, !dbg !99, !tbaa !6
-  %196 = getelementptr inbounds i64, i64* %195, i64 1, !dbg !99
-  %197 = getelementptr inbounds i64, i64* %196, i64 1, !dbg !99
-  %198 = bitcast i64* %196 to <2 x i64>*, !dbg !99
-  store <2 x i64> <i64 57646075230342354, i64 155261597153597850>, <2 x i64>* %198, align 8, !dbg !99, !tbaa !6
-  %199 = getelementptr inbounds i64, i64* %197, i64 1, !dbg !99
-  store i64* %199, i64** %194, align 8, !dbg !99
-  %send28 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.17, i64 0), !dbg !99
-  %200 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !100
-  %201 = load i64*, i64** %200, align 8, !dbg !100
-  store i64 %62, i64* %201, align 8, !dbg !100, !tbaa !6
-  %202 = getelementptr inbounds i64, i64* %201, i64 1, !dbg !100
-  store i64 %send28, i64* %202, align 8, !dbg !100, !tbaa !6
-  %203 = getelementptr inbounds i64, i64* %202, i64 1, !dbg !100
-  store i64* %203, i64** %200, align 8, !dbg !100
-  %send30 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.18, i64 0), !dbg !100
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 33), i64** %75, align 8, !dbg !100, !tbaa !14
-  %204 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !101
-  %205 = load i64*, i64** %204, align 8, !dbg !101
-  store i64 %62, i64* %205, align 8, !dbg !101, !tbaa !6
-  %206 = getelementptr inbounds i64, i64* %205, i64 1, !dbg !101
-  %207 = getelementptr inbounds i64, i64* %206, i64 1, !dbg !101
-  %208 = bitcast i64* %206 to <2 x i64>*, !dbg !101
-  store <2 x i64> <i64 75660473739824338, i64 75660473739824338>, <2 x i64>* %208, align 8, !dbg !101, !tbaa !6
-  %209 = getelementptr inbounds i64, i64* %207, i64 1, !dbg !101
-  store i64* %209, i64** %204, align 8, !dbg !101
-  %send32 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.19, i64 0), !dbg !101
-  %210 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !102
-  %211 = load i64*, i64** %210, align 8, !dbg !102
-  store i64 %62, i64* %211, align 8, !dbg !102, !tbaa !6
-  %212 = getelementptr inbounds i64, i64* %211, i64 1, !dbg !102
-  store i64 %send32, i64* %212, align 8, !dbg !102, !tbaa !6
-  %213 = getelementptr inbounds i64, i64* %212, i64 1, !dbg !102
-  store i64* %213, i64** %210, align 8, !dbg !102
-  %send34 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.20, i64 0), !dbg !102
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 36), i64** %75, align 8, !dbg !102, !tbaa !14
-  %214 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !103
-  %215 = load i64*, i64** %214, align 8, !dbg !103
-  store i64 %62, i64* %215, align 8, !dbg !103, !tbaa !6
-  %216 = getelementptr inbounds i64, i64* %215, i64 1, !dbg !103
-  %217 = getelementptr inbounds i64, i64* %216, i64 1, !dbg !103
-  %218 = bitcast i64* %216 to <2 x i64>*, !dbg !103
-  store <2 x i64> <i64 45035996273704962, i64 17>, <2 x i64>* %218, align 8, !dbg !103, !tbaa !6
-  %219 = getelementptr inbounds i64, i64* %217, i64 1, !dbg !103
-  store i64* %219, i64** %214, align 8, !dbg !103
-  %send36 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus.21, i64 0), !dbg !103
-  %220 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !104
-  %221 = load i64*, i64** %220, align 8, !dbg !104
-  store i64 %62, i64* %221, align 8, !dbg !104, !tbaa !6
-  %222 = getelementptr inbounds i64, i64* %221, i64 1, !dbg !104
-  store i64 %send36, i64* %222, align 8, !dbg !104, !tbaa !6
-  %223 = getelementptr inbounds i64, i64* %222, i64 1, !dbg !104
-  store i64* %223, i64** %220, align 8, !dbg !104
-  %send38 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.22, i64 0), !dbg !104
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 37), i64** %75, align 8, !dbg !104, !tbaa !14
+  %103 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #19, !dbg !87
+  %104 = bitcast i8* %103 to i16*, !dbg !87
+  %105 = load i16, i16* %104, align 8, !dbg !87
+  %106 = and i16 %105, -384, !dbg !87
+  %107 = or i16 %106, 1, !dbg !87
+  store i16 %107, i16* %104, align 8, !dbg !87
+  %108 = getelementptr inbounds i8, i8* %103, i64 8, !dbg !87
+  %109 = bitcast i8* %108 to i32*, !dbg !87
+  store i32 2, i32* %109, align 8, !dbg !87, !tbaa !142
+  %110 = getelementptr inbounds i8, i8* %103, i64 12, !dbg !87
+  %111 = getelementptr inbounds i8, i8* %103, i64 4, !dbg !87
+  %112 = bitcast i8* %111 to i32*, !dbg !87
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %110, i8 0, i64 20, i1 false) #17, !dbg !87
+  store i32 2, i32* %112, align 4, !dbg !87, !tbaa !145
+  store i64 %rubyId_x.i, i64* %positional_table348.i, align 8, !dbg !87
+  %113 = getelementptr i64, i64* %positional_table348.i, i32 1, !dbg !87
+  store i64 %rubyId_y.i, i64* %113, align 8, !dbg !87
+  %114 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #19, !dbg !87
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %114, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %42, i64 noundef 16, i1 noundef false) #17, !dbg !87
+  %115 = getelementptr inbounds i8, i8* %103, i64 32, !dbg !87
+  %116 = bitcast i8* %115 to i8**, !dbg !87
+  store i8* %114, i8** %116, align 8, !dbg !87, !tbaa !146
+  call void @sorbet_vm_define_method(i64 %60, i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 131), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#3lte", i8* nonnull %103, %struct.rb_iseq_struct* %stackFrame346.i, i1 noundef zeroext false) #17, !dbg !87
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %48, align 8, !dbg !87, !tbaa !14
+  %117 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !89
+  %118 = load i64*, i64** %117, align 8, !dbg !89
+  store i64 %35, i64* %118, align 8, !dbg !89, !tbaa !6
+  %119 = getelementptr inbounds i64, i64* %118, i64 1, !dbg !89
+  %120 = getelementptr inbounds i64, i64* %119, i64 1, !dbg !89
+  %121 = bitcast i64* %119 to <2 x i64>*, !dbg !89
+  store <2 x i64> <i64 45035996273704962, i64 54043195528445954>, <2 x i64>* %121, align 8, !dbg !89, !tbaa !6
+  %122 = getelementptr inbounds i64, i64* %120, i64 1, !dbg !89
+  store i64* %122, i64** %117, align 8, !dbg !89
+  %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus, i64 0), !dbg !89
+  %123 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !90
+  %124 = load i64*, i64** %123, align 8, !dbg !90
+  store i64 %35, i64* %124, align 8, !dbg !90, !tbaa !6
+  %125 = getelementptr inbounds i64, i64* %124, i64 1, !dbg !90
+  store i64 %send4, i64* %125, align 8, !dbg !90, !tbaa !6
+  %126 = getelementptr inbounds i64, i64* %125, i64 1, !dbg !90
+  store i64* %126, i64** %123, align 8, !dbg !90
+  %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p, i64 0), !dbg !90
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %48, align 8, !dbg !90, !tbaa !14
+  %127 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !91
+  %128 = load i64*, i64** %127, align 8, !dbg !91
+  store i64 %35, i64* %128, align 8, !dbg !91, !tbaa !6
+  %129 = getelementptr inbounds i64, i64* %128, i64 1, !dbg !91
+  %130 = getelementptr inbounds i64, i64* %129, i64 1, !dbg !91
+  %131 = bitcast i64* %129 to <2 x i64>*, !dbg !91
+  store <2 x i64> <i64 146704757861593906, i64 194442913911721170>, <2 x i64>* %131, align 8, !dbg !91, !tbaa !6
+  %132 = getelementptr inbounds i64, i64* %130, i64 1, !dbg !91
+  store i64* %132, i64** %127, align 8, !dbg !91
+  %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus, i64 0), !dbg !91
+  %133 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !92
+  %134 = load i64*, i64** %133, align 8, !dbg !92
+  store i64 %35, i64* %134, align 8, !dbg !92, !tbaa !6
+  %135 = getelementptr inbounds i64, i64* %134, i64 1, !dbg !92
+  store i64 %send8, i64* %135, align 8, !dbg !92, !tbaa !6
+  %136 = getelementptr inbounds i64, i64* %135, i64 1, !dbg !92
+  store i64* %136, i64** %133, align 8, !dbg !92
+  %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.12, i64 0), !dbg !92
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 29), i64** %48, align 8, !dbg !92, !tbaa !14
+  %137 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !93
+  %138 = load i64*, i64** %137, align 8, !dbg !93
+  store i64 %35, i64* %138, align 8, !dbg !93, !tbaa !6
+  %139 = getelementptr inbounds i64, i64* %138, i64 1, !dbg !93
+  %140 = getelementptr inbounds i64, i64* %139, i64 1, !dbg !93
+  %141 = bitcast i64* %139 to <2 x i64>*, !dbg !93
+  store <2 x i64> <i64 193204424014194282, i64 53142475602971858>, <2 x i64>* %141, align 8, !dbg !93, !tbaa !6
+  %142 = getelementptr inbounds i64, i64* %140, i64 1, !dbg !93
+  store i64* %142, i64** %137, align 8, !dbg !93
+  %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt, i64 0), !dbg !93
+  %143 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !94
+  %144 = load i64*, i64** %143, align 8, !dbg !94
+  store i64 %35, i64* %144, align 8, !dbg !94, !tbaa !6
+  %145 = getelementptr inbounds i64, i64* %144, i64 1, !dbg !94
+  store i64 %send12, i64* %145, align 8, !dbg !94, !tbaa !6
+  %146 = getelementptr inbounds i64, i64* %145, i64 1, !dbg !94
+  store i64* %146, i64** %143, align 8, !dbg !94
+  %send14 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.13, i64 0), !dbg !94
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 30), i64** %48, align 8, !dbg !94, !tbaa !14
+  %147 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !95
+  %148 = load i64*, i64** %147, align 8, !dbg !95
+  store i64 %35, i64* %148, align 8, !dbg !95, !tbaa !6
+  %149 = getelementptr inbounds i64, i64* %148, i64 1, !dbg !95
+  %150 = getelementptr inbounds i64, i64* %149, i64 1, !dbg !95
+  %151 = bitcast i64* %149 to <2 x i64>*, !dbg !95
+  store <2 x i64> <i64 61248954932238746, i64 133982088914272258>, <2 x i64>* %151, align 8, !dbg !95, !tbaa !6
+  %152 = getelementptr inbounds i64, i64* %150, i64 1, !dbg !95
+  store i64* %152, i64** %147, align 8, !dbg !95
+  %send16 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt.14, i64 0), !dbg !95
+  %153 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !96
+  %154 = load i64*, i64** %153, align 8, !dbg !96
+  store i64 %35, i64* %154, align 8, !dbg !96, !tbaa !6
+  %155 = getelementptr inbounds i64, i64* %154, i64 1, !dbg !96
+  store i64 %send16, i64* %155, align 8, !dbg !96, !tbaa !6
+  %156 = getelementptr inbounds i64, i64* %155, i64 1, !dbg !96
+  store i64* %156, i64** %153, align 8, !dbg !96
+  %send18 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.15, i64 0), !dbg !96
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 31), i64** %48, align 8, !dbg !96, !tbaa !14
+  %157 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !97
+  %158 = load i64*, i64** %157, align 8, !dbg !97
+  store i64 %35, i64* %158, align 8, !dbg !97, !tbaa !6
+  %159 = getelementptr inbounds i64, i64* %158, i64 1, !dbg !97
+  %160 = getelementptr inbounds i64, i64* %159, i64 1, !dbg !97
+  %161 = bitcast i64* %159 to <2 x i64>*, !dbg !97
+  store <2 x i64> <i64 180200280090161970, i64 155261597153597850>, <2 x i64>* %161, align 8, !dbg !97, !tbaa !6
+  %162 = getelementptr inbounds i64, i64* %160, i64 1, !dbg !97
+  store i64* %162, i64** %157, align 8, !dbg !97
+  %send20 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte, i64 0), !dbg !97
+  %163 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !98
+  %164 = load i64*, i64** %163, align 8, !dbg !98
+  store i64 %35, i64* %164, align 8, !dbg !98, !tbaa !6
+  %165 = getelementptr inbounds i64, i64* %164, i64 1, !dbg !98
+  store i64 %send20, i64* %165, align 8, !dbg !98, !tbaa !6
+  %166 = getelementptr inbounds i64, i64* %165, i64 1, !dbg !98
+  store i64* %166, i64** %163, align 8, !dbg !98
+  %send22 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.16, i64 0), !dbg !98
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 32), i64** %48, align 8, !dbg !98, !tbaa !14
+  %167 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !99
+  %168 = load i64*, i64** %167, align 8, !dbg !99
+  store i64 %35, i64* %168, align 8, !dbg !99, !tbaa !6
+  %169 = getelementptr inbounds i64, i64* %168, i64 1, !dbg !99
+  %170 = getelementptr inbounds i64, i64* %169, i64 1, !dbg !99
+  %171 = bitcast i64* %169 to <2 x i64>*, !dbg !99
+  store <2 x i64> <i64 57646075230342354, i64 155261597153597850>, <2 x i64>* %171, align 8, !dbg !99, !tbaa !6
+  %172 = getelementptr inbounds i64, i64* %170, i64 1, !dbg !99
+  store i64* %172, i64** %167, align 8, !dbg !99
+  %send24 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.17, i64 0), !dbg !99
+  %173 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !100
+  %174 = load i64*, i64** %173, align 8, !dbg !100
+  store i64 %35, i64* %174, align 8, !dbg !100, !tbaa !6
+  %175 = getelementptr inbounds i64, i64* %174, i64 1, !dbg !100
+  store i64 %send24, i64* %175, align 8, !dbg !100, !tbaa !6
+  %176 = getelementptr inbounds i64, i64* %175, i64 1, !dbg !100
+  store i64* %176, i64** %173, align 8, !dbg !100
+  %send26 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.18, i64 0), !dbg !100
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 33), i64** %48, align 8, !dbg !100, !tbaa !14
+  %177 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !101
+  %178 = load i64*, i64** %177, align 8, !dbg !101
+  store i64 %35, i64* %178, align 8, !dbg !101, !tbaa !6
+  %179 = getelementptr inbounds i64, i64* %178, i64 1, !dbg !101
+  %180 = getelementptr inbounds i64, i64* %179, i64 1, !dbg !101
+  %181 = bitcast i64* %179 to <2 x i64>*, !dbg !101
+  store <2 x i64> <i64 75660473739824338, i64 75660473739824338>, <2 x i64>* %181, align 8, !dbg !101, !tbaa !6
+  %182 = getelementptr inbounds i64, i64* %180, i64 1, !dbg !101
+  store i64* %182, i64** %177, align 8, !dbg !101
+  %send28 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.19, i64 0), !dbg !101
+  %183 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !102
+  %184 = load i64*, i64** %183, align 8, !dbg !102
+  store i64 %35, i64* %184, align 8, !dbg !102, !tbaa !6
+  %185 = getelementptr inbounds i64, i64* %184, i64 1, !dbg !102
+  store i64 %send28, i64* %185, align 8, !dbg !102, !tbaa !6
+  %186 = getelementptr inbounds i64, i64* %185, i64 1, !dbg !102
+  store i64* %186, i64** %183, align 8, !dbg !102
+  %send30 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.20, i64 0), !dbg !102
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 36), i64** %48, align 8, !dbg !102, !tbaa !14
+  %187 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !103
+  %188 = load i64*, i64** %187, align 8, !dbg !103
+  store i64 %35, i64* %188, align 8, !dbg !103, !tbaa !6
+  %189 = getelementptr inbounds i64, i64* %188, i64 1, !dbg !103
+  %190 = getelementptr inbounds i64, i64* %189, i64 1, !dbg !103
+  %191 = bitcast i64* %189 to <2 x i64>*, !dbg !103
+  store <2 x i64> <i64 45035996273704962, i64 17>, <2 x i64>* %191, align 8, !dbg !103, !tbaa !6
+  %192 = getelementptr inbounds i64, i64* %190, i64 1, !dbg !103
+  store i64* %192, i64** %187, align 8, !dbg !103
+  %send32 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus.21, i64 0), !dbg !103
+  %193 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !104
+  %194 = load i64*, i64** %193, align 8, !dbg !104
+  store i64 %35, i64* %194, align 8, !dbg !104, !tbaa !6
+  %195 = getelementptr inbounds i64, i64* %194, i64 1, !dbg !104
+  store i64 %send32, i64* %195, align 8, !dbg !104, !tbaa !6
+  %196 = getelementptr inbounds i64, i64* %195, i64 1, !dbg !104
+  store i64* %196, i64** %193, align 8, !dbg !104
+  %send34 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.22, i64 0), !dbg !104
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 37), i64** %48, align 8, !dbg !104, !tbaa !14
   %rubyStr_8.9.i = load i64, i64* @rubyStrFrozen_8.9, align 8, !dbg !105
-  %224 = load i64, i64* @rb_mKernel, align 8, !dbg !105
-  %225 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !105
-  %226 = load i64*, i64** %225, align 8, !dbg !105
-  store i64 %224, i64* %226, align 8, !dbg !105, !tbaa !6
-  %227 = getelementptr inbounds i64, i64* %226, i64 1, !dbg !105
-  store i64 %rubyStr_8.9.i, i64* %227, align 8, !dbg !105, !tbaa !6
-  %228 = getelementptr inbounds i64, i64* %227, i64 1, !dbg !105
-  store i64* %228, i64** %225, align 8, !dbg !105
-  %send40 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational, i64 0), !dbg !105
-  %229 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !106
-  %230 = load i64*, i64** %229, align 8, !dbg !106
-  store i64 %62, i64* %230, align 8, !dbg !106, !tbaa !6
-  %231 = getelementptr inbounds i64, i64* %230, i64 1, !dbg !106
-  store i64 36028797018963970, i64* %231, align 8, !dbg !106, !tbaa !6
-  %232 = getelementptr inbounds i64, i64* %231, i64 1, !dbg !106
-  store i64 %send40, i64* %232, align 8, !dbg !106, !tbaa !6
-  %233 = getelementptr inbounds i64, i64* %232, i64 1, !dbg !106
-  store i64* %233, i64** %229, align 8, !dbg !106
-  %send42 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus.23, i64 0), !dbg !106
-  %234 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !107
-  %235 = load i64*, i64** %234, align 8, !dbg !107
-  store i64 %62, i64* %235, align 8, !dbg !107, !tbaa !6
-  %236 = getelementptr inbounds i64, i64* %235, i64 1, !dbg !107
-  store i64 %send42, i64* %236, align 8, !dbg !107, !tbaa !6
-  %237 = getelementptr inbounds i64, i64* %236, i64 1, !dbg !107
-  store i64* %237, i64** %234, align 8, !dbg !107
-  %send44 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.24, i64 0), !dbg !107
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 38), i64** %75, align 8, !dbg !107, !tbaa !14
+  %197 = load i64, i64* @rb_mKernel, align 8, !dbg !105
+  %198 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !105
+  %199 = load i64*, i64** %198, align 8, !dbg !105
+  store i64 %197, i64* %199, align 8, !dbg !105, !tbaa !6
+  %200 = getelementptr inbounds i64, i64* %199, i64 1, !dbg !105
+  store i64 %rubyStr_8.9.i, i64* %200, align 8, !dbg !105, !tbaa !6
+  %201 = getelementptr inbounds i64, i64* %200, i64 1, !dbg !105
+  store i64* %201, i64** %198, align 8, !dbg !105
+  %send36 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational, i64 0), !dbg !105
+  %202 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !106
+  %203 = load i64*, i64** %202, align 8, !dbg !106
+  store i64 %35, i64* %203, align 8, !dbg !106, !tbaa !6
+  %204 = getelementptr inbounds i64, i64* %203, i64 1, !dbg !106
+  store i64 36028797018963970, i64* %204, align 8, !dbg !106, !tbaa !6
+  %205 = getelementptr inbounds i64, i64* %204, i64 1, !dbg !106
+  store i64 %send36, i64* %205, align 8, !dbg !106, !tbaa !6
+  %206 = getelementptr inbounds i64, i64* %205, i64 1, !dbg !106
+  store i64* %206, i64** %202, align 8, !dbg !106
+  %send38 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus.23, i64 0), !dbg !106
+  %207 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !107
+  %208 = load i64*, i64** %207, align 8, !dbg !107
+  store i64 %35, i64* %208, align 8, !dbg !107, !tbaa !6
+  %209 = getelementptr inbounds i64, i64* %208, i64 1, !dbg !107
+  store i64 %send38, i64* %209, align 8, !dbg !107, !tbaa !6
+  %210 = getelementptr inbounds i64, i64* %209, i64 1, !dbg !107
+  store i64* %210, i64** %207, align 8, !dbg !107
+  %send40 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.24, i64 0), !dbg !107
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 38), i64** %48, align 8, !dbg !107, !tbaa !14
   %rubyStr_5.i = load i64, i64* @rubyStrFrozen_5, align 8, !dbg !108
-  %238 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !108
-  %239 = load i64*, i64** %238, align 8, !dbg !108
-  store i64 %224, i64* %239, align 8, !dbg !108, !tbaa !6
-  %240 = getelementptr inbounds i64, i64* %239, i64 1, !dbg !108
-  store i64 1, i64* %240, align 8, !dbg !108, !tbaa !6
-  %241 = getelementptr inbounds i64, i64* %240, i64 1, !dbg !108
-  store i64 %rubyStr_5.i, i64* %241, align 8, !dbg !108, !tbaa !6
-  %242 = getelementptr inbounds i64, i64* %241, i64 1, !dbg !108
-  store i64* %242, i64** %238, align 8, !dbg !108
-  %send46 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Complex, i64 0), !dbg !108
-  %243 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !109
-  %244 = load i64*, i64** %243, align 8, !dbg !109
-  store i64 %62, i64* %244, align 8, !dbg !109, !tbaa !6
-  %245 = getelementptr inbounds i64, i64* %244, i64 1, !dbg !109
-  store i64 36028797018963970, i64* %245, align 8, !dbg !109, !tbaa !6
-  %246 = getelementptr inbounds i64, i64* %245, i64 1, !dbg !109
-  store i64 %send46, i64* %246, align 8, !dbg !109, !tbaa !6
-  %247 = getelementptr inbounds i64, i64* %246, i64 1, !dbg !109
-  store i64* %247, i64** %243, align 8, !dbg !109
-  %send48 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus.25, i64 0), !dbg !109
-  %248 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !110
-  %249 = load i64*, i64** %248, align 8, !dbg !110
-  store i64 %62, i64* %249, align 8, !dbg !110, !tbaa !6
-  %250 = getelementptr inbounds i64, i64* %249, i64 1, !dbg !110
-  store i64 %send48, i64* %250, align 8, !dbg !110, !tbaa !6
-  %251 = getelementptr inbounds i64, i64* %250, i64 1, !dbg !110
-  store i64* %251, i64** %248, align 8, !dbg !110
-  %send50 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.26, i64 0), !dbg !110
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 40), i64** %75, align 8, !dbg !110, !tbaa !14
-  %252 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !111
-  %253 = load i64*, i64** %252, align 8, !dbg !111
-  store i64 %62, i64* %253, align 8, !dbg !111, !tbaa !6
-  %254 = getelementptr inbounds i64, i64* %253, i64 1, !dbg !111
-  %255 = getelementptr inbounds i64, i64* %254, i64 1, !dbg !111
-  %256 = bitcast i64* %254 to <2 x i64>*, !dbg !111
-  store <2 x i64> <i64 199678348478539370, i64 7>, <2 x i64>* %256, align 8, !dbg !111, !tbaa !6
-  %257 = getelementptr inbounds i64, i64* %255, i64 1, !dbg !111
-  store i64* %257, i64** %252, align 8, !dbg !111
-  %send52 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus.27, i64 0), !dbg !111
-  %258 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !112
-  %259 = load i64*, i64** %258, align 8, !dbg !112
-  store i64 %62, i64* %259, align 8, !dbg !112, !tbaa !6
-  %260 = getelementptr inbounds i64, i64* %259, i64 1, !dbg !112
-  store i64 %send52, i64* %260, align 8, !dbg !112, !tbaa !6
-  %261 = getelementptr inbounds i64, i64* %260, i64 1, !dbg !112
-  store i64* %261, i64** %258, align 8, !dbg !112
-  %send54 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.28, i64 0), !dbg !112
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 41), i64** %75, align 8, !dbg !112, !tbaa !14
+  %211 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !108
+  %212 = load i64*, i64** %211, align 8, !dbg !108
+  store i64 %197, i64* %212, align 8, !dbg !108, !tbaa !6
+  %213 = getelementptr inbounds i64, i64* %212, i64 1, !dbg !108
+  store i64 1, i64* %213, align 8, !dbg !108, !tbaa !6
+  %214 = getelementptr inbounds i64, i64* %213, i64 1, !dbg !108
+  store i64 %rubyStr_5.i, i64* %214, align 8, !dbg !108, !tbaa !6
+  %215 = getelementptr inbounds i64, i64* %214, i64 1, !dbg !108
+  store i64* %215, i64** %211, align 8, !dbg !108
+  %send42 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Complex, i64 0), !dbg !108
+  %216 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !109
+  %217 = load i64*, i64** %216, align 8, !dbg !109
+  store i64 %35, i64* %217, align 8, !dbg !109, !tbaa !6
+  %218 = getelementptr inbounds i64, i64* %217, i64 1, !dbg !109
+  store i64 36028797018963970, i64* %218, align 8, !dbg !109, !tbaa !6
+  %219 = getelementptr inbounds i64, i64* %218, i64 1, !dbg !109
+  store i64 %send42, i64* %219, align 8, !dbg !109, !tbaa !6
+  %220 = getelementptr inbounds i64, i64* %219, i64 1, !dbg !109
+  store i64* %220, i64** %216, align 8, !dbg !109
+  %send44 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus.25, i64 0), !dbg !109
+  %221 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !110
+  %222 = load i64*, i64** %221, align 8, !dbg !110
+  store i64 %35, i64* %222, align 8, !dbg !110, !tbaa !6
+  %223 = getelementptr inbounds i64, i64* %222, i64 1, !dbg !110
+  store i64 %send44, i64* %223, align 8, !dbg !110, !tbaa !6
+  %224 = getelementptr inbounds i64, i64* %223, i64 1, !dbg !110
+  store i64* %224, i64** %221, align 8, !dbg !110
+  %send46 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.26, i64 0), !dbg !110
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 40), i64** %48, align 8, !dbg !110, !tbaa !14
+  %225 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !111
+  %226 = load i64*, i64** %225, align 8, !dbg !111
+  store i64 %35, i64* %226, align 8, !dbg !111, !tbaa !6
+  %227 = getelementptr inbounds i64, i64* %226, i64 1, !dbg !111
+  %228 = getelementptr inbounds i64, i64* %227, i64 1, !dbg !111
+  %229 = bitcast i64* %227 to <2 x i64>*, !dbg !111
+  store <2 x i64> <i64 199678348478539370, i64 7>, <2 x i64>* %229, align 8, !dbg !111, !tbaa !6
+  %230 = getelementptr inbounds i64, i64* %228, i64 1, !dbg !111
+  store i64* %230, i64** %225, align 8, !dbg !111
+  %send48 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus.27, i64 0), !dbg !111
+  %231 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !112
+  %232 = load i64*, i64** %231, align 8, !dbg !112
+  store i64 %35, i64* %232, align 8, !dbg !112, !tbaa !6
+  %233 = getelementptr inbounds i64, i64* %232, i64 1, !dbg !112
+  store i64 %send48, i64* %233, align 8, !dbg !112, !tbaa !6
+  %234 = getelementptr inbounds i64, i64* %233, i64 1, !dbg !112
+  store i64* %234, i64** %231, align 8, !dbg !112
+  %send50 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.28, i64 0), !dbg !112
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 41), i64** %48, align 8, !dbg !112, !tbaa !14
   %rubyStr_15.4.i = load i64, i64* @rubyStrFrozen_15.4, align 8, !dbg !113
-  %262 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !113
-  %263 = load i64*, i64** %262, align 8, !dbg !113
-  store i64 %224, i64* %263, align 8, !dbg !113, !tbaa !6
-  %264 = getelementptr inbounds i64, i64* %263, i64 1, !dbg !113
-  store i64 %rubyStr_15.4.i, i64* %264, align 8, !dbg !113, !tbaa !6
-  %265 = getelementptr inbounds i64, i64* %264, i64 1, !dbg !113
-  store i64* %265, i64** %262, align 8, !dbg !113
-  %send56 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational.29, i64 0), !dbg !113
-  %266 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !114
-  %267 = load i64*, i64** %266, align 8, !dbg !114
-  store i64 %62, i64* %267, align 8, !dbg !114, !tbaa !6
-  %268 = getelementptr inbounds i64, i64* %267, i64 1, !dbg !114
-  store i64 199622053483197234, i64* %268, align 8, !dbg !114, !tbaa !6
-  %269 = getelementptr inbounds i64, i64* %268, i64 1, !dbg !114
-  store i64 %send56, i64* %269, align 8, !dbg !114, !tbaa !6
-  %270 = getelementptr inbounds i64, i64* %269, i64 1, !dbg !114
-  store i64* %270, i64** %266, align 8, !dbg !114
-  %send58 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus.30, i64 0), !dbg !114
-  %271 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !115
-  %272 = load i64*, i64** %271, align 8, !dbg !115
-  store i64 %62, i64* %272, align 8, !dbg !115, !tbaa !6
-  %273 = getelementptr inbounds i64, i64* %272, i64 1, !dbg !115
-  store i64 %send58, i64* %273, align 8, !dbg !115, !tbaa !6
-  %274 = getelementptr inbounds i64, i64* %273, i64 1, !dbg !115
-  store i64* %274, i64** %271, align 8, !dbg !115
-  %send60 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.31, i64 0), !dbg !115
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 42), i64** %75, align 8, !dbg !115, !tbaa !14
+  %235 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !113
+  %236 = load i64*, i64** %235, align 8, !dbg !113
+  store i64 %197, i64* %236, align 8, !dbg !113, !tbaa !6
+  %237 = getelementptr inbounds i64, i64* %236, i64 1, !dbg !113
+  store i64 %rubyStr_15.4.i, i64* %237, align 8, !dbg !113, !tbaa !6
+  %238 = getelementptr inbounds i64, i64* %237, i64 1, !dbg !113
+  store i64* %238, i64** %235, align 8, !dbg !113
+  %send52 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational.29, i64 0), !dbg !113
+  %239 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !114
+  %240 = load i64*, i64** %239, align 8, !dbg !114
+  store i64 %35, i64* %240, align 8, !dbg !114, !tbaa !6
+  %241 = getelementptr inbounds i64, i64* %240, i64 1, !dbg !114
+  store i64 199622053483197234, i64* %241, align 8, !dbg !114, !tbaa !6
+  %242 = getelementptr inbounds i64, i64* %241, i64 1, !dbg !114
+  store i64 %send52, i64* %242, align 8, !dbg !114, !tbaa !6
+  %243 = getelementptr inbounds i64, i64* %242, i64 1, !dbg !114
+  store i64* %243, i64** %239, align 8, !dbg !114
+  %send54 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus.30, i64 0), !dbg !114
+  %244 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !115
+  %245 = load i64*, i64** %244, align 8, !dbg !115
+  store i64 %35, i64* %245, align 8, !dbg !115, !tbaa !6
+  %246 = getelementptr inbounds i64, i64* %245, i64 1, !dbg !115
+  store i64 %send54, i64* %246, align 8, !dbg !115, !tbaa !6
+  %247 = getelementptr inbounds i64, i64* %246, i64 1, !dbg !115
+  store i64* %247, i64** %244, align 8, !dbg !115
+  %send56 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.31, i64 0), !dbg !115
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 42), i64** %48, align 8, !dbg !115, !tbaa !14
   %rubyStr_18.i = load i64, i64* @rubyStrFrozen_18, align 8, !dbg !116
-  %275 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !116
-  %276 = load i64*, i64** %275, align 8, !dbg !116
-  store i64 %224, i64* %276, align 8, !dbg !116, !tbaa !6
-  %277 = getelementptr inbounds i64, i64* %276, i64 1, !dbg !116
-  store i64 1, i64* %277, align 8, !dbg !116, !tbaa !6
-  %278 = getelementptr inbounds i64, i64* %277, i64 1, !dbg !116
-  store i64 %rubyStr_18.i, i64* %278, align 8, !dbg !116, !tbaa !6
-  %279 = getelementptr inbounds i64, i64* %278, i64 1, !dbg !116
-  store i64* %279, i64** %275, align 8, !dbg !116
-  %send62 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Complex.32, i64 0), !dbg !116
-  %280 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !117
-  %281 = load i64*, i64** %280, align 8, !dbg !117
-  store i64 %62, i64* %281, align 8, !dbg !117, !tbaa !6
-  %282 = getelementptr inbounds i64, i64* %281, i64 1, !dbg !117
-  store i64 199565758487855106, i64* %282, align 8, !dbg !117, !tbaa !6
-  %283 = getelementptr inbounds i64, i64* %282, i64 1, !dbg !117
-  store i64 %send62, i64* %283, align 8, !dbg !117, !tbaa !6
-  %284 = getelementptr inbounds i64, i64* %283, i64 1, !dbg !117
-  store i64* %284, i64** %280, align 8, !dbg !117
-  %send64 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus.33, i64 0), !dbg !117
-  %285 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !118
-  %286 = load i64*, i64** %285, align 8, !dbg !118
-  store i64 %62, i64* %286, align 8, !dbg !118, !tbaa !6
-  %287 = getelementptr inbounds i64, i64* %286, i64 1, !dbg !118
-  store i64 %send64, i64* %287, align 8, !dbg !118, !tbaa !6
-  %288 = getelementptr inbounds i64, i64* %287, i64 1, !dbg !118
-  store i64* %288, i64** %285, align 8, !dbg !118
-  %send66 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.34, i64 0), !dbg !118
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 44), i64** %75, align 8, !dbg !118, !tbaa !14
-  %289 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !119
-  %290 = load i64*, i64** %289, align 8, !dbg !119
-  store i64 %62, i64* %290, align 8, !dbg !119, !tbaa !6
-  %291 = getelementptr inbounds i64, i64* %290, i64 1, !dbg !119
-  %292 = getelementptr inbounds i64, i64* %291, i64 1, !dbg !119
-  %293 = bitcast i64* %291 to <2 x i64>*, !dbg !119
-  store <2 x i64> <i64 113040350646999450, i64 13>, <2 x i64>* %293, align 8, !dbg !119, !tbaa !6
-  %294 = getelementptr inbounds i64, i64* %292, i64 1, !dbg !119
-  store i64* %294, i64** %289, align 8, !dbg !119
-  %send68 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt.35, i64 0), !dbg !119
-  %295 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !120
-  %296 = load i64*, i64** %295, align 8, !dbg !120
-  store i64 %62, i64* %296, align 8, !dbg !120, !tbaa !6
-  %297 = getelementptr inbounds i64, i64* %296, i64 1, !dbg !120
-  store i64 %send68, i64* %297, align 8, !dbg !120, !tbaa !6
-  %298 = getelementptr inbounds i64, i64* %297, i64 1, !dbg !120
-  store i64* %298, i64** %295, align 8, !dbg !120
-  %send70 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.36, i64 0), !dbg !120
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 45), i64** %75, align 8, !dbg !120, !tbaa !14
+  %248 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !116
+  %249 = load i64*, i64** %248, align 8, !dbg !116
+  store i64 %197, i64* %249, align 8, !dbg !116, !tbaa !6
+  %250 = getelementptr inbounds i64, i64* %249, i64 1, !dbg !116
+  store i64 1, i64* %250, align 8, !dbg !116, !tbaa !6
+  %251 = getelementptr inbounds i64, i64* %250, i64 1, !dbg !116
+  store i64 %rubyStr_18.i, i64* %251, align 8, !dbg !116, !tbaa !6
+  %252 = getelementptr inbounds i64, i64* %251, i64 1, !dbg !116
+  store i64* %252, i64** %248, align 8, !dbg !116
+  %send58 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Complex.32, i64 0), !dbg !116
+  %253 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !117
+  %254 = load i64*, i64** %253, align 8, !dbg !117
+  store i64 %35, i64* %254, align 8, !dbg !117, !tbaa !6
+  %255 = getelementptr inbounds i64, i64* %254, i64 1, !dbg !117
+  store i64 199565758487855106, i64* %255, align 8, !dbg !117, !tbaa !6
+  %256 = getelementptr inbounds i64, i64* %255, i64 1, !dbg !117
+  store i64 %send58, i64* %256, align 8, !dbg !117, !tbaa !6
+  %257 = getelementptr inbounds i64, i64* %256, i64 1, !dbg !117
+  store i64* %257, i64** %253, align 8, !dbg !117
+  %send60 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus.33, i64 0), !dbg !117
+  %258 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !118
+  %259 = load i64*, i64** %258, align 8, !dbg !118
+  store i64 %35, i64* %259, align 8, !dbg !118, !tbaa !6
+  %260 = getelementptr inbounds i64, i64* %259, i64 1, !dbg !118
+  store i64 %send60, i64* %260, align 8, !dbg !118, !tbaa !6
+  %261 = getelementptr inbounds i64, i64* %260, i64 1, !dbg !118
+  store i64* %261, i64** %258, align 8, !dbg !118
+  %send62 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.34, i64 0), !dbg !118
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 44), i64** %48, align 8, !dbg !118, !tbaa !14
+  %262 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !119
+  %263 = load i64*, i64** %262, align 8, !dbg !119
+  store i64 %35, i64* %263, align 8, !dbg !119, !tbaa !6
+  %264 = getelementptr inbounds i64, i64* %263, i64 1, !dbg !119
+  %265 = getelementptr inbounds i64, i64* %264, i64 1, !dbg !119
+  %266 = bitcast i64* %264 to <2 x i64>*, !dbg !119
+  store <2 x i64> <i64 113040350646999450, i64 13>, <2 x i64>* %266, align 8, !dbg !119, !tbaa !6
+  %267 = getelementptr inbounds i64, i64* %265, i64 1, !dbg !119
+  store i64* %267, i64** %262, align 8, !dbg !119
+  %send64 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt.35, i64 0), !dbg !119
+  %268 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !120
+  %269 = load i64*, i64** %268, align 8, !dbg !120
+  store i64 %35, i64* %269, align 8, !dbg !120, !tbaa !6
+  %270 = getelementptr inbounds i64, i64* %269, i64 1, !dbg !120
+  store i64 %send64, i64* %270, align 8, !dbg !120, !tbaa !6
+  %271 = getelementptr inbounds i64, i64* %270, i64 1, !dbg !120
+  store i64* %271, i64** %268, align 8, !dbg !120
+  %send66 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.36, i64 0), !dbg !120
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 45), i64** %48, align 8, !dbg !120, !tbaa !14
   %rubyStr_25.4.i = load i64, i64* @rubyStrFrozen_25.4, align 8, !dbg !121
-  %299 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !121
-  %300 = load i64*, i64** %299, align 8, !dbg !121
-  store i64 %224, i64* %300, align 8, !dbg !121, !tbaa !6
-  %301 = getelementptr inbounds i64, i64* %300, i64 1, !dbg !121
-  store i64 %rubyStr_25.4.i, i64* %301, align 8, !dbg !121, !tbaa !6
-  %302 = getelementptr inbounds i64, i64* %301, i64 1, !dbg !121
-  store i64* %302, i64** %299, align 8, !dbg !121
-  %send72 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational.37, i64 0), !dbg !121
-  %303 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !122
-  %304 = load i64*, i64** %303, align 8, !dbg !122
-  store i64 %62, i64* %304, align 8, !dbg !122, !tbaa !6
-  %305 = getelementptr inbounds i64, i64* %304, i64 1, !dbg !122
-  store i64 113040350646999450, i64* %305, align 8, !dbg !122, !tbaa !6
-  %306 = getelementptr inbounds i64, i64* %305, i64 1, !dbg !122
-  store i64 %send72, i64* %306, align 8, !dbg !122, !tbaa !6
-  %307 = getelementptr inbounds i64, i64* %306, i64 1, !dbg !122
-  store i64* %307, i64** %303, align 8, !dbg !122
-  %send74 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt.38, i64 0), !dbg !122
-  %308 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !123
-  %309 = load i64*, i64** %308, align 8, !dbg !123
-  store i64 %62, i64* %309, align 8, !dbg !123, !tbaa !6
-  %310 = getelementptr inbounds i64, i64* %309, i64 1, !dbg !123
-  store i64 %send74, i64* %310, align 8, !dbg !123, !tbaa !6
-  %311 = getelementptr inbounds i64, i64* %310, i64 1, !dbg !123
-  store i64* %311, i64** %308, align 8, !dbg !123
-  %send76 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.39, i64 0), !dbg !123
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 47), i64** %75, align 8, !dbg !123, !tbaa !14
-  %312 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !124
-  %313 = load i64*, i64** %312, align 8, !dbg !124
-  store i64 %62, i64* %313, align 8, !dbg !124, !tbaa !6
-  %314 = getelementptr inbounds i64, i64* %313, i64 1, !dbg !124
-  %315 = getelementptr inbounds i64, i64* %314, i64 1, !dbg !124
-  %316 = bitcast i64* %314 to <2 x i64>*, !dbg !124
-  store <2 x i64> <i64 113040350646999450, i64 41>, <2 x i64>* %316, align 8, !dbg !124, !tbaa !6
-  %317 = getelementptr inbounds i64, i64* %315, i64 1, !dbg !124
-  store i64* %317, i64** %312, align 8, !dbg !124
-  %send78 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.40, i64 0), !dbg !124
-  %318 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !125
-  %319 = load i64*, i64** %318, align 8, !dbg !125
-  store i64 %62, i64* %319, align 8, !dbg !125, !tbaa !6
-  %320 = getelementptr inbounds i64, i64* %319, i64 1, !dbg !125
-  store i64 %send78, i64* %320, align 8, !dbg !125, !tbaa !6
-  %321 = getelementptr inbounds i64, i64* %320, i64 1, !dbg !125
-  store i64* %321, i64** %318, align 8, !dbg !125
-  %send80 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.41, i64 0), !dbg !125
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 48), i64** %75, align 8, !dbg !125, !tbaa !14
+  %272 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !121
+  %273 = load i64*, i64** %272, align 8, !dbg !121
+  store i64 %197, i64* %273, align 8, !dbg !121, !tbaa !6
+  %274 = getelementptr inbounds i64, i64* %273, i64 1, !dbg !121
+  store i64 %rubyStr_25.4.i, i64* %274, align 8, !dbg !121, !tbaa !6
+  %275 = getelementptr inbounds i64, i64* %274, i64 1, !dbg !121
+  store i64* %275, i64** %272, align 8, !dbg !121
+  %send68 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational.37, i64 0), !dbg !121
+  %276 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !122
+  %277 = load i64*, i64** %276, align 8, !dbg !122
+  store i64 %35, i64* %277, align 8, !dbg !122, !tbaa !6
+  %278 = getelementptr inbounds i64, i64* %277, i64 1, !dbg !122
+  store i64 113040350646999450, i64* %278, align 8, !dbg !122, !tbaa !6
+  %279 = getelementptr inbounds i64, i64* %278, i64 1, !dbg !122
+  store i64 %send68, i64* %279, align 8, !dbg !122, !tbaa !6
+  %280 = getelementptr inbounds i64, i64* %279, i64 1, !dbg !122
+  store i64* %280, i64** %276, align 8, !dbg !122
+  %send70 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt.38, i64 0), !dbg !122
+  %281 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !123
+  %282 = load i64*, i64** %281, align 8, !dbg !123
+  store i64 %35, i64* %282, align 8, !dbg !123, !tbaa !6
+  %283 = getelementptr inbounds i64, i64* %282, i64 1, !dbg !123
+  store i64 %send70, i64* %283, align 8, !dbg !123, !tbaa !6
+  %284 = getelementptr inbounds i64, i64* %283, i64 1, !dbg !123
+  store i64* %284, i64** %281, align 8, !dbg !123
+  %send72 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.39, i64 0), !dbg !123
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 47), i64** %48, align 8, !dbg !123, !tbaa !14
+  %285 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !124
+  %286 = load i64*, i64** %285, align 8, !dbg !124
+  store i64 %35, i64* %286, align 8, !dbg !124, !tbaa !6
+  %287 = getelementptr inbounds i64, i64* %286, i64 1, !dbg !124
+  %288 = getelementptr inbounds i64, i64* %287, i64 1, !dbg !124
+  %289 = bitcast i64* %287 to <2 x i64>*, !dbg !124
+  store <2 x i64> <i64 113040350646999450, i64 41>, <2 x i64>* %289, align 8, !dbg !124, !tbaa !6
+  %290 = getelementptr inbounds i64, i64* %288, i64 1, !dbg !124
+  store i64* %290, i64** %285, align 8, !dbg !124
+  %send74 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.40, i64 0), !dbg !124
+  %291 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !125
+  %292 = load i64*, i64** %291, align 8, !dbg !125
+  store i64 %35, i64* %292, align 8, !dbg !125, !tbaa !6
+  %293 = getelementptr inbounds i64, i64* %292, i64 1, !dbg !125
+  store i64 %send74, i64* %293, align 8, !dbg !125, !tbaa !6
+  %294 = getelementptr inbounds i64, i64* %293, i64 1, !dbg !125
+  store i64* %294, i64** %291, align 8, !dbg !125
+  %send76 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.41, i64 0), !dbg !125
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 48), i64** %48, align 8, !dbg !125, !tbaa !14
   %rubyStr_5.923.i = load i64, i64* @rubyStrFrozen_5.923, align 8, !dbg !126
-  %322 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !126
-  %323 = load i64*, i64** %322, align 8, !dbg !126
-  store i64 %224, i64* %323, align 8, !dbg !126, !tbaa !6
-  %324 = getelementptr inbounds i64, i64* %323, i64 1, !dbg !126
-  store i64 %rubyStr_5.923.i, i64* %324, align 8, !dbg !126, !tbaa !6
-  %325 = getelementptr inbounds i64, i64* %324, i64 1, !dbg !126
-  store i64* %325, i64** %322, align 8, !dbg !126
-  %send82 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational.42, i64 0), !dbg !126
-  %326 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !127
-  %327 = load i64*, i64** %326, align 8, !dbg !127
-  store i64 %62, i64* %327, align 8, !dbg !127, !tbaa !6
-  %328 = getelementptr inbounds i64, i64* %327, i64 1, !dbg !127
-  store i64 113040350646999450, i64* %328, align 8, !dbg !127, !tbaa !6
-  %329 = getelementptr inbounds i64, i64* %328, i64 1, !dbg !127
-  store i64 %send82, i64* %329, align 8, !dbg !127, !tbaa !6
-  %330 = getelementptr inbounds i64, i64* %329, i64 1, !dbg !127
-  store i64* %330, i64** %326, align 8, !dbg !127
-  %send84 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.43, i64 0), !dbg !127
-  %331 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %65, i64 0, i32 1, !dbg !128
-  %332 = load i64*, i64** %331, align 8, !dbg !128
-  store i64 %62, i64* %332, align 8, !dbg !128, !tbaa !6
-  %333 = getelementptr inbounds i64, i64* %332, i64 1, !dbg !128
-  store i64 %send84, i64* %333, align 8, !dbg !128, !tbaa !6
-  %334 = getelementptr inbounds i64, i64* %333, i64 1, !dbg !128
-  store i64* %334, i64** %331, align 8, !dbg !128
-  %send86 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.44, i64 0), !dbg !128
-  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %66)
-  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %67)
-  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %68)
-  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %69)
+  %295 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !126
+  %296 = load i64*, i64** %295, align 8, !dbg !126
+  store i64 %197, i64* %296, align 8, !dbg !126, !tbaa !6
+  %297 = getelementptr inbounds i64, i64* %296, i64 1, !dbg !126
+  store i64 %rubyStr_5.923.i, i64* %297, align 8, !dbg !126, !tbaa !6
+  %298 = getelementptr inbounds i64, i64* %297, i64 1, !dbg !126
+  store i64* %298, i64** %295, align 8, !dbg !126
+  %send78 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational.42, i64 0), !dbg !126
+  %299 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !127
+  %300 = load i64*, i64** %299, align 8, !dbg !127
+  store i64 %35, i64* %300, align 8, !dbg !127, !tbaa !6
+  %301 = getelementptr inbounds i64, i64* %300, i64 1, !dbg !127
+  store i64 113040350646999450, i64* %301, align 8, !dbg !127, !tbaa !6
+  %302 = getelementptr inbounds i64, i64* %301, i64 1, !dbg !127
+  store i64 %send78, i64* %302, align 8, !dbg !127, !tbaa !6
+  %303 = getelementptr inbounds i64, i64* %302, i64 1, !dbg !127
+  store i64* %303, i64** %299, align 8, !dbg !127
+  %send80 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.43, i64 0), !dbg !127
+  %304 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !128
+  %305 = load i64*, i64** %304, align 8, !dbg !128
+  store i64 %35, i64* %305, align 8, !dbg !128, !tbaa !6
+  %306 = getelementptr inbounds i64, i64* %305, i64 1, !dbg !128
+  store i64 %send80, i64* %306, align 8, !dbg !128, !tbaa !6
+  %307 = getelementptr inbounds i64, i64* %306, i64 1, !dbg !128
+  store i64* %307, i64** %304, align 8, !dbg !128
+  %send82 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.44, i64 0), !dbg !128
+  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %39)
+  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %40)
+  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %41)
+  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %42)
   ret void
 }
 

--- a/test/testdata/compiler/globalfields.opt.ll.exp
+++ b/test/testdata/compiler/globalfields.opt.ll.exp
@@ -84,32 +84,25 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/globalfields.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [20 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @ic_new = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_new = internal unnamed_addr global i64 0, align 8
 @ic_initialize = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_initialize = internal unnamed_addr global i64 0, align 8
 @ic_read = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_read = internal unnamed_addr global i64 0, align 8
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
 @rubyStrFrozen_value = internal unnamed_addr global i64 0, align 8
 @ic_write = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_write = internal unnamed_addr global i64 0, align 8
 @ic_read.1 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.2 = internal global %struct.FunctionInlineCache zeroinitializer
-@"rubyIdPrecomputed_$f" = internal unnamed_addr global i64 0, align 8
 @ic_puts.3 = internal global %struct.FunctionInlineCache zeroinitializer
 @"stackFramePrecomputed_func_A#5write" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"stackFramePrecomputed_func_A#4read" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"stackFramePrecomputed_func_A.13<static-init>" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_<class:A>" = internal unnamed_addr global i64 0, align 8
-@rubyIdPrecomputed_v = internal unnamed_addr global i64 0, align 8
 @sorbet_moduleStringTable = internal unnamed_addr constant [133 x i8] c"<top (required)>\00test/testdata/compiler/globalfields.rb\00A\00Object\00new\00initialize\00read\00puts\00value\00write\00$f\00F\00master\00<class:A>\00normal\00v\00", align 1
+@sorbet_moduleIDTable = internal unnamed_addr global [10 x i64] zeroinitializer, align 8
+@sorbet_moduleIDDescriptors = internal unnamed_addr constant [10 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 65, i32 3 }, %struct.rb_code_position_struct { i32 69, i32 10 }, %struct.rb_code_position_struct { i32 80, i32 4 }, %struct.rb_code_position_struct { i32 85, i32 4 }, %struct.rb_code_position_struct { i32 96, i32 5 }, %struct.rb_code_position_struct { i32 102, i32 2 }, %struct.rb_code_position_struct { i32 114, i32 9 }, %struct.rb_code_position_struct { i32 124, i32 6 }, %struct.rb_code_position_struct { i32 131, i32 1 }], align 8
 @rb_cObject = external local_unnamed_addr constant i64
 @guard_epoch_A = linkonce local_unnamed_addr global i64 0
 @guarded_const_A = linkonce local_unnamed_addr global i64 0
@@ -139,6 +132,8 @@ declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %
 
 declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #1
 
+declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #1
+
 declare i64 @sorbet_maybeAllocateObjectFastPath(i64, %struct.FunctionInlineCache*) local_unnamed_addr #1
 
 declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #1
@@ -156,8 +151,6 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #2
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #2
-
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #1
 
 declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #1
 
@@ -196,239 +189,216 @@ entry:
   %locals.i15.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #11
-  store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %1 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 65), i64 noundef 3) #11
-  store i64 %1, i64* @rubyIdPrecomputed_new, align 8
-  %2 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 69), i64 noundef 10) #11
-  store i64 %2, i64* @rubyIdPrecomputed_initialize, align 8
-  %3 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 80), i64 noundef 4) #11
-  store i64 %3, i64* @rubyIdPrecomputed_read, align 8
-  %4 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 85), i64 noundef 4) #11
-  store i64 %4, i64* @rubyIdPrecomputed_puts, align 8
-  %5 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 96), i64 noundef 5) #11
-  store i64 %5, i64* @rubyIdPrecomputed_write, align 8
-  %6 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 102), i64 noundef 2) #11
-  store i64 %6, i64* @"rubyIdPrecomputed_$f", align 8
-  %7 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 114), i64 noundef 9) #11
-  store i64 %7, i64* @"rubyIdPrecomputed_<class:A>", align 8
-  %8 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 124), i64 noundef 6) #11
-  %9 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 131), i64 noundef 1) #11
-  store i64 %9, i64* @rubyIdPrecomputed_v, align 8
-  %10 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #11
-  tail call void @rb_gc_register_mark_object(i64 %10) #11
-  store i64 %10, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %11 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 38) #11
-  tail call void @rb_gc_register_mark_object(i64 %11) #11
-  store i64 %11, i64* @"rubyStrFrozen_test/testdata/compiler/globalfields.rb", align 8
+  tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([10 x %struct.rb_code_position_struct], [10 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 10, i8* noundef getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
+  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #11
+  tail call void @rb_gc_register_mark_object(i64 %0) #11
+  store i64 %0, i64* @"rubyStrFrozen_<top (required)>", align 8
+  %1 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 38) #11
+  tail call void @rb_gc_register_mark_object(i64 %1) #11
+  store i64 %1, i64* @"rubyStrFrozen_test/testdata/compiler/globalfields.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 20)
-  %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
+  %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
   %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/globalfields.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/globalfields.rb", align 8
-  %12 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/globalfields.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %12, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !17
+  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/globalfields.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %rubyId_new.i = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !dbg !17, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !17
-  %rubyId_initialize.i = load i64, i64* @rubyIdPrecomputed_initialize, align 8, !dbg !17
+  %rubyId_initialize.i = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !17, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 %rubyId_initialize.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !17
-  %rubyId_read.i = load i64, i64* @rubyIdPrecomputed_read, align 8, !dbg !18
+  %rubyId_read.i = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !18, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_read, i64 %rubyId_read.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !18
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !19
+  %rubyId_puts.i = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !dbg !19, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
-  %13 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 90), i64 noundef 5) #11
-  call void @rb_gc_register_mark_object(i64 %13) #11
-  store i64 %13, i64* @rubyStrFrozen_value, align 8
-  %rubyId_write.i = load i64, i64* @rubyIdPrecomputed_write, align 8, !dbg !20
+  %3 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 90), i64 noundef 5) #11
+  call void @rb_gc_register_mark_object(i64 %3) #11
+  store i64 %3, i64* @rubyStrFrozen_value, align 8
+  %rubyId_write.i = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 5), align 8, !dbg !20, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_write, i64 %rubyId_write.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !20
-  %rubyId_read6.i = load i64, i64* @rubyIdPrecomputed_read, align 8, !dbg !21
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_read.1, i64 %rubyId_read6.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !21
-  %rubyId_puts8.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !22
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts8.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !22
-  %rubyId_puts11.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !23
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts11.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !23
-  %14 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 96), i64 noundef 5) #11
-  call void @rb_gc_register_mark_object(i64 %14) #11
-  %rubyId_write.i.i = load i64, i64* @rubyIdPrecomputed_write, align 8
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_read.1, i64 %rubyId_read.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !21
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !22
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !23
+  %4 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 96), i64 noundef 5) #11
+  call void @rb_gc_register_mark_object(i64 %4) #11
   %"rubyStr_test/testdata/compiler/globalfields.rb.i14.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/globalfields.rb", align 8
-  %15 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %14, i64 %rubyId_write.i.i, i64 %"rubyStr_test/testdata/compiler/globalfields.rb.i14.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i15.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %15, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#5write", align 8
-  %16 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 80), i64 noundef 4) #11
-  call void @rb_gc_register_mark_object(i64 %16) #11
-  %rubyId_read.i.i = load i64, i64* @rubyIdPrecomputed_read, align 8
+  %5 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %4, i64 %rubyId_write.i, i64 %"rubyStr_test/testdata/compiler/globalfields.rb.i14.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i15.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %5, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#5write", align 8
+  %6 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 80), i64 noundef 4) #11
+  call void @rb_gc_register_mark_object(i64 %6) #11
   %"rubyStr_test/testdata/compiler/globalfields.rb.i16.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/globalfields.rb", align 8
-  %17 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %16, i64 %rubyId_read.i.i, i64 %"rubyStr_test/testdata/compiler/globalfields.rb.i16.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 9, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i17.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %17, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#4read", align 8
-  %18 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 114), i64 noundef 9) #11
-  call void @rb_gc_register_mark_object(i64 %18) #11
-  %"rubyId_<class:A>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:A>", align 8
+  %7 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %6, i64 %rubyId_read.i, i64 %"rubyStr_test/testdata/compiler/globalfields.rb.i16.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 9, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i17.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %7, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#4read", align 8
+  %8 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 114), i64 noundef 9) #11
+  call void @rb_gc_register_mark_object(i64 %8) #11
+  %"rubyId_<class:A>.i.i" = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 7), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/globalfields.rb.i18.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/globalfields.rb", align 8
-  %19 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %18, i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/globalfields.rb.i18.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i19.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %19, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %20 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !24
-  %21 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %20, i64 0, i32 18
-  %22 = load i64, i64* %21, align 8, !tbaa !26
-  %23 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !24
-  %24 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %23, i64 0, i32 2
-  %25 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %24, align 8, !tbaa !36
+  %9 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %8, i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/globalfields.rb.i18.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i19.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %9, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
+  %10 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !24
+  %11 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %10, i64 0, i32 18
+  %12 = load i64, i64* %11, align 8, !tbaa !26
+  %13 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !24
+  %14 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %13, i64 0, i32 2
+  %15 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %14, align 8, !tbaa !36
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %26 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %26, align 8, !tbaa !39
-  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 4
-  %28 = load i64*, i64** %27, align 8, !tbaa !41
-  %29 = load i64, i64* %28, align 8, !tbaa !6
-  %30 = and i64 %29, -33
-  store i64 %30, i64* %28, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %23, %struct.rb_control_frame_struct* %25, %struct.rb_iseq_struct* %stackFrame.i) #11
-  %31 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 0
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %31, align 8, !dbg !42, !tbaa !24
-  %32 = load i64, i64* @rb_cObject, align 8, !dbg !43
-  %33 = call i64 @rb_define_class(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 56), i64 %32) #11, !dbg !43
-  %34 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %33) #11, !dbg !43
-  %35 = bitcast i64* %positional_table.i.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %35) #11
+  %16 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %16, align 8, !tbaa !39
+  %17 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 4
+  %18 = load i64*, i64** %17, align 8, !tbaa !41
+  %19 = load i64, i64* %18, align 8, !tbaa !6
+  %20 = and i64 %19, -33
+  store i64 %20, i64* %18, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %13, %struct.rb_control_frame_struct* %15, %struct.rb_iseq_struct* %stackFrame.i) #11
+  %21 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 0
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %21, align 8, !dbg !42, !tbaa !24
+  %22 = load i64, i64* @rb_cObject, align 8, !dbg !43
+  %23 = call i64 @rb_define_class(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 56), i64 %22) #11, !dbg !43
+  %24 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %23) #11, !dbg !43
+  %25 = bitcast i64* %positional_table.i.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %25) #11
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %36 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !24
-  %37 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %36, i64 0, i32 2
-  %38 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %37, align 8, !tbaa !36
-  %39 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %39, align 8, !tbaa !39
-  %40 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 4
-  %41 = load i64*, i64** %40, align 8, !tbaa !41
-  %42 = load i64, i64* %41, align 8, !tbaa !6
-  %43 = and i64 %42, -33
-  store i64 %43, i64* %41, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %36, %struct.rb_control_frame_struct* %38, %struct.rb_iseq_struct* %stackFrame.i.i) #11
-  %44 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %34, i64 0, i32 0
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %44, align 8, !dbg !44, !tbaa !24
-  %45 = load i64, i64* @guard_epoch_A, align 8, !dbg !10
-  %46 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !45
-  %needTakeSlowPath = icmp ne i64 %45, %46, !dbg !10
-  br i1 %needTakeSlowPath, label %47, label %48, !dbg !10, !prof !46
+  %26 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !24
+  %27 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %26, i64 0, i32 2
+  %28 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %27, align 8, !tbaa !36
+  %29 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %28, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %29, align 8, !tbaa !39
+  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %28, i64 0, i32 4
+  %31 = load i64*, i64** %30, align 8, !tbaa !41
+  %32 = load i64, i64* %31, align 8, !tbaa !6
+  %33 = and i64 %32, -33
+  store i64 %33, i64* %31, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %26, %struct.rb_control_frame_struct* %28, %struct.rb_iseq_struct* %stackFrame.i.i) #11
+  %34 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 0
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %34, align 8, !dbg !44, !tbaa !24
+  %35 = load i64, i64* @guard_epoch_A, align 8, !dbg !10
+  %36 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !45
+  %needTakeSlowPath = icmp ne i64 %35, %36, !dbg !10
+  br i1 %needTakeSlowPath, label %37, label %38, !dbg !10, !prof !46
 
-47:                                               ; preds = %entry
+37:                                               ; preds = %entry
   call void @const_recompute_A(), !dbg !10
-  br label %48, !dbg !10
+  br label %38, !dbg !10
 
-48:                                               ; preds = %entry, %47
-  %49 = load i64, i64* @guarded_const_A, align 8, !dbg !10
-  %50 = load i64, i64* @guard_epoch_A, align 8, !dbg !10
-  %51 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !45
-  %guardUpdated = icmp eq i64 %50, %51, !dbg !10
+38:                                               ; preds = %entry, %37
+  %39 = load i64, i64* @guarded_const_A, align 8, !dbg !10
+  %40 = load i64, i64* @guard_epoch_A, align 8, !dbg !10
+  %41 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !45
+  %guardUpdated = icmp eq i64 %40, %41, !dbg !10
   call void @llvm.assume(i1 %guardUpdated), !dbg !10
   %stackFrame17.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#5write", align 8, !dbg !10
-  %52 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !10
-  %53 = bitcast i8* %52 to i16*, !dbg !10
-  %54 = load i16, i16* %53, align 8, !dbg !10
-  %55 = and i16 %54, -384, !dbg !10
-  %56 = or i16 %55, 1, !dbg !10
-  store i16 %56, i16* %53, align 8, !dbg !10
-  %57 = getelementptr inbounds i8, i8* %52, i64 8, !dbg !10
-  %58 = bitcast i8* %57 to i32*, !dbg !10
-  store i32 1, i32* %58, align 8, !dbg !10, !tbaa !47
-  %59 = getelementptr inbounds i8, i8* %52, i64 12, !dbg !10
-  %60 = getelementptr inbounds i8, i8* %52, i64 4, !dbg !10
-  %61 = bitcast i8* %60 to i32*, !dbg !10
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %59, i8 0, i64 20, i1 false) #11, !dbg !10
-  store i32 1, i32* %61, align 4, !dbg !10, !tbaa !50
-  %rubyId_v.i.i = load i64, i64* @rubyIdPrecomputed_v, align 8, !dbg !10
+  %42 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !10
+  %43 = bitcast i8* %42 to i16*, !dbg !10
+  %44 = load i16, i16* %43, align 8, !dbg !10
+  %45 = and i16 %44, -384, !dbg !10
+  %46 = or i16 %45, 1, !dbg !10
+  store i16 %46, i16* %43, align 8, !dbg !10
+  %47 = getelementptr inbounds i8, i8* %42, i64 8, !dbg !10
+  %48 = bitcast i8* %47 to i32*, !dbg !10
+  store i32 1, i32* %48, align 8, !dbg !10, !tbaa !47
+  %49 = getelementptr inbounds i8, i8* %42, i64 12, !dbg !10
+  %50 = getelementptr inbounds i8, i8* %42, i64 4, !dbg !10
+  %51 = bitcast i8* %50 to i32*, !dbg !10
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %49, i8 0, i64 20, i1 false) #11, !dbg !10
+  store i32 1, i32* %51, align 4, !dbg !10, !tbaa !50
+  %rubyId_v.i.i = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 9), align 8, !dbg !10, !invariant.load !5
   store i64 %rubyId_v.i.i, i64* %positional_table.i.i, align 8, !dbg !10
-  %62 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !10
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %62, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %35, i64 noundef 8, i1 noundef false) #11, !dbg !10
-  %63 = getelementptr inbounds i8, i8* %52, i64 32, !dbg !10
-  %64 = bitcast i8* %63 to i8**, !dbg !10
-  store i8* %62, i8** %64, align 8, !dbg !10, !tbaa !51
-  call void @sorbet_vm_define_method(i64 %49, i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 96), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_A#5write", i8* nonnull %52, %struct.rb_iseq_struct* %stackFrame17.i.i, i1 noundef zeroext false) #11, !dbg !10
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %44, align 8, !dbg !10, !tbaa !24
+  %52 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !10
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %52, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %25, i64 noundef 8, i1 noundef false) #11, !dbg !10
+  %53 = getelementptr inbounds i8, i8* %42, i64 32, !dbg !10
+  %54 = bitcast i8* %53 to i8**, !dbg !10
+  store i8* %52, i8** %54, align 8, !dbg !10, !tbaa !51
+  call void @sorbet_vm_define_method(i64 %39, i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 96), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_A#5write", i8* nonnull %42, %struct.rb_iseq_struct* %stackFrame17.i.i, i1 noundef zeroext false) #11, !dbg !10
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %34, align 8, !dbg !10, !tbaa !24
   %stackFrame26.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#4read", align 8, !dbg !52
-  %65 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !52
-  %66 = bitcast i8* %65 to i16*, !dbg !52
-  %67 = load i16, i16* %66, align 8, !dbg !52
-  %68 = and i16 %67, -384, !dbg !52
-  store i16 %68, i16* %66, align 8, !dbg !52
-  %69 = getelementptr inbounds i8, i8* %65, i64 4, !dbg !52
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %69, i8 0, i64 28, i1 false) #11, !dbg !52
-  call void @sorbet_vm_define_method(i64 %49, i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 80), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_A#4read", i8* nonnull %65, %struct.rb_iseq_struct* %stackFrame26.i.i, i1 noundef zeroext false) #11, !dbg !52
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %35) #11
+  %55 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !52
+  %56 = bitcast i8* %55 to i16*, !dbg !52
+  %57 = load i16, i16* %56, align 8, !dbg !52
+  %58 = and i16 %57, -384, !dbg !52
+  store i16 %58, i16* %56, align 8, !dbg !52
+  %59 = getelementptr inbounds i8, i8* %55, i64 4, !dbg !52
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %59, i8 0, i64 28, i1 false) #11, !dbg !52
+  call void @sorbet_vm_define_method(i64 %39, i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 80), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_A#4read", i8* nonnull %55, %struct.rb_iseq_struct* %stackFrame26.i.i, i1 noundef zeroext false) #11, !dbg !52
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %25) #11
   call void @sorbet_popFrame() #11, !dbg !43
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %31, align 8, !dbg !43, !tbaa !24
-  %70 = call i64 @sorbet_maybeAllocateObjectFastPath(i64 %49, %struct.FunctionInlineCache* noundef @ic_new) #11, !dbg !17
-  %71 = icmp eq i64 %70, 52, !dbg !17
-  br i1 %71, label %slowNew.i, label %fastNew.i, !dbg !17
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %21, align 8, !dbg !43, !tbaa !24
+  %60 = call i64 @sorbet_maybeAllocateObjectFastPath(i64 %39, %struct.FunctionInlineCache* noundef @ic_new) #11, !dbg !17
+  %61 = icmp eq i64 %60, 52, !dbg !17
+  br i1 %61, label %slowNew.i, label %fastNew.i, !dbg !17
 
-slowNew.i:                                        ; preds = %48
-  %72 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !17
-  %73 = load i64*, i64** %72, align 8, !dbg !17
-  store i64 %49, i64* %73, align 8, !dbg !17, !tbaa !6
-  %74 = getelementptr inbounds i64, i64* %73, i64 1, !dbg !17
-  store i64* %74, i64** %72, align 8, !dbg !17
-  %75 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_new, i64 noundef 0) #11, !dbg !17
+slowNew.i:                                        ; preds = %38
+  %62 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 1, !dbg !17
+  %63 = load i64*, i64** %62, align 8, !dbg !17
+  store i64 %39, i64* %63, align 8, !dbg !17, !tbaa !6
+  %64 = getelementptr inbounds i64, i64* %63, i64 1, !dbg !17
+  store i64* %64, i64** %62, align 8, !dbg !17
+  %65 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_new, i64 noundef 0) #11, !dbg !17
   br label %"func_<root>.17<static-init>$153.exit", !dbg !17
 
-fastNew.i:                                        ; preds = %48
-  %76 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !17
-  %77 = load i64*, i64** %76, align 8, !dbg !17
-  store i64 %70, i64* %77, align 8, !dbg !17, !tbaa !6
-  %78 = getelementptr inbounds i64, i64* %77, i64 1, !dbg !17
-  store i64* %78, i64** %76, align 8, !dbg !17
-  %79 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 noundef 0) #11, !dbg !17
+fastNew.i:                                        ; preds = %38
+  %66 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 1, !dbg !17
+  %67 = load i64*, i64** %66, align 8, !dbg !17
+  store i64 %60, i64* %67, align 8, !dbg !17, !tbaa !6
+  %68 = getelementptr inbounds i64, i64* %67, i64 1, !dbg !17
+  store i64* %68, i64** %66, align 8, !dbg !17
+  %69 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 noundef 0) #11, !dbg !17
   br label %"func_<root>.17<static-init>$153.exit", !dbg !17
 
 "func_<root>.17<static-init>$153.exit":           ; preds = %slowNew.i, %fastNew.i
-  %initializedObject.i = phi i64 [ %75, %slowNew.i ], [ %70, %fastNew.i ], !dbg !17
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 15), i64** %31, align 8, !dbg !17, !tbaa !24
-  %80 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !18
-  %81 = load i64*, i64** %80, align 8, !dbg !18
-  store i64 %initializedObject.i, i64* %81, align 8, !dbg !18, !tbaa !6
-  %82 = getelementptr inbounds i64, i64* %81, i64 1, !dbg !18
-  store i64* %82, i64** %80, align 8, !dbg !18
+  %initializedObject.i = phi i64 [ %65, %slowNew.i ], [ %60, %fastNew.i ], !dbg !17
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 15), i64** %21, align 8, !dbg !17, !tbaa !24
+  %70 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 1, !dbg !18
+  %71 = load i64*, i64** %70, align 8, !dbg !18
+  store i64 %initializedObject.i, i64* %71, align 8, !dbg !18, !tbaa !6
+  %72 = getelementptr inbounds i64, i64* %71, i64 1, !dbg !18
+  store i64* %72, i64** %70, align 8, !dbg !18
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_read, i64 0), !dbg !18
-  %83 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !19
-  %84 = load i64*, i64** %83, align 8, !dbg !19
-  store i64 %22, i64* %84, align 8, !dbg !19, !tbaa !6
-  %85 = getelementptr inbounds i64, i64* %84, i64 1, !dbg !19
-  store i64 %send, i64* %85, align 8, !dbg !19, !tbaa !6
-  %86 = getelementptr inbounds i64, i64* %85, i64 1, !dbg !19
-  store i64* %86, i64** %83, align 8, !dbg !19
+  %73 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 1, !dbg !19
+  %74 = load i64*, i64** %73, align 8, !dbg !19
+  store i64 %12, i64* %74, align 8, !dbg !19, !tbaa !6
+  %75 = getelementptr inbounds i64, i64* %74, i64 1, !dbg !19
+  store i64 %send, i64* %75, align 8, !dbg !19, !tbaa !6
+  %76 = getelementptr inbounds i64, i64* %75, i64 1, !dbg !19
+  store i64* %76, i64** %73, align 8, !dbg !19
   %send2 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !19
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %31, align 8, !dbg !19, !tbaa !24
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %21, align 8, !dbg !19, !tbaa !24
   %rubyStr_value.i = load i64, i64* @rubyStrFrozen_value, align 8, !dbg !53
-  %87 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !20
-  %88 = load i64*, i64** %87, align 8, !dbg !20
-  store i64 %initializedObject.i, i64* %88, align 8, !dbg !20, !tbaa !6
-  %89 = getelementptr inbounds i64, i64* %88, i64 1, !dbg !20
-  store i64 %rubyStr_value.i, i64* %89, align 8, !dbg !20, !tbaa !6
-  %90 = getelementptr inbounds i64, i64* %89, i64 1, !dbg !20
-  store i64* %90, i64** %87, align 8, !dbg !20
+  %77 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 1, !dbg !20
+  %78 = load i64*, i64** %77, align 8, !dbg !20
+  store i64 %initializedObject.i, i64* %78, align 8, !dbg !20, !tbaa !6
+  %79 = getelementptr inbounds i64, i64* %78, i64 1, !dbg !20
+  store i64 %rubyStr_value.i, i64* %79, align 8, !dbg !20, !tbaa !6
+  %80 = getelementptr inbounds i64, i64* %79, i64 1, !dbg !20
+  store i64* %80, i64** %77, align 8, !dbg !20
   %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_write, i64 0), !dbg !20
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %31, align 8, !dbg !20, !tbaa !24
-  %91 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !21
-  %92 = load i64*, i64** %91, align 8, !dbg !21
-  store i64 %initializedObject.i, i64* %92, align 8, !dbg !21, !tbaa !6
-  %93 = getelementptr inbounds i64, i64* %92, i64 1, !dbg !21
-  store i64* %93, i64** %91, align 8, !dbg !21
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %21, align 8, !dbg !20, !tbaa !24
+  %81 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 1, !dbg !21
+  %82 = load i64*, i64** %81, align 8, !dbg !21
+  store i64 %initializedObject.i, i64* %82, align 8, !dbg !21, !tbaa !6
+  %83 = getelementptr inbounds i64, i64* %82, i64 1, !dbg !21
+  store i64* %83, i64** %81, align 8, !dbg !21
   %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_read.1, i64 0), !dbg !21
-  %94 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !22
-  %95 = load i64*, i64** %94, align 8, !dbg !22
-  store i64 %22, i64* %95, align 8, !dbg !22, !tbaa !6
-  %96 = getelementptr inbounds i64, i64* %95, i64 1, !dbg !22
-  store i64 %send6, i64* %96, align 8, !dbg !22, !tbaa !6
-  %97 = getelementptr inbounds i64, i64* %96, i64 1, !dbg !22
-  store i64* %97, i64** %94, align 8, !dbg !22
+  %84 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 1, !dbg !22
+  %85 = load i64*, i64** %84, align 8, !dbg !22
+  store i64 %12, i64* %85, align 8, !dbg !22, !tbaa !6
+  %86 = getelementptr inbounds i64, i64* %85, i64 1, !dbg !22
+  store i64 %send6, i64* %86, align 8, !dbg !22, !tbaa !6
+  %87 = getelementptr inbounds i64, i64* %86, i64 1, !dbg !22
+  store i64* %87, i64** %84, align 8, !dbg !22
   %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.2, i64 0), !dbg !22
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %31, align 8, !dbg !22, !tbaa !24
-  %"rubyId_$f.i" = load i64, i64* @"rubyIdPrecomputed_$f", align 8, !dbg !23
-  %98 = call %struct.rb_global_entry* @rb_global_entry(i64 %"rubyId_$f.i") #11, !dbg !23
-  %99 = call i64 @rb_gvar_get(%struct.rb_global_entry* %98) #11, !dbg !23
-  %100 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !23
-  %101 = load i64*, i64** %100, align 8, !dbg !23
-  store i64 %22, i64* %101, align 8, !dbg !23, !tbaa !6
-  %102 = getelementptr inbounds i64, i64* %101, i64 1, !dbg !23
-  store i64 %99, i64* %102, align 8, !dbg !23, !tbaa !6
-  %103 = getelementptr inbounds i64, i64* %102, i64 1, !dbg !23
-  store i64* %103, i64** %100, align 8, !dbg !23
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %21, align 8, !dbg !22, !tbaa !24
+  %"rubyId_$f.i" = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 6), align 8, !dbg !23, !invariant.load !5
+  %88 = call %struct.rb_global_entry* @rb_global_entry(i64 %"rubyId_$f.i") #11, !dbg !23
+  %89 = call i64 @rb_gvar_get(%struct.rb_global_entry* %88) #11, !dbg !23
+  %90 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 1, !dbg !23
+  %91 = load i64*, i64** %90, align 8, !dbg !23
+  store i64 %12, i64* %91, align 8, !dbg !23, !tbaa !6
+  %92 = getelementptr inbounds i64, i64* %91, i64 1, !dbg !23
+  store i64 %89, i64* %92, align 8, !dbg !23, !tbaa !6
+  %93 = getelementptr inbounds i64, i64* %92, i64 1, !dbg !23
+  store i64* %93, i64** %90, align 8, !dbg !23
   %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.3, i64 0), !dbg !23
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %31, align 8, !dbg !23, !tbaa !24
-  %104 = call i64 @sorbet_setConstant(i64 %32, i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 105), i64 noundef 1, i64 noundef 3) #11, !dbg !54
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %21, align 8, !dbg !23, !tbaa !24
+  %94 = call i64 @sorbet_setConstant(i64 %22, i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 105), i64 noundef 1, i64 noundef 3) #11, !dbg !54
   ret void
 }
 
@@ -449,11 +419,10 @@ argCountFailBlock:                                ; preds = %functionEntryInitia
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
   %rawArg_v = load i64, i64* %argArray, align 8, !dbg !56
   store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %0, align 8, !dbg !58, !tbaa !24
-  %"rubyId_$f" = load i64, i64* @"rubyIdPrecomputed_$f", align 8, !dbg !59
+  %"rubyId_$f" = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 6), align 8, !dbg !59, !invariant.load !5
   %1 = tail call %struct.rb_global_entry* @rb_global_entry(i64 %"rubyId_$f") #11, !dbg !59
   %2 = tail call i64 @rb_gvar_set(%struct.rb_global_entry* %1, i64 %rawArg_v) #11, !dbg !59
-  %"rubyId_$f6" = load i64, i64* @"rubyIdPrecomputed_$f", align 8, !dbg !60
-  %3 = tail call %struct.rb_global_entry* @rb_global_entry(i64 %"rubyId_$f6") #11, !dbg !60
+  %3 = tail call %struct.rb_global_entry* @rb_global_entry(i64 %"rubyId_$f") #11, !dbg !60
   %4 = tail call i64 @rb_gvar_get(%struct.rb_global_entry* %3) #11, !dbg !60
   ret i64 %4
 }
@@ -472,7 +441,7 @@ argCountFailBlock:                                ; preds = %functionEntryInitia
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
   store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %0, align 8, !dbg !64, !tbaa !24
-  %"rubyId_$f" = load i64, i64* @"rubyIdPrecomputed_$f", align 8, !dbg !65
+  %"rubyId_$f" = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 6), align 8, !dbg !65, !invariant.load !5
   %1 = tail call %struct.rb_global_entry* @rb_global_entry(i64 %"rubyId_$f") #11, !dbg !65
   %2 = tail call i64 @rb_gvar_get(%struct.rb_global_entry* %1) #11, !dbg !65
   ret i64 %2

--- a/test/testdata/compiler/hello.opt.ll.exp
+++ b/test/testdata/compiler/hello.opt.ll.exp
@@ -81,15 +81,15 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/hello.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [5 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @"rubyStrFrozen_hello world" = internal unnamed_addr global i64 0, align 8
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
 @sorbet_moduleStringTable = internal unnamed_addr constant [73 x i8] c"<top (required)>\00test/testdata/compiler/hello.rb\00hello world\00puts\00master\00", align 1
+@sorbet_moduleIDTable = internal unnamed_addr global [2 x i64] zeroinitializer, align 8
+@sorbet_moduleIDDescriptors = internal unnamed_addr constant [2 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 61, i32 4 }], align 8
 
 declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
 
@@ -103,9 +103,9 @@ declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_u
 
 declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #0
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
+declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #0
 
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #0
+declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
 
 declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
 
@@ -131,52 +131,49 @@ define void @Init_hello() local_unnamed_addr #3 {
 entry:
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([73 x i8], [73 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #5
-  store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %1 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([73 x i8], [73 x i8]* @sorbet_moduleStringTable, i64 0, i64 61), i64 noundef 4) #5
-  store i64 %1, i64* @rubyIdPrecomputed_puts, align 8
-  %2 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([73 x i8], [73 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #5
-  tail call void @rb_gc_register_mark_object(i64 %2) #5
-  store i64 %2, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %3 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([73 x i8], [73 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 31) #5
-  tail call void @rb_gc_register_mark_object(i64 %3) #5
-  store i64 %3, i64* @"rubyStrFrozen_test/testdata/compiler/hello.rb", align 8
+  tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([2 x i64], [2 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([2 x %struct.rb_code_position_struct], [2 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 2, i8* noundef getelementptr inbounds ([73 x i8], [73 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
+  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([73 x i8], [73 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #5
+  tail call void @rb_gc_register_mark_object(i64 %0) #5
+  store i64 %0, i64* @"rubyStrFrozen_<top (required)>", align 8
+  %1 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([73 x i8], [73 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 31) #5
+  tail call void @rb_gc_register_mark_object(i64 %1) #5
+  store i64 %1, i64* @"rubyStrFrozen_test/testdata/compiler/hello.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 5)
-  %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
+  %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([2 x i64], [2 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
   %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/hello.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/hello.rb", align 8
-  %4 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/hello.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %4, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %5 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([73 x i8], [73 x i8]* @sorbet_moduleStringTable, i64 0, i64 49), i64 noundef 11) #5
-  call void @rb_gc_register_mark_object(i64 %5) #5
-  store i64 %5, i64* @"rubyStrFrozen_hello world", align 8
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !10
+  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/hello.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %3 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([73 x i8], [73 x i8]* @sorbet_moduleStringTable, i64 0, i64 49), i64 noundef 11) #5
+  call void @rb_gc_register_mark_object(i64 %3) #5
+  store i64 %3, i64* @"rubyStrFrozen_hello world", align 8
+  %rubyId_puts.i = load i64, i64* getelementptr inbounds ([2 x i64], [2 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !dbg !10, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !10
-  %6 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !15
-  %7 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %6, i64 0, i32 18
-  %8 = load i64, i64* %7, align 8, !tbaa !17
-  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
-  %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 2
-  %11 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %10, align 8, !tbaa !27
+  %4 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !15
+  %5 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %4, i64 0, i32 18
+  %6 = load i64, i64* %5, align 8, !tbaa !17
+  %7 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
+  %8 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %7, i64 0, i32 2
+  %9 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %8, align 8, !tbaa !27
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %12, align 8, !tbaa !30
-  %13 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 4
-  %14 = load i64*, i64** %13, align 8, !tbaa !32
-  %15 = load i64, i64* %14, align 8, !tbaa !6
-  %16 = and i64 %15, -33
-  store i64 %16, i64* %14, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %9, %struct.rb_control_frame_struct* %11, %struct.rb_iseq_struct* %stackFrame.i) #5
-  %17 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 0
-  store i64* getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %17, align 8, !dbg !33, !tbaa !15
+  %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %10, align 8, !tbaa !30
+  %11 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 4
+  %12 = load i64*, i64** %11, align 8, !tbaa !32
+  %13 = load i64, i64* %12, align 8, !tbaa !6
+  %14 = and i64 %13, -33
+  store i64 %14, i64* %12, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %7, %struct.rb_control_frame_struct* %9, %struct.rb_iseq_struct* %stackFrame.i) #5
+  %15 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 0
+  store i64* getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %15, align 8, !dbg !33, !tbaa !15
   %"rubyStr_hello world.i" = load i64, i64* @"rubyStrFrozen_hello world", align 8, !dbg !34
-  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 1, !dbg !10
-  %19 = load i64*, i64** %18, align 8, !dbg !10
-  store i64 %8, i64* %19, align 8, !dbg !10, !tbaa !6
-  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !10
-  store i64 %"rubyStr_hello world.i", i64* %20, align 8, !dbg !10, !tbaa !6
-  %21 = getelementptr inbounds i64, i64* %20, i64 1, !dbg !10
-  store i64* %21, i64** %18, align 8, !dbg !10
+  %16 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 1, !dbg !10
+  %17 = load i64*, i64** %16, align 8, !dbg !10
+  store i64 %6, i64* %17, align 8, !dbg !10, !tbaa !6
+  %18 = getelementptr inbounds i64, i64* %17, i64 1, !dbg !10
+  store i64 %"rubyStr_hello world.i", i64* %18, align 8, !dbg !10, !tbaa !6
+  %19 = getelementptr inbounds i64, i64* %18, i64 1, !dbg !10
+  store i64* %19, i64** %16, align 8, !dbg !10
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !10
   ret void
 }

--- a/test/testdata/compiler/intrinsics/bang.opt.ll.exp
+++ b/test/testdata/compiler/intrinsics/bang.opt.ll.exp
@@ -81,20 +81,15 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [23 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @ic_test = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_test = internal unnamed_addr global i64 0, align 8
 @"stackFramePrecomputed_func_Bad#1!" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_!" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_bad bang overload" = internal unnamed_addr global i64 0, align 8
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
 @"stackFramePrecomputed_func_Bad.13<static-init>" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_<class:Bad>" = internal unnamed_addr global i64 0, align 8
 @stackFramePrecomputed_func_Main.4test = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"ic_!" = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.1 = internal global %struct.FunctionInlineCache zeroinitializer
@@ -106,14 +101,13 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @"ic_!.6" = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.7 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_new = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_new = internal unnamed_addr global i64 0, align 8
 @ic_initialize = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_initialize = internal unnamed_addr global i64 0, align 8
 @"ic_!.8" = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.9 = internal global %struct.FunctionInlineCache zeroinitializer
 @"stackFramePrecomputed_func_Main.13<static-init>" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_<module:Main>" = internal unnamed_addr global i64 0, align 8
 @sorbet_moduleStringTable = internal unnamed_addr constant [166 x i8] c"<top (required)>\00test/testdata/compiler/intrinsics/bang.rb\00Bad\00Object\00Main\00test\00master\00!\00bad bang overload\00puts\00<class:Bad>\00normal\00hello\00new\00initialize\00<module:Main>\00", align 1
+@sorbet_moduleIDTable = internal unnamed_addr global [9 x i64] zeroinitializer, align 8
+@sorbet_moduleIDDescriptors = internal unnamed_addr constant [9 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 75, i32 4 }, %struct.rb_code_position_struct { i32 87, i32 1 }, %struct.rb_code_position_struct { i32 107, i32 4 }, %struct.rb_code_position_struct { i32 112, i32 11 }, %struct.rb_code_position_struct { i32 124, i32 6 }, %struct.rb_code_position_struct { i32 137, i32 3 }, %struct.rb_code_position_struct { i32 141, i32 10 }, %struct.rb_code_position_struct { i32 152, i32 13 }], align 8
 @rb_cObject = external local_unnamed_addr constant i64
 @guard_epoch_Bad = linkonce local_unnamed_addr global i64 0
 @guarded_const_Bad = linkonce local_unnamed_addr global i64 0
@@ -143,6 +137,8 @@ declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %
 
 declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #1
 
+declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #1
+
 declare i64 @sorbet_maybeAllocateObjectFastPath(i64, %struct.FunctionInlineCache*) local_unnamed_addr #1
 
 declare i64 @sorbet_vm_bang(%struct.FunctionInlineCache*, %struct.rb_control_frame_struct*, i64) local_unnamed_addr #1
@@ -152,8 +148,6 @@ declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #1
 declare i64 @rb_define_module(i8*) local_unnamed_addr #1
 
 declare i64 @rb_define_class(i8*, i64) local_unnamed_addr #1
-
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #1
 
 declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #1
 
@@ -186,197 +180,170 @@ entry:
   %locals.i30.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #10
-  store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %1 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 75), i64 noundef 4) #10
-  store i64 %1, i64* @rubyIdPrecomputed_test, align 8
-  %2 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 87), i64 noundef 1) #10
-  store i64 %2, i64* @"rubyIdPrecomputed_!", align 8
-  %3 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 107), i64 noundef 4) #10
-  store i64 %3, i64* @rubyIdPrecomputed_puts, align 8
-  %4 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 112), i64 noundef 11) #10
-  store i64 %4, i64* @"rubyIdPrecomputed_<class:Bad>", align 8
-  %5 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 124), i64 noundef 6) #10
-  %6 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 137), i64 noundef 3) #10
-  store i64 %6, i64* @rubyIdPrecomputed_new, align 8
-  %7 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 141), i64 noundef 10) #10
-  store i64 %7, i64* @rubyIdPrecomputed_initialize, align 8
-  %8 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 152), i64 noundef 13) #10
-  store i64 %8, i64* @"rubyIdPrecomputed_<module:Main>", align 8
-  %9 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #10
-  tail call void @rb_gc_register_mark_object(i64 %9) #10
-  store i64 %9, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %10 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 41) #10
-  tail call void @rb_gc_register_mark_object(i64 %10) #10
-  store i64 %10, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
+  tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([9 x i64], [9 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([9 x %struct.rb_code_position_struct], [9 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 9, i8* noundef getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
+  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #10
+  tail call void @rb_gc_register_mark_object(i64 %0) #10
+  store i64 %0, i64* @"rubyStrFrozen_<top (required)>", align 8
+  %1 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 41) #10
+  tail call void @rb_gc_register_mark_object(i64 %1) #10
+  store i64 %1, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 23)
-  %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
+  %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([9 x i64], [9 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
   %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
-  %11 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %11, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %rubyId_test.i = load i64, i64* @rubyIdPrecomputed_test, align 8, !dbg !10
+  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %rubyId_test.i = load i64, i64* getelementptr inbounds ([9 x i64], [9 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !dbg !10, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test, i64 %rubyId_test.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !10
-  %12 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 87), i64 noundef 1) #10
-  call void @rb_gc_register_mark_object(i64 %12) #10
-  %"rubyId_!.i.i" = load i64, i64* @"rubyIdPrecomputed_!", align 8
+  %3 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 87), i64 noundef 1) #10
+  call void @rb_gc_register_mark_object(i64 %3) #10
+  %"rubyId_!.i.i" = load i64, i64* getelementptr inbounds ([9 x i64], [9 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i29.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
-  %13 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %12, i64 %"rubyId_!.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i29.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i30.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %13, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad#1!", align 8
-  %14 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 89), i64 noundef 17) #10
-  call void @rb_gc_register_mark_object(i64 %14) #10
-  store i64 %14, i64* @"rubyStrFrozen_bad bang overload", align 8
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !15
+  %4 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %3, i64 %"rubyId_!.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i29.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i30.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %4, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad#1!", align 8
+  %5 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 89), i64 noundef 17) #10
+  call void @rb_gc_register_mark_object(i64 %5) #10
+  store i64 %5, i64* @"rubyStrFrozen_bad bang overload", align 8
+  %rubyId_puts.i = load i64, i64* getelementptr inbounds ([9 x i64], [9 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !15, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
-  %15 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 112), i64 noundef 11) #10
-  call void @rb_gc_register_mark_object(i64 %15) #10
-  %"rubyId_<class:Bad>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:Bad>", align 8
+  %6 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 112), i64 noundef 11) #10
+  call void @rb_gc_register_mark_object(i64 %6) #10
+  %"rubyId_<class:Bad>.i.i" = load i64, i64* getelementptr inbounds ([9 x i64], [9 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i31.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
-  %16 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %15, i64 %"rubyId_<class:Bad>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i31.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i32.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %16, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad.13<static-init>", align 8
-  %17 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 75), i64 noundef 4) #10
-  call void @rb_gc_register_mark_object(i64 %17) #10
-  %rubyId_test.i.i = load i64, i64* @rubyIdPrecomputed_test, align 8
+  %7 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %6, i64 %"rubyId_<class:Bad>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i31.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i32.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %7, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad.13<static-init>", align 8
+  %8 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 75), i64 noundef 4) #10
+  call void @rb_gc_register_mark_object(i64 %8) #10
   %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i33.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
-  %18 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %17, i64 %rubyId_test.i.i, i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i33.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 13, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i34.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %18, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Main.4test, align 8
-  %"rubyId_!.i" = load i64, i64* @"rubyIdPrecomputed_!", align 8, !dbg !17
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_!", i64 %"rubyId_!.i", i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !17
-  %rubyId_puts3.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !19
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts3.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
-  %"rubyId_!6.i" = load i64, i64* @"rubyIdPrecomputed_!", align 8, !dbg !20
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_!.2", i64 %"rubyId_!6.i", i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !20
-  %rubyId_puts8.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !21
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts8.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !21
-  %"rubyId_!11.i" = load i64, i64* @"rubyIdPrecomputed_!", align 8, !dbg !22
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_!.4", i64 %"rubyId_!11.i", i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !22
-  %rubyId_puts13.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !23
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.5, i64 %rubyId_puts13.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !23
-  %19 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 131), i64 noundef 5) #10
-  call void @rb_gc_register_mark_object(i64 %19) #10
-  store i64 %19, i64* @rubyStrFrozen_hello, align 8
-  %"rubyId_!16.i" = load i64, i64* @"rubyIdPrecomputed_!", align 8, !dbg !24
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_!.6", i64 %"rubyId_!16.i", i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !24
-  %rubyId_puts18.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !25
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.7, i64 %rubyId_puts18.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !25
-  %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !26
+  %9 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %8, i64 %rubyId_test.i, i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i33.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 13, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i34.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %9, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Main.4test, align 8
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_!", i64 %"rubyId_!.i.i", i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !17
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_!.2", i64 %"rubyId_!.i.i", i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !20
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !21
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_!.4", i64 %"rubyId_!.i.i", i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !22
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.5, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !23
+  %10 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 131), i64 noundef 5) #10
+  call void @rb_gc_register_mark_object(i64 %10) #10
+  store i64 %10, i64* @rubyStrFrozen_hello, align 8
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_!.6", i64 %"rubyId_!.i.i", i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !24
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.7, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !25
+  %rubyId_new.i = load i64, i64* getelementptr inbounds ([9 x i64], [9 x i64]* @sorbet_moduleIDTable, i64 0, i64 6), align 8, !dbg !26, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !26
-  %rubyId_initialize.i = load i64, i64* @rubyIdPrecomputed_initialize, align 8, !dbg !26
+  %rubyId_initialize.i = load i64, i64* getelementptr inbounds ([9 x i64], [9 x i64]* @sorbet_moduleIDTable, i64 0, i64 7), align 8, !dbg !26, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 %rubyId_initialize.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !26
-  %"rubyId_!24.i" = load i64, i64* @"rubyIdPrecomputed_!", align 8, !dbg !27
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_!.8", i64 %"rubyId_!24.i", i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !27
-  %rubyId_puts26.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !28
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.9, i64 %rubyId_puts26.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !28
-  %20 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 152), i64 noundef 13) #10
-  call void @rb_gc_register_mark_object(i64 %20) #10
-  %"rubyId_<module:Main>.i.i" = load i64, i64* @"rubyIdPrecomputed_<module:Main>", align 8
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_!.8", i64 %"rubyId_!.i.i", i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !27
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.9, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !28
+  %11 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 152), i64 noundef 13) #10
+  call void @rb_gc_register_mark_object(i64 %11) #10
+  %"rubyId_<module:Main>.i.i" = load i64, i64* getelementptr inbounds ([9 x i64], [9 x i64]* @sorbet_moduleIDTable, i64 0, i64 8), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i35.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
-  %21 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %20, i64 %"rubyId_<module:Main>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i35.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 12, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i36.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %21, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Main.13<static-init>", align 8
-  %22 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !29
-  %23 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %22, i64 0, i32 2
-  %24 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %23, align 8, !tbaa !31
+  %12 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %11, i64 %"rubyId_<module:Main>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i35.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 12, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i36.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %12, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Main.13<static-init>", align 8
+  %13 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !29
+  %14 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %13, i64 0, i32 2
+  %15 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %14, align 8, !tbaa !31
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %25 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %25, align 8, !tbaa !35
-  %26 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 4
-  %27 = load i64*, i64** %26, align 8, !tbaa !37
-  %28 = load i64, i64* %27, align 8, !tbaa !6
-  %29 = and i64 %28, -33
-  store i64 %29, i64* %27, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %22, %struct.rb_control_frame_struct* %24, %struct.rb_iseq_struct* %stackFrame.i) #10
-  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 0
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %30, align 8, !dbg !38, !tbaa !29
-  %31 = load i64, i64* @rb_cObject, align 8, !dbg !39
-  %32 = call i64 @rb_define_class(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 59), i64 %31) #10, !dbg !39
-  %33 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %32) #10, !dbg !39
+  %16 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %16, align 8, !tbaa !35
+  %17 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 4
+  %18 = load i64*, i64** %17, align 8, !tbaa !37
+  %19 = load i64, i64* %18, align 8, !tbaa !6
+  %20 = and i64 %19, -33
+  store i64 %20, i64* %18, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %13, %struct.rb_control_frame_struct* %15, %struct.rb_iseq_struct* %stackFrame.i) #10
+  %21 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 0
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %21, align 8, !dbg !38, !tbaa !29
+  %22 = load i64, i64* @rb_cObject, align 8, !dbg !39
+  %23 = call i64 @rb_define_class(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 59), i64 %22) #10, !dbg !39
+  %24 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %23) #10, !dbg !39
   %stackFrame.i1.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad.13<static-init>", align 8
-  %34 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !29
-  %35 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %34, i64 0, i32 2
-  %36 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %35, align 8, !tbaa !31
-  %37 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i1.i, %struct.rb_iseq_struct** %37, align 8, !tbaa !35
-  %38 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 4
-  %39 = load i64*, i64** %38, align 8, !tbaa !37
-  %40 = load i64, i64* %39, align 8, !tbaa !6
-  %41 = and i64 %40, -33
-  store i64 %41, i64* %39, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %34, %struct.rb_control_frame_struct* %36, %struct.rb_iseq_struct* %stackFrame.i1.i) #10
-  %42 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 0
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %42, align 8, !dbg !40, !tbaa !29
-  %43 = load i64, i64* @guard_epoch_Bad, align 8, !dbg !43
-  %44 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !43, !tbaa !44
-  %needTakeSlowPath = icmp ne i64 %43, %44, !dbg !43
-  br i1 %needTakeSlowPath, label %45, label %46, !dbg !43, !prof !46
+  %25 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !29
+  %26 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %25, i64 0, i32 2
+  %27 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %26, align 8, !tbaa !31
+  %28 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %27, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i1.i, %struct.rb_iseq_struct** %28, align 8, !tbaa !35
+  %29 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %27, i64 0, i32 4
+  %30 = load i64*, i64** %29, align 8, !tbaa !37
+  %31 = load i64, i64* %30, align 8, !tbaa !6
+  %32 = and i64 %31, -33
+  store i64 %32, i64* %30, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %25, %struct.rb_control_frame_struct* %27, %struct.rb_iseq_struct* %stackFrame.i1.i) #10
+  %33 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 0
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %33, align 8, !dbg !40, !tbaa !29
+  %34 = load i64, i64* @guard_epoch_Bad, align 8, !dbg !43
+  %35 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !43, !tbaa !44
+  %needTakeSlowPath = icmp ne i64 %34, %35, !dbg !43
+  br i1 %needTakeSlowPath, label %36, label %37, !dbg !43, !prof !46
 
-45:                                               ; preds = %entry
+36:                                               ; preds = %entry
   call void @const_recompute_Bad(), !dbg !43
-  br label %46, !dbg !43
+  br label %37, !dbg !43
 
-46:                                               ; preds = %entry, %45
-  %47 = load i64, i64* @guarded_const_Bad, align 8, !dbg !43
-  %48 = load i64, i64* @guard_epoch_Bad, align 8, !dbg !43
-  %49 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !43, !tbaa !44
-  %guardUpdated = icmp eq i64 %48, %49, !dbg !43
+37:                                               ; preds = %entry, %36
+  %38 = load i64, i64* @guarded_const_Bad, align 8, !dbg !43
+  %39 = load i64, i64* @guard_epoch_Bad, align 8, !dbg !43
+  %40 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !43, !tbaa !44
+  %guardUpdated = icmp eq i64 %39, %40, !dbg !43
   call void @llvm.assume(i1 %guardUpdated), !dbg !43
   %stackFrame7.i2.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad#1!", align 8, !dbg !43
-  %50 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #11, !dbg !43
-  %51 = bitcast i8* %50 to i16*, !dbg !43
-  %52 = load i16, i16* %51, align 8, !dbg !43
-  %53 = and i16 %52, -384, !dbg !43
-  store i16 %53, i16* %51, align 8, !dbg !43
-  %54 = getelementptr inbounds i8, i8* %50, i64 4, !dbg !43
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %54, i8 0, i64 28, i1 false) #10, !dbg !43
-  call void @sorbet_vm_define_method(i64 %47, i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 87), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Bad#1!", i8* nonnull %50, %struct.rb_iseq_struct* %stackFrame7.i2.i, i1 noundef zeroext false) #10, !dbg !43
+  %41 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #11, !dbg !43
+  %42 = bitcast i8* %41 to i16*, !dbg !43
+  %43 = load i16, i16* %42, align 8, !dbg !43
+  %44 = and i16 %43, -384, !dbg !43
+  store i16 %44, i16* %42, align 8, !dbg !43
+  %45 = getelementptr inbounds i8, i8* %41, i64 4, !dbg !43
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %45, i8 0, i64 28, i1 false) #10, !dbg !43
+  call void @sorbet_vm_define_method(i64 %38, i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 87), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Bad#1!", i8* nonnull %41, %struct.rb_iseq_struct* %stackFrame7.i2.i, i1 noundef zeroext false) #10, !dbg !43
   call void @sorbet_popFrame() #10, !dbg !39
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %30, align 8, !dbg !39, !tbaa !29
-  %55 = call i64 @rb_define_module(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 70)) #10, !dbg !47
-  %56 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %55) #10, !dbg !47
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %21, align 8, !dbg !39, !tbaa !29
+  %46 = call i64 @rb_define_module(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 70)) #10, !dbg !47
+  %47 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %46) #10, !dbg !47
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Main.13<static-init>", align 8
-  %57 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !29
-  %58 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %57, i64 0, i32 2
-  %59 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %58, align 8, !tbaa !31
-  %60 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %59, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %60, align 8, !tbaa !35
-  %61 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %59, i64 0, i32 4
-  %62 = load i64*, i64** %61, align 8, !tbaa !37
-  %63 = load i64, i64* %62, align 8, !tbaa !6
-  %64 = and i64 %63, -33
-  store i64 %64, i64* %62, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %57, %struct.rb_control_frame_struct* %59, %struct.rb_iseq_struct* %stackFrame.i.i) #10
-  %65 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 0
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %65, align 8, !dbg !48, !tbaa !29
-  %66 = load i64, i64* @guard_epoch_Main, align 8, !dbg !51
-  %67 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !51, !tbaa !44
-  %needTakeSlowPath1 = icmp ne i64 %66, %67, !dbg !51
-  br i1 %needTakeSlowPath1, label %68, label %69, !dbg !51, !prof !46
+  %48 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !29
+  %49 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %48, i64 0, i32 2
+  %50 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %49, align 8, !tbaa !31
+  %51 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %50, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %51, align 8, !tbaa !35
+  %52 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %50, i64 0, i32 4
+  %53 = load i64*, i64** %52, align 8, !tbaa !37
+  %54 = load i64, i64* %53, align 8, !tbaa !6
+  %55 = and i64 %54, -33
+  store i64 %55, i64* %53, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %48, %struct.rb_control_frame_struct* %50, %struct.rb_iseq_struct* %stackFrame.i.i) #10
+  %56 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %47, i64 0, i32 0
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %56, align 8, !dbg !48, !tbaa !29
+  %57 = load i64, i64* @guard_epoch_Main, align 8, !dbg !51
+  %58 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !51, !tbaa !44
+  %needTakeSlowPath1 = icmp ne i64 %57, %58, !dbg !51
+  br i1 %needTakeSlowPath1, label %59, label %60, !dbg !51, !prof !46
 
-68:                                               ; preds = %46
+59:                                               ; preds = %37
   call void @const_recompute_Main(), !dbg !51
-  br label %69, !dbg !51
+  br label %60, !dbg !51
 
-69:                                               ; preds = %46, %68
-  %70 = load i64, i64* @guarded_const_Main, align 8, !dbg !51
-  %71 = load i64, i64* @guard_epoch_Main, align 8, !dbg !51
-  %72 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !51, !tbaa !44
-  %guardUpdated2 = icmp eq i64 %71, %72, !dbg !51
+60:                                               ; preds = %37, %59
+  %61 = load i64, i64* @guarded_const_Main, align 8, !dbg !51
+  %62 = load i64, i64* @guard_epoch_Main, align 8, !dbg !51
+  %63 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !51, !tbaa !44
+  %guardUpdated2 = icmp eq i64 %62, %63, !dbg !51
   call void @llvm.assume(i1 %guardUpdated2), !dbg !51
   %stackFrame7.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Main.4test, align 8, !dbg !51
-  %73 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #11, !dbg !51
-  %74 = bitcast i8* %73 to i16*, !dbg !51
-  %75 = load i16, i16* %74, align 8, !dbg !51
-  %76 = and i16 %75, -384, !dbg !51
-  store i16 %76, i16* %74, align 8, !dbg !51
-  %77 = getelementptr inbounds i8, i8* %73, i64 4, !dbg !51
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %77, i8 0, i64 28, i1 false) #10, !dbg !51
-  call void @sorbet_vm_define_method(i64 %70, i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 75), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_Main.4test, i8* nonnull %73, %struct.rb_iseq_struct* %stackFrame7.i.i, i1 noundef zeroext true) #10, !dbg !51
+  %64 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #11, !dbg !51
+  %65 = bitcast i8* %64 to i16*, !dbg !51
+  %66 = load i16, i16* %65, align 8, !dbg !51
+  %67 = and i16 %66, -384, !dbg !51
+  store i16 %67, i16* %65, align 8, !dbg !51
+  %68 = getelementptr inbounds i8, i8* %64, i64 4, !dbg !51
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %68, i8 0, i64 28, i1 false) #10, !dbg !51
+  call void @sorbet_vm_define_method(i64 %61, i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 75), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_Main.4test, i8* nonnull %64, %struct.rb_iseq_struct* %stackFrame7.i.i, i1 noundef zeroext true) #10, !dbg !51
   call void @sorbet_popFrame() #10, !dbg !47
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %30, align 8, !dbg !47, !tbaa !29
-  %78 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !10
-  %79 = load i64*, i64** %78, align 8, !dbg !10
-  store i64 %70, i64* %79, align 8, !dbg !10, !tbaa !6
-  %80 = getelementptr inbounds i64, i64* %79, i64 1, !dbg !10
-  store i64* %80, i64** %78, align 8, !dbg !10
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %21, align 8, !dbg !47, !tbaa !29
+  %69 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 1, !dbg !10
+  %70 = load i64*, i64** %69, align 8, !dbg !10
+  store i64 %61, i64* %70, align 8, !dbg !10, !tbaa !6
+  %71 = getelementptr inbounds i64, i64* %70, i64 1, !dbg !10
+  store i64* %71, i64** %69, align 8, !dbg !10
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test, i64 0), !dbg !10
   ret void
 }

--- a/test/testdata/compiler/intrinsics/t_must.opt.ll.exp
+++ b/test/testdata/compiler/intrinsics/t_must.opt.ll.exp
@@ -84,45 +84,31 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [28 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @ic_test_known_nil = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_test_known_nil = internal unnamed_addr global i64 0, align 8
 @ic_test_nilable_arg = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_test_nilable_arg = internal unnamed_addr global i64 0, align 8
 @ic_test_nilable_arg.1 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_test_nilable_arg.2 = internal global %struct.FunctionInlineCache zeroinitializer
 @stackFramePrecomputed_func_Test.14test_known_nil = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_<exceptionValue>" = internal unnamed_addr global i64 0, align 8
-@"rubyIdPrecomputed_<magic>" = internal unnamed_addr global i64 0, align 8
-@"rubyIdPrecomputed_<returnMethodTemp>" = internal unnamed_addr global i64 0, align 8
-@"rubyIdPrecomputed_<gotoDeadTemp>" = internal unnamed_addr global i64 0, align 8
 @"stackFramePrecomputed_func_Test.14test_known_nil$block_2" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_rescue in test_known_nil" = internal unnamed_addr global i64 0, align 8
 @"stackFramePrecomputed_func_Test.14test_known_nil$block_3" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_ensure in test_known_nil" = internal unnamed_addr global i64 0, align 8
 @"<retry-singleton>" = internal unnamed_addr global i64 0
 @"ic_is_a?" = internal global %struct.FunctionInlineCache zeroinitializer
-@"rubyIdPrecomputed_is_a?" = internal unnamed_addr global i64 0, align 8
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
 @stackFramePrecomputed_func_Test.16test_nilable_arg = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@rubyIdPrecomputed_arg = internal unnamed_addr global i64 0, align 8
 @"stackFramePrecomputed_func_Test.16test_nilable_arg$block_2" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_rescue in test_nilable_arg" = internal unnamed_addr global i64 0, align 8
 @"stackFramePrecomputed_func_Test.16test_nilable_arg$block_3" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_ensure in test_nilable_arg" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_ wasn't nil" = internal unnamed_addr global i64 0, align 8
-@"rubyIdPrecomputed_<string-interpolate>" = internal unnamed_addr global i64 0, align 8
 @ic_puts.3 = internal global %struct.FunctionInlineCache zeroinitializer
 @"ic_is_a?.4" = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.5 = internal global %struct.FunctionInlineCache zeroinitializer
 @"stackFramePrecomputed_func_Test.13<static-init>" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_<module:Test>" = internal unnamed_addr global i64 0, align 8
 @sorbet_moduleStringTable = internal unnamed_addr constant [358 x i8] c"<top (required)>\00test/testdata/compiler/intrinsics/t_must.rb\00Test\00test_known_nil\00test_nilable_arg\00master\00<exceptionValue>\00<magic>\00<returnMethodTemp>\00<gotoDeadTemp>\00rescue in test_known_nil\00ensure in test_known_nil\00T\00must\00StandardError\00is_a?\00puts\00arg\00rescue in test_nilable_arg\00ensure in test_nilable_arg\00 wasn't nil\00<string-interpolate>\00<module:Test>\00normal\00", align 1
+@sorbet_moduleIDTable = internal unnamed_addr global [18 x i64] zeroinitializer, align 8
+@sorbet_moduleIDDescriptors = internal unnamed_addr constant [18 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 66, i32 14 }, %struct.rb_code_position_struct { i32 81, i32 16 }, %struct.rb_code_position_struct { i32 105, i32 16 }, %struct.rb_code_position_struct { i32 122, i32 7 }, %struct.rb_code_position_struct { i32 130, i32 18 }, %struct.rb_code_position_struct { i32 149, i32 14 }, %struct.rb_code_position_struct { i32 164, i32 24 }, %struct.rb_code_position_struct { i32 189, i32 24 }, %struct.rb_code_position_struct { i32 216, i32 4 }, %struct.rb_code_position_struct { i32 235, i32 5 }, %struct.rb_code_position_struct { i32 241, i32 4 }, %struct.rb_code_position_struct { i32 246, i32 3 }, %struct.rb_code_position_struct { i32 250, i32 26 }, %struct.rb_code_position_struct { i32 277, i32 26 }, %struct.rb_code_position_struct { i32 316, i32 20 }, %struct.rb_code_position_struct { i32 337, i32 13 }, %struct.rb_code_position_struct { i32 351, i32 6 }], align 8
 @guard_epoch_Test = linkonce local_unnamed_addr global i64 0
 @guarded_const_Test = linkonce local_unnamed_addr global i64 0
 @rb_eStandardError = external local_unnamed_addr constant i64
@@ -156,6 +142,8 @@ declare i64 @sorbet_stringInterpolate(i64, i64, i32, i64*, i64 (i64, i64, i32, i
 
 declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #1
 
+declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #1
+
 declare i64 @sorbet_vm_isa_p(%struct.FunctionInlineCache*, %struct.rb_control_frame_struct*, i64, i64) local_unnamed_addr #1
 
 declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #1
@@ -169,8 +157,6 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #2
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #2
-
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #1
 
 declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #1
 
@@ -214,267 +200,222 @@ entry:
   %locals.i17.i = alloca i64, i32 4, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #14
-  store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %1 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 66), i64 noundef 14) #14
-  store i64 %1, i64* @rubyIdPrecomputed_test_known_nil, align 8
-  %2 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 81), i64 noundef 16) #14
-  store i64 %2, i64* @rubyIdPrecomputed_test_nilable_arg, align 8
-  %3 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 105), i64 noundef 16) #14
-  store i64 %3, i64* @"rubyIdPrecomputed_<exceptionValue>", align 8
-  %4 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 122), i64 noundef 7) #14
-  store i64 %4, i64* @"rubyIdPrecomputed_<magic>", align 8
-  %5 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 130), i64 noundef 18) #14
-  store i64 %5, i64* @"rubyIdPrecomputed_<returnMethodTemp>", align 8
-  %6 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 149), i64 noundef 14) #14
-  store i64 %6, i64* @"rubyIdPrecomputed_<gotoDeadTemp>", align 8
-  %7 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 164), i64 noundef 24) #14
-  store i64 %7, i64* @"rubyIdPrecomputed_rescue in test_known_nil", align 8
-  %8 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 189), i64 noundef 24) #14
-  store i64 %8, i64* @"rubyIdPrecomputed_ensure in test_known_nil", align 8
-  %9 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 216), i64 noundef 4) #14
-  %10 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 235), i64 noundef 5) #14
-  store i64 %10, i64* @"rubyIdPrecomputed_is_a?", align 8
-  %11 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 241), i64 noundef 4) #14
-  store i64 %11, i64* @rubyIdPrecomputed_puts, align 8
-  %12 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 246), i64 noundef 3) #14
-  store i64 %12, i64* @rubyIdPrecomputed_arg, align 8
-  %13 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 250), i64 noundef 26) #14
-  store i64 %13, i64* @"rubyIdPrecomputed_rescue in test_nilable_arg", align 8
-  %14 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 277), i64 noundef 26) #14
-  store i64 %14, i64* @"rubyIdPrecomputed_ensure in test_nilable_arg", align 8
-  %15 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 316), i64 noundef 20) #14
-  store i64 %15, i64* @"rubyIdPrecomputed_<string-interpolate>", align 8
-  %16 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 337), i64 noundef 13) #14
-  store i64 %16, i64* @"rubyIdPrecomputed_<module:Test>", align 8
-  %17 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 351), i64 noundef 6) #14
-  %18 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #14
-  tail call void @rb_gc_register_mark_object(i64 %18) #14
-  store i64 %18, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %19 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 43) #14
-  tail call void @rb_gc_register_mark_object(i64 %19) #14
-  store i64 %19, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
+  tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([18 x i64], [18 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([18 x %struct.rb_code_position_struct], [18 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 18, i8* noundef getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
+  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #14
+  tail call void @rb_gc_register_mark_object(i64 %0) #14
+  store i64 %0, i64* @"rubyStrFrozen_<top (required)>", align 8
+  %1 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 43) #14
+  tail call void @rb_gc_register_mark_object(i64 %1) #14
+  store i64 %1, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 28)
-  %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
+  %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([18 x i64], [18 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
   %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
-  %20 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %20, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %rubyId_test_known_nil.i = load i64, i64* @rubyIdPrecomputed_test_known_nil, align 8, !dbg !17
+  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %rubyId_test_known_nil.i = load i64, i64* getelementptr inbounds ([18 x i64], [18 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !dbg !17, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test_known_nil, i64 %rubyId_test_known_nil.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !17
-  %rubyId_test_nilable_arg.i = load i64, i64* @rubyIdPrecomputed_test_nilable_arg, align 8, !dbg !18
+  %rubyId_test_nilable_arg.i = load i64, i64* getelementptr inbounds ([18 x i64], [18 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !18, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test_nilable_arg, i64 %rubyId_test_nilable_arg.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !18
-  %rubyId_test_nilable_arg2.i = load i64, i64* @rubyIdPrecomputed_test_nilable_arg, align 8, !dbg !19
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test_nilable_arg.1, i64 %rubyId_test_nilable_arg2.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
-  %rubyId_test_nilable_arg4.i = load i64, i64* @rubyIdPrecomputed_test_nilable_arg, align 8, !dbg !20
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test_nilable_arg.2, i64 %rubyId_test_nilable_arg4.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !20
-  %21 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 66), i64 noundef 14) #14
-  call void @rb_gc_register_mark_object(i64 %21) #14
-  %22 = bitcast i64* %locals.i17.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 32, i8* nonnull %22)
-  %rubyId_test_known_nil.i.i = load i64, i64* @rubyIdPrecomputed_test_known_nil, align 8
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test_nilable_arg.1, i64 %rubyId_test_nilable_arg.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test_nilable_arg.2, i64 %rubyId_test_nilable_arg.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !20
+  %3 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 66), i64 noundef 14) #14
+  call void @rb_gc_register_mark_object(i64 %3) #14
+  %4 = bitcast i64* %locals.i17.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 32, i8* nonnull %4)
   %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i16.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
-  %"rubyId_<exceptionValue>.i.i" = load i64, i64* @"rubyIdPrecomputed_<exceptionValue>", align 8
+  %"rubyId_<exceptionValue>.i.i" = load i64, i64* getelementptr inbounds ([18 x i64], [18 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !invariant.load !5
   store i64 %"rubyId_<exceptionValue>.i.i", i64* %locals.i17.i, align 8
-  %"rubyId_<magic>.i.i" = load i64, i64* @"rubyIdPrecomputed_<magic>", align 8
-  %23 = getelementptr i64, i64* %locals.i17.i, i32 1
-  store i64 %"rubyId_<magic>.i.i", i64* %23, align 8
-  %"rubyId_<returnMethodTemp>.i.i" = load i64, i64* @"rubyIdPrecomputed_<returnMethodTemp>", align 8
-  %24 = getelementptr i64, i64* %locals.i17.i, i32 2
-  store i64 %"rubyId_<returnMethodTemp>.i.i", i64* %24, align 8
-  %"rubyId_<gotoDeadTemp>.i.i" = load i64, i64* @"rubyIdPrecomputed_<gotoDeadTemp>", align 8
-  %25 = getelementptr i64, i64* %locals.i17.i, i32 3
-  store i64 %"rubyId_<gotoDeadTemp>.i.i", i64* %25, align 8
-  %26 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %21, i64 %rubyId_test_known_nil.i.i, i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i16.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i17.i, i32 noundef 4, i32 noundef 2)
-  store %struct.rb_iseq_struct* %26, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.14test_known_nil, align 8
-  call void @llvm.lifetime.end.p0i8(i64 32, i8* nonnull %22)
-  %27 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 164), i64 noundef 24) #14
-  call void @rb_gc_register_mark_object(i64 %27) #14
+  %"rubyId_<magic>.i.i" = load i64, i64* getelementptr inbounds ([18 x i64], [18 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !invariant.load !5
+  %5 = getelementptr i64, i64* %locals.i17.i, i32 1
+  store i64 %"rubyId_<magic>.i.i", i64* %5, align 8
+  %"rubyId_<returnMethodTemp>.i.i" = load i64, i64* getelementptr inbounds ([18 x i64], [18 x i64]* @sorbet_moduleIDTable, i64 0, i64 5), align 8, !invariant.load !5
+  %6 = getelementptr i64, i64* %locals.i17.i, i32 2
+  store i64 %"rubyId_<returnMethodTemp>.i.i", i64* %6, align 8
+  %"rubyId_<gotoDeadTemp>.i.i" = load i64, i64* getelementptr inbounds ([18 x i64], [18 x i64]* @sorbet_moduleIDTable, i64 0, i64 6), align 8, !invariant.load !5
+  %7 = getelementptr i64, i64* %locals.i17.i, i32 3
+  store i64 %"rubyId_<gotoDeadTemp>.i.i", i64* %7, align 8
+  %8 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %3, i64 %rubyId_test_known_nil.i, i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i16.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i17.i, i32 noundef 4, i32 noundef 2)
+  store %struct.rb_iseq_struct* %8, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.14test_known_nil, align 8
+  call void @llvm.lifetime.end.p0i8(i64 32, i8* nonnull %4)
+  %9 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 164), i64 noundef 24) #14
+  call void @rb_gc_register_mark_object(i64 %9) #14
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.14test_known_nil, align 8
-  %"rubyId_rescue in test_known_nil.i.i" = load i64, i64* @"rubyIdPrecomputed_rescue in test_known_nil", align 8
+  %"rubyId_rescue in test_known_nil.i.i" = load i64, i64* getelementptr inbounds ([18 x i64], [18 x i64]* @sorbet_moduleIDTable, i64 0, i64 7), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i18.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
-  %28 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %27, i64 %"rubyId_rescue in test_known_nil.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i18.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 4, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %28, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.14test_known_nil$block_2", align 8
-  %29 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 189), i64 noundef 24) #14
-  call void @rb_gc_register_mark_object(i64 %29) #14
+  %10 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %9, i64 %"rubyId_rescue in test_known_nil.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i18.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 4, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %10, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.14test_known_nil$block_2", align 8
+  %11 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 189), i64 noundef 24) #14
+  call void @rb_gc_register_mark_object(i64 %11) #14
   %stackFrame.i19.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.14test_known_nil, align 8
-  %"rubyId_ensure in test_known_nil.i.i" = load i64, i64* @"rubyIdPrecomputed_ensure in test_known_nil", align 8
+  %"rubyId_ensure in test_known_nil.i.i" = load i64, i64* getelementptr inbounds ([18 x i64], [18 x i64]* @sorbet_moduleIDTable, i64 0, i64 8), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i20.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
-  %30 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %29, i64 %"rubyId_ensure in test_known_nil.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i20.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i19.i, i32 noundef 5, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %30, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.14test_known_nil$block_3", align 8
-  %31 = call i64 @sorbet_getConstant(i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @sorbet_getTRetry.retry, i64 0, i64 0), i64 noundef 25) #14
-  store i64 %31, i64* @"<retry-singleton>", align 8
-  %"rubyId_is_a?.i" = load i64, i64* @"rubyIdPrecomputed_is_a?", align 8, !dbg !21
+  %12 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %11, i64 %"rubyId_ensure in test_known_nil.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i20.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i19.i, i32 noundef 5, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %12, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.14test_known_nil$block_3", align 8
+  %13 = call i64 @sorbet_getConstant(i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @sorbet_getTRetry.retry, i64 0, i64 0), i64 noundef 25) #14
+  store i64 %13, i64* @"<retry-singleton>", align 8
+  %"rubyId_is_a?.i" = load i64, i64* getelementptr inbounds ([18 x i64], [18 x i64]* @sorbet_moduleIDTable, i64 0, i64 10), align 8, !dbg !21, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_is_a?", i64 %"rubyId_is_a?.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !21
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !24
+  %rubyId_puts.i = load i64, i64* getelementptr inbounds ([18 x i64], [18 x i64]* @sorbet_moduleIDTable, i64 0, i64 11), align 8, !dbg !24, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !24
-  %32 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 81), i64 noundef 16) #14
-  call void @rb_gc_register_mark_object(i64 %32) #14
-  %33 = bitcast i64* %locals.i22.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 40, i8* nonnull %33)
-  %rubyId_test_nilable_arg.i.i = load i64, i64* @rubyIdPrecomputed_test_nilable_arg, align 8
+  %14 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 81), i64 noundef 16) #14
+  call void @rb_gc_register_mark_object(i64 %14) #14
+  %15 = bitcast i64* %locals.i22.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 40, i8* nonnull %15)
   %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i21.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
-  %"rubyId_<exceptionValue>.i23.i" = load i64, i64* @"rubyIdPrecomputed_<exceptionValue>", align 8
-  store i64 %"rubyId_<exceptionValue>.i23.i", i64* %locals.i22.i, align 8
-  %rubyId_arg.i.i = load i64, i64* @rubyIdPrecomputed_arg, align 8
-  %34 = getelementptr i64, i64* %locals.i22.i, i32 1
-  store i64 %rubyId_arg.i.i, i64* %34, align 8
-  %"rubyId_<magic>.i24.i" = load i64, i64* @"rubyIdPrecomputed_<magic>", align 8
-  %35 = getelementptr i64, i64* %locals.i22.i, i32 2
-  store i64 %"rubyId_<magic>.i24.i", i64* %35, align 8
-  %"rubyId_<returnMethodTemp>.i25.i" = load i64, i64* @"rubyIdPrecomputed_<returnMethodTemp>", align 8
-  %36 = getelementptr i64, i64* %locals.i22.i, i32 3
-  store i64 %"rubyId_<returnMethodTemp>.i25.i", i64* %36, align 8
-  %"rubyId_<gotoDeadTemp>.i26.i" = load i64, i64* @"rubyIdPrecomputed_<gotoDeadTemp>", align 8
-  %37 = getelementptr i64, i64* %locals.i22.i, i32 4
-  store i64 %"rubyId_<gotoDeadTemp>.i26.i", i64* %37, align 8
-  %38 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %32, i64 %rubyId_test_nilable_arg.i.i, i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i21.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 14, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i22.i, i32 noundef 5, i32 noundef 3)
-  store %struct.rb_iseq_struct* %38, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.16test_nilable_arg, align 8
-  call void @llvm.lifetime.end.p0i8(i64 40, i8* nonnull %33)
-  %39 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 250), i64 noundef 26) #14
-  call void @rb_gc_register_mark_object(i64 %39) #14
+  store i64 %"rubyId_<exceptionValue>.i.i", i64* %locals.i22.i, align 8
+  %rubyId_arg.i.i = load i64, i64* getelementptr inbounds ([18 x i64], [18 x i64]* @sorbet_moduleIDTable, i64 0, i64 12), align 8, !invariant.load !5
+  %16 = getelementptr i64, i64* %locals.i22.i, i32 1
+  store i64 %rubyId_arg.i.i, i64* %16, align 8
+  %17 = getelementptr i64, i64* %locals.i22.i, i32 2
+  store i64 %"rubyId_<magic>.i.i", i64* %17, align 8
+  %18 = getelementptr i64, i64* %locals.i22.i, i32 3
+  store i64 %"rubyId_<returnMethodTemp>.i.i", i64* %18, align 8
+  %19 = getelementptr i64, i64* %locals.i22.i, i32 4
+  store i64 %"rubyId_<gotoDeadTemp>.i.i", i64* %19, align 8
+  %20 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %14, i64 %rubyId_test_nilable_arg.i, i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i21.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 14, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i22.i, i32 noundef 5, i32 noundef 3)
+  store %struct.rb_iseq_struct* %20, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.16test_nilable_arg, align 8
+  call void @llvm.lifetime.end.p0i8(i64 40, i8* nonnull %15)
+  %21 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 250), i64 noundef 26) #14
+  call void @rb_gc_register_mark_object(i64 %21) #14
   %stackFrame.i27.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.16test_nilable_arg, align 8
-  %"rubyId_rescue in test_nilable_arg.i.i" = load i64, i64* @"rubyIdPrecomputed_rescue in test_nilable_arg", align 8
+  %"rubyId_rescue in test_nilable_arg.i.i" = load i64, i64* getelementptr inbounds ([18 x i64], [18 x i64]* @sorbet_moduleIDTable, i64 0, i64 13), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i28.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
-  %40 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %39, i64 %"rubyId_rescue in test_nilable_arg.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i28.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i27.i, i32 noundef 4, i32 noundef 14, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
-  store %struct.rb_iseq_struct* %40, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.16test_nilable_arg$block_2", align 8
-  %41 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 277), i64 noundef 26) #14
-  call void @rb_gc_register_mark_object(i64 %41) #14
+  %22 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %21, i64 %"rubyId_rescue in test_nilable_arg.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i28.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i27.i, i32 noundef 4, i32 noundef 14, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
+  store %struct.rb_iseq_struct* %22, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.16test_nilable_arg$block_2", align 8
+  %23 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 277), i64 noundef 26) #14
+  call void @rb_gc_register_mark_object(i64 %23) #14
   %stackFrame.i29.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.16test_nilable_arg, align 8
-  %"rubyId_ensure in test_nilable_arg.i.i" = load i64, i64* @"rubyIdPrecomputed_ensure in test_nilable_arg", align 8
+  %"rubyId_ensure in test_nilable_arg.i.i" = load i64, i64* getelementptr inbounds ([18 x i64], [18 x i64]* @sorbet_moduleIDTable, i64 0, i64 14), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i30.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
-  %42 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %41, i64 %"rubyId_ensure in test_nilable_arg.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i30.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i29.i, i32 noundef 5, i32 noundef 14, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
-  store %struct.rb_iseq_struct* %42, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.16test_nilable_arg$block_3", align 8
-  %43 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 304), i64 noundef 11) #14
-  call void @rb_gc_register_mark_object(i64 %43) #14
-  store i64 %43, i64* @"rubyStrFrozen_ wasn't nil", align 8
-  %rubyId_puts8.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !25
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts8.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !25
-  %"rubyId_is_a?11.i" = load i64, i64* @"rubyIdPrecomputed_is_a?", align 8, !dbg !28
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_is_a?.4", i64 %"rubyId_is_a?11.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !28
-  %rubyId_puts13.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !30
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.5, i64 %rubyId_puts13.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !30
-  %44 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 337), i64 noundef 13) #14
-  call void @rb_gc_register_mark_object(i64 %44) #14
-  %"rubyId_<module:Test>.i.i" = load i64, i64* @"rubyIdPrecomputed_<module:Test>", align 8
+  %24 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %23, i64 %"rubyId_ensure in test_nilable_arg.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i30.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i29.i, i32 noundef 5, i32 noundef 14, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
+  store %struct.rb_iseq_struct* %24, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.16test_nilable_arg$block_3", align 8
+  %25 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 304), i64 noundef 11) #14
+  call void @rb_gc_register_mark_object(i64 %25) #14
+  store i64 %25, i64* @"rubyStrFrozen_ wasn't nil", align 8
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !25
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_is_a?.4", i64 %"rubyId_is_a?.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !28
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.5, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !30
+  %26 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 337), i64 noundef 13) #14
+  call void @rb_gc_register_mark_object(i64 %26) #14
+  %"rubyId_<module:Test>.i.i" = load i64, i64* getelementptr inbounds ([18 x i64], [18 x i64]* @sorbet_moduleIDTable, i64 0, i64 16), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i31.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
-  %45 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %44, i64 %"rubyId_<module:Test>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i31.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i32.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %45, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.13<static-init>", align 8
-  %46 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !31
-  %47 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %46, i64 0, i32 2
-  %48 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %47, align 8, !tbaa !33
+  %27 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %26, i64 %"rubyId_<module:Test>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i31.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i32.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %27, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.13<static-init>", align 8
+  %28 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !31
+  %29 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %28, i64 0, i32 2
+  %30 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %29, align 8, !tbaa !33
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %49 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %48, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %49, align 8, !tbaa !37
-  %50 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %48, i64 0, i32 4
-  %51 = load i64*, i64** %50, align 8, !tbaa !39
-  %52 = load i64, i64* %51, align 8, !tbaa !6
-  %53 = and i64 %52, -33
-  store i64 %53, i64* %51, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %46, %struct.rb_control_frame_struct* %48, %struct.rb_iseq_struct* %stackFrame.i) #14
-  %54 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %48, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %54, align 8, !dbg !40, !tbaa !31
-  %55 = call i64 @rb_define_module(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 61)) #14, !dbg !41
-  %56 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %55) #14, !dbg !41
-  %57 = bitcast i64* %positional_table.i.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %57) #14
+  %31 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %30, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %31, align 8, !tbaa !37
+  %32 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %30, i64 0, i32 4
+  %33 = load i64*, i64** %32, align 8, !tbaa !39
+  %34 = load i64, i64* %33, align 8, !tbaa !6
+  %35 = and i64 %34, -33
+  store i64 %35, i64* %33, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %28, %struct.rb_control_frame_struct* %30, %struct.rb_iseq_struct* %stackFrame.i) #14
+  %36 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %30, i64 0, i32 0
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %36, align 8, !dbg !40, !tbaa !31
+  %37 = call i64 @rb_define_module(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 61)) #14, !dbg !41
+  %38 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %37) #14, !dbg !41
+  %39 = bitcast i64* %positional_table.i.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %39) #14
   %stackFrame.i.i1 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.13<static-init>", align 8
-  %58 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !31
-  %59 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %58, i64 0, i32 2
-  %60 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %59, align 8, !tbaa !33
-  %61 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %60, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i.i1, %struct.rb_iseq_struct** %61, align 8, !tbaa !37
-  %62 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %60, i64 0, i32 4
-  %63 = load i64*, i64** %62, align 8, !tbaa !39
-  %64 = load i64, i64* %63, align 8, !tbaa !6
-  %65 = and i64 %64, -33
-  store i64 %65, i64* %63, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %58, %struct.rb_control_frame_struct* %60, %struct.rb_iseq_struct* %stackFrame.i.i1) #14
-  %66 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %66, align 8, !dbg !42, !tbaa !31
-  %67 = load i64, i64* @guard_epoch_Test, align 8, !dbg !43
-  %68 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !43, !tbaa !44
-  %needTakeSlowPath = icmp ne i64 %67, %68, !dbg !43
-  br i1 %needTakeSlowPath, label %69, label %70, !dbg !43, !prof !46
+  %40 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !31
+  %41 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %40, i64 0, i32 2
+  %42 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %41, align 8, !tbaa !33
+  %43 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %42, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i.i1, %struct.rb_iseq_struct** %43, align 8, !tbaa !37
+  %44 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %42, i64 0, i32 4
+  %45 = load i64*, i64** %44, align 8, !tbaa !39
+  %46 = load i64, i64* %45, align 8, !tbaa !6
+  %47 = and i64 %46, -33
+  store i64 %47, i64* %45, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %40, %struct.rb_control_frame_struct* %42, %struct.rb_iseq_struct* %stackFrame.i.i1) #14
+  %48 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 0
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %48, align 8, !dbg !42, !tbaa !31
+  %49 = load i64, i64* @guard_epoch_Test, align 8, !dbg !43
+  %50 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !43, !tbaa !44
+  %needTakeSlowPath = icmp ne i64 %49, %50, !dbg !43
+  br i1 %needTakeSlowPath, label %51, label %52, !dbg !43, !prof !46
 
-69:                                               ; preds = %entry
+51:                                               ; preds = %entry
   call void @const_recompute_Test(), !dbg !43
-  br label %70, !dbg !43
+  br label %52, !dbg !43
 
-70:                                               ; preds = %entry, %69
-  %71 = load i64, i64* @guarded_const_Test, align 8, !dbg !43
-  %72 = load i64, i64* @guard_epoch_Test, align 8, !dbg !43
-  %73 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !43, !tbaa !44
-  %guardUpdated = icmp eq i64 %72, %73, !dbg !43
+52:                                               ; preds = %entry, %51
+  %53 = load i64, i64* @guarded_const_Test, align 8, !dbg !43
+  %54 = load i64, i64* @guard_epoch_Test, align 8, !dbg !43
+  %55 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !43, !tbaa !44
+  %guardUpdated = icmp eq i64 %54, %55, !dbg !43
   call void @llvm.assume(i1 %guardUpdated), !dbg !43
   %stackFrame17.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.14test_known_nil, align 8, !dbg !43
-  %74 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #15, !dbg !43
-  %75 = bitcast i8* %74 to i16*, !dbg !43
-  %76 = load i16, i16* %75, align 8, !dbg !43
-  %77 = and i16 %76, -384, !dbg !43
-  store i16 %77, i16* %75, align 8, !dbg !43
-  %78 = getelementptr inbounds i8, i8* %74, i64 4, !dbg !43
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %78, i8 0, i64 28, i1 false) #14, !dbg !43
-  call void @sorbet_vm_define_method(i64 %71, i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 66), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_Test.14test_known_nil, i8* nonnull %74, %struct.rb_iseq_struct* %stackFrame17.i.i, i1 noundef zeroext true) #14, !dbg !43
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %66, align 8, !dbg !43, !tbaa !31
+  %56 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #15, !dbg !43
+  %57 = bitcast i8* %56 to i16*, !dbg !43
+  %58 = load i16, i16* %57, align 8, !dbg !43
+  %59 = and i16 %58, -384, !dbg !43
+  store i16 %59, i16* %57, align 8, !dbg !43
+  %60 = getelementptr inbounds i8, i8* %56, i64 4, !dbg !43
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %60, i8 0, i64 28, i1 false) #14, !dbg !43
+  call void @sorbet_vm_define_method(i64 %53, i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 66), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_Test.14test_known_nil, i8* nonnull %56, %struct.rb_iseq_struct* %stackFrame17.i.i, i1 noundef zeroext true) #14, !dbg !43
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %48, align 8, !dbg !43, !tbaa !31
   %stackFrame26.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.16test_nilable_arg, align 8, !dbg !10
-  %79 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #15, !dbg !10
-  %80 = bitcast i8* %79 to i16*, !dbg !10
-  %81 = load i16, i16* %80, align 8, !dbg !10
-  %82 = and i16 %81, -384, !dbg !10
-  %83 = or i16 %82, 1, !dbg !10
-  store i16 %83, i16* %80, align 8, !dbg !10
-  %84 = getelementptr inbounds i8, i8* %79, i64 8, !dbg !10
-  %85 = bitcast i8* %84 to i32*, !dbg !10
-  store i32 1, i32* %85, align 8, !dbg !10, !tbaa !47
-  %86 = getelementptr inbounds i8, i8* %79, i64 12, !dbg !10
-  %87 = getelementptr inbounds i8, i8* %79, i64 4, !dbg !10
-  %88 = bitcast i8* %87 to i32*, !dbg !10
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %86, i8 0, i64 20, i1 false) #14, !dbg !10
-  store i32 1, i32* %88, align 4, !dbg !10, !tbaa !50
-  %rubyId_arg.i.i2 = load i64, i64* @rubyIdPrecomputed_arg, align 8, !dbg !10
-  store i64 %rubyId_arg.i.i2, i64* %positional_table.i.i, align 8, !dbg !10
-  %89 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #15, !dbg !10
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %89, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %57, i64 noundef 8, i1 noundef false) #14, !dbg !10
-  %90 = getelementptr inbounds i8, i8* %79, i64 32, !dbg !10
-  %91 = bitcast i8* %90 to i8**, !dbg !10
-  store i8* %89, i8** %91, align 8, !dbg !10, !tbaa !51
-  call void @sorbet_vm_define_method(i64 %71, i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 81), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_Test.16test_nilable_arg, i8* nonnull %79, %struct.rb_iseq_struct* %stackFrame26.i.i, i1 noundef zeroext true) #14, !dbg !10
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %57) #14
+  %61 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #15, !dbg !10
+  %62 = bitcast i8* %61 to i16*, !dbg !10
+  %63 = load i16, i16* %62, align 8, !dbg !10
+  %64 = and i16 %63, -384, !dbg !10
+  %65 = or i16 %64, 1, !dbg !10
+  store i16 %65, i16* %62, align 8, !dbg !10
+  %66 = getelementptr inbounds i8, i8* %61, i64 8, !dbg !10
+  %67 = bitcast i8* %66 to i32*, !dbg !10
+  store i32 1, i32* %67, align 8, !dbg !10, !tbaa !47
+  %68 = getelementptr inbounds i8, i8* %61, i64 12, !dbg !10
+  %69 = getelementptr inbounds i8, i8* %61, i64 4, !dbg !10
+  %70 = bitcast i8* %69 to i32*, !dbg !10
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %68, i8 0, i64 20, i1 false) #14, !dbg !10
+  store i32 1, i32* %70, align 4, !dbg !10, !tbaa !50
+  store i64 %rubyId_arg.i.i, i64* %positional_table.i.i, align 8, !dbg !10
+  %71 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #15, !dbg !10
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %71, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %39, i64 noundef 8, i1 noundef false) #14, !dbg !10
+  %72 = getelementptr inbounds i8, i8* %61, i64 32, !dbg !10
+  %73 = bitcast i8* %72 to i8**, !dbg !10
+  store i8* %71, i8** %73, align 8, !dbg !10, !tbaa !51
+  call void @sorbet_vm_define_method(i64 %53, i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 81), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_Test.16test_nilable_arg, i8* nonnull %61, %struct.rb_iseq_struct* %stackFrame26.i.i, i1 noundef zeroext true) #14, !dbg !10
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %39) #14
   call void @sorbet_popFrame() #14, !dbg !41
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %54, align 8, !dbg !41, !tbaa !31
-  %92 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %48, i64 0, i32 1, !dbg !17
-  %93 = load i64*, i64** %92, align 8, !dbg !17
-  store i64 %71, i64* %93, align 8, !dbg !17, !tbaa !6
-  %94 = getelementptr inbounds i64, i64* %93, i64 1, !dbg !17
-  store i64* %94, i64** %92, align 8, !dbg !17
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %36, align 8, !dbg !41, !tbaa !31
+  %74 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %30, i64 0, i32 1, !dbg !17
+  %75 = load i64*, i64** %74, align 8, !dbg !17
+  store i64 %53, i64* %75, align 8, !dbg !17, !tbaa !6
+  %76 = getelementptr inbounds i64, i64* %75, i64 1, !dbg !17
+  store i64* %76, i64** %74, align 8, !dbg !17
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test_known_nil, i64 0), !dbg !17
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %54, align 8, !dbg !17, !tbaa !31
-  %95 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %48, i64 0, i32 1, !dbg !18
-  %96 = load i64*, i64** %95, align 8, !dbg !18
-  store i64 %71, i64* %96, align 8, !dbg !18, !tbaa !6
-  %97 = getelementptr inbounds i64, i64* %96, i64 1, !dbg !18
-  store i64 21, i64* %97, align 8, !dbg !18, !tbaa !6
-  %98 = getelementptr inbounds i64, i64* %97, i64 1, !dbg !18
-  store i64* %98, i64** %95, align 8, !dbg !18
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %36, align 8, !dbg !17, !tbaa !31
+  %77 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %30, i64 0, i32 1, !dbg !18
+  %78 = load i64*, i64** %77, align 8, !dbg !18
+  store i64 %53, i64* %78, align 8, !dbg !18, !tbaa !6
+  %79 = getelementptr inbounds i64, i64* %78, i64 1, !dbg !18
+  store i64 21, i64* %79, align 8, !dbg !18, !tbaa !6
+  %80 = getelementptr inbounds i64, i64* %79, i64 1, !dbg !18
+  store i64* %80, i64** %77, align 8, !dbg !18
   %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test_nilable_arg, i64 0), !dbg !18
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %54, align 8, !dbg !18, !tbaa !31
-  %99 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %48, i64 0, i32 1, !dbg !19
-  %100 = load i64*, i64** %99, align 8, !dbg !19
-  store i64 %71, i64* %100, align 8, !dbg !19, !tbaa !6
-  %101 = getelementptr inbounds i64, i64* %100, i64 1, !dbg !19
-  store i64 0, i64* %101, align 8, !dbg !19, !tbaa !6
-  %102 = getelementptr inbounds i64, i64* %101, i64 1, !dbg !19
-  store i64* %102, i64** %99, align 8, !dbg !19
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %36, align 8, !dbg !18, !tbaa !31
+  %81 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %30, i64 0, i32 1, !dbg !19
+  %82 = load i64*, i64** %81, align 8, !dbg !19
+  store i64 %53, i64* %82, align 8, !dbg !19, !tbaa !6
+  %83 = getelementptr inbounds i64, i64* %82, i64 1, !dbg !19
+  store i64 0, i64* %83, align 8, !dbg !19, !tbaa !6
+  %84 = getelementptr inbounds i64, i64* %83, i64 1, !dbg !19
+  store i64* %84, i64** %81, align 8, !dbg !19
   %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test_nilable_arg.1, i64 0), !dbg !19
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %54, align 8, !dbg !19, !tbaa !31
-  %103 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %48, i64 0, i32 1, !dbg !20
-  %104 = load i64*, i64** %103, align 8, !dbg !20
-  store i64 %71, i64* %104, align 8, !dbg !20, !tbaa !6
-  %105 = getelementptr inbounds i64, i64* %104, i64 1, !dbg !20
-  store i64 8, i64* %105, align 8, !dbg !20, !tbaa !6
-  %106 = getelementptr inbounds i64, i64* %105, i64 1, !dbg !20
-  store i64* %106, i64** %103, align 8, !dbg !20
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %36, align 8, !dbg !19, !tbaa !31
+  %85 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %30, i64 0, i32 1, !dbg !20
+  %86 = load i64*, i64** %85, align 8, !dbg !20
+  store i64 %53, i64* %86, align 8, !dbg !20, !tbaa !6
+  %87 = getelementptr inbounds i64, i64* %86, i64 1, !dbg !20
+  store i64 8, i64* %87, align 8, !dbg !20, !tbaa !6
+  %88 = getelementptr inbounds i64, i64* %87, i64 1, !dbg !20
+  store i64* %88, i64** %85, align 8, !dbg !20
   %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test_nilable_arg.2, i64 0), !dbg !20
   ret void
 }
@@ -771,7 +712,7 @@ rb_vm_check_ints.exit:                            ; preds = %sorbet_T_must.exit,
   store i64 %26, i64* %callArgs0Addr, align 8, !dbg !82
   %callArgs1Addr = getelementptr [3 x i64], [3 x i64]* %callArgs, i64 0, i64 1, !dbg !82
   store i64 %"rubyStr_ wasn't nil", i64* %callArgs1Addr, align 8, !dbg !82
-  %"rubyId_<string-interpolate>" = load i64, i64* @"rubyIdPrecomputed_<string-interpolate>", align 8, !dbg !82
+  %"rubyId_<string-interpolate>" = load i64, i64* getelementptr inbounds ([18 x i64], [18 x i64]* @sorbet_moduleIDTable, i64 0, i64 15), align 8, !dbg !82, !invariant.load !5
   %rawSendResult13 = call i64 @sorbet_stringInterpolate(i64 noundef 8, i64 %"rubyId_<string-interpolate>", i32 noundef 2, i64* noundef nonnull %callArgs0Addr, i64 (i64, i64, i32, i64*, i64)* noundef null, i64 noundef 0), !dbg !82
   %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !25
   %28 = load i64*, i64** %27, align 8, !dbg !25

--- a/test/testdata/compiler/literal_hash.opt.ll.exp
+++ b/test/testdata/compiler/literal_hash.opt.ll.exp
@@ -81,7 +81,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/literal_hash.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [15 x i64] zeroinitializer
@@ -93,18 +92,17 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @rubyStrFrozen_wat = internal unnamed_addr global i64 0, align 8
 @rubyStrFrozen_how = internal unnamed_addr global i64 0, align 8
 @rubyStrFrozen_unknown = internal unnamed_addr global i64 0, align 8
-@rubyIdPrecomputed_do = internal unnamed_addr global i64 0, align 8
 @ruby_hashLiteral1 = internal unnamed_addr global i64 0, align 8
 @ruby_hashLiteral2 = internal unnamed_addr global i64 0, align 8
 @ruby_hashLiteral3 = internal unnamed_addr global i64 0, align 8
 @ruby_hashLiteral4 = internal unnamed_addr global i64 0, align 8
 @ruby_hashLiteral5 = internal unnamed_addr global i64 0, align 8
 @ruby_hashLiteral6 = internal unnamed_addr global i64 0, align 8
-@rubyIdPrecomputed_symbol = internal unnamed_addr global i64 0, align 8
 @ruby_hashLiteral7 = internal unnamed_addr global i64 0, align 8
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
 @sorbet_moduleStringTable = internal unnamed_addr constant [140 x i8] c"<top (required)>\00test/testdata/compiler/literal_hash.rb\00foo\00bar\00baz\00quux\00wat\00how\00unknown\00do\00magic\00one\00two\00true\00false\00nil\00symbol\00puts\00master\00", align 1
+@sorbet_moduleIDTable = internal unnamed_addr global [4 x i64] zeroinitializer, align 8
+@sorbet_moduleIDDescriptors = internal unnamed_addr constant [4 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 89, i32 2 }, %struct.rb_code_position_struct { i32 121, i32 6 }, %struct.rb_code_position_struct { i32 128, i32 4 }], align 8
 
 ; Function Attrs: nounwind readnone willreturn
 declare i64 @rb_id2sym(i64) local_unnamed_addr #0
@@ -125,9 +123,9 @@ declare i64 @sorbet_globalConstRegister(i64) local_unnamed_addr #1
 
 declare i64 @sorbet_globalConstDupHash(i64) local_unnamed_addr #1
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #1
+declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #1
 
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #1
+declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #1
 
 declare i64 @rb_hash_new_with_size(i64) local_unnamed_addr #1
 
@@ -159,51 +157,44 @@ entry:
   %argArray.i.i = alloca [14 x i64], align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #7
-  store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %1 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 89), i64 noundef 2) #7
-  store i64 %1, i64* @rubyIdPrecomputed_do, align 8
-  %2 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 121), i64 noundef 6) #7
-  store i64 %2, i64* @rubyIdPrecomputed_symbol, align 8
-  %3 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 128), i64 noundef 4) #7
-  store i64 %3, i64* @rubyIdPrecomputed_puts, align 8
-  %4 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #7
-  tail call void @rb_gc_register_mark_object(i64 %4) #7
-  store i64 %4, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %5 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 38) #7
-  tail call void @rb_gc_register_mark_object(i64 %5) #7
-  store i64 %5, i64* @"rubyStrFrozen_test/testdata/compiler/literal_hash.rb", align 8
+  tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([4 x %struct.rb_code_position_struct], [4 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 4, i8* noundef getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
+  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #7
+  tail call void @rb_gc_register_mark_object(i64 %0) #7
+  store i64 %0, i64* @"rubyStrFrozen_<top (required)>", align 8
+  %1 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 38) #7
+  tail call void @rb_gc_register_mark_object(i64 %1) #7
+  store i64 %1, i64* @"rubyStrFrozen_test/testdata/compiler/literal_hash.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 15)
-  %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
+  %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
   %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/literal_hash.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/literal_hash.rb", align 8
-  %6 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/literal_hash.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 15)
-  store %struct.rb_iseq_struct* %6, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %7 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 56), i64 noundef 3) #7
+  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/literal_hash.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 15)
+  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %3 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 56), i64 noundef 3) #7
+  call void @rb_gc_register_mark_object(i64 %3) #7
+  store i64 %3, i64* @rubyStrFrozen_foo, align 8
+  %4 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 60), i64 noundef 3) #7
+  call void @rb_gc_register_mark_object(i64 %4) #7
+  store i64 %4, i64* @rubyStrFrozen_bar, align 8
+  %5 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 64), i64 noundef 3) #7
+  call void @rb_gc_register_mark_object(i64 %5) #7
+  store i64 %5, i64* @rubyStrFrozen_baz, align 8
+  %6 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 68), i64 noundef 4) #7
+  call void @rb_gc_register_mark_object(i64 %6) #7
+  store i64 %6, i64* @rubyStrFrozen_quux, align 8
+  %7 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 73), i64 noundef 3) #7
   call void @rb_gc_register_mark_object(i64 %7) #7
-  store i64 %7, i64* @rubyStrFrozen_foo, align 8
-  %8 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 60), i64 noundef 3) #7
+  store i64 %7, i64* @rubyStrFrozen_wat, align 8
+  %8 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 77), i64 noundef 3) #7
   call void @rb_gc_register_mark_object(i64 %8) #7
-  store i64 %8, i64* @rubyStrFrozen_bar, align 8
-  %9 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 64), i64 noundef 3) #7
+  store i64 %8, i64* @rubyStrFrozen_how, align 8
+  %9 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 81), i64 noundef 7) #7
   call void @rb_gc_register_mark_object(i64 %9) #7
-  store i64 %9, i64* @rubyStrFrozen_baz, align 8
-  %10 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 68), i64 noundef 4) #7
+  store i64 %9, i64* @rubyStrFrozen_unknown, align 8
+  %10 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 92), i64 noundef 5) #7
   call void @rb_gc_register_mark_object(i64 %10) #7
-  store i64 %10, i64* @rubyStrFrozen_quux, align 8
-  %11 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 73), i64 noundef 3) #7
-  call void @rb_gc_register_mark_object(i64 %11) #7
-  store i64 %11, i64* @rubyStrFrozen_wat, align 8
-  %12 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 77), i64 noundef 3) #7
-  call void @rb_gc_register_mark_object(i64 %12) #7
-  store i64 %12, i64* @rubyStrFrozen_how, align 8
-  %13 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 81), i64 noundef 7) #7
-  call void @rb_gc_register_mark_object(i64 %13) #7
-  store i64 %13, i64* @rubyStrFrozen_unknown, align 8
-  %14 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 92), i64 noundef 5) #7
-  call void @rb_gc_register_mark_object(i64 %14) #7
-  %15 = bitcast [14 x i64]* %argArray.i.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 112, i8* nonnull %15)
+  %11 = bitcast [14 x i64]* %argArray.i.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 112, i8* nonnull %11)
   %rubyStr_foo.i.i = load i64, i64* @rubyStrFrozen_foo, align 8
   %hashArgs0Addr.i.i = getelementptr [14 x i64], [14 x i64]* %argArray.i.i, i64 0, i64 0
   store i64 %rubyStr_foo.i.i, i64* %hashArgs0Addr.i.i, align 8
@@ -235,141 +226,141 @@ entry:
   %rubyStr_unknown.i.i = load i64, i64* @rubyStrFrozen_unknown, align 8
   %hashArgs11Addr.i.i = getelementptr [14 x i64], [14 x i64]* %argArray.i.i, i64 0, i64 11
   store i64 %rubyStr_unknown.i.i, i64* %hashArgs11Addr.i.i, align 8
-  %rubyId_do.i.i = load i64, i64* @rubyIdPrecomputed_do, align 8
+  %rubyId_do.i.i = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !invariant.load !5
   %rawSym.i.i = call i64 @rb_id2sym(i64 %rubyId_do.i.i) #8
   %hashArgs12Addr.i.i = getelementptr [14 x i64], [14 x i64]* %argArray.i.i, i64 0, i64 12
   store i64 %rawSym.i.i, i64* %hashArgs12Addr.i.i, align 8
   %hashArgs13Addr.i.i = getelementptr [14 x i64], [14 x i64]* %argArray.i.i, i64 0, i64 13
-  store i64 %14, i64* %hashArgs13Addr.i.i, align 8
-  %16 = call i64 @rb_hash_new_with_size(i64 noundef 7) #7
-  call void @rb_hash_bulk_insert(i64 noundef 14, i64* noundef nonnull %hashArgs0Addr.i.i, i64 %16) #7
-  %17 = call i64 @sorbet_globalConstRegister(i64 %16) #7
-  store i64 %17, i64* @ruby_hashLiteral1, align 8
-  call void @llvm.lifetime.end.p0i8(i64 112, i8* nonnull %15)
-  %18 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 98), i64 noundef 3) #7
-  call void @rb_gc_register_mark_object(i64 %18) #7
-  %19 = bitcast [2 x i64]* %argArray.i1.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %19)
+  store i64 %10, i64* %hashArgs13Addr.i.i, align 8
+  %12 = call i64 @rb_hash_new_with_size(i64 noundef 7) #7
+  call void @rb_hash_bulk_insert(i64 noundef 14, i64* noundef nonnull %hashArgs0Addr.i.i, i64 %12) #7
+  %13 = call i64 @sorbet_globalConstRegister(i64 %12) #7
+  store i64 %13, i64* @ruby_hashLiteral1, align 8
+  call void @llvm.lifetime.end.p0i8(i64 112, i8* nonnull %11)
+  %14 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 98), i64 noundef 3) #7
+  call void @rb_gc_register_mark_object(i64 %14) #7
+  %15 = bitcast [2 x i64]* %argArray.i1.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %15)
   %hashArgs0Addr.i2.i = getelementptr [2 x i64], [2 x i64]* %argArray.i1.i, i64 0, i64 0
   store i64 3, i64* %hashArgs0Addr.i2.i, align 8
   %hashArgs1Addr.i3.i = getelementptr [2 x i64], [2 x i64]* %argArray.i1.i, i64 0, i64 1
-  store i64 %18, i64* %hashArgs1Addr.i3.i, align 8
-  %20 = call i64 @rb_hash_new_with_size(i64 noundef 1) #7
-  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %hashArgs0Addr.i2.i, i64 %20) #7
-  %21 = call i64 @sorbet_globalConstRegister(i64 %20) #7
-  store i64 %21, i64* @ruby_hashLiteral2, align 8
-  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %19)
-  %22 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 102), i64 noundef 3) #7
-  call void @rb_gc_register_mark_object(i64 %22) #7
-  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %19)
+  store i64 %14, i64* %hashArgs1Addr.i3.i, align 8
+  %16 = call i64 @rb_hash_new_with_size(i64 noundef 1) #7
+  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %hashArgs0Addr.i2.i, i64 %16) #7
+  %17 = call i64 @sorbet_globalConstRegister(i64 %16) #7
+  store i64 %17, i64* @ruby_hashLiteral2, align 8
+  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %15)
+  %18 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 102), i64 noundef 3) #7
+  call void @rb_gc_register_mark_object(i64 %18) #7
+  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %15)
   store i64 2, i64* %hashArgs0Addr.i2.i, align 8
-  store i64 %22, i64* %hashArgs1Addr.i3.i, align 8
-  %23 = call i64 @rb_hash_new_with_size(i64 noundef 1) #7
-  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %hashArgs0Addr.i2.i, i64 %23) #7
-  %24 = call i64 @sorbet_globalConstRegister(i64 %23) #7
-  store i64 %24, i64* @ruby_hashLiteral3, align 8
-  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %19)
-  %25 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 106), i64 noundef 4) #7
-  call void @rb_gc_register_mark_object(i64 %25) #7
-  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %19)
+  store i64 %18, i64* %hashArgs1Addr.i3.i, align 8
+  %19 = call i64 @rb_hash_new_with_size(i64 noundef 1) #7
+  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %hashArgs0Addr.i2.i, i64 %19) #7
+  %20 = call i64 @sorbet_globalConstRegister(i64 %19) #7
+  store i64 %20, i64* @ruby_hashLiteral3, align 8
+  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %15)
+  %21 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 106), i64 noundef 4) #7
+  call void @rb_gc_register_mark_object(i64 %21) #7
+  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %15)
   store i64 20, i64* %hashArgs0Addr.i2.i, align 8
-  store i64 %25, i64* %hashArgs1Addr.i3.i, align 8
-  %26 = call i64 @rb_hash_new_with_size(i64 noundef 1) #7
-  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %hashArgs0Addr.i2.i, i64 %26) #7
-  %27 = call i64 @sorbet_globalConstRegister(i64 %26) #7
-  store i64 %27, i64* @ruby_hashLiteral4, align 8
-  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %19)
-  %28 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 111), i64 noundef 5) #7
-  call void @rb_gc_register_mark_object(i64 %28) #7
-  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %19)
+  store i64 %21, i64* %hashArgs1Addr.i3.i, align 8
+  %22 = call i64 @rb_hash_new_with_size(i64 noundef 1) #7
+  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %hashArgs0Addr.i2.i, i64 %22) #7
+  %23 = call i64 @sorbet_globalConstRegister(i64 %22) #7
+  store i64 %23, i64* @ruby_hashLiteral4, align 8
+  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %15)
+  %24 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 111), i64 noundef 5) #7
+  call void @rb_gc_register_mark_object(i64 %24) #7
+  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %15)
   store i64 0, i64* %hashArgs0Addr.i2.i, align 8
-  store i64 %28, i64* %hashArgs1Addr.i3.i, align 8
-  %29 = call i64 @rb_hash_new_with_size(i64 noundef 1) #7
-  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %hashArgs0Addr.i2.i, i64 %29) #7
-  %30 = call i64 @sorbet_globalConstRegister(i64 %29) #7
-  store i64 %30, i64* @ruby_hashLiteral5, align 8
-  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %19)
-  %31 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 117), i64 noundef 3) #7
-  call void @rb_gc_register_mark_object(i64 %31) #7
-  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %19)
+  store i64 %24, i64* %hashArgs1Addr.i3.i, align 8
+  %25 = call i64 @rb_hash_new_with_size(i64 noundef 1) #7
+  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %hashArgs0Addr.i2.i, i64 %25) #7
+  %26 = call i64 @sorbet_globalConstRegister(i64 %25) #7
+  store i64 %26, i64* @ruby_hashLiteral5, align 8
+  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %15)
+  %27 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 117), i64 noundef 3) #7
+  call void @rb_gc_register_mark_object(i64 %27) #7
+  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %15)
   store i64 8, i64* %hashArgs0Addr.i2.i, align 8
-  store i64 %31, i64* %hashArgs1Addr.i3.i, align 8
-  %32 = call i64 @rb_hash_new_with_size(i64 noundef 1) #7
-  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %hashArgs0Addr.i2.i, i64 %32) #7
-  %33 = call i64 @sorbet_globalConstRegister(i64 %32) #7
-  store i64 %33, i64* @ruby_hashLiteral6, align 8
-  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %19)
-  %34 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 121), i64 noundef 6) #7
-  call void @rb_gc_register_mark_object(i64 %34) #7
-  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %19)
-  %rubyId_symbol.i.i = load i64, i64* @rubyIdPrecomputed_symbol, align 8
+  store i64 %27, i64* %hashArgs1Addr.i3.i, align 8
+  %28 = call i64 @rb_hash_new_with_size(i64 noundef 1) #7
+  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %hashArgs0Addr.i2.i, i64 %28) #7
+  %29 = call i64 @sorbet_globalConstRegister(i64 %28) #7
+  store i64 %29, i64* @ruby_hashLiteral6, align 8
+  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %15)
+  %30 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 121), i64 noundef 6) #7
+  call void @rb_gc_register_mark_object(i64 %30) #7
+  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %15)
+  %rubyId_symbol.i.i = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !invariant.load !5
   %rawSym.i17.i = call i64 @rb_id2sym(i64 %rubyId_symbol.i.i) #8
   store i64 %rawSym.i17.i, i64* %hashArgs0Addr.i2.i, align 8
-  store i64 %34, i64* %hashArgs1Addr.i3.i, align 8
-  %35 = call i64 @rb_hash_new_with_size(i64 noundef 1) #7
-  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %hashArgs0Addr.i2.i, i64 %35) #7
-  %36 = call i64 @sorbet_globalConstRegister(i64 %35) #7
-  store i64 %36, i64* @ruby_hashLiteral7, align 8
-  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %19)
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !10
+  store i64 %30, i64* %hashArgs1Addr.i3.i, align 8
+  %31 = call i64 @rb_hash_new_with_size(i64 noundef 1) #7
+  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %hashArgs0Addr.i2.i, i64 %31) #7
+  %32 = call i64 @sorbet_globalConstRegister(i64 %31) #7
+  store i64 %32, i64* @ruby_hashLiteral7, align 8
+  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %15)
+  %rubyId_puts.i = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !10, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 7, i32 noundef 0, i64* noundef null), !dbg !10
-  %37 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !15
-  %38 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %37, i64 0, i32 18
-  %39 = load i64, i64* %38, align 8, !tbaa !17
-  %40 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
-  %41 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %40, i64 0, i32 2
-  %42 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %41, align 8, !tbaa !27
+  %33 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !15
+  %34 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %33, i64 0, i32 18
+  %35 = load i64, i64* %34, align 8, !tbaa !17
+  %36 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
+  %37 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %36, i64 0, i32 2
+  %38 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %37, align 8, !tbaa !27
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %43 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %42, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %43, align 8, !tbaa !30
-  %44 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %42, i64 0, i32 4
-  %45 = load i64*, i64** %44, align 8, !tbaa !32
-  %46 = load i64, i64* %45, align 8, !tbaa !6
-  %47 = and i64 %46, -33
-  store i64 %47, i64* %45, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %40, %struct.rb_control_frame_struct* %42, %struct.rb_iseq_struct* %stackFrame.i) #7
-  %48 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %42, i64 0, i32 0
-  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %48, align 8, !dbg !33, !tbaa !15
+  %39 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %39, align 8, !tbaa !30
+  %40 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 4
+  %41 = load i64*, i64** %40, align 8, !tbaa !32
+  %42 = load i64, i64* %41, align 8, !tbaa !6
+  %43 = and i64 %42, -33
+  store i64 %43, i64* %41, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %36, %struct.rb_control_frame_struct* %38, %struct.rb_iseq_struct* %stackFrame.i) #7
+  %44 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 0
+  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %44, align 8, !dbg !33, !tbaa !15
   %hashLiteral.i = load i64, i64* @ruby_hashLiteral1, align 8, !dbg !34
   %duplicatedHash.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral.i) #7, !dbg !34
-  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %48, align 8, !dbg !34, !tbaa !15
+  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %44, align 8, !dbg !34, !tbaa !15
   %hashLiteral80.i = load i64, i64* @ruby_hashLiteral2, align 8, !dbg !35
   %duplicatedHash81.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral80.i) #7, !dbg !35
-  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %48, align 8, !dbg !35, !tbaa !15
+  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %44, align 8, !dbg !35, !tbaa !15
   %hashLiteral87.i = load i64, i64* @ruby_hashLiteral3, align 8, !dbg !36
   %duplicatedHash88.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral87.i) #7, !dbg !36
-  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %48, align 8, !dbg !36, !tbaa !15
+  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %44, align 8, !dbg !36, !tbaa !15
   %hashLiteral94.i = load i64, i64* @ruby_hashLiteral4, align 8, !dbg !37
   %duplicatedHash95.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral94.i) #7, !dbg !37
-  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %48, align 8, !dbg !37, !tbaa !15
+  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %44, align 8, !dbg !37, !tbaa !15
   %hashLiteral101.i = load i64, i64* @ruby_hashLiteral5, align 8, !dbg !38
   %duplicatedHash102.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral101.i) #7, !dbg !38
-  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %48, align 8, !dbg !38, !tbaa !15
+  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %44, align 8, !dbg !38, !tbaa !15
   %hashLiteral108.i = load i64, i64* @ruby_hashLiteral6, align 8, !dbg !39
   %duplicatedHash109.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral108.i) #7, !dbg !39
-  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %48, align 8, !dbg !39, !tbaa !15
+  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %44, align 8, !dbg !39, !tbaa !15
   %hashLiteral115.i = load i64, i64* @ruby_hashLiteral7, align 8, !dbg !40
   %duplicatedHash116.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral115.i) #7, !dbg !40
-  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %48, align 8, !dbg !40, !tbaa !15
-  %49 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %42, i64 0, i32 1, !dbg !10
-  %50 = load i64*, i64** %49, align 8, !dbg !10
-  store i64 %39, i64* %50, align 8, !dbg !10, !tbaa !6
+  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %44, align 8, !dbg !40, !tbaa !15
+  %45 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !10
+  %46 = load i64*, i64** %45, align 8, !dbg !10
+  store i64 %35, i64* %46, align 8, !dbg !10, !tbaa !6
+  %47 = getelementptr inbounds i64, i64* %46, i64 1, !dbg !10
+  store i64 %duplicatedHash.i, i64* %47, align 8, !dbg !10, !tbaa !6
+  %48 = getelementptr inbounds i64, i64* %47, i64 1, !dbg !10
+  store i64 %duplicatedHash81.i, i64* %48, align 8, !dbg !10, !tbaa !6
+  %49 = getelementptr inbounds i64, i64* %48, i64 1, !dbg !10
+  store i64 %duplicatedHash88.i, i64* %49, align 8, !dbg !10, !tbaa !6
+  %50 = getelementptr inbounds i64, i64* %49, i64 1, !dbg !10
+  store i64 %duplicatedHash95.i, i64* %50, align 8, !dbg !10, !tbaa !6
   %51 = getelementptr inbounds i64, i64* %50, i64 1, !dbg !10
-  store i64 %duplicatedHash.i, i64* %51, align 8, !dbg !10, !tbaa !6
+  store i64 %duplicatedHash102.i, i64* %51, align 8, !dbg !10, !tbaa !6
   %52 = getelementptr inbounds i64, i64* %51, i64 1, !dbg !10
-  store i64 %duplicatedHash81.i, i64* %52, align 8, !dbg !10, !tbaa !6
+  store i64 %duplicatedHash109.i, i64* %52, align 8, !dbg !10, !tbaa !6
   %53 = getelementptr inbounds i64, i64* %52, i64 1, !dbg !10
-  store i64 %duplicatedHash88.i, i64* %53, align 8, !dbg !10, !tbaa !6
+  store i64 %duplicatedHash116.i, i64* %53, align 8, !dbg !10, !tbaa !6
   %54 = getelementptr inbounds i64, i64* %53, i64 1, !dbg !10
-  store i64 %duplicatedHash95.i, i64* %54, align 8, !dbg !10, !tbaa !6
-  %55 = getelementptr inbounds i64, i64* %54, i64 1, !dbg !10
-  store i64 %duplicatedHash102.i, i64* %55, align 8, !dbg !10, !tbaa !6
-  %56 = getelementptr inbounds i64, i64* %55, i64 1, !dbg !10
-  store i64 %duplicatedHash109.i, i64* %56, align 8, !dbg !10, !tbaa !6
-  %57 = getelementptr inbounds i64, i64* %56, i64 1, !dbg !10
-  store i64 %duplicatedHash116.i, i64* %57, align 8, !dbg !10, !tbaa !6
-  %58 = getelementptr inbounds i64, i64* %57, i64 1, !dbg !10
-  store i64* %58, i64** %49, align 8, !dbg !10
+  store i64* %54, i64** %45, align 8, !dbg !10
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !10
   ret void
 }

--- a/test/testdata/compiler/literal_type_tests.rb
+++ b/test/testdata/compiler/literal_type_tests.rb
@@ -30,7 +30,8 @@ def literal_integer(obj)
 end
 
 # INITIAL-LABEL: define internal i64 @"func_Object#14literal_symbol"
-# INITIAL: [[ID:%[_a-zA-Z]+]] = load i64, i64* @rubyIdPrecomputed_matching{{.*}}
+# INITIAL: [[ID_ADDR:%[_a-zA-Z0-9]+]] = load i64*, i64** @addr_id_matching{{.*}}
+# INITIAL-NEXT: [[ID:%[_a-zA-Z0-9]+]] = load i64, i64* [[ID_ADDR]]{{.*}}
 # INITIAL-NEXT: [[SYM:%[_a-zA-Z]+]] = call i64 @rb_id2sym(i64 [[ID]]{{.*}}
 # INITIAL-NEXT: [[COND:%[0-9]+]] = call i1 @sorbet_i_isa_Symbol(i64 [[SYM]]{{.*}}
 # INITIAL-NEXT: call void @llvm.assume(i1 [[COND]]){{.*}}

--- a/test/testdata/compiler/literals.opt.ll.exp
+++ b/test/testdata/compiler/literals.opt.ll.exp
@@ -81,22 +81,21 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/literals.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [11 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
 @ic_puts.1 = internal global %struct.FunctionInlineCache zeroinitializer
 @rubyStrFrozen_str = internal unnamed_addr global i64 0, align 8
 @ic_puts.2 = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_sym = internal unnamed_addr global i64 0, align 8
 @ic_puts.3 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.4 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.5 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.6 = internal global %struct.FunctionInlineCache zeroinitializer
 @sorbet_moduleStringTable = internal unnamed_addr constant [72 x i8] c"<top (required)>\00test/testdata/compiler/literals.rb\00puts\00str\00sym\00master\00", align 1
+@sorbet_moduleIDTable = internal unnamed_addr global [3 x i64] zeroinitializer, align 8
+@sorbet_moduleIDDescriptors = internal unnamed_addr constant [3 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 52, i32 4 }, %struct.rb_code_position_struct { i32 61, i32 3 }], align 8
 
 ; Function Attrs: nounwind readnone willreturn
 declare i64 @rb_id2sym(i64) local_unnamed_addr #0
@@ -113,9 +112,9 @@ declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_u
 
 declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #1
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #1
+declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #1
 
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #1
+declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #1
 
 declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #1
 
@@ -141,122 +140,111 @@ define void @Init_literals() local_unnamed_addr #4 {
 entry:
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([72 x i8], [72 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #6
-  store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %1 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([72 x i8], [72 x i8]* @sorbet_moduleStringTable, i64 0, i64 52), i64 noundef 4) #6
-  store i64 %1, i64* @rubyIdPrecomputed_puts, align 8
-  %2 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([72 x i8], [72 x i8]* @sorbet_moduleStringTable, i64 0, i64 61), i64 noundef 3) #6
-  store i64 %2, i64* @rubyIdPrecomputed_sym, align 8
-  %3 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([72 x i8], [72 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #6
-  tail call void @rb_gc_register_mark_object(i64 %3) #6
-  store i64 %3, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %4 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([72 x i8], [72 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 34) #6
-  tail call void @rb_gc_register_mark_object(i64 %4) #6
-  store i64 %4, i64* @"rubyStrFrozen_test/testdata/compiler/literals.rb", align 8
+  tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([3 x %struct.rb_code_position_struct], [3 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 3, i8* noundef getelementptr inbounds ([72 x i8], [72 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
+  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([72 x i8], [72 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #6
+  tail call void @rb_gc_register_mark_object(i64 %0) #6
+  store i64 %0, i64* @"rubyStrFrozen_<top (required)>", align 8
+  %1 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([72 x i8], [72 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 34) #6
+  tail call void @rb_gc_register_mark_object(i64 %1) #6
+  store i64 %1, i64* @"rubyStrFrozen_test/testdata/compiler/literals.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 11)
-  %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
+  %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
   %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/literals.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/literals.rb", align 8
-  %5 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/literals.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %5, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !10
+  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/literals.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %rubyId_puts.i = load i64, i64* getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !dbg !10, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !10
-  %rubyId_puts1.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !15
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts1.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
-  %6 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([72 x i8], [72 x i8]* @sorbet_moduleStringTable, i64 0, i64 57), i64 noundef 3) #6
-  call void @rb_gc_register_mark_object(i64 %6) #6
-  store i64 %6, i64* @rubyStrFrozen_str, align 8
-  %rubyId_puts4.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !16
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts4.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !16
-  %rubyId_puts7.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !17
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts7.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !17
-  %rubyId_puts10.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !18
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.4, i64 %rubyId_puts10.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !18
-  %rubyId_puts13.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !19
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.5, i64 %rubyId_puts13.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
-  %rubyId_puts16.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !20
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.6, i64 %rubyId_puts16.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !20
-  %7 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !21
-  %8 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %7, i64 0, i32 18
-  %9 = load i64, i64* %8, align 8, !tbaa !23
-  %10 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !21
-  %11 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %10, i64 0, i32 2
-  %12 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %11, align 8, !tbaa !33
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
+  %3 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([72 x i8], [72 x i8]* @sorbet_moduleStringTable, i64 0, i64 57), i64 noundef 3) #6
+  call void @rb_gc_register_mark_object(i64 %3) #6
+  store i64 %3, i64* @rubyStrFrozen_str, align 8
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !16
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !17
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.4, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !18
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.5, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.6, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !20
+  %4 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !21
+  %5 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %4, i64 0, i32 18
+  %6 = load i64, i64* %5, align 8, !tbaa !23
+  %7 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !21
+  %8 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %7, i64 0, i32 2
+  %9 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %8, align 8, !tbaa !33
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %13 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %13, align 8, !tbaa !36
-  %14 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 4
-  %15 = load i64*, i64** %14, align 8, !tbaa !38
-  %16 = load i64, i64* %15, align 8, !tbaa !6
-  %17 = and i64 %16, -33
-  store i64 %17, i64* %15, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %10, %struct.rb_control_frame_struct* %12, %struct.rb_iseq_struct* %stackFrame.i) #6
-  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 0
-  store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %18, align 8, !dbg !39, !tbaa !21
-  %19 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 1, !dbg !10
-  %20 = load i64*, i64** %19, align 8, !dbg !10
-  store i64 %9, i64* %20, align 8, !dbg !10, !tbaa !6
-  %21 = getelementptr inbounds i64, i64* %20, i64 1, !dbg !10
-  store i64 85, i64* %21, align 8, !dbg !10, !tbaa !6
-  %22 = getelementptr inbounds i64, i64* %21, i64 1, !dbg !10
-  store i64* %22, i64** %19, align 8, !dbg !10
+  %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %10, align 8, !tbaa !36
+  %11 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 4
+  %12 = load i64*, i64** %11, align 8, !tbaa !38
+  %13 = load i64, i64* %12, align 8, !tbaa !6
+  %14 = and i64 %13, -33
+  store i64 %14, i64* %12, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %7, %struct.rb_control_frame_struct* %9, %struct.rb_iseq_struct* %stackFrame.i) #6
+  %15 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 0
+  store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %15, align 8, !dbg !39, !tbaa !21
+  %16 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 1, !dbg !10
+  %17 = load i64*, i64** %16, align 8, !dbg !10
+  store i64 %6, i64* %17, align 8, !dbg !10, !tbaa !6
+  %18 = getelementptr inbounds i64, i64* %17, i64 1, !dbg !10
+  store i64 85, i64* %18, align 8, !dbg !10, !tbaa !6
+  %19 = getelementptr inbounds i64, i64* %18, i64 1, !dbg !10
+  store i64* %19, i64** %16, align 8, !dbg !10
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !10
-  store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %18, align 8, !dbg !10, !tbaa !21
-  %23 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 1, !dbg !15
-  %24 = load i64*, i64** %23, align 8, !dbg !15
-  store i64 %9, i64* %24, align 8, !dbg !15, !tbaa !6
-  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !15
-  store i64 56565211319773434, i64* %25, align 8, !dbg !15, !tbaa !6
-  %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !15
-  store i64* %26, i64** %23, align 8, !dbg !15
+  store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %15, align 8, !dbg !10, !tbaa !21
+  %20 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 1, !dbg !15
+  %21 = load i64*, i64** %20, align 8, !dbg !15
+  store i64 %6, i64* %21, align 8, !dbg !15, !tbaa !6
+  %22 = getelementptr inbounds i64, i64* %21, i64 1, !dbg !15
+  store i64 56565211319773434, i64* %22, align 8, !dbg !15, !tbaa !6
+  %23 = getelementptr inbounds i64, i64* %22, i64 1, !dbg !15
+  store i64* %23, i64** %20, align 8, !dbg !15
   %send2 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.1, i64 0), !dbg !15
-  store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %18, align 8, !dbg !15, !tbaa !21
+  store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %15, align 8, !dbg !15, !tbaa !21
   %rubyStr_str.i = load i64, i64* @rubyStrFrozen_str, align 8, !dbg !40
-  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 1, !dbg !16
-  %28 = load i64*, i64** %27, align 8, !dbg !16
-  store i64 %9, i64* %28, align 8, !dbg !16, !tbaa !6
-  %29 = getelementptr inbounds i64, i64* %28, i64 1, !dbg !16
-  store i64 %rubyStr_str.i, i64* %29, align 8, !dbg !16, !tbaa !6
-  %30 = getelementptr inbounds i64, i64* %29, i64 1, !dbg !16
-  store i64* %30, i64** %27, align 8, !dbg !16
+  %24 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 1, !dbg !16
+  %25 = load i64*, i64** %24, align 8, !dbg !16
+  store i64 %6, i64* %25, align 8, !dbg !16, !tbaa !6
+  %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !16
+  store i64 %rubyStr_str.i, i64* %26, align 8, !dbg !16, !tbaa !6
+  %27 = getelementptr inbounds i64, i64* %26, i64 1, !dbg !16
+  store i64* %27, i64** %24, align 8, !dbg !16
   %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.2, i64 0), !dbg !16
-  store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %18, align 8, !dbg !16, !tbaa !21
-  %rubyId_sym.i = load i64, i64* @rubyIdPrecomputed_sym, align 8, !dbg !41
+  store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %15, align 8, !dbg !16, !tbaa !21
+  %rubyId_sym.i = load i64, i64* getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !41, !invariant.load !5
   %rawSym.i = call i64 @rb_id2sym(i64 %rubyId_sym.i) #6, !dbg !41
-  %31 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 1, !dbg !17
-  %32 = load i64*, i64** %31, align 8, !dbg !17
-  store i64 %9, i64* %32, align 8, !dbg !17, !tbaa !6
-  %33 = getelementptr inbounds i64, i64* %32, i64 1, !dbg !17
-  store i64 %rawSym.i, i64* %33, align 8, !dbg !17, !tbaa !6
-  %34 = getelementptr inbounds i64, i64* %33, i64 1, !dbg !17
-  store i64* %34, i64** %31, align 8, !dbg !17
+  %28 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 1, !dbg !17
+  %29 = load i64*, i64** %28, align 8, !dbg !17
+  store i64 %6, i64* %29, align 8, !dbg !17, !tbaa !6
+  %30 = getelementptr inbounds i64, i64* %29, i64 1, !dbg !17
+  store i64 %rawSym.i, i64* %30, align 8, !dbg !17, !tbaa !6
+  %31 = getelementptr inbounds i64, i64* %30, i64 1, !dbg !17
+  store i64* %31, i64** %28, align 8, !dbg !17
   %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.3, i64 0), !dbg !17
-  store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %18, align 8, !dbg !17, !tbaa !21
-  %35 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 1, !dbg !18
-  %36 = load i64*, i64** %35, align 8, !dbg !18
-  store i64 %9, i64* %36, align 8, !dbg !18, !tbaa !6
-  %37 = getelementptr inbounds i64, i64* %36, i64 1, !dbg !18
-  store i64 0, i64* %37, align 8, !dbg !18, !tbaa !6
-  %38 = getelementptr inbounds i64, i64* %37, i64 1, !dbg !18
-  store i64* %38, i64** %35, align 8, !dbg !18
+  store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %15, align 8, !dbg !17, !tbaa !21
+  %32 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 1, !dbg !18
+  %33 = load i64*, i64** %32, align 8, !dbg !18
+  store i64 %6, i64* %33, align 8, !dbg !18, !tbaa !6
+  %34 = getelementptr inbounds i64, i64* %33, i64 1, !dbg !18
+  store i64 0, i64* %34, align 8, !dbg !18, !tbaa !6
+  %35 = getelementptr inbounds i64, i64* %34, i64 1, !dbg !18
+  store i64* %35, i64** %32, align 8, !dbg !18
   %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.4, i64 0), !dbg !18
-  store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %18, align 8, !dbg !18, !tbaa !21
-  %39 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 1, !dbg !19
-  %40 = load i64*, i64** %39, align 8, !dbg !19
-  store i64 %9, i64* %40, align 8, !dbg !19, !tbaa !6
-  %41 = getelementptr inbounds i64, i64* %40, i64 1, !dbg !19
-  store i64 20, i64* %41, align 8, !dbg !19, !tbaa !6
-  %42 = getelementptr inbounds i64, i64* %41, i64 1, !dbg !19
-  store i64* %42, i64** %39, align 8, !dbg !19
+  store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %15, align 8, !dbg !18, !tbaa !21
+  %36 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 1, !dbg !19
+  %37 = load i64*, i64** %36, align 8, !dbg !19
+  store i64 %6, i64* %37, align 8, !dbg !19, !tbaa !6
+  %38 = getelementptr inbounds i64, i64* %37, i64 1, !dbg !19
+  store i64 20, i64* %38, align 8, !dbg !19, !tbaa !6
+  %39 = getelementptr inbounds i64, i64* %38, i64 1, !dbg !19
+  store i64* %39, i64** %36, align 8, !dbg !19
   %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.5, i64 0), !dbg !19
-  store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %18, align 8, !dbg !19, !tbaa !21
-  %43 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 1, !dbg !20
-  %44 = load i64*, i64** %43, align 8, !dbg !20
-  store i64 %9, i64* %44, align 8, !dbg !20, !tbaa !6
-  %45 = getelementptr inbounds i64, i64* %44, i64 1, !dbg !20
-  store i64 8, i64* %45, align 8, !dbg !20, !tbaa !6
-  %46 = getelementptr inbounds i64, i64* %45, i64 1, !dbg !20
-  store i64* %46, i64** %43, align 8, !dbg !20
+  store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %15, align 8, !dbg !19, !tbaa !21
+  %40 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 1, !dbg !20
+  %41 = load i64*, i64** %40, align 8, !dbg !20
+  store i64 %6, i64* %41, align 8, !dbg !20, !tbaa !6
+  %42 = getelementptr inbounds i64, i64* %41, i64 1, !dbg !20
+  store i64 8, i64* %42, align 8, !dbg !20, !tbaa !6
+  %43 = getelementptr inbounds i64, i64* %42, i64 1, !dbg !20
+  store i64* %43, i64** %40, align 8, !dbg !20
   %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.6, i64 0), !dbg !20
   ret void
 }

--- a/test/testdata/compiler/repeated_casts.opt.ll.exp
+++ b/test/testdata/compiler/repeated_casts.opt.ll.exp
@@ -81,21 +81,18 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_Object#10doubleCast" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@rubyIdPrecomputed_doubleCast = internal unnamed_addr global i64 0, align 8
 @rubyStrFrozen_doubleCast = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/repeated_casts.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [12 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @ic_foo = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_foo = internal unnamed_addr global i64 0, align 8
 @ic_foo.1 = internal global %struct.FunctionInlineCache zeroinitializer
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@rubyIdPrecomputed_a = internal unnamed_addr global i64 0, align 8
 @"stackFramePrecomputed_func_A#3foo" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"stackFramePrecomputed_func_A.13<static-init>" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_<class:A>" = internal unnamed_addr global i64 0, align 8
 @sorbet_moduleStringTable = internal unnamed_addr constant [115 x i8] c"doubleCast\00test/testdata/compiler/repeated_casts.rb\00A\00T.cast\00foo\00<top (required)>\00Object\00normal\00a\00master\00<class:A>\00", align 1
+@sorbet_moduleIDTable = internal unnamed_addr global [6 x i64] zeroinitializer, align 8
+@sorbet_moduleIDDescriptors = internal unnamed_addr constant [6 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 10 }, %struct.rb_code_position_struct { i32 61, i32 3 }, %struct.rb_code_position_struct { i32 65, i32 16 }, %struct.rb_code_position_struct { i32 89, i32 6 }, %struct.rb_code_position_struct { i32 96, i32 1 }, %struct.rb_code_position_struct { i32 105, i32 9 }], align 8
 @guard_epoch_A = linkonce local_unnamed_addr global i64 0
 @guarded_const_A = linkonce local_unnamed_addr global i64 0
 @rb_cObject = external local_unnamed_addr constant i64
@@ -129,6 +126,8 @@ declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %
 
 declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #3
 
+declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #3
+
 declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #3
 
 declare i64 @rb_define_class(i8*, i64) local_unnamed_addr #3
@@ -138,8 +137,6 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #4
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #4
-
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #3
 
 declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #3
 
@@ -235,134 +232,122 @@ entry:
   %locals.i4.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 10) #16
-  store i64 %0, i64* @rubyIdPrecomputed_doubleCast, align 8
-  %1 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 61), i64 noundef 3) #16
-  store i64 %1, i64* @rubyIdPrecomputed_foo, align 8
-  %2 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 65), i64 noundef 16) #16
-  store i64 %2, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %3 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 89), i64 noundef 6) #16
-  %4 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 96), i64 noundef 1) #16
-  store i64 %4, i64* @rubyIdPrecomputed_a, align 8
-  %5 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 105), i64 noundef 9) #16
-  store i64 %5, i64* @"rubyIdPrecomputed_<class:A>", align 8
-  %6 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 10) #16
-  tail call void @rb_gc_register_mark_object(i64 %6) #16
-  store i64 %6, i64* @rubyStrFrozen_doubleCast, align 8
-  %7 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 11), i64 noundef 40) #16
-  tail call void @rb_gc_register_mark_object(i64 %7) #16
-  store i64 %7, i64* @"rubyStrFrozen_test/testdata/compiler/repeated_casts.rb", align 8
+  tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([6 x %struct.rb_code_position_struct], [6 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 6, i8* noundef getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
+  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 10) #16
+  tail call void @rb_gc_register_mark_object(i64 %0) #16
+  store i64 %0, i64* @rubyStrFrozen_doubleCast, align 8
+  %1 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 11), i64 noundef 40) #16
+  tail call void @rb_gc_register_mark_object(i64 %1) #16
+  store i64 %1, i64* @"rubyStrFrozen_test/testdata/compiler/repeated_casts.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 12)
-  %rubyId_doubleCast.i.i = load i64, i64* @rubyIdPrecomputed_doubleCast, align 8
+  %rubyId_doubleCast.i.i = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
   %rubyStr_doubleCast.i.i = load i64, i64* @rubyStrFrozen_doubleCast, align 8
   %"rubyStr_test/testdata/compiler/repeated_casts.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/repeated_casts.rb", align 8
-  %8 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_doubleCast.i.i, i64 %rubyId_doubleCast.i.i, i64 %"rubyStr_test/testdata/compiler/repeated_casts.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 1)
-  store %struct.rb_iseq_struct* %8, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#10doubleCast", align 8
-  %rubyId_foo.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !19
+  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_doubleCast.i.i, i64 %rubyId_doubleCast.i.i, i64 %"rubyStr_test/testdata/compiler/repeated_casts.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 1)
+  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#10doubleCast", align 8
+  %rubyId_foo.i = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !dbg !19, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !19
-  %rubyId_foo1.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !24
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo.1, i64 %rubyId_foo1.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !24
-  %9 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 65), i64 noundef 16) #16
-  call void @rb_gc_register_mark_object(i64 %9) #16
-  %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo.1, i64 %rubyId_foo.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !24
+  %3 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 65), i64 noundef 16) #16
+  call void @rb_gc_register_mark_object(i64 %3) #16
+  %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/repeated_casts.rb.i3.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/repeated_casts.rb", align 8
-  %10 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %9, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/repeated_casts.rb.i3.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i4.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %10, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %11 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 61), i64 noundef 3) #16
-  call void @rb_gc_register_mark_object(i64 %11) #16
-  %rubyId_foo.i.i = load i64, i64* @rubyIdPrecomputed_foo, align 8
+  %4 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %3, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/repeated_casts.rb.i3.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i4.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %4, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %5 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 61), i64 noundef 3) #16
+  call void @rb_gc_register_mark_object(i64 %5) #16
   %"rubyStr_test/testdata/compiler/repeated_casts.rb.i5.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/repeated_casts.rb", align 8
-  %12 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %11, i64 %rubyId_foo.i.i, i64 %"rubyStr_test/testdata/compiler/repeated_casts.rb.i5.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i6.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %12, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#3foo", align 8
-  %13 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 105), i64 noundef 9) #16
-  call void @rb_gc_register_mark_object(i64 %13) #16
-  %"rubyId_<class:A>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:A>", align 8
+  %6 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %5, i64 %rubyId_foo.i, i64 %"rubyStr_test/testdata/compiler/repeated_casts.rb.i5.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i6.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %6, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#3foo", align 8
+  %7 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 105), i64 noundef 9) #16
+  call void @rb_gc_register_mark_object(i64 %7) #16
+  %"rubyId_<class:A>.i.i" = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleIDTable, i64 0, i64 5), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/repeated_casts.rb.i7.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/repeated_casts.rb", align 8
-  %14 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %13, i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/repeated_casts.rb.i7.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i8.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %14, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %15 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %16 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %15, i64 0, i32 2
-  %17 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %16, align 8, !tbaa !27
-  %18 = bitcast i64* %positional_table.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %18)
+  %8 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %7, i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/repeated_casts.rb.i7.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i8.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %8, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
+  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 2
+  %11 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %10, align 8, !tbaa !27
+  %12 = bitcast i64* %positional_table.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %12)
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %19 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %19, align 8, !tbaa !31
-  %20 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 4
-  %21 = load i64*, i64** %20, align 8, !tbaa !33
-  %22 = load i64, i64* %21, align 8, !tbaa !6
-  %23 = and i64 %22, -33
-  store i64 %23, i64* %21, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %15, %struct.rb_control_frame_struct* %17, %struct.rb_iseq_struct* %stackFrame.i) #16
-  %24 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 0
-  store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %24, align 8, !dbg !34, !tbaa !14
-  %25 = load i64, i64* @rb_cObject, align 8, !dbg !35
-  %26 = call i64 @rb_define_class(i8* getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 52), i64 %25) #16, !dbg !35
-  %27 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %26) #16, !dbg !35
+  %13 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %13, align 8, !tbaa !31
+  %14 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 4
+  %15 = load i64*, i64** %14, align 8, !tbaa !33
+  %16 = load i64, i64* %15, align 8, !tbaa !6
+  %17 = and i64 %16, -33
+  store i64 %17, i64* %15, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %9, %struct.rb_control_frame_struct* %11, %struct.rb_iseq_struct* %stackFrame.i) #16
+  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 0
+  store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %18, align 8, !dbg !34, !tbaa !14
+  %19 = load i64, i64* @rb_cObject, align 8, !dbg !35
+  %20 = call i64 @rb_define_class(i8* getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 52), i64 %19) #16, !dbg !35
+  %21 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %20) #16, !dbg !35
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %28 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %29 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %28, i64 0, i32 2
-  %30 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %29, align 8, !tbaa !27
-  %31 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %30, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %31, align 8, !tbaa !31
-  %32 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %30, i64 0, i32 4
-  %33 = load i64*, i64** %32, align 8, !tbaa !33
-  %34 = load i64, i64* %33, align 8, !tbaa !6
-  %35 = and i64 %34, -33
-  store i64 %35, i64* %33, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %28, %struct.rb_control_frame_struct* %30, %struct.rb_iseq_struct* %stackFrame.i.i) #16
-  %36 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %27, i64 0, i32 0
-  store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %36, align 8, !dbg !36, !tbaa !14
-  %37 = load i64, i64* @guard_epoch_A, align 8, !dbg !39
-  %38 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !39, !tbaa !20
-  %needTakeSlowPath = icmp ne i64 %37, %38, !dbg !39
-  br i1 %needTakeSlowPath, label %39, label %40, !dbg !39, !prof !22
+  %22 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %23 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %22, i64 0, i32 2
+  %24 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %23, align 8, !tbaa !27
+  %25 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %25, align 8, !tbaa !31
+  %26 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 4
+  %27 = load i64*, i64** %26, align 8, !tbaa !33
+  %28 = load i64, i64* %27, align 8, !tbaa !6
+  %29 = and i64 %28, -33
+  store i64 %29, i64* %27, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %22, %struct.rb_control_frame_struct* %24, %struct.rb_iseq_struct* %stackFrame.i.i) #16
+  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %21, i64 0, i32 0
+  store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %30, align 8, !dbg !36, !tbaa !14
+  %31 = load i64, i64* @guard_epoch_A, align 8, !dbg !39
+  %32 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !39, !tbaa !20
+  %needTakeSlowPath = icmp ne i64 %31, %32, !dbg !39
+  br i1 %needTakeSlowPath, label %33, label %34, !dbg !39, !prof !22
 
-39:                                               ; preds = %entry
+33:                                               ; preds = %entry
   call void @const_recompute_A(), !dbg !39
-  br label %40, !dbg !39
+  br label %34, !dbg !39
 
-40:                                               ; preds = %entry, %39
-  %41 = load i64, i64* @guarded_const_A, align 8, !dbg !39
-  %42 = load i64, i64* @guard_epoch_A, align 8, !dbg !39
-  %43 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !39, !tbaa !20
-  %guardUpdated = icmp eq i64 %42, %43, !dbg !39
+34:                                               ; preds = %entry, %33
+  %35 = load i64, i64* @guarded_const_A, align 8, !dbg !39
+  %36 = load i64, i64* @guard_epoch_A, align 8, !dbg !39
+  %37 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !39, !tbaa !20
+  %guardUpdated = icmp eq i64 %36, %37, !dbg !39
   call void @llvm.assume(i1 %guardUpdated), !dbg !39
   %stackFrame7.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#3foo", align 8, !dbg !39
-  %44 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #17, !dbg !39
-  %45 = bitcast i8* %44 to i16*, !dbg !39
-  %46 = load i16, i16* %45, align 8, !dbg !39
-  %47 = and i16 %46, -384, !dbg !39
-  store i16 %47, i16* %45, align 8, !dbg !39
-  %48 = getelementptr inbounds i8, i8* %44, i64 4, !dbg !39
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %48, i8 0, i64 28, i1 false) #16, !dbg !39
-  call void @sorbet_vm_define_method(i64 %41, i8* getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 61), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_A#3foo", i8* nonnull %44, %struct.rb_iseq_struct* %stackFrame7.i.i, i1 noundef zeroext false) #16, !dbg !39
+  %38 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #17, !dbg !39
+  %39 = bitcast i8* %38 to i16*, !dbg !39
+  %40 = load i16, i16* %39, align 8, !dbg !39
+  %41 = and i16 %40, -384, !dbg !39
+  store i16 %41, i16* %39, align 8, !dbg !39
+  %42 = getelementptr inbounds i8, i8* %38, i64 4, !dbg !39
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %42, i8 0, i64 28, i1 false) #16, !dbg !39
+  call void @sorbet_vm_define_method(i64 %35, i8* getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 61), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_A#3foo", i8* nonnull %38, %struct.rb_iseq_struct* %stackFrame7.i.i, i1 noundef zeroext false) #16, !dbg !39
   call void @sorbet_popFrame() #16, !dbg !35
-  store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %24, align 8, !dbg !35, !tbaa !14
+  store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %18, align 8, !dbg !35, !tbaa !14
   %stackFrame19.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#10doubleCast", align 8, !dbg !25
-  %49 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #17, !dbg !25
-  %50 = bitcast i8* %49 to i16*, !dbg !25
-  %51 = load i16, i16* %50, align 8, !dbg !25
-  %52 = and i16 %51, -384, !dbg !25
-  %53 = or i16 %52, 1, !dbg !25
-  store i16 %53, i16* %50, align 8, !dbg !25
-  %54 = getelementptr inbounds i8, i8* %49, i64 8, !dbg !25
-  %55 = bitcast i8* %54 to i32*, !dbg !25
-  store i32 1, i32* %55, align 8, !dbg !25, !tbaa !40
-  %56 = getelementptr inbounds i8, i8* %49, i64 12, !dbg !25
-  %57 = getelementptr inbounds i8, i8* %49, i64 4, !dbg !25
-  %58 = bitcast i8* %57 to i32*, !dbg !25
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %56, i8 0, i64 20, i1 false) #16, !dbg !25
-  store i32 1, i32* %58, align 4, !dbg !25, !tbaa !43
-  %rubyId_a.i = load i64, i64* @rubyIdPrecomputed_a, align 8, !dbg !25
+  %43 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #17, !dbg !25
+  %44 = bitcast i8* %43 to i16*, !dbg !25
+  %45 = load i16, i16* %44, align 8, !dbg !25
+  %46 = and i16 %45, -384, !dbg !25
+  %47 = or i16 %46, 1, !dbg !25
+  store i16 %47, i16* %44, align 8, !dbg !25
+  %48 = getelementptr inbounds i8, i8* %43, i64 8, !dbg !25
+  %49 = bitcast i8* %48 to i32*, !dbg !25
+  store i32 1, i32* %49, align 8, !dbg !25, !tbaa !40
+  %50 = getelementptr inbounds i8, i8* %43, i64 12, !dbg !25
+  %51 = getelementptr inbounds i8, i8* %43, i64 4, !dbg !25
+  %52 = bitcast i8* %51 to i32*, !dbg !25
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %50, i8 0, i64 20, i1 false) #16, !dbg !25
+  store i32 1, i32* %52, align 4, !dbg !25, !tbaa !43
+  %rubyId_a.i = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !dbg !25, !invariant.load !5
   store i64 %rubyId_a.i, i64* %positional_table.i, align 8, !dbg !25
-  %59 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #17, !dbg !25
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %59, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %18, i64 noundef 8, i1 noundef false) #16, !dbg !25
-  %60 = getelementptr inbounds i8, i8* %49, i64 32, !dbg !25
-  %61 = bitcast i8* %60 to i8**, !dbg !25
-  store i8* %59, i8** %61, align 8, !dbg !25, !tbaa !44
-  call void @sorbet_vm_define_method(i64 %25, i8* noundef getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#10doubleCast", i8* nonnull %49, %struct.rb_iseq_struct* %stackFrame19.i, i1 noundef zeroext false) #16, !dbg !25
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %18)
+  %53 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #17, !dbg !25
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %53, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %12, i64 noundef 8, i1 noundef false) #16, !dbg !25
+  %54 = getelementptr inbounds i8, i8* %43, i64 32, !dbg !25
+  %55 = bitcast i8* %54 to i8**, !dbg !25
+  store i8* %53, i8** %55, align 8, !dbg !25, !tbaa !44
+  call void @sorbet_vm_define_method(i64 %19, i8* noundef getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#10doubleCast", i8* nonnull %43, %struct.rb_iseq_struct* %stackFrame19.i, i1 noundef zeroext false) #16, !dbg !25
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %12)
   ret void
 }
 

--- a/test/testdata/compiler/send_with_block_param.opt.ll.exp
+++ b/test/testdata/compiler/send_with_block_param.opt.ll.exp
@@ -83,17 +83,16 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/send_with_block_param.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [7 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @ruby_hashLiteral1 = internal unnamed_addr global i64 0, align 8
-@rubyIdPrecomputed_map = internal unnamed_addr global i64 0, align 8
 @ic_map = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
 @sorbet_moduleStringTable = internal unnamed_addr constant [104 x i8] c"<top (required)>\00test/testdata/compiler/send_with_block_param.rb\00T\00unsafe\00<build-array>\00map\00puts\00master\00", align 1
+@sorbet_moduleIDTable = internal unnamed_addr global [5 x i64] zeroinitializer, align 8
+@sorbet_moduleIDDescriptors = internal unnamed_addr constant [5 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 67, i32 6 }, %struct.rb_code_position_struct { i32 74, i32 13 }, %struct.rb_code_position_struct { i32 88, i32 3 }, %struct.rb_code_position_struct { i32 92, i32 4 }], align 8
 
 declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
 
@@ -110,6 +109,8 @@ declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %
 declare i64 @sorbet_globalConstRegister(i64) local_unnamed_addr #0
 
 declare i64 @sorbet_globalConstDupHash(i64) local_unnamed_addr #0
+
+declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #0
 
 declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
 
@@ -154,110 +155,103 @@ entry:
   %argArray.i.i = alloca [2 x i64], align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([104 x i8], [104 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #7
-  store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %1 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([104 x i8], [104 x i8]* @sorbet_moduleStringTable, i64 0, i64 67), i64 noundef 6) #7
-  %2 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([104 x i8], [104 x i8]* @sorbet_moduleStringTable, i64 0, i64 74), i64 noundef 13) #7
-  %3 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([104 x i8], [104 x i8]* @sorbet_moduleStringTable, i64 0, i64 88), i64 noundef 3) #7
-  store i64 %3, i64* @rubyIdPrecomputed_map, align 8
-  %4 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([104 x i8], [104 x i8]* @sorbet_moduleStringTable, i64 0, i64 92), i64 noundef 4) #7
-  store i64 %4, i64* @rubyIdPrecomputed_puts, align 8
-  %5 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([104 x i8], [104 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #7
-  tail call void @rb_gc_register_mark_object(i64 %5) #7
-  store i64 %5, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %6 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([104 x i8], [104 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 47) #7
-  tail call void @rb_gc_register_mark_object(i64 %6) #7
-  store i64 %6, i64* @"rubyStrFrozen_test/testdata/compiler/send_with_block_param.rb", align 8
+  tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([5 x %struct.rb_code_position_struct], [5 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 5, i8* noundef getelementptr inbounds ([104 x i8], [104 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
+  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([104 x i8], [104 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #7
+  tail call void @rb_gc_register_mark_object(i64 %0) #7
+  store i64 %0, i64* @"rubyStrFrozen_<top (required)>", align 8
+  %1 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([104 x i8], [104 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 47) #7
+  tail call void @rb_gc_register_mark_object(i64 %1) #7
+  store i64 %1, i64* @"rubyStrFrozen_test/testdata/compiler/send_with_block_param.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 7)
-  %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
+  %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
   %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/send_with_block_param.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/send_with_block_param.rb", align 8
-  %7 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/send_with_block_param.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %7, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %8 = bitcast [2 x i64]* %argArray.i.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %8)
+  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/send_with_block_param.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %3 = bitcast [2 x i64]* %argArray.i.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %3)
   %hashArgs0Addr.i.i = getelementptr [2 x i64], [2 x i64]* %argArray.i.i, i64 0, i64 0
-  %9 = bitcast i64* %hashArgs0Addr.i.i to <2 x i64>*
-  store <2 x i64> <i64 3, i64 5>, <2 x i64>* %9, align 8
-  %10 = call i64 @rb_hash_new_with_size(i64 noundef 1) #7
-  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %hashArgs0Addr.i.i, i64 %10) #7
-  %11 = call i64 @sorbet_globalConstRegister(i64 %10) #7
-  store i64 %11, i64* @ruby_hashLiteral1, align 8
-  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %8)
-  %rubyId_map.i = load i64, i64* @rubyIdPrecomputed_map, align 8, !dbg !10
+  %4 = bitcast i64* %hashArgs0Addr.i.i to <2 x i64>*
+  store <2 x i64> <i64 3, i64 5>, <2 x i64>* %4, align 8
+  %5 = call i64 @rb_hash_new_with_size(i64 noundef 1) #7
+  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %hashArgs0Addr.i.i, i64 %5) #7
+  %6 = call i64 @sorbet_globalConstRegister(i64 %5) #7
+  store i64 %6, i64* @ruby_hashLiteral1, align 8
+  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %3)
+  %rubyId_map.i = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !10, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_map, i64 %rubyId_map.i, i32 noundef 18, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !10
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !15
+  %rubyId_puts.i = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !dbg !15, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
-  %12 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !16
-  %13 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %12, i64 0, i32 18
-  %14 = load i64, i64* %13, align 8, !tbaa !18
-  %15 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !16
-  %16 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %15, i64 0, i32 2
-  %17 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %16, align 8, !tbaa !28
-  %18 = bitcast [4 x i64]* %callArgs.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 32, i8* nonnull %18)
+  %7 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !16
+  %8 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %7, i64 0, i32 18
+  %9 = load i64, i64* %8, align 8, !tbaa !18
+  %10 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !16
+  %11 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %10, i64 0, i32 2
+  %12 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %11, align 8, !tbaa !28
+  %13 = bitcast [4 x i64]* %callArgs.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 32, i8* nonnull %13)
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %19 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %16, align 8, !tbaa !28
-  %20 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %19, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %20, align 8, !tbaa !31
-  %21 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %19, i64 0, i32 4
-  %22 = load i64*, i64** %21, align 8, !tbaa !33
-  %23 = load i64, i64* %22, align 8, !tbaa !6
-  %24 = and i64 %23, -33
-  store i64 %24, i64* %22, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %15, %struct.rb_control_frame_struct* %19, %struct.rb_iseq_struct* %stackFrame.i) #7
-  %25 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 0
-  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %25, align 8, !dbg !34, !tbaa !16
+  %14 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %11, align 8, !tbaa !28
+  %15 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %14, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %15, align 8, !tbaa !31
+  %16 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %14, i64 0, i32 4
+  %17 = load i64*, i64** %16, align 8, !tbaa !33
+  %18 = load i64, i64* %17, align 8, !tbaa !6
+  %19 = and i64 %18, -33
+  store i64 %19, i64* %17, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %10, %struct.rb_control_frame_struct* %14, %struct.rb_iseq_struct* %stackFrame.i) #7
+  %20 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 0
+  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %20, align 8, !dbg !34, !tbaa !16
   %hashLiteral.i = load i64, i64* @ruby_hashLiteral1, align 8, !dbg !35
   %duplicatedHash.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral.i) #7, !dbg !35
   %callArgs0Addr.i = getelementptr [4 x i64], [4 x i64]* %callArgs.i, i64 0, i64 0, !dbg !36
   call void @llvm.experimental.noalias.scope.decl(metadata !37) #7, !dbg !36
-  %26 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !36, !tbaa !16
-  %27 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %26, i64 0, i32 5, !dbg !36
-  %28 = load i32, i32* %27, align 8, !dbg !36, !tbaa !40
-  %29 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %26, i64 0, i32 6, !dbg !36
-  %30 = load i32, i32* %29, align 4, !dbg !36, !tbaa !41
-  %31 = xor i32 %30, -1, !dbg !36
-  %32 = and i32 %31, %28, !dbg !36
-  %33 = icmp eq i32 %32, 0, !dbg !36
-  br i1 %33, label %rb_vm_check_ints.exit.i, label %34, !dbg !36, !prof !42
+  %21 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !36, !tbaa !16
+  %22 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 5, !dbg !36
+  %23 = load i32, i32* %22, align 8, !dbg !36, !tbaa !40
+  %24 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 6, !dbg !36
+  %25 = load i32, i32* %24, align 4, !dbg !36, !tbaa !41
+  %26 = xor i32 %25, -1, !dbg !36
+  %27 = and i32 %26, %23, !dbg !36
+  %28 = icmp eq i32 %27, 0, !dbg !36
+  br i1 %28, label %rb_vm_check_ints.exit.i, label %29, !dbg !36, !prof !42
 
-34:                                               ; preds = %entry
-  %35 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %26, i64 0, i32 8, !dbg !36
-  %36 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %35, align 8, !dbg !36, !tbaa !43
-  %37 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %36, i32 noundef 0) #7, !dbg !36
+29:                                               ; preds = %entry
+  %30 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 8, !dbg !36
+  %31 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %30, align 8, !dbg !36, !tbaa !43
+  %32 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %31, i32 noundef 0) #7, !dbg !36
   br label %rb_vm_check_ints.exit.i, !dbg !36
 
-rb_vm_check_ints.exit.i:                          ; preds = %34, %entry
-  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %25, align 8, !dbg !36, !tbaa !16
+rb_vm_check_ints.exit.i:                          ; preds = %29, %entry
+  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %20, align 8, !dbg !36, !tbaa !16
   store i64 3, i64* %callArgs0Addr.i, align 8, !dbg !10
   call void @llvm.experimental.noalias.scope.decl(metadata !44) #7, !dbg !10
-  %38 = call i64 @rb_ary_new_from_values(i64 noundef 1, i64* noundef nonnull %callArgs0Addr.i) #7, !dbg !10
-  %39 = icmp eq i64 %duplicatedHash.i, 8, !dbg !10
-  br i1 %39, label %"func_<root>.17<static-init>$153.exit", label %40, !dbg !10
+  %33 = call i64 @rb_ary_new_from_values(i64 noundef 1, i64* noundef nonnull %callArgs0Addr.i) #7, !dbg !10
+  %34 = icmp eq i64 %duplicatedHash.i, 8, !dbg !10
+  br i1 %34, label %"func_<root>.17<static-init>$153.exit", label %35, !dbg !10
 
-40:                                               ; preds = %rb_vm_check_ints.exit.i
-  %41 = call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @.str.7, i64 0, i64 0), i64 noundef 7) #7, !dbg !10
-  %42 = call i64 @rb_funcallv_with_cc(%struct.rb_call_data* noundef nonnull @sorbet_makeBlockHandlerProc.rb_funcallv_data, i64 %duplicatedHash.i, i64 %41, i32 noundef 0, i64* noundef null) #7, !dbg !10
+35:                                               ; preds = %rb_vm_check_ints.exit.i
+  %36 = call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @.str.7, i64 0, i64 0), i64 noundef 7) #7, !dbg !10
+  %37 = call i64 @rb_funcallv_with_cc(%struct.rb_call_data* noundef nonnull @sorbet_makeBlockHandlerProc.rb_funcallv_data, i64 %duplicatedHash.i, i64 %36, i32 noundef 0, i64* noundef null) #7, !dbg !10
   br label %"func_<root>.17<static-init>$153.exit", !dbg !10
 
-"func_<root>.17<static-init>$153.exit":           ; preds = %rb_vm_check_ints.exit.i, %40
-  %43 = phi i64 [ %42, %40 ], [ 0, %rb_vm_check_ints.exit.i ], !dbg !10
-  %44 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 1, !dbg !10
-  %45 = load i64*, i64** %44, align 8, !dbg !10
-  store i64 %38, i64* %45, align 8, !dbg !10, !tbaa !6
-  %46 = getelementptr inbounds i64, i64* %45, i64 1, !dbg !10
-  store i64* %46, i64** %44, align 8, !dbg !10
-  %send.i = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_map, i64 %43) #7, !dbg !10
-  %47 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 1, !dbg !15
-  %48 = load i64*, i64** %47, align 8, !dbg !15
-  store i64 %14, i64* %48, align 8, !dbg !15, !tbaa !6
-  %49 = getelementptr inbounds i64, i64* %48, i64 1, !dbg !15
-  store i64 %send.i, i64* %49, align 8, !dbg !15, !tbaa !6
-  %50 = getelementptr inbounds i64, i64* %49, i64 1, !dbg !15
-  store i64* %50, i64** %47, align 8, !dbg !15
+"func_<root>.17<static-init>$153.exit":           ; preds = %rb_vm_check_ints.exit.i, %35
+  %38 = phi i64 [ %37, %35 ], [ 0, %rb_vm_check_ints.exit.i ], !dbg !10
+  %39 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 1, !dbg !10
+  %40 = load i64*, i64** %39, align 8, !dbg !10
+  store i64 %33, i64* %40, align 8, !dbg !10, !tbaa !6
+  %41 = getelementptr inbounds i64, i64* %40, i64 1, !dbg !10
+  store i64* %41, i64** %39, align 8, !dbg !10
+  %send.i = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_map, i64 %38) #7, !dbg !10
+  %42 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 1, !dbg !15
+  %43 = load i64*, i64** %42, align 8, !dbg !15
+  store i64 %9, i64* %43, align 8, !dbg !15, !tbaa !6
+  %44 = getelementptr inbounds i64, i64* %43, i64 1, !dbg !15
+  store i64 %send.i, i64* %44, align 8, !dbg !15, !tbaa !6
+  %45 = getelementptr inbounds i64, i64* %44, i64 1, !dbg !15
+  store i64* %45, i64** %42, align 8, !dbg !15
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !15
-  call void @llvm.lifetime.end.p0i8(i64 32, i8* nonnull %18)
+  call void @llvm.lifetime.end.p0i8(i64 32, i8* nonnull %13)
   ret void
 }
 

--- a/test/testdata/compiler/sig_rewriter.opt.ll.exp
+++ b/test/testdata/compiler/sig_rewriter.opt.ll.exp
@@ -82,29 +82,22 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [14 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @ic_new = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_new = internal unnamed_addr global i64 0, align 8
 @ic_initialize = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_initialize = internal unnamed_addr global i64 0, align 8
 @ic_foo = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_foo = internal unnamed_addr global i64 0, align 8
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
 @"stackFramePrecomputed_func_A#3foo" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"stackFramePrecomputed_func_A.13<static-init>" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_<class:A>" = internal unnamed_addr global i64 0, align 8
 @"stackFramePrecomputed_func_A.13<static-init>$block_1" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_block in <class:A>" = internal unnamed_addr global i64 0, align 8
 @ic_returns = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_returns = internal unnamed_addr global i64 0, align 8
 @ic_extend = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_extend = internal unnamed_addr global i64 0, align 8
 @sorbet_moduleStringTable = internal unnamed_addr constant [175 x i8] c"<top (required)>\00test/testdata/compiler/sig_rewriter.rb\00A\00Object\00new\00initialize\00foo\00puts\00master\00Return value\00Integer\00<class:A>\00block in <class:A>\00returns\00T::Sig\00extend\00normal\00", align 1
+@sorbet_moduleIDTable = internal unnamed_addr global [10 x i64] zeroinitializer, align 8
+@sorbet_moduleIDDescriptors = internal unnamed_addr constant [10 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 65, i32 3 }, %struct.rb_code_position_struct { i32 69, i32 10 }, %struct.rb_code_position_struct { i32 80, i32 3 }, %struct.rb_code_position_struct { i32 84, i32 4 }, %struct.rb_code_position_struct { i32 117, i32 9 }, %struct.rb_code_position_struct { i32 127, i32 18 }, %struct.rb_code_position_struct { i32 146, i32 7 }, %struct.rb_code_position_struct { i32 161, i32 6 }, %struct.rb_code_position_struct { i32 168, i32 6 }], align 8
 @rb_cObject = external local_unnamed_addr constant i64
 @"guard_epoch_T::Sig" = linkonce local_unnamed_addr global i64 0
 @"guarded_const_T::Sig" = linkonce local_unnamed_addr global i64 0
@@ -140,13 +133,13 @@ declare void @sorbet_vm_register_sig(i64, i64, i64, i64, i64 (i64, i64, i32, i64
 
 declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)*, i8*, %struct.rb_iseq_struct*, i1 zeroext) local_unnamed_addr #2
 
+declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #2
+
 declare i64 @sorbet_maybeAllocateObjectFastPath(i64, %struct.FunctionInlineCache*) local_unnamed_addr #2
 
 declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #2
 
 declare i64 @rb_define_class(i8*, i64) local_unnamed_addr #2
-
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #2
 
 declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #2
 
@@ -177,194 +170,174 @@ entry:
   %locals.i10.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #11
-  store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %1 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 65), i64 noundef 3) #11
-  store i64 %1, i64* @rubyIdPrecomputed_new, align 8
-  %2 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 69), i64 noundef 10) #11
-  store i64 %2, i64* @rubyIdPrecomputed_initialize, align 8
-  %3 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 80), i64 noundef 3) #11
-  store i64 %3, i64* @rubyIdPrecomputed_foo, align 8
-  %4 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 84), i64 noundef 4) #11
-  store i64 %4, i64* @rubyIdPrecomputed_puts, align 8
-  %5 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 117), i64 noundef 9) #11
-  store i64 %5, i64* @"rubyIdPrecomputed_<class:A>", align 8
-  %6 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 127), i64 noundef 18) #11
-  store i64 %6, i64* @"rubyIdPrecomputed_block in <class:A>", align 8
-  %7 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 146), i64 noundef 7) #11
-  store i64 %7, i64* @rubyIdPrecomputed_returns, align 8
-  %8 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 161), i64 noundef 6) #11
-  store i64 %8, i64* @rubyIdPrecomputed_extend, align 8
-  %9 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 168), i64 noundef 6) #11
-  %10 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #11
-  tail call void @rb_gc_register_mark_object(i64 %10) #11
-  store i64 %10, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %11 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 38) #11
-  tail call void @rb_gc_register_mark_object(i64 %11) #11
-  store i64 %11, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
+  tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([10 x %struct.rb_code_position_struct], [10 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 10, i8* noundef getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
+  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #11
+  tail call void @rb_gc_register_mark_object(i64 %0) #11
+  store i64 %0, i64* @"rubyStrFrozen_<top (required)>", align 8
+  %1 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 38) #11
+  tail call void @rb_gc_register_mark_object(i64 %1) #11
+  store i64 %1, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 14)
-  %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
+  %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
   %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
-  %12 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %12, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %rubyId_new.i = load i64, i64* @rubyIdPrecomputed_new, align 8, !dbg !10
+  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %rubyId_new.i = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !dbg !10, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !10
-  %rubyId_initialize.i = load i64, i64* @rubyIdPrecomputed_initialize, align 8, !dbg !10
+  %rubyId_initialize.i = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !10, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 %rubyId_initialize.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !10
-  %rubyId_foo.i = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !10
+  %rubyId_foo.i = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !10, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !10
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !15
+  %rubyId_puts.i = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !dbg !15, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
-  %13 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 80), i64 noundef 3) #11
-  call void @rb_gc_register_mark_object(i64 %13) #11
-  %rubyId_foo.i.i = load i64, i64* @rubyIdPrecomputed_foo, align 8
+  %3 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 80), i64 noundef 3) #11
+  call void @rb_gc_register_mark_object(i64 %3) #11
   %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i9.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
-  %14 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %13, i64 %rubyId_foo.i.i, i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i9.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i10.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %14, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#3foo", align 8
-  %15 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 117), i64 noundef 9) #11
-  call void @rb_gc_register_mark_object(i64 %15) #11
-  %"rubyId_<class:A>.i.i" = load i64, i64* @"rubyIdPrecomputed_<class:A>", align 8
+  %4 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %3, i64 %rubyId_foo.i, i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i9.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i10.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %4, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#3foo", align 8
+  %5 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 117), i64 noundef 9) #11
+  call void @rb_gc_register_mark_object(i64 %5) #11
+  %"rubyId_<class:A>.i.i" = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 5), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i11.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
-  %16 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %15, i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i11.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i12.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %16, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %17 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 127), i64 noundef 18) #11
-  call void @rb_gc_register_mark_object(i64 %17) #11
+  %6 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %5, i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i11.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i12.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %6, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
+  %7 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 127), i64 noundef 18) #11
+  call void @rb_gc_register_mark_object(i64 %7) #11
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %"rubyId_block in <class:A>.i.i" = load i64, i64* @"rubyIdPrecomputed_block in <class:A>", align 8
+  %"rubyId_block in <class:A>.i.i" = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 6), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i13.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
-  %18 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %17, i64 %"rubyId_block in <class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i13.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %18, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>$block_1", align 8
-  %rubyId_returns.i = load i64, i64* @rubyIdPrecomputed_returns, align 8, !dbg !16
+  %8 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %7, i64 %"rubyId_block in <class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i13.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %8, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>$block_1", align 8
+  %rubyId_returns.i = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 7), align 8, !dbg !16, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !16
-  %rubyId_extend.i = load i64, i64* @rubyIdPrecomputed_extend, align 8, !dbg !19
+  %rubyId_extend.i = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 8), align 8, !dbg !19, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
-  %19 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !20
-  %20 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %19, i64 0, i32 18
-  %21 = load i64, i64* %20, align 8, !tbaa !22
-  %22 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !20
-  %23 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %22, i64 0, i32 2
-  %24 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %23, align 8, !tbaa !32
+  %9 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !20
+  %10 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %9, i64 0, i32 18
+  %11 = load i64, i64* %10, align 8, !tbaa !22
+  %12 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !20
+  %13 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %12, i64 0, i32 2
+  %14 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %13, align 8, !tbaa !32
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %25 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %25, align 8, !tbaa !35
-  %26 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 4
-  %27 = load i64*, i64** %26, align 8, !tbaa !37
-  %28 = load i64, i64* %27, align 8, !tbaa !6
-  %29 = and i64 %28, -33
-  store i64 %29, i64* %27, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %22, %struct.rb_control_frame_struct* %24, %struct.rb_iseq_struct* %stackFrame.i) #11
-  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 0
-  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %30, align 8, !dbg !38, !tbaa !20
-  %31 = load i64, i64* @rb_cObject, align 8, !dbg !39
-  %32 = call i64 @rb_define_class(i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 56), i64 %31) #11, !dbg !39
-  %33 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %32) #11, !dbg !39
+  %15 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %14, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %15, align 8, !tbaa !35
+  %16 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %14, i64 0, i32 4
+  %17 = load i64*, i64** %16, align 8, !tbaa !37
+  %18 = load i64, i64* %17, align 8, !tbaa !6
+  %19 = and i64 %18, -33
+  store i64 %19, i64* %17, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %12, %struct.rb_control_frame_struct* %14, %struct.rb_iseq_struct* %stackFrame.i) #11
+  %20 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %14, i64 0, i32 0
+  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %20, align 8, !dbg !38, !tbaa !20
+  %21 = load i64, i64* @rb_cObject, align 8, !dbg !39
+  %22 = call i64 @rb_define_class(i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 56), i64 %21) #11, !dbg !39
+  %23 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %22) #11, !dbg !39
   %stackFrame.i.i1 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %34 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !20
-  %35 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %34, i64 0, i32 2
-  %36 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %35, align 8, !tbaa !32
-  %37 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i.i1, %struct.rb_iseq_struct** %37, align 8, !tbaa !35
-  %38 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 4
-  %39 = load i64*, i64** %38, align 8, !tbaa !37
-  %40 = load i64, i64* %39, align 8, !tbaa !6
-  %41 = and i64 %40, -33
-  store i64 %41, i64* %39, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %34, %struct.rb_control_frame_struct* %36, %struct.rb_iseq_struct* %stackFrame.i.i1) #11
-  %42 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 0
-  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %42, align 8, !dbg !40, !tbaa !20
-  %rubyId_foo.i.i2 = load i64, i64* @rubyIdPrecomputed_foo, align 8, !dbg !42
-  %rawSym.i.i = call i64 @rb_id2sym(i64 %rubyId_foo.i.i2) #11, !dbg !42
-  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym.i.i, i64 %32, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_A.13<static-init>L62$block_1") #11, !dbg !42
-  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %42, align 8, !dbg !42, !tbaa !20
-  %43 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !43
-  %44 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !43, !tbaa !44
-  %needTakeSlowPath = icmp ne i64 %43, %44, !dbg !43
-  br i1 %needTakeSlowPath, label %45, label %46, !dbg !43, !prof !45
+  %24 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !20
+  %25 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %24, i64 0, i32 2
+  %26 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %25, align 8, !tbaa !32
+  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i.i1, %struct.rb_iseq_struct** %27, align 8, !tbaa !35
+  %28 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 4
+  %29 = load i64*, i64** %28, align 8, !tbaa !37
+  %30 = load i64, i64* %29, align 8, !tbaa !6
+  %31 = and i64 %30, -33
+  store i64 %31, i64* %29, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %24, %struct.rb_control_frame_struct* %26, %struct.rb_iseq_struct* %stackFrame.i.i1) #11
+  %32 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 0
+  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %32, align 8, !dbg !40, !tbaa !20
+  %rawSym.i.i = call i64 @rb_id2sym(i64 %rubyId_foo.i) #11, !dbg !42
+  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym.i.i, i64 %22, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_A.13<static-init>L62$block_1") #11, !dbg !42
+  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %32, align 8, !dbg !42, !tbaa !20
+  %33 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !43
+  %34 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !43, !tbaa !44
+  %needTakeSlowPath = icmp ne i64 %33, %34, !dbg !43
+  br i1 %needTakeSlowPath, label %35, label %36, !dbg !43, !prof !45
 
-45:                                               ; preds = %entry
+35:                                               ; preds = %entry
   call void @"const_recompute_T::Sig"(), !dbg !43
-  br label %46, !dbg !43
+  br label %36, !dbg !43
 
-46:                                               ; preds = %entry, %45
-  %47 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !43
-  %48 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !43
-  %49 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !43, !tbaa !44
-  %guardUpdated = icmp eq i64 %48, %49, !dbg !43
+36:                                               ; preds = %entry, %35
+  %37 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !43
+  %38 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !43
+  %39 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !43, !tbaa !44
+  %guardUpdated = icmp eq i64 %38, %39, !dbg !43
   call void @llvm.assume(i1 %guardUpdated), !dbg !43
-  %50 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 1, !dbg !43
-  %51 = load i64*, i64** %50, align 8, !dbg !43
-  store i64 %32, i64* %51, align 8, !dbg !43, !tbaa !6
-  %52 = getelementptr inbounds i64, i64* %51, i64 1, !dbg !43
-  store i64 %47, i64* %52, align 8, !dbg !43, !tbaa !6
-  %53 = getelementptr inbounds i64, i64* %52, i64 1, !dbg !43
-  store i64* %53, i64** %50, align 8, !dbg !43
+  %40 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 1, !dbg !43
+  %41 = load i64*, i64** %40, align 8, !dbg !43
+  store i64 %22, i64* %41, align 8, !dbg !43, !tbaa !6
+  %42 = getelementptr inbounds i64, i64* %41, i64 1, !dbg !43
+  store i64 %37, i64* %42, align 8, !dbg !43, !tbaa !6
+  %43 = getelementptr inbounds i64, i64* %42, i64 1, !dbg !43
+  store i64* %43, i64** %40, align 8, !dbg !43
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !43
-  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %42, align 8, !dbg !43, !tbaa !20
-  %54 = load i64, i64* @guard_epoch_A, align 8, !dbg !46
-  %55 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !46, !tbaa !44
-  %needTakeSlowPath3 = icmp ne i64 %54, %55, !dbg !46
-  br i1 %needTakeSlowPath3, label %56, label %57, !dbg !46, !prof !45
+  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %32, align 8, !dbg !43, !tbaa !20
+  %44 = load i64, i64* @guard_epoch_A, align 8, !dbg !46
+  %45 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !46, !tbaa !44
+  %needTakeSlowPath2 = icmp ne i64 %44, %45, !dbg !46
+  br i1 %needTakeSlowPath2, label %46, label %47, !dbg !46, !prof !45
 
-56:                                               ; preds = %46
+46:                                               ; preds = %36
   call void @const_recompute_A(), !dbg !46
-  br label %57, !dbg !46
+  br label %47, !dbg !46
 
-57:                                               ; preds = %46, %56
-  %58 = load i64, i64* @guarded_const_A, align 8, !dbg !46
-  %59 = load i64, i64* @guard_epoch_A, align 8, !dbg !46
-  %60 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !46, !tbaa !44
-  %guardUpdated4 = icmp eq i64 %59, %60, !dbg !46
-  call void @llvm.assume(i1 %guardUpdated4), !dbg !46
+47:                                               ; preds = %36, %46
+  %48 = load i64, i64* @guarded_const_A, align 8, !dbg !46
+  %49 = load i64, i64* @guard_epoch_A, align 8, !dbg !46
+  %50 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !46, !tbaa !44
+  %guardUpdated3 = icmp eq i64 %49, %50, !dbg !46
+  call void @llvm.assume(i1 %guardUpdated3), !dbg !46
   %stackFrame42.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#3foo", align 8, !dbg !46
-  %61 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !46
-  %62 = bitcast i8* %61 to i16*, !dbg !46
-  %63 = load i16, i16* %62, align 8, !dbg !46
-  %64 = and i16 %63, -384, !dbg !46
-  store i16 %64, i16* %62, align 8, !dbg !46
-  %65 = getelementptr inbounds i8, i8* %61, i64 4, !dbg !46
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %65, i8 0, i64 28, i1 false) #11, !dbg !46
-  call void @sorbet_vm_define_method(i64 %58, i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 80), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_A#3foo", i8* nonnull %61, %struct.rb_iseq_struct* %stackFrame42.i.i, i1 noundef zeroext false) #11, !dbg !46
+  %51 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !46
+  %52 = bitcast i8* %51 to i16*, !dbg !46
+  %53 = load i16, i16* %52, align 8, !dbg !46
+  %54 = and i16 %53, -384, !dbg !46
+  store i16 %54, i16* %52, align 8, !dbg !46
+  %55 = getelementptr inbounds i8, i8* %51, i64 4, !dbg !46
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %55, i8 0, i64 28, i1 false) #11, !dbg !46
+  call void @sorbet_vm_define_method(i64 %48, i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 80), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_A#3foo", i8* nonnull %51, %struct.rb_iseq_struct* %stackFrame42.i.i, i1 noundef zeroext false) #11, !dbg !46
   call void @sorbet_popFrame() #11, !dbg !39
-  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %30, align 8, !dbg !39, !tbaa !20
-  %66 = call i64 @sorbet_maybeAllocateObjectFastPath(i64 %58, %struct.FunctionInlineCache* noundef @ic_new) #11, !dbg !10
-  %67 = icmp eq i64 %66, 52, !dbg !10
-  br i1 %67, label %slowNew.i, label %fastNew.i, !dbg !10
+  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %20, align 8, !dbg !39, !tbaa !20
+  %56 = call i64 @sorbet_maybeAllocateObjectFastPath(i64 %48, %struct.FunctionInlineCache* noundef @ic_new) #11, !dbg !10
+  %57 = icmp eq i64 %56, 52, !dbg !10
+  br i1 %57, label %slowNew.i, label %fastNew.i, !dbg !10
 
-slowNew.i:                                        ; preds = %57
-  %68 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !10
-  %69 = load i64*, i64** %68, align 8, !dbg !10
-  store i64 %58, i64* %69, align 8, !dbg !10, !tbaa !6
-  %70 = getelementptr inbounds i64, i64* %69, i64 1, !dbg !10
-  store i64* %70, i64** %68, align 8, !dbg !10
-  %71 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_new, i64 noundef 0) #11, !dbg !10
+slowNew.i:                                        ; preds = %47
+  %58 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %14, i64 0, i32 1, !dbg !10
+  %59 = load i64*, i64** %58, align 8, !dbg !10
+  store i64 %48, i64* %59, align 8, !dbg !10, !tbaa !6
+  %60 = getelementptr inbounds i64, i64* %59, i64 1, !dbg !10
+  store i64* %60, i64** %58, align 8, !dbg !10
+  %61 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_new, i64 noundef 0) #11, !dbg !10
   br label %"func_<root>.17<static-init>$153.exit", !dbg !10
 
-fastNew.i:                                        ; preds = %57
-  %72 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !10
-  %73 = load i64*, i64** %72, align 8, !dbg !10
-  store i64 %66, i64* %73, align 8, !dbg !10, !tbaa !6
-  %74 = getelementptr inbounds i64, i64* %73, i64 1, !dbg !10
-  store i64* %74, i64** %72, align 8, !dbg !10
-  %75 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 noundef 0) #11, !dbg !10
+fastNew.i:                                        ; preds = %47
+  %62 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %14, i64 0, i32 1, !dbg !10
+  %63 = load i64*, i64** %62, align 8, !dbg !10
+  store i64 %56, i64* %63, align 8, !dbg !10, !tbaa !6
+  %64 = getelementptr inbounds i64, i64* %63, i64 1, !dbg !10
+  store i64* %64, i64** %62, align 8, !dbg !10
+  %65 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 noundef 0) #11, !dbg !10
   br label %"func_<root>.17<static-init>$153.exit", !dbg !10
 
 "func_<root>.17<static-init>$153.exit":           ; preds = %slowNew.i, %fastNew.i
-  %initializedObject.i = phi i64 [ %71, %slowNew.i ], [ %66, %fastNew.i ], !dbg !10
-  %76 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !10
-  %77 = load i64*, i64** %76, align 8, !dbg !10
-  store i64 %initializedObject.i, i64* %77, align 8, !dbg !10, !tbaa !6
-  %78 = getelementptr inbounds i64, i64* %77, i64 1, !dbg !10
-  store i64* %78, i64** %76, align 8, !dbg !10
-  %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo, i64 0), !dbg !10
-  %79 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !15
-  %80 = load i64*, i64** %79, align 8, !dbg !15
-  store i64 %21, i64* %80, align 8, !dbg !15, !tbaa !6
-  %81 = getelementptr inbounds i64, i64* %80, i64 1, !dbg !15
-  store i64 %send6, i64* %81, align 8, !dbg !15, !tbaa !6
-  %82 = getelementptr inbounds i64, i64* %81, i64 1, !dbg !15
-  store i64* %82, i64** %79, align 8, !dbg !15
-  %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !15
+  %initializedObject.i = phi i64 [ %61, %slowNew.i ], [ %56, %fastNew.i ], !dbg !10
+  %66 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %14, i64 0, i32 1, !dbg !10
+  %67 = load i64*, i64** %66, align 8, !dbg !10
+  store i64 %initializedObject.i, i64* %67, align 8, !dbg !10, !tbaa !6
+  %68 = getelementptr inbounds i64, i64* %67, i64 1, !dbg !10
+  store i64* %68, i64** %66, align 8, !dbg !10
+  %send5 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo, i64 0), !dbg !10
+  %69 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %14, i64 0, i32 1, !dbg !15
+  %70 = load i64*, i64** %69, align 8, !dbg !15
+  store i64 %11, i64* %70, align 8, !dbg !15, !tbaa !6
+  %71 = getelementptr inbounds i64, i64* %70, i64 1, !dbg !15
+  store i64 %send5, i64* %71, align 8, !dbg !15, !tbaa !6
+  %72 = getelementptr inbounds i64, i64* %71, i64 1, !dbg !15
+  store i64* %72, i64** %69, align 8, !dbg !15
+  %send7 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !15
   ret void
 }
 

--- a/test/testdata/compiler/splat_assign.opt.ll.exp
+++ b/test/testdata/compiler/splat_assign.opt.ll.exp
@@ -81,16 +81,16 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/splat_assign.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [13 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
 @ic_puts.6 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.10 = internal global %struct.FunctionInlineCache zeroinitializer
 @sorbet_moduleStringTable = internal unnamed_addr constant [100 x i8] c"<top (required)>\00test/testdata/compiler/splat_assign.rb\00<build-array>\00<expand-splat>\00[]\00puts\00master\00", align 1
+@sorbet_moduleIDTable = internal unnamed_addr global [5 x i64] zeroinitializer, align 8
+@sorbet_moduleIDDescriptors = internal unnamed_addr constant [5 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 56, i32 13 }, %struct.rb_code_position_struct { i32 70, i32 14 }, %struct.rb_code_position_struct { i32 85, i32 2 }, %struct.rb_code_position_struct { i32 88, i32 4 }], align 8
 
 declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
 
@@ -106,9 +106,9 @@ declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %
 
 declare i64 @sorbet_vm_expandSplatIntrinsic(i64, i64, i64) local_unnamed_addr #0
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
+declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #0
 
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #0
+declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
 
 declare i64 @rb_ary_new_from_values(i64, i64*) local_unnamed_addr #0
 
@@ -146,309 +146,301 @@ entry:
   %callArgs.i = alloca [8 x i64], align 8
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #7
-  store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %1 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 56), i64 noundef 13) #7
-  %2 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 70), i64 noundef 14) #7
-  %3 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 85), i64 noundef 2) #7
-  %4 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 88), i64 noundef 4) #7
-  store i64 %4, i64* @rubyIdPrecomputed_puts, align 8
-  %5 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #7
-  tail call void @rb_gc_register_mark_object(i64 %5) #7
-  store i64 %5, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %6 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 38) #7
-  tail call void @rb_gc_register_mark_object(i64 %6) #7
-  store i64 %6, i64* @"rubyStrFrozen_test/testdata/compiler/splat_assign.rb", align 8
+  tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([5 x %struct.rb_code_position_struct], [5 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 5, i8* noundef getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
+  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #7
+  tail call void @rb_gc_register_mark_object(i64 %0) #7
+  store i64 %0, i64* @"rubyStrFrozen_<top (required)>", align 8
+  %1 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 38) #7
+  tail call void @rb_gc_register_mark_object(i64 %1) #7
+  store i64 %1, i64* @"rubyStrFrozen_test/testdata/compiler/splat_assign.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 13)
-  %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
+  %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
   %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/splat_assign.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/splat_assign.rb", align 8
-  %7 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/splat_assign.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 8)
-  store %struct.rb_iseq_struct* %7, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !10
+  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/splat_assign.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 8)
+  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %rubyId_puts.i = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !dbg !10, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !10
-  %rubyId_puts12.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !15
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.6, i64 %rubyId_puts12.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
-  %rubyId_puts21.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !16
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.10, i64 %rubyId_puts21.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !16
-  %8 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !17
-  %9 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %8, i64 0, i32 18
-  %10 = load i64, i64* %9, align 8, !tbaa !19
-  %11 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !17
-  %12 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %11, i64 0, i32 2
-  %13 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %12, align 8, !tbaa !29
-  %14 = bitcast [8 x i64]* %callArgs.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 64, i8* nonnull %14)
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.6, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.10, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !16
+  %3 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !17
+  %4 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %3, i64 0, i32 18
+  %5 = load i64, i64* %4, align 8, !tbaa !19
+  %6 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !17
+  %7 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %6, i64 0, i32 2
+  %8 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %7, align 8, !tbaa !29
+  %9 = bitcast [8 x i64]* %callArgs.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 64, i8* nonnull %9)
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %15 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %12, align 8, !tbaa !29
-  %16 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %16, align 8, !tbaa !32
-  %17 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 4
-  %18 = load i64*, i64** %17, align 8, !tbaa !34
-  %19 = load i64, i64* %18, align 8, !tbaa !6
-  %20 = and i64 %19, -33
-  store i64 %20, i64* %18, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %11, %struct.rb_control_frame_struct* %15, %struct.rb_iseq_struct* %stackFrame.i) #7
-  %21 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %13, i64 0, i32 0
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %21, align 8, !dbg !35, !tbaa !17
+  %10 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %7, align 8, !tbaa !29
+  %11 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %10, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %11, align 8, !tbaa !32
+  %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %10, i64 0, i32 4
+  %13 = load i64*, i64** %12, align 8, !tbaa !34
+  %14 = load i64, i64* %13, align 8, !tbaa !6
+  %15 = and i64 %14, -33
+  store i64 %15, i64* %13, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %6, %struct.rb_control_frame_struct* %10, %struct.rb_iseq_struct* %stackFrame.i) #7
+  %16 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %8, i64 0, i32 0
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %16, align 8, !dbg !35, !tbaa !17
   %callArgs0Addr.i = getelementptr [8 x i64], [8 x i64]* %callArgs.i, i64 0, i64 0, !dbg !36
   %callArgs1Addr.i = getelementptr [8 x i64], [8 x i64]* %callArgs.i, i64 0, i64 1, !dbg !36
   %callArgs2Addr.i = getelementptr [8 x i64], [8 x i64]* %callArgs.i, i64 0, i64 2, !dbg !36
-  %22 = bitcast i64* %callArgs0Addr.i to <4 x i64>*, !dbg !36
-  store <4 x i64> <i64 3, i64 5, i64 7, i64 9>, <4 x i64>* %22, align 8, !dbg !36
+  %17 = bitcast i64* %callArgs0Addr.i to <4 x i64>*, !dbg !36
+  store <4 x i64> <i64 3, i64 5, i64 7, i64 9>, <4 x i64>* %17, align 8, !dbg !36
   %callArgs4Addr.i = getelementptr [8 x i64], [8 x i64]* %callArgs.i, i64 0, i64 4, !dbg !36
-  %23 = bitcast i64* %callArgs4Addr.i to <2 x i64>*, !dbg !36
-  store <2 x i64> <i64 11, i64 13>, <2 x i64>* %23, align 8, !dbg !36
+  %18 = bitcast i64* %callArgs4Addr.i to <2 x i64>*, !dbg !36
+  store <2 x i64> <i64 11, i64 13>, <2 x i64>* %18, align 8, !dbg !36
   %callArgs6Addr.i = getelementptr [8 x i64], [8 x i64]* %callArgs.i, i64 0, i64 6, !dbg !36
   store i64 15, i64* %callArgs6Addr.i, align 8, !dbg !36
   call void @llvm.experimental.noalias.scope.decl(metadata !37) #7, !dbg !36
-  %24 = call i64 @rb_ary_new_from_values(i64 noundef 7, i64* noundef nonnull align 8 %callArgs0Addr.i) #7, !dbg !36
-  store i64 %24, i64* %callArgs0Addr.i, align 8, !dbg !40
-  %25 = bitcast i64* %callArgs1Addr.i to <2 x i64>*, !dbg !40
-  store <2 x i64> <i64 3, i64 5>, <2 x i64>* %25, align 8, !dbg !40
+  %19 = call i64 @rb_ary_new_from_values(i64 noundef 7, i64* noundef nonnull align 8 %callArgs0Addr.i) #7, !dbg !36
+  store i64 %19, i64* %callArgs0Addr.i, align 8, !dbg !40
+  %20 = bitcast i64* %callArgs1Addr.i to <2 x i64>*, !dbg !40
+  store <2 x i64> <i64 3, i64 5>, <2 x i64>* %20, align 8, !dbg !40
   call void @llvm.experimental.noalias.scope.decl(metadata !41) #7, !dbg !40
-  %26 = getelementptr inbounds i64, i64* %callArgs0Addr.i, i64 1, !dbg !40
-  %27 = getelementptr inbounds i64, i64* %callArgs0Addr.i, i64 2, !dbg !40
-  %28 = call i64 @sorbet_vm_expandSplatIntrinsic(i64 %24, i64 3, i64 5) #7, !dbg !40, !noalias !41
+  %21 = getelementptr inbounds i64, i64* %callArgs0Addr.i, i64 1, !dbg !40
+  %22 = getelementptr inbounds i64, i64* %callArgs0Addr.i, i64 2, !dbg !40
+  %23 = call i64 @sorbet_vm_expandSplatIntrinsic(i64 %19, i64 3, i64 5) #7, !dbg !40, !noalias !41
   store i64 1, i64* %callArgs0Addr.i, align 8, !dbg !40
   call void @llvm.experimental.noalias.scope.decl(metadata !44) #7, !dbg !40
-  %29 = call i64 @rb_ary_entry(i64 %28, i64 0) #7, !dbg !40
-  %30 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !40, !tbaa !17
-  %31 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %30, i64 0, i32 5, !dbg !40
-  %32 = load i32, i32* %31, align 8, !dbg !40, !tbaa !47
-  %33 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %30, i64 0, i32 6, !dbg !40
-  %34 = load i32, i32* %33, align 4, !dbg !40, !tbaa !48
-  %35 = xor i32 %34, -1, !dbg !40
-  %36 = and i32 %35, %32, !dbg !40
-  %37 = icmp eq i32 %36, 0, !dbg !40
-  br i1 %37, label %sorbet_rb_array_square_br.exit370.i, label %38, !dbg !40, !prof !49
+  %24 = call i64 @rb_ary_entry(i64 %23, i64 0) #7, !dbg !40
+  %25 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !40, !tbaa !17
+  %26 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %25, i64 0, i32 5, !dbg !40
+  %27 = load i32, i32* %26, align 8, !dbg !40, !tbaa !47
+  %28 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %25, i64 0, i32 6, !dbg !40
+  %29 = load i32, i32* %28, align 4, !dbg !40, !tbaa !48
+  %30 = xor i32 %29, -1, !dbg !40
+  %31 = and i32 %30, %27, !dbg !40
+  %32 = icmp eq i32 %31, 0, !dbg !40
+  br i1 %32, label %sorbet_rb_array_square_br.exit370.i, label %33, !dbg !40, !prof !49
 
-38:                                               ; preds = %entry
-  %39 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %30, i64 0, i32 8, !dbg !40
-  %40 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %39, align 8, !dbg !40, !tbaa !50
-  %41 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %40, i32 noundef 0) #7, !dbg !40
+33:                                               ; preds = %entry
+  %34 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %25, i64 0, i32 8, !dbg !40
+  %35 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %34, align 8, !dbg !40, !tbaa !50
+  %36 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %35, i32 noundef 0) #7, !dbg !40
   br label %sorbet_rb_array_square_br.exit370.i, !dbg !40
 
-sorbet_rb_array_square_br.exit370.i:              ; preds = %38, %entry
+sorbet_rb_array_square_br.exit370.i:              ; preds = %33, %entry
   store i64 -3, i64* %callArgs0Addr.i, align 8, !dbg !40
   call void @llvm.experimental.noalias.scope.decl(metadata !51) #7, !dbg !40
-  %42 = call i64 @rb_ary_entry(i64 %28, i64 -2) #7, !dbg !40
-  %43 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !40, !tbaa !17
-  %44 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %43, i64 0, i32 5, !dbg !40
-  %45 = load i32, i32* %44, align 8, !dbg !40, !tbaa !47
-  %46 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %43, i64 0, i32 6, !dbg !40
-  %47 = load i32, i32* %46, align 4, !dbg !40, !tbaa !48
-  %48 = xor i32 %47, -1, !dbg !40
-  %49 = and i32 %48, %45, !dbg !40
-  %50 = icmp eq i32 %49, 0, !dbg !40
-  br i1 %50, label %sorbet_rb_array_square_br.exit371.i, label %51, !dbg !40, !prof !49
+  %37 = call i64 @rb_ary_entry(i64 %23, i64 -2) #7, !dbg !40
+  %38 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !40, !tbaa !17
+  %39 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %38, i64 0, i32 5, !dbg !40
+  %40 = load i32, i32* %39, align 8, !dbg !40, !tbaa !47
+  %41 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %38, i64 0, i32 6, !dbg !40
+  %42 = load i32, i32* %41, align 4, !dbg !40, !tbaa !48
+  %43 = xor i32 %42, -1, !dbg !40
+  %44 = and i32 %43, %40, !dbg !40
+  %45 = icmp eq i32 %44, 0, !dbg !40
+  br i1 %45, label %sorbet_rb_array_square_br.exit371.i, label %46, !dbg !40, !prof !49
 
-51:                                               ; preds = %sorbet_rb_array_square_br.exit370.i
-  %52 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %43, i64 0, i32 8, !dbg !40
-  %53 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %52, align 8, !dbg !40, !tbaa !50
-  %54 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %53, i32 noundef 0) #7, !dbg !40
+46:                                               ; preds = %sorbet_rb_array_square_br.exit370.i
+  %47 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %38, i64 0, i32 8, !dbg !40
+  %48 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %47, align 8, !dbg !40, !tbaa !50
+  %49 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %48, i32 noundef 0) #7, !dbg !40
   br label %sorbet_rb_array_square_br.exit371.i, !dbg !40
 
-sorbet_rb_array_square_br.exit371.i:              ; preds = %51, %sorbet_rb_array_square_br.exit370.i
+sorbet_rb_array_square_br.exit371.i:              ; preds = %46, %sorbet_rb_array_square_br.exit370.i
   store i64 -1, i64* %callArgs0Addr.i, align 8, !dbg !40
   call void @llvm.experimental.noalias.scope.decl(metadata !54) #7, !dbg !40
-  %55 = call i64 @rb_ary_entry(i64 %28, i64 -1) #7, !dbg !40
-  %56 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !40, !tbaa !17
-  %57 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %56, i64 0, i32 5, !dbg !40
-  %58 = load i32, i32* %57, align 8, !dbg !40, !tbaa !47
-  %59 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %56, i64 0, i32 6, !dbg !40
-  %60 = load i32, i32* %59, align 4, !dbg !40, !tbaa !48
-  %61 = xor i32 %60, -1, !dbg !40
-  %62 = and i32 %61, %58, !dbg !40
-  %63 = icmp eq i32 %62, 0, !dbg !40
-  br i1 %63, label %sorbet_rb_array_square_br.exit372.i, label %64, !dbg !40, !prof !49
+  %50 = call i64 @rb_ary_entry(i64 %23, i64 -1) #7, !dbg !40
+  %51 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !40, !tbaa !17
+  %52 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %51, i64 0, i32 5, !dbg !40
+  %53 = load i32, i32* %52, align 8, !dbg !40, !tbaa !47
+  %54 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %51, i64 0, i32 6, !dbg !40
+  %55 = load i32, i32* %54, align 4, !dbg !40, !tbaa !48
+  %56 = xor i32 %55, -1, !dbg !40
+  %57 = and i32 %56, %53, !dbg !40
+  %58 = icmp eq i32 %57, 0, !dbg !40
+  br i1 %58, label %sorbet_rb_array_square_br.exit372.i, label %59, !dbg !40, !prof !49
 
-64:                                               ; preds = %sorbet_rb_array_square_br.exit371.i
-  %65 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %56, i64 0, i32 8, !dbg !40
-  %66 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %65, align 8, !dbg !40, !tbaa !50
-  %67 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %66, i32 noundef 0) #7, !dbg !40
+59:                                               ; preds = %sorbet_rb_array_square_br.exit371.i
+  %60 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %51, i64 0, i32 8, !dbg !40
+  %61 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %60, align 8, !dbg !40, !tbaa !50
+  %62 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %61, i32 noundef 0) #7, !dbg !40
   br label %sorbet_rb_array_square_br.exit372.i, !dbg !40
 
-sorbet_rb_array_square_br.exit372.i:              ; preds = %64, %sorbet_rb_array_square_br.exit371.i
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %21, align 8, !dbg !35, !tbaa !17
-  store i64 %29, i64* %callArgs0Addr.i, align 8, !dbg !57
-  store i64 %42, i64* %callArgs1Addr.i, align 8, !dbg !57
-  store i64 %55, i64* %callArgs2Addr.i, align 8, !dbg !57
+sorbet_rb_array_square_br.exit372.i:              ; preds = %59, %sorbet_rb_array_square_br.exit371.i
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %16, align 8, !dbg !35, !tbaa !17
+  store i64 %24, i64* %callArgs0Addr.i, align 8, !dbg !57
+  store i64 %37, i64* %callArgs1Addr.i, align 8, !dbg !57
+  store i64 %50, i64* %callArgs2Addr.i, align 8, !dbg !57
   call void @llvm.experimental.noalias.scope.decl(metadata !58) #7, !dbg !57
-  %68 = call i64 @rb_ary_new_from_values(i64 noundef 3, i64* noundef nonnull %callArgs0Addr.i) #7, !dbg !57
-  %69 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %13, i64 0, i32 1, !dbg !10
-  %70 = load i64*, i64** %69, align 8, !dbg !10
-  store i64 %10, i64* %70, align 8, !dbg !10, !tbaa !6
-  %71 = getelementptr inbounds i64, i64* %70, i64 1, !dbg !10
-  store i64 %68, i64* %71, align 8, !dbg !10, !tbaa !6
-  %72 = getelementptr inbounds i64, i64* %71, i64 1, !dbg !10
-  store i64* %72, i64** %69, align 8, !dbg !10
+  %63 = call i64 @rb_ary_new_from_values(i64 noundef 3, i64* noundef nonnull %callArgs0Addr.i) #7, !dbg !57
+  %64 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %8, i64 0, i32 1, !dbg !10
+  %65 = load i64*, i64** %64, align 8, !dbg !10
+  store i64 %5, i64* %65, align 8, !dbg !10, !tbaa !6
+  %66 = getelementptr inbounds i64, i64* %65, i64 1, !dbg !10
+  store i64 %63, i64* %66, align 8, !dbg !10, !tbaa !6
+  %67 = getelementptr inbounds i64, i64* %66, i64 1, !dbg !10
+  store i64* %67, i64** %64, align 8, !dbg !10
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !10
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %21, align 8, !dbg !10, !tbaa !17
-  %73 = bitcast i64* %callArgs0Addr.i to <2 x i64>*, !dbg !61
-  store <2 x i64> <i64 3, i64 5>, <2 x i64>* %73, align 8, !dbg !61
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %16, align 8, !dbg !10, !tbaa !17
+  %68 = bitcast i64* %callArgs0Addr.i to <2 x i64>*, !dbg !61
+  store <2 x i64> <i64 3, i64 5>, <2 x i64>* %68, align 8, !dbg !61
   call void @llvm.experimental.noalias.scope.decl(metadata !62) #7, !dbg !61
-  %74 = call i64 @rb_ary_new_from_values(i64 noundef 2, i64* noundef nonnull %callArgs0Addr.i) #7, !dbg !61
-  store i64 %74, i64* %callArgs0Addr.i, align 8, !dbg !65
-  store <2 x i64> <i64 3, i64 5>, <2 x i64>* %25, align 8, !dbg !65
+  %69 = call i64 @rb_ary_new_from_values(i64 noundef 2, i64* noundef nonnull %callArgs0Addr.i) #7, !dbg !61
+  store i64 %69, i64* %callArgs0Addr.i, align 8, !dbg !65
+  store <2 x i64> <i64 3, i64 5>, <2 x i64>* %20, align 8, !dbg !65
   call void @llvm.experimental.noalias.scope.decl(metadata !66) #7, !dbg !65
-  %75 = call i64 @sorbet_vm_expandSplatIntrinsic(i64 %74, i64 3, i64 5) #7, !dbg !65, !noalias !66
+  %70 = call i64 @sorbet_vm_expandSplatIntrinsic(i64 %69, i64 3, i64 5) #7, !dbg !65, !noalias !66
   store i64 1, i64* %callArgs0Addr.i, align 8, !dbg !65
   call void @llvm.experimental.noalias.scope.decl(metadata !69) #7, !dbg !65
-  %76 = call i64 @rb_ary_entry(i64 %75, i64 0) #7, !dbg !65
-  %77 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !65, !tbaa !17
-  %78 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %77, i64 0, i32 5, !dbg !65
-  %79 = load i32, i32* %78, align 8, !dbg !65, !tbaa !47
-  %80 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %77, i64 0, i32 6, !dbg !65
-  %81 = load i32, i32* %80, align 4, !dbg !65, !tbaa !48
-  %82 = xor i32 %81, -1, !dbg !65
-  %83 = and i32 %82, %79, !dbg !65
-  %84 = icmp eq i32 %83, 0, !dbg !65
-  br i1 %84, label %sorbet_rb_array_square_br.exit373.i, label %85, !dbg !65, !prof !49
+  %71 = call i64 @rb_ary_entry(i64 %70, i64 0) #7, !dbg !65
+  %72 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !65, !tbaa !17
+  %73 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %72, i64 0, i32 5, !dbg !65
+  %74 = load i32, i32* %73, align 8, !dbg !65, !tbaa !47
+  %75 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %72, i64 0, i32 6, !dbg !65
+  %76 = load i32, i32* %75, align 4, !dbg !65, !tbaa !48
+  %77 = xor i32 %76, -1, !dbg !65
+  %78 = and i32 %77, %74, !dbg !65
+  %79 = icmp eq i32 %78, 0, !dbg !65
+  br i1 %79, label %sorbet_rb_array_square_br.exit373.i, label %80, !dbg !65, !prof !49
 
-85:                                               ; preds = %sorbet_rb_array_square_br.exit372.i
-  %86 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %77, i64 0, i32 8, !dbg !65
-  %87 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %86, align 8, !dbg !65, !tbaa !50
-  %88 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %87, i32 noundef 0) #7, !dbg !65
+80:                                               ; preds = %sorbet_rb_array_square_br.exit372.i
+  %81 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %72, i64 0, i32 8, !dbg !65
+  %82 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %81, align 8, !dbg !65, !tbaa !50
+  %83 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %82, i32 noundef 0) #7, !dbg !65
   br label %sorbet_rb_array_square_br.exit373.i, !dbg !65
 
-sorbet_rb_array_square_br.exit373.i:              ; preds = %85, %sorbet_rb_array_square_br.exit372.i
+sorbet_rb_array_square_br.exit373.i:              ; preds = %80, %sorbet_rb_array_square_br.exit372.i
   store i64 -3, i64* %callArgs0Addr.i, align 8, !dbg !65
   call void @llvm.experimental.noalias.scope.decl(metadata !72) #7, !dbg !65
-  %89 = call i64 @rb_ary_entry(i64 %75, i64 -2) #7, !dbg !65
-  %90 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !65, !tbaa !17
-  %91 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %90, i64 0, i32 5, !dbg !65
-  %92 = load i32, i32* %91, align 8, !dbg !65, !tbaa !47
-  %93 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %90, i64 0, i32 6, !dbg !65
-  %94 = load i32, i32* %93, align 4, !dbg !65, !tbaa !48
-  %95 = xor i32 %94, -1, !dbg !65
-  %96 = and i32 %95, %92, !dbg !65
-  %97 = icmp eq i32 %96, 0, !dbg !65
-  br i1 %97, label %sorbet_rb_array_square_br.exit374.i, label %98, !dbg !65, !prof !49
+  %84 = call i64 @rb_ary_entry(i64 %70, i64 -2) #7, !dbg !65
+  %85 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !65, !tbaa !17
+  %86 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %85, i64 0, i32 5, !dbg !65
+  %87 = load i32, i32* %86, align 8, !dbg !65, !tbaa !47
+  %88 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %85, i64 0, i32 6, !dbg !65
+  %89 = load i32, i32* %88, align 4, !dbg !65, !tbaa !48
+  %90 = xor i32 %89, -1, !dbg !65
+  %91 = and i32 %90, %87, !dbg !65
+  %92 = icmp eq i32 %91, 0, !dbg !65
+  br i1 %92, label %sorbet_rb_array_square_br.exit374.i, label %93, !dbg !65, !prof !49
 
-98:                                               ; preds = %sorbet_rb_array_square_br.exit373.i
-  %99 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %90, i64 0, i32 8, !dbg !65
-  %100 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %99, align 8, !dbg !65, !tbaa !50
-  %101 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %100, i32 noundef 0) #7, !dbg !65
+93:                                               ; preds = %sorbet_rb_array_square_br.exit373.i
+  %94 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %85, i64 0, i32 8, !dbg !65
+  %95 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %94, align 8, !dbg !65, !tbaa !50
+  %96 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %95, i32 noundef 0) #7, !dbg !65
   br label %sorbet_rb_array_square_br.exit374.i, !dbg !65
 
-sorbet_rb_array_square_br.exit374.i:              ; preds = %98, %sorbet_rb_array_square_br.exit373.i
+sorbet_rb_array_square_br.exit374.i:              ; preds = %93, %sorbet_rb_array_square_br.exit373.i
   store i64 -1, i64* %callArgs0Addr.i, align 8, !dbg !65
   call void @llvm.experimental.noalias.scope.decl(metadata !75) #7, !dbg !65
-  %102 = call i64 @rb_ary_entry(i64 %75, i64 -1) #7, !dbg !65
-  %103 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !65, !tbaa !17
-  %104 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %103, i64 0, i32 5, !dbg !65
-  %105 = load i32, i32* %104, align 8, !dbg !65, !tbaa !47
-  %106 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %103, i64 0, i32 6, !dbg !65
-  %107 = load i32, i32* %106, align 4, !dbg !65, !tbaa !48
-  %108 = xor i32 %107, -1, !dbg !65
-  %109 = and i32 %108, %105, !dbg !65
-  %110 = icmp eq i32 %109, 0, !dbg !65
-  br i1 %110, label %sorbet_rb_array_square_br.exit375.i, label %111, !dbg !65, !prof !49
+  %97 = call i64 @rb_ary_entry(i64 %70, i64 -1) #7, !dbg !65
+  %98 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !65, !tbaa !17
+  %99 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %98, i64 0, i32 5, !dbg !65
+  %100 = load i32, i32* %99, align 8, !dbg !65, !tbaa !47
+  %101 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %98, i64 0, i32 6, !dbg !65
+  %102 = load i32, i32* %101, align 4, !dbg !65, !tbaa !48
+  %103 = xor i32 %102, -1, !dbg !65
+  %104 = and i32 %103, %100, !dbg !65
+  %105 = icmp eq i32 %104, 0, !dbg !65
+  br i1 %105, label %sorbet_rb_array_square_br.exit375.i, label %106, !dbg !65, !prof !49
 
-111:                                              ; preds = %sorbet_rb_array_square_br.exit374.i
-  %112 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %103, i64 0, i32 8, !dbg !65
-  %113 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %112, align 8, !dbg !65, !tbaa !50
-  %114 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %113, i32 noundef 0) #7, !dbg !65
+106:                                              ; preds = %sorbet_rb_array_square_br.exit374.i
+  %107 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %98, i64 0, i32 8, !dbg !65
+  %108 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %107, align 8, !dbg !65, !tbaa !50
+  %109 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %108, i32 noundef 0) #7, !dbg !65
   br label %sorbet_rb_array_square_br.exit375.i, !dbg !65
 
-sorbet_rb_array_square_br.exit375.i:              ; preds = %111, %sorbet_rb_array_square_br.exit374.i
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %21, align 8, !dbg !35, !tbaa !17
-  store i64 %76, i64* %callArgs0Addr.i, align 8, !dbg !78
-  store i64 %89, i64* %callArgs1Addr.i, align 8, !dbg !78
-  store i64 %102, i64* %callArgs2Addr.i, align 8, !dbg !78
+sorbet_rb_array_square_br.exit375.i:              ; preds = %106, %sorbet_rb_array_square_br.exit374.i
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %16, align 8, !dbg !35, !tbaa !17
+  store i64 %71, i64* %callArgs0Addr.i, align 8, !dbg !78
+  store i64 %84, i64* %callArgs1Addr.i, align 8, !dbg !78
+  store i64 %97, i64* %callArgs2Addr.i, align 8, !dbg !78
   call void @llvm.experimental.noalias.scope.decl(metadata !79) #7, !dbg !78
-  %115 = call i64 @rb_ary_new_from_values(i64 noundef 3, i64* noundef nonnull %callArgs0Addr.i) #7, !dbg !78
-  %116 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %13, i64 0, i32 1, !dbg !15
-  %117 = load i64*, i64** %116, align 8, !dbg !15
-  store i64 %10, i64* %117, align 8, !dbg !15, !tbaa !6
-  %118 = getelementptr inbounds i64, i64* %117, i64 1, !dbg !15
-  store i64 %115, i64* %118, align 8, !dbg !15, !tbaa !6
-  %119 = getelementptr inbounds i64, i64* %118, i64 1, !dbg !15
-  store i64* %119, i64** %116, align 8, !dbg !15
+  %110 = call i64 @rb_ary_new_from_values(i64 noundef 3, i64* noundef nonnull %callArgs0Addr.i) #7, !dbg !78
+  %111 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %8, i64 0, i32 1, !dbg !15
+  %112 = load i64*, i64** %111, align 8, !dbg !15
+  store i64 %5, i64* %112, align 8, !dbg !15, !tbaa !6
+  %113 = getelementptr inbounds i64, i64* %112, i64 1, !dbg !15
+  store i64 %110, i64* %113, align 8, !dbg !15, !tbaa !6
+  %114 = getelementptr inbounds i64, i64* %113, i64 1, !dbg !15
+  store i64* %114, i64** %111, align 8, !dbg !15
   %send2 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.6, i64 0), !dbg !15
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %21, align 8, !dbg !35, !tbaa !17
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %16, align 8, !dbg !35, !tbaa !17
   call void @llvm.experimental.noalias.scope.decl(metadata !82) #7, !dbg !85
-  %120 = call i64 @rb_ary_new() #7, !dbg !85
-  store i64 %120, i64* %callArgs0Addr.i, align 8, !dbg !86
-  store <2 x i64> <i64 3, i64 5>, <2 x i64>* %25, align 8, !dbg !86
+  %115 = call i64 @rb_ary_new() #7, !dbg !85
+  store i64 %115, i64* %callArgs0Addr.i, align 8, !dbg !86
+  store <2 x i64> <i64 3, i64 5>, <2 x i64>* %20, align 8, !dbg !86
   call void @llvm.experimental.noalias.scope.decl(metadata !87) #7, !dbg !86
-  %121 = call i64 @sorbet_vm_expandSplatIntrinsic(i64 %120, i64 3, i64 5) #7, !dbg !86, !noalias !87
+  %116 = call i64 @sorbet_vm_expandSplatIntrinsic(i64 %115, i64 3, i64 5) #7, !dbg !86, !noalias !87
   store i64 1, i64* %callArgs0Addr.i, align 8, !dbg !86
   call void @llvm.experimental.noalias.scope.decl(metadata !90) #7, !dbg !86
-  %122 = call i64 @rb_ary_entry(i64 %121, i64 0) #7, !dbg !86
-  %123 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !86, !tbaa !17
-  %124 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %123, i64 0, i32 5, !dbg !86
-  %125 = load i32, i32* %124, align 8, !dbg !86, !tbaa !47
-  %126 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %123, i64 0, i32 6, !dbg !86
-  %127 = load i32, i32* %126, align 4, !dbg !86, !tbaa !48
-  %128 = xor i32 %127, -1, !dbg !86
-  %129 = and i32 %128, %125, !dbg !86
-  %130 = icmp eq i32 %129, 0, !dbg !86
-  br i1 %130, label %sorbet_rb_array_square_br.exit368.i, label %131, !dbg !86, !prof !49
+  %117 = call i64 @rb_ary_entry(i64 %116, i64 0) #7, !dbg !86
+  %118 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !86, !tbaa !17
+  %119 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %118, i64 0, i32 5, !dbg !86
+  %120 = load i32, i32* %119, align 8, !dbg !86, !tbaa !47
+  %121 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %118, i64 0, i32 6, !dbg !86
+  %122 = load i32, i32* %121, align 4, !dbg !86, !tbaa !48
+  %123 = xor i32 %122, -1, !dbg !86
+  %124 = and i32 %123, %120, !dbg !86
+  %125 = icmp eq i32 %124, 0, !dbg !86
+  br i1 %125, label %sorbet_rb_array_square_br.exit368.i, label %126, !dbg !86, !prof !49
 
-131:                                              ; preds = %sorbet_rb_array_square_br.exit375.i
-  %132 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %123, i64 0, i32 8, !dbg !86
-  %133 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %132, align 8, !dbg !86, !tbaa !50
-  %134 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %133, i32 noundef 0) #7, !dbg !86
+126:                                              ; preds = %sorbet_rb_array_square_br.exit375.i
+  %127 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %118, i64 0, i32 8, !dbg !86
+  %128 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %127, align 8, !dbg !86, !tbaa !50
+  %129 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %128, i32 noundef 0) #7, !dbg !86
   br label %sorbet_rb_array_square_br.exit368.i, !dbg !86
 
-sorbet_rb_array_square_br.exit368.i:              ; preds = %131, %sorbet_rb_array_square_br.exit375.i
+sorbet_rb_array_square_br.exit368.i:              ; preds = %126, %sorbet_rb_array_square_br.exit375.i
   store i64 -3, i64* %callArgs0Addr.i, align 8, !dbg !86
   call void @llvm.experimental.noalias.scope.decl(metadata !93) #7, !dbg !86
-  %135 = call i64 @rb_ary_entry(i64 %121, i64 -2) #7, !dbg !86
-  %136 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !86, !tbaa !17
-  %137 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %136, i64 0, i32 5, !dbg !86
-  %138 = load i32, i32* %137, align 8, !dbg !86, !tbaa !47
-  %139 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %136, i64 0, i32 6, !dbg !86
-  %140 = load i32, i32* %139, align 4, !dbg !86, !tbaa !48
-  %141 = xor i32 %140, -1, !dbg !86
-  %142 = and i32 %141, %138, !dbg !86
-  %143 = icmp eq i32 %142, 0, !dbg !86
-  br i1 %143, label %sorbet_rb_array_square_br.exit.i, label %144, !dbg !86, !prof !49
+  %130 = call i64 @rb_ary_entry(i64 %116, i64 -2) #7, !dbg !86
+  %131 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !86, !tbaa !17
+  %132 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %131, i64 0, i32 5, !dbg !86
+  %133 = load i32, i32* %132, align 8, !dbg !86, !tbaa !47
+  %134 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %131, i64 0, i32 6, !dbg !86
+  %135 = load i32, i32* %134, align 4, !dbg !86, !tbaa !48
+  %136 = xor i32 %135, -1, !dbg !86
+  %137 = and i32 %136, %133, !dbg !86
+  %138 = icmp eq i32 %137, 0, !dbg !86
+  br i1 %138, label %sorbet_rb_array_square_br.exit.i, label %139, !dbg !86, !prof !49
 
-144:                                              ; preds = %sorbet_rb_array_square_br.exit368.i
-  %145 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %136, i64 0, i32 8, !dbg !86
-  %146 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %145, align 8, !dbg !86, !tbaa !50
-  %147 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %146, i32 noundef 0) #7, !dbg !86
+139:                                              ; preds = %sorbet_rb_array_square_br.exit368.i
+  %140 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %131, i64 0, i32 8, !dbg !86
+  %141 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %140, align 8, !dbg !86, !tbaa !50
+  %142 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %141, i32 noundef 0) #7, !dbg !86
   br label %sorbet_rb_array_square_br.exit.i, !dbg !86
 
-sorbet_rb_array_square_br.exit.i:                 ; preds = %144, %sorbet_rb_array_square_br.exit368.i
+sorbet_rb_array_square_br.exit.i:                 ; preds = %139, %sorbet_rb_array_square_br.exit368.i
   store i64 -1, i64* %callArgs0Addr.i, align 8, !dbg !86
   call void @llvm.experimental.noalias.scope.decl(metadata !96) #7, !dbg !86
-  %148 = call i64 @rb_ary_entry(i64 %121, i64 -1) #7, !dbg !86
-  %149 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !86, !tbaa !17
-  %150 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %149, i64 0, i32 5, !dbg !86
-  %151 = load i32, i32* %150, align 8, !dbg !86, !tbaa !47
-  %152 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %149, i64 0, i32 6, !dbg !86
-  %153 = load i32, i32* %152, align 4, !dbg !86, !tbaa !48
-  %154 = xor i32 %153, -1, !dbg !86
-  %155 = and i32 %154, %151, !dbg !86
-  %156 = icmp eq i32 %155, 0, !dbg !86
-  br i1 %156, label %"func_<root>.17<static-init>$153.exit", label %157, !dbg !86, !prof !49
+  %143 = call i64 @rb_ary_entry(i64 %116, i64 -1) #7, !dbg !86
+  %144 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !86, !tbaa !17
+  %145 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %144, i64 0, i32 5, !dbg !86
+  %146 = load i32, i32* %145, align 8, !dbg !86, !tbaa !47
+  %147 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %144, i64 0, i32 6, !dbg !86
+  %148 = load i32, i32* %147, align 4, !dbg !86, !tbaa !48
+  %149 = xor i32 %148, -1, !dbg !86
+  %150 = and i32 %149, %146, !dbg !86
+  %151 = icmp eq i32 %150, 0, !dbg !86
+  br i1 %151, label %"func_<root>.17<static-init>$153.exit", label %152, !dbg !86, !prof !49
 
-157:                                              ; preds = %sorbet_rb_array_square_br.exit.i
-  %158 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %149, i64 0, i32 8, !dbg !86
-  %159 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %158, align 8, !dbg !86, !tbaa !50
-  %160 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %159, i32 noundef 0) #7, !dbg !86
+152:                                              ; preds = %sorbet_rb_array_square_br.exit.i
+  %153 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %144, i64 0, i32 8, !dbg !86
+  %154 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %153, align 8, !dbg !86, !tbaa !50
+  %155 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %154, i32 noundef 0) #7, !dbg !86
   br label %"func_<root>.17<static-init>$153.exit", !dbg !86
 
-"func_<root>.17<static-init>$153.exit":           ; preds = %sorbet_rb_array_square_br.exit.i, %157
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %21, align 8, !dbg !35, !tbaa !17
-  store i64 %122, i64* %callArgs0Addr.i, align 8, !dbg !99
-  store i64 %135, i64* %callArgs1Addr.i, align 8, !dbg !99
-  store i64 %148, i64* %callArgs2Addr.i, align 8, !dbg !99
+"func_<root>.17<static-init>$153.exit":           ; preds = %sorbet_rb_array_square_br.exit.i, %152
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %16, align 8, !dbg !35, !tbaa !17
+  store i64 %117, i64* %callArgs0Addr.i, align 8, !dbg !99
+  store i64 %130, i64* %callArgs1Addr.i, align 8, !dbg !99
+  store i64 %143, i64* %callArgs2Addr.i, align 8, !dbg !99
   call void @llvm.experimental.noalias.scope.decl(metadata !100) #7, !dbg !99
-  %161 = call i64 @rb_ary_new_from_values(i64 noundef 3, i64* noundef nonnull %callArgs0Addr.i) #7, !dbg !99
-  %162 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %13, i64 0, i32 1, !dbg !16
-  %163 = load i64*, i64** %162, align 8, !dbg !16
-  store i64 %10, i64* %163, align 8, !dbg !16, !tbaa !6
-  %164 = getelementptr inbounds i64, i64* %163, i64 1, !dbg !16
-  store i64 %161, i64* %164, align 8, !dbg !16, !tbaa !6
-  %165 = getelementptr inbounds i64, i64* %164, i64 1, !dbg !16
-  store i64* %165, i64** %162, align 8, !dbg !16
+  %156 = call i64 @rb_ary_new_from_values(i64 noundef 3, i64* noundef nonnull %callArgs0Addr.i) #7, !dbg !99
+  %157 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %8, i64 0, i32 1, !dbg !16
+  %158 = load i64*, i64** %157, align 8, !dbg !16
+  store i64 %5, i64* %158, align 8, !dbg !16, !tbaa !6
+  %159 = getelementptr inbounds i64, i64* %158, i64 1, !dbg !16
+  store i64 %156, i64* %159, align 8, !dbg !16, !tbaa !6
+  %160 = getelementptr inbounds i64, i64* %159, i64 1, !dbg !16
+  store i64* %160, i64** %157, align 8, !dbg !16
   %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.10, i64 0), !dbg !16
-  call void @llvm.lifetime.end.p0i8(i64 64, i8* nonnull %14)
+  call void @llvm.lifetime.end.p0i8(i64 64, i8* nonnull %9)
   ret void
 }
 

--- a/test/testdata/compiler/unsafe.opt.ll.exp
+++ b/test/testdata/compiler/unsafe.opt.ll.exp
@@ -81,14 +81,14 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyIdPrecomputed_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
 @"rubyStrFrozen_test/testdata/compiler/unsafe.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [5 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyIdPrecomputed_puts = internal unnamed_addr global i64 0, align 8
 @sorbet_moduleStringTable = internal unnamed_addr constant [71 x i8] c"<top (required)>\00test/testdata/compiler/unsafe.rb\00T\00unsafe\00puts\00master\00", align 1
+@sorbet_moduleIDTable = internal unnamed_addr global [3 x i64] zeroinitializer, align 8
+@sorbet_moduleIDDescriptors = internal unnamed_addr constant [3 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 52, i32 6 }, %struct.rb_code_position_struct { i32 59, i32 4 }], align 8
 
 declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
 
@@ -102,9 +102,9 @@ declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_u
 
 declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %struct.rb_control_frame_struct*, %struct.rb_iseq_struct*) local_unnamed_addr #0
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
+declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #0
 
-declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #0
+declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
 
 declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
 
@@ -135,67 +135,63 @@ define void @Init_unsafe() local_unnamed_addr #4 {
 entry:
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = tail call i64 @rb_intern2(i8* noundef getelementptr inbounds ([71 x i8], [71 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #6
-  store i64 %0, i64* @"rubyIdPrecomputed_<top (required)>", align 8
-  %1 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([71 x i8], [71 x i8]* @sorbet_moduleStringTable, i64 0, i64 52), i64 noundef 6) #6
-  %2 = tail call i64 @rb_intern2(i8* getelementptr inbounds ([71 x i8], [71 x i8]* @sorbet_moduleStringTable, i64 0, i64 59), i64 noundef 4) #6
-  store i64 %2, i64* @rubyIdPrecomputed_puts, align 8
-  %3 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([71 x i8], [71 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #6
-  tail call void @rb_gc_register_mark_object(i64 %3) #6
-  store i64 %3, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %4 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([71 x i8], [71 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 32) #6
-  tail call void @rb_gc_register_mark_object(i64 %4) #6
-  store i64 %4, i64* @"rubyStrFrozen_test/testdata/compiler/unsafe.rb", align 8
+  tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([3 x %struct.rb_code_position_struct], [3 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 3, i8* noundef getelementptr inbounds ([71 x i8], [71 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
+  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([71 x i8], [71 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #6
+  tail call void @rb_gc_register_mark_object(i64 %0) #6
+  store i64 %0, i64* @"rubyStrFrozen_<top (required)>", align 8
+  %1 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([71 x i8], [71 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 32) #6
+  tail call void @rb_gc_register_mark_object(i64 %1) #6
+  store i64 %1, i64* @"rubyStrFrozen_test/testdata/compiler/unsafe.rb", align 8
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 5)
-  %"rubyId_<top (required)>.i.i" = load i64, i64* @"rubyIdPrecomputed_<top (required)>", align 8
+  %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
   %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
   %"rubyStr_test/testdata/compiler/unsafe.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/unsafe.rb", align 8
-  %5 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/unsafe.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %5, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %rubyId_puts.i = load i64, i64* @rubyIdPrecomputed_puts, align 8, !dbg !10
+  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/unsafe.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %rubyId_puts.i = load i64, i64* getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !10, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !10
-  %6 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !15
-  %7 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %6, i64 0, i32 18
-  %8 = load i64, i64* %7, align 8, !tbaa !17
-  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
-  %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 2
-  %11 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %10, align 8, !tbaa !27
+  %3 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !15
+  %4 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %3, i64 0, i32 18
+  %5 = load i64, i64* %4, align 8, !tbaa !17
+  %6 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
+  %7 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %6, i64 0, i32 2
+  %8 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %7, align 8, !tbaa !27
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %12, align 8, !tbaa !30
-  %13 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 4
-  %14 = load i64*, i64** %13, align 8, !tbaa !32
-  %15 = load i64, i64* %14, align 8, !tbaa !6
-  %16 = and i64 %15, -33
-  store i64 %16, i64* %14, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %9, %struct.rb_control_frame_struct* %11, %struct.rb_iseq_struct* %stackFrame.i) #6
-  %17 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 0
-  store i64* getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %17, align 8, !dbg !33, !tbaa !15
+  %9 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %8, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %9, align 8, !tbaa !30
+  %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %8, i64 0, i32 4
+  %11 = load i64*, i64** %10, align 8, !tbaa !32
+  %12 = load i64, i64* %11, align 8, !tbaa !6
+  %13 = and i64 %12, -33
+  store i64 %13, i64* %11, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %6, %struct.rb_control_frame_struct* %8, %struct.rb_iseq_struct* %stackFrame.i) #6
+  %14 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %8, i64 0, i32 0
+  store i64* getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %14, align 8, !dbg !33, !tbaa !15
   call void @llvm.experimental.noalias.scope.decl(metadata !34) #6, !dbg !37
-  %18 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !37, !tbaa !15
-  %19 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %18, i64 0, i32 5, !dbg !37
-  %20 = load i32, i32* %19, align 8, !dbg !37, !tbaa !38
-  %21 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %18, i64 0, i32 6, !dbg !37
-  %22 = load i32, i32* %21, align 4, !dbg !37, !tbaa !39
-  %23 = xor i32 %22, -1, !dbg !37
-  %24 = and i32 %23, %20, !dbg !37
-  %25 = icmp eq i32 %24, 0, !dbg !37
-  br i1 %25, label %"func_<root>.17<static-init>$153.exit", label %26, !dbg !37, !prof !40
+  %15 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !37, !tbaa !15
+  %16 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %15, i64 0, i32 5, !dbg !37
+  %17 = load i32, i32* %16, align 8, !dbg !37, !tbaa !38
+  %18 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %15, i64 0, i32 6, !dbg !37
+  %19 = load i32, i32* %18, align 4, !dbg !37, !tbaa !39
+  %20 = xor i32 %19, -1, !dbg !37
+  %21 = and i32 %20, %17, !dbg !37
+  %22 = icmp eq i32 %21, 0, !dbg !37
+  br i1 %22, label %"func_<root>.17<static-init>$153.exit", label %23, !dbg !37, !prof !40
 
-26:                                               ; preds = %entry
-  %27 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %18, i64 0, i32 8, !dbg !37
-  %28 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %27, align 8, !dbg !37, !tbaa !41
-  %29 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %28, i32 noundef 0) #6, !dbg !37
+23:                                               ; preds = %entry
+  %24 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %15, i64 0, i32 8, !dbg !37
+  %25 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %24, align 8, !dbg !37, !tbaa !41
+  %26 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %25, i32 noundef 0) #6, !dbg !37
   br label %"func_<root>.17<static-init>$153.exit", !dbg !37
 
-"func_<root>.17<static-init>$153.exit":           ; preds = %entry, %26
-  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 1, !dbg !10
-  %31 = load i64*, i64** %30, align 8, !dbg !10
-  store i64 %8, i64* %31, align 8, !dbg !10, !tbaa !6
-  %32 = getelementptr inbounds i64, i64* %31, i64 1, !dbg !10
-  store i64 3, i64* %32, align 8, !dbg !10, !tbaa !6
-  %33 = getelementptr inbounds i64, i64* %32, i64 1, !dbg !10
-  store i64* %33, i64** %30, align 8, !dbg !10
+"func_<root>.17<static-init>$153.exit":           ; preds = %entry, %23
+  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %8, i64 0, i32 1, !dbg !10
+  %28 = load i64*, i64** %27, align 8, !dbg !10
+  store i64 %5, i64* %28, align 8, !dbg !10, !tbaa !6
+  %29 = getelementptr inbounds i64, i64* %28, i64 1, !dbg !10
+  store i64 3, i64* %29, align 8, !dbg !10, !tbaa !6
+  %30 = getelementptr inbounds i64, i64* %29, i64 1, !dbg !10
+  store i64* %30, i64** %27, align 8, !dbg !10
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !10
   ret void
 }


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is the followup to #5613, implementing the plan for the ID table described therein.

The main benefits here are less LLVM IR to optimize.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.  The compiler exp diffs are rather large, but that's mostly just a function of shifting LLVM IR values around, since we now have fewer LLVM IR temporaries.
