### PR TITLE
just show a notification for jump-to-def in untyped files

### DIFF
--- a/main/lsp/requests/definition.cc
+++ b/main/lsp/requests/definition.cc
@@ -78,15 +78,13 @@ unique_ptr<ResponseMessage> DefinitionTask::runRequest(LSPTypecheckerInterface &
 
     if (notifyAboutUntypedFile) {
         ENFORCE(fref.exists());
-        auto offsets = core::File::locStrictSigil(fref.data(gs).source());
-        core::Loc loc{fref, offsets};
-        auto msg = fmt::format("Could not go to definition because the file is not at least `# typed: true`");
+        auto level = fref.data(gs).strictLevel;
+        ENFORCE(level < core::StrictLevel::True);
+        string asString = level == core::StrictLevel::Ignore ? "ignore" : "false";
+        auto msg = fmt::format("File is `# typed: {}`, could not go to definition", asString);
         auto params = make_unique<ShowMessageParams>(MessageType::Info, msg);
         this->config.output->write(make_unique<LSPMessage>(
             make_unique<NotificationMessage>("2.0", LSPMethod::WindowShowMessage, move(params))));
-        // Jump the user to the sigil location.
-        ENFORCE(locations.empty());
-        addLocIfExists(gs, locations, loc);
     }
     response->result = move(locations);
     return response;

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -504,10 +504,17 @@ void DefAssertion::check(const UnorderedMap<string, shared_ptr<core::File>> &sou
     const int id = nextId++;
     auto responses = getLSPResponsesFor(lspWrapper, makeDefinitionRequest(id, queryLoc.uri, line, character));
     {
-        INFO("Unexpected number of responses to a `textDocument/definition` request.\n"
-             "If you are seeing this error in an untyped file, please convert this\n"
-             "test to a protocol test.");
-        REQUIRE_EQ(1, responses.size());
+        INFO("Unexpected number of responses to a `textDocument/definition` request.");
+        const auto numResponses = absl::c_count_if(responses, [](const auto &m) { return m->isResponse(); });
+        REQUIRE_EQ(1, numResponses);
+        const auto numRequests = absl::c_count_if(responses, [](const auto &m) { return m->isRequest(); });
+        REQUIRE_EQ(0, numRequests);
+        // Ensure the lone response is at the front.
+        absl::c_partition(responses, [](const auto &m) { return m->isResponse(); });
+        // We would like to verify the number of notifications here, but the number
+        // of notifications depends on the typed-ness of the file as well as the
+        // particular kind of query we're running, and we don't have access to the
+        // latter here.
     }
     assertResponseMessage(id, *responses.at(0));
 

--- a/test/lsp/ProtocolTest.cc
+++ b/test/lsp/ProtocolTest.cc
@@ -237,35 +237,6 @@ vector<unique_ptr<Location>> ProtocolTest::getDefinitions(std::string_view uri, 
     return {};
 }
 
-void ProtocolTest::assertDefinitionJumpsToUntypedSigil(std::string_view uri, int line, int column,
-                                                       const Range &sigilRange) {
-    // `send` will eat the notifications, so send the message manually.
-    auto defRequest = getDefinition(uri, line, column);
-    auto results = verify(getLSPResponsesFor(*lspWrapper, LSPMessage::fromClient(defRequest->toJSON())));
-    const auto numResponses = absl::c_count_if(results, [](const auto &m) { return m->isResponse(); });
-    REQUIRE_EQ(1, numResponses);
-    const auto numRequests = absl::c_count_if(results, [](const auto &m) { return m->isRequest(); });
-    REQUIRE_EQ(0, numRequests);
-    // Ensure the lone response is at the front.
-    absl::c_partition(results, [](const auto &m) { return m->isResponse(); });
-    auto &responseMsg = results.at(0);
-    REQUIRE(responseMsg->isResponse());
-    auto &response = responseMsg->asResponse();
-    REQUIRE(response.result.has_value());
-    auto &defResult = get<variant<JSONNullObject, vector<unique_ptr<Location>>>>(response.result.value());
-    auto locs = move(get<vector<unique_ptr<Location>>>(defResult));
-    REQUIRE_EQ(locs.size(), 1);
-    auto &loc = locs.at(0);
-    REQUIRE_EQ(loc->range->cmp(sigilRange), 0);
-    REQUIRE_EQ(results.size() - numResponses, 1);
-    auto &notificationMsg = results.at(1);
-    REQUIRE(notificationMsg->isNotification());
-    auto &notification = notificationMsg->asNotification();
-    auto *showMessageParams = get_if<std::unique_ptr<ShowMessageParams>>(&notification.params);
-    REQUIRE_NE(showMessageParams, nullptr);
-    REQUIRE_EQ((*showMessageParams)->type, MessageType::Info);
-}
-
 void ProtocolTest::assertDiagnostics(vector<unique_ptr<LSPMessage>> messages, vector<ExpectedDiagnostic> expected) {
     for (auto &msg : messages) {
         // Ignore typecheck run and sorbet/fence messages. They do not impact semantics.

--- a/test/lsp/ProtocolTest.h
+++ b/test/lsp/ProtocolTest.h
@@ -99,8 +99,6 @@ protected:
 
     std::vector<std::unique_ptr<Location>> getDefinitions(std::string_view uri, int line, int character);
 
-    void assertDefinitionJumpsToUntypedSigil(std::string_view uri, int line, int column, const Range &sigilRange);
-
     /**
      * ProtocolTest maintains the latest diagnostics for files received over a session, as LSP is not required to
      * re-send diagnostics that have not changed. send() automatically updates diagnostics, but if a test manually

--- a/test/lsp/protocol_test_corpus.cc
+++ b/test/lsp/protocol_test_corpus.cc
@@ -5,7 +5,6 @@
 #include "absl/strings/str_replace.h"
 #include "common/common.h"
 #include "test/helpers/lsp.h"
-#include "test/helpers/position_assertions.h"
 
 namespace sorbet::test::lsp {
 using namespace std;
@@ -87,6 +86,22 @@ TEST_CASE_FIXTURE(ProtocolTest, "Cancellation") {
         assertResponseError(-32800, "cancel", *errorMsg);
     }
     REQUIRE_EQ(requestIds.size(), 0);
+}
+
+// Asserts that Sorbet returns an empty result when requesting definitions in untyped Ruby files.
+TEST_CASE_FIXTURE(ProtocolTest, "DefinitionError") {
+    assertDiagnostics(initializeLSP(), {});
+    assertDiagnostics(send(*openFile("foobar.rb", "class Foobar\n  def bar\n    1\n  end\nend\n\nbar\n")), {});
+    auto defResponses = send(*getDefinition("foobar.rb", 6, 1));
+    INFO("Expected a single response to a definition request to an untyped document.");
+    REQUIRE_EQ(defResponses.size(), 1);
+    assertResponseMessage(nextId - 1, *defResponses.at(0));
+
+    auto &respMsg = defResponses.at(0)->asResponse();
+    REQUIRE(respMsg.result);
+    auto &result = get<variant<JSONNullObject, vector<unique_ptr<Location>>>>(*(respMsg.result));
+    auto &array = get<vector<unique_ptr<Location>>>(result);
+    REQUIRE_EQ(array.size(), 0);
 }
 
 // Ensures that Sorbet merges didChanges that are interspersed with canceled requests.
@@ -649,52 +664,6 @@ TEST_CASE_FIXTURE(ProtocolTest, "ReportsSyntaxErrors") {
     auto counters = getCounters();
     CHECK_EQ(counters.getCategoryCounter("lsp.slow_path_reason", "syntax_error"), 1);
     CHECK_EQ(counters.getCategoryCounter("lsp.slow_path_reason", "changed_definition"), 0);
-}
-
-// We're writing this as a protocol test because the model for jump-to-def on
-// methods in untyped files doesn't really fit the regular testsuite: we want to
-// make sure that we jump to the typed sigil, but that doesn't represent a
-// definition, nor can (or do) we want to go from the "definition" to all the uses.
-// Furthermore, we also want to find a "definition" for e.g. method sends and
-// things that wouldn't normally get definitions from untyped files.
-TEST_CASE_FIXTURE(ProtocolTest, "UntypedFileMethodJumpToDef") {
-    assertDiagnostics(initializeLSP(), {});
-
-    // Create a new file.
-    assertDiagnostics(send(*openFile("foo.rb", "# typed: false\n"
-                                               "class A\n"
-                                               "def method_with_posarg(x)\n"
-                                               "  x\n"
-                                               "end\n"
-                                               "def method_with_optarg(y='optional')\n"
-                                               "  y\n"
-                                               "end\n"
-                                               "def method_with_kwarg(kw:)\n"
-                                               "  kw\n"
-                                               "end\n"
-                                               "def method_with_rest_arg(*arg)\n"
-                                               "  arg\n"
-                                               "end\n"
-                                               "end\n"
-                                               "\n"
-                                               "A.new.method")),
-                      {});
-
-    const auto falseSigilLine = 0, falseSigilStart = 9, falseSigilEnd = 14;
-    auto falseSigilRangePtr = RangeAssertion::makeRange(falseSigilLine, falseSigilStart, falseSigilEnd);
-    const auto &falseSigilRange = *falseSigilRangePtr;
-    // Positional arg
-    assertDefinitionJumpsToUntypedSigil("foo.rb", 3, 2, falseSigilRange);
-    // Optional arg
-    assertDefinitionJumpsToUntypedSigil("foo.rb", 6, 2, falseSigilRange);
-    // Keyword arg
-    assertDefinitionJumpsToUntypedSigil("foo.rb", 9, 2, falseSigilRange);
-    // Rest arg
-    assertDefinitionJumpsToUntypedSigil("foo.rb", 12, 2, falseSigilRange);
-    // `new` send, which wouldn't normally get caught, since we're in an untyped file.
-    assertDefinitionJumpsToUntypedSigil("foo.rb", 16, 2, falseSigilRange);
-    // `method` send
-    assertDefinitionJumpsToUntypedSigil("foo.rb", 16, 6, falseSigilRange);
 }
 
 } // namespace sorbet::test::lsp

--- a/test/lsp/protocol_test_corpus.cc
+++ b/test/lsp/protocol_test_corpus.cc
@@ -94,7 +94,14 @@ TEST_CASE_FIXTURE(ProtocolTest, "DefinitionError") {
     assertDiagnostics(send(*openFile("foobar.rb", "class Foobar\n  def bar\n    1\n  end\nend\n\nbar\n")), {});
     auto defResponses = send(*getDefinition("foobar.rb", 6, 1));
     INFO("Expected a single response to a definition request to an untyped document.");
-    REQUIRE_EQ(defResponses.size(), 1);
+    const auto numResponses = absl::c_count_if(defResponses, [](const auto &m) { return m->isResponse(); });
+    REQUIRE_EQ(1, numResponses);
+    const auto numRequests = absl::c_count_if(defResponses, [](const auto &m) { return m->isRequest(); });
+    REQUIRE_EQ(0, numRequests);
+    const auto numNotifications = absl::c_count_if(defResponses, [](const auto &m) { return m->isNotification(); });
+    REQUIRE_EQ(1, numNotifications);
+    // Ensure the lone response is at the front.
+    absl::c_partition(defResponses, [](const auto &m) { return m->isResponse(); });
     assertResponseMessage(nextId - 1, *defResponses.at(0));
 
     auto &respMsg = defResponses.at(0)->asResponse();

--- a/test/testdata/lsp/definitions_and_usages_untyped__untyped.rb
+++ b/test/testdata/lsp/definitions_and_usages_untyped__untyped.rb
@@ -1,7 +1,4 @@
 # typed: false
-# We don't test that certain queries would return (nothing); we leave that to
-# protocol_test_corpus.cc, since we would give those queries a "definition" of
-# the `false` sigil, above.
 
 module Untyped
      # ^^^^^^^ def: Untyped
@@ -12,6 +9,7 @@ module Untyped
     # ^^^^ def: Type
 
       def bat; end
+        # ^^^ def: (nothing) 1
   end
 end
 
@@ -19,6 +17,7 @@ def main
   # go-to-def/find-refs/highlight should work on constant refs.
   TypedFoo.new.bar
 # ^^^^^^^^ usage: TypedFoo
+             # ^^^ def: (nothing) 2
   Untyped::Bar.new.bat
 # ^^^^^^^ usage: Untyped
          # ^^^ usage: Bar


### PR DESCRIPTION
This reverts commit 0c572269c.
This partially reverts commit 016ed659f8a83bca63673fa6257c873c8081589b.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We had some reports from users that the behavior added in PR #5598 was confusing, especially in conjunction with VSCode's Cmd-hover over method calls, which would just show the `# typed: false` sigil and some trailing lines.

Unfortunately, #5598 did a little bit too much, and a straight revert of that PR removes too much; we'd like to keep the notification for doing the jump-to-def, but we've like to not return the location of `# typed: false`.

So ba243c24eb04949aed938d8bf0392b23007177cb is a revert of the relevant protocol tests we added in #5598.  We tweak the notification in c2ce812d1884e70c3a2601e31ed984b8bc5afd57 and remove the "definition" location, which requires updating the tests.  And now we really do need the handling of notifications in `DefAssertion::check`, so we need to revert #5689 as well.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
