### PR TITLE
give a little nudge for completion in untyped files

### DIFF
--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -1244,7 +1244,7 @@ unique_ptr<ResponseMessage> CompletionTask::runRequest(LSPTypecheckerInterface &
         ENFORCE(fref.exists());
         auto level = fref.data(gs).strictLevel;
         if (level < core::StrictLevel::True) {
-            items.emplace_back(getCompletionItemForUntyped(gs, queryLoc, 0, "(file is not typed)"));
+            items.emplace_back(getCompletionItemForUntyped(gs, queryLoc, 0, "(file is not `# typed: true` or higher)"));
             response->result = make_unique<CompletionList>(false, move(items));
             return response;
         }

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -992,9 +992,9 @@ void logEmptyCompletion(const core::GlobalState &gs, core::FileRef fref, core::L
 CompletionTask::CompletionTask(const LSPConfiguration &config, MessageId id, unique_ptr<CompletionParams> params)
     : LSPRequestTask(config, move(id), LSPMethod::TextDocumentCompletion), params(move(params)) {}
 
-unique_ptr<CompletionItem> CompletionTask::getCompletionItemForUntypedReceiver(const core::GlobalState &gs,
-                                                                               core::Loc queryLoc, size_t sortIdx) {
-    string label("(call site is T.untyped)");
+unique_ptr<CompletionItem> CompletionTask::getCompletionItemForUntyped(const core::GlobalState &gs, core::Loc queryLoc,
+                                                                       size_t sortIdx, std::string_view message) {
+    string label(message);
     auto item = make_unique<CompletionItem>(label);
     item->sortText = formatSortIndex(sortIdx);
     item->kind = CompletionItemKind::Method;
@@ -1172,7 +1172,7 @@ vector<unique_ptr<CompletionItem>> CompletionTask::getCompletionItems(LSPTypeche
     {
         Timer timeit(gs.tracer(), LSP_COMPLETION_METRICS_PREFIX ".method_items");
         if (receiverIsUntyped) {
-            items.push_back(getCompletionItemForUntypedReceiver(gs, params.queryLoc, items.size()));
+            items.push_back(getCompletionItemForUntyped(gs, params.queryLoc, items.size(), "(call site is T.untyped)"));
         } else {
             for (auto &similarMethod : dedupedSimilarMethods) {
                 // Even though we might have one or more TypeConstraints on the DispatchResult that triggered this
@@ -1239,6 +1239,14 @@ unique_ptr<ResponseMessage> CompletionTask::runRequest(LSPTypecheckerInterface &
                 response->result = make_unique<CompletionList>(false, move(items));
                 return response;
             }
+        }
+
+        ENFORCE(fref.exists());
+        auto level = fref.data(gs).strictLevel;
+        if (level < core::StrictLevel::True) {
+            items.emplace_back(getCompletionItemForUntyped(gs, queryLoc, 0, "(file is not typed)"));
+            response->result = make_unique<CompletionList>(false, move(items));
+            return response;
         }
 
         logEmptyCompletion(gs, fref, queryLoc, "no query result");

--- a/main/lsp/requests/completion.h
+++ b/main/lsp/requests/completion.h
@@ -45,8 +45,8 @@ class CompletionTask final : public LSPRequestTask {
     std::vector<std::unique_ptr<CompletionItem>> getCompletionItems(LSPTypecheckerInterface &typechecker,
                                                                     SearchParams &params);
 
-    std::unique_ptr<CompletionItem> getCompletionItemForUntypedReceiver(const core::GlobalState &gs, core::Loc queryLoc,
-                                                                        size_t sortIdx);
+    std::unique_ptr<CompletionItem> getCompletionItemForUntyped(const core::GlobalState &gs, core::Loc queryLoc,
+                                                                size_t sortIdx, std::string_view message);
 
     std::unique_ptr<CompletionItem> getCompletionItemForMethod(LSPTypecheckerInterface &typechecker,
                                                                core::DispatchResult &dispatchResult,

--- a/test/testdata/lsp/completion/untyped_file.rb
+++ b/test/testdata/lsp/completion/untyped_file.rb
@@ -3,13 +3,13 @@
 class AnImportantClass
   def important_method(important_parameter)
     important
-           # ^ completion: (file is not typed)
+           # ^ completion: (file is not `# typed: true` or higher)
   end
 end
 
 An # error: Unable to resolve constant
-# ^ completion: (file is not typed)
+# ^ completion: (file is not `# typed: true` or higher)
 
 AnImportantClass.n
-#                 ^ completion: (file is not typed)
+#                 ^ completion: (file is not `# typed: true` or higher)
 

--- a/test/testdata/lsp/completion/untyped_file.rb
+++ b/test/testdata/lsp/completion/untyped_file.rb
@@ -3,13 +3,13 @@
 class AnImportantClass
   def important_method(important_parameter)
     important
-           # ^ completion: (nothing)
+           # ^ completion: (file is not typed)
   end
 end
 
 An # error: Unable to resolve constant
-# ^ completion: (nothing)
+# ^ completion: (file is not typed)
 
 AnImportantClass.n
-#                 ^ completion: (nothing)
+#                 ^ completion: (file is not typed)
 

--- a/test/testdata/lsp/completion/untyped_file.rb
+++ b/test/testdata/lsp/completion/untyped_file.rb
@@ -1,0 +1,15 @@
+# typed: false
+
+class AnImportantClass
+  def important_method(important_parameter)
+    important
+           # ^ completion: (nothing)
+  end
+end
+
+An # error: Unable to resolve constant
+# ^ completion: (nothing)
+
+AnImportantClass.n
+#                 ^ completion: (nothing)
+


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Followup to #5663: we can give a nudge on untyped files in addition to giving nudges on untyped receivers.  (And given the way the completion code works, we need to put the check for the former in a different place.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
