### PR TITLE
fix codeaction lsp crash

### DIFF
--- a/main/lsp/json_types.cc
+++ b/main/lsp/json_types.cc
@@ -107,19 +107,16 @@ unique_ptr<Range> Range::fromLoc(const core::GlobalState &gs, core::Loc loc) {
                               make_unique<Position>(pair.second.line - 1, pair.second.column - 1));
 }
 
-core::Loc Range::toLoc(const core::GlobalState &gs, core::FileRef file) const {
+std::optional<core::Loc> Range::toLoc(const core::GlobalState &gs, core::FileRef file) const {
     ENFORCE(start->line >= 0);
     ENFORCE(start->character >= 0);
     ENFORCE(end->line >= 0);
     ENFORCE(end->character >= 0);
 
-    auto sPos = core::Loc::pos2Offset(file.data(gs),
-                                      core::Loc::Detail{(uint32_t)start->line + 1, (uint32_t)start->character + 1});
-    auto ePos =
-        core::Loc::pos2Offset(file.data(gs), core::Loc::Detail{(uint32_t)end->line + 1, (uint32_t)end->character + 1});
+    core::Loc::Detail sDetail{(uint32_t)start->line + 1, (uint32_t)start->character + 1};
+    core::Loc::Detail eDetail{(uint32_t)end->line + 1, (uint32_t)end->character + 1};
 
-    // These offsets are non-nullopt assuming the input Range is valid
-    return core::Loc(file, sPos.value(), ePos.value());
+    return core::Loc::fromDetails(gs, file, sDetail, eDetail);
 }
 
 int Range::cmp(const Range &b) const {

--- a/main/lsp/tools/make_lsp_types.cc
+++ b/main/lsp/tools/make_lsp_types.cc
@@ -99,19 +99,20 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                                    "std::string showRaw() const;",
                                });
 
-    auto Range = makeObject("Range",
-                            {
-                                makeField("start", Position),
-                                makeField("end", Position),
-                            },
-                            classTypes,
-                            {
-                                "// Returns nullptr if loc does not exist",
-                                "static std::unique_ptr<Range> fromLoc(const core::GlobalState &gs, core::Loc loc);",
-                                "core::Loc toLoc(const core::GlobalState &gs, core::FileRef file) const;",
-                                "int cmp(const Range &b) const;",
-                                "std::unique_ptr<Range> copy() const;",
-                            });
+    auto Range =
+        makeObject("Range",
+                   {
+                       makeField("start", Position),
+                       makeField("end", Position),
+                   },
+                   classTypes,
+                   {
+                       "// Returns nullptr if loc does not exist",
+                       "static std::unique_ptr<Range> fromLoc(const core::GlobalState &gs, core::Loc loc);",
+                       "std::optional<core::Loc> toLoc(const core::GlobalState &gs, core::FileRef file) const;",
+                       "int cmp(const Range &b) const;",
+                       "std::unique_ptr<Range> copy() const;",
+                   });
 
     auto Location = makeObject("Location",
                                {


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Noticed this when looking at rubocop autofixes on Stripe's codebase.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No tests given that we're interacting with external software here.  We could write some kind of protocol recording test, I guess?
