### PR TITLE
untangle `LocOffsets` from `Loc.h`

### DIFF
--- a/core/FileRef.h
+++ b/core/FileRef.h
@@ -1,0 +1,57 @@
+#ifndef SORBET_CORE_FILEREF_H
+#define SORBET_CORE_FILEREF_H
+
+#include "common/common.h"
+
+namespace sorbet::core {
+class GlobalState;
+class File;
+
+class FileRef final {
+public:
+    FileRef() : _id(0){};
+    FileRef(unsigned int id);
+
+    FileRef(FileRef &f) = default;
+    FileRef(const FileRef &f) = default;
+    FileRef(FileRef &&f) = default;
+    FileRef &operator=(const FileRef &f) = default;
+    FileRef &operator=(FileRef &&f) = default;
+
+    bool operator==(const FileRef &rhs) const {
+        return _id == rhs._id;
+    }
+
+    bool operator!=(const FileRef &rhs) const {
+        return !(rhs == *this);
+    }
+
+    bool operator<(const FileRef &rhs) const {
+        return _id < rhs._id;
+    }
+
+    bool operator>(const FileRef &rhs) const {
+        return _id > rhs._id;
+    }
+
+    inline unsigned int id() const {
+        return _id;
+    }
+
+    inline bool exists() const {
+        return _id > 0;
+    }
+
+    const File &data(const GlobalState &gs) const;
+    File &data(GlobalState &gs) const;
+    const File &dataAllowingUnsafe(const GlobalState &gs) const;
+    File &dataAllowingUnsafe(GlobalState &gs) const;
+
+private:
+    uint32_t _id;
+};
+CheckSize(FileRef, 4, 4);
+
+} // namespace sorbet::core
+
+#endif

--- a/core/Files.h
+++ b/core/Files.h
@@ -2,6 +2,8 @@
 #define SORBET_AST_FILES_H
 
 #include "core/CompiledLevel.h"
+#include "core/FileRef.h"
+#include "core/LocOffsets.h"
 #include "core/Names.h"
 #include "core/StrictLevel.h"
 #include <string>
@@ -9,57 +11,11 @@
 
 namespace sorbet::core {
 class GlobalState;
-class File;
 struct GlobalStateHash;
 struct FileHash;
 namespace serialize {
 class SerializerImpl;
 }
-
-class FileRef final {
-public:
-    FileRef() : _id(0){};
-    FileRef(unsigned int id);
-
-    FileRef(FileRef &f) = default;
-    FileRef(const FileRef &f) = default;
-    FileRef(FileRef &&f) = default;
-    FileRef &operator=(const FileRef &f) = default;
-    FileRef &operator=(FileRef &&f) = default;
-
-    bool operator==(const FileRef &rhs) const {
-        return _id == rhs._id;
-    }
-
-    bool operator!=(const FileRef &rhs) const {
-        return !(rhs == *this);
-    }
-
-    bool operator<(const FileRef &rhs) const {
-        return _id < rhs._id;
-    }
-
-    bool operator>(const FileRef &rhs) const {
-        return _id > rhs._id;
-    }
-
-    inline unsigned int id() const {
-        return _id;
-    }
-
-    inline bool exists() const {
-        return _id > 0;
-    }
-
-    const File &data(const GlobalState &gs) const;
-    File &data(GlobalState &gs) const;
-    const File &dataAllowingUnsafe(const GlobalState &gs) const;
-    File &dataAllowingUnsafe(GlobalState &gs) const;
-
-private:
-    uint32_t _id;
-};
-CheckSize(FileRef, 4, 4);
 
 class File final {
 public:

--- a/core/Loc.h
+++ b/core/Loc.h
@@ -1,7 +1,8 @@
 #ifndef SORBET_AST_LOC_H
 #define SORBET_AST_LOC_H
 
-#include "Files.h"
+#include "core/Files.h"
+#include "core/LocOffsets.h"
 
 namespace sorbet::core {
 namespace serialize {
@@ -10,48 +11,6 @@ class SerializerImpl;
 class GlobalState;
 class Context;
 class MutableContext;
-
-constexpr int INVALID_POS_LOC = 0xfffffff;
-struct LocOffsets {
-    uint32_t beginLoc = INVALID_POS_LOC;
-    uint32_t endLoc = INVALID_POS_LOC;
-    uint32_t beginPos() const {
-        return beginLoc;
-    };
-
-    uint32_t endPos() const {
-        return endLoc;
-    }
-    bool exists() const {
-        return endLoc != INVALID_POS_LOC && beginLoc != INVALID_POS_LOC;
-    }
-    bool empty() const {
-        ENFORCE_NO_TIMER(exists());
-        return beginLoc == endLoc;
-    }
-    static LocOffsets none() {
-        return LocOffsets{INVALID_POS_LOC, INVALID_POS_LOC};
-    }
-    LocOffsets join(LocOffsets other) const;
-    // For a given LocOffsets, returns a zero-length version that starts at the same location.
-    LocOffsets copyWithZeroLength() const {
-        return LocOffsets{beginPos(), beginPos()};
-    }
-    // As above, but returns a zero-length version that starts at the end of the location.
-    LocOffsets copyEndWithZeroLength() const {
-        return LocOffsets{endPos(), endPos()};
-    }
-
-    std::string showRaw(const Context ctx) const;
-    std::string showRaw(const MutableContext ctx) const;
-    std::string showRaw(const GlobalState &gs, const FileRef file) const;
-    std::string showRaw() const;
-
-    bool operator==(const LocOffsets &rhs) const;
-
-    bool operator!=(const LocOffsets &rhs) const;
-};
-CheckSize(LocOffsets, 8, 4);
 
 class Loc final {
     struct {

--- a/core/LocOffsets.h
+++ b/core/LocOffsets.h
@@ -1,0 +1,56 @@
+#ifndef SORBET_CORE_LOCOFFSETS_H
+#define SORBET_CORE_LOCOFFSETS_H
+
+#include "common/common.h"
+#include "core/FileRef.h"
+
+namespace sorbet::core {
+class GlobalState;
+class Context;
+class MutableContext;
+
+constexpr int INVALID_POS_LOC = 0xfffffff;
+struct LocOffsets {
+    uint32_t beginLoc = INVALID_POS_LOC;
+    uint32_t endLoc = INVALID_POS_LOC;
+    uint32_t beginPos() const {
+        return beginLoc;
+    };
+
+    uint32_t endPos() const {
+        return endLoc;
+    }
+    bool exists() const {
+        return endLoc != INVALID_POS_LOC && beginLoc != INVALID_POS_LOC;
+    }
+    bool empty() const {
+        ENFORCE_NO_TIMER(exists());
+        return beginLoc == endLoc;
+    }
+    static LocOffsets none() {
+        return LocOffsets{INVALID_POS_LOC, INVALID_POS_LOC};
+    }
+    LocOffsets join(LocOffsets other) const;
+    // For a given LocOffsets, returns a zero-length version that starts at the same location.
+    LocOffsets copyWithZeroLength() const {
+        return LocOffsets{beginPos(), beginPos()};
+    }
+    // As above, but returns a zero-length version that starts at the end of the location.
+    LocOffsets copyEndWithZeroLength() const {
+        return LocOffsets{endPos(), endPos()};
+    }
+
+    std::string showRaw(const Context ctx) const;
+    std::string showRaw(const MutableContext ctx) const;
+    std::string showRaw(const GlobalState &gs, const FileRef file) const;
+    std::string showRaw() const;
+
+    bool operator==(const LocOffsets &rhs) const;
+
+    bool operator!=(const LocOffsets &rhs) const;
+};
+CheckSize(LocOffsets, 8, 4);
+
+} // namespace sorbet::core
+
+#endif // SORBET_CORE_LOCOFFSETS_H


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

For #5598 (and maybe other LSP queries, like find all references), the plan is to jump the user to the location of the `typed:` sigil when we're jumping to definition in an untyped file.  To do that, it seems reasonable to record the `LocOffsets` of the sigil when we compute the original sigil for the file.  To do that, we need to arrange things such that `Loc.h` doesn't depend on `Files.h`: we need to pull `LocOffsets` out to its own file...but we also need to pull `FileRef` out to its own file, so `LocOffsets.h` can depend on `FileRef.h` and not `Files.h`.

Regardless of whether we store `LocOffsets` in the `File` structure itself or we change `File::fileStrictSigil` to additionally compute the `LocOffsets`, we need a change like this.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No functional change intended.