### PR TITLE
Remove type-alias export restriction in --stripe-packages

### DIFF
--- a/core/errors/packager.h
+++ b/core/errors/packager.h
@@ -26,6 +26,6 @@ constexpr ErrorClass MissingImport{3718, StrictLevel::False};
 // 3719 PackagedSymbolInUnpackagedContext
 constexpr ErrorClass UsedTestOnlyName{3720, StrictLevel::False};
 constexpr ErrorClass InvalidExport{3721, StrictLevel::False};
-constexpr ErrorClass ExportingTypeAlias{3722, StrictLevel::False};
+/* constexpr ErrorClass ExportingTypeAlias{3722, StrictLevel::False}; */
 } // namespace sorbet::core::errors::Packager
 #endif

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -215,15 +215,6 @@ public:
             // When exporting a field, we also export its parent namespace. This is a bit of a hack, and it would be
             // great to remove this, but this was the behavior of the previous packager implementation.
             exportParentNamespace(ctx, sym.data(ctx)->owner);
-
-            if (sym.data(ctx)->flags.isStaticFieldTypeAlias) {
-                if (auto e = ctx.beginError(send.loc, core::errors::Packager::ExportingTypeAlias)) {
-                    e.setHeader("Exporting a type alias is not allowed in package specifications");
-                    e.addErrorLine(sym.data(ctx)->loc(), "Originally defined here");
-                    e.addErrorNote(
-                        "You can put the type alias into a module and export the module to work around this error");
-                }
-            }
         } else {
             std::string_view kind = ""sv;
             switch (lit->symbol.kind()) {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -849,14 +849,7 @@ private:
 
         if (rhsSym.isTypeAlias(ctx)) {
             if (auto e = ctx.beginError(it.rhs->loc, core::errors::Resolver::ReassignsTypeAlias)) {
-                if (ctx.file.data(ctx).isPackage()) {
-                    // In --stripe-packages mode, this error surfaces when type aliases
-                    // are exported by a package. TODO (aadi-stripe, 12/30/2021) update docs for
-                    // error 5034 as part of any larger --stripe-packages documentation effort.
-                    e.setHeader("Exporting a type alias is not allowed in package specifications");
-                } else {
-                    e.setHeader("Reassigning a type alias is not allowed");
-                }
+                e.setHeader("Reassigning a type alias is not allowed");
                 e.addErrorLine(rhsSym.loc(ctx), "Originally defined here");
                 auto rhsLoc = ctx.locAt(it.rhs->loc);
                 if (rhsLoc.exists()) {

--- a/test/cli/package-type-alias-export/test.out
+++ b/test/cli/package-type-alias-export/test.out
@@ -1,9 +1,1 @@
-__package.rb:5: Exporting a type alias is not allowed in package specifications https://srb.help/3722
-     5 |  export MyPackage::A
-          ^^^^^^^^^^^^^^^^^^^
-    a.rb:6: Originally defined here
-     6 |  A = T.type_alias {String}
-          ^
-  Note:
-    You can put the type alias into a module and export the module to work around this error
-Errors: 1
+No errors! Great job.


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

As of latest `--stripe-packages` design changes, we do not need this error anymore. Packages can export type-aliases at top-level without issue.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Remove unnecessary restriction.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tested on Stripe codebase.

See included automated tests.