### PR TITLE
detect use of `each` and recommend `test_each` instead

### DIFF
--- a/core/errors/rewriter.h
+++ b/core/errors/rewriter.h
@@ -15,5 +15,6 @@ constexpr ErrorClass ComputedBySymbol{3509, StrictLevel::False};
 constexpr ErrorClass InitializeReturnType{3510, StrictLevel::False};
 constexpr ErrorClass InvalidStructMember{3511, StrictLevel::False};
 constexpr ErrorClass NilableUntyped{3512, StrictLevel::False};
+constexpr ErrorClass UseTestEachNotEach{3513, StrictLevel::True};
 } // namespace sorbet::core::errors::Rewriter
 #endif

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -330,7 +330,8 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, ast::Send *
         //
         // We only check for this when we're recursing into describe blocks, because
         // that's usually where the problems come up.
-        if (level == RunSingleLevel::Interior && send->fun == core::Names::each() && send->numNonBlockArgs() == 0 && !block->args.empty()) {
+        if (level == RunSingleLevel::Interior && send->fun == core::Names::each() && send->numNonBlockArgs() == 0 &&
+            !block->args.empty()) {
             auto &blockBody = block->body;
             ast::Send *blockSend = nullptr;
             if (auto *seq = ast::cast_tree<ast::InsSeq>(blockBody)) {
@@ -349,10 +350,10 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, ast::Send *
                 // Drop the block body so the user doesn't get mysterious errors about
                 // certain functions not existing on our synthesized classes for
                 // describe blocks.
-                return ast::MK::Send(send->loc, send->recv.deepCopy(), send->fun, send->funLoc, send->numNonBlockArgs(),
-                                     ast::MK::SendArgs(ast::MK::Block(block->loc, ast::MK::EmptyTree(),
-                                                                      std::move(block->args))),
-                                     send->flags);
+                return ast::MK::Send(
+                    send->loc, send->recv.deepCopy(), send->fun, send->funLoc, send->numNonBlockArgs(),
+                    ast::MK::SendArgs(ast::MK::Block(block->loc, ast::MK::EmptyTree(), std::move(block->args))),
+                    send->flags);
             }
         }
         return nullptr;

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -327,6 +327,9 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, ast::Send *
         // and be extremely puzzled that Sorbet produces errors about their tests,
         // especially because the test works at runtime.  Try to detect when people are
         // using `each` and hint that they should be doing something else.
+        //
+        // We only check for this when we're recursing into describe blocks, because
+        // that's usually where the problems come up.
         if (level == RunSingleLevel::Interior && send->fun == core::Names::each() && send->numNonBlockArgs() == 0 && !block->args.empty()) {
             auto &blockBody = block->body;
             ast::Send *blockSend = nullptr;

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -344,7 +344,7 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, ast::Send *
                 auto sendLoc = send->recv.loc().join(send->funLoc);
                 if (auto e = ctx.beginError(sendLoc, core::errors::Rewriter::UseTestEachNotEach)) {
                     e.setHeader("`{}` cannot be used to write table-driven tests with Sorbet", "each");
-                    e.replaceWith("Use `test_each`", ctx.locAt(sendLoc), "test_each({})", send->recv.toString(ctx));
+                    e.replaceWith("Use `test_each`", ctx.locAt(sendLoc), "test_each({})", *ctx.locAt(send->recv.loc()).source(ctx));
 
                     ENFORCE(send->numNonBlockArgs() == 0);
                     // Drop the block body so the user doesn't get mysterious errors about

--- a/test/cli/autocorrect-test-each/each.rb
+++ b/test/cli/autocorrect-test-each/each.rb
@@ -1,34 +1,65 @@
 # typed: true
 extend T::Sig
 
-def it(name, &blk); end
-def test_each(val, &blk); end
-def foo(x); end
+class MyTest
+  # Hack in things that look Minitest-ish.
+  def self.describe(name, &blk); end
+  def self.it(name, &blk); end
+  def self.test_each(val, &blk); end
 
-[1, 2].each do |x|
-  it "asdf #{x}" do
-    z = foo(x)
-  end
-end
 
-[[1, 2], [3, 4]].each do |(x, y)|
-  it "asdf #{x} #{y}" do
-    z = foo(x) + foo(y)
+  # This is actually an OK use of `each`.
+  [1, 2].each do |x|
+    describe "weird case #{x}" do
+      it "doesn't call out to test_method" do
+        z = x.to_s
+      end
+    end
   end
-end
 
-{1 => 2, 3 => 4}.each do |x, y|
-  it "asdf #{x} #{y} hash" do
+  describe "array test" do
+    [1, 2].each do |x|
+      it "asdf #{x}" do
+        z = test_method(x)
+      end
+    end
   end
-end
 
-{1 => 2, 3 => 4}.each do |a|
-  it "asdf #{a} hash" do
+  describe "nested array test" do
+    [[1, 2], [3, 4]].each do |(x, y)|
+      it "asdf #{x} #{y}" do
+        z = test_method(x) + test_method(y)
+      end
+    end
   end
-end
 
-test_each([1,2]) do |x|
-  it "asdf #{x} test_each" do
-    z = foo(x)
+  describe "hash test" do
+    {1 => 2, 3 => 4}.each do |x, y|
+      it "asdf #{x} #{y} hash" do
+        z = test_method(x) + test_method(y)
+      end
+    end
   end
+
+  describe "hash test one arg" do
+    {1 => 2, 3 => 4}.each do |a|
+      it "asdf #{a} hash" do
+        # We should not complain about this use of `each`.
+        z = 0
+        a.each do
+          z += test_method(a)
+        end
+      end
+    end
+  end
+
+  describe "test_each should work" do
+    test_each([1,2]) do |x|
+      it "asdf #{x} test_each" do
+        z = test_method(x)
+      end
+    end
+  end
+
+  def test_method(x); end
 end

--- a/test/cli/autocorrect-test-each/each.rb
+++ b/test/cli/autocorrect-test-each/each.rb
@@ -1,0 +1,34 @@
+# typed: true
+extend T::Sig
+
+def it(name, &blk); end
+def test_each(val, &blk); end
+def foo(x); end
+
+[1, 2].each do |x|
+  it "asdf #{x}" do
+    z = foo(x)
+  end
+end
+
+[[1, 2], [3, 4]].each do |(x, y)|
+  it "asdf #{x} #{y}" do
+    z = foo(x) + foo(y)
+  end
+end
+
+{1 => 2, 3 => 4}.each do |x, y|
+  it "asdf #{x} #{y} hash" do
+  end
+end
+
+{1 => 2, 3 => 4}.each do |a|
+  it "asdf #{a} hash" do
+  end
+end
+
+test_each([1,2]) do |x|
+  it "asdf #{x} test_each" do
+    z = foo(x)
+  end
+end

--- a/test/cli/autocorrect-test-each/test.out
+++ b/test/cli/autocorrect-test-each/test.out
@@ -1,36 +1,67 @@
 # typed: true
 extend T::Sig
 
-def it(name, &blk); end
-def test_each(val, &blk); end
-def foo(x); end
+class MyTest
+  # Hack in things that look Minitest-ish.
+  def self.describe(name, &blk); end
+  def self.it(name, &blk); end
+  def self.test_each(val, &blk); end
 
-test_each([1, 2]) do |x|
-  it "asdf #{x}" do
-    z = foo(x)
-  end
-end
 
-test_each([[1, 2], [3, 4]]) do |(x, y)|
-  it "asdf #{x} #{y}" do
-    z = foo(x) + foo(y)
+  # This is actually an OK use of `each`.
+  [1, 2].each do |x|
+    describe "weird case #{x}" do
+      it "doesn't call out to test_method" do
+        z = x.to_s
+      end
+    end
   end
-end
 
-test_each({1 => 2, 3 => 4}) do |x, y|
-  it "asdf #{x} #{y} hash" do
+  describe "array test" do
+    test_each([1, 2]) do |x|
+      it "asdf #{x}" do
+        z = test_method(x)
+      end
+    end
   end
-end
 
-test_each({1 => 2, 3 => 4}) do |a|
-  it "asdf #{a} hash" do
+  describe "nested array test" do
+    test_each([[1, 2], [3, 4]]) do |(x, y)|
+      it "asdf #{x} #{y}" do
+        z = test_method(x) + test_method(y)
+      end
+    end
   end
-end
 
-test_each([1,2]) do |x|
-  it "asdf #{x} test_each" do
-    z = foo(x)
+  describe "hash test" do
+    test_each({1 => 2, 3 => 4}) do |x, y|
+      it "asdf #{x} #{y} hash" do
+        z = test_method(x) + test_method(y)
+      end
+    end
   end
+
+  describe "hash test one arg" do
+    test_each({1 => 2, 3 => 4}) do |a|
+      it "asdf #{a} hash" do
+        # We should not complain about this use of `each`.
+        z = 0
+        a.each do
+          z += test_method(a)
+        end
+      end
+    end
+  end
+
+  describe "test_each should work" do
+    test_each([1,2]) do |x|
+      it "asdf #{x} test_each" do
+        z = test_method(x)
+      end
+    end
+  end
+
+  def test_method(x); end
 end
 ==========
 No errors! Great job.

--- a/test/cli/autocorrect-test-each/test.out
+++ b/test/cli/autocorrect-test-each/test.out
@@ -1,0 +1,36 @@
+# typed: true
+extend T::Sig
+
+def it(name, &blk); end
+def test_each(val, &blk); end
+def foo(x); end
+
+test_each([1, 2]) do |x|
+  it "asdf #{x}" do
+    z = foo(x)
+  end
+end
+
+test_each([[1, 2], [3, 4]]) do |(x, y)|
+  it "asdf #{x} #{y}" do
+    z = foo(x) + foo(y)
+  end
+end
+
+test_each({1 => 2, 3 => 4}) do |x, y|
+  it "asdf #{x} #{y} hash" do
+  end
+end
+
+test_each({1 => 2, 3 => 4}) do |a|
+  it "asdf #{a} hash" do
+  end
+end
+
+test_each([1,2]) do |x|
+  it "asdf #{x} test_each" do
+    z = foo(x)
+  end
+end
+==========
+No errors! Great job.

--- a/test/cli/autocorrect-test-each/test.sh
+++ b/test/cli/autocorrect-test-each/test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+tmp="$(mktemp)"
+infile="test/cli/autocorrect-test-each/each.rb"
+cp "$infile" "$tmp"
+
+# Run the autocorrect in place, on the temp file
+main/sorbet --silence-dev-message -a "$tmp" 2> /dev/null
+
+# cat the file to see the autocorrected output
+cat "$tmp"
+
+echo "=========="
+
+# Verify that we made the right autocorrects for `test_each`
+main/sorbet --silence-dev-message "$tmp" 2>&1
+
+rm "$tmp"

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -531,6 +531,12 @@ generated setter method will then be given an invalid name ending with `==`.
 `T.nilable(T.untyped)` is just `T.untyped`, because `nil` is a valid value of
 type `T.untyped` (along with all other values).
 
+## 3513
+
+Type-checking table-driven tests written with `each` is quite complicated in
+the general case.  Sorbet therefore requires table-driven tests to be written
+using `test_each`
+
 ## 3702
 
 > This error is specific to Stripe's custom `--stripe-packages` mode. If you are

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -533,9 +533,9 @@ type `T.untyped` (along with all other values).
 
 ## 3513
 
-Type-checking table-driven tests written with `each` is quite complicated in
-the general case.  Sorbet therefore requires table-driven tests to be written
-using `test_each`
+Type-checking table-driven tests written with `each` is quite complicated in the
+general case. Sorbet therefore requires table-driven tests to be written using
+`test_each`
 
 ## 3702
 


### PR DESCRIPTION

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The need to use `test_each` often puzzles people, especially because they get inscrutable static errors *and* they don't get any runtime errors when they use `each`.  Try to determine if people are doing this and provide an error that points them in the correct direction.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
