### PR TITLE
be more careful with read errors from the watchman process

### DIFF
--- a/main/lsp/watchman/WatchmanProcess.cc
+++ b/main/lsp/watchman/WatchmanProcess.cc
@@ -62,14 +62,24 @@ void WatchmanProcess::start() {
         string buffer;
 
         while (!isStopped()) {
+            errno = 0;
             auto maybeLine = FileOps::readLineFromFd(fd, buffer);
             if (maybeLine.result == FileOps::ReadResult::Timeout) {
                 // Timeout occurred. See if we should abort before reading further.
                 continue;
-            } else if (maybeLine.result == FileOps::ReadResult::ErrorOrEof) {
+            }
+
+            if (maybeLine.result == FileOps::ReadResult::ErrorOrEof) {
+                if (errno == EINTR) {
+                    continue;
+                }
+
                 // Exit loop; unable to read from Watchman process.
+                exitWithCode(1, "Unknown error while reading from Watchman process");
                 break;
             }
+
+            ENFORCE(maybeLine.result == FileOps::ReadResult::Success);
 
             const string &line = *maybeLine.output;
             // Line found!
@@ -106,6 +116,8 @@ void WatchmanProcess::start() {
             exit(1);
         }
     }
+
+    ENFORCE(isStopped());
 }
 
 bool WatchmanProcess::isStopped() {


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We occasionally see people get stuck with error messages in vscode that persist over time.  We're not entirely sure why they happen -- finding a reproducible testcase is hard -- but one plausible theory that's been put forth is that we don't do a good job of handling watchman errors.

In particular, we pass an exit handler into the watchman process manager, and the code path touched in this PR doesn't call this exit handler.  So the theorized error situation looks like:

1. we try to read from the watchman process.
2. we get some kind of error from `select(2)` or `read(2)`
3. we break out of the "reading from watchman" loop
4. the watchman process's manager thread exits
5. we are now no longer observing file changes, and our main loop has not noticed that watchman has gone away.

Hence, this PR: we notify the main loop that "hey, watchman had a problem" in addition to breaking out of the thread.  The theory is that this should force the main loop (or whatever is managing the `sorbet` process) to restart and begin handling file changes again.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No additional tests beyond thinking real hard about the changes.
