### PR TITLE
don't pass `defer_vcs: false` on watchman startup

### DIFF
--- a/main/lsp/watchman/WatchmanProcess.cc
+++ b/main/lsp/watchman/WatchmanProcess.cc
@@ -46,7 +46,6 @@ void WatchmanProcess::start() {
             // Exclude rsync tmpfiles
             "[\"not\", [\"match\", \"**/.~tmp~/**\", \"wholename\", {{\"includedotfiles\": true}}]]"
             "], "
-            "\"defer_vcs\": false, "
             "\"fields\": [\"name\"], "
             "\"empty_on_fresh_instance\": true"
             "}}]",


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The watchman documentation for [`defer_vcs`](https://facebook.github.io/watchman/docs/cmd/subscribe.html#filesystem-settling) indicates that, by default, subscription notifications will not be sent until after an outstanding version control notification is complete.  It also says:

> In some circumstances it is desirable for a client to observe the creation of the control files at the start of a version control operation. You may specify that you want this behavior by passing the defer_vcs flag to your subscription command invocation:

which is what Sorbet currently does.

I don't see any reason for Sorbet to do this, and it seems to make far more sense that we should avoid being notified of file changes until after a version control operation is complete.  (Sorbet does not watch for the control files referenced in the watchman documentation.)  Stripe uses watchman in other ways in our development environment and none of these uses, AFAICT, set `defer_vcs: false`.

I guess I can imagine scenarios where you're rebasing or checking out a new branch where with the new regime, we receive one large batch of notifications and therefore take the slow path (too many files changed), but under the old regime, we would have received small numbers of files at a time and therefore could have taken the fast path each time...but this seems unlikely.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
