### PR TITLE
shrink `File` and add size assertions

### DIFF
--- a/core/CompiledLevel.h
+++ b/core/CompiledLevel.h
@@ -1,8 +1,10 @@
 #ifndef SORBET_CORE_COMPILED_LEVEL_H
 #define SORBET_CORE_COMPILED_LEVEL_H
 
+#include <stdint.h>
+
 namespace sorbet::core {
-enum class CompiledLevel {
+enum class CompiledLevel : uint8_t {
 
     // This file has no compiled sigil present. The behavior here is the same as for `# compiled: false`, but it's
     // useful to distinguish files that have no sigil present for stats.

--- a/core/Files.h
+++ b/core/Files.h
@@ -115,7 +115,7 @@ public:
 
     const CompiledLevel compiledLevel;
 };
-CheckSize(File, 112, 8);
+CheckSize(File, 104, 8);
 
 template <typename H> H AbslHashValue(H h, const FileRef &m) {
     return H::combine(std::move(h), m.id());

--- a/core/Files.h
+++ b/core/Files.h
@@ -107,15 +107,18 @@ private:
     const std::string source_;
     mutable std::shared_ptr<std::vector<int>> lineBreaks_;
     mutable StrictLevel minErrorLevel_ = StrictLevel::Max;
-    std::shared_ptr<const FileHash> hash_;
 
 public:
     const StrictLevel originalSigil;
     StrictLevel strictLevel;
 
     const CompiledLevel compiledLevel;
+
+private:
+    std::shared_ptr<const FileHash> hash_;
+
 };
-CheckSize(File, 104, 8);
+CheckSize(File, 96, 8);
 
 template <typename H> H AbslHashValue(H h, const FileRef &m) {
     return H::combine(std::move(h), m.id());

--- a/core/Files.h
+++ b/core/Files.h
@@ -19,7 +19,7 @@ class SerializerImpl;
 
 class File final {
 public:
-    enum class Type {
+    enum class Type : uint8_t {
         NotYetRead,
         PayloadGeneration, // Files marked during --store-state
         Payload,           // Files loaded from the binary payload
@@ -115,7 +115,7 @@ public:
 
     const CompiledLevel compiledLevel;
 };
-CheckSize(File, 120, 8);
+CheckSize(File, 112, 8);
 
 template <typename H> H AbslHashValue(H h, const FileRef &m) {
     return H::combine(std::move(h), m.id());

--- a/core/Files.h
+++ b/core/Files.h
@@ -115,6 +115,7 @@ public:
 
     const CompiledLevel compiledLevel;
 };
+CheckSize(File, 120, 8);
 
 template <typename H> H AbslHashValue(H h, const FileRef &m) {
     return H::combine(std::move(h), m.id());

--- a/core/Files.h
+++ b/core/Files.h
@@ -116,7 +116,6 @@ public:
 
 private:
     std::shared_ptr<const FileHash> hash_;
-
 };
 CheckSize(File, 96, 8);
 

--- a/core/StrictLevel.h
+++ b/core/StrictLevel.h
@@ -1,8 +1,10 @@
 #ifndef SORBET_CORE_STRICT_LEVEL_H
 #define SORBET_CORE_STRICT_LEVEL_H
 
+#include <stdint.h>
+
 namespace sorbet::core {
-enum class StrictLevel {
+enum class StrictLevel : uint8_t {
     // Internal Sorbet errors. There is no syntax to make those errors ignored.
     // This error should _always_ be lower than any other level so that there's no way to silence internal errors.
     Internal = 0,


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

jez raised concerns that some changes to `File` in #5671 would expand it, which prompted me to look and notice that we can shrink `File` quite a bit.  So this is worth a megabyte or two on Stripe's codebase, which is not huge, but counts for something.

As a bonus, I think that #5673 won't have any effect on the size even after this PR :tada:.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
