### PR TITLE
parse incoming LSP messages more efficiently

### DIFF
--- a/main/lsp/LSPInput.cc
+++ b/main/lsp/LSPInput.cc
@@ -60,10 +60,11 @@ LSPInput::ReadOutput LSPFDInput::read(int timeoutMs) {
 
     ENFORCE(buffer.length() >= length);
 
-    string json = buffer.substr(0, length);
-    buffer.erase(0, length);
+    string_view json{buffer.data(), static_cast<size_t>(length)};
     logger->debug("Read: {}\n", json);
-    return ReadOutput{FileOps::ReadResult::Success, LSPMessage::fromClient(json)};
+    auto msg = LSPMessage::fromClient(json);
+    buffer.erase(0, length);
+    return ReadOutput{FileOps::ReadResult::Success, move(msg)};
 }
 
 LSPInput::ReadOutput LSPProgrammaticInput::read(int timeoutMs) {

--- a/main/lsp/LSPMessage.cc
+++ b/main/lsp/LSPMessage.cc
@@ -69,10 +69,10 @@ unique_ptr<LSPMessage> makeSorbetError(LSPErrorCodes code, string_view message, 
     }
 }
 
-unique_ptr<LSPMessage> LSPMessage::fromClient(const string &json) {
+unique_ptr<LSPMessage> LSPMessage::fromClient(std::string_view json) {
     rapidjson::MemoryPoolAllocator<> alloc;
     rapidjson::Document d(&alloc);
-    if (d.Parse(json.c_str()).HasParseError()) {
+    if (d.Parse(json.data(), json.size()).HasParseError()) {
         return makeSorbetError(LSPErrorCodes::ParseError,
                                fmt::format("Last LSP request: `{}` is not a valid json object", json));
     }
@@ -114,10 +114,10 @@ LSPMessage::RawLSPMessage fromJSONValue(rapidjson::Document &d) {
     }
 }
 
-LSPMessage::RawLSPMessage fromJSON(const std::string &json) {
+LSPMessage::RawLSPMessage fromJSON(std::string_view json) {
     rapidjson::MemoryPoolAllocator<> alloc;
     rapidjson::Document d(&alloc);
-    d.Parse(json.c_str());
+    d.Parse(json.data(), json.size());
     return fromJSONValue(d);
 }
 
@@ -125,7 +125,7 @@ LSPMessage::LSPMessage(RawLSPMessage msg) : msg(move(msg)) {}
 
 LSPMessage::LSPMessage(rapidjson::Document &d) : LSPMessage::LSPMessage(fromJSONValue(d)) {}
 
-LSPMessage::LSPMessage(const std::string &json) : LSPMessage::LSPMessage(fromJSON(json)) {}
+LSPMessage::LSPMessage(std::string_view json) : LSPMessage::LSPMessage(fromJSON(json)) {}
 
 LSPMessage::~LSPMessage() = default;
 

--- a/main/lsp/LSPMessage.h
+++ b/main/lsp/LSPMessage.h
@@ -53,11 +53,11 @@ public:
      * these SorbetErrors to return the error to the client (or to print it in the log), so it can be passed along as if
      * parsing succeeded.
      */
-    static std::unique_ptr<LSPMessage> fromClient(const std::string &json);
+    static std::unique_ptr<LSPMessage> fromClient(std::string_view json);
 
     LSPMessage(RawLSPMessage msg);
     LSPMessage(rapidjson::Document &d);
-    LSPMessage(const std::string &json);
+    LSPMessage(std::string_view json);
     ~LSPMessage();
 
     /**


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We're often allocating a separate `string` object when we could just pass a pointer and a length into `rapidjson`.  Probably not a huge deal, because incoming messages tend to be small, but cycles are cycles.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
