### PR TITLE
stop doing extra work in `maybeGetJSONField`

### DIFF
--- a/main/lsp/lsp_messages_gen_helpers.cc
+++ b/main/lsp/lsp_messages_gen_helpers.cc
@@ -55,10 +55,11 @@ string tryConvertToStringConstant(optional<const rapidjson::Value *> value, stri
 }
 
 optional<const rapidjson::Value *> maybeGetJSONField(const rapidjson::Value &value, const string &name) {
-    if (value.HasMember(name)) {
-        return &value[name];
+    auto iter = value.FindMember(name);
+    if (iter == value.MemberEnd()) {
+        return nullopt;
     }
-    return nullopt;
+    return &iter->value;
 }
 
 const rapidjson::Value &assertJSONField(optional<const rapidjson::Value *> maybeValue, string_view name) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

rapidjson provides APIs to return an iterator to a member if it exists, so we should use that rather than a more roundabout scheme.  (Member access is also linear time complexity, so this should definitely be more efficient.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
