### PR TITLE
make logging for empty parse results slightly more efficient

### DIFF
--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -56,15 +56,18 @@ unique_ptr<core::FileHash> computeFileHashForAST(spdlog::logger &logger, unique_
                 writer.Bool(true);
 
                 writer.String("file_path");
-                writer.String(string(file.file.data(*lgs).path()));
+                auto path = file.file.data(*lgs).path();
+                writer.String(path.data(), path.size());
 
                 writer.String("contents");
-                writer.String(string(file.file.data(*lgs).source()));
+                auto source = file.file.data(*lgs).source();
+                writer.String(source.data(), source.size());
 
                 writer.EndObject();
             }
 
-            logger.debug(result.GetString());
+            auto view = string_view{result.GetString(), result.GetLength()};
+            logger.debug(view);
 
             core::GlobalStateHash invalid;
             invalid.hierarchyHash = core::GlobalStateHash::HASH_STATE_INVALID;


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We can avoid a few unnecessary constructions of `std::string` and an unnecessary call to `strlen` when sending the whole thing to the logger.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No functional change intended.
