### PR TITLE
Change `PackageInfo::importsPackage` to take a mangled name

### DIFF
--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -76,7 +76,7 @@ public:
         return vector<vector<core::NameRef>>();
     }
 
-    std::optional<ImportType> importsPackage(const PackageInfo &other) const {
+    std::optional<ImportType> importsPackage(core::NameRef mangledName) const {
         notImplemented();
         return nullopt;
     }

--- a/core/packages/PackageInfo.cc
+++ b/core/packages/PackageInfo.cc
@@ -44,13 +44,11 @@ ImportInfo ImportInfo::fromPackage(const core::GlobalState &gs, const PackageInf
     auto &db = gs.packageDB();
 
     for (auto pkg : db.packages()) {
-        auto &pkgInfo = db.getPackageInfo(pkg);
-        if (!info.importsPackage(pkgInfo)) {
+        if (!info.importsPackage(pkg)) {
             continue;
         }
 
-        auto &fullName = pkgInfo.fullName();
-
+        auto &fullName = db.getPackageInfo(pkg).fullName();
         if (thisName.size() >= fullName.size()) {
             if (std::equal(fullName.begin(), fullName.end(), thisName.begin())) {
                 res.parentImports.emplace_back(pkg);

--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -35,7 +35,7 @@ public:
     virtual bool exists() const final;
     std::string show(const core::GlobalState &gs) const;
 
-    virtual std::optional<ImportType> importsPackage(const PackageInfo &other) const = 0;
+    virtual std::optional<ImportType> importsPackage(core::NameRef mangledName) const = 0;
 
     // autocorrects
     virtual std::optional<core::AutocorrectSuggestion> addImport(const core::GlobalState &gs, const PackageInfo &pkg,

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -457,13 +457,17 @@ public:
         return rv;
     }
 
-    std::optional<core::packages::ImportType> importsPackage(const PackageInfo &other) const {
-        ENFORCE(other.exists());
+    std::optional<core::packages::ImportType> importsPackage(core::NameRef mangledName) const {
+        if (!mangledName.exists()) {
+            return std::nullopt;
+        }
+
         auto imp =
-            absl::c_find_if(importedPackageNames, [&](auto &i) { return i.name.mangledName == other.mangledName(); });
+            absl::c_find_if(importedPackageNames, [mangledName](auto &i) { return i.name.mangledName == mangledName; });
         if (imp == importedPackageNames.end()) {
             return nullopt;
         }
+
         switch (imp->type) {
             case ImportType::Normal:
                 return core::packages::ImportType::Normal;

--- a/resolver/SuggestPackage.cc
+++ b/resolver/SuggestPackage.cc
@@ -154,7 +154,7 @@ private:
             auto &fullName = other.fullName();
             if (fullName.size() >= prefixSize && canImport(other) &&
                 std::equal(fullName.begin(), fullName.begin() + prefixSize, prefixBegin)) {
-                matches.emplace_back(PackageMatch{name, currentPkg.importsPackage(other)});
+                matches.emplace_back(PackageMatch{name, currentPkg.importsPackage(name)});
             }
         }
     }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
`PackageInfo::importsPackage` only uses the `mangledName` of the other package when checking if it's imported, so let's relax the type of `importPackage` a bit.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Require a `PackageInfo` in fewer places.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
