### PR TITLE
make `File::isStdlib` use existing information

### DIFF
--- a/core/Files.cc
+++ b/core/Files.cc
@@ -248,7 +248,7 @@ bool File::isRBI() const {
 }
 
 bool File::isStdlib() const {
-    return fileStrictSigil(source()) == StrictLevel::Stdlib;
+    return this->originalSigil == StrictLevel::Stdlib;
 }
 
 bool File::isPackage() const {


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We should not need to compute this information over and over again.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No functional change intended.
