### PR TITLE
srb init special case for ruby2_keywords in Ruby 3.1

### DIFF
--- a/gems/sorbet/lib/gem-generator-tracepoint/tracepoint_serializer.rb
+++ b/gems/sorbet/lib/gem-generator-tracepoint/tracepoint_serializer.rb
@@ -197,7 +197,10 @@ module Sorbet::Private
           when :rest
             "*#{name}"
           when :keyrest
-            "**#{name}"
+            case name
+            when :** then "**"
+            else "**#{name}"
+            end
           when :block
             "&#{name}"
           else

--- a/gems/sorbet/lib/gem-generator-tracepoint/tracepoint_serializer.rb
+++ b/gems/sorbet/lib/gem-generator-tracepoint/tracepoint_serializer.rb
@@ -195,14 +195,20 @@ module Sorbet::Private
           when :key
             "#{name}: nil"
           when :rest
-            "*#{name}"
+            case name
+            when :* then "*"
+            else "*#{name}"
+            end
           when :keyrest
             case name
             when :** then "**"
             else "**#{name}"
             end
           when :block
-            "&#{name}"
+            case name
+            when :& then "&"
+            else "&#{name}"
+            end
           else
             raise "Unknown parameter type: #{type}"
           end


### PR DESCRIPTION
This prints something different on Ruby 3.0 vs Ruby 3.1

```ruby
class A
  ruby2_keywords def foo(*args); end
end
p(A.instance_method(:foo).parameters)
```

Ruby 3.0

```ruby
[[:rest, :args]]
```

Ruby 3.1

```ruby
[[:rest, :args], [:keyrest, :**]]
```

I have no clue why this behavior changed, but it meant that we would
serialize a gem RBI that looked like

```ruby
class A
  def foo(*args, ****)
  end
end
```

which is a syntax error.


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #5741



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I have decided not to write a test for this, because the test case would
have different behavior on Ruby 3.0 and Ruby 3.1, making it hard to fit
into our existing test snapshot testing framework.

I tested that using a local copy of the `sorbet` and `sorbet-static` gem fixed
the issue when running `srb init` for a gem that had a definition like the
above.