### PR TITLE
don't allocate in `FileOps::readLinefromFd`

### DIFF
--- a/common/BUILD
+++ b/common/BUILD
@@ -43,6 +43,7 @@ cc_library(
         "@com_google_absl//absl/container:inlined_vector",
         "@com_google_absl//absl/debugging:symbolize",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/types:span",
         "@pdqsort",
         "@spdlog",
     ],

--- a/common/FileOps.h
+++ b/common/FileOps.h
@@ -1,5 +1,6 @@
 #ifndef SORBET_COMMON_FILEOPS_HPP
 #define SORBET_COMMON_FILEOPS_HPP
+#include "absl/types/span.h"
 #include "common/common.h"
 #include <string>
 #include <string_view>
@@ -62,7 +63,8 @@ public:
      * - 0 if timeout occurs.
      * - <0 if an error or EOF occurs.
      */
-    static int readFd(int fd, std::vector<char> &output, int timeoutMs = 100);
+    static int readFd(int fd, absl::Span<char> output, int timeoutMs = 100);
+
     /**
      * Attempts to read data up to a newline (\n) from the given file descriptor.
      * Timeout is specified in milliseconds.

--- a/common/common.cc
+++ b/common/common.cc
@@ -142,7 +142,7 @@ string_view sorbet::FileOps::getExtension(string_view path) {
     return path.substr(found + 1);
 }
 
-int sorbet::FileOps::readFd(int fd, std::vector<char> &output, int timeoutMs) {
+int sorbet::FileOps::readFd(int fd, absl::Span<char> output, int timeoutMs) {
     // Prepare to use select()
     fd_set set;
     FD_ZERO(&set);
@@ -179,7 +179,8 @@ sorbet::FileOps::ReadLineOutput sorbet::FileOps::readLineFromFd(int fd, string &
     }
 
     constexpr int BUFF_SIZE = 1024 * 8;
-    vector<char> buf(BUFF_SIZE);
+    char chars[BUFF_SIZE];
+    absl::Span<char> buf(chars);
 
     int result = FileOps::readFd(fd, buf, timeoutMs);
     if (result == 0) {

--- a/main/lsp/LSPInput.cc
+++ b/main/lsp/LSPInput.cc
@@ -44,7 +44,7 @@ LSPInput::ReadOutput LSPFDInput::read(int timeoutMs) {
         // Need to read more.
         int moreNeeded = length - buffer.length();
         vector<char> buf(moreNeeded);
-        int result = FileOps::readFd(inputFd, buf);
+        int result = FileOps::readFd(inputFd, absl::MakeSpan(buf));
         if (result > 0) {
             buffer.append(buf.begin(), buf.begin() + result);
         }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

A little less allocation here seems like a good thing.  (I think it would also be a good thing to tackle the same sort of problems in `LSPInput.cc`, but the surgery required there is more extensive.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
