### PR TITLE
Ensure some `type_member` errors always appear on fast path

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2328,10 +2328,6 @@ class ResolveTypeMembersAndFieldsWalk {
     static bool resolveJob(core::MutableContext ctx, ResolveAssignItem &job, vector<bool> &resolvedAttachedClasses) {
         ENFORCE(job.lhs.isTypeAlias(ctx) || job.lhs.isTypeMember());
 
-        if (isLHSResolved(ctx, job.lhs)) {
-            return true;
-        }
-
         auto it = std::remove_if(job.dependencies.begin(), job.dependencies.end(), [&](core::SymbolRef dep) {
             if (isGenericResolved(ctx, dep)) {
                 if (dep.isClassOrModule()) {
@@ -2349,7 +2345,7 @@ class ResolveTypeMembersAndFieldsWalk {
         }
         if (job.lhs.isTypeMember()) {
             resolveTypeMember(ctx.withOwner(job.owner), job.lhs.asTypeMemberRef(), job.rhs, resolvedAttachedClasses);
-        } else {
+        } else if (!isLHSResolved(ctx, job.lhs)) {
             resolveTypeAlias(ctx.withOwner(job.owner), job.lhs, job.rhs);
         }
 

--- a/test/testdata/infer/generics/bounds.rb
+++ b/test/testdata/infer/generics/bounds.rb
@@ -1,5 +1,4 @@
 # typed: true
-# disable-fast-path: true
 
 class Animal; end
 class Cat < Animal; end

--- a/test/testdata/infer/generics/bounds_super.rb
+++ b/test/testdata/infer/generics/bounds_super.rb
@@ -1,5 +1,4 @@
 # typed: true
-# disable-fast-path: true
 
 class Animal; end
 class Cat < Animal; end

--- a/test/testdata/resolver/nilable_untyped.rb
+++ b/test/testdata/resolver/nilable_untyped.rb
@@ -1,7 +1,4 @@
 # typed: false
-#
-# The type_member errors don't get re-raised in the fast-path
-# disable-fast-path: true
 
 
 Bad = T.type_alias {T.nilable(T.untyped)}

--- a/test/testdata/resolver/type_member_bad_parent.rb
+++ b/test/testdata/resolver/type_member_bad_parent.rb
@@ -1,5 +1,4 @@
 # typed: true
-# disable-fast-path: true
 
 class Parent
   Elem = 3

--- a/test/testdata/resolver/type_member_fixed_order.rb
+++ b/test/testdata/resolver/type_member_fixed_order.rb
@@ -1,5 +1,4 @@
 # typed: true
-# disable-fast-path: true
 
 class B < A
   extend T::Generic

--- a/test/testdata/resolver/type_member_module_bound.rb
+++ b/test/testdata/resolver/type_member_module_bound.rb
@@ -1,5 +1,4 @@
 # typed: strict
-# disable-fast-path: true
 
 class Foo; end
 class Bar < Foo; end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I noticed this while working on #5656.

Every time we have `disable-fast-path` in a test, that's covering up a known
bug. It looks like we didn't have a dedicated bug report for this individual
bug, but for what it's worth there is a vague tracking issue for the class of
problems: <https://github.com/sorbet/sorbet/issues/1906>


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.