### PR TITLE
Fix return type for String#strip! and String#rstrip!

### DIFF
--- a/rbi/core/string.rbi
+++ b/rbi/core/string.rbi
@@ -1729,7 +1729,7 @@ class String < Object
   # "  hello".rstrip!    #=> nil
   # "hello".rstrip!      #=> nil
   # ```
-  sig {returns(String)}
+  sig {returns(T.nilable(String))}
   def rstrip!(); end
 
   # Both forms iterate through *str*, matching the pattern (which may be a
@@ -2028,7 +2028,7 @@ class String < Object
   # "  hello  ".strip!  #=> "hello"
   # "hello".strip!      #=> nil
   # ```
-  sig {returns(String)}
+  sig {returns(T.nilable(String))}
   def strip!(); end
 
   # Returns a copy of `str` with the *first* occurrence of `pattern` replaced by


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Doc 
- https://docs.ruby-lang.org/en/2.7.0/String.html#method-i-strip-21
- https://docs.ruby-lang.org/en/2.7.0/String.html#method-i-rstrip-21

Also mentioned in the comments
- https://github.com/iownthegame/sorbet/blob/0ece9516f7d1648bd0b2025d5a4a043da2f11d22/rbi/core/string.rbi#L2029
- https://github.com/iownthegame/sorbet/blob/0ece9516f7d1648bd0b2025d5a4a043da2f11d22/rbi/core/string.rbi#L1730

```rb
$ irb
> "abc".strip!
=> nil
> "abc".rstrip!
=> nil
```

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
