### PR TITLE
move `LSPConfiguration::lspPos2Loc` to `Position::asLoc`

### DIFF
--- a/main/lsp/LSPConfiguration.cc
+++ b/main/lsp/LSPConfiguration.cc
@@ -113,27 +113,6 @@ void LSPConfiguration::setClientConfig(const shared_ptr<const LSPClientConfigura
     this->clientConfig = clientConfig;
 }
 
-// LSP Spec: line / col in Position are 0-based
-// Sorbet:   line / col in core::Loc are 1-based (like most editors)
-// LSP Spec: distinguishes Position (zero-width) and Range (start & end)
-// Sorbet:   zero-width core::Loc is a Position
-//
-// https://microsoft.github.io/language-server-protocol/specification#text-documents
-//
-// Returns nullopt if the position does not represent a valid location.
-optional<core::Loc> LSPConfiguration::lspPos2Loc(const core::FileRef fref, const Position &pos,
-                                                 const core::GlobalState &gs) const {
-    core::Loc::Detail reqPos;
-    reqPos.line = pos.line + 1;
-    reqPos.column = pos.character + 1;
-    if (auto maybeOffset = core::Loc::pos2Offset(fref.data(gs), reqPos)) {
-        auto offset = maybeOffset.value();
-        return core::Loc{fref, offset, offset};
-    } else {
-        return nullopt;
-    }
-}
-
 string LSPConfiguration::localName2Remote(string_view filePath) const {
     ENFORCE(absl::StartsWith(filePath, rootPath));
     assertHasClientConfig();

--- a/main/lsp/LSPConfiguration.h
+++ b/main/lsp/LSPConfiguration.h
@@ -107,7 +107,6 @@ public:
     std::vector<std::string> frefsToPaths(const core::GlobalState &gs, const std::vector<core::FileRef> &refs) const;
     std::string remoteName2Local(std::string_view uri) const;
     std::string localName2Remote(std::string_view filePath) const;
-    std::optional<core::Loc> lspPos2Loc(core::FileRef fref, const Position &pos, const core::GlobalState &gs) const;
     // returns nullptr if this loc doesn't exist
     std::unique_ptr<Location> loc2Location(const core::GlobalState &gs, core::Loc loc) const;
     bool isFileIgnored(std::string_view filePath) const;

--- a/main/lsp/LSPQuery.cc
+++ b/main/lsp/LSPQuery.cc
@@ -78,7 +78,7 @@ LSPQueryResult LSPQuery::byLoc(const LSPConfiguration &config, LSPTypecheckerInt
         return LSPQueryResult{{}, nullptr};
     }
 
-    auto loc = config.lspPos2Loc(fref, pos, gs);
+    auto loc = pos.asLoc(gs, fref);
     if (!loc.has_value()) {
         if (typechecker.isStale()) {
             // File location was not valid, but it's _probably_ not the client's fault--instead it's

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -1213,7 +1213,7 @@ unique_ptr<ResponseMessage> CompletionTask::runRequest(LSPTypecheckerInterface &
         return response;
     }
     auto pos = *params->position;
-    auto maybeQueryLoc = config.lspPos2Loc(fref, pos, gs);
+    auto maybeQueryLoc = pos.asLoc(gs, fref);
     if (!maybeQueryLoc.has_value()) {
         response->result = std::move(emptyResult);
         return response;

--- a/main/lsp/requests/signature_help.cc
+++ b/main/lsp/requests/signature_help.cc
@@ -89,7 +89,7 @@ unique_ptr<ResponseMessage> SignatureHelpTask::runRequest(LSPTypecheckerInterfac
                 return response;
             }
             auto src = fref.data(gs).source();
-            auto loc = config.lspPos2Loc(fref, *params->position, gs);
+            auto loc = params->position->asLoc(gs, fref);
             ENFORCE(loc.has_value(), "LSPQuery::byLoc should have reported an error earlier if nullopt");
             string_view call_str = src.substr(sendLocIndex, loc.value().endPos() - sendLocIndex);
             int numberCommas = absl::c_count(call_str, ',');

--- a/main/lsp/tools/make_lsp_types.cc
+++ b/main/lsp/tools/make_lsp_types.cc
@@ -87,17 +87,19 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                                    },
                                    classTypes);
 
-    auto Position = makeObject("Position",
-                               {
-                                   makeField("line", JSONInt),
-                                   makeField("character", JSONInt),
-                               },
-                               classTypes,
-                               {
-                                   "int cmp(const Position &b) const;",
-                                   "std::unique_ptr<Position> copy() const;",
-                                   "std::string showRaw() const;",
-                               });
+    auto Position =
+        makeObject("Position",
+                   {
+                       makeField("line", JSONInt),
+                       makeField("character", JSONInt),
+                   },
+                   classTypes,
+                   {
+                       "int cmp(const Position &b) const;",
+                       "std::unique_ptr<Position> copy() const;",
+                       "std::string showRaw() const;",
+                       "std::optional<core::Loc> asLoc(const core::GlobalState &gs, core::FileRef fref) const;",
+                   });
 
     auto Range =
         makeObject("Range",


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This function doesn't really belong on `LSPConfiguration`; having it on `Position` makes a lot more sense.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
