### PR TITLE
rename `Position::asLoc` to `toLoc`

### DIFF
--- a/main/lsp/LSPQuery.cc
+++ b/main/lsp/LSPQuery.cc
@@ -78,7 +78,7 @@ LSPQueryResult LSPQuery::byLoc(const LSPConfiguration &config, LSPTypecheckerInt
         return LSPQueryResult{{}, nullptr};
     }
 
-    auto loc = pos.asLoc(gs, fref);
+    auto loc = pos.toLoc(gs, fref);
     if (!loc.has_value()) {
         if (typechecker.isStale()) {
             // File location was not valid, but it's _probably_ not the client's fault--instead it's

--- a/main/lsp/json_types.cc
+++ b/main/lsp/json_types.cc
@@ -167,7 +167,7 @@ string Position::showRaw() const {
 // https://microsoft.github.io/language-server-protocol/specification#text-documents
 //
 // Returns nullopt if the position does not represent a valid location.
-optional<core::Loc> Position::asLoc(const core::GlobalState &gs, const core::FileRef fref) const {
+optional<core::Loc> Position::toLoc(const core::GlobalState &gs, const core::FileRef fref) const {
     core::Loc::Detail reqPos{static_cast<uint32_t>(this->line + 1), static_cast<uint32_t>(this->character + 1)};
     if (auto maybeOffset = core::Loc::pos2Offset(fref.data(gs), reqPos)) {
         auto offset = maybeOffset.value();

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -1213,7 +1213,7 @@ unique_ptr<ResponseMessage> CompletionTask::runRequest(LSPTypecheckerInterface &
         return response;
     }
     auto pos = *params->position;
-    auto maybeQueryLoc = pos.asLoc(gs, fref);
+    auto maybeQueryLoc = pos.toLoc(gs, fref);
     if (!maybeQueryLoc.has_value()) {
         response->result = std::move(emptyResult);
         return response;

--- a/main/lsp/requests/signature_help.cc
+++ b/main/lsp/requests/signature_help.cc
@@ -89,7 +89,7 @@ unique_ptr<ResponseMessage> SignatureHelpTask::runRequest(LSPTypecheckerInterfac
                 return response;
             }
             auto src = fref.data(gs).source();
-            auto loc = params->position->asLoc(gs, fref);
+            auto loc = params->position->toLoc(gs, fref);
             ENFORCE(loc.has_value(), "LSPQuery::byLoc should have reported an error earlier if nullopt");
             string_view call_str = src.substr(sendLocIndex, loc.value().endPos() - sendLocIndex);
             int numberCommas = absl::c_count(call_str, ',');

--- a/main/lsp/tools/make_lsp_types.cc
+++ b/main/lsp/tools/make_lsp_types.cc
@@ -98,7 +98,7 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                        "int cmp(const Position &b) const;",
                        "std::unique_ptr<Position> copy() const;",
                        "std::string showRaw() const;",
-                       "std::optional<core::Loc> asLoc(const core::GlobalState &gs, core::FileRef fref) const;",
+                       "std::optional<core::Loc> toLoc(const core::GlobalState &gs, core::FileRef fref) const;",
                    });
 
     auto Range =


### PR DESCRIPTION

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

jez pointed this out in review feedback on #5682.  I didn't see the comment prior to commit, and I agree that the suggested name is better.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
