### PR TITLE
revert some changes in `DefAssertion::check`

### DIFF
--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -504,17 +504,10 @@ void DefAssertion::check(const UnorderedMap<string, shared_ptr<core::File>> &sou
     const int id = nextId++;
     auto responses = getLSPResponsesFor(lspWrapper, makeDefinitionRequest(id, queryLoc.uri, line, character));
     {
-        INFO("Unexpected number of responses to a `textDocument/definition` request.");
-        const auto numResponses = absl::c_count_if(responses, [](const auto &m) { return m->isResponse(); });
-        REQUIRE_EQ(1, numResponses);
-        const auto numRequests = absl::c_count_if(responses, [](const auto &m) { return m->isRequest(); });
-        REQUIRE_EQ(0, numRequests);
-        // Ensure the lone response is at the front.
-        absl::c_partition(responses, [](const auto &m) { return m->isResponse(); });
-        // We would like to verify the number of notifications here, but the number
-        // of notifications depends on the typed-ness of the file as well as the
-        // particular kind of query we're running, and we don't have access to the
-        // latter here.
+        INFO("Unexpected number of responses to a `textDocument/definition` request.\n"
+             "If you are seeing this error in an untyped file, please convert this\n"
+             "test to a protocol test.");
+        REQUIRE_EQ(1, responses.size());
     }
     assertResponseMessage(id, *responses.at(0));
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I realized the changes that landed in #5598 contained some unnecessary changes: I had added some code to `position_assertions.cc` to account for the new notification that was sent for jump-to-def requests.  But later, due to test constraints, I wound up moving the tests out of the `test_corpus`-based framework.  So this code is no longer necessary and in fact is somewhat harmful (since some jump-to-def tests in untyped files can't really be written in this framework, and we shouldn't be pretending otherwise).

I reverted the change and added a bit of explanation to the `INFO` message if people run into this assertion.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
