### PR TITLE
Add immutable struct

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -225,6 +225,7 @@ NameDef names[] = {
     {"computedBy", "computed_by"},
     {"factory"},
     {"InexactStruct", "InexactStruct", true},
+    {"ImmutableStruct", "ImmutableStruct", true},
     {"Chalk", "Chalk", true},
     {"ODM", "ODM", true},
     {"Document", "Document", true},

--- a/gems/sorbet-runtime/lib/types/props/_props.rb
+++ b/gems/sorbet-runtime/lib/types/props/_props.rb
@@ -84,8 +84,11 @@ module T::Props
   end
 
   module Prop
+    extend T::Helpers
+
     module ClassMethods
       extend T::Sig
+      include T::Props::Common::ClassMethods
 
       # Define a new property. See {file:README.md} for some concrete
       #  examples.
@@ -167,6 +170,7 @@ module T::Props
         decorator.prop_defined(name, cls, rules)
       end
     end
+    mixes_in_class_methods(ClassMethods)
   end
 
   module Const

--- a/gems/sorbet-runtime/lib/types/props/_props.rb
+++ b/gems/sorbet-runtime/lib/types/props/_props.rb
@@ -16,152 +16,232 @@ module T::Props
   # it needs to be exposed here.
   #####
 
+  module Common
+    extend T::Helpers
+
+    module ClassMethods
+      def props
+        decorator.props
+      end
+
+      def plugins
+        @plugins ||= []
+      end
+
+      def decorator_class
+        Decorator
+      end
+
+      def decorator
+        @decorator ||= decorator_class.new(self)
+      end
+
+      def reload_decorator!
+        @decorator = decorator_class.new(self)
+      end
+
+      # Validates the value of the specified prop. This method allows the caller to
+      #  validate a value for a prop without having to set the data on the instance.
+      #  Throws if invalid.
+      #
+      # @param prop [Symbol]
+      # @param val [Object]
+      # @return [void]
+      def validate_prop_value(prop, val)
+        decorator.validate_prop_value(prop, val)
+      end
+
+      # Needs to be documented
+      def plugin(mod)
+        decorator.plugin(mod)
+      end
+
+      def included(child)
+        child.extend(T::Props::Common::ClassMethods)
+        decorator.model_inherited(child)
+        super
+      end
+
+      def prepended(child)
+        child.extend(T::Props::Common::ClassMethods)
+        decorator.model_inherited(child)
+        super
+      end
+
+      def extended(child)
+        child.extend(T::Props::Common::ClassMethods)
+        decorator.model_inherited(child.singleton_class)
+        super
+      end
+
+      def inherited(child)
+        child.extend(T::Props::Common::ClassMethods)
+        decorator.model_inherited(child)
+        super
+      end
+    end
+    mixes_in_class_methods(ClassMethods)
+  end
+
+  module Prop
+    module ClassMethods
+      extend T::Sig
+
+      # Define a new property. See {file:README.md} for some concrete
+      #  examples.
+      #
+      # Defining a property defines a method with the same name as the
+      # property, that returns the current value, and a `prop=` method
+      # to set its value. Properties will be inherited by subclasses of
+      # a document class.
+      #
+      # Must be kept in sync with the implementation in `const`. Kept separate to avoid creating a dependency between
+      # `const` and `prop`.
+      #
+      # @param name [Symbol] The name of this property
+      # @param cls [Class,T::Types::Base] The type of this
+      #   property. If the type is itself a `Document` subclass, this
+      #   property will be recursively serialized/deserialized.
+      # @param rules [Hash] Options to control this property's behavior.
+      # @option rules [T::Boolean,Symbol] :optional If `true`, this property
+      #   is never required to be set before an instance is serialized.
+      #   If `:on_load` (default), when this property is missing or nil, a
+      #   new model cannot be saved, and an existing model can only be
+      #   saved if the property was already missing when it was loaded.
+      #   If `false`, when the property is missing/nil after deserialization, it
+      #   will be set to the default value (as defined by the `default` or
+      #   `factory` option) or will raise if they are not present.
+      #   Deprecated: For `Model`s, if `:optional` is set to the special value
+      #   `:existing`, the property can be saved as nil even if it was
+      #   deserialized with a non-nil value. (Deprecated because there should
+      #   never be a need for this behavior; the new behavior of non-optional
+      #   properties should be sufficient.)
+      # @option rules [Array] :enum An array of legal values; The
+      #  property is required to take on one of those values.
+      # @option rules [T::Boolean] :dont_store If true, this property will
+      #   not be saved on the hash resulting from
+      #   {T::Props::Serializable#serialize}
+      # @option rules [Object] :ifunset A value to be returned if this
+      #   property is requested but has never been set (is set to
+      #   `nil`). It is applied at property-access time, and never saved
+      #   back onto the object or into the database.
+      #
+      #   ``:ifunset`` is considered **DEPRECATED** and should not be used
+      #    in new code, in favor of just setting a default value.
+      # @option rules [Model, Symbol, Proc] :foreign A model class that this
+      #  property is a reference to. Passing `:foreign` will define a
+      #  `:"#{name}_"` method, that will load and return the
+      #  corresponding foreign model.
+      #
+      #  A symbol can be passed to avoid load-order dependencies; It
+      #  will be lazily resolved relative to the enclosing module of the
+      #  defining class.
+      #
+      #  A callable (proc or method) can be passed to dynamically specify the
+      #  foreign model. This will be passed the object instance so that other
+      #  properties of the object can be used to determine the relevant model
+      #  class. It should return a string/symbol class name or the foreign model
+      #  class directly.
+      #
+      # @option rules [Object] :default A default value that will be set
+      #   by `#initialize` if none is provided in the initialization
+      #   hash. This will not affect objects loaded by {.from_hash}.
+      # @option rules [Proc] :factory A `Proc` that will be called to
+      #   generate an initial value for this prop on `#initialize`, if
+      #   none is provided.
+      # @option rules [T::Boolean] :immutable If true, this prop cannot be
+      #   modified after an instance is created or loaded from a hash.
+      # @option rules [T::Boolean] :override It is an error to redeclare a
+      #   `prop` that has already been declared (including on a
+      #   superclass), unless `:override` is set to `true`.
+      # @option rules [Symbol, Array] :redaction A redaction directive that may
+      #   be passed to Chalk::Tools::RedactionUtils.redact_with_directive to
+      #   sanitize this parameter for display. Will define a
+      #   `:"#{name}_redacted"` method, which will return the value in sanitized
+      #   form.
+      #
+      # @return [void]
+      sig {params(name: Symbol, cls: T.untyped, rules: T.untyped).void}
+      def prop(name, cls, rules={})
+        cls = T::Utils.coerce(cls) if !cls.is_a?(Module)
+        decorator.prop_defined(name, cls, rules)
+      end
+    end
+  end
+
+  module Const
+    extend T::Helpers
+
+    module ClassMethods
+      extend T::Sig
+      include T::Props::Common::ClassMethods
+
+      # Shorthand helper to define a `prop` with `immutable => true`
+      sig {params(name: Symbol, cls_or_args: T.untyped, args: T::Hash[Symbol, T.untyped]).void}
+      def const(name, cls_or_args, args={})
+        if (cls_or_args.is_a?(Hash) && cls_or_args.key?(:immutable)) || args.key?(:immutable)
+          Kernel.raise ArgumentError.new("Cannot pass 'immutable' argument when using 'const' keyword to define a prop")
+        end
+
+        if cls_or_args.is_a?(Hash)
+          cls_or_args[:immutable] = true
+        else
+          args[:immutable] = true
+        end
+
+        # Must be kept in sync with the implementation in `prop`. Kept separate to avoid creating a dependency between
+        # `const` and `prop`.
+        cls_or_args = T::Utils.coerce(cls_or_args) if !cls_or_args.is_a?(Module)
+        decorator.prop_defined(name, cls_or_args, args)
+      end
+
+      def included(child)
+        child.extend(T::Props::Const::ClassMethods)
+        super
+      end
+
+      def prepended(child)
+        child.extend(T::Props::Const::ClassMethods)
+        super
+      end
+
+      def extended(child)
+        child.extend(T::Props::Const::ClassMethods)
+        super
+      end
+
+      def inherited(child)
+        child.extend(T::Props::Const::ClassMethods)
+        super
+      end
+    end
+    mixes_in_class_methods(ClassMethods)
+  end
+
   module ClassMethods
     extend T::Sig
     extend T::Helpers
-
-    def props
-      decorator.props
-    end
-    def plugins
-      @plugins ||= []
-    end
-
-    def decorator_class
-      Decorator
-    end
-
-    def decorator
-      @decorator ||= decorator_class.new(self)
-    end
-    def reload_decorator!
-      @decorator = decorator_class.new(self)
-    end
-
-    # Define a new property. See {file:README.md} for some concrete
-    #  examples.
-    #
-    # Defining a property defines a method with the same name as the
-    # property, that returns the current value, and a `prop=` method
-    # to set its value. Properties will be inherited by subclasses of
-    # a document class.
-    #
-    # @param name [Symbol] The name of this property
-    # @param cls [Class,T::Types::Base] The type of this
-    #   property. If the type is itself a `Document` subclass, this
-    #   property will be recursively serialized/deserialized.
-    # @param rules [Hash] Options to control this property's behavior.
-    # @option rules [T::Boolean,Symbol] :optional If `true`, this property
-    #   is never required to be set before an instance is serialized.
-    #   If `:on_load` (default), when this property is missing or nil, a
-    #   new model cannot be saved, and an existing model can only be
-    #   saved if the property was already missing when it was loaded.
-    #   If `false`, when the property is missing/nil after deserialization, it
-    #   will be set to the default value (as defined by the `default` or
-    #   `factory` option) or will raise if they are not present.
-    #   Deprecated: For `Model`s, if `:optional` is set to the special value
-    #   `:existing`, the property can be saved as nil even if it was
-    #   deserialized with a non-nil value. (Deprecated because there should
-    #   never be a need for this behavior; the new behavior of non-optional
-    #   properties should be sufficient.)
-    # @option rules [Array] :enum An array of legal values; The
-    #  property is required to take on one of those values.
-    # @option rules [T::Boolean] :dont_store If true, this property will
-    #   not be saved on the hash resulting from
-    #   {T::Props::Serializable#serialize}
-    # @option rules [Object] :ifunset A value to be returned if this
-    #   property is requested but has never been set (is set to
-    #   `nil`). It is applied at property-access time, and never saved
-    #   back onto the object or into the database.
-    #
-    #   ``:ifunset`` is considered **DEPRECATED** and should not be used
-    #    in new code, in favor of just setting a default value.
-    # @option rules [Model, Symbol, Proc] :foreign A model class that this
-    #  property is a reference to. Passing `:foreign` will define a
-    #  `:"#{name}_"` method, that will load and return the
-    #  corresponding foreign model.
-    #
-    #  A symbol can be passed to avoid load-order dependencies; It
-    #  will be lazily resolved relative to the enclosing module of the
-    #  defining class.
-    #
-    #  A callable (proc or method) can be passed to dynamically specify the
-    #  foreign model. This will be passed the object instance so that other
-    #  properties of the object can be used to determine the relevant model
-    #  class. It should return a string/symbol class name or the foreign model
-    #  class directly.
-    #
-    # @option rules [Object] :default A default value that will be set
-    #   by `#initialize` if none is provided in the initialization
-    #   hash. This will not affect objects loaded by {.from_hash}.
-    # @option rules [Proc] :factory A `Proc` that will be called to
-    #   generate an initial value for this prop on `#initialize`, if
-    #   none is provided.
-    # @option rules [T::Boolean] :immutable If true, this prop cannot be
-    #   modified after an instance is created or loaded from a hash.
-    # @option rules [T::Boolean] :override It is an error to redeclare a
-    #   `prop` that has already been declared (including on a
-    #   superclass), unless `:override` is set to `true`.
-    # @option rules [Symbol, Array] :redaction A redaction directive that may
-    #   be passed to Chalk::Tools::RedactionUtils.redact_with_directive to
-    #   sanitize this parameter for display. Will define a
-    #   `:"#{name}_redacted"` method, which will return the value in sanitized
-    #   form.
-    #
-    # @return [void]
-    sig {params(name: Symbol, cls: T.untyped, rules: T.untyped).void}
-    def prop(name, cls, rules={})
-      cls = T::Utils.coerce(cls) if !cls.is_a?(Module)
-      decorator.prop_defined(name, cls, rules)
-    end
-
-    # Validates the value of the specified prop. This method allows the caller to
-    #  validate a value for a prop without having to set the data on the instance.
-    #  Throws if invalid.
-    #
-    # @param prop [Symbol]
-    # @param val [Object]
-    # @return [void]
-    def validate_prop_value(prop, val)
-      decorator.validate_prop_value(prop, val)
-    end
-
-    # Needs to be documented
-    def plugin(mod)
-      decorator.plugin(mod)
-    end
-
-    # Shorthand helper to define a `prop` with `immutable => true`
-    sig {params(name: Symbol, cls_or_args: T.untyped, args: T::Hash[Symbol, T.untyped]).void}
-    def const(name, cls_or_args, args={})
-      if (cls_or_args.is_a?(Hash) && cls_or_args.key?(:immutable)) || args.key?(:immutable)
-        Kernel.raise ArgumentError.new("Cannot pass 'immutable' argument when using 'const' keyword to define a prop")
-      end
-
-      if cls_or_args.is_a?(Hash)
-        self.prop(name, cls_or_args.merge(immutable: true))
-      else
-        self.prop(name, cls_or_args, args.merge(immutable: true))
-      end
-    end
+    include Prop::ClassMethods
+    include Const::ClassMethods
+    include Common::ClassMethods
 
     def included(child)
-      decorator.model_inherited(child)
+      child.extend(T::Props::ClassMethods)
       super
     end
 
     def prepended(child)
-      decorator.model_inherited(child)
+      child.extend(T::Props::ClassMethods)
       super
     end
 
     def extended(child)
-      decorator.model_inherited(child.singleton_class)
+      child.extend(T::Props::ClassMethods)
       super
     end
 
     def inherited(child)
-      decorator.model_inherited(child)
+      child.extend(T::Props::ClassMethods)
       super
     end
   end

--- a/gems/sorbet-runtime/lib/types/props/constructor.rb
+++ b/gems/sorbet-runtime/lib/types/props/constructor.rb
@@ -1,11 +1,16 @@
 # frozen_string_literal: true
 # typed: false
 
+module T::Props::ConstructorImpl
+  include T::Props::WeakConstructorImpl
+end
+
 module T::Props::Constructor
+  include T::Props::ConstructorImpl
   include T::Props::WeakConstructor
 end
 
-module T::Props::Constructor::DecoratorMethods
+module T::Props::ConstructorImpl::DecoratorMethods
   extend T::Sig
 
   # Set values for all props that have no defaults. Override what `WeakConstructor`

--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -22,7 +22,7 @@ class T::Props::Decorator
 
   sig {params(klass: T.untyped).void.checked(:never)}
   def initialize(klass)
-    @class = T.let(klass, T.all(Module, T::Props::ClassMethods))
+    @class = T.let(klass, T.all(Module, T::Props::Common::ClassMethods))
     @class.plugins.each do |mod|
       T::Props::Plugin::Private.apply_decorator_methods(mod, self)
     end
@@ -80,7 +80,7 @@ class T::Props::Decorator
   end
 
   # checked(:never) - O(prop accesses)
-  sig {returns(T.all(Module, T::Props::ClassMethods)).checked(:never)}
+  sig {returns(T.all(Module, T::Props::Common::ClassMethods)).checked(:never)}
   def decorated_class
     @class
   end
@@ -598,8 +598,7 @@ class T::Props::Decorator
   # prepended, or inherited.
   sig {params(child: Module).void.checked(:never)}
   def model_inherited(child)
-    child.extend(T::Props::ClassMethods)
-    child = T.cast(child, T.all(Module, T::Props::ClassMethods))
+    child = T.cast(child, T.all(Module, T::Props::Common::ClassMethods))
 
     child.plugins.concat(decorated_class.plugins)
     decorated_class.plugins.each do |mod|

--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -639,13 +639,13 @@ class T::Props::Decorator
     end
   end
 
-  sig {params(child: T.all(Module, T::Props::ClassMethods), prop: Symbol).returns(T::Boolean).checked(:never)}
+  sig {params(child: T.all(Module, T::Props::Common::ClassMethods), prop: Symbol).returns(T::Boolean).checked(:never)}
   private def clobber_getter?(child, prop)
     !!(child.decorator.method(:prop_get).owner != method(:prop_get).owner &&
        child.instance_method(prop).source_location&.first == __FILE__)
   end
 
-  sig {params(child: T.all(Module, T::Props::ClassMethods), prop: Symbol).returns(T::Boolean).checked(:never)}
+  sig {params(child: T.all(Module, T::Props::Common::ClassMethods), prop: Symbol).returns(T::Boolean).checked(:never)}
   private def clobber_setter?(child, prop)
     !!(child.decorator.method(:prop_set).owner != method(:prop_set).owner &&
        child.instance_method("#{prop}=").source_location&.first == __FILE__)

--- a/gems/sorbet-runtime/lib/types/props/plugin.rb
+++ b/gems/sorbet-runtime/lib/types/props/plugin.rb
@@ -2,7 +2,7 @@
 # typed: false
 
 module T::Props::Plugin
-  include T::Props
+  include T::Props::Common
   extend T::Helpers
 
   module ClassMethods

--- a/gems/sorbet-runtime/lib/types/props/private/setter_factory.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/setter_factory.rb
@@ -11,7 +11,7 @@ module T::Props
 
       sig do
         params(
-          klass: T.all(Module, T::Props::ClassMethods),
+          klass: T.all(Module, T::Props::Common::ClassMethods),
           prop: Symbol,
           rules: T::Hash[Symbol, T.untyped]
         )
@@ -53,7 +53,7 @@ module T::Props
           prop: Symbol,
           accessor_key: Symbol,
           non_nil_type: Module,
-          klass: T.all(Module, T::Props::ClassMethods),
+          klass: T.all(Module, T::Props::Common::ClassMethods),
         )
         .returns(SetterProc)
       end
@@ -76,7 +76,7 @@ module T::Props
           prop: Symbol,
           accessor_key: Symbol,
           non_nil_type: T::Types::Base,
-          klass: T.all(Module, T::Props::ClassMethods),
+          klass: T.all(Module, T::Props::Common::ClassMethods),
           validate: T.nilable(ValidateProc)
         )
         .returns(SetterProc)
@@ -107,7 +107,7 @@ module T::Props
           prop: Symbol,
           accessor_key: Symbol,
           non_nil_type: Module,
-          klass: T.all(Module, T::Props::ClassMethods),
+          klass: T.all(Module, T::Props::Common::ClassMethods),
         )
         .returns(SetterProc)
       end
@@ -134,7 +134,7 @@ module T::Props
           prop: Symbol,
           accessor_key: Symbol,
           non_nil_type: T::Types::Base,
-          klass: T.all(Module, T::Props::ClassMethods),
+          klass: T.all(Module, T::Props::Common::ClassMethods),
           validate: T.nilable(ValidateProc),
         )
         .returns(SetterProc)
@@ -165,7 +165,7 @@ module T::Props
 
       sig do
         params(
-          klass: T.all(Module, T::Props::ClassMethods),
+          klass: T.all(Module, T::Props::Common::ClassMethods),
           prop: Symbol,
           type: T.any(T::Types::Base, Module),
           val: T.untyped,

--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # typed: false
 
-module T::Props::Serializable
+module T::Props::SerializableImpl
   include T::Props::Plugin
   # Required because we have special handling for `optional: false`
   include T::Props::Optional
@@ -176,7 +176,7 @@ end
 
 # NB: This must stay in the same file where T::Props::Serializable is defined due to
 # T::Props::Decorator#apply_plugin; see https://git.corp.stripe.com/stripe-internal/pay-server/blob/fc7f15593b49875f2d0499ffecfd19798bac05b3/chalk/odm/lib/chalk-odm/document_decorator.rb#L716-L717
-module T::Props::Serializable::DecoratorMethods
+module T::Props::SerializableImpl::DecoratorMethods
   include T::Props::HasLazilySpecializedMethods::DecoratorMethods
 
   VALID_RULE_KEYS = {dont_store: true, name: true, raise_on_nil_write: true}.freeze
@@ -346,7 +346,7 @@ end
 
 # NB: This must stay in the same file where T::Props::Serializable is defined due to
 # T::Props::Decorator#apply_plugin; see https://git.corp.stripe.com/stripe-internal/pay-server/blob/fc7f15593b49875f2d0499ffecfd19798bac05b3/chalk/odm/lib/chalk-odm/document_decorator.rb#L716-L717
-module T::Props::Serializable::ClassMethods
+module T::Props::SerializableImpl::ClassMethods
   def prop_by_serialized_forms
     @prop_by_serialized_forms ||= {}
   end
@@ -363,4 +363,9 @@ module T::Props::Serializable::ClassMethods
   def from_hash!(hash)
     self.decorator.from_hash(hash, true)
   end
+end
+
+module T::Props::Serializable
+  include T::Props
+  include T::Props::SerializableImpl
 end

--- a/gems/sorbet-runtime/lib/types/props/weak_constructor.rb
+++ b/gems/sorbet-runtime/lib/types/props/weak_constructor.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # typed: false
 
-module T::Props::WeakConstructor
+module T::Props::WeakConstructorImpl
   include T::Props::Optional
   extend T::Sig
 
@@ -19,7 +19,7 @@ module T::Props::WeakConstructor
   end
 end
 
-module T::Props::WeakConstructor::DecoratorMethods
+module T::Props::WeakConstructorImpl::DecoratorMethods
   extend T::Sig
 
   # Set values for all props that have no defaults. Ignore any not present.
@@ -64,4 +64,9 @@ module T::Props::WeakConstructor::DecoratorMethods
     end
     result
   end
+end
+
+module T::Props::WeakConstructor
+  include T::Props
+  include T::Props::WeakConstructorImpl
 end

--- a/gems/sorbet-runtime/lib/types/struct.rb
+++ b/gems/sorbet-runtime/lib/types/struct.rb
@@ -19,8 +19,8 @@ end
 
 class T::ImmutableStruct
   include T::Props::Const
-  include T::Props::Serializable
-  include T::Props::Constructor
+  include T::Props::SerializableImpl
+  include T::Props::ConstructorImpl
 
   def self.inherited(subclass)
     super(subclass)

--- a/gems/sorbet-runtime/lib/types/struct.rb
+++ b/gems/sorbet-runtime/lib/types/struct.rb
@@ -16,3 +16,30 @@ class T::Struct < T::InexactStruct
     end
   end
 end
+
+class T::ImmutableStruct
+  include T::Props::Const
+  include T::Props::Serializable
+  include T::Props::Constructor
+
+  def self.inherited(subclass)
+    super(subclass)
+    T::Private::ClassUtils.replace_method(subclass.singleton_class, :inherited) do |s|
+      super(s)
+      raise "#{self.name} is a subclass of T::ImmutableStruct and cannot be subclassed"
+    end
+  end
+
+  def self.include(mod)
+    if mod == T::Props::Prop || mod == T::Props
+      raise "#{self.name} is a subclass of T::ImmutableStruct and cannot include T::Props"
+    end
+
+    super
+  end
+
+  def initialize(hash={})
+    super
+    freeze
+  end
+end

--- a/rbi/sorbet/tprops.rbi
+++ b/rbi/sorbet/tprops.rbi
@@ -178,13 +178,16 @@ module T::Props::PrettyPrintable::DecoratorMethods
   extend T::Sig
 end
 
-module T::Props::SerializableImpl
-  def deserialize(hash, strict = nil); end
+module T::Props::With
   def recursive_stringify_keys(obj); end
-  def serialize(strict = nil); end
   sig {params(changed_props: T.untyped).returns(T.self_type)}
   def with(changed_props); end
   def with_existing_hash(changed_props, existing_hash:); end
+end
+
+module T::Props::SerializableImpl
+  def deserialize(hash, strict = nil); end
+  def serialize(strict = nil); end
   include T::Props::Optional
   include T::Props::Plugin
   include T::Props::PrettyPrintable
@@ -193,6 +196,7 @@ end
 
 module T::Props::Serializable
   include T::Props
+  include T::Props::With
   include T::Props::SerializableImpl
 end
 

--- a/rbi/sorbet/tprops.rbi
+++ b/rbi/sorbet/tprops.rbi
@@ -14,8 +14,8 @@ end
 
 class T::ImmutableStruct
   include T::Props::Const
-  include T::Props::Serializable
-  include T::Props::Constructor
+  include T::Props::SerializableImpl
+  include T::Props::ConstructorImpl
 end
 
 module T::Props
@@ -141,13 +141,23 @@ module T::Props::Optional::DecoratorMethods
   def valid_rule_key?(key); end
 end
 
-module T::Props::WeakConstructor
+module T::Props::WeakConstructorImpl
   def initialize(hash = nil); end
   include T::Props::Optional
 end
 
+module T::Props::WeakConstructor
+  include T::Props
+  include T::Props::WeakConstructorImpl
+end
+
+module T::Props::ConstructorImpl
+  include T::Props::WeakConstructorImpl
+end
+
 module T::Props::Constructor
   def initialize(hash = nil); end
+  include T::Props::ConstructorImpl
   include T::Props::WeakConstructor
 end
 
@@ -168,7 +178,7 @@ module T::Props::PrettyPrintable::DecoratorMethods
   extend T::Sig
 end
 
-module T::Props::Serializable
+module T::Props::SerializableImpl
   def deserialize(hash, strict = nil); end
   def recursive_stringify_keys(obj); end
   def serialize(strict = nil); end
@@ -178,10 +188,15 @@ module T::Props::Serializable
   include T::Props::Optional
   include T::Props::Plugin
   include T::Props::PrettyPrintable
-  mixes_in_class_methods(T::Props::Serializable::ClassMethods)
+  mixes_in_class_methods(T::Props::SerializableImpl::ClassMethods)
 end
 
-module T::Props::Serializable::DecoratorMethods
+module T::Props::Serializable
+  include T::Props
+  include T::Props::SerializableImpl
+end
+
+module T::Props::SerializableImpl::DecoratorMethods
   def add_prop_definition(prop, rules); end
   def extra_props(instance); end
   def from_hash(hash, strict = nil); end
@@ -196,7 +211,7 @@ module T::Props::Serializable::DecoratorMethods
   def valid_rule_key?(key); end
 end
 
-module T::Props::Serializable::ClassMethods
+module T::Props::SerializableImpl::ClassMethods
   def from_hash!(hash); end
   def from_hash(hash, strict = nil); end
   def prop_by_serialized_forms; end

--- a/rbi/sorbet/tprops.rbi
+++ b/rbi/sorbet/tprops.rbi
@@ -12,6 +12,12 @@ end
 class T::Struct < T::InexactStruct
 end
 
+class T::ImmutableStruct
+  include T::Props::Const
+  include T::Props::Serializable
+  include T::Props::Constructor
+end
+
 module T::Props
   extend T::Helpers
   mixes_in_class_methods(T::Props::ClassMethods)

--- a/rbi/sorbet/tprops.rbi
+++ b/rbi/sorbet/tprops.rbi
@@ -20,12 +20,19 @@ end
 
 module T::Props
   extend T::Helpers
+  include T::Props::Common
   mixes_in_class_methods(T::Props::ClassMethods)
 end
 
 module T::Props::Prop::ClassMethods
+  include T::Props::Common::ClassMethods
   sig {params(name: Symbol, cls: T.untyped, rules: T.untyped).void}
   def prop(name, cls, rules = nil); end
+end
+
+module T::Props::Prop
+  extend T::Helpers
+  mixes_in_class_methods(T::Props::Prop::ClassMethods)
 end
 
 module T::Props::Const
@@ -34,6 +41,7 @@ module T::Props::Const
 end
 
 module T::Props::Const::ClassMethods
+  include T::Props::Common::ClassMethods
   sig {params(name: Symbol, cls_or_args: T.untyped, args: T::Hash[Symbol, T.untyped]).void}
   def const(name, cls_or_args, args={}, &blk); end
 end

--- a/rbi/sorbet/tprops.rbi
+++ b/rbi/sorbet/tprops.rbi
@@ -17,11 +17,22 @@ module T::Props
   mixes_in_class_methods(T::Props::ClassMethods)
 end
 
-module T::Props::ClassMethods
-  sig {params(name: Symbol, cls_or_args: T.untyped, args: T::Hash[Symbol, T.untyped]).void}
-  def const(name, cls_or_args, args={}, &blk); end
+module T::Props::Prop::ClassMethods
   sig {params(name: Symbol, cls: T.untyped, rules: T.untyped).void}
   def prop(name, cls, rules = nil); end
+end
+
+module T::Props::Const
+  extend T::Helpers
+  mixes_in_class_methods(T::Props::Const::ClassMethods)
+end
+
+module T::Props::Const::ClassMethods
+  sig {params(name: Symbol, cls_or_args: T.untyped, args: T::Hash[Symbol, T.untyped]).void}
+  def const(name, cls_or_args, args={}, &blk); end
+end
+
+module T::Props::Common::ClassMethods
   def decorator; end
   def decorator_class; end
   def plugin(mod); end
@@ -29,6 +40,12 @@ module T::Props::ClassMethods
   def props; end
   def reload_decorator!; end
   def validate_prop_value(prop, val); end
+end
+
+module T::Props::ClassMethods
+  include T::Props::Prop::ClassMethods
+  include T::Props::Const::ClassMethods
+  include T::Props::Common::ClassMethods
 end
 
 module T::Props::CustomType
@@ -89,7 +106,7 @@ end
 
 module T::Props::Plugin
   extend T::Helpers
-  include T::Props
+  include T::Props::Common
   mixes_in_class_methods(T::Props::Plugin::ClassMethods)
 end
 

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -49,6 +49,11 @@ bool isTInexactStruct(const ast::ExpressionPtr &expr) {
     return struct_ != nullptr && struct_->cnst == core::Names::Constants::InexactStruct() && isT(struct_->scope);
 }
 
+bool isTImmutableStruct(const ast::ExpressionPtr &expr) {
+    auto *struct_ = ast::cast_tree<ast::UnresolvedConstantLit>(expr);
+    return struct_ != nullptr && struct_->cnst == core::Names::Constants::ImmutableStruct() && isT(struct_->scope);
+}
+
 bool isChalkODMDocument(const ast::ExpressionPtr &expr) {
     auto *document = ast::cast_tree<ast::UnresolvedConstantLit>(expr);
     if (document == nullptr || document->cnst != core::Names::Constants::Document()) {
@@ -67,6 +72,7 @@ enum class SyntacticSuperClass {
     TStruct,
     TInexactStruct,
     ChalkODMDocument,
+    TImmutableStruct,
 };
 
 bool knownNonModel(SyntacticSuperClass syntacticSuperClass) {
@@ -74,6 +80,7 @@ bool knownNonModel(SyntacticSuperClass syntacticSuperClass) {
         case SyntacticSuperClass::TStruct:
         case SyntacticSuperClass::TInexactStruct:
         case SyntacticSuperClass::ChalkODMDocument:
+        case SyntacticSuperClass::TImmutableStruct:
             return true;
         case SyntacticSuperClass::Unknown:
             return false;
@@ -84,6 +91,7 @@ bool knownNonDocument(SyntacticSuperClass syntacticSuperClass) {
     switch (syntacticSuperClass) {
         case SyntacticSuperClass::TStruct:
         case SyntacticSuperClass::TInexactStruct:
+        case SyntacticSuperClass::TImmutableStruct:
             return true;
         case SyntacticSuperClass::ChalkODMDocument:
         case SyntacticSuperClass::Unknown:
@@ -94,6 +102,7 @@ bool knownNonDocument(SyntacticSuperClass syntacticSuperClass) {
 bool wantTypedInitialize(SyntacticSuperClass syntacticSuperClass) {
     switch (syntacticSuperClass) {
         case SyntacticSuperClass::TStruct:
+        case SyntacticSuperClass::TImmutableStruct:
             return true;
         case SyntacticSuperClass::TInexactStruct:
         case SyntacticSuperClass::ChalkODMDocument:
@@ -595,6 +604,8 @@ void Prop::run(core::MutableContext ctx, ast::ClassDef *klass) {
             syntacticSuperClass = SyntacticSuperClass::TStruct;
         } else if (isTInexactStruct(superClass)) {
             syntacticSuperClass = SyntacticSuperClass::TInexactStruct;
+        } else if (isTImmutableStruct(superClass)) {
+            syntacticSuperClass = SyntacticSuperClass::TImmutableStruct;
         } else if (isChalkODMDocument(superClass)) {
             syntacticSuperClass = SyntacticSuperClass::ChalkODMDocument;
         }
@@ -609,7 +620,8 @@ void Prop::run(core::MutableContext ctx, ast::ClassDef *klass) {
             continue;
         }
         auto propInfo = parseProp(ctx, send);
-        if (!propInfo.has_value()) {
+        if (!propInfo.has_value() ||
+            (!propInfo->isImmutable && syntacticSuperClass == SyntacticSuperClass::TImmutableStruct)) {
             continue;
         }
         auto processed = processProp(ctx, propInfo.value(), propContext);

--- a/test/testdata/lsp/completion/constants_t.rb
+++ b/test/testdata/lsp/completion/constants_t.rb
@@ -3,7 +3,7 @@
 class A
   # TODO(jez) We should sort exact prefix matches ahead of fuzzy matches
   extend T::S # error-with-dupes: Unable to resolve
-  #          ^ completion: InexactStruct, Set, Sig, Struct
+  #          ^ completion: ImmutableStruct, InexactStruct, Set, Sig, Struct
   extend T::H # error-with-dupes: Unable to resolve
   #          ^ completion: Hash, Helpers
   extend T::G # error-with-dupes: Unable to resolve

--- a/test/testdata/packager/rbi_gen/__package.rbi-gen.exp
+++ b/test/testdata/packager/rbi_gen/__package.rbi-gen.exp
@@ -224,11 +224,15 @@ module RBIGen::Public::DefDelegator
 end
 class RBIGen::Public::CustomStruct
   include T::Props
+  include T::Props::Common
   const :bar, T.nilable(String)
   prop :foo, Integer
   sig {void}
   def my_method; end
   extend T::Props::ClassMethods
+  extend T::Props::Const::ClassMethods
+  extend T::Props::Prop::ClassMethods
+  extend T::Props::Common::ClassMethods
   extend T::Sig
 end
 class RBIGen::Public::ClassWithTypeParams

--- a/test/testdata/rewriter/prop.rb.symbol-table-raw.exp
+++ b/test/testdata/rewriter/prop.rb.symbol-table-raw.exp
@@ -2,7 +2,7 @@ class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
     method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=2:1 end=146:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <C <U AdvancedODM>> < <C <U Object>> (<C <U Props>>) @ Loc {file=test/testdata/rewriter/prop.rb start=38:1 end=38:18}
+  class <C <U AdvancedODM>> < <C <U Object>> (<C <U Props>>, <C <U Common>>) @ Loc {file=test/testdata/rewriter/prop.rb start=38:1 end=38:18}
     method <C <U AdvancedODM>>#<U array> (<blk>) -> AppliedType {       klass = <C <U Array>>       targs = [         <C <U Elem>> = T.untyped       ]     } @ Loc {file=test/testdata/rewriter/prop.rb start=43:5 end=43:23}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
     method <C <U AdvancedODM>>#<U array=> (array, <blk>) -> AppliedType {       klass = <C <U Array>>       targs = [         <C <U Elem>> = T.untyped       ]     } @ Loc {file=test/testdata/rewriter/prop.rb start=43:5 end=43:23}
@@ -101,7 +101,7 @@ class <C <U <root>>> < <C <U Object>> ()
     method <C <U AdvancedODM>>#<U t_nilable=> (t_nilable, <blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=41:5 end=41:39}
       argument t_nilable<> -> T.nilable(String) @ Loc {file=test/testdata/rewriter/prop.rb start=41:11 end=41:20}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <S <C <U AdvancedODM>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U ClassMethods>>) @ Loc {file=test/testdata/rewriter/prop.rb start=38:7 end=38:18}
+  class <S <C <U AdvancedODM>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U ClassMethods>>, <C <U ClassMethods>>, <C <U ClassMethods>>, <C <U ClassMethods>>) @ Loc {file=test/testdata/rewriter/prop.rb start=38:7 end=38:18}
     type-member(+) <S <C <U AdvancedODM>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U AdvancedODM>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=AdvancedODM) @ Loc {file=test/testdata/rewriter/prop.rb start=38:7 end=38:18}
     method <S <C <U AdvancedODM>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=38:1 end=62:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
@@ -116,7 +116,7 @@ class <C <U <root>>> < <C <U Object>> ()
       type-member(+) <C <U Chalk>>::<S <C <U ODM>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<C <U Chalk>>::<S <C <U ODM>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=Chalk::ODM) @ Loc {file=test/testdata/rewriter/prop.rb start=82:7 end=82:17}
   class <S <C <U Chalk>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> () @ Loc {file=test/testdata/rewriter/prop.rb start=82:7 end=82:12}
     type-member(+) <S <C <U Chalk>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U Chalk>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=Chalk) @ Loc {file=test/testdata/rewriter/prop.rb start=82:7 end=82:12}
-  class <C <U EncryptedProp>> < <C <U Object>> (<C <U Props>>) @ Loc {file=test/testdata/rewriter/prop.rb start=87:1 end=87:20}
+  class <C <U EncryptedProp>> < <C <U Object>> (<C <U Props>>, <C <U Common>>) @ Loc {file=test/testdata/rewriter/prop.rb start=87:1 end=87:20}
     method <C <U EncryptedProp>>#<U bar> (<blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=91:3 end=91:56}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
     method <C <U EncryptedProp>>#<U encrypted_bar> (<blk>) -> Opus::DB::Model::Mixins::Encryptable::EncryptedValue | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=91:3 end=91:56}
@@ -131,7 +131,7 @@ class <C <U <root>>> < <C <U Object>> ()
     method <C <U EncryptedProp>>#<U foo=> (foo, <blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=90:3 end=90:22}
       argument foo<> -> T.nilable(String) @ Loc {file=test/testdata/rewriter/prop.rb start=90:19 end=90:22}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <S <C <U EncryptedProp>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U ClassMethods>>) @ Loc {file=test/testdata/rewriter/prop.rb start=87:7 end=87:20}
+  class <S <C <U EncryptedProp>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U ClassMethods>>, <C <U ClassMethods>>, <C <U ClassMethods>>, <C <U ClassMethods>>) @ Loc {file=test/testdata/rewriter/prop.rb start=87:7 end=87:20}
     type-member(+) <S <C <U EncryptedProp>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U EncryptedProp>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=EncryptedProp) @ Loc {file=test/testdata/rewriter/prop.rb start=87:7 end=87:20}
     method <S <C <U EncryptedProp>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=87:1 end=92:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
@@ -174,7 +174,7 @@ class <C <U <root>>> < <C <U Object>> ()
       type-member(+) <C <U Opus>>::<S <C <U DB>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<C <U Opus>>::<S <C <U DB>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=Opus::DB) @ Loc {file=test/testdata/rewriter/prop.rb start=84:7 end=84:15}
   class <S <C <U Opus>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> () @ Loc {file=test/testdata/rewriter/prop.rb start=84:7 end=84:11}
     type-member(+) <S <C <U Opus>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U Opus>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=Opus) @ Loc {file=test/testdata/rewriter/prop.rb start=84:7 end=84:11}
-  class <C <U PropHelpers>> < <C <U Object>> (<C <U Props>>) @ Loc {file=test/testdata/rewriter/prop.rb start=64:1 end=64:18}
+  class <C <U PropHelpers>> < <C <U Object>> (<C <U Props>>, <C <U Common>>) @ Loc {file=test/testdata/rewriter/prop.rb start=64:1 end=64:18}
     method <C <U PropHelpers>>#<U created> (<blk>) -> Float @ Loc {file=test/testdata/rewriter/prop.rb start=69:3 end=69:15}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
     method <C <U PropHelpers>>#<U created=> (created, <blk>) -> Float @ Loc {file=test/testdata/rewriter/prop.rb start=69:3 end=69:15}
@@ -185,7 +185,7 @@ class <C <U <root>>> < <C <U Object>> ()
     method <C <U PropHelpers>>#<U token=> (token, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=68:3 end=68:13}
       argument token<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=68:3 end=68:8}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <S <C <U PropHelpers>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U ClassMethods>>) @ Loc {file=test/testdata/rewriter/prop.rb start=64:7 end=64:18}
+  class <S <C <U PropHelpers>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U ClassMethods>>, <C <U ClassMethods>>, <C <U ClassMethods>>, <C <U ClassMethods>>) @ Loc {file=test/testdata/rewriter/prop.rb start=64:7 end=64:18}
     type-member(+) <S <C <U PropHelpers>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U PropHelpers>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=PropHelpers) @ Loc {file=test/testdata/rewriter/prop.rb start=64:7 end=64:18}
     method <S <C <U PropHelpers>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=64:1 end=70:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
@@ -195,7 +195,7 @@ class <C <U <root>>> < <C <U Object>> ()
     method <S <C <U PropHelpers>> $1>#<U token_prop> (opts, <blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=66:3 end=66:31}
       argument opts<optional> @ Loc {file=test/testdata/rewriter/prop.rb start=66:23 end=66:27}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <C <U PropHelpers2>> < <C <U Object>> (<C <U Props>>) @ Loc {file=test/testdata/rewriter/prop.rb start=72:1 end=72:19}
+  class <C <U PropHelpers2>> < <C <U Object>> (<C <U Props>>, <C <U Common>>) @ Loc {file=test/testdata/rewriter/prop.rb start=72:1 end=72:19}
     method <C <U PropHelpers2>>#<U created> (<blk>) -> Float @ Loc {file=test/testdata/rewriter/prop.rb start=77:3 end=77:32}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
     method <C <U PropHelpers2>>#<U token> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=76:3 end=76:25}
@@ -203,7 +203,7 @@ class <C <U <root>>> < <C <U Object>> ()
     method <C <U PropHelpers2>>#<U token=> (token, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=76:3 end=76:25}
       argument token<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=76:15 end=76:20}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <S <C <U PropHelpers2>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U ClassMethods>>) @ Loc {file=test/testdata/rewriter/prop.rb start=72:7 end=72:19}
+  class <S <C <U PropHelpers2>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U ClassMethods>>, <C <U ClassMethods>>, <C <U ClassMethods>>, <C <U ClassMethods>>) @ Loc {file=test/testdata/rewriter/prop.rb start=72:7 end=72:19}
     type-member(+) <S <C <U PropHelpers2>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U PropHelpers2>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=PropHelpers2) @ Loc {file=test/testdata/rewriter/prop.rb start=72:7 end=72:19}
     method <S <C <U PropHelpers2>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=72:1 end=78:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
@@ -213,7 +213,7 @@ class <C <U <root>>> < <C <U Object>> ()
     method <S <C <U PropHelpers2>> $1>#<U timestamped_token_prop> (opts, <blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=74:3 end=74:43}
       argument opts<optional> @ Loc {file=test/testdata/rewriter/prop.rb start=74:35 end=74:39}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <C <U SomeODM>> < <C <U Object>> (<C <U Props>>) @ Loc {file=test/testdata/rewriter/prop.rb start=23:1 end=23:14}
+  class <C <U SomeODM>> < <C <U Object>> (<C <U Props>>, <C <U Common>>) @ Loc {file=test/testdata/rewriter/prop.rb start=23:1 end=23:14}
     method <C <U SomeODM>>#<U foo> (<blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=27:5 end=27:22}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
     method <C <U SomeODM>>#<U foo2> (<blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=30:5 end=30:13}
@@ -224,7 +224,7 @@ class <C <U <root>>> < <C <U Object>> ()
     method <C <U SomeODM>>#<U foo=> (foo, <blk>) -> String @ Loc {file=test/testdata/rewriter/prop.rb start=27:5 end=27:22}
       argument foo<> -> String @ Loc {file=test/testdata/rewriter/prop.rb start=27:11 end=27:14}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-  class <S <C <U SomeODM>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U ClassMethods>>, <C <U Sig>>) @ Loc {file=test/testdata/rewriter/prop.rb start=23:7 end=23:14}
+  class <S <C <U SomeODM>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U ClassMethods>>, <C <U ClassMethods>>, <C <U ClassMethods>>, <C <U ClassMethods>>, <C <U Sig>>) @ Loc {file=test/testdata/rewriter/prop.rb start=23:7 end=23:14}
     type-member(+) <S <C <U SomeODM>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U SomeODM>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=SomeODM) @ Loc {file=test/testdata/rewriter/prop.rb start=23:7 end=23:14}
     method <S <C <U SomeODM>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=23:1 end=33:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}

--- a/test/testdata/rewriter/struct.rb
+++ b/test/testdata/rewriter/struct.rb
@@ -120,3 +120,19 @@ class FullyQualifiedStructUsages
   Foo.new.a
   Bar.new.a
 end
+
+class Immutable < T::ImmutableStruct
+  prop :a, Integer
+# ^^^^ error: Method `prop` does not exist on `T.class_of(Immutable)`
+
+  const :b, String
+end
+
+class ImmutableTest
+  Immutable.new(a: 1, b: "foo")
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Unrecognized keyword argument `a` passed for method `Immutable#initialize`
+
+  obj = Immutable.new(b: "foo")
+  obj.b = "bar"
+    # ^^^ error: Method `b=` does not exist on `Immutable`
+end

--- a/test/testdata/rewriter/struct.rb
+++ b/test/testdata/rewriter/struct.rb
@@ -136,3 +136,6 @@ class ImmutableTest
   obj.b = "bar"
     # ^^^ error: Method `b=` does not exist on `Immutable`
 end
+
+Immutable.new(b: "foo").with(b: "bar")
+                      # ^^^^ error: Method `with` does not exist on `Immutable`

--- a/test/testdata/rewriter/struct.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/struct.rb.rewrite-tree.exp
@@ -493,4 +493,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     obj.b=("bar")
   end
+
+  <emptyTree>::<C Immutable>.new(:b, "foo").with(:b, "bar")
 end

--- a/test/testdata/rewriter/struct.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/struct.rb.rewrite-tree.exp
@@ -456,4 +456,41 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <emptyTree>::<C Bar>.new().a()
   end
+
+  class <emptyTree>::<C Immutable><<C <todo sym>>> < (<emptyTree>::<C T>::<C ImmutableStruct>)
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:b, <emptyTree>::<C String>).void()
+    end
+
+    def initialize<<todo method>>(b:, &<blk>)
+      begin
+        @b = ::T.let(b, <emptyTree>::<C String>)
+        nil
+      end
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.returns(<emptyTree>::<C String>)
+    end
+
+    def b<<todo method>>(&<blk>)
+      @b
+    end
+
+    ::Sorbet::Private::Static.keep_def(<self>, :initialize, :normal)
+
+    <self>.prop(:a, <emptyTree>::<C Integer>)
+
+    <self>.const(:b, <emptyTree>::<C String>, :without_accessors, true)
+
+    ::Sorbet::Private::Static.keep_def(<self>, :b, :attr_reader)
+  end
+
+  class <emptyTree>::<C ImmutableTest><<C <todo sym>>> < (::<todo sym>)
+    <emptyTree>::<C Immutable>.new(:a, 1, :b, "foo")
+
+    obj = <emptyTree>::<C Immutable>.new(:b, "foo")
+
+    obj.b=("bar")
+  end
 end

--- a/test/testdata/rewriter/struct.rb.symbol-table-raw.exp
+++ b/test/testdata/rewriter/struct.rb.symbol-table-raw.exp
@@ -1,6 +1,6 @@
 class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
-    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=2:1 end=122:4}
+    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=2:1 end=138:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
   class <C <U AccidentallyStruct>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=37:1 end=37:25}
     class <C <U AccidentallyStruct>>::<C <U A>> < <C <U Struct>> () @ Loc {file=test/testdata/rewriter/struct.rb start=42:5 end=42:31}
@@ -85,6 +85,22 @@ class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U FullyQualifiedStructUsages>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=115:7 end=115:33}
     type-member(+) <S <C <U FullyQualifiedStructUsages>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U FullyQualifiedStructUsages>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=FullyQualifiedStructUsages) @ Loc {file=test/testdata/rewriter/struct.rb start=115:7 end=115:33}
     method <S <C <U FullyQualifiedStructUsages>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=115:1 end=122:4}
+      argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+  class <C <U Immutable>> < <C <U T>>::<C <U ImmutableStruct>> () @ Loc {file=test/testdata/rewriter/struct.rb start=124:1 end=124:37}
+    field <C <U Immutable>>#<U @b> -> String @ Loc {file=test/testdata/rewriter/struct.rb start=128:10 end=128:11}
+    method <C <U Immutable>>#<U b> (<blk>) -> String @ Loc {file=test/testdata/rewriter/struct.rb start=128:3 end=128:19}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+    method <C <U Immutable>>#<U initialize> (b, <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/rewriter/struct.rb start=124:1 end=124:37}
+      argument b<keyword> -> String @ Loc {file=test/testdata/rewriter/struct.rb start=128:3 end=128:19}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+  class <S <C <U Immutable>> $1>[<C <U <AttachedClass>>>] < <C <U T>>::<S <C <U ImmutableStruct>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=124:7 end=124:16}
+    type-member(+) <S <C <U Immutable>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U Immutable>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=Immutable) @ Loc {file=test/testdata/rewriter/struct.rb start=124:7 end=124:16}
+    method <S <C <U Immutable>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=124:1 end=129:4}
+      argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+  class <C <U ImmutableTest>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=131:1 end=131:20}
+  class <S <C <U ImmutableTest>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=131:7 end=131:20}
+    type-member(+) <S <C <U ImmutableTest>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U ImmutableTest>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=ImmutableTest) @ Loc {file=test/testdata/rewriter/struct.rb start=131:7 end=131:20}
+    method <S <C <U ImmutableTest>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=131:1 end=138:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
   class <C <U InvalidMember>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=45:1 end=45:20}
     class <C <U InvalidMember>>::<C <U A>> < <C <U Struct>> () @ Loc {file=test/testdata/rewriter/struct.rb start=46:3 end=46:24}

--- a/test/testdata/rewriter/struct.rb.symbol-table-raw.exp
+++ b/test/testdata/rewriter/struct.rb.symbol-table-raw.exp
@@ -1,6 +1,6 @@
 class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
-    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=2:1 end=138:4}
+    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=2:1 end=140:39}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
   class <C <U AccidentallyStruct>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=37:1 end=37:25}
     class <C <U AccidentallyStruct>>::<C <U A>> < <C <U Struct>> () @ Loc {file=test/testdata/rewriter/struct.rb start=42:5 end=42:31}

--- a/test/testdata/rewriter/t_struct/default.rb
+++ b/test/testdata/rewriter/t_struct/default.rb
@@ -12,6 +12,6 @@ Default.new(foo: "no")
 T.reveal_type(Default.new(foo: 3).foo) # error: Revealed type: `Integer`
 
 class Bad < T::Struct
-  prop :no_type_on_prop  # error: Not enough arguments provided for method `T::Props::ClassMethods#prop`
-  const :no_type_on_const  # error: Not enough arguments provided for method `T::Props::ClassMethods#const`
+  prop :no_type_on_prop  # error: Not enough arguments provided for method `T::Props::Prop::ClassMethods#prop`
+  const :no_type_on_const  # error: Not enough arguments provided for method `T::Props::Const::ClassMethods#const`
 end


### PR DESCRIPTION
This PR adds the `T::ImmutableStruct` class. This class is very similar to a regular `T::Struct`, but does not have the `prop` method defined and all objects created are frozen by default.

The most impactful change is the first commit. Let me know if you have alternatives on how to achieve this.

I recommend reviewing the changes per commit. The changes are
- Split the `T::Props` module into three separates modules `Common`, `Prop` and `Const`. The purpose of the split is to allow the inclusion a granular inclusion of `Const` or `Prop` with the common functionality needed for both, while trying to minimize breaking changes as much as possible (i.e.: any class including `T::Props` should continue to work the same)
- The `Serializable` module had an expectation that `Props` would always be included as well, through the inclusion of `Plugin`. This is the only breaking change I was not able to avoid, since we wanted the immutable structs to have serialization functionality, but not `prop`. Classes that include `Serializable` now need to explicitly include `T::Props` or `T::Const` and this commit makes that change in the tests
- Add the `T::ImmutableStruct` class, including only `Const` and preventing folks from including `T::Props` or `T::Props::Prop`, which would defeat its purpose
- Add support for `T::ImmutableStruct` in the prop rewriter to get the correct signatures for the `initialize` method

### Motivation

Having the implementation of immutable structs is useful for working with value objects, which should not be mutable by default. With this implementation, incorrect usage of `T::ImmutableStruct`, such as invoking `prop` or trying to change the value of an existing `prop`, is caught in static analysis.

The proposal to have this built into `sorbet-runtime` is because of the coupling with the prop rewriter, which can only add the correct `initialize` signature for known built-in structs.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.