### PR TITLE
provide error documentation in the `codeDescription` field

### DIFF
--- a/main/lsp/ErrorReporter.cc
+++ b/main/lsp/ErrorReporter.cc
@@ -155,11 +155,9 @@ void ErrorReporter::pushDiagnostics(uint32_t epoch, core::FileRef file, const ve
             }
         }
         // Add link to error documentation.
-        relatedInformation.push_back(make_unique<DiagnosticRelatedInformation>(
-            make_unique<Location>(absl::StrCat(config->opts.errorUrlBase, error->what.code),
-                                  make_unique<Range>(make_unique<Position>(0, 0), make_unique<Position>(0, 0))),
-            "Click for more information on this error."));
         diagnostic->relatedInformation = move(relatedInformation);
+        diagnostic->codeDescription =
+            make_unique<CodeDescription>(absl::StrCat(config->opts.errorUrlBase, error->what.code));
         diagnostics.push_back(move(diagnostic));
     }
 

--- a/main/lsp/tools/make_lsp_types.cc
+++ b/main/lsp/tools/make_lsp_types.cc
@@ -140,12 +140,20 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
 
     auto DiagnosticTag = makeIntEnum("DiagnosticTag", {{"Unnecessary", 1}, {"Deprecated", 2}}, enumTypes);
 
+    auto CodeDescription = makeObject("CodeDescription",
+                                      {
+                                          // URI
+                                          makeField("href", JSONString),
+                                      },
+                                      classTypes);
+
     auto Diagnostic =
         makeObject("Diagnostic",
                    {
                        makeField("range", Range),
                        makeField("severity", makeOptional(DiagnosticSeverity)),
                        makeField("code", makeOptional(makeVariant({JSONInt, JSONString}))),
+                       makeField("codeDescription", makeOptional(CodeDescription)),
                        makeField("source", makeOptional(JSONString)),
                        makeField("message", JSONString),
                        makeField("relatedInformation", makeOptional(makeArray(DiagnosticRelatedInformation))),


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We currently provide a link to the error documentation via `Diagnostic.relatedInformation.location`, which requires us to provide a useless location within the "file" and a message directing the user to click for more information.  Since LSP 3.16, there's `Diagnostic.codeDescription` which is just the URI to the documentation.  This latter method is smaller in the over-the-wire protocol (less repeated/useless information) and displays slightly more nicely in the UI.

Before:

![image](https://user-images.githubusercontent.com/151096/165800876-13ac1f0f-7bfc-443b-8e06-7c1e2403956e.png)

After:

![image](https://user-images.githubusercontent.com/151096/165800807-afe20b94-aaf4-4f4d-8cf5-3b23fa7bc61a.png)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
