### PR TITLE
Remove MIN_LOOP_GLOBAL

### DIFF
--- a/cfg/CFG.h
+++ b/cfg/CFG.h
@@ -141,7 +141,7 @@ public:
 
     // special minLoops
     static constexpr int MIN_LOOP_FIELD = -1;
-    static constexpr int MIN_LOOP_GLOBAL = -2;
+    // static constexpr int MIN_LOOP_GLOBAL = -2;
     static constexpr int MIN_LOOP_LET = -3;
 
     // special ruby region id offsets for exception handling

--- a/cfg/builder/builder_entry.cc
+++ b/cfg/builder/builder_entry.cc
@@ -111,8 +111,6 @@ unique_ptr<CFG> CFGBuilder::buildFor(core::Context ctx, ast::MethodDef &md) {
         aliasesPrefix.emplace_back(local, core::LocOffsets::none(), make_insn<Alias>(global));
         if (global.isFieldOrStaticField()) {
             res->minLoops[local.id()] = CFG::MIN_LOOP_FIELD;
-        } else {
-            res->minLoops[local.id()] = CFG::MIN_LOOP_GLOBAL;
         }
     }
     for (auto kv : discoveredUndeclaredFields) {

--- a/cfg/builder/builder_entry.cc
+++ b/cfg/builder/builder_entry.cc
@@ -111,6 +111,13 @@ unique_ptr<CFG> CFGBuilder::buildFor(core::Context ctx, ast::MethodDef &md) {
         aliasesPrefix.emplace_back(local, core::LocOffsets::none(), make_insn<Alias>(global));
         if (global.isFieldOrStaticField()) {
             res->minLoops[local.id()] = CFG::MIN_LOOP_FIELD;
+        } else {
+            // We used to have special handling here for "MIN_LOOP_GLOBAL" but it was meaningless,
+            // because it only happened for type members, and we already prohibit re-assigning type
+            // members (in namer). If this ENFORCE fails, we might have to resurrect the old logic
+            // we had for handling MIN_LOOP_GLOBAL (or at least, add some tests that would trigger
+            // pinning errors).
+            // ENFORCE(global.isTypeMember());
         }
     }
     for (auto kv : discoveredUndeclaredFields) {

--- a/cfg/builder/builder_entry.cc
+++ b/cfg/builder/builder_entry.cc
@@ -117,7 +117,7 @@ unique_ptr<CFG> CFGBuilder::buildFor(core::Context ctx, ast::MethodDef &md) {
             // members (in namer). If this ENFORCE fails, we might have to resurrect the old logic
             // we had for handling MIN_LOOP_GLOBAL (or at least, add some tests that would trigger
             // pinning errors).
-            // ENFORCE(global.isTypeMember());
+            ENFORCE(global.isTypeMember());
         }
     }
     for (auto kv : discoveredUndeclaredFields) {

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -44,6 +44,12 @@ void CFGBuilder::unconditionalJump(BasicBlock *from, BasicBlock *to, CFG &inWhat
 namespace {
 
 LocalRef global2Local(CFGContext cctx, core::SymbolRef what) {
+    if (what == core::Symbols::StubModule()) {
+        // We don't need all stub module assignments to alias to the same temporary.
+        // (The fact that there's a StubModule at all means an error was already reported elsewhere)
+        return cctx.newTemporary(what.name(cctx.ctx));
+    }
+
     // Note: this will add an empty local to aliases if 'what' is not there
     LocalRef &alias = cctx.aliases[what];
     if (!alias.exists()) {

--- a/core/errors/infer.h
+++ b/core/errors/infer.h
@@ -15,7 +15,7 @@ constexpr ErrorClass OverloadedArgumentCountMismatch{7008, StrictLevel::True};
 constexpr ErrorClass BareTypeUsage{7009, StrictLevel::True};
 constexpr ErrorClass GenericArgumentCountMismatch{7010, StrictLevel::True};
 constexpr ErrorClass IncompleteType{7011, StrictLevel::True};
-constexpr ErrorClass GlobalReassignmentTypeMismatch{7012, StrictLevel::True};
+// constexpr ErrorClass GlobalReassignmentTypeMismatch{7012, StrictLevel::True};
 constexpr ErrorClass FieldReassignmentTypeMismatch{7013, StrictLevel::True};
 // constexpr ErrorClass GenericMethodConstraintUnsolved{7013, StrictLevel::True};
 constexpr ErrorClass RevealType{7014, StrictLevel::True};

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1523,17 +1523,6 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                             tp = cur;
                         }
                         break;
-                    case cfg::CFG::MIN_LOOP_GLOBAL:
-                        if (!asGoodAs) {
-                            if (auto e =
-                                    ctx.beginError(bind.loc, core::errors::Infer::GlobalReassignmentTypeMismatch)) {
-                                e.setHeader(
-                                    "Reassigning global with a value of wrong type: `{}` is not a subtype of `{}`",
-                                    tp.type.show(ctx), cur.type.show(ctx));
-                            }
-                            tp = cur;
-                        }
-                        break;
                     case cfg::CFG::MIN_LOOP_LET:
                         if (!asGoodAs) {
                             if (auto e = ctx.beginError(bind.loc, core::errors::Infer::PinnedVariableMismatch)) {

--- a/test/testdata/infer/isa_generic.rb.cfg-text.exp
+++ b/test/testdata/infer/isa_generic.rb.cfg-text.exp
@@ -268,20 +268,20 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Concrete), <C Klass>$10: Runtime object representing type: String, <block-pre-call-temp>$12: Sorbet::Private::Static::Void, <selfRestore>$13: T.class_of(Concrete)):
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Concrete), <block-pre-call-temp>$12: Sorbet::Private::Static::Void, <selfRestore>$13: T.class_of(Concrete)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=2](<C Klass>$10: Runtime object representing type: String, <block-pre-call-temp>$12: Sorbet::Private::Static::Void, <selfRestore>$13: T.class_of(Concrete)):
+bb3[rubyRegionId=0, firstDead=2](<block-pre-call-temp>$12: Sorbet::Private::Static::Void, <selfRestore>$13: T.class_of(Concrete)):
     <C Klass>$10: T.untyped = Solve<<block-pre-call-temp>$12, type_template>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=6](<self>: T.class_of(Concrete), <C Klass>$10: Runtime object representing type: String, <block-pre-call-temp>$12: Sorbet::Private::Static::Void, <selfRestore>$13: T.class_of(Concrete)):
+bb5[rubyRegionId=1, firstDead=6](<self>: T.class_of(Concrete), <block-pre-call-temp>$12: Sorbet::Private::Static::Void, <selfRestore>$13: T.class_of(Concrete)):
     # outerLoops: 1
     <self>: T.class_of(Concrete) = loadSelf(type_template)
     <hashTemp>$16: Symbol(:fixed) = :fixed

--- a/test/testdata/infer/self_type.rb.cfg-text.exp
+++ b/test/testdata/infer/self_type.rb.cfg-text.exp
@@ -287,13 +287,13 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Generic), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Generic), <C TM>$28: Runtime object representing type: Generic::TM):
+bb2[rubyRegionId=1, firstDead=-1](<self>: T.class_of(Generic), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Generic)):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=11](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Generic), <C TM>$28: Runtime object representing type: Generic::TM):
+bb3[rubyRegionId=0, firstDead=11](<block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Generic)):
     <statTemp>$3: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$9, sig>
     <self>: T.class_of(Generic) = <selfRestore>$10
     <cfgAlias>$24: T.class_of(T::Generic) = alias <C Generic>
@@ -309,7 +309,7 @@ bb3[rubyRegionId=0, firstDead=11](<block-pre-call-temp>$9: Sorbet::Private::Stat
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=7](<self>: T.class_of(Generic), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Generic), <C TM>$28: Runtime object representing type: Generic::TM):
+bb5[rubyRegionId=1, firstDead=7](<self>: T.class_of(Generic), <block-pre-call-temp>$9: Sorbet::Private::Static::Void, <selfRestore>$10: T.class_of(Generic)):
     # outerLoops: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <cfgAlias>$16: T.class_of(Generic) = alias <C Generic>


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The GlobalReassignmentTypeMismatchError error class was never being reported
because MIN_LOOP_GLOBAL was not really doing anything. We don't need to treat
these constants specially.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

The ENFORCE I left behind says that the other half of the `if` could only be
type member symbols. In those cases:

- we already prevent reassignment to the symbols in namer (you can't assign to a
  constant with the same name twice)
- we technically do have two writes to the temporary variables, because all
  constant assignments like `X = type_member` get two writes:

  - `<C X>$1 = alias ::X`
  - `<C X>$1 = type_member`

  For the `type_member` case, we don't actually care about pinning, because
  right now the `alias` instruction pins the temporary variable to a meta type,
  while the `type_member` call always returns `T.untyped`. `T.untyped` is
  compatible with anything so there are never pinning errors we should be
  printing, even if we did somehow allow reassignments to constants.

Anyways, pretty sure that this is all just dead code.