### PR TITLE
Fix typo in generics.md

### DIFF
--- a/website/docs/generics.md
+++ b/website/docs/generics.md
@@ -24,7 +24,7 @@ It is imperative to thoroughly test abstractions making use of Sorbet generics.
 The tests you'll need to write look substantially different from other Ruby
 tests you may be accustomed to writing, because the tests need to deal with what
 code should or should not typecheck, rather than code that should or should not
-run correctly. These tests
+run correctly.
 
 - Many things that shouldn't type check **do type check anyways**.
 


### PR DESCRIPTION
### Motivation
There's a small typo in the docs.

### Test plan
n/a
