### PR TITLE
stop doing extra work in `tryConvertToString`

### DIFF
--- a/main/lsp/lsp_messages_gen_helpers.cc
+++ b/main/lsp/lsp_messages_gen_helpers.cc
@@ -42,7 +42,7 @@ string tryConvertToString(optional<const rapidjson::Value *> value, string_view 
     if (!realValue.IsString()) {
         throw JSONTypeError(name, "string", realValue);
     }
-    return realValue.GetString();
+    return string(realValue.GetString(), realValue.GetStringLength());
 }
 
 string tryConvertToStringConstant(optional<const rapidjson::Value *> value, string_view constantValue,


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

`GetString()` returns a `char *`, so the previous code required an extra `strlen` to construct the returned string.  But this is silly; the JSON values know their length, so we can provide that directly and avoid a `strlen` call.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
