### PR TITLE
Document all remaining error codes (part 3)

### DIFF
--- a/core/errors/resolver.h
+++ b/core/errors/resolver.h
@@ -70,7 +70,7 @@ constexpr ErrorClass InvalidRequiredAncestor{5062, StrictLevel::True};
 constexpr ErrorClass UselessRequiredAncestor{5063, StrictLevel::True};
 constexpr ErrorClass UnsatisfiedRequiredAncestor{5064, StrictLevel::True};
 constexpr ErrorClass UnsatisfiableRequiredAncestor{5065, StrictLevel::True};
-constexpr ErrorClass ExperimentalRequiredAncestor{5066, StrictLevel::False};
+// constexpr ErrorClass ExperimentalRequiredAncestor{5066, StrictLevel::False};
 constexpr ErrorClass NonClassSuperclass{5067, StrictLevel::False};
 constexpr ErrorClass AmbiguousDefinitionError{5068, StrictLevel::False};
 constexpr ErrorClass MultipleStatementsInSig{5069, StrictLevel::False};

--- a/tools/scripts/check_error_classes.sh
+++ b/tools/scripts/check_error_classes.sh
@@ -35,16 +35,19 @@ fi
 
 while IFS= read -r error_code
 do
-  if [[ "$error_code" = 5* ]]; then
-    # TODO(jez) Document all other error codes
-    continue
-  fi
-
   if ! grep -q "^## $error_code\$" website/docs/error-reference.md; then
     echo "error: The error error '$error_code' in core/errors/ is not documented in website/docs/error-reference.md. Defined here:"
     grep -r -n "$error_code" core/errors | indent4
-    had_error=1
+    had_error=2
   fi
 done < <(awk '{ print $2 }' < "$tmp_output")
+
+if [ "$had_error" = 2 ]; then
+  echo "When documenting errors in the error reference, think outside the box."
+  echo "Think about how the error might be confusing *in practice*, and document"
+  echo "*that* example in context. The error reference is a chance to give error"
+  echo "messages that would otherwise be hard to produce, as well as additional"
+  echo "context, especially for new Sorbet users."
+fi
 
 exit "$had_error"

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -1120,8 +1120,8 @@ Parent::MY_CONST   # ok
 
 ## 5003
 
-Sorbet failed to parse a method signature. For more documentation on 
-valid `sig` syntax, see [Method Signatures](sigs.md).
+Sorbet failed to parse a method signature. For more documentation on valid `sig`
+syntax, see [Method Signatures](sigs.md).
 
 ## 5004
 
@@ -1418,8 +1418,7 @@ So you do not need to manually insert a `raise` inside the body of an abstract
 method.
 
 If you would like to define a method in an abstract class or interface with a
-default implementation, use the `overridable` annotation on the
-signature:
+default implementation, use the `overridable` annotation on the signature:
 
 ```ruby
 class AbstractService
@@ -1444,8 +1443,8 @@ There are a few constraints around how methods like `include`, `extend`,
     defined in `*.rb` or `*.rbi` files that are not being ignored, or
   - Hide the `include` or `extend` invocations from Sorbet by using
     [`# typed: ignore` sigils](static.md) to ignore the entire file, or
-  - Hide only the individual call from Sorbet statically using something
-    like `send(:include, ...)`.
+  - Hide only the individual call from Sorbet statically using something like
+    `send(:include, ...)`.
 - `mixes_in_class_methods` and `requires_ancestor` must only be declared in a
   `module`, not a `class`. Classes are never mixed into other classes or
   modules, so these methods would have no meaning in a class.

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -1120,7 +1120,7 @@ Parent::MY_CONST   # ok
 
 ## 5003
 
-Sorbet failed to parse a method signature. For more documentation on what's
+Sorbet failed to parse a method signature. For more documentation on 
 valid `sig` syntax, see [Method Signatures](sigs.md).
 
 ## 5004
@@ -1348,14 +1348,14 @@ Eric Lippert, who worked on the design and implementation of C# for many years.
 →
 [Why isn't there variance for generic classes?](https://stackoverflow.com/questions/2733346/why-isnt-there-generic-variance-for-classes-in-c-sharp-4-0/2734070#2734070)
 
-The answer concludes that the main selling point of having covariant classes it
+The answer concludes that the main selling point of having covariant classes is
 to make immutable generic classes, at the cost of a more complex implementation
 of generics.
 
 ## 5017
 
 The `type_member` and `type_template` declarations from a parent class must all
-be repeated in the same order a child class (and before any newly-added type
+be repeated in the same order in a child class (and before any newly-added type
 members belonging only to the child class).
 
 One non-obvious way this error can manifest is via code generation tooling. If a
@@ -1388,7 +1388,7 @@ other kind of constant in the child.
 
 Abstract methods must not have bodies. For more information, see
 [Abstract Classes and Interfaces](abstract.md). Despite these methods not having
-a body, Sorbet's [runtime support](runtime.md) via the `sorbet-runtime` will
+a body, Sorbet's [runtime support](runtime.md) via the `sorbet-runtime` gem will
 convert these methods to raise. For example:
 
 ```ruby
@@ -1418,7 +1418,7 @@ So you do not need to manually insert a `raise` inside the body of an abstract
 method.
 
 If you would like to define a method in an abstract class or interface with a
-default implementation, feel free to use the `overridable` annotation on the
+default implementation, use the `overridable` annotation on the
 signature:
 
 ```ruby
@@ -1444,7 +1444,7 @@ There are a few constraints around how methods like `include`, `extend`,
     defined in `*.rb` or `*.rbi` files that are not being ignored, or
   - Hide the `include` or `extend` invocations from Sorbet by using
     [`# typed: ignore` sigils](static.md) to ignore the entire file, or
-  - Hide hiding only the individual call from Sorbet statically using something
+  - Hide only the individual call from Sorbet statically using something
     like `send(:include, ...)`.
 - `mixes_in_class_methods` and `requires_ancestor` must only be declared in a
   `module`, not a `class`. Classes are never mixed into other classes or
@@ -1961,7 +1961,7 @@ The new syntax avoids incurring eagerly evaluating the right-hand side of the
 type alias, potentially forcing one or more constants to be autoloaded before
 they would otherwise be required. This improves load-time performance in
 lazily-loaded environments (usually: development environments) and also prevents
-certain modes of use of Sorbet to introduce load-time cyclic references.
+certain Sorbet usage patterns from introducing load-time cyclic references.
 
 ## 5044
 
@@ -2054,7 +2054,7 @@ docs for error code [5016](#5016).
 
 ## 5045
 
-This error is regards misuse of user-defined generic classes. This error is
+This error regards misuse of user-defined generic classes. This error is
 reported even at `# typed: true`. Otherwise, the error explanation is the same
 as for error code [5046](#5046).
 
@@ -2454,7 +2454,7 @@ either case.
 
 In Stripe's codebase, this is generally not a problem at runtime, as we use
 Sorbet's own autoloader generation to pre-declare filler namespaces, keeping the
-Ruby runtime es behavior equivalent to Sorbet. However, the autoloader has some
+Ruby runtime's behavior equivalent to Sorbet. However, the autoloader has some
 edge cases, which can often cause deviations between Ruby's runtime and Sorbet.
 This error helps guard against these issues.
 

--- a/website/docs/override-checking.md
+++ b/website/docs/override-checking.md
@@ -86,6 +86,32 @@ Since `Child#takes_integer_or_string` has been defined in a way that breaks that
 contract that it's "at least as good" as the parent class definition, Sorbet
 must report an error where the invalid override happens.
 
+When considering that the return type is "at least as good" as the parent, the
+subtyping relationship is flipped. Here's an example of incorrect return type
+variance:
+
+```ruby
+class Parent
+  extend T::Sig
+
+  sig {overridable.returns(Numeric)}
+  def returns_at_most_numeric; end
+end
+
+class Child < Parent
+  sig {override.returns(T.any(Numeric, String))}
+  def returns_at_most_numeric; end # error
+end
+```
+
+In this example, the `Parent` definition declares that `returns_at_most_numeric`
+will only ever return at most an `Numeric`, so that all callers will be able to
+assume that they'll only be given an `Numeric` back (including maybe a subclass
+of `Numeric`, like `Integer` or `Float`), but never something else, like a
+`String`. So the above definition of `Child#returns_at_most_numeric` is an
+invalid override, because it attempts to widen the method's declared return type
+to something wider than what the parent specified.
+
 ## What's next?
 
 - [Final Methods, Classes, and Modules](final.md)

--- a/website/docs/stdlib-generics.md
+++ b/website/docs/stdlib-generics.md
@@ -18,6 +18,7 @@ namespace to represent them:
 - `T::Set[Type]`
 - `T::Enumerable[Type]`
 - `T::Enumerator[Type]`
+- `T::Enumerator::Lazy[Type]`
 - `T::Range[Type]`
 
 Inside a sig, just writing `Array` or `Hash` will be treated as


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This finally enforces that all error classes have an entry in
`error-reference.md` on the website.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See changes to `tools/scripts/check_error_classes.sh`.