### PR TITLE
Store the package name mapping in the PackageDB instead of the file table

### DIFF
--- a/ast/substitute/Substitute.cc
+++ b/ast/substitute/Substitute.cc
@@ -131,24 +131,12 @@ public:
 ParsedFile Substitute::run(core::MutableContext ctx, const core::NameSubstitution &subst, ParsedFile what) {
     SubstWalk walk(subst);
     what.tree = TreeMap::apply(ctx, walk, std::move(what.tree));
-
-    auto pkg = what.file.data(ctx).getPackage();
-    if (pkg.exists()) {
-        what.file.data(ctx).setPackage(subst.substitute(pkg));
-    }
-
     return what;
 }
 
 ParsedFile Substitute::run(core::MutableContext ctx, core::LazyNameSubstitution &subst, ParsedFile what) {
     SubstWalk walk(subst);
     what.tree = TreeMap::apply(ctx, walk, std::move(what.tree));
-
-    auto pkg = what.file.data(ctx).getPackage();
-    if (pkg.exists()) {
-        what.file.data(ctx).setPackage(subst.substitute(pkg));
-    }
-
     return what;
 }
 

--- a/core/Files.cc
+++ b/core/Files.cc
@@ -412,14 +412,6 @@ void File::setCached(bool value) {
     flags.cached = value;
 }
 
-NameRef File::getPackage() const {
-    return this->package;
-}
-
-void File::setPackage(NameRef mangledName) {
-    this->package = mangledName;
-}
-
 bool File::isPackaged() const {
     switch (this->packagedLevel) {
         case PackagedLevel::False:

--- a/core/Files.h
+++ b/core/Files.h
@@ -67,12 +67,6 @@ public:
     bool cached() const;
     void setCached(bool value);
 
-    // Fetch the mangled name of the package that this file belongs to.
-    NameRef getPackage() const;
-
-    // Set the mangled name of the package that this file belongs to.
-    void setPackage(NameRef mangledName);
-
     // Returns whether or not this file is considered to be packaged.
     bool isPackaged() const;
 
@@ -122,11 +116,6 @@ public:
     const std::string path_;
     const std::string source_;
     mutable std::shared_ptr<std::vector<int>> lineBreaks_;
-
-    // NOTE: this currently is overhead neutral even when `--stripe-packages` is disabled.
-    // Depending on what `File` requires in the future, we may look at moving it into the
-    // PackageDB to avoid memory overhead in non-Stripe codebases.
-    NameRef package = core::NameRef::noName();
 
     mutable StrictLevel minErrorLevel_ = StrictLevel::Max;
 

--- a/core/packages/PackageDB.h
+++ b/core/packages/PackageDB.h
@@ -24,6 +24,13 @@ class PackageDB final {
 public:
     NameRef enterPackage(std::unique_ptr<PackageInfo> pkg);
 
+    // Fetch the mangled package name for a file, returning a core::NameRef::noName() that doesn't exist if there is no
+    // associated packge for the file.
+    const NameRef getPackageNameForFile(FileRef file) const;
+
+    // Set the associated package for the file.
+    void setPackageNameForFile(FileRef file, NameRef mangledName);
+
     const PackageInfo &getPackageForFile(const core::GlobalState &gs, core::FileRef file) const;
     const PackageInfo &getPackageInfo(core::NameRef mangledName) const;
 
@@ -55,6 +62,11 @@ private:
     std::vector<NameRef> secondaryTestPackageNamespaceRefs_;
     std::vector<std::string> extraPackageFilesDirectoryPrefixes_;
     std::string errorHint_;
+
+    // This vector is kept in sync with the size of the file table in the global state by
+    // `Packager::setPackageNameOnFiles`. A `FileRef` being out of bounds in this vector is treated as the file having
+    // no associated package.
+    std::vector<NameRef> packageForFile_;
 
     UnorderedMap<core::NameRef, std::unique_ptr<packages::PackageInfo>> packages_;
     UnorderedMap<std::string, core::NameRef> packagesByPathPrefix;

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1020,7 +1020,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                     if (it->main.method.exists() && it->main.method.data(ctx)->flags.isPackagePrivate) {
                         core::ClassOrModuleRef klass = it->main.method.data(ctx)->owner;
                         if (klass.exists()) {
-                            const auto &curPkg = ctx.state.packageDB().getPackageInfo(ctx.file.data(ctx).getPackage());
+                            const auto &curPkg = ctx.state.packageDB().getPackageForFile(ctx, ctx.file);
                             if (curPkg.exists() && !curPkg.ownsSymbol(ctx, klass)) {
                                 if (auto e = ctx.beginError(bind.loc, core::errors::Infer::PackagePrivateMethod)) {
                                     auto &curPkgName = curPkg.fullName();

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -685,10 +685,10 @@ int realmain(int argc, char *argv[]) {
                 auto info = core::packages::ImportInfo::fromPackage(*gs, pkg);
 
                 // Only keep inputs that are part of the package whose interface we're generating
-                auto it = std::remove_if(inputFiles.begin(), inputFiles.end(), [&gs = *gs, &info](auto file) {
-                    // NOTE: the files haven't been read at this point, but their package will be known.
-                    return info.package != file.dataAllowingUnsafe(gs).getPackage();
-                });
+                auto it =
+                    std::remove_if(inputFiles.begin(), inputFiles.end(), [&db = gs->packageDB(), &info](auto file) {
+                        return info.package != db.getPackageNameForFile(file);
+                    });
                 inputFiles.erase(it, inputFiles.end());
 
                 // Record parent information in GlobalState to guide the resolver when stubbing out constants that come

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -2049,12 +2049,28 @@ vector<ast::ParsedFile> Packager::findPackages(core::GlobalState &gs, WorkerPool
 }
 
 void Packager::setPackageNameOnFiles(core::GlobalState &gs, const vector<ast::ParsedFile> &files) {
+    std::vector<std::pair<core::FileRef, core::NameRef>> mapping;
+    mapping.reserve(files.size());
+
     // Step 1a, add package references to every file. This could be parallel if needed, file access will be unique and
     // no symbols will be allocated.
-    auto packages = gs.unfreezePackages();
-    for (auto &f : files) {
-        auto &pkg = packages.db.getPackageForFile(gs, f.file);
-        packages.db.setPackageNameForFile(f.file, pkg.mangledName());
+    {
+        auto &db = gs.packageDB();
+        for (auto &f : files) {
+            auto &pkg = db.getPackageForFile(gs, f.file);
+            if (!pkg.exists()) {
+                continue;
+            }
+
+            mapping.emplace_back(f.file, pkg.mangledName());
+        }
+    }
+
+    {
+        auto packages = gs.unfreezePackages();
+        for (auto [file, package] : mapping) {
+            packages.db.setPackageNameForFile(file, package);
+        }
     }
 
     return;
@@ -2063,12 +2079,28 @@ void Packager::setPackageNameOnFiles(core::GlobalState &gs, const vector<ast::Pa
 // NOTE: we use `dataAllowingUnsafe` here, as determining the package for a file is something that can be done from its
 // path alone.
 void Packager::setPackageNameOnFiles(core::GlobalState &gs, const vector<core::FileRef> &files) {
+    std::vector<std::pair<core::FileRef, core::NameRef>> mapping;
+    mapping.reserve(files.size());
+
     // Step 1a, add package references to every file. This could be parallel if needed, file access will be unique and
     // no symbols will be allocated.
-    auto packages = gs.unfreezePackages();
-    for (auto file : files) {
-        auto &pkg = packages.db.getPackageForFile(gs, file);
-        packages.db.setPackageNameForFile(file, pkg.mangledName());
+    {
+        auto &db = gs.packageDB();
+        for (auto &f : files) {
+            auto &pkg = db.getPackageForFile(gs, f);
+            if (!pkg.exists()) {
+                continue;
+            }
+
+            mapping.emplace_back(f, pkg.mangledName());
+        }
+    }
+
+    {
+        auto packages = gs.unfreezePackages();
+        for (auto [file, package] : mapping) {
+            packages.db.setPackageNameForFile(file, package);
+        }
     }
 
     return;

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -2051,16 +2051,10 @@ vector<ast::ParsedFile> Packager::findPackages(core::GlobalState &gs, WorkerPool
 void Packager::setPackageNameOnFiles(core::GlobalState &gs, const vector<ast::ParsedFile> &files) {
     // Step 1a, add package references to every file. This could be parallel if needed, file access will be unique and
     // no symbols will be allocated.
-    auto &packageDB = gs.packageDB();
+    auto packages = gs.unfreezePackages();
     for (auto &f : files) {
-        f.file.data(gs).setPackage(core::NameRef::noName());
-
-        auto &pkg = packageDB.getPackageForFile(gs, f.file);
-        if (!pkg.exists()) {
-            continue;
-        }
-
-        f.file.data(gs).setPackage(pkg.mangledName());
+        auto &pkg = packages.db.getPackageForFile(gs, f.file);
+        packages.db.setPackageNameForFile(f.file, pkg.mangledName());
     }
 
     return;
@@ -2071,16 +2065,10 @@ void Packager::setPackageNameOnFiles(core::GlobalState &gs, const vector<ast::Pa
 void Packager::setPackageNameOnFiles(core::GlobalState &gs, const vector<core::FileRef> &files) {
     // Step 1a, add package references to every file. This could be parallel if needed, file access will be unique and
     // no symbols will be allocated.
-    auto &packageDB = gs.packageDB();
+    auto packages = gs.unfreezePackages();
     for (auto file : files) {
-        file.dataAllowingUnsafe(gs).setPackage(core::NameRef::noName());
-
-        auto &pkg = packageDB.getPackageForFile(gs, file);
-        if (!pkg.exists()) {
-            continue;
-        }
-
-        file.dataAllowingUnsafe(gs).setPackage(pkg.mangledName());
+        auto &pkg = packages.db.getPackageForFile(gs, file);
+        packages.db.setPackageNameForFile(file, pkg.mangledName());
     }
 
     return;

--- a/resolver/SuggestPackage.cc
+++ b/resolver/SuggestPackage.cc
@@ -39,8 +39,7 @@ public:
     core::Context ctx;
     const core::packages::PackageInfo &currentPkg;
 
-    PackageContext(core::Context ctx)
-        : ctx(ctx), currentPkg(ctx.state.packageDB().getPackageInfo(ctx.file.data(ctx).getPackage())) {}
+    PackageContext(core::Context ctx) : ctx(ctx), currentPkg(ctx.state.packageDB().getPackageForFile(ctx, ctx.file)) {}
 
     const core::packages::PackageDB &db() const {
         return ctx.state.packageDB();

--- a/test/pkg_autocorrects_test.cc
+++ b/test/pkg_autocorrects_test.cc
@@ -72,11 +72,11 @@ struct TestPackageFile {
     }
 
     const core::packages::PackageInfo &targetPackage(core::GlobalState &gs) const {
-        return gs.packageDB().getPackageInfo(targetParsedFile.file.data(gs).getPackage());
+        return gs.packageDB().getPackageForFile(gs, targetParsedFile.file);
     }
 
     const core::packages::PackageInfo &newPackage(core::GlobalState &gs) const {
-        return gs.packageDB().getPackageInfo(newParsedFile.file.data(gs).getPackage());
+        return gs.packageDB().getPackageForFile(gs, newParsedFile.file);
     }
 
     const core::SymbolRef getConstantRef(core::GlobalState &gs, vector<string> rawName) const {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Storing a `NameRef` in the file table is problematic, as multiple global states can share file tables, but have differing name tables. This PR moves the mapping from file to package into the PackageDB instead, avoiding the situation where we might have incompatible `NameRef` values stored in the file table.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Stable package to file mapping.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
