### PR TITLE
avoid allocating strings on every call to `maybeGetJSONField`

### DIFF
--- a/main/lsp/lsp_messages_gen_helpers.cc
+++ b/main/lsp/lsp_messages_gen_helpers.cc
@@ -54,7 +54,8 @@ string tryConvertToStringConstant(optional<const rapidjson::Value *> value, stri
     return strValue;
 }
 
-optional<const rapidjson::Value *> maybeGetJSONField(const rapidjson::Value &value, const string &name) {
+optional<const rapidjson::Value *> maybeGetJSONField(const rapidjson::Value &value, string_view nameStr) {
+    rapidjson::Value name(rapidjson::StringRef(nameStr.data(), nameStr.size()));
     auto iter = value.FindMember(name);
     if (iter == value.MemberEnd()) {
         return nullopt;

--- a/main/lsp/lsp_messages_gen_helpers.h
+++ b/main/lsp/lsp_messages_gen_helpers.h
@@ -22,8 +22,7 @@ std::string tryConvertToString(std::optional<const rapidjson::Value *> value, st
 std::string tryConvertToStringConstant(std::optional<const rapidjson::Value *> value, std::string_view constantValue,
                                        std::string_view name);
 
-// N.B.: Uses a string reference since rapidjson APIs require a C string.
-std::optional<const rapidjson::Value *> maybeGetJSONField(const rapidjson::Value &value, const std::string &name);
+std::optional<const rapidjson::Value *> maybeGetJSONField(const rapidjson::Value &value, std::string_view name);
 
 const rapidjson::Value &assertJSONField(std::optional<const rapidjson::Value *> maybeValue, std::string_view name);
 


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

There's no need for `maybeGetJSONField` to require a full string if we make better use of the rapidjson APIs.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
