### PR TITLE
log an integer offset rather than the raw `LocOffsets`

### DIFF
--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -974,7 +974,7 @@ void logEmptyCompletion(const core::GlobalState &gs, core::FileRef fref, core::L
         writer.String(path.data(), path.size());
 
         writer.String("query_pos");
-        writer.String(queryLoc.offsets().showRaw());
+        writer.Uint(queryLoc.offsets().beginPos());
 
         writer.String("contents");
         auto source = fref.data(gs).source();


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I realized when trying to analyze these logs that a) trying to parse out the offset from the raw `LocOffsets` output is annoying and b) the `LocOffsets` is zero-width anyway, so we just care about the beginning position.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
