### PR TITLE
better locs for string attrs

### DIFF
--- a/rewriter/AttrReader.cc
+++ b/rewriter/AttrReader.cc
@@ -39,6 +39,16 @@ pair<core::NameRef, core::LocOffsets> getName(core::MutableContext ctx, ast::Exp
                 res = core::Names::empty();
             }
             loc = lit->loc;
+            if (::sorbet::debug_mode) {
+                auto l = ctx.locAt(loc);
+                ENFORCE(l.exists());
+                auto source = l.source(ctx).value();
+                ENFORCE(source.size() > 2);
+                ENFORCE(source[0] == '"' || source[0] == '\'');
+                auto lastChar = source[source.size()-1];
+                ENFORCE(lastChar == '"' || lastChar == '\'');
+            }
+            loc = core::LocOffsets{loc.beginPos() + 1, loc.endPos() - 1};
         }
     }
     if (!res.exists()) {

--- a/rewriter/AttrReader.cc
+++ b/rewriter/AttrReader.cc
@@ -39,7 +39,7 @@ pair<core::NameRef, core::LocOffsets> getName(core::MutableContext ctx, ast::Exp
                 res = core::Names::empty();
             }
             loc = lit->loc;
-            if (::sorbet::debug_mode) {
+            DEBUG_ONLY({
                 auto l = ctx.locAt(loc);
                 ENFORCE(l.exists());
                 auto source = l.source(ctx).value();
@@ -47,7 +47,7 @@ pair<core::NameRef, core::LocOffsets> getName(core::MutableContext ctx, ast::Exp
                 ENFORCE(source[0] == '"' || source[0] == '\'');
                 auto lastChar = source[source.size() - 1];
                 ENFORCE(lastChar == '"' || lastChar == '\'');
-            }
+            });
             loc = core::LocOffsets{loc.beginPos() + 1, loc.endPos() - 1};
         }
     }

--- a/rewriter/AttrReader.cc
+++ b/rewriter/AttrReader.cc
@@ -45,7 +45,7 @@ pair<core::NameRef, core::LocOffsets> getName(core::MutableContext ctx, ast::Exp
                 auto source = l.source(ctx).value();
                 ENFORCE(source.size() > 2);
                 ENFORCE(source[0] == '"' || source[0] == '\'');
-                auto lastChar = source[source.size()-1];
+                auto lastChar = source[source.size() - 1];
                 ENFORCE(lastChar == '"' || lastChar == '\'');
             }
             loc = core::LocOffsets{loc.beginPos() + 1, loc.endPos() - 1};

--- a/test/testdata/rewriter/attr.rb
+++ b/test/testdata/rewriter/attr.rb
@@ -7,6 +7,9 @@ class TestAttr
     @v1 = T.let(0, Integer)
     @v2 = T.let("", String)
     @v6 = T.let("", String)
+    @strv7 = T.let(0.0, Float)
+    @strv8 = T.let(0.0, Float)
+    @strv9 = T.let(0.0, Float)
   end
 
   sig {returns(Integer)}
@@ -23,4 +26,13 @@ class TestAttr
   attr_writer :v4, :v5 # error-with-dupes: This function does not have a `sig`
 #              ^^        error: Use of undeclared variable `@v4`
 #                   ^^   error: Use of undeclared variable `@v5`
+
+  sig {returns(Float)}
+  attr_reader "strv7"
+
+  sig {params(strv8: Float).returns(Float)}
+  attr_writer "strv8"
+
+  sig {returns(Float)}
+  attr_accessor "strv9"
 end

--- a/test/testdata/rewriter/attr.rb.flatten-tree.exp
+++ b/test/testdata/rewriter/attr.rb.flatten-tree.exp
@@ -24,6 +24,18 @@ begin
           ::Sorbet::Private::Static.keep_for_typechecking(::String)
           T.let("", String)
         end
+        @strv7 = begin
+          ::Sorbet::Private::Static.keep_for_typechecking(::Float)
+          T.let(0.000000, Float)
+        end
+        @strv8 = begin
+          ::Sorbet::Private::Static.keep_for_typechecking(::Float)
+          T.let(0.000000, Float)
+        end
+        @strv9 = begin
+          ::Sorbet::Private::Static.keep_for_typechecking(::Float)
+          T.let(0.000000, Float)
+        end
       end
     end
 
@@ -55,6 +67,22 @@ begin
       @v5 = v5
     end
 
+    def strv7(<blk>)
+      @strv7
+    end
+
+    def strv8=(strv8, <blk>)
+      @strv8 = strv8
+    end
+
+    def strv9(<blk>)
+      @strv9
+    end
+
+    def strv9=("strv9", <blk>)
+      @strv9 = strv9
+    end
+
     def self.<static-init>(<blk>)
       begin
         ::Sorbet::Private::Static::ResolvedSig.sig(<self>, false, :initialize) do ||
@@ -75,6 +103,18 @@ begin
         ::Sorbet::Private::Static::ResolvedSig.sig(<self>, false, :v3) do ||
           <self>.returns(::String)
         end
+        ::Sorbet::Private::Static::ResolvedSig.sig(<self>, false, :strv7) do ||
+          <self>.returns(::Float)
+        end
+        ::Sorbet::Private::Static::ResolvedSig.sig(<self>, false, :strv8=) do ||
+          <self>.params(:strv8, ::Float).returns(::Float)
+        end
+        ::Sorbet::Private::Static::ResolvedSig.sig(<self>, false, :strv9) do ||
+          <self>.returns(::Float)
+        end
+        ::Sorbet::Private::Static::ResolvedSig.sig(<self>, false, :strv9=) do ||
+          <self>.params(:strv9, ::Float).returns(::Float)
+        end
         <self>.extend(::T::Sig)
         ::Sorbet::Private::Static.keep_def(<self>, :initialize, :normal)
         ::Sorbet::Private::Static.keep_def(<self>, :v1, :normal)
@@ -84,6 +124,10 @@ begin
         ::Sorbet::Private::Static.keep_def(<self>, :v3, :normal)
         ::Sorbet::Private::Static.keep_def(<self>, :v4=, :normal)
         ::Sorbet::Private::Static.keep_def(<self>, :v5=, :normal)
+        ::Sorbet::Private::Static.keep_def(<self>, :strv7, :normal)
+        ::Sorbet::Private::Static.keep_def(<self>, :strv8=, :normal)
+        ::Sorbet::Private::Static.keep_def(<self>, :strv9, :normal)
+        ::Sorbet::Private::Static.keep_def(<self>, :strv9=, :normal)
         <emptyTree>
       end
     end

--- a/test/testdata/rewriter/attr.rb.flatten-tree.exp
+++ b/test/testdata/rewriter/attr.rb.flatten-tree.exp
@@ -79,7 +79,7 @@ begin
       @strv9
     end
 
-    def strv9=("strv9", <blk>)
+    def strv9=(strv9, <blk>)
       @strv9 = strv9
     end
 

--- a/test/testdata/rewriter/attr.rb.symbol-table-raw.exp
+++ b/test/testdata/rewriter/attr.rb.symbol-table-raw.exp
@@ -18,8 +18,8 @@ class <C <U <root>>> < <C <U Object>> ()
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/attr.rb start=??? end=???}
     method <C <U TestAttr>>#<U strv9> (<blk>) -> Float @ Loc {file=test/testdata/rewriter/attr.rb start=37:3 end=37:24}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/attr.rb start=??? end=???}
-    method <C <U TestAttr>>#<U strv9=> ("strv9", <blk>) -> Float @ Loc {file=test/testdata/rewriter/attr.rb start=37:3 end=37:24}
-      argument "strv9"<> -> Float @ Loc {file=test/testdata/rewriter/attr.rb start=37:17 end=37:24}
+    method <C <U TestAttr>>#<U strv9=> (strv9, <blk>) -> Float @ Loc {file=test/testdata/rewriter/attr.rb start=37:3 end=37:24}
+      argument strv9<> -> Float @ Loc {file=test/testdata/rewriter/attr.rb start=37:18 end=37:23}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/attr.rb start=??? end=???}
     method <C <U TestAttr>>#<U v1> (<blk>) -> Integer @ Loc {file=test/testdata/rewriter/attr.rb start=16:3 end=16:11}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/attr.rb start=??? end=???}

--- a/test/testdata/rewriter/attr.rb.symbol-table-raw.exp
+++ b/test/testdata/rewriter/attr.rb.symbol-table-raw.exp
@@ -1,33 +1,46 @@
 class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
-    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/attr.rb start=2:1 end=26:4}
+    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/attr.rb start=2:1 end=38:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/attr.rb start=??? end=???}
   class <C <U TestAttr>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/attr.rb start=2:1 end=2:15}
+    field <C <U TestAttr>>#<U @strv7> -> Float @ Loc {file=test/testdata/rewriter/attr.rb start=10:5 end=10:11}
+    field <C <U TestAttr>>#<U @strv8> -> Float @ Loc {file=test/testdata/rewriter/attr.rb start=11:5 end=11:11}
+    field <C <U TestAttr>>#<U @strv9> -> Float @ Loc {file=test/testdata/rewriter/attr.rb start=12:5 end=12:11}
     field <C <U TestAttr>>#<U @v1> -> Integer @ Loc {file=test/testdata/rewriter/attr.rb start=7:5 end=7:8}
     field <C <U TestAttr>>#<U @v2> -> String @ Loc {file=test/testdata/rewriter/attr.rb start=8:5 end=8:8}
     field <C <U TestAttr>>#<U @v6> -> String @ Loc {file=test/testdata/rewriter/attr.rb start=9:5 end=9:8}
     method <C <U TestAttr>>#<U initialize> (<blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/rewriter/attr.rb start=6:3 end=6:17}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/attr.rb start=??? end=???}
-    method <C <U TestAttr>>#<U v1> (<blk>) -> Integer @ Loc {file=test/testdata/rewriter/attr.rb start=13:3 end=13:11}
+    method <C <U TestAttr>>#<U strv7> (<blk>) -> Float @ Loc {file=test/testdata/rewriter/attr.rb start=31:3 end=31:22}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/attr.rb start=??? end=???}
-    method <C <U TestAttr>>#<U v1=> (v1, <blk>) -> Integer @ Loc {file=test/testdata/rewriter/attr.rb start=15:3 end=15:18}
-      argument v1<> -> Integer @ Loc {file=test/testdata/rewriter/attr.rb start=14:15 end=14:17}
+    method <C <U TestAttr>>#<U strv8=> (strv8, <blk>) -> Float @ Loc {file=test/testdata/rewriter/attr.rb start=34:3 end=34:22}
+      argument strv8<> -> Float @ Loc {file=test/testdata/rewriter/attr.rb start=33:15 end=33:20}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/attr.rb start=??? end=???}
-    method <C <U TestAttr>>#<U v2> (<blk>) -> String @ Loc {file=test/testdata/rewriter/attr.rb start=18:3 end=18:20}
+    method <C <U TestAttr>>#<U strv9> (<blk>) -> Float @ Loc {file=test/testdata/rewriter/attr.rb start=37:3 end=37:24}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/attr.rb start=??? end=???}
-    method <C <U TestAttr>>#<U v2=> (v2, <blk>) -> String @ Loc {file=test/testdata/rewriter/attr.rb start=18:3 end=18:20}
-      argument v2<> -> String @ Loc {file=test/testdata/rewriter/attr.rb start=18:18 end=18:20}
+    method <C <U TestAttr>>#<U strv9=> ("strv9", <blk>) -> Float @ Loc {file=test/testdata/rewriter/attr.rb start=37:3 end=37:24}
+      argument "strv9"<> -> Float @ Loc {file=test/testdata/rewriter/attr.rb start=37:17 end=37:24}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/attr.rb start=??? end=???}
-    method <C <U TestAttr>>#<U v3> (<blk>) -> String @ Loc {file=test/testdata/rewriter/attr.rb start=21:3 end=21:18}
+    method <C <U TestAttr>>#<U v1> (<blk>) -> Integer @ Loc {file=test/testdata/rewriter/attr.rb start=16:3 end=16:11}
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/attr.rb start=??? end=???}
-    method <C <U TestAttr>>#<U v4=> (v4, <blk>) @ Loc {file=test/testdata/rewriter/attr.rb start=23:3 end=23:23}
-      argument v4<> @ Loc {file=test/testdata/rewriter/attr.rb start=23:16 end=23:18}
+    method <C <U TestAttr>>#<U v1=> (v1, <blk>) -> Integer @ Loc {file=test/testdata/rewriter/attr.rb start=18:3 end=18:18}
+      argument v1<> -> Integer @ Loc {file=test/testdata/rewriter/attr.rb start=17:15 end=17:17}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/attr.rb start=??? end=???}
+    method <C <U TestAttr>>#<U v2> (<blk>) -> String @ Loc {file=test/testdata/rewriter/attr.rb start=21:3 end=21:20}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/attr.rb start=??? end=???}
+    method <C <U TestAttr>>#<U v2=> (v2, <blk>) -> String @ Loc {file=test/testdata/rewriter/attr.rb start=21:3 end=21:20}
+      argument v2<> -> String @ Loc {file=test/testdata/rewriter/attr.rb start=21:18 end=21:20}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/attr.rb start=??? end=???}
+    method <C <U TestAttr>>#<U v3> (<blk>) -> String @ Loc {file=test/testdata/rewriter/attr.rb start=24:3 end=24:18}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/attr.rb start=??? end=???}
+    method <C <U TestAttr>>#<U v4=> (v4, <blk>) @ Loc {file=test/testdata/rewriter/attr.rb start=26:3 end=26:23}
+      argument v4<> @ Loc {file=test/testdata/rewriter/attr.rb start=26:16 end=26:18}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/attr.rb start=??? end=???}
-    method <C <U TestAttr>>#<U v5=> (v5, <blk>) @ Loc {file=test/testdata/rewriter/attr.rb start=23:3 end=23:23}
-      argument v5<> @ Loc {file=test/testdata/rewriter/attr.rb start=23:21 end=23:23}
+    method <C <U TestAttr>>#<U v5=> (v5, <blk>) @ Loc {file=test/testdata/rewriter/attr.rb start=26:3 end=26:23}
+      argument v5<> @ Loc {file=test/testdata/rewriter/attr.rb start=26:21 end=26:23}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/attr.rb start=??? end=???}
   class <S <C <U TestAttr>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U Sig>>) @ Loc {file=test/testdata/rewriter/attr.rb start=2:7 end=2:15}
     type-member(+) <S <C <U TestAttr>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U TestAttr>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=TestAttr) @ Loc {file=test/testdata/rewriter/attr.rb start=2:7 end=2:15}
-    method <S <C <U TestAttr>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/attr.rb start=2:1 end=26:4}
+    method <S <C <U TestAttr>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/attr.rb start=2:1 end=38:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/attr.rb start=??? end=???}
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is split off from #5706: while working on that PR, I noticed that `attr_reader` and friends with string names had locs that were slightly different than when using symbol names.  This PR brings the two closer together.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
