### PR TITLE
avoid untyped file completions if we have parse errors

### DIFF
--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -1243,7 +1243,7 @@ unique_ptr<ResponseMessage> CompletionTask::runRequest(LSPTypecheckerInterface &
 
         ENFORCE(fref.exists());
         auto level = fref.data(gs).strictLevel;
-        if (level < core::StrictLevel::True) {
+        if (!fref.data(gs).hasParseErrors() && level < core::StrictLevel::True) {
             items.emplace_back(getCompletionItemForUntyped(gs, queryLoc, 0, "(file is not `# typed: true` or higher)"));
             response->result = make_unique<CompletionList>(false, move(items));
             return response;

--- a/test/testdata/lsp/completion/untyped_parse_errors.rb
+++ b/test/testdata/lsp/completion/untyped_parse_errors.rb
@@ -1,0 +1,6 @@
+# typed: false
+
+class A
+  e.
+  # ^ completion: (nothing)
+end # error: unexpected token


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Addressing #5696.

This is not a perfect solution, because the parse error might not affect the site we're trying to complete at.  But this is an untyped file, so things are best-effort anyway.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.  The testcase in #5696 was hard to do because we wanted to record the completion *and* the end of file at the same place, and the test harness doesn't really support doing that.  So this is the next best thing.