### PR TITLE
track the kind of `LiteralType` in counters

### DIFF
--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -326,16 +326,20 @@ void sanityCheckProxyType(const GlobalState &gs, TypePtr underlying) {
 } // namespace
 
 LiteralType::LiteralType(int64_t val) : value(val), literalKind(LiteralTypeKind::Integer) {
-    categoryCounterInc("types.allocated", "literaltype");
+    categoryCounterInc("types.allocated", "literaltype.integer");
 }
 
 LiteralType::LiteralType(double val) : floatval(val), literalKind(LiteralTypeKind::Float) {
-    categoryCounterInc("types.allocated", "literaltype");
+    categoryCounterInc("types.allocated", "literaltype.double");
 }
 
 LiteralType::LiteralType(ClassOrModuleRef klass, NameRef val)
     : nameId(val.rawId()), literalKind(klass == Symbols::String() ? LiteralTypeKind::String : LiteralTypeKind::Symbol) {
-    categoryCounterInc("types.allocated", "literaltype");
+    if (klass == Symbols::String()) {
+        categoryCounterInc("types.allocated", "literaltype.string");
+    } else {
+        categoryCounterInc("types.allocated", "literaltype.symbol");
+    }
     ENFORCE(klass == Symbols::String() || klass == Symbols::Symbol());
 }
 


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

More statistics is more better.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
