### PR TITLE
Add new model token prop analysis printer to runAutogen

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -200,6 +200,8 @@ NameDef names[] = {
     {"prop"},
     {"tokenProp", "token_prop"},
     {"timestampedTokenProp", "timestamped_token_prop"},
+    {"registerPrefix", "register_prefix"},
+    {"setArchiveTokenPrefix", "set_archive_token_prefix"},
     {"createdProp", "created_prop"},
     {"updatedProp", "updated_prop"},
     {"merchantProp", "merchant_prop"},
@@ -283,6 +285,8 @@ NameDef names[] = {
 
     {"keywordInit", "keyword_init"},
 
+    {"configureArchival", "configure_archival"},
+    {"originalClass", "original_class"},
     {"DB", "DB", true},
     {"Model", "Model", true},
     {"Mixins", "Mixins", true},
@@ -290,6 +294,12 @@ NameDef names[] = {
     {"EncryptedValue", "EncryptedValue", true},
     {"Command", "Command", true},
     {"Enum", "Enum", true},
+    {"Event", "Event", true},
+    {"DeprecatedFramework", "DeprecatedFramework", true},
+    {"Risk", "Risk", true},
+    {"Denylists", "Denylists", true},
+    {"AbstractBlacklistRecord", "AbstractBlacklistRecord", true},
+    {"AbstractEvent", "AbstractEvent", true},
 
     {"ActiveRecord", "ActiveRecord", true},
     {"Migration", "Migration", true},
@@ -566,6 +576,8 @@ NameDef names[] = {
 
     // used by the compiler
     {"returnValue", "<returnValue>"},
+    // Model DSL
+    {"modelDsl", "model"},
 };
 
 void emit_name_header(ostream &out, NameDef &name) {

--- a/main/autogen/BUILD
+++ b/main/autogen/BUILD
@@ -8,6 +8,7 @@ cc_library(
         "crc_builder.cc",
         "token_prop_analysis.cc",
         "subclasses.cc",
+        "token_prop_analysis.cc",
     ],
     hdrs = [
         "autogen.h",
@@ -17,6 +18,7 @@ cc_library(
         "crc_builder.h",
         "token_prop_analysis.h",
         "subclasses.h",
+        "token_prop_analysis.h",
     ],
     linkstatic = select({
         "//tools/config:linkshared": 0,

--- a/main/autogen/BUILD
+++ b/main/autogen/BUILD
@@ -6,6 +6,7 @@ cc_library(
         "cache.cc",
         "constant_hash.cc",
         "crc_builder.cc",
+        "token_prop_analysis.cc",
         "subclasses.cc",
     ],
     hdrs = [
@@ -14,6 +15,7 @@ cc_library(
         "cache.h",
         "constant_hash.h",
         "crc_builder.h",
+        "token_prop_analysis.h",
         "subclasses.h",
     ],
     linkstatic = select({

--- a/main/autogen/data/definitions.h
+++ b/main/autogen/data/definitions.h
@@ -176,11 +176,6 @@ struct ParsedFile {
     std::vector<std::string> listAllClasses(core::Context ctx);
 };
 
-struct LocInfo {
-    core::FileRef file;
-    core::LocOffsets loc;
-};
-
 struct PropInfo {
     core::NameRef name;
     bool isTimestamped;

--- a/main/autogen/data/definitions.h
+++ b/main/autogen/data/definitions.h
@@ -176,6 +176,45 @@ struct ParsedFile {
     std::vector<std::string> listAllClasses(core::Context ctx);
 };
 
+struct LocInfo {
+    core::FileRef file;
+    core::LocOffsets loc;
+};
+
+struct PropInfo {
+    core::NameRef name;
+    bool isTimestamped;
+
+    std::string toString(const std::vector<core::NameRef> &klass, const core::GlobalState &gs) const;
+};
+
+struct TokenProps {
+    std::vector<PropInfo> props;
+    std::vector<std::vector<core::NameRef>> ancestors;
+
+    // file
+    core::FileRef file;
+
+    void formatString(fmt::memory_buffer &out, const std::vector<core::NameRef> &klass,
+                      const core::GlobalState &gs) const;
+};
+
+void printName(fmt::memory_buffer &out, const std::vector<core::NameRef> &parts, const core::GlobalState &gs);
+UnorderedMap<std::vector<core::NameRef>, TokenProps>
+mergeAndFilterAllTokenProps(const core::GlobalState &gs,
+                            UnorderedMap<std::vector<core::NameRef>, TokenProps> allTokenProps);
+
+struct TokenPropAnalysisFile {
+    // the checksum of this file
+    uint32_t cksum;
+
+    // map of class -> TokenProps
+    UnorderedMap<std::vector<core::NameRef>, TokenProps> tokenPropsByClass;
+
+    // file
+    core::FileRef file;
+};
+
 // A `Package` represents Autogen's view of a package file
 struct Package {
     // the original file AST from Sorbet

--- a/main/autogen/token_prop_analysis.cc
+++ b/main/autogen/token_prop_analysis.cc
@@ -1,0 +1,192 @@
+#include "main/autogen/token_prop_analysis.h"
+#include "ast/Helpers.h"
+#include "ast/ast.h"
+#include "ast/treemap/treemap.h"
+#include "common/formatting.h"
+#include "main/autogen/crc_builder.h"
+
+using namespace std;
+namespace sorbet::autogen {
+
+const std::vector<uint32_t> KNOWN_PROP_METHODS = {
+    core::Names::tokenProp().rawId(), core::Names::timestampedTokenProp().rawId(),
+    core::Names::registerPrefix().rawId(), core::Names::setArchiveTokenPrefix().rawId()};
+
+const std::vector<core::NameRef> ABSTRACT_BLACKLIST_RECORD = {
+    core::Names::Constants::Opus(),
+    core::Names::Constants::Risk(),
+    core::Names::Constants::Denylists(),
+    core::Names::Constants::Model(),
+    core::Names::Constants::AbstractBlacklistRecord(),
+};
+
+class TokenPropAnalysisWalk {
+    UnorderedMap<vector<core::NameRef>, TokenProps> tokenPropsByClass;
+    vector<vector<core::NameRef>> nestingScopes;
+    core::FileRef file;
+    bool validScope;
+
+    // Convert a symbol name into a fully qualified name
+    vector<core::NameRef> symbolName(core::Context ctx, core::SymbolRef sym) {
+        vector<core::NameRef> out;
+        while (sym.exists() && sym != core::Symbols::root()) {
+            out.emplace_back(sym.name(ctx));
+            sym = sym.owner(ctx);
+        }
+        reverse(out.begin(), out.end());
+        return out;
+    }
+
+    struct PropInfoInternal {
+        core::NameRef name;
+        bool isTimestamped;
+    };
+
+    std::optional<PropInfoInternal> parseProp(core::Context ctx, ast::Send *send) {
+        switch (send->fun.rawId()) {
+            case core::Names::timestampedTokenProp().rawId():
+                if (send->numPosArgs() > 0) {
+                    auto *lit = ast::cast_tree<ast::Literal>(send->getPosArg(0));
+                    if (lit && lit->isString()) {
+                        return PropInfoInternal{lit->asString(), true};
+                    } else {
+                        return PropInfoInternal{core::NameRef::noName(), true};
+                    }
+                }
+                break;
+            case core::Names::setArchiveTokenPrefix().rawId():
+            case core::Names::registerPrefix().rawId():
+            case core::Names::tokenProp().rawId():
+                if (send->numPosArgs() > 0) {
+                    auto *lit = ast::cast_tree<ast::Literal>(send->getPosArg(0));
+                    if (lit && lit->isString()) {
+                        return PropInfoInternal{lit->asString(), false};
+                    } else {
+                        return PropInfoInternal{core::NameRef::noName(), false};
+                    }
+                }
+                break;
+            default:
+                return std::nullopt;
+        }
+
+        return std::nullopt;
+    }
+
+public:
+    TokenPropAnalysisWalk(core::FileRef a_file) {
+        validScope = true;
+        file = a_file;
+    }
+
+    void preTransformClassDef(core::Context ctx, ast::ExpressionPtr &tree) {
+        auto &original = ast::cast_tree_nonnull<ast::ClassDef>(tree);
+        if (original.symbol.data(ctx)->owner == core::Symbols::PackageSpecRegistry()) {
+            // this is a package, so do not enter a definition for it
+            return;
+        }
+
+        vector<vector<core::NameRef>> ancestors;
+        for (auto &ancst : original.ancestors) {
+            auto *cnst = ast::cast_tree<ast::ConstantLit>(ancst);
+            if (cnst == nullptr || cnst->original == nullptr) {
+                // ignore them if they're not statically-known ancestors (i.e. not constants)
+                continue;
+            }
+
+            const auto ancstName = symbolName(ctx, cnst->symbol);
+            ancestors.emplace_back(std::move(ancstName));
+        }
+
+        const vector<core::NameRef> className = symbolName(ctx, original.symbol);
+        nestingScopes.emplace_back(className);
+        tokenPropsByClass.emplace(className, TokenProps{{}, ancestors, file});
+
+        return;
+    }
+
+    void postTransformClassDef(core::Context ctx, ast::ExpressionPtr &tree) {
+        if (nestingScopes.size() == 0 || !validScope) {
+            // Not in any scope
+            return;
+        }
+
+        nestingScopes.pop_back();
+
+        return;
+    }
+
+    void preTransformSend(core::Context ctx, ast::ExpressionPtr &tree) {
+        if (nestingScopes.size() == 0) {
+            // Not in any scope
+            return;
+        }
+
+        auto *original = ast::cast_tree<ast::Send>(tree);
+        auto &curScope = nestingScopes.back();
+
+        uint32_t funId = original->fun.rawId();
+        bool isProp = absl::c_any_of(KNOWN_PROP_METHODS, [&](const auto &nrid) -> bool { return nrid == funId; });
+        if (isProp) {
+            if (!validScope) {
+                return;
+            }
+
+            const auto prop = parseProp(ctx, original);
+            if (prop.has_value()) {
+                tokenPropsByClass[curScope].props.emplace_back(
+                    PropInfo{std::move((*prop).name), std::move((*prop).isTimestamped)});
+            } else {
+                tokenPropsByClass[curScope].props.emplace_back(PropInfo{core::NameRef::noName(), false});
+            }
+
+            return;
+        }
+
+        return;
+    }
+
+    void preTransformMethodDef(core::Context ctx, ast::ExpressionPtr &tree) {
+        if (nestingScopes.size() == 0 || !validScope) {
+            // Not already in a valid scope
+            return;
+        }
+
+        auto &curScope = nestingScopes.back();
+        if (curScope == ABSTRACT_BLACKLIST_RECORD) {
+            return;
+        }
+
+        validScope = false;
+        return;
+    }
+
+    void postTransformMethodDef(core::Context ctx, ast::ExpressionPtr &tree) {
+        if (nestingScopes.size() == 0 || validScope) {
+            // Already in a valid scope, or never in a scope
+            return;
+        }
+
+        validScope = true;
+        return;
+    }
+
+    TokenPropAnalysisFile tokenPropAnalysisFile() {
+        TokenPropAnalysisFile out;
+        out.tokenPropsByClass = std::move(tokenPropsByClass);
+        out.file = std::move(file);
+        return out;
+    }
+};
+
+TokenPropAnalysisFile TokenPropAnalysis::generate(core::Context ctx, ast::ParsedFile tree,
+                                                  const CRCBuilder &crcBuilder) {
+    TokenPropAnalysisWalk walk(tree.file);
+    ast::TreeWalk::apply(ctx, walk, tree.tree);
+    auto tpaf = walk.tokenPropAnalysisFile();
+    auto src = tree.file.data(ctx).source();
+    tpaf.cksum = crcBuilder.crc32(src);
+    return tpaf;
+}
+
+} // namespace sorbet::autogen

--- a/main/autogen/token_prop_analysis.h
+++ b/main/autogen/token_prop_analysis.h
@@ -1,0 +1,17 @@
+#ifndef DSL_ANALYSIS_H
+#define DSL_ANALYSIS_H
+
+#include "main/autogen/crc_builder.h"
+#include "main/autogen/data/definitions.h"
+#include "main/options/options.h"
+
+namespace sorbet::autogen {
+
+class TokenPropAnalysis final {
+public:
+    static TokenPropAnalysisFile generate(core::Context ctx, ast::ParsedFile tree, const CRCBuilder &crcBuilder);
+    TokenPropAnalysis() = delete;
+};
+
+} // namespace sorbet::autogen
+#endif // AUTOGEN_H

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -80,6 +80,7 @@ const vector<PrintOptions> print_options({
     {"package-tree", &Printers::Packager, false},
     {"minimized-rbi", &Printers::MinimizeRBI},
     {"payload-sources", &Printers::PayloadSources},
+    {"token-prop-analysis", &Printers::TokenPropAnalysis, true},
 });
 
 PrinterConfig::PrinterConfig() : state(make_shared<GuardedState>()){};
@@ -148,6 +149,7 @@ vector<reference_wrapper<PrinterConfig>> Printers::printers() {
         AutogenMsgPack,
         AutogenAutoloader,
         AutogenSubclasses,
+        TokenPropAnalysis,
         Packager,
         MinimizeRBI,
         PayloadSources,
@@ -155,7 +157,8 @@ vector<reference_wrapper<PrinterConfig>> Printers::printers() {
 }
 
 bool Printers::isAutogen() const {
-    return Autogen.enabled || AutogenMsgPack.enabled || AutogenSubclasses.enabled || AutogenAutoloader.enabled;
+    return Autogen.enabled || AutogenMsgPack.enabled || AutogenSubclasses.enabled || AutogenAutoloader.enabled ||
+           TokenPropAnalysis.enabled;
 }
 
 struct StopAfterOptions {

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -83,6 +83,7 @@ struct Printers {
     PrinterConfig AutogenMsgPack;
     PrinterConfig AutogenAutoloader;
     PrinterConfig AutogenSubclasses;
+    PrinterConfig TokenPropAnalysis;
     PrinterConfig Packager;
     PrinterConfig MinimizeRBI;
     PrinterConfig PayloadSources;

--- a/test/cli/autogen_token_props/test.out
+++ b/test/cli/autogen_token_props/test.out
@@ -1,0 +1,9 @@
+No errors! Great job.
+TokenPropsModel:
+  props:
+  - a
+  - m
+  - tok
+  - bc
+  - d
+

--- a/test/cli/autogen_token_props/test.sh
+++ b/test/cli/autogen_token_props/test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -eu
+cd test/cli/autogen_token_props || exit 1
+
+../../../main/sorbet --silence-dev-message -p token-prop-analysis --stop-after=namer . 2>&1
+

--- a/test/cli/autogen_token_props/token_props.rb
+++ b/test/cli/autogen_token_props/token_props.rb
@@ -1,0 +1,18 @@
+# typed: strict
+
+module Chalk
+  module ODM
+    class Model; end
+  end
+end
+
+class TokenPropsModel < Chalk::ODM::Model
+  token_prop 'a'
+  register_prefix 'm'
+  timestamped_token_prop
+  timestamped_token_prop 'bc'
+  set_archive_token_prefix 'd'
+
+  sig {void}
+  def foo; end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Adds a new autogen pass and printer called (`-p token-prop-analysis`) which captures data about the `token_prop` DSL in the Stripe codebase.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
We want to performantly capture DSL data regarding "token props" in the Stripe codebase statically without loading Ruby classes.

Token props are a special DSL at Stripe that are specific to data model classes, allowing application code to load data model objects based on a primary key.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Tested on Stripe codebase.