### PR TITLE
Add the mangled package name to files

### DIFF
--- a/ast/substitute/Substitute.cc
+++ b/ast/substitute/Substitute.cc
@@ -128,15 +128,27 @@ public:
 };
 } // namespace
 
-ExpressionPtr Substitute::run(core::MutableContext ctx, const core::NameSubstitution &subst, ExpressionPtr what) {
+ParsedFile Substitute::run(core::MutableContext ctx, const core::NameSubstitution &subst, ParsedFile what) {
     SubstWalk walk(subst);
-    what = TreeMap::apply(ctx, walk, std::move(what));
+    what.tree = TreeMap::apply(ctx, walk, std::move(what.tree));
+
+    auto pkg = what.file.data(ctx).getPackage();
+    if (pkg.exists()) {
+        what.file.data(ctx).setPackage(subst.substitute(pkg));
+    }
+
     return what;
 }
 
-ExpressionPtr Substitute::run(core::MutableContext ctx, core::LazyNameSubstitution &subst, ExpressionPtr what) {
+ParsedFile Substitute::run(core::MutableContext ctx, core::LazyNameSubstitution &subst, ParsedFile what) {
     SubstWalk walk(subst);
-    what = TreeMap::apply(ctx, walk, std::move(what));
+    what.tree = TreeMap::apply(ctx, walk, std::move(what.tree));
+
+    auto pkg = what.file.data(ctx).getPackage();
+    if (pkg.exists()) {
+        what.file.data(ctx).setPackage(subst.substitute(pkg));
+    }
+
     return what;
 }
 

--- a/ast/substitute/substitute.h
+++ b/ast/substitute/substitute.h
@@ -11,8 +11,8 @@ class LazyNameSubstitution;
 namespace sorbet::ast {
 class Substitute {
 public:
-    static ExpressionPtr run(core::MutableContext ctx, const core::NameSubstitution &subst, ExpressionPtr what);
-    static ExpressionPtr run(core::MutableContext ctx, core::LazyNameSubstitution &subst, ExpressionPtr what);
+    static ParsedFile run(core::MutableContext ctx, const core::NameSubstitution &subst, ParsedFile what);
+    static ParsedFile run(core::MutableContext ctx, core::LazyNameSubstitution &subst, ParsedFile what);
 };
 } // namespace sorbet::ast
 #endif // SORBET_SUBSTITUTE_H

--- a/core/Files.cc
+++ b/core/Files.cc
@@ -353,4 +353,12 @@ void File::setCached(bool value) {
     flags.cached = value;
 }
 
+NameRef File::getPackage() const {
+    return this->package;
+}
+
+void File::setPackage(NameRef mangledName) {
+    this->package = mangledName;
+}
+
 } // namespace sorbet::core

--- a/core/Files.h
+++ b/core/Files.h
@@ -65,6 +65,12 @@ public:
     bool cached() const;
     void setCached(bool value);
 
+    // Fetch the mangled name of the package that this file belongs to.
+    NameRef getPackage() const;
+
+    // Set the mangled name of the package that this file belongs to.
+    void setPackage(NameRef mangledName);
+
     File(std::string &&path_, std::string &&source_, Type sourceType, uint32_t epoch = 0);
     File(File &&other) = delete;
     File(const File &other) = delete;
@@ -103,6 +109,8 @@ private:
     CheckSize(Flags, 1, 1);
 
     Flags flags;
+
+    NameRef package = core::NameRef::noName();
 
     const std::string path_;
     const std::string source_;

--- a/core/Files.h
+++ b/core/Files.h
@@ -110,6 +110,8 @@ private:
 
     Flags flags;
 
+    // NOTE: this adds some overhead even when `--stripe-packages` is disabled. In the future we may look at moving it
+    // into the PackageDB to avoid the memory overhad in non-stripe codebases.
     NameRef package = core::NameRef::noName();
 
     const std::string path_;

--- a/core/Files.h
+++ b/core/Files.h
@@ -126,7 +126,7 @@ public:
 private:
     std::shared_ptr<const FileHash> hash_;
 };
-CheckSize(File, 96, 8);
+CheckSize(File, 104, 8);
 
 template <typename H> H AbslHashValue(H h, const FileRef &m) {
     return H::combine(std::move(h), m.id());

--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -24,7 +24,7 @@ pair<ast::ParsedFile, core::UsageHash> rewriteAST(const core::GlobalState &origi
     core::LazyNameSubstitution subst(originalGS, newGS);
     core::MutableContext ctx(newGS, core::Symbols::root(), newFref);
     core::UnfreezeNameTable nameTableAccess(newGS);
-    rewritten.tree = ast::Substitute::run(ctx, subst, move(rewritten.tree));
+    rewritten = ast::Substitute::run(ctx, subst, move(rewritten));
     return make_pair<ast::ParsedFile, core::UsageHash>(move(rewritten), subst.getAllNames());
 }
 
@@ -110,7 +110,7 @@ unique_ptr<core::FileHash> computeFileHashForFile(shared_ptr<core::File> forWhat
     // when fromGS == toGS (hence we intentionally do not unfreeze name table).
     core::LazyNameSubstitution subst(*lgs, *lgs);
     core::MutableContext ctx(*lgs, core::Symbols::root(), fref);
-    ast.tree = ast::Substitute::run(ctx, subst, move(ast.tree));
+    ast = ast::Substitute::run(ctx, subst, move(ast));
     return computeFileHashForAST(logger, lgs, subst.getAllNames(), move(ast));
 }
 }; // namespace

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1020,7 +1020,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                     if (it->main.method.exists() && it->main.method.data(ctx)->flags.isPackagePrivate) {
                         core::ClassOrModuleRef klass = it->main.method.data(ctx)->owner;
                         if (klass.exists()) {
-                            const auto &curPkg = ctx.state.packageDB().getPackageForFile(ctx, ctx.file);
+                            const auto &curPkg = ctx.state.packageDB().getPackageInfo(ctx.file.data(ctx).getPackage());
                             if (curPkg.exists() && !curPkg.ownsSymbol(ctx, klass)) {
                                 if (auto e = ctx.beginError(bind.loc, core::errors::Infer::PackagePrivateMethod)) {
                                     auto &curPkgName = curPkg.fullName();

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -541,7 +541,7 @@ vector<ast::ParsedFile> mergeIndexResults(core::GlobalState &cgs, const options:
                             auto file = tree.file;
                             if (!file.data(cgs).cached()) {
                                 core::MutableContext ctx(cgs, core::Symbols::root(), file);
-                                tree.tree = ast::Substitute::run(ctx, *job.subst, move(tree.tree));
+                                tree = ast::Substitute::run(ctx, *job.subst, move(tree));
                             }
                         }
                     }

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -2044,10 +2044,49 @@ vector<ast::ParsedFile> Packager::findPackages(core::GlobalState &gs, WorkerPool
     return files;
 }
 
+void Packager::setPackageNameOnFiles(core::GlobalState &gs, const vector<ast::ParsedFile> &files) {
+    // Step 1a, add package references to every file. This could be parallel if needed, file access will be unique and
+    // no symbols will be allocated.
+    auto &packageDB = gs.packageDB();
+    for (auto &f : files) {
+        f.file.data(gs).setPackage(core::NameRef::noName());
+
+        auto &pkg = packageDB.getPackageForFile(gs, f.file);
+        if (!pkg.exists()) {
+            continue;
+        }
+
+        f.file.data(gs).setPackage(pkg.mangledName());
+    }
+
+    return;
+}
+
+// NOTE: we use `dataAllowingUnsafe` here, as determining the package for a file is something that can be done from its
+// path alone.
+void Packager::setPackageNameOnFiles(core::GlobalState &gs, const vector<core::FileRef> &files) {
+    // Step 1a, add package references to every file. This could be parallel if needed, file access will be unique and
+    // no symbols will be allocated.
+    auto &packageDB = gs.packageDB();
+    for (auto file : files) {
+        file.dataAllowingUnsafe(gs).setPackage(core::NameRef::noName());
+
+        auto &pkg = packageDB.getPackageForFile(gs, file);
+        if (!pkg.exists()) {
+            continue;
+        }
+
+        file.dataAllowingUnsafe(gs).setPackage(pkg.mangledName());
+    }
+
+    return;
+}
+
 vector<ast::ParsedFile> Packager::run(core::GlobalState &gs, WorkerPool &workers, vector<ast::ParsedFile> files) {
     Timer timeit(gs.tracer(), "packager");
 
     files = findPackages(gs, workers, std::move(files));
+    setPackageNameOnFiles(gs, files);
     if (gs.runningUnderAutogen) {
         // Autogen only requires package metadata. Remove the package files.
         auto it = std::remove_if(files.begin(), files.end(),
@@ -2084,6 +2123,7 @@ vector<ast::ParsedFile> Packager::run(core::GlobalState &gs, WorkerPool &workers
                     } else {
                         job = rewritePackagedFile(ctx, move(job));
                     }
+
                     results.emplace_back(move(job));
                 }
             }

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -2167,7 +2167,9 @@ template <typename StateType> vector<ast::ParsedFile> runIncrementalImpl(StateTy
 } // namespace
 
 vector<ast::ParsedFile> Packager::runIncremental(core::GlobalState &gs, vector<ast::ParsedFile> files) {
-    return runIncrementalImpl(gs, move(files));
+    files = runIncrementalImpl(gs, move(files));
+    Packager::setPackageNameOnFiles(gs, files);
+    return files;
 }
 
 vector<ast::ParsedFile> Packager::runIncrementalBestEffort(const core::GlobalState &gs, vector<ast::ParsedFile> files) {

--- a/packager/packager.h
+++ b/packager/packager.h
@@ -99,6 +99,12 @@ public:
 
     static void dumpPackageInfo(const core::GlobalState &gs, std::string output);
 
+    // For each file, set its package name.
+    static void setPackageNameOnFiles(core::GlobalState &gs, const std::vector<ast::ParsedFile> &files);
+
+    // For each file, set its package name.
+    static void setPackageNameOnFiles(core::GlobalState &gs, const std::vector<core::FileRef> &files);
+
     Packager() = delete;
 };
 } // namespace sorbet::packager

--- a/resolver/SuggestPackage.cc
+++ b/resolver/SuggestPackage.cc
@@ -39,7 +39,8 @@ public:
     core::Context ctx;
     const core::packages::PackageInfo &currentPkg;
 
-    PackageContext(core::Context ctx) : ctx(ctx), currentPkg(ctx.state.packageDB().getPackageForFile(ctx, ctx.file)) {}
+    PackageContext(core::Context ctx)
+        : ctx(ctx), currentPkg(ctx.state.packageDB().getPackageInfo(ctx.file.data(ctx).getPackage())) {}
 
     const core::packages::PackageDB &db() const {
         return ctx.state.packageDB();

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -485,6 +485,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
             // RBI generation
             {
                 packageTrees = packager::Packager::findPackages(*rbiGenGs, *workers, move(packageTrees));
+                packager::Packager::setPackageNameOnFiles(*rbiGenGs, packageTrees);
                 auto packageNamespaces = packager::RBIGenerator::buildPackageNamespace(*rbiGenGs, *workers);
                 for (auto &package : rbiGenGs->packageDB().packages()) {
                     auto output = packager::RBIGenerator::runOnce(*rbiGenGs, package, packageNamespaces);

--- a/test/pkg_autocorrects_test.cc
+++ b/test/pkg_autocorrects_test.cc
@@ -72,11 +72,11 @@ struct TestPackageFile {
     }
 
     const core::packages::PackageInfo &targetPackage(core::GlobalState &gs) const {
-        return gs.packageDB().getPackageForFile(gs, targetParsedFile.file);
+        return gs.packageDB().getPackageInfo(targetParsedFile.file.data(gs).getPackage());
     }
 
     const core::packages::PackageInfo &newPackage(core::GlobalState &gs) const {
-        return gs.packageDB().getPackageForFile(gs, newParsedFile.file);
+        return gs.packageDB().getPackageInfo(newParsedFile.file.data(gs).getPackage());
     }
 
     const core::SymbolRef getConstantRef(core::GlobalState &gs, vector<string> rawName) const {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Add the mangled package name to `core::File`, so that it's faster to retrieve later on in the pipeline. Set the mangled package name while building the package db.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Improve the performance of fetching a `PackageInfo` value for a file.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
