### PR TITLE
assert no notifications for typed files in some places

### DIFF
--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -514,7 +514,16 @@ void DefAssertion::check(const UnorderedMap<string, shared_ptr<core::File>> &sou
         // We would like to verify the number of notifications here, but the number
         // of notifications depends on the typed-ness of the file as well as the
         // particular kind of query we're running, and we don't have access to the
-        // latter here.
+        // latter here.  We can definitely assert that typed files have no notifications,
+        // though.
+        auto foundFile = sourceFileContents.find(locFilename);
+        REQUIRE_NE(sourceFileContents.end(), foundFile);
+        auto &file = foundFile->second;
+        if (file->strictLevel >= core::StrictLevel::True) {
+            const auto numNotifications =
+                absl::c_count_if(responses, [](const auto &m) { return m->isNotification(); });
+            REQUIRE_EQ(0, numNotifications);
+        }
     }
     assertResponseMessage(id, *responses.at(0));
 
@@ -600,7 +609,16 @@ void UsageAssertion::check(const UnorderedMap<string, shared_ptr<core::File>> &s
         // We would like to verify the number of notifications here, but the number
         // of notifications depends on the typed-ness of the file as well as the
         // particular kind of query we're running, and we don't have access to the
-        // latter here.
+        // latter here.  We can definitely assert that typed files have no notifications,
+        // though.
+        auto foundFile = sourceFileContents.find(locFilename);
+        REQUIRE_NE(sourceFileContents.end(), foundFile);
+        auto &file = foundFile->second;
+        if (file->strictLevel >= core::StrictLevel::True) {
+            const auto numNotifications =
+                absl::c_count_if(responses, [](const auto &m) { return m->isNotification(); });
+            REQUIRE_EQ(0, numNotifications);
+        }
     }
 
     assertResponseMessage(id, *responses.at(0));


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Realized after working on #5709 that we can assert something about the notifications in typed files for defs and uses, which should help prevent some kinds of regressions.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
