### PR TITLE
Improve error message for type_member bounds

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2215,16 +2215,14 @@ class ResolveTypeMembersAndFieldsWalk {
             if (!core::Types::isSubType(ctx, parentType->lowerBound, memberType->lowerBound)) {
                 auto errLoc = lowerBoundTypeLoc.exists() ? lowerBoundTypeLoc : ctx.locAt(rhs->loc);
                 if (auto e = ctx.state.beginError(errLoc, core::errors::Resolver::ParentTypeBoundsMismatch)) {
-                    e.setHeader("The `{}` type bound `{}` is lower than the `{}` type bound of `{}` for {} `{}`",
-                                data->flags.isFixed ? "fixed:" : "lower:", memberType->lowerBound.show(ctx),
-                                parentData->flags.isFixed ? "fixed:" : "lower:", parentType->lowerBound.show(ctx),
+                    e.setHeader("The `{}` type bound `{}` must be {} the parent's `{}` type bound `{}` "
+                                "for {} `{}`",
+                                data->flags.isFixed ? "fixed" : "lower", memberType->lowerBound.show(ctx),
+                                parentData->flags.isFixed ? "equivalent to" : "a supertype of",
+                                parentData->flags.isFixed ? "fixed" : "lower", parentType->lowerBound.show(ctx),
                                 rhs->fun.show(ctx), data->name.show(ctx));
                     e.addErrorLine(parentMember.data(ctx)->loc(), "`{}` defined in parent here",
                                    parentMember.show(ctx));
-                    if (parentData->flags.isFixed) {
-                        e.addErrorNote("Because `{}` specified `{}`, `{}` must specify an equivalent type",
-                                       parentMember.show(ctx), "fixed:", lhs.show(ctx));
-                    }
                     if (lowerBoundTypeLoc.exists()) {
                         auto replacementType = ctx.state.suggestUnsafe.has_value() ? core::Types::untypedUntracked()
                                                                                    : parentType->lowerBound;
@@ -2235,16 +2233,14 @@ class ResolveTypeMembersAndFieldsWalk {
             if (!core::Types::isSubType(ctx, memberType->upperBound, parentType->upperBound)) {
                 auto errLoc = upperBoundTypeLoc.exists() ? upperBoundTypeLoc : ctx.locAt(rhs->loc);
                 if (auto e = ctx.state.beginError(errLoc, core::errors::Resolver::ParentTypeBoundsMismatch)) {
-                    e.setHeader("The `{}` type bound `{}` is higher than the `{}` type bound of `{}` for {} `{}`",
-                                data->flags.isFixed ? "fixed:" : "upper:", memberType->upperBound.show(ctx),
-                                parentData->flags.isFixed ? "fixed:" : "upper:", parentType->upperBound.show(ctx),
+                    e.setHeader("The `{}` type bound `{}` must be {} the parent's `{}` type bound `{}` "
+                                "for {} `{}`",
+                                data->flags.isFixed ? "fixed" : "upper", memberType->upperBound.show(ctx),
+                                parentData->flags.isFixed ? "equivalent to" : "a subtype of",
+                                parentData->flags.isFixed ? "fixed" : "upper", parentType->upperBound.show(ctx),
                                 rhs->fun.show(ctx), data->name.show(ctx));
                     e.addErrorLine(parentMember.data(ctx)->loc(), "`{}` defined in parent here",
                                    parentMember.show(ctx));
-                    if (parentData->flags.isFixed) {
-                        e.addErrorNote("Because `{}` specified `{}`, `{}` must specify an equivalent type",
-                                       parentMember.show(ctx), "fixed:", lhs.show(ctx));
-                    }
                     if (upperBoundTypeLoc.exists()) {
                         auto replacementType = ctx.state.suggestUnsafe.has_value() ? core::Types::untypedUntracked()
                                                                                    : parentType->upperBound;
@@ -2258,9 +2254,8 @@ class ResolveTypeMembersAndFieldsWalk {
         // This will be a no-op in the case that the type member is fixed.
         if (!core::Types::isSubType(ctx, memberType->lowerBound, memberType->upperBound)) {
             if (auto e = ctx.beginError(rhs->loc, core::errors::Resolver::InvalidTypeMemberBounds)) {
-                e.setHeader("The `{}` type bound `{}` is not a subtype of the `{}` type bound `{}` for `{}`",
-                            "lower:", memberType->lowerBound.show(ctx), "upper:", memberType->upperBound.show(ctx),
-                            lhs.show(ctx));
+                e.setHeader("The `{}` type bound `{}` is not a subtype of the `{}` type bound `{}` for `{}`", "lower",
+                            memberType->lowerBound.show(ctx), "upper", memberType->upperBound.show(ctx), lhs.show(ctx));
             }
         }
 

--- a/test/cli/type_member_bounds/test.out
+++ b/test/cli/type_member_bounds/test.out
@@ -1,0 +1,223 @@
+test.rb:24: The `fixed:` type bound `Child1` is lower than the `fixed:` type bound of `Parent1` for type_member `A1` https://srb.help/5053
+    24 |  A1 = type_member {{fixed: Child1}}
+                                    ^^^^^^
+    test.rb:10: `Parent2::A1` defined in parent here
+    10 |  A1 = type_member {{fixed: Parent1}}
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Note:
+    Because `Parent2::A1` specified `fixed:`, `Child2::A1` must specify an equivalent type
+  Autocorrect: Done
+    test.rb:24: Replaced with `Parent1`
+    24 |  A1 = type_member {{fixed: Child1}}
+                                    ^^^^^^
+
+test.rb:25: The `fixed:` type bound `GrandParent1` is higher than the `fixed:` type bound of `Parent1` for type_member `A2` https://srb.help/5053
+    25 |  A2 = type_member {{fixed: GrandParent1}}
+                                    ^^^^^^^^^^^^
+    test.rb:11: `Parent2::A2` defined in parent here
+    11 |  A2 = type_member {{fixed: Parent1}}
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Note:
+    Because `Parent2::A2` specified `fixed:`, `Child2::A2` must specify an equivalent type
+  Autocorrect: Done
+    test.rb:25: Replaced with `Parent1`
+    25 |  A2 = type_member {{fixed: GrandParent1}}
+                                    ^^^^^^^^^^^^
+
+test.rb:27: The `lower:` type bound `Child1` is lower than the `lower:` type bound of `Parent1` for type_member `B` https://srb.help/5053
+    27 |  B = type_member {{lower: Child1}}
+                                   ^^^^^^
+    test.rb:13: `Parent2::B` defined in parent here
+    13 |  B = type_member {{lower: Parent1}}
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    test.rb:27: Replaced with `Parent1`
+    27 |  B = type_member {{lower: Child1}}
+                                   ^^^^^^
+
+test.rb:29: The `upper:` type bound `GrandParent1` is higher than the `upper:` type bound of `Parent1` for type_member `C` https://srb.help/5053
+    29 |  C = type_member {{upper: GrandParent1}}
+                                   ^^^^^^^^^^^^
+    test.rb:15: `Parent2::C` defined in parent here
+    15 |  C = type_member {{upper: Parent1}}
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    test.rb:29: Replaced with `Parent1`
+    29 |  C = type_member {{upper: GrandParent1}}
+                                   ^^^^^^^^^^^^
+
+test.rb:31: The `lower:` type bound `Child1` is lower than the `fixed:` type bound of `Parent1` for type_template `D1` https://srb.help/5053
+    31 |  D1 = type_template {{lower: Child1, upper: Parent1}}
+                                      ^^^^^^
+    test.rb:17: `T.class_of(Parent2)::D1` defined in parent here
+    17 |  D1 = type_template {{fixed: Parent1}}
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Note:
+    Because `T.class_of(Parent2)::D1` specified `fixed:`, `T.class_of(Child2)::D1` must specify an equivalent type
+  Autocorrect: Done
+    test.rb:31: Replaced with `Parent1`
+    31 |  D1 = type_template {{lower: Child1, upper: Parent1}}
+                                      ^^^^^^
+
+test.rb:32: The `upper:` type bound `GrandParent1` is higher than the `fixed:` type bound of `Parent1` for type_template `D2` https://srb.help/5053
+    32 |  D2 = type_template {{lower: Parent1, upper: GrandParent1}}
+                                                      ^^^^^^^^^^^^
+    test.rb:18: `T.class_of(Parent2)::D2` defined in parent here
+    18 |  D2 = type_template {{fixed: Parent1}}
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Note:
+    Because `T.class_of(Parent2)::D2` specified `fixed:`, `T.class_of(Child2)::D2` must specify an equivalent type
+  Autocorrect: Done
+    test.rb:32: Replaced with `Parent1`
+    32 |  D2 = type_template {{lower: Parent1, upper: GrandParent1}}
+                                                      ^^^^^^^^^^^^
+Errors: 6
+
+--------------------------------------------------------------------------
+
+# typed: true
+
+class GrandParent1; end
+class Parent1 < GrandParent1; end
+class Child1 < Parent1; end
+
+class Parent2
+  extend T::Generic
+
+  A1 = type_member {{fixed: Parent1}}
+  A2 = type_member {{fixed: Parent1}}
+
+  B = type_member {{lower: Parent1}}
+
+  C = type_member {{upper: Parent1}}
+
+  D1 = type_template {{fixed: Parent1}}
+  D2 = type_template {{fixed: Parent1}}
+end
+
+class Child2 < Parent2
+  extend T::Generic
+
+  A1 = type_member {{fixed: Parent1}}
+  A2 = type_member {{fixed: Parent1}}
+
+  B = type_member {{lower: Parent1}}
+
+  C = type_member {{upper: Parent1}}
+
+  D1 = type_template {{lower: Parent1, upper: Parent1}}
+  D2 = type_template {{lower: Parent1, upper: Parent1}}
+end
+
+--------------------------------------------------------------------------
+
+test.rb:24: The `fixed:` type bound `Child1` is lower than the `fixed:` type bound of `Parent1` for type_member `A1` https://srb.help/5053
+    24 |  A1 = type_member {{fixed: Child1}}
+                                    ^^^^^^
+    test.rb:10: `Parent2::A1` defined in parent here
+    10 |  A1 = type_member {{fixed: Parent1}}
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Note:
+    Because `Parent2::A1` specified `fixed:`, `Child2::A1` must specify an equivalent type
+  Autocorrect: Done
+    test.rb:24: Replaced with `T.untyped`
+    24 |  A1 = type_member {{fixed: Child1}}
+                                    ^^^^^^
+
+test.rb:25: The `fixed:` type bound `GrandParent1` is higher than the `fixed:` type bound of `Parent1` for type_member `A2` https://srb.help/5053
+    25 |  A2 = type_member {{fixed: GrandParent1}}
+                                    ^^^^^^^^^^^^
+    test.rb:11: `Parent2::A2` defined in parent here
+    11 |  A2 = type_member {{fixed: Parent1}}
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Note:
+    Because `Parent2::A2` specified `fixed:`, `Child2::A2` must specify an equivalent type
+  Autocorrect: Done
+    test.rb:25: Replaced with `T.untyped`
+    25 |  A2 = type_member {{fixed: GrandParent1}}
+                                    ^^^^^^^^^^^^
+
+test.rb:27: The `lower:` type bound `Child1` is lower than the `lower:` type bound of `Parent1` for type_member `B` https://srb.help/5053
+    27 |  B = type_member {{lower: Child1}}
+                                   ^^^^^^
+    test.rb:13: `Parent2::B` defined in parent here
+    13 |  B = type_member {{lower: Parent1}}
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    test.rb:27: Replaced with `T.untyped`
+    27 |  B = type_member {{lower: Child1}}
+                                   ^^^^^^
+
+test.rb:29: The `upper:` type bound `GrandParent1` is higher than the `upper:` type bound of `Parent1` for type_member `C` https://srb.help/5053
+    29 |  C = type_member {{upper: GrandParent1}}
+                                   ^^^^^^^^^^^^
+    test.rb:15: `Parent2::C` defined in parent here
+    15 |  C = type_member {{upper: Parent1}}
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    test.rb:29: Replaced with `T.untyped`
+    29 |  C = type_member {{upper: GrandParent1}}
+                                   ^^^^^^^^^^^^
+
+test.rb:31: The `lower:` type bound `Child1` is lower than the `fixed:` type bound of `Parent1` for type_template `D1` https://srb.help/5053
+    31 |  D1 = type_template {{lower: Child1, upper: Parent1}}
+                                      ^^^^^^
+    test.rb:17: `T.class_of(Parent2)::D1` defined in parent here
+    17 |  D1 = type_template {{fixed: Parent1}}
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Note:
+    Because `T.class_of(Parent2)::D1` specified `fixed:`, `T.class_of(Child2)::D1` must specify an equivalent type
+  Autocorrect: Done
+    test.rb:31: Replaced with `T.untyped`
+    31 |  D1 = type_template {{lower: Child1, upper: Parent1}}
+                                      ^^^^^^
+
+test.rb:32: The `upper:` type bound `GrandParent1` is higher than the `fixed:` type bound of `Parent1` for type_template `D2` https://srb.help/5053
+    32 |  D2 = type_template {{lower: Parent1, upper: GrandParent1}}
+                                                      ^^^^^^^^^^^^
+    test.rb:18: `T.class_of(Parent2)::D2` defined in parent here
+    18 |  D2 = type_template {{fixed: Parent1}}
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Note:
+    Because `T.class_of(Parent2)::D2` specified `fixed:`, `T.class_of(Child2)::D2` must specify an equivalent type
+  Autocorrect: Done
+    test.rb:32: Replaced with `T.untyped`
+    32 |  D2 = type_template {{lower: Parent1, upper: GrandParent1}}
+                                                      ^^^^^^^^^^^^
+Errors: 6
+
+--------------------------------------------------------------------------
+
+# typed: true
+
+class GrandParent1; end
+class Parent1 < GrandParent1; end
+class Child1 < Parent1; end
+
+class Parent2
+  extend T::Generic
+
+  A1 = type_member {{fixed: Parent1}}
+  A2 = type_member {{fixed: Parent1}}
+
+  B = type_member {{lower: Parent1}}
+
+  C = type_member {{upper: Parent1}}
+
+  D1 = type_template {{fixed: Parent1}}
+  D2 = type_template {{fixed: Parent1}}
+end
+
+class Child2 < Parent2
+  extend T::Generic
+
+  A1 = type_member {{fixed: T.untyped}}
+  A2 = type_member {{fixed: T.untyped}}
+
+  B = type_member {{lower: T.untyped}}
+
+  C = type_member {{upper: T.untyped}}
+
+  D1 = type_template {{lower: T.untyped, upper: Parent1}}
+  D2 = type_template {{lower: Parent1, upper: T.untyped}}
+end

--- a/test/cli/type_member_bounds/test.out
+++ b/test/cli/type_member_bounds/test.out
@@ -1,30 +1,26 @@
-test.rb:24: The `fixed:` type bound `Child1` is lower than the `fixed:` type bound of `Parent1` for type_member `A1` https://srb.help/5053
+test.rb:24: The `fixed` type bound `Child1` must be equivalent to the parent's `fixed` type bound `Parent1` for type_member `A1` https://srb.help/5053
     24 |  A1 = type_member {{fixed: Child1}}
                                     ^^^^^^
     test.rb:10: `Parent2::A1` defined in parent here
     10 |  A1 = type_member {{fixed: Parent1}}
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Note:
-    Because `Parent2::A1` specified `fixed:`, `Child2::A1` must specify an equivalent type
   Autocorrect: Done
     test.rb:24: Replaced with `Parent1`
     24 |  A1 = type_member {{fixed: Child1}}
                                     ^^^^^^
 
-test.rb:25: The `fixed:` type bound `GrandParent1` is higher than the `fixed:` type bound of `Parent1` for type_member `A2` https://srb.help/5053
+test.rb:25: The `fixed` type bound `GrandParent1` must be equivalent to the parent's `fixed` type bound `Parent1` for type_member `A2` https://srb.help/5053
     25 |  A2 = type_member {{fixed: GrandParent1}}
                                     ^^^^^^^^^^^^
     test.rb:11: `Parent2::A2` defined in parent here
     11 |  A2 = type_member {{fixed: Parent1}}
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Note:
-    Because `Parent2::A2` specified `fixed:`, `Child2::A2` must specify an equivalent type
   Autocorrect: Done
     test.rb:25: Replaced with `Parent1`
     25 |  A2 = type_member {{fixed: GrandParent1}}
                                     ^^^^^^^^^^^^
 
-test.rb:27: The `lower:` type bound `Child1` is lower than the `lower:` type bound of `Parent1` for type_member `B` https://srb.help/5053
+test.rb:27: The `lower` type bound `Child1` must be a supertype of the parent's `lower` type bound `Parent1` for type_member `B` https://srb.help/5053
     27 |  B = type_member {{lower: Child1}}
                                    ^^^^^^
     test.rb:13: `Parent2::B` defined in parent here
@@ -35,7 +31,7 @@ test.rb:27: The `lower:` type bound `Child1` is lower than the `lower:` type bou
     27 |  B = type_member {{lower: Child1}}
                                    ^^^^^^
 
-test.rb:29: The `upper:` type bound `GrandParent1` is higher than the `upper:` type bound of `Parent1` for type_member `C` https://srb.help/5053
+test.rb:29: The `upper` type bound `GrandParent1` must be a subtype of the parent's `upper` type bound `Parent1` for type_member `C` https://srb.help/5053
     29 |  C = type_member {{upper: GrandParent1}}
                                    ^^^^^^^^^^^^
     test.rb:15: `Parent2::C` defined in parent here
@@ -46,27 +42,23 @@ test.rb:29: The `upper:` type bound `GrandParent1` is higher than the `upper:` t
     29 |  C = type_member {{upper: GrandParent1}}
                                    ^^^^^^^^^^^^
 
-test.rb:31: The `lower:` type bound `Child1` is lower than the `fixed:` type bound of `Parent1` for type_template `D1` https://srb.help/5053
+test.rb:31: The `lower` type bound `Child1` must be equivalent to the parent's `fixed` type bound `Parent1` for type_template `D1` https://srb.help/5053
     31 |  D1 = type_template {{lower: Child1, upper: Parent1}}
                                       ^^^^^^
     test.rb:17: `T.class_of(Parent2)::D1` defined in parent here
     17 |  D1 = type_template {{fixed: Parent1}}
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Note:
-    Because `T.class_of(Parent2)::D1` specified `fixed:`, `T.class_of(Child2)::D1` must specify an equivalent type
   Autocorrect: Done
     test.rb:31: Replaced with `Parent1`
     31 |  D1 = type_template {{lower: Child1, upper: Parent1}}
                                       ^^^^^^
 
-test.rb:32: The `upper:` type bound `GrandParent1` is higher than the `fixed:` type bound of `Parent1` for type_template `D2` https://srb.help/5053
+test.rb:32: The `upper` type bound `GrandParent1` must be equivalent to the parent's `fixed` type bound `Parent1` for type_template `D2` https://srb.help/5053
     32 |  D2 = type_template {{lower: Parent1, upper: GrandParent1}}
                                                       ^^^^^^^^^^^^
     test.rb:18: `T.class_of(Parent2)::D2` defined in parent here
     18 |  D2 = type_template {{fixed: Parent1}}
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Note:
-    Because `T.class_of(Parent2)::D2` specified `fixed:`, `T.class_of(Child2)::D2` must specify an equivalent type
   Autocorrect: Done
     test.rb:32: Replaced with `Parent1`
     32 |  D2 = type_template {{lower: Parent1, upper: GrandParent1}}
@@ -111,33 +103,29 @@ end
 
 --------------------------------------------------------------------------
 
-test.rb:24: The `fixed:` type bound `Child1` is lower than the `fixed:` type bound of `Parent1` for type_member `A1` https://srb.help/5053
+test.rb:24: The `fixed` type bound `Child1` must be equivalent to the parent's `fixed` type bound `Parent1` for type_member `A1` https://srb.help/5053
     24 |  A1 = type_member {{fixed: Child1}}
                                     ^^^^^^
     test.rb:10: `Parent2::A1` defined in parent here
     10 |  A1 = type_member {{fixed: Parent1}}
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Note:
-    Because `Parent2::A1` specified `fixed:`, `Child2::A1` must specify an equivalent type
   Autocorrect: Done
     test.rb:24: Replaced with `T.untyped`
     24 |  A1 = type_member {{fixed: Child1}}
                                     ^^^^^^
 
-test.rb:25: The `fixed:` type bound `GrandParent1` is higher than the `fixed:` type bound of `Parent1` for type_member `A2` https://srb.help/5053
+test.rb:25: The `fixed` type bound `GrandParent1` must be equivalent to the parent's `fixed` type bound `Parent1` for type_member `A2` https://srb.help/5053
     25 |  A2 = type_member {{fixed: GrandParent1}}
                                     ^^^^^^^^^^^^
     test.rb:11: `Parent2::A2` defined in parent here
     11 |  A2 = type_member {{fixed: Parent1}}
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Note:
-    Because `Parent2::A2` specified `fixed:`, `Child2::A2` must specify an equivalent type
   Autocorrect: Done
     test.rb:25: Replaced with `T.untyped`
     25 |  A2 = type_member {{fixed: GrandParent1}}
                                     ^^^^^^^^^^^^
 
-test.rb:27: The `lower:` type bound `Child1` is lower than the `lower:` type bound of `Parent1` for type_member `B` https://srb.help/5053
+test.rb:27: The `lower` type bound `Child1` must be a supertype of the parent's `lower` type bound `Parent1` for type_member `B` https://srb.help/5053
     27 |  B = type_member {{lower: Child1}}
                                    ^^^^^^
     test.rb:13: `Parent2::B` defined in parent here
@@ -148,7 +136,7 @@ test.rb:27: The `lower:` type bound `Child1` is lower than the `lower:` type bou
     27 |  B = type_member {{lower: Child1}}
                                    ^^^^^^
 
-test.rb:29: The `upper:` type bound `GrandParent1` is higher than the `upper:` type bound of `Parent1` for type_member `C` https://srb.help/5053
+test.rb:29: The `upper` type bound `GrandParent1` must be a subtype of the parent's `upper` type bound `Parent1` for type_member `C` https://srb.help/5053
     29 |  C = type_member {{upper: GrandParent1}}
                                    ^^^^^^^^^^^^
     test.rb:15: `Parent2::C` defined in parent here
@@ -159,27 +147,23 @@ test.rb:29: The `upper:` type bound `GrandParent1` is higher than the `upper:` t
     29 |  C = type_member {{upper: GrandParent1}}
                                    ^^^^^^^^^^^^
 
-test.rb:31: The `lower:` type bound `Child1` is lower than the `fixed:` type bound of `Parent1` for type_template `D1` https://srb.help/5053
+test.rb:31: The `lower` type bound `Child1` must be equivalent to the parent's `fixed` type bound `Parent1` for type_template `D1` https://srb.help/5053
     31 |  D1 = type_template {{lower: Child1, upper: Parent1}}
                                       ^^^^^^
     test.rb:17: `T.class_of(Parent2)::D1` defined in parent here
     17 |  D1 = type_template {{fixed: Parent1}}
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Note:
-    Because `T.class_of(Parent2)::D1` specified `fixed:`, `T.class_of(Child2)::D1` must specify an equivalent type
   Autocorrect: Done
     test.rb:31: Replaced with `T.untyped`
     31 |  D1 = type_template {{lower: Child1, upper: Parent1}}
                                       ^^^^^^
 
-test.rb:32: The `upper:` type bound `GrandParent1` is higher than the `fixed:` type bound of `Parent1` for type_template `D2` https://srb.help/5053
+test.rb:32: The `upper` type bound `GrandParent1` must be equivalent to the parent's `fixed` type bound `Parent1` for type_template `D2` https://srb.help/5053
     32 |  D2 = type_template {{lower: Parent1, upper: GrandParent1}}
                                                       ^^^^^^^^^^^^
     test.rb:18: `T.class_of(Parent2)::D2` defined in parent here
     18 |  D2 = type_template {{fixed: Parent1}}
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Note:
-    Because `T.class_of(Parent2)::D2` specified `fixed:`, `T.class_of(Child2)::D2` must specify an equivalent type
   Autocorrect: Done
     test.rb:32: Replaced with `T.untyped`
     32 |  D2 = type_template {{lower: Parent1, upper: GrandParent1}}

--- a/test/cli/type_member_bounds/test.rb
+++ b/test/cli/type_member_bounds/test.rb
@@ -1,0 +1,33 @@
+# typed: true
+
+class GrandParent1; end
+class Parent1 < GrandParent1; end
+class Child1 < Parent1; end
+
+class Parent2
+  extend T::Generic
+
+  A1 = type_member {{fixed: Parent1}}
+  A2 = type_member {{fixed: Parent1}}
+
+  B = type_member {{lower: Parent1}}
+
+  C = type_member {{upper: Parent1}}
+
+  D1 = type_template {{fixed: Parent1}}
+  D2 = type_template {{fixed: Parent1}}
+end
+
+class Child2 < Parent2
+  extend T::Generic
+
+  A1 = type_member {{fixed: Child1}}
+  A2 = type_member {{fixed: GrandParent1}}
+
+  B = type_member {{lower: Child1}}
+
+  C = type_member {{upper: GrandParent1}}
+
+  D1 = type_template {{lower: Child1, upper: Parent1}}
+  D2 = type_template {{lower: Parent1, upper: GrandParent1}}
+end

--- a/test/cli/type_member_bounds/test.sh
+++ b/test/cli/type_member_bounds/test.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+cwd="$(pwd)"
+infile="$cwd/test/cli/type_member_bounds/test.rb"
+
+tmp="$(mktemp -d)"
+
+(
+  cp "$infile" "$tmp"
+
+  cd "$tmp" || exit 1
+  if "$cwd/main/sorbet" --silence-dev-message -a test.rb 2>&1; then
+    echo "Expected to fail!"
+    exit 1
+  fi
+
+  echo
+  echo --------------------------------------------------------------------------
+  echo
+
+  # Also cat the file, to make that the autocorrect applied
+  cat test.rb
+
+  rm test.rb
+)
+
+echo
+echo --------------------------------------------------------------------------
+echo
+
+(
+  cp "$infile" "$tmp"
+
+  cd "$tmp" || exit 1
+  if "$cwd/main/sorbet" --silence-dev-message --suggest-unsafe -a test.rb 2>&1; then
+    echo "Expected to fail!"
+    exit 1
+  fi
+
+  echo
+  echo --------------------------------------------------------------------------
+  echo
+
+  # Also cat the file, to make that the autocorrect applied
+  cat test.rb
+
+  rm test.rb
+)
+
+rm -r "$tmp"

--- a/test/testdata/infer/generics/bounds.rb
+++ b/test/testdata/infer/generics/bounds.rb
@@ -26,7 +26,7 @@ class A1
 
   # should fail: the bounds are invalid
   T5 = type_member {{lower: Animal, upper: Persian}}
-     # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Animal` is not a subtype of `Persian`
+     # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: The `lower` type bound `Animal` is not a subtype of the `upper` type bound `Persian` for `A1::T5`
 
   # should fail: type member used as an argument to another type
   T6 = type_member {{fixed: T::Array[T1]}}
@@ -53,7 +53,7 @@ class A1
 
   # should fail: multiple upper and lower bounds specified
   T12 = type_member {{lower: Integer, lower: String, upper: BasicObject, upper: TrueClass}}
-      # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `String` is not a subtype of `TrueClass`
+      # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: The `lower` type bound `String` is not a subtype of the `upper` type bound `TrueClass` for `A1::T12`
                                     # ^^^^^ error: Hash key `lower` is duplicated
                                                                        # ^^^^^ error: Hash key `upper` is duplicated
 

--- a/test/testdata/infer/generics/bounds_super.rb
+++ b/test/testdata/infer/generics/bounds_super.rb
@@ -20,8 +20,8 @@ end
 class B2 < A
   extend T::Generic
   T1 = type_member {{fixed: String}}
-     # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: parent lower bound `Serval` is not a subtype of lower bound `String`
-     # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: upper bound `String` is not a subtype of parent upper bound `Animal`
+  #                         ^^^^^^ error: The `fixed` type bound `String` must be a supertype of the parent's `lower` type bound `Serval` for type_member `T1`
+  #                         ^^^^^^ error: The `fixed` type bound `String` must be a subtype of the parent's `upper` type bound `Animal` for type_member `T1`
 end
 
 # should pass: the bounds are a refinement of the ones on A
@@ -34,13 +34,13 @@ end
 class C2 < A
   extend T::Generic
   T1 = type_member {{lower: Serval, upper: Object}}
-     # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: upper bound `Object` is not a subtype of parent upper bound `Animal`
+  #                                        ^^^^^^ error: The `upper` type bound `Object` must be a subtype of the parent's `upper` type bound `Animal` for type_member `T1`
 end
 
 # should fail: the implicit bounds of top and bottom are too wide for T1
 class D1 < A
   T1 = type_member
-     # ^^^^^^^^^^^ error: parent lower bound `Serval` is not a subtype of lower bound `T.noreturn`
-     # ^^^^^^^^^^^ error: upper bound `<top>` is not a subtype of parent upper bound `Animal`
+     # ^^^^^^^^^^^ error: The `lower` type bound `T.noreturn` must be a supertype of the parent's `lower` type bound `Serval` for type_member `T1`
+     # ^^^^^^^^^^^ error: The `upper` type bound `<top>` must be a subtype of the parent's `upper` type bound `Animal` for type_member `T1`
 end
 

--- a/test/testdata/resolver/type_member_fixed_order.rb
+++ b/test/testdata/resolver/type_member_fixed_order.rb
@@ -4,8 +4,8 @@
 class B < A
   extend T::Generic
   X = type_template {{fixed: String}}
-    # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: parent lower bound `Integer`
-    # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: upper bound `String`
+  #                          ^^^^^^ error: The `fixed` type bound `String` must be equivalent to the parent's `fixed` type bound `Integer` for type_template `X`
+  #                          ^^^^^^ error: The `fixed` type bound `String` must be equivalent to the parent's `fixed` type bound `Integer` for type_template `X`
 end
 
 class A

--- a/test/testdata/resolver/type_member_module_bound.rb
+++ b/test/testdata/resolver/type_member_module_bound.rb
@@ -12,8 +12,8 @@ class A
   include M
 
   Args = type_member {{fixed: NilClass}}
-       # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: parent lower bound `Bar` is not a subtype of lower bound `NilClass`
-       # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: upper bound `NilClass` is not a subtype of parent upper bound `Foo`
+  #                           ^^^^^^^^ error: The `fixed` type bound `NilClass` must be a supertype of the parent's `lower` type bound `Bar` for type_member `Args`
+  #                           ^^^^^^^^ error: The `fixed` type bound `NilClass` must be a subtype of the parent's `upper` type bound `Foo` for type_member `Args`
 end
 
 # Ensure that type_templates depend on the singleton mixins
@@ -22,8 +22,8 @@ class B
   extend M
 
   Args = type_template {{fixed: NilClass}}
-       # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: parent lower bound `Bar` is not a subtype of lower bound `NilClass`
-       # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: upper bound `NilClass` is not a subtype of parent upper bound `Foo`
+  #                             ^^^^^^^^ error: The `fixed` type bound `NilClass` must be a supertype of the parent's `lower` type bound `Bar` for type_template `Args`
+  #                             ^^^^^^^^ error: The `fixed` type bound `NilClass` must be a subtype of the parent's `upper` type bound `Foo` for type_template `Args`
 end
 
 module M
@@ -38,5 +38,5 @@ class C
   include M
 
   Args = type_member {{upper:Foo, lower: Baz}}
-       # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: parent lower bound `Bar` is not a subtype of lower bound `Baz`
+  #                                      ^^^ error: The `lower` type bound `Baz` must be a supertype of the parent's `lower` type bound `Bar` for type_member `Args`
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

- Better style conformance with the error message
- More context in the error message
- Built-in autocorrect (say: you change the `fixed:` type in a parent and want
  to automatically apply to all children)
- Explains `fixed` if relevant

Closes https://github.com/sorbet/sorbet/issues/5653

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

**Before**
<img width="787" alt="Screen Shot 2022-04-19 at 5 11 23 PM" src="https://user-images.githubusercontent.com/5544532/164121391-7e9b60eb-0632-4029-9236-b597cf34036e.png">

**After**
<img width="903" alt="Screen Shot 2022-04-19 at 5 10 45 PM" src="https://user-images.githubusercontent.com/5544532/164121393-c2771cda-2ae2-466c-8de2-ad820836795b.png">
