### PR TITLE
test the placeholder text in `PrepareRenameResponse`

### DIFF
--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -1294,23 +1294,30 @@ shared_ptr<ApplyRenameAssertion> ApplyRenameAssertion::make(string_view filename
                                                             int assertionLine, string_view assertionContents,
                                                             string_view assertionType) {
     static const regex newNameRegex(
-        R"(^\[(\w+)\]\s+(?:(?:newName:\s+(\w+))?\s?(?:invalid:\s+(true))?\s?(?:expectedErrorMessage:\s+(.+))?)$)");
+        R"(^\[(\w+)\]\s+(?:(?:newName:\s+(\w+))?\s?(?:placeholderText:\s+([^ ]+))?\s?(?:invalid:\s+(true))?\s?(?:expectedErrorMessage:\s+(.+))?)$)");
 
     smatch matches;
     string assertionContentsString = string(assertionContents);
     if (regex_search(assertionContentsString, matches, newNameRegex)) {
         auto version = matches[1].str();
         auto newName = matches[2].str();
-        auto invalid = !matches[3].str().empty();
-        auto expectedErrorMessage = matches[4].str();
-        if (!newName.empty() || invalid) {
-            return make_shared<ApplyRenameAssertion>(filename, range, assertionLine, version, newName, invalid,
+        auto placeholderText = matches[3].str();
+        if (!newName.empty() && placeholderText.empty()) {
+            ADD_FAIL_CHECK_AT(string(filename).c_str(), assertionLine + 1,
+                              "placeholderText must be provided if newName is provided");
+            return nullptr;
+        }
+
+        auto invalid = !matches[4].str().empty();
+        auto expectedErrorMessage = matches[5].str();
+        if ((!newName.empty() && !placeholderText.empty()) || invalid) {
+            return make_shared<ApplyRenameAssertion>(filename, range, assertionLine, version, newName, placeholderText, invalid,
                                                      expectedErrorMessage);
         }
     }
 
     ADD_FAIL_CHECK_AT(string(filename).c_str(), assertionLine + 1,
-                      fmt::format("Improperly formatted apply-rename assertion. Expected '[<version>] newName: <name> "
+                      fmt::format("Improperly formatted apply-rename assertion. Expected '[<version>] newName: <name> placeholderText: <name> "
                                   "(invalid: true) (expectedErrorMessage: <message>)'. Found '{}' in file {}",
                                   assertionContents, filename));
 
@@ -1318,9 +1325,9 @@ shared_ptr<ApplyRenameAssertion> ApplyRenameAssertion::make(string_view filename
 }
 
 ApplyRenameAssertion::ApplyRenameAssertion(string_view filename, unique_ptr<Range> &range, int assertionLine,
-                                           string_view version, string newName, bool invalid,
+                                           string_view version, string newName, string placeholderText, bool invalid,
                                            string expectedErrorMessage)
-    : RangeAssertion(filename, range, assertionLine), version(string(version)), newName(newName), invalid(invalid),
+    : RangeAssertion(filename, range, assertionLine), version(string(version)), newName(newName), placeholderText(placeholderText), invalid(invalid),
       expectedErrorMessage(expectedErrorMessage) {}
 
 void ApplyRenameAssertion::checkAll(const vector<shared_ptr<RangeAssertion>> &assertions,

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -1311,13 +1311,14 @@ shared_ptr<ApplyRenameAssertion> ApplyRenameAssertion::make(string_view filename
         auto invalid = !matches[4].str().empty();
         auto expectedErrorMessage = matches[5].str();
         if ((!newName.empty() && !placeholderText.empty()) || invalid) {
-            return make_shared<ApplyRenameAssertion>(filename, range, assertionLine, version, newName, placeholderText, invalid,
-                                                     expectedErrorMessage);
+            return make_shared<ApplyRenameAssertion>(filename, range, assertionLine, version, newName, placeholderText,
+                                                     invalid, expectedErrorMessage);
         }
     }
 
     ADD_FAIL_CHECK_AT(string(filename).c_str(), assertionLine + 1,
-                      fmt::format("Improperly formatted apply-rename assertion. Expected '[<version>] newName: <name> placeholderText: <name> "
+                      fmt::format("Improperly formatted apply-rename assertion. Expected '[<version>] newName: <name> "
+                                  "placeholderText: <name> "
                                   "(invalid: true) (expectedErrorMessage: <message>)'. Found '{}' in file {}",
                                   assertionContents, filename));
 
@@ -1327,8 +1328,8 @@ shared_ptr<ApplyRenameAssertion> ApplyRenameAssertion::make(string_view filename
 ApplyRenameAssertion::ApplyRenameAssertion(string_view filename, unique_ptr<Range> &range, int assertionLine,
                                            string_view version, string newName, string placeholderText, bool invalid,
                                            string expectedErrorMessage)
-    : RangeAssertion(filename, range, assertionLine), version(string(version)), newName(newName), placeholderText(placeholderText), invalid(invalid),
-      expectedErrorMessage(expectedErrorMessage) {}
+    : RangeAssertion(filename, range, assertionLine), version(string(version)), newName(newName),
+      placeholderText(placeholderText), invalid(invalid), expectedErrorMessage(expectedErrorMessage) {}
 
 void ApplyRenameAssertion::checkAll(const vector<shared_ptr<RangeAssertion>> &assertions,
                                     const UnorderedMap<string, shared_ptr<core::File>> &sourceFileContents,

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -1343,13 +1343,16 @@ void ApplyRenameAssertion::checkAll(const vector<shared_ptr<RangeAssertion>> &as
 void ApplyRenameAssertion::check(const UnorderedMap<std::string, std::shared_ptr<core::File>> &sourceFileContents,
                                  LSPWrapper &wrapper, int &nextId, std::string errorPrefix) {
     auto prepareRenameResponse = doTextDocumentPrepareRename(wrapper, *this->range, nextId, this->filename);
-    // TODO: test placeholder in prepareRenameResponse
 
     // A rename at an invalid position
     if (newName.empty() && invalid) {
         REQUIRE_EQ(prepareRenameResponse, nullptr);
     } else {
         REQUIRE_NE(prepareRenameResponse, nullptr);
+        auto &optPlaceholder = prepareRenameResponse->placeholder;
+        REQUIRE(optPlaceholder.has_value());
+        auto &placeholder = *optPlaceholder;
+        REQUIRE_EQ(this->placeholderText, placeholder);
     }
 
     auto workspaceEdits =

--- a/test/helpers/position_assertions.h
+++ b/test/helpers/position_assertions.h
@@ -345,12 +345,14 @@ public:
                          LSPWrapper &wrapper, int &nextId, std::string errorPrefix = "");
 
     ApplyRenameAssertion(std::string_view filename, std::unique_ptr<Range> &range, int assertionLine,
-                         std::string_view version, std::string newName, bool invalid, std::string expectedErrorMessage);
+                         std::string_view version, std::string newName, std::string placeholderText, bool invalid, std::string expectedErrorMessage);
 
     // The part between [..] in the assertion which specifies which `.[..].rbedited` file to compare against
     const std::string version;
     // New name for constant
     const std::string newName;
+    // The name of the thing being renamed
+    const std::string placeholderText;
     const bool invalid;
     const std::string expectedErrorMessage;
 

--- a/test/helpers/position_assertions.h
+++ b/test/helpers/position_assertions.h
@@ -345,7 +345,8 @@ public:
                          LSPWrapper &wrapper, int &nextId, std::string errorPrefix = "");
 
     ApplyRenameAssertion(std::string_view filename, std::unique_ptr<Range> &range, int assertionLine,
-                         std::string_view version, std::string newName, std::string placeholderText, bool invalid, std::string expectedErrorMessage);
+                         std::string_view version, std::string newName, std::string placeholderText, bool invalid,
+                         std::string expectedErrorMessage);
 
     // The part between [..] in the assertion which specifies which `.[..].rbedited` file to compare against
     const std::string version;

--- a/test/testdata/lsp/rename/constant__class_definition.A.rbedited
+++ b/test/testdata/lsp/rename/constant__class_definition.A.rbedited
@@ -2,13 +2,13 @@
 # frozen_string_literal: true
 
 FOO = 1
-# ^ apply-rename: [C] newName: BAZ
+# ^ apply-rename: [C] newName: BAZ placeholderText: FOO
 
 class Bar
-#     ^ apply-rename: [B] newName: foo invalid: true
+#     ^ apply-rename: [B] newName: foo placeholderText: Foo invalid: true
   class Foo
   end
 end
 
 foo = Bar.new
-#     ^ apply-rename: [A] newName: Bar
+#     ^ apply-rename: [A] newName: Bar placeholderText: Foo

--- a/test/testdata/lsp/rename/constant__class_definition.C.rbedited
+++ b/test/testdata/lsp/rename/constant__class_definition.C.rbedited
@@ -2,13 +2,13 @@
 # frozen_string_literal: true
 
 BAZ = 1
-# ^ apply-rename: [C] newName: BAZ
+# ^ apply-rename: [C] newName: BAZ placeholderText: FOO
 
 class Foo
-#     ^ apply-rename: [B] newName: foo invalid: true
+#     ^ apply-rename: [B] newName: foo placeholderText: Foo invalid: true
   class Foo
   end
 end
 
 foo = Foo.new
-#     ^ apply-rename: [A] newName: Bar
+#     ^ apply-rename: [A] newName: Bar placeholderText: Foo

--- a/test/testdata/lsp/rename/constant__class_definition.rb
+++ b/test/testdata/lsp/rename/constant__class_definition.rb
@@ -2,13 +2,13 @@
 # frozen_string_literal: true
 
 FOO = 1
-# ^ apply-rename: [C] newName: BAZ
+# ^ apply-rename: [C] newName: BAZ placeholderText: FOO
 
 class Foo
-#     ^ apply-rename: [B] newName: foo invalid: true
+#     ^ apply-rename: [B] newName: foo placeholderText: Foo invalid: true
   class Foo
   end
 end
 
 foo = Foo.new
-#     ^ apply-rename: [A] newName: Bar
+#     ^ apply-rename: [A] newName: Bar placeholderText: Foo

--- a/test/testdata/lsp/rename/constant__rbi_class_reference.A.rbedited
+++ b/test/testdata/lsp/rename/constant__rbi_class_reference.A.rbedited
@@ -7,6 +7,6 @@ sig { params(foo: Bar::Foo).returns(Bar::Foo) }
 def foo(foo); end
 
 class Baz
-#     ^ apply-rename: [D] newName: Bar invalid: true expectedErrorMessage: Renaming constants defined in .rbi files is not supported; symbol Baz is defined at test/testdata/lsp/rename/constant__rbi_class_reference.rbi
+#     ^ apply-rename: [D] newName: Bar placeholderText: Baz invalid: true expectedErrorMessage: Renaming constants defined in .rbi files is not supported; symbol Baz is defined at test/testdata/lsp/rename/constant__rbi_class_reference.rbi
 
 end

--- a/test/testdata/lsp/rename/constant__rbi_class_reference.rbi
+++ b/test/testdata/lsp/rename/constant__rbi_class_reference.rbi
@@ -7,6 +7,6 @@ sig { params(foo: Foo::Foo).returns(Foo::Foo) }
 def foo(foo); end
 
 class Baz
-#     ^ apply-rename: [D] newName: Bar invalid: true expectedErrorMessage: Renaming constants defined in .rbi files is not supported; symbol Baz is defined at test/testdata/lsp/rename/constant__rbi_class_reference.rbi
+#     ^ apply-rename: [D] newName: Bar placeholderText: Baz invalid: true expectedErrorMessage: Renaming constants defined in .rbi files is not supported; symbol Baz is defined at test/testdata/lsp/rename/constant__rbi_class_reference.rbi
 
 end

--- a/test/testdata/lsp/rename/method_attr.rb
+++ b/test/testdata/lsp/rename/method_attr.rb
@@ -12,4 +12,4 @@ end
 
 f = Foo.new
 f.foo
-#  ^ apply-rename: [B] newName: bar invalid: true expectedErrorMessage: Sorbet does not support renaming `attr_reader`s
+#  ^ apply-rename: [B] newName: bar placeholderText: foo invalid: true expectedErrorMessage: Sorbet does not support renaming `attr_reader`s

--- a/test/testdata/lsp/rename/method_class_hierarchy.A.rbedited
+++ b/test/testdata/lsp/rename/method_class_hierarchy.A.rbedited
@@ -12,7 +12,7 @@ end
 
 class A < BaseWithMethod
   def bar
-#     ^ apply-rename: [A] newName: bar
+#     ^ apply-rename: [A] newName: bar placeholderText: foo
   end
 end
 

--- a/test/testdata/lsp/rename/method_class_hierarchy.rb
+++ b/test/testdata/lsp/rename/method_class_hierarchy.rb
@@ -12,7 +12,7 @@ end
 
 class A < BaseWithMethod
   def foo
-#     ^ apply-rename: [A] newName: bar
+#     ^ apply-rename: [A] newName: bar placeholderText: foo
   end
 end
 

--- a/test/testdata/lsp/rename/method_class_method.A.rbedited
+++ b/test/testdata/lsp/rename/method_class_method.A.rbedited
@@ -3,7 +3,7 @@
 
 class Foo
   def self.bar
-#          ^ apply-rename: [A] newName: bar
+#          ^ apply-rename: [A] newName: bar placeholderText: foo
   end
 
   def foo

--- a/test/testdata/lsp/rename/method_class_method.rb
+++ b/test/testdata/lsp/rename/method_class_method.rb
@@ -3,7 +3,7 @@
 
 class Foo
   def self.foo
-#          ^ apply-rename: [A] newName: bar
+#          ^ apply-rename: [A] newName: bar placeholderText: foo
   end
 
   def foo

--- a/test/testdata/lsp/rename/method_fromsend.A.rbedited
+++ b/test/testdata/lsp/rename/method_fromsend.A.rbedited
@@ -19,7 +19,7 @@ end
 f = M::Foo.new
 f.baz(f.x)
 f.baz
-# ^ apply-rename: [A] newName: baz
+# ^ apply-rename: [A] newName: baz placeholderText: bar
 f  .  baz  (   )
 
 M::Foo.new.baz 3

--- a/test/testdata/lsp/rename/method_fromsend.rb
+++ b/test/testdata/lsp/rename/method_fromsend.rb
@@ -19,7 +19,7 @@ end
 f = M::Foo.new
 f.bar(f.x)
 f.bar
-# ^ apply-rename: [A] newName: baz
+# ^ apply-rename: [A] newName: baz placeholderText: bar
 f  .  bar  (   )
 
 M::Foo.new.bar 3

--- a/test/testdata/lsp/rename/method_mixins.A.rbedited
+++ b/test/testdata/lsp/rename/method_mixins.A.rbedited
@@ -7,20 +7,20 @@ end
 module BaseWithMethod
   include Base
   def foo
-#     ^ apply-rename: [B] newName: bar
+#     ^ apply-rename: [B] newName: bar placeholderText: foo
   end
 end
 
 module OtherModuleWithMethod
   def foo
-#     ^ apply-rename: [D] newName: bar
+#     ^ apply-rename: [D] newName: bar placeholderText: foo
   end
 end
 
 class A
   include BaseWithMethod
   def bar
-#     ^ apply-rename: [A] newName: bar
+#     ^ apply-rename: [A] newName: bar placeholderText: foo
   end
 end
 
@@ -31,7 +31,7 @@ end
 class C
   include Base
   def foo
-#     ^ apply-rename: [C] newName: bar
+#     ^ apply-rename: [C] newName: bar placeholderText: foo
   end
 end
 
@@ -47,4 +47,4 @@ A.new.bar
 B.new.foo
 D.new.foo
 E.new.foo
-#     ^ apply-rename: [E] newName: bar
+#     ^ apply-rename: [E] newName: bar placeholderText: foo

--- a/test/testdata/lsp/rename/method_mixins.B.rbedited
+++ b/test/testdata/lsp/rename/method_mixins.B.rbedited
@@ -7,20 +7,20 @@ end
 module BaseWithMethod
   include Base
   def bar
-#     ^ apply-rename: [B] newName: bar
+#     ^ apply-rename: [B] newName: bar placeholderText: foo
   end
 end
 
 module OtherModuleWithMethod
   def foo
-#     ^ apply-rename: [D] newName: bar
+#     ^ apply-rename: [D] newName: bar placeholderText: foo
   end
 end
 
 class A
   include BaseWithMethod
   def bar
-#     ^ apply-rename: [A] newName: bar
+#     ^ apply-rename: [A] newName: bar placeholderText: foo
   end
 end
 
@@ -31,7 +31,7 @@ end
 class C
   include Base
   def foo
-#     ^ apply-rename: [C] newName: bar
+#     ^ apply-rename: [C] newName: bar placeholderText: foo
   end
 end
 
@@ -47,4 +47,4 @@ A.new.bar
 B.new.bar
 D.new.foo
 E.new.foo
-#     ^ apply-rename: [E] newName: bar
+#     ^ apply-rename: [E] newName: bar placeholderText: foo

--- a/test/testdata/lsp/rename/method_mixins.C.rbedited
+++ b/test/testdata/lsp/rename/method_mixins.C.rbedited
@@ -7,20 +7,20 @@ end
 module BaseWithMethod
   include Base
   def foo
-#     ^ apply-rename: [B] newName: bar
+#     ^ apply-rename: [B] newName: bar placeholderText: foo
   end
 end
 
 module OtherModuleWithMethod
   def foo
-#     ^ apply-rename: [D] newName: bar
+#     ^ apply-rename: [D] newName: bar placeholderText: foo
   end
 end
 
 class A
   include BaseWithMethod
   def foo
-#     ^ apply-rename: [A] newName: bar
+#     ^ apply-rename: [A] newName: bar placeholderText: foo
   end
 end
 
@@ -31,7 +31,7 @@ end
 class C
   include Base
   def bar
-#     ^ apply-rename: [C] newName: bar
+#     ^ apply-rename: [C] newName: bar placeholderText: foo
   end
 end
 
@@ -47,4 +47,4 @@ A.new.foo
 B.new.foo
 D.new.bar
 E.new.foo
-#     ^ apply-rename: [E] newName: bar
+#     ^ apply-rename: [E] newName: bar placeholderText: foo

--- a/test/testdata/lsp/rename/method_mixins.D.rbedited
+++ b/test/testdata/lsp/rename/method_mixins.D.rbedited
@@ -7,20 +7,20 @@ end
 module BaseWithMethod
   include Base
   def foo
-#     ^ apply-rename: [B] newName: bar
+#     ^ apply-rename: [B] newName: bar placeholderText: foo
   end
 end
 
 module OtherModuleWithMethod
   def bar
-#     ^ apply-rename: [D] newName: bar
+#     ^ apply-rename: [D] newName: bar placeholderText: foo
   end
 end
 
 class A
   include BaseWithMethod
   def foo
-#     ^ apply-rename: [A] newName: bar
+#     ^ apply-rename: [A] newName: bar placeholderText: foo
   end
 end
 
@@ -31,7 +31,7 @@ end
 class C
   include Base
   def foo
-#     ^ apply-rename: [C] newName: bar
+#     ^ apply-rename: [C] newName: bar placeholderText: foo
   end
 end
 
@@ -47,4 +47,4 @@ A.new.foo
 B.new.foo
 D.new.foo
 E.new.bar
-#     ^ apply-rename: [E] newName: bar
+#     ^ apply-rename: [E] newName: bar placeholderText: foo

--- a/test/testdata/lsp/rename/method_mixins.E.rbedited
+++ b/test/testdata/lsp/rename/method_mixins.E.rbedited
@@ -7,20 +7,20 @@ end
 module BaseWithMethod
   include Base
   def foo
-#     ^ apply-rename: [B] newName: bar
+#     ^ apply-rename: [B] newName: bar placeholderText: foo
   end
 end
 
 module OtherModuleWithMethod
   def bar
-#     ^ apply-rename: [D] newName: bar
+#     ^ apply-rename: [D] newName: bar placeholderText: foo
   end
 end
 
 class A
   include BaseWithMethod
   def foo
-#     ^ apply-rename: [A] newName: bar
+#     ^ apply-rename: [A] newName: bar placeholderText: foo
   end
 end
 
@@ -31,7 +31,7 @@ end
 class C
   include Base
   def foo
-#     ^ apply-rename: [C] newName: bar
+#     ^ apply-rename: [C] newName: bar placeholderText: foo
   end
 end
 
@@ -47,4 +47,4 @@ A.new.foo
 B.new.foo
 D.new.foo
 E.new.bar
-#     ^ apply-rename: [E] newName: bar
+#     ^ apply-rename: [E] newName: bar placeholderText: foo

--- a/test/testdata/lsp/rename/method_mixins.rb
+++ b/test/testdata/lsp/rename/method_mixins.rb
@@ -7,20 +7,20 @@ end
 module BaseWithMethod
   include Base
   def foo
-#     ^ apply-rename: [B] newName: bar
+#     ^ apply-rename: [B] newName: bar placeholderText: foo
   end
 end
 
 module OtherModuleWithMethod
   def foo
-#     ^ apply-rename: [D] newName: bar
+#     ^ apply-rename: [D] newName: bar placeholderText: foo
   end
 end
 
 class A
   include BaseWithMethod
   def foo
-#     ^ apply-rename: [A] newName: bar
+#     ^ apply-rename: [A] newName: bar placeholderText: foo
   end
 end
 
@@ -31,7 +31,7 @@ end
 class C
   include Base
   def foo
-#     ^ apply-rename: [C] newName: bar
+#     ^ apply-rename: [C] newName: bar placeholderText: foo
   end
 end
 
@@ -47,4 +47,4 @@ A.new.foo
 B.new.foo
 D.new.foo
 E.new.foo
-#     ^ apply-rename: [E] newName: bar
+#     ^ apply-rename: [E] newName: bar placeholderText: foo

--- a/test/testdata/lsp/rename/method_names.A.rbedited
+++ b/test/testdata/lsp/rename/method_names.A.rbedited
@@ -6,7 +6,7 @@ class C1
 
   sig { returns(C1) }
   def m2
-#     ^ apply-rename: [A] newName: m2
+#     ^ apply-rename: [A] newName: m2 placeholderText: m1
     self
   end
 

--- a/test/testdata/lsp/rename/method_names.rb
+++ b/test/testdata/lsp/rename/method_names.rb
@@ -6,7 +6,7 @@ class C1
 
   sig { returns(C1) }
   def m1
-#     ^ apply-rename: [A] newName: m2
+#     ^ apply-rename: [A] newName: m2 placeholderText: m1
     self
   end
 

--- a/test/testdata/lsp/rename/method_nilable.A.rbedited
+++ b/test/testdata/lsp/rename/method_nilable.A.rbedited
@@ -3,7 +3,7 @@
 
 class C1
   def m2
-#      ^ apply-rename: [A] newName: m2
+#      ^ apply-rename: [A] newName: m2 placeholderText: m1
   end
 end
 
@@ -13,6 +13,6 @@ class CallerClass
   sig { params(c: T.nilable(C1)).void }
   def caller(c)
     c&.m2
-#      ^ apply-rename: [B] newName: m2
+#      ^ apply-rename: [B] newName: m2 placeholderText: m1
   end
 end

--- a/test/testdata/lsp/rename/method_nilable.B.rbedited
+++ b/test/testdata/lsp/rename/method_nilable.B.rbedited
@@ -3,7 +3,7 @@
 
 class C1
   def m2
-#      ^ apply-rename: [A] newName: m2
+#      ^ apply-rename: [A] newName: m2 placeholderText: m1
   end
 end
 
@@ -13,6 +13,6 @@ class CallerClass
   sig { params(c: T.nilable(C1)).void }
   def caller(c)
     c&.m2
-#      ^ apply-rename: [B] newName: m2
+#      ^ apply-rename: [B] newName: m2 placeholderText: m1
   end
 end

--- a/test/testdata/lsp/rename/method_nilable.rb
+++ b/test/testdata/lsp/rename/method_nilable.rb
@@ -3,7 +3,7 @@
 
 class C1
   def m1
-#      ^ apply-rename: [A] newName: m2
+#      ^ apply-rename: [A] newName: m2 placeholderText: m1
   end
 end
 
@@ -13,6 +13,6 @@ class CallerClass
   sig { params(c: T.nilable(C1)).void }
   def caller(c)
     c&.m1
-#      ^ apply-rename: [B] newName: m2
+#      ^ apply-rename: [B] newName: m2 placeholderText: m1
   end
 end

--- a/test/testdata/lsp/rename/method_operator_renames.rb
+++ b/test/testdata/lsp/rename/method_operator_renames.rb
@@ -2,22 +2,22 @@
 
 class Foo
   def call
-#     ^ apply-rename: [A] newName: foo invalid: true expectedErrorMessage: The `call` method cannot be renamed.
+#     ^ apply-rename: [A] newName: foo placeholderText: call invalid: true expectedErrorMessage: The `call` method cannot be renamed.
   end
 
   def [](a)
-#     ^ apply-rename: [B] newName: foo invalid: true expectedErrorMessage: The `[]` method cannot be renamed.
+#     ^ apply-rename: [B] newName: foo placeholderText: [] invalid: true expectedErrorMessage: The `[]` method cannot be renamed.
   end
 
   def +(a)
-#     ^ apply-rename: [C] newName: foo invalid: true expectedErrorMessage: The `+` method cannot be renamed.
+#     ^ apply-rename: [C] newName: foo placeholderText: + invalid: true expectedErrorMessage: The `+` method cannot be renamed.
   end
 end
 
 class Bar
   # not called
   def call
-#     ^ apply-rename: [D] newName: foo invalid: true expectedErrorMessage: The `call` method cannot be renamed.
+#     ^ apply-rename: [D] newName: foo placeholderText: call invalid: true expectedErrorMessage: The `call` method cannot be renamed.
   end
 end
 

--- a/test/testdata/lsp/rename/method_simple.A.rbedited
+++ b/test/testdata/lsp/rename/method_simple.A.rbedited
@@ -4,7 +4,7 @@
 module M
   class Foo
     def bazz(a=1)
-#     ^ apply-rename: [A] newName: bazz
+#     ^ apply-rename: [A] newName: bazz placeholderText: bar
     end
 
     def caller

--- a/test/testdata/lsp/rename/method_simple.rb
+++ b/test/testdata/lsp/rename/method_simple.rb
@@ -4,7 +4,7 @@
 module M
   class Foo
     def bar(a=1)
-#     ^ apply-rename: [A] newName: bazz
+#     ^ apply-rename: [A] newName: bazz placeholderText: bar
     end
 
     def caller

--- a/test/testdata/lsp/rename/method_union_2.A.rbedited
+++ b/test/testdata/lsp/rename/method_union_2.A.rbedited
@@ -10,5 +10,5 @@ end
 
 animal = T.let(Cat.new, T.any(Dog, Cat))
 animal.sound_new
-#      ^ apply-rename: [A] newName: sound_new
+#      ^ apply-rename: [A] newName: sound_new placeholderText: sound
 

--- a/test/testdata/lsp/rename/method_union_2.rb
+++ b/test/testdata/lsp/rename/method_union_2.rb
@@ -10,5 +10,5 @@ end
 
 animal = T.let(Cat.new, T.any(Dog, Cat))
 animal.sound
-#      ^ apply-rename: [A] newName: sound_new
+#      ^ apply-rename: [A] newName: sound_new placeholderText: sound
 

--- a/test/testdata/lsp/rename/method_union_types.A.rbedited
+++ b/test/testdata/lsp/rename/method_union_types.A.rbedited
@@ -3,25 +3,25 @@
 
 class C1
   def m2
-#      ^ apply-rename: [A] newName: m2
+#      ^ apply-rename: [A] newName: m2 placeholderText: m1
   end
 end
 
 class C2
   def m2
-#      ^ apply-rename: [B] newName: m2
+#      ^ apply-rename: [B] newName: m2 placeholderText: m1
   end
 end
 
 class C11 < C1
   def m2
-#      ^ apply-rename: [D] newName: m2
+#      ^ apply-rename: [D] newName: m2 placeholderText: m1
   end
 end
 
 class C3
   def m2
-#      ^ apply-rename: [E] newName: m2
+#      ^ apply-rename: [E] newName: m2 placeholderText: m1
   end
 end
 
@@ -31,7 +31,7 @@ class CallerClass
   sig { params(c: T.any(C1, C2)).void }
   def caller(c)
     c.m2
-#      ^ apply-rename: [C] newName: m2
+#      ^ apply-rename: [C] newName: m2 placeholderText: m1
   end
 
   sig { params(c: T.any(C11, C3)).void }

--- a/test/testdata/lsp/rename/method_union_types.B.rbedited
+++ b/test/testdata/lsp/rename/method_union_types.B.rbedited
@@ -3,25 +3,25 @@
 
 class C1
   def m2
-#      ^ apply-rename: [A] newName: m2
+#      ^ apply-rename: [A] newName: m2 placeholderText: m1
   end
 end
 
 class C2
   def m2
-#      ^ apply-rename: [B] newName: m2
+#      ^ apply-rename: [B] newName: m2 placeholderText: m1
   end
 end
 
 class C11 < C1
   def m2
-#      ^ apply-rename: [D] newName: m2
+#      ^ apply-rename: [D] newName: m2 placeholderText: m1
   end
 end
 
 class C3
   def m2
-#      ^ apply-rename: [E] newName: m2
+#      ^ apply-rename: [E] newName: m2 placeholderText: m1
   end
 end
 
@@ -31,7 +31,7 @@ class CallerClass
   sig { params(c: T.any(C1, C2)).void }
   def caller(c)
     c.m2
-#      ^ apply-rename: [C] newName: m2
+#      ^ apply-rename: [C] newName: m2 placeholderText: m1
   end
 
   sig { params(c: T.any(C11, C3)).void }

--- a/test/testdata/lsp/rename/method_union_types.C.rbedited
+++ b/test/testdata/lsp/rename/method_union_types.C.rbedited
@@ -3,25 +3,25 @@
 
 class C1
   def m2
-#      ^ apply-rename: [A] newName: m2
+#      ^ apply-rename: [A] newName: m2 placeholderText: m1
   end
 end
 
 class C2
   def m2
-#      ^ apply-rename: [B] newName: m2
+#      ^ apply-rename: [B] newName: m2 placeholderText: m1
   end
 end
 
 class C11 < C1
   def m2
-#      ^ apply-rename: [D] newName: m2
+#      ^ apply-rename: [D] newName: m2 placeholderText: m1
   end
 end
 
 class C3
   def m2
-#      ^ apply-rename: [E] newName: m2
+#      ^ apply-rename: [E] newName: m2 placeholderText: m1
   end
 end
 
@@ -31,7 +31,7 @@ class CallerClass
   sig { params(c: T.any(C1, C2)).void }
   def caller(c)
     c.m2
-#      ^ apply-rename: [C] newName: m2
+#      ^ apply-rename: [C] newName: m2 placeholderText: m1
   end
 
   sig { params(c: T.any(C11, C3)).void }

--- a/test/testdata/lsp/rename/method_union_types.D.rbedited
+++ b/test/testdata/lsp/rename/method_union_types.D.rbedited
@@ -3,25 +3,25 @@
 
 class C1
   def m2
-#      ^ apply-rename: [A] newName: m2
+#      ^ apply-rename: [A] newName: m2 placeholderText: m1
   end
 end
 
 class C2
   def m2
-#      ^ apply-rename: [B] newName: m2
+#      ^ apply-rename: [B] newName: m2 placeholderText: m1
   end
 end
 
 class C11 < C1
   def m2
-#      ^ apply-rename: [D] newName: m2
+#      ^ apply-rename: [D] newName: m2 placeholderText: m1
   end
 end
 
 class C3
   def m2
-#      ^ apply-rename: [E] newName: m2
+#      ^ apply-rename: [E] newName: m2 placeholderText: m1
   end
 end
 
@@ -31,7 +31,7 @@ class CallerClass
   sig { params(c: T.any(C1, C2)).void }
   def caller(c)
     c.m2
-#      ^ apply-rename: [C] newName: m2
+#      ^ apply-rename: [C] newName: m2 placeholderText: m1
   end
 
   sig { params(c: T.any(C11, C3)).void }

--- a/test/testdata/lsp/rename/method_union_types.E.rbedited
+++ b/test/testdata/lsp/rename/method_union_types.E.rbedited
@@ -3,25 +3,25 @@
 
 class C1
   def m2
-#      ^ apply-rename: [A] newName: m2
+#      ^ apply-rename: [A] newName: m2 placeholderText: m1
   end
 end
 
 class C2
   def m2
-#      ^ apply-rename: [B] newName: m2
+#      ^ apply-rename: [B] newName: m2 placeholderText: m1
   end
 end
 
 class C11 < C1
   def m2
-#      ^ apply-rename: [D] newName: m2
+#      ^ apply-rename: [D] newName: m2 placeholderText: m1
   end
 end
 
 class C3
   def m2
-#      ^ apply-rename: [E] newName: m2
+#      ^ apply-rename: [E] newName: m2 placeholderText: m1
   end
 end
 
@@ -31,7 +31,7 @@ class CallerClass
   sig { params(c: T.any(C1, C2)).void }
   def caller(c)
     c.m2
-#      ^ apply-rename: [C] newName: m2
+#      ^ apply-rename: [C] newName: m2 placeholderText: m1
   end
 
   sig { params(c: T.any(C11, C3)).void }

--- a/test/testdata/lsp/rename/method_union_types.rb
+++ b/test/testdata/lsp/rename/method_union_types.rb
@@ -3,25 +3,25 @@
 
 class C1
   def m1
-#      ^ apply-rename: [A] newName: m2
+#      ^ apply-rename: [A] newName: m2 placeholderText: m1
   end
 end
 
 class C2
   def m1
-#      ^ apply-rename: [B] newName: m2
+#      ^ apply-rename: [B] newName: m2 placeholderText: m1
   end
 end
 
 class C11 < C1
   def m1
-#      ^ apply-rename: [D] newName: m2
+#      ^ apply-rename: [D] newName: m2 placeholderText: m1
   end
 end
 
 class C3
   def m1
-#      ^ apply-rename: [E] newName: m2
+#      ^ apply-rename: [E] newName: m2 placeholderText: m1
   end
 end
 
@@ -31,7 +31,7 @@ class CallerClass
   sig { params(c: T.any(C1, C2)).void }
   def caller(c)
     c.m1
-#      ^ apply-rename: [C] newName: m2
+#      ^ apply-rename: [C] newName: m2 placeholderText: m1
   end
 
   sig { params(c: T.any(C11, C3)).void }

--- a/test/testdata/lsp/rename/uppercase_method.A.rbedited
+++ b/test/testdata/lsp/rename/uppercase_method.A.rbedited
@@ -1,7 +1,7 @@
 # typed: true
 
 def ORIGIN(x = nil); end
-#   ^ apply-rename: [A] newName: ORIGIN
+#   ^ apply-rename: [A] newName: ORIGIN placeholderText: origin
 
 ORIGIN()
 

--- a/test/testdata/lsp/rename/uppercase_method.rb
+++ b/test/testdata/lsp/rename/uppercase_method.rb
@@ -1,7 +1,7 @@
 # typed: true
 
 def origin(x = nil); end
-#   ^ apply-rename: [A] newName: ORIGIN
+#   ^ apply-rename: [A] newName: ORIGIN placeholderText: origin
 
 origin()
 


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

There is a TODO in `position_assertions.cc` about testing the placeholder text that we return in `textDocument/prepareRename`.  This text is shown to the user (at least in VSCode), so it would be good to test that we are showing the user the thing we expect to be showing them.

I think this would have also cleared up some of the confusion in #4734 around identifier locations: the tests would have required `placeholderText`, and it would have been a little more obvious what we were trying to fix with the fiddling around the location of `IdentResponse`, or at least what would break if we had used the unadulterated location of the `IdentResponse`.

cc @vinistock

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
