### PR TITLE
Add a section for subclassing T::Struct

### DIFF
--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -1877,55 +1877,8 @@ each overload has a descriptive name.
 
 ## 5041
 
-Sorbet does not allow inheriting from a class which inherits from `T::Struct`.
-
-```ruby
-class S < T::Struct
-  prop :foo, Integer
-end
-
-class Bad < S; end # error
-```
-
-This limitation exists because, in order to generate a static type for
-`initialize` for a struct, we need to know all of the `prop`s that are declared
-on this struct. By disallowing inheritance of structs, we can know that all of
-the props declared on this struct were syntactically present in the class body.
-
-One common situation where inheritance may be desired is when a parent struct
-declares some common props, and children structs declare their own props.
-
-```ruby
-class Parent < T::Struct
-  prop :foo, Integer
-end
-
-class ChildOne < Parent # error
-  prop :bar, String
-end
-
-class ChildTwo < Parent # error
-  prop :quz, Symbol
-end
-```
-
-We can restructure the code to use composition instead of inheritance.
-
-```ruby
-class Common < T::Struct
-  prop :foo, Integer
-end
-
-class ChildOne < T::Struct
-  prop :common, Common
-  prop :bar, String
-end
-
-class ChildTwo < T::Struct
-  prop :common, Common
-  prop :quz, Symbol
-end
-```
+See [T::Struct: Structs and inheritance](tstruct.md#structs-and-inheritance) for
+more information.
 
 ## 5042
 

--- a/website/docs/tstruct.md
+++ b/website/docs/tstruct.md
@@ -68,3 +68,40 @@ my_struct.serialize # => { "foo": 4, "quz": 0.5 }
 ```
 
 Note that `bar` is skipped because it is `nil`.
+
+## Inheriting from Derived of T::Struct
+
+Trying to create a subclass of a subclass of T::Struct will result in an a 
+[5041](https://sorbet.org/docs/error-reference#5041) error. So code like this
+will create an error:
+
+```ruby
+class Parent < T::Struct
+  prop :foo, Integer
+end
+
+class ChildOne < Parent # error
+  prop :bar, Integer
+end
+
+class ChildTwo < Parent # error
+  prop :baz, Integer
+end
+```
+
+If this structure is required, then using composition is one viable solution:
+```ruby
+class Common < T::Struct
+  prop :foo, Integer
+end
+
+class ChildOne < T::Struct
+  prop :common, Common
+  prop :bar, Integer
+end
+
+class ChildTwo < T::Struct
+  prop :common, Common
+  prop :quz, Integer
+end
+```


### PR DESCRIPTION
No where in this page does it explain that you can't derive a subclass from a parent that subclasses `T::Struct`. Nor is there any explanation of an alternative until after it fails and you look up the error code. This change links to the error code and providing an explanation that it can occur and how to overcome it.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
It was a nasty surprise to discover I couldn't do what the documentation didn't say I couldn't do.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
