### PR TITLE
Stop sending notification about `# typed: false` file

### DIFF
--- a/test/lsp/protocol_test_corpus.cc
+++ b/test/lsp/protocol_test_corpus.cc
@@ -99,7 +99,7 @@ TEST_CASE_FIXTURE(ProtocolTest, "DefinitionError") {
     const auto numRequests = absl::c_count_if(defResponses, [](const auto &m) { return m->isRequest(); });
     REQUIRE_EQ(0, numRequests);
     const auto numNotifications = absl::c_count_if(defResponses, [](const auto &m) { return m->isNotification(); });
-    REQUIRE_EQ(1, numNotifications);
+    REQUIRE_EQ(0, numNotifications);
     // Ensure the lone response is at the front.
     absl::c_partition(defResponses, [](const auto &m) { return m->isResponse(); });
     assertResponseMessage(nextId - 1, *defResponses.at(0));


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We're going to go with #5716 only to show the user what's happening when they
attempt to jump-to-def in a `typed: false` file.

It turns out that VS Code will send `textDocument/definition` requests all over
the place as long as the user is holding down Cmd (not only once the click has
come through).

It sends the `textDocument/definition` request to see whether it can change a
piece of the source document to look like a blue link.

If it had been the case that VS Code just sent a request once the user had
committed to the request, it would have been easier to tell them why they were
getting no results.

Hopefully the hover message from #5716 will be enough to tell people what's
happening.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.