### PR TITLE
give a little nudge for completing call sites that are not typed

### DIFF
--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -896,7 +896,7 @@ vector<unique_ptr<CompletionItem>> allSimilarConstantItems(const core::GlobalSta
 }
 
 vector<SimilarMethod> computeDedupedMethods(const core::GlobalState &gs, const core::DispatchResult &dispatchResult,
-                                             bool isPrivateOk, string_view prefix) {
+                                            bool isPrivateOk, string_view prefix) {
     ENFORCE(!dispatchResult.main.receiver.isUntyped());
 
     vector<SimilarMethod> dedupedSimilarMethods;
@@ -939,12 +939,10 @@ vector<SimilarMethod> computeDedupedMethods(const core::GlobalState &gs, const c
         auto leftShortName = left.method.data(gs)->name.shortName(gs);
         auto rightShortName = right.method.data(gs)->name.shortName(gs);
         if (leftShortName != rightShortName) {
-            if (absl::StartsWith(leftShortName, prefix) &&
-                !absl::StartsWith(rightShortName, prefix)) {
+            if (absl::StartsWith(leftShortName, prefix) && !absl::StartsWith(rightShortName, prefix)) {
                 return true;
             }
-            if (!absl::StartsWith(leftShortName, prefix) &&
-                absl::StartsWith(rightShortName, prefix)) {
+            if (!absl::StartsWith(leftShortName, prefix) && absl::StartsWith(rightShortName, prefix)) {
                 return false;
             }
 
@@ -962,8 +960,8 @@ vector<SimilarMethod> computeDedupedMethods(const core::GlobalState &gs, const c
 CompletionTask::CompletionTask(const LSPConfiguration &config, MessageId id, unique_ptr<CompletionParams> params)
     : LSPRequestTask(config, move(id), LSPMethod::TextDocumentCompletion), params(move(params)) {}
 
-unique_ptr<CompletionItem>
-CompletionTask::getCompletionItemForUntypedReceiver(const core::GlobalState &gs, core::Loc queryLoc, size_t sortIdx) {
+unique_ptr<CompletionItem> CompletionTask::getCompletionItemForUntypedReceiver(const core::GlobalState &gs,
+                                                                               core::Loc queryLoc, size_t sortIdx) {
     string label("(call site is T.untyped)");
     auto item = make_unique<CompletionItem>(label);
     item->sortText = formatSortIndex(sortIdx);
@@ -1115,7 +1113,8 @@ vector<unique_ptr<CompletionItem>> CompletionTask::getCompletionItems(LSPTypeche
         if (forMethods.dispatchResult->main.receiver.isUntyped()) {
             receiverIsUntyped = true;
         } else {
-            dedupedSimilarMethods = computeDedupedMethods(gs, *forMethods.dispatchResult, forMethods.isPrivateOk, params.prefix);
+            dedupedSimilarMethods =
+                computeDedupedMethods(gs, *forMethods.dispatchResult, forMethods.isPrivateOk, params.prefix);
         }
     }
 
@@ -1146,8 +1145,8 @@ vector<unique_ptr<CompletionItem>> CompletionTask::getCompletionItems(LSPTypeche
             for (auto &similarMethod : dedupedSimilarMethods) {
                 // Even though we might have one or more TypeConstraints on the DispatchResult that triggered this
                 // completion request, those constraints are the result of solving the current method. These new methods
-                // we're about to suggest are their own methods with their own type variables, so it doesn't make sense to
-                // use the old constraint for the new methods.
+                // we're about to suggest are their own methods with their own type variables, so it doesn't make sense
+                // to use the old constraint for the new methods.
                 //
                 // What this means in practice is that the prettified `sig` in the completion documentation will show
                 // `T.type_parameter(:U)` instead of a solved type.

--- a/main/lsp/requests/completion.h
+++ b/main/lsp/requests/completion.h
@@ -45,6 +45,8 @@ class CompletionTask final : public LSPRequestTask {
     std::vector<std::unique_ptr<CompletionItem>> getCompletionItems(LSPTypecheckerInterface &typechecker,
                                                                     SearchParams &params);
 
+    std::unique_ptr<CompletionItem> getCompletionItemForUntypedReceiver(const core::GlobalState &gs, core::Loc queryLoc, size_t sortIdx);
+
     std::unique_ptr<CompletionItem> getCompletionItemForMethod(LSPTypecheckerInterface &typechecker,
                                                                core::DispatchResult &dispatchResult,
                                                                core::MethodRef what, const core::TypePtr &receiverType,

--- a/main/lsp/requests/completion.h
+++ b/main/lsp/requests/completion.h
@@ -45,7 +45,8 @@ class CompletionTask final : public LSPRequestTask {
     std::vector<std::unique_ptr<CompletionItem>> getCompletionItems(LSPTypecheckerInterface &typechecker,
                                                                     SearchParams &params);
 
-    std::unique_ptr<CompletionItem> getCompletionItemForUntypedReceiver(const core::GlobalState &gs, core::Loc queryLoc, size_t sortIdx);
+    std::unique_ptr<CompletionItem> getCompletionItemForUntypedReceiver(const core::GlobalState &gs, core::Loc queryLoc,
+                                                                        size_t sortIdx);
 
     std::unique_ptr<CompletionItem> getCompletionItemForMethod(LSPTypecheckerInterface &typechecker,
                                                                core::DispatchResult &dispatchResult,

--- a/test/testdata/lsp/completion/untyped_receiver.A.rbedited
+++ b/test/testdata/lsp/completion/untyped_receiver.A.rbedited
@@ -1,0 +1,9 @@
+# typed: true
+extend T::Sig
+
+sig {params(x: T.untyped).void}
+def foo(x)
+  x.
+  # ^ completion: (call site is T.untyped)
+  # ^ apply-completion: [A] item: 0
+end # error: unexpected token

--- a/test/testdata/lsp/completion/untyped_receiver.rb
+++ b/test/testdata/lsp/completion/untyped_receiver.rb
@@ -4,5 +4,6 @@ extend T::Sig
 sig {params(x: T.untyped).void}
 def foo(x)
   x.
-  # ^ completion: (nothing)
+  # ^ completion: (call site is T.untyped)
+  # ^ apply-completion: [A] item: 0
 end # error: unexpected token


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

One problem with Sorbet's LSP implementation is that when Sorbet can't return meaningful results (e.g. the file is not typed, or a particular call site is not typed), there's no information given to the user to indicate *why* there's no meaningful results.  (This is not necessarily Sorbet's fault; LSP is not quite rich enough to communicate this sort of information in a number of cases.)  From a user's perspective, this looks like Sorbet whimsically responds to their requests, sometimes returning interesting things and sometimes not.

This PR is an attempt to address one of those areas: completing method calls when the receiver is `T.untyped`.  We don't currently return anything for such cases (since you could literally be calling any method).  Instead of returning no results, this PR changes things so that we return a single item indicating that the call site is `T.untyped` and does no modification of the document if it is chosen.

The expectation/hope is that the user is motivated to figure out why the callsite is `T.untyped` so they can get better completion results.

Come to think of it, we probably also want to do a similar thing if our initial query results are empty because the file didn't have type information in the first place.  That could be a followup PR!

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
