### PR TITLE
avoid jump-to-def into RBI files for classes if there are multiple locations

### DIFF
--- a/main/lsp/requests/definition.cc
+++ b/main/lsp/requests/definition.cc
@@ -31,9 +31,21 @@ unique_ptr<ResponseMessage> DefinitionTask::runRequest(LSPTypecheckerInterface &
         // Only support go-to-definition on constants and fields in untyped files.
         if (auto c = resp->isConstant()) {
             auto sym = c->symbol;
+            vector<pair<core::Loc, unique_ptr<Location>>> locMapping;
             for (auto loc : sym.locs(gs)) {
-                addLocIfExists(gs, locations, loc);
+                locMapping.emplace_back(loc, config.loc2Location(gs, loc));
             }
+            // Move all non-existent Locations to the front of the vector.
+            auto validLocations = absl::c_partition(locMapping, [](const auto &p) { return p.second == nullptr; });
+            // If we have multiple locations, eliminate "definitions" in RBI files
+            // for classes and modules, since the one(s) in Ruby files are more
+            // likely to be what the user is looking for.
+            if (sym.isClassOrModule() && std::distance(validLocations, locMapping.end()) > 1) {
+                validLocations = std::partition(validLocations, locMapping.end(),
+                                                [&gs](const auto &p) { return p.first.file().data(gs).isRBI(); });
+            }
+            std::transform(validLocations, locMapping.end(), std::back_inserter(locations),
+                           [](auto &p) { return std::move(p.second); });
         } else if (resp->isField() || (fileIsTyped && (resp->isIdent() || resp->isLiteral()))) {
             const auto &retType = resp->getTypeAndOrigins();
             for (auto &originLoc : retType.origins) {

--- a/test/testdata/lsp/definitions_rb_and_rbi__1.rb
+++ b/test/testdata/lsp/definitions_rb_and_rbi__1.rb
@@ -1,0 +1,11 @@
+# typed: true
+
+class MyClass
+    # ^^^^^^^ def: MyClass
+  def do_something; end
+end
+
+class MyModule
+    # ^^^^^^^^ def: MyModule
+  def some_fun; end
+end

--- a/test/testdata/lsp/definitions_rb_and_rbi__2.rb
+++ b/test/testdata/lsp/definitions_rb_and_rbi__2.rb
@@ -1,0 +1,13 @@
+# typed: true
+
+class OtherClass
+  extend T::Sig
+
+  sig {params(c: MyClass).void}
+  #              ^^^^^^^ usage: MyClass
+  def do_something(c); end
+
+  sig {params(m: MyModule).void}
+  #              ^^^^^^^^ usage: MyModule
+  def do_something_else(m); end
+end

--- a/test/testdata/lsp/definitions_rb_and_rbi__3.rbi
+++ b/test/testdata/lsp/definitions_rb_and_rbi__3.rbi
@@ -1,0 +1,15 @@
+# typed: true
+
+# The usage annotation here is kind of a hack: we want the only
+# definition for go-to-definition to exist in the rb file defining
+# MyClass, but the test harness will see this class if we don't
+# say that it's a "use", even though semantically it is a def.
+class MyClass
+    # ^^^^^^^ usage: MyClass
+  def magic_dynamically_defined_fun; end
+end
+
+class MyModule
+    # ^^^^^^^^ usage: MyModule
+  def magic_dynamically_defined_fun; end
+end


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This comes up as a user request from time to time, and also makes more sense: the user wants to see the definition, which almost certainly doesn't live in an RBI file.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
