### PR TITLE
Drop two errors back down to `typed: false`

### DIFF
--- a/core/errors/resolver.h
+++ b/core/errors/resolver.h
@@ -30,8 +30,7 @@ constexpr ErrorClass RecursiveTypeAlias{5024, StrictLevel::False};
 constexpr ErrorClass TypeAliasInGenericClass{5025, StrictLevel::False};
 constexpr ErrorClass BadStdlibGeneric{5026, StrictLevel::False};
 
-// This is for type signatures that we permit at False but ban in True code
-constexpr ErrorClass InvalidTypeDeclarationTyped{5027, StrictLevel::True};
+// constexpr ErrorClass InvalidTypeDeclarationTyped{5027, StrictLevel::True};
 // constexpr ErrorClass ConstantMissingTypeAnnotation{5028, StrictLevel::Strict};
 constexpr ErrorClass RecursiveClassAlias{5030, StrictLevel::False};
 constexpr ErrorClass ConstantInTypeAlias{5031, StrictLevel::False};

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -956,7 +956,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx,
                         // constructors like `Types::any` do not expect to see bound variables, and will panic.
                         result.type = core::make_type<core::SelfTypeParam>(sym);
                     } else {
-                        if (auto e = ctx.beginError(i.loc, core::errors::Resolver::InvalidTypeDeclarationTyped)) {
+                        if (auto e = ctx.beginError(i.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                             string typeSource = isTypeTemplate ? "type_template" : "type_member";
                             string typeStr = usedOnSourceClass ? symData->name.show(ctx) : sym.show(ctx);
 
@@ -1069,7 +1069,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx,
 
             if (recvi->symbol == core::Symbols::Magic() && s.fun == core::Names::callWithSplat()) {
                 // TODO(pay-server) remove this block
-                if (auto e = ctx.beginError(recvi->loc, core::errors::Resolver::InvalidTypeDeclarationTyped)) {
+                if (auto e = ctx.beginError(recvi->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                     e.setHeader("Malformed type declaration: splats cannot be used in types");
                 }
                 result.type = core::Types::untypedUntracked();

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -1068,7 +1068,6 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx,
             }
 
             if (recvi->symbol == core::Symbols::Magic() && s.fun == core::Names::callWithSplat()) {
-                // TODO(pay-server) remove this block
                 if (auto e = ctx.beginError(recvi->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                     e.setHeader("Malformed type declaration: splats cannot be used in types");
                 }

--- a/test/cli/type-member-template/test.out
+++ b/test/cli/type-member-template/test.out
@@ -1,4 +1,4 @@
-test/cli/type-member-template/type-member-template.rb:10: `type_template` type `Template` used in an instance method definition https://srb.help/5027
+test/cli/type-member-template/type-member-template.rb:10: `type_template` type `Template` used in an instance method definition https://srb.help/5004
     10 |  sig {returns(Template)}
                        ^^^^^^^^
     test/cli/type-member-template/type-member-template.rb:8: `Template` defined here
@@ -7,7 +7,7 @@ test/cli/type-member-template/type-member-template.rb:10: `type_template` type `
   Note:
     Only a `type_member` can be used in an instance method definition.
 
-test/cli/type-member-template/type-member-template.rb:13: `type_member` type `Member` used in a singleton method definition https://srb.help/5027
+test/cli/type-member-template/type-member-template.rb:13: `type_member` type `Member` used in a singleton method definition https://srb.help/5004
     13 |  sig {returns(Member)}
                        ^^^^^^
     test/cli/type-member-template/type-member-template.rb:7: `Member` defined here

--- a/test/testdata/resolver/sig_compat.rb
+++ b/test/testdata/resolver/sig_compat.rb
@@ -1,11 +1,11 @@
 # typed: false
-# Not typed; Demonstrating lax `sig`-parsing in untyped code
+
 
 class A
   sig do
     params(
       b: T.deprecated_enum([1,2]),
-      c: T.any(*[Integer, String])
+      c: T.any(*[Integer, String]) # error: splats cannot be used in types
     ).returns(T.untyped)
   end
   def f(b, c)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We had a TODO for these errors to fix Stripe's codebase so that we could drop these errors back down to `# typed: false`.

It looks like there are only three violations for this error now. I've prepped a PR to Stripe's codebase to fix those (replacing the offenses with `T.untyped` mostly).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a