### PR TITLE
Add a few extra log lines for constant cache checking

### DIFF
--- a/test/cli/autogen-constant-cache/test.out
+++ b/test/cli/autogen-constant-cache/test.out
@@ -11,5 +11,6 @@ All constant hashes unchanged; exiting
 
 Running autogen with constant-related changes: should re-run
 Checking 1 changed files
+Rerunning autogen: constant hash for file `example.rb` does not match stored hash
 Autogen still needs rerunning
 No errors! Great job.


### PR DESCRIPTION
Adds some extra log lines to our autogen cache-checking.

### Motivation
We want a bit more insight into why we're using or not using the cached version, so add some extra log lines.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
