### PR TITLE
Reject calls to methods on unbound type members

### DIFF
--- a/core/TypePtr.cc
+++ b/core/TypePtr.cc
@@ -78,6 +78,9 @@ bool TypePtr::isNilClass() const {
 bool TypePtr::isBottom() const {
     return isa_type<ClassType>(*this) && cast_type_nonnull<ClassType>(*this).symbol == Symbols::bottom();
 }
+bool TypePtr::isTop() const {
+    return isa_type<ClassType>(*this) && cast_type_nonnull<ClassType>(*this).symbol == Symbols::top();
+}
 
 int TypePtr::kind() const {
     switch (tag()) {

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -277,6 +277,8 @@ public:
 
     bool isBottom() const;
 
+    bool isTop() const;
+
     // Used in subtyping.cc to order types.
     int kind() const;
 

--- a/core/errors/infer.h
+++ b/core/errors/infer.h
@@ -43,6 +43,7 @@ constexpr ErrorClass TakesNoBlock{7035, StrictLevel::True};
 constexpr ErrorClass PackagePrivateMethod{7036, StrictLevel::True};
 constexpr ErrorClass CallAfterAndAnd{7037, StrictLevel::True};
 constexpr ErrorClass CallOnTypeArgument{7038, StrictLevel::True};
+constexpr ErrorClass CallOnUnboundedTypeMember{7039, StrictLevel::True};
 // N.B infer does not run for untyped call at all. StrictLevel::False here would be meaningless
 } // namespace sorbet::core::errors::Infer
 #endif

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -143,16 +143,41 @@ DispatchResult TupleType::dispatchCall(const GlobalState &gs, const DispatchArgs
     return dispatchCallProxyType(gs, underlying(gs), args);
 }
 
+namespace {
+void autocorrectReceiver(const core::GlobalState &gs, core::ErrorBuilder &e, core::Loc receiverLoc,
+                         core::NameRef methodName) {
+    if (receiverLoc.exists() && (gs.suggestUnsafe.has_value())) {
+        auto wrapInFn = gs.suggestUnsafe.value();
+        if (receiverLoc.empty()) {
+            auto shortName = methodName.shortName(gs);
+            auto beginAdjust = -2;                     // (&
+            auto endAdjust = 1 + shortName.size() + 1; // :foo)
+            auto blockPassLoc = receiverLoc.adjust(gs, beginAdjust, endAdjust);
+            if (blockPassLoc.exists()) {
+                auto blockPassSource = blockPassLoc.source(gs).value();
+                if (blockPassSource == fmt::format("(&:{})", shortName)) {
+                    e.replaceWith(fmt::format("Expand to block with `{}`", wrapInFn), blockPassLoc, " {{|x| {}(x).{}}}",
+                                  wrapInFn, shortName);
+                }
+            }
+        } else {
+            e.replaceWith(fmt::format("Wrap in `{}`", wrapInFn), receiverLoc, "{}({})", wrapInFn,
+                          receiverLoc.source(gs).value());
+        }
+    }
+}
+} // namespace
+
 DispatchResult SelfTypeParam::dispatchCall(const GlobalState &gs, const DispatchArgs &args) const {
+    auto emptyResult = DispatchResult(Types::untypedUntracked(), std::move(args.selfType), Symbols::noMethod());
     if (this->definition.isTypeArgument()) {
-        auto result = DispatchResult(Types::untypedUntracked(), std::move(args.selfType), Symbols::noMethod());
         if (args.suppressErrors) {
             // Short circuit here to avoid constructing an expensive error message.
-            return result;
+            return emptyResult;
         }
         auto funLoc = args.funLoc();
         auto errLoc = (funLoc.exists() && !funLoc.empty()) ? args.funLoc() : args.callLoc();
-        auto e = gs.beginError(errLoc, errors::Infer::CallOnTypeArgument);
+        auto e = gs.beginError(errLoc, errors::Infer::CallOnUnboundedTypeMember);
         if (e) {
             auto thisStr = args.thisType.show(gs);
             if (args.fullType.type != args.thisType) {
@@ -162,39 +187,43 @@ DispatchResult SelfTypeParam::dispatchCall(const GlobalState &gs, const Dispatch
                 e.setHeader("Call to method `{}` on unconstrained generic type `{}`", args.name.show(gs), thisStr);
             }
             e.addErrorSection(args.fullType.explainGot(gs, args.originForUninitialized));
-
-            auto receiverLoc = core::Loc{args.locs.file, args.locs.receiver};
-            if (receiverLoc.exists() && (gs.suggestUnsafe.has_value())) {
-                auto wrapInFn = gs.suggestUnsafe.value();
-                if (receiverLoc.empty()) {
-                    auto shortName = args.name.shortName(gs);
-                    auto beginAdjust = -2;                     // (&
-                    auto endAdjust = 1 + shortName.size() + 1; // :foo)
-                    auto blockPassLoc = receiverLoc.adjust(gs, beginAdjust, endAdjust);
-                    if (blockPassLoc.exists()) {
-                        auto blockPassSource = blockPassLoc.source(gs).value();
-                        if (blockPassSource == fmt::format("(&:{})", shortName)) {
-                            e.replaceWith(fmt::format("Expand to block with `{}`", wrapInFn), blockPassLoc,
-                                          " {{|x| {}(x).{}}}", wrapInFn, shortName);
-                        }
-                    }
-                } else {
-                    e.replaceWith(fmt::format("Wrap in `{}`", wrapInFn), receiverLoc, "{}({})", wrapInFn,
-                                  receiverLoc.source(gs).value());
-                }
-            }
+            autocorrectReceiver(gs, e, args.receiverLoc(), args.name);
         }
-        result.main.errors.emplace_back(e.build());
-        return result;
+        emptyResult.main.errors.emplace_back(e.build());
+        return emptyResult;
     } else {
         ENFORCE(this->definition.isTypeMember());
         auto typeMember = this->definition.asTypeMemberRef();
         auto lambdaParam = cast_type_nonnull<LambdaParam>(typeMember.data(gs)->resultType);
-
-        // TODO(jez) Specific error message (short-circuit) when upperBound is top
-        // TODO(jez) Might be worth documenting what <top> is (it's not BasicObject)
-
         auto upperBound = lambdaParam.upperBound;
+        if (upperBound.isTop()) {
+            if (args.suppressErrors) {
+                return emptyResult;
+            }
+
+            auto funLoc = args.funLoc();
+            auto errLoc = (funLoc.exists() && !funLoc.empty()) ? args.funLoc() : args.callLoc();
+            auto e = gs.beginError(errLoc, errors::Infer::CallOnTypeArgument);
+            if (e) {
+                auto member = typeMember.data(gs)->owner.asClassOrModuleRef().data(gs)->attachedClass(gs).exists()
+                                  ? "template"
+                                  : "member";
+                auto thisStr = args.thisType.show(gs);
+                if (args.fullType.type != args.thisType) {
+                    e.setHeader("Call to method `{}` on unbounded type {} `{}` component of `{}`", args.name.show(gs),
+                                member, thisStr, args.fullType.type.show(gs));
+                } else {
+                    e.setHeader("Call to method `{}` on unbounded type {} `{}`", args.name.show(gs), member, thisStr);
+                }
+                e.addErrorSection(args.fullType.explainGot(gs, args.originForUninitialized));
+                autocorrectReceiver(gs, e, args.receiverLoc(), args.name);
+                e.addErrorSection(ErrorSection(ErrorColors::format("Consider adding an `{}` bound to `{}` here",
+                                                                   "upper", this->definition.show(gs)),
+                                               {{this->definition.loc(gs), ""}}));
+            }
+            emptyResult.main.errors.emplace_back(e.build());
+            return emptyResult;
+        }
 
         return upperBound.dispatchCall(gs, args.withThisRef(upperBound));
     }

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -187,9 +187,16 @@ DispatchResult SelfTypeParam::dispatchCall(const GlobalState &gs, const Dispatch
         result.main.errors.emplace_back(e.build());
         return result;
     } else {
-        // TODO: https://github.com/sorbet/sorbet/issues/1731
-        auto untypedUntracked = Types::untypedUntracked();
-        return untypedUntracked.dispatchCall(gs, args.withThisRef(untypedUntracked));
+        ENFORCE(this->definition.isTypeMember());
+        auto typeMember = this->definition.asTypeMemberRef();
+        auto lambdaParam = cast_type_nonnull<LambdaParam>(typeMember.data(gs)->resultType);
+
+        // TODO(jez) Specific error message (short-circuit) when upperBound is top
+        // TODO(jez) Might be worth documenting what <top> is (it's not BasicObject)
+
+        auto upperBound = lambdaParam.upperBound;
+
+        return upperBound.dispatchCall(gs, args.withThisRef(upperBound));
     }
 }
 

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -177,7 +177,7 @@ DispatchResult SelfTypeParam::dispatchCall(const GlobalState &gs, const Dispatch
         }
         auto funLoc = args.funLoc();
         auto errLoc = (funLoc.exists() && !funLoc.empty()) ? args.funLoc() : args.callLoc();
-        auto e = gs.beginError(errLoc, errors::Infer::CallOnUnboundedTypeMember);
+        auto e = gs.beginError(errLoc, errors::Infer::CallOnTypeArgument);
         if (e) {
             auto thisStr = args.thisType.show(gs);
             if (args.fullType.type != args.thisType) {
@@ -203,7 +203,7 @@ DispatchResult SelfTypeParam::dispatchCall(const GlobalState &gs, const Dispatch
 
             auto funLoc = args.funLoc();
             auto errLoc = (funLoc.exists() && !funLoc.empty()) ? args.funLoc() : args.callLoc();
-            auto e = gs.beginError(errLoc, errors::Infer::CallOnTypeArgument);
+            auto e = gs.beginError(errLoc, errors::Infer::CallOnUnboundedTypeMember);
             if (e) {
                 auto member = typeMember.data(gs)->owner.asClassOrModuleRef().data(gs)->attachedClass(gs).exists()
                                   ? "template"

--- a/test/cli/call_on_unbounded_type_member/test.out
+++ b/test/cli/call_on_unbounded_type_member/test.out
@@ -1,0 +1,181 @@
+test.rb:21: Expected `A` but found `Box::Elem` for argument `a` https://srb.help/7002
+    21 |    takes_a(x)
+                    ^
+  Expected `A` for argument `a` of method `Object#takes_a`:
+    test.rb:9:
+     9 |sig {params(a: A).void}
+                    ^
+  Got `Box::Elem` originating from:
+    test.rb:19:
+    19 |  def initialize(x)
+                         ^
+
+test.rb:59: Revealed type: `T.untyped` https://srb.help/7014
+    59 |    T.reveal_type(props)
+            ^^^^^^^^^^^^^^^^^^^^
+  Got `T.untyped` originating from:
+    test.rb:58:
+    58 |    props = model.class.all_props
+                    ^^^^^^^^^^^^^^^^^^^^^
+Errors: 2
+
+--------------------------------------------------------------------------
+
+# typed: true
+extend T::Sig
+
+class A
+  def only_on_a; end
+end
+class B; end
+
+sig {params(a: A).void}
+def takes_a(a); end
+
+class Box
+  extend T::Sig
+  extend T::Generic
+
+  Elem = type_member
+
+  sig {params(x: Elem).void}
+  def initialize(x)
+    x.only_on_a
+    takes_a(x)
+  end
+end
+
+Box[A].new(A.new)
+Box[B].new(B.new)
+
+module HasProps
+  extend T::Helpers
+  def prop(name, type); end
+
+  module ClassMethods
+    extend T::Sig
+    sig {returns(T::Array[Symbol])}
+    def all_props; []; end
+  end
+  mixes_in_class_methods(ClassMethods)
+end
+
+class ChalkODMDocument
+  include HasProps
+end
+
+class DataView
+  extend T::Sig
+  extend T::Generic
+  DataViewModelBad = type_template
+  DataViewModel = type_template {{upper: ChalkODMDocument}}
+
+  sig {params(model: DataViewModelBad).returns(T.attached_class)}
+  def self.bad_from_instance(model)
+    model.class.props
+    new()
+  end
+
+  sig {params(model: DataViewModel).returns(T.attached_class)}
+  def self.from_instance(model)
+    props = model.class.all_props
+    T.reveal_type(props)
+
+    model.does_not_exist
+    new()
+  end
+end
+
+--------------------------------------------------------------------------
+
+test.rb:21: Expected `A` but found `Box::Elem` for argument `a` https://srb.help/7002
+    21 |    takes_a(x)
+                    ^
+  Expected `A` for argument `a` of method `Object#takes_a`:
+    test.rb:9:
+     9 |sig {params(a: A).void}
+                    ^
+  Got `Box::Elem` originating from:
+    test.rb:19:
+    19 |  def initialize(x)
+                         ^
+  Autocorrect: Done
+    test.rb:21: Replaced with `T.unsafe(x)`
+    21 |    takes_a(x)
+                    ^
+
+test.rb:59: Revealed type: `T.untyped` https://srb.help/7014
+    59 |    T.reveal_type(props)
+            ^^^^^^^^^^^^^^^^^^^^
+  Got `T.untyped` originating from:
+    test.rb:58:
+    58 |    props = model.class.all_props
+                    ^^^^^^^^^^^^^^^^^^^^^
+Errors: 2
+
+--------------------------------------------------------------------------
+
+# typed: true
+extend T::Sig
+
+class A
+  def only_on_a; end
+end
+class B; end
+
+sig {params(a: A).void}
+def takes_a(a); end
+
+class Box
+  extend T::Sig
+  extend T::Generic
+
+  Elem = type_member
+
+  sig {params(x: Elem).void}
+  def initialize(x)
+    x.only_on_a
+    takes_a(T.unsafe(x))
+  end
+end
+
+Box[A].new(A.new)
+Box[B].new(B.new)
+
+module HasProps
+  extend T::Helpers
+  def prop(name, type); end
+
+  module ClassMethods
+    extend T::Sig
+    sig {returns(T::Array[Symbol])}
+    def all_props; []; end
+  end
+  mixes_in_class_methods(ClassMethods)
+end
+
+class ChalkODMDocument
+  include HasProps
+end
+
+class DataView
+  extend T::Sig
+  extend T::Generic
+  DataViewModelBad = type_template
+  DataViewModel = type_template {{upper: ChalkODMDocument}}
+
+  sig {params(model: DataViewModelBad).returns(T.attached_class)}
+  def self.bad_from_instance(model)
+    model.class.props
+    new()
+  end
+
+  sig {params(model: DataViewModel).returns(T.attached_class)}
+  def self.from_instance(model)
+    props = model.class.all_props
+    T.reveal_type(props)
+
+    model.does_not_exist
+    new()
+  end
+end

--- a/test/cli/call_on_unbounded_type_member/test.out
+++ b/test/cli/call_on_unbounded_type_member/test.out
@@ -1,3 +1,15 @@
+test.rb:20: Call to method `only_on_a` on unbounded type member `Box::Elem` https://srb.help/7038
+    20 |    x.only_on_a
+              ^^^^^^^^^
+  Got `Box::Elem` originating from:
+    test.rb:19:
+    19 |  def initialize(x)
+                         ^
+  Consider adding an `upper` bound to `Box::Elem` here
+    test.rb:16:
+    16 |  Elem = type_member
+          ^^^^^^^^^^^^^^^^^^
+
 test.rb:21: Expected `A` but found `Box::Elem` for argument `a` https://srb.help/7002
     21 |    takes_a(x)
                     ^
@@ -10,14 +22,34 @@ test.rb:21: Expected `A` but found `Box::Elem` for argument `a` https://srb.help
     19 |  def initialize(x)
                          ^
 
-test.rb:59: Revealed type: `T.untyped` https://srb.help/7014
+test.rb:52: Call to method `class` on unbounded type template `T.class_of(DataView)::DataViewModelBad` https://srb.help/7038
+    52 |    model.class.props
+                  ^^^^^
+  Got `T.class_of(DataView)::DataViewModelBad` originating from:
+    test.rb:51:
+    51 |  def self.bad_from_instance(model)
+                                     ^^^^^
+  Consider adding an `upper` bound to `T.class_of(DataView)::DataViewModelBad` here
+    test.rb:47:
+    47 |  DataViewModelBad = type_template
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+test.rb:59: Revealed type: `T::Array[Symbol]` https://srb.help/7014
     59 |    T.reveal_type(props)
             ^^^^^^^^^^^^^^^^^^^^
-  Got `T.untyped` originating from:
+  Got `T::Array[Symbol]` originating from:
     test.rb:58:
     58 |    props = model.class.all_props
                     ^^^^^^^^^^^^^^^^^^^^^
-Errors: 2
+
+test.rb:61: Method `does_not_exist` does not exist on `ChalkODMDocument` component of `T.class_of(DataView)::DataViewModel` https://srb.help/7003
+    61 |    model.does_not_exist
+                  ^^^^^^^^^^^^^^
+  Got `T.class_of(DataView)::DataViewModel` originating from:
+    test.rb:57:
+    57 |  def self.from_instance(model)
+                                 ^^^^^
+Errors: 5
 
 --------------------------------------------------------------------------
 
@@ -88,6 +120,22 @@ end
 
 --------------------------------------------------------------------------
 
+test.rb:20: Call to method `only_on_a` on unbounded type member `Box::Elem` https://srb.help/7038
+    20 |    x.only_on_a
+              ^^^^^^^^^
+  Got `Box::Elem` originating from:
+    test.rb:19:
+    19 |  def initialize(x)
+                         ^
+  Autocorrect: Done
+    test.rb:20: Replaced with `T.unsafe(x)`
+    20 |    x.only_on_a
+            ^
+  Consider adding an `upper` bound to `Box::Elem` here
+    test.rb:16:
+    16 |  Elem = type_member
+          ^^^^^^^^^^^^^^^^^^
+
 test.rb:21: Expected `A` but found `Box::Elem` for argument `a` https://srb.help/7002
     21 |    takes_a(x)
                     ^
@@ -104,14 +152,42 @@ test.rb:21: Expected `A` but found `Box::Elem` for argument `a` https://srb.help
     21 |    takes_a(x)
                     ^
 
-test.rb:59: Revealed type: `T.untyped` https://srb.help/7014
+test.rb:52: Call to method `class` on unbounded type template `T.class_of(DataView)::DataViewModelBad` https://srb.help/7038
+    52 |    model.class.props
+                  ^^^^^
+  Got `T.class_of(DataView)::DataViewModelBad` originating from:
+    test.rb:51:
+    51 |  def self.bad_from_instance(model)
+                                     ^^^^^
+  Autocorrect: Done
+    test.rb:52: Replaced with `T.unsafe(model)`
+    52 |    model.class.props
+            ^^^^^
+  Consider adding an `upper` bound to `T.class_of(DataView)::DataViewModelBad` here
+    test.rb:47:
+    47 |  DataViewModelBad = type_template
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+test.rb:59: Revealed type: `T::Array[Symbol]` https://srb.help/7014
     59 |    T.reveal_type(props)
             ^^^^^^^^^^^^^^^^^^^^
-  Got `T.untyped` originating from:
+  Got `T::Array[Symbol]` originating from:
     test.rb:58:
     58 |    props = model.class.all_props
                     ^^^^^^^^^^^^^^^^^^^^^
-Errors: 2
+
+test.rb:61: Method `does_not_exist` does not exist on `ChalkODMDocument` component of `T.class_of(DataView)::DataViewModel` https://srb.help/7003
+    61 |    model.does_not_exist
+                  ^^^^^^^^^^^^^^
+  Got `T.class_of(DataView)::DataViewModel` originating from:
+    test.rb:57:
+    57 |  def self.from_instance(model)
+                                 ^^^^^
+  Autocorrect: Done
+    test.rb:61: Replaced with `T.unsafe(model)`
+    61 |    model.does_not_exist
+            ^^^^^
+Errors: 5
 
 --------------------------------------------------------------------------
 
@@ -134,7 +210,7 @@ class Box
 
   sig {params(x: Elem).void}
   def initialize(x)
-    x.only_on_a
+    T.unsafe(x).only_on_a
     takes_a(T.unsafe(x))
   end
 end
@@ -166,7 +242,7 @@ class DataView
 
   sig {params(model: DataViewModelBad).returns(T.attached_class)}
   def self.bad_from_instance(model)
-    model.class.props
+    T.unsafe(model).class.props
     new()
   end
 
@@ -175,7 +251,7 @@ class DataView
     props = model.class.all_props
     T.reveal_type(props)
 
-    model.does_not_exist
+    T.unsafe(model).does_not_exist
     new()
   end
 end

--- a/test/cli/call_on_unbounded_type_member/test.out
+++ b/test/cli/call_on_unbounded_type_member/test.out
@@ -22,34 +22,68 @@ test.rb:21: Expected `A` but found `Box::Elem` for argument `a` https://srb.help
     19 |  def initialize(x)
                          ^
 
-test.rb:52: Call to method `class` on unbounded type template `T.class_of(DataView)::DataViewModelBad` https://srb.help/7039
-    52 |    model.class.props
+test.rb:23: Call to method `is_a?` on unbounded type member `Box::Elem` https://srb.help/7039
+    23 |    if x.is_a?(A)
+                 ^^^^^
+  Got `Box::Elem` originating from:
+    test.rb:19:
+    19 |  def initialize(x)
+                         ^
+  Consider adding an `upper` bound to `Box::Elem` here
+    test.rb:16:
+    16 |  Elem = type_member
+          ^^^^^^^^^^^^^^^^^^
+
+test.rb:24: Revealed type: `T.all(A, Box::Elem)` https://srb.help/7014
+    24 |      T.reveal_type(x)
+              ^^^^^^^^^^^^^^^^
+  Got `T.all(A, Box::Elem)` originating from:
+    test.rb:19:
+    19 |  def initialize(x)
+                         ^
+    test.rb:23:
+    23 |    if x.is_a?(A)
+               ^^^^^^^^^^
+
+test.rb:26: Revealed type: `Box::Elem` https://srb.help/7014
+    26 |      T.reveal_type(x)
+              ^^^^^^^^^^^^^^^^
+  Got `Box::Elem` originating from:
+    test.rb:19:
+    19 |  def initialize(x)
+                         ^
+    test.rb:23:
+    23 |    if x.is_a?(A)
+               ^^^^^^^^^^
+
+test.rb:58: Call to method `class` on unbounded type template `T.class_of(DataView)::DataViewModelBad` https://srb.help/7039
+    58 |    model.class.props
                   ^^^^^
   Got `T.class_of(DataView)::DataViewModelBad` originating from:
-    test.rb:51:
-    51 |  def self.bad_from_instance(model)
+    test.rb:57:
+    57 |  def self.bad_from_instance(model)
                                      ^^^^^
   Consider adding an `upper` bound to `T.class_of(DataView)::DataViewModelBad` here
-    test.rb:47:
-    47 |  DataViewModelBad = type_template
+    test.rb:53:
+    53 |  DataViewModelBad = type_template
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-test.rb:59: Revealed type: `T::Array[Symbol]` https://srb.help/7014
-    59 |    T.reveal_type(props)
+test.rb:65: Revealed type: `T::Array[Symbol]` https://srb.help/7014
+    65 |    T.reveal_type(props)
             ^^^^^^^^^^^^^^^^^^^^
   Got `T::Array[Symbol]` originating from:
-    test.rb:58:
-    58 |    props = model.class.all_props
+    test.rb:64:
+    64 |    props = model.class.all_props
                     ^^^^^^^^^^^^^^^^^^^^^
 
-test.rb:61: Method `does_not_exist` does not exist on `ChalkODMDocument` component of `T.class_of(DataView)::DataViewModel` https://srb.help/7003
-    61 |    model.does_not_exist
+test.rb:67: Method `does_not_exist` does not exist on `ChalkODMDocument` component of `T.class_of(DataView)::DataViewModel` https://srb.help/7003
+    67 |    model.does_not_exist
                   ^^^^^^^^^^^^^^
   Got `T.class_of(DataView)::DataViewModel` originating from:
-    test.rb:57:
-    57 |  def self.from_instance(model)
+    test.rb:63:
+    63 |  def self.from_instance(model)
                                  ^^^^^
-Errors: 5
+Errors: 8
 
 --------------------------------------------------------------------------
 
@@ -74,6 +108,12 @@ class Box
   def initialize(x)
     x.only_on_a
     takes_a(x)
+
+    if x.is_a?(A)
+      T.reveal_type(x)
+    else
+      T.reveal_type(x)
+    end
   end
 end
 
@@ -152,42 +192,80 @@ test.rb:21: Expected `A` but found `Box::Elem` for argument `a` https://srb.help
     21 |    takes_a(x)
                     ^
 
-test.rb:52: Call to method `class` on unbounded type template `T.class_of(DataView)::DataViewModelBad` https://srb.help/7039
-    52 |    model.class.props
+test.rb:23: Call to method `is_a?` on unbounded type member `Box::Elem` https://srb.help/7039
+    23 |    if x.is_a?(A)
+                 ^^^^^
+  Got `Box::Elem` originating from:
+    test.rb:19:
+    19 |  def initialize(x)
+                         ^
+  Autocorrect: Done
+    test.rb:23: Replaced with `T.unsafe(x)`
+    23 |    if x.is_a?(A)
+               ^
+  Consider adding an `upper` bound to `Box::Elem` here
+    test.rb:16:
+    16 |  Elem = type_member
+          ^^^^^^^^^^^^^^^^^^
+
+test.rb:24: Revealed type: `T.all(A, Box::Elem)` https://srb.help/7014
+    24 |      T.reveal_type(x)
+              ^^^^^^^^^^^^^^^^
+  Got `T.all(A, Box::Elem)` originating from:
+    test.rb:19:
+    19 |  def initialize(x)
+                         ^
+    test.rb:23:
+    23 |    if x.is_a?(A)
+               ^^^^^^^^^^
+
+test.rb:26: Revealed type: `Box::Elem` https://srb.help/7014
+    26 |      T.reveal_type(x)
+              ^^^^^^^^^^^^^^^^
+  Got `Box::Elem` originating from:
+    test.rb:19:
+    19 |  def initialize(x)
+                         ^
+    test.rb:23:
+    23 |    if x.is_a?(A)
+               ^^^^^^^^^^
+
+test.rb:58: Call to method `class` on unbounded type template `T.class_of(DataView)::DataViewModelBad` https://srb.help/7039
+    58 |    model.class.props
                   ^^^^^
   Got `T.class_of(DataView)::DataViewModelBad` originating from:
-    test.rb:51:
-    51 |  def self.bad_from_instance(model)
+    test.rb:57:
+    57 |  def self.bad_from_instance(model)
                                      ^^^^^
   Autocorrect: Done
-    test.rb:52: Replaced with `T.unsafe(model)`
-    52 |    model.class.props
+    test.rb:58: Replaced with `T.unsafe(model)`
+    58 |    model.class.props
             ^^^^^
   Consider adding an `upper` bound to `T.class_of(DataView)::DataViewModelBad` here
-    test.rb:47:
-    47 |  DataViewModelBad = type_template
+    test.rb:53:
+    53 |  DataViewModelBad = type_template
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-test.rb:59: Revealed type: `T::Array[Symbol]` https://srb.help/7014
-    59 |    T.reveal_type(props)
+test.rb:65: Revealed type: `T::Array[Symbol]` https://srb.help/7014
+    65 |    T.reveal_type(props)
             ^^^^^^^^^^^^^^^^^^^^
   Got `T::Array[Symbol]` originating from:
-    test.rb:58:
-    58 |    props = model.class.all_props
+    test.rb:64:
+    64 |    props = model.class.all_props
                     ^^^^^^^^^^^^^^^^^^^^^
 
-test.rb:61: Method `does_not_exist` does not exist on `ChalkODMDocument` component of `T.class_of(DataView)::DataViewModel` https://srb.help/7003
-    61 |    model.does_not_exist
+test.rb:67: Method `does_not_exist` does not exist on `ChalkODMDocument` component of `T.class_of(DataView)::DataViewModel` https://srb.help/7003
+    67 |    model.does_not_exist
                   ^^^^^^^^^^^^^^
   Got `T.class_of(DataView)::DataViewModel` originating from:
-    test.rb:57:
-    57 |  def self.from_instance(model)
+    test.rb:63:
+    63 |  def self.from_instance(model)
                                  ^^^^^
   Autocorrect: Done
-    test.rb:61: Replaced with `T.unsafe(model)`
-    61 |    model.does_not_exist
+    test.rb:67: Replaced with `T.unsafe(model)`
+    67 |    model.does_not_exist
             ^^^^^
-Errors: 5
+Errors: 8
 
 --------------------------------------------------------------------------
 
@@ -212,6 +290,12 @@ class Box
   def initialize(x)
     T.unsafe(x).only_on_a
     takes_a(T.unsafe(x))
+
+    if T.unsafe(x).is_a?(A)
+      T.reveal_type(x)
+    else
+      T.reveal_type(x)
+    end
   end
 end
 

--- a/test/cli/call_on_unbounded_type_member/test.out
+++ b/test/cli/call_on_unbounded_type_member/test.out
@@ -1,4 +1,4 @@
-test.rb:20: Call to method `only_on_a` on unbounded type member `Box::Elem` https://srb.help/7038
+test.rb:20: Call to method `only_on_a` on unbounded type member `Box::Elem` https://srb.help/7039
     20 |    x.only_on_a
               ^^^^^^^^^
   Got `Box::Elem` originating from:
@@ -22,7 +22,7 @@ test.rb:21: Expected `A` but found `Box::Elem` for argument `a` https://srb.help
     19 |  def initialize(x)
                          ^
 
-test.rb:52: Call to method `class` on unbounded type template `T.class_of(DataView)::DataViewModelBad` https://srb.help/7038
+test.rb:52: Call to method `class` on unbounded type template `T.class_of(DataView)::DataViewModelBad` https://srb.help/7039
     52 |    model.class.props
                   ^^^^^
   Got `T.class_of(DataView)::DataViewModelBad` originating from:
@@ -120,7 +120,7 @@ end
 
 --------------------------------------------------------------------------
 
-test.rb:20: Call to method `only_on_a` on unbounded type member `Box::Elem` https://srb.help/7038
+test.rb:20: Call to method `only_on_a` on unbounded type member `Box::Elem` https://srb.help/7039
     20 |    x.only_on_a
               ^^^^^^^^^
   Got `Box::Elem` originating from:
@@ -152,7 +152,7 @@ test.rb:21: Expected `A` but found `Box::Elem` for argument `a` https://srb.help
     21 |    takes_a(x)
                     ^
 
-test.rb:52: Call to method `class` on unbounded type template `T.class_of(DataView)::DataViewModelBad` https://srb.help/7038
+test.rb:52: Call to method `class` on unbounded type template `T.class_of(DataView)::DataViewModelBad` https://srb.help/7039
     52 |    model.class.props
                   ^^^^^
   Got `T.class_of(DataView)::DataViewModelBad` originating from:

--- a/test/cli/call_on_unbounded_type_member/test.out
+++ b/test/cli/call_on_unbounded_type_member/test.out
@@ -29,10 +29,8 @@ test.rb:23: Call to method `is_a?` on unbounded type member `Box::Elem` https://
     test.rb:19:
     19 |  def initialize(x)
                          ^
-  Consider adding an `upper` bound to `Box::Elem` here
-    test.rb:16:
-    16 |  Elem = type_member
-          ^^^^^^^^^^^^^^^^^^
+  Note:
+    Use `case` instead of `is_a?` to check the type of an unconstrained generic type member
 
 test.rb:24: Revealed type: `T.all(A, Box::Elem)` https://srb.help/7014
     24 |      T.reveal_type(x)
@@ -203,10 +201,8 @@ test.rb:23: Call to method `is_a?` on unbounded type member `Box::Elem` https://
     test.rb:23: Replaced with `T.unsafe(x)`
     23 |    if x.is_a?(A)
                ^
-  Consider adding an `upper` bound to `Box::Elem` here
-    test.rb:16:
-    16 |  Elem = type_member
-          ^^^^^^^^^^^^^^^^^^
+  Note:
+    Use `case` instead of `is_a?` to check the type of an unconstrained generic type member
 
 test.rb:24: Revealed type: `T.all(A, Box::Elem)` https://srb.help/7014
     24 |      T.reveal_type(x)

--- a/test/cli/call_on_unbounded_type_member/test.rb
+++ b/test/cli/call_on_unbounded_type_member/test.rb
@@ -1,0 +1,64 @@
+# typed: true
+extend T::Sig
+
+class A
+  def only_on_a; end
+end
+class B; end
+
+sig {params(a: A).void}
+def takes_a(a); end
+
+class Box
+  extend T::Sig
+  extend T::Generic
+
+  Elem = type_member
+
+  sig {params(x: Elem).void}
+  def initialize(x)
+    x.only_on_a
+    takes_a(x)
+  end
+end
+
+Box[A].new(A.new)
+Box[B].new(B.new)
+
+module HasProps
+  extend T::Helpers
+  def prop(name, type); end
+
+  module ClassMethods
+    extend T::Sig
+    sig {returns(T::Array[Symbol])}
+    def all_props; []; end
+  end
+  mixes_in_class_methods(ClassMethods)
+end
+
+class ChalkODMDocument
+  include HasProps
+end
+
+class DataView
+  extend T::Sig
+  extend T::Generic
+  DataViewModelBad = type_template
+  DataViewModel = type_template {{upper: ChalkODMDocument}}
+
+  sig {params(model: DataViewModelBad).returns(T.attached_class)}
+  def self.bad_from_instance(model)
+    model.class.props
+    new()
+  end
+
+  sig {params(model: DataViewModel).returns(T.attached_class)}
+  def self.from_instance(model)
+    props = model.class.all_props
+    T.reveal_type(props)
+
+    model.does_not_exist
+    new()
+  end
+end

--- a/test/cli/call_on_unbounded_type_member/test.rb
+++ b/test/cli/call_on_unbounded_type_member/test.rb
@@ -19,6 +19,12 @@ class Box
   def initialize(x)
     x.only_on_a
     takes_a(x)
+
+    if x.is_a?(A)
+      T.reveal_type(x)
+    else
+      T.reveal_type(x)
+    end
   end
 end
 

--- a/test/cli/call_on_unbounded_type_member/test.sh
+++ b/test/cli/call_on_unbounded_type_member/test.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+cwd="$(pwd)"
+infile="$cwd/test/cli/call_on_unbounded_type_member/test.rb"
+
+tmp="$(mktemp -d)"
+
+(
+  cp "$infile" "$tmp"
+
+  cd "$tmp" || exit 1
+  if "$cwd/main/sorbet" --silence-dev-message -a test.rb 2>&1; then
+    echo "Expected to fail!"
+    exit 1
+  fi
+
+  echo
+  echo --------------------------------------------------------------------------
+  echo
+
+  # Also cat the file, to make that the autocorrect applied
+  cat test.rb
+
+  rm test.rb
+)
+
+echo
+echo --------------------------------------------------------------------------
+echo
+
+(
+  cp "$infile" "$tmp"
+
+  cd "$tmp" || exit 1
+  if "$cwd/main/sorbet" --silence-dev-message --suggest-unsafe -a test.rb 2>&1; then
+    echo "Expected to fail!"
+    exit 1
+  fi
+
+  echo
+  echo --------------------------------------------------------------------------
+  echo
+
+  # Also cat the file, to make that the autocorrect applied
+  cat test.rb
+
+  rm test.rb
+)
+
+rm -r "$tmp"

--- a/test/cli/type_argument_suggest_unsafe/test.out
+++ b/test/cli/type_argument_suggest_unsafe/test.out
@@ -10,30 +10,64 @@ type_argument_suggest_unsafe.rb:10: Call to method `foo` on unconstrained generi
     10 |  x.foo # error: Call to method `foo` on unconstrained generic type `Object#example1#U`
           ^
 
-type_argument_suggest_unsafe.rb:32: Call to method `foo` on generic type `T.type_parameter(:U) (of Object#example3)` component of `T.any(M, T.type_parameter(:U) (of Object#example3))` https://srb.help/7038
-    32 |  x.foo # error: Method `foo` does not exist on `Object#example3#U` component of `T.any(M, Object#example3#U)`
-            ^^^
-  Got `T.any(M, T.type_parameter(:U) (of Object#example3))` originating from:
-    type_argument_suggest_unsafe.rb:31:
-    31 |def example3(x)
+type_argument_suggest_unsafe.rb:12: Call to method `is_a?` on unconstrained generic type `T.type_parameter(:U) (of Object#example1)` https://srb.help/7038
+    12 |  if x.is_a?(Integer)
+               ^^^^^
+  Got `T.type_parameter(:U) (of Object#example1)` originating from:
+    type_argument_suggest_unsafe.rb:9:
+     9 |def example1(x)
                      ^
   Autocorrect: Done
-    type_argument_suggest_unsafe.rb:32: Replaced with `T.unsafe(x)`
-    32 |  x.foo # error: Method `foo` does not exist on `Object#example3#U` component of `T.any(M, Object#example3#U)`
+    type_argument_suggest_unsafe.rb:12: Replaced with `T.unsafe(x)`
+    12 |  if x.is_a?(Integer)
+             ^
+
+type_argument_suggest_unsafe.rb:13: Revealed type: `T.all(Integer, T.type_parameter(:U) (of Object#example1))` https://srb.help/7014
+    13 |    T.reveal_type(x)
+            ^^^^^^^^^^^^^^^^
+  Got `T.all(Integer, T.type_parameter(:U) (of Object#example1))` originating from:
+    type_argument_suggest_unsafe.rb:9:
+     9 |def example1(x)
+                     ^
+    type_argument_suggest_unsafe.rb:12:
+    12 |  if x.is_a?(Integer)
+             ^^^^^^^^^^^^^^^^
+
+type_argument_suggest_unsafe.rb:15: Revealed type: `T.type_parameter(:U) (of Object#example1)` https://srb.help/7014
+    15 |    T.reveal_type(x)
+            ^^^^^^^^^^^^^^^^
+  Got `T.type_parameter(:U) (of Object#example1)` originating from:
+    type_argument_suggest_unsafe.rb:9:
+     9 |def example1(x)
+                     ^
+    type_argument_suggest_unsafe.rb:12:
+    12 |  if x.is_a?(Integer)
+             ^^^^^^^^^^^^^^^^
+
+type_argument_suggest_unsafe.rb:38: Call to method `foo` on generic type `T.type_parameter(:U) (of Object#example3)` component of `T.any(M, T.type_parameter(:U) (of Object#example3))` https://srb.help/7038
+    38 |  x.foo # error: Method `foo` does not exist on `Object#example3#U` component of `T.any(M, Object#example3#U)`
+            ^^^
+  Got `T.any(M, T.type_parameter(:U) (of Object#example3))` originating from:
+    type_argument_suggest_unsafe.rb:37:
+    37 |def example3(x)
+                     ^
+  Autocorrect: Done
+    type_argument_suggest_unsafe.rb:38: Replaced with `T.unsafe(x)`
+    38 |  x.foo # error: Method `foo` does not exist on `Object#example3#U` component of `T.any(M, Object#example3#U)`
           ^
 
-type_argument_suggest_unsafe.rb:41: Call to method `foo` on unconstrained generic type `T.type_parameter(:U) (of Object#example4)` https://srb.help/7038
-    41 |  xs.map(&:foo) # error: Method `foo` does not exist on `Object#example4#U`
+type_argument_suggest_unsafe.rb:47: Call to method `foo` on unconstrained generic type `T.type_parameter(:U) (of Object#example4)` https://srb.help/7038
+    47 |  xs.map(&:foo) # error: Method `foo` does not exist on `Object#example4#U`
                   ^^^^
   Got `T.type_parameter(:U) (of Object#example4)` originating from:
-    type_argument_suggest_unsafe.rb:41:
-    41 |  xs.map(&:foo) # error: Method `foo` does not exist on `Object#example4#U`
+    type_argument_suggest_unsafe.rb:47:
+    47 |  xs.map(&:foo) # error: Method `foo` does not exist on `Object#example4#U`
                   ^
   Autocorrect: Done
-    type_argument_suggest_unsafe.rb:41: Replaced with `{|x| T.unsafe(x).foo}`
-    41 |  xs.map(&:foo) # error: Method `foo` does not exist on `Object#example4#U`
+    type_argument_suggest_unsafe.rb:47: Replaced with `{|x| T.unsafe(x).foo}`
+    47 |  xs.map(&:foo) # error: Method `foo` does not exist on `Object#example4#U`
                 ^^^^^^^
-Errors: 3
+Errors: 6
 
 --------------------------------------------------------------------------
 
@@ -47,6 +81,12 @@ sig do
 end
 def example1(x)
   T.unsafe(x).foo # error: Call to method `foo` on unconstrained generic type `Object#example1#U`
+
+  if T.unsafe(x).is_a?(Integer)
+    T.reveal_type(x)
+  else
+    T.reveal_type(x)
+  end
 end
 
 module M

--- a/test/cli/type_argument_suggest_unsafe/test.out
+++ b/test/cli/type_argument_suggest_unsafe/test.out
@@ -9,6 +9,8 @@ type_argument_suggest_unsafe.rb:10: Call to method `foo` on unconstrained generi
     type_argument_suggest_unsafe.rb:10: Replaced with `T.unsafe(x)`
     10 |  x.foo # error: Call to method `foo` on unconstrained generic type `Object#example1#U`
           ^
+  Note:
+    Consider using `T.all(T.type_parameter(:U), Constraint)` to place a constraint on this type
 
 type_argument_suggest_unsafe.rb:12: Call to method `is_a?` on unconstrained generic type `T.type_parameter(:U) (of Object#example1)` https://srb.help/7038
     12 |  if x.is_a?(Integer)
@@ -21,6 +23,8 @@ type_argument_suggest_unsafe.rb:12: Call to method `is_a?` on unconstrained gene
     type_argument_suggest_unsafe.rb:12: Replaced with `T.unsafe(x)`
     12 |  if x.is_a?(Integer)
              ^
+  Note:
+    Use `case` instead of `is_a?` to check the type of an unconstrained generic type parameter
 
 type_argument_suggest_unsafe.rb:13: Revealed type: `T.all(Integer, T.type_parameter(:U) (of Object#example1))` https://srb.help/7014
     13 |    T.reveal_type(x)
@@ -55,6 +59,8 @@ type_argument_suggest_unsafe.rb:38: Call to method `foo` on generic type `T.type
     type_argument_suggest_unsafe.rb:38: Replaced with `T.unsafe(x)`
     38 |  x.foo # error: Method `foo` does not exist on `Object#example3#U` component of `T.any(M, Object#example3#U)`
           ^
+  Note:
+    Consider using `T.all(T.type_parameter(:U), Constraint)` to place a constraint on this type
 
 type_argument_suggest_unsafe.rb:47: Call to method `foo` on unconstrained generic type `T.type_parameter(:U) (of Object#example4)` https://srb.help/7038
     47 |  xs.map(&:foo) # error: Method `foo` does not exist on `Object#example4#U`
@@ -67,6 +73,8 @@ type_argument_suggest_unsafe.rb:47: Call to method `foo` on unconstrained generi
     type_argument_suggest_unsafe.rb:47: Replaced with `{|x| T.unsafe(x).foo}`
     47 |  xs.map(&:foo) # error: Method `foo` does not exist on `Object#example4#U`
                 ^^^^^^^
+  Note:
+    Consider using `T.all(T.type_parameter(:U), Constraint)` to place a constraint on this type
 Errors: 6
 
 --------------------------------------------------------------------------

--- a/test/cli/type_argument_suggest_unsafe/type_argument_suggest_unsafe.rb
+++ b/test/cli/type_argument_suggest_unsafe/type_argument_suggest_unsafe.rb
@@ -8,6 +8,12 @@ sig do
 end
 def example1(x)
   x.foo # error: Call to method `foo` on unconstrained generic type `Object#example1#U`
+
+  if x.is_a?(Integer)
+    T.reveal_type(x)
+  else
+    T.reveal_type(x)
+  end
 end
 
 module M

--- a/test/testdata/infer/generics/fixed_noreturn.rb
+++ b/test/testdata/infer/generics/fixed_noreturn.rb
@@ -1,0 +1,56 @@
+# typed: strict
+extend T::Sig
+
+module List
+  extend T::Sig
+  extend T::Generic
+  abstract!
+
+  Elem = type_member(:out)
+
+  sig {abstract.returns(Elem)}
+  def head!; end
+end
+
+class Nil
+  extend T::Sig
+  extend T::Generic
+  include List
+
+  Elem = type_member {{fixed: T.noreturn}}
+
+  sig {override.returns(Elem)}
+  def head!
+    raise "Called head on Nil list"
+  end
+
+  sig {void}
+  def example
+    head!.not_exist # error: This code is unreachable
+  end
+end
+
+class Cons < T::Struct
+  extend T::Sig
+  extend T::Generic
+
+  include List
+
+  Elem = type_member
+
+  const :head, Elem, override: true
+  const :tail, List[Elem], override: true
+
+  sig {override.returns(Elem)}
+  def head!; head; end
+end
+
+sig {params(xs: Nil).void}
+def takes_nil(xs)
+  xs.head!.not_exists # error: This code is unreachable
+end
+
+T.reveal_type(Nil.new) # error: `Nil`
+empty = T.let(Nil.new, List[Integer])
+T.let(Cons.new(head: 0, tail: empty), List[Integer])
+T.let(Cons.new(head: 0, tail: Nil.new), List[Integer])

--- a/test/testdata/infer/generics/type_member_dispatch_call.rb
+++ b/test/testdata/infer/generics/type_member_dispatch_call.rb
@@ -1,7 +1,5 @@
 # typed: true
 
-# https://github.com/sorbet/sorbet/issues/1731
-
 class Box
   extend T::Sig
   extend T::Generic
@@ -10,12 +8,8 @@ class Box
 
   sig {params(x: Elem).void}
   def foo(x)
-    # correct
     T.reveal_type(x) # error: `Box::Elem`
-
-    # incorrect--no error for method not existing
-    len = x.length
-    T.reveal_type(len) # error: `T.untyped`
+    x.length  # error: Call to method `length` on unbounded type member `Box::Elem`
   end
 end
 
@@ -25,13 +19,10 @@ class StringBox < Box
 
   sig {params(x: Elem).void}
   def bar(x)
-    # correct
     T.reveal_type(x) # error: `String`
-
-    # probably correct to say that method exists?
-    len = x.length
-    T.reveal_type(len) # error: `Integer`
+    T.reveal_type(x.length) # error: `Integer`
   end
 end
 
+Box[Integer].new.foo(0) # would not have `length` method
 StringBox.new.foo('')

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -3552,6 +3552,45 @@ end
 Remember that in Sorbet, [interfaces](abstract.md) must be explicitly
 implemented in a given class.
 
+## 7039
+
+<!-- TODO(jez) Link to generic docs once written -->
+
+Consider this example:
+
+```ruby
+class A
+  def only_on_a; end
+end
+
+class Box
+  extend T::Sig
+  extend T::Generic
+  Elem = type_member
+
+  sig {params(x: Elem).void}
+  def initialize(x)
+    x.only_on_a # error, see below for fix
+  end
+end
+```
+
+In this example, we're trying to to call the method `only_on_a`, but we haven't
+specified any type bounds on the `Elem` type parameter, which means we can't
+make any assumption about what methods it might have.
+
+If we want to always be able to call the method `only_on_a`, we can place a
+upper bound on `Elem`:
+
+```ruby
+# ...
+  Elem = type_member {{upper: A}}
+# ...
+```
+
+This will guarantee that `Elem` is always at least `A`, which will let Sorbet
+allow the call to `x.only_on_a`.
+
 <!-- -->
 
 [report an issue]: https://github.com/sorbet/sorbet/issues

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -3552,6 +3552,26 @@ end
 Remember that in Sorbet, [interfaces](abstract.md) must be explicitly
 implemented in a given class.
 
+Sometimes this error happens due to a call to `is_a?` on a type parameter. To
+sidestep this error, rewrite the program to use `case`:
+
+```ruby
+# ...
+def example(x)
+  if x.is_a?(Integer) # error
+    # ...
+  end
+
+  case x
+  when Integer # OK
+    # ...
+  end
+end
+```
+
+Or if it's imperative to continue using `is_a?`, change the type to
+`T.all(Kernel, T.type_parameter(:U))`.
+
 ## 7039
 
 <!-- TODO(jez) Link to generic docs once written -->
@@ -3590,6 +3610,26 @@ upper bound on `Elem`:
 
 This will guarantee that `Elem` is always at least `A`, which will let Sorbet
 allow the call to `x.only_on_a`.
+
+Sometimes this error happens due to a call to `is_a?` on a type member. To
+sidestep this error, rewrite the program to use `case`:
+
+```ruby
+# ...
+def example(x)
+  if x.is_a?(Integer) # error
+    # ...
+  end
+
+  case x
+  when Integer # OK
+    # ...
+  end
+end
+```
+
+Or if it's imperative to continue using `is_a?`, change the type to
+`T.all(Kernel, Elem)` and/or add an upper bound of `Kernel` to the type member.
 
 <!-- -->
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #1731

I used

```
srb tc --suggest-unsafe --autocorrect
```

to fix the type errors that this PR caused to Stripe's codebase.

The only kinds of errors that this PR caused but could not be automatically fixed were of this shape:

https://github.com/sorbet/sorbet/issues/5728

Fortunately, there weren't that many of them.

Feel free to read more about about autocorrects in Sorbet here:

https://sorbet.org/docs/cli#silencing-errors-in-bulk


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.