### PR TITLE
store Ruby strings in a single table for compiled modules

### DIFF
--- a/compiler/Core/CompilerState.cc
+++ b/compiler/Core/CompilerState.cc
@@ -21,10 +21,10 @@ namespace sorbet::compiler {
 CompilerState::CompilerState(const core::GlobalState &gs, llvm::LLVMContext &lctx, llvm::Module *module,
                              llvm::DIBuilder *debug, llvm::DICompileUnit *compileUnit, core::FileRef file,
                              llvm::BasicBlock *allocRubyIdsEntry, llvm::BasicBlock *globalConstructorsEntry,
-                             StringTable &stringTable, IDTable &idTable)
+                             StringTable &stringTable, IDTable &idTable, RubyStringTable &rubyStringTable)
     : gs(gs), lctx(lctx), module(module), allocRubyIdsEntry(allocRubyIdsEntry),
       globalConstructorsEntry(globalConstructorsEntry), debug(debug), compileUnit(compileUnit),
-      functionEntryInitializers(nullptr), file(file), stringTable(stringTable), idTable(idTable) {}
+      functionEntryInitializers(nullptr), file(file), stringTable(stringTable), idTable(idTable), rubyStringTable(rubyStringTable) {}
 
 llvm::StructType *CompilerState::getValueType() {
     auto intType = llvm::Type::getInt64Ty(lctx);

--- a/compiler/Core/CompilerState.cc
+++ b/compiler/Core/CompilerState.cc
@@ -24,7 +24,8 @@ CompilerState::CompilerState(const core::GlobalState &gs, llvm::LLVMContext &lct
                              StringTable &stringTable, IDTable &idTable, RubyStringTable &rubyStringTable)
     : gs(gs), lctx(lctx), module(module), allocRubyIdsEntry(allocRubyIdsEntry),
       globalConstructorsEntry(globalConstructorsEntry), debug(debug), compileUnit(compileUnit),
-      functionEntryInitializers(nullptr), file(file), stringTable(stringTable), idTable(idTable), rubyStringTable(rubyStringTable) {}
+      functionEntryInitializers(nullptr), file(file), stringTable(stringTable), idTable(idTable),
+      rubyStringTable(rubyStringTable) {}
 
 llvm::StructType *CompilerState::getValueType() {
     auto intType = llvm::Type::getInt64Ty(lctx);
@@ -220,7 +221,8 @@ void IDTable::defineGlobalVariables(llvm::LLVMContext &lctx, llvm::Module &modul
                               builder.CreateConstGEP2_32(nullptr, stringTable, 0, 0)});
 }
 
-void RubyStringTable::defineGlobalVariables(llvm::LLVMContext &lctx, llvm::Module &module, llvm::IRBuilderBase &builder) {
+void RubyStringTable::defineGlobalVariables(llvm::LLVMContext &lctx, llvm::Module &module,
+                                            llvm::IRBuilderBase &builder) {
     vector<pair<string_view, RubyStringTable::RubyStringTableEntry>> tableElements;
     tableElements.reserve(this->map.size());
     absl::c_copy(this->map, std::back_inserter(tableElements));

--- a/compiler/Core/CompilerState.h
+++ b/compiler/Core/CompilerState.h
@@ -95,6 +95,7 @@ private:
 public:
     llvm::Value *stringTableRef(std::string_view str);
     llvm::Value *idTableRef(std::string_view str);
+    llvm::Value *rubyStringTableRef(std::string_view str);
 
     // useful apis for getting common types
 

--- a/compiler/Core/CompilerState.h
+++ b/compiler/Core/CompilerState.h
@@ -65,7 +65,8 @@ public:
     // Things created and managed ouside of us (by either Sorbet or plugin_injector)
     CompilerState(const core::GlobalState &gs, llvm::LLVMContext &lctx, llvm::Module *, llvm::DIBuilder *,
                   llvm::DICompileUnit *, core::FileRef, llvm::BasicBlock *allocRubyIdsEntry,
-                  llvm::BasicBlock *globalConstructorsEntry, StringTable &stringTable, IDTable &idTable);
+                  llvm::BasicBlock *globalConstructorsEntry, StringTable &stringTable, IDTable &idTable,
+                  RubyStringTable &rubyStringTable);
 
     const core::GlobalState &gs;
     llvm::LLVMContext &lctx;
@@ -86,6 +87,7 @@ public:
     core::FileRef file;
     StringTable &stringTable;
     IDTable &idTable;
+    RubyStringTable &rubyStringTable;
 
 private:
     StringTable::StringTableEntry insertIntoStringTable(std::string_view str);

--- a/compiler/Core/CompilerState.h
+++ b/compiler/Core/CompilerState.h
@@ -42,6 +42,23 @@ struct IDTable {
     void defineGlobalVariables(llvm::LLVMContext &lctx, llvm::Module &module, llvm::IRBuilderBase &builder);
 };
 
+struct RubyStringTable {
+    struct RubyStringTableEntry {
+        uint32_t offset;
+        uint32_t stringTableOffset = 0;
+        uint32_t stringLength = 0;
+        llvm::GlobalVariable *addrVar = nullptr;
+    };
+
+    UnorderedMap<std::string, RubyStringTableEntry> map;
+
+    void clear() {
+        this->map.clear();
+    }
+
+    void defineGlobalVariables(llvm::LLVMContext &lctx, llvm::Module &module, llvm::IRBuilderBase &builder);
+};
+
 // Like GlobalState, but for the Sorbet Compiler.
 class CompilerState {
 public:

--- a/compiler/IREmitter/Payload/codegen-payload.c
+++ b/compiler/IREmitter/Payload/codegen-payload.c
@@ -168,14 +168,21 @@ SORBET_ALIVE(void, sorbet_vm_define_method,
 SORBET_ALIVE(void, sorbet_vm_define_prop_getter,
              (VALUE klass, const char *name, rb_sorbet_func_t methodPtr, void *paramp, rb_iseq_t *iseq));
 
-// The layout of this struct is known to the compiler.
+// The layout of these structs is known to the compiler.
 struct IDDescriptor {
+    unsigned int offset;
+    unsigned int length;
+};
+
+struct RubyStringDescriptor {
     unsigned int offset;
     unsigned int length;
 };
 
 SORBET_ALIVE(void, sorbet_vm_intern_ids,
              (ID * idTable, struct IDDescriptor *idDescriptors, unsigned int numIDs, const char *stringTable));
+SORBET_ALIVE(void, sorbet_vm_init_string_table,
+             (VALUE * rubyStringTable, struct RubyStringDescriptor *descriptors, unsigned int numRubyStrings, const char *stringTable));
 
 SORBET_ALIVE(VALUE, sorbet_maybeAllocateObjectFastPath, (VALUE recv, struct FunctionInlineCache *newCache));
 SORBET_ALIVE(VALUE, sorbet_vm_instance_variable_get,

--- a/compiler/IREmitter/Payload/codegen-payload.c
+++ b/compiler/IREmitter/Payload/codegen-payload.c
@@ -182,7 +182,8 @@ struct RubyStringDescriptor {
 SORBET_ALIVE(void, sorbet_vm_intern_ids,
              (ID * idTable, struct IDDescriptor *idDescriptors, unsigned int numIDs, const char *stringTable));
 SORBET_ALIVE(void, sorbet_vm_init_string_table,
-             (VALUE * rubyStringTable, struct RubyStringDescriptor *descriptors, unsigned int numRubyStrings, const char *stringTable));
+             (VALUE * rubyStringTable, struct RubyStringDescriptor *descriptors, unsigned int numRubyStrings,
+              const char *stringTable));
 
 SORBET_ALIVE(VALUE, sorbet_maybeAllocateObjectFastPath, (VALUE recv, struct FunctionInlineCache *newCache));
 SORBET_ALIVE(VALUE, sorbet_vm_instance_variable_get,

--- a/compiler/IREmitter/Payload/codegen-payload.c
+++ b/compiler/IREmitter/Payload/codegen-payload.c
@@ -858,13 +858,6 @@ VALUE sorbet_cPtrToRubyString(const char *ptr, long length) {
 }
 
 SORBET_INLINE
-VALUE sorbet_cPtrToRubyStringFrozen(const char *ptr, long length) {
-    VALUE ret = sorbet_vm_fstring_new(ptr, length);
-    rb_gc_register_mark_object(ret);
-    return ret;
-}
-
-SORBET_INLINE
 VALUE sorbet_cPtrToRubyRegexpFrozen(const char *ptr, long length, int options) {
     VALUE ret = rb_reg_new(ptr, length, options);
     rb_gc_register_mark_object(ret);

--- a/compiler/IREmitter/Payload/vm-payload.c
+++ b/compiler/IREmitter/Payload/vm-payload.c
@@ -557,7 +557,8 @@ void sorbet_vm_intern_ids(ID *idTable, struct IDDescriptor *idDescriptors, size_
 extern VALUE sorbet_vm_fstring_new(const char *ptr, long len);
 extern void rb_gc_register_address(VALUE *addr);
 
-void sorbet_vm_init_string_table(VALUE *rubyStringTable, struct RubyStringDescriptor *descriptors, size_t numRubyStrings, const char *stringTable) {
+void sorbet_vm_init_string_table(VALUE *rubyStringTable, struct RubyStringDescriptor *descriptors,
+                                 size_t numRubyStrings, const char *stringTable) {
     for (size_t i = 0; i < numRubyStrings; ++i) {
         const struct RubyStringDescriptor *desc = &descriptors[i];
         rubyStringTable[i] = sorbet_vm_fstring_new(&stringTable[desc->offset], desc->length);

--- a/compiler/IREmitter/Payload/vm-payload.c
+++ b/compiler/IREmitter/Payload/vm-payload.c
@@ -536,8 +536,13 @@ void sorbet_vm_define_prop_getter(VALUE klass, const char *name, rb_sorbet_func_
     sorbet_vm_define_method(klass, name, methodPtr, paramp, iseq, isSelf);
 }
 
-// The layout of this struct is known to the compiler.
+// The layout of these structs is known to the compiler.
 struct IDDescriptor {
+    unsigned int offset;
+    unsigned int length;
+};
+
+struct RubyStringDescriptor {
     unsigned int offset;
     unsigned int length;
 };
@@ -546,5 +551,21 @@ void sorbet_vm_intern_ids(ID *idTable, struct IDDescriptor *idDescriptors, size_
     for (size_t i = 0; i < numIDs; ++i) {
         const struct IDDescriptor *desc = &idDescriptors[i];
         idTable[i] = rb_intern2(&stringTable[desc->offset], desc->length);
+    }
+}
+
+extern VALUE sorbet_vm_fstring_new(const char *ptr, long len);
+extern void rb_gc_register_address(VALUE *addr);
+
+void sorbet_vm_init_string_table(VALUE *rubyStringTable, struct RubyStringDescriptor *descriptors, size_t numRubyStrings, const char *stringTable) {
+    for (size_t i = 0; i < numRubyStrings; ++i) {
+        const struct RubyStringDescriptor *desc = &descriptors[i];
+        rubyStringTable[i] = sorbet_vm_fstring_new(&stringTable[desc->offset], desc->length);
+        // TODO(froydnj) This is going to allocate a separate linked list node for
+        // every literal string in the program, which seems suboptimal.  We could
+        // investigate a internal-only ruby object that knew how to "mark" itself
+        // and marked every address in here during a GC?  Or add a special
+        // rb_gc_register_address_range function?
+        rb_gc_register_address(&rubyStringTable[i]);
     }
 }

--- a/test/testdata/compiler/all_arguments.opt.ll.exp
+++ b/test/testdata/compiler/all_arguments.opt.ll.exp
@@ -82,8 +82,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_Object#14take_arguments" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@rubyStrFrozen_take_arguments = internal unnamed_addr global i64 0, align 8
-@"rubyStrFrozen_test/testdata/compiler/all_arguments.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [32 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @ic_inspect = internal global %struct.FunctionInlineCache zeroinitializer
@@ -113,6 +111,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @sorbet_moduleStringTable = internal unnamed_addr constant [138 x i8] c"take_arguments\00test/testdata/compiler/all_arguments.rb\00g\00d\00e\00<build-array>\00inspect\00puts\00<top (required)>\00normal\00Object\00a\00b\00c\00f\00baz\00master\00", align 1
 @sorbet_moduleIDTable = internal unnamed_addr global [14 x i64] zeroinitializer, align 8
 @sorbet_moduleIDDescriptors = internal unnamed_addr constant [14 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 14 }, %struct.rb_code_position_struct { i32 55, i32 1 }, %struct.rb_code_position_struct { i32 57, i32 1 }, %struct.rb_code_position_struct { i32 59, i32 1 }, %struct.rb_code_position_struct { i32 61, i32 13 }, %struct.rb_code_position_struct { i32 75, i32 7 }, %struct.rb_code_position_struct { i32 83, i32 4 }, %struct.rb_code_position_struct { i32 88, i32 16 }, %struct.rb_code_position_struct { i32 105, i32 6 }, %struct.rb_code_position_struct { i32 119, i32 1 }, %struct.rb_code_position_struct { i32 121, i32 1 }, %struct.rb_code_position_struct { i32 123, i32 1 }, %struct.rb_code_position_struct { i32 125, i32 1 }, %struct.rb_code_position_struct { i32 127, i32 3 }], align 8
+@sorbet_moduleRubyStringTable = internal unnamed_addr global [3 x i64] zeroinitializer, align 8
+@sorbet_moduleRubyStringDescriptors = internal unnamed_addr constant [3 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 14 }, %struct.rb_code_position_struct { i32 15, i32 39 }, %struct.rb_code_position_struct { i32 88, i32 16 }], align 8
 @rb_cObject = external local_unnamed_addr constant i64
 
 ; Function Attrs: nounwind readnone willreturn
@@ -144,7 +144,7 @@ declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_
 
 declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #2
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #2
+declare void @sorbet_vm_init_string_table(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #2
 
 declare i32 @rb_block_given_p() local_unnamed_addr #2
 
@@ -155,8 +155,6 @@ declare i64 @rb_ary_new_from_values(i64, i64*) local_unnamed_addr #2
 declare i64 @rb_hash_new() local_unnamed_addr #2
 
 declare i64 @rb_hash_dup(i64) local_unnamed_addr #2
-
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #2
 
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #1
@@ -463,122 +461,115 @@ entry:
   %20 = bitcast i64* %keywords154.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %20)
   tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([14 x %struct.rb_code_position_struct], [14 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 14, i8* noundef getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
-  %21 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 14) #11
-  tail call void @rb_gc_register_mark_object(i64 %21) #11
-  store i64 %21, i64* @rubyStrFrozen_take_arguments, align 8
-  %22 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 15), i64 noundef 39) #11
-  tail call void @rb_gc_register_mark_object(i64 %22) #11
-  store i64 %22, i64* @"rubyStrFrozen_test/testdata/compiler/all_arguments.rb", align 8
+  tail call void @sorbet_vm_init_string_table(i64* noundef getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleRubyStringTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([3 x %struct.rb_code_position_struct], [3 x %struct.rb_code_position_struct]* @sorbet_moduleRubyStringDescriptors, i32 0, i32 0), i32 noundef 3, i8* noundef getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 32)
-  %23 = bitcast i64* %locals.i.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %23)
+  %21 = bitcast i64* %locals.i.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %21)
   %rubyId_take_arguments.i.i = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
-  %rubyStr_take_arguments.i.i = load i64, i64* @rubyStrFrozen_take_arguments, align 8
-  %"rubyStr_test/testdata/compiler/all_arguments.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/all_arguments.rb", align 8
+  %rubyStr_take_arguments.i.i = load i64, i64* getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 0), align 8, !invariant.load !5
+  %"rubyStr_test/testdata/compiler/all_arguments.rb.i.i" = load i64, i64* getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
   %rubyId_g.i.i = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !invariant.load !5
   store i64 %rubyId_g.i.i, i64* %locals.i.i, align 8
-  %24 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_take_arguments.i.i, i64 %rubyId_take_arguments.i.i, i64 %"rubyStr_test/testdata/compiler/all_arguments.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i.i, i32 noundef 1, i32 noundef 8)
-  store %struct.rb_iseq_struct* %24, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#14take_arguments", align 8
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %23)
+  %22 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_take_arguments.i.i, i64 %rubyId_take_arguments.i.i, i64 %"rubyStr_test/testdata/compiler/all_arguments.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i.i, i32 noundef 1, i32 noundef 8)
+  store %struct.rb_iseq_struct* %22, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#14take_arguments", align 8
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %21)
   %rubyId_inspect.i = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 5), align 8, !dbg !29, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_inspect, i64 %rubyId_inspect.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !29
   %rubyId_puts.i = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 6), align 8, !dbg !36, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !36
-  %25 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 88), i64 noundef 16) #11
-  call void @rb_gc_register_mark_object(i64 %25) #11
   %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 7), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/all_arguments.rb.i163.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/all_arguments.rb", align 8
-  %26 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %25, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/all_arguments.rb.i163.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i164.i, i32 noundef 0, i32 noundef 11)
-  store %struct.rb_iseq_struct* %26, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %"rubyStr_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 2), align 8, !invariant.load !5
+  %23 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/all_arguments.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i164.i, i32 noundef 0, i32 noundef 11)
+  store %struct.rb_iseq_struct* %23, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
   %rubyId_d.i = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !39, !invariant.load !5
-  %27 = call i64 @rb_id2sym(i64 %rubyId_d.i) #13, !dbg !39
-  store i64 %27, i64* %keywords.i, align 8, !dbg !39
+  %24 = call i64 @rb_id2sym(i64 %rubyId_d.i) #13, !dbg !39
+  store i64 %24, i64* %keywords.i, align 8, !dbg !39
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 8, i32 noundef 1, i64* noundef nonnull align 8 %keywords.i), !dbg !39
-  store i64 %27, i64* %keywords4.i, align 8, !dbg !40
+  store i64 %24, i64* %keywords4.i, align 8, !dbg !40
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.1, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 7, i32 noundef 1, i64* noundef nonnull align 8 %keywords4.i), !dbg !40
-  store i64 %27, i64* %keywords10.i, align 8, !dbg !41
+  store i64 %24, i64* %keywords10.i, align 8, !dbg !41
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.2, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 6, i32 noundef 1, i64* noundef nonnull align 8 %keywords10.i), !dbg !41
-  store i64 %27, i64* %keywords16.i, align 8, !dbg !42
+  store i64 %24, i64* %keywords16.i, align 8, !dbg !42
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.3, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 5, i32 noundef 1, i64* noundef nonnull align 8 %keywords16.i), !dbg !42
-  store i64 %27, i64* %keywords22.i, align 8, !dbg !43
+  store i64 %24, i64* %keywords22.i, align 8, !dbg !43
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.4, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 4, i32 noundef 1, i64* noundef nonnull align 8 %keywords22.i), !dbg !43
-  store i64 %27, i64* %keywords28.i, align 8, !dbg !44
+  store i64 %24, i64* %keywords28.i, align 8, !dbg !44
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.5, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 3, i32 noundef 1, i64* noundef nonnull align 8 %keywords28.i), !dbg !44
-  store i64 %27, i64* %keywords34.i, align 8, !dbg !45
+  store i64 %24, i64* %keywords34.i, align 8, !dbg !45
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.6, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 2, i32 noundef 1, i64* noundef nonnull align 8 %keywords34.i), !dbg !45
-  store i64 %27, i64* %keywords40.i, align 8, !dbg !46
+  store i64 %24, i64* %keywords40.i, align 8, !dbg !46
   %rubyId_e.i = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !46, !invariant.load !5
-  %28 = call i64 @rb_id2sym(i64 %rubyId_e.i) #13, !dbg !46
-  %29 = getelementptr i64, i64* %keywords40.i, i32 1, !dbg !46
-  store i64 %28, i64* %29, align 8, !dbg !46
+  %25 = call i64 @rb_id2sym(i64 %rubyId_e.i) #13, !dbg !46
+  %26 = getelementptr i64, i64* %keywords40.i, i32 1, !dbg !46
+  store i64 %25, i64* %26, align 8, !dbg !46
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.7, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 9, i32 noundef 2, i64* noundef nonnull align 8 %keywords40.i), !dbg !46
-  store i64 %27, i64* %keywords47.i, align 8, !dbg !47
-  %30 = getelementptr i64, i64* %keywords47.i, i32 1, !dbg !47
-  store i64 %28, i64* %30, align 8, !dbg !47
+  store i64 %24, i64* %keywords47.i, align 8, !dbg !47
+  %27 = getelementptr i64, i64* %keywords47.i, i32 1, !dbg !47
+  store i64 %25, i64* %27, align 8, !dbg !47
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.8, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 8, i32 noundef 2, i64* noundef nonnull align 8 %keywords47.i), !dbg !47
-  store i64 %27, i64* %keywords55.i, align 8, !dbg !48
-  %31 = getelementptr i64, i64* %keywords55.i, i32 1, !dbg !48
-  store i64 %28, i64* %31, align 8, !dbg !48
+  store i64 %24, i64* %keywords55.i, align 8, !dbg !48
+  %28 = getelementptr i64, i64* %keywords55.i, i32 1, !dbg !48
+  store i64 %25, i64* %28, align 8, !dbg !48
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.9, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 7, i32 noundef 2, i64* noundef nonnull align 8 %keywords55.i), !dbg !48
-  store i64 %27, i64* %keywords63.i, align 8, !dbg !49
-  %32 = getelementptr i64, i64* %keywords63.i, i32 1, !dbg !49
-  store i64 %28, i64* %32, align 8, !dbg !49
+  store i64 %24, i64* %keywords63.i, align 8, !dbg !49
+  %29 = getelementptr i64, i64* %keywords63.i, i32 1, !dbg !49
+  store i64 %25, i64* %29, align 8, !dbg !49
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.10, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 6, i32 noundef 2, i64* noundef nonnull align 8 %keywords63.i), !dbg !49
-  store i64 %27, i64* %keywords71.i, align 8, !dbg !50
-  %33 = getelementptr i64, i64* %keywords71.i, i32 1, !dbg !50
-  store i64 %28, i64* %33, align 8, !dbg !50
+  store i64 %24, i64* %keywords71.i, align 8, !dbg !50
+  %30 = getelementptr i64, i64* %keywords71.i, i32 1, !dbg !50
+  store i64 %25, i64* %30, align 8, !dbg !50
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.11, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 5, i32 noundef 2, i64* noundef nonnull align 8 %keywords71.i), !dbg !50
-  store i64 %27, i64* %keywords79.i, align 8, !dbg !51
-  %34 = getelementptr i64, i64* %keywords79.i, i32 1, !dbg !51
-  store i64 %28, i64* %34, align 8, !dbg !51
+  store i64 %24, i64* %keywords79.i, align 8, !dbg !51
+  %31 = getelementptr i64, i64* %keywords79.i, i32 1, !dbg !51
+  store i64 %25, i64* %31, align 8, !dbg !51
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.12, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 4, i32 noundef 2, i64* noundef nonnull align 8 %keywords79.i), !dbg !51
-  store i64 %27, i64* %keywords87.i, align 8, !dbg !52
-  %35 = getelementptr i64, i64* %keywords87.i, i32 1, !dbg !52
-  store i64 %28, i64* %35, align 8, !dbg !52
+  store i64 %24, i64* %keywords87.i, align 8, !dbg !52
+  %32 = getelementptr i64, i64* %keywords87.i, i32 1, !dbg !52
+  store i64 %25, i64* %32, align 8, !dbg !52
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.13, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 3, i32 noundef 2, i64* noundef nonnull align 8 %keywords87.i), !dbg !52
-  store i64 %27, i64* %keywords95.i, align 8, !dbg !53
-  %36 = getelementptr i64, i64* %keywords95.i, i32 1, !dbg !53
-  store i64 %28, i64* %36, align 8, !dbg !53
+  store i64 %24, i64* %keywords95.i, align 8, !dbg !53
+  %33 = getelementptr i64, i64* %keywords95.i, i32 1, !dbg !53
+  store i64 %25, i64* %33, align 8, !dbg !53
   %rubyId_baz.i = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 13), align 8, !dbg !53, !invariant.load !5
-  %37 = call i64 @rb_id2sym(i64 %rubyId_baz.i) #13, !dbg !53
-  %38 = getelementptr i64, i64* %keywords95.i, i32 2, !dbg !53
-  store i64 %37, i64* %38, align 8, !dbg !53
+  %34 = call i64 @rb_id2sym(i64 %rubyId_baz.i) #13, !dbg !53
+  %35 = getelementptr i64, i64* %keywords95.i, i32 2, !dbg !53
+  store i64 %34, i64* %35, align 8, !dbg !53
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.14, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 10, i32 noundef 3, i64* noundef nonnull align 8 %keywords95.i), !dbg !53
-  store i64 %27, i64* %keywords104.i, align 8, !dbg !54
-  %39 = getelementptr i64, i64* %keywords104.i, i32 1, !dbg !54
-  store i64 %28, i64* %39, align 8, !dbg !54
-  %40 = getelementptr i64, i64* %keywords104.i, i32 2, !dbg !54
-  store i64 %37, i64* %40, align 8, !dbg !54
+  store i64 %24, i64* %keywords104.i, align 8, !dbg !54
+  %36 = getelementptr i64, i64* %keywords104.i, i32 1, !dbg !54
+  store i64 %25, i64* %36, align 8, !dbg !54
+  %37 = getelementptr i64, i64* %keywords104.i, i32 2, !dbg !54
+  store i64 %34, i64* %37, align 8, !dbg !54
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.15, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 9, i32 noundef 3, i64* noundef nonnull align 8 %keywords104.i), !dbg !54
-  store i64 %27, i64* %keywords114.i, align 8, !dbg !55
-  %41 = getelementptr i64, i64* %keywords114.i, i32 1, !dbg !55
-  store i64 %28, i64* %41, align 8, !dbg !55
-  %42 = getelementptr i64, i64* %keywords114.i, i32 2, !dbg !55
-  store i64 %37, i64* %42, align 8, !dbg !55
+  store i64 %24, i64* %keywords114.i, align 8, !dbg !55
+  %38 = getelementptr i64, i64* %keywords114.i, i32 1, !dbg !55
+  store i64 %25, i64* %38, align 8, !dbg !55
+  %39 = getelementptr i64, i64* %keywords114.i, i32 2, !dbg !55
+  store i64 %34, i64* %39, align 8, !dbg !55
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.16, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 8, i32 noundef 3, i64* noundef nonnull align 8 %keywords114.i), !dbg !55
-  store i64 %27, i64* %keywords124.i, align 8, !dbg !56
-  %43 = getelementptr i64, i64* %keywords124.i, i32 1, !dbg !56
-  store i64 %28, i64* %43, align 8, !dbg !56
-  %44 = getelementptr i64, i64* %keywords124.i, i32 2, !dbg !56
-  store i64 %37, i64* %44, align 8, !dbg !56
+  store i64 %24, i64* %keywords124.i, align 8, !dbg !56
+  %40 = getelementptr i64, i64* %keywords124.i, i32 1, !dbg !56
+  store i64 %25, i64* %40, align 8, !dbg !56
+  %41 = getelementptr i64, i64* %keywords124.i, i32 2, !dbg !56
+  store i64 %34, i64* %41, align 8, !dbg !56
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.17, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 7, i32 noundef 3, i64* noundef nonnull align 8 %keywords124.i), !dbg !56
-  store i64 %27, i64* %keywords134.i, align 8, !dbg !57
-  %45 = getelementptr i64, i64* %keywords134.i, i32 1, !dbg !57
-  store i64 %28, i64* %45, align 8, !dbg !57
-  %46 = getelementptr i64, i64* %keywords134.i, i32 2, !dbg !57
-  store i64 %37, i64* %46, align 8, !dbg !57
+  store i64 %24, i64* %keywords134.i, align 8, !dbg !57
+  %42 = getelementptr i64, i64* %keywords134.i, i32 1, !dbg !57
+  store i64 %25, i64* %42, align 8, !dbg !57
+  %43 = getelementptr i64, i64* %keywords134.i, i32 2, !dbg !57
+  store i64 %34, i64* %43, align 8, !dbg !57
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.18, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 6, i32 noundef 3, i64* noundef nonnull align 8 %keywords134.i), !dbg !57
-  store i64 %27, i64* %keywords144.i, align 8, !dbg !58
-  %47 = getelementptr i64, i64* %keywords144.i, i32 1, !dbg !58
-  store i64 %28, i64* %47, align 8, !dbg !58
-  %48 = getelementptr i64, i64* %keywords144.i, i32 2, !dbg !58
-  store i64 %37, i64* %48, align 8, !dbg !58
+  store i64 %24, i64* %keywords144.i, align 8, !dbg !58
+  %44 = getelementptr i64, i64* %keywords144.i, i32 1, !dbg !58
+  store i64 %25, i64* %44, align 8, !dbg !58
+  %45 = getelementptr i64, i64* %keywords144.i, i32 2, !dbg !58
+  store i64 %34, i64* %45, align 8, !dbg !58
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.19, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 5, i32 noundef 3, i64* noundef nonnull align 8 %keywords144.i), !dbg !58
-  store i64 %27, i64* %keywords154.i, align 8, !dbg !59
-  %49 = getelementptr i64, i64* %keywords154.i, i32 1, !dbg !59
-  store i64 %28, i64* %49, align 8, !dbg !59
-  %50 = getelementptr i64, i64* %keywords154.i, i32 2, !dbg !59
-  store i64 %37, i64* %50, align 8, !dbg !59
+  store i64 %24, i64* %keywords154.i, align 8, !dbg !59
+  %46 = getelementptr i64, i64* %keywords154.i, i32 1, !dbg !59
+  store i64 %25, i64* %46, align 8, !dbg !59
+  %47 = getelementptr i64, i64* %keywords154.i, i32 2, !dbg !59
+  store i64 %34, i64* %47, align 8, !dbg !59
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.20, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 4, i32 noundef 3, i64* noundef nonnull align 8 %keywords154.i), !dbg !59
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %0)
   call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %1)
@@ -601,469 +592,469 @@ entry:
   call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %18)
   call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %19)
   call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %20)
-  %51 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
-  %52 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %51, i64 0, i32 18
-  %53 = load i64, i64* %52, align 8, !tbaa !60
-  %54 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %55 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %54, i64 0, i32 2
-  %56 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %55, align 8, !tbaa !70
-  %57 = bitcast i64* %positional_table.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 32, i8* nonnull %57)
-  %58 = bitcast i64* %keyword_table.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %58)
+  %48 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
+  %49 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %48, i64 0, i32 18
+  %50 = load i64, i64* %49, align 8, !tbaa !60
+  %51 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %52 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %51, i64 0, i32 2
+  %53 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %52, align 8, !tbaa !70
+  %54 = bitcast i64* %positional_table.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 32, i8* nonnull %54)
+  %55 = bitcast i64* %keyword_table.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %55)
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %59 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %59, align 8, !tbaa !73
-  %60 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 4
-  %61 = load i64*, i64** %60, align 8, !tbaa !20
-  %62 = load i64, i64* %61, align 8, !tbaa !6
-  %63 = and i64 %62, -33
-  store i64 %63, i64* %61, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %54, %struct.rb_control_frame_struct* %56, %struct.rb_iseq_struct* %stackFrame.i) #11
-  %64 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 0
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %64, align 8, !dbg !74, !tbaa !14
-  %65 = load i64, i64* @rb_cObject, align 8, !dbg !37
+  %56 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %56, align 8, !tbaa !73
+  %57 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 4
+  %58 = load i64*, i64** %57, align 8, !tbaa !20
+  %59 = load i64, i64* %58, align 8, !tbaa !6
+  %60 = and i64 %59, -33
+  store i64 %60, i64* %58, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %51, %struct.rb_control_frame_struct* %53, %struct.rb_iseq_struct* %stackFrame.i) #11
+  %61 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 0
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %61, align 8, !dbg !74, !tbaa !14
+  %62 = load i64, i64* @rb_cObject, align 8, !dbg !37
   %stackFrame386.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#14take_arguments", align 8, !dbg !37
-  %66 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #14, !dbg !37
-  %67 = bitcast i8* %66 to i16*, !dbg !37
-  %68 = load i16, i16* %67, align 8, !dbg !37
-  %69 = and i16 %68, -384, !dbg !37
-  %70 = or i16 %69, 119, !dbg !37
-  store i16 %70, i16* %67, align 8, !dbg !37
-  %71 = getelementptr inbounds i8, i8* %66, i64 8, !dbg !37
-  %72 = bitcast i8* %71 to i32*, !dbg !37
-  %73 = getelementptr inbounds i8, i8* %66, i64 12, !dbg !37
+  %63 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #14, !dbg !37
+  %64 = bitcast i8* %63 to i16*, !dbg !37
+  %65 = load i16, i16* %64, align 8, !dbg !37
+  %66 = and i16 %65, -384, !dbg !37
+  %67 = or i16 %66, 119, !dbg !37
+  store i16 %67, i16* %64, align 8, !dbg !37
+  %68 = getelementptr inbounds i8, i8* %63, i64 8, !dbg !37
+  %69 = bitcast i8* %68 to i32*, !dbg !37
+  %70 = getelementptr inbounds i8, i8* %63, i64 12, !dbg !37
+  %71 = bitcast i8* %70 to i32*, !dbg !37
+  %72 = getelementptr inbounds i8, i8* %63, i64 16, !dbg !37
+  %73 = getelementptr inbounds i8, i8* %63, i64 20, !dbg !37
   %74 = bitcast i8* %73 to i32*, !dbg !37
-  %75 = getelementptr inbounds i8, i8* %66, i64 16, !dbg !37
-  %76 = getelementptr inbounds i8, i8* %66, i64 20, !dbg !37
-  %77 = bitcast i8* %76 to i32*, !dbg !37
-  store i32 0, i32* %77, align 4, !dbg !37, !tbaa !75
-  %78 = getelementptr inbounds i8, i8* %66, i64 24, !dbg !37
-  %79 = bitcast i8* %78 to i32*, !dbg !37
-  store i32 0, i32* %79, align 8, !dbg !37, !tbaa !78
-  %80 = getelementptr inbounds i8, i8* %66, i64 28, !dbg !37
-  %81 = bitcast i8* %80 to i32*, !dbg !37
-  store i32 3, i32* %81, align 4, !dbg !37, !tbaa !79
-  %82 = getelementptr inbounds i8, i8* %66, i64 4, !dbg !37
-  %83 = bitcast i8* %82 to i32*, !dbg !37
-  %84 = bitcast i32* %83 to <4 x i32>*, !dbg !37
-  store <4 x i32> <i32 7, i32 1, i32 1, i32 2>, <4 x i32>* %84, align 4, !dbg !37, !tbaa !80
-  %85 = load <2 x i64>, <2 x i64>* bitcast (i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 9) to <2 x i64>*), align 8, !dbg !37, !invariant.load !5
-  %86 = bitcast i64* %positional_table.i to <2 x i64>*, !dbg !37
-  store <2 x i64> %85, <2 x i64>* %86, align 8, !dbg !37
+  store i32 0, i32* %74, align 4, !dbg !37, !tbaa !75
+  %75 = getelementptr inbounds i8, i8* %63, i64 24, !dbg !37
+  %76 = bitcast i8* %75 to i32*, !dbg !37
+  store i32 0, i32* %76, align 8, !dbg !37, !tbaa !78
+  %77 = getelementptr inbounds i8, i8* %63, i64 28, !dbg !37
+  %78 = bitcast i8* %77 to i32*, !dbg !37
+  store i32 3, i32* %78, align 4, !dbg !37, !tbaa !79
+  %79 = getelementptr inbounds i8, i8* %63, i64 4, !dbg !37
+  %80 = bitcast i8* %79 to i32*, !dbg !37
+  %81 = bitcast i32* %80 to <4 x i32>*, !dbg !37
+  store <4 x i32> <i32 7, i32 1, i32 1, i32 2>, <4 x i32>* %81, align 4, !dbg !37, !tbaa !80
+  %82 = load <2 x i64>, <2 x i64>* bitcast (i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 9) to <2 x i64>*), align 8, !dbg !37, !invariant.load !5
+  %83 = bitcast i64* %positional_table.i to <2 x i64>*, !dbg !37
+  store <2 x i64> %82, <2 x i64>* %83, align 8, !dbg !37
   %rubyId_c.i = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 11), align 8, !dbg !37, !invariant.load !5
-  %87 = getelementptr i64, i64* %positional_table.i, i32 2, !dbg !37
-  store i64 %rubyId_c.i, i64* %87, align 8, !dbg !37
-  %88 = getelementptr i64, i64* %positional_table.i, i32 3, !dbg !37
-  store i64 %rubyId_g.i.i, i64* %88, align 8, !dbg !37
-  %89 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 4, i64 noundef 8) #14, !dbg !37
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %89, i8* nocapture noundef nonnull readonly align 8 dereferenceable(24) %57, i64 noundef 32, i1 noundef false) #11, !dbg !37
-  %90 = getelementptr inbounds i8, i8* %66, i64 32, !dbg !37
-  %91 = bitcast i8* %90 to i8**, !dbg !37
-  store i8* %89, i8** %91, align 8, !dbg !37, !tbaa !81
+  %84 = getelementptr i64, i64* %positional_table.i, i32 2, !dbg !37
+  store i64 %rubyId_c.i, i64* %84, align 8, !dbg !37
+  %85 = getelementptr i64, i64* %positional_table.i, i32 3, !dbg !37
+  store i64 %rubyId_g.i.i, i64* %85, align 8, !dbg !37
+  %86 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 4, i64 noundef 8) #14, !dbg !37
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %86, i8* nocapture noundef nonnull readonly align 8 dereferenceable(24) %54, i64 noundef 32, i1 noundef false) #11, !dbg !37
+  %87 = getelementptr inbounds i8, i8* %63, i64 32, !dbg !37
+  %88 = bitcast i8* %87 to i8**, !dbg !37
+  store i8* %86, i8** %88, align 8, !dbg !37, !tbaa !81
   store i64 %rubyId_d.i, i64* %keyword_table.i, align 8, !dbg !37
-  %92 = getelementptr i64, i64* %keyword_table.i, i32 1, !dbg !37
-  store i64 %rubyId_e.i, i64* %92, align 8, !dbg !37
+  %89 = getelementptr i64, i64* %keyword_table.i, i32 1, !dbg !37
+  store i64 %rubyId_e.i, i64* %89, align 8, !dbg !37
   %rubyId_f.i = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 12), align 8, !dbg !37, !invariant.load !5
-  %93 = getelementptr i64, i64* %keyword_table.i, i32 2, !dbg !37
-  store i64 %rubyId_f.i, i64* %93, align 8, !dbg !37
-  %94 = getelementptr inbounds i8, i8* %66, i64 40, !dbg !37
-  %95 = bitcast i8* %94 to i32*, !dbg !37
-  store i32 2, i32* %95, align 8, !dbg !37, !tbaa !82
-  %96 = getelementptr inbounds i8, i8* %66, i64 44, !dbg !37
-  %97 = bitcast i8* %96 to i32*, !dbg !37
-  store i32 1, i32* %97, align 4, !dbg !37, !tbaa !83
-  %98 = load i32, i32* %72, align 8, !dbg !37, !tbaa !84
-  %99 = load i32, i32* %74, align 4, !dbg !37, !tbaa !85
-  %100 = add i32 %98, 2, !dbg !37
-  %101 = add i32 %100, %99, !dbg !37
-  %102 = getelementptr inbounds i8, i8* %66, i64 48, !dbg !37
-  %103 = bitcast i8* %102 to i32*, !dbg !37
-  store i32 %101, i32* %103, align 8, !dbg !37, !tbaa !86
-  %104 = load i16, i16* %67, align 8, !dbg !37
-  %105 = and i16 %104, 32, !dbg !37
-  %106 = icmp eq i16 %105, 0, !dbg !37
-  br i1 %106, label %"func_<root>.17<static-init>$153.exit", label %107, !dbg !37
+  %90 = getelementptr i64, i64* %keyword_table.i, i32 2, !dbg !37
+  store i64 %rubyId_f.i, i64* %90, align 8, !dbg !37
+  %91 = getelementptr inbounds i8, i8* %63, i64 40, !dbg !37
+  %92 = bitcast i8* %91 to i32*, !dbg !37
+  store i32 2, i32* %92, align 8, !dbg !37, !tbaa !82
+  %93 = getelementptr inbounds i8, i8* %63, i64 44, !dbg !37
+  %94 = bitcast i8* %93 to i32*, !dbg !37
+  store i32 1, i32* %94, align 4, !dbg !37, !tbaa !83
+  %95 = load i32, i32* %69, align 8, !dbg !37, !tbaa !84
+  %96 = load i32, i32* %71, align 4, !dbg !37, !tbaa !85
+  %97 = add i32 %95, 2, !dbg !37
+  %98 = add i32 %97, %96, !dbg !37
+  %99 = getelementptr inbounds i8, i8* %63, i64 48, !dbg !37
+  %100 = bitcast i8* %99 to i32*, !dbg !37
+  store i32 %98, i32* %100, align 8, !dbg !37, !tbaa !86
+  %101 = load i16, i16* %64, align 8, !dbg !37
+  %102 = and i16 %101, 32, !dbg !37
+  %103 = icmp eq i16 %102, 0, !dbg !37
+  br i1 %103, label %"func_<root>.17<static-init>$153.exit", label %104, !dbg !37
 
-107:                                              ; preds = %entry
-  %108 = add nsw i32 %101, 1, !dbg !37
-  %109 = getelementptr inbounds i8, i8* %66, i64 52, !dbg !37
-  %110 = bitcast i8* %109 to i32*, !dbg !37
-  store i32 %108, i32* %110, align 4, !dbg !37, !tbaa !87
+104:                                              ; preds = %entry
+  %105 = add nsw i32 %98, 1, !dbg !37
+  %106 = getelementptr inbounds i8, i8* %63, i64 52, !dbg !37
+  %107 = bitcast i8* %106 to i32*, !dbg !37
+  store i32 %105, i32* %107, align 4, !dbg !37, !tbaa !87
   br label %"func_<root>.17<static-init>$153.exit", !dbg !37
 
-"func_<root>.17<static-init>$153.exit":           ; preds = %entry, %107
-  %111 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 3, i64 noundef 8) #14, !dbg !37
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %111, i8* nocapture noundef nonnull readonly align 8 dereferenceable(24) %58, i64 noundef 24, i1 noundef false) #11, !dbg !37
-  %112 = getelementptr inbounds i8, i8* %66, i64 56, !dbg !37
-  %113 = bitcast i8* %112 to i8**, !dbg !37
-  store i8* %111, i8** %113, align 8, !dbg !37, !tbaa !88
-  call void @sorbet_vm_define_method(i64 %65, i8* noundef getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#14take_arguments", i8* nonnull %66, %struct.rb_iseq_struct* %stackFrame386.i, i1 noundef zeroext false) #11, !dbg !37
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %64, align 8, !dbg !37, !tbaa !14
-  %114 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 1, !dbg !39
-  %115 = load i64*, i64** %114, align 8, !dbg !39
-  store i64 %53, i64* %115, align 8, !dbg !39, !tbaa !6
+"func_<root>.17<static-init>$153.exit":           ; preds = %entry, %104
+  %108 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 3, i64 noundef 8) #14, !dbg !37
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %108, i8* nocapture noundef nonnull readonly align 8 dereferenceable(24) %55, i64 noundef 24, i1 noundef false) #11, !dbg !37
+  %109 = getelementptr inbounds i8, i8* %63, i64 56, !dbg !37
+  %110 = bitcast i8* %109 to i8**, !dbg !37
+  store i8* %108, i8** %110, align 8, !dbg !37, !tbaa !88
+  call void @sorbet_vm_define_method(i64 %62, i8* noundef getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#14take_arguments", i8* nonnull %63, %struct.rb_iseq_struct* %stackFrame386.i, i1 noundef zeroext false) #11, !dbg !37
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %61, align 8, !dbg !37, !tbaa !14
+  %111 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !39
+  %112 = load i64*, i64** %111, align 8, !dbg !39
+  store i64 %50, i64* %112, align 8, !dbg !39, !tbaa !6
+  %113 = getelementptr inbounds i64, i64* %112, i64 1, !dbg !39
+  %114 = getelementptr inbounds i64, i64* %113, i64 1, !dbg !39
+  %115 = getelementptr inbounds i64, i64* %114, i64 1, !dbg !39
   %116 = getelementptr inbounds i64, i64* %115, i64 1, !dbg !39
-  %117 = getelementptr inbounds i64, i64* %116, i64 1, !dbg !39
-  %118 = getelementptr inbounds i64, i64* %117, i64 1, !dbg !39
+  %117 = bitcast i64* %113 to <4 x i64>*, !dbg !39
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %117, align 8, !dbg !39, !tbaa !6
+  %118 = getelementptr inbounds i64, i64* %116, i64 1, !dbg !39
   %119 = getelementptr inbounds i64, i64* %118, i64 1, !dbg !39
-  %120 = bitcast i64* %116 to <4 x i64>*, !dbg !39
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %120, align 8, !dbg !39, !tbaa !6
+  %120 = bitcast i64* %118 to <2 x i64>*, !dbg !39
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %120, align 8, !dbg !39, !tbaa !6
   %121 = getelementptr inbounds i64, i64* %119, i64 1, !dbg !39
+  store i64 -13, i64* %121, align 8, !dbg !39, !tbaa !6
   %122 = getelementptr inbounds i64, i64* %121, i64 1, !dbg !39
-  %123 = bitcast i64* %121 to <2 x i64>*, !dbg !39
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %123, align 8, !dbg !39, !tbaa !6
-  %124 = getelementptr inbounds i64, i64* %122, i64 1, !dbg !39
-  store i64 -13, i64* %124, align 8, !dbg !39, !tbaa !6
-  %125 = getelementptr inbounds i64, i64* %124, i64 1, !dbg !39
-  store i64 -15, i64* %125, align 8, !dbg !39, !tbaa !6
-  %126 = getelementptr inbounds i64, i64* %125, i64 1, !dbg !39
-  store i64* %126, i64** %114, align 8, !dbg !39
+  store i64 -15, i64* %122, align 8, !dbg !39, !tbaa !6
+  %123 = getelementptr inbounds i64, i64* %122, i64 1, !dbg !39
+  store i64* %123, i64** %111, align 8, !dbg !39
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments, i64 0), !dbg !39
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %64, align 8, !dbg !39, !tbaa !14
-  %127 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 1, !dbg !40
-  %128 = load i64*, i64** %127, align 8, !dbg !40
-  store i64 %53, i64* %128, align 8, !dbg !40, !tbaa !6
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %61, align 8, !dbg !39, !tbaa !14
+  %124 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !40
+  %125 = load i64*, i64** %124, align 8, !dbg !40
+  store i64 %50, i64* %125, align 8, !dbg !40, !tbaa !6
+  %126 = getelementptr inbounds i64, i64* %125, i64 1, !dbg !40
+  %127 = getelementptr inbounds i64, i64* %126, i64 1, !dbg !40
+  %128 = getelementptr inbounds i64, i64* %127, i64 1, !dbg !40
   %129 = getelementptr inbounds i64, i64* %128, i64 1, !dbg !40
-  %130 = getelementptr inbounds i64, i64* %129, i64 1, !dbg !40
-  %131 = getelementptr inbounds i64, i64* %130, i64 1, !dbg !40
+  %130 = bitcast i64* %126 to <4 x i64>*, !dbg !40
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %130, align 8, !dbg !40, !tbaa !6
+  %131 = getelementptr inbounds i64, i64* %129, i64 1, !dbg !40
   %132 = getelementptr inbounds i64, i64* %131, i64 1, !dbg !40
-  %133 = bitcast i64* %129 to <4 x i64>*, !dbg !40
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %133, align 8, !dbg !40, !tbaa !6
+  %133 = bitcast i64* %131 to <2 x i64>*, !dbg !40
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %133, align 8, !dbg !40, !tbaa !6
   %134 = getelementptr inbounds i64, i64* %132, i64 1, !dbg !40
+  store i64 -15, i64* %134, align 8, !dbg !40, !tbaa !6
   %135 = getelementptr inbounds i64, i64* %134, i64 1, !dbg !40
-  %136 = bitcast i64* %134 to <2 x i64>*, !dbg !40
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %136, align 8, !dbg !40, !tbaa !6
-  %137 = getelementptr inbounds i64, i64* %135, i64 1, !dbg !40
-  store i64 -15, i64* %137, align 8, !dbg !40, !tbaa !6
-  %138 = getelementptr inbounds i64, i64* %137, i64 1, !dbg !40
-  store i64* %138, i64** %127, align 8, !dbg !40
+  store i64* %135, i64** %124, align 8, !dbg !40
   %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.1, i64 0), !dbg !40
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %64, align 8, !dbg !40, !tbaa !14
-  %139 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 1, !dbg !41
-  %140 = load i64*, i64** %139, align 8, !dbg !41
-  store i64 %53, i64* %140, align 8, !dbg !41, !tbaa !6
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %61, align 8, !dbg !40, !tbaa !14
+  %136 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !41
+  %137 = load i64*, i64** %136, align 8, !dbg !41
+  store i64 %50, i64* %137, align 8, !dbg !41, !tbaa !6
+  %138 = getelementptr inbounds i64, i64* %137, i64 1, !dbg !41
+  %139 = getelementptr inbounds i64, i64* %138, i64 1, !dbg !41
+  %140 = getelementptr inbounds i64, i64* %139, i64 1, !dbg !41
   %141 = getelementptr inbounds i64, i64* %140, i64 1, !dbg !41
-  %142 = getelementptr inbounds i64, i64* %141, i64 1, !dbg !41
-  %143 = getelementptr inbounds i64, i64* %142, i64 1, !dbg !41
+  %142 = bitcast i64* %138 to <4 x i64>*, !dbg !41
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %142, align 8, !dbg !41, !tbaa !6
+  %143 = getelementptr inbounds i64, i64* %141, i64 1, !dbg !41
   %144 = getelementptr inbounds i64, i64* %143, i64 1, !dbg !41
-  %145 = bitcast i64* %141 to <4 x i64>*, !dbg !41
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %145, align 8, !dbg !41, !tbaa !6
+  %145 = bitcast i64* %143 to <2 x i64>*, !dbg !41
+  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %145, align 8, !dbg !41, !tbaa !6
   %146 = getelementptr inbounds i64, i64* %144, i64 1, !dbg !41
-  %147 = getelementptr inbounds i64, i64* %146, i64 1, !dbg !41
-  %148 = bitcast i64* %146 to <2 x i64>*, !dbg !41
-  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %148, align 8, !dbg !41, !tbaa !6
-  %149 = getelementptr inbounds i64, i64* %147, i64 1, !dbg !41
-  store i64* %149, i64** %139, align 8, !dbg !41
+  store i64* %146, i64** %136, align 8, !dbg !41
   %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.2, i64 0), !dbg !41
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %64, align 8, !dbg !41, !tbaa !14
-  %150 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 1, !dbg !42
-  %151 = load i64*, i64** %150, align 8, !dbg !42
-  store i64 %53, i64* %151, align 8, !dbg !42, !tbaa !6
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %61, align 8, !dbg !41, !tbaa !14
+  %147 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !42
+  %148 = load i64*, i64** %147, align 8, !dbg !42
+  store i64 %50, i64* %148, align 8, !dbg !42, !tbaa !6
+  %149 = getelementptr inbounds i64, i64* %148, i64 1, !dbg !42
+  %150 = getelementptr inbounds i64, i64* %149, i64 1, !dbg !42
+  %151 = getelementptr inbounds i64, i64* %150, i64 1, !dbg !42
   %152 = getelementptr inbounds i64, i64* %151, i64 1, !dbg !42
-  %153 = getelementptr inbounds i64, i64* %152, i64 1, !dbg !42
-  %154 = getelementptr inbounds i64, i64* %153, i64 1, !dbg !42
+  %153 = bitcast i64* %149 to <4 x i64>*, !dbg !42
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %153, align 8, !dbg !42, !tbaa !6
+  %154 = getelementptr inbounds i64, i64* %152, i64 1, !dbg !42
+  store i64 -15, i64* %154, align 8, !dbg !42, !tbaa !6
   %155 = getelementptr inbounds i64, i64* %154, i64 1, !dbg !42
-  %156 = bitcast i64* %152 to <4 x i64>*, !dbg !42
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %156, align 8, !dbg !42, !tbaa !6
-  %157 = getelementptr inbounds i64, i64* %155, i64 1, !dbg !42
-  store i64 -15, i64* %157, align 8, !dbg !42, !tbaa !6
-  %158 = getelementptr inbounds i64, i64* %157, i64 1, !dbg !42
-  store i64* %158, i64** %150, align 8, !dbg !42
+  store i64* %155, i64** %147, align 8, !dbg !42
   %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.3, i64 0), !dbg !42
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %64, align 8, !dbg !42, !tbaa !14
-  %159 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 1, !dbg !43
-  %160 = load i64*, i64** %159, align 8, !dbg !43
-  store i64 %53, i64* %160, align 8, !dbg !43, !tbaa !6
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %61, align 8, !dbg !42, !tbaa !14
+  %156 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !43
+  %157 = load i64*, i64** %156, align 8, !dbg !43
+  store i64 %50, i64* %157, align 8, !dbg !43, !tbaa !6
+  %158 = getelementptr inbounds i64, i64* %157, i64 1, !dbg !43
+  %159 = getelementptr inbounds i64, i64* %158, i64 1, !dbg !43
+  %160 = getelementptr inbounds i64, i64* %159, i64 1, !dbg !43
   %161 = getelementptr inbounds i64, i64* %160, i64 1, !dbg !43
-  %162 = getelementptr inbounds i64, i64* %161, i64 1, !dbg !43
-  %163 = getelementptr inbounds i64, i64* %162, i64 1, !dbg !43
-  %164 = getelementptr inbounds i64, i64* %163, i64 1, !dbg !43
-  %165 = bitcast i64* %161 to <4 x i64>*, !dbg !43
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %165, align 8, !dbg !43, !tbaa !6
-  %166 = getelementptr inbounds i64, i64* %164, i64 1, !dbg !43
-  store i64* %166, i64** %159, align 8, !dbg !43
+  %162 = bitcast i64* %158 to <4 x i64>*, !dbg !43
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %162, align 8, !dbg !43, !tbaa !6
+  %163 = getelementptr inbounds i64, i64* %161, i64 1, !dbg !43
+  store i64* %163, i64** %156, align 8, !dbg !43
   %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.4, i64 0), !dbg !43
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %64, align 8, !dbg !43, !tbaa !14
-  %167 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 1, !dbg !44
-  %168 = load i64*, i64** %167, align 8, !dbg !44
-  store i64 %53, i64* %168, align 8, !dbg !44, !tbaa !6
-  %169 = getelementptr inbounds i64, i64* %168, i64 1, !dbg !44
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %61, align 8, !dbg !43, !tbaa !14
+  %164 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !44
+  %165 = load i64*, i64** %164, align 8, !dbg !44
+  store i64 %50, i64* %165, align 8, !dbg !44, !tbaa !6
+  %166 = getelementptr inbounds i64, i64* %165, i64 1, !dbg !44
+  %167 = getelementptr inbounds i64, i64* %166, i64 1, !dbg !44
+  %168 = bitcast i64* %166 to <2 x i64>*, !dbg !44
+  store <2 x i64> <i64 -1, i64 -3>, <2 x i64>* %168, align 8, !dbg !44, !tbaa !6
+  %169 = getelementptr inbounds i64, i64* %167, i64 1, !dbg !44
+  store i64 -15, i64* %169, align 8, !dbg !44, !tbaa !6
   %170 = getelementptr inbounds i64, i64* %169, i64 1, !dbg !44
-  %171 = bitcast i64* %169 to <2 x i64>*, !dbg !44
-  store <2 x i64> <i64 -1, i64 -3>, <2 x i64>* %171, align 8, !dbg !44, !tbaa !6
-  %172 = getelementptr inbounds i64, i64* %170, i64 1, !dbg !44
-  store i64 -15, i64* %172, align 8, !dbg !44, !tbaa !6
-  %173 = getelementptr inbounds i64, i64* %172, i64 1, !dbg !44
-  store i64* %173, i64** %167, align 8, !dbg !44
+  store i64* %170, i64** %164, align 8, !dbg !44
   %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.5, i64 0), !dbg !44
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %64, align 8, !dbg !44, !tbaa !14
-  %174 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 1, !dbg !45
-  %175 = load i64*, i64** %174, align 8, !dbg !45
-  store i64 %53, i64* %175, align 8, !dbg !45, !tbaa !6
-  %176 = getelementptr inbounds i64, i64* %175, i64 1, !dbg !45
-  %177 = getelementptr inbounds i64, i64* %176, i64 1, !dbg !45
-  %178 = bitcast i64* %176 to <2 x i64>*, !dbg !45
-  store <2 x i64> <i64 -1, i64 -15>, <2 x i64>* %178, align 8, !dbg !45, !tbaa !6
-  %179 = getelementptr inbounds i64, i64* %177, i64 1, !dbg !45
-  store i64* %179, i64** %174, align 8, !dbg !45
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %61, align 8, !dbg !44, !tbaa !14
+  %171 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !45
+  %172 = load i64*, i64** %171, align 8, !dbg !45
+  store i64 %50, i64* %172, align 8, !dbg !45, !tbaa !6
+  %173 = getelementptr inbounds i64, i64* %172, i64 1, !dbg !45
+  %174 = getelementptr inbounds i64, i64* %173, i64 1, !dbg !45
+  %175 = bitcast i64* %173 to <2 x i64>*, !dbg !45
+  store <2 x i64> <i64 -1, i64 -15>, <2 x i64>* %175, align 8, !dbg !45, !tbaa !6
+  %176 = getelementptr inbounds i64, i64* %174, i64 1, !dbg !45
+  store i64* %176, i64** %171, align 8, !dbg !45
   %send14 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.6, i64 0), !dbg !45
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %64, align 8, !dbg !45, !tbaa !14
-  %180 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 1, !dbg !46
-  %181 = load i64*, i64** %180, align 8, !dbg !46
-  store i64 %53, i64* %181, align 8, !dbg !46, !tbaa !6
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %61, align 8, !dbg !45, !tbaa !14
+  %177 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !46
+  %178 = load i64*, i64** %177, align 8, !dbg !46
+  store i64 %50, i64* %178, align 8, !dbg !46, !tbaa !6
+  %179 = getelementptr inbounds i64, i64* %178, i64 1, !dbg !46
+  %180 = getelementptr inbounds i64, i64* %179, i64 1, !dbg !46
+  %181 = getelementptr inbounds i64, i64* %180, i64 1, !dbg !46
   %182 = getelementptr inbounds i64, i64* %181, i64 1, !dbg !46
-  %183 = getelementptr inbounds i64, i64* %182, i64 1, !dbg !46
-  %184 = getelementptr inbounds i64, i64* %183, i64 1, !dbg !46
+  %183 = bitcast i64* %179 to <4 x i64>*, !dbg !46
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %183, align 8, !dbg !46, !tbaa !6
+  %184 = getelementptr inbounds i64, i64* %182, i64 1, !dbg !46
   %185 = getelementptr inbounds i64, i64* %184, i64 1, !dbg !46
-  %186 = bitcast i64* %182 to <4 x i64>*, !dbg !46
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %186, align 8, !dbg !46, !tbaa !6
+  %186 = bitcast i64* %184 to <2 x i64>*, !dbg !46
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %186, align 8, !dbg !46, !tbaa !6
   %187 = getelementptr inbounds i64, i64* %185, i64 1, !dbg !46
+  store i64 -13, i64* %187, align 8, !dbg !46, !tbaa !6
   %188 = getelementptr inbounds i64, i64* %187, i64 1, !dbg !46
-  %189 = bitcast i64* %187 to <2 x i64>*, !dbg !46
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %189, align 8, !dbg !46, !tbaa !6
-  %190 = getelementptr inbounds i64, i64* %188, i64 1, !dbg !46
-  store i64 -13, i64* %190, align 8, !dbg !46, !tbaa !6
-  %191 = getelementptr inbounds i64, i64* %190, i64 1, !dbg !46
-  store i64 -15, i64* %191, align 8, !dbg !46, !tbaa !6
-  %192 = getelementptr inbounds i64, i64* %191, i64 1, !dbg !46
-  store i64 -17, i64* %192, align 8, !dbg !46, !tbaa !6
-  %193 = getelementptr inbounds i64, i64* %192, i64 1, !dbg !46
-  store i64* %193, i64** %180, align 8, !dbg !46
+  store i64 -15, i64* %188, align 8, !dbg !46, !tbaa !6
+  %189 = getelementptr inbounds i64, i64* %188, i64 1, !dbg !46
+  store i64 -17, i64* %189, align 8, !dbg !46, !tbaa !6
+  %190 = getelementptr inbounds i64, i64* %189, i64 1, !dbg !46
+  store i64* %190, i64** %177, align 8, !dbg !46
   %send16 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.7, i64 0), !dbg !46
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %64, align 8, !dbg !46, !tbaa !14
-  %194 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 1, !dbg !47
-  %195 = load i64*, i64** %194, align 8, !dbg !47
-  store i64 %53, i64* %195, align 8, !dbg !47, !tbaa !6
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %61, align 8, !dbg !46, !tbaa !14
+  %191 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !47
+  %192 = load i64*, i64** %191, align 8, !dbg !47
+  store i64 %50, i64* %192, align 8, !dbg !47, !tbaa !6
+  %193 = getelementptr inbounds i64, i64* %192, i64 1, !dbg !47
+  %194 = getelementptr inbounds i64, i64* %193, i64 1, !dbg !47
+  %195 = getelementptr inbounds i64, i64* %194, i64 1, !dbg !47
   %196 = getelementptr inbounds i64, i64* %195, i64 1, !dbg !47
-  %197 = getelementptr inbounds i64, i64* %196, i64 1, !dbg !47
-  %198 = getelementptr inbounds i64, i64* %197, i64 1, !dbg !47
+  %197 = bitcast i64* %193 to <4 x i64>*, !dbg !47
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %197, align 8, !dbg !47, !tbaa !6
+  %198 = getelementptr inbounds i64, i64* %196, i64 1, !dbg !47
   %199 = getelementptr inbounds i64, i64* %198, i64 1, !dbg !47
-  %200 = bitcast i64* %196 to <4 x i64>*, !dbg !47
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %200, align 8, !dbg !47, !tbaa !6
+  %200 = bitcast i64* %198 to <2 x i64>*, !dbg !47
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %200, align 8, !dbg !47, !tbaa !6
   %201 = getelementptr inbounds i64, i64* %199, i64 1, !dbg !47
+  store i64 -15, i64* %201, align 8, !dbg !47, !tbaa !6
   %202 = getelementptr inbounds i64, i64* %201, i64 1, !dbg !47
-  %203 = bitcast i64* %201 to <2 x i64>*, !dbg !47
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %203, align 8, !dbg !47, !tbaa !6
-  %204 = getelementptr inbounds i64, i64* %202, i64 1, !dbg !47
-  store i64 -15, i64* %204, align 8, !dbg !47, !tbaa !6
-  %205 = getelementptr inbounds i64, i64* %204, i64 1, !dbg !47
-  store i64 -17, i64* %205, align 8, !dbg !47, !tbaa !6
-  %206 = getelementptr inbounds i64, i64* %205, i64 1, !dbg !47
-  store i64* %206, i64** %194, align 8, !dbg !47
+  store i64 -17, i64* %202, align 8, !dbg !47, !tbaa !6
+  %203 = getelementptr inbounds i64, i64* %202, i64 1, !dbg !47
+  store i64* %203, i64** %191, align 8, !dbg !47
   %send18 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.8, i64 0), !dbg !47
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %64, align 8, !dbg !47, !tbaa !14
-  %207 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 1, !dbg !48
-  %208 = load i64*, i64** %207, align 8, !dbg !48
-  store i64 %53, i64* %208, align 8, !dbg !48, !tbaa !6
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %61, align 8, !dbg !47, !tbaa !14
+  %204 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !48
+  %205 = load i64*, i64** %204, align 8, !dbg !48
+  store i64 %50, i64* %205, align 8, !dbg !48, !tbaa !6
+  %206 = getelementptr inbounds i64, i64* %205, i64 1, !dbg !48
+  %207 = getelementptr inbounds i64, i64* %206, i64 1, !dbg !48
+  %208 = getelementptr inbounds i64, i64* %207, i64 1, !dbg !48
   %209 = getelementptr inbounds i64, i64* %208, i64 1, !dbg !48
-  %210 = getelementptr inbounds i64, i64* %209, i64 1, !dbg !48
-  %211 = getelementptr inbounds i64, i64* %210, i64 1, !dbg !48
+  %210 = bitcast i64* %206 to <4 x i64>*, !dbg !48
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %210, align 8, !dbg !48, !tbaa !6
+  %211 = getelementptr inbounds i64, i64* %209, i64 1, !dbg !48
   %212 = getelementptr inbounds i64, i64* %211, i64 1, !dbg !48
-  %213 = bitcast i64* %209 to <4 x i64>*, !dbg !48
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %213, align 8, !dbg !48, !tbaa !6
+  %213 = bitcast i64* %211 to <2 x i64>*, !dbg !48
+  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %213, align 8, !dbg !48, !tbaa !6
   %214 = getelementptr inbounds i64, i64* %212, i64 1, !dbg !48
+  store i64 -17, i64* %214, align 8, !dbg !48, !tbaa !6
   %215 = getelementptr inbounds i64, i64* %214, i64 1, !dbg !48
-  %216 = bitcast i64* %214 to <2 x i64>*, !dbg !48
-  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %216, align 8, !dbg !48, !tbaa !6
-  %217 = getelementptr inbounds i64, i64* %215, i64 1, !dbg !48
-  store i64 -17, i64* %217, align 8, !dbg !48, !tbaa !6
-  %218 = getelementptr inbounds i64, i64* %217, i64 1, !dbg !48
-  store i64* %218, i64** %207, align 8, !dbg !48
+  store i64* %215, i64** %204, align 8, !dbg !48
   %send20 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.9, i64 0), !dbg !48
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %64, align 8, !dbg !48, !tbaa !14
-  %219 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 1, !dbg !49
-  %220 = load i64*, i64** %219, align 8, !dbg !49
-  store i64 %53, i64* %220, align 8, !dbg !49, !tbaa !6
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %61, align 8, !dbg !48, !tbaa !14
+  %216 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !49
+  %217 = load i64*, i64** %216, align 8, !dbg !49
+  store i64 %50, i64* %217, align 8, !dbg !49, !tbaa !6
+  %218 = getelementptr inbounds i64, i64* %217, i64 1, !dbg !49
+  %219 = getelementptr inbounds i64, i64* %218, i64 1, !dbg !49
+  %220 = getelementptr inbounds i64, i64* %219, i64 1, !dbg !49
   %221 = getelementptr inbounds i64, i64* %220, i64 1, !dbg !49
-  %222 = getelementptr inbounds i64, i64* %221, i64 1, !dbg !49
-  %223 = getelementptr inbounds i64, i64* %222, i64 1, !dbg !49
+  %222 = bitcast i64* %218 to <4 x i64>*, !dbg !49
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %222, align 8, !dbg !49, !tbaa !6
+  %223 = getelementptr inbounds i64, i64* %221, i64 1, !dbg !49
   %224 = getelementptr inbounds i64, i64* %223, i64 1, !dbg !49
-  %225 = bitcast i64* %221 to <4 x i64>*, !dbg !49
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %225, align 8, !dbg !49, !tbaa !6
+  %225 = bitcast i64* %223 to <2 x i64>*, !dbg !49
+  store <2 x i64> <i64 -15, i64 -17>, <2 x i64>* %225, align 8, !dbg !49, !tbaa !6
   %226 = getelementptr inbounds i64, i64* %224, i64 1, !dbg !49
-  %227 = getelementptr inbounds i64, i64* %226, i64 1, !dbg !49
-  %228 = bitcast i64* %226 to <2 x i64>*, !dbg !49
-  store <2 x i64> <i64 -15, i64 -17>, <2 x i64>* %228, align 8, !dbg !49, !tbaa !6
-  %229 = getelementptr inbounds i64, i64* %227, i64 1, !dbg !49
-  store i64* %229, i64** %219, align 8, !dbg !49
+  store i64* %226, i64** %216, align 8, !dbg !49
   %send22 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.10, i64 0), !dbg !49
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 20), i64** %64, align 8, !dbg !49, !tbaa !14
-  %230 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 1, !dbg !50
-  %231 = load i64*, i64** %230, align 8, !dbg !50
-  store i64 %53, i64* %231, align 8, !dbg !50, !tbaa !6
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 20), i64** %61, align 8, !dbg !49, !tbaa !14
+  %227 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !50
+  %228 = load i64*, i64** %227, align 8, !dbg !50
+  store i64 %50, i64* %228, align 8, !dbg !50, !tbaa !6
+  %229 = getelementptr inbounds i64, i64* %228, i64 1, !dbg !50
+  %230 = getelementptr inbounds i64, i64* %229, i64 1, !dbg !50
+  %231 = getelementptr inbounds i64, i64* %230, i64 1, !dbg !50
   %232 = getelementptr inbounds i64, i64* %231, i64 1, !dbg !50
-  %233 = getelementptr inbounds i64, i64* %232, i64 1, !dbg !50
-  %234 = getelementptr inbounds i64, i64* %233, i64 1, !dbg !50
+  %233 = bitcast i64* %229 to <4 x i64>*, !dbg !50
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %233, align 8, !dbg !50, !tbaa !6
+  %234 = getelementptr inbounds i64, i64* %232, i64 1, !dbg !50
+  store i64 -17, i64* %234, align 8, !dbg !50, !tbaa !6
   %235 = getelementptr inbounds i64, i64* %234, i64 1, !dbg !50
-  %236 = bitcast i64* %232 to <4 x i64>*, !dbg !50
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %236, align 8, !dbg !50, !tbaa !6
-  %237 = getelementptr inbounds i64, i64* %235, i64 1, !dbg !50
-  store i64 -17, i64* %237, align 8, !dbg !50, !tbaa !6
-  %238 = getelementptr inbounds i64, i64* %237, i64 1, !dbg !50
-  store i64* %238, i64** %230, align 8, !dbg !50
+  store i64* %235, i64** %227, align 8, !dbg !50
   %send24 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.11, i64 0), !dbg !50
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %64, align 8, !dbg !50, !tbaa !14
-  %239 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 1, !dbg !51
-  %240 = load i64*, i64** %239, align 8, !dbg !51
-  store i64 %53, i64* %240, align 8, !dbg !51, !tbaa !6
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %61, align 8, !dbg !50, !tbaa !14
+  %236 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !51
+  %237 = load i64*, i64** %236, align 8, !dbg !51
+  store i64 %50, i64* %237, align 8, !dbg !51, !tbaa !6
+  %238 = getelementptr inbounds i64, i64* %237, i64 1, !dbg !51
+  %239 = getelementptr inbounds i64, i64* %238, i64 1, !dbg !51
+  %240 = getelementptr inbounds i64, i64* %239, i64 1, !dbg !51
   %241 = getelementptr inbounds i64, i64* %240, i64 1, !dbg !51
-  %242 = getelementptr inbounds i64, i64* %241, i64 1, !dbg !51
-  %243 = getelementptr inbounds i64, i64* %242, i64 1, !dbg !51
-  %244 = getelementptr inbounds i64, i64* %243, i64 1, !dbg !51
-  %245 = bitcast i64* %241 to <4 x i64>*, !dbg !51
-  store <4 x i64> <i64 -1, i64 -3, i64 -15, i64 -17>, <4 x i64>* %245, align 8, !dbg !51, !tbaa !6
-  %246 = getelementptr inbounds i64, i64* %244, i64 1, !dbg !51
-  store i64* %246, i64** %239, align 8, !dbg !51
+  %242 = bitcast i64* %238 to <4 x i64>*, !dbg !51
+  store <4 x i64> <i64 -1, i64 -3, i64 -15, i64 -17>, <4 x i64>* %242, align 8, !dbg !51, !tbaa !6
+  %243 = getelementptr inbounds i64, i64* %241, i64 1, !dbg !51
+  store i64* %243, i64** %236, align 8, !dbg !51
   %send26 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.12, i64 0), !dbg !51
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %64, align 8, !dbg !51, !tbaa !14
-  %247 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 1, !dbg !52
-  %248 = load i64*, i64** %247, align 8, !dbg !52
-  store i64 %53, i64* %248, align 8, !dbg !52, !tbaa !6
-  %249 = getelementptr inbounds i64, i64* %248, i64 1, !dbg !52
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %61, align 8, !dbg !51, !tbaa !14
+  %244 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !52
+  %245 = load i64*, i64** %244, align 8, !dbg !52
+  store i64 %50, i64* %245, align 8, !dbg !52, !tbaa !6
+  %246 = getelementptr inbounds i64, i64* %245, i64 1, !dbg !52
+  %247 = getelementptr inbounds i64, i64* %246, i64 1, !dbg !52
+  %248 = bitcast i64* %246 to <2 x i64>*, !dbg !52
+  store <2 x i64> <i64 -1, i64 -15>, <2 x i64>* %248, align 8, !dbg !52, !tbaa !6
+  %249 = getelementptr inbounds i64, i64* %247, i64 1, !dbg !52
+  store i64 -17, i64* %249, align 8, !dbg !52, !tbaa !6
   %250 = getelementptr inbounds i64, i64* %249, i64 1, !dbg !52
-  %251 = bitcast i64* %249 to <2 x i64>*, !dbg !52
-  store <2 x i64> <i64 -1, i64 -15>, <2 x i64>* %251, align 8, !dbg !52, !tbaa !6
-  %252 = getelementptr inbounds i64, i64* %250, i64 1, !dbg !52
-  store i64 -17, i64* %252, align 8, !dbg !52, !tbaa !6
-  %253 = getelementptr inbounds i64, i64* %252, i64 1, !dbg !52
-  store i64* %253, i64** %247, align 8, !dbg !52
+  store i64* %250, i64** %244, align 8, !dbg !52
   %send28 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.13, i64 0), !dbg !52
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %64, align 8, !dbg !52, !tbaa !14
-  %254 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 1, !dbg !53
-  %255 = load i64*, i64** %254, align 8, !dbg !53
-  store i64 %53, i64* %255, align 8, !dbg !53, !tbaa !6
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %61, align 8, !dbg !52, !tbaa !14
+  %251 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !53
+  %252 = load i64*, i64** %251, align 8, !dbg !53
+  store i64 %50, i64* %252, align 8, !dbg !53, !tbaa !6
+  %253 = getelementptr inbounds i64, i64* %252, i64 1, !dbg !53
+  %254 = getelementptr inbounds i64, i64* %253, i64 1, !dbg !53
+  %255 = getelementptr inbounds i64, i64* %254, i64 1, !dbg !53
   %256 = getelementptr inbounds i64, i64* %255, i64 1, !dbg !53
-  %257 = getelementptr inbounds i64, i64* %256, i64 1, !dbg !53
-  %258 = getelementptr inbounds i64, i64* %257, i64 1, !dbg !53
+  %257 = bitcast i64* %253 to <4 x i64>*, !dbg !53
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %257, align 8, !dbg !53, !tbaa !6
+  %258 = getelementptr inbounds i64, i64* %256, i64 1, !dbg !53
   %259 = getelementptr inbounds i64, i64* %258, i64 1, !dbg !53
-  %260 = bitcast i64* %256 to <4 x i64>*, !dbg !53
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %260, align 8, !dbg !53, !tbaa !6
+  %260 = bitcast i64* %258 to <2 x i64>*, !dbg !53
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %260, align 8, !dbg !53, !tbaa !6
   %261 = getelementptr inbounds i64, i64* %259, i64 1, !dbg !53
+  store i64 -13, i64* %261, align 8, !dbg !53, !tbaa !6
   %262 = getelementptr inbounds i64, i64* %261, i64 1, !dbg !53
-  %263 = bitcast i64* %261 to <2 x i64>*, !dbg !53
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %263, align 8, !dbg !53, !tbaa !6
-  %264 = getelementptr inbounds i64, i64* %262, i64 1, !dbg !53
-  store i64 -13, i64* %264, align 8, !dbg !53, !tbaa !6
+  store i64 -15, i64* %262, align 8, !dbg !53, !tbaa !6
+  %263 = getelementptr inbounds i64, i64* %262, i64 1, !dbg !53
+  store i64 -17, i64* %263, align 8, !dbg !53, !tbaa !6
+  %264 = getelementptr inbounds i64, i64* %263, i64 1, !dbg !53
+  store i64 -19, i64* %264, align 8, !dbg !53, !tbaa !6
   %265 = getelementptr inbounds i64, i64* %264, i64 1, !dbg !53
-  store i64 -15, i64* %265, align 8, !dbg !53, !tbaa !6
-  %266 = getelementptr inbounds i64, i64* %265, i64 1, !dbg !53
-  store i64 -17, i64* %266, align 8, !dbg !53, !tbaa !6
-  %267 = getelementptr inbounds i64, i64* %266, i64 1, !dbg !53
-  store i64 -19, i64* %267, align 8, !dbg !53, !tbaa !6
-  %268 = getelementptr inbounds i64, i64* %267, i64 1, !dbg !53
-  store i64* %268, i64** %254, align 8, !dbg !53
+  store i64* %265, i64** %251, align 8, !dbg !53
   %send30 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.14, i64 0), !dbg !53
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %64, align 8, !dbg !53, !tbaa !14
-  %269 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 1, !dbg !54
-  %270 = load i64*, i64** %269, align 8, !dbg !54
-  store i64 %53, i64* %270, align 8, !dbg !54, !tbaa !6
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %61, align 8, !dbg !53, !tbaa !14
+  %266 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !54
+  %267 = load i64*, i64** %266, align 8, !dbg !54
+  store i64 %50, i64* %267, align 8, !dbg !54, !tbaa !6
+  %268 = getelementptr inbounds i64, i64* %267, i64 1, !dbg !54
+  %269 = getelementptr inbounds i64, i64* %268, i64 1, !dbg !54
+  %270 = getelementptr inbounds i64, i64* %269, i64 1, !dbg !54
   %271 = getelementptr inbounds i64, i64* %270, i64 1, !dbg !54
-  %272 = getelementptr inbounds i64, i64* %271, i64 1, !dbg !54
-  %273 = getelementptr inbounds i64, i64* %272, i64 1, !dbg !54
+  %272 = bitcast i64* %268 to <4 x i64>*, !dbg !54
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %272, align 8, !dbg !54, !tbaa !6
+  %273 = getelementptr inbounds i64, i64* %271, i64 1, !dbg !54
   %274 = getelementptr inbounds i64, i64* %273, i64 1, !dbg !54
-  %275 = bitcast i64* %271 to <4 x i64>*, !dbg !54
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %275, align 8, !dbg !54, !tbaa !6
+  %275 = bitcast i64* %273 to <2 x i64>*, !dbg !54
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %275, align 8, !dbg !54, !tbaa !6
   %276 = getelementptr inbounds i64, i64* %274, i64 1, !dbg !54
+  store i64 -15, i64* %276, align 8, !dbg !54, !tbaa !6
   %277 = getelementptr inbounds i64, i64* %276, i64 1, !dbg !54
-  %278 = bitcast i64* %276 to <2 x i64>*, !dbg !54
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %278, align 8, !dbg !54, !tbaa !6
-  %279 = getelementptr inbounds i64, i64* %277, i64 1, !dbg !54
-  store i64 -15, i64* %279, align 8, !dbg !54, !tbaa !6
-  %280 = getelementptr inbounds i64, i64* %279, i64 1, !dbg !54
-  store i64 -17, i64* %280, align 8, !dbg !54, !tbaa !6
-  %281 = getelementptr inbounds i64, i64* %280, i64 1, !dbg !54
-  store i64 -19, i64* %281, align 8, !dbg !54, !tbaa !6
-  %282 = getelementptr inbounds i64, i64* %281, i64 1, !dbg !54
-  store i64* %282, i64** %269, align 8, !dbg !54
+  store i64 -17, i64* %277, align 8, !dbg !54, !tbaa !6
+  %278 = getelementptr inbounds i64, i64* %277, i64 1, !dbg !54
+  store i64 -19, i64* %278, align 8, !dbg !54, !tbaa !6
+  %279 = getelementptr inbounds i64, i64* %278, i64 1, !dbg !54
+  store i64* %279, i64** %266, align 8, !dbg !54
   %send32 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.15, i64 0), !dbg !54
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %64, align 8, !dbg !54, !tbaa !14
-  %283 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 1, !dbg !55
-  %284 = load i64*, i64** %283, align 8, !dbg !55
-  store i64 %53, i64* %284, align 8, !dbg !55, !tbaa !6
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %61, align 8, !dbg !54, !tbaa !14
+  %280 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !55
+  %281 = load i64*, i64** %280, align 8, !dbg !55
+  store i64 %50, i64* %281, align 8, !dbg !55, !tbaa !6
+  %282 = getelementptr inbounds i64, i64* %281, i64 1, !dbg !55
+  %283 = getelementptr inbounds i64, i64* %282, i64 1, !dbg !55
+  %284 = getelementptr inbounds i64, i64* %283, i64 1, !dbg !55
   %285 = getelementptr inbounds i64, i64* %284, i64 1, !dbg !55
-  %286 = getelementptr inbounds i64, i64* %285, i64 1, !dbg !55
-  %287 = getelementptr inbounds i64, i64* %286, i64 1, !dbg !55
+  %286 = bitcast i64* %282 to <4 x i64>*, !dbg !55
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %286, align 8, !dbg !55, !tbaa !6
+  %287 = getelementptr inbounds i64, i64* %285, i64 1, !dbg !55
   %288 = getelementptr inbounds i64, i64* %287, i64 1, !dbg !55
-  %289 = bitcast i64* %285 to <4 x i64>*, !dbg !55
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %289, align 8, !dbg !55, !tbaa !6
+  %289 = bitcast i64* %287 to <2 x i64>*, !dbg !55
+  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %289, align 8, !dbg !55, !tbaa !6
   %290 = getelementptr inbounds i64, i64* %288, i64 1, !dbg !55
+  store i64 -17, i64* %290, align 8, !dbg !55, !tbaa !6
   %291 = getelementptr inbounds i64, i64* %290, i64 1, !dbg !55
-  %292 = bitcast i64* %290 to <2 x i64>*, !dbg !55
-  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %292, align 8, !dbg !55, !tbaa !6
-  %293 = getelementptr inbounds i64, i64* %291, i64 1, !dbg !55
-  store i64 -17, i64* %293, align 8, !dbg !55, !tbaa !6
-  %294 = getelementptr inbounds i64, i64* %293, i64 1, !dbg !55
-  store i64 -19, i64* %294, align 8, !dbg !55, !tbaa !6
-  %295 = getelementptr inbounds i64, i64* %294, i64 1, !dbg !55
-  store i64* %295, i64** %283, align 8, !dbg !55
+  store i64 -19, i64* %291, align 8, !dbg !55, !tbaa !6
+  %292 = getelementptr inbounds i64, i64* %291, i64 1, !dbg !55
+  store i64* %292, i64** %280, align 8, !dbg !55
   %send34 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.16, i64 0), !dbg !55
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %64, align 8, !dbg !55, !tbaa !14
-  %296 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 1, !dbg !56
-  %297 = load i64*, i64** %296, align 8, !dbg !56
-  store i64 %53, i64* %297, align 8, !dbg !56, !tbaa !6
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %61, align 8, !dbg !55, !tbaa !14
+  %293 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !56
+  %294 = load i64*, i64** %293, align 8, !dbg !56
+  store i64 %50, i64* %294, align 8, !dbg !56, !tbaa !6
+  %295 = getelementptr inbounds i64, i64* %294, i64 1, !dbg !56
+  %296 = getelementptr inbounds i64, i64* %295, i64 1, !dbg !56
+  %297 = getelementptr inbounds i64, i64* %296, i64 1, !dbg !56
   %298 = getelementptr inbounds i64, i64* %297, i64 1, !dbg !56
-  %299 = getelementptr inbounds i64, i64* %298, i64 1, !dbg !56
-  %300 = getelementptr inbounds i64, i64* %299, i64 1, !dbg !56
+  %299 = bitcast i64* %295 to <4 x i64>*, !dbg !56
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %299, align 8, !dbg !56, !tbaa !6
+  %300 = getelementptr inbounds i64, i64* %298, i64 1, !dbg !56
   %301 = getelementptr inbounds i64, i64* %300, i64 1, !dbg !56
-  %302 = bitcast i64* %298 to <4 x i64>*, !dbg !56
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %302, align 8, !dbg !56, !tbaa !6
+  %302 = bitcast i64* %300 to <2 x i64>*, !dbg !56
+  store <2 x i64> <i64 -15, i64 -17>, <2 x i64>* %302, align 8, !dbg !56, !tbaa !6
   %303 = getelementptr inbounds i64, i64* %301, i64 1, !dbg !56
+  store i64 -19, i64* %303, align 8, !dbg !56, !tbaa !6
   %304 = getelementptr inbounds i64, i64* %303, i64 1, !dbg !56
-  %305 = bitcast i64* %303 to <2 x i64>*, !dbg !56
-  store <2 x i64> <i64 -15, i64 -17>, <2 x i64>* %305, align 8, !dbg !56, !tbaa !6
-  %306 = getelementptr inbounds i64, i64* %304, i64 1, !dbg !56
-  store i64 -19, i64* %306, align 8, !dbg !56, !tbaa !6
-  %307 = getelementptr inbounds i64, i64* %306, i64 1, !dbg !56
-  store i64* %307, i64** %296, align 8, !dbg !56
+  store i64* %304, i64** %293, align 8, !dbg !56
   %send36 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.17, i64 0), !dbg !56
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %64, align 8, !dbg !56, !tbaa !14
-  %308 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 1, !dbg !57
-  %309 = load i64*, i64** %308, align 8, !dbg !57
-  store i64 %53, i64* %309, align 8, !dbg !57, !tbaa !6
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %61, align 8, !dbg !56, !tbaa !14
+  %305 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !57
+  %306 = load i64*, i64** %305, align 8, !dbg !57
+  store i64 %50, i64* %306, align 8, !dbg !57, !tbaa !6
+  %307 = getelementptr inbounds i64, i64* %306, i64 1, !dbg !57
+  %308 = getelementptr inbounds i64, i64* %307, i64 1, !dbg !57
+  %309 = getelementptr inbounds i64, i64* %308, i64 1, !dbg !57
   %310 = getelementptr inbounds i64, i64* %309, i64 1, !dbg !57
-  %311 = getelementptr inbounds i64, i64* %310, i64 1, !dbg !57
-  %312 = getelementptr inbounds i64, i64* %311, i64 1, !dbg !57
+  %311 = bitcast i64* %307 to <4 x i64>*, !dbg !57
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %311, align 8, !dbg !57, !tbaa !6
+  %312 = getelementptr inbounds i64, i64* %310, i64 1, !dbg !57
   %313 = getelementptr inbounds i64, i64* %312, i64 1, !dbg !57
-  %314 = bitcast i64* %310 to <4 x i64>*, !dbg !57
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %314, align 8, !dbg !57, !tbaa !6
+  %314 = bitcast i64* %312 to <2 x i64>*, !dbg !57
+  store <2 x i64> <i64 -17, i64 -19>, <2 x i64>* %314, align 8, !dbg !57, !tbaa !6
   %315 = getelementptr inbounds i64, i64* %313, i64 1, !dbg !57
-  %316 = getelementptr inbounds i64, i64* %315, i64 1, !dbg !57
-  %317 = bitcast i64* %315 to <2 x i64>*, !dbg !57
-  store <2 x i64> <i64 -17, i64 -19>, <2 x i64>* %317, align 8, !dbg !57, !tbaa !6
-  %318 = getelementptr inbounds i64, i64* %316, i64 1, !dbg !57
-  store i64* %318, i64** %308, align 8, !dbg !57
+  store i64* %315, i64** %305, align 8, !dbg !57
   %send38 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.18, i64 0), !dbg !57
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 29), i64** %64, align 8, !dbg !57, !tbaa !14
-  %319 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 1, !dbg !58
-  %320 = load i64*, i64** %319, align 8, !dbg !58
-  store i64 %53, i64* %320, align 8, !dbg !58, !tbaa !6
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 29), i64** %61, align 8, !dbg !57, !tbaa !14
+  %316 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !58
+  %317 = load i64*, i64** %316, align 8, !dbg !58
+  store i64 %50, i64* %317, align 8, !dbg !58, !tbaa !6
+  %318 = getelementptr inbounds i64, i64* %317, i64 1, !dbg !58
+  %319 = getelementptr inbounds i64, i64* %318, i64 1, !dbg !58
+  %320 = getelementptr inbounds i64, i64* %319, i64 1, !dbg !58
   %321 = getelementptr inbounds i64, i64* %320, i64 1, !dbg !58
-  %322 = getelementptr inbounds i64, i64* %321, i64 1, !dbg !58
-  %323 = getelementptr inbounds i64, i64* %322, i64 1, !dbg !58
+  %322 = bitcast i64* %318 to <4 x i64>*, !dbg !58
+  store <4 x i64> <i64 -1, i64 -3, i64 -15, i64 -17>, <4 x i64>* %322, align 8, !dbg !58, !tbaa !6
+  %323 = getelementptr inbounds i64, i64* %321, i64 1, !dbg !58
+  store i64 -19, i64* %323, align 8, !dbg !58, !tbaa !6
   %324 = getelementptr inbounds i64, i64* %323, i64 1, !dbg !58
-  %325 = bitcast i64* %321 to <4 x i64>*, !dbg !58
-  store <4 x i64> <i64 -1, i64 -3, i64 -15, i64 -17>, <4 x i64>* %325, align 8, !dbg !58, !tbaa !6
-  %326 = getelementptr inbounds i64, i64* %324, i64 1, !dbg !58
-  store i64 -19, i64* %326, align 8, !dbg !58, !tbaa !6
-  %327 = getelementptr inbounds i64, i64* %326, i64 1, !dbg !58
-  store i64* %327, i64** %319, align 8, !dbg !58
+  store i64* %324, i64** %316, align 8, !dbg !58
   %send40 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.19, i64 0), !dbg !58
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 30), i64** %64, align 8, !dbg !58, !tbaa !14
-  %328 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %56, i64 0, i32 1, !dbg !59
-  %329 = load i64*, i64** %328, align 8, !dbg !59
-  store i64 %53, i64* %329, align 8, !dbg !59, !tbaa !6
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 30), i64** %61, align 8, !dbg !58, !tbaa !14
+  %325 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !59
+  %326 = load i64*, i64** %325, align 8, !dbg !59
+  store i64 %50, i64* %326, align 8, !dbg !59, !tbaa !6
+  %327 = getelementptr inbounds i64, i64* %326, i64 1, !dbg !59
+  %328 = getelementptr inbounds i64, i64* %327, i64 1, !dbg !59
+  %329 = getelementptr inbounds i64, i64* %328, i64 1, !dbg !59
   %330 = getelementptr inbounds i64, i64* %329, i64 1, !dbg !59
-  %331 = getelementptr inbounds i64, i64* %330, i64 1, !dbg !59
-  %332 = getelementptr inbounds i64, i64* %331, i64 1, !dbg !59
-  %333 = getelementptr inbounds i64, i64* %332, i64 1, !dbg !59
-  %334 = bitcast i64* %330 to <4 x i64>*, !dbg !59
-  store <4 x i64> <i64 -1, i64 -15, i64 -17, i64 -19>, <4 x i64>* %334, align 8, !dbg !59, !tbaa !6
-  %335 = getelementptr inbounds i64, i64* %333, i64 1, !dbg !59
-  store i64* %335, i64** %328, align 8, !dbg !59
+  %331 = bitcast i64* %327 to <4 x i64>*, !dbg !59
+  store <4 x i64> <i64 -1, i64 -15, i64 -17, i64 -19>, <4 x i64>* %331, align 8, !dbg !59, !tbaa !6
+  %332 = getelementptr inbounds i64, i64* %330, i64 1, !dbg !59
+  store i64* %332, i64** %325, align 8, !dbg !59
   %send42 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.20, i64 0), !dbg !59
-  call void @llvm.lifetime.end.p0i8(i64 32, i8* nonnull %57)
-  call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %58)
+  call void @llvm.lifetime.end.p0i8(i64 32, i8* nonnull %54)
+  call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %55)
   ret void
 }
 

--- a/test/testdata/compiler/block_arg_expand.opt.ll.exp
+++ b/test/testdata/compiler/block_arg_expand.opt.ll.exp
@@ -89,12 +89,9 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"rubyStrFrozen_test/testdata/compiler/block_arg_expand.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [32 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyStrFrozen_block in <top (required)>" = internal unnamed_addr global i64 0, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_2" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_3" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_4" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
@@ -114,6 +111,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @sorbet_moduleStringTable = internal unnamed_addr constant [163 x i8] c"<top (required)>\00test/testdata/compiler/block_arg_expand.rb\00<block-call>\00block in <top (required)>\00<build-array>\00each\00T.let\00Integer\00+\00p\00x\00default\00something\00master\00", align 1
 @sorbet_moduleIDTable = internal unnamed_addr global [10 x i64] zeroinitializer, align 8
 @sorbet_moduleIDDescriptors = internal unnamed_addr constant [10 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 60, i32 12 }, %struct.rb_code_position_struct { i32 73, i32 25 }, %struct.rb_code_position_struct { i32 99, i32 13 }, %struct.rb_code_position_struct { i32 113, i32 4 }, %struct.rb_code_position_struct { i32 132, i32 1 }, %struct.rb_code_position_struct { i32 134, i32 1 }, %struct.rb_code_position_struct { i32 136, i32 1 }, %struct.rb_code_position_struct { i32 138, i32 7 }, %struct.rb_code_position_struct { i32 146, i32 9 }], align 8
+@sorbet_moduleRubyStringTable = internal unnamed_addr global [3 x i64] zeroinitializer, align 8
+@sorbet_moduleRubyStringDescriptors = internal unnamed_addr constant [3 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 17, i32 42 }, %struct.rb_code_position_struct { i32 73, i32 25 }], align 8
 
 ; Function Attrs: nounwind readnone willreturn
 declare i64 @rb_id2sym(i64) local_unnamed_addr #0
@@ -145,7 +144,7 @@ declare %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64) local_unnamed_addr 
 
 declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #2
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #2
+declare void @sorbet_vm_init_string_table(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #2
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #3
@@ -156,8 +155,6 @@ declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #3
 declare void @rb_ary_detransient(i64) local_unnamed_addr #2
 
 declare i64 @rb_ary_new_from_values(i64, i64*) local_unnamed_addr #2
-
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #2
 
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #4
@@ -751,735 +748,718 @@ entry:
   %locals.i.i = alloca i64, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
   tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([10 x %struct.rb_code_position_struct], [10 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 10, i8* noundef getelementptr inbounds ([163 x i8], [163 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
-  %8 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([163 x i8], [163 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #13
-  tail call void @rb_gc_register_mark_object(i64 %8) #13
-  store i64 %8, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %9 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 42) #13
-  tail call void @rb_gc_register_mark_object(i64 %9) #13
-  store i64 %9, i64* @"rubyStrFrozen_test/testdata/compiler/block_arg_expand.rb", align 8
+  tail call void @sorbet_vm_init_string_table(i64* noundef getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleRubyStringTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([3 x %struct.rb_code_position_struct], [3 x %struct.rb_code_position_struct]* @sorbet_moduleRubyStringDescriptors, i32 0, i32 0), i32 noundef 3, i8* noundef getelementptr inbounds ([163 x i8], [163 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 32)
-  %10 = bitcast i64* %locals.i.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %10)
+  %8 = bitcast i64* %locals.i.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %8)
   %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
-  %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_arg_expand.rb", align 8
+  %"rubyStr_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 0), align 8, !invariant.load !5
+  %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i.i" = load i64, i64* getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
   %"rubyId_<block-call>.i.i" = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !invariant.load !5
   store i64 %"rubyId_<block-call>.i.i", i64* %locals.i.i, align 8
-  %11 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i.i, i32 noundef 1, i32 noundef 3)
-  store %struct.rb_iseq_struct* %11, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %10)
-  %12 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @sorbet_moduleStringTable, i64 0, i64 73), i64 noundef 25) #13
-  call void @rb_gc_register_mark_object(i64 %12) #13
-  store i64 %12, i64* @"rubyStrFrozen_block in <top (required)>", align 8
-  %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %9 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i.i, i32 noundef 1, i32 noundef 3)
+  store %struct.rb_iseq_struct* %9, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %8)
   %"rubyId_block in <top (required)>.i.i" = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i26.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_arg_expand.rb", align 8
-  %13 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %12, i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i26.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
-  store %struct.rb_iseq_struct* %13, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1", align 8
+  %"rubyStr_block in <top (required)>.i.i" = load i64, i64* getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 2), align 8, !invariant.load !5
+  %10 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i.i", i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* %9, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
+  store %struct.rb_iseq_struct* %10, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1", align 8
   %stackFrame.i27.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %"rubyStr_block in <top (required)>.i29.i" = load i64, i64* @"rubyStrFrozen_block in <top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i30.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_arg_expand.rb", align 8
-  %14 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i29.i", i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i30.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i27.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
-  store %struct.rb_iseq_struct* %14, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_2", align 8
+  %11 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i.i", i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i27.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
+  store %struct.rb_iseq_struct* %11, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_2", align 8
   %stackFrame.i31.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %"rubyStr_block in <top (required)>.i33.i" = load i64, i64* @"rubyStrFrozen_block in <top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i34.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_arg_expand.rb", align 8
-  %15 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i33.i", i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i34.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i31.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
-  store %struct.rb_iseq_struct* %15, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_3", align 8
+  %12 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i.i", i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i31.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
+  store %struct.rb_iseq_struct* %12, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_3", align 8
   %stackFrame.i35.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %"rubyStr_block in <top (required)>.i37.i" = load i64, i64* @"rubyStrFrozen_block in <top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i38.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_arg_expand.rb", align 8
-  %16 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i37.i", i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i38.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i35.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
-  store %struct.rb_iseq_struct* %16, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_4", align 8
+  %13 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i.i", i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i35.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
+  store %struct.rb_iseq_struct* %13, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_4", align 8
   %stackFrame.i39.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %"rubyStr_block in <top (required)>.i41.i" = load i64, i64* @"rubyStrFrozen_block in <top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i42.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_arg_expand.rb", align 8
-  %17 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i41.i", i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i42.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i39.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
-  store %struct.rb_iseq_struct* %17, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_5", align 8
-  %18 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_1", i8* noundef null, i32 noundef 2, i32 noundef 2) #13
-  %19 = ptrtoint %struct.vm_ifunc* %18 to i64
-  %20 = call i64 @sorbet_globalConstRegister(i64 %19)
-  store i64 %20, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8
+  %14 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i.i", i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_arg_expand.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i39.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
+  store %struct.rb_iseq_struct* %14, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_5", align 8
+  %15 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_1", i8* noundef null, i32 noundef 2, i32 noundef 2) #13
+  %16 = ptrtoint %struct.vm_ifunc* %15 to i64
+  %17 = call i64 @sorbet_globalConstRegister(i64 %16)
+  store i64 %17, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8
   %"rubyId_+.i" = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 5), align 8, !dbg !30, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_+", i64 %"rubyId_+.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !30
-  %21 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_2", i8* noundef null, i32 noundef 1, i32 noundef 1) #13
-  %22 = ptrtoint %struct.vm_ifunc* %21 to i64
-  %23 = call i64 @sorbet_globalConstRegister(i64 %22)
-  store i64 %23, i64* @"func_<root>.17<static-init>$153$block_2_ifunc", align 8
+  %18 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_2", i8* noundef null, i32 noundef 1, i32 noundef 1) #13
+  %19 = ptrtoint %struct.vm_ifunc* %18 to i64
+  %20 = call i64 @sorbet_globalConstRegister(i64 %19)
+  store i64 %20, i64* @"func_<root>.17<static-init>$153$block_2_ifunc", align 8
   %rubyId_p.i = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 6), align 8, !dbg !45, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !45
-  %24 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_3", i8* noundef null, i32 noundef 0, i32 noundef 1) #13
+  %21 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_3", i8* noundef null, i32 noundef 0, i32 noundef 1) #13
+  %22 = ptrtoint %struct.vm_ifunc* %21 to i64
+  %23 = call i64 @sorbet_globalConstRegister(i64 %22)
+  store i64 %23, i64* @"func_<root>.17<static-init>$153$block_3_ifunc", align 8
+  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.5, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !52
+  %24 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_4", i8* noundef null, i32 noundef 0, i32 noundef 2) #13
   %25 = ptrtoint %struct.vm_ifunc* %24 to i64
   %26 = call i64 @sorbet_globalConstRegister(i64 %25)
-  store i64 %26, i64* @"func_<root>.17<static-init>$153$block_3_ifunc", align 8
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.5, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !52
-  %27 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_4", i8* noundef null, i32 noundef 0, i32 noundef 2) #13
-  %28 = ptrtoint %struct.vm_ifunc* %27 to i64
-  %29 = call i64 @sorbet_globalConstRegister(i64 %28)
-  store i64 %29, i64* @"func_<root>.17<static-init>$153$block_4_ifunc", align 8
+  store i64 %26, i64* @"func_<root>.17<static-init>$153$block_4_ifunc", align 8
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.8, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !60
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.9, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !61
-  %30 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_5", i8* noundef null, i32 noundef 1, i32 noundef 2) #13
-  %31 = ptrtoint %struct.vm_ifunc* %30 to i64
-  %32 = call i64 @sorbet_globalConstRegister(i64 %31)
-  store i64 %32, i64* @"func_<root>.17<static-init>$153$block_5_ifunc", align 8
+  %27 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_5", i8* noundef null, i32 noundef 1, i32 noundef 2) #13
+  %28 = ptrtoint %struct.vm_ifunc* %27 to i64
+  %29 = call i64 @sorbet_globalConstRegister(i64 %28)
+  store i64 %29, i64* @"func_<root>.17<static-init>$153$block_5_ifunc", align 8
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.12, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !68
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.13, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !69
-  %33 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
-  %34 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %33, i64 0, i32 2
-  %35 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %34, align 8, !tbaa !17
-  %36 = bitcast [3 x i64]* %callArgs.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %36)
+  %30 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
+  %31 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %30, i64 0, i32 2
+  %32 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %31, align 8, !tbaa !17
+  %33 = bitcast [3 x i64]* %callArgs.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %33)
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %37 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %34, align 8, !tbaa !17
-  %38 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %38, align 8, !tbaa !21
-  %39 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 4
-  %40 = load i64*, i64** %39, align 8, !tbaa !23
-  %41 = load i64, i64* %40, align 8, !tbaa !6
-  %42 = and i64 %41, -33
-  store i64 %42, i64* %40, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %33, %struct.rb_control_frame_struct* %37, %struct.rb_iseq_struct* %stackFrame.i) #13
-  %43 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %35, i64 0, i32 0
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %43, align 8, !dbg !71, !tbaa !15
+  %34 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %31, align 8, !tbaa !17
+  %35 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %34, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %35, align 8, !tbaa !21
+  %36 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %34, i64 0, i32 4
+  %37 = load i64*, i64** %36, align 8, !tbaa !23
+  %38 = load i64, i64* %37, align 8, !tbaa !6
+  %39 = and i64 %38, -33
+  store i64 %39, i64* %37, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %30, %struct.rb_control_frame_struct* %34, %struct.rb_iseq_struct* %stackFrame.i) #13
+  %40 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 0
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %40, align 8, !dbg !71, !tbaa !15
   %callArgs0Addr.i = getelementptr [3 x i64], [3 x i64]* %callArgs.i, i64 0, i64 0, !dbg !72
-  %44 = bitcast i64* %callArgs0Addr.i to <2 x i64>*, !dbg !72
-  store <2 x i64> <i64 3, i64 5>, <2 x i64>* %44, align 8, !dbg !72
+  %41 = bitcast i64* %callArgs0Addr.i to <2 x i64>*, !dbg !72
+  store <2 x i64> <i64 3, i64 5>, <2 x i64>* %41, align 8, !dbg !72
   call void @llvm.experimental.noalias.scope.decl(metadata !73) #13, !dbg !72
-  %45 = call i64 @rb_ary_new_from_values(i64 noundef 2, i64* noundef nonnull align 8 %callArgs0Addr.i) #13, !dbg !72
-  store i64 %45, i64* %callArgs0Addr.i, align 8, !dbg !76
+  %42 = call i64 @rb_ary_new_from_values(i64 noundef 2, i64* noundef nonnull align 8 %callArgs0Addr.i) #13, !dbg !72
+  store i64 %42, i64* %callArgs0Addr.i, align 8, !dbg !76
   call void @llvm.experimental.noalias.scope.decl(metadata !77) #13, !dbg !76
-  %46 = call i64 @rb_ary_new_from_values(i64 noundef 1, i64* noundef nonnull %callArgs0Addr.i) #13, !dbg !76
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %43, align 8, !dbg !76, !tbaa !15
+  %43 = call i64 @rb_ary_new_from_values(i64 noundef 1, i64* noundef nonnull %callArgs0Addr.i) #13, !dbg !76
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %40, align 8, !dbg !76, !tbaa !15
   %rubyId_each.i = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !dbg !80, !invariant.load !5
-  %47 = load i64, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8, !dbg !80
-  %48 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %47) #13, !dbg !80
-  %49 = bitcast %struct.sorbet_inlineIntrinsicEnv* %6 to i8*, !dbg !80
-  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %49) #13, !dbg !80
-  %50 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %6, i64 0, i32 0, !dbg !80
-  store i64 %46, i64* %50, align 8, !dbg !80, !tbaa !81
-  %51 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %6, i64 0, i32 1, !dbg !80
-  store i64 %rubyId_each.i, i64* %51, align 8, !dbg !80, !tbaa !83
-  %52 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %6, i64 0, i32 2, !dbg !80
-  store i32 0, i32* %52, align 8, !dbg !80, !tbaa !84
-  %53 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %6, i64 0, i32 3, !dbg !80
-  %54 = bitcast i64** %53 to i8*, !dbg !80
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %54, i8 0, i64 16, i1 false) #13, !dbg !80
-  %55 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !80, !tbaa !15
-  %56 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %55, i64 0, i32 2, !dbg !80
-  %57 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %56, align 8, !dbg !80, !tbaa !17
-  %58 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %57, i64 0, i32 3, !dbg !80
-  %59 = bitcast i64* %58 to %struct.rb_captured_block*, !dbg !80
-  %60 = getelementptr inbounds i64, i64* %58, i64 2, !dbg !80
-  %61 = bitcast i64* %60 to %struct.vm_ifunc**, !dbg !80
-  store %struct.vm_ifunc* %48, %struct.vm_ifunc** %61, align 8, !dbg !80, !tbaa !27
+  %44 = load i64, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8, !dbg !80
+  %45 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %44) #13, !dbg !80
+  %46 = bitcast %struct.sorbet_inlineIntrinsicEnv* %6 to i8*, !dbg !80
+  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %46) #13, !dbg !80
+  %47 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %6, i64 0, i32 0, !dbg !80
+  store i64 %43, i64* %47, align 8, !dbg !80, !tbaa !81
+  %48 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %6, i64 0, i32 1, !dbg !80
+  store i64 %rubyId_each.i, i64* %48, align 8, !dbg !80, !tbaa !83
+  %49 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %6, i64 0, i32 2, !dbg !80
+  store i32 0, i32* %49, align 8, !dbg !80, !tbaa !84
+  %50 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %6, i64 0, i32 3, !dbg !80
+  %51 = bitcast i64** %50 to i8*, !dbg !80
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %51, i8 0, i64 16, i1 false) #13, !dbg !80
+  %52 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !80, !tbaa !15
+  %53 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %52, i64 0, i32 2, !dbg !80
+  %54 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %53, align 8, !dbg !80, !tbaa !17
+  %55 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %54, i64 0, i32 3, !dbg !80
+  %56 = bitcast i64* %55 to %struct.rb_captured_block*, !dbg !80
+  %57 = getelementptr inbounds i64, i64* %55, i64 2, !dbg !80
+  %58 = bitcast i64* %57 to %struct.vm_ifunc**, !dbg !80
+  store %struct.vm_ifunc* %45, %struct.vm_ifunc** %58, align 8, !dbg !80, !tbaa !27
   call void @llvm.experimental.noalias.scope.decl(metadata !85) #13, !dbg !80
-  %62 = ptrtoint %struct.rb_captured_block* %59 to i64, !dbg !80
-  %63 = or i64 %62, 3, !dbg !80
-  %64 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %55, i64 0, i32 17, !dbg !80
-  %65 = and i64 %63, -4, !dbg !88
-  %66 = inttoptr i64 %65 to %struct.rb_captured_block*, !dbg !88
-  store i64 0, i64* %64, align 8, !dbg !88, !tbaa !90
-  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %66) #13, !dbg !88
-  %67 = inttoptr i64 %46 to %struct.iseq_inline_iv_cache_entry*, !dbg !88
-  %68 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %67, i64 0, i32 0, !dbg !88
-  %69 = load i64, i64* %68, align 8, !dbg !88, !tbaa !25
-  %70 = and i64 %69, 8192, !dbg !88
-  %71 = icmp eq i64 %70, 0, !dbg !88
-  br i1 %71, label %75, label %72, !dbg !88
+  %59 = ptrtoint %struct.rb_captured_block* %56 to i64, !dbg !80
+  %60 = or i64 %59, 3, !dbg !80
+  %61 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %52, i64 0, i32 17, !dbg !80
+  %62 = and i64 %60, -4, !dbg !88
+  %63 = inttoptr i64 %62 to %struct.rb_captured_block*, !dbg !88
+  store i64 0, i64* %61, align 8, !dbg !88, !tbaa !90
+  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %63) #13, !dbg !88
+  %64 = inttoptr i64 %43 to %struct.iseq_inline_iv_cache_entry*, !dbg !88
+  %65 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %64, i64 0, i32 0, !dbg !88
+  %66 = load i64, i64* %65, align 8, !dbg !88, !tbaa !25
+  %67 = and i64 %66, 8192, !dbg !88
+  %68 = icmp eq i64 %67, 0, !dbg !88
+  br i1 %68, label %72, label %69, !dbg !88
+
+69:                                               ; preds = %entry
+  %70 = lshr i64 %66, 15, !dbg !88
+  %71 = and i64 %70, 3, !dbg !88
+  br label %rb_array_len.exit1.i3.i, !dbg !88
 
 72:                                               ; preds = %entry
-  %73 = lshr i64 %69, 15, !dbg !88
-  %74 = and i64 %73, 3, !dbg !88
+  %73 = inttoptr i64 %43 to %struct.RArray*, !dbg !88
+  %74 = getelementptr inbounds %struct.RArray, %struct.RArray* %73, i64 0, i32 1, i32 0, i32 0, !dbg !88
+  %75 = load i64, i64* %74, align 8, !dbg !88, !tbaa !27
   br label %rb_array_len.exit1.i3.i, !dbg !88
 
-75:                                               ; preds = %entry
-  %76 = inttoptr i64 %46 to %struct.RArray*, !dbg !88
-  %77 = getelementptr inbounds %struct.RArray, %struct.RArray* %76, i64 0, i32 1, i32 0, i32 0, !dbg !88
-  %78 = load i64, i64* %77, align 8, !dbg !88, !tbaa !27
-  br label %rb_array_len.exit1.i3.i, !dbg !88
+rb_array_len.exit1.i3.i:                          ; preds = %72, %69
+  %76 = phi i64 [ %71, %69 ], [ %75, %72 ], !dbg !88
+  %77 = icmp sgt i64 %76, 0, !dbg !88
+  br i1 %77, label %78, label %forward_sorbet_rb_array_each_withBlock.exit.i, !dbg !88
 
-rb_array_len.exit1.i3.i:                          ; preds = %75, %72
-  %79 = phi i64 [ %74, %72 ], [ %78, %75 ], !dbg !88
-  %80 = icmp sgt i64 %79, 0, !dbg !88
-  br i1 %80, label %81, label %forward_sorbet_rb_array_each_withBlock.exit.i, !dbg !88
+78:                                               ; preds = %rb_array_len.exit1.i3.i
+  %79 = bitcast i64* %1 to i8*, !dbg !88
+  %80 = inttoptr i64 %43 to %struct.RArray*, !dbg !80
+  %81 = getelementptr inbounds %struct.RArray, %struct.RArray* %80, i64 0, i32 1, i32 0, i32 0, !dbg !80
+  %82 = getelementptr inbounds %struct.RArray, %struct.RArray* %80, i64 0, i32 1, i32 0, i32 2, !dbg !80
+  br label %83, !dbg !88
 
-81:                                               ; preds = %rb_array_len.exit1.i3.i
-  %82 = bitcast i64* %1 to i8*, !dbg !88
-  %83 = inttoptr i64 %46 to %struct.RArray*, !dbg !80
-  %84 = getelementptr inbounds %struct.RArray, %struct.RArray* %83, i64 0, i32 1, i32 0, i32 0, !dbg !80
-  %85 = getelementptr inbounds %struct.RArray, %struct.RArray* %83, i64 0, i32 1, i32 0, i32 2, !dbg !80
-  br label %86, !dbg !88
+83:                                               ; preds = %rb_array_len.exit.i5.i, %78
+  %84 = phi i64 [ 0, %78 ], [ %94, %rb_array_len.exit.i5.i ], !dbg !88
+  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 dereferenceable(8) %79) #13, !dbg !88
+  %85 = load i64, i64* %65, align 8, !dbg !88, !tbaa !25
+  %86 = and i64 %85, 8192, !dbg !88
+  %87 = icmp eq i64 %86, 0, !dbg !88
+  br i1 %87, label %88, label %rb_array_const_ptr_transient.exit.i4.i, !dbg !88
 
-86:                                               ; preds = %rb_array_len.exit.i5.i, %81
-  %87 = phi i64 [ 0, %81 ], [ %97, %rb_array_len.exit.i5.i ], !dbg !88
-  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 dereferenceable(8) %82) #13, !dbg !88
-  %88 = load i64, i64* %68, align 8, !dbg !88, !tbaa !25
-  %89 = and i64 %88, 8192, !dbg !88
-  %90 = icmp eq i64 %89, 0, !dbg !88
-  br i1 %90, label %91, label %rb_array_const_ptr_transient.exit.i4.i, !dbg !88
-
-91:                                               ; preds = %86
-  %92 = load i64*, i64** %85, align 8, !dbg !88, !tbaa !27
+88:                                               ; preds = %83
+  %89 = load i64*, i64** %82, align 8, !dbg !88, !tbaa !27
   br label %rb_array_const_ptr_transient.exit.i4.i, !dbg !88
 
-rb_array_const_ptr_transient.exit.i4.i:           ; preds = %91, %86
-  %93 = phi i64* [ %92, %91 ], [ %84, %86 ], !dbg !88
-  %94 = getelementptr inbounds i64, i64* %93, i64 %87, !dbg !88
-  %95 = load i64, i64* %94, align 8, !dbg !88, !tbaa !6
-  store i64 %95, i64* %1, align 8, !dbg !88, !tbaa !6
-  %96 = call i64 @"func_<root>.17<static-init>$153$block_1"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %1, i64 undef) #13, !dbg !88
-  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %82) #13, !dbg !88
-  %97 = add nuw nsw i64 %87, 1, !dbg !88
-  %98 = load i64, i64* %68, align 8, !dbg !88, !tbaa !25
-  %99 = and i64 %98, 8192, !dbg !88
-  %100 = icmp eq i64 %99, 0, !dbg !88
-  br i1 %100, label %104, label %101, !dbg !88
+rb_array_const_ptr_transient.exit.i4.i:           ; preds = %88, %83
+  %90 = phi i64* [ %89, %88 ], [ %81, %83 ], !dbg !88
+  %91 = getelementptr inbounds i64, i64* %90, i64 %84, !dbg !88
+  %92 = load i64, i64* %91, align 8, !dbg !88, !tbaa !6
+  store i64 %92, i64* %1, align 8, !dbg !88, !tbaa !6
+  %93 = call i64 @"func_<root>.17<static-init>$153$block_1"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %1, i64 undef) #13, !dbg !88
+  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %79) #13, !dbg !88
+  %94 = add nuw nsw i64 %84, 1, !dbg !88
+  %95 = load i64, i64* %65, align 8, !dbg !88, !tbaa !25
+  %96 = and i64 %95, 8192, !dbg !88
+  %97 = icmp eq i64 %96, 0, !dbg !88
+  br i1 %97, label %101, label %98, !dbg !88
+
+98:                                               ; preds = %rb_array_const_ptr_transient.exit.i4.i
+  %99 = lshr i64 %95, 15, !dbg !88
+  %100 = and i64 %99, 3, !dbg !88
+  br label %rb_array_len.exit.i5.i, !dbg !88
 
 101:                                              ; preds = %rb_array_const_ptr_transient.exit.i4.i
-  %102 = lshr i64 %98, 15, !dbg !88
-  %103 = and i64 %102, 3, !dbg !88
+  %102 = load i64, i64* %81, align 8, !dbg !88, !tbaa !27
   br label %rb_array_len.exit.i5.i, !dbg !88
 
-104:                                              ; preds = %rb_array_const_ptr_transient.exit.i4.i
-  %105 = load i64, i64* %84, align 8, !dbg !88, !tbaa !27
-  br label %rb_array_len.exit.i5.i, !dbg !88
-
-rb_array_len.exit.i5.i:                           ; preds = %104, %101
-  %106 = phi i64 [ %103, %101 ], [ %105, %104 ], !dbg !88
-  %107 = icmp sgt i64 %106, %97, !dbg !88
-  br i1 %107, label %86, label %forward_sorbet_rb_array_each_withBlock.exit.i, !dbg !88, !llvm.loop !91
+rb_array_len.exit.i5.i:                           ; preds = %101, %98
+  %103 = phi i64 [ %100, %98 ], [ %102, %101 ], !dbg !88
+  %104 = icmp sgt i64 %103, %94, !dbg !88
+  br i1 %104, label %83, label %forward_sorbet_rb_array_each_withBlock.exit.i, !dbg !88, !llvm.loop !91
 
 forward_sorbet_rb_array_each_withBlock.exit.i:    ; preds = %rb_array_len.exit.i5.i, %rb_array_len.exit1.i3.i
   call void @sorbet_popFrame() #13, !dbg !88
-  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %49) #13, !dbg !80
-  %108 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !80, !tbaa !15
-  %109 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %108, i64 0, i32 5, !dbg !80
-  %110 = load i32, i32* %109, align 8, !dbg !80, !tbaa !37
-  %111 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %108, i64 0, i32 6, !dbg !80
-  %112 = load i32, i32* %111, align 4, !dbg !80, !tbaa !38
-  %113 = xor i32 %112, -1, !dbg !80
-  %114 = and i32 %113, %110, !dbg !80
-  %115 = icmp eq i32 %114, 0, !dbg !80
-  br i1 %115, label %rb_check_arity.1.exit.i8.i, label %116, !dbg !80, !prof !31
+  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %46) #13, !dbg !80
+  %105 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !80, !tbaa !15
+  %106 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %105, i64 0, i32 5, !dbg !80
+  %107 = load i32, i32* %106, align 8, !dbg !80, !tbaa !37
+  %108 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %105, i64 0, i32 6, !dbg !80
+  %109 = load i32, i32* %108, align 4, !dbg !80, !tbaa !38
+  %110 = xor i32 %109, -1, !dbg !80
+  %111 = and i32 %110, %107, !dbg !80
+  %112 = icmp eq i32 %111, 0, !dbg !80
+  br i1 %112, label %rb_check_arity.1.exit.i8.i, label %113, !dbg !80, !prof !31
 
-116:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.exit.i
-  %117 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %108, i64 0, i32 8, !dbg !80
-  %118 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %117, align 8, !dbg !80, !tbaa !39
-  %119 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %118, i32 noundef 0) #13, !dbg !80
+113:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.exit.i
+  %114 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %105, i64 0, i32 8, !dbg !80
+  %115 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %114, align 8, !dbg !80, !tbaa !39
+  %116 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %115, i32 noundef 0) #13, !dbg !80
   br label %rb_check_arity.1.exit.i8.i, !dbg !80
 
-rb_check_arity.1.exit.i8.i:                       ; preds = %116, %forward_sorbet_rb_array_each_withBlock.exit.i
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %43, align 8, !dbg !80, !tbaa !15
-  %120 = load i64, i64* @"func_<root>.17<static-init>$153$block_2_ifunc", align 8, !dbg !93
-  %121 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %120) #13, !dbg !93
-  %122 = bitcast %struct.sorbet_inlineIntrinsicEnv* %5 to i8*, !dbg !93
-  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %122) #13, !dbg !93
-  %123 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %5, i64 0, i32 0, !dbg !93
-  store i64 %46, i64* %123, align 8, !dbg !93, !tbaa !81
-  %124 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %5, i64 0, i32 1, !dbg !93
-  store i64 %rubyId_each.i, i64* %124, align 8, !dbg !93, !tbaa !83
-  %125 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %5, i64 0, i32 2, !dbg !93
-  store i32 0, i32* %125, align 8, !dbg !93, !tbaa !84
-  %126 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %5, i64 0, i32 3, !dbg !93
-  %127 = bitcast i64** %126 to i8*, !dbg !93
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %127, i8 0, i64 16, i1 false) #13, !dbg !93
-  %128 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !93, !tbaa !15
-  %129 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %128, i64 0, i32 2, !dbg !93
-  %130 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %129, align 8, !dbg !93, !tbaa !17
-  %131 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %130, i64 0, i32 3, !dbg !93
-  %132 = bitcast i64* %131 to %struct.rb_captured_block*, !dbg !93
-  %133 = getelementptr inbounds i64, i64* %131, i64 2, !dbg !93
-  %134 = bitcast i64* %133 to %struct.vm_ifunc**, !dbg !93
-  store %struct.vm_ifunc* %121, %struct.vm_ifunc** %134, align 8, !dbg !93, !tbaa !27
+rb_check_arity.1.exit.i8.i:                       ; preds = %113, %forward_sorbet_rb_array_each_withBlock.exit.i
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %40, align 8, !dbg !80, !tbaa !15
+  %117 = load i64, i64* @"func_<root>.17<static-init>$153$block_2_ifunc", align 8, !dbg !93
+  %118 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %117) #13, !dbg !93
+  %119 = bitcast %struct.sorbet_inlineIntrinsicEnv* %5 to i8*, !dbg !93
+  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %119) #13, !dbg !93
+  %120 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %5, i64 0, i32 0, !dbg !93
+  store i64 %43, i64* %120, align 8, !dbg !93, !tbaa !81
+  %121 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %5, i64 0, i32 1, !dbg !93
+  store i64 %rubyId_each.i, i64* %121, align 8, !dbg !93, !tbaa !83
+  %122 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %5, i64 0, i32 2, !dbg !93
+  store i32 0, i32* %122, align 8, !dbg !93, !tbaa !84
+  %123 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %5, i64 0, i32 3, !dbg !93
+  %124 = bitcast i64** %123 to i8*, !dbg !93
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %124, i8 0, i64 16, i1 false) #13, !dbg !93
+  %125 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !93, !tbaa !15
+  %126 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %125, i64 0, i32 2, !dbg !93
+  %127 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %126, align 8, !dbg !93, !tbaa !17
+  %128 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %127, i64 0, i32 3, !dbg !93
+  %129 = bitcast i64* %128 to %struct.rb_captured_block*, !dbg !93
+  %130 = getelementptr inbounds i64, i64* %128, i64 2, !dbg !93
+  %131 = bitcast i64* %130 to %struct.vm_ifunc**, !dbg !93
+  store %struct.vm_ifunc* %118, %struct.vm_ifunc** %131, align 8, !dbg !93, !tbaa !27
   call void @llvm.experimental.noalias.scope.decl(metadata !94) #13, !dbg !93
-  %135 = ptrtoint %struct.rb_captured_block* %132 to i64, !dbg !93
-  %136 = or i64 %135, 3, !dbg !93
-  %137 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %128, i64 0, i32 17, !dbg !93
-  %138 = and i64 %136, -4, !dbg !97
-  %139 = inttoptr i64 %138 to %struct.rb_captured_block*, !dbg !97
-  store i64 0, i64* %137, align 8, !dbg !97, !tbaa !90
-  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %139) #13, !dbg !97
-  %140 = load i64, i64* %68, align 8, !dbg !97, !tbaa !25
-  %141 = and i64 %140, 8192, !dbg !97
-  %142 = icmp eq i64 %141, 0, !dbg !97
-  br i1 %142, label %146, label %143, !dbg !97
+  %132 = ptrtoint %struct.rb_captured_block* %129 to i64, !dbg !93
+  %133 = or i64 %132, 3, !dbg !93
+  %134 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %125, i64 0, i32 17, !dbg !93
+  %135 = and i64 %133, -4, !dbg !97
+  %136 = inttoptr i64 %135 to %struct.rb_captured_block*, !dbg !97
+  store i64 0, i64* %134, align 8, !dbg !97, !tbaa !90
+  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %136) #13, !dbg !97
+  %137 = load i64, i64* %65, align 8, !dbg !97, !tbaa !25
+  %138 = and i64 %137, 8192, !dbg !97
+  %139 = icmp eq i64 %138, 0, !dbg !97
+  br i1 %139, label %143, label %140, !dbg !97
+
+140:                                              ; preds = %rb_check_arity.1.exit.i8.i
+  %141 = lshr i64 %137, 15, !dbg !97
+  %142 = and i64 %141, 3, !dbg !97
+  br label %rb_array_len.exit1.i9.i, !dbg !97
 
 143:                                              ; preds = %rb_check_arity.1.exit.i8.i
-  %144 = lshr i64 %140, 15, !dbg !97
-  %145 = and i64 %144, 3, !dbg !97
+  %144 = inttoptr i64 %43 to %struct.RArray*, !dbg !97
+  %145 = getelementptr inbounds %struct.RArray, %struct.RArray* %144, i64 0, i32 1, i32 0, i32 0, !dbg !97
+  %146 = load i64, i64* %145, align 8, !dbg !97, !tbaa !27
   br label %rb_array_len.exit1.i9.i, !dbg !97
 
-146:                                              ; preds = %rb_check_arity.1.exit.i8.i
-  %147 = inttoptr i64 %46 to %struct.RArray*, !dbg !97
-  %148 = getelementptr inbounds %struct.RArray, %struct.RArray* %147, i64 0, i32 1, i32 0, i32 0, !dbg !97
-  %149 = load i64, i64* %148, align 8, !dbg !97, !tbaa !27
-  br label %rb_array_len.exit1.i9.i, !dbg !97
+rb_array_len.exit1.i9.i:                          ; preds = %143, %140
+  %147 = phi i64 [ %142, %140 ], [ %146, %143 ], !dbg !97
+  %148 = icmp sgt i64 %147, 0, !dbg !97
+  br i1 %148, label %149, label %forward_sorbet_rb_array_each_withBlock.1.exit.i, !dbg !97
 
-rb_array_len.exit1.i9.i:                          ; preds = %146, %143
-  %150 = phi i64 [ %145, %143 ], [ %149, %146 ], !dbg !97
-  %151 = icmp sgt i64 %150, 0, !dbg !97
-  br i1 %151, label %152, label %forward_sorbet_rb_array_each_withBlock.1.exit.i, !dbg !97
+149:                                              ; preds = %rb_array_len.exit1.i9.i
+  %150 = inttoptr i64 %43 to %struct.RArray*, !dbg !93
+  %151 = getelementptr inbounds %struct.RArray, %struct.RArray* %150, i64 0, i32 1, i32 0, i32 0, !dbg !93
+  %152 = getelementptr inbounds %struct.RArray, %struct.RArray* %150, i64 0, i32 1, i32 0, i32 2, !dbg !93
+  br label %153, !dbg !97
 
-152:                                              ; preds = %rb_array_len.exit1.i9.i
-  %153 = inttoptr i64 %46 to %struct.RArray*, !dbg !93
-  %154 = getelementptr inbounds %struct.RArray, %struct.RArray* %153, i64 0, i32 1, i32 0, i32 0, !dbg !93
-  %155 = getelementptr inbounds %struct.RArray, %struct.RArray* %153, i64 0, i32 1, i32 0, i32 2, !dbg !93
-  br label %156, !dbg !97
+153:                                              ; preds = %rb_array_len.exit.i11.i, %149
+  %154 = phi i64 [ 0, %149 ], [ %178, %rb_array_len.exit.i11.i ], !dbg !97
+  %155 = load i64, i64* %65, align 8, !dbg !97, !tbaa !25
+  %156 = and i64 %155, 8192, !dbg !97
+  %157 = icmp eq i64 %156, 0, !dbg !97
+  br i1 %157, label %158, label %rb_array_const_ptr_transient.exit.i10.i, !dbg !97
 
-156:                                              ; preds = %rb_array_len.exit.i11.i, %152
-  %157 = phi i64 [ 0, %152 ], [ %181, %rb_array_len.exit.i11.i ], !dbg !97
-  %158 = load i64, i64* %68, align 8, !dbg !97, !tbaa !25
-  %159 = and i64 %158, 8192, !dbg !97
-  %160 = icmp eq i64 %159, 0, !dbg !97
-  br i1 %160, label %161, label %rb_array_const_ptr_transient.exit.i10.i, !dbg !97
-
-161:                                              ; preds = %156
-  %162 = load i64*, i64** %155, align 8, !dbg !97, !tbaa !27
+158:                                              ; preds = %153
+  %159 = load i64*, i64** %152, align 8, !dbg !97, !tbaa !27
   br label %rb_array_const_ptr_transient.exit.i10.i, !dbg !97
 
-rb_array_const_ptr_transient.exit.i10.i:          ; preds = %161, %156
-  %163 = phi i64* [ %162, %161 ], [ %154, %156 ], !dbg !97
-  %164 = getelementptr inbounds i64, i64* %163, i64 %157, !dbg !97
-  %165 = load i64, i64* %164, align 8, !dbg !97, !tbaa !6
+rb_array_const_ptr_transient.exit.i10.i:          ; preds = %158, %153
+  %160 = phi i64* [ %159, %158 ], [ %151, %153 ], !dbg !97
+  %161 = getelementptr inbounds i64, i64* %160, i64 %154, !dbg !97
+  %162 = load i64, i64* %161, align 8, !dbg !97, !tbaa !6
   call void @llvm.experimental.noalias.scope.decl(metadata !99) #13, !dbg !97
-  %166 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !93, !tbaa !15, !noalias !99
-  %167 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %166, i64 0, i32 2, !dbg !93
-  %168 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %167, align 8, !dbg !93, !tbaa !17, !noalias !99
-  %169 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %168, i64 0, i32 3, !dbg !93
-  %170 = load i64, i64* %169, align 8, !dbg !93, !tbaa !42, !noalias !99
+  %163 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !93, !tbaa !15, !noalias !99
+  %164 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %163, i64 0, i32 2, !dbg !93
+  %165 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %164, align 8, !dbg !93, !tbaa !17, !noalias !99
+  %166 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %165, i64 0, i32 3, !dbg !93
+  %167 = load i64, i64* %166, align 8, !dbg !93, !tbaa !42, !noalias !99
   %stackFrame.i.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_2", align 8, !dbg !93, !noalias !99
-  %171 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %168, i64 0, i32 2, !dbg !93
-  store %struct.rb_iseq_struct* %stackFrame.i.i.i, %struct.rb_iseq_struct** %171, align 8, !dbg !93, !tbaa !21, !noalias !99
-  %172 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %168, i64 0, i32 4, !dbg !93
-  %173 = load i64*, i64** %172, align 8, !dbg !93, !tbaa !23, !noalias !99
-  %174 = load i64, i64* %173, align 8, !dbg !93, !tbaa !6, !noalias !99
-  %175 = and i64 %174, -129, !dbg !93
-  store i64 %175, i64* %173, align 8, !dbg !93, !tbaa !6, !noalias !99
-  %176 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %168, i64 0, i32 0, !dbg !93
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %176, align 8, !dbg !102, !tbaa !15, !noalias !99
-  %177 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %168, i64 0, i32 1, !dbg !104
-  %178 = load i64*, i64** %177, align 8, !dbg !104
-  store i64 %170, i64* %178, align 8, !dbg !104, !tbaa !6
-  %179 = getelementptr inbounds i64, i64* %178, i64 1, !dbg !104
-  store i64 %165, i64* %179, align 8, !dbg !104, !tbaa !6
-  %180 = getelementptr inbounds i64, i64* %179, i64 1, !dbg !104
-  store i64* %180, i64** %177, align 8, !dbg !104
+  %168 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %165, i64 0, i32 2, !dbg !93
+  store %struct.rb_iseq_struct* %stackFrame.i.i.i, %struct.rb_iseq_struct** %168, align 8, !dbg !93, !tbaa !21, !noalias !99
+  %169 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %165, i64 0, i32 4, !dbg !93
+  %170 = load i64*, i64** %169, align 8, !dbg !93, !tbaa !23, !noalias !99
+  %171 = load i64, i64* %170, align 8, !dbg !93, !tbaa !6, !noalias !99
+  %172 = and i64 %171, -129, !dbg !93
+  store i64 %172, i64* %170, align 8, !dbg !93, !tbaa !6, !noalias !99
+  %173 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %165, i64 0, i32 0, !dbg !93
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %173, align 8, !dbg !102, !tbaa !15, !noalias !99
+  %174 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %165, i64 0, i32 1, !dbg !104
+  %175 = load i64*, i64** %174, align 8, !dbg !104
+  store i64 %167, i64* %175, align 8, !dbg !104, !tbaa !6
+  %176 = getelementptr inbounds i64, i64* %175, i64 1, !dbg !104
+  store i64 %162, i64* %176, align 8, !dbg !104, !tbaa !6
+  %177 = getelementptr inbounds i64, i64* %176, i64 1, !dbg !104
+  store i64* %177, i64** %174, align 8, !dbg !104
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p, i64 0), !dbg !104
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %176, align 8, !dbg !104, !tbaa !15, !noalias !99
-  %181 = add nuw nsw i64 %157, 1, !dbg !97
-  %182 = load i64, i64* %68, align 8, !dbg !97, !tbaa !25
-  %183 = and i64 %182, 8192, !dbg !97
-  %184 = icmp eq i64 %183, 0, !dbg !97
-  br i1 %184, label %188, label %185, !dbg !97
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %173, align 8, !dbg !104, !tbaa !15, !noalias !99
+  %178 = add nuw nsw i64 %154, 1, !dbg !97
+  %179 = load i64, i64* %65, align 8, !dbg !97, !tbaa !25
+  %180 = and i64 %179, 8192, !dbg !97
+  %181 = icmp eq i64 %180, 0, !dbg !97
+  br i1 %181, label %185, label %182, !dbg !97
+
+182:                                              ; preds = %rb_array_const_ptr_transient.exit.i10.i
+  %183 = lshr i64 %179, 15, !dbg !97
+  %184 = and i64 %183, 3, !dbg !97
+  br label %rb_array_len.exit.i11.i, !dbg !97
 
 185:                                              ; preds = %rb_array_const_ptr_transient.exit.i10.i
-  %186 = lshr i64 %182, 15, !dbg !97
-  %187 = and i64 %186, 3, !dbg !97
+  %186 = load i64, i64* %151, align 8, !dbg !97, !tbaa !27
   br label %rb_array_len.exit.i11.i, !dbg !97
 
-188:                                              ; preds = %rb_array_const_ptr_transient.exit.i10.i
-  %189 = load i64, i64* %154, align 8, !dbg !97, !tbaa !27
-  br label %rb_array_len.exit.i11.i, !dbg !97
-
-rb_array_len.exit.i11.i:                          ; preds = %188, %185
-  %190 = phi i64 [ %187, %185 ], [ %189, %188 ], !dbg !97
-  %191 = icmp sgt i64 %190, %181, !dbg !97
-  br i1 %191, label %156, label %forward_sorbet_rb_array_each_withBlock.1.exit.i, !dbg !97, !llvm.loop !105
+rb_array_len.exit.i11.i:                          ; preds = %185, %182
+  %187 = phi i64 [ %184, %182 ], [ %186, %185 ], !dbg !97
+  %188 = icmp sgt i64 %187, %178, !dbg !97
+  br i1 %188, label %153, label %forward_sorbet_rb_array_each_withBlock.1.exit.i, !dbg !97, !llvm.loop !105
 
 forward_sorbet_rb_array_each_withBlock.1.exit.i:  ; preds = %rb_array_len.exit.i11.i, %rb_array_len.exit1.i9.i
   call void @sorbet_popFrame() #13, !dbg !97
-  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %122) #13, !dbg !93
-  %192 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !93, !tbaa !15
-  %193 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %192, i64 0, i32 5, !dbg !93
-  %194 = load i32, i32* %193, align 8, !dbg !93, !tbaa !37
-  %195 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %192, i64 0, i32 6, !dbg !93
-  %196 = load i32, i32* %195, align 4, !dbg !93, !tbaa !38
-  %197 = xor i32 %196, -1, !dbg !93
-  %198 = and i32 %197, %194, !dbg !93
-  %199 = icmp eq i32 %198, 0, !dbg !93
-  br i1 %199, label %rb_check_arity.1.exit.i14.i, label %200, !dbg !93, !prof !31
+  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %119) #13, !dbg !93
+  %189 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !93, !tbaa !15
+  %190 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %189, i64 0, i32 5, !dbg !93
+  %191 = load i32, i32* %190, align 8, !dbg !93, !tbaa !37
+  %192 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %189, i64 0, i32 6, !dbg !93
+  %193 = load i32, i32* %192, align 4, !dbg !93, !tbaa !38
+  %194 = xor i32 %193, -1, !dbg !93
+  %195 = and i32 %194, %191, !dbg !93
+  %196 = icmp eq i32 %195, 0, !dbg !93
+  br i1 %196, label %rb_check_arity.1.exit.i14.i, label %197, !dbg !93, !prof !31
 
-200:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.1.exit.i
-  %201 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %192, i64 0, i32 8, !dbg !93
-  %202 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %201, align 8, !dbg !93, !tbaa !39
-  %203 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %202, i32 noundef 0) #13, !dbg !93
+197:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.1.exit.i
+  %198 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %189, i64 0, i32 8, !dbg !93
+  %199 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %198, align 8, !dbg !93, !tbaa !39
+  %200 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %199, i32 noundef 0) #13, !dbg !93
   br label %rb_check_arity.1.exit.i14.i, !dbg !93
 
-rb_check_arity.1.exit.i14.i:                      ; preds = %200, %forward_sorbet_rb_array_each_withBlock.1.exit.i
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %43, align 8, !dbg !93, !tbaa !15
-  %204 = load i64, i64* @"func_<root>.17<static-init>$153$block_3_ifunc", align 8, !dbg !106
-  %205 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %204) #13, !dbg !106
-  %206 = bitcast %struct.sorbet_inlineIntrinsicEnv* %4 to i8*, !dbg !106
-  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %206) #13, !dbg !106
-  %207 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %4, i64 0, i32 0, !dbg !106
-  store i64 %46, i64* %207, align 8, !dbg !106, !tbaa !81
-  %208 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %4, i64 0, i32 1, !dbg !106
-  store i64 %rubyId_each.i, i64* %208, align 8, !dbg !106, !tbaa !83
-  %209 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %4, i64 0, i32 2, !dbg !106
-  store i32 0, i32* %209, align 8, !dbg !106, !tbaa !84
-  %210 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %4, i64 0, i32 3, !dbg !106
-  %211 = bitcast i64** %210 to i8*, !dbg !106
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %211, i8 0, i64 16, i1 false) #13, !dbg !106
-  %212 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !106, !tbaa !15
-  %213 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %212, i64 0, i32 2, !dbg !106
-  %214 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %213, align 8, !dbg !106, !tbaa !17
-  %215 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %214, i64 0, i32 3, !dbg !106
-  %216 = bitcast i64* %215 to %struct.rb_captured_block*, !dbg !106
-  %217 = getelementptr inbounds i64, i64* %215, i64 2, !dbg !106
-  %218 = bitcast i64* %217 to %struct.vm_ifunc**, !dbg !106
-  store %struct.vm_ifunc* %205, %struct.vm_ifunc** %218, align 8, !dbg !106, !tbaa !27
+rb_check_arity.1.exit.i14.i:                      ; preds = %197, %forward_sorbet_rb_array_each_withBlock.1.exit.i
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %40, align 8, !dbg !93, !tbaa !15
+  %201 = load i64, i64* @"func_<root>.17<static-init>$153$block_3_ifunc", align 8, !dbg !106
+  %202 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %201) #13, !dbg !106
+  %203 = bitcast %struct.sorbet_inlineIntrinsicEnv* %4 to i8*, !dbg !106
+  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %203) #13, !dbg !106
+  %204 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %4, i64 0, i32 0, !dbg !106
+  store i64 %43, i64* %204, align 8, !dbg !106, !tbaa !81
+  %205 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %4, i64 0, i32 1, !dbg !106
+  store i64 %rubyId_each.i, i64* %205, align 8, !dbg !106, !tbaa !83
+  %206 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %4, i64 0, i32 2, !dbg !106
+  store i32 0, i32* %206, align 8, !dbg !106, !tbaa !84
+  %207 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %4, i64 0, i32 3, !dbg !106
+  %208 = bitcast i64** %207 to i8*, !dbg !106
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %208, i8 0, i64 16, i1 false) #13, !dbg !106
+  %209 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !106, !tbaa !15
+  %210 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %209, i64 0, i32 2, !dbg !106
+  %211 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %210, align 8, !dbg !106, !tbaa !17
+  %212 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %211, i64 0, i32 3, !dbg !106
+  %213 = bitcast i64* %212 to %struct.rb_captured_block*, !dbg !106
+  %214 = getelementptr inbounds i64, i64* %212, i64 2, !dbg !106
+  %215 = bitcast i64* %214 to %struct.vm_ifunc**, !dbg !106
+  store %struct.vm_ifunc* %202, %struct.vm_ifunc** %215, align 8, !dbg !106, !tbaa !27
   call void @llvm.experimental.noalias.scope.decl(metadata !107) #13, !dbg !106
-  %219 = ptrtoint %struct.rb_captured_block* %216 to i64, !dbg !106
-  %220 = or i64 %219, 3, !dbg !106
-  %221 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %212, i64 0, i32 17, !dbg !106
-  %222 = and i64 %220, -4, !dbg !110
-  %223 = inttoptr i64 %222 to %struct.rb_captured_block*, !dbg !110
-  store i64 0, i64* %221, align 8, !dbg !110, !tbaa !90
-  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %223) #13, !dbg !110
-  %224 = load i64, i64* %68, align 8, !dbg !110, !tbaa !25
-  %225 = and i64 %224, 8192, !dbg !110
-  %226 = icmp eq i64 %225, 0, !dbg !110
-  br i1 %226, label %230, label %227, !dbg !110
+  %216 = ptrtoint %struct.rb_captured_block* %213 to i64, !dbg !106
+  %217 = or i64 %216, 3, !dbg !106
+  %218 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %209, i64 0, i32 17, !dbg !106
+  %219 = and i64 %217, -4, !dbg !110
+  %220 = inttoptr i64 %219 to %struct.rb_captured_block*, !dbg !110
+  store i64 0, i64* %218, align 8, !dbg !110, !tbaa !90
+  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %220) #13, !dbg !110
+  %221 = load i64, i64* %65, align 8, !dbg !110, !tbaa !25
+  %222 = and i64 %221, 8192, !dbg !110
+  %223 = icmp eq i64 %222, 0, !dbg !110
+  br i1 %223, label %227, label %224, !dbg !110
+
+224:                                              ; preds = %rb_check_arity.1.exit.i14.i
+  %225 = lshr i64 %221, 15, !dbg !110
+  %226 = and i64 %225, 3, !dbg !110
+  br label %rb_array_len.exit1.i15.i, !dbg !110
 
 227:                                              ; preds = %rb_check_arity.1.exit.i14.i
-  %228 = lshr i64 %224, 15, !dbg !110
-  %229 = and i64 %228, 3, !dbg !110
+  %228 = inttoptr i64 %43 to %struct.RArray*, !dbg !110
+  %229 = getelementptr inbounds %struct.RArray, %struct.RArray* %228, i64 0, i32 1, i32 0, i32 0, !dbg !110
+  %230 = load i64, i64* %229, align 8, !dbg !110, !tbaa !27
   br label %rb_array_len.exit1.i15.i, !dbg !110
 
-230:                                              ; preds = %rb_check_arity.1.exit.i14.i
-  %231 = inttoptr i64 %46 to %struct.RArray*, !dbg !110
-  %232 = getelementptr inbounds %struct.RArray, %struct.RArray* %231, i64 0, i32 1, i32 0, i32 0, !dbg !110
-  %233 = load i64, i64* %232, align 8, !dbg !110, !tbaa !27
-  br label %rb_array_len.exit1.i15.i, !dbg !110
+rb_array_len.exit1.i15.i:                         ; preds = %227, %224
+  %231 = phi i64 [ %226, %224 ], [ %230, %227 ], !dbg !110
+  %232 = icmp sgt i64 %231, 0, !dbg !110
+  br i1 %232, label %233, label %forward_sorbet_rb_array_each_withBlock.3.exit.i, !dbg !110
 
-rb_array_len.exit1.i15.i:                         ; preds = %230, %227
-  %234 = phi i64 [ %229, %227 ], [ %233, %230 ], !dbg !110
-  %235 = icmp sgt i64 %234, 0, !dbg !110
-  br i1 %235, label %236, label %forward_sorbet_rb_array_each_withBlock.3.exit.i, !dbg !110
+233:                                              ; preds = %rb_array_len.exit1.i15.i
+  %234 = inttoptr i64 %43 to %struct.RArray*, !dbg !106
+  %235 = getelementptr inbounds %struct.RArray, %struct.RArray* %234, i64 0, i32 1, i32 0, i32 0, !dbg !106
+  %236 = getelementptr inbounds %struct.RArray, %struct.RArray* %234, i64 0, i32 1, i32 0, i32 2, !dbg !106
+  br label %237, !dbg !110
 
-236:                                              ; preds = %rb_array_len.exit1.i15.i
-  %237 = inttoptr i64 %46 to %struct.RArray*, !dbg !106
-  %238 = getelementptr inbounds %struct.RArray, %struct.RArray* %237, i64 0, i32 1, i32 0, i32 0, !dbg !106
-  %239 = getelementptr inbounds %struct.RArray, %struct.RArray* %237, i64 0, i32 1, i32 0, i32 2, !dbg !106
-  br label %240, !dbg !110
+237:                                              ; preds = %rb_array_len.exit.i18.i, %233
+  %238 = phi i64 [ 0, %233 ], [ %262, %rb_array_len.exit.i18.i ], !dbg !110
+  %239 = load i64, i64* %65, align 8, !dbg !110, !tbaa !25
+  %240 = and i64 %239, 8192, !dbg !110
+  %241 = icmp eq i64 %240, 0, !dbg !110
+  br i1 %241, label %242, label %rb_array_const_ptr_transient.exit.i17.i, !dbg !110
 
-240:                                              ; preds = %rb_array_len.exit.i18.i, %236
-  %241 = phi i64 [ 0, %236 ], [ %265, %rb_array_len.exit.i18.i ], !dbg !110
-  %242 = load i64, i64* %68, align 8, !dbg !110, !tbaa !25
-  %243 = and i64 %242, 8192, !dbg !110
-  %244 = icmp eq i64 %243, 0, !dbg !110
-  br i1 %244, label %245, label %rb_array_const_ptr_transient.exit.i17.i, !dbg !110
-
-245:                                              ; preds = %240
-  %246 = load i64*, i64** %239, align 8, !dbg !110, !tbaa !27
+242:                                              ; preds = %237
+  %243 = load i64*, i64** %236, align 8, !dbg !110, !tbaa !27
   br label %rb_array_const_ptr_transient.exit.i17.i, !dbg !110
 
-rb_array_const_ptr_transient.exit.i17.i:          ; preds = %245, %240
-  %247 = phi i64* [ %246, %245 ], [ %238, %240 ], !dbg !110
-  %248 = getelementptr inbounds i64, i64* %247, i64 %241, !dbg !110
-  %249 = load i64, i64* %248, align 8, !dbg !110, !tbaa !6
+rb_array_const_ptr_transient.exit.i17.i:          ; preds = %242, %237
+  %244 = phi i64* [ %243, %242 ], [ %235, %237 ], !dbg !110
+  %245 = getelementptr inbounds i64, i64* %244, i64 %238, !dbg !110
+  %246 = load i64, i64* %245, align 8, !dbg !110, !tbaa !6
   call void @llvm.experimental.noalias.scope.decl(metadata !112) #13, !dbg !110
-  %250 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !106, !tbaa !15, !noalias !112
-  %251 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %250, i64 0, i32 2, !dbg !106
-  %252 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %251, align 8, !dbg !106, !tbaa !17, !noalias !112
-  %253 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %252, i64 0, i32 3, !dbg !106
-  %254 = load i64, i64* %253, align 8, !dbg !106, !tbaa !42, !noalias !112
+  %247 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !106, !tbaa !15, !noalias !112
+  %248 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %247, i64 0, i32 2, !dbg !106
+  %249 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %248, align 8, !dbg !106, !tbaa !17, !noalias !112
+  %250 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %249, i64 0, i32 3, !dbg !106
+  %251 = load i64, i64* %250, align 8, !dbg !106, !tbaa !42, !noalias !112
   %stackFrame.i.i16.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_3", align 8, !dbg !106, !noalias !112
-  %255 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %252, i64 0, i32 2, !dbg !106
-  store %struct.rb_iseq_struct* %stackFrame.i.i16.i, %struct.rb_iseq_struct** %255, align 8, !dbg !106, !tbaa !21, !noalias !112
-  %256 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %252, i64 0, i32 4, !dbg !106
-  %257 = load i64*, i64** %256, align 8, !dbg !106, !tbaa !23, !noalias !112
-  %258 = load i64, i64* %257, align 8, !dbg !106, !tbaa !6, !noalias !112
-  %259 = and i64 %258, -129, !dbg !106
-  store i64 %259, i64* %257, align 8, !dbg !106, !tbaa !6, !noalias !112
-  %260 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %252, i64 0, i32 0, !dbg !106
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %260, align 8, !dbg !106, !tbaa !15, !noalias !112
-  %261 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %252, i64 0, i32 1, !dbg !115
-  %262 = load i64*, i64** %261, align 8, !dbg !115
-  store i64 %254, i64* %262, align 8, !dbg !115, !tbaa !6
-  %263 = getelementptr inbounds i64, i64* %262, i64 1, !dbg !115
-  store i64 %249, i64* %263, align 8, !dbg !115, !tbaa !6
-  %264 = getelementptr inbounds i64, i64* %263, i64 1, !dbg !115
-  store i64* %264, i64** %261, align 8, !dbg !115
+  %252 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %249, i64 0, i32 2, !dbg !106
+  store %struct.rb_iseq_struct* %stackFrame.i.i16.i, %struct.rb_iseq_struct** %252, align 8, !dbg !106, !tbaa !21, !noalias !112
+  %253 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %249, i64 0, i32 4, !dbg !106
+  %254 = load i64*, i64** %253, align 8, !dbg !106, !tbaa !23, !noalias !112
+  %255 = load i64, i64* %254, align 8, !dbg !106, !tbaa !6, !noalias !112
+  %256 = and i64 %255, -129, !dbg !106
+  store i64 %256, i64* %254, align 8, !dbg !106, !tbaa !6, !noalias !112
+  %257 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %249, i64 0, i32 0, !dbg !106
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %257, align 8, !dbg !106, !tbaa !15, !noalias !112
+  %258 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %249, i64 0, i32 1, !dbg !115
+  %259 = load i64*, i64** %258, align 8, !dbg !115
+  store i64 %251, i64* %259, align 8, !dbg !115, !tbaa !6
+  %260 = getelementptr inbounds i64, i64* %259, i64 1, !dbg !115
+  store i64 %246, i64* %260, align 8, !dbg !115, !tbaa !6
+  %261 = getelementptr inbounds i64, i64* %260, i64 1, !dbg !115
+  store i64* %261, i64** %258, align 8, !dbg !115
   %send14 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.5, i64 0), !dbg !115
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %260, align 8, !dbg !115, !tbaa !15, !noalias !112
-  %265 = add nuw nsw i64 %241, 1, !dbg !110
-  %266 = load i64, i64* %68, align 8, !dbg !110, !tbaa !25
-  %267 = and i64 %266, 8192, !dbg !110
-  %268 = icmp eq i64 %267, 0, !dbg !110
-  br i1 %268, label %272, label %269, !dbg !110
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %257, align 8, !dbg !115, !tbaa !15, !noalias !112
+  %262 = add nuw nsw i64 %238, 1, !dbg !110
+  %263 = load i64, i64* %65, align 8, !dbg !110, !tbaa !25
+  %264 = and i64 %263, 8192, !dbg !110
+  %265 = icmp eq i64 %264, 0, !dbg !110
+  br i1 %265, label %269, label %266, !dbg !110
+
+266:                                              ; preds = %rb_array_const_ptr_transient.exit.i17.i
+  %267 = lshr i64 %263, 15, !dbg !110
+  %268 = and i64 %267, 3, !dbg !110
+  br label %rb_array_len.exit.i18.i, !dbg !110
 
 269:                                              ; preds = %rb_array_const_ptr_transient.exit.i17.i
-  %270 = lshr i64 %266, 15, !dbg !110
-  %271 = and i64 %270, 3, !dbg !110
+  %270 = load i64, i64* %235, align 8, !dbg !110, !tbaa !27
   br label %rb_array_len.exit.i18.i, !dbg !110
 
-272:                                              ; preds = %rb_array_const_ptr_transient.exit.i17.i
-  %273 = load i64, i64* %238, align 8, !dbg !110, !tbaa !27
-  br label %rb_array_len.exit.i18.i, !dbg !110
-
-rb_array_len.exit.i18.i:                          ; preds = %272, %269
-  %274 = phi i64 [ %271, %269 ], [ %273, %272 ], !dbg !110
-  %275 = icmp sgt i64 %274, %265, !dbg !110
-  br i1 %275, label %240, label %forward_sorbet_rb_array_each_withBlock.3.exit.i, !dbg !110, !llvm.loop !117
+rb_array_len.exit.i18.i:                          ; preds = %269, %266
+  %271 = phi i64 [ %268, %266 ], [ %270, %269 ], !dbg !110
+  %272 = icmp sgt i64 %271, %262, !dbg !110
+  br i1 %272, label %237, label %forward_sorbet_rb_array_each_withBlock.3.exit.i, !dbg !110, !llvm.loop !117
 
 forward_sorbet_rb_array_each_withBlock.3.exit.i:  ; preds = %rb_array_len.exit.i18.i, %rb_array_len.exit1.i15.i
   call void @sorbet_popFrame() #13, !dbg !110
-  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %206) #13, !dbg !106
-  %276 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !106, !tbaa !15
-  %277 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %276, i64 0, i32 5, !dbg !106
-  %278 = load i32, i32* %277, align 8, !dbg !106, !tbaa !37
-  %279 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %276, i64 0, i32 6, !dbg !106
-  %280 = load i32, i32* %279, align 4, !dbg !106, !tbaa !38
-  %281 = xor i32 %280, -1, !dbg !106
-  %282 = and i32 %281, %278, !dbg !106
-  %283 = icmp eq i32 %282, 0, !dbg !106
-  br i1 %283, label %rb_check_arity.1.exit.i21.i, label %284, !dbg !106, !prof !31
+  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %203) #13, !dbg !106
+  %273 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !106, !tbaa !15
+  %274 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %273, i64 0, i32 5, !dbg !106
+  %275 = load i32, i32* %274, align 8, !dbg !106, !tbaa !37
+  %276 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %273, i64 0, i32 6, !dbg !106
+  %277 = load i32, i32* %276, align 4, !dbg !106, !tbaa !38
+  %278 = xor i32 %277, -1, !dbg !106
+  %279 = and i32 %278, %275, !dbg !106
+  %280 = icmp eq i32 %279, 0, !dbg !106
+  br i1 %280, label %rb_check_arity.1.exit.i21.i, label %281, !dbg !106, !prof !31
 
-284:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.3.exit.i
-  %285 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %276, i64 0, i32 8, !dbg !106
-  %286 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %285, align 8, !dbg !106, !tbaa !39
-  %287 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %286, i32 noundef 0) #13, !dbg !106
+281:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.3.exit.i
+  %282 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %273, i64 0, i32 8, !dbg !106
+  %283 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %282, align 8, !dbg !106, !tbaa !39
+  %284 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %283, i32 noundef 0) #13, !dbg !106
   br label %rb_check_arity.1.exit.i21.i, !dbg !106
 
-rb_check_arity.1.exit.i21.i:                      ; preds = %284, %forward_sorbet_rb_array_each_withBlock.3.exit.i
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %43, align 8, !dbg !106, !tbaa !15
-  %288 = load i64, i64* @"func_<root>.17<static-init>$153$block_4_ifunc", align 8, !dbg !118
-  %289 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %288) #13, !dbg !118
-  %290 = bitcast %struct.sorbet_inlineIntrinsicEnv* %3 to i8*, !dbg !118
-  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %290) #13, !dbg !118
-  %291 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %3, i64 0, i32 0, !dbg !118
-  store i64 %46, i64* %291, align 8, !dbg !118, !tbaa !81
-  %292 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %3, i64 0, i32 1, !dbg !118
-  store i64 %rubyId_each.i, i64* %292, align 8, !dbg !118, !tbaa !83
-  %293 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %3, i64 0, i32 2, !dbg !118
-  store i32 0, i32* %293, align 8, !dbg !118, !tbaa !84
-  %294 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %3, i64 0, i32 3, !dbg !118
-  %295 = bitcast i64** %294 to i8*, !dbg !118
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %295, i8 0, i64 16, i1 false) #13, !dbg !118
-  %296 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !118, !tbaa !15
-  %297 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %296, i64 0, i32 2, !dbg !118
-  %298 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %297, align 8, !dbg !118, !tbaa !17
-  %299 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %298, i64 0, i32 3, !dbg !118
-  %300 = bitcast i64* %299 to %struct.rb_captured_block*, !dbg !118
-  %301 = getelementptr inbounds i64, i64* %299, i64 2, !dbg !118
-  %302 = bitcast i64* %301 to %struct.vm_ifunc**, !dbg !118
-  store %struct.vm_ifunc* %289, %struct.vm_ifunc** %302, align 8, !dbg !118, !tbaa !27
+rb_check_arity.1.exit.i21.i:                      ; preds = %281, %forward_sorbet_rb_array_each_withBlock.3.exit.i
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %40, align 8, !dbg !106, !tbaa !15
+  %285 = load i64, i64* @"func_<root>.17<static-init>$153$block_4_ifunc", align 8, !dbg !118
+  %286 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %285) #13, !dbg !118
+  %287 = bitcast %struct.sorbet_inlineIntrinsicEnv* %3 to i8*, !dbg !118
+  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %287) #13, !dbg !118
+  %288 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %3, i64 0, i32 0, !dbg !118
+  store i64 %43, i64* %288, align 8, !dbg !118, !tbaa !81
+  %289 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %3, i64 0, i32 1, !dbg !118
+  store i64 %rubyId_each.i, i64* %289, align 8, !dbg !118, !tbaa !83
+  %290 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %3, i64 0, i32 2, !dbg !118
+  store i32 0, i32* %290, align 8, !dbg !118, !tbaa !84
+  %291 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %3, i64 0, i32 3, !dbg !118
+  %292 = bitcast i64** %291 to i8*, !dbg !118
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %292, i8 0, i64 16, i1 false) #13, !dbg !118
+  %293 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !118, !tbaa !15
+  %294 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %293, i64 0, i32 2, !dbg !118
+  %295 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %294, align 8, !dbg !118, !tbaa !17
+  %296 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %295, i64 0, i32 3, !dbg !118
+  %297 = bitcast i64* %296 to %struct.rb_captured_block*, !dbg !118
+  %298 = getelementptr inbounds i64, i64* %296, i64 2, !dbg !118
+  %299 = bitcast i64* %298 to %struct.vm_ifunc**, !dbg !118
+  store %struct.vm_ifunc* %286, %struct.vm_ifunc** %299, align 8, !dbg !118, !tbaa !27
   call void @llvm.experimental.noalias.scope.decl(metadata !119) #13, !dbg !118
-  %303 = ptrtoint %struct.rb_captured_block* %300 to i64, !dbg !118
-  %304 = or i64 %303, 3, !dbg !118
-  %305 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %296, i64 0, i32 17, !dbg !118
-  %306 = and i64 %304, -4, !dbg !122
-  %307 = inttoptr i64 %306 to %struct.rb_captured_block*, !dbg !122
-  store i64 0, i64* %305, align 8, !dbg !122, !tbaa !90
-  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %307) #13, !dbg !122
-  %308 = load i64, i64* %68, align 8, !dbg !122, !tbaa !25
-  %309 = and i64 %308, 8192, !dbg !122
-  %310 = icmp eq i64 %309, 0, !dbg !122
-  br i1 %310, label %314, label %311, !dbg !122
+  %300 = ptrtoint %struct.rb_captured_block* %297 to i64, !dbg !118
+  %301 = or i64 %300, 3, !dbg !118
+  %302 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %293, i64 0, i32 17, !dbg !118
+  %303 = and i64 %301, -4, !dbg !122
+  %304 = inttoptr i64 %303 to %struct.rb_captured_block*, !dbg !122
+  store i64 0, i64* %302, align 8, !dbg !122, !tbaa !90
+  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %304) #13, !dbg !122
+  %305 = load i64, i64* %65, align 8, !dbg !122, !tbaa !25
+  %306 = and i64 %305, 8192, !dbg !122
+  %307 = icmp eq i64 %306, 0, !dbg !122
+  br i1 %307, label %311, label %308, !dbg !122
+
+308:                                              ; preds = %rb_check_arity.1.exit.i21.i
+  %309 = lshr i64 %305, 15, !dbg !122
+  %310 = and i64 %309, 3, !dbg !122
+  br label %rb_array_len.exit1.i22.i, !dbg !122
 
 311:                                              ; preds = %rb_check_arity.1.exit.i21.i
-  %312 = lshr i64 %308, 15, !dbg !122
-  %313 = and i64 %312, 3, !dbg !122
+  %312 = inttoptr i64 %43 to %struct.RArray*, !dbg !122
+  %313 = getelementptr inbounds %struct.RArray, %struct.RArray* %312, i64 0, i32 1, i32 0, i32 0, !dbg !122
+  %314 = load i64, i64* %313, align 8, !dbg !122, !tbaa !27
   br label %rb_array_len.exit1.i22.i, !dbg !122
 
-314:                                              ; preds = %rb_check_arity.1.exit.i21.i
-  %315 = inttoptr i64 %46 to %struct.RArray*, !dbg !122
-  %316 = getelementptr inbounds %struct.RArray, %struct.RArray* %315, i64 0, i32 1, i32 0, i32 0, !dbg !122
-  %317 = load i64, i64* %316, align 8, !dbg !122, !tbaa !27
-  br label %rb_array_len.exit1.i22.i, !dbg !122
+rb_array_len.exit1.i22.i:                         ; preds = %311, %308
+  %315 = phi i64 [ %310, %308 ], [ %314, %311 ], !dbg !122
+  %316 = icmp sgt i64 %315, 0, !dbg !122
+  br i1 %316, label %317, label %forward_sorbet_rb_array_each_withBlock.6.exit.i, !dbg !122
 
-rb_array_len.exit1.i22.i:                         ; preds = %314, %311
-  %318 = phi i64 [ %313, %311 ], [ %317, %314 ], !dbg !122
-  %319 = icmp sgt i64 %318, 0, !dbg !122
-  br i1 %319, label %320, label %forward_sorbet_rb_array_each_withBlock.6.exit.i, !dbg !122
+317:                                              ; preds = %rb_array_len.exit1.i22.i
+  %318 = bitcast i64* %0 to i8*, !dbg !122
+  %319 = inttoptr i64 %43 to %struct.RArray*, !dbg !118
+  %320 = getelementptr inbounds %struct.RArray, %struct.RArray* %319, i64 0, i32 1, i32 0, i32 0, !dbg !118
+  %321 = getelementptr inbounds %struct.RArray, %struct.RArray* %319, i64 0, i32 1, i32 0, i32 2, !dbg !118
+  br label %322, !dbg !122
 
-320:                                              ; preds = %rb_array_len.exit1.i22.i
-  %321 = bitcast i64* %0 to i8*, !dbg !122
-  %322 = inttoptr i64 %46 to %struct.RArray*, !dbg !118
-  %323 = getelementptr inbounds %struct.RArray, %struct.RArray* %322, i64 0, i32 1, i32 0, i32 0, !dbg !118
-  %324 = getelementptr inbounds %struct.RArray, %struct.RArray* %322, i64 0, i32 1, i32 0, i32 2, !dbg !118
-  br label %325, !dbg !122
+322:                                              ; preds = %rb_array_len.exit.i24.i, %317
+  %323 = phi i64 [ 0, %317 ], [ %333, %rb_array_len.exit.i24.i ], !dbg !122
+  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 dereferenceable(8) %318) #13, !dbg !122
+  %324 = load i64, i64* %65, align 8, !dbg !122, !tbaa !25
+  %325 = and i64 %324, 8192, !dbg !122
+  %326 = icmp eq i64 %325, 0, !dbg !122
+  br i1 %326, label %327, label %rb_array_const_ptr_transient.exit.i23.i, !dbg !122
 
-325:                                              ; preds = %rb_array_len.exit.i24.i, %320
-  %326 = phi i64 [ 0, %320 ], [ %336, %rb_array_len.exit.i24.i ], !dbg !122
-  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 dereferenceable(8) %321) #13, !dbg !122
-  %327 = load i64, i64* %68, align 8, !dbg !122, !tbaa !25
-  %328 = and i64 %327, 8192, !dbg !122
-  %329 = icmp eq i64 %328, 0, !dbg !122
-  br i1 %329, label %330, label %rb_array_const_ptr_transient.exit.i23.i, !dbg !122
-
-330:                                              ; preds = %325
-  %331 = load i64*, i64** %324, align 8, !dbg !122, !tbaa !27
+327:                                              ; preds = %322
+  %328 = load i64*, i64** %321, align 8, !dbg !122, !tbaa !27
   br label %rb_array_const_ptr_transient.exit.i23.i, !dbg !122
 
-rb_array_const_ptr_transient.exit.i23.i:          ; preds = %330, %325
-  %332 = phi i64* [ %331, %330 ], [ %323, %325 ], !dbg !122
-  %333 = getelementptr inbounds i64, i64* %332, i64 %326, !dbg !122
-  %334 = load i64, i64* %333, align 8, !dbg !122, !tbaa !6
-  store i64 %334, i64* %0, align 8, !dbg !122, !tbaa !6
-  %335 = call i64 @"func_<root>.17<static-init>$153$block_4"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %0, i64 undef) #13, !dbg !122
-  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %321) #13, !dbg !122
-  %336 = add nuw nsw i64 %326, 1, !dbg !122
-  %337 = load i64, i64* %68, align 8, !dbg !122, !tbaa !25
-  %338 = and i64 %337, 8192, !dbg !122
-  %339 = icmp eq i64 %338, 0, !dbg !122
-  br i1 %339, label %343, label %340, !dbg !122
+rb_array_const_ptr_transient.exit.i23.i:          ; preds = %327, %322
+  %329 = phi i64* [ %328, %327 ], [ %320, %322 ], !dbg !122
+  %330 = getelementptr inbounds i64, i64* %329, i64 %323, !dbg !122
+  %331 = load i64, i64* %330, align 8, !dbg !122, !tbaa !6
+  store i64 %331, i64* %0, align 8, !dbg !122, !tbaa !6
+  %332 = call i64 @"func_<root>.17<static-init>$153$block_4"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %0, i64 undef) #13, !dbg !122
+  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %318) #13, !dbg !122
+  %333 = add nuw nsw i64 %323, 1, !dbg !122
+  %334 = load i64, i64* %65, align 8, !dbg !122, !tbaa !25
+  %335 = and i64 %334, 8192, !dbg !122
+  %336 = icmp eq i64 %335, 0, !dbg !122
+  br i1 %336, label %340, label %337, !dbg !122
+
+337:                                              ; preds = %rb_array_const_ptr_transient.exit.i23.i
+  %338 = lshr i64 %334, 15, !dbg !122
+  %339 = and i64 %338, 3, !dbg !122
+  br label %rb_array_len.exit.i24.i, !dbg !122
 
 340:                                              ; preds = %rb_array_const_ptr_transient.exit.i23.i
-  %341 = lshr i64 %337, 15, !dbg !122
-  %342 = and i64 %341, 3, !dbg !122
+  %341 = load i64, i64* %320, align 8, !dbg !122, !tbaa !27
   br label %rb_array_len.exit.i24.i, !dbg !122
 
-343:                                              ; preds = %rb_array_const_ptr_transient.exit.i23.i
-  %344 = load i64, i64* %323, align 8, !dbg !122, !tbaa !27
-  br label %rb_array_len.exit.i24.i, !dbg !122
-
-rb_array_len.exit.i24.i:                          ; preds = %343, %340
-  %345 = phi i64 [ %342, %340 ], [ %344, %343 ], !dbg !122
-  %346 = icmp sgt i64 %345, %336, !dbg !122
-  br i1 %346, label %325, label %forward_sorbet_rb_array_each_withBlock.6.exit.i, !dbg !122, !llvm.loop !124
+rb_array_len.exit.i24.i:                          ; preds = %340, %337
+  %342 = phi i64 [ %339, %337 ], [ %341, %340 ], !dbg !122
+  %343 = icmp sgt i64 %342, %333, !dbg !122
+  br i1 %343, label %322, label %forward_sorbet_rb_array_each_withBlock.6.exit.i, !dbg !122, !llvm.loop !124
 
 forward_sorbet_rb_array_each_withBlock.6.exit.i:  ; preds = %rb_array_len.exit.i24.i, %rb_array_len.exit1.i22.i
   call void @sorbet_popFrame() #13, !dbg !122
-  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %290) #13, !dbg !118
-  %347 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !118, !tbaa !15
-  %348 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %347, i64 0, i32 5, !dbg !118
-  %349 = load i32, i32* %348, align 8, !dbg !118, !tbaa !37
-  %350 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %347, i64 0, i32 6, !dbg !118
-  %351 = load i32, i32* %350, align 4, !dbg !118, !tbaa !38
-  %352 = xor i32 %351, -1, !dbg !118
-  %353 = and i32 %352, %349, !dbg !118
-  %354 = icmp eq i32 %353, 0, !dbg !118
-  br i1 %354, label %rb_check_arity.1.exit.i.i, label %355, !dbg !118, !prof !31
+  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %287) #13, !dbg !118
+  %344 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !118, !tbaa !15
+  %345 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %344, i64 0, i32 5, !dbg !118
+  %346 = load i32, i32* %345, align 8, !dbg !118, !tbaa !37
+  %347 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %344, i64 0, i32 6, !dbg !118
+  %348 = load i32, i32* %347, align 4, !dbg !118, !tbaa !38
+  %349 = xor i32 %348, -1, !dbg !118
+  %350 = and i32 %349, %346, !dbg !118
+  %351 = icmp eq i32 %350, 0, !dbg !118
+  br i1 %351, label %rb_check_arity.1.exit.i.i, label %352, !dbg !118, !prof !31
 
-355:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.6.exit.i
-  %356 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %347, i64 0, i32 8, !dbg !118
-  %357 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %356, align 8, !dbg !118, !tbaa !39
-  %358 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %357, i32 noundef 0) #13, !dbg !118
+352:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.6.exit.i
+  %353 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %344, i64 0, i32 8, !dbg !118
+  %354 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %353, align 8, !dbg !118, !tbaa !39
+  %355 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %354, i32 noundef 0) #13, !dbg !118
   br label %rb_check_arity.1.exit.i.i, !dbg !118
 
-rb_check_arity.1.exit.i.i:                        ; preds = %355, %forward_sorbet_rb_array_each_withBlock.6.exit.i
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %43, align 8, !dbg !118, !tbaa !15
-  %359 = load i64, i64* @"func_<root>.17<static-init>$153$block_5_ifunc", align 8, !dbg !125
-  %360 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %359) #13, !dbg !125
-  %361 = bitcast %struct.sorbet_inlineIntrinsicEnv* %7 to i8*, !dbg !125
-  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %361) #13, !dbg !125
-  %362 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %7, i64 0, i32 0, !dbg !125
-  store i64 %46, i64* %362, align 8, !dbg !125, !tbaa !81
-  %363 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %7, i64 0, i32 1, !dbg !125
-  store i64 %rubyId_each.i, i64* %363, align 8, !dbg !125, !tbaa !83
-  %364 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %7, i64 0, i32 2, !dbg !125
-  store i32 0, i32* %364, align 8, !dbg !125, !tbaa !84
-  %365 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %7, i64 0, i32 3, !dbg !125
-  %366 = bitcast i64** %365 to i8*, !dbg !125
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %366, i8 0, i64 16, i1 false) #13, !dbg !125
-  %367 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !125, !tbaa !15
-  %368 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %367, i64 0, i32 2, !dbg !125
-  %369 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %368, align 8, !dbg !125, !tbaa !17
-  %370 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %369, i64 0, i32 3, !dbg !125
-  %371 = bitcast i64* %370 to %struct.rb_captured_block*, !dbg !125
-  %372 = getelementptr inbounds i64, i64* %370, i64 2, !dbg !125
-  %373 = bitcast i64* %372 to %struct.vm_ifunc**, !dbg !125
-  store %struct.vm_ifunc* %360, %struct.vm_ifunc** %373, align 8, !dbg !125, !tbaa !27
+rb_check_arity.1.exit.i.i:                        ; preds = %352, %forward_sorbet_rb_array_each_withBlock.6.exit.i
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %40, align 8, !dbg !118, !tbaa !15
+  %356 = load i64, i64* @"func_<root>.17<static-init>$153$block_5_ifunc", align 8, !dbg !125
+  %357 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %356) #13, !dbg !125
+  %358 = bitcast %struct.sorbet_inlineIntrinsicEnv* %7 to i8*, !dbg !125
+  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %358) #13, !dbg !125
+  %359 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %7, i64 0, i32 0, !dbg !125
+  store i64 %43, i64* %359, align 8, !dbg !125, !tbaa !81
+  %360 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %7, i64 0, i32 1, !dbg !125
+  store i64 %rubyId_each.i, i64* %360, align 8, !dbg !125, !tbaa !83
+  %361 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %7, i64 0, i32 2, !dbg !125
+  store i32 0, i32* %361, align 8, !dbg !125, !tbaa !84
+  %362 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %7, i64 0, i32 3, !dbg !125
+  %363 = bitcast i64** %362 to i8*, !dbg !125
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %363, i8 0, i64 16, i1 false) #13, !dbg !125
+  %364 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !125, !tbaa !15
+  %365 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %364, i64 0, i32 2, !dbg !125
+  %366 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %365, align 8, !dbg !125, !tbaa !17
+  %367 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %366, i64 0, i32 3, !dbg !125
+  %368 = bitcast i64* %367 to %struct.rb_captured_block*, !dbg !125
+  %369 = getelementptr inbounds i64, i64* %367, i64 2, !dbg !125
+  %370 = bitcast i64* %369 to %struct.vm_ifunc**, !dbg !125
+  store %struct.vm_ifunc* %357, %struct.vm_ifunc** %370, align 8, !dbg !125, !tbaa !27
   call void @llvm.experimental.noalias.scope.decl(metadata !126) #13, !dbg !125
-  %374 = ptrtoint %struct.rb_captured_block* %371 to i64, !dbg !125
-  %375 = or i64 %374, 3, !dbg !125
-  %376 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %367, i64 0, i32 17, !dbg !125
-  %377 = and i64 %375, -4, !dbg !129
-  %378 = inttoptr i64 %377 to %struct.rb_captured_block*, !dbg !129
-  store i64 0, i64* %376, align 8, !dbg !129, !tbaa !90
-  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %378) #13, !dbg !129
-  %379 = load i64, i64* %68, align 8, !dbg !129, !tbaa !25
-  %380 = and i64 %379, 8192, !dbg !129
-  %381 = icmp eq i64 %380, 0, !dbg !129
-  br i1 %381, label %385, label %382, !dbg !129
+  %371 = ptrtoint %struct.rb_captured_block* %368 to i64, !dbg !125
+  %372 = or i64 %371, 3, !dbg !125
+  %373 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %364, i64 0, i32 17, !dbg !125
+  %374 = and i64 %372, -4, !dbg !129
+  %375 = inttoptr i64 %374 to %struct.rb_captured_block*, !dbg !129
+  store i64 0, i64* %373, align 8, !dbg !129, !tbaa !90
+  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %375) #13, !dbg !129
+  %376 = load i64, i64* %65, align 8, !dbg !129, !tbaa !25
+  %377 = and i64 %376, 8192, !dbg !129
+  %378 = icmp eq i64 %377, 0, !dbg !129
+  br i1 %378, label %382, label %379, !dbg !129
+
+379:                                              ; preds = %rb_check_arity.1.exit.i.i
+  %380 = lshr i64 %376, 15, !dbg !129
+  %381 = and i64 %380, 3, !dbg !129
+  br label %rb_array_len.exit1.i.i, !dbg !129
 
 382:                                              ; preds = %rb_check_arity.1.exit.i.i
-  %383 = lshr i64 %379, 15, !dbg !129
-  %384 = and i64 %383, 3, !dbg !129
+  %383 = inttoptr i64 %43 to %struct.RArray*, !dbg !129
+  %384 = getelementptr inbounds %struct.RArray, %struct.RArray* %383, i64 0, i32 1, i32 0, i32 0, !dbg !129
+  %385 = load i64, i64* %384, align 8, !dbg !129, !tbaa !27
   br label %rb_array_len.exit1.i.i, !dbg !129
 
-385:                                              ; preds = %rb_check_arity.1.exit.i.i
-  %386 = inttoptr i64 %46 to %struct.RArray*, !dbg !129
-  %387 = getelementptr inbounds %struct.RArray, %struct.RArray* %386, i64 0, i32 1, i32 0, i32 0, !dbg !129
-  %388 = load i64, i64* %387, align 8, !dbg !129, !tbaa !27
-  br label %rb_array_len.exit1.i.i, !dbg !129
+rb_array_len.exit1.i.i:                           ; preds = %382, %379
+  %386 = phi i64 [ %381, %379 ], [ %385, %382 ], !dbg !129
+  %387 = icmp sgt i64 %386, 0, !dbg !129
+  br i1 %387, label %388, label %forward_sorbet_rb_array_each_withBlock.10.exit.i, !dbg !129
 
-rb_array_len.exit1.i.i:                           ; preds = %385, %382
-  %389 = phi i64 [ %384, %382 ], [ %388, %385 ], !dbg !129
-  %390 = icmp sgt i64 %389, 0, !dbg !129
-  br i1 %390, label %391, label %forward_sorbet_rb_array_each_withBlock.10.exit.i, !dbg !129
+388:                                              ; preds = %rb_array_len.exit1.i.i
+  %389 = bitcast i64* %2 to i8*, !dbg !129
+  %390 = inttoptr i64 %43 to %struct.RArray*, !dbg !125
+  %391 = getelementptr inbounds %struct.RArray, %struct.RArray* %390, i64 0, i32 1, i32 0, i32 0, !dbg !125
+  %392 = getelementptr inbounds %struct.RArray, %struct.RArray* %390, i64 0, i32 1, i32 0, i32 2, !dbg !125
+  br label %393, !dbg !129
 
-391:                                              ; preds = %rb_array_len.exit1.i.i
-  %392 = bitcast i64* %2 to i8*, !dbg !129
-  %393 = inttoptr i64 %46 to %struct.RArray*, !dbg !125
-  %394 = getelementptr inbounds %struct.RArray, %struct.RArray* %393, i64 0, i32 1, i32 0, i32 0, !dbg !125
-  %395 = getelementptr inbounds %struct.RArray, %struct.RArray* %393, i64 0, i32 1, i32 0, i32 2, !dbg !125
-  br label %396, !dbg !129
+393:                                              ; preds = %rb_array_len.exit.i.i, %388
+  %394 = phi i64 [ 0, %388 ], [ %404, %rb_array_len.exit.i.i ], !dbg !129
+  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 dereferenceable(8) %389) #13, !dbg !129
+  %395 = load i64, i64* %65, align 8, !dbg !129, !tbaa !25
+  %396 = and i64 %395, 8192, !dbg !129
+  %397 = icmp eq i64 %396, 0, !dbg !129
+  br i1 %397, label %398, label %rb_array_const_ptr_transient.exit.i.i, !dbg !129
 
-396:                                              ; preds = %rb_array_len.exit.i.i, %391
-  %397 = phi i64 [ 0, %391 ], [ %407, %rb_array_len.exit.i.i ], !dbg !129
-  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 dereferenceable(8) %392) #13, !dbg !129
-  %398 = load i64, i64* %68, align 8, !dbg !129, !tbaa !25
-  %399 = and i64 %398, 8192, !dbg !129
-  %400 = icmp eq i64 %399, 0, !dbg !129
-  br i1 %400, label %401, label %rb_array_const_ptr_transient.exit.i.i, !dbg !129
-
-401:                                              ; preds = %396
-  %402 = load i64*, i64** %395, align 8, !dbg !129, !tbaa !27
+398:                                              ; preds = %393
+  %399 = load i64*, i64** %392, align 8, !dbg !129, !tbaa !27
   br label %rb_array_const_ptr_transient.exit.i.i, !dbg !129
 
-rb_array_const_ptr_transient.exit.i.i:            ; preds = %401, %396
-  %403 = phi i64* [ %402, %401 ], [ %394, %396 ], !dbg !129
-  %404 = getelementptr inbounds i64, i64* %403, i64 %397, !dbg !129
-  %405 = load i64, i64* %404, align 8, !dbg !129, !tbaa !6
-  store i64 %405, i64* %2, align 8, !dbg !129, !tbaa !6
-  %406 = call i64 @"func_<root>.17<static-init>$153$block_5"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %2, i64 undef) #13, !dbg !129
-  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %392) #13, !dbg !129
-  %407 = add nuw nsw i64 %397, 1, !dbg !129
-  %408 = load i64, i64* %68, align 8, !dbg !129, !tbaa !25
-  %409 = and i64 %408, 8192, !dbg !129
-  %410 = icmp eq i64 %409, 0, !dbg !129
-  br i1 %410, label %414, label %411, !dbg !129
+rb_array_const_ptr_transient.exit.i.i:            ; preds = %398, %393
+  %400 = phi i64* [ %399, %398 ], [ %391, %393 ], !dbg !129
+  %401 = getelementptr inbounds i64, i64* %400, i64 %394, !dbg !129
+  %402 = load i64, i64* %401, align 8, !dbg !129, !tbaa !6
+  store i64 %402, i64* %2, align 8, !dbg !129, !tbaa !6
+  %403 = call i64 @"func_<root>.17<static-init>$153$block_5"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %2, i64 undef) #13, !dbg !129
+  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %389) #13, !dbg !129
+  %404 = add nuw nsw i64 %394, 1, !dbg !129
+  %405 = load i64, i64* %65, align 8, !dbg !129, !tbaa !25
+  %406 = and i64 %405, 8192, !dbg !129
+  %407 = icmp eq i64 %406, 0, !dbg !129
+  br i1 %407, label %411, label %408, !dbg !129
+
+408:                                              ; preds = %rb_array_const_ptr_transient.exit.i.i
+  %409 = lshr i64 %405, 15, !dbg !129
+  %410 = and i64 %409, 3, !dbg !129
+  br label %rb_array_len.exit.i.i, !dbg !129
 
 411:                                              ; preds = %rb_array_const_ptr_transient.exit.i.i
-  %412 = lshr i64 %408, 15, !dbg !129
-  %413 = and i64 %412, 3, !dbg !129
+  %412 = load i64, i64* %391, align 8, !dbg !129, !tbaa !27
   br label %rb_array_len.exit.i.i, !dbg !129
 
-414:                                              ; preds = %rb_array_const_ptr_transient.exit.i.i
-  %415 = load i64, i64* %394, align 8, !dbg !129, !tbaa !27
-  br label %rb_array_len.exit.i.i, !dbg !129
-
-rb_array_len.exit.i.i:                            ; preds = %414, %411
-  %416 = phi i64 [ %413, %411 ], [ %415, %414 ], !dbg !129
-  %417 = icmp sgt i64 %416, %407, !dbg !129
-  br i1 %417, label %396, label %forward_sorbet_rb_array_each_withBlock.10.exit.i, !dbg !129, !llvm.loop !131
+rb_array_len.exit.i.i:                            ; preds = %411, %408
+  %413 = phi i64 [ %410, %408 ], [ %412, %411 ], !dbg !129
+  %414 = icmp sgt i64 %413, %404, !dbg !129
+  br i1 %414, label %393, label %forward_sorbet_rb_array_each_withBlock.10.exit.i, !dbg !129, !llvm.loop !131
 
 forward_sorbet_rb_array_each_withBlock.10.exit.i: ; preds = %rb_array_len.exit.i.i, %rb_array_len.exit1.i.i
   call void @sorbet_popFrame() #13, !dbg !129
-  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %361) #13, !dbg !125
-  %418 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !125, !tbaa !15
-  %419 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %418, i64 0, i32 5, !dbg !125
-  %420 = load i32, i32* %419, align 8, !dbg !125, !tbaa !37
-  %421 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %418, i64 0, i32 6, !dbg !125
-  %422 = load i32, i32* %421, align 4, !dbg !125, !tbaa !38
-  %423 = xor i32 %422, -1, !dbg !125
-  %424 = and i32 %423, %420, !dbg !125
-  %425 = icmp eq i32 %424, 0, !dbg !125
-  br i1 %425, label %"func_<root>.17<static-init>$153.exit", label %426, !dbg !125, !prof !31
+  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %358) #13, !dbg !125
+  %415 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !125, !tbaa !15
+  %416 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %415, i64 0, i32 5, !dbg !125
+  %417 = load i32, i32* %416, align 8, !dbg !125, !tbaa !37
+  %418 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %415, i64 0, i32 6, !dbg !125
+  %419 = load i32, i32* %418, align 4, !dbg !125, !tbaa !38
+  %420 = xor i32 %419, -1, !dbg !125
+  %421 = and i32 %420, %417, !dbg !125
+  %422 = icmp eq i32 %421, 0, !dbg !125
+  br i1 %422, label %"func_<root>.17<static-init>$153.exit", label %423, !dbg !125, !prof !31
 
-426:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.10.exit.i
-  %427 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %418, i64 0, i32 8, !dbg !125
-  %428 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %427, align 8, !dbg !125, !tbaa !39
-  %429 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %428, i32 noundef 0) #13, !dbg !125
+423:                                              ; preds = %forward_sorbet_rb_array_each_withBlock.10.exit.i
+  %424 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %415, i64 0, i32 8, !dbg !125
+  %425 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %424, align 8, !dbg !125, !tbaa !39
+  %426 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %425, i32 noundef 0) #13, !dbg !125
   br label %"func_<root>.17<static-init>$153.exit", !dbg !125
 
-"func_<root>.17<static-init>$153.exit":           ; preds = %forward_sorbet_rb_array_each_withBlock.10.exit.i, %426
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %43, align 8, !tbaa !15
-  call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %36)
+"func_<root>.17<static-init>$153.exit":           ; preds = %forward_sorbet_rb_array_each_withBlock.10.exit.i, %423
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %40, align 8, !tbaa !15
+  call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %33)
   ret void
 }
 

--- a/test/testdata/compiler/block_args.opt.ll.exp
+++ b/test/testdata/compiler/block_args.opt.ll.exp
@@ -90,8 +90,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"rubyStrFrozen_test/testdata/compiler/block_args.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [5 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
@@ -101,6 +99,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @sorbet_moduleStringTable = internal unnamed_addr constant [112 x i8] c"<top (required)>\00test/testdata/compiler/block_args.rb\00block in <top (required)>\00<build-array>\00map\00+\00puts\00master\00", align 1
 @sorbet_moduleIDTable = internal unnamed_addr global [6 x i64] zeroinitializer, align 8
 @sorbet_moduleIDDescriptors = internal unnamed_addr constant [6 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 54, i32 25 }, %struct.rb_code_position_struct { i32 80, i32 13 }, %struct.rb_code_position_struct { i32 94, i32 3 }, %struct.rb_code_position_struct { i32 98, i32 1 }, %struct.rb_code_position_struct { i32 100, i32 4 }], align 8
+@sorbet_moduleRubyStringTable = internal unnamed_addr global [3 x i64] zeroinitializer, align 8
+@sorbet_moduleRubyStringDescriptors = internal unnamed_addr constant [3 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 17, i32 36 }, %struct.rb_code_position_struct { i32 54, i32 25 }], align 8
 
 declare i64 @rb_ary_push(i64, i64) local_unnamed_addr #0
 
@@ -128,7 +128,7 @@ declare %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64) local_unnamed_addr 
 
 declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #0
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
+declare void @sorbet_vm_init_string_table(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #0
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #1
@@ -139,8 +139,6 @@ declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #1
 declare i64 @rb_ary_new_capa(i64) local_unnamed_addr #0
 
 declare i64 @rb_ary_new_from_values(i64, i64*) local_unnamed_addr #0
-
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
 
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #2
@@ -280,207 +278,199 @@ entry:
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
   tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([6 x %struct.rb_code_position_struct], [6 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 6, i8* noundef getelementptr inbounds ([112 x i8], [112 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
-  %2 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([112 x i8], [112 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #11
-  tail call void @rb_gc_register_mark_object(i64 %2) #11
-  store i64 %2, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %3 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([112 x i8], [112 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 36) #11
-  tail call void @rb_gc_register_mark_object(i64 %3) #11
-  store i64 %3, i64* @"rubyStrFrozen_test/testdata/compiler/block_args.rb", align 8
+  tail call void @sorbet_vm_init_string_table(i64* noundef getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleRubyStringTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([3 x %struct.rb_code_position_struct], [3 x %struct.rb_code_position_struct]* @sorbet_moduleRubyStringDescriptors, i32 0, i32 0), i32 noundef 3, i8* noundef getelementptr inbounds ([112 x i8], [112 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 5)
   %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
-  %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/block_args.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_args.rb", align 8
-  %4 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_args.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 3)
-  store %struct.rb_iseq_struct* %4, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %5 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([112 x i8], [112 x i8]* @sorbet_moduleStringTable, i64 0, i64 54), i64 noundef 25) #11
-  call void @rb_gc_register_mark_object(i64 %5) #11
-  %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %"rubyStr_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 0), align 8, !invariant.load !5
+  %"rubyStr_test/testdata/compiler/block_args.rb.i.i" = load i64, i64* getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
+  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_args.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 3)
+  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
   %"rubyId_block in <top (required)>.i.i" = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/block_args.rb.i3.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_args.rb", align 8
-  %6 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %5, i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_args.rb.i3.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
-  store %struct.rb_iseq_struct* %6, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1", align 8
-  %7 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_1", i8* noundef null, i32 noundef 1, i32 noundef 1) #11
-  %8 = ptrtoint %struct.vm_ifunc* %7 to i64
-  %9 = call i64 @sorbet_globalConstRegister(i64 %8)
-  store i64 %9, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8
+  %"rubyStr_block in <top (required)>.i.i" = load i64, i64* getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 2), align 8, !invariant.load !5
+  %3 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i.i", i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_args.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* %2, i32 noundef 2, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
+  store %struct.rb_iseq_struct* %3, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1", align 8
+  %4 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_1", i8* noundef null, i32 noundef 1, i32 noundef 1) #11
+  %5 = ptrtoint %struct.vm_ifunc* %4 to i64
+  %6 = call i64 @sorbet_globalConstRegister(i64 %5)
+  store i64 %6, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8
   %"rubyId_+.i" = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !dbg !26, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_+", i64 %"rubyId_+.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !26
   %rubyId_puts.i = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleIDTable, i64 0, i64 5), align 8, !dbg !38, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !38
-  %10 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !15
-  %11 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %10, i64 0, i32 18
-  %12 = load i64, i64* %11, align 8, !tbaa !39
-  %13 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
-  %14 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %13, i64 0, i32 2
-  %15 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %14, align 8, !tbaa !17
-  %16 = bitcast [3 x i64]* %callArgs.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %16)
+  %7 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !15
+  %8 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %7, i64 0, i32 18
+  %9 = load i64, i64* %8, align 8, !tbaa !39
+  %10 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
+  %11 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %10, i64 0, i32 2
+  %12 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %11, align 8, !tbaa !17
+  %13 = bitcast [3 x i64]* %callArgs.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %13)
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %17 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %14, align 8, !tbaa !17
-  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %18, align 8, !tbaa !21
-  %19 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 4
-  %20 = load i64*, i64** %19, align 8, !tbaa !23
-  %21 = load i64, i64* %20, align 8, !tbaa !6
-  %22 = and i64 %21, -33
-  store i64 %22, i64* %20, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %13, %struct.rb_control_frame_struct* %17, %struct.rb_iseq_struct* %stackFrame.i) #11
-  %23 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 0
-  store i64* getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %23, align 8, !dbg !48, !tbaa !15
+  %14 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %11, align 8, !tbaa !17
+  %15 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %14, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %15, align 8, !tbaa !21
+  %16 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %14, i64 0, i32 4
+  %17 = load i64*, i64** %16, align 8, !tbaa !23
+  %18 = load i64, i64* %17, align 8, !tbaa !6
+  %19 = and i64 %18, -33
+  store i64 %19, i64* %17, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %10, %struct.rb_control_frame_struct* %14, %struct.rb_iseq_struct* %stackFrame.i) #11
+  %20 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 0
+  store i64* getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %20, align 8, !dbg !48, !tbaa !15
   %callArgs0Addr.i = getelementptr [3 x i64], [3 x i64]* %callArgs.i, i64 0, i64 0, !dbg !49
-  %24 = bitcast i64* %callArgs0Addr.i to <2 x i64>*, !dbg !49
-  store <2 x i64> <i64 3, i64 5>, <2 x i64>* %24, align 8, !dbg !49
+  %21 = bitcast i64* %callArgs0Addr.i to <2 x i64>*, !dbg !49
+  store <2 x i64> <i64 3, i64 5>, <2 x i64>* %21, align 8, !dbg !49
   call void @llvm.experimental.noalias.scope.decl(metadata !50) #11, !dbg !49
-  %25 = call i64 @rb_ary_new_from_values(i64 noundef 2, i64* noundef nonnull align 8 %callArgs0Addr.i) #11, !dbg !49
+  %22 = call i64 @rb_ary_new_from_values(i64 noundef 2, i64* noundef nonnull align 8 %callArgs0Addr.i) #11, !dbg !49
   %rubyId_map.i = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !49, !invariant.load !5
-  %26 = load i64, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8, !dbg !49
-  %27 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %26) #11, !dbg !49
-  %28 = bitcast %struct.sorbet_inlineIntrinsicEnv* %1 to i8*, !dbg !49
-  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %28) #11, !dbg !49
-  %29 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %1, i64 0, i32 0, !dbg !49
-  store i64 %25, i64* %29, align 8, !dbg !49, !tbaa !53
-  %30 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %1, i64 0, i32 1, !dbg !49
-  store i64 %rubyId_map.i, i64* %30, align 8, !dbg !49, !tbaa !55
-  %31 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %1, i64 0, i32 2, !dbg !49
-  store i32 0, i32* %31, align 8, !dbg !49, !tbaa !56
-  %32 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %1, i64 0, i32 3, !dbg !49
-  %33 = bitcast i64** %32 to i8*, !dbg !49
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %33, i8 0, i64 16, i1 false) #11, !dbg !49
-  %34 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !49, !tbaa !15
-  %35 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %34, i64 0, i32 2, !dbg !49
-  %36 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %35, align 8, !dbg !49, !tbaa !17
-  %37 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 3, !dbg !49
-  %38 = bitcast i64* %37 to %struct.rb_captured_block*, !dbg !49
-  %39 = getelementptr inbounds i64, i64* %37, i64 2, !dbg !49
-  %40 = bitcast i64* %39 to %struct.vm_ifunc**, !dbg !49
-  store %struct.vm_ifunc* %27, %struct.vm_ifunc** %40, align 8, !dbg !49, !tbaa !57
+  %23 = load i64, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8, !dbg !49
+  %24 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %23) #11, !dbg !49
+  %25 = bitcast %struct.sorbet_inlineIntrinsicEnv* %1 to i8*, !dbg !49
+  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %25) #11, !dbg !49
+  %26 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %1, i64 0, i32 0, !dbg !49
+  store i64 %22, i64* %26, align 8, !dbg !49, !tbaa !53
+  %27 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %1, i64 0, i32 1, !dbg !49
+  store i64 %rubyId_map.i, i64* %27, align 8, !dbg !49, !tbaa !55
+  %28 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %1, i64 0, i32 2, !dbg !49
+  store i32 0, i32* %28, align 8, !dbg !49, !tbaa !56
+  %29 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %1, i64 0, i32 3, !dbg !49
+  %30 = bitcast i64** %29 to i8*, !dbg !49
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %30, i8 0, i64 16, i1 false) #11, !dbg !49
+  %31 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !49, !tbaa !15
+  %32 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %31, i64 0, i32 2, !dbg !49
+  %33 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %32, align 8, !dbg !49, !tbaa !17
+  %34 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 3, !dbg !49
+  %35 = bitcast i64* %34 to %struct.rb_captured_block*, !dbg !49
+  %36 = getelementptr inbounds i64, i64* %34, i64 2, !dbg !49
+  %37 = bitcast i64* %36 to %struct.vm_ifunc**, !dbg !49
+  store %struct.vm_ifunc* %24, %struct.vm_ifunc** %37, align 8, !dbg !49, !tbaa !57
   call void @llvm.experimental.noalias.scope.decl(metadata !58) #11, !dbg !49
-  %41 = ptrtoint %struct.rb_captured_block* %38 to i64, !dbg !49
-  %42 = or i64 %41, 3, !dbg !49
-  %43 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %34, i64 0, i32 17, !dbg !49
-  %44 = and i64 %42, -4, !dbg !61
-  %45 = inttoptr i64 %44 to %struct.rb_captured_block*, !dbg !61
-  store i64 0, i64* %43, align 8, !dbg !61, !tbaa !63
-  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %45) #11, !dbg !61
-  %46 = inttoptr i64 %25 to %struct.iseq_inline_iv_cache_entry*, !dbg !61
-  %47 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %46, i64 0, i32 0, !dbg !61
-  %48 = load i64, i64* %47, align 8, !dbg !61, !tbaa !27
-  %49 = and i64 %48, 8192, !dbg !61
-  %50 = icmp eq i64 %49, 0, !dbg !61
-  br i1 %50, label %54, label %51, !dbg !61
+  %38 = ptrtoint %struct.rb_captured_block* %35 to i64, !dbg !49
+  %39 = or i64 %38, 3, !dbg !49
+  %40 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %31, i64 0, i32 17, !dbg !49
+  %41 = and i64 %39, -4, !dbg !61
+  %42 = inttoptr i64 %41 to %struct.rb_captured_block*, !dbg !61
+  store i64 0, i64* %40, align 8, !dbg !61, !tbaa !63
+  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %42) #11, !dbg !61
+  %43 = inttoptr i64 %22 to %struct.iseq_inline_iv_cache_entry*, !dbg !61
+  %44 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %43, i64 0, i32 0, !dbg !61
+  %45 = load i64, i64* %44, align 8, !dbg !61, !tbaa !27
+  %46 = and i64 %45, 8192, !dbg !61
+  %47 = icmp eq i64 %46, 0, !dbg !61
+  br i1 %47, label %51, label %48, !dbg !61
+
+48:                                               ; preds = %entry
+  %49 = lshr i64 %45, 15, !dbg !61
+  %50 = and i64 %49, 3, !dbg !61
+  br label %rb_array_len.exit2.i.i, !dbg !61
 
 51:                                               ; preds = %entry
-  %52 = lshr i64 %48, 15, !dbg !61
-  %53 = and i64 %52, 3, !dbg !61
+  %52 = inttoptr i64 %22 to %struct.RArray*, !dbg !61
+  %53 = getelementptr inbounds %struct.RArray, %struct.RArray* %52, i64 0, i32 1, i32 0, i32 0, !dbg !61
+  %54 = load i64, i64* %53, align 8, !dbg !61, !tbaa !57
   br label %rb_array_len.exit2.i.i, !dbg !61
 
-54:                                               ; preds = %entry
-  %55 = inttoptr i64 %25 to %struct.RArray*, !dbg !61
-  %56 = getelementptr inbounds %struct.RArray, %struct.RArray* %55, i64 0, i32 1, i32 0, i32 0, !dbg !61
-  %57 = load i64, i64* %56, align 8, !dbg !61, !tbaa !57
-  br label %rb_array_len.exit2.i.i, !dbg !61
+rb_array_len.exit2.i.i:                           ; preds = %51, %48
+  %55 = phi i64 [ %50, %48 ], [ %54, %51 ], !dbg !61
+  %56 = call i64 @rb_ary_new_capa(i64 %55) #11, !dbg !61
+  %57 = load i64, i64* %44, align 8, !dbg !61, !tbaa !27
+  %58 = and i64 %57, 8192, !dbg !61
+  %59 = icmp eq i64 %58, 0, !dbg !61
+  br i1 %59, label %63, label %60, !dbg !61
 
-rb_array_len.exit2.i.i:                           ; preds = %54, %51
-  %58 = phi i64 [ %53, %51 ], [ %57, %54 ], !dbg !61
-  %59 = call i64 @rb_ary_new_capa(i64 %58) #11, !dbg !61
-  %60 = load i64, i64* %47, align 8, !dbg !61, !tbaa !27
-  %61 = and i64 %60, 8192, !dbg !61
-  %62 = icmp eq i64 %61, 0, !dbg !61
-  br i1 %62, label %66, label %63, !dbg !61
+60:                                               ; preds = %rb_array_len.exit2.i.i
+  %61 = lshr i64 %57, 15, !dbg !61
+  %62 = and i64 %61, 3, !dbg !61
+  br label %rb_array_len.exit1.i.i, !dbg !61
 
 63:                                               ; preds = %rb_array_len.exit2.i.i
-  %64 = lshr i64 %60, 15, !dbg !61
-  %65 = and i64 %64, 3, !dbg !61
+  %64 = inttoptr i64 %22 to %struct.RArray*, !dbg !61
+  %65 = getelementptr inbounds %struct.RArray, %struct.RArray* %64, i64 0, i32 1, i32 0, i32 0, !dbg !61
+  %66 = load i64, i64* %65, align 8, !dbg !61, !tbaa !57
   br label %rb_array_len.exit1.i.i, !dbg !61
 
-66:                                               ; preds = %rb_array_len.exit2.i.i
-  %67 = inttoptr i64 %25 to %struct.RArray*, !dbg !61
-  %68 = getelementptr inbounds %struct.RArray, %struct.RArray* %67, i64 0, i32 1, i32 0, i32 0, !dbg !61
-  %69 = load i64, i64* %68, align 8, !dbg !61, !tbaa !57
-  br label %rb_array_len.exit1.i.i, !dbg !61
+rb_array_len.exit1.i.i:                           ; preds = %63, %60
+  %67 = phi i64 [ %62, %60 ], [ %66, %63 ], !dbg !61
+  %68 = icmp sgt i64 %67, 0, !dbg !61
+  br i1 %68, label %69, label %forward_sorbet_rb_array_collect_withBlock.exit.i, !dbg !61
 
-rb_array_len.exit1.i.i:                           ; preds = %66, %63
-  %70 = phi i64 [ %65, %63 ], [ %69, %66 ], !dbg !61
-  %71 = icmp sgt i64 %70, 0, !dbg !61
-  br i1 %71, label %72, label %forward_sorbet_rb_array_collect_withBlock.exit.i, !dbg !61
+69:                                               ; preds = %rb_array_len.exit1.i.i
+  %70 = bitcast i64* %0 to i8*, !dbg !61
+  %71 = inttoptr i64 %22 to %struct.RArray*, !dbg !49
+  %72 = getelementptr inbounds %struct.RArray, %struct.RArray* %71, i64 0, i32 1, i32 0, i32 0, !dbg !49
+  %73 = getelementptr inbounds %struct.RArray, %struct.RArray* %71, i64 0, i32 1, i32 0, i32 2, !dbg !49
+  br label %74, !dbg !61
 
-72:                                               ; preds = %rb_array_len.exit1.i.i
-  %73 = bitcast i64* %0 to i8*, !dbg !61
-  %74 = inttoptr i64 %25 to %struct.RArray*, !dbg !49
-  %75 = getelementptr inbounds %struct.RArray, %struct.RArray* %74, i64 0, i32 1, i32 0, i32 0, !dbg !49
-  %76 = getelementptr inbounds %struct.RArray, %struct.RArray* %74, i64 0, i32 1, i32 0, i32 2, !dbg !49
-  br label %77, !dbg !61
+74:                                               ; preds = %rb_array_len.exit.i.i, %69
+  %75 = phi i64 [ 0, %69 ], [ %86, %rb_array_len.exit.i.i ], !dbg !61
+  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 dereferenceable(8) %70) #11, !dbg !61
+  %76 = load i64, i64* %44, align 8, !dbg !61, !tbaa !27
+  %77 = and i64 %76, 8192, !dbg !61
+  %78 = icmp eq i64 %77, 0, !dbg !61
+  br i1 %78, label %79, label %rb_array_const_ptr_transient.exit.i.i, !dbg !61
 
-77:                                               ; preds = %rb_array_len.exit.i.i, %72
-  %78 = phi i64 [ 0, %72 ], [ %89, %rb_array_len.exit.i.i ], !dbg !61
-  call void @llvm.lifetime.start.p0i8(i64 noundef 8, i8* noundef nonnull align 8 dereferenceable(8) %73) #11, !dbg !61
-  %79 = load i64, i64* %47, align 8, !dbg !61, !tbaa !27
-  %80 = and i64 %79, 8192, !dbg !61
-  %81 = icmp eq i64 %80, 0, !dbg !61
-  br i1 %81, label %82, label %rb_array_const_ptr_transient.exit.i.i, !dbg !61
-
-82:                                               ; preds = %77
-  %83 = load i64*, i64** %76, align 8, !dbg !61, !tbaa !57
+79:                                               ; preds = %74
+  %80 = load i64*, i64** %73, align 8, !dbg !61, !tbaa !57
   br label %rb_array_const_ptr_transient.exit.i.i, !dbg !61
 
-rb_array_const_ptr_transient.exit.i.i:            ; preds = %82, %77
-  %84 = phi i64* [ %83, %82 ], [ %75, %77 ], !dbg !61
-  %85 = getelementptr inbounds i64, i64* %84, i64 %78, !dbg !61
-  %86 = load i64, i64* %85, align 8, !dbg !61, !tbaa !6
-  store i64 %86, i64* %0, align 8, !dbg !61, !tbaa !6
-  %87 = call i64 @"func_<root>.17<static-init>$153$block_1"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %0, i64 undef) #11, !dbg !61
-  %88 = call i64 @rb_ary_push(i64 %59, i64 %87) #11, !dbg !61
-  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %73) #11, !dbg !61
-  %89 = add nuw nsw i64 %78, 1, !dbg !61
-  %90 = load i64, i64* %47, align 8, !dbg !61, !tbaa !27
-  %91 = and i64 %90, 8192, !dbg !61
-  %92 = icmp eq i64 %91, 0, !dbg !61
-  br i1 %92, label %96, label %93, !dbg !61
+rb_array_const_ptr_transient.exit.i.i:            ; preds = %79, %74
+  %81 = phi i64* [ %80, %79 ], [ %72, %74 ], !dbg !61
+  %82 = getelementptr inbounds i64, i64* %81, i64 %75, !dbg !61
+  %83 = load i64, i64* %82, align 8, !dbg !61, !tbaa !6
+  store i64 %83, i64* %0, align 8, !dbg !61, !tbaa !6
+  %84 = call i64 @"func_<root>.17<static-init>$153$block_1"(i64 undef, i64 undef, i32 noundef 1, i64* noalias nocapture noundef nonnull readonly align 8 dereferenceable(8) %0, i64 undef) #11, !dbg !61
+  %85 = call i64 @rb_ary_push(i64 %56, i64 %84) #11, !dbg !61
+  call void @llvm.lifetime.end.p0i8(i64 noundef 8, i8* noundef nonnull %70) #11, !dbg !61
+  %86 = add nuw nsw i64 %75, 1, !dbg !61
+  %87 = load i64, i64* %44, align 8, !dbg !61, !tbaa !27
+  %88 = and i64 %87, 8192, !dbg !61
+  %89 = icmp eq i64 %88, 0, !dbg !61
+  br i1 %89, label %93, label %90, !dbg !61
+
+90:                                               ; preds = %rb_array_const_ptr_transient.exit.i.i
+  %91 = lshr i64 %87, 15, !dbg !61
+  %92 = and i64 %91, 3, !dbg !61
+  br label %rb_array_len.exit.i.i, !dbg !61
 
 93:                                               ; preds = %rb_array_const_ptr_transient.exit.i.i
-  %94 = lshr i64 %90, 15, !dbg !61
-  %95 = and i64 %94, 3, !dbg !61
+  %94 = load i64, i64* %72, align 8, !dbg !61, !tbaa !57
   br label %rb_array_len.exit.i.i, !dbg !61
 
-96:                                               ; preds = %rb_array_const_ptr_transient.exit.i.i
-  %97 = load i64, i64* %75, align 8, !dbg !61, !tbaa !57
-  br label %rb_array_len.exit.i.i, !dbg !61
-
-rb_array_len.exit.i.i:                            ; preds = %96, %93
-  %98 = phi i64 [ %95, %93 ], [ %97, %96 ], !dbg !61
-  %99 = icmp slt i64 %89, %98, !dbg !61
-  br i1 %99, label %77, label %forward_sorbet_rb_array_collect_withBlock.exit.i, !dbg !61, !llvm.loop !64
+rb_array_len.exit.i.i:                            ; preds = %93, %90
+  %95 = phi i64 [ %92, %90 ], [ %94, %93 ], !dbg !61
+  %96 = icmp slt i64 %86, %95, !dbg !61
+  br i1 %96, label %74, label %forward_sorbet_rb_array_collect_withBlock.exit.i, !dbg !61, !llvm.loop !64
 
 forward_sorbet_rb_array_collect_withBlock.exit.i: ; preds = %rb_array_len.exit.i.i, %rb_array_len.exit1.i.i
   call void @sorbet_popFrame() #11, !dbg !61
-  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %28) #11, !dbg !49
-  %100 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !49, !tbaa !15
-  %101 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %100, i64 0, i32 5, !dbg !49
-  %102 = load i32, i32* %101, align 8, !dbg !49, !tbaa !35
-  %103 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %100, i64 0, i32 6, !dbg !49
-  %104 = load i32, i32* %103, align 4, !dbg !49, !tbaa !36
-  %105 = xor i32 %104, -1, !dbg !49
-  %106 = and i32 %105, %102, !dbg !49
-  %107 = icmp eq i32 %106, 0, !dbg !49
-  br i1 %107, label %"func_<root>.17<static-init>$153.exit", label %108, !dbg !49, !prof !29
+  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %25) #11, !dbg !49
+  %97 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !49, !tbaa !15
+  %98 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %97, i64 0, i32 5, !dbg !49
+  %99 = load i32, i32* %98, align 8, !dbg !49, !tbaa !35
+  %100 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %97, i64 0, i32 6, !dbg !49
+  %101 = load i32, i32* %100, align 4, !dbg !49, !tbaa !36
+  %102 = xor i32 %101, -1, !dbg !49
+  %103 = and i32 %102, %99, !dbg !49
+  %104 = icmp eq i32 %103, 0, !dbg !49
+  br i1 %104, label %"func_<root>.17<static-init>$153.exit", label %105, !dbg !49, !prof !29
 
-108:                                              ; preds = %forward_sorbet_rb_array_collect_withBlock.exit.i
-  %109 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %100, i64 0, i32 8, !dbg !49
-  %110 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %109, align 8, !dbg !49, !tbaa !37
-  %111 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %110, i32 noundef 0) #11, !dbg !49
+105:                                              ; preds = %forward_sorbet_rb_array_collect_withBlock.exit.i
+  %106 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %97, i64 0, i32 8, !dbg !49
+  %107 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %106, align 8, !dbg !49, !tbaa !37
+  %108 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %107, i32 noundef 0) #11, !dbg !49
   br label %"func_<root>.17<static-init>$153.exit", !dbg !49
 
-"func_<root>.17<static-init>$153.exit":           ; preds = %forward_sorbet_rb_array_collect_withBlock.exit.i, %108
-  store i64* getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %23, align 8, !tbaa !15
-  %112 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 1, !dbg !38
-  %113 = load i64*, i64** %112, align 8, !dbg !38
-  store i64 %12, i64* %113, align 8, !dbg !38, !tbaa !6
-  %114 = getelementptr inbounds i64, i64* %113, i64 1, !dbg !38
-  store i64 %59, i64* %114, align 8, !dbg !38, !tbaa !6
-  %115 = getelementptr inbounds i64, i64* %114, i64 1, !dbg !38
-  store i64* %115, i64** %112, align 8, !dbg !38
+"func_<root>.17<static-init>$153.exit":           ; preds = %forward_sorbet_rb_array_collect_withBlock.exit.i, %105
+  store i64* getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %20, align 8, !tbaa !15
+  %109 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 1, !dbg !38
+  %110 = load i64*, i64** %109, align 8, !dbg !38
+  store i64 %9, i64* %110, align 8, !dbg !38, !tbaa !6
+  %111 = getelementptr inbounds i64, i64* %110, i64 1, !dbg !38
+  store i64 %56, i64* %111, align 8, !dbg !38, !tbaa !6
+  %112 = getelementptr inbounds i64, i64* %111, i64 1, !dbg !38
+  store i64* %112, i64** %109, align 8, !dbg !38
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !38
-  call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %16)
+  call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %13)
   ret void
 }
 

--- a/test/testdata/compiler/block_no_args.opt.ll.exp
+++ b/test/testdata/compiler/block_no_args.opt.ll.exp
@@ -83,17 +83,16 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"rubyStrFrozen_test/testdata/compiler/block_no_args.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [7 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"func_<root>.17<static-init>$153$block_1_ifunc" = internal unnamed_addr global i64 0
-@rubyStrFrozen_hi = internal unnamed_addr global i64 0, align 8
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
 @sorbet_moduleStringTable = internal unnamed_addr constant [111 x i8] c"<top (required)>\00test/testdata/compiler/block_no_args.rb\00block in <top (required)>\00times\00hi\00puts\00Kernel\00master\00", align 1
 @sorbet_moduleIDTable = internal unnamed_addr global [4 x i64] zeroinitializer, align 8
 @sorbet_moduleIDDescriptors = internal unnamed_addr constant [4 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 57, i32 25 }, %struct.rb_code_position_struct { i32 83, i32 5 }, %struct.rb_code_position_struct { i32 92, i32 4 }], align 8
+@sorbet_moduleRubyStringTable = internal unnamed_addr global [4 x i64] zeroinitializer, align 8
+@sorbet_moduleRubyStringDescriptors = internal unnamed_addr constant [4 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 17, i32 39 }, %struct.rb_code_position_struct { i32 57, i32 25 }, %struct.rb_code_position_struct { i32 89, i32 2 }], align 8
 @rb_mKernel = external local_unnamed_addr constant i64
 
 declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
@@ -118,9 +117,7 @@ declare %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64) local_unnamed_addr 
 
 declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #0
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
-
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
+declare void @sorbet_vm_init_string_table(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #0
 
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #1
@@ -159,7 +156,7 @@ functionEntryInitializers:
   store i64 %7, i64* %5, align 8, !tbaa !6
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
   store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %8, align 8, !dbg !24, !tbaa !15
-  %rubyStr_hi = load i64, i64* @rubyStrFrozen_hi, align 8, !dbg !25
+  %rubyStr_hi = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 3), align 8, !dbg !25, !invariant.load !5
   %9 = load i64, i64* @rb_mKernel, align 8, !dbg !26
   %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !26
   %11 = load i64*, i64** %10, align 8, !dbg !26
@@ -179,118 +176,107 @@ entry:
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
   tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([4 x %struct.rb_code_position_struct], [4 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 4, i8* noundef getelementptr inbounds ([111 x i8], [111 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
-  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([111 x i8], [111 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #7
-  tail call void @rb_gc_register_mark_object(i64 %0) #7
-  store i64 %0, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %1 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([111 x i8], [111 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 39) #7
-  tail call void @rb_gc_register_mark_object(i64 %1) #7
-  store i64 %1, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args.rb", align 8
+  tail call void @sorbet_vm_init_string_table(i64* noundef getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleRubyStringTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([4 x %struct.rb_code_position_struct], [4 x %struct.rb_code_position_struct]* @sorbet_moduleRubyStringDescriptors, i32 0, i32 0), i32 noundef 4, i8* noundef getelementptr inbounds ([111 x i8], [111 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 7)
   %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
-  %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/block_no_args.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args.rb", align 8
-  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_no_args.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %3 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([111 x i8], [111 x i8]* @sorbet_moduleStringTable, i64 0, i64 57), i64 noundef 25) #7
-  call void @rb_gc_register_mark_object(i64 %3) #7
-  %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %"rubyStr_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 0), align 8, !invariant.load !5
+  %"rubyStr_test/testdata/compiler/block_no_args.rb.i.i" = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
+  %0 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_no_args.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %0, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
   %"rubyId_block in <top (required)>.i.i" = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/block_no_args.rb.i2.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args.rb", align 8
-  %4 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %3, i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_no_args.rb.i2.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %4, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1", align 8
-  %5 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_1", i8* noundef null, i32 noundef 0, i32 noundef 0) #7
-  %6 = ptrtoint %struct.vm_ifunc* %5 to i64
-  %7 = call i64 @sorbet_globalConstRegister(i64 %6)
-  store i64 %7, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8
-  %8 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([111 x i8], [111 x i8]* @sorbet_moduleStringTable, i64 0, i64 89), i64 noundef 2) #7
-  call void @rb_gc_register_mark_object(i64 %8) #7
-  store i64 %8, i64* @rubyStrFrozen_hi, align 8
+  %"rubyStr_block in <top (required)>.i.i" = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 2), align 8, !invariant.load !5
+  %1 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i.i", i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_no_args.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* %0, i32 noundef 2, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %1, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1", align 8
+  %2 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_1", i8* noundef null, i32 noundef 0, i32 noundef 0) #7
+  %3 = ptrtoint %struct.vm_ifunc* %2 to i64
+  %4 = call i64 @sorbet_globalConstRegister(i64 %3)
+  store i64 %4, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8
   %rubyId_puts.i = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !26, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !26
-  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
-  %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 2
-  %11 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %10, align 8, !tbaa !17
+  %5 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
+  %6 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %5, i64 0, i32 2
+  %7 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %6, align 8, !tbaa !17
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %12, align 8, !tbaa !21
-  %13 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 4
-  %14 = load i64*, i64** %13, align 8, !tbaa !23
-  %15 = load i64, i64* %14, align 8, !tbaa !6
-  %16 = and i64 %15, -33
-  store i64 %16, i64* %14, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %9, %struct.rb_control_frame_struct* %11, %struct.rb_iseq_struct* %stackFrame.i) #7
-  %17 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 0
-  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %17, align 8, !dbg !27, !tbaa !15
-  %18 = load i64, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8, !dbg !28
-  %19 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %18) #7, !dbg !28
-  %20 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !28, !tbaa !15
-  %21 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %20, i64 0, i32 2, !dbg !28
-  %22 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %21, align 8, !dbg !28, !tbaa !17
-  %23 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %22, i64 0, i32 3, !dbg !28
-  %24 = bitcast i64* %23 to %struct.rb_captured_block*, !dbg !28
-  %25 = getelementptr inbounds i64, i64* %23, i64 2, !dbg !28
-  %26 = bitcast i64* %25 to %struct.vm_ifunc**, !dbg !28
-  store %struct.vm_ifunc* %19, %struct.vm_ifunc** %26, align 8, !dbg !28, !tbaa !29
+  %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %7, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %8, align 8, !tbaa !21
+  %9 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %7, i64 0, i32 4
+  %10 = load i64*, i64** %9, align 8, !tbaa !23
+  %11 = load i64, i64* %10, align 8, !tbaa !6
+  %12 = and i64 %11, -33
+  store i64 %12, i64* %10, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %5, %struct.rb_control_frame_struct* %7, %struct.rb_iseq_struct* %stackFrame.i) #7
+  %13 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %7, i64 0, i32 0
+  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %13, align 8, !dbg !27, !tbaa !15
+  %14 = load i64, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8, !dbg !28
+  %15 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %14) #7, !dbg !28
+  %16 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !28, !tbaa !15
+  %17 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 2, !dbg !28
+  %18 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %17, align 8, !dbg !28, !tbaa !17
+  %19 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 3, !dbg !28
+  %20 = bitcast i64* %19 to %struct.rb_captured_block*, !dbg !28
+  %21 = getelementptr inbounds i64, i64* %19, i64 2, !dbg !28
+  %22 = bitcast i64* %21 to %struct.vm_ifunc**, !dbg !28
+  store %struct.vm_ifunc* %15, %struct.vm_ifunc** %22, align 8, !dbg !28, !tbaa !29
   call void @llvm.experimental.noalias.scope.decl(metadata !30) #7, !dbg !28
-  %27 = ptrtoint %struct.rb_captured_block* %24 to i64, !dbg !28
-  %28 = or i64 %27, 3, !dbg !28
-  %29 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %20, i64 0, i32 17, !dbg !28
-  %30 = and i64 %28, -4, !dbg !33
-  %31 = inttoptr i64 %30 to %struct.rb_captured_block*, !dbg !33
-  store i64 0, i64* %29, align 8, !dbg !33, !tbaa !35
-  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %31) #7, !dbg !33
-  %32 = load i64, i64* @rb_mKernel, align 8, !dbg !28
-  br label %33, !dbg !33
+  %23 = ptrtoint %struct.rb_captured_block* %20 to i64, !dbg !28
+  %24 = or i64 %23, 3, !dbg !28
+  %25 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 17, !dbg !28
+  %26 = and i64 %24, -4, !dbg !33
+  %27 = inttoptr i64 %26 to %struct.rb_captured_block*, !dbg !33
+  store i64 0, i64* %25, align 8, !dbg !33, !tbaa !35
+  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %27) #7, !dbg !33
+  %rubyStr_hi.i2.i.i = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 3), align 8, !dbg !28, !invariant.load !5
+  %28 = load i64, i64* @rb_mKernel, align 8, !dbg !28
+  br label %29, !dbg !33
 
-33:                                               ; preds = %33, %entry
-  %34 = phi i64 [ 0, %entry ], [ %48, %33 ], !dbg !33
-  %35 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !28, !tbaa !15
-  %36 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %35, i64 0, i32 2, !dbg !28
-  %37 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %36, align 8, !dbg !28, !tbaa !17
+29:                                               ; preds = %29, %entry
+  %30 = phi i64 [ 0, %entry ], [ %44, %29 ], !dbg !33
+  %31 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !28, !tbaa !15
+  %32 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %31, i64 0, i32 2, !dbg !28
+  %33 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %32, align 8, !dbg !28, !tbaa !17
   %stackFrame.i1.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1", align 8, !dbg !28
-  %38 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 2, !dbg !28
-  store %struct.rb_iseq_struct* %stackFrame.i1.i.i, %struct.rb_iseq_struct** %38, align 8, !dbg !28, !tbaa !21
-  %39 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 4, !dbg !28
-  %40 = load i64*, i64** %39, align 8, !dbg !28, !tbaa !23
-  %41 = load i64, i64* %40, align 8, !dbg !28, !tbaa !6
-  %42 = and i64 %41, -129, !dbg !28
-  store i64 %42, i64* %40, align 8, !dbg !28, !tbaa !6
-  %43 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 0, !dbg !28
-  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %43, align 8, !dbg !36, !tbaa !15
-  %rubyStr_hi.i2.i.i = load i64, i64* @rubyStrFrozen_hi, align 8, !dbg !38
-  %44 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %37, i64 0, i32 1, !dbg !39
-  %45 = load i64*, i64** %44, align 8, !dbg !39
-  store i64 %32, i64* %45, align 8, !dbg !39, !tbaa !6
-  %46 = getelementptr inbounds i64, i64* %45, i64 1, !dbg !39
-  store i64 %rubyStr_hi.i2.i.i, i64* %46, align 8, !dbg !39, !tbaa !6
-  %47 = getelementptr inbounds i64, i64* %46, i64 1, !dbg !39
-  store i64* %47, i64** %44, align 8, !dbg !39
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !39
-  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %43, align 8, !dbg !39, !tbaa !15
-  %48 = add nuw nsw i64 %34, 1, !dbg !33
-  %49 = icmp eq i64 %48, 10, !dbg !33
-  br i1 %49, label %forward_sorbet_rb_int_dotimes_withBlock.exit.i, label %33, !dbg !33, !llvm.loop !40
+  %34 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 2, !dbg !28
+  store %struct.rb_iseq_struct* %stackFrame.i1.i.i, %struct.rb_iseq_struct** %34, align 8, !dbg !28, !tbaa !21
+  %35 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 4, !dbg !28
+  %36 = load i64*, i64** %35, align 8, !dbg !28, !tbaa !23
+  %37 = load i64, i64* %36, align 8, !dbg !28, !tbaa !6
+  %38 = and i64 %37, -129, !dbg !28
+  store i64 %38, i64* %36, align 8, !dbg !28, !tbaa !6
+  %39 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 0, !dbg !28
+  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %39, align 8, !dbg !36, !tbaa !15
+  %40 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %33, i64 0, i32 1, !dbg !38
+  %41 = load i64*, i64** %40, align 8, !dbg !38
+  store i64 %28, i64* %41, align 8, !dbg !38, !tbaa !6
+  %42 = getelementptr inbounds i64, i64* %41, i64 1, !dbg !38
+  store i64 %rubyStr_hi.i2.i.i, i64* %42, align 8, !dbg !38, !tbaa !6
+  %43 = getelementptr inbounds i64, i64* %42, i64 1, !dbg !38
+  store i64* %43, i64** %40, align 8, !dbg !38
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !38
+  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %39, align 8, !dbg !38, !tbaa !15
+  %44 = add nuw nsw i64 %30, 1, !dbg !33
+  %45 = icmp eq i64 %44, 10, !dbg !33
+  br i1 %45, label %forward_sorbet_rb_int_dotimes_withBlock.exit.i, label %29, !dbg !33, !llvm.loop !39
 
-forward_sorbet_rb_int_dotimes_withBlock.exit.i:   ; preds = %33
+forward_sorbet_rb_int_dotimes_withBlock.exit.i:   ; preds = %29
   call void @sorbet_popFrame() #7, !dbg !33
-  %50 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !28, !tbaa !15
-  %51 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %50, i64 0, i32 5, !dbg !28
-  %52 = load i32, i32* %51, align 8, !dbg !28, !tbaa !42
-  %53 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %50, i64 0, i32 6, !dbg !28
-  %54 = load i32, i32* %53, align 4, !dbg !28, !tbaa !43
-  %55 = xor i32 %54, -1, !dbg !28
-  %56 = and i32 %55, %52, !dbg !28
-  %57 = icmp eq i32 %56, 0, !dbg !28
-  br i1 %57, label %"func_<root>.17<static-init>$153.exit", label %58, !dbg !28, !prof !44
+  %46 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !28, !tbaa !15
+  %47 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %46, i64 0, i32 5, !dbg !28
+  %48 = load i32, i32* %47, align 8, !dbg !28, !tbaa !41
+  %49 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %46, i64 0, i32 6, !dbg !28
+  %50 = load i32, i32* %49, align 4, !dbg !28, !tbaa !42
+  %51 = xor i32 %50, -1, !dbg !28
+  %52 = and i32 %51, %48, !dbg !28
+  %53 = icmp eq i32 %52, 0, !dbg !28
+  br i1 %53, label %"func_<root>.17<static-init>$153.exit", label %54, !dbg !28, !prof !43
 
-58:                                               ; preds = %forward_sorbet_rb_int_dotimes_withBlock.exit.i
-  %59 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %50, i64 0, i32 8, !dbg !28
-  %60 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %59, align 8, !dbg !28, !tbaa !45
-  %61 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %60, i32 noundef 0) #7, !dbg !28
+54:                                               ; preds = %forward_sorbet_rb_int_dotimes_withBlock.exit.i
+  %55 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %46, i64 0, i32 8, !dbg !28
+  %56 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %55, align 8, !dbg !28, !tbaa !44
+  %57 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %56, i32 noundef 0) #7, !dbg !28
   br label %"func_<root>.17<static-init>$153.exit", !dbg !28
 
-"func_<root>.17<static-init>$153.exit":           ; preds = %forward_sorbet_rb_int_dotimes_withBlock.exit.i, %58
-  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %17, align 8, !tbaa !15
+"func_<root>.17<static-init>$153.exit":           ; preds = %forward_sorbet_rb_int_dotimes_withBlock.exit.i, %54
+  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %13, align 8, !tbaa !15
   ret void
 }
 
@@ -347,11 +333,10 @@ attributes #7 = { nounwind }
 !35 = !{!18, !7, i64 128}
 !36 = !DILocation(line: 4, column: 1, scope: !10, inlinedAt: !37)
 !37 = distinct !DILocation(line: 4, column: 1, scope: !11, inlinedAt: !34)
-!38 = !DILocation(line: 5, column: 15, scope: !10, inlinedAt: !37)
-!39 = !DILocation(line: 5, column: 3, scope: !10, inlinedAt: !37)
-!40 = distinct !{!40, !41}
-!41 = !{!"llvm.loop.unroll.disable"}
-!42 = !{!18, !19, i64 40}
-!43 = !{!18, !19, i64 44}
-!44 = !{!"branch_weights", i32 2000, i32 1}
-!45 = !{!18, !16, i64 56}
+!38 = !DILocation(line: 5, column: 3, scope: !10, inlinedAt: !37)
+!39 = distinct !{!39, !40}
+!40 = !{!"llvm.loop.unroll.disable"}
+!41 = !{!18, !19, i64 40}
+!42 = !{!18, !19, i64 44}
+!43 = !{!"branch_weights", i32 2000, i32 1}
+!44 = !{!18, !16, i64 56}

--- a/test/testdata/compiler/block_no_args_capture.opt.ll.exp
+++ b/test/testdata/compiler/block_no_args_capture.opt.ll.exp
@@ -84,17 +84,16 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"rubyStrFrozen_test/testdata/compiler/block_no_args_capture.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [8 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@rubyStrFrozen_hi = internal unnamed_addr global i64 0, align 8
 @"func_<root>.17<static-init>$153$block_1_ifunc" = internal unnamed_addr global i64 0
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
 @sorbet_moduleStringTable = internal unnamed_addr constant [121 x i8] c"<top (required)>\00test/testdata/compiler/block_no_args_capture.rb\00s\00block in <top (required)>\00hi\00times\00puts\00Kernel\00master\00", align 1
 @sorbet_moduleIDTable = internal unnamed_addr global [5 x i64] zeroinitializer, align 8
 @sorbet_moduleIDDescriptors = internal unnamed_addr constant [5 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 65, i32 1 }, %struct.rb_code_position_struct { i32 67, i32 25 }, %struct.rb_code_position_struct { i32 96, i32 5 }, %struct.rb_code_position_struct { i32 102, i32 4 }], align 8
+@sorbet_moduleRubyStringTable = internal unnamed_addr global [4 x i64] zeroinitializer, align 8
+@sorbet_moduleRubyStringDescriptors = internal unnamed_addr constant [4 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 17, i32 47 }, %struct.rb_code_position_struct { i32 67, i32 25 }, %struct.rb_code_position_struct { i32 93, i32 2 }], align 8
 @rb_mKernel = external local_unnamed_addr constant i64
 
 declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
@@ -121,15 +120,13 @@ declare %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64) local_unnamed_addr 
 
 declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #0
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
+declare void @sorbet_vm_init_string_table(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #0
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #1
-
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
 
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #2
@@ -194,159 +191,148 @@ entry:
   %locals.i.i = alloca i64, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
   tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([5 x %struct.rb_code_position_struct], [5 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 5, i8* noundef getelementptr inbounds ([121 x i8], [121 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
-  %1 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([121 x i8], [121 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #9
-  tail call void @rb_gc_register_mark_object(i64 %1) #9
-  store i64 %1, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %2 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([121 x i8], [121 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 47) #9
-  tail call void @rb_gc_register_mark_object(i64 %2) #9
-  store i64 %2, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args_capture.rb", align 8
+  tail call void @sorbet_vm_init_string_table(i64* noundef getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleRubyStringTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([4 x %struct.rb_code_position_struct], [4 x %struct.rb_code_position_struct]* @sorbet_moduleRubyStringDescriptors, i32 0, i32 0), i32 noundef 4, i8* noundef getelementptr inbounds ([121 x i8], [121 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 8)
-  %3 = bitcast i64* %locals.i.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %3)
+  %1 = bitcast i64* %locals.i.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %1)
   %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
-  %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/block_no_args_capture.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args_capture.rb", align 8
+  %"rubyStr_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 0), align 8, !invariant.load !5
+  %"rubyStr_test/testdata/compiler/block_no_args_capture.rb.i.i" = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
   %rubyId_s.i.i = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !invariant.load !5
   store i64 %rubyId_s.i.i, i64* %locals.i.i, align 8
-  %4 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_no_args_capture.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i.i, i32 noundef 1, i32 noundef 2)
-  store %struct.rb_iseq_struct* %4, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %3)
-  %5 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([121 x i8], [121 x i8]* @sorbet_moduleStringTable, i64 0, i64 67), i64 noundef 25) #9
-  call void @rb_gc_register_mark_object(i64 %5) #9
-  %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_no_args_capture.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i.i, i32 noundef 1, i32 noundef 2)
+  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %1)
   %"rubyId_block in <top (required)>.i.i" = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/block_no_args_capture.rb.i2.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args_capture.rb", align 8
-  %6 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %5, i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_no_args_capture.rb.i2.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %6, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1", align 8
-  %7 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([121 x i8], [121 x i8]* @sorbet_moduleStringTable, i64 0, i64 93), i64 noundef 2) #9
-  call void @rb_gc_register_mark_object(i64 %7) #9
-  store i64 %7, i64* @rubyStrFrozen_hi, align 8
-  %8 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_1", i8* noundef null, i32 noundef 0, i32 noundef 0) #9
-  %9 = ptrtoint %struct.vm_ifunc* %8 to i64
-  %10 = call i64 @sorbet_globalConstRegister(i64 %9)
-  store i64 %10, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8
+  %"rubyStr_block in <top (required)>.i.i" = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 2), align 8, !invariant.load !5
+  %3 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i.i", i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_no_args_capture.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* %2, i32 noundef 2, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %3, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1", align 8
+  %4 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_1", i8* noundef null, i32 noundef 0, i32 noundef 0) #9
+  %5 = ptrtoint %struct.vm_ifunc* %4 to i64
+  %6 = call i64 @sorbet_globalConstRegister(i64 %5)
+  store i64 %6, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8
   %rubyId_puts.i = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !dbg !24, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !24
-  %11 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
-  %12 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %11, i64 0, i32 2
-  %13 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %12, align 8, !tbaa !17
+  %7 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
+  %8 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %7, i64 0, i32 2
+  %9 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %8, align 8, !tbaa !17
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %14 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %13, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %14, align 8, !tbaa !21
-  %15 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %13, i64 0, i32 4
-  %16 = load i64*, i64** %15, align 8, !tbaa !25
-  %17 = load i64, i64* %16, align 8, !tbaa !6
-  %18 = and i64 %17, -33
-  store i64 %18, i64* %16, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %11, %struct.rb_control_frame_struct* %13, %struct.rb_iseq_struct* %stackFrame.i) #9
-  %19 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %13, i64 0, i32 0
-  store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %19, align 8, !dbg !26, !tbaa !15
-  %rubyStr_hi.i = load i64, i64* @rubyStrFrozen_hi, align 8, !dbg !27
-  %20 = load i64*, i64** %15, align 8, !dbg !27, !tbaa !25
-  %21 = load i64, i64* %20, align 8, !dbg !27, !tbaa !6
-  %22 = and i64 %21, 8, !dbg !27
-  %23 = icmp eq i64 %22, 0, !dbg !27
-  br i1 %23, label %24, label %26, !dbg !27, !prof !28
+  %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %10, align 8, !tbaa !21
+  %11 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 4
+  %12 = load i64*, i64** %11, align 8, !tbaa !25
+  %13 = load i64, i64* %12, align 8, !tbaa !6
+  %14 = and i64 %13, -33
+  store i64 %14, i64* %12, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %7, %struct.rb_control_frame_struct* %9, %struct.rb_iseq_struct* %stackFrame.i) #9
+  %15 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 0
+  store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %15, align 8, !dbg !26, !tbaa !15
+  %rubyStr_hi.i = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 3), align 8, !dbg !27, !invariant.load !5
+  %16 = load i64*, i64** %11, align 8, !dbg !27, !tbaa !25
+  %17 = load i64, i64* %16, align 8, !dbg !27, !tbaa !6
+  %18 = and i64 %17, 8, !dbg !27
+  %19 = icmp eq i64 %18, 0, !dbg !27
+  br i1 %19, label %20, label %22, !dbg !27, !prof !28
 
-24:                                               ; preds = %entry
-  %25 = getelementptr inbounds i64, i64* %20, i64 -3, !dbg !27
-  store i64 %rubyStr_hi.i, i64* %25, align 8, !dbg !27, !tbaa !6
-  br label %27, !dbg !27
+20:                                               ; preds = %entry
+  %21 = getelementptr inbounds i64, i64* %16, i64 -3, !dbg !27
+  store i64 %rubyStr_hi.i, i64* %21, align 8, !dbg !27, !tbaa !6
+  br label %23, !dbg !27
 
-26:                                               ; preds = %entry
-  call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %20, i32 noundef -3, i64 %rubyStr_hi.i) #9, !dbg !27
-  br label %27, !dbg !27
+22:                                               ; preds = %entry
+  call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %16, i32 noundef -3, i64 %rubyStr_hi.i) #9, !dbg !27
+  br label %23, !dbg !27
 
-27:                                               ; preds = %26, %24
-  store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %19, align 8, !dbg !27, !tbaa !15
+23:                                               ; preds = %22, %20
+  store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %15, align 8, !dbg !27, !tbaa !15
   %rubyId_times.i = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !29, !invariant.load !5
-  %28 = load i64, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8, !dbg !29
-  %29 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %28) #9, !dbg !29
-  %30 = bitcast %struct.sorbet_inlineIntrinsicEnv* %0 to i8*, !dbg !29
-  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %30) #9, !dbg !29
-  %31 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %0, i64 0, i32 0, !dbg !29
-  store i64 21, i64* %31, align 8, !dbg !29, !tbaa !30
-  %32 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %0, i64 0, i32 1, !dbg !29
-  store i64 %rubyId_times.i, i64* %32, align 8, !dbg !29, !tbaa !32
-  %33 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %0, i64 0, i32 2, !dbg !29
-  store i32 0, i32* %33, align 8, !dbg !29, !tbaa !33
-  %34 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %0, i64 0, i32 3, !dbg !29
-  %35 = bitcast i64** %34 to i8*, !dbg !29
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %35, i8 0, i64 16, i1 false) #9, !dbg !29
-  %36 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !29, !tbaa !15
-  %37 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %36, i64 0, i32 2, !dbg !29
-  %38 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %37, align 8, !dbg !29, !tbaa !17
-  %39 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 3, !dbg !29
-  %40 = bitcast i64* %39 to %struct.rb_captured_block*, !dbg !29
-  %41 = getelementptr inbounds i64, i64* %39, i64 2, !dbg !29
-  %42 = bitcast i64* %41 to %struct.vm_ifunc**, !dbg !29
-  store %struct.vm_ifunc* %29, %struct.vm_ifunc** %42, align 8, !dbg !29, !tbaa !34
+  %24 = load i64, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8, !dbg !29
+  %25 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %24) #9, !dbg !29
+  %26 = bitcast %struct.sorbet_inlineIntrinsicEnv* %0 to i8*, !dbg !29
+  call void @llvm.lifetime.start.p0i8(i64 noundef 40, i8* noundef nonnull %26) #9, !dbg !29
+  %27 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %0, i64 0, i32 0, !dbg !29
+  store i64 21, i64* %27, align 8, !dbg !29, !tbaa !30
+  %28 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %0, i64 0, i32 1, !dbg !29
+  store i64 %rubyId_times.i, i64* %28, align 8, !dbg !29, !tbaa !32
+  %29 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %0, i64 0, i32 2, !dbg !29
+  store i32 0, i32* %29, align 8, !dbg !29, !tbaa !33
+  %30 = getelementptr inbounds %struct.sorbet_inlineIntrinsicEnv, %struct.sorbet_inlineIntrinsicEnv* %0, i64 0, i32 3, !dbg !29
+  %31 = bitcast i64** %30 to i8*, !dbg !29
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %31, i8 0, i64 16, i1 false) #9, !dbg !29
+  %32 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !29, !tbaa !15
+  %33 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %32, i64 0, i32 2, !dbg !29
+  %34 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %33, align 8, !dbg !29, !tbaa !17
+  %35 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %34, i64 0, i32 3, !dbg !29
+  %36 = bitcast i64* %35 to %struct.rb_captured_block*, !dbg !29
+  %37 = getelementptr inbounds i64, i64* %35, i64 2, !dbg !29
+  %38 = bitcast i64* %37 to %struct.vm_ifunc**, !dbg !29
+  store %struct.vm_ifunc* %25, %struct.vm_ifunc** %38, align 8, !dbg !29, !tbaa !34
   call void @llvm.experimental.noalias.scope.decl(metadata !35) #9, !dbg !29
-  %43 = ptrtoint %struct.rb_captured_block* %40 to i64, !dbg !29
-  %44 = or i64 %43, 3, !dbg !29
-  %45 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %36, i64 0, i32 17, !dbg !29
-  %46 = and i64 %44, -4, !dbg !38
-  %47 = inttoptr i64 %46 to %struct.rb_captured_block*, !dbg !38
-  store i64 0, i64* %45, align 8, !dbg !38, !tbaa !40
-  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %47) #9, !dbg !38
-  %48 = load i64, i64* @rb_mKernel, align 8, !dbg !29
-  br label %49, !dbg !38
+  %39 = ptrtoint %struct.rb_captured_block* %36 to i64, !dbg !29
+  %40 = or i64 %39, 3, !dbg !29
+  %41 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %32, i64 0, i32 17, !dbg !29
+  %42 = and i64 %40, -4, !dbg !38
+  %43 = inttoptr i64 %42 to %struct.rb_captured_block*, !dbg !38
+  store i64 0, i64* %41, align 8, !dbg !38, !tbaa !40
+  call void @sorbet_pushBlockFrame(%struct.rb_captured_block* %43) #9, !dbg !38
+  %44 = load i64, i64* @rb_mKernel, align 8, !dbg !29
+  br label %45, !dbg !38
 
-49:                                               ; preds = %49, %27
-  %50 = phi i64 [ 0, %27 ], [ %70, %49 ], !dbg !38
-  %51 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !29, !tbaa !15
-  %52 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %51, i64 0, i32 2, !dbg !29
-  %53 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %52, align 8, !dbg !29, !tbaa !17
+45:                                               ; preds = %45, %23
+  %46 = phi i64 [ 0, %23 ], [ %66, %45 ], !dbg !38
+  %47 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !29, !tbaa !15
+  %48 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %47, i64 0, i32 2, !dbg !29
+  %49 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %48, align 8, !dbg !29, !tbaa !17
   %stackFrame.i1.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1", align 8, !dbg !29
-  %54 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 2, !dbg !29
-  store %struct.rb_iseq_struct* %stackFrame.i1.i.i, %struct.rb_iseq_struct** %54, align 8, !dbg !29, !tbaa !21
-  %55 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 4, !dbg !29
-  %56 = load i64*, i64** %55, align 8, !dbg !29
-  %57 = load i64, i64* %56, align 8, !dbg !29, !tbaa !6
-  %58 = and i64 %57, -129, !dbg !29
-  store i64 %58, i64* %56, align 8, !dbg !29, !tbaa !6
-  %59 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 0, !dbg !29
-  store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %59, align 8, !dbg !41, !tbaa !15
-  %60 = getelementptr inbounds i64, i64* %56, i64 -1, !dbg !43
+  %50 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %49, i64 0, i32 2, !dbg !29
+  store %struct.rb_iseq_struct* %stackFrame.i1.i.i, %struct.rb_iseq_struct** %50, align 8, !dbg !29, !tbaa !21
+  %51 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %49, i64 0, i32 4, !dbg !29
+  %52 = load i64*, i64** %51, align 8, !dbg !29
+  %53 = load i64, i64* %52, align 8, !dbg !29, !tbaa !6
+  %54 = and i64 %53, -129, !dbg !29
+  store i64 %54, i64* %52, align 8, !dbg !29, !tbaa !6
+  %55 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %49, i64 0, i32 0, !dbg !29
+  store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %55, align 8, !dbg !41, !tbaa !15
+  %56 = getelementptr inbounds i64, i64* %52, i64 -1, !dbg !43
+  %57 = load i64, i64* %56, align 8, !dbg !43, !tbaa !6
+  %58 = and i64 %57, -4, !dbg !43
+  %59 = inttoptr i64 %58 to i64*, !dbg !43
+  %60 = getelementptr inbounds i64, i64* %59, i64 -3, !dbg !43
   %61 = load i64, i64* %60, align 8, !dbg !43, !tbaa !6
-  %62 = and i64 %61, -4, !dbg !43
-  %63 = inttoptr i64 %62 to i64*, !dbg !43
-  %64 = getelementptr inbounds i64, i64* %63, i64 -3, !dbg !43
-  %65 = load i64, i64* %64, align 8, !dbg !43, !tbaa !6
-  %66 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !43
-  %67 = load i64*, i64** %66, align 8, !dbg !43
-  store i64 %48, i64* %67, align 8, !dbg !43, !tbaa !6
-  %68 = getelementptr inbounds i64, i64* %67, i64 1, !dbg !43
-  store i64 %65, i64* %68, align 8, !dbg !43, !tbaa !6
-  %69 = getelementptr inbounds i64, i64* %68, i64 1, !dbg !43
-  store i64* %69, i64** %66, align 8, !dbg !43
+  %62 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %49, i64 0, i32 1, !dbg !43
+  %63 = load i64*, i64** %62, align 8, !dbg !43
+  store i64 %44, i64* %63, align 8, !dbg !43, !tbaa !6
+  %64 = getelementptr inbounds i64, i64* %63, i64 1, !dbg !43
+  store i64 %61, i64* %64, align 8, !dbg !43, !tbaa !6
+  %65 = getelementptr inbounds i64, i64* %64, i64 1, !dbg !43
+  store i64* %65, i64** %62, align 8, !dbg !43
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !43
-  store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %59, align 8, !dbg !43, !tbaa !15
-  %70 = add nuw nsw i64 %50, 1, !dbg !38
-  %71 = icmp eq i64 %70, 10, !dbg !38
-  br i1 %71, label %forward_sorbet_rb_int_dotimes_withBlock.exit.i, label %49, !dbg !38, !llvm.loop !44
+  store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %55, align 8, !dbg !43, !tbaa !15
+  %66 = add nuw nsw i64 %46, 1, !dbg !38
+  %67 = icmp eq i64 %66, 10, !dbg !38
+  br i1 %67, label %forward_sorbet_rb_int_dotimes_withBlock.exit.i, label %45, !dbg !38, !llvm.loop !44
 
-forward_sorbet_rb_int_dotimes_withBlock.exit.i:   ; preds = %49
+forward_sorbet_rb_int_dotimes_withBlock.exit.i:   ; preds = %45
   call void @sorbet_popFrame() #9, !dbg !38
-  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %30) #9, !dbg !29
-  %72 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !29, !tbaa !15
-  %73 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %72, i64 0, i32 5, !dbg !29
-  %74 = load i32, i32* %73, align 8, !dbg !29, !tbaa !46
-  %75 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %72, i64 0, i32 6, !dbg !29
-  %76 = load i32, i32* %75, align 4, !dbg !29, !tbaa !47
-  %77 = xor i32 %76, -1, !dbg !29
-  %78 = and i32 %77, %74, !dbg !29
-  %79 = icmp eq i32 %78, 0, !dbg !29
-  br i1 %79, label %"func_<root>.17<static-init>$153.exit", label %80, !dbg !29, !prof !28
+  call void @llvm.lifetime.end.p0i8(i64 noundef 40, i8* noundef nonnull %26) #9, !dbg !29
+  %68 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !29, !tbaa !15
+  %69 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %68, i64 0, i32 5, !dbg !29
+  %70 = load i32, i32* %69, align 8, !dbg !29, !tbaa !46
+  %71 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %68, i64 0, i32 6, !dbg !29
+  %72 = load i32, i32* %71, align 4, !dbg !29, !tbaa !47
+  %73 = xor i32 %72, -1, !dbg !29
+  %74 = and i32 %73, %70, !dbg !29
+  %75 = icmp eq i32 %74, 0, !dbg !29
+  br i1 %75, label %"func_<root>.17<static-init>$153.exit", label %76, !dbg !29, !prof !28
 
-80:                                               ; preds = %forward_sorbet_rb_int_dotimes_withBlock.exit.i
-  %81 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %72, i64 0, i32 8, !dbg !29
-  %82 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %81, align 8, !dbg !29, !tbaa !48
-  %83 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %82, i32 noundef 0) #9, !dbg !29
+76:                                               ; preds = %forward_sorbet_rb_int_dotimes_withBlock.exit.i
+  %77 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %68, i64 0, i32 8, !dbg !29
+  %78 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %77, align 8, !dbg !29, !tbaa !48
+  %79 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %78, i32 noundef 0) #9, !dbg !29
   br label %"func_<root>.17<static-init>$153.exit", !dbg !29
 
-"func_<root>.17<static-init>$153.exit":           ; preds = %forward_sorbet_rb_int_dotimes_withBlock.exit.i, %80
-  store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %19, align 8, !tbaa !15
+"func_<root>.17<static-init>$153.exit":           ; preds = %forward_sorbet_rb_int_dotimes_withBlock.exit.i, %76
+  store i64* getelementptr inbounds ([8 x i64], [8 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %15, align 8, !tbaa !15
   ret void
 }
 

--- a/test/testdata/compiler/block_no_args_captures_constant.opt.ll.exp
+++ b/test/testdata/compiler/block_no_args_captures_constant.opt.ll.exp
@@ -85,8 +85,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_Object#3foo" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@rubyStrFrozen_foo = internal unnamed_addr global i64 0, align 8
-@"rubyStrFrozen_test/testdata/compiler/block_no_args_captures_constant.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [13 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @"stackFramePrecomputed_func_Object#3foo$block_1" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
@@ -94,11 +92,12 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @"func_Object#3foo$block_1_ifunc" = internal unnamed_addr global i64 0
 @ic_puts.1 = internal global %struct.FunctionInlineCache zeroinitializer
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@rubyStrFrozen_hi = internal unnamed_addr global i64 0, align 8
 @ic_foo = internal global %struct.FunctionInlineCache zeroinitializer
 @sorbet_moduleStringTable = internal unnamed_addr constant [136 x i8] c"foo\00test/testdata/compiler/block_no_args_captures_constant.rb\00block in foo\00A\00puts\00Kernel\00times\00<top (required)>\00hi\00Object\00normal\00master\00", align 1
 @sorbet_moduleIDTable = internal unnamed_addr global [6 x i64] zeroinitializer, align 8
 @sorbet_moduleIDDescriptors = internal unnamed_addr constant [6 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 3 }, %struct.rb_code_position_struct { i32 62, i32 12 }, %struct.rb_code_position_struct { i32 77, i32 4 }, %struct.rb_code_position_struct { i32 89, i32 5 }, %struct.rb_code_position_struct { i32 95, i32 16 }, %struct.rb_code_position_struct { i32 122, i32 6 }], align 8
+@sorbet_moduleRubyStringTable = internal unnamed_addr global [5 x i64] zeroinitializer, align 8
+@sorbet_moduleRubyStringDescriptors = internal unnamed_addr constant [5 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 3 }, %struct.rb_code_position_struct { i32 4, i32 57 }, %struct.rb_code_position_struct { i32 62, i32 12 }, %struct.rb_code_position_struct { i32 95, i32 16 }, %struct.rb_code_position_struct { i32 112, i32 2 }], align 8
 @guard_epoch_A = linkonce local_unnamed_addr global i64 0
 @guarded_const_A = linkonce local_unnamed_addr global i64 0
 @rb_mKernel = external local_unnamed_addr constant i64
@@ -135,9 +134,7 @@ declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_
 
 declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #1
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #1
-
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #1
+declare void @sorbet_vm_init_string_table(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #1
 
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #0
@@ -324,78 +321,65 @@ entry:
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
   tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([6 x %struct.rb_code_position_struct], [6 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 6, i8* noundef getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
-  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 3) #12
-  tail call void @rb_gc_register_mark_object(i64 %0) #12
-  store i64 %0, i64* @rubyStrFrozen_foo, align 8
-  %1 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i64 0, i64 4), i64 noundef 57) #12
-  tail call void @rb_gc_register_mark_object(i64 %1) #12
-  store i64 %1, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args_captures_constant.rb", align 8
+  tail call void @sorbet_vm_init_string_table(i64* noundef getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleRubyStringTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([5 x %struct.rb_code_position_struct], [5 x %struct.rb_code_position_struct]* @sorbet_moduleRubyStringDescriptors, i32 0, i32 0), i32 noundef 5, i8* noundef getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 13)
   %rubyId_foo.i.i = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
-  %rubyStr_foo.i.i = load i64, i64* @rubyStrFrozen_foo, align 8
-  %"rubyStr_test/testdata/compiler/block_no_args_captures_constant.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args_captures_constant.rb", align 8
-  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_foo.i.i, i64 %rubyId_foo.i.i, i64 %"rubyStr_test/testdata/compiler/block_no_args_captures_constant.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8
-  %3 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i64 0, i64 62), i64 noundef 12) #12
-  call void @rb_gc_register_mark_object(i64 %3) #12
-  %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8
+  %rubyStr_foo.i.i = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 0), align 8, !invariant.load !5
+  %"rubyStr_test/testdata/compiler/block_no_args_captures_constant.rb.i.i" = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
+  %0 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_foo.i.i, i64 %rubyId_foo.i.i, i64 %"rubyStr_test/testdata/compiler/block_no_args_captures_constant.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %0, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8
   %"rubyId_block in foo.i.i" = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/block_no_args_captures_constant.rb.i5.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args_captures_constant.rb", align 8
-  %4 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %3, i64 %"rubyId_block in foo.i.i", i64 %"rubyStr_test/testdata/compiler/block_no_args_captures_constant.rb.i5.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %4, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo$block_1", align 8
+  %"rubyStr_block in foo.i.i" = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 2), align 8, !invariant.load !5
+  %1 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in foo.i.i", i64 %"rubyId_block in foo.i.i", i64 %"rubyStr_test/testdata/compiler/block_no_args_captures_constant.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* %0, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %1, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo$block_1", align 8
   %rubyId_puts.i = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !19, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
-  %5 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_Object#3foo$block_1", i8* noundef null, i32 noundef 0, i32 noundef 0) #12
-  %6 = ptrtoint %struct.vm_ifunc* %5 to i64
-  %7 = call i64 @sorbet_globalConstRegister(i64 %6)
-  store i64 %7, i64* @"func_Object#3foo$block_1_ifunc", align 8
+  %2 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_Object#3foo$block_1", i8* noundef null, i32 noundef 0, i32 noundef 0) #12
+  %3 = ptrtoint %struct.vm_ifunc* %2 to i64
+  %4 = call i64 @sorbet_globalConstRegister(i64 %3)
+  store i64 %4, i64* @"func_Object#3foo$block_1_ifunc", align 8
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !49
-  %8 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i64 0, i64 95), i64 noundef 16) #12
-  call void @rb_gc_register_mark_object(i64 %8) #12
   %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/block_no_args_captures_constant.rb.i6.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_no_args_captures_constant.rb", align 8
-  %9 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %8, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_no_args_captures_constant.rb.i6.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i7.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %9, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %10 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i64 0, i64 112), i64 noundef 2) #12
-  call void @rb_gc_register_mark_object(i64 %10) #12
-  store i64 %10, i64* @rubyStrFrozen_hi, align 8
+  %"rubyStr_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 3), align 8, !invariant.load !5
+  %5 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_no_args_captures_constant.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i7.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %5, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !50
-  %11 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
-  %12 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %11, i64 0, i32 18
-  %13 = load i64, i64* %12, align 8, !tbaa !52
-  %14 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %15 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %14, i64 0, i32 2
-  %16 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %15, align 8, !tbaa !24
+  %6 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
+  %7 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %6, i64 0, i32 18
+  %8 = load i64, i64* %7, align 8, !tbaa !52
+  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 2
+  %11 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %10, align 8, !tbaa !24
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %17 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %16, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %17, align 8, !tbaa !35
-  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %16, i64 0, i32 4
-  %19 = load i64*, i64** %18, align 8, !tbaa !37
-  %20 = load i64, i64* %19, align 8, !tbaa !6
-  %21 = and i64 %20, -33
-  store i64 %21, i64* %19, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %14, %struct.rb_control_frame_struct* %16, %struct.rb_iseq_struct* %stackFrame.i) #12
-  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %16, i64 0, i32 0
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %22, align 8, !dbg !60, !tbaa !14
-  %rubyStr_hi.i = load i64, i64* @rubyStrFrozen_hi, align 8, !dbg !61
-  %23 = load i64, i64* @rb_cObject, align 8, !dbg !61
-  %24 = call i64 @sorbet_setConstant(i64 %23, i8* getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i64 0, i64 75), i64 noundef 1, i64 %rubyStr_hi.i) #12, !dbg !61
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %22, align 8, !dbg !61, !tbaa !14
+  %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %12, align 8, !tbaa !35
+  %13 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 4
+  %14 = load i64*, i64** %13, align 8, !tbaa !37
+  %15 = load i64, i64* %14, align 8, !tbaa !6
+  %16 = and i64 %15, -33
+  store i64 %16, i64* %14, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %9, %struct.rb_control_frame_struct* %11, %struct.rb_iseq_struct* %stackFrame.i) #12
+  %17 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 0
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %17, align 8, !dbg !60, !tbaa !14
+  %rubyStr_hi.i = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 4), align 8, !dbg !61, !invariant.load !5
+  %18 = load i64, i64* @rb_cObject, align 8, !dbg !61
+  %19 = call i64 @sorbet_setConstant(i64 %18, i8* getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i64 0, i64 75), i64 noundef 1, i64 %rubyStr_hi.i) #12, !dbg !61
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %17, align 8, !dbg !61, !tbaa !14
   %stackFrame12.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8, !dbg !62
-  %25 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #13, !dbg !62
-  %26 = bitcast i8* %25 to i16*, !dbg !62
-  %27 = load i16, i16* %26, align 8, !dbg !62
-  %28 = and i16 %27, -384, !dbg !62
-  store i16 %28, i16* %26, align 8, !dbg !62
-  %29 = getelementptr inbounds i8, i8* %25, i64 4, !dbg !62
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %29, i8 0, i64 28, i1 false) #12, !dbg !62
-  call void @sorbet_vm_define_method(i64 %23, i8* noundef getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#3foo", i8* nonnull %25, %struct.rb_iseq_struct* %stackFrame12.i, i1 noundef zeroext false) #12, !dbg !62
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %22, align 8, !dbg !62, !tbaa !14
-  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %16, i64 0, i32 1, !dbg !50
-  %31 = load i64*, i64** %30, align 8, !dbg !50
-  store i64 %13, i64* %31, align 8, !dbg !50, !tbaa !6
-  %32 = getelementptr inbounds i64, i64* %31, i64 1, !dbg !50
-  store i64* %32, i64** %30, align 8, !dbg !50
+  %20 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #13, !dbg !62
+  %21 = bitcast i8* %20 to i16*, !dbg !62
+  %22 = load i16, i16* %21, align 8, !dbg !62
+  %23 = and i16 %22, -384, !dbg !62
+  store i16 %23, i16* %21, align 8, !dbg !62
+  %24 = getelementptr inbounds i8, i8* %20, i64 4, !dbg !62
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %24, i8 0, i64 28, i1 false) #12, !dbg !62
+  call void @sorbet_vm_define_method(i64 %18, i8* noundef getelementptr inbounds ([136 x i8], [136 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#3foo", i8* nonnull %20, %struct.rb_iseq_struct* %stackFrame12.i, i1 noundef zeroext false) #12, !dbg !62
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %17, align 8, !dbg !62, !tbaa !14
+  %25 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 1, !dbg !50
+  %26 = load i64*, i64** %25, align 8, !dbg !50
+  store i64 %8, i64* %26, align 8, !dbg !50, !tbaa !6
+  %27 = getelementptr inbounds i64, i64* %26, i64 1, !dbg !50
+  store i64* %27, i64** %25, align 8, !dbg !50
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo, i64 0), !dbg !50
   ret void
 }

--- a/test/testdata/compiler/block_type_checking.opt.ll.exp
+++ b/test/testdata/compiler/block_type_checking.opt.ll.exp
@@ -86,8 +86,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [19 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
@@ -107,6 +105,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @sorbet_moduleStringTable = internal unnamed_addr constant [247 x i8] c"<top (required)>\00test/testdata/compiler/block_type_checking.rb\00block in <top (required)>\00Foo\00Object\00new\00initialize\00bar\00p\00master\00Parameter 'x'\00Integer\00+\00Return value\00<class:Foo>\00block in <class:Foo>\00x\00blk\00proc\00T\00returns\00params\00T::Sig\00extend\00normal\00", align 1
 @sorbet_moduleIDTable = internal unnamed_addr global [16 x i64] zeroinitializer, align 8
 @sorbet_moduleIDDescriptors = internal unnamed_addr constant [16 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 63, i32 25 }, %struct.rb_code_position_struct { i32 100, i32 3 }, %struct.rb_code_position_struct { i32 104, i32 10 }, %struct.rb_code_position_struct { i32 115, i32 3 }, %struct.rb_code_position_struct { i32 119, i32 1 }, %struct.rb_code_position_struct { i32 150, i32 1 }, %struct.rb_code_position_struct { i32 165, i32 11 }, %struct.rb_code_position_struct { i32 177, i32 20 }, %struct.rb_code_position_struct { i32 198, i32 1 }, %struct.rb_code_position_struct { i32 200, i32 3 }, %struct.rb_code_position_struct { i32 204, i32 4 }, %struct.rb_code_position_struct { i32 211, i32 7 }, %struct.rb_code_position_struct { i32 219, i32 6 }, %struct.rb_code_position_struct { i32 233, i32 6 }, %struct.rb_code_position_struct { i32 240, i32 6 }], align 8
+@sorbet_moduleRubyStringTable = internal unnamed_addr global [6 x i64] zeroinitializer, align 8
+@sorbet_moduleRubyStringDescriptors = internal unnamed_addr constant [6 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 17, i32 45 }, %struct.rb_code_position_struct { i32 63, i32 25 }, %struct.rb_code_position_struct { i32 115, i32 3 }, %struct.rb_code_position_struct { i32 165, i32 11 }, %struct.rb_code_position_struct { i32 177, i32 20 }], align 8
 @rb_cObject = external local_unnamed_addr constant i64
 @"guard_epoch_T::Sig" = linkonce local_unnamed_addr global i64 0
 @"guarded_const_T::Sig" = linkonce local_unnamed_addr global i64 0
@@ -155,9 +155,9 @@ declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_
 
 declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #3
 
-declare i64 @sorbet_maybeAllocateObjectFastPath(i64, %struct.FunctionInlineCache*) local_unnamed_addr #3
+declare void @sorbet_vm_init_string_table(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #3
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #3
+declare i64 @sorbet_maybeAllocateObjectFastPath(i64, %struct.FunctionInlineCache*) local_unnamed_addr #3
 
 declare i64 @sorbet_vm_callBlock(%struct.rb_control_frame_struct*, i32, i64* nocapture, i32) local_unnamed_addr #3
 
@@ -168,8 +168,6 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #4
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #4
-
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #3
 
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #2
@@ -240,236 +238,221 @@ entry:
   %0 = bitcast i64* %keywords.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %0)
   tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([16 x %struct.rb_code_position_struct], [16 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 16, i8* noundef getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
-  %1 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #17
-  tail call void @rb_gc_register_mark_object(i64 %1) #17
-  store i64 %1, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %2 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 45) #17
-  tail call void @rb_gc_register_mark_object(i64 %2) #17
-  store i64 %2, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
+  tail call void @sorbet_vm_init_string_table(i64* noundef getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleRubyStringTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([6 x %struct.rb_code_position_struct], [6 x %struct.rb_code_position_struct]* @sorbet_moduleRubyStringDescriptors, i32 0, i32 0), i32 noundef 6, i8* noundef getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 19)
   %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
-  %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/block_type_checking.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
-  %3 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %3, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %4 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 63), i64 noundef 25) #17
-  call void @rb_gc_register_mark_object(i64 %4) #17
-  %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %"rubyStr_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 0), align 8, !invariant.load !5
+  %"rubyStr_test/testdata/compiler/block_type_checking.rb.i.i" = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
+  %1 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %1, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
   %"rubyId_block in <top (required)>.i.i" = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/block_type_checking.rb.i14.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
-  %5 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %4, i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i14.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %5, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1", align 8
+  %"rubyStr_block in <top (required)>.i.i" = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 2), align 8, !invariant.load !5
+  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i.i", i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* %1, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1", align 8
   %rubyId_new.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !31, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !31
   %rubyId_initialize.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !31, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 %rubyId_initialize.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !31
   %rubyId_bar.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !dbg !31, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_bar, i64 %rubyId_bar.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !31
-  %6 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_1", i8* noundef null, i32 noundef 0, i32 noundef 0) #17
-  %7 = ptrtoint %struct.vm_ifunc* %6 to i64
-  %8 = call i64 @sorbet_globalConstRegister(i64 %7)
-  store i64 %8, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8
+  %3 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_1", i8* noundef null, i32 noundef 0, i32 noundef 0) #17
+  %4 = ptrtoint %struct.vm_ifunc* %3 to i64
+  %5 = call i64 @sorbet_globalConstRegister(i64 %4)
+  store i64 %5, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8
   %rubyId_p.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 5), align 8, !dbg !32, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !32
-  %9 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 115), i64 noundef 3) #17
-  call void @rb_gc_register_mark_object(i64 %9) #17
-  %"rubyStr_test/testdata/compiler/block_type_checking.rb.i15.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
-  %10 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %9, i64 %rubyId_bar.i, i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i15.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 9, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i16.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %10, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo#3bar", align 8
-  %11 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 165), i64 noundef 11) #17
-  call void @rb_gc_register_mark_object(i64 %11) #17
+  %rubyStr_bar.i.i = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 3), align 8, !invariant.load !5
+  %6 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_bar.i.i, i64 %rubyId_bar.i, i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 9, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i16.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %6, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo#3bar", align 8
   %"rubyId_<class:Foo>.i.i" = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 7), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/block_type_checking.rb.i17.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
-  %12 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %11, i64 %"rubyId_<class:Foo>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i17.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i18.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %12, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>", align 8
-  %13 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 177), i64 noundef 20) #17
-  call void @rb_gc_register_mark_object(i64 %13) #17
-  %stackFrame.i19.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>", align 8
+  %"rubyStr_<class:Foo>.i.i" = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 4), align 8, !invariant.load !5
+  %7 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<class:Foo>.i.i", i64 %"rubyId_<class:Foo>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i18.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %7, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>", align 8
   %"rubyId_block in <class:Foo>.i.i" = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 8), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/block_type_checking.rb.i20.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/block_type_checking.rb", align 8
-  %14 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %13, i64 %"rubyId_block in <class:Foo>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i20.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i19.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %14, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>$block_1", align 8
+  %"rubyStr_block in <class:Foo>.i.i" = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 5), align 8, !invariant.load !5
+  %8 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <class:Foo>.i.i", i64 %"rubyId_block in <class:Foo>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* %7, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %8, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>$block_1", align 8
   %rubyId_proc.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 11), align 8, !dbg !33, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_proc, i64 %rubyId_proc.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !33
   %rubyId_returns.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 12), align 8, !dbg !33, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !33
   %rubyId_params.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 13), align 8, !dbg !29, !invariant.load !5
   %rubyId_x.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 9), align 8, !dbg !29, !invariant.load !5
-  %15 = call i64 @rb_id2sym(i64 %rubyId_x.i) #18, !dbg !29
-  store i64 %15, i64* %keywords.i, align 8, !dbg !29
+  %9 = call i64 @rb_id2sym(i64 %rubyId_x.i) #18, !dbg !29
+  store i64 %9, i64* %keywords.i, align 8, !dbg !29
   %rubyId_blk.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 10), align 8, !dbg !29, !invariant.load !5
-  %16 = call i64 @rb_id2sym(i64 %rubyId_blk.i) #18, !dbg !29
-  %17 = getelementptr i64, i64* %keywords.i, i32 1, !dbg !29
-  store i64 %16, i64* %17, align 8, !dbg !29
+  %10 = call i64 @rb_id2sym(i64 %rubyId_blk.i) #18, !dbg !29
+  %11 = getelementptr i64, i64* %keywords.i, i32 1, !dbg !29
+  store i64 %10, i64* %11, align 8, !dbg !29
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull align 8 %keywords.i), !dbg !29
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.1, i64 %rubyId_returns.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !29
   %rubyId_extend.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 14), align 8, !dbg !34, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !34
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %0)
-  %18 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !15
-  %19 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %18, i64 0, i32 18
-  %20 = load i64, i64* %19, align 8, !tbaa !35
-  %21 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
-  %22 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 2
-  %23 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %22, align 8, !tbaa !17
+  %12 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !15
+  %13 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %12, i64 0, i32 18
+  %14 = load i64, i64* %13, align 8, !tbaa !35
+  %15 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
+  %16 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %15, i64 0, i32 2
+  %17 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %16, align 8, !tbaa !17
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %24 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %24, align 8, !tbaa !21
-  %25 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 4
-  %26 = load i64*, i64** %25, align 8, !tbaa !23
-  %27 = load i64, i64* %26, align 8, !tbaa !6
-  %28 = and i64 %27, -33
-  store i64 %28, i64* %26, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %21, %struct.rb_control_frame_struct* %23, %struct.rb_iseq_struct* %stackFrame.i) #17
-  %29 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 0
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %29, align 8, !dbg !44, !tbaa !15
-  %30 = load i64, i64* @rb_cObject, align 8, !dbg !45
-  %31 = call i64 @rb_define_class(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 89), i64 %30) #17, !dbg !45
-  %32 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %31) #17, !dbg !45
-  %33 = bitcast i64* %positional_table.i.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %33) #17
-  %stackFrame.i.i1 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>", align 8
-  %34 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
-  %35 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %34, i64 0, i32 2
-  %36 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %35, align 8, !tbaa !17
-  %37 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i.i1, %struct.rb_iseq_struct** %37, align 8, !tbaa !21
-  %38 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 4
-  %39 = load i64*, i64** %38, align 8, !tbaa !23
-  %40 = load i64, i64* %39, align 8, !tbaa !6
-  %41 = and i64 %40, -33
-  store i64 %41, i64* %39, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %34, %struct.rb_control_frame_struct* %36, %struct.rb_iseq_struct* %stackFrame.i.i1) #17
-  %42 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 0
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %42, align 8, !dbg !46, !tbaa !15
+  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %18, align 8, !tbaa !21
+  %19 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 4
+  %20 = load i64*, i64** %19, align 8, !tbaa !23
+  %21 = load i64, i64* %20, align 8, !tbaa !6
+  %22 = and i64 %21, -33
+  store i64 %22, i64* %20, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %15, %struct.rb_control_frame_struct* %17, %struct.rb_iseq_struct* %stackFrame.i) #17
+  %23 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 0
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %23, align 8, !dbg !44, !tbaa !15
+  %24 = load i64, i64* @rb_cObject, align 8, !dbg !45
+  %25 = call i64 @rb_define_class(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 89), i64 %24) #17, !dbg !45
+  %26 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %25) #17, !dbg !45
+  %27 = bitcast i64* %positional_table.i.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %27) #17
+  %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>", align 8
+  %28 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
+  %29 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %28, i64 0, i32 2
+  %30 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %29, align 8, !tbaa !17
+  %31 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %30, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %31, align 8, !tbaa !21
+  %32 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %30, i64 0, i32 4
+  %33 = load i64*, i64** %32, align 8, !tbaa !23
+  %34 = load i64, i64* %33, align 8, !tbaa !6
+  %35 = and i64 %34, -33
+  store i64 %35, i64* %33, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %28, %struct.rb_control_frame_struct* %30, %struct.rb_iseq_struct* %stackFrame.i.i) #17
+  %36 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 0
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %36, align 8, !dbg !46, !tbaa !15
   %rawSym.i.i = call i64 @rb_id2sym(i64 %rubyId_bar.i) #17, !dbg !47
-  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym.i.i, i64 %31, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_Foo.13<static-init>L62$block_1") #17, !dbg !47
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %42, align 8, !dbg !47, !tbaa !15
-  %43 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !48
-  %44 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !48, !tbaa !49
-  %needTakeSlowPath = icmp ne i64 %43, %44, !dbg !48
-  br i1 %needTakeSlowPath, label %45, label %46, !dbg !48, !prof !50
+  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym.i.i, i64 %25, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_Foo.13<static-init>L62$block_1") #17, !dbg !47
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %36, align 8, !dbg !47, !tbaa !15
+  %37 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !48
+  %38 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !48, !tbaa !49
+  %needTakeSlowPath = icmp ne i64 %37, %38, !dbg !48
+  br i1 %needTakeSlowPath, label %39, label %40, !dbg !48, !prof !50
 
-45:                                               ; preds = %entry
+39:                                               ; preds = %entry
   call void @"const_recompute_T::Sig"(), !dbg !48
-  br label %46, !dbg !48
+  br label %40, !dbg !48
 
-46:                                               ; preds = %entry, %45
-  %47 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !48
-  %48 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !48
-  %49 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !48, !tbaa !49
-  %guardUpdated = icmp eq i64 %48, %49, !dbg !48
+40:                                               ; preds = %entry, %39
+  %41 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !48
+  %42 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !48
+  %43 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !48, !tbaa !49
+  %guardUpdated = icmp eq i64 %42, %43, !dbg !48
   call void @llvm.assume(i1 %guardUpdated), !dbg !48
-  %50 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 1, !dbg !48
-  %51 = load i64*, i64** %50, align 8, !dbg !48
-  store i64 %31, i64* %51, align 8, !dbg !48, !tbaa !6
-  %52 = getelementptr inbounds i64, i64* %51, i64 1, !dbg !48
-  store i64 %47, i64* %52, align 8, !dbg !48, !tbaa !6
-  %53 = getelementptr inbounds i64, i64* %52, i64 1, !dbg !48
-  store i64* %53, i64** %50, align 8, !dbg !48
+  %44 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 1, !dbg !48
+  %45 = load i64*, i64** %44, align 8, !dbg !48
+  store i64 %25, i64* %45, align 8, !dbg !48, !tbaa !6
+  %46 = getelementptr inbounds i64, i64* %45, i64 1, !dbg !48
+  store i64 %41, i64* %46, align 8, !dbg !48, !tbaa !6
+  %47 = getelementptr inbounds i64, i64* %46, i64 1, !dbg !48
+  store i64* %47, i64** %44, align 8, !dbg !48
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !48
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %42, align 8, !dbg !48, !tbaa !15
-  %54 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !26
-  %55 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !26, !tbaa !49
-  %needTakeSlowPath2 = icmp ne i64 %54, %55, !dbg !26
-  br i1 %needTakeSlowPath2, label %56, label %57, !dbg !26, !prof !50
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %36, align 8, !dbg !48, !tbaa !15
+  %48 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !26
+  %49 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !26, !tbaa !49
+  %needTakeSlowPath1 = icmp ne i64 %48, %49, !dbg !26
+  br i1 %needTakeSlowPath1, label %50, label %51, !dbg !26, !prof !50
 
-56:                                               ; preds = %46
+50:                                               ; preds = %40
   call void @const_recompute_Foo(), !dbg !26
-  br label %57, !dbg !26
+  br label %51, !dbg !26
 
-57:                                               ; preds = %46, %56
-  %58 = load i64, i64* @guarded_const_Foo, align 8, !dbg !26
-  %59 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !26
-  %60 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !26, !tbaa !49
-  %guardUpdated3 = icmp eq i64 %59, %60, !dbg !26
-  call void @llvm.assume(i1 %guardUpdated3), !dbg !26
+51:                                               ; preds = %40, %50
+  %52 = load i64, i64* @guarded_const_Foo, align 8, !dbg !26
+  %53 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !26
+  %54 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !26, !tbaa !49
+  %guardUpdated2 = icmp eq i64 %53, %54, !dbg !26
+  call void @llvm.assume(i1 %guardUpdated2), !dbg !26
   %stackFrame42.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo#3bar", align 8, !dbg !26
-  %61 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #19, !dbg !26
-  %62 = bitcast i8* %61 to i16*, !dbg !26
-  %63 = load i16, i16* %62, align 8, !dbg !26
-  %64 = and i16 %63, -384, !dbg !26
-  %65 = or i16 %64, 65, !dbg !26
-  store i16 %65, i16* %62, align 8, !dbg !26
-  %66 = getelementptr inbounds i8, i8* %61, i64 8, !dbg !26
-  %67 = bitcast i8* %66 to i32*, !dbg !26
-  store i32 1, i32* %67, align 8, !dbg !26, !tbaa !51
-  %68 = getelementptr inbounds i8, i8* %61, i64 12, !dbg !26
-  %69 = getelementptr inbounds i8, i8* %61, i64 28, !dbg !26
-  %70 = bitcast i8* %69 to i32*, !dbg !26
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %68, i8 0, i64 16, i1 false) #17, !dbg !26
-  store i32 1, i32* %70, align 4, !dbg !26, !tbaa !54
-  %71 = getelementptr inbounds i8, i8* %61, i64 4, !dbg !26
-  %72 = bitcast i8* %71 to i32*, !dbg !26
-  store i32 2, i32* %72, align 4, !dbg !26, !tbaa !55
+  %55 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #19, !dbg !26
+  %56 = bitcast i8* %55 to i16*, !dbg !26
+  %57 = load i16, i16* %56, align 8, !dbg !26
+  %58 = and i16 %57, -384, !dbg !26
+  %59 = or i16 %58, 65, !dbg !26
+  store i16 %59, i16* %56, align 8, !dbg !26
+  %60 = getelementptr inbounds i8, i8* %55, i64 8, !dbg !26
+  %61 = bitcast i8* %60 to i32*, !dbg !26
+  store i32 1, i32* %61, align 8, !dbg !26, !tbaa !51
+  %62 = getelementptr inbounds i8, i8* %55, i64 12, !dbg !26
+  %63 = getelementptr inbounds i8, i8* %55, i64 28, !dbg !26
+  %64 = bitcast i8* %63 to i32*, !dbg !26
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %62, i8 0, i64 16, i1 false) #17, !dbg !26
+  store i32 1, i32* %64, align 4, !dbg !26, !tbaa !54
+  %65 = getelementptr inbounds i8, i8* %55, i64 4, !dbg !26
+  %66 = bitcast i8* %65 to i32*, !dbg !26
+  store i32 2, i32* %66, align 4, !dbg !26, !tbaa !55
   store i64 %rubyId_x.i, i64* %positional_table.i.i, align 8, !dbg !26
-  %73 = getelementptr i64, i64* %positional_table.i.i, i32 1, !dbg !26
-  store i64 %rubyId_blk.i, i64* %73, align 8, !dbg !26
-  %74 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #19, !dbg !26
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %74, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %33, i64 noundef 16, i1 noundef false) #17, !dbg !26
-  %75 = getelementptr inbounds i8, i8* %61, i64 32, !dbg !26
-  %76 = bitcast i8* %75 to i8**, !dbg !26
-  store i8* %74, i8** %76, align 8, !dbg !26, !tbaa !56
-  call void @sorbet_vm_define_method(i64 %58, i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 115), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Foo#3bar", i8* nonnull %61, %struct.rb_iseq_struct* %stackFrame42.i.i, i1 noundef zeroext false) #17, !dbg !26
-  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %33) #17
+  %67 = getelementptr i64, i64* %positional_table.i.i, i32 1, !dbg !26
+  store i64 %rubyId_blk.i, i64* %67, align 8, !dbg !26
+  %68 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #19, !dbg !26
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %68, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %27, i64 noundef 16, i1 noundef false) #17, !dbg !26
+  %69 = getelementptr inbounds i8, i8* %55, i64 32, !dbg !26
+  %70 = bitcast i8* %69 to i8**, !dbg !26
+  store i8* %68, i8** %70, align 8, !dbg !26, !tbaa !56
+  call void @sorbet_vm_define_method(i64 %52, i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 115), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Foo#3bar", i8* nonnull %55, %struct.rb_iseq_struct* %stackFrame42.i.i, i1 noundef zeroext false) #17, !dbg !26
+  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %27) #17
   call void @sorbet_popFrame() #17, !dbg !45
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 15), i64** %29, align 8, !dbg !45, !tbaa !15
-  %77 = call i64 @sorbet_maybeAllocateObjectFastPath(i64 %58, %struct.FunctionInlineCache* noundef @ic_new) #17, !dbg !31
-  %78 = icmp eq i64 %77, 52, !dbg !31
-  br i1 %78, label %slowNew.i, label %fastNew.i, !dbg !31
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 15), i64** %23, align 8, !dbg !45, !tbaa !15
+  %71 = call i64 @sorbet_maybeAllocateObjectFastPath(i64 %52, %struct.FunctionInlineCache* noundef @ic_new) #17, !dbg !31
+  %72 = icmp eq i64 %71, 52, !dbg !31
+  br i1 %72, label %slowNew.i, label %fastNew.i, !dbg !31
 
-slowNew.i:                                        ; preds = %57
-  %79 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 1, !dbg !31
-  %80 = load i64*, i64** %79, align 8, !dbg !31
-  store i64 %58, i64* %80, align 8, !dbg !31, !tbaa !6
-  %81 = getelementptr inbounds i64, i64* %80, i64 1, !dbg !31
-  store i64* %81, i64** %79, align 8, !dbg !31
-  %82 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_new, i64 noundef 0) #17, !dbg !31
+slowNew.i:                                        ; preds = %51
+  %73 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 1, !dbg !31
+  %74 = load i64*, i64** %73, align 8, !dbg !31
+  store i64 %52, i64* %74, align 8, !dbg !31, !tbaa !6
+  %75 = getelementptr inbounds i64, i64* %74, i64 1, !dbg !31
+  store i64* %75, i64** %73, align 8, !dbg !31
+  %76 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_new, i64 noundef 0) #17, !dbg !31
   br label %"func_<root>.17<static-init>$153.exit", !dbg !31
 
-fastNew.i:                                        ; preds = %57
-  %83 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 1, !dbg !31
-  %84 = load i64*, i64** %83, align 8, !dbg !31
-  store i64 %77, i64* %84, align 8, !dbg !31, !tbaa !6
-  %85 = getelementptr inbounds i64, i64* %84, i64 1, !dbg !31
-  store i64* %85, i64** %83, align 8, !dbg !31
-  %86 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 noundef 0) #17, !dbg !31
+fastNew.i:                                        ; preds = %51
+  %77 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 1, !dbg !31
+  %78 = load i64*, i64** %77, align 8, !dbg !31
+  store i64 %71, i64* %78, align 8, !dbg !31, !tbaa !6
+  %79 = getelementptr inbounds i64, i64* %78, i64 1, !dbg !31
+  store i64* %79, i64** %77, align 8, !dbg !31
+  %80 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 noundef 0) #17, !dbg !31
   br label %"func_<root>.17<static-init>$153.exit", !dbg !31
 
 "func_<root>.17<static-init>$153.exit":           ; preds = %slowNew.i, %fastNew.i
-  %initializedObject.i = phi i64 [ %82, %slowNew.i ], [ %77, %fastNew.i ], !dbg !31
-  %87 = load i64, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8, !dbg !31
-  %88 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %87) #17, !dbg !31
-  %89 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 1, !dbg !31
-  %90 = load i64*, i64** %89, align 8, !dbg !31
-  store i64 %initializedObject.i, i64* %90, align 8, !dbg !31, !tbaa !6
-  %91 = getelementptr inbounds i64, i64* %90, i64 1, !dbg !31
-  store i64 11, i64* %91, align 8, !dbg !31, !tbaa !6
-  %92 = getelementptr inbounds i64, i64* %91, i64 1, !dbg !31
-  store i64* %92, i64** %89, align 8, !dbg !31
-  %93 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !31, !tbaa !15
-  %94 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %93, i64 0, i32 2, !dbg !31
-  %95 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %94, align 8, !dbg !31, !tbaa !17
-  %96 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %95, i64 0, i32 3, !dbg !31
-  %97 = bitcast i64* %96 to %struct.rb_captured_block*, !dbg !31
-  %98 = getelementptr inbounds i64, i64* %96, i64 2, !dbg !31
-  %99 = bitcast i64* %98 to %struct.vm_ifunc**, !dbg !31
-  store %struct.vm_ifunc* %88, %struct.vm_ifunc** %99, align 8, !dbg !31, !tbaa !57
-  %100 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %93, i64 0, i32 17, !dbg !31
-  store i64 0, i64* %100, align 8, !dbg !31, !tbaa !58
+  %initializedObject.i = phi i64 [ %76, %slowNew.i ], [ %71, %fastNew.i ], !dbg !31
+  %81 = load i64, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8, !dbg !31
+  %82 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %81) #17, !dbg !31
+  %83 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 1, !dbg !31
+  %84 = load i64*, i64** %83, align 8, !dbg !31
+  store i64 %initializedObject.i, i64* %84, align 8, !dbg !31, !tbaa !6
+  %85 = getelementptr inbounds i64, i64* %84, i64 1, !dbg !31
+  store i64 11, i64* %85, align 8, !dbg !31, !tbaa !6
+  %86 = getelementptr inbounds i64, i64* %85, i64 1, !dbg !31
+  store i64* %86, i64** %83, align 8, !dbg !31
+  %87 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !31, !tbaa !15
+  %88 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %87, i64 0, i32 2, !dbg !31
+  %89 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %88, align 8, !dbg !31, !tbaa !17
+  %90 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %89, i64 0, i32 3, !dbg !31
+  %91 = bitcast i64* %90 to %struct.rb_captured_block*, !dbg !31
+  %92 = getelementptr inbounds i64, i64* %90, i64 2, !dbg !31
+  %93 = bitcast i64* %92 to %struct.vm_ifunc**, !dbg !31
+  store %struct.vm_ifunc* %82, %struct.vm_ifunc** %93, align 8, !dbg !31, !tbaa !57
+  %94 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %87, i64 0, i32 17, !dbg !31
+  store i64 0, i64* %94, align 8, !dbg !31, !tbaa !58
   call void @llvm.experimental.noalias.scope.decl(metadata !59) #17, !dbg !31
-  %101 = ptrtoint %struct.rb_captured_block* %97 to i64, !dbg !31
-  %102 = or i64 %101, 3, !dbg !31
-  %103 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_bar, i64 %102) #17, !dbg !31
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %29, align 8, !dbg !31, !tbaa !15
-  %104 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 1, !dbg !32
-  %105 = load i64*, i64** %104, align 8, !dbg !32
-  store i64 %20, i64* %105, align 8, !dbg !32, !tbaa !6
-  %106 = getelementptr inbounds i64, i64* %105, i64 1, !dbg !32
-  store i64 %103, i64* %106, align 8, !dbg !32, !tbaa !6
-  %107 = getelementptr inbounds i64, i64* %106, i64 1, !dbg !32
-  store i64* %107, i64** %104, align 8, !dbg !32
-  %send5 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p, i64 0), !dbg !32
+  %95 = ptrtoint %struct.rb_captured_block* %91 to i64, !dbg !31
+  %96 = or i64 %95, 3, !dbg !31
+  %97 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_bar, i64 %96) #17, !dbg !31
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %23, align 8, !dbg !31, !tbaa !15
+  %98 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 1, !dbg !32
+  %99 = load i64*, i64** %98, align 8, !dbg !32
+  store i64 %14, i64* %99, align 8, !dbg !32, !tbaa !6
+  %100 = getelementptr inbounds i64, i64* %99, i64 1, !dbg !32
+  store i64 %97, i64* %100, align 8, !dbg !32, !tbaa !6
+  %101 = getelementptr inbounds i64, i64* %100, i64 1, !dbg !32
+  store i64* %101, i64** %98, align 8, !dbg !32
+  %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p, i64 0), !dbg !32
   ret void
 }
 

--- a/test/testdata/compiler/boolean_ops.opt.ll.exp
+++ b/test/testdata/compiler/boolean_ops.opt.ll.exp
@@ -81,8 +81,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"rubyStrFrozen_test/testdata/compiler/boolean_ops.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [6 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @"ic_!" = internal global %struct.FunctionInlineCache zeroinitializer
@@ -90,6 +88,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @sorbet_moduleStringTable = internal unnamed_addr constant [71 x i8] c"<top (required)>\00test/testdata/compiler/boolean_ops.rb\00>\00!\00puts\00master\00", align 1
 @sorbet_moduleIDTable = internal unnamed_addr global [4 x i64] zeroinitializer, align 8
 @sorbet_moduleIDDescriptors = internal unnamed_addr constant [4 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 55, i32 1 }, %struct.rb_code_position_struct { i32 57, i32 1 }, %struct.rb_code_position_struct { i32 59, i32 4 }], align 8
+@sorbet_moduleRubyStringTable = internal unnamed_addr global [2 x i64] zeroinitializer, align 8
+@sorbet_moduleRubyStringDescriptors = internal unnamed_addr constant [2 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 17, i32 37 }], align 8
 
 declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
 
@@ -105,11 +105,9 @@ declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %
 
 declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #0
 
+declare void @sorbet_vm_init_string_table(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #0
+
 declare i64 @sorbet_vm_bang(%struct.FunctionInlineCache*, %struct.rb_control_frame_struct*, i64) local_unnamed_addr #0
-
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
-
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
 
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #1
@@ -139,65 +137,60 @@ entry:
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
   tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([4 x %struct.rb_code_position_struct], [4 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 4, i8* noundef getelementptr inbounds ([71 x i8], [71 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
-  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([71 x i8], [71 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #6
-  tail call void @rb_gc_register_mark_object(i64 %0) #6
-  store i64 %0, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %1 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([71 x i8], [71 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 37) #6
-  tail call void @rb_gc_register_mark_object(i64 %1) #6
-  store i64 %1, i64* @"rubyStrFrozen_test/testdata/compiler/boolean_ops.rb", align 8
+  tail call void @sorbet_vm_init_string_table(i64* noundef getelementptr inbounds ([2 x i64], [2 x i64]* @sorbet_moduleRubyStringTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([2 x %struct.rb_code_position_struct], [2 x %struct.rb_code_position_struct]* @sorbet_moduleRubyStringDescriptors, i32 0, i32 0), i32 noundef 2, i8* noundef getelementptr inbounds ([71 x i8], [71 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([6 x i64], [6 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 6)
   %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
-  %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/boolean_ops.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/boolean_ops.rb", align 8
-  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/boolean_ops.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %"rubyStr_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([2 x i64], [2 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 0), align 8, !invariant.load !5
+  %"rubyStr_test/testdata/compiler/boolean_ops.rb.i.i" = load i64, i64* getelementptr inbounds ([2 x i64], [2 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
+  %0 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/boolean_ops.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %0, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
   %"rubyId_!.i" = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !10, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_!", i64 %"rubyId_!.i", i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !10
   %rubyId_puts.i = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !15, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
-  %3 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !16
-  %4 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %3, i64 0, i32 18
-  %5 = load i64, i64* %4, align 8, !tbaa !18
-  %6 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !16
-  %7 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %6, i64 0, i32 2
-  %8 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %7, align 8, !tbaa !28
+  %1 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !16
+  %2 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %1, i64 0, i32 18
+  %3 = load i64, i64* %2, align 8, !tbaa !18
+  %4 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !16
+  %5 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %4, i64 0, i32 2
+  %6 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %5, align 8, !tbaa !28
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %9 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %8, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %9, align 8, !tbaa !31
-  %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %8, i64 0, i32 4
-  %11 = load i64*, i64** %10, align 8, !tbaa !33
-  %12 = load i64, i64* %11, align 8, !tbaa !6
-  %13 = and i64 %12, -33
-  store i64 %13, i64* %11, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %6, %struct.rb_control_frame_struct* %8, %struct.rb_iseq_struct* %stackFrame.i) #6
-  %14 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %8, i64 0, i32 0
-  store i64* getelementptr inbounds ([6 x i64], [6 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %14, align 8, !dbg !34, !tbaa !16
+  %7 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %6, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %7, align 8, !tbaa !31
+  %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %6, i64 0, i32 4
+  %9 = load i64*, i64** %8, align 8, !tbaa !33
+  %10 = load i64, i64* %9, align 8, !tbaa !6
+  %11 = and i64 %10, -33
+  store i64 %11, i64* %9, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %4, %struct.rb_control_frame_struct* %6, %struct.rb_iseq_struct* %stackFrame.i) #6
+  %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %6, i64 0, i32 0
+  store i64* getelementptr inbounds ([6 x i64], [6 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %12, align 8, !dbg !34, !tbaa !16
   call void @llvm.experimental.noalias.scope.decl(metadata !35) #6, !dbg !38
-  %15 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !38, !tbaa !16
-  %16 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %15, i64 0, i32 5, !dbg !38
-  %17 = load i32, i32* %16, align 8, !dbg !38, !tbaa !39
-  %18 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %15, i64 0, i32 6, !dbg !38
-  %19 = load i32, i32* %18, align 4, !dbg !38, !tbaa !40
-  %20 = xor i32 %19, -1, !dbg !38
-  %21 = and i32 %20, %17, !dbg !38
-  %22 = icmp eq i32 %21, 0, !dbg !38
-  br i1 %22, label %"func_<root>.17<static-init>$153.exit", label %23, !dbg !38, !prof !41
+  %13 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !38, !tbaa !16
+  %14 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %13, i64 0, i32 5, !dbg !38
+  %15 = load i32, i32* %14, align 8, !dbg !38, !tbaa !39
+  %16 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %13, i64 0, i32 6, !dbg !38
+  %17 = load i32, i32* %16, align 4, !dbg !38, !tbaa !40
+  %18 = xor i32 %17, -1, !dbg !38
+  %19 = and i32 %18, %15, !dbg !38
+  %20 = icmp eq i32 %19, 0, !dbg !38
+  br i1 %20, label %"func_<root>.17<static-init>$153.exit", label %21, !dbg !38, !prof !41
 
-23:                                               ; preds = %entry
-  %24 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %15, i64 0, i32 8, !dbg !38
-  %25 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %24, align 8, !dbg !38, !tbaa !42
-  %26 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %25, i32 noundef 0) #6, !dbg !38
+21:                                               ; preds = %entry
+  %22 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %13, i64 0, i32 8, !dbg !38
+  %23 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %22, align 8, !dbg !38, !tbaa !42
+  %24 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %23, i32 noundef 0) #6, !dbg !38
   br label %"func_<root>.17<static-init>$153.exit", !dbg !38
 
-"func_<root>.17<static-init>$153.exit":           ; preds = %entry, %23
-  %27 = call i64 @sorbet_vm_bang(%struct.FunctionInlineCache* noundef @"ic_!", %struct.rb_control_frame_struct* nonnull %8, i64 noundef 0) #6, !dbg !10
-  %28 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %8, i64 0, i32 1, !dbg !15
-  %29 = load i64*, i64** %28, align 8, !dbg !15
-  store i64 %5, i64* %29, align 8, !dbg !15, !tbaa !6
-  %30 = getelementptr inbounds i64, i64* %29, i64 1, !dbg !15
-  store i64 %27, i64* %30, align 8, !dbg !15, !tbaa !6
-  %31 = getelementptr inbounds i64, i64* %30, i64 1, !dbg !15
-  store i64* %31, i64** %28, align 8, !dbg !15
+"func_<root>.17<static-init>$153.exit":           ; preds = %entry, %21
+  %25 = call i64 @sorbet_vm_bang(%struct.FunctionInlineCache* noundef @"ic_!", %struct.rb_control_frame_struct* nonnull %6, i64 noundef 0) #6, !dbg !10
+  %26 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %6, i64 0, i32 1, !dbg !15
+  %27 = load i64*, i64** %26, align 8, !dbg !15
+  store i64 %3, i64* %27, align 8, !dbg !15, !tbaa !6
+  %28 = getelementptr inbounds i64, i64* %27, i64 1, !dbg !15
+  store i64 %25, i64* %28, align 8, !dbg !15, !tbaa !6
+  %29 = getelementptr inbounds i64, i64* %28, i64 1, !dbg !15
+  store i64* %29, i64** %26, align 8, !dbg !15
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !15
   ret void
 }

--- a/test/testdata/compiler/casts.opt.ll.exp
+++ b/test/testdata/compiler/casts.opt.ll.exp
@@ -82,8 +82,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_Object#6fooAll" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@rubyStrFrozen_fooAll = internal unnamed_addr global i64 0, align 8
-@"rubyStrFrozen_test/testdata/compiler/casts.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [30 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @"stackFramePrecomputed_func_Object#7fooAny1" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
@@ -104,6 +102,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @sorbet_moduleStringTable = internal unnamed_addr constant [218 x i8] c"fooAll\00test/testdata/compiler/casts.rb\00Kernel\00T.cast\00fooAny1\00T.any(Integer, Float)\00fooAny2\00T.any(Float, Integer)\00fooInt\00Integer\00+\00fooArray\00T::Array[Integer]\00<top (required)>\00normal\00Object\00arg\00puts\00<build-array>\00master\00", align 1
 @sorbet_moduleIDTable = internal unnamed_addr global [11 x i64] zeroinitializer, align 8
 @sorbet_moduleIDDescriptors = internal unnamed_addr constant [11 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 6 }, %struct.rb_code_position_struct { i32 53, i32 7 }, %struct.rb_code_position_struct { i32 83, i32 7 }, %struct.rb_code_position_struct { i32 113, i32 6 }, %struct.rb_code_position_struct { i32 128, i32 1 }, %struct.rb_code_position_struct { i32 130, i32 8 }, %struct.rb_code_position_struct { i32 157, i32 16 }, %struct.rb_code_position_struct { i32 174, i32 6 }, %struct.rb_code_position_struct { i32 188, i32 3 }, %struct.rb_code_position_struct { i32 192, i32 4 }, %struct.rb_code_position_struct { i32 197, i32 13 }], align 8
+@sorbet_moduleRubyStringTable = internal unnamed_addr global [7 x i64] zeroinitializer, align 8
+@sorbet_moduleRubyStringDescriptors = internal unnamed_addr constant [7 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 6 }, %struct.rb_code_position_struct { i32 7, i32 31 }, %struct.rb_code_position_struct { i32 53, i32 7 }, %struct.rb_code_position_struct { i32 83, i32 7 }, %struct.rb_code_position_struct { i32 113, i32 6 }, %struct.rb_code_position_struct { i32 130, i32 8 }, %struct.rb_code_position_struct { i32 157, i32 16 }], align 8
 @rb_mKernel = external local_unnamed_addr constant i64
 @rb_cObject = external local_unnamed_addr constant i64
 
@@ -134,11 +134,9 @@ declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_
 
 declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #3
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #3
+declare void @sorbet_vm_init_string_table(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #3
 
 declare i64 @rb_ary_new_from_values(i64, i64*) local_unnamed_addr #3
-
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #3
 
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #2
@@ -481,48 +479,33 @@ entry:
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
   tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([11 x %struct.rb_code_position_struct], [11 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 11, i8* noundef getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
-  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 6) #17
-  tail call void @rb_gc_register_mark_object(i64 %0) #17
-  store i64 %0, i64* @rubyStrFrozen_fooAll, align 8
-  %1 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 7), i64 noundef 31) #17
-  tail call void @rb_gc_register_mark_object(i64 %1) #17
-  store i64 %1, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
+  tail call void @sorbet_vm_init_string_table(i64* noundef getelementptr inbounds ([7 x i64], [7 x i64]* @sorbet_moduleRubyStringTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([7 x %struct.rb_code_position_struct], [7 x %struct.rb_code_position_struct]* @sorbet_moduleRubyStringDescriptors, i32 0, i32 0), i32 noundef 7, i8* noundef getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 30)
   %rubyId_fooAll.i.i = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
-  %rubyStr_fooAll.i.i = load i64, i64* @rubyStrFrozen_fooAll, align 8
-  %"rubyStr_test/testdata/compiler/casts.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
-  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_fooAll.i.i, i64 %rubyId_fooAll.i.i, i64 %"rubyStr_test/testdata/compiler/casts.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#6fooAll", align 8
-  %3 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 53), i64 noundef 7) #17
-  call void @rb_gc_register_mark_object(i64 %3) #17
+  %rubyStr_fooAll.i.i = load i64, i64* getelementptr inbounds ([7 x i64], [7 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 0), align 8, !invariant.load !5
+  %"rubyStr_test/testdata/compiler/casts.rb.i.i" = load i64, i64* getelementptr inbounds ([7 x i64], [7 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
+  %0 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_fooAll.i.i, i64 %rubyId_fooAll.i.i, i64 %"rubyStr_test/testdata/compiler/casts.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %0, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#6fooAll", align 8
   %rubyId_fooAny1.i.i = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/casts.rb.i24.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
-  %4 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %3, i64 %rubyId_fooAny1.i.i, i64 %"rubyStr_test/testdata/compiler/casts.rb.i24.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 9, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i25.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %4, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#7fooAny1", align 8
-  %5 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 83), i64 noundef 7) #17
-  call void @rb_gc_register_mark_object(i64 %5) #17
+  %rubyStr_fooAny1.i.i = load i64, i64* getelementptr inbounds ([7 x i64], [7 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 2), align 8, !invariant.load !5
+  %1 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_fooAny1.i.i, i64 %rubyId_fooAny1.i.i, i64 %"rubyStr_test/testdata/compiler/casts.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 9, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i25.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %1, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#7fooAny1", align 8
   %rubyId_fooAny2.i.i = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/casts.rb.i26.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
-  %6 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %5, i64 %rubyId_fooAny2.i.i, i64 %"rubyStr_test/testdata/compiler/casts.rb.i26.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 13, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i27.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %6, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#7fooAny2", align 8
-  %7 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 113), i64 noundef 6) #17
-  call void @rb_gc_register_mark_object(i64 %7) #17
+  %rubyStr_fooAny2.i.i = load i64, i64* getelementptr inbounds ([7 x i64], [7 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 3), align 8, !invariant.load !5
+  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_fooAny2.i.i, i64 %rubyId_fooAny2.i.i, i64 %"rubyStr_test/testdata/compiler/casts.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 13, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i27.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#7fooAny2", align 8
   %rubyId_fooInt.i.i = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/casts.rb.i28.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
-  %8 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %7, i64 %rubyId_fooInt.i.i, i64 %"rubyStr_test/testdata/compiler/casts.rb.i28.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 17, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i29.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %8, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#6fooInt", align 8
-  %9 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 130), i64 noundef 8) #17
-  call void @rb_gc_register_mark_object(i64 %9) #17
+  %rubyStr_fooInt.i.i = load i64, i64* getelementptr inbounds ([7 x i64], [7 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 4), align 8, !invariant.load !5
+  %3 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_fooInt.i.i, i64 %rubyId_fooInt.i.i, i64 %"rubyStr_test/testdata/compiler/casts.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 17, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i29.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %3, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#6fooInt", align 8
   %rubyId_fooArray.i.i = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 5), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/casts.rb.i30.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
-  %10 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %9, i64 %rubyId_fooArray.i.i, i64 %"rubyStr_test/testdata/compiler/casts.rb.i30.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 21, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i31.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %10, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#8fooArray", align 8
-  %11 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 157), i64 noundef 16) #17
-  call void @rb_gc_register_mark_object(i64 %11) #17
+  %rubyStr_fooArray.i.i = load i64, i64* getelementptr inbounds ([7 x i64], [7 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 5), align 8, !invariant.load !5
+  %4 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_fooArray.i.i, i64 %rubyId_fooArray.i.i, i64 %"rubyStr_test/testdata/compiler/casts.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 21, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i31.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %4, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#8fooArray", align 8
   %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 6), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/casts.rb.i32.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/casts.rb", align 8
-  %12 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %11, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/casts.rb.i32.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i33.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %12, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %"rubyStr_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([7 x i64], [7 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 6), align 8, !invariant.load !5
+  %5 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/casts.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i33.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %5, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooInt, i64 %rubyId_fooInt.i.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !55
   %rubyId_puts.i = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 9), align 8, !dbg !56, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !56
@@ -534,247 +517,247 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !62
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooArray, i64 %rubyId_fooArray.i.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !63
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.4, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !64
-  %13 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
-  %14 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %13, i64 0, i32 18
-  %15 = load i64, i64* %14, align 8, !tbaa !65
-  %16 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %17 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 2
-  %18 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %17, align 8, !tbaa !74
-  %19 = bitcast [4 x i64]* %callArgs.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 32, i8* nonnull %19)
-  %20 = bitcast i64* %positional_table.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %20)
-  %21 = bitcast i64* %positional_table84.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %21)
-  %22 = bitcast i64* %positional_table96.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %22)
-  %23 = bitcast i64* %positional_table108.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %23)
-  %24 = bitcast i64* %positional_table120.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %24)
+  %6 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
+  %7 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %6, i64 0, i32 18
+  %8 = load i64, i64* %7, align 8, !tbaa !65
+  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 2
+  %11 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %10, align 8, !tbaa !74
+  %12 = bitcast [4 x i64]* %callArgs.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 32, i8* nonnull %12)
+  %13 = bitcast i64* %positional_table.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %13)
+  %14 = bitcast i64* %positional_table84.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %14)
+  %15 = bitcast i64* %positional_table96.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %15)
+  %16 = bitcast i64* %positional_table108.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %16)
+  %17 = bitcast i64* %positional_table120.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %17)
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %25 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %17, align 8, !tbaa !74
-  %26 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %26, align 8, !tbaa !75
-  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 4
-  %28 = load i64*, i64** %27, align 8, !tbaa !77
-  %29 = load i64, i64* %28, align 8, !tbaa !6
-  %30 = and i64 %29, -33
-  store i64 %30, i64* %28, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %16, %struct.rb_control_frame_struct* %25, %struct.rb_iseq_struct* %stackFrame.i) #17
-  %31 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 0
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %31, align 8, !dbg !78, !tbaa !14
-  %32 = load i64, i64* @rb_cObject, align 8, !dbg !49
+  %18 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %10, align 8, !tbaa !74
+  %19 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %19, align 8, !tbaa !75
+  %20 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 4
+  %21 = load i64*, i64** %20, align 8, !tbaa !77
+  %22 = load i64, i64* %21, align 8, !tbaa !6
+  %23 = and i64 %22, -33
+  store i64 %23, i64* %21, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %9, %struct.rb_control_frame_struct* %18, %struct.rb_iseq_struct* %stackFrame.i) #17
+  %24 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 0
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %24, align 8, !dbg !78, !tbaa !14
+  %25 = load i64, i64* @rb_cObject, align 8, !dbg !49
   %stackFrame73.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#6fooAll", align 8, !dbg !49
-  %33 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !49
-  %34 = bitcast i8* %33 to i16*, !dbg !49
-  %35 = load i16, i16* %34, align 8, !dbg !49
-  %36 = and i16 %35, -384, !dbg !49
-  %37 = or i16 %36, 1, !dbg !49
-  store i16 %37, i16* %34, align 8, !dbg !49
-  %38 = getelementptr inbounds i8, i8* %33, i64 8, !dbg !49
-  %39 = bitcast i8* %38 to i32*, !dbg !49
-  store i32 1, i32* %39, align 8, !dbg !49, !tbaa !79
-  %40 = getelementptr inbounds i8, i8* %33, i64 12, !dbg !49
-  %41 = getelementptr inbounds i8, i8* %33, i64 4, !dbg !49
-  %42 = bitcast i8* %41 to i32*, !dbg !49
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %40, i8 0, i64 20, i1 false) #17, !dbg !49
-  store i32 1, i32* %42, align 4, !dbg !49, !tbaa !82
+  %26 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !49
+  %27 = bitcast i8* %26 to i16*, !dbg !49
+  %28 = load i16, i16* %27, align 8, !dbg !49
+  %29 = and i16 %28, -384, !dbg !49
+  %30 = or i16 %29, 1, !dbg !49
+  store i16 %30, i16* %27, align 8, !dbg !49
+  %31 = getelementptr inbounds i8, i8* %26, i64 8, !dbg !49
+  %32 = bitcast i8* %31 to i32*, !dbg !49
+  store i32 1, i32* %32, align 8, !dbg !49, !tbaa !79
+  %33 = getelementptr inbounds i8, i8* %26, i64 12, !dbg !49
+  %34 = getelementptr inbounds i8, i8* %26, i64 4, !dbg !49
+  %35 = bitcast i8* %34 to i32*, !dbg !49
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %33, i8 0, i64 20, i1 false) #17, !dbg !49
+  store i32 1, i32* %35, align 4, !dbg !49, !tbaa !82
   %rubyId_arg.i = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 8), align 8, !dbg !49, !invariant.load !5
   store i64 %rubyId_arg.i, i64* %positional_table.i, align 8, !dbg !49
-  %43 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !49
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %43, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %20, i64 noundef 8, i1 noundef false) #17, !dbg !49
-  %44 = getelementptr inbounds i8, i8* %33, i64 32, !dbg !49
-  %45 = bitcast i8* %44 to i8**, !dbg !49
-  store i8* %43, i8** %45, align 8, !dbg !49, !tbaa !83
-  call void @sorbet_vm_define_method(i64 %32, i8* noundef getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#6fooAll", i8* nonnull %33, %struct.rb_iseq_struct* %stackFrame73.i, i1 noundef zeroext false) #17, !dbg !49
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %31, align 8, !dbg !49, !tbaa !14
+  %36 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !49
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %36, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %13, i64 noundef 8, i1 noundef false) #17, !dbg !49
+  %37 = getelementptr inbounds i8, i8* %26, i64 32, !dbg !49
+  %38 = bitcast i8* %37 to i8**, !dbg !49
+  store i8* %36, i8** %38, align 8, !dbg !49, !tbaa !83
+  call void @sorbet_vm_define_method(i64 %25, i8* noundef getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#6fooAll", i8* nonnull %26, %struct.rb_iseq_struct* %stackFrame73.i, i1 noundef zeroext false) #17, !dbg !49
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %24, align 8, !dbg !49, !tbaa !14
   %stackFrame82.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#7fooAny1", align 8, !dbg !51
-  %46 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !51
-  %47 = bitcast i8* %46 to i16*, !dbg !51
-  %48 = load i16, i16* %47, align 8, !dbg !51
-  %49 = and i16 %48, -384, !dbg !51
-  %50 = or i16 %49, 1, !dbg !51
-  store i16 %50, i16* %47, align 8, !dbg !51
-  %51 = getelementptr inbounds i8, i8* %46, i64 8, !dbg !51
-  %52 = bitcast i8* %51 to i32*, !dbg !51
-  store i32 1, i32* %52, align 8, !dbg !51, !tbaa !79
-  %53 = getelementptr inbounds i8, i8* %46, i64 12, !dbg !51
-  %54 = getelementptr inbounds i8, i8* %46, i64 4, !dbg !51
-  %55 = bitcast i8* %54 to i32*, !dbg !51
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %53, i8 0, i64 20, i1 false) #17, !dbg !51
-  store i32 1, i32* %55, align 4, !dbg !51, !tbaa !82
+  %39 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !51
+  %40 = bitcast i8* %39 to i16*, !dbg !51
+  %41 = load i16, i16* %40, align 8, !dbg !51
+  %42 = and i16 %41, -384, !dbg !51
+  %43 = or i16 %42, 1, !dbg !51
+  store i16 %43, i16* %40, align 8, !dbg !51
+  %44 = getelementptr inbounds i8, i8* %39, i64 8, !dbg !51
+  %45 = bitcast i8* %44 to i32*, !dbg !51
+  store i32 1, i32* %45, align 8, !dbg !51, !tbaa !79
+  %46 = getelementptr inbounds i8, i8* %39, i64 12, !dbg !51
+  %47 = getelementptr inbounds i8, i8* %39, i64 4, !dbg !51
+  %48 = bitcast i8* %47 to i32*, !dbg !51
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %46, i8 0, i64 20, i1 false) #17, !dbg !51
+  store i32 1, i32* %48, align 4, !dbg !51, !tbaa !82
   store i64 %rubyId_arg.i, i64* %positional_table84.i, align 8, !dbg !51
-  %56 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !51
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %56, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %21, i64 noundef 8, i1 noundef false) #17, !dbg !51
-  %57 = getelementptr inbounds i8, i8* %46, i64 32, !dbg !51
-  %58 = bitcast i8* %57 to i8**, !dbg !51
-  store i8* %56, i8** %58, align 8, !dbg !51, !tbaa !83
-  call void @sorbet_vm_define_method(i64 %32, i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 53), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#7fooAny1", i8* nonnull %46, %struct.rb_iseq_struct* %stackFrame82.i, i1 noundef zeroext false) #17, !dbg !51
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %31, align 8, !dbg !51, !tbaa !14
+  %49 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !51
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %49, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %14, i64 noundef 8, i1 noundef false) #17, !dbg !51
+  %50 = getelementptr inbounds i8, i8* %39, i64 32, !dbg !51
+  %51 = bitcast i8* %50 to i8**, !dbg !51
+  store i8* %49, i8** %51, align 8, !dbg !51, !tbaa !83
+  call void @sorbet_vm_define_method(i64 %25, i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 53), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#7fooAny1", i8* nonnull %39, %struct.rb_iseq_struct* %stackFrame82.i, i1 noundef zeroext false) #17, !dbg !51
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %24, align 8, !dbg !51, !tbaa !14
   %stackFrame94.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#7fooAny2", align 8, !dbg !52
-  %59 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !52
-  %60 = bitcast i8* %59 to i16*, !dbg !52
-  %61 = load i16, i16* %60, align 8, !dbg !52
-  %62 = and i16 %61, -384, !dbg !52
-  %63 = or i16 %62, 1, !dbg !52
-  store i16 %63, i16* %60, align 8, !dbg !52
-  %64 = getelementptr inbounds i8, i8* %59, i64 8, !dbg !52
-  %65 = bitcast i8* %64 to i32*, !dbg !52
-  store i32 1, i32* %65, align 8, !dbg !52, !tbaa !79
-  %66 = getelementptr inbounds i8, i8* %59, i64 12, !dbg !52
-  %67 = getelementptr inbounds i8, i8* %59, i64 4, !dbg !52
-  %68 = bitcast i8* %67 to i32*, !dbg !52
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %66, i8 0, i64 20, i1 false) #17, !dbg !52
-  store i32 1, i32* %68, align 4, !dbg !52, !tbaa !82
+  %52 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !52
+  %53 = bitcast i8* %52 to i16*, !dbg !52
+  %54 = load i16, i16* %53, align 8, !dbg !52
+  %55 = and i16 %54, -384, !dbg !52
+  %56 = or i16 %55, 1, !dbg !52
+  store i16 %56, i16* %53, align 8, !dbg !52
+  %57 = getelementptr inbounds i8, i8* %52, i64 8, !dbg !52
+  %58 = bitcast i8* %57 to i32*, !dbg !52
+  store i32 1, i32* %58, align 8, !dbg !52, !tbaa !79
+  %59 = getelementptr inbounds i8, i8* %52, i64 12, !dbg !52
+  %60 = getelementptr inbounds i8, i8* %52, i64 4, !dbg !52
+  %61 = bitcast i8* %60 to i32*, !dbg !52
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %59, i8 0, i64 20, i1 false) #17, !dbg !52
+  store i32 1, i32* %61, align 4, !dbg !52, !tbaa !82
   store i64 %rubyId_arg.i, i64* %positional_table96.i, align 8, !dbg !52
-  %69 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !52
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %69, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %22, i64 noundef 8, i1 noundef false) #17, !dbg !52
-  %70 = getelementptr inbounds i8, i8* %59, i64 32, !dbg !52
-  %71 = bitcast i8* %70 to i8**, !dbg !52
-  store i8* %69, i8** %71, align 8, !dbg !52, !tbaa !83
-  call void @sorbet_vm_define_method(i64 %32, i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 83), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#7fooAny2", i8* nonnull %59, %struct.rb_iseq_struct* %stackFrame94.i, i1 noundef zeroext false) #17, !dbg !52
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %31, align 8, !dbg !52, !tbaa !14
+  %62 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !52
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %62, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %15, i64 noundef 8, i1 noundef false) #17, !dbg !52
+  %63 = getelementptr inbounds i8, i8* %52, i64 32, !dbg !52
+  %64 = bitcast i8* %63 to i8**, !dbg !52
+  store i8* %62, i8** %64, align 8, !dbg !52, !tbaa !83
+  call void @sorbet_vm_define_method(i64 %25, i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 83), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#7fooAny2", i8* nonnull %52, %struct.rb_iseq_struct* %stackFrame94.i, i1 noundef zeroext false) #17, !dbg !52
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %24, align 8, !dbg !52, !tbaa !14
   %stackFrame106.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#6fooInt", align 8, !dbg !53
-  %72 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !53
-  %73 = bitcast i8* %72 to i16*, !dbg !53
-  %74 = load i16, i16* %73, align 8, !dbg !53
-  %75 = and i16 %74, -384, !dbg !53
-  %76 = or i16 %75, 1, !dbg !53
-  store i16 %76, i16* %73, align 8, !dbg !53
-  %77 = getelementptr inbounds i8, i8* %72, i64 8, !dbg !53
-  %78 = bitcast i8* %77 to i32*, !dbg !53
-  store i32 1, i32* %78, align 8, !dbg !53, !tbaa !79
-  %79 = getelementptr inbounds i8, i8* %72, i64 12, !dbg !53
-  %80 = getelementptr inbounds i8, i8* %72, i64 4, !dbg !53
-  %81 = bitcast i8* %80 to i32*, !dbg !53
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %79, i8 0, i64 20, i1 false) #17, !dbg !53
-  store i32 1, i32* %81, align 4, !dbg !53, !tbaa !82
+  %65 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !53
+  %66 = bitcast i8* %65 to i16*, !dbg !53
+  %67 = load i16, i16* %66, align 8, !dbg !53
+  %68 = and i16 %67, -384, !dbg !53
+  %69 = or i16 %68, 1, !dbg !53
+  store i16 %69, i16* %66, align 8, !dbg !53
+  %70 = getelementptr inbounds i8, i8* %65, i64 8, !dbg !53
+  %71 = bitcast i8* %70 to i32*, !dbg !53
+  store i32 1, i32* %71, align 8, !dbg !53, !tbaa !79
+  %72 = getelementptr inbounds i8, i8* %65, i64 12, !dbg !53
+  %73 = getelementptr inbounds i8, i8* %65, i64 4, !dbg !53
+  %74 = bitcast i8* %73 to i32*, !dbg !53
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %72, i8 0, i64 20, i1 false) #17, !dbg !53
+  store i32 1, i32* %74, align 4, !dbg !53, !tbaa !82
   store i64 %rubyId_arg.i, i64* %positional_table108.i, align 8, !dbg !53
-  %82 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !53
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %82, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %23, i64 noundef 8, i1 noundef false) #17, !dbg !53
-  %83 = getelementptr inbounds i8, i8* %72, i64 32, !dbg !53
-  %84 = bitcast i8* %83 to i8**, !dbg !53
-  store i8* %82, i8** %84, align 8, !dbg !53, !tbaa !83
-  call void @sorbet_vm_define_method(i64 %32, i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 113), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#6fooInt", i8* nonnull %72, %struct.rb_iseq_struct* %stackFrame106.i, i1 noundef zeroext false) #17, !dbg !53
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %31, align 8, !dbg !53, !tbaa !14
+  %75 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !53
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %75, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %16, i64 noundef 8, i1 noundef false) #17, !dbg !53
+  %76 = getelementptr inbounds i8, i8* %65, i64 32, !dbg !53
+  %77 = bitcast i8* %76 to i8**, !dbg !53
+  store i8* %75, i8** %77, align 8, !dbg !53, !tbaa !83
+  call void @sorbet_vm_define_method(i64 %25, i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 113), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#6fooInt", i8* nonnull %65, %struct.rb_iseq_struct* %stackFrame106.i, i1 noundef zeroext false) #17, !dbg !53
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %24, align 8, !dbg !53, !tbaa !14
   %stackFrame118.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#8fooArray", align 8, !dbg !54
-  %85 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !54
-  %86 = bitcast i8* %85 to i16*, !dbg !54
-  %87 = load i16, i16* %86, align 8, !dbg !54
-  %88 = and i16 %87, -384, !dbg !54
-  %89 = or i16 %88, 1, !dbg !54
-  store i16 %89, i16* %86, align 8, !dbg !54
-  %90 = getelementptr inbounds i8, i8* %85, i64 8, !dbg !54
-  %91 = bitcast i8* %90 to i32*, !dbg !54
-  store i32 1, i32* %91, align 8, !dbg !54, !tbaa !79
-  %92 = getelementptr inbounds i8, i8* %85, i64 12, !dbg !54
-  %93 = getelementptr inbounds i8, i8* %85, i64 4, !dbg !54
-  %94 = bitcast i8* %93 to i32*, !dbg !54
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %92, i8 0, i64 20, i1 false) #17, !dbg !54
-  store i32 1, i32* %94, align 4, !dbg !54, !tbaa !82
+  %78 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !54
+  %79 = bitcast i8* %78 to i16*, !dbg !54
+  %80 = load i16, i16* %79, align 8, !dbg !54
+  %81 = and i16 %80, -384, !dbg !54
+  %82 = or i16 %81, 1, !dbg !54
+  store i16 %82, i16* %79, align 8, !dbg !54
+  %83 = getelementptr inbounds i8, i8* %78, i64 8, !dbg !54
+  %84 = bitcast i8* %83 to i32*, !dbg !54
+  store i32 1, i32* %84, align 8, !dbg !54, !tbaa !79
+  %85 = getelementptr inbounds i8, i8* %78, i64 12, !dbg !54
+  %86 = getelementptr inbounds i8, i8* %78, i64 4, !dbg !54
+  %87 = bitcast i8* %86 to i32*, !dbg !54
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %85, i8 0, i64 20, i1 false) #17, !dbg !54
+  store i32 1, i32* %87, align 4, !dbg !54, !tbaa !82
   store i64 %rubyId_arg.i, i64* %positional_table120.i, align 8, !dbg !54
-  %95 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !54
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %95, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %24, i64 noundef 8, i1 noundef false) #17, !dbg !54
-  %96 = getelementptr inbounds i8, i8* %85, i64 32, !dbg !54
-  %97 = bitcast i8* %96 to i8**, !dbg !54
-  store i8* %95, i8** %97, align 8, !dbg !54, !tbaa !83
-  call void @sorbet_vm_define_method(i64 %32, i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 130), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#8fooArray", i8* nonnull %85, %struct.rb_iseq_struct* %stackFrame118.i, i1 noundef zeroext false) #17, !dbg !54
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %31, align 8, !dbg !54, !tbaa !14
-  %98 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 1, !dbg !55
-  %99 = load i64*, i64** %98, align 8, !dbg !55
-  store i64 %15, i64* %99, align 8, !dbg !55, !tbaa !6
-  %100 = getelementptr inbounds i64, i64* %99, i64 1, !dbg !55
-  store i64 5, i64* %100, align 8, !dbg !55, !tbaa !6
-  %101 = getelementptr inbounds i64, i64* %100, i64 1, !dbg !55
-  store i64* %101, i64** %98, align 8, !dbg !55
+  %88 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #18, !dbg !54
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %88, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %17, i64 noundef 8, i1 noundef false) #17, !dbg !54
+  %89 = getelementptr inbounds i8, i8* %78, i64 32, !dbg !54
+  %90 = bitcast i8* %89 to i8**, !dbg !54
+  store i8* %88, i8** %90, align 8, !dbg !54, !tbaa !83
+  call void @sorbet_vm_define_method(i64 %25, i8* getelementptr inbounds ([218 x i8], [218 x i8]* @sorbet_moduleStringTable, i64 0, i64 130), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#8fooArray", i8* nonnull %78, %struct.rb_iseq_struct* %stackFrame118.i, i1 noundef zeroext false) #17, !dbg !54
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %24, align 8, !dbg !54, !tbaa !14
+  %91 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 1, !dbg !55
+  %92 = load i64*, i64** %91, align 8, !dbg !55
+  store i64 %8, i64* %92, align 8, !dbg !55, !tbaa !6
+  %93 = getelementptr inbounds i64, i64* %92, i64 1, !dbg !55
+  store i64 5, i64* %93, align 8, !dbg !55, !tbaa !6
+  %94 = getelementptr inbounds i64, i64* %93, i64 1, !dbg !55
+  store i64* %94, i64** %91, align 8, !dbg !55
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_fooInt, i64 0), !dbg !55
-  %102 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 1, !dbg !56
-  %103 = load i64*, i64** %102, align 8, !dbg !56
-  store i64 %15, i64* %103, align 8, !dbg !56, !tbaa !6
-  %104 = getelementptr inbounds i64, i64* %103, i64 1, !dbg !56
-  store i64 %send, i64* %104, align 8, !dbg !56, !tbaa !6
-  %105 = getelementptr inbounds i64, i64* %104, i64 1, !dbg !56
-  store i64* %105, i64** %102, align 8, !dbg !56
+  %95 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 1, !dbg !56
+  %96 = load i64*, i64** %95, align 8, !dbg !56
+  store i64 %8, i64* %96, align 8, !dbg !56, !tbaa !6
+  %97 = getelementptr inbounds i64, i64* %96, i64 1, !dbg !56
+  store i64 %send, i64* %97, align 8, !dbg !56, !tbaa !6
+  %98 = getelementptr inbounds i64, i64* %97, i64 1, !dbg !56
+  store i64* %98, i64** %95, align 8, !dbg !56
   %send2 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !56
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %31, align 8, !dbg !56, !tbaa !14
-  %106 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 1, !dbg !57
-  %107 = load i64*, i64** %106, align 8, !dbg !57
-  store i64 %15, i64* %107, align 8, !dbg !57, !tbaa !6
-  %108 = getelementptr inbounds i64, i64* %107, i64 1, !dbg !57
-  store i64 5, i64* %108, align 8, !dbg !57, !tbaa !6
-  %109 = getelementptr inbounds i64, i64* %108, i64 1, !dbg !57
-  store i64* %109, i64** %106, align 8, !dbg !57
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %24, align 8, !dbg !56, !tbaa !14
+  %99 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 1, !dbg !57
+  %100 = load i64*, i64** %99, align 8, !dbg !57
+  store i64 %8, i64* %100, align 8, !dbg !57, !tbaa !6
+  %101 = getelementptr inbounds i64, i64* %100, i64 1, !dbg !57
+  store i64 5, i64* %101, align 8, !dbg !57, !tbaa !6
+  %102 = getelementptr inbounds i64, i64* %101, i64 1, !dbg !57
+  store i64* %102, i64** %99, align 8, !dbg !57
   %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_fooAny1, i64 0), !dbg !57
-  %110 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 1, !dbg !58
-  %111 = load i64*, i64** %110, align 8, !dbg !58
-  store i64 %15, i64* %111, align 8, !dbg !58, !tbaa !6
-  %112 = getelementptr inbounds i64, i64* %111, i64 1, !dbg !58
-  store i64 %send4, i64* %112, align 8, !dbg !58, !tbaa !6
-  %113 = getelementptr inbounds i64, i64* %112, i64 1, !dbg !58
-  store i64* %113, i64** %110, align 8, !dbg !58
+  %103 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 1, !dbg !58
+  %104 = load i64*, i64** %103, align 8, !dbg !58
+  store i64 %8, i64* %104, align 8, !dbg !58, !tbaa !6
+  %105 = getelementptr inbounds i64, i64* %104, i64 1, !dbg !58
+  store i64 %send4, i64* %105, align 8, !dbg !58, !tbaa !6
+  %106 = getelementptr inbounds i64, i64* %105, i64 1, !dbg !58
+  store i64* %106, i64** %103, align 8, !dbg !58
   %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.1, i64 0), !dbg !58
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %31, align 8, !dbg !58, !tbaa !14
-  %114 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 1, !dbg !59
-  %115 = load i64*, i64** %114, align 8, !dbg !59
-  store i64 %15, i64* %115, align 8, !dbg !59, !tbaa !6
-  %116 = getelementptr inbounds i64, i64* %115, i64 1, !dbg !59
-  store i64 5, i64* %116, align 8, !dbg !59, !tbaa !6
-  %117 = getelementptr inbounds i64, i64* %116, i64 1, !dbg !59
-  store i64* %117, i64** %114, align 8, !dbg !59
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %24, align 8, !dbg !58, !tbaa !14
+  %107 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 1, !dbg !59
+  %108 = load i64*, i64** %107, align 8, !dbg !59
+  store i64 %8, i64* %108, align 8, !dbg !59, !tbaa !6
+  %109 = getelementptr inbounds i64, i64* %108, i64 1, !dbg !59
+  store i64 5, i64* %109, align 8, !dbg !59, !tbaa !6
+  %110 = getelementptr inbounds i64, i64* %109, i64 1, !dbg !59
+  store i64* %110, i64** %107, align 8, !dbg !59
   %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_fooAny2, i64 0), !dbg !59
-  %118 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 1, !dbg !60
-  %119 = load i64*, i64** %118, align 8, !dbg !60
-  store i64 %15, i64* %119, align 8, !dbg !60, !tbaa !6
-  %120 = getelementptr inbounds i64, i64* %119, i64 1, !dbg !60
-  store i64 %send8, i64* %120, align 8, !dbg !60, !tbaa !6
-  %121 = getelementptr inbounds i64, i64* %120, i64 1, !dbg !60
-  store i64* %121, i64** %118, align 8, !dbg !60
+  %111 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 1, !dbg !60
+  %112 = load i64*, i64** %111, align 8, !dbg !60
+  store i64 %8, i64* %112, align 8, !dbg !60, !tbaa !6
+  %113 = getelementptr inbounds i64, i64* %112, i64 1, !dbg !60
+  store i64 %send8, i64* %113, align 8, !dbg !60, !tbaa !6
+  %114 = getelementptr inbounds i64, i64* %113, i64 1, !dbg !60
+  store i64* %114, i64** %111, align 8, !dbg !60
   %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.2, i64 0), !dbg !60
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %31, align 8, !dbg !60, !tbaa !14
-  %122 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 1, !dbg !61
-  %123 = load i64*, i64** %122, align 8, !dbg !61
-  store i64 %15, i64* %123, align 8, !dbg !61, !tbaa !6
-  %124 = getelementptr inbounds i64, i64* %123, i64 1, !dbg !61
-  store i64 5, i64* %124, align 8, !dbg !61, !tbaa !6
-  %125 = getelementptr inbounds i64, i64* %124, i64 1, !dbg !61
-  store i64* %125, i64** %122, align 8, !dbg !61
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %24, align 8, !dbg !60, !tbaa !14
+  %115 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 1, !dbg !61
+  %116 = load i64*, i64** %115, align 8, !dbg !61
+  store i64 %8, i64* %116, align 8, !dbg !61, !tbaa !6
+  %117 = getelementptr inbounds i64, i64* %116, i64 1, !dbg !61
+  store i64 5, i64* %117, align 8, !dbg !61, !tbaa !6
+  %118 = getelementptr inbounds i64, i64* %117, i64 1, !dbg !61
+  store i64* %118, i64** %115, align 8, !dbg !61
   %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_fooAll, i64 0), !dbg !61
-  %126 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 1, !dbg !62
-  %127 = load i64*, i64** %126, align 8, !dbg !62
-  store i64 %15, i64* %127, align 8, !dbg !62, !tbaa !6
-  %128 = getelementptr inbounds i64, i64* %127, i64 1, !dbg !62
-  store i64 %send12, i64* %128, align 8, !dbg !62, !tbaa !6
-  %129 = getelementptr inbounds i64, i64* %128, i64 1, !dbg !62
-  store i64* %129, i64** %126, align 8, !dbg !62
+  %119 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 1, !dbg !62
+  %120 = load i64*, i64** %119, align 8, !dbg !62
+  store i64 %8, i64* %120, align 8, !dbg !62, !tbaa !6
+  %121 = getelementptr inbounds i64, i64* %120, i64 1, !dbg !62
+  store i64 %send12, i64* %121, align 8, !dbg !62, !tbaa !6
+  %122 = getelementptr inbounds i64, i64* %121, i64 1, !dbg !62
+  store i64* %122, i64** %119, align 8, !dbg !62
   %send14 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.3, i64 0), !dbg !62
-  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 29), i64** %31, align 8, !dbg !62, !tbaa !14
+  store i64* getelementptr inbounds ([30 x i64], [30 x i64]* @iseqEncodedArray, i64 0, i64 29), i64** %24, align 8, !dbg !62, !tbaa !14
   %callArgs0Addr.i = getelementptr [4 x i64], [4 x i64]* %callArgs.i, i64 0, i64 0, !dbg !84
   store i64 5, i64* %callArgs0Addr.i, align 8, !dbg !84
   call void @llvm.experimental.noalias.scope.decl(metadata !85) #17, !dbg !84
-  %130 = call i64 @rb_ary_new_from_values(i64 noundef 1, i64* noundef nonnull align 8 %callArgs0Addr.i) #17, !dbg !84
-  %131 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 1, !dbg !63
-  %132 = load i64*, i64** %131, align 8, !dbg !63
-  store i64 %15, i64* %132, align 8, !dbg !63, !tbaa !6
-  %133 = getelementptr inbounds i64, i64* %132, i64 1, !dbg !63
-  store i64 %130, i64* %133, align 8, !dbg !63, !tbaa !6
-  %134 = getelementptr inbounds i64, i64* %133, i64 1, !dbg !63
-  store i64* %134, i64** %131, align 8, !dbg !63
+  %123 = call i64 @rb_ary_new_from_values(i64 noundef 1, i64* noundef nonnull align 8 %callArgs0Addr.i) #17, !dbg !84
+  %124 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 1, !dbg !63
+  %125 = load i64*, i64** %124, align 8, !dbg !63
+  store i64 %8, i64* %125, align 8, !dbg !63, !tbaa !6
+  %126 = getelementptr inbounds i64, i64* %125, i64 1, !dbg !63
+  store i64 %123, i64* %126, align 8, !dbg !63, !tbaa !6
+  %127 = getelementptr inbounds i64, i64* %126, i64 1, !dbg !63
+  store i64* %127, i64** %124, align 8, !dbg !63
   %send16 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_fooArray, i64 0), !dbg !63
-  %135 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 1, !dbg !64
-  %136 = load i64*, i64** %135, align 8, !dbg !64
-  store i64 %15, i64* %136, align 8, !dbg !64, !tbaa !6
-  %137 = getelementptr inbounds i64, i64* %136, i64 1, !dbg !64
-  store i64 %send16, i64* %137, align 8, !dbg !64, !tbaa !6
-  %138 = getelementptr inbounds i64, i64* %137, i64 1, !dbg !64
-  store i64* %138, i64** %135, align 8, !dbg !64
+  %128 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 1, !dbg !64
+  %129 = load i64*, i64** %128, align 8, !dbg !64
+  store i64 %8, i64* %129, align 8, !dbg !64, !tbaa !6
+  %130 = getelementptr inbounds i64, i64* %129, i64 1, !dbg !64
+  store i64 %send16, i64* %130, align 8, !dbg !64, !tbaa !6
+  %131 = getelementptr inbounds i64, i64* %130, i64 1, !dbg !64
+  store i64* %131, i64** %128, align 8, !dbg !64
   %send18 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.4, i64 0), !dbg !64
-  call void @llvm.lifetime.end.p0i8(i64 32, i8* nonnull %19)
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %20)
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %21)
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %22)
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %23)
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %24)
+  call void @llvm.lifetime.end.p0i8(i64 32, i8* nonnull %12)
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %13)
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %14)
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %15)
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %16)
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %17)
   ret void
 }
 

--- a/test/testdata/compiler/class.opt.ll.exp
+++ b/test/testdata/compiler/class.opt.ll.exp
@@ -77,19 +77,16 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"rubyStrFrozen_test/testdata/compiler/class.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [10 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @"stackFramePrecomputed_func_Foo.13<static-init>" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyStrFrozen_<module:Foo>" = internal unnamed_addr global i64 0, align 8
 @"stackFramePrecomputed_func_Foo::Bar.13<static-init>" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyStrFrozen_<class:Foo::Bar>" = internal unnamed_addr global i64 0, align 8
 @"stackFramePrecomputed_func_Baz.13<static-init>" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyStrFrozen_<class:Baz>" = internal unnamed_addr global i64 0, align 8
 @sorbet_moduleStringTable = internal unnamed_addr constant [117 x i8] c"<top (required)>\00test/testdata/compiler/class.rb\00Foo\00Baz\00Object\00master\00<module:Foo>\00Bar\00<class:Foo::Bar>\00<class:Baz>\00", align 1
 @sorbet_moduleIDTable = internal unnamed_addr global [4 x i64] zeroinitializer, align 8
 @sorbet_moduleIDDescriptors = internal unnamed_addr constant [4 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 71, i32 12 }, %struct.rb_code_position_struct { i32 88, i32 16 }, %struct.rb_code_position_struct { i32 105, i32 11 }], align 8
+@sorbet_moduleRubyStringTable = internal unnamed_addr global [5 x i64] zeroinitializer, align 8
+@sorbet_moduleRubyStringDescriptors = internal unnamed_addr constant [5 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 17, i32 31 }, %struct.rb_code_position_struct { i32 71, i32 12 }, %struct.rb_code_position_struct { i32 88, i32 16 }, %struct.rb_code_position_struct { i32 105, i32 11 }], align 8
 @guard_epoch_Foo = linkonce local_unnamed_addr global i64 0
 @guarded_const_Foo = linkonce local_unnamed_addr global i64 0
 @rb_cObject = external local_unnamed_addr constant i64
@@ -110,7 +107,7 @@ declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %
 
 declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #0
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
+declare void @sorbet_vm_init_string_table(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #0
 
 declare i64 @rb_define_module(i8*) local_unnamed_addr #0
 
@@ -118,37 +115,31 @@ declare i64 @rb_define_class(i8*, i64) local_unnamed_addr #0
 
 declare i64 @rb_define_class_under(i64, i8*, i64) local_unnamed_addr #0
 
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
-
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #1
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #2 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #7
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #6
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #2 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #7
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #6
   unreachable
 }
 
 define internal fastcc void @sorbet_globalConstructors(i64 %realpath) unnamed_addr {
 allocRubyIds:
   tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([4 x %struct.rb_code_position_struct], [4 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 4, i8* noundef getelementptr inbounds ([117 x i8], [117 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
-  tail call fastcc void @"Constr_rubyStrFrozen_<top (required)>"() #8
-  tail call fastcc void @"Constr_rubyStrFrozen_test/testdata/compiler/class.rb"() #8
+  tail call void @sorbet_vm_init_string_table(i64* noundef getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleRubyStringTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([5 x %struct.rb_code_position_struct], [5 x %struct.rb_code_position_struct]* @sorbet_moduleRubyStringDescriptors, i32 0, i32 0), i32 noundef 5, i8* noundef getelementptr inbounds ([117 x i8], [117 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([10 x i64], [10 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 10)
   tail call fastcc void @"Constr_stackFramePrecomputed_func_<root>.17<static-init>$153"(i64 %realpath)
-  tail call fastcc void @"Constr_rubyStrFrozen_<module:Foo>"() #8
   tail call fastcc void @"Constr_stackFramePrecomputed_func_Foo.13<static-init>"(i64 %realpath)
-  tail call fastcc void @"Constr_rubyStrFrozen_<class:Foo::Bar>"() #8
   tail call fastcc void @"Constr_stackFramePrecomputed_func_Foo::Bar.13<static-init>"(i64 %realpath)
-  tail call fastcc void @"Constr_rubyStrFrozen_<class:Baz>"() #8
   tail call fastcc void @"Constr_stackFramePrecomputed_func_Baz.13<static-init>"(i64 %realpath)
   ret void
 }
@@ -157,34 +148,16 @@ allocRubyIds:
 define internal fastcc void @"Constr_stackFramePrecomputed_func_<root>.17<static-init>$153"(i64 %realpath) unnamed_addr #3 {
 entryInitializers:
   %"rubyId_<top (required)>" = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
-  %"rubyStr_<top (required)>" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/class.rb" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/class.rb", align 8
+  %"rubyStr_<top (required)>" = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 0), align 8, !invariant.load !5
+  %"rubyStr_test/testdata/compiler/class.rb" = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
   %locals = alloca i64, i32 0, align 8
   %0 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>", i64 %"rubyId_<top (required)>", i64 %"rubyStr_test/testdata/compiler/class.rb", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %0, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
   ret void
 }
 
-; Function Attrs: nounwind ssp
-define internal fastcc void @"Constr_rubyStrFrozen_<top (required)>"() unnamed_addr #4 {
-constr:
-  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([117 x i8], [117 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #8
-  tail call void @rb_gc_register_mark_object(i64 %0) #8
-  store i64 %0, i64* @"rubyStrFrozen_<top (required)>", align 8
-  ret void
-}
-
-; Function Attrs: nounwind ssp
-define internal fastcc void @"Constr_rubyStrFrozen_test/testdata/compiler/class.rb"() unnamed_addr #4 {
-constr:
-  %0 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([117 x i8], [117 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 31) #8
-  tail call void @rb_gc_register_mark_object(i64 %0) #8
-  store i64 %0, i64* @"rubyStrFrozen_test/testdata/compiler/class.rb", align 8
-  ret void
-}
-
 ; Function Attrs: sspreq
-define void @Init_class() local_unnamed_addr #5 {
+define void @Init_class() local_unnamed_addr #4 {
 entry:
   %realpath = tail call i64 @sorbet_readRealpath()
   tail call fastcc void @sorbet_globalConstructors(i64 %realpath)
@@ -199,11 +172,11 @@ entry:
   %6 = load i64, i64* %5, align 8, !tbaa !6
   %7 = and i64 %6, -33
   store i64 %7, i64* %5, align 8, !tbaa !6
-  tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame.i) #8
+  tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %0, %struct.rb_control_frame_struct* %2, %struct.rb_iseq_struct* %stackFrame.i) #7
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
   store i64* getelementptr inbounds ([10 x i64], [10 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %8, align 8, !dbg !19, !tbaa !10
-  %9 = tail call i64 @rb_define_module(i8* getelementptr inbounds ([117 x i8], [117 x i8]* @sorbet_moduleStringTable, i64 0, i64 49)) #8, !dbg !24
-  %10 = tail call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %9) #8, !dbg !24
+  %9 = tail call i64 @rb_define_module(i8* getelementptr inbounds ([117 x i8], [117 x i8]* @sorbet_moduleStringTable, i64 0, i64 49)) #7, !dbg !24
+  %10 = tail call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %9) #7, !dbg !24
   %stackFrame.i1.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>", align 8
   %11 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !10
   %12 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %11, i64 0, i32 2
@@ -215,7 +188,7 @@ entry:
   %17 = load i64, i64* %16, align 8, !tbaa !6
   %18 = and i64 %17, -33
   store i64 %18, i64* %16, align 8, !tbaa !6
-  tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %11, %struct.rb_control_frame_struct* %13, %struct.rb_iseq_struct* %stackFrame.i1.i) #8
+  tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %11, %struct.rb_control_frame_struct* %13, %struct.rb_iseq_struct* %stackFrame.i1.i) #7
   %19 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %10, i64 0, i32 0
   store i64* getelementptr inbounds ([10 x i64], [10 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %19, align 8, !dbg !25, !tbaa !10
   %20 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !28
@@ -234,8 +207,8 @@ entry:
   %guardUpdated = icmp eq i64 %25, %26, !dbg !28
   tail call void @llvm.assume(i1 %guardUpdated), !dbg !28
   %27 = load i64, i64* @rb_cObject, align 8, !dbg !28
-  %28 = tail call i64 @rb_define_class_under(i64 %24, i8* getelementptr inbounds ([117 x i8], [117 x i8]* @sorbet_moduleStringTable, i64 0, i64 84), i64 %27) #8, !dbg !28
-  %29 = tail call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %28) #8, !dbg !28
+  %28 = tail call i64 @rb_define_class_under(i64 %24, i8* getelementptr inbounds ([117 x i8], [117 x i8]* @sorbet_moduleStringTable, i64 0, i64 84), i64 %27) #7, !dbg !28
+  %29 = tail call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %28) #7, !dbg !28
   %stackFrame.i.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo::Bar.13<static-init>", align 8
   %30 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !10
   %31 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %30, i64 0, i32 2
@@ -247,14 +220,14 @@ entry:
   %36 = load i64, i64* %35, align 8, !tbaa !6
   %37 = and i64 %36, -33
   store i64 %37, i64* %35, align 8, !tbaa !6
-  tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %30, %struct.rb_control_frame_struct* %32, %struct.rb_iseq_struct* %stackFrame.i.i.i) #8
+  tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %30, %struct.rb_control_frame_struct* %32, %struct.rb_iseq_struct* %stackFrame.i.i.i) #7
   %38 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %29, i64 0, i32 0
   store i64* getelementptr inbounds ([10 x i64], [10 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %38, align 8, !dbg !32, !tbaa !10
-  tail call void @sorbet_popFrame() #8, !dbg !28
-  tail call void @sorbet_popFrame() #8, !dbg !24
+  tail call void @sorbet_popFrame() #7, !dbg !28
+  tail call void @sorbet_popFrame() #7, !dbg !24
   store i64* getelementptr inbounds ([10 x i64], [10 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %8, align 8, !dbg !24, !tbaa !10
-  %39 = tail call i64 @rb_define_class(i8* getelementptr inbounds ([117 x i8], [117 x i8]* @sorbet_moduleStringTable, i64 0, i64 53), i64 %27) #8, !dbg !35
-  %40 = tail call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %39) #8, !dbg !35
+  %39 = tail call i64 @rb_define_class(i8* getelementptr inbounds ([117 x i8], [117 x i8]* @sorbet_moduleStringTable, i64 0, i64 53), i64 %27) #7, !dbg !35
+  %40 = tail call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %39) #7, !dbg !35
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Baz.13<static-init>", align 8
   %41 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !10
   %42 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %41, i64 0, i32 2
@@ -266,10 +239,10 @@ entry:
   %47 = load i64, i64* %46, align 8, !tbaa !6
   %48 = and i64 %47, -33
   store i64 %48, i64* %46, align 8, !tbaa !6
-  tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %41, %struct.rb_control_frame_struct* %43, %struct.rb_iseq_struct* %stackFrame.i.i) #8
+  tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %41, %struct.rb_control_frame_struct* %43, %struct.rb_iseq_struct* %stackFrame.i.i) #7
   %49 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %40, i64 0, i32 0
   store i64* getelementptr inbounds ([10 x i64], [10 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %49, align 8, !dbg !36, !tbaa !10
-  tail call void @sorbet_popFrame() #8, !dbg !35
+  tail call void @sorbet_popFrame() #7, !dbg !35
   ret void
 }
 
@@ -277,20 +250,11 @@ entry:
 define internal fastcc void @"Constr_stackFramePrecomputed_func_Foo.13<static-init>"(i64 %realpath) unnamed_addr #3 {
 entryInitializers:
   %"rubyId_<module:Foo>" = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !invariant.load !5
-  %"rubyStr_<module:Foo>" = load i64, i64* @"rubyStrFrozen_<module:Foo>", align 8
-  %"rubyStr_test/testdata/compiler/class.rb" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/class.rb", align 8
+  %"rubyStr_<module:Foo>" = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 2), align 8, !invariant.load !5
+  %"rubyStr_test/testdata/compiler/class.rb" = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
   %locals = alloca i64, i32 0, align 8
   %0 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<module:Foo>", i64 %"rubyId_<module:Foo>", i64 %"rubyStr_test/testdata/compiler/class.rb", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %0, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>", align 8
-  ret void
-}
-
-; Function Attrs: nounwind ssp
-define internal fastcc void @"Constr_rubyStrFrozen_<module:Foo>"() unnamed_addr #4 {
-constr:
-  %0 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([117 x i8], [117 x i8]* @sorbet_moduleStringTable, i64 0, i64 71), i64 noundef 12) #8
-  tail call void @rb_gc_register_mark_object(i64 %0) #8
-  store i64 %0, i64* @"rubyStrFrozen_<module:Foo>", align 8
   ret void
 }
 
@@ -298,20 +262,11 @@ constr:
 define internal fastcc void @"Constr_stackFramePrecomputed_func_Foo::Bar.13<static-init>"(i64 %realpath) unnamed_addr #3 {
 entryInitializers:
   %"rubyId_<class:Foo::Bar>" = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !invariant.load !5
-  %"rubyStr_<class:Foo::Bar>" = load i64, i64* @"rubyStrFrozen_<class:Foo::Bar>", align 8
-  %"rubyStr_test/testdata/compiler/class.rb" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/class.rb", align 8
+  %"rubyStr_<class:Foo::Bar>" = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 3), align 8, !invariant.load !5
+  %"rubyStr_test/testdata/compiler/class.rb" = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
   %locals = alloca i64, i32 0, align 8
   %0 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<class:Foo::Bar>", i64 %"rubyId_<class:Foo::Bar>", i64 %"rubyStr_test/testdata/compiler/class.rb", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals, i32 noundef 0, i32 noundef 0)
   store %struct.rb_iseq_struct* %0, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo::Bar.13<static-init>", align 8
-  ret void
-}
-
-; Function Attrs: nounwind ssp
-define internal fastcc void @"Constr_rubyStrFrozen_<class:Foo::Bar>"() unnamed_addr #4 {
-constr:
-  %0 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([117 x i8], [117 x i8]* @sorbet_moduleStringTable, i64 0, i64 88), i64 noundef 16) #8
-  tail call void @rb_gc_register_mark_object(i64 %0) #8
-  store i64 %0, i64* @"rubyStrFrozen_<class:Foo::Bar>", align 8
   ret void
 }
 
@@ -319,25 +274,16 @@ constr:
 define internal fastcc void @"Constr_stackFramePrecomputed_func_Baz.13<static-init>"(i64 %realpath) unnamed_addr #3 {
 entryInitializers:
   %"rubyId_<class:Baz>" = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !invariant.load !5
-  %"rubyStr_<class:Baz>" = load i64, i64* @"rubyStrFrozen_<class:Baz>", align 8
-  %"rubyStr_test/testdata/compiler/class.rb" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/class.rb", align 8
+  %"rubyStr_<class:Baz>" = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 4), align 8, !invariant.load !5
+  %"rubyStr_test/testdata/compiler/class.rb" = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
   %locals = alloca i64, i32 0, align 8
   %0 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<class:Baz>", i64 %"rubyId_<class:Baz>", i64 %"rubyStr_test/testdata/compiler/class.rb", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals, i32 noundef 0, i32 noundef 0)
   store %struct.rb_iseq_struct* %0, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Baz.13<static-init>", align 8
   ret void
 }
 
-; Function Attrs: nounwind ssp
-define internal fastcc void @"Constr_rubyStrFrozen_<class:Baz>"() unnamed_addr #4 {
-constr:
-  %0 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([117 x i8], [117 x i8]* @sorbet_moduleStringTable, i64 0, i64 105), i64 noundef 11) #8
-  tail call void @rb_gc_register_mark_object(i64 %0) #8
-  store i64 %0, i64* @"rubyStrFrozen_<class:Baz>", align 8
-  ret void
-}
-
 ; Function Attrs: nofree nosync nounwind willreturn
-declare void @llvm.assume(i1 noundef) #6
+declare void @llvm.assume(i1 noundef) #5
 
 ; Function Attrs: ssp
 define linkonce void @const_recompute_Foo() local_unnamed_addr #3 {
@@ -352,11 +298,10 @@ attributes #0 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-preci
 attributes #1 = { noreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #2 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #3 = { ssp }
-attributes #4 = { nounwind ssp }
-attributes #5 = { sspreq }
-attributes #6 = { nofree nosync nounwind willreturn }
-attributes #7 = { noreturn nounwind }
-attributes #8 = { nounwind }
+attributes #4 = { sspreq }
+attributes #5 = { nofree nosync nounwind willreturn }
+attributes #6 = { noreturn nounwind }
+attributes #7 = { nounwind }
 
 !llvm.module.flags = !{!0, !1, !2}
 !llvm.dbg.cu = !{!3}

--- a/test/testdata/compiler/classfields.opt.ll.exp
+++ b/test/testdata/compiler/classfields.opt.ll.exp
@@ -82,8 +82,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"rubyStrFrozen_test/testdata/compiler/classfields.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [29 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @ic_new = internal global %struct.FunctionInlineCache zeroinitializer
@@ -97,12 +95,13 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ic_puts.4 = internal global %struct.FunctionInlineCache zeroinitializer
 @"stackFramePrecomputed_func_B#5write" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"stackFramePrecomputed_func_B#4read" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@rubyStrFrozen_read = internal unnamed_addr global i64 0, align 8
 @stackFramePrecomputed_func_B.4read = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"stackFramePrecomputed_func_B.13<static-init>" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @sorbet_moduleStringTable = internal unnamed_addr constant [125 x i8] c"<top (required)>\00test/testdata/compiler/classfields.rb\00B\00Object\00new\00initialize\00write\00read\00puts\00master\00@@f\00<class:B>\00normal\00a\00", align 1
 @sorbet_moduleIDTable = internal unnamed_addr global [10 x i64] zeroinitializer, align 8
 @sorbet_moduleIDDescriptors = internal unnamed_addr constant [10 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 64, i32 3 }, %struct.rb_code_position_struct { i32 68, i32 10 }, %struct.rb_code_position_struct { i32 79, i32 5 }, %struct.rb_code_position_struct { i32 85, i32 4 }, %struct.rb_code_position_struct { i32 90, i32 4 }, %struct.rb_code_position_struct { i32 102, i32 3 }, %struct.rb_code_position_struct { i32 106, i32 9 }, %struct.rb_code_position_struct { i32 116, i32 6 }, %struct.rb_code_position_struct { i32 123, i32 1 }], align 8
+@sorbet_moduleRubyStringTable = internal unnamed_addr global [5 x i64] zeroinitializer, align 8
+@sorbet_moduleRubyStringDescriptors = internal unnamed_addr constant [5 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 17, i32 37 }, %struct.rb_code_position_struct { i32 79, i32 5 }, %struct.rb_code_position_struct { i32 85, i32 4 }, %struct.rb_code_position_struct { i32 106, i32 9 }], align 8
 @rb_cObject = external local_unnamed_addr constant i64
 @guard_epoch_B = linkonce local_unnamed_addr global i64 0
 @guarded_const_B = linkonce local_unnamed_addr global i64 0
@@ -132,9 +131,9 @@ declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_
 
 declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #1
 
-declare i64 @sorbet_maybeAllocateObjectFastPath(i64, %struct.FunctionInlineCache*) local_unnamed_addr #1
+declare void @sorbet_vm_init_string_table(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #1
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #1
+declare i64 @sorbet_maybeAllocateObjectFastPath(i64, %struct.FunctionInlineCache*) local_unnamed_addr #1
 
 declare i64 @rb_define_class(i8*, i64) local_unnamed_addr #1
 
@@ -147,8 +146,6 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #2
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #2
-
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #1
 
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #0
@@ -187,18 +184,13 @@ entry:
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
   tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([10 x %struct.rb_code_position_struct], [10 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 10, i8* noundef getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
-  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #11
-  tail call void @rb_gc_register_mark_object(i64 %0) #11
-  store i64 %0, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %1 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 37) #11
-  tail call void @rb_gc_register_mark_object(i64 %1) #11
-  store i64 %1, i64* @"rubyStrFrozen_test/testdata/compiler/classfields.rb", align 8
+  tail call void @sorbet_vm_init_string_table(i64* noundef getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleRubyStringTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([5 x %struct.rb_code_position_struct], [5 x %struct.rb_code_position_struct]* @sorbet_moduleRubyStringDescriptors, i32 0, i32 0), i32 noundef 5, i8* noundef getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 29)
   %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
-  %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/classfields.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/classfields.rb", align 8
-  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/classfields.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %"rubyStr_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 0), align 8, !invariant.load !5
+  %"rubyStr_test/testdata/compiler/classfields.rb.i.i" = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
+  %0 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/classfields.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %0, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
   %rubyId_new.i = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !dbg !17, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !17
   %rubyId_initialize.i = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !17, !invariant.load !5
@@ -213,209 +205,200 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_initialize.2, i64 %rubyId_initialize.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !20
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_read.3, i64 %rubyId_read.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !20
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.4, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !21
-  %3 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 79), i64 noundef 5) #11
-  call void @rb_gc_register_mark_object(i64 %3) #11
-  %"rubyStr_test/testdata/compiler/classfields.rb.i16.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/classfields.rb", align 8
-  %4 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %3, i64 %rubyId_write.i, i64 %"rubyStr_test/testdata/compiler/classfields.rb.i16.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 7, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i17.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %4, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B#5write", align 8
-  %5 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 85), i64 noundef 4) #11
-  call void @rb_gc_register_mark_object(i64 %5) #11
-  store i64 %5, i64* @rubyStrFrozen_read, align 8
-  %"rubyStr_test/testdata/compiler/classfields.rb.i18.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/classfields.rb", align 8
-  %6 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %5, i64 %rubyId_read.i, i64 %"rubyStr_test/testdata/compiler/classfields.rb.i18.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 16, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i19.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %6, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B#4read", align 8
-  %rubyStr_read.i21.i = load i64, i64* @rubyStrFrozen_read, align 8
-  %"rubyStr_test/testdata/compiler/classfields.rb.i22.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/classfields.rb", align 8
-  %7 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_read.i21.i, i64 %rubyId_read.i, i64 %"rubyStr_test/testdata/compiler/classfields.rb.i22.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 19, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i23.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %7, %struct.rb_iseq_struct** @stackFramePrecomputed_func_B.4read, align 8
-  %8 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 106), i64 noundef 9) #11
-  call void @rb_gc_register_mark_object(i64 %8) #11
+  %rubyStr_write.i.i = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 2), align 8, !invariant.load !5
+  %1 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_write.i.i, i64 %rubyId_write.i, i64 %"rubyStr_test/testdata/compiler/classfields.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 7, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i17.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %1, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B#5write", align 8
+  %rubyStr_read.i.i = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 3), align 8, !invariant.load !5
+  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_read.i.i, i64 %rubyId_read.i, i64 %"rubyStr_test/testdata/compiler/classfields.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 16, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i19.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B#4read", align 8
+  %3 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_read.i.i, i64 %rubyId_read.i, i64 %"rubyStr_test/testdata/compiler/classfields.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 19, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i23.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %3, %struct.rb_iseq_struct** @stackFramePrecomputed_func_B.4read, align 8
   %"rubyId_<class:B>.i.i" = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 7), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/classfields.rb.i24.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/classfields.rb", align 8
-  %9 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %8, i64 %"rubyId_<class:B>.i.i", i64 %"rubyStr_test/testdata/compiler/classfields.rb.i24.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i25.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %9, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B.13<static-init>", align 8
-  %10 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !22
-  %11 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %10, i64 0, i32 18
-  %12 = load i64, i64* %11, align 8, !tbaa !24
-  %13 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !22
-  %14 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %13, i64 0, i32 2
-  %15 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %14, align 8, !tbaa !34
+  %"rubyStr_<class:B>.i.i" = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 4), align 8, !invariant.load !5
+  %4 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<class:B>.i.i", i64 %"rubyId_<class:B>.i.i", i64 %"rubyStr_test/testdata/compiler/classfields.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i25.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %4, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B.13<static-init>", align 8
+  %5 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !22
+  %6 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %5, i64 0, i32 18
+  %7 = load i64, i64* %6, align 8, !tbaa !24
+  %8 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !22
+  %9 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %8, i64 0, i32 2
+  %10 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %9, align 8, !tbaa !34
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %16 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %16, align 8, !tbaa !37
-  %17 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 4
-  %18 = load i64*, i64** %17, align 8, !tbaa !39
-  %19 = load i64, i64* %18, align 8, !tbaa !6
-  %20 = and i64 %19, -33
-  store i64 %20, i64* %18, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %13, %struct.rb_control_frame_struct* %15, %struct.rb_iseq_struct* %stackFrame.i) #11
-  %21 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 0
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %21, align 8, !dbg !40, !tbaa !22
-  %22 = load i64, i64* @rb_cObject, align 8, !dbg !41
-  %23 = call i64 @rb_define_class(i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 55), i64 %22) #11, !dbg !41
-  %24 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %23) #11, !dbg !41
-  %25 = bitcast i64* %positional_table.i.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %25) #11
+  %11 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %10, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %11, align 8, !tbaa !37
+  %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %10, i64 0, i32 4
+  %13 = load i64*, i64** %12, align 8, !tbaa !39
+  %14 = load i64, i64* %13, align 8, !tbaa !6
+  %15 = and i64 %14, -33
+  store i64 %15, i64* %13, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %8, %struct.rb_control_frame_struct* %10, %struct.rb_iseq_struct* %stackFrame.i) #11
+  %16 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %10, i64 0, i32 0
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %16, align 8, !dbg !40, !tbaa !22
+  %17 = load i64, i64* @rb_cObject, align 8, !dbg !41
+  %18 = call i64 @rb_define_class(i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 55), i64 %17) #11, !dbg !41
+  %19 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %18) #11, !dbg !41
+  %20 = bitcast i64* %positional_table.i.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %20) #11
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B.13<static-init>", align 8
-  %26 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !22
-  %27 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %26, i64 0, i32 2
-  %28 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %27, align 8, !tbaa !34
-  %29 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %28, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %29, align 8, !tbaa !37
-  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %28, i64 0, i32 4
-  %31 = load i64*, i64** %30, align 8, !tbaa !39
-  %32 = load i64, i64* %31, align 8, !tbaa !6
-  %33 = and i64 %32, -33
-  store i64 %33, i64* %31, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %26, %struct.rb_control_frame_struct* %28, %struct.rb_iseq_struct* %stackFrame.i.i) #11
-  %34 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 0
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %34, align 8, !dbg !42, !tbaa !22
+  %21 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !22
+  %22 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 2
+  %23 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %22, align 8, !tbaa !34
+  %24 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %24, align 8, !tbaa !37
+  %25 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 4
+  %26 = load i64*, i64** %25, align 8, !tbaa !39
+  %27 = load i64, i64* %26, align 8, !tbaa !6
+  %28 = and i64 %27, -33
+  store i64 %28, i64* %26, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %21, %struct.rb_control_frame_struct* %23, %struct.rb_iseq_struct* %stackFrame.i.i) #11
+  %29 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %19, i64 0, i32 0
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %29, align 8, !dbg !42, !tbaa !22
+  %30 = load i64, i64* @guard_epoch_B, align 8, !dbg !10
+  %31 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !43
+  %needTakeSlowPath = icmp ne i64 %30, %31, !dbg !10
+  br i1 %needTakeSlowPath, label %32, label %33, !dbg !10, !prof !44
+
+32:                                               ; preds = %entry
+  call void @const_recompute_B(), !dbg !10
+  br label %33, !dbg !10
+
+33:                                               ; preds = %entry, %32
+  %34 = load i64, i64* @guarded_const_B, align 8, !dbg !10
   %35 = load i64, i64* @guard_epoch_B, align 8, !dbg !10
   %36 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !43
-  %needTakeSlowPath = icmp ne i64 %35, %36, !dbg !10
-  br i1 %needTakeSlowPath, label %37, label %38, !dbg !10, !prof !44
-
-37:                                               ; preds = %entry
-  call void @const_recompute_B(), !dbg !10
-  br label %38, !dbg !10
-
-38:                                               ; preds = %entry, %37
-  %39 = load i64, i64* @guarded_const_B, align 8, !dbg !10
-  %40 = load i64, i64* @guard_epoch_B, align 8, !dbg !10
-  %41 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !43
-  %guardUpdated = icmp eq i64 %40, %41, !dbg !10
+  %guardUpdated = icmp eq i64 %35, %36, !dbg !10
   call void @llvm.assume(i1 %guardUpdated), !dbg !10
   %stackFrame25.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B#5write", align 8, !dbg !10
-  %42 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !10
-  %43 = bitcast i8* %42 to i16*, !dbg !10
-  %44 = load i16, i16* %43, align 8, !dbg !10
-  %45 = and i16 %44, -384, !dbg !10
-  %46 = or i16 %45, 1, !dbg !10
-  store i16 %46, i16* %43, align 8, !dbg !10
-  %47 = getelementptr inbounds i8, i8* %42, i64 8, !dbg !10
-  %48 = bitcast i8* %47 to i32*, !dbg !10
-  store i32 1, i32* %48, align 8, !dbg !10, !tbaa !45
-  %49 = getelementptr inbounds i8, i8* %42, i64 12, !dbg !10
-  %50 = getelementptr inbounds i8, i8* %42, i64 4, !dbg !10
-  %51 = bitcast i8* %50 to i32*, !dbg !10
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %49, i8 0, i64 20, i1 false) #11, !dbg !10
-  store i32 1, i32* %51, align 4, !dbg !10, !tbaa !48
+  %37 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !10
+  %38 = bitcast i8* %37 to i16*, !dbg !10
+  %39 = load i16, i16* %38, align 8, !dbg !10
+  %40 = and i16 %39, -384, !dbg !10
+  %41 = or i16 %40, 1, !dbg !10
+  store i16 %41, i16* %38, align 8, !dbg !10
+  %42 = getelementptr inbounds i8, i8* %37, i64 8, !dbg !10
+  %43 = bitcast i8* %42 to i32*, !dbg !10
+  store i32 1, i32* %43, align 8, !dbg !10, !tbaa !45
+  %44 = getelementptr inbounds i8, i8* %37, i64 12, !dbg !10
+  %45 = getelementptr inbounds i8, i8* %37, i64 4, !dbg !10
+  %46 = bitcast i8* %45 to i32*, !dbg !10
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %44, i8 0, i64 20, i1 false) #11, !dbg !10
+  store i32 1, i32* %46, align 4, !dbg !10, !tbaa !48
   %rubyId_a.i.i = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 9), align 8, !dbg !10, !invariant.load !5
   store i64 %rubyId_a.i.i, i64* %positional_table.i.i, align 8, !dbg !10
-  %52 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !10
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %52, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %25, i64 noundef 8, i1 noundef false) #11, !dbg !10
-  %53 = getelementptr inbounds i8, i8* %42, i64 32, !dbg !10
-  %54 = bitcast i8* %53 to i8**, !dbg !10
-  store i8* %52, i8** %54, align 8, !dbg !10, !tbaa !49
-  call void @sorbet_vm_define_method(i64 %39, i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 79), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_B#5write", i8* nonnull %42, %struct.rb_iseq_struct* %stackFrame25.i.i, i1 noundef zeroext false) #11, !dbg !10
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %34, align 8, !dbg !10, !tbaa !22
+  %47 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !10
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %47, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %20, i64 noundef 8, i1 noundef false) #11, !dbg !10
+  %48 = getelementptr inbounds i8, i8* %37, i64 32, !dbg !10
+  %49 = bitcast i8* %48 to i8**, !dbg !10
+  store i8* %47, i8** %49, align 8, !dbg !10, !tbaa !49
+  call void @sorbet_vm_define_method(i64 %34, i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 79), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_B#5write", i8* nonnull %37, %struct.rb_iseq_struct* %stackFrame25.i.i, i1 noundef zeroext false) #11, !dbg !10
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %29, align 8, !dbg !10, !tbaa !22
   %stackFrame34.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_B#4read", align 8, !dbg !50
-  %55 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !50
-  %56 = bitcast i8* %55 to i16*, !dbg !50
-  %57 = load i16, i16* %56, align 8, !dbg !50
-  %58 = and i16 %57, -384, !dbg !50
-  store i16 %58, i16* %56, align 8, !dbg !50
-  %59 = getelementptr inbounds i8, i8* %55, i64 4, !dbg !50
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %59, i8 0, i64 28, i1 false) #11, !dbg !50
-  call void @sorbet_vm_define_method(i64 %39, i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 85), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_B#4read", i8* nonnull %55, %struct.rb_iseq_struct* %stackFrame34.i.i, i1 noundef zeroext false) #11, !dbg !50
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %34, align 8, !dbg !50, !tbaa !22
+  %50 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !50
+  %51 = bitcast i8* %50 to i16*, !dbg !50
+  %52 = load i16, i16* %51, align 8, !dbg !50
+  %53 = and i16 %52, -384, !dbg !50
+  store i16 %53, i16* %51, align 8, !dbg !50
+  %54 = getelementptr inbounds i8, i8* %50, i64 4, !dbg !50
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %54, i8 0, i64 28, i1 false) #11, !dbg !50
+  call void @sorbet_vm_define_method(i64 %34, i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 85), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_B#4read", i8* nonnull %50, %struct.rb_iseq_struct* %stackFrame34.i.i, i1 noundef zeroext false) #11, !dbg !50
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %29, align 8, !dbg !50, !tbaa !22
   %stackFrame44.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_B.4read, align 8, !dbg !51
-  %60 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !51
-  %61 = bitcast i8* %60 to i16*, !dbg !51
-  %62 = load i16, i16* %61, align 8, !dbg !51
-  %63 = and i16 %62, -384, !dbg !51
-  store i16 %63, i16* %61, align 8, !dbg !51
-  %64 = getelementptr inbounds i8, i8* %60, i64 4, !dbg !51
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %64, i8 0, i64 28, i1 false) #11, !dbg !51
-  call void @sorbet_vm_define_method(i64 %39, i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 85), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_B.4read, i8* nonnull %60, %struct.rb_iseq_struct* %stackFrame44.i.i, i1 noundef zeroext true) #11, !dbg !51
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %25) #11
+  %55 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !51
+  %56 = bitcast i8* %55 to i16*, !dbg !51
+  %57 = load i16, i16* %56, align 8, !dbg !51
+  %58 = and i16 %57, -384, !dbg !51
+  store i16 %58, i16* %56, align 8, !dbg !51
+  %59 = getelementptr inbounds i8, i8* %55, i64 4, !dbg !51
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %59, i8 0, i64 28, i1 false) #11, !dbg !51
+  call void @sorbet_vm_define_method(i64 %34, i8* getelementptr inbounds ([125 x i8], [125 x i8]* @sorbet_moduleStringTable, i64 0, i64 85), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_B.4read, i8* nonnull %55, %struct.rb_iseq_struct* %stackFrame44.i.i, i1 noundef zeroext true) #11, !dbg !51
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %20) #11
   call void @sorbet_popFrame() #11, !dbg !41
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %21, align 8, !dbg !41, !tbaa !22
-  %65 = call i64 @sorbet_maybeAllocateObjectFastPath(i64 %39, %struct.FunctionInlineCache* noundef @ic_new) #11, !dbg !17
-  %66 = icmp eq i64 %65, 52, !dbg !17
-  br i1 %66, label %slowNew.i, label %fastNew.i, !dbg !17
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %16, align 8, !dbg !41, !tbaa !22
+  %60 = call i64 @sorbet_maybeAllocateObjectFastPath(i64 %34, %struct.FunctionInlineCache* noundef @ic_new) #11, !dbg !17
+  %61 = icmp eq i64 %60, 52, !dbg !17
+  br i1 %61, label %slowNew.i, label %fastNew.i, !dbg !17
 
-slowNew.i:                                        ; preds = %38
-  %67 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 1, !dbg !17
-  %68 = load i64*, i64** %67, align 8, !dbg !17
-  store i64 %39, i64* %68, align 8, !dbg !17, !tbaa !6
-  %69 = getelementptr inbounds i64, i64* %68, i64 1, !dbg !17
-  store i64* %69, i64** %67, align 8, !dbg !17
-  %70 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_new, i64 noundef 0) #11, !dbg !17
+slowNew.i:                                        ; preds = %33
+  %62 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %10, i64 0, i32 1, !dbg !17
+  %63 = load i64*, i64** %62, align 8, !dbg !17
+  store i64 %34, i64* %63, align 8, !dbg !17, !tbaa !6
+  %64 = getelementptr inbounds i64, i64* %63, i64 1, !dbg !17
+  store i64* %64, i64** %62, align 8, !dbg !17
+  %65 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_new, i64 noundef 0) #11, !dbg !17
   br label %afterNew.i, !dbg !17
 
-fastNew.i:                                        ; preds = %38
-  %71 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 1, !dbg !17
-  %72 = load i64*, i64** %71, align 8, !dbg !17
-  store i64 %65, i64* %72, align 8, !dbg !17, !tbaa !6
-  %73 = getelementptr inbounds i64, i64* %72, i64 1, !dbg !17
-  store i64* %73, i64** %71, align 8, !dbg !17
-  %74 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 noundef 0) #11, !dbg !17
+fastNew.i:                                        ; preds = %33
+  %66 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %10, i64 0, i32 1, !dbg !17
+  %67 = load i64*, i64** %66, align 8, !dbg !17
+  store i64 %60, i64* %67, align 8, !dbg !17, !tbaa !6
+  %68 = getelementptr inbounds i64, i64* %67, i64 1, !dbg !17
+  store i64* %68, i64** %66, align 8, !dbg !17
+  %69 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 noundef 0) #11, !dbg !17
   br label %afterNew.i, !dbg !17
 
 afterNew.i:                                       ; preds = %fastNew.i, %slowNew.i
-  %initializedObject.i = phi i64 [ %70, %slowNew.i ], [ %65, %fastNew.i ], !dbg !17
-  %75 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 1, !dbg !17
-  %76 = load i64*, i64** %75, align 8, !dbg !17
-  store i64 %initializedObject.i, i64* %76, align 8, !dbg !17, !tbaa !6
-  %77 = getelementptr inbounds i64, i64* %76, i64 1, !dbg !17
-  store i64 3, i64* %77, align 8, !dbg !17, !tbaa !6
-  %78 = getelementptr inbounds i64, i64* %77, i64 1, !dbg !17
-  store i64* %78, i64** %75, align 8, !dbg !17
+  %initializedObject.i = phi i64 [ %65, %slowNew.i ], [ %60, %fastNew.i ], !dbg !17
+  %70 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %10, i64 0, i32 1, !dbg !17
+  %71 = load i64*, i64** %70, align 8, !dbg !17
+  store i64 %initializedObject.i, i64* %71, align 8, !dbg !17, !tbaa !6
+  %72 = getelementptr inbounds i64, i64* %71, i64 1, !dbg !17
+  store i64 3, i64* %72, align 8, !dbg !17, !tbaa !6
+  %73 = getelementptr inbounds i64, i64* %72, i64 1, !dbg !17
+  store i64* %73, i64** %70, align 8, !dbg !17
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_write, i64 0), !dbg !17
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %21, align 8, !dbg !17, !tbaa !22
-  %79 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 1, !dbg !18
-  %80 = load i64*, i64** %79, align 8, !dbg !18
-  store i64 %39, i64* %80, align 8, !dbg !18, !tbaa !6
-  %81 = getelementptr inbounds i64, i64* %80, i64 1, !dbg !18
-  store i64* %81, i64** %79, align 8, !dbg !18
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %16, align 8, !dbg !17, !tbaa !22
+  %74 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %10, i64 0, i32 1, !dbg !18
+  %75 = load i64*, i64** %74, align 8, !dbg !18
+  store i64 %34, i64* %75, align 8, !dbg !18, !tbaa !6
+  %76 = getelementptr inbounds i64, i64* %75, i64 1, !dbg !18
+  store i64* %76, i64** %74, align 8, !dbg !18
   %send5 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_read, i64 0), !dbg !18
-  %82 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 1, !dbg !19
-  %83 = load i64*, i64** %82, align 8, !dbg !19
-  store i64 %12, i64* %83, align 8, !dbg !19, !tbaa !6
-  %84 = getelementptr inbounds i64, i64* %83, i64 1, !dbg !19
-  store i64 %send5, i64* %84, align 8, !dbg !19, !tbaa !6
-  %85 = getelementptr inbounds i64, i64* %84, i64 1, !dbg !19
-  store i64* %85, i64** %82, align 8, !dbg !19
+  %77 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %10, i64 0, i32 1, !dbg !19
+  %78 = load i64*, i64** %77, align 8, !dbg !19
+  store i64 %7, i64* %78, align 8, !dbg !19, !tbaa !6
+  %79 = getelementptr inbounds i64, i64* %78, i64 1, !dbg !19
+  store i64 %send5, i64* %79, align 8, !dbg !19, !tbaa !6
+  %80 = getelementptr inbounds i64, i64* %79, i64 1, !dbg !19
+  store i64* %80, i64** %77, align 8, !dbg !19
   %send7 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !19
-  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %21, align 8, !dbg !19, !tbaa !22
-  %86 = call i64 @sorbet_maybeAllocateObjectFastPath(i64 %39, %struct.FunctionInlineCache* noundef @ic_new.1) #11, !dbg !20
-  %87 = icmp eq i64 %86, 52, !dbg !20
-  br i1 %87, label %slowNew50.i, label %fastNew51.i, !dbg !20
+  store i64* getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %16, align 8, !dbg !19, !tbaa !22
+  %81 = call i64 @sorbet_maybeAllocateObjectFastPath(i64 %34, %struct.FunctionInlineCache* noundef @ic_new.1) #11, !dbg !20
+  %82 = icmp eq i64 %81, 52, !dbg !20
+  br i1 %82, label %slowNew50.i, label %fastNew51.i, !dbg !20
 
 slowNew50.i:                                      ; preds = %afterNew.i
-  %88 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 1, !dbg !20
-  %89 = load i64*, i64** %88, align 8, !dbg !20
-  store i64 %39, i64* %89, align 8, !dbg !20, !tbaa !6
-  %90 = getelementptr inbounds i64, i64* %89, i64 1, !dbg !20
-  store i64* %90, i64** %88, align 8, !dbg !20
-  %91 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_new.1, i64 noundef 0) #11, !dbg !20
+  %83 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %10, i64 0, i32 1, !dbg !20
+  %84 = load i64*, i64** %83, align 8, !dbg !20
+  store i64 %34, i64* %84, align 8, !dbg !20, !tbaa !6
+  %85 = getelementptr inbounds i64, i64* %84, i64 1, !dbg !20
+  store i64* %85, i64** %83, align 8, !dbg !20
+  %86 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_new.1, i64 noundef 0) #11, !dbg !20
   br label %"func_<root>.17<static-init>$153.exit", !dbg !20
 
 fastNew51.i:                                      ; preds = %afterNew.i
-  %92 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 1, !dbg !20
-  %93 = load i64*, i64** %92, align 8, !dbg !20
-  store i64 %86, i64* %93, align 8, !dbg !20, !tbaa !6
-  %94 = getelementptr inbounds i64, i64* %93, i64 1, !dbg !20
-  store i64* %94, i64** %92, align 8, !dbg !20
-  %95 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_initialize.2, i64 noundef 0) #11, !dbg !20
+  %87 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %10, i64 0, i32 1, !dbg !20
+  %88 = load i64*, i64** %87, align 8, !dbg !20
+  store i64 %81, i64* %88, align 8, !dbg !20, !tbaa !6
+  %89 = getelementptr inbounds i64, i64* %88, i64 1, !dbg !20
+  store i64* %89, i64** %87, align 8, !dbg !20
+  %90 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_initialize.2, i64 noundef 0) #11, !dbg !20
   br label %"func_<root>.17<static-init>$153.exit", !dbg !20
 
 "func_<root>.17<static-init>$153.exit":           ; preds = %slowNew50.i, %fastNew51.i
-  %initializedObject56.i = phi i64 [ %91, %slowNew50.i ], [ %86, %fastNew51.i ], !dbg !20
-  %96 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 1, !dbg !20
-  %97 = load i64*, i64** %96, align 8, !dbg !20
-  store i64 %initializedObject56.i, i64* %97, align 8, !dbg !20, !tbaa !6
-  %98 = getelementptr inbounds i64, i64* %97, i64 1, !dbg !20
-  store i64* %98, i64** %96, align 8, !dbg !20
+  %initializedObject56.i = phi i64 [ %86, %slowNew50.i ], [ %81, %fastNew51.i ], !dbg !20
+  %91 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %10, i64 0, i32 1, !dbg !20
+  %92 = load i64*, i64** %91, align 8, !dbg !20
+  store i64 %initializedObject56.i, i64* %92, align 8, !dbg !20, !tbaa !6
+  %93 = getelementptr inbounds i64, i64* %92, i64 1, !dbg !20
+  store i64* %93, i64** %91, align 8, !dbg !20
   %send9 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_read.3, i64 0), !dbg !20
-  %99 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 1, !dbg !21
-  %100 = load i64*, i64** %99, align 8, !dbg !21
-  store i64 %12, i64* %100, align 8, !dbg !21, !tbaa !6
-  %101 = getelementptr inbounds i64, i64* %100, i64 1, !dbg !21
-  store i64 %send9, i64* %101, align 8, !dbg !21, !tbaa !6
-  %102 = getelementptr inbounds i64, i64* %101, i64 1, !dbg !21
-  store i64* %102, i64** %99, align 8, !dbg !21
+  %94 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %10, i64 0, i32 1, !dbg !21
+  %95 = load i64*, i64** %94, align 8, !dbg !21
+  store i64 %7, i64* %95, align 8, !dbg !21, !tbaa !6
+  %96 = getelementptr inbounds i64, i64* %95, i64 1, !dbg !21
+  store i64 %send9, i64* %96, align 8, !dbg !21, !tbaa !6
+  %97 = getelementptr inbounds i64, i64* %96, i64 1, !dbg !21
+  store i64* %97, i64** %94, align 8, !dbg !21
   %send11 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.4, i64 0), !dbg !21
   ret void
 }

--- a/test/testdata/compiler/constant_cache.opt.ll.exp
+++ b/test/testdata/compiler/constant_cache.opt.ll.exp
@@ -82,8 +82,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_Object#3foo" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@rubyStrFrozen_foo = internal unnamed_addr global i64 0, align 8
-@"rubyStrFrozen_test/testdata/compiler/constant_cache.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [13 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
@@ -96,6 +94,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @sorbet_moduleStringTable = internal unnamed_addr constant [100 x i8] c"foo\00test/testdata/compiler/constant_cache.rb\00A\00puts\00<top (required)>\00Object\00normal\00master\00<class:A>\00", align 1
 @sorbet_moduleIDTable = internal unnamed_addr global [5 x i64] zeroinitializer, align 8
 @sorbet_moduleIDDescriptors = internal unnamed_addr constant [5 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 3 }, %struct.rb_code_position_struct { i32 47, i32 4 }, %struct.rb_code_position_struct { i32 52, i32 16 }, %struct.rb_code_position_struct { i32 76, i32 6 }, %struct.rb_code_position_struct { i32 90, i32 9 }], align 8
+@sorbet_moduleRubyStringTable = internal unnamed_addr global [4 x i64] zeroinitializer, align 8
+@sorbet_moduleRubyStringDescriptors = internal unnamed_addr constant [4 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 3 }, %struct.rb_code_position_struct { i32 4, i32 40 }, %struct.rb_code_position_struct { i32 52, i32 16 }, %struct.rb_code_position_struct { i32 90, i32 9 }], align 8
 @guard_epoch_A = linkonce local_unnamed_addr global i64 0
 @guarded_const_A = linkonce local_unnamed_addr global i64 0
 @rb_cObject = external local_unnamed_addr constant i64
@@ -125,11 +125,9 @@ declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_
 
 declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #1
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #1
+declare void @sorbet_vm_init_string_table(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #1
 
 declare i64 @rb_define_class(i8*, i64) local_unnamed_addr #1
-
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #1
 
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #0
@@ -226,87 +224,78 @@ entry:
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
   tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([5 x %struct.rb_code_position_struct], [5 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 5, i8* noundef getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
-  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 3) #11
-  tail call void @rb_gc_register_mark_object(i64 %0) #11
-  store i64 %0, i64* @rubyStrFrozen_foo, align 8
-  %1 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 4), i64 noundef 40) #11
-  tail call void @rb_gc_register_mark_object(i64 %1) #11
-  store i64 %1, i64* @"rubyStrFrozen_test/testdata/compiler/constant_cache.rb", align 8
+  tail call void @sorbet_vm_init_string_table(i64* noundef getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleRubyStringTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([4 x %struct.rb_code_position_struct], [4 x %struct.rb_code_position_struct]* @sorbet_moduleRubyStringDescriptors, i32 0, i32 0), i32 noundef 4, i8* noundef getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 13)
   %rubyId_foo.i.i = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
-  %rubyStr_foo.i.i = load i64, i64* @rubyStrFrozen_foo, align 8
-  %"rubyStr_test/testdata/compiler/constant_cache.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/constant_cache.rb", align 8
-  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_foo.i.i, i64 %rubyId_foo.i.i, i64 %"rubyStr_test/testdata/compiler/constant_cache.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8
+  %rubyStr_foo.i.i = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 0), align 8, !invariant.load !5
+  %"rubyStr_test/testdata/compiler/constant_cache.rb.i.i" = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
+  %0 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_foo.i.i, i64 %rubyId_foo.i.i, i64 %"rubyStr_test/testdata/compiler/constant_cache.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %0, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8
   %rubyId_puts.i = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !dbg !19, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !23
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !24
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !25
-  %3 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 52), i64 noundef 16) #11
-  call void @rb_gc_register_mark_object(i64 %3) #11
   %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/constant_cache.rb.i12.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/constant_cache.rb", align 8
-  %4 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %3, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/constant_cache.rb.i12.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i13.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %4, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %"rubyStr_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 2), align 8, !invariant.load !5
+  %1 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/constant_cache.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i13.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %1, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !26
-  %5 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 90), i64 noundef 9) #11
-  call void @rb_gc_register_mark_object(i64 %5) #11
   %"rubyId_<class:A>.i.i" = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/constant_cache.rb.i14.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/constant_cache.rb", align 8
-  %6 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %5, i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/constant_cache.rb.i14.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i15.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %6, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %7 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
-  %8 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %7, i64 0, i32 18
-  %9 = load i64, i64* %8, align 8, !tbaa !28
-  %10 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %11 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %10, i64 0, i32 2
-  %12 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %11, align 8, !tbaa !37
+  %"rubyStr_<class:A>.i.i" = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 3), align 8, !invariant.load !5
+  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<class:A>.i.i", i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/constant_cache.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i15.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
+  %3 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
+  %4 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %3, i64 0, i32 18
+  %5 = load i64, i64* %4, align 8, !tbaa !28
+  %6 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %7 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %6, i64 0, i32 2
+  %8 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %7, align 8, !tbaa !37
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %13 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %13, align 8, !tbaa !40
-  %14 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 4
-  %15 = load i64*, i64** %14, align 8, !tbaa !42
-  %16 = load i64, i64* %15, align 8, !tbaa !6
-  %17 = and i64 %16, -33
-  store i64 %17, i64* %15, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %10, %struct.rb_control_frame_struct* %12, %struct.rb_iseq_struct* %stackFrame.i) #11
-  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 0
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %18, align 8, !dbg !43, !tbaa !14
-  %19 = load i64, i64* @rb_cObject, align 8, !dbg !44
-  %20 = call i64 @rb_define_class(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 45), i64 %19) #11, !dbg !44
-  %21 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %20) #11, !dbg !44
+  %9 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %8, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %9, align 8, !tbaa !40
+  %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %8, i64 0, i32 4
+  %11 = load i64*, i64** %10, align 8, !tbaa !42
+  %12 = load i64, i64* %11, align 8, !tbaa !6
+  %13 = and i64 %12, -33
+  store i64 %13, i64* %11, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %6, %struct.rb_control_frame_struct* %8, %struct.rb_iseq_struct* %stackFrame.i) #11
+  %14 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %8, i64 0, i32 0
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %14, align 8, !dbg !43, !tbaa !14
+  %15 = load i64, i64* @rb_cObject, align 8, !dbg !44
+  %16 = call i64 @rb_define_class(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 45), i64 %15) #11, !dbg !44
+  %17 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %16) #11, !dbg !44
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %22 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %23 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %22, i64 0, i32 2
-  %24 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %23, align 8, !tbaa !37
-  %25 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %25, align 8, !tbaa !40
-  %26 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 4
-  %27 = load i64*, i64** %26, align 8, !tbaa !42
-  %28 = load i64, i64* %27, align 8, !tbaa !6
-  %29 = and i64 %28, -33
-  store i64 %29, i64* %27, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %22, %struct.rb_control_frame_struct* %24, %struct.rb_iseq_struct* %stackFrame.i.i) #11
-  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %21, i64 0, i32 0
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %30, align 8, !dbg !45, !tbaa !14
+  %18 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %19 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %18, i64 0, i32 2
+  %20 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %19, align 8, !tbaa !37
+  %21 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %20, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %21, align 8, !tbaa !40
+  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %20, i64 0, i32 4
+  %23 = load i64*, i64** %22, align 8, !tbaa !42
+  %24 = load i64, i64* %23, align 8, !tbaa !6
+  %25 = and i64 %24, -33
+  store i64 %25, i64* %23, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %18, %struct.rb_control_frame_struct* %20, %struct.rb_iseq_struct* %stackFrame.i.i) #11
+  %26 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 0
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %26, align 8, !dbg !45, !tbaa !14
   call void @sorbet_popFrame() #11, !dbg !44
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %18, align 8, !dbg !44, !tbaa !14
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %14, align 8, !dbg !44, !tbaa !14
   %stackFrame21.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8, !dbg !48
-  %31 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !48
-  %32 = bitcast i8* %31 to i16*, !dbg !48
-  %33 = load i16, i16* %32, align 8, !dbg !48
-  %34 = and i16 %33, -384, !dbg !48
-  store i16 %34, i16* %32, align 8, !dbg !48
-  %35 = getelementptr inbounds i8, i8* %31, i64 4, !dbg !48
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %35, i8 0, i64 28, i1 false) #11, !dbg !48
-  call void @sorbet_vm_define_method(i64 %19, i8* noundef getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#3foo", i8* nonnull %31, %struct.rb_iseq_struct* %stackFrame21.i, i1 noundef zeroext false) #11, !dbg !48
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %18, align 8, !dbg !48, !tbaa !14
-  %36 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 1, !dbg !26
-  %37 = load i64*, i64** %36, align 8, !dbg !26
-  store i64 %9, i64* %37, align 8, !dbg !26, !tbaa !6
-  %38 = getelementptr inbounds i64, i64* %37, i64 1, !dbg !26
-  store i64* %38, i64** %36, align 8, !dbg !26
+  %27 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !48
+  %28 = bitcast i8* %27 to i16*, !dbg !48
+  %29 = load i16, i16* %28, align 8, !dbg !48
+  %30 = and i16 %29, -384, !dbg !48
+  store i16 %30, i16* %28, align 8, !dbg !48
+  %31 = getelementptr inbounds i8, i8* %27, i64 4, !dbg !48
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %31, i8 0, i64 28, i1 false) #11, !dbg !48
+  call void @sorbet_vm_define_method(i64 %15, i8* noundef getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#3foo", i8* nonnull %27, %struct.rb_iseq_struct* %stackFrame21.i, i1 noundef zeroext false) #11, !dbg !48
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %14, align 8, !dbg !48, !tbaa !14
+  %32 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %8, i64 0, i32 1, !dbg !26
+  %33 = load i64*, i64** %32, align 8, !dbg !26
+  store i64 %5, i64* %33, align 8, !dbg !26, !tbaa !6
+  %34 = getelementptr inbounds i64, i64* %33, i64 1, !dbg !26
+  store i64* %34, i64** %32, align 8, !dbg !26
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo, i64 0), !dbg !26
   ret void
 }

--- a/test/testdata/compiler/custom_plus.opt.ll.exp
+++ b/test/testdata/compiler/custom_plus.opt.ll.exp
@@ -82,15 +82,11 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_Object#8delegate" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@rubyStrFrozen_delegate = internal unnamed_addr global i64 0, align 8
-@"rubyStrFrozen_test/testdata/compiler/custom_plus.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [23 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @"ic_+" = internal global %struct.FunctionInlineCache zeroinitializer
 @"ic_==" = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyStrFrozen_ok = internal unnamed_addr global i64 0, align 8
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyStrFrozen_fail = internal unnamed_addr global i64 0, align 8
 @ic_puts.1 = internal global %struct.FunctionInlineCache zeroinitializer
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @ic_new = internal global %struct.FunctionInlineCache zeroinitializer
@@ -101,6 +97,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @sorbet_moduleStringTable = internal unnamed_addr constant [134 x i8] c"delegate\00test/testdata/compiler/custom_plus.rb\00+\00==\00ok\00puts\00fail\00<top (required)>\00A\00Object\00new\00initialize\00normal\00a\00master\00<class:A>\00b\00", align 1
 @sorbet_moduleIDTable = internal unnamed_addr global [11 x i64] zeroinitializer, align 8
 @sorbet_moduleIDDescriptors = internal unnamed_addr constant [11 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 8 }, %struct.rb_code_position_struct { i32 47, i32 1 }, %struct.rb_code_position_struct { i32 49, i32 2 }, %struct.rb_code_position_struct { i32 55, i32 4 }, %struct.rb_code_position_struct { i32 65, i32 16 }, %struct.rb_code_position_struct { i32 91, i32 3 }, %struct.rb_code_position_struct { i32 95, i32 10 }, %struct.rb_code_position_struct { i32 106, i32 6 }, %struct.rb_code_position_struct { i32 113, i32 1 }, %struct.rb_code_position_struct { i32 122, i32 9 }, %struct.rb_code_position_struct { i32 132, i32 1 }], align 8
+@sorbet_moduleRubyStringTable = internal unnamed_addr global [7 x i64] zeroinitializer, align 8
+@sorbet_moduleRubyStringDescriptors = internal unnamed_addr constant [7 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 8 }, %struct.rb_code_position_struct { i32 9, i32 37 }, %struct.rb_code_position_struct { i32 52, i32 2 }, %struct.rb_code_position_struct { i32 60, i32 4 }, %struct.rb_code_position_struct { i32 65, i32 16 }, %struct.rb_code_position_struct { i32 47, i32 1 }, %struct.rb_code_position_struct { i32 122, i32 9 }], align 8
 @rb_cObject = external local_unnamed_addr constant i64
 @guard_epoch_A = linkonce local_unnamed_addr global i64 0
 @guarded_const_A = linkonce local_unnamed_addr global i64 0
@@ -130,9 +128,9 @@ declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_
 
 declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #1
 
-declare i64 @sorbet_maybeAllocateObjectFastPath(i64, %struct.FunctionInlineCache*) local_unnamed_addr #1
+declare void @sorbet_vm_init_string_table(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #1
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #1
+declare i64 @sorbet_maybeAllocateObjectFastPath(i64, %struct.FunctionInlineCache*) local_unnamed_addr #1
 
 declare i64 @sorbet_vm_plus(%struct.rb_control_frame_struct*, %struct.FunctionInlineCache*, i64, i64) local_unnamed_addr #1
 
@@ -145,8 +143,6 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #2
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #2
-
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #1
 
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #0
@@ -195,11 +191,11 @@ fillRequiredArgs:                                 ; preds = %functionEntryInitia
   %2 = tail call i64 @sorbet_vm_eqeq(%struct.rb_control_frame_struct* nonnull %cfp, %struct.FunctionInlineCache* noundef @"ic_==", i64 %1, i64 %rawArg_a), !dbg !19
   %3 = and i64 %2, -9, !dbg !19
   %4 = icmp ne i64 %3, 0, !dbg !19
-  %.sink = select i1 %4, i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 16), i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 18), !dbg !19
-  %rubyStrFrozen_fail.sink = select i1 %4, i64* @rubyStrFrozen_ok, i64* @rubyStrFrozen_fail, !dbg !19
+  %.sink42 = select i1 %4, i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 16), i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 18), !dbg !19
+  %.sink = select i1 %4, i64* getelementptr inbounds ([7 x i64], [7 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 2), i64* getelementptr inbounds ([7 x i64], [7 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 3), !dbg !19
   %ic_puts.1.sink = select i1 %4, %struct.FunctionInlineCache* @ic_puts, %struct.FunctionInlineCache* @ic_puts.1, !dbg !19
-  store i64* %.sink, i64** %0, align 8, !tbaa !14
-  %rubyStr_fail = load i64, i64* %rubyStrFrozen_fail.sink, align 8, !dbg !20
+  store i64* %.sink42, i64** %0, align 8, !tbaa !14
+  %rubyStr_fail = load i64, i64* %.sink, align 8, !dbg !20, !invariant.load !5
   %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !20
   %6 = load i64*, i64** %5, align 8, !dbg !20
   store i64 %selfRaw, i64* %6, align 8, !dbg !20, !tbaa !6
@@ -362,60 +358,43 @@ entry:
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
   tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([11 x %struct.rb_code_position_struct], [11 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 11, i8* noundef getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
-  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 8) #11
-  tail call void @rb_gc_register_mark_object(i64 %0) #11
-  store i64 %0, i64* @rubyStrFrozen_delegate, align 8
-  %1 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 9), i64 noundef 37) #11
-  tail call void @rb_gc_register_mark_object(i64 %1) #11
-  store i64 %1, i64* @"rubyStrFrozen_test/testdata/compiler/custom_plus.rb", align 8
+  tail call void @sorbet_vm_init_string_table(i64* noundef getelementptr inbounds ([7 x i64], [7 x i64]* @sorbet_moduleRubyStringTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([7 x %struct.rb_code_position_struct], [7 x %struct.rb_code_position_struct]* @sorbet_moduleRubyStringDescriptors, i32 0, i32 0), i32 noundef 7, i8* noundef getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 23)
   %rubyId_delegate.i.i = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
-  %rubyStr_delegate.i.i = load i64, i64* @rubyStrFrozen_delegate, align 8
-  %"rubyStr_test/testdata/compiler/custom_plus.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/custom_plus.rb", align 8
-  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_delegate.i.i, i64 %rubyId_delegate.i.i, i64 %"rubyStr_test/testdata/compiler/custom_plus.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 14, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#8delegate", align 8
+  %rubyStr_delegate.i.i = load i64, i64* getelementptr inbounds ([7 x i64], [7 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 0), align 8, !invariant.load !5
+  %"rubyStr_test/testdata/compiler/custom_plus.rb.i.i" = load i64, i64* getelementptr inbounds ([7 x i64], [7 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
+  %0 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_delegate.i.i, i64 %rubyId_delegate.i.i, i64 %"rubyStr_test/testdata/compiler/custom_plus.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 14, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %0, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#8delegate", align 8
   %"rubyId_+.i" = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !dbg !19, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_+", i64 %"rubyId_+.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
   %"rubyId_==.i" = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !19, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_==", i64 %"rubyId_==.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
-  %3 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 52), i64 noundef 2) #11
-  call void @rb_gc_register_mark_object(i64 %3) #11
-  store i64 %3, i64* @rubyStrFrozen_ok, align 8
   %rubyId_puts.i = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !46, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !46
-  %4 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 60), i64 noundef 4) #11
-  call void @rb_gc_register_mark_object(i64 %4) #11
-  store i64 %4, i64* @rubyStrFrozen_fail, align 8
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !47
-  %5 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 65), i64 noundef 16) #11
-  call void @rb_gc_register_mark_object(i64 %5) #11
   %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/custom_plus.rb.i11.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/custom_plus.rb", align 8
-  %6 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %5, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/custom_plus.rb.i11.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i12.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %6, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %"rubyStr_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([7 x i64], [7 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 4), align 8, !invariant.load !5
+  %1 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/custom_plus.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i12.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %1, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
   %rubyId_new.i = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 5), align 8, !dbg !43, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !43
   %rubyId_initialize.i = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 6), align 8, !dbg !43, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 %rubyId_initialize.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !43
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_delegate, i64 %rubyId_delegate.i.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !45
-  %7 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 47), i64 noundef 1) #11
-  call void @rb_gc_register_mark_object(i64 %7) #11
-  %"rubyStr_test/testdata/compiler/custom_plus.rb.i13.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/custom_plus.rb", align 8
-  %8 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %7, i64 %"rubyId_+.i", i64 %"rubyStr_test/testdata/compiler/custom_plus.rb.i13.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 7, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i14.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %8, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#1+", align 8
-  %9 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([134 x i8], [134 x i8]* @sorbet_moduleStringTable, i64 0, i64 122), i64 noundef 9) #11
-  call void @rb_gc_register_mark_object(i64 %9) #11
+  %"rubyStr_+.i.i" = load i64, i64* getelementptr inbounds ([7 x i64], [7 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 5), align 8, !invariant.load !5
+  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_+.i.i", i64 %"rubyId_+.i", i64 %"rubyStr_test/testdata/compiler/custom_plus.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 7, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i14.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#1+", align 8
   %"rubyId_<class:A>.i.i" = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 9), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/custom_plus.rb.i15.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/custom_plus.rb", align 8
-  %10 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %9, i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/custom_plus.rb.i15.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i16.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %10, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %11 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
-  %12 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %11, i64 0, i32 18
-  %13 = load i64, i64* %12, align 8, !tbaa !48
-  %14 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %15 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %14, i64 0, i32 2
-  %16 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %15, align 8, !tbaa !25
-  call fastcc void @"func_<root>.17<static-init>$153"(i64 %13, %struct.rb_control_frame_struct* %16) #11
+  %"rubyStr_<class:A>.i.i" = load i64, i64* getelementptr inbounds ([7 x i64], [7 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 6), align 8, !invariant.load !5
+  %3 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<class:A>.i.i", i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/custom_plus.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i16.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %3, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
+  %4 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
+  %5 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %4, i64 0, i32 18
+  %6 = load i64, i64* %5, align 8, !tbaa !48
+  %7 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %8 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %7, i64 0, i32 2
+  %9 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %8, align 8, !tbaa !25
+  call fastcc void @"func_<root>.17<static-init>$153"(i64 %6, %struct.rb_control_frame_struct* %9) #11
   ret void
 }
 

--- a/test/testdata/compiler/direct_call.opt.ll.exp
+++ b/test/testdata/compiler/direct_call.opt.ll.exp
@@ -81,8 +81,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_Object#3foo" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@rubyStrFrozen_foo = internal unnamed_addr global i64 0, align 8
-@"rubyStrFrozen_test/testdata/compiler/direct_call.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [13 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @"stackFramePrecomputed_func_Object#3bar" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
@@ -93,6 +91,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @sorbet_moduleStringTable = internal unnamed_addr constant [89 x i8] c"foo\00test/testdata/compiler/direct_call.rb\00bar\00<top (required)>\00normal\00Object\00puts\00master\00", align 1
 @sorbet_moduleIDTable = internal unnamed_addr global [5 x i64] zeroinitializer, align 8
 @sorbet_moduleIDDescriptors = internal unnamed_addr constant [5 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 3 }, %struct.rb_code_position_struct { i32 42, i32 3 }, %struct.rb_code_position_struct { i32 46, i32 16 }, %struct.rb_code_position_struct { i32 63, i32 6 }, %struct.rb_code_position_struct { i32 77, i32 4 }], align 8
+@sorbet_moduleRubyStringTable = internal unnamed_addr global [4 x i64] zeroinitializer, align 8
+@sorbet_moduleRubyStringDescriptors = internal unnamed_addr constant [4 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 3 }, %struct.rb_code_position_struct { i32 4, i32 37 }, %struct.rb_code_position_struct { i32 42, i32 3 }, %struct.rb_code_position_struct { i32 46, i32 16 }], align 8
 @rb_cObject = external local_unnamed_addr constant i64
 
 ; Function Attrs: noreturn
@@ -114,9 +114,7 @@ declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_
 
 declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #1
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #1
-
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #1
+declare void @sorbet_vm_init_string_table(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #1
 
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #0
@@ -186,85 +184,76 @@ entry:
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
   tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([5 x %struct.rb_code_position_struct], [5 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 5, i8* noundef getelementptr inbounds ([89 x i8], [89 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
-  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([89 x i8], [89 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 3) #9
-  tail call void @rb_gc_register_mark_object(i64 %0) #9
-  store i64 %0, i64* @rubyStrFrozen_foo, align 8
-  %1 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([89 x i8], [89 x i8]* @sorbet_moduleStringTable, i64 0, i64 4), i64 noundef 37) #9
-  tail call void @rb_gc_register_mark_object(i64 %1) #9
-  store i64 %1, i64* @"rubyStrFrozen_test/testdata/compiler/direct_call.rb", align 8
+  tail call void @sorbet_vm_init_string_table(i64* noundef getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleRubyStringTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([4 x %struct.rb_code_position_struct], [4 x %struct.rb_code_position_struct]* @sorbet_moduleRubyStringDescriptors, i32 0, i32 0), i32 noundef 4, i8* noundef getelementptr inbounds ([89 x i8], [89 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 13)
   %rubyId_foo.i.i = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
-  %rubyStr_foo.i.i = load i64, i64* @rubyStrFrozen_foo, align 8
-  %"rubyStr_test/testdata/compiler/direct_call.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/direct_call.rb", align 8
-  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_foo.i.i, i64 %rubyId_foo.i.i, i64 %"rubyStr_test/testdata/compiler/direct_call.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8
-  %3 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([89 x i8], [89 x i8]* @sorbet_moduleStringTable, i64 0, i64 42), i64 noundef 3) #9
-  call void @rb_gc_register_mark_object(i64 %3) #9
+  %rubyStr_foo.i.i = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 0), align 8, !invariant.load !5
+  %"rubyStr_test/testdata/compiler/direct_call.rb.i.i" = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
+  %0 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_foo.i.i, i64 %rubyId_foo.i.i, i64 %"rubyStr_test/testdata/compiler/direct_call.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %0, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8
   %rubyId_bar.i.i = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/direct_call.rb.i5.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/direct_call.rb", align 8
-  %4 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %3, i64 %rubyId_bar.i.i, i64 %"rubyStr_test/testdata/compiler/direct_call.rb.i5.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i6.i, i32 noundef 0, i32 noundef 1)
-  store %struct.rb_iseq_struct* %4, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3bar", align 8
+  %rubyStr_bar.i.i = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 2), align 8, !invariant.load !5
+  %1 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_bar.i.i, i64 %rubyId_bar.i.i, i64 %"rubyStr_test/testdata/compiler/direct_call.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i6.i, i32 noundef 0, i32 noundef 1)
+  store %struct.rb_iseq_struct* %1, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3bar", align 8
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !22
-  %5 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([89 x i8], [89 x i8]* @sorbet_moduleStringTable, i64 0, i64 46), i64 noundef 16) #9
-  call void @rb_gc_register_mark_object(i64 %5) #9
   %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/direct_call.rb.i7.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/direct_call.rb", align 8
-  %6 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %5, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/direct_call.rb.i7.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i8.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %6, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %"rubyStr_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 3), align 8, !invariant.load !5
+  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/direct_call.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i8.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_bar, i64 %rubyId_bar.i.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !23
   %rubyId_puts.i = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !dbg !25, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !25
-  %7 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
-  %8 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %7, i64 0, i32 18
-  %9 = load i64, i64* %8, align 8, !tbaa !26
-  %10 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %11 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %10, i64 0, i32 2
-  %12 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %11, align 8, !tbaa !36
+  %3 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
+  %4 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %3, i64 0, i32 18
+  %5 = load i64, i64* %4, align 8, !tbaa !26
+  %6 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %7 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %6, i64 0, i32 2
+  %8 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %7, align 8, !tbaa !36
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %13 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %13, align 8, !tbaa !39
-  %14 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 4
-  %15 = load i64*, i64** %14, align 8, !tbaa !41
-  %16 = load i64, i64* %15, align 8, !tbaa !6
-  %17 = and i64 %16, -33
-  store i64 %17, i64* %15, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %10, %struct.rb_control_frame_struct* %12, %struct.rb_iseq_struct* %stackFrame.i) #9
-  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 0
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %18, align 8, !dbg !42, !tbaa !14
-  %19 = load i64, i64* @rb_cObject, align 8, !dbg !43
+  %9 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %8, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %9, align 8, !tbaa !39
+  %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %8, i64 0, i32 4
+  %11 = load i64*, i64** %10, align 8, !tbaa !41
+  %12 = load i64, i64* %11, align 8, !tbaa !6
+  %13 = and i64 %12, -33
+  store i64 %13, i64* %11, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %6, %struct.rb_control_frame_struct* %8, %struct.rb_iseq_struct* %stackFrame.i) #9
+  %14 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %8, i64 0, i32 0
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %14, align 8, !dbg !42, !tbaa !14
+  %15 = load i64, i64* @rb_cObject, align 8, !dbg !43
   %stackFrame21.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo", align 8, !dbg !43
-  %20 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #10, !dbg !43
-  %21 = bitcast i8* %20 to i16*, !dbg !43
-  %22 = load i16, i16* %21, align 8, !dbg !43
-  %23 = and i16 %22, -384, !dbg !43
-  store i16 %23, i16* %21, align 8, !dbg !43
-  %24 = getelementptr inbounds i8, i8* %20, i64 4, !dbg !43
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %24, i8 0, i64 28, i1 false) #9, !dbg !43
-  call void @sorbet_vm_define_method(i64 %19, i8* noundef getelementptr inbounds ([89 x i8], [89 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#3foo", i8* nonnull %20, %struct.rb_iseq_struct* %stackFrame21.i, i1 noundef zeroext false) #9, !dbg !43
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %18, align 8, !dbg !43, !tbaa !14
+  %16 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #10, !dbg !43
+  %17 = bitcast i8* %16 to i16*, !dbg !43
+  %18 = load i16, i16* %17, align 8, !dbg !43
+  %19 = and i16 %18, -384, !dbg !43
+  store i16 %19, i16* %17, align 8, !dbg !43
+  %20 = getelementptr inbounds i8, i8* %16, i64 4, !dbg !43
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %20, i8 0, i64 28, i1 false) #9, !dbg !43
+  call void @sorbet_vm_define_method(i64 %15, i8* noundef getelementptr inbounds ([89 x i8], [89 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#3foo", i8* nonnull %16, %struct.rb_iseq_struct* %stackFrame21.i, i1 noundef zeroext false) #9, !dbg !43
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %14, align 8, !dbg !43, !tbaa !14
   %stackFrame30.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3bar", align 8, !dbg !44
-  %25 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #10, !dbg !44
-  %26 = bitcast i8* %25 to i16*, !dbg !44
-  %27 = load i16, i16* %26, align 8, !dbg !44
-  %28 = and i16 %27, -384, !dbg !44
-  store i16 %28, i16* %26, align 8, !dbg !44
-  %29 = getelementptr inbounds i8, i8* %25, i64 4, !dbg !44
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %29, i8 0, i64 28, i1 false) #9, !dbg !44
-  call void @sorbet_vm_define_method(i64 %19, i8* getelementptr inbounds ([89 x i8], [89 x i8]* @sorbet_moduleStringTable, i64 0, i64 42), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#3bar", i8* nonnull %25, %struct.rb_iseq_struct* %stackFrame30.i, i1 noundef zeroext false) #9, !dbg !44
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %18, align 8, !dbg !44, !tbaa !14
-  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 1, !dbg !23
-  %31 = load i64*, i64** %30, align 8, !dbg !23
-  store i64 %9, i64* %31, align 8, !dbg !23, !tbaa !6
-  %32 = getelementptr inbounds i64, i64* %31, i64 1, !dbg !23
-  store i64* %32, i64** %30, align 8, !dbg !23
+  %21 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #10, !dbg !44
+  %22 = bitcast i8* %21 to i16*, !dbg !44
+  %23 = load i16, i16* %22, align 8, !dbg !44
+  %24 = and i16 %23, -384, !dbg !44
+  store i16 %24, i16* %22, align 8, !dbg !44
+  %25 = getelementptr inbounds i8, i8* %21, i64 4, !dbg !44
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %25, i8 0, i64 28, i1 false) #9, !dbg !44
+  call void @sorbet_vm_define_method(i64 %15, i8* getelementptr inbounds ([89 x i8], [89 x i8]* @sorbet_moduleStringTable, i64 0, i64 42), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#3bar", i8* nonnull %21, %struct.rb_iseq_struct* %stackFrame30.i, i1 noundef zeroext false) #9, !dbg !44
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %14, align 8, !dbg !44, !tbaa !14
+  %26 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %8, i64 0, i32 1, !dbg !23
+  %27 = load i64*, i64** %26, align 8, !dbg !23
+  store i64 %5, i64* %27, align 8, !dbg !23, !tbaa !6
+  %28 = getelementptr inbounds i64, i64* %27, i64 1, !dbg !23
+  store i64* %28, i64** %26, align 8, !dbg !23
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_bar, i64 0), !dbg !23
-  %33 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 1, !dbg !25
-  %34 = load i64*, i64** %33, align 8, !dbg !25
-  store i64 %9, i64* %34, align 8, !dbg !25, !tbaa !6
-  %35 = getelementptr inbounds i64, i64* %34, i64 1, !dbg !25
-  store i64 %send, i64* %35, align 8, !dbg !25, !tbaa !6
-  %36 = getelementptr inbounds i64, i64* %35, i64 1, !dbg !25
-  store i64* %36, i64** %33, align 8, !dbg !25
+  %29 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %8, i64 0, i32 1, !dbg !25
+  %30 = load i64*, i64** %29, align 8, !dbg !25
+  store i64 %5, i64* %30, align 8, !dbg !25, !tbaa !6
+  %31 = getelementptr inbounds i64, i64* %30, i64 1, !dbg !25
+  store i64 %send, i64* %31, align 8, !dbg !25, !tbaa !6
+  %32 = getelementptr inbounds i64, i64* %31, i64 1, !dbg !25
+  store i64* %32, i64** %29, align 8, !dbg !25
   %send2 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !25
   ret void
 }

--- a/test/testdata/compiler/exceptions/basic.opt.ll.exp
+++ b/test/testdata/compiler/exceptions/basic.opt.ll.exp
@@ -83,35 +83,29 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"rubyStrFrozen_test/testdata/compiler/exceptions/basic.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [28 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
-@"rubyStrFrozen_=== no-raise ===" = internal unnamed_addr global i64 0, align 8
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_test = internal global %struct.FunctionInlineCache zeroinitializer
-@"rubyStrFrozen_=== raise ===" = internal unnamed_addr global i64 0, align 8
 @ic_puts.1 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_test.2 = internal global %struct.FunctionInlineCache zeroinitializer
 @stackFramePrecomputed_func_A.4test = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"stackFramePrecomputed_func_A.4test$block_2" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"stackFramePrecomputed_func_A.4test$block_3" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"<retry-singleton>" = internal unnamed_addr global i64 0
-@rubyStrFrozen_begin = internal unnamed_addr global i64 0, align 8
 @ic_puts.3 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.4 = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyStrFrozen_foo = internal unnamed_addr global i64 0, align 8
 @ic_raise = internal global %struct.FunctionInlineCache zeroinitializer
 @"ic_is_a?" = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.5 = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyStrFrozen_else = internal unnamed_addr global i64 0, align 8
 @ic_puts.6 = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyStrFrozen_ensure = internal unnamed_addr global i64 0, align 8
 @ic_puts.7 = internal global %struct.FunctionInlineCache zeroinitializer
 @"stackFramePrecomputed_func_A.13<static-init>" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @sorbet_moduleStringTable = internal unnamed_addr constant [273 x i8] c"<top (required)>\00test/testdata/compiler/exceptions/basic.rb\00A\00Object\00=== no-raise ===\00puts\00test\00=== raise ===\00master\00<exceptionValue>\00x\00<returnMethodTemp>\00<magic>\00<gotoDeadTemp>\00rescue in test\00ensure in test\00begin\00foo\00raise\00StandardError\00is_a?\00else\00ensure\00<class:A>\00normal\00", align 1
 @sorbet_moduleIDTable = internal unnamed_addr global [14 x i64] zeroinitializer, align 8
 @sorbet_moduleIDDescriptors = internal unnamed_addr constant [14 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 86, i32 4 }, %struct.rb_code_position_struct { i32 91, i32 4 }, %struct.rb_code_position_struct { i32 117, i32 16 }, %struct.rb_code_position_struct { i32 134, i32 1 }, %struct.rb_code_position_struct { i32 136, i32 18 }, %struct.rb_code_position_struct { i32 155, i32 7 }, %struct.rb_code_position_struct { i32 163, i32 14 }, %struct.rb_code_position_struct { i32 178, i32 14 }, %struct.rb_code_position_struct { i32 193, i32 14 }, %struct.rb_code_position_struct { i32 218, i32 5 }, %struct.rb_code_position_struct { i32 238, i32 5 }, %struct.rb_code_position_struct { i32 256, i32 9 }, %struct.rb_code_position_struct { i32 266, i32 6 }], align 8
+@sorbet_moduleRubyStringTable = internal unnamed_addr global [12 x i64] zeroinitializer, align 8
+@sorbet_moduleRubyStringDescriptors = internal unnamed_addr constant [12 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 17, i32 42 }, %struct.rb_code_position_struct { i32 69, i32 16 }, %struct.rb_code_position_struct { i32 96, i32 13 }, %struct.rb_code_position_struct { i32 91, i32 4 }, %struct.rb_code_position_struct { i32 178, i32 14 }, %struct.rb_code_position_struct { i32 193, i32 14 }, %struct.rb_code_position_struct { i32 208, i32 5 }, %struct.rb_code_position_struct { i32 214, i32 3 }, %struct.rb_code_position_struct { i32 244, i32 4 }, %struct.rb_code_position_struct { i32 249, i32 6 }, %struct.rb_code_position_struct { i32 256, i32 9 }], align 8
 @rb_cObject = external local_unnamed_addr constant i64
 @guard_epoch_A = linkonce local_unnamed_addr global i64 0
 @guarded_const_A = linkonce local_unnamed_addr global i64 0
@@ -146,9 +140,9 @@ declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_
 
 declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #1
 
-declare i64 @sorbet_vm_isa_p(%struct.FunctionInlineCache*, %struct.rb_control_frame_struct*, i64, i64) local_unnamed_addr #1
+declare void @sorbet_vm_init_string_table(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #1
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #1
+declare i64 @sorbet_vm_isa_p(%struct.FunctionInlineCache*, %struct.rb_control_frame_struct*, i64, i64) local_unnamed_addr #1
 
 declare i64 @sorbet_run_exception_handling(%struct.rb_execution_context_struct*, i64 (i64**, i64, %struct.rb_control_frame_struct*)*, i64**, i64, %struct.rb_control_frame_struct*, i64 (i64**, i64, %struct.rb_control_frame_struct*)*, i64 (i64**, i64, %struct.rb_control_frame_struct*)*, i64 (i64**, i64, %struct.rb_control_frame_struct*)*, i64, i64, i64) local_unnamed_addr #1
 
@@ -159,8 +153,6 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #2
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #2
-
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #1
 
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #0
@@ -197,201 +189,169 @@ entry:
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
   tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([14 x %struct.rb_code_position_struct], [14 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 14, i8* noundef getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
-  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #11
-  tail call void @rb_gc_register_mark_object(i64 %0) #11
-  store i64 %0, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %1 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 42) #11
-  tail call void @rb_gc_register_mark_object(i64 %1) #11
-  store i64 %1, i64* @"rubyStrFrozen_test/testdata/compiler/exceptions/basic.rb", align 8
+  tail call void @sorbet_vm_init_string_table(i64* noundef getelementptr inbounds ([12 x i64], [12 x i64]* @sorbet_moduleRubyStringTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([12 x %struct.rb_code_position_struct], [12 x %struct.rb_code_position_struct]* @sorbet_moduleRubyStringDescriptors, i32 0, i32 0), i32 noundef 12, i8* noundef getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 28)
   %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
-  %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/exceptions/basic.rb", align 8
-  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %3 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 69), i64 noundef 16) #11
-  call void @rb_gc_register_mark_object(i64 %3) #11
-  store i64 %3, i64* @"rubyStrFrozen_=== no-raise ===", align 8
+  %"rubyStr_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([12 x i64], [12 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 0), align 8, !invariant.load !5
+  %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i.i" = load i64, i64* getelementptr inbounds ([12 x i64], [12 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
+  %0 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %0, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
   %rubyId_puts.i = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !dbg !17, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !17
   %rubyId_test.i = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !18, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test, i64 %rubyId_test.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !18
-  %4 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 96), i64 noundef 13) #11
-  call void @rb_gc_register_mark_object(i64 %4) #11
-  store i64 %4, i64* @"rubyStrFrozen_=== raise ===", align 8
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test.2, i64 %rubyId_test.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !20
-  %5 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 91), i64 noundef 4) #11
-  call void @rb_gc_register_mark_object(i64 %5) #11
-  %6 = bitcast i64* %locals.i26.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 40, i8* nonnull %6)
-  %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i25.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/exceptions/basic.rb", align 8
-  %7 = load <4 x i64>, <4 x i64>* bitcast (i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 3) to <4 x i64>*), align 8, !invariant.load !5
-  %8 = bitcast i64* %locals.i26.i to <4 x i64>*
-  store <4 x i64> %7, <4 x i64>* %8, align 8
+  %1 = bitcast i64* %locals.i26.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 40, i8* nonnull %1)
+  %rubyStr_test.i.i = load i64, i64* getelementptr inbounds ([12 x i64], [12 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 4), align 8, !invariant.load !5
+  %2 = load <4 x i64>, <4 x i64>* bitcast (i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 3) to <4 x i64>*), align 8, !invariant.load !5
+  %3 = bitcast i64* %locals.i26.i to <4 x i64>*
+  store <4 x i64> %2, <4 x i64>* %3, align 8
   %"rubyId_<gotoDeadTemp>.i.i" = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 7), align 8, !invariant.load !5
-  %9 = getelementptr i64, i64* %locals.i26.i, i32 4
-  store i64 %"rubyId_<gotoDeadTemp>.i.i", i64* %9, align 8
-  %10 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %5, i64 %rubyId_test.i, i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i25.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i26.i, i32 noundef 5, i32 noundef 2)
-  store %struct.rb_iseq_struct* %10, %struct.rb_iseq_struct** @stackFramePrecomputed_func_A.4test, align 8
-  call void @llvm.lifetime.end.p0i8(i64 40, i8* nonnull %6)
-  %11 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 178), i64 noundef 14) #11
-  call void @rb_gc_register_mark_object(i64 %11) #11
-  %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_A.4test, align 8
+  %4 = getelementptr i64, i64* %locals.i26.i, i32 4
+  store i64 %"rubyId_<gotoDeadTemp>.i.i", i64* %4, align 8
+  %5 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_test.i.i, i64 %rubyId_test.i, i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i26.i, i32 noundef 5, i32 noundef 2)
+  store %struct.rb_iseq_struct* %5, %struct.rb_iseq_struct** @stackFramePrecomputed_func_A.4test, align 8
+  call void @llvm.lifetime.end.p0i8(i64 40, i8* nonnull %1)
   %"rubyId_rescue in test.i.i" = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 8), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i27.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/exceptions/basic.rb", align 8
-  %12 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %11, i64 %"rubyId_rescue in test.i.i", i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i27.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 4, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %12, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.4test$block_2", align 8
-  %13 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 193), i64 noundef 14) #11
-  call void @rb_gc_register_mark_object(i64 %13) #11
+  %"rubyStr_rescue in test.i.i" = load i64, i64* getelementptr inbounds ([12 x i64], [12 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 5), align 8, !invariant.load !5
+  %6 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_rescue in test.i.i", i64 %"rubyId_rescue in test.i.i", i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* %5, i32 noundef 4, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %6, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.4test$block_2", align 8
   %stackFrame.i28.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_A.4test, align 8
   %"rubyId_ensure in test.i.i" = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 9), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i29.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/exceptions/basic.rb", align 8
-  %14 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %13, i64 %"rubyId_ensure in test.i.i", i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i29.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i28.i, i32 noundef 5, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %14, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.4test$block_3", align 8
-  %15 = call i64 @sorbet_getConstant(i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @sorbet_getTRetry.retry, i64 0, i64 0), i64 noundef 25) #11
-  store i64 %15, i64* @"<retry-singleton>", align 8
-  %16 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 208), i64 noundef 5) #11
-  call void @rb_gc_register_mark_object(i64 %16) #11
-  store i64 %16, i64* @rubyStrFrozen_begin, align 8
+  %"rubyStr_ensure in test.i.i" = load i64, i64* getelementptr inbounds ([12 x i64], [12 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 6), align 8, !invariant.load !5
+  %7 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_ensure in test.i.i", i64 %"rubyId_ensure in test.i.i", i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i28.i, i32 noundef 5, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %7, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.4test$block_3", align 8
+  %8 = call i64 @sorbet_getConstant(i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @sorbet_getTRetry.retry, i64 0, i64 0), i64 noundef 25) #11
+  store i64 %8, i64* @"<retry-singleton>", align 8
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !21
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.4, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !24
-  %17 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 214), i64 noundef 3) #11
-  call void @rb_gc_register_mark_object(i64 %17) #11
-  store i64 %17, i64* @rubyStrFrozen_foo, align 8
   %rubyId_raise.i = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 10), align 8, !dbg !25, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_raise, i64 %rubyId_raise.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !25
   %"rubyId_is_a?.i" = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 11), align 8, !dbg !26, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_is_a?", i64 %"rubyId_is_a?.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !26
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.5, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !28
-  %18 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 244), i64 noundef 4) #11
-  call void @rb_gc_register_mark_object(i64 %18) #11
-  store i64 %18, i64* @rubyStrFrozen_else, align 8
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.6, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !29
-  %19 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 249), i64 noundef 6) #11
-  call void @rb_gc_register_mark_object(i64 %19) #11
-  store i64 %19, i64* @rubyStrFrozen_ensure, align 8
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.7, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !31
-  %20 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 256), i64 noundef 9) #11
-  call void @rb_gc_register_mark_object(i64 %20) #11
   %"rubyId_<class:A>.i.i" = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 12), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i30.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/exceptions/basic.rb", align 8
-  %21 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %20, i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i30.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i31.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %21, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %22 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !33
-  %23 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %22, i64 0, i32 18
-  %24 = load i64, i64* %23, align 8, !tbaa !35
-  %25 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !33
-  %26 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %25, i64 0, i32 2
-  %27 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %26, align 8, !tbaa !45
+  %"rubyStr_<class:A>.i.i" = load i64, i64* getelementptr inbounds ([12 x i64], [12 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 11), align 8, !invariant.load !5
+  %9 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<class:A>.i.i", i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i31.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %9, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
+  %10 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !33
+  %11 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %10, i64 0, i32 18
+  %12 = load i64, i64* %11, align 8, !tbaa !35
+  %13 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !33
+  %14 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %13, i64 0, i32 2
+  %15 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %14, align 8, !tbaa !45
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %28 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %27, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %28, align 8, !tbaa !48
-  %29 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %27, i64 0, i32 4
-  %30 = load i64*, i64** %29, align 8, !tbaa !50
-  %31 = load i64, i64* %30, align 8, !tbaa !6
-  %32 = and i64 %31, -33
-  store i64 %32, i64* %30, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %25, %struct.rb_control_frame_struct* %27, %struct.rb_iseq_struct* %stackFrame.i) #11
-  %33 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %27, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %33, align 8, !dbg !51, !tbaa !33
-  %34 = load i64, i64* @rb_cObject, align 8, !dbg !52
-  %35 = call i64 @rb_define_class(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 60), i64 %34) #11, !dbg !52
-  %36 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %35) #11, !dbg !52
-  %37 = bitcast i64* %positional_table.i.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %37) #11
-  %stackFrame.i.i1 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %38 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !33
-  %39 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %38, i64 0, i32 2
-  %40 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %39, align 8, !tbaa !45
-  %41 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %40, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i.i1, %struct.rb_iseq_struct** %41, align 8, !tbaa !48
-  %42 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %40, i64 0, i32 4
-  %43 = load i64*, i64** %42, align 8, !tbaa !50
-  %44 = load i64, i64* %43, align 8, !tbaa !6
-  %45 = and i64 %44, -33
-  store i64 %45, i64* %43, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %38, %struct.rb_control_frame_struct* %40, %struct.rb_iseq_struct* %stackFrame.i.i1) #11
-  %46 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %36, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %46, align 8, !dbg !53, !tbaa !33
-  %47 = load i64, i64* @guard_epoch_A, align 8, !dbg !10
-  %48 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !54
-  %needTakeSlowPath = icmp ne i64 %47, %48, !dbg !10
-  br i1 %needTakeSlowPath, label %49, label %50, !dbg !10, !prof !55
+  %16 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %16, align 8, !tbaa !48
+  %17 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 4
+  %18 = load i64*, i64** %17, align 8, !tbaa !50
+  %19 = load i64, i64* %18, align 8, !tbaa !6
+  %20 = and i64 %19, -33
+  store i64 %20, i64* %18, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %13, %struct.rb_control_frame_struct* %15, %struct.rb_iseq_struct* %stackFrame.i) #11
+  %21 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 0
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %21, align 8, !dbg !51, !tbaa !33
+  %22 = load i64, i64* @rb_cObject, align 8, !dbg !52
+  %23 = call i64 @rb_define_class(i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 60), i64 %22) #11, !dbg !52
+  %24 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %23) #11, !dbg !52
+  %25 = bitcast i64* %positional_table.i.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %25) #11
+  %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
+  %26 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !33
+  %27 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %26, i64 0, i32 2
+  %28 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %27, align 8, !tbaa !45
+  %29 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %28, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %29, align 8, !tbaa !48
+  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %28, i64 0, i32 4
+  %31 = load i64*, i64** %30, align 8, !tbaa !50
+  %32 = load i64, i64* %31, align 8, !tbaa !6
+  %33 = and i64 %32, -33
+  store i64 %33, i64* %31, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %26, %struct.rb_control_frame_struct* %28, %struct.rb_iseq_struct* %stackFrame.i.i) #11
+  %34 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 0
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %34, align 8, !dbg !53, !tbaa !33
+  %35 = load i64, i64* @guard_epoch_A, align 8, !dbg !10
+  %36 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !54
+  %needTakeSlowPath = icmp ne i64 %35, %36, !dbg !10
+  br i1 %needTakeSlowPath, label %37, label %38, !dbg !10, !prof !55
 
-49:                                               ; preds = %entry
+37:                                               ; preds = %entry
   call void @const_recompute_A(), !dbg !10
-  br label %50, !dbg !10
+  br label %38, !dbg !10
 
-50:                                               ; preds = %entry, %49
-  %51 = load i64, i64* @guarded_const_A, align 8, !dbg !10
-  %52 = load i64, i64* @guard_epoch_A, align 8, !dbg !10
-  %53 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !54
-  %guardUpdated = icmp eq i64 %52, %53, !dbg !10
+38:                                               ; preds = %entry, %37
+  %39 = load i64, i64* @guarded_const_A, align 8, !dbg !10
+  %40 = load i64, i64* @guard_epoch_A, align 8, !dbg !10
+  %41 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !54
+  %guardUpdated = icmp eq i64 %40, %41, !dbg !10
   call void @llvm.assume(i1 %guardUpdated), !dbg !10
   %stackFrame7.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_A.4test, align 8, !dbg !10
-  %54 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !10
-  %55 = bitcast i8* %54 to i16*, !dbg !10
-  %56 = load i16, i16* %55, align 8, !dbg !10
-  %57 = and i16 %56, -384, !dbg !10
-  %58 = or i16 %57, 1, !dbg !10
-  store i16 %58, i16* %55, align 8, !dbg !10
-  %59 = getelementptr inbounds i8, i8* %54, i64 8, !dbg !10
-  %60 = bitcast i8* %59 to i32*, !dbg !10
-  store i32 1, i32* %60, align 8, !dbg !10, !tbaa !56
-  %61 = getelementptr inbounds i8, i8* %54, i64 12, !dbg !10
-  %62 = getelementptr inbounds i8, i8* %54, i64 4, !dbg !10
-  %63 = bitcast i8* %62 to i32*, !dbg !10
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %61, i8 0, i64 20, i1 false) #11, !dbg !10
-  store i32 1, i32* %63, align 4, !dbg !10, !tbaa !59
-  %64 = extractelement <4 x i64> %7, i32 1, !dbg !10
-  store i64 %64, i64* %positional_table.i.i, align 8, !dbg !10
-  %65 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !10
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %65, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %37, i64 noundef 8, i1 noundef false) #11, !dbg !10
-  %66 = getelementptr inbounds i8, i8* %54, i64 32, !dbg !10
-  %67 = bitcast i8* %66 to i8**, !dbg !10
-  store i8* %65, i8** %67, align 8, !dbg !10, !tbaa !60
-  call void @sorbet_vm_define_method(i64 %51, i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 91), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_A.4test, i8* nonnull %54, %struct.rb_iseq_struct* %stackFrame7.i.i, i1 noundef zeroext true) #11, !dbg !10
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %37) #11
+  %42 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !10
+  %43 = bitcast i8* %42 to i16*, !dbg !10
+  %44 = load i16, i16* %43, align 8, !dbg !10
+  %45 = and i16 %44, -384, !dbg !10
+  %46 = or i16 %45, 1, !dbg !10
+  store i16 %46, i16* %43, align 8, !dbg !10
+  %47 = getelementptr inbounds i8, i8* %42, i64 8, !dbg !10
+  %48 = bitcast i8* %47 to i32*, !dbg !10
+  store i32 1, i32* %48, align 8, !dbg !10, !tbaa !56
+  %49 = getelementptr inbounds i8, i8* %42, i64 12, !dbg !10
+  %50 = getelementptr inbounds i8, i8* %42, i64 4, !dbg !10
+  %51 = bitcast i8* %50 to i32*, !dbg !10
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %49, i8 0, i64 20, i1 false) #11, !dbg !10
+  store i32 1, i32* %51, align 4, !dbg !10, !tbaa !59
+  %52 = extractelement <4 x i64> %2, i32 1, !dbg !10
+  store i64 %52, i64* %positional_table.i.i, align 8, !dbg !10
+  %53 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !10
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %53, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %25, i64 noundef 8, i1 noundef false) #11, !dbg !10
+  %54 = getelementptr inbounds i8, i8* %42, i64 32, !dbg !10
+  %55 = bitcast i8* %54 to i8**, !dbg !10
+  store i8* %53, i8** %55, align 8, !dbg !10, !tbaa !60
+  call void @sorbet_vm_define_method(i64 %39, i8* getelementptr inbounds ([273 x i8], [273 x i8]* @sorbet_moduleStringTable, i64 0, i64 91), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_A.4test, i8* nonnull %42, %struct.rb_iseq_struct* %stackFrame7.i.i, i1 noundef zeroext true) #11, !dbg !10
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %25) #11
   call void @sorbet_popFrame() #11, !dbg !52
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %33, align 8, !dbg !52, !tbaa !33
-  %"rubyStr_=== no-raise ===.i" = load i64, i64* @"rubyStrFrozen_=== no-raise ===", align 8, !dbg !61
-  %68 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %27, i64 0, i32 1, !dbg !17
-  %69 = load i64*, i64** %68, align 8, !dbg !17
-  store i64 %24, i64* %69, align 8, !dbg !17, !tbaa !6
-  %70 = getelementptr inbounds i64, i64* %69, i64 1, !dbg !17
-  store i64 %"rubyStr_=== no-raise ===.i", i64* %70, align 8, !dbg !17, !tbaa !6
-  %71 = getelementptr inbounds i64, i64* %70, i64 1, !dbg !17
-  store i64* %71, i64** %68, align 8, !dbg !17
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %21, align 8, !dbg !52, !tbaa !33
+  %"rubyStr_=== no-raise ===.i" = load i64, i64* getelementptr inbounds ([12 x i64], [12 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 2), align 8, !dbg !61, !invariant.load !5
+  %56 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 1, !dbg !17
+  %57 = load i64*, i64** %56, align 8, !dbg !17
+  store i64 %12, i64* %57, align 8, !dbg !17, !tbaa !6
+  %58 = getelementptr inbounds i64, i64* %57, i64 1, !dbg !17
+  store i64 %"rubyStr_=== no-raise ===.i", i64* %58, align 8, !dbg !17, !tbaa !6
+  %59 = getelementptr inbounds i64, i64* %58, i64 1, !dbg !17
+  store i64* %59, i64** %56, align 8, !dbg !17
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !17
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %33, align 8, !dbg !17, !tbaa !33
-  %72 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %27, i64 0, i32 1, !dbg !18
-  %73 = load i64*, i64** %72, align 8, !dbg !18
-  store i64 %51, i64* %73, align 8, !dbg !18, !tbaa !6
-  %74 = getelementptr inbounds i64, i64* %73, i64 1, !dbg !18
-  store i64 0, i64* %74, align 8, !dbg !18, !tbaa !6
-  %75 = getelementptr inbounds i64, i64* %74, i64 1, !dbg !18
-  store i64* %75, i64** %72, align 8, !dbg !18
-  %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test, i64 0), !dbg !18
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %33, align 8, !dbg !18, !tbaa !33
-  %"rubyStr_=== raise ===.i" = load i64, i64* @"rubyStrFrozen_=== raise ===", align 8, !dbg !62
-  %76 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %27, i64 0, i32 1, !dbg !19
-  %77 = load i64*, i64** %76, align 8, !dbg !19
-  store i64 %24, i64* %77, align 8, !dbg !19, !tbaa !6
-  %78 = getelementptr inbounds i64, i64* %77, i64 1, !dbg !19
-  store i64 %"rubyStr_=== raise ===.i", i64* %78, align 8, !dbg !19, !tbaa !6
-  %79 = getelementptr inbounds i64, i64* %78, i64 1, !dbg !19
-  store i64* %79, i64** %76, align 8, !dbg !19
-  %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.1, i64 0), !dbg !19
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %33, align 8, !dbg !19, !tbaa !33
-  %80 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %27, i64 0, i32 1, !dbg !20
-  %81 = load i64*, i64** %80, align 8, !dbg !20
-  store i64 %51, i64* %81, align 8, !dbg !20, !tbaa !6
-  %82 = getelementptr inbounds i64, i64* %81, i64 1, !dbg !20
-  store i64 20, i64* %82, align 8, !dbg !20, !tbaa !6
-  %83 = getelementptr inbounds i64, i64* %82, i64 1, !dbg !20
-  store i64* %83, i64** %80, align 8, !dbg !20
-  %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test.2, i64 0), !dbg !20
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %21, align 8, !dbg !17, !tbaa !33
+  %60 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 1, !dbg !18
+  %61 = load i64*, i64** %60, align 8, !dbg !18
+  store i64 %39, i64* %61, align 8, !dbg !18, !tbaa !6
+  %62 = getelementptr inbounds i64, i64* %61, i64 1, !dbg !18
+  store i64 0, i64* %62, align 8, !dbg !18, !tbaa !6
+  %63 = getelementptr inbounds i64, i64* %62, i64 1, !dbg !18
+  store i64* %63, i64** %60, align 8, !dbg !18
+  %send3 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test, i64 0), !dbg !18
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %21, align 8, !dbg !18, !tbaa !33
+  %"rubyStr_=== raise ===.i" = load i64, i64* getelementptr inbounds ([12 x i64], [12 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 3), align 8, !dbg !62, !invariant.load !5
+  %64 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 1, !dbg !19
+  %65 = load i64*, i64** %64, align 8, !dbg !19
+  store i64 %12, i64* %65, align 8, !dbg !19, !tbaa !6
+  %66 = getelementptr inbounds i64, i64* %65, i64 1, !dbg !19
+  store i64 %"rubyStr_=== raise ===.i", i64* %66, align 8, !dbg !19, !tbaa !6
+  %67 = getelementptr inbounds i64, i64* %66, i64 1, !dbg !19
+  store i64* %67, i64** %64, align 8, !dbg !19
+  %send5 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.1, i64 0), !dbg !19
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %21, align 8, !dbg !19, !tbaa !33
+  %68 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 1, !dbg !20
+  %69 = load i64*, i64** %68, align 8, !dbg !20
+  store i64 %39, i64* %69, align 8, !dbg !20, !tbaa !6
+  %70 = getelementptr inbounds i64, i64* %69, i64 1, !dbg !20
+  store i64 20, i64* %70, align 8, !dbg !20, !tbaa !6
+  %71 = getelementptr inbounds i64, i64* %70, i64 1, !dbg !20
+  store i64* %71, i64** %68, align 8, !dbg !20
+  %send7 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test.2, i64 0), !dbg !20
   ret void
 }
 
@@ -456,7 +416,7 @@ functionEntryInitializers:
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
   %4 = load i64, i64* %3, align 8, !tbaa !69
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %pc, align 8, !tbaa !33
-  %rubyStr_begin = load i64, i64* @rubyStrFrozen_begin, align 8, !dbg !70
+  %rubyStr_begin = load i64, i64* getelementptr inbounds ([12 x i64], [12 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 7), align 8, !dbg !70, !invariant.load !5
   %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !21
   %6 = load i64*, i64** %5, align 8, !dbg !21
   store i64 %4, i64* %6, align 8, !dbg !21, !tbaa !6
@@ -487,7 +447,7 @@ BB5:                                              ; preds = %functionEntryInitia
   store i64* %21, i64** %18, align 8, !dbg !24
   %send25 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.4, i64 0), !dbg !24
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %pc, align 8, !dbg !24, !tbaa !33
-  %rubyStr_foo = load i64, i64* @rubyStrFrozen_foo, align 8, !dbg !71
+  %rubyStr_foo = load i64, i64* getelementptr inbounds ([12 x i64], [12 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 8), align 8, !dbg !71, !invariant.load !5
   %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !25
   %23 = load i64*, i64** %22, align 8, !dbg !25
   store i64 %4, i64* %23, align 8, !dbg !25, !tbaa !6
@@ -653,7 +613,7 @@ functionEntryInitializers:
   %7 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %6, align 8, !tbaa !45
   %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %7, i64 0, i32 0
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %8, align 8, !tbaa !33
-  %rubyStr_ensure = load i64, i64* @rubyStrFrozen_ensure, align 8, !dbg !75
+  %rubyStr_ensure = load i64, i64* getelementptr inbounds ([12 x i64], [12 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 10), align 8, !dbg !75, !invariant.load !5
   %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !31, !tbaa !33
   %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 2, !dbg !31
   %11 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %10, align 8, !dbg !31, !tbaa !45
@@ -678,7 +638,7 @@ functionEntryInitializers:
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
   %4 = load i64, i64* %3, align 8, !tbaa !69
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %pc, align 8, !tbaa !33
-  %rubyStr_else = load i64, i64* @rubyStrFrozen_else, align 8, !dbg !76
+  %rubyStr_else = load i64, i64* getelementptr inbounds ([12 x i64], [12 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 9), align 8, !dbg !76, !invariant.load !5
   %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !29
   %6 = load i64*, i64** %5, align 8, !dbg !29
   store i64 %4, i64* %6, align 8, !dbg !29, !tbaa !6

--- a/test/testdata/compiler/float-intrinsics.opt.ll.exp
+++ b/test/testdata/compiler/float-intrinsics.opt.ll.exp
@@ -83,8 +83,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_Object#4plus" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@rubyStrFrozen_plus = internal unnamed_addr global i64 0, align 8
-@"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [49 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @"stackFramePrecomputed_func_Object#5minus" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
@@ -93,7 +91,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @"stackFramePrecomputed_func_Object#3lte" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyStrFrozen_block in <top (required)>" = internal unnamed_addr global i64 0, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_2" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_3" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_4" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
@@ -128,39 +125,35 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ic_p.20 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_plus.21 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_p.22 = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyStrFrozen_8.9 = internal unnamed_addr global i64 0, align 8
 @ic_Rational = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_plus.23 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_p.24 = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyStrFrozen_5 = internal unnamed_addr global i64 0, align 8
 @ic_Complex = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_plus.25 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_p.26 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_minus.27 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_p.28 = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyStrFrozen_15.4 = internal unnamed_addr global i64 0, align 8
 @ic_Rational.29 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_minus.30 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_p.31 = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyStrFrozen_18 = internal unnamed_addr global i64 0, align 8
 @ic_Complex.32 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_minus.33 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_p.34 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_lt.35 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_p.36 = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyStrFrozen_25.4 = internal unnamed_addr global i64 0, align 8
 @ic_Rational.37 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_lt.38 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_p.39 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_lte.40 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_p.41 = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyStrFrozen_5.923 = internal unnamed_addr global i64 0, align 8
 @ic_Rational.42 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_lte.43 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_p.44 = internal global %struct.FunctionInlineCache zeroinitializer
 @sorbet_moduleStringTable = internal unnamed_addr constant [309 x i8] c"plus\00test/testdata/compiler/float-intrinsics.rb\00Parameter 'x'\00Float\00Parameter 'y'\00T.untyped\00+\00Return value\00minus\00-\00lt\00<\00T::Boolean\00lte\00<=\00<top (required)>\00<block-call>\00block in <top (required)>\00x\00y\00untyped\00T\00params\00returns\00T::Sig\00extend\00normal\00Object\00p\008.9\00Rational\00Kernel\005\00Complex\0015.4\0018\0025.4\005.923\00master\00", align 1
 @sorbet_moduleIDTable = internal unnamed_addr global [21 x i64] zeroinitializer, align 8
 @sorbet_moduleIDDescriptors = internal unnamed_addr constant [21 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 4 }, %struct.rb_code_position_struct { i32 92, i32 1 }, %struct.rb_code_position_struct { i32 107, i32 5 }, %struct.rb_code_position_struct { i32 113, i32 1 }, %struct.rb_code_position_struct { i32 115, i32 2 }, %struct.rb_code_position_struct { i32 118, i32 1 }, %struct.rb_code_position_struct { i32 131, i32 3 }, %struct.rb_code_position_struct { i32 135, i32 2 }, %struct.rb_code_position_struct { i32 138, i32 16 }, %struct.rb_code_position_struct { i32 155, i32 12 }, %struct.rb_code_position_struct { i32 168, i32 25 }, %struct.rb_code_position_struct { i32 194, i32 1 }, %struct.rb_code_position_struct { i32 196, i32 1 }, %struct.rb_code_position_struct { i32 198, i32 7 }, %struct.rb_code_position_struct { i32 208, i32 6 }, %struct.rb_code_position_struct { i32 215, i32 7 }, %struct.rb_code_position_struct { i32 230, i32 6 }, %struct.rb_code_position_struct { i32 237, i32 6 }, %struct.rb_code_position_struct { i32 251, i32 1 }, %struct.rb_code_position_struct { i32 257, i32 8 }, %struct.rb_code_position_struct { i32 275, i32 7 }], align 8
+@sorbet_moduleRubyStringTable = internal unnamed_addr global [13 x i64] zeroinitializer, align 8
+@sorbet_moduleRubyStringDescriptors = internal unnamed_addr constant [13 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 4 }, %struct.rb_code_position_struct { i32 5, i32 42 }, %struct.rb_code_position_struct { i32 107, i32 5 }, %struct.rb_code_position_struct { i32 115, i32 2 }, %struct.rb_code_position_struct { i32 131, i32 3 }, %struct.rb_code_position_struct { i32 138, i32 16 }, %struct.rb_code_position_struct { i32 168, i32 25 }, %struct.rb_code_position_struct { i32 253, i32 3 }, %struct.rb_code_position_struct { i32 273, i32 1 }, %struct.rb_code_position_struct { i32 283, i32 4 }, %struct.rb_code_position_struct { i32 288, i32 2 }, %struct.rb_code_position_struct { i32 291, i32 4 }, %struct.rb_code_position_struct { i32 296, i32 5 }], align 8
 @guard_epoch_T = linkonce local_unnamed_addr global i64 0
 @guarded_const_T = linkonce local_unnamed_addr global i64 0
 @rb_cFloat = external local_unnamed_addr constant i64
@@ -206,9 +199,7 @@ declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_
 
 declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #0
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
-
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
+declare void @sorbet_vm_init_string_table(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #0
 
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #3
@@ -833,103 +824,80 @@ entry:
   %3 = bitcast i64* %keywords38.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %3)
   tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([21 x %struct.rb_code_position_struct], [21 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 21, i8* noundef getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
-  %4 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 4) #17
-  tail call void @rb_gc_register_mark_object(i64 %4) #17
-  store i64 %4, i64* @rubyStrFrozen_plus, align 8
-  %5 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 5), i64 noundef 42) #17
-  tail call void @rb_gc_register_mark_object(i64 %5) #17
-  store i64 %5, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
+  tail call void @sorbet_vm_init_string_table(i64* noundef getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([13 x %struct.rb_code_position_struct], [13 x %struct.rb_code_position_struct]* @sorbet_moduleRubyStringDescriptors, i32 0, i32 0), i32 noundef 13, i8* noundef getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 49)
   %rubyId_plus.i.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
-  %rubyStr_plus.i.i = load i64, i64* @rubyStrFrozen_plus, align 8
-  %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
-  %6 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_plus.i.i, i64 %rubyId_plus.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %6, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#4plus", align 8
-  %7 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 107), i64 noundef 5) #17
-  call void @rb_gc_register_mark_object(i64 %7) #17
+  %rubyStr_plus.i.i = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 0), align 8, !invariant.load !5
+  %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i.i" = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
+  %4 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_plus.i.i, i64 %rubyId_plus.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %4, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#4plus", align 8
   %rubyId_minus.i.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i156.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
-  %8 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %7, i64 %rubyId_minus.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i156.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 13, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i157.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %8, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#5minus", align 8
+  %rubyStr_minus.i.i = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 2), align 8, !invariant.load !5
+  %5 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_minus.i.i, i64 %rubyId_minus.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 13, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i157.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %5, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#5minus", align 8
   %rubyId_-.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !37, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_-, i64 %rubyId_-.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !37
-  %9 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 115), i64 noundef 2) #17
-  call void @rb_gc_register_mark_object(i64 %9) #17
   %rubyId_lt.i.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i158.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
-  %10 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %9, i64 %rubyId_lt.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i158.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 18, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i159.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %10, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#2lt", align 8
-  %11 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 131), i64 noundef 3) #17
-  call void @rb_gc_register_mark_object(i64 %11) #17
+  %rubyStr_lt.i.i = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 3), align 8, !invariant.load !5
+  %6 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_lt.i.i, i64 %rubyId_lt.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 18, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i159.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %6, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#2lt", align 8
   %rubyId_lte.i.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 6), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i160.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
-  %12 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %11, i64 %rubyId_lte.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i160.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 23, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i161.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %12, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3lte", align 8
-  %13 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 138), i64 noundef 16) #17
-  call void @rb_gc_register_mark_object(i64 %13) #17
-  %14 = bitcast i64* %locals.i163.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %14)
+  %rubyStr_lte.i.i = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 4), align 8, !invariant.load !5
+  %7 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_lte.i.i, i64 %rubyId_lte.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 23, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i161.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %7, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3lte", align 8
+  %8 = bitcast i64* %locals.i163.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %8)
   %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 8), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i162.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
+  %"rubyStr_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 5), align 8, !invariant.load !5
   %"rubyId_<block-call>.i.i" = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 9), align 8, !invariant.load !5
   store i64 %"rubyId_<block-call>.i.i", i64* %locals.i163.i, align 8
-  %15 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %13, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i162.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i163.i, i32 noundef 1, i32 noundef 4)
-  store %struct.rb_iseq_struct* %15, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %14)
-  %16 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 168), i64 noundef 25) #17
-  call void @rb_gc_register_mark_object(i64 %16) #17
-  store i64 %16, i64* @"rubyStrFrozen_block in <top (required)>", align 8
-  %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %9 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i163.i, i32 noundef 1, i32 noundef 4)
+  store %struct.rb_iseq_struct* %9, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %8)
   %"rubyId_block in <top (required)>.i.i" = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 10), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i164.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
-  %17 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %16, i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i164.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %17, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1", align 8
+  %"rubyStr_block in <top (required)>.i.i" = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 6), align 8, !invariant.load !5
+  %10 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i.i", i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* %9, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %10, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1", align 8
   %stackFrame.i165.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %"rubyStr_block in <top (required)>.i167.i" = load i64, i64* @"rubyStrFrozen_block in <top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i168.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
-  %18 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i167.i", i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i168.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i165.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %18, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_2", align 8
+  %11 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i.i", i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i165.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %11, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_2", align 8
   %stackFrame.i169.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %"rubyStr_block in <top (required)>.i171.i" = load i64, i64* @"rubyStrFrozen_block in <top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i172.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
-  %19 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i171.i", i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i172.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i169.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %19, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_3", align 8
+  %12 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i.i", i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i169.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %12, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_3", align 8
   %stackFrame.i173.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %"rubyStr_block in <top (required)>.i175.i" = load i64, i64* @"rubyStrFrozen_block in <top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i176.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/float-intrinsics.rb", align 8
-  %20 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i175.i", i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i176.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i173.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %20, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_4", align 8
+  %13 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i.i", i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i173.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %13, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_4", align 8
   %rubyId_untyped.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 13), align 8, !dbg !64, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped, i64 %rubyId_untyped.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !64
   %rubyId_params.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 14), align 8, !dbg !68, !invariant.load !5
   %rubyId_x.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 11), align 8, !dbg !68, !invariant.load !5
-  %21 = call i64 @rb_id2sym(i64 %rubyId_x.i) #18, !dbg !68
-  store i64 %21, i64* %keywords.i, align 8, !dbg !68
+  %14 = call i64 @rb_id2sym(i64 %rubyId_x.i) #18, !dbg !68
+  store i64 %14, i64* %keywords.i, align 8, !dbg !68
   %rubyId_y.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 12), align 8, !dbg !68, !invariant.load !5
-  %22 = call i64 @rb_id2sym(i64 %rubyId_y.i) #18, !dbg !68
-  %23 = getelementptr i64, i64* %keywords.i, i32 1, !dbg !68
-  store i64 %22, i64* %23, align 8, !dbg !68
+  %15 = call i64 @rb_id2sym(i64 %rubyId_y.i) #18, !dbg !68
+  %16 = getelementptr i64, i64* %keywords.i, i32 1, !dbg !68
+  store i64 %15, i64* %16, align 8, !dbg !68
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull align 8 %keywords.i), !dbg !68
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.1, i64 %rubyId_untyped.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !69
   %rubyId_returns.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 15), align 8, !dbg !68, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !68
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.2, i64 %rubyId_untyped.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !72
-  store i64 %21, i64* %keywords12.i, align 8, !dbg !73
-  %24 = getelementptr i64, i64* %keywords12.i, i32 1, !dbg !73
-  store i64 %22, i64* %24, align 8, !dbg !73
+  store i64 %14, i64* %keywords12.i, align 8, !dbg !73
+  %17 = getelementptr i64, i64* %keywords12.i, i32 1, !dbg !73
+  store i64 %15, i64* %17, align 8, !dbg !73
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params.3, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull align 8 %keywords12.i), !dbg !73
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.4, i64 %rubyId_untyped.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !74
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.5, i64 %rubyId_returns.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !73
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.6, i64 %rubyId_untyped.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !77
-  store i64 %21, i64* %keywords26.i, align 8, !dbg !78
-  %25 = getelementptr i64, i64* %keywords26.i, i32 1, !dbg !78
-  store i64 %22, i64* %25, align 8, !dbg !78
+  store i64 %14, i64* %keywords26.i, align 8, !dbg !78
+  %18 = getelementptr i64, i64* %keywords26.i, i32 1, !dbg !78
+  store i64 %15, i64* %18, align 8, !dbg !78
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params.7, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull align 8 %keywords26.i), !dbg !78
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.8, i64 %rubyId_returns.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !78
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.9, i64 %rubyId_untyped.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !81
-  store i64 %21, i64* %keywords38.i, align 8, !dbg !82
-  %26 = getelementptr i64, i64* %keywords38.i, i32 1, !dbg !82
-  store i64 %22, i64* %26, align 8, !dbg !82
+  store i64 %14, i64* %keywords38.i, align 8, !dbg !82
+  %19 = getelementptr i64, i64* %keywords38.i, i32 1, !dbg !82
+  store i64 %15, i64* %19, align 8, !dbg !82
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params.10, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull align 8 %keywords38.i), !dbg !82
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.11, i64 %rubyId_returns.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !82
   %rubyId_extend.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 16), align 8, !dbg !88, !invariant.load !5
@@ -951,47 +919,29 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.20, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !102
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus.21, i64 %rubyId_plus.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !103
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.22, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !104
-  %27 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 253), i64 noundef 3) #17
-  call void @rb_gc_register_mark_object(i64 %27) #17
-  store i64 %27, i64* @rubyStrFrozen_8.9, align 8
   %rubyId_Rational.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 19), align 8, !dbg !105, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational, i64 %rubyId_Rational.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !105
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus.23, i64 %rubyId_plus.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !106
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.24, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !107
-  %28 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 273), i64 noundef 1) #17
-  call void @rb_gc_register_mark_object(i64 %28) #17
-  store i64 %28, i64* @rubyStrFrozen_5, align 8
   %rubyId_Complex.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 20), align 8, !dbg !108, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Complex, i64 %rubyId_Complex.i, i32 noundef 16, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !108
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus.25, i64 %rubyId_plus.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !109
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.26, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !110
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus.27, i64 %rubyId_minus.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !111
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.28, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !112
-  %29 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 283), i64 noundef 4) #17
-  call void @rb_gc_register_mark_object(i64 %29) #17
-  store i64 %29, i64* @rubyStrFrozen_15.4, align 8
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational.29, i64 %rubyId_Rational.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !113
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus.30, i64 %rubyId_minus.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !114
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.31, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !115
-  %30 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 288), i64 noundef 2) #17
-  call void @rb_gc_register_mark_object(i64 %30) #17
-  store i64 %30, i64* @rubyStrFrozen_18, align 8
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Complex.32, i64 %rubyId_Complex.i, i32 noundef 16, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !116
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus.33, i64 %rubyId_minus.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !117
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.34, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !118
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt.35, i64 %rubyId_lt.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !119
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.36, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !120
-  %31 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 291), i64 noundef 4) #17
-  call void @rb_gc_register_mark_object(i64 %31) #17
-  store i64 %31, i64* @rubyStrFrozen_25.4, align 8
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational.37, i64 %rubyId_Rational.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !121
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt.38, i64 %rubyId_lt.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !122
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.39, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !123
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.40, i64 %rubyId_lte.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !124
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.41, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !125
-  %32 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 296), i64 noundef 5) #17
-  call void @rb_gc_register_mark_object(i64 %32) #17
-  store i64 %32, i64* @rubyStrFrozen_5.923, align 8
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational.42, i64 %rubyId_Rational.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !126
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.43, i64 %rubyId_lte.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !127
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.44, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !128
@@ -999,553 +949,553 @@ entry:
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %3)
-  %33 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
-  %34 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %33, i64 0, i32 18
-  %35 = load i64, i64* %34, align 8, !tbaa !129
-  %36 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %37 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %36, i64 0, i32 2
-  %38 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %37, align 8, !tbaa !59
-  %39 = bitcast i64* %positional_table.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %39)
-  %40 = bitcast i64* %positional_table320.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %40)
-  %41 = bitcast i64* %positional_table334.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %41)
-  %42 = bitcast i64* %positional_table348.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %42)
+  %20 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
+  %21 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %20, i64 0, i32 18
+  %22 = load i64, i64* %21, align 8, !tbaa !129
+  %23 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %24 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %23, i64 0, i32 2
+  %25 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %24, align 8, !tbaa !59
+  %26 = bitcast i64* %positional_table.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %26)
+  %27 = bitcast i64* %positional_table320.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %27)
+  %28 = bitcast i64* %positional_table334.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %28)
+  %29 = bitcast i64* %positional_table348.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %29)
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %43 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %43, align 8, !tbaa !62
-  %44 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 4
-  %45 = load i64*, i64** %44, align 8, !tbaa !63
-  %46 = load i64, i64* %45, align 8, !tbaa !6
-  %47 = and i64 %46, -33
-  store i64 %47, i64* %45, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %36, %struct.rb_control_frame_struct* %38, %struct.rb_iseq_struct* %stackFrame.i) #17
-  %48 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 0
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %48, align 8, !dbg !137, !tbaa !14
+  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %30, align 8, !tbaa !62
+  %31 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 4
+  %32 = load i64*, i64** %31, align 8, !tbaa !63
+  %33 = load i64, i64* %32, align 8, !tbaa !6
+  %34 = and i64 %33, -33
+  store i64 %34, i64* %32, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %23, %struct.rb_control_frame_struct* %25, %struct.rb_iseq_struct* %stackFrame.i) #17
+  %35 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 0
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %35, align 8, !dbg !137, !tbaa !14
   %rawSym.i = call i64 @rb_id2sym(i64 %rubyId_plus.i.i) #17, !dbg !138
-  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym.i, i64 %35, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_1") #17, !dbg !138
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %48, align 8, !dbg !138, !tbaa !14
+  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym.i, i64 %22, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_1") #17, !dbg !138
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %35, align 8, !dbg !138, !tbaa !14
   %rawSym257.i = call i64 @rb_id2sym(i64 %rubyId_minus.i.i) #17, !dbg !139
-  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym257.i, i64 %35, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_2") #17, !dbg !139
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %48, align 8, !dbg !139, !tbaa !14
+  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym257.i, i64 %22, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_2") #17, !dbg !139
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %35, align 8, !dbg !139, !tbaa !14
   %rawSym271.i = call i64 @rb_id2sym(i64 %rubyId_lt.i.i) #17, !dbg !140
-  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym271.i, i64 %35, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_3") #17, !dbg !140
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %48, align 8, !dbg !140, !tbaa !14
+  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym271.i, i64 %22, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_3") #17, !dbg !140
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %35, align 8, !dbg !140, !tbaa !14
   %rawSym285.i = call i64 @rb_id2sym(i64 %rubyId_lte.i.i) #17, !dbg !141
-  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym285.i, i64 %35, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_4") #17, !dbg !141
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %48, align 8, !dbg !141, !tbaa !14
-  %49 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !88
-  %50 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !88, !tbaa !65
-  %needTakeSlowPath = icmp ne i64 %49, %50, !dbg !88
-  br i1 %needTakeSlowPath, label %51, label %52, !dbg !88, !prof !67
+  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym285.i, i64 %22, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_4") #17, !dbg !141
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %35, align 8, !dbg !141, !tbaa !14
+  %36 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !88
+  %37 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !88, !tbaa !65
+  %needTakeSlowPath = icmp ne i64 %36, %37, !dbg !88
+  br i1 %needTakeSlowPath, label %38, label %39, !dbg !88, !prof !67
 
-51:                                               ; preds = %entry
+38:                                               ; preds = %entry
   call void @"const_recompute_T::Sig"(), !dbg !88
-  br label %52, !dbg !88
+  br label %39, !dbg !88
 
-52:                                               ; preds = %entry, %51
-  %53 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !88
-  %54 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !88
-  %55 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !88, !tbaa !65
-  %guardUpdated = icmp eq i64 %54, %55, !dbg !88
+39:                                               ; preds = %entry, %38
+  %40 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !88
+  %41 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !88
+  %42 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !88, !tbaa !65
+  %guardUpdated = icmp eq i64 %41, %42, !dbg !88
   call void @llvm.assume(i1 %guardUpdated), !dbg !88
-  %56 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !88
-  %57 = load i64*, i64** %56, align 8, !dbg !88
-  store i64 %35, i64* %57, align 8, !dbg !88, !tbaa !6
-  %58 = getelementptr inbounds i64, i64* %57, i64 1, !dbg !88
-  store i64 %53, i64* %58, align 8, !dbg !88, !tbaa !6
-  %59 = getelementptr inbounds i64, i64* %58, i64 1, !dbg !88
-  store i64* %59, i64** %56, align 8, !dbg !88
+  %43 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !88
+  %44 = load i64*, i64** %43, align 8, !dbg !88
+  store i64 %22, i64* %44, align 8, !dbg !88, !tbaa !6
+  %45 = getelementptr inbounds i64, i64* %44, i64 1, !dbg !88
+  store i64 %40, i64* %45, align 8, !dbg !88, !tbaa !6
+  %46 = getelementptr inbounds i64, i64* %45, i64 1, !dbg !88
+  store i64* %46, i64** %43, align 8, !dbg !88
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !88
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %48, align 8, !dbg !88, !tbaa !14
-  %60 = load i64, i64* @rb_cObject, align 8, !dbg !84
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %35, align 8, !dbg !88, !tbaa !14
+  %47 = load i64, i64* @rb_cObject, align 8, !dbg !84
   %stackFrame308.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#4plus", align 8, !dbg !84
-  %61 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #19, !dbg !84
-  %62 = bitcast i8* %61 to i16*, !dbg !84
-  %63 = load i16, i16* %62, align 8, !dbg !84
-  %64 = and i16 %63, -384, !dbg !84
-  %65 = or i16 %64, 1, !dbg !84
-  store i16 %65, i16* %62, align 8, !dbg !84
-  %66 = getelementptr inbounds i8, i8* %61, i64 8, !dbg !84
-  %67 = bitcast i8* %66 to i32*, !dbg !84
-  store i32 2, i32* %67, align 8, !dbg !84, !tbaa !142
-  %68 = getelementptr inbounds i8, i8* %61, i64 12, !dbg !84
-  %69 = getelementptr inbounds i8, i8* %61, i64 4, !dbg !84
-  %70 = bitcast i8* %69 to i32*, !dbg !84
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %68, i8 0, i64 20, i1 false) #17, !dbg !84
-  store i32 2, i32* %70, align 4, !dbg !84, !tbaa !145
+  %48 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #19, !dbg !84
+  %49 = bitcast i8* %48 to i16*, !dbg !84
+  %50 = load i16, i16* %49, align 8, !dbg !84
+  %51 = and i16 %50, -384, !dbg !84
+  %52 = or i16 %51, 1, !dbg !84
+  store i16 %52, i16* %49, align 8, !dbg !84
+  %53 = getelementptr inbounds i8, i8* %48, i64 8, !dbg !84
+  %54 = bitcast i8* %53 to i32*, !dbg !84
+  store i32 2, i32* %54, align 8, !dbg !84, !tbaa !142
+  %55 = getelementptr inbounds i8, i8* %48, i64 12, !dbg !84
+  %56 = getelementptr inbounds i8, i8* %48, i64 4, !dbg !84
+  %57 = bitcast i8* %56 to i32*, !dbg !84
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %55, i8 0, i64 20, i1 false) #17, !dbg !84
+  store i32 2, i32* %57, align 4, !dbg !84, !tbaa !145
   store i64 %rubyId_x.i, i64* %positional_table.i, align 8, !dbg !84
-  %71 = getelementptr i64, i64* %positional_table.i, i32 1, !dbg !84
-  store i64 %rubyId_y.i, i64* %71, align 8, !dbg !84
-  %72 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #19, !dbg !84
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %72, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %39, i64 noundef 16, i1 noundef false) #17, !dbg !84
-  %73 = getelementptr inbounds i8, i8* %61, i64 32, !dbg !84
-  %74 = bitcast i8* %73 to i8**, !dbg !84
-  store i8* %72, i8** %74, align 8, !dbg !84, !tbaa !146
-  call void @sorbet_vm_define_method(i64 %60, i8* noundef getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#4plus", i8* nonnull %61, %struct.rb_iseq_struct* %stackFrame308.i, i1 noundef zeroext false) #17, !dbg !84
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %48, align 8, !dbg !84, !tbaa !14
+  %58 = getelementptr i64, i64* %positional_table.i, i32 1, !dbg !84
+  store i64 %rubyId_y.i, i64* %58, align 8, !dbg !84
+  %59 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #19, !dbg !84
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %59, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %26, i64 noundef 16, i1 noundef false) #17, !dbg !84
+  %60 = getelementptr inbounds i8, i8* %48, i64 32, !dbg !84
+  %61 = bitcast i8* %60 to i8**, !dbg !84
+  store i8* %59, i8** %61, align 8, !dbg !84, !tbaa !146
+  call void @sorbet_vm_define_method(i64 %47, i8* noundef getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#4plus", i8* nonnull %48, %struct.rb_iseq_struct* %stackFrame308.i, i1 noundef zeroext false) #17, !dbg !84
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %35, align 8, !dbg !84, !tbaa !14
   %stackFrame318.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#5minus", align 8, !dbg !85
-  %75 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #19, !dbg !85
-  %76 = bitcast i8* %75 to i16*, !dbg !85
-  %77 = load i16, i16* %76, align 8, !dbg !85
-  %78 = and i16 %77, -384, !dbg !85
-  %79 = or i16 %78, 1, !dbg !85
-  store i16 %79, i16* %76, align 8, !dbg !85
-  %80 = getelementptr inbounds i8, i8* %75, i64 8, !dbg !85
-  %81 = bitcast i8* %80 to i32*, !dbg !85
-  store i32 2, i32* %81, align 8, !dbg !85, !tbaa !142
-  %82 = getelementptr inbounds i8, i8* %75, i64 12, !dbg !85
-  %83 = getelementptr inbounds i8, i8* %75, i64 4, !dbg !85
-  %84 = bitcast i8* %83 to i32*, !dbg !85
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %82, i8 0, i64 20, i1 false) #17, !dbg !85
-  store i32 2, i32* %84, align 4, !dbg !85, !tbaa !145
+  %62 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #19, !dbg !85
+  %63 = bitcast i8* %62 to i16*, !dbg !85
+  %64 = load i16, i16* %63, align 8, !dbg !85
+  %65 = and i16 %64, -384, !dbg !85
+  %66 = or i16 %65, 1, !dbg !85
+  store i16 %66, i16* %63, align 8, !dbg !85
+  %67 = getelementptr inbounds i8, i8* %62, i64 8, !dbg !85
+  %68 = bitcast i8* %67 to i32*, !dbg !85
+  store i32 2, i32* %68, align 8, !dbg !85, !tbaa !142
+  %69 = getelementptr inbounds i8, i8* %62, i64 12, !dbg !85
+  %70 = getelementptr inbounds i8, i8* %62, i64 4, !dbg !85
+  %71 = bitcast i8* %70 to i32*, !dbg !85
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %69, i8 0, i64 20, i1 false) #17, !dbg !85
+  store i32 2, i32* %71, align 4, !dbg !85, !tbaa !145
   store i64 %rubyId_x.i, i64* %positional_table320.i, align 8, !dbg !85
-  %85 = getelementptr i64, i64* %positional_table320.i, i32 1, !dbg !85
-  store i64 %rubyId_y.i, i64* %85, align 8, !dbg !85
-  %86 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #19, !dbg !85
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %86, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %40, i64 noundef 16, i1 noundef false) #17, !dbg !85
-  %87 = getelementptr inbounds i8, i8* %75, i64 32, !dbg !85
-  %88 = bitcast i8* %87 to i8**, !dbg !85
-  store i8* %86, i8** %88, align 8, !dbg !85, !tbaa !146
-  call void @sorbet_vm_define_method(i64 %60, i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 107), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#5minus", i8* nonnull %75, %struct.rb_iseq_struct* %stackFrame318.i, i1 noundef zeroext false) #17, !dbg !85
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %48, align 8, !dbg !85, !tbaa !14
+  %72 = getelementptr i64, i64* %positional_table320.i, i32 1, !dbg !85
+  store i64 %rubyId_y.i, i64* %72, align 8, !dbg !85
+  %73 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #19, !dbg !85
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %73, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %27, i64 noundef 16, i1 noundef false) #17, !dbg !85
+  %74 = getelementptr inbounds i8, i8* %62, i64 32, !dbg !85
+  %75 = bitcast i8* %74 to i8**, !dbg !85
+  store i8* %73, i8** %75, align 8, !dbg !85, !tbaa !146
+  call void @sorbet_vm_define_method(i64 %47, i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 107), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#5minus", i8* nonnull %62, %struct.rb_iseq_struct* %stackFrame318.i, i1 noundef zeroext false) #17, !dbg !85
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %35, align 8, !dbg !85, !tbaa !14
   %stackFrame332.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#2lt", align 8, !dbg !86
-  %89 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #19, !dbg !86
-  %90 = bitcast i8* %89 to i16*, !dbg !86
-  %91 = load i16, i16* %90, align 8, !dbg !86
-  %92 = and i16 %91, -384, !dbg !86
-  %93 = or i16 %92, 1, !dbg !86
-  store i16 %93, i16* %90, align 8, !dbg !86
-  %94 = getelementptr inbounds i8, i8* %89, i64 8, !dbg !86
-  %95 = bitcast i8* %94 to i32*, !dbg !86
-  store i32 2, i32* %95, align 8, !dbg !86, !tbaa !142
-  %96 = getelementptr inbounds i8, i8* %89, i64 12, !dbg !86
-  %97 = getelementptr inbounds i8, i8* %89, i64 4, !dbg !86
-  %98 = bitcast i8* %97 to i32*, !dbg !86
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %96, i8 0, i64 20, i1 false) #17, !dbg !86
-  store i32 2, i32* %98, align 4, !dbg !86, !tbaa !145
+  %76 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #19, !dbg !86
+  %77 = bitcast i8* %76 to i16*, !dbg !86
+  %78 = load i16, i16* %77, align 8, !dbg !86
+  %79 = and i16 %78, -384, !dbg !86
+  %80 = or i16 %79, 1, !dbg !86
+  store i16 %80, i16* %77, align 8, !dbg !86
+  %81 = getelementptr inbounds i8, i8* %76, i64 8, !dbg !86
+  %82 = bitcast i8* %81 to i32*, !dbg !86
+  store i32 2, i32* %82, align 8, !dbg !86, !tbaa !142
+  %83 = getelementptr inbounds i8, i8* %76, i64 12, !dbg !86
+  %84 = getelementptr inbounds i8, i8* %76, i64 4, !dbg !86
+  %85 = bitcast i8* %84 to i32*, !dbg !86
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %83, i8 0, i64 20, i1 false) #17, !dbg !86
+  store i32 2, i32* %85, align 4, !dbg !86, !tbaa !145
   store i64 %rubyId_x.i, i64* %positional_table334.i, align 8, !dbg !86
-  %99 = getelementptr i64, i64* %positional_table334.i, i32 1, !dbg !86
-  store i64 %rubyId_y.i, i64* %99, align 8, !dbg !86
-  %100 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #19, !dbg !86
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %100, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %41, i64 noundef 16, i1 noundef false) #17, !dbg !86
-  %101 = getelementptr inbounds i8, i8* %89, i64 32, !dbg !86
-  %102 = bitcast i8* %101 to i8**, !dbg !86
-  store i8* %100, i8** %102, align 8, !dbg !86, !tbaa !146
-  call void @sorbet_vm_define_method(i64 %60, i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 115), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#2lt", i8* nonnull %89, %struct.rb_iseq_struct* %stackFrame332.i, i1 noundef zeroext false) #17, !dbg !86
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %48, align 8, !dbg !86, !tbaa !14
+  %86 = getelementptr i64, i64* %positional_table334.i, i32 1, !dbg !86
+  store i64 %rubyId_y.i, i64* %86, align 8, !dbg !86
+  %87 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #19, !dbg !86
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %87, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %28, i64 noundef 16, i1 noundef false) #17, !dbg !86
+  %88 = getelementptr inbounds i8, i8* %76, i64 32, !dbg !86
+  %89 = bitcast i8* %88 to i8**, !dbg !86
+  store i8* %87, i8** %89, align 8, !dbg !86, !tbaa !146
+  call void @sorbet_vm_define_method(i64 %47, i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 115), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#2lt", i8* nonnull %76, %struct.rb_iseq_struct* %stackFrame332.i, i1 noundef zeroext false) #17, !dbg !86
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %35, align 8, !dbg !86, !tbaa !14
   %stackFrame346.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3lte", align 8, !dbg !87
-  %103 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #19, !dbg !87
-  %104 = bitcast i8* %103 to i16*, !dbg !87
-  %105 = load i16, i16* %104, align 8, !dbg !87
-  %106 = and i16 %105, -384, !dbg !87
-  %107 = or i16 %106, 1, !dbg !87
-  store i16 %107, i16* %104, align 8, !dbg !87
-  %108 = getelementptr inbounds i8, i8* %103, i64 8, !dbg !87
-  %109 = bitcast i8* %108 to i32*, !dbg !87
-  store i32 2, i32* %109, align 8, !dbg !87, !tbaa !142
-  %110 = getelementptr inbounds i8, i8* %103, i64 12, !dbg !87
-  %111 = getelementptr inbounds i8, i8* %103, i64 4, !dbg !87
-  %112 = bitcast i8* %111 to i32*, !dbg !87
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %110, i8 0, i64 20, i1 false) #17, !dbg !87
-  store i32 2, i32* %112, align 4, !dbg !87, !tbaa !145
+  %90 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #19, !dbg !87
+  %91 = bitcast i8* %90 to i16*, !dbg !87
+  %92 = load i16, i16* %91, align 8, !dbg !87
+  %93 = and i16 %92, -384, !dbg !87
+  %94 = or i16 %93, 1, !dbg !87
+  store i16 %94, i16* %91, align 8, !dbg !87
+  %95 = getelementptr inbounds i8, i8* %90, i64 8, !dbg !87
+  %96 = bitcast i8* %95 to i32*, !dbg !87
+  store i32 2, i32* %96, align 8, !dbg !87, !tbaa !142
+  %97 = getelementptr inbounds i8, i8* %90, i64 12, !dbg !87
+  %98 = getelementptr inbounds i8, i8* %90, i64 4, !dbg !87
+  %99 = bitcast i8* %98 to i32*, !dbg !87
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %97, i8 0, i64 20, i1 false) #17, !dbg !87
+  store i32 2, i32* %99, align 4, !dbg !87, !tbaa !145
   store i64 %rubyId_x.i, i64* %positional_table348.i, align 8, !dbg !87
-  %113 = getelementptr i64, i64* %positional_table348.i, i32 1, !dbg !87
-  store i64 %rubyId_y.i, i64* %113, align 8, !dbg !87
-  %114 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #19, !dbg !87
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %114, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %42, i64 noundef 16, i1 noundef false) #17, !dbg !87
-  %115 = getelementptr inbounds i8, i8* %103, i64 32, !dbg !87
-  %116 = bitcast i8* %115 to i8**, !dbg !87
-  store i8* %114, i8** %116, align 8, !dbg !87, !tbaa !146
-  call void @sorbet_vm_define_method(i64 %60, i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 131), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#3lte", i8* nonnull %103, %struct.rb_iseq_struct* %stackFrame346.i, i1 noundef zeroext false) #17, !dbg !87
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %48, align 8, !dbg !87, !tbaa !14
-  %117 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !89
-  %118 = load i64*, i64** %117, align 8, !dbg !89
-  store i64 %35, i64* %118, align 8, !dbg !89, !tbaa !6
-  %119 = getelementptr inbounds i64, i64* %118, i64 1, !dbg !89
-  %120 = getelementptr inbounds i64, i64* %119, i64 1, !dbg !89
-  %121 = bitcast i64* %119 to <2 x i64>*, !dbg !89
-  store <2 x i64> <i64 45035996273704962, i64 54043195528445954>, <2 x i64>* %121, align 8, !dbg !89, !tbaa !6
-  %122 = getelementptr inbounds i64, i64* %120, i64 1, !dbg !89
-  store i64* %122, i64** %117, align 8, !dbg !89
+  %100 = getelementptr i64, i64* %positional_table348.i, i32 1, !dbg !87
+  store i64 %rubyId_y.i, i64* %100, align 8, !dbg !87
+  %101 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #19, !dbg !87
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %101, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %29, i64 noundef 16, i1 noundef false) #17, !dbg !87
+  %102 = getelementptr inbounds i8, i8* %90, i64 32, !dbg !87
+  %103 = bitcast i8* %102 to i8**, !dbg !87
+  store i8* %101, i8** %103, align 8, !dbg !87, !tbaa !146
+  call void @sorbet_vm_define_method(i64 %47, i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 131), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#3lte", i8* nonnull %90, %struct.rb_iseq_struct* %stackFrame346.i, i1 noundef zeroext false) #17, !dbg !87
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %35, align 8, !dbg !87, !tbaa !14
+  %104 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !89
+  %105 = load i64*, i64** %104, align 8, !dbg !89
+  store i64 %22, i64* %105, align 8, !dbg !89, !tbaa !6
+  %106 = getelementptr inbounds i64, i64* %105, i64 1, !dbg !89
+  %107 = getelementptr inbounds i64, i64* %106, i64 1, !dbg !89
+  %108 = bitcast i64* %106 to <2 x i64>*, !dbg !89
+  store <2 x i64> <i64 45035996273704962, i64 54043195528445954>, <2 x i64>* %108, align 8, !dbg !89, !tbaa !6
+  %109 = getelementptr inbounds i64, i64* %107, i64 1, !dbg !89
+  store i64* %109, i64** %104, align 8, !dbg !89
   %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus, i64 0), !dbg !89
-  %123 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !90
-  %124 = load i64*, i64** %123, align 8, !dbg !90
-  store i64 %35, i64* %124, align 8, !dbg !90, !tbaa !6
-  %125 = getelementptr inbounds i64, i64* %124, i64 1, !dbg !90
-  store i64 %send4, i64* %125, align 8, !dbg !90, !tbaa !6
-  %126 = getelementptr inbounds i64, i64* %125, i64 1, !dbg !90
-  store i64* %126, i64** %123, align 8, !dbg !90
+  %110 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !90
+  %111 = load i64*, i64** %110, align 8, !dbg !90
+  store i64 %22, i64* %111, align 8, !dbg !90, !tbaa !6
+  %112 = getelementptr inbounds i64, i64* %111, i64 1, !dbg !90
+  store i64 %send4, i64* %112, align 8, !dbg !90, !tbaa !6
+  %113 = getelementptr inbounds i64, i64* %112, i64 1, !dbg !90
+  store i64* %113, i64** %110, align 8, !dbg !90
   %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p, i64 0), !dbg !90
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %48, align 8, !dbg !90, !tbaa !14
-  %127 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !91
-  %128 = load i64*, i64** %127, align 8, !dbg !91
-  store i64 %35, i64* %128, align 8, !dbg !91, !tbaa !6
-  %129 = getelementptr inbounds i64, i64* %128, i64 1, !dbg !91
-  %130 = getelementptr inbounds i64, i64* %129, i64 1, !dbg !91
-  %131 = bitcast i64* %129 to <2 x i64>*, !dbg !91
-  store <2 x i64> <i64 146704757861593906, i64 194442913911721170>, <2 x i64>* %131, align 8, !dbg !91, !tbaa !6
-  %132 = getelementptr inbounds i64, i64* %130, i64 1, !dbg !91
-  store i64* %132, i64** %127, align 8, !dbg !91
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %35, align 8, !dbg !90, !tbaa !14
+  %114 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !91
+  %115 = load i64*, i64** %114, align 8, !dbg !91
+  store i64 %22, i64* %115, align 8, !dbg !91, !tbaa !6
+  %116 = getelementptr inbounds i64, i64* %115, i64 1, !dbg !91
+  %117 = getelementptr inbounds i64, i64* %116, i64 1, !dbg !91
+  %118 = bitcast i64* %116 to <2 x i64>*, !dbg !91
+  store <2 x i64> <i64 146704757861593906, i64 194442913911721170>, <2 x i64>* %118, align 8, !dbg !91, !tbaa !6
+  %119 = getelementptr inbounds i64, i64* %117, i64 1, !dbg !91
+  store i64* %119, i64** %114, align 8, !dbg !91
   %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus, i64 0), !dbg !91
-  %133 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !92
-  %134 = load i64*, i64** %133, align 8, !dbg !92
-  store i64 %35, i64* %134, align 8, !dbg !92, !tbaa !6
-  %135 = getelementptr inbounds i64, i64* %134, i64 1, !dbg !92
-  store i64 %send8, i64* %135, align 8, !dbg !92, !tbaa !6
-  %136 = getelementptr inbounds i64, i64* %135, i64 1, !dbg !92
-  store i64* %136, i64** %133, align 8, !dbg !92
+  %120 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !92
+  %121 = load i64*, i64** %120, align 8, !dbg !92
+  store i64 %22, i64* %121, align 8, !dbg !92, !tbaa !6
+  %122 = getelementptr inbounds i64, i64* %121, i64 1, !dbg !92
+  store i64 %send8, i64* %122, align 8, !dbg !92, !tbaa !6
+  %123 = getelementptr inbounds i64, i64* %122, i64 1, !dbg !92
+  store i64* %123, i64** %120, align 8, !dbg !92
   %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.12, i64 0), !dbg !92
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 29), i64** %48, align 8, !dbg !92, !tbaa !14
-  %137 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !93
-  %138 = load i64*, i64** %137, align 8, !dbg !93
-  store i64 %35, i64* %138, align 8, !dbg !93, !tbaa !6
-  %139 = getelementptr inbounds i64, i64* %138, i64 1, !dbg !93
-  %140 = getelementptr inbounds i64, i64* %139, i64 1, !dbg !93
-  %141 = bitcast i64* %139 to <2 x i64>*, !dbg !93
-  store <2 x i64> <i64 193204424014194282, i64 53142475602971858>, <2 x i64>* %141, align 8, !dbg !93, !tbaa !6
-  %142 = getelementptr inbounds i64, i64* %140, i64 1, !dbg !93
-  store i64* %142, i64** %137, align 8, !dbg !93
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 29), i64** %35, align 8, !dbg !92, !tbaa !14
+  %124 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !93
+  %125 = load i64*, i64** %124, align 8, !dbg !93
+  store i64 %22, i64* %125, align 8, !dbg !93, !tbaa !6
+  %126 = getelementptr inbounds i64, i64* %125, i64 1, !dbg !93
+  %127 = getelementptr inbounds i64, i64* %126, i64 1, !dbg !93
+  %128 = bitcast i64* %126 to <2 x i64>*, !dbg !93
+  store <2 x i64> <i64 193204424014194282, i64 53142475602971858>, <2 x i64>* %128, align 8, !dbg !93, !tbaa !6
+  %129 = getelementptr inbounds i64, i64* %127, i64 1, !dbg !93
+  store i64* %129, i64** %124, align 8, !dbg !93
   %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt, i64 0), !dbg !93
-  %143 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !94
-  %144 = load i64*, i64** %143, align 8, !dbg !94
-  store i64 %35, i64* %144, align 8, !dbg !94, !tbaa !6
-  %145 = getelementptr inbounds i64, i64* %144, i64 1, !dbg !94
-  store i64 %send12, i64* %145, align 8, !dbg !94, !tbaa !6
-  %146 = getelementptr inbounds i64, i64* %145, i64 1, !dbg !94
-  store i64* %146, i64** %143, align 8, !dbg !94
+  %130 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !94
+  %131 = load i64*, i64** %130, align 8, !dbg !94
+  store i64 %22, i64* %131, align 8, !dbg !94, !tbaa !6
+  %132 = getelementptr inbounds i64, i64* %131, i64 1, !dbg !94
+  store i64 %send12, i64* %132, align 8, !dbg !94, !tbaa !6
+  %133 = getelementptr inbounds i64, i64* %132, i64 1, !dbg !94
+  store i64* %133, i64** %130, align 8, !dbg !94
   %send14 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.13, i64 0), !dbg !94
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 30), i64** %48, align 8, !dbg !94, !tbaa !14
-  %147 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !95
-  %148 = load i64*, i64** %147, align 8, !dbg !95
-  store i64 %35, i64* %148, align 8, !dbg !95, !tbaa !6
-  %149 = getelementptr inbounds i64, i64* %148, i64 1, !dbg !95
-  %150 = getelementptr inbounds i64, i64* %149, i64 1, !dbg !95
-  %151 = bitcast i64* %149 to <2 x i64>*, !dbg !95
-  store <2 x i64> <i64 61248954932238746, i64 133982088914272258>, <2 x i64>* %151, align 8, !dbg !95, !tbaa !6
-  %152 = getelementptr inbounds i64, i64* %150, i64 1, !dbg !95
-  store i64* %152, i64** %147, align 8, !dbg !95
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 30), i64** %35, align 8, !dbg !94, !tbaa !14
+  %134 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !95
+  %135 = load i64*, i64** %134, align 8, !dbg !95
+  store i64 %22, i64* %135, align 8, !dbg !95, !tbaa !6
+  %136 = getelementptr inbounds i64, i64* %135, i64 1, !dbg !95
+  %137 = getelementptr inbounds i64, i64* %136, i64 1, !dbg !95
+  %138 = bitcast i64* %136 to <2 x i64>*, !dbg !95
+  store <2 x i64> <i64 61248954932238746, i64 133982088914272258>, <2 x i64>* %138, align 8, !dbg !95, !tbaa !6
+  %139 = getelementptr inbounds i64, i64* %137, i64 1, !dbg !95
+  store i64* %139, i64** %134, align 8, !dbg !95
   %send16 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt.14, i64 0), !dbg !95
-  %153 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !96
-  %154 = load i64*, i64** %153, align 8, !dbg !96
-  store i64 %35, i64* %154, align 8, !dbg !96, !tbaa !6
-  %155 = getelementptr inbounds i64, i64* %154, i64 1, !dbg !96
-  store i64 %send16, i64* %155, align 8, !dbg !96, !tbaa !6
-  %156 = getelementptr inbounds i64, i64* %155, i64 1, !dbg !96
-  store i64* %156, i64** %153, align 8, !dbg !96
+  %140 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !96
+  %141 = load i64*, i64** %140, align 8, !dbg !96
+  store i64 %22, i64* %141, align 8, !dbg !96, !tbaa !6
+  %142 = getelementptr inbounds i64, i64* %141, i64 1, !dbg !96
+  store i64 %send16, i64* %142, align 8, !dbg !96, !tbaa !6
+  %143 = getelementptr inbounds i64, i64* %142, i64 1, !dbg !96
+  store i64* %143, i64** %140, align 8, !dbg !96
   %send18 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.15, i64 0), !dbg !96
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 31), i64** %48, align 8, !dbg !96, !tbaa !14
-  %157 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !97
-  %158 = load i64*, i64** %157, align 8, !dbg !97
-  store i64 %35, i64* %158, align 8, !dbg !97, !tbaa !6
-  %159 = getelementptr inbounds i64, i64* %158, i64 1, !dbg !97
-  %160 = getelementptr inbounds i64, i64* %159, i64 1, !dbg !97
-  %161 = bitcast i64* %159 to <2 x i64>*, !dbg !97
-  store <2 x i64> <i64 180200280090161970, i64 155261597153597850>, <2 x i64>* %161, align 8, !dbg !97, !tbaa !6
-  %162 = getelementptr inbounds i64, i64* %160, i64 1, !dbg !97
-  store i64* %162, i64** %157, align 8, !dbg !97
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 31), i64** %35, align 8, !dbg !96, !tbaa !14
+  %144 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !97
+  %145 = load i64*, i64** %144, align 8, !dbg !97
+  store i64 %22, i64* %145, align 8, !dbg !97, !tbaa !6
+  %146 = getelementptr inbounds i64, i64* %145, i64 1, !dbg !97
+  %147 = getelementptr inbounds i64, i64* %146, i64 1, !dbg !97
+  %148 = bitcast i64* %146 to <2 x i64>*, !dbg !97
+  store <2 x i64> <i64 180200280090161970, i64 155261597153597850>, <2 x i64>* %148, align 8, !dbg !97, !tbaa !6
+  %149 = getelementptr inbounds i64, i64* %147, i64 1, !dbg !97
+  store i64* %149, i64** %144, align 8, !dbg !97
   %send20 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte, i64 0), !dbg !97
-  %163 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !98
-  %164 = load i64*, i64** %163, align 8, !dbg !98
-  store i64 %35, i64* %164, align 8, !dbg !98, !tbaa !6
-  %165 = getelementptr inbounds i64, i64* %164, i64 1, !dbg !98
-  store i64 %send20, i64* %165, align 8, !dbg !98, !tbaa !6
-  %166 = getelementptr inbounds i64, i64* %165, i64 1, !dbg !98
-  store i64* %166, i64** %163, align 8, !dbg !98
+  %150 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !98
+  %151 = load i64*, i64** %150, align 8, !dbg !98
+  store i64 %22, i64* %151, align 8, !dbg !98, !tbaa !6
+  %152 = getelementptr inbounds i64, i64* %151, i64 1, !dbg !98
+  store i64 %send20, i64* %152, align 8, !dbg !98, !tbaa !6
+  %153 = getelementptr inbounds i64, i64* %152, i64 1, !dbg !98
+  store i64* %153, i64** %150, align 8, !dbg !98
   %send22 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.16, i64 0), !dbg !98
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 32), i64** %48, align 8, !dbg !98, !tbaa !14
-  %167 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !99
-  %168 = load i64*, i64** %167, align 8, !dbg !99
-  store i64 %35, i64* %168, align 8, !dbg !99, !tbaa !6
-  %169 = getelementptr inbounds i64, i64* %168, i64 1, !dbg !99
-  %170 = getelementptr inbounds i64, i64* %169, i64 1, !dbg !99
-  %171 = bitcast i64* %169 to <2 x i64>*, !dbg !99
-  store <2 x i64> <i64 57646075230342354, i64 155261597153597850>, <2 x i64>* %171, align 8, !dbg !99, !tbaa !6
-  %172 = getelementptr inbounds i64, i64* %170, i64 1, !dbg !99
-  store i64* %172, i64** %167, align 8, !dbg !99
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 32), i64** %35, align 8, !dbg !98, !tbaa !14
+  %154 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !99
+  %155 = load i64*, i64** %154, align 8, !dbg !99
+  store i64 %22, i64* %155, align 8, !dbg !99, !tbaa !6
+  %156 = getelementptr inbounds i64, i64* %155, i64 1, !dbg !99
+  %157 = getelementptr inbounds i64, i64* %156, i64 1, !dbg !99
+  %158 = bitcast i64* %156 to <2 x i64>*, !dbg !99
+  store <2 x i64> <i64 57646075230342354, i64 155261597153597850>, <2 x i64>* %158, align 8, !dbg !99, !tbaa !6
+  %159 = getelementptr inbounds i64, i64* %157, i64 1, !dbg !99
+  store i64* %159, i64** %154, align 8, !dbg !99
   %send24 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.17, i64 0), !dbg !99
-  %173 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !100
-  %174 = load i64*, i64** %173, align 8, !dbg !100
-  store i64 %35, i64* %174, align 8, !dbg !100, !tbaa !6
-  %175 = getelementptr inbounds i64, i64* %174, i64 1, !dbg !100
-  store i64 %send24, i64* %175, align 8, !dbg !100, !tbaa !6
-  %176 = getelementptr inbounds i64, i64* %175, i64 1, !dbg !100
-  store i64* %176, i64** %173, align 8, !dbg !100
+  %160 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !100
+  %161 = load i64*, i64** %160, align 8, !dbg !100
+  store i64 %22, i64* %161, align 8, !dbg !100, !tbaa !6
+  %162 = getelementptr inbounds i64, i64* %161, i64 1, !dbg !100
+  store i64 %send24, i64* %162, align 8, !dbg !100, !tbaa !6
+  %163 = getelementptr inbounds i64, i64* %162, i64 1, !dbg !100
+  store i64* %163, i64** %160, align 8, !dbg !100
   %send26 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.18, i64 0), !dbg !100
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 33), i64** %48, align 8, !dbg !100, !tbaa !14
-  %177 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !101
-  %178 = load i64*, i64** %177, align 8, !dbg !101
-  store i64 %35, i64* %178, align 8, !dbg !101, !tbaa !6
-  %179 = getelementptr inbounds i64, i64* %178, i64 1, !dbg !101
-  %180 = getelementptr inbounds i64, i64* %179, i64 1, !dbg !101
-  %181 = bitcast i64* %179 to <2 x i64>*, !dbg !101
-  store <2 x i64> <i64 75660473739824338, i64 75660473739824338>, <2 x i64>* %181, align 8, !dbg !101, !tbaa !6
-  %182 = getelementptr inbounds i64, i64* %180, i64 1, !dbg !101
-  store i64* %182, i64** %177, align 8, !dbg !101
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 33), i64** %35, align 8, !dbg !100, !tbaa !14
+  %164 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !101
+  %165 = load i64*, i64** %164, align 8, !dbg !101
+  store i64 %22, i64* %165, align 8, !dbg !101, !tbaa !6
+  %166 = getelementptr inbounds i64, i64* %165, i64 1, !dbg !101
+  %167 = getelementptr inbounds i64, i64* %166, i64 1, !dbg !101
+  %168 = bitcast i64* %166 to <2 x i64>*, !dbg !101
+  store <2 x i64> <i64 75660473739824338, i64 75660473739824338>, <2 x i64>* %168, align 8, !dbg !101, !tbaa !6
+  %169 = getelementptr inbounds i64, i64* %167, i64 1, !dbg !101
+  store i64* %169, i64** %164, align 8, !dbg !101
   %send28 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.19, i64 0), !dbg !101
-  %183 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !102
-  %184 = load i64*, i64** %183, align 8, !dbg !102
-  store i64 %35, i64* %184, align 8, !dbg !102, !tbaa !6
-  %185 = getelementptr inbounds i64, i64* %184, i64 1, !dbg !102
-  store i64 %send28, i64* %185, align 8, !dbg !102, !tbaa !6
-  %186 = getelementptr inbounds i64, i64* %185, i64 1, !dbg !102
-  store i64* %186, i64** %183, align 8, !dbg !102
+  %170 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !102
+  %171 = load i64*, i64** %170, align 8, !dbg !102
+  store i64 %22, i64* %171, align 8, !dbg !102, !tbaa !6
+  %172 = getelementptr inbounds i64, i64* %171, i64 1, !dbg !102
+  store i64 %send28, i64* %172, align 8, !dbg !102, !tbaa !6
+  %173 = getelementptr inbounds i64, i64* %172, i64 1, !dbg !102
+  store i64* %173, i64** %170, align 8, !dbg !102
   %send30 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.20, i64 0), !dbg !102
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 36), i64** %48, align 8, !dbg !102, !tbaa !14
-  %187 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !103
-  %188 = load i64*, i64** %187, align 8, !dbg !103
-  store i64 %35, i64* %188, align 8, !dbg !103, !tbaa !6
-  %189 = getelementptr inbounds i64, i64* %188, i64 1, !dbg !103
-  %190 = getelementptr inbounds i64, i64* %189, i64 1, !dbg !103
-  %191 = bitcast i64* %189 to <2 x i64>*, !dbg !103
-  store <2 x i64> <i64 45035996273704962, i64 17>, <2 x i64>* %191, align 8, !dbg !103, !tbaa !6
-  %192 = getelementptr inbounds i64, i64* %190, i64 1, !dbg !103
-  store i64* %192, i64** %187, align 8, !dbg !103
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 36), i64** %35, align 8, !dbg !102, !tbaa !14
+  %174 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !103
+  %175 = load i64*, i64** %174, align 8, !dbg !103
+  store i64 %22, i64* %175, align 8, !dbg !103, !tbaa !6
+  %176 = getelementptr inbounds i64, i64* %175, i64 1, !dbg !103
+  %177 = getelementptr inbounds i64, i64* %176, i64 1, !dbg !103
+  %178 = bitcast i64* %176 to <2 x i64>*, !dbg !103
+  store <2 x i64> <i64 45035996273704962, i64 17>, <2 x i64>* %178, align 8, !dbg !103, !tbaa !6
+  %179 = getelementptr inbounds i64, i64* %177, i64 1, !dbg !103
+  store i64* %179, i64** %174, align 8, !dbg !103
   %send32 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus.21, i64 0), !dbg !103
-  %193 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !104
-  %194 = load i64*, i64** %193, align 8, !dbg !104
-  store i64 %35, i64* %194, align 8, !dbg !104, !tbaa !6
-  %195 = getelementptr inbounds i64, i64* %194, i64 1, !dbg !104
-  store i64 %send32, i64* %195, align 8, !dbg !104, !tbaa !6
-  %196 = getelementptr inbounds i64, i64* %195, i64 1, !dbg !104
-  store i64* %196, i64** %193, align 8, !dbg !104
+  %180 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !104
+  %181 = load i64*, i64** %180, align 8, !dbg !104
+  store i64 %22, i64* %181, align 8, !dbg !104, !tbaa !6
+  %182 = getelementptr inbounds i64, i64* %181, i64 1, !dbg !104
+  store i64 %send32, i64* %182, align 8, !dbg !104, !tbaa !6
+  %183 = getelementptr inbounds i64, i64* %182, i64 1, !dbg !104
+  store i64* %183, i64** %180, align 8, !dbg !104
   %send34 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.22, i64 0), !dbg !104
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 37), i64** %48, align 8, !dbg !104, !tbaa !14
-  %rubyStr_8.9.i = load i64, i64* @rubyStrFrozen_8.9, align 8, !dbg !105
-  %197 = load i64, i64* @rb_mKernel, align 8, !dbg !105
-  %198 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !105
-  %199 = load i64*, i64** %198, align 8, !dbg !105
-  store i64 %197, i64* %199, align 8, !dbg !105, !tbaa !6
-  %200 = getelementptr inbounds i64, i64* %199, i64 1, !dbg !105
-  store i64 %rubyStr_8.9.i, i64* %200, align 8, !dbg !105, !tbaa !6
-  %201 = getelementptr inbounds i64, i64* %200, i64 1, !dbg !105
-  store i64* %201, i64** %198, align 8, !dbg !105
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 37), i64** %35, align 8, !dbg !104, !tbaa !14
+  %rubyStr_8.9.i = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 7), align 8, !dbg !105, !invariant.load !5
+  %184 = load i64, i64* @rb_mKernel, align 8, !dbg !105
+  %185 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !105
+  %186 = load i64*, i64** %185, align 8, !dbg !105
+  store i64 %184, i64* %186, align 8, !dbg !105, !tbaa !6
+  %187 = getelementptr inbounds i64, i64* %186, i64 1, !dbg !105
+  store i64 %rubyStr_8.9.i, i64* %187, align 8, !dbg !105, !tbaa !6
+  %188 = getelementptr inbounds i64, i64* %187, i64 1, !dbg !105
+  store i64* %188, i64** %185, align 8, !dbg !105
   %send36 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational, i64 0), !dbg !105
-  %202 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !106
-  %203 = load i64*, i64** %202, align 8, !dbg !106
-  store i64 %35, i64* %203, align 8, !dbg !106, !tbaa !6
-  %204 = getelementptr inbounds i64, i64* %203, i64 1, !dbg !106
-  store i64 36028797018963970, i64* %204, align 8, !dbg !106, !tbaa !6
-  %205 = getelementptr inbounds i64, i64* %204, i64 1, !dbg !106
-  store i64 %send36, i64* %205, align 8, !dbg !106, !tbaa !6
-  %206 = getelementptr inbounds i64, i64* %205, i64 1, !dbg !106
-  store i64* %206, i64** %202, align 8, !dbg !106
+  %189 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !106
+  %190 = load i64*, i64** %189, align 8, !dbg !106
+  store i64 %22, i64* %190, align 8, !dbg !106, !tbaa !6
+  %191 = getelementptr inbounds i64, i64* %190, i64 1, !dbg !106
+  store i64 36028797018963970, i64* %191, align 8, !dbg !106, !tbaa !6
+  %192 = getelementptr inbounds i64, i64* %191, i64 1, !dbg !106
+  store i64 %send36, i64* %192, align 8, !dbg !106, !tbaa !6
+  %193 = getelementptr inbounds i64, i64* %192, i64 1, !dbg !106
+  store i64* %193, i64** %189, align 8, !dbg !106
   %send38 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus.23, i64 0), !dbg !106
-  %207 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !107
-  %208 = load i64*, i64** %207, align 8, !dbg !107
-  store i64 %35, i64* %208, align 8, !dbg !107, !tbaa !6
-  %209 = getelementptr inbounds i64, i64* %208, i64 1, !dbg !107
-  store i64 %send38, i64* %209, align 8, !dbg !107, !tbaa !6
-  %210 = getelementptr inbounds i64, i64* %209, i64 1, !dbg !107
-  store i64* %210, i64** %207, align 8, !dbg !107
+  %194 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !107
+  %195 = load i64*, i64** %194, align 8, !dbg !107
+  store i64 %22, i64* %195, align 8, !dbg !107, !tbaa !6
+  %196 = getelementptr inbounds i64, i64* %195, i64 1, !dbg !107
+  store i64 %send38, i64* %196, align 8, !dbg !107, !tbaa !6
+  %197 = getelementptr inbounds i64, i64* %196, i64 1, !dbg !107
+  store i64* %197, i64** %194, align 8, !dbg !107
   %send40 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.24, i64 0), !dbg !107
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 38), i64** %48, align 8, !dbg !107, !tbaa !14
-  %rubyStr_5.i = load i64, i64* @rubyStrFrozen_5, align 8, !dbg !108
-  %211 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !108
-  %212 = load i64*, i64** %211, align 8, !dbg !108
-  store i64 %197, i64* %212, align 8, !dbg !108, !tbaa !6
-  %213 = getelementptr inbounds i64, i64* %212, i64 1, !dbg !108
-  store i64 1, i64* %213, align 8, !dbg !108, !tbaa !6
-  %214 = getelementptr inbounds i64, i64* %213, i64 1, !dbg !108
-  store i64 %rubyStr_5.i, i64* %214, align 8, !dbg !108, !tbaa !6
-  %215 = getelementptr inbounds i64, i64* %214, i64 1, !dbg !108
-  store i64* %215, i64** %211, align 8, !dbg !108
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 38), i64** %35, align 8, !dbg !107, !tbaa !14
+  %rubyStr_5.i = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 8), align 8, !dbg !108, !invariant.load !5
+  %198 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !108
+  %199 = load i64*, i64** %198, align 8, !dbg !108
+  store i64 %184, i64* %199, align 8, !dbg !108, !tbaa !6
+  %200 = getelementptr inbounds i64, i64* %199, i64 1, !dbg !108
+  store i64 1, i64* %200, align 8, !dbg !108, !tbaa !6
+  %201 = getelementptr inbounds i64, i64* %200, i64 1, !dbg !108
+  store i64 %rubyStr_5.i, i64* %201, align 8, !dbg !108, !tbaa !6
+  %202 = getelementptr inbounds i64, i64* %201, i64 1, !dbg !108
+  store i64* %202, i64** %198, align 8, !dbg !108
   %send42 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Complex, i64 0), !dbg !108
-  %216 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !109
-  %217 = load i64*, i64** %216, align 8, !dbg !109
-  store i64 %35, i64* %217, align 8, !dbg !109, !tbaa !6
-  %218 = getelementptr inbounds i64, i64* %217, i64 1, !dbg !109
-  store i64 36028797018963970, i64* %218, align 8, !dbg !109, !tbaa !6
-  %219 = getelementptr inbounds i64, i64* %218, i64 1, !dbg !109
-  store i64 %send42, i64* %219, align 8, !dbg !109, !tbaa !6
-  %220 = getelementptr inbounds i64, i64* %219, i64 1, !dbg !109
-  store i64* %220, i64** %216, align 8, !dbg !109
+  %203 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !109
+  %204 = load i64*, i64** %203, align 8, !dbg !109
+  store i64 %22, i64* %204, align 8, !dbg !109, !tbaa !6
+  %205 = getelementptr inbounds i64, i64* %204, i64 1, !dbg !109
+  store i64 36028797018963970, i64* %205, align 8, !dbg !109, !tbaa !6
+  %206 = getelementptr inbounds i64, i64* %205, i64 1, !dbg !109
+  store i64 %send42, i64* %206, align 8, !dbg !109, !tbaa !6
+  %207 = getelementptr inbounds i64, i64* %206, i64 1, !dbg !109
+  store i64* %207, i64** %203, align 8, !dbg !109
   %send44 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus.25, i64 0), !dbg !109
-  %221 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !110
-  %222 = load i64*, i64** %221, align 8, !dbg !110
-  store i64 %35, i64* %222, align 8, !dbg !110, !tbaa !6
-  %223 = getelementptr inbounds i64, i64* %222, i64 1, !dbg !110
-  store i64 %send44, i64* %223, align 8, !dbg !110, !tbaa !6
-  %224 = getelementptr inbounds i64, i64* %223, i64 1, !dbg !110
-  store i64* %224, i64** %221, align 8, !dbg !110
+  %208 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !110
+  %209 = load i64*, i64** %208, align 8, !dbg !110
+  store i64 %22, i64* %209, align 8, !dbg !110, !tbaa !6
+  %210 = getelementptr inbounds i64, i64* %209, i64 1, !dbg !110
+  store i64 %send44, i64* %210, align 8, !dbg !110, !tbaa !6
+  %211 = getelementptr inbounds i64, i64* %210, i64 1, !dbg !110
+  store i64* %211, i64** %208, align 8, !dbg !110
   %send46 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.26, i64 0), !dbg !110
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 40), i64** %48, align 8, !dbg !110, !tbaa !14
-  %225 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !111
-  %226 = load i64*, i64** %225, align 8, !dbg !111
-  store i64 %35, i64* %226, align 8, !dbg !111, !tbaa !6
-  %227 = getelementptr inbounds i64, i64* %226, i64 1, !dbg !111
-  %228 = getelementptr inbounds i64, i64* %227, i64 1, !dbg !111
-  %229 = bitcast i64* %227 to <2 x i64>*, !dbg !111
-  store <2 x i64> <i64 199678348478539370, i64 7>, <2 x i64>* %229, align 8, !dbg !111, !tbaa !6
-  %230 = getelementptr inbounds i64, i64* %228, i64 1, !dbg !111
-  store i64* %230, i64** %225, align 8, !dbg !111
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 40), i64** %35, align 8, !dbg !110, !tbaa !14
+  %212 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !111
+  %213 = load i64*, i64** %212, align 8, !dbg !111
+  store i64 %22, i64* %213, align 8, !dbg !111, !tbaa !6
+  %214 = getelementptr inbounds i64, i64* %213, i64 1, !dbg !111
+  %215 = getelementptr inbounds i64, i64* %214, i64 1, !dbg !111
+  %216 = bitcast i64* %214 to <2 x i64>*, !dbg !111
+  store <2 x i64> <i64 199678348478539370, i64 7>, <2 x i64>* %216, align 8, !dbg !111, !tbaa !6
+  %217 = getelementptr inbounds i64, i64* %215, i64 1, !dbg !111
+  store i64* %217, i64** %212, align 8, !dbg !111
   %send48 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus.27, i64 0), !dbg !111
-  %231 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !112
-  %232 = load i64*, i64** %231, align 8, !dbg !112
-  store i64 %35, i64* %232, align 8, !dbg !112, !tbaa !6
-  %233 = getelementptr inbounds i64, i64* %232, i64 1, !dbg !112
-  store i64 %send48, i64* %233, align 8, !dbg !112, !tbaa !6
-  %234 = getelementptr inbounds i64, i64* %233, i64 1, !dbg !112
-  store i64* %234, i64** %231, align 8, !dbg !112
+  %218 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !112
+  %219 = load i64*, i64** %218, align 8, !dbg !112
+  store i64 %22, i64* %219, align 8, !dbg !112, !tbaa !6
+  %220 = getelementptr inbounds i64, i64* %219, i64 1, !dbg !112
+  store i64 %send48, i64* %220, align 8, !dbg !112, !tbaa !6
+  %221 = getelementptr inbounds i64, i64* %220, i64 1, !dbg !112
+  store i64* %221, i64** %218, align 8, !dbg !112
   %send50 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.28, i64 0), !dbg !112
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 41), i64** %48, align 8, !dbg !112, !tbaa !14
-  %rubyStr_15.4.i = load i64, i64* @rubyStrFrozen_15.4, align 8, !dbg !113
-  %235 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !113
-  %236 = load i64*, i64** %235, align 8, !dbg !113
-  store i64 %197, i64* %236, align 8, !dbg !113, !tbaa !6
-  %237 = getelementptr inbounds i64, i64* %236, i64 1, !dbg !113
-  store i64 %rubyStr_15.4.i, i64* %237, align 8, !dbg !113, !tbaa !6
-  %238 = getelementptr inbounds i64, i64* %237, i64 1, !dbg !113
-  store i64* %238, i64** %235, align 8, !dbg !113
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 41), i64** %35, align 8, !dbg !112, !tbaa !14
+  %rubyStr_15.4.i = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 9), align 8, !dbg !113, !invariant.load !5
+  %222 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !113
+  %223 = load i64*, i64** %222, align 8, !dbg !113
+  store i64 %184, i64* %223, align 8, !dbg !113, !tbaa !6
+  %224 = getelementptr inbounds i64, i64* %223, i64 1, !dbg !113
+  store i64 %rubyStr_15.4.i, i64* %224, align 8, !dbg !113, !tbaa !6
+  %225 = getelementptr inbounds i64, i64* %224, i64 1, !dbg !113
+  store i64* %225, i64** %222, align 8, !dbg !113
   %send52 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational.29, i64 0), !dbg !113
-  %239 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !114
-  %240 = load i64*, i64** %239, align 8, !dbg !114
-  store i64 %35, i64* %240, align 8, !dbg !114, !tbaa !6
-  %241 = getelementptr inbounds i64, i64* %240, i64 1, !dbg !114
-  store i64 199622053483197234, i64* %241, align 8, !dbg !114, !tbaa !6
-  %242 = getelementptr inbounds i64, i64* %241, i64 1, !dbg !114
-  store i64 %send52, i64* %242, align 8, !dbg !114, !tbaa !6
-  %243 = getelementptr inbounds i64, i64* %242, i64 1, !dbg !114
-  store i64* %243, i64** %239, align 8, !dbg !114
+  %226 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !114
+  %227 = load i64*, i64** %226, align 8, !dbg !114
+  store i64 %22, i64* %227, align 8, !dbg !114, !tbaa !6
+  %228 = getelementptr inbounds i64, i64* %227, i64 1, !dbg !114
+  store i64 199622053483197234, i64* %228, align 8, !dbg !114, !tbaa !6
+  %229 = getelementptr inbounds i64, i64* %228, i64 1, !dbg !114
+  store i64 %send52, i64* %229, align 8, !dbg !114, !tbaa !6
+  %230 = getelementptr inbounds i64, i64* %229, i64 1, !dbg !114
+  store i64* %230, i64** %226, align 8, !dbg !114
   %send54 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus.30, i64 0), !dbg !114
-  %244 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !115
-  %245 = load i64*, i64** %244, align 8, !dbg !115
-  store i64 %35, i64* %245, align 8, !dbg !115, !tbaa !6
-  %246 = getelementptr inbounds i64, i64* %245, i64 1, !dbg !115
-  store i64 %send54, i64* %246, align 8, !dbg !115, !tbaa !6
-  %247 = getelementptr inbounds i64, i64* %246, i64 1, !dbg !115
-  store i64* %247, i64** %244, align 8, !dbg !115
+  %231 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !115
+  %232 = load i64*, i64** %231, align 8, !dbg !115
+  store i64 %22, i64* %232, align 8, !dbg !115, !tbaa !6
+  %233 = getelementptr inbounds i64, i64* %232, i64 1, !dbg !115
+  store i64 %send54, i64* %233, align 8, !dbg !115, !tbaa !6
+  %234 = getelementptr inbounds i64, i64* %233, i64 1, !dbg !115
+  store i64* %234, i64** %231, align 8, !dbg !115
   %send56 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.31, i64 0), !dbg !115
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 42), i64** %48, align 8, !dbg !115, !tbaa !14
-  %rubyStr_18.i = load i64, i64* @rubyStrFrozen_18, align 8, !dbg !116
-  %248 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !116
-  %249 = load i64*, i64** %248, align 8, !dbg !116
-  store i64 %197, i64* %249, align 8, !dbg !116, !tbaa !6
-  %250 = getelementptr inbounds i64, i64* %249, i64 1, !dbg !116
-  store i64 1, i64* %250, align 8, !dbg !116, !tbaa !6
-  %251 = getelementptr inbounds i64, i64* %250, i64 1, !dbg !116
-  store i64 %rubyStr_18.i, i64* %251, align 8, !dbg !116, !tbaa !6
-  %252 = getelementptr inbounds i64, i64* %251, i64 1, !dbg !116
-  store i64* %252, i64** %248, align 8, !dbg !116
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 42), i64** %35, align 8, !dbg !115, !tbaa !14
+  %rubyStr_18.i = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 10), align 8, !dbg !116, !invariant.load !5
+  %235 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !116
+  %236 = load i64*, i64** %235, align 8, !dbg !116
+  store i64 %184, i64* %236, align 8, !dbg !116, !tbaa !6
+  %237 = getelementptr inbounds i64, i64* %236, i64 1, !dbg !116
+  store i64 1, i64* %237, align 8, !dbg !116, !tbaa !6
+  %238 = getelementptr inbounds i64, i64* %237, i64 1, !dbg !116
+  store i64 %rubyStr_18.i, i64* %238, align 8, !dbg !116, !tbaa !6
+  %239 = getelementptr inbounds i64, i64* %238, i64 1, !dbg !116
+  store i64* %239, i64** %235, align 8, !dbg !116
   %send58 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Complex.32, i64 0), !dbg !116
-  %253 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !117
-  %254 = load i64*, i64** %253, align 8, !dbg !117
-  store i64 %35, i64* %254, align 8, !dbg !117, !tbaa !6
-  %255 = getelementptr inbounds i64, i64* %254, i64 1, !dbg !117
-  store i64 199565758487855106, i64* %255, align 8, !dbg !117, !tbaa !6
-  %256 = getelementptr inbounds i64, i64* %255, i64 1, !dbg !117
-  store i64 %send58, i64* %256, align 8, !dbg !117, !tbaa !6
-  %257 = getelementptr inbounds i64, i64* %256, i64 1, !dbg !117
-  store i64* %257, i64** %253, align 8, !dbg !117
+  %240 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !117
+  %241 = load i64*, i64** %240, align 8, !dbg !117
+  store i64 %22, i64* %241, align 8, !dbg !117, !tbaa !6
+  %242 = getelementptr inbounds i64, i64* %241, i64 1, !dbg !117
+  store i64 199565758487855106, i64* %242, align 8, !dbg !117, !tbaa !6
+  %243 = getelementptr inbounds i64, i64* %242, i64 1, !dbg !117
+  store i64 %send58, i64* %243, align 8, !dbg !117, !tbaa !6
+  %244 = getelementptr inbounds i64, i64* %243, i64 1, !dbg !117
+  store i64* %244, i64** %240, align 8, !dbg !117
   %send60 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus.33, i64 0), !dbg !117
-  %258 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !118
-  %259 = load i64*, i64** %258, align 8, !dbg !118
-  store i64 %35, i64* %259, align 8, !dbg !118, !tbaa !6
-  %260 = getelementptr inbounds i64, i64* %259, i64 1, !dbg !118
-  store i64 %send60, i64* %260, align 8, !dbg !118, !tbaa !6
-  %261 = getelementptr inbounds i64, i64* %260, i64 1, !dbg !118
-  store i64* %261, i64** %258, align 8, !dbg !118
+  %245 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !118
+  %246 = load i64*, i64** %245, align 8, !dbg !118
+  store i64 %22, i64* %246, align 8, !dbg !118, !tbaa !6
+  %247 = getelementptr inbounds i64, i64* %246, i64 1, !dbg !118
+  store i64 %send60, i64* %247, align 8, !dbg !118, !tbaa !6
+  %248 = getelementptr inbounds i64, i64* %247, i64 1, !dbg !118
+  store i64* %248, i64** %245, align 8, !dbg !118
   %send62 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.34, i64 0), !dbg !118
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 44), i64** %48, align 8, !dbg !118, !tbaa !14
-  %262 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !119
-  %263 = load i64*, i64** %262, align 8, !dbg !119
-  store i64 %35, i64* %263, align 8, !dbg !119, !tbaa !6
-  %264 = getelementptr inbounds i64, i64* %263, i64 1, !dbg !119
-  %265 = getelementptr inbounds i64, i64* %264, i64 1, !dbg !119
-  %266 = bitcast i64* %264 to <2 x i64>*, !dbg !119
-  store <2 x i64> <i64 113040350646999450, i64 13>, <2 x i64>* %266, align 8, !dbg !119, !tbaa !6
-  %267 = getelementptr inbounds i64, i64* %265, i64 1, !dbg !119
-  store i64* %267, i64** %262, align 8, !dbg !119
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 44), i64** %35, align 8, !dbg !118, !tbaa !14
+  %249 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !119
+  %250 = load i64*, i64** %249, align 8, !dbg !119
+  store i64 %22, i64* %250, align 8, !dbg !119, !tbaa !6
+  %251 = getelementptr inbounds i64, i64* %250, i64 1, !dbg !119
+  %252 = getelementptr inbounds i64, i64* %251, i64 1, !dbg !119
+  %253 = bitcast i64* %251 to <2 x i64>*, !dbg !119
+  store <2 x i64> <i64 113040350646999450, i64 13>, <2 x i64>* %253, align 8, !dbg !119, !tbaa !6
+  %254 = getelementptr inbounds i64, i64* %252, i64 1, !dbg !119
+  store i64* %254, i64** %249, align 8, !dbg !119
   %send64 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt.35, i64 0), !dbg !119
-  %268 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !120
-  %269 = load i64*, i64** %268, align 8, !dbg !120
-  store i64 %35, i64* %269, align 8, !dbg !120, !tbaa !6
-  %270 = getelementptr inbounds i64, i64* %269, i64 1, !dbg !120
-  store i64 %send64, i64* %270, align 8, !dbg !120, !tbaa !6
-  %271 = getelementptr inbounds i64, i64* %270, i64 1, !dbg !120
-  store i64* %271, i64** %268, align 8, !dbg !120
+  %255 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !120
+  %256 = load i64*, i64** %255, align 8, !dbg !120
+  store i64 %22, i64* %256, align 8, !dbg !120, !tbaa !6
+  %257 = getelementptr inbounds i64, i64* %256, i64 1, !dbg !120
+  store i64 %send64, i64* %257, align 8, !dbg !120, !tbaa !6
+  %258 = getelementptr inbounds i64, i64* %257, i64 1, !dbg !120
+  store i64* %258, i64** %255, align 8, !dbg !120
   %send66 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.36, i64 0), !dbg !120
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 45), i64** %48, align 8, !dbg !120, !tbaa !14
-  %rubyStr_25.4.i = load i64, i64* @rubyStrFrozen_25.4, align 8, !dbg !121
-  %272 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !121
-  %273 = load i64*, i64** %272, align 8, !dbg !121
-  store i64 %197, i64* %273, align 8, !dbg !121, !tbaa !6
-  %274 = getelementptr inbounds i64, i64* %273, i64 1, !dbg !121
-  store i64 %rubyStr_25.4.i, i64* %274, align 8, !dbg !121, !tbaa !6
-  %275 = getelementptr inbounds i64, i64* %274, i64 1, !dbg !121
-  store i64* %275, i64** %272, align 8, !dbg !121
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 45), i64** %35, align 8, !dbg !120, !tbaa !14
+  %rubyStr_25.4.i = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 11), align 8, !dbg !121, !invariant.load !5
+  %259 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !121
+  %260 = load i64*, i64** %259, align 8, !dbg !121
+  store i64 %184, i64* %260, align 8, !dbg !121, !tbaa !6
+  %261 = getelementptr inbounds i64, i64* %260, i64 1, !dbg !121
+  store i64 %rubyStr_25.4.i, i64* %261, align 8, !dbg !121, !tbaa !6
+  %262 = getelementptr inbounds i64, i64* %261, i64 1, !dbg !121
+  store i64* %262, i64** %259, align 8, !dbg !121
   %send68 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational.37, i64 0), !dbg !121
-  %276 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !122
-  %277 = load i64*, i64** %276, align 8, !dbg !122
-  store i64 %35, i64* %277, align 8, !dbg !122, !tbaa !6
-  %278 = getelementptr inbounds i64, i64* %277, i64 1, !dbg !122
-  store i64 113040350646999450, i64* %278, align 8, !dbg !122, !tbaa !6
-  %279 = getelementptr inbounds i64, i64* %278, i64 1, !dbg !122
-  store i64 %send68, i64* %279, align 8, !dbg !122, !tbaa !6
-  %280 = getelementptr inbounds i64, i64* %279, i64 1, !dbg !122
-  store i64* %280, i64** %276, align 8, !dbg !122
+  %263 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !122
+  %264 = load i64*, i64** %263, align 8, !dbg !122
+  store i64 %22, i64* %264, align 8, !dbg !122, !tbaa !6
+  %265 = getelementptr inbounds i64, i64* %264, i64 1, !dbg !122
+  store i64 113040350646999450, i64* %265, align 8, !dbg !122, !tbaa !6
+  %266 = getelementptr inbounds i64, i64* %265, i64 1, !dbg !122
+  store i64 %send68, i64* %266, align 8, !dbg !122, !tbaa !6
+  %267 = getelementptr inbounds i64, i64* %266, i64 1, !dbg !122
+  store i64* %267, i64** %263, align 8, !dbg !122
   %send70 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt.38, i64 0), !dbg !122
-  %281 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !123
-  %282 = load i64*, i64** %281, align 8, !dbg !123
-  store i64 %35, i64* %282, align 8, !dbg !123, !tbaa !6
-  %283 = getelementptr inbounds i64, i64* %282, i64 1, !dbg !123
-  store i64 %send70, i64* %283, align 8, !dbg !123, !tbaa !6
-  %284 = getelementptr inbounds i64, i64* %283, i64 1, !dbg !123
-  store i64* %284, i64** %281, align 8, !dbg !123
+  %268 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !123
+  %269 = load i64*, i64** %268, align 8, !dbg !123
+  store i64 %22, i64* %269, align 8, !dbg !123, !tbaa !6
+  %270 = getelementptr inbounds i64, i64* %269, i64 1, !dbg !123
+  store i64 %send70, i64* %270, align 8, !dbg !123, !tbaa !6
+  %271 = getelementptr inbounds i64, i64* %270, i64 1, !dbg !123
+  store i64* %271, i64** %268, align 8, !dbg !123
   %send72 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.39, i64 0), !dbg !123
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 47), i64** %48, align 8, !dbg !123, !tbaa !14
-  %285 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !124
-  %286 = load i64*, i64** %285, align 8, !dbg !124
-  store i64 %35, i64* %286, align 8, !dbg !124, !tbaa !6
-  %287 = getelementptr inbounds i64, i64* %286, i64 1, !dbg !124
-  %288 = getelementptr inbounds i64, i64* %287, i64 1, !dbg !124
-  %289 = bitcast i64* %287 to <2 x i64>*, !dbg !124
-  store <2 x i64> <i64 113040350646999450, i64 41>, <2 x i64>* %289, align 8, !dbg !124, !tbaa !6
-  %290 = getelementptr inbounds i64, i64* %288, i64 1, !dbg !124
-  store i64* %290, i64** %285, align 8, !dbg !124
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 47), i64** %35, align 8, !dbg !123, !tbaa !14
+  %272 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !124
+  %273 = load i64*, i64** %272, align 8, !dbg !124
+  store i64 %22, i64* %273, align 8, !dbg !124, !tbaa !6
+  %274 = getelementptr inbounds i64, i64* %273, i64 1, !dbg !124
+  %275 = getelementptr inbounds i64, i64* %274, i64 1, !dbg !124
+  %276 = bitcast i64* %274 to <2 x i64>*, !dbg !124
+  store <2 x i64> <i64 113040350646999450, i64 41>, <2 x i64>* %276, align 8, !dbg !124, !tbaa !6
+  %277 = getelementptr inbounds i64, i64* %275, i64 1, !dbg !124
+  store i64* %277, i64** %272, align 8, !dbg !124
   %send74 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.40, i64 0), !dbg !124
-  %291 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !125
-  %292 = load i64*, i64** %291, align 8, !dbg !125
-  store i64 %35, i64* %292, align 8, !dbg !125, !tbaa !6
-  %293 = getelementptr inbounds i64, i64* %292, i64 1, !dbg !125
-  store i64 %send74, i64* %293, align 8, !dbg !125, !tbaa !6
-  %294 = getelementptr inbounds i64, i64* %293, i64 1, !dbg !125
-  store i64* %294, i64** %291, align 8, !dbg !125
+  %278 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !125
+  %279 = load i64*, i64** %278, align 8, !dbg !125
+  store i64 %22, i64* %279, align 8, !dbg !125, !tbaa !6
+  %280 = getelementptr inbounds i64, i64* %279, i64 1, !dbg !125
+  store i64 %send74, i64* %280, align 8, !dbg !125, !tbaa !6
+  %281 = getelementptr inbounds i64, i64* %280, i64 1, !dbg !125
+  store i64* %281, i64** %278, align 8, !dbg !125
   %send76 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.41, i64 0), !dbg !125
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 48), i64** %48, align 8, !dbg !125, !tbaa !14
-  %rubyStr_5.923.i = load i64, i64* @rubyStrFrozen_5.923, align 8, !dbg !126
-  %295 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !126
-  %296 = load i64*, i64** %295, align 8, !dbg !126
-  store i64 %197, i64* %296, align 8, !dbg !126, !tbaa !6
-  %297 = getelementptr inbounds i64, i64* %296, i64 1, !dbg !126
-  store i64 %rubyStr_5.923.i, i64* %297, align 8, !dbg !126, !tbaa !6
-  %298 = getelementptr inbounds i64, i64* %297, i64 1, !dbg !126
-  store i64* %298, i64** %295, align 8, !dbg !126
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 48), i64** %35, align 8, !dbg !125, !tbaa !14
+  %rubyStr_5.923.i = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 12), align 8, !dbg !126, !invariant.load !5
+  %282 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !126
+  %283 = load i64*, i64** %282, align 8, !dbg !126
+  store i64 %184, i64* %283, align 8, !dbg !126, !tbaa !6
+  %284 = getelementptr inbounds i64, i64* %283, i64 1, !dbg !126
+  store i64 %rubyStr_5.923.i, i64* %284, align 8, !dbg !126, !tbaa !6
+  %285 = getelementptr inbounds i64, i64* %284, i64 1, !dbg !126
+  store i64* %285, i64** %282, align 8, !dbg !126
   %send78 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational.42, i64 0), !dbg !126
-  %299 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !127
-  %300 = load i64*, i64** %299, align 8, !dbg !127
-  store i64 %35, i64* %300, align 8, !dbg !127, !tbaa !6
-  %301 = getelementptr inbounds i64, i64* %300, i64 1, !dbg !127
-  store i64 113040350646999450, i64* %301, align 8, !dbg !127, !tbaa !6
-  %302 = getelementptr inbounds i64, i64* %301, i64 1, !dbg !127
-  store i64 %send78, i64* %302, align 8, !dbg !127, !tbaa !6
-  %303 = getelementptr inbounds i64, i64* %302, i64 1, !dbg !127
-  store i64* %303, i64** %299, align 8, !dbg !127
+  %286 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !127
+  %287 = load i64*, i64** %286, align 8, !dbg !127
+  store i64 %22, i64* %287, align 8, !dbg !127, !tbaa !6
+  %288 = getelementptr inbounds i64, i64* %287, i64 1, !dbg !127
+  store i64 113040350646999450, i64* %288, align 8, !dbg !127, !tbaa !6
+  %289 = getelementptr inbounds i64, i64* %288, i64 1, !dbg !127
+  store i64 %send78, i64* %289, align 8, !dbg !127, !tbaa !6
+  %290 = getelementptr inbounds i64, i64* %289, i64 1, !dbg !127
+  store i64* %290, i64** %286, align 8, !dbg !127
   %send80 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.43, i64 0), !dbg !127
-  %304 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !128
-  %305 = load i64*, i64** %304, align 8, !dbg !128
-  store i64 %35, i64* %305, align 8, !dbg !128, !tbaa !6
-  %306 = getelementptr inbounds i64, i64* %305, i64 1, !dbg !128
-  store i64 %send80, i64* %306, align 8, !dbg !128, !tbaa !6
-  %307 = getelementptr inbounds i64, i64* %306, i64 1, !dbg !128
-  store i64* %307, i64** %304, align 8, !dbg !128
+  %291 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !128
+  %292 = load i64*, i64** %291, align 8, !dbg !128
+  store i64 %22, i64* %292, align 8, !dbg !128, !tbaa !6
+  %293 = getelementptr inbounds i64, i64* %292, i64 1, !dbg !128
+  store i64 %send80, i64* %293, align 8, !dbg !128, !tbaa !6
+  %294 = getelementptr inbounds i64, i64* %293, i64 1, !dbg !128
+  store i64* %294, i64** %291, align 8, !dbg !128
   %send82 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.44, i64 0), !dbg !128
-  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %39)
-  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %40)
-  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %41)
-  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %42)
+  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %26)
+  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %27)
+  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %28)
+  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %29)
   ret void
 }
 

--- a/test/testdata/compiler/globalfields.opt.ll.exp
+++ b/test/testdata/compiler/globalfields.opt.ll.exp
@@ -84,15 +84,12 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"rubyStrFrozen_test/testdata/compiler/globalfields.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [20 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @ic_new = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_initialize = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_read = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyStrFrozen_value = internal unnamed_addr global i64 0, align 8
 @ic_write = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_read.1 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.2 = internal global %struct.FunctionInlineCache zeroinitializer
@@ -103,6 +100,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @sorbet_moduleStringTable = internal unnamed_addr constant [133 x i8] c"<top (required)>\00test/testdata/compiler/globalfields.rb\00A\00Object\00new\00initialize\00read\00puts\00value\00write\00$f\00F\00master\00<class:A>\00normal\00v\00", align 1
 @sorbet_moduleIDTable = internal unnamed_addr global [10 x i64] zeroinitializer, align 8
 @sorbet_moduleIDDescriptors = internal unnamed_addr constant [10 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 65, i32 3 }, %struct.rb_code_position_struct { i32 69, i32 10 }, %struct.rb_code_position_struct { i32 80, i32 4 }, %struct.rb_code_position_struct { i32 85, i32 4 }, %struct.rb_code_position_struct { i32 96, i32 5 }, %struct.rb_code_position_struct { i32 102, i32 2 }, %struct.rb_code_position_struct { i32 114, i32 9 }, %struct.rb_code_position_struct { i32 124, i32 6 }, %struct.rb_code_position_struct { i32 131, i32 1 }], align 8
+@sorbet_moduleRubyStringTable = internal unnamed_addr global [6 x i64] zeroinitializer, align 8
+@sorbet_moduleRubyStringDescriptors = internal unnamed_addr constant [6 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 17, i32 38 }, %struct.rb_code_position_struct { i32 90, i32 5 }, %struct.rb_code_position_struct { i32 96, i32 5 }, %struct.rb_code_position_struct { i32 80, i32 4 }, %struct.rb_code_position_struct { i32 114, i32 9 }], align 8
 @rb_cObject = external local_unnamed_addr constant i64
 @guard_epoch_A = linkonce local_unnamed_addr global i64 0
 @guarded_const_A = linkonce local_unnamed_addr global i64 0
@@ -134,9 +133,9 @@ declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_
 
 declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #1
 
-declare i64 @sorbet_maybeAllocateObjectFastPath(i64, %struct.FunctionInlineCache*) local_unnamed_addr #1
+declare void @sorbet_vm_init_string_table(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #1
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #1
+declare i64 @sorbet_maybeAllocateObjectFastPath(i64, %struct.FunctionInlineCache*) local_unnamed_addr #1
 
 declare i64 @rb_define_class(i8*, i64) local_unnamed_addr #1
 
@@ -151,8 +150,6 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #2
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #2
-
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #1
 
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #0
@@ -190,18 +187,13 @@ entry:
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
   tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([10 x %struct.rb_code_position_struct], [10 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 10, i8* noundef getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
-  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #11
-  tail call void @rb_gc_register_mark_object(i64 %0) #11
-  store i64 %0, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %1 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 38) #11
-  tail call void @rb_gc_register_mark_object(i64 %1) #11
-  store i64 %1, i64* @"rubyStrFrozen_test/testdata/compiler/globalfields.rb", align 8
+  tail call void @sorbet_vm_init_string_table(i64* noundef getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleRubyStringTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([6 x %struct.rb_code_position_struct], [6 x %struct.rb_code_position_struct]* @sorbet_moduleRubyStringDescriptors, i32 0, i32 0), i32 noundef 6, i8* noundef getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 20)
   %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
-  %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/globalfields.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/globalfields.rb", align 8
-  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/globalfields.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %"rubyStr_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 0), align 8, !invariant.load !5
+  %"rubyStr_test/testdata/compiler/globalfields.rb.i.i" = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
+  %0 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/globalfields.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %0, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
   %rubyId_new.i = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !dbg !17, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !17
   %rubyId_initialize.i = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !17, !invariant.load !5
@@ -210,195 +202,186 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_read, i64 %rubyId_read.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !18
   %rubyId_puts.i = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !dbg !19, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
-  %3 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 90), i64 noundef 5) #11
-  call void @rb_gc_register_mark_object(i64 %3) #11
-  store i64 %3, i64* @rubyStrFrozen_value, align 8
   %rubyId_write.i = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 5), align 8, !dbg !20, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_write, i64 %rubyId_write.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !20
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_read.1, i64 %rubyId_read.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !21
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !22
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !23
-  %4 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 96), i64 noundef 5) #11
-  call void @rb_gc_register_mark_object(i64 %4) #11
-  %"rubyStr_test/testdata/compiler/globalfields.rb.i14.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/globalfields.rb", align 8
-  %5 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %4, i64 %rubyId_write.i, i64 %"rubyStr_test/testdata/compiler/globalfields.rb.i14.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i15.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %5, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#5write", align 8
-  %6 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 80), i64 noundef 4) #11
-  call void @rb_gc_register_mark_object(i64 %6) #11
-  %"rubyStr_test/testdata/compiler/globalfields.rb.i16.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/globalfields.rb", align 8
-  %7 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %6, i64 %rubyId_read.i, i64 %"rubyStr_test/testdata/compiler/globalfields.rb.i16.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 9, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i17.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %7, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#4read", align 8
-  %8 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 114), i64 noundef 9) #11
-  call void @rb_gc_register_mark_object(i64 %8) #11
+  %rubyStr_write.i.i = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 3), align 8, !invariant.load !5
+  %1 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_write.i.i, i64 %rubyId_write.i, i64 %"rubyStr_test/testdata/compiler/globalfields.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i15.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %1, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#5write", align 8
+  %rubyStr_read.i.i = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 4), align 8, !invariant.load !5
+  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_read.i.i, i64 %rubyId_read.i, i64 %"rubyStr_test/testdata/compiler/globalfields.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 9, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i17.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#4read", align 8
   %"rubyId_<class:A>.i.i" = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 7), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/globalfields.rb.i18.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/globalfields.rb", align 8
-  %9 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %8, i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/globalfields.rb.i18.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i19.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %9, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %10 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !24
-  %11 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %10, i64 0, i32 18
-  %12 = load i64, i64* %11, align 8, !tbaa !26
-  %13 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !24
-  %14 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %13, i64 0, i32 2
-  %15 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %14, align 8, !tbaa !36
+  %"rubyStr_<class:A>.i.i" = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 5), align 8, !invariant.load !5
+  %3 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<class:A>.i.i", i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/globalfields.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i19.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %3, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
+  %4 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !24
+  %5 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %4, i64 0, i32 18
+  %6 = load i64, i64* %5, align 8, !tbaa !26
+  %7 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !24
+  %8 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %7, i64 0, i32 2
+  %9 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %8, align 8, !tbaa !36
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %16 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %16, align 8, !tbaa !39
-  %17 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 4
-  %18 = load i64*, i64** %17, align 8, !tbaa !41
-  %19 = load i64, i64* %18, align 8, !tbaa !6
-  %20 = and i64 %19, -33
-  store i64 %20, i64* %18, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %13, %struct.rb_control_frame_struct* %15, %struct.rb_iseq_struct* %stackFrame.i) #11
-  %21 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 0
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %21, align 8, !dbg !42, !tbaa !24
-  %22 = load i64, i64* @rb_cObject, align 8, !dbg !43
-  %23 = call i64 @rb_define_class(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 56), i64 %22) #11, !dbg !43
-  %24 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %23) #11, !dbg !43
-  %25 = bitcast i64* %positional_table.i.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %25) #11
+  %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %10, align 8, !tbaa !39
+  %11 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 4
+  %12 = load i64*, i64** %11, align 8, !tbaa !41
+  %13 = load i64, i64* %12, align 8, !tbaa !6
+  %14 = and i64 %13, -33
+  store i64 %14, i64* %12, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %7, %struct.rb_control_frame_struct* %9, %struct.rb_iseq_struct* %stackFrame.i) #11
+  %15 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 0
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %15, align 8, !dbg !42, !tbaa !24
+  %16 = load i64, i64* @rb_cObject, align 8, !dbg !43
+  %17 = call i64 @rb_define_class(i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 56), i64 %16) #11, !dbg !43
+  %18 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %17) #11, !dbg !43
+  %19 = bitcast i64* %positional_table.i.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %19) #11
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %26 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !24
-  %27 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %26, i64 0, i32 2
-  %28 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %27, align 8, !tbaa !36
-  %29 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %28, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %29, align 8, !tbaa !39
-  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %28, i64 0, i32 4
-  %31 = load i64*, i64** %30, align 8, !tbaa !41
-  %32 = load i64, i64* %31, align 8, !tbaa !6
-  %33 = and i64 %32, -33
-  store i64 %33, i64* %31, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %26, %struct.rb_control_frame_struct* %28, %struct.rb_iseq_struct* %stackFrame.i.i) #11
-  %34 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 0
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %34, align 8, !dbg !44, !tbaa !24
-  %35 = load i64, i64* @guard_epoch_A, align 8, !dbg !10
-  %36 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !45
-  %needTakeSlowPath = icmp ne i64 %35, %36, !dbg !10
-  br i1 %needTakeSlowPath, label %37, label %38, !dbg !10, !prof !46
+  %20 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !24
+  %21 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %20, i64 0, i32 2
+  %22 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %21, align 8, !tbaa !36
+  %23 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %22, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %23, align 8, !tbaa !39
+  %24 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %22, i64 0, i32 4
+  %25 = load i64*, i64** %24, align 8, !tbaa !41
+  %26 = load i64, i64* %25, align 8, !tbaa !6
+  %27 = and i64 %26, -33
+  store i64 %27, i64* %25, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %20, %struct.rb_control_frame_struct* %22, %struct.rb_iseq_struct* %stackFrame.i.i) #11
+  %28 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 0
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %28, align 8, !dbg !44, !tbaa !24
+  %29 = load i64, i64* @guard_epoch_A, align 8, !dbg !10
+  %30 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !45
+  %needTakeSlowPath = icmp ne i64 %29, %30, !dbg !10
+  br i1 %needTakeSlowPath, label %31, label %32, !dbg !10, !prof !46
 
-37:                                               ; preds = %entry
+31:                                               ; preds = %entry
   call void @const_recompute_A(), !dbg !10
-  br label %38, !dbg !10
+  br label %32, !dbg !10
 
-38:                                               ; preds = %entry, %37
-  %39 = load i64, i64* @guarded_const_A, align 8, !dbg !10
-  %40 = load i64, i64* @guard_epoch_A, align 8, !dbg !10
-  %41 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !45
-  %guardUpdated = icmp eq i64 %40, %41, !dbg !10
+32:                                               ; preds = %entry, %31
+  %33 = load i64, i64* @guarded_const_A, align 8, !dbg !10
+  %34 = load i64, i64* @guard_epoch_A, align 8, !dbg !10
+  %35 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !10, !tbaa !45
+  %guardUpdated = icmp eq i64 %34, %35, !dbg !10
   call void @llvm.assume(i1 %guardUpdated), !dbg !10
   %stackFrame17.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#5write", align 8, !dbg !10
-  %42 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !10
-  %43 = bitcast i8* %42 to i16*, !dbg !10
-  %44 = load i16, i16* %43, align 8, !dbg !10
-  %45 = and i16 %44, -384, !dbg !10
-  %46 = or i16 %45, 1, !dbg !10
-  store i16 %46, i16* %43, align 8, !dbg !10
-  %47 = getelementptr inbounds i8, i8* %42, i64 8, !dbg !10
-  %48 = bitcast i8* %47 to i32*, !dbg !10
-  store i32 1, i32* %48, align 8, !dbg !10, !tbaa !47
-  %49 = getelementptr inbounds i8, i8* %42, i64 12, !dbg !10
-  %50 = getelementptr inbounds i8, i8* %42, i64 4, !dbg !10
-  %51 = bitcast i8* %50 to i32*, !dbg !10
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %49, i8 0, i64 20, i1 false) #11, !dbg !10
-  store i32 1, i32* %51, align 4, !dbg !10, !tbaa !50
+  %36 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !10
+  %37 = bitcast i8* %36 to i16*, !dbg !10
+  %38 = load i16, i16* %37, align 8, !dbg !10
+  %39 = and i16 %38, -384, !dbg !10
+  %40 = or i16 %39, 1, !dbg !10
+  store i16 %40, i16* %37, align 8, !dbg !10
+  %41 = getelementptr inbounds i8, i8* %36, i64 8, !dbg !10
+  %42 = bitcast i8* %41 to i32*, !dbg !10
+  store i32 1, i32* %42, align 8, !dbg !10, !tbaa !47
+  %43 = getelementptr inbounds i8, i8* %36, i64 12, !dbg !10
+  %44 = getelementptr inbounds i8, i8* %36, i64 4, !dbg !10
+  %45 = bitcast i8* %44 to i32*, !dbg !10
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %43, i8 0, i64 20, i1 false) #11, !dbg !10
+  store i32 1, i32* %45, align 4, !dbg !10, !tbaa !50
   %rubyId_v.i.i = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 9), align 8, !dbg !10, !invariant.load !5
   store i64 %rubyId_v.i.i, i64* %positional_table.i.i, align 8, !dbg !10
-  %52 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !10
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %52, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %25, i64 noundef 8, i1 noundef false) #11, !dbg !10
-  %53 = getelementptr inbounds i8, i8* %42, i64 32, !dbg !10
-  %54 = bitcast i8* %53 to i8**, !dbg !10
-  store i8* %52, i8** %54, align 8, !dbg !10, !tbaa !51
-  call void @sorbet_vm_define_method(i64 %39, i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 96), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_A#5write", i8* nonnull %42, %struct.rb_iseq_struct* %stackFrame17.i.i, i1 noundef zeroext false) #11, !dbg !10
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %34, align 8, !dbg !10, !tbaa !24
+  %46 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #12, !dbg !10
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %46, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %19, i64 noundef 8, i1 noundef false) #11, !dbg !10
+  %47 = getelementptr inbounds i8, i8* %36, i64 32, !dbg !10
+  %48 = bitcast i8* %47 to i8**, !dbg !10
+  store i8* %46, i8** %48, align 8, !dbg !10, !tbaa !51
+  call void @sorbet_vm_define_method(i64 %33, i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 96), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_A#5write", i8* nonnull %36, %struct.rb_iseq_struct* %stackFrame17.i.i, i1 noundef zeroext false) #11, !dbg !10
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %28, align 8, !dbg !10, !tbaa !24
   %stackFrame26.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#4read", align 8, !dbg !52
-  %55 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !52
-  %56 = bitcast i8* %55 to i16*, !dbg !52
-  %57 = load i16, i16* %56, align 8, !dbg !52
-  %58 = and i16 %57, -384, !dbg !52
-  store i16 %58, i16* %56, align 8, !dbg !52
-  %59 = getelementptr inbounds i8, i8* %55, i64 4, !dbg !52
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %59, i8 0, i64 28, i1 false) #11, !dbg !52
-  call void @sorbet_vm_define_method(i64 %39, i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 80), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_A#4read", i8* nonnull %55, %struct.rb_iseq_struct* %stackFrame26.i.i, i1 noundef zeroext false) #11, !dbg !52
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %25) #11
+  %49 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !52
+  %50 = bitcast i8* %49 to i16*, !dbg !52
+  %51 = load i16, i16* %50, align 8, !dbg !52
+  %52 = and i16 %51, -384, !dbg !52
+  store i16 %52, i16* %50, align 8, !dbg !52
+  %53 = getelementptr inbounds i8, i8* %49, i64 4, !dbg !52
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %53, i8 0, i64 28, i1 false) #11, !dbg !52
+  call void @sorbet_vm_define_method(i64 %33, i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 80), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_A#4read", i8* nonnull %49, %struct.rb_iseq_struct* %stackFrame26.i.i, i1 noundef zeroext false) #11, !dbg !52
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %19) #11
   call void @sorbet_popFrame() #11, !dbg !43
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %21, align 8, !dbg !43, !tbaa !24
-  %60 = call i64 @sorbet_maybeAllocateObjectFastPath(i64 %39, %struct.FunctionInlineCache* noundef @ic_new) #11, !dbg !17
-  %61 = icmp eq i64 %60, 52, !dbg !17
-  br i1 %61, label %slowNew.i, label %fastNew.i, !dbg !17
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %15, align 8, !dbg !43, !tbaa !24
+  %54 = call i64 @sorbet_maybeAllocateObjectFastPath(i64 %33, %struct.FunctionInlineCache* noundef @ic_new) #11, !dbg !17
+  %55 = icmp eq i64 %54, 52, !dbg !17
+  br i1 %55, label %slowNew.i, label %fastNew.i, !dbg !17
 
-slowNew.i:                                        ; preds = %38
-  %62 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 1, !dbg !17
-  %63 = load i64*, i64** %62, align 8, !dbg !17
-  store i64 %39, i64* %63, align 8, !dbg !17, !tbaa !6
-  %64 = getelementptr inbounds i64, i64* %63, i64 1, !dbg !17
-  store i64* %64, i64** %62, align 8, !dbg !17
-  %65 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_new, i64 noundef 0) #11, !dbg !17
+slowNew.i:                                        ; preds = %32
+  %56 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 1, !dbg !17
+  %57 = load i64*, i64** %56, align 8, !dbg !17
+  store i64 %33, i64* %57, align 8, !dbg !17, !tbaa !6
+  %58 = getelementptr inbounds i64, i64* %57, i64 1, !dbg !17
+  store i64* %58, i64** %56, align 8, !dbg !17
+  %59 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_new, i64 noundef 0) #11, !dbg !17
   br label %"func_<root>.17<static-init>$153.exit", !dbg !17
 
-fastNew.i:                                        ; preds = %38
-  %66 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 1, !dbg !17
-  %67 = load i64*, i64** %66, align 8, !dbg !17
-  store i64 %60, i64* %67, align 8, !dbg !17, !tbaa !6
-  %68 = getelementptr inbounds i64, i64* %67, i64 1, !dbg !17
-  store i64* %68, i64** %66, align 8, !dbg !17
-  %69 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 noundef 0) #11, !dbg !17
+fastNew.i:                                        ; preds = %32
+  %60 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 1, !dbg !17
+  %61 = load i64*, i64** %60, align 8, !dbg !17
+  store i64 %54, i64* %61, align 8, !dbg !17, !tbaa !6
+  %62 = getelementptr inbounds i64, i64* %61, i64 1, !dbg !17
+  store i64* %62, i64** %60, align 8, !dbg !17
+  %63 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 noundef 0) #11, !dbg !17
   br label %"func_<root>.17<static-init>$153.exit", !dbg !17
 
 "func_<root>.17<static-init>$153.exit":           ; preds = %slowNew.i, %fastNew.i
-  %initializedObject.i = phi i64 [ %65, %slowNew.i ], [ %60, %fastNew.i ], !dbg !17
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 15), i64** %21, align 8, !dbg !17, !tbaa !24
-  %70 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 1, !dbg !18
-  %71 = load i64*, i64** %70, align 8, !dbg !18
-  store i64 %initializedObject.i, i64* %71, align 8, !dbg !18, !tbaa !6
-  %72 = getelementptr inbounds i64, i64* %71, i64 1, !dbg !18
-  store i64* %72, i64** %70, align 8, !dbg !18
+  %initializedObject.i = phi i64 [ %59, %slowNew.i ], [ %54, %fastNew.i ], !dbg !17
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 15), i64** %15, align 8, !dbg !17, !tbaa !24
+  %64 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 1, !dbg !18
+  %65 = load i64*, i64** %64, align 8, !dbg !18
+  store i64 %initializedObject.i, i64* %65, align 8, !dbg !18, !tbaa !6
+  %66 = getelementptr inbounds i64, i64* %65, i64 1, !dbg !18
+  store i64* %66, i64** %64, align 8, !dbg !18
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_read, i64 0), !dbg !18
-  %73 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 1, !dbg !19
-  %74 = load i64*, i64** %73, align 8, !dbg !19
-  store i64 %12, i64* %74, align 8, !dbg !19, !tbaa !6
-  %75 = getelementptr inbounds i64, i64* %74, i64 1, !dbg !19
-  store i64 %send, i64* %75, align 8, !dbg !19, !tbaa !6
-  %76 = getelementptr inbounds i64, i64* %75, i64 1, !dbg !19
-  store i64* %76, i64** %73, align 8, !dbg !19
+  %67 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 1, !dbg !19
+  %68 = load i64*, i64** %67, align 8, !dbg !19
+  store i64 %6, i64* %68, align 8, !dbg !19, !tbaa !6
+  %69 = getelementptr inbounds i64, i64* %68, i64 1, !dbg !19
+  store i64 %send, i64* %69, align 8, !dbg !19, !tbaa !6
+  %70 = getelementptr inbounds i64, i64* %69, i64 1, !dbg !19
+  store i64* %70, i64** %67, align 8, !dbg !19
   %send2 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !19
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %21, align 8, !dbg !19, !tbaa !24
-  %rubyStr_value.i = load i64, i64* @rubyStrFrozen_value, align 8, !dbg !53
-  %77 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 1, !dbg !20
-  %78 = load i64*, i64** %77, align 8, !dbg !20
-  store i64 %initializedObject.i, i64* %78, align 8, !dbg !20, !tbaa !6
-  %79 = getelementptr inbounds i64, i64* %78, i64 1, !dbg !20
-  store i64 %rubyStr_value.i, i64* %79, align 8, !dbg !20, !tbaa !6
-  %80 = getelementptr inbounds i64, i64* %79, i64 1, !dbg !20
-  store i64* %80, i64** %77, align 8, !dbg !20
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %15, align 8, !dbg !19, !tbaa !24
+  %rubyStr_value.i = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 2), align 8, !dbg !53, !invariant.load !5
+  %71 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 1, !dbg !20
+  %72 = load i64*, i64** %71, align 8, !dbg !20
+  store i64 %initializedObject.i, i64* %72, align 8, !dbg !20, !tbaa !6
+  %73 = getelementptr inbounds i64, i64* %72, i64 1, !dbg !20
+  store i64 %rubyStr_value.i, i64* %73, align 8, !dbg !20, !tbaa !6
+  %74 = getelementptr inbounds i64, i64* %73, i64 1, !dbg !20
+  store i64* %74, i64** %71, align 8, !dbg !20
   %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_write, i64 0), !dbg !20
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %21, align 8, !dbg !20, !tbaa !24
-  %81 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 1, !dbg !21
-  %82 = load i64*, i64** %81, align 8, !dbg !21
-  store i64 %initializedObject.i, i64* %82, align 8, !dbg !21, !tbaa !6
-  %83 = getelementptr inbounds i64, i64* %82, i64 1, !dbg !21
-  store i64* %83, i64** %81, align 8, !dbg !21
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %15, align 8, !dbg !20, !tbaa !24
+  %75 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 1, !dbg !21
+  %76 = load i64*, i64** %75, align 8, !dbg !21
+  store i64 %initializedObject.i, i64* %76, align 8, !dbg !21, !tbaa !6
+  %77 = getelementptr inbounds i64, i64* %76, i64 1, !dbg !21
+  store i64* %77, i64** %75, align 8, !dbg !21
   %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_read.1, i64 0), !dbg !21
-  %84 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 1, !dbg !22
-  %85 = load i64*, i64** %84, align 8, !dbg !22
-  store i64 %12, i64* %85, align 8, !dbg !22, !tbaa !6
-  %86 = getelementptr inbounds i64, i64* %85, i64 1, !dbg !22
-  store i64 %send6, i64* %86, align 8, !dbg !22, !tbaa !6
-  %87 = getelementptr inbounds i64, i64* %86, i64 1, !dbg !22
-  store i64* %87, i64** %84, align 8, !dbg !22
+  %78 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 1, !dbg !22
+  %79 = load i64*, i64** %78, align 8, !dbg !22
+  store i64 %6, i64* %79, align 8, !dbg !22, !tbaa !6
+  %80 = getelementptr inbounds i64, i64* %79, i64 1, !dbg !22
+  store i64 %send6, i64* %80, align 8, !dbg !22, !tbaa !6
+  %81 = getelementptr inbounds i64, i64* %80, i64 1, !dbg !22
+  store i64* %81, i64** %78, align 8, !dbg !22
   %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.2, i64 0), !dbg !22
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %21, align 8, !dbg !22, !tbaa !24
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %15, align 8, !dbg !22, !tbaa !24
   %"rubyId_$f.i" = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 6), align 8, !dbg !23, !invariant.load !5
-  %88 = call %struct.rb_global_entry* @rb_global_entry(i64 %"rubyId_$f.i") #11, !dbg !23
-  %89 = call i64 @rb_gvar_get(%struct.rb_global_entry* %88) #11, !dbg !23
-  %90 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 1, !dbg !23
-  %91 = load i64*, i64** %90, align 8, !dbg !23
-  store i64 %12, i64* %91, align 8, !dbg !23, !tbaa !6
-  %92 = getelementptr inbounds i64, i64* %91, i64 1, !dbg !23
-  store i64 %89, i64* %92, align 8, !dbg !23, !tbaa !6
-  %93 = getelementptr inbounds i64, i64* %92, i64 1, !dbg !23
-  store i64* %93, i64** %90, align 8, !dbg !23
+  %82 = call %struct.rb_global_entry* @rb_global_entry(i64 %"rubyId_$f.i") #11, !dbg !23
+  %83 = call i64 @rb_gvar_get(%struct.rb_global_entry* %82) #11, !dbg !23
+  %84 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 1, !dbg !23
+  %85 = load i64*, i64** %84, align 8, !dbg !23
+  store i64 %6, i64* %85, align 8, !dbg !23, !tbaa !6
+  %86 = getelementptr inbounds i64, i64* %85, i64 1, !dbg !23
+  store i64 %83, i64* %86, align 8, !dbg !23, !tbaa !6
+  %87 = getelementptr inbounds i64, i64* %86, i64 1, !dbg !23
+  store i64* %87, i64** %84, align 8, !dbg !23
   %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.3, i64 0), !dbg !23
-  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %21, align 8, !dbg !23, !tbaa !24
-  %94 = call i64 @sorbet_setConstant(i64 %22, i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 105), i64 noundef 1, i64 noundef 3) #11, !dbg !54
+  store i64* getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %15, align 8, !dbg !23, !tbaa !24
+  %88 = call i64 @sorbet_setConstant(i64 %16, i8* getelementptr inbounds ([133 x i8], [133 x i8]* @sorbet_moduleStringTable, i64 0, i64 105), i64 noundef 1, i64 noundef 3) #11, !dbg !54
   ret void
 }
 

--- a/test/testdata/compiler/hello.opt.ll.exp
+++ b/test/testdata/compiler/hello.opt.ll.exp
@@ -81,15 +81,14 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"rubyStrFrozen_test/testdata/compiler/hello.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [5 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
-@"rubyStrFrozen_hello world" = internal unnamed_addr global i64 0, align 8
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
 @sorbet_moduleStringTable = internal unnamed_addr constant [73 x i8] c"<top (required)>\00test/testdata/compiler/hello.rb\00hello world\00puts\00master\00", align 1
 @sorbet_moduleIDTable = internal unnamed_addr global [2 x i64] zeroinitializer, align 8
 @sorbet_moduleIDDescriptors = internal unnamed_addr constant [2 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 61, i32 4 }], align 8
+@sorbet_moduleRubyStringTable = internal unnamed_addr global [3 x i64] zeroinitializer, align 8
+@sorbet_moduleRubyStringDescriptors = internal unnamed_addr constant [3 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 17, i32 31 }, %struct.rb_code_position_struct { i32 49, i32 11 }], align 8
 
 declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
 
@@ -105,9 +104,7 @@ declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %
 
 declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #0
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
-
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
+declare void @sorbet_vm_init_string_table(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #0
 
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #1
@@ -132,48 +129,40 @@ entry:
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
   tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([2 x i64], [2 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([2 x %struct.rb_code_position_struct], [2 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 2, i8* noundef getelementptr inbounds ([73 x i8], [73 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
-  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([73 x i8], [73 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #5
-  tail call void @rb_gc_register_mark_object(i64 %0) #5
-  store i64 %0, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %1 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([73 x i8], [73 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 31) #5
-  tail call void @rb_gc_register_mark_object(i64 %1) #5
-  store i64 %1, i64* @"rubyStrFrozen_test/testdata/compiler/hello.rb", align 8
+  tail call void @sorbet_vm_init_string_table(i64* noundef getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleRubyStringTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([3 x %struct.rb_code_position_struct], [3 x %struct.rb_code_position_struct]* @sorbet_moduleRubyStringDescriptors, i32 0, i32 0), i32 noundef 3, i8* noundef getelementptr inbounds ([73 x i8], [73 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 5)
   %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([2 x i64], [2 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
-  %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/hello.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/hello.rb", align 8
-  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/hello.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %3 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([73 x i8], [73 x i8]* @sorbet_moduleStringTable, i64 0, i64 49), i64 noundef 11) #5
-  call void @rb_gc_register_mark_object(i64 %3) #5
-  store i64 %3, i64* @"rubyStrFrozen_hello world", align 8
+  %"rubyStr_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 0), align 8, !invariant.load !5
+  %"rubyStr_test/testdata/compiler/hello.rb.i.i" = load i64, i64* getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
+  %0 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/hello.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %0, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
   %rubyId_puts.i = load i64, i64* getelementptr inbounds ([2 x i64], [2 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !dbg !10, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !10
-  %4 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !15
-  %5 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %4, i64 0, i32 18
-  %6 = load i64, i64* %5, align 8, !tbaa !17
-  %7 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
-  %8 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %7, i64 0, i32 2
-  %9 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %8, align 8, !tbaa !27
+  %1 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !15
+  %2 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %1, i64 0, i32 18
+  %3 = load i64, i64* %2, align 8, !tbaa !17
+  %4 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
+  %5 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %4, i64 0, i32 2
+  %6 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %5, align 8, !tbaa !27
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %10, align 8, !tbaa !30
-  %11 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 4
-  %12 = load i64*, i64** %11, align 8, !tbaa !32
-  %13 = load i64, i64* %12, align 8, !tbaa !6
-  %14 = and i64 %13, -33
-  store i64 %14, i64* %12, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %7, %struct.rb_control_frame_struct* %9, %struct.rb_iseq_struct* %stackFrame.i) #5
-  %15 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 0
-  store i64* getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %15, align 8, !dbg !33, !tbaa !15
-  %"rubyStr_hello world.i" = load i64, i64* @"rubyStrFrozen_hello world", align 8, !dbg !34
-  %16 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 1, !dbg !10
-  %17 = load i64*, i64** %16, align 8, !dbg !10
-  store i64 %6, i64* %17, align 8, !dbg !10, !tbaa !6
-  %18 = getelementptr inbounds i64, i64* %17, i64 1, !dbg !10
-  store i64 %"rubyStr_hello world.i", i64* %18, align 8, !dbg !10, !tbaa !6
-  %19 = getelementptr inbounds i64, i64* %18, i64 1, !dbg !10
-  store i64* %19, i64** %16, align 8, !dbg !10
+  %7 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %6, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %7, align 8, !tbaa !30
+  %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %6, i64 0, i32 4
+  %9 = load i64*, i64** %8, align 8, !tbaa !32
+  %10 = load i64, i64* %9, align 8, !tbaa !6
+  %11 = and i64 %10, -33
+  store i64 %11, i64* %9, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %4, %struct.rb_control_frame_struct* %6, %struct.rb_iseq_struct* %stackFrame.i) #5
+  %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %6, i64 0, i32 0
+  store i64* getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %12, align 8, !dbg !33, !tbaa !15
+  %"rubyStr_hello world.i" = load i64, i64* getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 2), align 8, !dbg !34, !invariant.load !5
+  %13 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %6, i64 0, i32 1, !dbg !10
+  %14 = load i64*, i64** %13, align 8, !dbg !10
+  store i64 %3, i64* %14, align 8, !dbg !10, !tbaa !6
+  %15 = getelementptr inbounds i64, i64* %14, i64 1, !dbg !10
+  store i64 %"rubyStr_hello world.i", i64* %15, align 8, !dbg !10, !tbaa !6
+  %16 = getelementptr inbounds i64, i64* %15, i64 1, !dbg !10
+  store i64* %16, i64** %13, align 8, !dbg !10
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !10
   ret void
 }

--- a/test/testdata/compiler/intrinsics/bang.opt.ll.exp
+++ b/test/testdata/compiler/intrinsics/bang.opt.ll.exp
@@ -81,13 +81,10 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [23 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @ic_test = internal global %struct.FunctionInlineCache zeroinitializer
 @"stackFramePrecomputed_func_Bad#1!" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyStrFrozen_bad bang overload" = internal unnamed_addr global i64 0, align 8
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
 @"stackFramePrecomputed_func_Bad.13<static-init>" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @stackFramePrecomputed_func_Main.4test = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
@@ -97,7 +94,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @ic_puts.3 = internal global %struct.FunctionInlineCache zeroinitializer
 @"ic_!.4" = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.5 = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyStrFrozen_hello = internal unnamed_addr global i64 0, align 8
 @"ic_!.6" = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.7 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_new = internal global %struct.FunctionInlineCache zeroinitializer
@@ -108,6 +104,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @sorbet_moduleStringTable = internal unnamed_addr constant [166 x i8] c"<top (required)>\00test/testdata/compiler/intrinsics/bang.rb\00Bad\00Object\00Main\00test\00master\00!\00bad bang overload\00puts\00<class:Bad>\00normal\00hello\00new\00initialize\00<module:Main>\00", align 1
 @sorbet_moduleIDTable = internal unnamed_addr global [9 x i64] zeroinitializer, align 8
 @sorbet_moduleIDDescriptors = internal unnamed_addr constant [9 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 75, i32 4 }, %struct.rb_code_position_struct { i32 87, i32 1 }, %struct.rb_code_position_struct { i32 107, i32 4 }, %struct.rb_code_position_struct { i32 112, i32 11 }, %struct.rb_code_position_struct { i32 124, i32 6 }, %struct.rb_code_position_struct { i32 137, i32 3 }, %struct.rb_code_position_struct { i32 141, i32 10 }, %struct.rb_code_position_struct { i32 152, i32 13 }], align 8
+@sorbet_moduleRubyStringTable = internal unnamed_addr global [8 x i64] zeroinitializer, align 8
+@sorbet_moduleRubyStringDescriptors = internal unnamed_addr constant [8 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 17, i32 41 }, %struct.rb_code_position_struct { i32 87, i32 1 }, %struct.rb_code_position_struct { i32 89, i32 17 }, %struct.rb_code_position_struct { i32 112, i32 11 }, %struct.rb_code_position_struct { i32 75, i32 4 }, %struct.rb_code_position_struct { i32 131, i32 5 }, %struct.rb_code_position_struct { i32 152, i32 13 }], align 8
 @rb_cObject = external local_unnamed_addr constant i64
 @guard_epoch_Bad = linkonce local_unnamed_addr global i64 0
 @guarded_const_Bad = linkonce local_unnamed_addr global i64 0
@@ -139,17 +137,15 @@ declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_
 
 declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #1
 
+declare void @sorbet_vm_init_string_table(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #1
+
 declare i64 @sorbet_maybeAllocateObjectFastPath(i64, %struct.FunctionInlineCache*) local_unnamed_addr #1
 
 declare i64 @sorbet_vm_bang(%struct.FunctionInlineCache*, %struct.rb_control_frame_struct*, i64) local_unnamed_addr #1
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #1
-
 declare i64 @rb_define_module(i8*) local_unnamed_addr #1
 
 declare i64 @rb_define_class(i8*, i64) local_unnamed_addr #1
-
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #1
 
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #0
@@ -181,51 +177,34 @@ entry:
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
   tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([9 x i64], [9 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([9 x %struct.rb_code_position_struct], [9 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 9, i8* noundef getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
-  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #10
-  tail call void @rb_gc_register_mark_object(i64 %0) #10
-  store i64 %0, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %1 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 41) #10
-  tail call void @rb_gc_register_mark_object(i64 %1) #10
-  store i64 %1, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
+  tail call void @sorbet_vm_init_string_table(i64* noundef getelementptr inbounds ([8 x i64], [8 x i64]* @sorbet_moduleRubyStringTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([8 x %struct.rb_code_position_struct], [8 x %struct.rb_code_position_struct]* @sorbet_moduleRubyStringDescriptors, i32 0, i32 0), i32 noundef 8, i8* noundef getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 23)
   %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([9 x i64], [9 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
-  %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
-  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %"rubyStr_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([8 x i64], [8 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 0), align 8, !invariant.load !5
+  %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i.i" = load i64, i64* getelementptr inbounds ([8 x i64], [8 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
+  %0 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %0, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
   %rubyId_test.i = load i64, i64* getelementptr inbounds ([9 x i64], [9 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !dbg !10, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test, i64 %rubyId_test.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !10
-  %3 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 87), i64 noundef 1) #10
-  call void @rb_gc_register_mark_object(i64 %3) #10
   %"rubyId_!.i.i" = load i64, i64* getelementptr inbounds ([9 x i64], [9 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i29.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
-  %4 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %3, i64 %"rubyId_!.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i29.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i30.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %4, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad#1!", align 8
-  %5 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 89), i64 noundef 17) #10
-  call void @rb_gc_register_mark_object(i64 %5) #10
-  store i64 %5, i64* @"rubyStrFrozen_bad bang overload", align 8
+  %"rubyStr_!.i.i" = load i64, i64* getelementptr inbounds ([8 x i64], [8 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 2), align 8, !invariant.load !5
+  %1 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_!.i.i", i64 %"rubyId_!.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i30.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %1, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad#1!", align 8
   %rubyId_puts.i = load i64, i64* getelementptr inbounds ([9 x i64], [9 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !15, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
-  %6 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 112), i64 noundef 11) #10
-  call void @rb_gc_register_mark_object(i64 %6) #10
   %"rubyId_<class:Bad>.i.i" = load i64, i64* getelementptr inbounds ([9 x i64], [9 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i31.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
-  %7 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %6, i64 %"rubyId_<class:Bad>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i31.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i32.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %7, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad.13<static-init>", align 8
-  %8 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 75), i64 noundef 4) #10
-  call void @rb_gc_register_mark_object(i64 %8) #10
-  %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i33.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
-  %9 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %8, i64 %rubyId_test.i, i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i33.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 13, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i34.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %9, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Main.4test, align 8
+  %"rubyStr_<class:Bad>.i.i" = load i64, i64* getelementptr inbounds ([8 x i64], [8 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 4), align 8, !invariant.load !5
+  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<class:Bad>.i.i", i64 %"rubyId_<class:Bad>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i32.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad.13<static-init>", align 8
+  %rubyStr_test.i.i = load i64, i64* getelementptr inbounds ([8 x i64], [8 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 5), align 8, !invariant.load !5
+  %3 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_test.i.i, i64 %rubyId_test.i, i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 13, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i34.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %3, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Main.4test, align 8
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_!", i64 %"rubyId_!.i.i", i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !17
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_!.2", i64 %"rubyId_!.i.i", i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !20
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !21
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_!.4", i64 %"rubyId_!.i.i", i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !22
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.5, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !23
-  %10 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 131), i64 noundef 5) #10
-  call void @rb_gc_register_mark_object(i64 %10) #10
-  store i64 %10, i64* @rubyStrFrozen_hello, align 8
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_!.6", i64 %"rubyId_!.i.i", i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !24
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.7, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !25
   %rubyId_new.i = load i64, i64* getelementptr inbounds ([9 x i64], [9 x i64]* @sorbet_moduleIDTable, i64 0, i64 6), align 8, !dbg !26, !invariant.load !5
@@ -234,116 +213,114 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 %rubyId_initialize.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !26
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_!.8", i64 %"rubyId_!.i.i", i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !27
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.9, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !28
-  %11 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 152), i64 noundef 13) #10
-  call void @rb_gc_register_mark_object(i64 %11) #10
   %"rubyId_<module:Main>.i.i" = load i64, i64* getelementptr inbounds ([9 x i64], [9 x i64]* @sorbet_moduleIDTable, i64 0, i64 8), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i35.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/bang.rb", align 8
-  %12 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %11, i64 %"rubyId_<module:Main>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i35.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 12, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i36.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %12, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Main.13<static-init>", align 8
-  %13 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !29
-  %14 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %13, i64 0, i32 2
-  %15 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %14, align 8, !tbaa !31
+  %"rubyStr_<module:Main>.i.i" = load i64, i64* getelementptr inbounds ([8 x i64], [8 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 7), align 8, !invariant.load !5
+  %4 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<module:Main>.i.i", i64 %"rubyId_<module:Main>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/bang.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 12, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i36.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %4, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Main.13<static-init>", align 8
+  %5 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !29
+  %6 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %5, i64 0, i32 2
+  %7 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %6, align 8, !tbaa !31
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %16 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %16, align 8, !tbaa !35
-  %17 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 4
-  %18 = load i64*, i64** %17, align 8, !tbaa !37
-  %19 = load i64, i64* %18, align 8, !tbaa !6
-  %20 = and i64 %19, -33
-  store i64 %20, i64* %18, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %13, %struct.rb_control_frame_struct* %15, %struct.rb_iseq_struct* %stackFrame.i) #10
-  %21 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 0
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %21, align 8, !dbg !38, !tbaa !29
-  %22 = load i64, i64* @rb_cObject, align 8, !dbg !39
-  %23 = call i64 @rb_define_class(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 59), i64 %22) #10, !dbg !39
-  %24 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %23) #10, !dbg !39
+  %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %7, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %8, align 8, !tbaa !35
+  %9 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %7, i64 0, i32 4
+  %10 = load i64*, i64** %9, align 8, !tbaa !37
+  %11 = load i64, i64* %10, align 8, !tbaa !6
+  %12 = and i64 %11, -33
+  store i64 %12, i64* %10, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %5, %struct.rb_control_frame_struct* %7, %struct.rb_iseq_struct* %stackFrame.i) #10
+  %13 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %7, i64 0, i32 0
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %13, align 8, !dbg !38, !tbaa !29
+  %14 = load i64, i64* @rb_cObject, align 8, !dbg !39
+  %15 = call i64 @rb_define_class(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 59), i64 %14) #10, !dbg !39
+  %16 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %15) #10, !dbg !39
   %stackFrame.i1.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad.13<static-init>", align 8
-  %25 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !29
-  %26 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %25, i64 0, i32 2
-  %27 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %26, align 8, !tbaa !31
-  %28 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %27, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i1.i, %struct.rb_iseq_struct** %28, align 8, !tbaa !35
-  %29 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %27, i64 0, i32 4
-  %30 = load i64*, i64** %29, align 8, !tbaa !37
-  %31 = load i64, i64* %30, align 8, !tbaa !6
-  %32 = and i64 %31, -33
-  store i64 %32, i64* %30, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %25, %struct.rb_control_frame_struct* %27, %struct.rb_iseq_struct* %stackFrame.i1.i) #10
-  %33 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 0
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %33, align 8, !dbg !40, !tbaa !29
-  %34 = load i64, i64* @guard_epoch_Bad, align 8, !dbg !43
-  %35 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !43, !tbaa !44
-  %needTakeSlowPath = icmp ne i64 %34, %35, !dbg !43
-  br i1 %needTakeSlowPath, label %36, label %37, !dbg !43, !prof !46
+  %17 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !29
+  %18 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %17, i64 0, i32 2
+  %19 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %18, align 8, !tbaa !31
+  %20 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %19, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i1.i, %struct.rb_iseq_struct** %20, align 8, !tbaa !35
+  %21 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %19, i64 0, i32 4
+  %22 = load i64*, i64** %21, align 8, !tbaa !37
+  %23 = load i64, i64* %22, align 8, !tbaa !6
+  %24 = and i64 %23, -33
+  store i64 %24, i64* %22, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %17, %struct.rb_control_frame_struct* %19, %struct.rb_iseq_struct* %stackFrame.i1.i) #10
+  %25 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %16, i64 0, i32 0
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %25, align 8, !dbg !40, !tbaa !29
+  %26 = load i64, i64* @guard_epoch_Bad, align 8, !dbg !43
+  %27 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !43, !tbaa !44
+  %needTakeSlowPath = icmp ne i64 %26, %27, !dbg !43
+  br i1 %needTakeSlowPath, label %28, label %29, !dbg !43, !prof !46
 
-36:                                               ; preds = %entry
+28:                                               ; preds = %entry
   call void @const_recompute_Bad(), !dbg !43
-  br label %37, !dbg !43
+  br label %29, !dbg !43
 
-37:                                               ; preds = %entry, %36
-  %38 = load i64, i64* @guarded_const_Bad, align 8, !dbg !43
-  %39 = load i64, i64* @guard_epoch_Bad, align 8, !dbg !43
-  %40 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !43, !tbaa !44
-  %guardUpdated = icmp eq i64 %39, %40, !dbg !43
+29:                                               ; preds = %entry, %28
+  %30 = load i64, i64* @guarded_const_Bad, align 8, !dbg !43
+  %31 = load i64, i64* @guard_epoch_Bad, align 8, !dbg !43
+  %32 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !43, !tbaa !44
+  %guardUpdated = icmp eq i64 %31, %32, !dbg !43
   call void @llvm.assume(i1 %guardUpdated), !dbg !43
   %stackFrame7.i2.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Bad#1!", align 8, !dbg !43
-  %41 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #11, !dbg !43
-  %42 = bitcast i8* %41 to i16*, !dbg !43
-  %43 = load i16, i16* %42, align 8, !dbg !43
-  %44 = and i16 %43, -384, !dbg !43
-  store i16 %44, i16* %42, align 8, !dbg !43
-  %45 = getelementptr inbounds i8, i8* %41, i64 4, !dbg !43
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %45, i8 0, i64 28, i1 false) #10, !dbg !43
-  call void @sorbet_vm_define_method(i64 %38, i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 87), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Bad#1!", i8* nonnull %41, %struct.rb_iseq_struct* %stackFrame7.i2.i, i1 noundef zeroext false) #10, !dbg !43
+  %33 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #11, !dbg !43
+  %34 = bitcast i8* %33 to i16*, !dbg !43
+  %35 = load i16, i16* %34, align 8, !dbg !43
+  %36 = and i16 %35, -384, !dbg !43
+  store i16 %36, i16* %34, align 8, !dbg !43
+  %37 = getelementptr inbounds i8, i8* %33, i64 4, !dbg !43
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %37, i8 0, i64 28, i1 false) #10, !dbg !43
+  call void @sorbet_vm_define_method(i64 %30, i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 87), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Bad#1!", i8* nonnull %33, %struct.rb_iseq_struct* %stackFrame7.i2.i, i1 noundef zeroext false) #10, !dbg !43
   call void @sorbet_popFrame() #10, !dbg !39
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %21, align 8, !dbg !39, !tbaa !29
-  %46 = call i64 @rb_define_module(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 70)) #10, !dbg !47
-  %47 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %46) #10, !dbg !47
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %13, align 8, !dbg !39, !tbaa !29
+  %38 = call i64 @rb_define_module(i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 70)) #10, !dbg !47
+  %39 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %38) #10, !dbg !47
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Main.13<static-init>", align 8
-  %48 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !29
-  %49 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %48, i64 0, i32 2
-  %50 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %49, align 8, !tbaa !31
-  %51 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %50, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %51, align 8, !tbaa !35
-  %52 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %50, i64 0, i32 4
-  %53 = load i64*, i64** %52, align 8, !tbaa !37
-  %54 = load i64, i64* %53, align 8, !tbaa !6
-  %55 = and i64 %54, -33
-  store i64 %55, i64* %53, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %48, %struct.rb_control_frame_struct* %50, %struct.rb_iseq_struct* %stackFrame.i.i) #10
-  %56 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %47, i64 0, i32 0
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %56, align 8, !dbg !48, !tbaa !29
-  %57 = load i64, i64* @guard_epoch_Main, align 8, !dbg !51
-  %58 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !51, !tbaa !44
-  %needTakeSlowPath1 = icmp ne i64 %57, %58, !dbg !51
-  br i1 %needTakeSlowPath1, label %59, label %60, !dbg !51, !prof !46
+  %40 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !29
+  %41 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %40, i64 0, i32 2
+  %42 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %41, align 8, !tbaa !31
+  %43 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %42, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %43, align 8, !tbaa !35
+  %44 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %42, i64 0, i32 4
+  %45 = load i64*, i64** %44, align 8, !tbaa !37
+  %46 = load i64, i64* %45, align 8, !tbaa !6
+  %47 = and i64 %46, -33
+  store i64 %47, i64* %45, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %40, %struct.rb_control_frame_struct* %42, %struct.rb_iseq_struct* %stackFrame.i.i) #10
+  %48 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %39, i64 0, i32 0
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %48, align 8, !dbg !48, !tbaa !29
+  %49 = load i64, i64* @guard_epoch_Main, align 8, !dbg !51
+  %50 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !51, !tbaa !44
+  %needTakeSlowPath1 = icmp ne i64 %49, %50, !dbg !51
+  br i1 %needTakeSlowPath1, label %51, label %52, !dbg !51, !prof !46
 
-59:                                               ; preds = %37
+51:                                               ; preds = %29
   call void @const_recompute_Main(), !dbg !51
-  br label %60, !dbg !51
+  br label %52, !dbg !51
 
-60:                                               ; preds = %37, %59
-  %61 = load i64, i64* @guarded_const_Main, align 8, !dbg !51
-  %62 = load i64, i64* @guard_epoch_Main, align 8, !dbg !51
-  %63 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !51, !tbaa !44
-  %guardUpdated2 = icmp eq i64 %62, %63, !dbg !51
+52:                                               ; preds = %29, %51
+  %53 = load i64, i64* @guarded_const_Main, align 8, !dbg !51
+  %54 = load i64, i64* @guard_epoch_Main, align 8, !dbg !51
+  %55 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !51, !tbaa !44
+  %guardUpdated2 = icmp eq i64 %54, %55, !dbg !51
   call void @llvm.assume(i1 %guardUpdated2), !dbg !51
   %stackFrame7.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Main.4test, align 8, !dbg !51
-  %64 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #11, !dbg !51
-  %65 = bitcast i8* %64 to i16*, !dbg !51
-  %66 = load i16, i16* %65, align 8, !dbg !51
-  %67 = and i16 %66, -384, !dbg !51
-  store i16 %67, i16* %65, align 8, !dbg !51
-  %68 = getelementptr inbounds i8, i8* %64, i64 4, !dbg !51
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %68, i8 0, i64 28, i1 false) #10, !dbg !51
-  call void @sorbet_vm_define_method(i64 %61, i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 75), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_Main.4test, i8* nonnull %64, %struct.rb_iseq_struct* %stackFrame7.i.i, i1 noundef zeroext true) #10, !dbg !51
+  %56 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #11, !dbg !51
+  %57 = bitcast i8* %56 to i16*, !dbg !51
+  %58 = load i16, i16* %57, align 8, !dbg !51
+  %59 = and i16 %58, -384, !dbg !51
+  store i16 %59, i16* %57, align 8, !dbg !51
+  %60 = getelementptr inbounds i8, i8* %56, i64 4, !dbg !51
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %60, i8 0, i64 28, i1 false) #10, !dbg !51
+  call void @sorbet_vm_define_method(i64 %53, i8* getelementptr inbounds ([166 x i8], [166 x i8]* @sorbet_moduleStringTable, i64 0, i64 75), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_Main.4test, i8* nonnull %56, %struct.rb_iseq_struct* %stackFrame7.i.i, i1 noundef zeroext true) #10, !dbg !51
   call void @sorbet_popFrame() #10, !dbg !47
-  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %21, align 8, !dbg !47, !tbaa !29
-  %69 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %15, i64 0, i32 1, !dbg !10
-  %70 = load i64*, i64** %69, align 8, !dbg !10
-  store i64 %61, i64* %70, align 8, !dbg !10, !tbaa !6
-  %71 = getelementptr inbounds i64, i64* %70, i64 1, !dbg !10
-  store i64* %71, i64** %69, align 8, !dbg !10
+  store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %13, align 8, !dbg !47, !tbaa !29
+  %61 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %7, i64 0, i32 1, !dbg !10
+  %62 = load i64*, i64** %61, align 8, !dbg !10
+  store i64 %53, i64* %62, align 8, !dbg !10, !tbaa !6
+  %63 = getelementptr inbounds i64, i64* %62, i64 1, !dbg !10
+  store i64* %63, i64** %61, align 8, !dbg !10
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test, i64 0), !dbg !10
   ret void
 }
@@ -362,7 +339,7 @@ argCountFailBlock:                                ; preds = %functionEntryInitia
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
   store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %0, align 8, !dbg !54, !tbaa !29
-  %"rubyStr_bad bang overload" = load i64, i64* @"rubyStrFrozen_bad bang overload", align 8, !dbg !55
+  %"rubyStr_bad bang overload" = load i64, i64* getelementptr inbounds ([8 x i64], [8 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 3), align 8, !dbg !55, !invariant.load !5
   %1 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !15
   %2 = load i64*, i64** %1, align 8, !dbg !15
   store i64 %selfRaw, i64* %2, align 8, !dbg !15, !tbaa !6
@@ -419,7 +396,7 @@ fillRequiredArgs:                                 ; preds = %functionEntryInitia
   store i64* %15, i64** %12, align 8, !dbg !23
   %send100 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.5, i64 0), !dbg !23
   store i64* getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %0, align 8, !dbg !23, !tbaa !29
-  %rubyStr_hello = load i64, i64* @rubyStrFrozen_hello, align 8, !dbg !58
+  %rubyStr_hello = load i64, i64* getelementptr inbounds ([8 x i64], [8 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 6), align 8, !dbg !58, !invariant.load !5
   %16 = tail call i64 @sorbet_vm_bang(%struct.FunctionInlineCache* noundef @"ic_!.6", %struct.rb_control_frame_struct* nonnull %cfp, i64 %rubyStr_hello), !dbg !24
   %17 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !25
   %18 = load i64*, i64** %17, align 8, !dbg !25

--- a/test/testdata/compiler/intrinsics/t_must.opt.ll.exp
+++ b/test/testdata/compiler/intrinsics/t_must.opt.ll.exp
@@ -84,8 +84,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [28 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @ic_test_known_nil = internal global %struct.FunctionInlineCache zeroinitializer
@@ -101,7 +99,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @stackFramePrecomputed_func_Test.16test_nilable_arg = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"stackFramePrecomputed_func_Test.16test_nilable_arg$block_2" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
 @"stackFramePrecomputed_func_Test.16test_nilable_arg$block_3" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyStrFrozen_ wasn't nil" = internal unnamed_addr global i64 0, align 8
 @ic_puts.3 = internal global %struct.FunctionInlineCache zeroinitializer
 @"ic_is_a?.4" = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.5 = internal global %struct.FunctionInlineCache zeroinitializer
@@ -109,6 +106,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @sorbet_moduleStringTable = internal unnamed_addr constant [358 x i8] c"<top (required)>\00test/testdata/compiler/intrinsics/t_must.rb\00Test\00test_known_nil\00test_nilable_arg\00master\00<exceptionValue>\00<magic>\00<returnMethodTemp>\00<gotoDeadTemp>\00rescue in test_known_nil\00ensure in test_known_nil\00T\00must\00StandardError\00is_a?\00puts\00arg\00rescue in test_nilable_arg\00ensure in test_nilable_arg\00 wasn't nil\00<string-interpolate>\00<module:Test>\00normal\00", align 1
 @sorbet_moduleIDTable = internal unnamed_addr global [18 x i64] zeroinitializer, align 8
 @sorbet_moduleIDDescriptors = internal unnamed_addr constant [18 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 66, i32 14 }, %struct.rb_code_position_struct { i32 81, i32 16 }, %struct.rb_code_position_struct { i32 105, i32 16 }, %struct.rb_code_position_struct { i32 122, i32 7 }, %struct.rb_code_position_struct { i32 130, i32 18 }, %struct.rb_code_position_struct { i32 149, i32 14 }, %struct.rb_code_position_struct { i32 164, i32 24 }, %struct.rb_code_position_struct { i32 189, i32 24 }, %struct.rb_code_position_struct { i32 216, i32 4 }, %struct.rb_code_position_struct { i32 235, i32 5 }, %struct.rb_code_position_struct { i32 241, i32 4 }, %struct.rb_code_position_struct { i32 246, i32 3 }, %struct.rb_code_position_struct { i32 250, i32 26 }, %struct.rb_code_position_struct { i32 277, i32 26 }, %struct.rb_code_position_struct { i32 316, i32 20 }, %struct.rb_code_position_struct { i32 337, i32 13 }, %struct.rb_code_position_struct { i32 351, i32 6 }], align 8
+@sorbet_moduleRubyStringTable = internal unnamed_addr global [10 x i64] zeroinitializer, align 8
+@sorbet_moduleRubyStringDescriptors = internal unnamed_addr constant [10 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 17, i32 43 }, %struct.rb_code_position_struct { i32 66, i32 14 }, %struct.rb_code_position_struct { i32 164, i32 24 }, %struct.rb_code_position_struct { i32 189, i32 24 }, %struct.rb_code_position_struct { i32 81, i32 16 }, %struct.rb_code_position_struct { i32 250, i32 26 }, %struct.rb_code_position_struct { i32 277, i32 26 }, %struct.rb_code_position_struct { i32 304, i32 11 }, %struct.rb_code_position_struct { i32 337, i32 13 }], align 8
 @guard_epoch_Test = linkonce local_unnamed_addr global i64 0
 @guarded_const_Test = linkonce local_unnamed_addr global i64 0
 @rb_eStandardError = external local_unnamed_addr constant i64
@@ -144,9 +143,9 @@ declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_
 
 declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #1
 
-declare i64 @sorbet_vm_isa_p(%struct.FunctionInlineCache*, %struct.rb_control_frame_struct*, i64, i64) local_unnamed_addr #1
+declare void @sorbet_vm_init_string_table(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #1
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #1
+declare i64 @sorbet_vm_isa_p(%struct.FunctionInlineCache*, %struct.rb_control_frame_struct*, i64, i64) local_unnamed_addr #1
 
 declare i64 @sorbet_run_exception_handling(%struct.rb_execution_context_struct*, i64 (i64**, i64, %struct.rb_control_frame_struct*)*, i64**, i64, %struct.rb_control_frame_struct*, i64 (i64**, i64, %struct.rb_control_frame_struct*)*, i64 (i64**, i64, %struct.rb_control_frame_struct*)*, i64 (i64**, i64, %struct.rb_control_frame_struct*)*, i64, i64, i64) local_unnamed_addr #1
 
@@ -157,8 +156,6 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #2
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #2
-
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #1
 
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #0
@@ -201,222 +198,198 @@ entry:
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
   tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([18 x i64], [18 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([18 x %struct.rb_code_position_struct], [18 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 18, i8* noundef getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
-  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #14
-  tail call void @rb_gc_register_mark_object(i64 %0) #14
-  store i64 %0, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %1 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 43) #14
-  tail call void @rb_gc_register_mark_object(i64 %1) #14
-  store i64 %1, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
+  tail call void @sorbet_vm_init_string_table(i64* noundef getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleRubyStringTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([10 x %struct.rb_code_position_struct], [10 x %struct.rb_code_position_struct]* @sorbet_moduleRubyStringDescriptors, i32 0, i32 0), i32 noundef 10, i8* noundef getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 28)
   %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([18 x i64], [18 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
-  %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
-  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %"rubyStr_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 0), align 8, !invariant.load !5
+  %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i.i" = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
+  %0 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %0, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
   %rubyId_test_known_nil.i = load i64, i64* getelementptr inbounds ([18 x i64], [18 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !dbg !17, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test_known_nil, i64 %rubyId_test_known_nil.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !17
   %rubyId_test_nilable_arg.i = load i64, i64* getelementptr inbounds ([18 x i64], [18 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !18, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test_nilable_arg, i64 %rubyId_test_nilable_arg.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !18
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test_nilable_arg.1, i64 %rubyId_test_nilable_arg.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test_nilable_arg.2, i64 %rubyId_test_nilable_arg.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !20
-  %3 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 66), i64 noundef 14) #14
-  call void @rb_gc_register_mark_object(i64 %3) #14
-  %4 = bitcast i64* %locals.i17.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 32, i8* nonnull %4)
-  %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i16.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
+  %1 = bitcast i64* %locals.i17.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 32, i8* nonnull %1)
+  %rubyStr_test_known_nil.i.i = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 2), align 8, !invariant.load !5
   %"rubyId_<exceptionValue>.i.i" = load i64, i64* getelementptr inbounds ([18 x i64], [18 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !invariant.load !5
   store i64 %"rubyId_<exceptionValue>.i.i", i64* %locals.i17.i, align 8
   %"rubyId_<magic>.i.i" = load i64, i64* getelementptr inbounds ([18 x i64], [18 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !invariant.load !5
-  %5 = getelementptr i64, i64* %locals.i17.i, i32 1
-  store i64 %"rubyId_<magic>.i.i", i64* %5, align 8
+  %2 = getelementptr i64, i64* %locals.i17.i, i32 1
+  store i64 %"rubyId_<magic>.i.i", i64* %2, align 8
   %"rubyId_<returnMethodTemp>.i.i" = load i64, i64* getelementptr inbounds ([18 x i64], [18 x i64]* @sorbet_moduleIDTable, i64 0, i64 5), align 8, !invariant.load !5
-  %6 = getelementptr i64, i64* %locals.i17.i, i32 2
-  store i64 %"rubyId_<returnMethodTemp>.i.i", i64* %6, align 8
+  %3 = getelementptr i64, i64* %locals.i17.i, i32 2
+  store i64 %"rubyId_<returnMethodTemp>.i.i", i64* %3, align 8
   %"rubyId_<gotoDeadTemp>.i.i" = load i64, i64* getelementptr inbounds ([18 x i64], [18 x i64]* @sorbet_moduleIDTable, i64 0, i64 6), align 8, !invariant.load !5
-  %7 = getelementptr i64, i64* %locals.i17.i, i32 3
-  store i64 %"rubyId_<gotoDeadTemp>.i.i", i64* %7, align 8
-  %8 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %3, i64 %rubyId_test_known_nil.i, i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i16.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i17.i, i32 noundef 4, i32 noundef 2)
-  store %struct.rb_iseq_struct* %8, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.14test_known_nil, align 8
-  call void @llvm.lifetime.end.p0i8(i64 32, i8* nonnull %4)
-  %9 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 164), i64 noundef 24) #14
-  call void @rb_gc_register_mark_object(i64 %9) #14
-  %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.14test_known_nil, align 8
+  %4 = getelementptr i64, i64* %locals.i17.i, i32 3
+  store i64 %"rubyId_<gotoDeadTemp>.i.i", i64* %4, align 8
+  %5 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_test_known_nil.i.i, i64 %rubyId_test_known_nil.i, i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i17.i, i32 noundef 4, i32 noundef 2)
+  store %struct.rb_iseq_struct* %5, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.14test_known_nil, align 8
+  call void @llvm.lifetime.end.p0i8(i64 32, i8* nonnull %1)
   %"rubyId_rescue in test_known_nil.i.i" = load i64, i64* getelementptr inbounds ([18 x i64], [18 x i64]* @sorbet_moduleIDTable, i64 0, i64 7), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i18.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
-  %10 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %9, i64 %"rubyId_rescue in test_known_nil.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i18.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 4, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %10, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.14test_known_nil$block_2", align 8
-  %11 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 189), i64 noundef 24) #14
-  call void @rb_gc_register_mark_object(i64 %11) #14
+  %"rubyStr_rescue in test_known_nil.i.i" = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 3), align 8, !invariant.load !5
+  %6 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_rescue in test_known_nil.i.i", i64 %"rubyId_rescue in test_known_nil.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* %5, i32 noundef 4, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %6, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.14test_known_nil$block_2", align 8
   %stackFrame.i19.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.14test_known_nil, align 8
   %"rubyId_ensure in test_known_nil.i.i" = load i64, i64* getelementptr inbounds ([18 x i64], [18 x i64]* @sorbet_moduleIDTable, i64 0, i64 8), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i20.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
-  %12 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %11, i64 %"rubyId_ensure in test_known_nil.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i20.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i19.i, i32 noundef 5, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %12, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.14test_known_nil$block_3", align 8
-  %13 = call i64 @sorbet_getConstant(i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @sorbet_getTRetry.retry, i64 0, i64 0), i64 noundef 25) #14
-  store i64 %13, i64* @"<retry-singleton>", align 8
+  %"rubyStr_ensure in test_known_nil.i.i" = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 4), align 8, !invariant.load !5
+  %7 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_ensure in test_known_nil.i.i", i64 %"rubyId_ensure in test_known_nil.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i19.i, i32 noundef 5, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %7, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.14test_known_nil$block_3", align 8
+  %8 = call i64 @sorbet_getConstant(i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @sorbet_getTRetry.retry, i64 0, i64 0), i64 noundef 25) #14
+  store i64 %8, i64* @"<retry-singleton>", align 8
   %"rubyId_is_a?.i" = load i64, i64* getelementptr inbounds ([18 x i64], [18 x i64]* @sorbet_moduleIDTable, i64 0, i64 10), align 8, !dbg !21, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_is_a?", i64 %"rubyId_is_a?.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !21
   %rubyId_puts.i = load i64, i64* getelementptr inbounds ([18 x i64], [18 x i64]* @sorbet_moduleIDTable, i64 0, i64 11), align 8, !dbg !24, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !24
-  %14 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 81), i64 noundef 16) #14
-  call void @rb_gc_register_mark_object(i64 %14) #14
-  %15 = bitcast i64* %locals.i22.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 40, i8* nonnull %15)
-  %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i21.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
+  %9 = bitcast i64* %locals.i22.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 40, i8* nonnull %9)
+  %rubyStr_test_nilable_arg.i.i = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 5), align 8, !invariant.load !5
   store i64 %"rubyId_<exceptionValue>.i.i", i64* %locals.i22.i, align 8
   %rubyId_arg.i.i = load i64, i64* getelementptr inbounds ([18 x i64], [18 x i64]* @sorbet_moduleIDTable, i64 0, i64 12), align 8, !invariant.load !5
-  %16 = getelementptr i64, i64* %locals.i22.i, i32 1
-  store i64 %rubyId_arg.i.i, i64* %16, align 8
-  %17 = getelementptr i64, i64* %locals.i22.i, i32 2
-  store i64 %"rubyId_<magic>.i.i", i64* %17, align 8
-  %18 = getelementptr i64, i64* %locals.i22.i, i32 3
-  store i64 %"rubyId_<returnMethodTemp>.i.i", i64* %18, align 8
-  %19 = getelementptr i64, i64* %locals.i22.i, i32 4
-  store i64 %"rubyId_<gotoDeadTemp>.i.i", i64* %19, align 8
-  %20 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %14, i64 %rubyId_test_nilable_arg.i, i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i21.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 14, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i22.i, i32 noundef 5, i32 noundef 3)
-  store %struct.rb_iseq_struct* %20, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.16test_nilable_arg, align 8
-  call void @llvm.lifetime.end.p0i8(i64 40, i8* nonnull %15)
-  %21 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 250), i64 noundef 26) #14
-  call void @rb_gc_register_mark_object(i64 %21) #14
-  %stackFrame.i27.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.16test_nilable_arg, align 8
+  %10 = getelementptr i64, i64* %locals.i22.i, i32 1
+  store i64 %rubyId_arg.i.i, i64* %10, align 8
+  %11 = getelementptr i64, i64* %locals.i22.i, i32 2
+  store i64 %"rubyId_<magic>.i.i", i64* %11, align 8
+  %12 = getelementptr i64, i64* %locals.i22.i, i32 3
+  store i64 %"rubyId_<returnMethodTemp>.i.i", i64* %12, align 8
+  %13 = getelementptr i64, i64* %locals.i22.i, i32 4
+  store i64 %"rubyId_<gotoDeadTemp>.i.i", i64* %13, align 8
+  %14 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_test_nilable_arg.i.i, i64 %rubyId_test_nilable_arg.i, i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 14, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i22.i, i32 noundef 5, i32 noundef 3)
+  store %struct.rb_iseq_struct* %14, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.16test_nilable_arg, align 8
+  call void @llvm.lifetime.end.p0i8(i64 40, i8* nonnull %9)
   %"rubyId_rescue in test_nilable_arg.i.i" = load i64, i64* getelementptr inbounds ([18 x i64], [18 x i64]* @sorbet_moduleIDTable, i64 0, i64 13), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i28.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
-  %22 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %21, i64 %"rubyId_rescue in test_nilable_arg.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i28.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i27.i, i32 noundef 4, i32 noundef 14, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
-  store %struct.rb_iseq_struct* %22, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.16test_nilable_arg$block_2", align 8
-  %23 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 277), i64 noundef 26) #14
-  call void @rb_gc_register_mark_object(i64 %23) #14
+  %"rubyStr_rescue in test_nilable_arg.i.i" = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 6), align 8, !invariant.load !5
+  %15 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_rescue in test_nilable_arg.i.i", i64 %"rubyId_rescue in test_nilable_arg.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* %14, i32 noundef 4, i32 noundef 14, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
+  store %struct.rb_iseq_struct* %15, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.16test_nilable_arg$block_2", align 8
   %stackFrame.i29.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.16test_nilable_arg, align 8
   %"rubyId_ensure in test_nilable_arg.i.i" = load i64, i64* getelementptr inbounds ([18 x i64], [18 x i64]* @sorbet_moduleIDTable, i64 0, i64 14), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i30.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
-  %24 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %23, i64 %"rubyId_ensure in test_nilable_arg.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i30.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i29.i, i32 noundef 5, i32 noundef 14, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
-  store %struct.rb_iseq_struct* %24, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.16test_nilable_arg$block_3", align 8
-  %25 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 304), i64 noundef 11) #14
-  call void @rb_gc_register_mark_object(i64 %25) #14
-  store i64 %25, i64* @"rubyStrFrozen_ wasn't nil", align 8
+  %"rubyStr_ensure in test_nilable_arg.i.i" = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 7), align 8, !invariant.load !5
+  %16 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_ensure in test_nilable_arg.i.i", i64 %"rubyId_ensure in test_nilable_arg.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i29.i, i32 noundef 5, i32 noundef 14, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
+  store %struct.rb_iseq_struct* %16, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.16test_nilable_arg$block_3", align 8
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !25
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_is_a?.4", i64 %"rubyId_is_a?.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !28
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.5, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !30
-  %26 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 337), i64 noundef 13) #14
-  call void @rb_gc_register_mark_object(i64 %26) #14
   %"rubyId_<module:Test>.i.i" = load i64, i64* getelementptr inbounds ([18 x i64], [18 x i64]* @sorbet_moduleIDTable, i64 0, i64 16), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i31.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/intrinsics/t_must.rb", align 8
-  %27 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %26, i64 %"rubyId_<module:Test>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i31.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i32.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %27, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.13<static-init>", align 8
-  %28 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !31
-  %29 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %28, i64 0, i32 2
-  %30 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %29, align 8, !tbaa !33
+  %"rubyStr_<module:Test>.i.i" = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 9), align 8, !invariant.load !5
+  %17 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<module:Test>.i.i", i64 %"rubyId_<module:Test>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i32.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %17, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.13<static-init>", align 8
+  %18 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !31
+  %19 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %18, i64 0, i32 2
+  %20 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %19, align 8, !tbaa !33
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %31 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %30, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %31, align 8, !tbaa !37
-  %32 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %30, i64 0, i32 4
-  %33 = load i64*, i64** %32, align 8, !tbaa !39
-  %34 = load i64, i64* %33, align 8, !tbaa !6
-  %35 = and i64 %34, -33
-  store i64 %35, i64* %33, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %28, %struct.rb_control_frame_struct* %30, %struct.rb_iseq_struct* %stackFrame.i) #14
-  %36 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %30, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %36, align 8, !dbg !40, !tbaa !31
-  %37 = call i64 @rb_define_module(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 61)) #14, !dbg !41
-  %38 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %37) #14, !dbg !41
-  %39 = bitcast i64* %positional_table.i.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %39) #14
-  %stackFrame.i.i1 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.13<static-init>", align 8
-  %40 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !31
-  %41 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %40, i64 0, i32 2
-  %42 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %41, align 8, !tbaa !33
-  %43 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %42, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i.i1, %struct.rb_iseq_struct** %43, align 8, !tbaa !37
-  %44 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %42, i64 0, i32 4
-  %45 = load i64*, i64** %44, align 8, !tbaa !39
-  %46 = load i64, i64* %45, align 8, !tbaa !6
-  %47 = and i64 %46, -33
-  store i64 %47, i64* %45, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %40, %struct.rb_control_frame_struct* %42, %struct.rb_iseq_struct* %stackFrame.i.i1) #14
-  %48 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 0
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %48, align 8, !dbg !42, !tbaa !31
-  %49 = load i64, i64* @guard_epoch_Test, align 8, !dbg !43
-  %50 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !43, !tbaa !44
-  %needTakeSlowPath = icmp ne i64 %49, %50, !dbg !43
-  br i1 %needTakeSlowPath, label %51, label %52, !dbg !43, !prof !46
+  %21 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %20, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %21, align 8, !tbaa !37
+  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %20, i64 0, i32 4
+  %23 = load i64*, i64** %22, align 8, !tbaa !39
+  %24 = load i64, i64* %23, align 8, !tbaa !6
+  %25 = and i64 %24, -33
+  store i64 %25, i64* %23, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %18, %struct.rb_control_frame_struct* %20, %struct.rb_iseq_struct* %stackFrame.i) #14
+  %26 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %20, i64 0, i32 0
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %26, align 8, !dbg !40, !tbaa !31
+  %27 = call i64 @rb_define_module(i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 61)) #14, !dbg !41
+  %28 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %27) #14, !dbg !41
+  %29 = bitcast i64* %positional_table.i.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %29) #14
+  %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.13<static-init>", align 8
+  %30 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !31
+  %31 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %30, i64 0, i32 2
+  %32 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %31, align 8, !tbaa !33
+  %33 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %33, align 8, !tbaa !37
+  %34 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %32, i64 0, i32 4
+  %35 = load i64*, i64** %34, align 8, !tbaa !39
+  %36 = load i64, i64* %35, align 8, !tbaa !6
+  %37 = and i64 %36, -33
+  store i64 %37, i64* %35, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %30, %struct.rb_control_frame_struct* %32, %struct.rb_iseq_struct* %stackFrame.i.i) #14
+  %38 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %28, i64 0, i32 0
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %38, align 8, !dbg !42, !tbaa !31
+  %39 = load i64, i64* @guard_epoch_Test, align 8, !dbg !43
+  %40 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !43, !tbaa !44
+  %needTakeSlowPath = icmp ne i64 %39, %40, !dbg !43
+  br i1 %needTakeSlowPath, label %41, label %42, !dbg !43, !prof !46
 
-51:                                               ; preds = %entry
+41:                                               ; preds = %entry
   call void @const_recompute_Test(), !dbg !43
-  br label %52, !dbg !43
+  br label %42, !dbg !43
 
-52:                                               ; preds = %entry, %51
-  %53 = load i64, i64* @guarded_const_Test, align 8, !dbg !43
-  %54 = load i64, i64* @guard_epoch_Test, align 8, !dbg !43
-  %55 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !43, !tbaa !44
-  %guardUpdated = icmp eq i64 %54, %55, !dbg !43
+42:                                               ; preds = %entry, %41
+  %43 = load i64, i64* @guarded_const_Test, align 8, !dbg !43
+  %44 = load i64, i64* @guard_epoch_Test, align 8, !dbg !43
+  %45 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !43, !tbaa !44
+  %guardUpdated = icmp eq i64 %44, %45, !dbg !43
   call void @llvm.assume(i1 %guardUpdated), !dbg !43
   %stackFrame17.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.14test_known_nil, align 8, !dbg !43
-  %56 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #15, !dbg !43
-  %57 = bitcast i8* %56 to i16*, !dbg !43
-  %58 = load i16, i16* %57, align 8, !dbg !43
-  %59 = and i16 %58, -384, !dbg !43
-  store i16 %59, i16* %57, align 8, !dbg !43
-  %60 = getelementptr inbounds i8, i8* %56, i64 4, !dbg !43
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %60, i8 0, i64 28, i1 false) #14, !dbg !43
-  call void @sorbet_vm_define_method(i64 %53, i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 66), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_Test.14test_known_nil, i8* nonnull %56, %struct.rb_iseq_struct* %stackFrame17.i.i, i1 noundef zeroext true) #14, !dbg !43
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %48, align 8, !dbg !43, !tbaa !31
+  %46 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #15, !dbg !43
+  %47 = bitcast i8* %46 to i16*, !dbg !43
+  %48 = load i16, i16* %47, align 8, !dbg !43
+  %49 = and i16 %48, -384, !dbg !43
+  store i16 %49, i16* %47, align 8, !dbg !43
+  %50 = getelementptr inbounds i8, i8* %46, i64 4, !dbg !43
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %50, i8 0, i64 28, i1 false) #14, !dbg !43
+  call void @sorbet_vm_define_method(i64 %43, i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 66), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_Test.14test_known_nil, i8* nonnull %46, %struct.rb_iseq_struct* %stackFrame17.i.i, i1 noundef zeroext true) #14, !dbg !43
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %38, align 8, !dbg !43, !tbaa !31
   %stackFrame26.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @stackFramePrecomputed_func_Test.16test_nilable_arg, align 8, !dbg !10
-  %61 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #15, !dbg !10
-  %62 = bitcast i8* %61 to i16*, !dbg !10
-  %63 = load i16, i16* %62, align 8, !dbg !10
-  %64 = and i16 %63, -384, !dbg !10
-  %65 = or i16 %64, 1, !dbg !10
-  store i16 %65, i16* %62, align 8, !dbg !10
-  %66 = getelementptr inbounds i8, i8* %61, i64 8, !dbg !10
-  %67 = bitcast i8* %66 to i32*, !dbg !10
-  store i32 1, i32* %67, align 8, !dbg !10, !tbaa !47
-  %68 = getelementptr inbounds i8, i8* %61, i64 12, !dbg !10
-  %69 = getelementptr inbounds i8, i8* %61, i64 4, !dbg !10
-  %70 = bitcast i8* %69 to i32*, !dbg !10
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %68, i8 0, i64 20, i1 false) #14, !dbg !10
-  store i32 1, i32* %70, align 4, !dbg !10, !tbaa !50
+  %51 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #15, !dbg !10
+  %52 = bitcast i8* %51 to i16*, !dbg !10
+  %53 = load i16, i16* %52, align 8, !dbg !10
+  %54 = and i16 %53, -384, !dbg !10
+  %55 = or i16 %54, 1, !dbg !10
+  store i16 %55, i16* %52, align 8, !dbg !10
+  %56 = getelementptr inbounds i8, i8* %51, i64 8, !dbg !10
+  %57 = bitcast i8* %56 to i32*, !dbg !10
+  store i32 1, i32* %57, align 8, !dbg !10, !tbaa !47
+  %58 = getelementptr inbounds i8, i8* %51, i64 12, !dbg !10
+  %59 = getelementptr inbounds i8, i8* %51, i64 4, !dbg !10
+  %60 = bitcast i8* %59 to i32*, !dbg !10
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %58, i8 0, i64 20, i1 false) #14, !dbg !10
+  store i32 1, i32* %60, align 4, !dbg !10, !tbaa !50
   store i64 %rubyId_arg.i.i, i64* %positional_table.i.i, align 8, !dbg !10
-  %71 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #15, !dbg !10
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %71, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %39, i64 noundef 8, i1 noundef false) #14, !dbg !10
-  %72 = getelementptr inbounds i8, i8* %61, i64 32, !dbg !10
-  %73 = bitcast i8* %72 to i8**, !dbg !10
-  store i8* %71, i8** %73, align 8, !dbg !10, !tbaa !51
-  call void @sorbet_vm_define_method(i64 %53, i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 81), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_Test.16test_nilable_arg, i8* nonnull %61, %struct.rb_iseq_struct* %stackFrame26.i.i, i1 noundef zeroext true) #14, !dbg !10
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %39) #14
+  %61 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #15, !dbg !10
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %61, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %29, i64 noundef 8, i1 noundef false) #14, !dbg !10
+  %62 = getelementptr inbounds i8, i8* %51, i64 32, !dbg !10
+  %63 = bitcast i8* %62 to i8**, !dbg !10
+  store i8* %61, i8** %63, align 8, !dbg !10, !tbaa !51
+  call void @sorbet_vm_define_method(i64 %43, i8* getelementptr inbounds ([358 x i8], [358 x i8]* @sorbet_moduleStringTable, i64 0, i64 81), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @func_Test.16test_nilable_arg, i8* nonnull %51, %struct.rb_iseq_struct* %stackFrame26.i.i, i1 noundef zeroext true) #14, !dbg !10
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %29) #14
   call void @sorbet_popFrame() #14, !dbg !41
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %36, align 8, !dbg !41, !tbaa !31
-  %74 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %30, i64 0, i32 1, !dbg !17
-  %75 = load i64*, i64** %74, align 8, !dbg !17
-  store i64 %53, i64* %75, align 8, !dbg !17, !tbaa !6
-  %76 = getelementptr inbounds i64, i64* %75, i64 1, !dbg !17
-  store i64* %76, i64** %74, align 8, !dbg !17
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %26, align 8, !dbg !41, !tbaa !31
+  %64 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %20, i64 0, i32 1, !dbg !17
+  %65 = load i64*, i64** %64, align 8, !dbg !17
+  store i64 %43, i64* %65, align 8, !dbg !17, !tbaa !6
+  %66 = getelementptr inbounds i64, i64* %65, i64 1, !dbg !17
+  store i64* %66, i64** %64, align 8, !dbg !17
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test_known_nil, i64 0), !dbg !17
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %36, align 8, !dbg !17, !tbaa !31
-  %77 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %30, i64 0, i32 1, !dbg !18
-  %78 = load i64*, i64** %77, align 8, !dbg !18
-  store i64 %53, i64* %78, align 8, !dbg !18, !tbaa !6
-  %79 = getelementptr inbounds i64, i64* %78, i64 1, !dbg !18
-  store i64 21, i64* %79, align 8, !dbg !18, !tbaa !6
-  %80 = getelementptr inbounds i64, i64* %79, i64 1, !dbg !18
-  store i64* %80, i64** %77, align 8, !dbg !18
-  %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test_nilable_arg, i64 0), !dbg !18
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %36, align 8, !dbg !18, !tbaa !31
-  %81 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %30, i64 0, i32 1, !dbg !19
-  %82 = load i64*, i64** %81, align 8, !dbg !19
-  store i64 %53, i64* %82, align 8, !dbg !19, !tbaa !6
-  %83 = getelementptr inbounds i64, i64* %82, i64 1, !dbg !19
-  store i64 0, i64* %83, align 8, !dbg !19, !tbaa !6
-  %84 = getelementptr inbounds i64, i64* %83, i64 1, !dbg !19
-  store i64* %84, i64** %81, align 8, !dbg !19
-  %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test_nilable_arg.1, i64 0), !dbg !19
-  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %36, align 8, !dbg !19, !tbaa !31
-  %85 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %30, i64 0, i32 1, !dbg !20
-  %86 = load i64*, i64** %85, align 8, !dbg !20
-  store i64 %53, i64* %86, align 8, !dbg !20, !tbaa !6
-  %87 = getelementptr inbounds i64, i64* %86, i64 1, !dbg !20
-  store i64 8, i64* %87, align 8, !dbg !20, !tbaa !6
-  %88 = getelementptr inbounds i64, i64* %87, i64 1, !dbg !20
-  store i64* %88, i64** %85, align 8, !dbg !20
-  %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test_nilable_arg.2, i64 0), !dbg !20
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %26, align 8, !dbg !17, !tbaa !31
+  %67 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %20, i64 0, i32 1, !dbg !18
+  %68 = load i64*, i64** %67, align 8, !dbg !18
+  store i64 %43, i64* %68, align 8, !dbg !18, !tbaa !6
+  %69 = getelementptr inbounds i64, i64* %68, i64 1, !dbg !18
+  store i64 21, i64* %69, align 8, !dbg !18, !tbaa !6
+  %70 = getelementptr inbounds i64, i64* %69, i64 1, !dbg !18
+  store i64* %70, i64** %67, align 8, !dbg !18
+  %send3 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test_nilable_arg, i64 0), !dbg !18
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %26, align 8, !dbg !18, !tbaa !31
+  %71 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %20, i64 0, i32 1, !dbg !19
+  %72 = load i64*, i64** %71, align 8, !dbg !19
+  store i64 %43, i64* %72, align 8, !dbg !19, !tbaa !6
+  %73 = getelementptr inbounds i64, i64* %72, i64 1, !dbg !19
+  store i64 0, i64* %73, align 8, !dbg !19, !tbaa !6
+  %74 = getelementptr inbounds i64, i64* %73, i64 1, !dbg !19
+  store i64* %74, i64** %71, align 8, !dbg !19
+  %send5 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test_nilable_arg.1, i64 0), !dbg !19
+  store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %26, align 8, !dbg !19, !tbaa !31
+  %75 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %20, i64 0, i32 1, !dbg !20
+  %76 = load i64*, i64** %75, align 8, !dbg !20
+  store i64 %43, i64* %76, align 8, !dbg !20, !tbaa !6
+  %77 = getelementptr inbounds i64, i64* %76, i64 1, !dbg !20
+  store i64 8, i64* %77, align 8, !dbg !20, !tbaa !6
+  %78 = getelementptr inbounds i64, i64* %77, i64 1, !dbg !20
+  store i64* %78, i64** %75, align 8, !dbg !20
+  %send7 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_test_nilable_arg.2, i64 0), !dbg !20
   ret void
 }
 
@@ -705,7 +678,7 @@ sorbet_T_must.exit:                               ; preds = %functionEntryInitia
 
 rb_vm_check_ints.exit:                            ; preds = %sorbet_T_must.exit, %20
   store i64* getelementptr inbounds ([28 x i64], [28 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %pc, align 8, !dbg !74, !tbaa !31
-  %"rubyStr_ wasn't nil" = load i64, i64* @"rubyStrFrozen_ wasn't nil", align 8, !dbg !81
+  %"rubyStr_ wasn't nil" = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 8), align 8, !dbg !81, !invariant.load !5
   %24 = load i64*, i64** %5, align 8, !dbg !82, !tbaa !39
   %25 = getelementptr inbounds i64, i64* %24, i64 -4, !dbg !82
   %26 = load i64, i64* %25, align 8, !dbg !82, !tbaa !6

--- a/test/testdata/compiler/literal_hash.opt.ll.exp
+++ b/test/testdata/compiler/literal_hash.opt.ll.exp
@@ -81,17 +81,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"rubyStrFrozen_test/testdata/compiler/literal_hash.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [15 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
-@rubyStrFrozen_foo = internal unnamed_addr global i64 0, align 8
-@rubyStrFrozen_bar = internal unnamed_addr global i64 0, align 8
-@rubyStrFrozen_baz = internal unnamed_addr global i64 0, align 8
-@rubyStrFrozen_quux = internal unnamed_addr global i64 0, align 8
-@rubyStrFrozen_wat = internal unnamed_addr global i64 0, align 8
-@rubyStrFrozen_how = internal unnamed_addr global i64 0, align 8
-@rubyStrFrozen_unknown = internal unnamed_addr global i64 0, align 8
 @ruby_hashLiteral1 = internal unnamed_addr global i64 0, align 8
 @ruby_hashLiteral2 = internal unnamed_addr global i64 0, align 8
 @ruby_hashLiteral3 = internal unnamed_addr global i64 0, align 8
@@ -103,6 +94,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @sorbet_moduleStringTable = internal unnamed_addr constant [140 x i8] c"<top (required)>\00test/testdata/compiler/literal_hash.rb\00foo\00bar\00baz\00quux\00wat\00how\00unknown\00do\00magic\00one\00two\00true\00false\00nil\00symbol\00puts\00master\00", align 1
 @sorbet_moduleIDTable = internal unnamed_addr global [4 x i64] zeroinitializer, align 8
 @sorbet_moduleIDDescriptors = internal unnamed_addr constant [4 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 89, i32 2 }, %struct.rb_code_position_struct { i32 121, i32 6 }, %struct.rb_code_position_struct { i32 128, i32 4 }], align 8
+@sorbet_moduleRubyStringTable = internal unnamed_addr global [16 x i64] zeroinitializer, align 8
+@sorbet_moduleRubyStringDescriptors = internal unnamed_addr constant [16 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 17, i32 38 }, %struct.rb_code_position_struct { i32 56, i32 3 }, %struct.rb_code_position_struct { i32 60, i32 3 }, %struct.rb_code_position_struct { i32 64, i32 3 }, %struct.rb_code_position_struct { i32 68, i32 4 }, %struct.rb_code_position_struct { i32 73, i32 3 }, %struct.rb_code_position_struct { i32 77, i32 3 }, %struct.rb_code_position_struct { i32 81, i32 7 }, %struct.rb_code_position_struct { i32 92, i32 5 }, %struct.rb_code_position_struct { i32 98, i32 3 }, %struct.rb_code_position_struct { i32 102, i32 3 }, %struct.rb_code_position_struct { i32 106, i32 4 }, %struct.rb_code_position_struct { i32 111, i32 5 }, %struct.rb_code_position_struct { i32 117, i32 3 }, %struct.rb_code_position_struct { i32 121, i32 6 }], align 8
 
 ; Function Attrs: nounwind readnone willreturn
 declare i64 @rb_id2sym(i64) local_unnamed_addr #0
@@ -125,13 +118,11 @@ declare i64 @sorbet_globalConstDupHash(i64) local_unnamed_addr #1
 
 declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #1
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #1
+declare void @sorbet_vm_init_string_table(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #1
 
 declare i64 @rb_hash_new_with_size(i64) local_unnamed_addr #1
 
 declare void @rb_hash_bulk_insert(i64, i64*, i64) local_unnamed_addr #1
-
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #1
 
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #2
@@ -158,209 +149,174 @@ entry:
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
   tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([4 x %struct.rb_code_position_struct], [4 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 4, i8* noundef getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
-  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #7
-  tail call void @rb_gc_register_mark_object(i64 %0) #7
-  store i64 %0, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %1 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 38) #7
-  tail call void @rb_gc_register_mark_object(i64 %1) #7
-  store i64 %1, i64* @"rubyStrFrozen_test/testdata/compiler/literal_hash.rb", align 8
+  tail call void @sorbet_vm_init_string_table(i64* noundef getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleRubyStringTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([16 x %struct.rb_code_position_struct], [16 x %struct.rb_code_position_struct]* @sorbet_moduleRubyStringDescriptors, i32 0, i32 0), i32 noundef 16, i8* noundef getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 15)
   %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
-  %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/literal_hash.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/literal_hash.rb", align 8
-  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/literal_hash.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 15)
-  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %3 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 56), i64 noundef 3) #7
-  call void @rb_gc_register_mark_object(i64 %3) #7
-  store i64 %3, i64* @rubyStrFrozen_foo, align 8
-  %4 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 60), i64 noundef 3) #7
-  call void @rb_gc_register_mark_object(i64 %4) #7
-  store i64 %4, i64* @rubyStrFrozen_bar, align 8
-  %5 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 64), i64 noundef 3) #7
-  call void @rb_gc_register_mark_object(i64 %5) #7
-  store i64 %5, i64* @rubyStrFrozen_baz, align 8
-  %6 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 68), i64 noundef 4) #7
-  call void @rb_gc_register_mark_object(i64 %6) #7
-  store i64 %6, i64* @rubyStrFrozen_quux, align 8
-  %7 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 73), i64 noundef 3) #7
-  call void @rb_gc_register_mark_object(i64 %7) #7
-  store i64 %7, i64* @rubyStrFrozen_wat, align 8
-  %8 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 77), i64 noundef 3) #7
-  call void @rb_gc_register_mark_object(i64 %8) #7
-  store i64 %8, i64* @rubyStrFrozen_how, align 8
-  %9 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 81), i64 noundef 7) #7
-  call void @rb_gc_register_mark_object(i64 %9) #7
-  store i64 %9, i64* @rubyStrFrozen_unknown, align 8
-  %10 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 92), i64 noundef 5) #7
-  call void @rb_gc_register_mark_object(i64 %10) #7
-  %11 = bitcast [14 x i64]* %argArray.i.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 112, i8* nonnull %11)
-  %rubyStr_foo.i.i = load i64, i64* @rubyStrFrozen_foo, align 8
+  %"rubyStr_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 0), align 8, !invariant.load !5
+  %"rubyStr_test/testdata/compiler/literal_hash.rb.i.i" = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
+  %0 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/literal_hash.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 6, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 15)
+  store %struct.rb_iseq_struct* %0, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %1 = bitcast [14 x i64]* %argArray.i.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 112, i8* nonnull %1)
+  %rubyStr_foo.i.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 2), align 8, !invariant.load !5
   %hashArgs0Addr.i.i = getelementptr [14 x i64], [14 x i64]* %argArray.i.i, i64 0, i64 0
   store i64 %rubyStr_foo.i.i, i64* %hashArgs0Addr.i.i, align 8
   %hashArgs1Addr.i.i = getelementptr [14 x i64], [14 x i64]* %argArray.i.i, i64 0, i64 1
   store i64 3, i64* %hashArgs1Addr.i.i, align 8
-  %rubyStr_bar.i.i = load i64, i64* @rubyStrFrozen_bar, align 8
+  %rubyStr_bar.i.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 3), align 8, !invariant.load !5
   %hashArgs2Addr.i.i = getelementptr [14 x i64], [14 x i64]* %argArray.i.i, i64 0, i64 2
   store i64 %rubyStr_bar.i.i, i64* %hashArgs2Addr.i.i, align 8
   %hashArgs3Addr.i.i = getelementptr [14 x i64], [14 x i64]* %argArray.i.i, i64 0, i64 3
   store i64 2, i64* %hashArgs3Addr.i.i, align 8
-  %rubyStr_baz.i.i = load i64, i64* @rubyStrFrozen_baz, align 8
+  %rubyStr_baz.i.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 4), align 8, !invariant.load !5
   %hashArgs4Addr.i.i = getelementptr [14 x i64], [14 x i64]* %argArray.i.i, i64 0, i64 4
   store i64 %rubyStr_baz.i.i, i64* %hashArgs4Addr.i.i, align 8
   %hashArgs5Addr.i.i = getelementptr [14 x i64], [14 x i64]* %argArray.i.i, i64 0, i64 5
   store i64 20, i64* %hashArgs5Addr.i.i, align 8
-  %rubyStr_quux.i.i = load i64, i64* @rubyStrFrozen_quux, align 8
+  %rubyStr_quux.i.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 5), align 8, !invariant.load !5
   %hashArgs6Addr.i.i = getelementptr [14 x i64], [14 x i64]* %argArray.i.i, i64 0, i64 6
   store i64 %rubyStr_quux.i.i, i64* %hashArgs6Addr.i.i, align 8
   %hashArgs7Addr.i.i = getelementptr [14 x i64], [14 x i64]* %argArray.i.i, i64 0, i64 7
   store i64 0, i64* %hashArgs7Addr.i.i, align 8
-  %rubyStr_wat.i.i = load i64, i64* @rubyStrFrozen_wat, align 8
+  %rubyStr_wat.i.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 6), align 8, !invariant.load !5
   %hashArgs8Addr.i.i = getelementptr [14 x i64], [14 x i64]* %argArray.i.i, i64 0, i64 8
   store i64 %rubyStr_wat.i.i, i64* %hashArgs8Addr.i.i, align 8
   %hashArgs9Addr.i.i = getelementptr [14 x i64], [14 x i64]* %argArray.i.i, i64 0, i64 9
   store i64 8, i64* %hashArgs9Addr.i.i, align 8
-  %rubyStr_how.i.i = load i64, i64* @rubyStrFrozen_how, align 8
   %hashArgs10Addr.i.i = getelementptr [14 x i64], [14 x i64]* %argArray.i.i, i64 0, i64 10
-  store i64 %rubyStr_how.i.i, i64* %hashArgs10Addr.i.i, align 8
-  %rubyStr_unknown.i.i = load i64, i64* @rubyStrFrozen_unknown, align 8
-  %hashArgs11Addr.i.i = getelementptr [14 x i64], [14 x i64]* %argArray.i.i, i64 0, i64 11
-  store i64 %rubyStr_unknown.i.i, i64* %hashArgs11Addr.i.i, align 8
+  %2 = load <2 x i64>, <2 x i64>* bitcast (i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 7) to <2 x i64>*), align 8, !invariant.load !5
+  %3 = bitcast i64* %hashArgs10Addr.i.i to <2 x i64>*
+  store <2 x i64> %2, <2 x i64>* %3, align 8
   %rubyId_do.i.i = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !invariant.load !5
-  %rawSym.i.i = call i64 @rb_id2sym(i64 %rubyId_do.i.i) #8
+  %rawSym.i.i = call i64 @rb_id2sym(i64 %rubyId_do.i.i) #7
   %hashArgs12Addr.i.i = getelementptr [14 x i64], [14 x i64]* %argArray.i.i, i64 0, i64 12
   store i64 %rawSym.i.i, i64* %hashArgs12Addr.i.i, align 8
+  %rubyStr_magic.i.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 9), align 8, !invariant.load !5
   %hashArgs13Addr.i.i = getelementptr [14 x i64], [14 x i64]* %argArray.i.i, i64 0, i64 13
-  store i64 %10, i64* %hashArgs13Addr.i.i, align 8
-  %12 = call i64 @rb_hash_new_with_size(i64 noundef 7) #7
-  call void @rb_hash_bulk_insert(i64 noundef 14, i64* noundef nonnull %hashArgs0Addr.i.i, i64 %12) #7
-  %13 = call i64 @sorbet_globalConstRegister(i64 %12) #7
-  store i64 %13, i64* @ruby_hashLiteral1, align 8
-  call void @llvm.lifetime.end.p0i8(i64 112, i8* nonnull %11)
-  %14 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 98), i64 noundef 3) #7
-  call void @rb_gc_register_mark_object(i64 %14) #7
-  %15 = bitcast [2 x i64]* %argArray.i1.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %15)
+  store i64 %rubyStr_magic.i.i, i64* %hashArgs13Addr.i.i, align 8
+  %4 = call i64 @rb_hash_new_with_size(i64 noundef 7) #8
+  call void @rb_hash_bulk_insert(i64 noundef 14, i64* noundef nonnull %hashArgs0Addr.i.i, i64 %4) #8
+  %5 = call i64 @sorbet_globalConstRegister(i64 %4) #8
+  store i64 %5, i64* @ruby_hashLiteral1, align 8
+  call void @llvm.lifetime.end.p0i8(i64 112, i8* nonnull %1)
+  %6 = bitcast [2 x i64]* %argArray.i1.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %6)
   %hashArgs0Addr.i2.i = getelementptr [2 x i64], [2 x i64]* %argArray.i1.i, i64 0, i64 0
   store i64 3, i64* %hashArgs0Addr.i2.i, align 8
+  %rubyStr_one.i.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 10), align 8, !invariant.load !5
   %hashArgs1Addr.i3.i = getelementptr [2 x i64], [2 x i64]* %argArray.i1.i, i64 0, i64 1
-  store i64 %14, i64* %hashArgs1Addr.i3.i, align 8
-  %16 = call i64 @rb_hash_new_with_size(i64 noundef 1) #7
-  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %hashArgs0Addr.i2.i, i64 %16) #7
-  %17 = call i64 @sorbet_globalConstRegister(i64 %16) #7
-  store i64 %17, i64* @ruby_hashLiteral2, align 8
-  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %15)
-  %18 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 102), i64 noundef 3) #7
-  call void @rb_gc_register_mark_object(i64 %18) #7
-  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %15)
+  store i64 %rubyStr_one.i.i, i64* %hashArgs1Addr.i3.i, align 8
+  %7 = call i64 @rb_hash_new_with_size(i64 noundef 1) #8
+  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %hashArgs0Addr.i2.i, i64 %7) #8
+  %8 = call i64 @sorbet_globalConstRegister(i64 %7) #8
+  store i64 %8, i64* @ruby_hashLiteral2, align 8
+  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %6)
+  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %6)
   store i64 2, i64* %hashArgs0Addr.i2.i, align 8
-  store i64 %18, i64* %hashArgs1Addr.i3.i, align 8
-  %19 = call i64 @rb_hash_new_with_size(i64 noundef 1) #7
-  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %hashArgs0Addr.i2.i, i64 %19) #7
-  %20 = call i64 @sorbet_globalConstRegister(i64 %19) #7
-  store i64 %20, i64* @ruby_hashLiteral3, align 8
-  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %15)
-  %21 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 106), i64 noundef 4) #7
-  call void @rb_gc_register_mark_object(i64 %21) #7
-  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %15)
+  %rubyStr_two.i.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 11), align 8, !invariant.load !5
+  store i64 %rubyStr_two.i.i, i64* %hashArgs1Addr.i3.i, align 8
+  %9 = call i64 @rb_hash_new_with_size(i64 noundef 1) #8
+  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %hashArgs0Addr.i2.i, i64 %9) #8
+  %10 = call i64 @sorbet_globalConstRegister(i64 %9) #8
+  store i64 %10, i64* @ruby_hashLiteral3, align 8
+  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %6)
+  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %6)
   store i64 20, i64* %hashArgs0Addr.i2.i, align 8
-  store i64 %21, i64* %hashArgs1Addr.i3.i, align 8
-  %22 = call i64 @rb_hash_new_with_size(i64 noundef 1) #7
-  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %hashArgs0Addr.i2.i, i64 %22) #7
-  %23 = call i64 @sorbet_globalConstRegister(i64 %22) #7
-  store i64 %23, i64* @ruby_hashLiteral4, align 8
-  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %15)
-  %24 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 111), i64 noundef 5) #7
-  call void @rb_gc_register_mark_object(i64 %24) #7
-  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %15)
+  %rubyStr_true.i.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 12), align 8, !invariant.load !5
+  store i64 %rubyStr_true.i.i, i64* %hashArgs1Addr.i3.i, align 8
+  %11 = call i64 @rb_hash_new_with_size(i64 noundef 1) #8
+  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %hashArgs0Addr.i2.i, i64 %11) #8
+  %12 = call i64 @sorbet_globalConstRegister(i64 %11) #8
+  store i64 %12, i64* @ruby_hashLiteral4, align 8
+  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %6)
+  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %6)
   store i64 0, i64* %hashArgs0Addr.i2.i, align 8
-  store i64 %24, i64* %hashArgs1Addr.i3.i, align 8
-  %25 = call i64 @rb_hash_new_with_size(i64 noundef 1) #7
-  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %hashArgs0Addr.i2.i, i64 %25) #7
-  %26 = call i64 @sorbet_globalConstRegister(i64 %25) #7
-  store i64 %26, i64* @ruby_hashLiteral5, align 8
-  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %15)
-  %27 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 117), i64 noundef 3) #7
-  call void @rb_gc_register_mark_object(i64 %27) #7
-  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %15)
+  %rubyStr_false.i.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 13), align 8, !invariant.load !5
+  store i64 %rubyStr_false.i.i, i64* %hashArgs1Addr.i3.i, align 8
+  %13 = call i64 @rb_hash_new_with_size(i64 noundef 1) #8
+  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %hashArgs0Addr.i2.i, i64 %13) #8
+  %14 = call i64 @sorbet_globalConstRegister(i64 %13) #8
+  store i64 %14, i64* @ruby_hashLiteral5, align 8
+  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %6)
+  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %6)
   store i64 8, i64* %hashArgs0Addr.i2.i, align 8
-  store i64 %27, i64* %hashArgs1Addr.i3.i, align 8
-  %28 = call i64 @rb_hash_new_with_size(i64 noundef 1) #7
-  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %hashArgs0Addr.i2.i, i64 %28) #7
-  %29 = call i64 @sorbet_globalConstRegister(i64 %28) #7
-  store i64 %29, i64* @ruby_hashLiteral6, align 8
-  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %15)
-  %30 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([140 x i8], [140 x i8]* @sorbet_moduleStringTable, i64 0, i64 121), i64 noundef 6) #7
-  call void @rb_gc_register_mark_object(i64 %30) #7
-  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %15)
+  %rubyStr_nil.i.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 14), align 8, !invariant.load !5
+  store i64 %rubyStr_nil.i.i, i64* %hashArgs1Addr.i3.i, align 8
+  %15 = call i64 @rb_hash_new_with_size(i64 noundef 1) #8
+  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %hashArgs0Addr.i2.i, i64 %15) #8
+  %16 = call i64 @sorbet_globalConstRegister(i64 %15) #8
+  store i64 %16, i64* @ruby_hashLiteral6, align 8
+  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %6)
+  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %6)
   %rubyId_symbol.i.i = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !invariant.load !5
-  %rawSym.i17.i = call i64 @rb_id2sym(i64 %rubyId_symbol.i.i) #8
+  %rawSym.i17.i = call i64 @rb_id2sym(i64 %rubyId_symbol.i.i) #7
   store i64 %rawSym.i17.i, i64* %hashArgs0Addr.i2.i, align 8
-  store i64 %30, i64* %hashArgs1Addr.i3.i, align 8
-  %31 = call i64 @rb_hash_new_with_size(i64 noundef 1) #7
-  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %hashArgs0Addr.i2.i, i64 %31) #7
-  %32 = call i64 @sorbet_globalConstRegister(i64 %31) #7
-  store i64 %32, i64* @ruby_hashLiteral7, align 8
-  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %15)
+  %rubyStr_symbol.i.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 15), align 8, !invariant.load !5
+  store i64 %rubyStr_symbol.i.i, i64* %hashArgs1Addr.i3.i, align 8
+  %17 = call i64 @rb_hash_new_with_size(i64 noundef 1) #8
+  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %hashArgs0Addr.i2.i, i64 %17) #8
+  %18 = call i64 @sorbet_globalConstRegister(i64 %17) #8
+  store i64 %18, i64* @ruby_hashLiteral7, align 8
+  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %6)
   %rubyId_puts.i = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !10, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 7, i32 noundef 0, i64* noundef null), !dbg !10
-  %33 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !15
-  %34 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %33, i64 0, i32 18
-  %35 = load i64, i64* %34, align 8, !tbaa !17
-  %36 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
-  %37 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %36, i64 0, i32 2
-  %38 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %37, align 8, !tbaa !27
+  %19 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !15
+  %20 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %19, i64 0, i32 18
+  %21 = load i64, i64* %20, align 8, !tbaa !17
+  %22 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
+  %23 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %22, i64 0, i32 2
+  %24 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %23, align 8, !tbaa !27
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %39 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %39, align 8, !tbaa !30
-  %40 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 4
-  %41 = load i64*, i64** %40, align 8, !tbaa !32
-  %42 = load i64, i64* %41, align 8, !tbaa !6
-  %43 = and i64 %42, -33
-  store i64 %43, i64* %41, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %36, %struct.rb_control_frame_struct* %38, %struct.rb_iseq_struct* %stackFrame.i) #7
-  %44 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 0
-  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %44, align 8, !dbg !33, !tbaa !15
+  %25 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %25, align 8, !tbaa !30
+  %26 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 4
+  %27 = load i64*, i64** %26, align 8, !tbaa !32
+  %28 = load i64, i64* %27, align 8, !tbaa !6
+  %29 = and i64 %28, -33
+  store i64 %29, i64* %27, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %22, %struct.rb_control_frame_struct* %24, %struct.rb_iseq_struct* %stackFrame.i) #8
+  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 0
+  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %30, align 8, !dbg !33, !tbaa !15
   %hashLiteral.i = load i64, i64* @ruby_hashLiteral1, align 8, !dbg !34
-  %duplicatedHash.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral.i) #7, !dbg !34
-  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %44, align 8, !dbg !34, !tbaa !15
+  %duplicatedHash.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral.i) #8, !dbg !34
+  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %30, align 8, !dbg !34, !tbaa !15
   %hashLiteral80.i = load i64, i64* @ruby_hashLiteral2, align 8, !dbg !35
-  %duplicatedHash81.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral80.i) #7, !dbg !35
-  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %44, align 8, !dbg !35, !tbaa !15
+  %duplicatedHash81.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral80.i) #8, !dbg !35
+  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %30, align 8, !dbg !35, !tbaa !15
   %hashLiteral87.i = load i64, i64* @ruby_hashLiteral3, align 8, !dbg !36
-  %duplicatedHash88.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral87.i) #7, !dbg !36
-  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %44, align 8, !dbg !36, !tbaa !15
+  %duplicatedHash88.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral87.i) #8, !dbg !36
+  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %30, align 8, !dbg !36, !tbaa !15
   %hashLiteral94.i = load i64, i64* @ruby_hashLiteral4, align 8, !dbg !37
-  %duplicatedHash95.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral94.i) #7, !dbg !37
-  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %44, align 8, !dbg !37, !tbaa !15
+  %duplicatedHash95.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral94.i) #8, !dbg !37
+  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %30, align 8, !dbg !37, !tbaa !15
   %hashLiteral101.i = load i64, i64* @ruby_hashLiteral5, align 8, !dbg !38
-  %duplicatedHash102.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral101.i) #7, !dbg !38
-  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %44, align 8, !dbg !38, !tbaa !15
+  %duplicatedHash102.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral101.i) #8, !dbg !38
+  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %30, align 8, !dbg !38, !tbaa !15
   %hashLiteral108.i = load i64, i64* @ruby_hashLiteral6, align 8, !dbg !39
-  %duplicatedHash109.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral108.i) #7, !dbg !39
-  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %44, align 8, !dbg !39, !tbaa !15
+  %duplicatedHash109.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral108.i) #8, !dbg !39
+  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %30, align 8, !dbg !39, !tbaa !15
   %hashLiteral115.i = load i64, i64* @ruby_hashLiteral7, align 8, !dbg !40
-  %duplicatedHash116.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral115.i) #7, !dbg !40
-  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %44, align 8, !dbg !40, !tbaa !15
-  %45 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %38, i64 0, i32 1, !dbg !10
-  %46 = load i64*, i64** %45, align 8, !dbg !10
-  store i64 %35, i64* %46, align 8, !dbg !10, !tbaa !6
-  %47 = getelementptr inbounds i64, i64* %46, i64 1, !dbg !10
-  store i64 %duplicatedHash.i, i64* %47, align 8, !dbg !10, !tbaa !6
-  %48 = getelementptr inbounds i64, i64* %47, i64 1, !dbg !10
-  store i64 %duplicatedHash81.i, i64* %48, align 8, !dbg !10, !tbaa !6
-  %49 = getelementptr inbounds i64, i64* %48, i64 1, !dbg !10
-  store i64 %duplicatedHash88.i, i64* %49, align 8, !dbg !10, !tbaa !6
-  %50 = getelementptr inbounds i64, i64* %49, i64 1, !dbg !10
-  store i64 %duplicatedHash95.i, i64* %50, align 8, !dbg !10, !tbaa !6
-  %51 = getelementptr inbounds i64, i64* %50, i64 1, !dbg !10
-  store i64 %duplicatedHash102.i, i64* %51, align 8, !dbg !10, !tbaa !6
-  %52 = getelementptr inbounds i64, i64* %51, i64 1, !dbg !10
-  store i64 %duplicatedHash109.i, i64* %52, align 8, !dbg !10, !tbaa !6
-  %53 = getelementptr inbounds i64, i64* %52, i64 1, !dbg !10
-  store i64 %duplicatedHash116.i, i64* %53, align 8, !dbg !10, !tbaa !6
-  %54 = getelementptr inbounds i64, i64* %53, i64 1, !dbg !10
-  store i64* %54, i64** %45, align 8, !dbg !10
+  %duplicatedHash116.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral115.i) #8, !dbg !40
+  store i64* getelementptr inbounds ([15 x i64], [15 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %30, align 8, !dbg !40, !tbaa !15
+  %31 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 1, !dbg !10
+  %32 = load i64*, i64** %31, align 8, !dbg !10
+  store i64 %21, i64* %32, align 8, !dbg !10, !tbaa !6
+  %33 = getelementptr inbounds i64, i64* %32, i64 1, !dbg !10
+  store i64 %duplicatedHash.i, i64* %33, align 8, !dbg !10, !tbaa !6
+  %34 = getelementptr inbounds i64, i64* %33, i64 1, !dbg !10
+  store i64 %duplicatedHash81.i, i64* %34, align 8, !dbg !10, !tbaa !6
+  %35 = getelementptr inbounds i64, i64* %34, i64 1, !dbg !10
+  store i64 %duplicatedHash88.i, i64* %35, align 8, !dbg !10, !tbaa !6
+  %36 = getelementptr inbounds i64, i64* %35, i64 1, !dbg !10
+  store i64 %duplicatedHash95.i, i64* %36, align 8, !dbg !10, !tbaa !6
+  %37 = getelementptr inbounds i64, i64* %36, i64 1, !dbg !10
+  store i64 %duplicatedHash102.i, i64* %37, align 8, !dbg !10, !tbaa !6
+  %38 = getelementptr inbounds i64, i64* %37, i64 1, !dbg !10
+  store i64 %duplicatedHash109.i, i64* %38, align 8, !dbg !10, !tbaa !6
+  %39 = getelementptr inbounds i64, i64* %38, i64 1, !dbg !10
+  store i64 %duplicatedHash116.i, i64* %39, align 8, !dbg !10, !tbaa !6
+  %40 = getelementptr inbounds i64, i64* %39, i64 1, !dbg !10
+  store i64* %40, i64** %31, align 8, !dbg !10
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !10
   ret void
 }
@@ -378,8 +334,8 @@ attributes #3 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-point
 attributes #4 = { sspreq }
 attributes #5 = { argmemonly nofree nosync nounwind willreturn }
 attributes #6 = { noreturn nounwind }
-attributes #7 = { nounwind }
-attributes #8 = { nounwind willreturn }
+attributes #7 = { nounwind willreturn }
+attributes #8 = { nounwind }
 
 !llvm.module.flags = !{!0, !1, !2}
 !llvm.dbg.cu = !{!3}

--- a/test/testdata/compiler/literal_type_tests.rb
+++ b/test/testdata/compiler/literal_type_tests.rb
@@ -39,7 +39,8 @@ end
 # INITIAL{LITERAL}: }
 
 # INITIAL-LABEL: define internal i64 @"func_Object#14literal_string"
-# INITIAL: [[STRING:%[_a-zA-Z]+]] = load i64, i64* @rubyStrFrozen_matching{{.*}}
+# INITIAL: [[STRING_TMP:%[_a-zA-Z0-9]+]] = load i64*, i64** @addr_rubystr_matching{{.*}}
+# INITIAL-NEXT: [[STRING:%[_a-zA-Z]+]] = load i64, i64* [[STRING_TMP]]{{.*}}
 # INITIAL-NEXT: [[COND:%[0-9]+]] = call i1 @sorbet_i_isa_String(i64 [[STRING]]{{.*}}
 # INITIAL-NEXT: call void @llvm.assume(i1 [[COND]]){{.*}}
 # INITIAL-NEXT: br i1 true, label %"fastSymCallIntrinsic_String_===", label %"alternativeCallIntrinsic_String_==="{{.*}}

--- a/test/testdata/compiler/literals.opt.ll.exp
+++ b/test/testdata/compiler/literals.opt.ll.exp
@@ -81,13 +81,10 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"rubyStrFrozen_test/testdata/compiler/literals.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [11 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.1 = internal global %struct.FunctionInlineCache zeroinitializer
-@rubyStrFrozen_str = internal unnamed_addr global i64 0, align 8
 @ic_puts.2 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.3 = internal global %struct.FunctionInlineCache zeroinitializer
 @ic_puts.4 = internal global %struct.FunctionInlineCache zeroinitializer
@@ -96,6 +93,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @sorbet_moduleStringTable = internal unnamed_addr constant [72 x i8] c"<top (required)>\00test/testdata/compiler/literals.rb\00puts\00str\00sym\00master\00", align 1
 @sorbet_moduleIDTable = internal unnamed_addr global [3 x i64] zeroinitializer, align 8
 @sorbet_moduleIDDescriptors = internal unnamed_addr constant [3 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 52, i32 4 }, %struct.rb_code_position_struct { i32 61, i32 3 }], align 8
+@sorbet_moduleRubyStringTable = internal unnamed_addr global [3 x i64] zeroinitializer, align 8
+@sorbet_moduleRubyStringDescriptors = internal unnamed_addr constant [3 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 17, i32 34 }, %struct.rb_code_position_struct { i32 57, i32 3 }], align 8
 
 ; Function Attrs: nounwind readnone willreturn
 declare i64 @rb_id2sym(i64) local_unnamed_addr #0
@@ -114,9 +113,7 @@ declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %
 
 declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #1
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #1
-
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #1
+declare void @sorbet_vm_init_string_table(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #1
 
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #2
@@ -141,110 +138,102 @@ entry:
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
   tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([3 x %struct.rb_code_position_struct], [3 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 3, i8* noundef getelementptr inbounds ([72 x i8], [72 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
-  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([72 x i8], [72 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #6
-  tail call void @rb_gc_register_mark_object(i64 %0) #6
-  store i64 %0, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %1 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([72 x i8], [72 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 34) #6
-  tail call void @rb_gc_register_mark_object(i64 %1) #6
-  store i64 %1, i64* @"rubyStrFrozen_test/testdata/compiler/literals.rb", align 8
+  tail call void @sorbet_vm_init_string_table(i64* noundef getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleRubyStringTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([3 x %struct.rb_code_position_struct], [3 x %struct.rb_code_position_struct]* @sorbet_moduleRubyStringDescriptors, i32 0, i32 0), i32 noundef 3, i8* noundef getelementptr inbounds ([72 x i8], [72 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 11)
   %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
-  %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/literals.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/literals.rb", align 8
-  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/literals.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %"rubyStr_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 0), align 8, !invariant.load !5
+  %"rubyStr_test/testdata/compiler/literals.rb.i.i" = load i64, i64* getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
+  %0 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/literals.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %0, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
   %rubyId_puts.i = load i64, i64* getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !dbg !10, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !10
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
-  %3 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([72 x i8], [72 x i8]* @sorbet_moduleStringTable, i64 0, i64 57), i64 noundef 3) #6
-  call void @rb_gc_register_mark_object(i64 %3) #6
-  store i64 %3, i64* @rubyStrFrozen_str, align 8
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !16
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !17
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.4, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !18
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.5, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.6, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !20
-  %4 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !21
-  %5 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %4, i64 0, i32 18
-  %6 = load i64, i64* %5, align 8, !tbaa !23
-  %7 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !21
-  %8 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %7, i64 0, i32 2
-  %9 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %8, align 8, !tbaa !33
+  %1 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !21
+  %2 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %1, i64 0, i32 18
+  %3 = load i64, i64* %2, align 8, !tbaa !23
+  %4 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !21
+  %5 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %4, i64 0, i32 2
+  %6 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %5, align 8, !tbaa !33
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %10, align 8, !tbaa !36
-  %11 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 4
-  %12 = load i64*, i64** %11, align 8, !tbaa !38
-  %13 = load i64, i64* %12, align 8, !tbaa !6
-  %14 = and i64 %13, -33
-  store i64 %14, i64* %12, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %7, %struct.rb_control_frame_struct* %9, %struct.rb_iseq_struct* %stackFrame.i) #6
-  %15 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 0
-  store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %15, align 8, !dbg !39, !tbaa !21
-  %16 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 1, !dbg !10
-  %17 = load i64*, i64** %16, align 8, !dbg !10
-  store i64 %6, i64* %17, align 8, !dbg !10, !tbaa !6
-  %18 = getelementptr inbounds i64, i64* %17, i64 1, !dbg !10
-  store i64 85, i64* %18, align 8, !dbg !10, !tbaa !6
-  %19 = getelementptr inbounds i64, i64* %18, i64 1, !dbg !10
-  store i64* %19, i64** %16, align 8, !dbg !10
+  %7 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %6, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %7, align 8, !tbaa !36
+  %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %6, i64 0, i32 4
+  %9 = load i64*, i64** %8, align 8, !tbaa !38
+  %10 = load i64, i64* %9, align 8, !tbaa !6
+  %11 = and i64 %10, -33
+  store i64 %11, i64* %9, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %4, %struct.rb_control_frame_struct* %6, %struct.rb_iseq_struct* %stackFrame.i) #6
+  %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %6, i64 0, i32 0
+  store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %12, align 8, !dbg !39, !tbaa !21
+  %13 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %6, i64 0, i32 1, !dbg !10
+  %14 = load i64*, i64** %13, align 8, !dbg !10
+  store i64 %3, i64* %14, align 8, !dbg !10, !tbaa !6
+  %15 = getelementptr inbounds i64, i64* %14, i64 1, !dbg !10
+  store i64 85, i64* %15, align 8, !dbg !10, !tbaa !6
+  %16 = getelementptr inbounds i64, i64* %15, i64 1, !dbg !10
+  store i64* %16, i64** %13, align 8, !dbg !10
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !10
-  store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %15, align 8, !dbg !10, !tbaa !21
-  %20 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 1, !dbg !15
-  %21 = load i64*, i64** %20, align 8, !dbg !15
-  store i64 %6, i64* %21, align 8, !dbg !15, !tbaa !6
-  %22 = getelementptr inbounds i64, i64* %21, i64 1, !dbg !15
-  store i64 56565211319773434, i64* %22, align 8, !dbg !15, !tbaa !6
-  %23 = getelementptr inbounds i64, i64* %22, i64 1, !dbg !15
-  store i64* %23, i64** %20, align 8, !dbg !15
+  store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %12, align 8, !dbg !10, !tbaa !21
+  %17 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %6, i64 0, i32 1, !dbg !15
+  %18 = load i64*, i64** %17, align 8, !dbg !15
+  store i64 %3, i64* %18, align 8, !dbg !15, !tbaa !6
+  %19 = getelementptr inbounds i64, i64* %18, i64 1, !dbg !15
+  store i64 56565211319773434, i64* %19, align 8, !dbg !15, !tbaa !6
+  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !15
+  store i64* %20, i64** %17, align 8, !dbg !15
   %send2 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.1, i64 0), !dbg !15
-  store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %15, align 8, !dbg !15, !tbaa !21
-  %rubyStr_str.i = load i64, i64* @rubyStrFrozen_str, align 8, !dbg !40
-  %24 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 1, !dbg !16
-  %25 = load i64*, i64** %24, align 8, !dbg !16
-  store i64 %6, i64* %25, align 8, !dbg !16, !tbaa !6
-  %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !16
-  store i64 %rubyStr_str.i, i64* %26, align 8, !dbg !16, !tbaa !6
-  %27 = getelementptr inbounds i64, i64* %26, i64 1, !dbg !16
-  store i64* %27, i64** %24, align 8, !dbg !16
+  store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %12, align 8, !dbg !15, !tbaa !21
+  %rubyStr_str.i = load i64, i64* getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 2), align 8, !dbg !40, !invariant.load !5
+  %21 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %6, i64 0, i32 1, !dbg !16
+  %22 = load i64*, i64** %21, align 8, !dbg !16
+  store i64 %3, i64* %22, align 8, !dbg !16, !tbaa !6
+  %23 = getelementptr inbounds i64, i64* %22, i64 1, !dbg !16
+  store i64 %rubyStr_str.i, i64* %23, align 8, !dbg !16, !tbaa !6
+  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !16
+  store i64* %24, i64** %21, align 8, !dbg !16
   %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.2, i64 0), !dbg !16
-  store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %15, align 8, !dbg !16, !tbaa !21
+  store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %12, align 8, !dbg !16, !tbaa !21
   %rubyId_sym.i = load i64, i64* getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !41, !invariant.load !5
   %rawSym.i = call i64 @rb_id2sym(i64 %rubyId_sym.i) #6, !dbg !41
-  %28 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 1, !dbg !17
-  %29 = load i64*, i64** %28, align 8, !dbg !17
-  store i64 %6, i64* %29, align 8, !dbg !17, !tbaa !6
-  %30 = getelementptr inbounds i64, i64* %29, i64 1, !dbg !17
-  store i64 %rawSym.i, i64* %30, align 8, !dbg !17, !tbaa !6
-  %31 = getelementptr inbounds i64, i64* %30, i64 1, !dbg !17
-  store i64* %31, i64** %28, align 8, !dbg !17
+  %25 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %6, i64 0, i32 1, !dbg !17
+  %26 = load i64*, i64** %25, align 8, !dbg !17
+  store i64 %3, i64* %26, align 8, !dbg !17, !tbaa !6
+  %27 = getelementptr inbounds i64, i64* %26, i64 1, !dbg !17
+  store i64 %rawSym.i, i64* %27, align 8, !dbg !17, !tbaa !6
+  %28 = getelementptr inbounds i64, i64* %27, i64 1, !dbg !17
+  store i64* %28, i64** %25, align 8, !dbg !17
   %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.3, i64 0), !dbg !17
-  store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %15, align 8, !dbg !17, !tbaa !21
-  %32 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 1, !dbg !18
-  %33 = load i64*, i64** %32, align 8, !dbg !18
-  store i64 %6, i64* %33, align 8, !dbg !18, !tbaa !6
-  %34 = getelementptr inbounds i64, i64* %33, i64 1, !dbg !18
-  store i64 0, i64* %34, align 8, !dbg !18, !tbaa !6
-  %35 = getelementptr inbounds i64, i64* %34, i64 1, !dbg !18
-  store i64* %35, i64** %32, align 8, !dbg !18
+  store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %12, align 8, !dbg !17, !tbaa !21
+  %29 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %6, i64 0, i32 1, !dbg !18
+  %30 = load i64*, i64** %29, align 8, !dbg !18
+  store i64 %3, i64* %30, align 8, !dbg !18, !tbaa !6
+  %31 = getelementptr inbounds i64, i64* %30, i64 1, !dbg !18
+  store i64 0, i64* %31, align 8, !dbg !18, !tbaa !6
+  %32 = getelementptr inbounds i64, i64* %31, i64 1, !dbg !18
+  store i64* %32, i64** %29, align 8, !dbg !18
   %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.4, i64 0), !dbg !18
-  store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %15, align 8, !dbg !18, !tbaa !21
-  %36 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 1, !dbg !19
-  %37 = load i64*, i64** %36, align 8, !dbg !19
-  store i64 %6, i64* %37, align 8, !dbg !19, !tbaa !6
-  %38 = getelementptr inbounds i64, i64* %37, i64 1, !dbg !19
-  store i64 20, i64* %38, align 8, !dbg !19, !tbaa !6
-  %39 = getelementptr inbounds i64, i64* %38, i64 1, !dbg !19
-  store i64* %39, i64** %36, align 8, !dbg !19
+  store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %12, align 8, !dbg !18, !tbaa !21
+  %33 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %6, i64 0, i32 1, !dbg !19
+  %34 = load i64*, i64** %33, align 8, !dbg !19
+  store i64 %3, i64* %34, align 8, !dbg !19, !tbaa !6
+  %35 = getelementptr inbounds i64, i64* %34, i64 1, !dbg !19
+  store i64 20, i64* %35, align 8, !dbg !19, !tbaa !6
+  %36 = getelementptr inbounds i64, i64* %35, i64 1, !dbg !19
+  store i64* %36, i64** %33, align 8, !dbg !19
   %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.5, i64 0), !dbg !19
-  store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %15, align 8, !dbg !19, !tbaa !21
-  %40 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 1, !dbg !20
-  %41 = load i64*, i64** %40, align 8, !dbg !20
-  store i64 %6, i64* %41, align 8, !dbg !20, !tbaa !6
-  %42 = getelementptr inbounds i64, i64* %41, i64 1, !dbg !20
-  store i64 8, i64* %42, align 8, !dbg !20, !tbaa !6
-  %43 = getelementptr inbounds i64, i64* %42, i64 1, !dbg !20
-  store i64* %43, i64** %40, align 8, !dbg !20
+  store i64* getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %12, align 8, !dbg !19, !tbaa !21
+  %37 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %6, i64 0, i32 1, !dbg !20
+  %38 = load i64*, i64** %37, align 8, !dbg !20
+  store i64 %3, i64* %38, align 8, !dbg !20, !tbaa !6
+  %39 = getelementptr inbounds i64, i64* %38, i64 1, !dbg !20
+  store i64 8, i64* %39, align 8, !dbg !20, !tbaa !6
+  %40 = getelementptr inbounds i64, i64* %39, i64 1, !dbg !20
+  store i64* %40, i64** %37, align 8, !dbg !20
   %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.6, i64 0), !dbg !20
   ret void
 }

--- a/test/testdata/compiler/repeated_casts.opt.ll.exp
+++ b/test/testdata/compiler/repeated_casts.opt.ll.exp
@@ -81,8 +81,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_Object#10doubleCast" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@rubyStrFrozen_doubleCast = internal unnamed_addr global i64 0, align 8
-@"rubyStrFrozen_test/testdata/compiler/repeated_casts.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [12 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @ic_foo = internal global %struct.FunctionInlineCache zeroinitializer
@@ -93,6 +91,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @sorbet_moduleStringTable = internal unnamed_addr constant [115 x i8] c"doubleCast\00test/testdata/compiler/repeated_casts.rb\00A\00T.cast\00foo\00<top (required)>\00Object\00normal\00a\00master\00<class:A>\00", align 1
 @sorbet_moduleIDTable = internal unnamed_addr global [6 x i64] zeroinitializer, align 8
 @sorbet_moduleIDDescriptors = internal unnamed_addr constant [6 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 10 }, %struct.rb_code_position_struct { i32 61, i32 3 }, %struct.rb_code_position_struct { i32 65, i32 16 }, %struct.rb_code_position_struct { i32 89, i32 6 }, %struct.rb_code_position_struct { i32 96, i32 1 }, %struct.rb_code_position_struct { i32 105, i32 9 }], align 8
+@sorbet_moduleRubyStringTable = internal unnamed_addr global [5 x i64] zeroinitializer, align 8
+@sorbet_moduleRubyStringDescriptors = internal unnamed_addr constant [5 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 10 }, %struct.rb_code_position_struct { i32 11, i32 40 }, %struct.rb_code_position_struct { i32 65, i32 16 }, %struct.rb_code_position_struct { i32 61, i32 3 }, %struct.rb_code_position_struct { i32 105, i32 9 }], align 8
 @guard_epoch_A = linkonce local_unnamed_addr global i64 0
 @guarded_const_A = linkonce local_unnamed_addr global i64 0
 @rb_cObject = external local_unnamed_addr constant i64
@@ -128,7 +128,7 @@ declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_
 
 declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #3
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #3
+declare void @sorbet_vm_init_string_table(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #3
 
 declare i64 @rb_define_class(i8*, i64) local_unnamed_addr #3
 
@@ -137,8 +137,6 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #4
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #4
-
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #3
 
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #2
@@ -233,121 +231,110 @@ entry:
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
   tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([6 x %struct.rb_code_position_struct], [6 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 6, i8* noundef getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
-  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 10) #16
-  tail call void @rb_gc_register_mark_object(i64 %0) #16
-  store i64 %0, i64* @rubyStrFrozen_doubleCast, align 8
-  %1 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 11), i64 noundef 40) #16
-  tail call void @rb_gc_register_mark_object(i64 %1) #16
-  store i64 %1, i64* @"rubyStrFrozen_test/testdata/compiler/repeated_casts.rb", align 8
+  tail call void @sorbet_vm_init_string_table(i64* noundef getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleRubyStringTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([5 x %struct.rb_code_position_struct], [5 x %struct.rb_code_position_struct]* @sorbet_moduleRubyStringDescriptors, i32 0, i32 0), i32 noundef 5, i8* noundef getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 12)
   %rubyId_doubleCast.i.i = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
-  %rubyStr_doubleCast.i.i = load i64, i64* @rubyStrFrozen_doubleCast, align 8
-  %"rubyStr_test/testdata/compiler/repeated_casts.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/repeated_casts.rb", align 8
-  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_doubleCast.i.i, i64 %rubyId_doubleCast.i.i, i64 %"rubyStr_test/testdata/compiler/repeated_casts.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 1)
-  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#10doubleCast", align 8
+  %rubyStr_doubleCast.i.i = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 0), align 8, !invariant.load !5
+  %"rubyStr_test/testdata/compiler/repeated_casts.rb.i.i" = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
+  %0 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_doubleCast.i.i, i64 %rubyId_doubleCast.i.i, i64 %"rubyStr_test/testdata/compiler/repeated_casts.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 1)
+  store %struct.rb_iseq_struct* %0, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#10doubleCast", align 8
   %rubyId_foo.i = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !dbg !19, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !19
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo.1, i64 %rubyId_foo.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !24
-  %3 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 65), i64 noundef 16) #16
-  call void @rb_gc_register_mark_object(i64 %3) #16
   %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/repeated_casts.rb.i3.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/repeated_casts.rb", align 8
-  %4 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %3, i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/repeated_casts.rb.i3.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i4.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %4, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %5 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 61), i64 noundef 3) #16
-  call void @rb_gc_register_mark_object(i64 %5) #16
-  %"rubyStr_test/testdata/compiler/repeated_casts.rb.i5.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/repeated_casts.rb", align 8
-  %6 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %5, i64 %rubyId_foo.i, i64 %"rubyStr_test/testdata/compiler/repeated_casts.rb.i5.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i6.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %6, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#3foo", align 8
-  %7 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 105), i64 noundef 9) #16
-  call void @rb_gc_register_mark_object(i64 %7) #16
+  %"rubyStr_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 2), align 8, !invariant.load !5
+  %1 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/repeated_casts.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i4.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %1, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %rubyStr_foo.i.i = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 3), align 8, !invariant.load !5
+  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_foo.i.i, i64 %rubyId_foo.i, i64 %"rubyStr_test/testdata/compiler/repeated_casts.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i6.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#3foo", align 8
   %"rubyId_<class:A>.i.i" = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleIDTable, i64 0, i64 5), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/repeated_casts.rb.i7.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/repeated_casts.rb", align 8
-  %8 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %7, i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/repeated_casts.rb.i7.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i8.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %8, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %9 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %10 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %9, i64 0, i32 2
-  %11 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %10, align 8, !tbaa !27
-  %12 = bitcast i64* %positional_table.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %12)
+  %"rubyStr_<class:A>.i.i" = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 4), align 8, !invariant.load !5
+  %3 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<class:A>.i.i", i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/repeated_casts.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i8.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %3, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
+  %4 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %5 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %4, i64 0, i32 2
+  %6 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %5, align 8, !tbaa !27
+  %7 = bitcast i64* %positional_table.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %7)
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %13 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %13, align 8, !tbaa !31
-  %14 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 4
-  %15 = load i64*, i64** %14, align 8, !tbaa !33
-  %16 = load i64, i64* %15, align 8, !tbaa !6
-  %17 = and i64 %16, -33
-  store i64 %17, i64* %15, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %9, %struct.rb_control_frame_struct* %11, %struct.rb_iseq_struct* %stackFrame.i) #16
-  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %11, i64 0, i32 0
-  store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %18, align 8, !dbg !34, !tbaa !14
-  %19 = load i64, i64* @rb_cObject, align 8, !dbg !35
-  %20 = call i64 @rb_define_class(i8* getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 52), i64 %19) #16, !dbg !35
-  %21 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %20) #16, !dbg !35
+  %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %6, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %8, align 8, !tbaa !31
+  %9 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %6, i64 0, i32 4
+  %10 = load i64*, i64** %9, align 8, !tbaa !33
+  %11 = load i64, i64* %10, align 8, !tbaa !6
+  %12 = and i64 %11, -33
+  store i64 %12, i64* %10, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %4, %struct.rb_control_frame_struct* %6, %struct.rb_iseq_struct* %stackFrame.i) #16
+  %13 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %6, i64 0, i32 0
+  store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %13, align 8, !dbg !34, !tbaa !14
+  %14 = load i64, i64* @rb_cObject, align 8, !dbg !35
+  %15 = call i64 @rb_define_class(i8* getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 52), i64 %14) #16, !dbg !35
+  %16 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %15) #16, !dbg !35
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %22 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %23 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %22, i64 0, i32 2
-  %24 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %23, align 8, !tbaa !27
-  %25 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %25, align 8, !tbaa !31
-  %26 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %24, i64 0, i32 4
-  %27 = load i64*, i64** %26, align 8, !tbaa !33
-  %28 = load i64, i64* %27, align 8, !tbaa !6
-  %29 = and i64 %28, -33
-  store i64 %29, i64* %27, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %22, %struct.rb_control_frame_struct* %24, %struct.rb_iseq_struct* %stackFrame.i.i) #16
-  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %21, i64 0, i32 0
-  store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %30, align 8, !dbg !36, !tbaa !14
+  %17 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %18 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %17, i64 0, i32 2
+  %19 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %18, align 8, !tbaa !27
+  %20 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %19, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %20, align 8, !tbaa !31
+  %21 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %19, i64 0, i32 4
+  %22 = load i64*, i64** %21, align 8, !tbaa !33
+  %23 = load i64, i64* %22, align 8, !tbaa !6
+  %24 = and i64 %23, -33
+  store i64 %24, i64* %22, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %17, %struct.rb_control_frame_struct* %19, %struct.rb_iseq_struct* %stackFrame.i.i) #16
+  %25 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %16, i64 0, i32 0
+  store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %25, align 8, !dbg !36, !tbaa !14
+  %26 = load i64, i64* @guard_epoch_A, align 8, !dbg !39
+  %27 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !39, !tbaa !20
+  %needTakeSlowPath = icmp ne i64 %26, %27, !dbg !39
+  br i1 %needTakeSlowPath, label %28, label %29, !dbg !39, !prof !22
+
+28:                                               ; preds = %entry
+  call void @const_recompute_A(), !dbg !39
+  br label %29, !dbg !39
+
+29:                                               ; preds = %entry, %28
+  %30 = load i64, i64* @guarded_const_A, align 8, !dbg !39
   %31 = load i64, i64* @guard_epoch_A, align 8, !dbg !39
   %32 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !39, !tbaa !20
-  %needTakeSlowPath = icmp ne i64 %31, %32, !dbg !39
-  br i1 %needTakeSlowPath, label %33, label %34, !dbg !39, !prof !22
-
-33:                                               ; preds = %entry
-  call void @const_recompute_A(), !dbg !39
-  br label %34, !dbg !39
-
-34:                                               ; preds = %entry, %33
-  %35 = load i64, i64* @guarded_const_A, align 8, !dbg !39
-  %36 = load i64, i64* @guard_epoch_A, align 8, !dbg !39
-  %37 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !39, !tbaa !20
-  %guardUpdated = icmp eq i64 %36, %37, !dbg !39
+  %guardUpdated = icmp eq i64 %31, %32, !dbg !39
   call void @llvm.assume(i1 %guardUpdated), !dbg !39
   %stackFrame7.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#3foo", align 8, !dbg !39
-  %38 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #17, !dbg !39
-  %39 = bitcast i8* %38 to i16*, !dbg !39
-  %40 = load i16, i16* %39, align 8, !dbg !39
-  %41 = and i16 %40, -384, !dbg !39
-  store i16 %41, i16* %39, align 8, !dbg !39
-  %42 = getelementptr inbounds i8, i8* %38, i64 4, !dbg !39
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %42, i8 0, i64 28, i1 false) #16, !dbg !39
-  call void @sorbet_vm_define_method(i64 %35, i8* getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 61), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_A#3foo", i8* nonnull %38, %struct.rb_iseq_struct* %stackFrame7.i.i, i1 noundef zeroext false) #16, !dbg !39
+  %33 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #17, !dbg !39
+  %34 = bitcast i8* %33 to i16*, !dbg !39
+  %35 = load i16, i16* %34, align 8, !dbg !39
+  %36 = and i16 %35, -384, !dbg !39
+  store i16 %36, i16* %34, align 8, !dbg !39
+  %37 = getelementptr inbounds i8, i8* %33, i64 4, !dbg !39
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %37, i8 0, i64 28, i1 false) #16, !dbg !39
+  call void @sorbet_vm_define_method(i64 %30, i8* getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 61), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_A#3foo", i8* nonnull %33, %struct.rb_iseq_struct* %stackFrame7.i.i, i1 noundef zeroext false) #16, !dbg !39
   call void @sorbet_popFrame() #16, !dbg !35
-  store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %18, align 8, !dbg !35, !tbaa !14
+  store i64* getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %13, align 8, !dbg !35, !tbaa !14
   %stackFrame19.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#10doubleCast", align 8, !dbg !25
-  %43 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #17, !dbg !25
-  %44 = bitcast i8* %43 to i16*, !dbg !25
-  %45 = load i16, i16* %44, align 8, !dbg !25
-  %46 = and i16 %45, -384, !dbg !25
-  %47 = or i16 %46, 1, !dbg !25
-  store i16 %47, i16* %44, align 8, !dbg !25
-  %48 = getelementptr inbounds i8, i8* %43, i64 8, !dbg !25
-  %49 = bitcast i8* %48 to i32*, !dbg !25
-  store i32 1, i32* %49, align 8, !dbg !25, !tbaa !40
-  %50 = getelementptr inbounds i8, i8* %43, i64 12, !dbg !25
-  %51 = getelementptr inbounds i8, i8* %43, i64 4, !dbg !25
-  %52 = bitcast i8* %51 to i32*, !dbg !25
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %50, i8 0, i64 20, i1 false) #16, !dbg !25
-  store i32 1, i32* %52, align 4, !dbg !25, !tbaa !43
+  %38 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #17, !dbg !25
+  %39 = bitcast i8* %38 to i16*, !dbg !25
+  %40 = load i16, i16* %39, align 8, !dbg !25
+  %41 = and i16 %40, -384, !dbg !25
+  %42 = or i16 %41, 1, !dbg !25
+  store i16 %42, i16* %39, align 8, !dbg !25
+  %43 = getelementptr inbounds i8, i8* %38, i64 8, !dbg !25
+  %44 = bitcast i8* %43 to i32*, !dbg !25
+  store i32 1, i32* %44, align 8, !dbg !25, !tbaa !40
+  %45 = getelementptr inbounds i8, i8* %38, i64 12, !dbg !25
+  %46 = getelementptr inbounds i8, i8* %38, i64 4, !dbg !25
+  %47 = bitcast i8* %46 to i32*, !dbg !25
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %45, i8 0, i64 20, i1 false) #16, !dbg !25
+  store i32 1, i32* %47, align 4, !dbg !25, !tbaa !43
   %rubyId_a.i = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !dbg !25, !invariant.load !5
   store i64 %rubyId_a.i, i64* %positional_table.i, align 8, !dbg !25
-  %53 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #17, !dbg !25
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %53, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %12, i64 noundef 8, i1 noundef false) #16, !dbg !25
-  %54 = getelementptr inbounds i8, i8* %43, i64 32, !dbg !25
-  %55 = bitcast i8* %54 to i8**, !dbg !25
-  store i8* %53, i8** %55, align 8, !dbg !25, !tbaa !44
-  call void @sorbet_vm_define_method(i64 %19, i8* noundef getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#10doubleCast", i8* nonnull %43, %struct.rb_iseq_struct* %stackFrame19.i, i1 noundef zeroext false) #16, !dbg !25
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %12)
+  %48 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 1, i64 noundef 8) #17, !dbg !25
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %48, i8* nocapture noundef nonnull readonly align 8 dereferenceable(8) %7, i64 noundef 8, i1 noundef false) #16, !dbg !25
+  %49 = getelementptr inbounds i8, i8* %38, i64 32, !dbg !25
+  %50 = bitcast i8* %49 to i8**, !dbg !25
+  store i8* %48, i8** %50, align 8, !dbg !25, !tbaa !44
+  call void @sorbet_vm_define_method(i64 %14, i8* noundef getelementptr inbounds ([115 x i8], [115 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#10doubleCast", i8* nonnull %38, %struct.rb_iseq_struct* %stackFrame19.i, i1 noundef zeroext false) #16, !dbg !25
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %7)
   ret void
 }
 

--- a/test/testdata/compiler/send_with_block_param.opt.ll.exp
+++ b/test/testdata/compiler/send_with_block_param.opt.ll.exp
@@ -83,8 +83,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"rubyStrFrozen_test/testdata/compiler/send_with_block_param.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [7 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @ruby_hashLiteral1 = internal unnamed_addr global i64 0, align 8
@@ -93,6 +91,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @sorbet_moduleStringTable = internal unnamed_addr constant [104 x i8] c"<top (required)>\00test/testdata/compiler/send_with_block_param.rb\00T\00unsafe\00<build-array>\00map\00puts\00master\00", align 1
 @sorbet_moduleIDTable = internal unnamed_addr global [5 x i64] zeroinitializer, align 8
 @sorbet_moduleIDDescriptors = internal unnamed_addr constant [5 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 67, i32 6 }, %struct.rb_code_position_struct { i32 74, i32 13 }, %struct.rb_code_position_struct { i32 88, i32 3 }, %struct.rb_code_position_struct { i32 92, i32 4 }], align 8
+@sorbet_moduleRubyStringTable = internal unnamed_addr global [2 x i64] zeroinitializer, align 8
+@sorbet_moduleRubyStringDescriptors = internal unnamed_addr constant [2 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 17, i32 47 }], align 8
 
 declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
 
@@ -112,7 +112,7 @@ declare i64 @sorbet_globalConstDupHash(i64) local_unnamed_addr #0
 
 declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #0
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
+declare void @sorbet_vm_init_string_table(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #0
 
 declare i64 @rb_intern2(i8*, i64) local_unnamed_addr #0
 
@@ -121,8 +121,6 @@ declare i64 @rb_ary_new_from_values(i64, i64*) local_unnamed_addr #0
 declare i64 @rb_hash_new_with_size(i64) local_unnamed_addr #0
 
 declare void @rb_hash_bulk_insert(i64, i64*, i64) local_unnamed_addr #0
-
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
 
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #1
@@ -156,102 +154,97 @@ entry:
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
   tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([5 x %struct.rb_code_position_struct], [5 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 5, i8* noundef getelementptr inbounds ([104 x i8], [104 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
-  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([104 x i8], [104 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #7
-  tail call void @rb_gc_register_mark_object(i64 %0) #7
-  store i64 %0, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %1 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([104 x i8], [104 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 47) #7
-  tail call void @rb_gc_register_mark_object(i64 %1) #7
-  store i64 %1, i64* @"rubyStrFrozen_test/testdata/compiler/send_with_block_param.rb", align 8
+  tail call void @sorbet_vm_init_string_table(i64* noundef getelementptr inbounds ([2 x i64], [2 x i64]* @sorbet_moduleRubyStringTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([2 x %struct.rb_code_position_struct], [2 x %struct.rb_code_position_struct]* @sorbet_moduleRubyStringDescriptors, i32 0, i32 0), i32 noundef 2, i8* noundef getelementptr inbounds ([104 x i8], [104 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 7)
   %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
-  %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/send_with_block_param.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/send_with_block_param.rb", align 8
-  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/send_with_block_param.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %3 = bitcast [2 x i64]* %argArray.i.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %3)
+  %"rubyStr_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([2 x i64], [2 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 0), align 8, !invariant.load !5
+  %"rubyStr_test/testdata/compiler/send_with_block_param.rb.i.i" = load i64, i64* getelementptr inbounds ([2 x i64], [2 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
+  %0 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/send_with_block_param.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %0, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %1 = bitcast [2 x i64]* %argArray.i.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %1)
   %hashArgs0Addr.i.i = getelementptr [2 x i64], [2 x i64]* %argArray.i.i, i64 0, i64 0
-  %4 = bitcast i64* %hashArgs0Addr.i.i to <2 x i64>*
-  store <2 x i64> <i64 3, i64 5>, <2 x i64>* %4, align 8
-  %5 = call i64 @rb_hash_new_with_size(i64 noundef 1) #7
-  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %hashArgs0Addr.i.i, i64 %5) #7
-  %6 = call i64 @sorbet_globalConstRegister(i64 %5) #7
-  store i64 %6, i64* @ruby_hashLiteral1, align 8
-  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %3)
+  %2 = bitcast i64* %hashArgs0Addr.i.i to <2 x i64>*
+  store <2 x i64> <i64 3, i64 5>, <2 x i64>* %2, align 8
+  %3 = call i64 @rb_hash_new_with_size(i64 noundef 1) #7
+  call void @rb_hash_bulk_insert(i64 noundef 2, i64* noundef nonnull %hashArgs0Addr.i.i, i64 %3) #7
+  %4 = call i64 @sorbet_globalConstRegister(i64 %3) #7
+  store i64 %4, i64* @ruby_hashLiteral1, align 8
+  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %1)
   %rubyId_map.i = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !10, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_map, i64 %rubyId_map.i, i32 noundef 18, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !10
   %rubyId_puts.i = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !dbg !15, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
-  %7 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !16
-  %8 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %7, i64 0, i32 18
-  %9 = load i64, i64* %8, align 8, !tbaa !18
-  %10 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !16
-  %11 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %10, i64 0, i32 2
-  %12 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %11, align 8, !tbaa !28
-  %13 = bitcast [4 x i64]* %callArgs.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 32, i8* nonnull %13)
+  %5 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !16
+  %6 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %5, i64 0, i32 18
+  %7 = load i64, i64* %6, align 8, !tbaa !18
+  %8 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !16
+  %9 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %8, i64 0, i32 2
+  %10 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %9, align 8, !tbaa !28
+  %11 = bitcast [4 x i64]* %callArgs.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 32, i8* nonnull %11)
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %14 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %11, align 8, !tbaa !28
-  %15 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %14, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %15, align 8, !tbaa !31
-  %16 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %14, i64 0, i32 4
-  %17 = load i64*, i64** %16, align 8, !tbaa !33
-  %18 = load i64, i64* %17, align 8, !tbaa !6
-  %19 = and i64 %18, -33
-  store i64 %19, i64* %17, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %10, %struct.rb_control_frame_struct* %14, %struct.rb_iseq_struct* %stackFrame.i) #7
-  %20 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 0
-  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %20, align 8, !dbg !34, !tbaa !16
+  %12 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %9, align 8, !tbaa !28
+  %13 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %13, align 8, !tbaa !31
+  %14 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 4
+  %15 = load i64*, i64** %14, align 8, !tbaa !33
+  %16 = load i64, i64* %15, align 8, !tbaa !6
+  %17 = and i64 %16, -33
+  store i64 %17, i64* %15, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %8, %struct.rb_control_frame_struct* %12, %struct.rb_iseq_struct* %stackFrame.i) #7
+  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %10, i64 0, i32 0
+  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %18, align 8, !dbg !34, !tbaa !16
   %hashLiteral.i = load i64, i64* @ruby_hashLiteral1, align 8, !dbg !35
   %duplicatedHash.i = call i64 @sorbet_globalConstDupHash(i64 %hashLiteral.i) #7, !dbg !35
   %callArgs0Addr.i = getelementptr [4 x i64], [4 x i64]* %callArgs.i, i64 0, i64 0, !dbg !36
   call void @llvm.experimental.noalias.scope.decl(metadata !37) #7, !dbg !36
-  %21 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !36, !tbaa !16
-  %22 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 5, !dbg !36
-  %23 = load i32, i32* %22, align 8, !dbg !36, !tbaa !40
-  %24 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 6, !dbg !36
-  %25 = load i32, i32* %24, align 4, !dbg !36, !tbaa !41
-  %26 = xor i32 %25, -1, !dbg !36
-  %27 = and i32 %26, %23, !dbg !36
-  %28 = icmp eq i32 %27, 0, !dbg !36
-  br i1 %28, label %rb_vm_check_ints.exit.i, label %29, !dbg !36, !prof !42
+  %19 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !36, !tbaa !16
+  %20 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %19, i64 0, i32 5, !dbg !36
+  %21 = load i32, i32* %20, align 8, !dbg !36, !tbaa !40
+  %22 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %19, i64 0, i32 6, !dbg !36
+  %23 = load i32, i32* %22, align 4, !dbg !36, !tbaa !41
+  %24 = xor i32 %23, -1, !dbg !36
+  %25 = and i32 %24, %21, !dbg !36
+  %26 = icmp eq i32 %25, 0, !dbg !36
+  br i1 %26, label %rb_vm_check_ints.exit.i, label %27, !dbg !36, !prof !42
 
-29:                                               ; preds = %entry
-  %30 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %21, i64 0, i32 8, !dbg !36
-  %31 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %30, align 8, !dbg !36, !tbaa !43
-  %32 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %31, i32 noundef 0) #7, !dbg !36
+27:                                               ; preds = %entry
+  %28 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %19, i64 0, i32 8, !dbg !36
+  %29 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %28, align 8, !dbg !36, !tbaa !43
+  %30 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %29, i32 noundef 0) #7, !dbg !36
   br label %rb_vm_check_ints.exit.i, !dbg !36
 
-rb_vm_check_ints.exit.i:                          ; preds = %29, %entry
-  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %20, align 8, !dbg !36, !tbaa !16
+rb_vm_check_ints.exit.i:                          ; preds = %27, %entry
+  store i64* getelementptr inbounds ([7 x i64], [7 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %18, align 8, !dbg !36, !tbaa !16
   store i64 3, i64* %callArgs0Addr.i, align 8, !dbg !10
   call void @llvm.experimental.noalias.scope.decl(metadata !44) #7, !dbg !10
-  %33 = call i64 @rb_ary_new_from_values(i64 noundef 1, i64* noundef nonnull %callArgs0Addr.i) #7, !dbg !10
-  %34 = icmp eq i64 %duplicatedHash.i, 8, !dbg !10
-  br i1 %34, label %"func_<root>.17<static-init>$153.exit", label %35, !dbg !10
+  %31 = call i64 @rb_ary_new_from_values(i64 noundef 1, i64* noundef nonnull %callArgs0Addr.i) #7, !dbg !10
+  %32 = icmp eq i64 %duplicatedHash.i, 8, !dbg !10
+  br i1 %32, label %"func_<root>.17<static-init>$153.exit", label %33, !dbg !10
 
-35:                                               ; preds = %rb_vm_check_ints.exit.i
-  %36 = call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @.str.7, i64 0, i64 0), i64 noundef 7) #7, !dbg !10
-  %37 = call i64 @rb_funcallv_with_cc(%struct.rb_call_data* noundef nonnull @sorbet_makeBlockHandlerProc.rb_funcallv_data, i64 %duplicatedHash.i, i64 %36, i32 noundef 0, i64* noundef null) #7, !dbg !10
+33:                                               ; preds = %rb_vm_check_ints.exit.i
+  %34 = call i64 @rb_intern2(i8* noundef getelementptr inbounds ([8 x i8], [8 x i8]* @.str.7, i64 0, i64 0), i64 noundef 7) #7, !dbg !10
+  %35 = call i64 @rb_funcallv_with_cc(%struct.rb_call_data* noundef nonnull @sorbet_makeBlockHandlerProc.rb_funcallv_data, i64 %duplicatedHash.i, i64 %34, i32 noundef 0, i64* noundef null) #7, !dbg !10
   br label %"func_<root>.17<static-init>$153.exit", !dbg !10
 
-"func_<root>.17<static-init>$153.exit":           ; preds = %rb_vm_check_ints.exit.i, %35
-  %38 = phi i64 [ %37, %35 ], [ 0, %rb_vm_check_ints.exit.i ], !dbg !10
-  %39 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 1, !dbg !10
-  %40 = load i64*, i64** %39, align 8, !dbg !10
-  store i64 %33, i64* %40, align 8, !dbg !10, !tbaa !6
-  %41 = getelementptr inbounds i64, i64* %40, i64 1, !dbg !10
-  store i64* %41, i64** %39, align 8, !dbg !10
-  %send.i = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_map, i64 %38) #7, !dbg !10
-  %42 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %12, i64 0, i32 1, !dbg !15
-  %43 = load i64*, i64** %42, align 8, !dbg !15
-  store i64 %9, i64* %43, align 8, !dbg !15, !tbaa !6
-  %44 = getelementptr inbounds i64, i64* %43, i64 1, !dbg !15
-  store i64 %send.i, i64* %44, align 8, !dbg !15, !tbaa !6
-  %45 = getelementptr inbounds i64, i64* %44, i64 1, !dbg !15
-  store i64* %45, i64** %42, align 8, !dbg !15
+"func_<root>.17<static-init>$153.exit":           ; preds = %rb_vm_check_ints.exit.i, %33
+  %36 = phi i64 [ %35, %33 ], [ 0, %rb_vm_check_ints.exit.i ], !dbg !10
+  %37 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %10, i64 0, i32 1, !dbg !10
+  %38 = load i64*, i64** %37, align 8, !dbg !10
+  store i64 %31, i64* %38, align 8, !dbg !10, !tbaa !6
+  %39 = getelementptr inbounds i64, i64* %38, i64 1, !dbg !10
+  store i64* %39, i64** %37, align 8, !dbg !10
+  %send.i = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_map, i64 %36) #7, !dbg !10
+  %40 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %10, i64 0, i32 1, !dbg !15
+  %41 = load i64*, i64** %40, align 8, !dbg !15
+  store i64 %7, i64* %41, align 8, !dbg !15, !tbaa !6
+  %42 = getelementptr inbounds i64, i64* %41, i64 1, !dbg !15
+  store i64 %send.i, i64* %42, align 8, !dbg !15, !tbaa !6
+  %43 = getelementptr inbounds i64, i64* %42, i64 1, !dbg !15
+  store i64* %43, i64** %40, align 8, !dbg !15
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !15
-  call void @llvm.lifetime.end.p0i8(i64 32, i8* nonnull %13)
+  call void @llvm.lifetime.end.p0i8(i64 32, i8* nonnull %11)
   ret void
 }
 

--- a/test/testdata/compiler/sig_rewriter.opt.ll.exp
+++ b/test/testdata/compiler/sig_rewriter.opt.ll.exp
@@ -82,8 +82,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [14 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @ic_new = internal global %struct.FunctionInlineCache zeroinitializer
@@ -98,6 +96,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @sorbet_moduleStringTable = internal unnamed_addr constant [175 x i8] c"<top (required)>\00test/testdata/compiler/sig_rewriter.rb\00A\00Object\00new\00initialize\00foo\00puts\00master\00Return value\00Integer\00<class:A>\00block in <class:A>\00returns\00T::Sig\00extend\00normal\00", align 1
 @sorbet_moduleIDTable = internal unnamed_addr global [10 x i64] zeroinitializer, align 8
 @sorbet_moduleIDDescriptors = internal unnamed_addr constant [10 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 65, i32 3 }, %struct.rb_code_position_struct { i32 69, i32 10 }, %struct.rb_code_position_struct { i32 80, i32 3 }, %struct.rb_code_position_struct { i32 84, i32 4 }, %struct.rb_code_position_struct { i32 117, i32 9 }, %struct.rb_code_position_struct { i32 127, i32 18 }, %struct.rb_code_position_struct { i32 146, i32 7 }, %struct.rb_code_position_struct { i32 161, i32 6 }, %struct.rb_code_position_struct { i32 168, i32 6 }], align 8
+@sorbet_moduleRubyStringTable = internal unnamed_addr global [5 x i64] zeroinitializer, align 8
+@sorbet_moduleRubyStringDescriptors = internal unnamed_addr constant [5 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 17, i32 38 }, %struct.rb_code_position_struct { i32 80, i32 3 }, %struct.rb_code_position_struct { i32 117, i32 9 }, %struct.rb_code_position_struct { i32 127, i32 18 }], align 8
 @rb_cObject = external local_unnamed_addr constant i64
 @"guard_epoch_T::Sig" = linkonce local_unnamed_addr global i64 0
 @"guarded_const_T::Sig" = linkonce local_unnamed_addr global i64 0
@@ -135,13 +135,11 @@ declare void @sorbet_vm_define_method(i64, i8*, i64 (i32, i64*, i64, %struct.rb_
 
 declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #2
 
+declare void @sorbet_vm_init_string_table(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #2
+
 declare i64 @sorbet_maybeAllocateObjectFastPath(i64, %struct.FunctionInlineCache*) local_unnamed_addr #2
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #2
-
 declare i64 @rb_define_class(i8*, i64) local_unnamed_addr #2
-
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #2
 
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #1
@@ -171,18 +169,13 @@ entry:
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
   tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([10 x %struct.rb_code_position_struct], [10 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 10, i8* noundef getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
-  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #11
-  tail call void @rb_gc_register_mark_object(i64 %0) #11
-  store i64 %0, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %1 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 38) #11
-  tail call void @rb_gc_register_mark_object(i64 %1) #11
-  store i64 %1, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
+  tail call void @sorbet_vm_init_string_table(i64* noundef getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleRubyStringTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([5 x %struct.rb_code_position_struct], [5 x %struct.rb_code_position_struct]* @sorbet_moduleRubyStringDescriptors, i32 0, i32 0), i32 noundef 5, i8* noundef getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 14)
   %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
-  %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
-  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %"rubyStr_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 0), align 8, !invariant.load !5
+  %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i.i" = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
+  %0 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %0, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
   %rubyId_new.i = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !dbg !10, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !10
   %rubyId_initialize.i = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !10, !invariant.load !5
@@ -191,153 +184,146 @@ entry:
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !10
   %rubyId_puts.i = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !dbg !15, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
-  %3 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 80), i64 noundef 3) #11
-  call void @rb_gc_register_mark_object(i64 %3) #11
-  %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i9.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
-  %4 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %3, i64 %rubyId_foo.i, i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i9.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i10.i, i32 noundef 0, i32 noundef 0)
-  store %struct.rb_iseq_struct* %4, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#3foo", align 8
-  %5 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 117), i64 noundef 9) #11
-  call void @rb_gc_register_mark_object(i64 %5) #11
+  %rubyStr_foo.i.i = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 2), align 8, !invariant.load !5
+  %1 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_foo.i.i, i64 %rubyId_foo.i, i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i10.i, i32 noundef 0, i32 noundef 0)
+  store %struct.rb_iseq_struct* %1, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#3foo", align 8
   %"rubyId_<class:A>.i.i" = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 5), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i11.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
-  %6 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %5, i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i11.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i12.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %6, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %7 = call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 127), i64 noundef 18) #11
-  call void @rb_gc_register_mark_object(i64 %7) #11
-  %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
+  %"rubyStr_<class:A>.i.i" = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 3), align 8, !invariant.load !5
+  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<class:A>.i.i", i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i12.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
   %"rubyId_block in <class:A>.i.i" = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 6), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i13.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/sig_rewriter.rb", align 8
-  %8 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %7, i64 %"rubyId_block in <class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i13.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %8, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>$block_1", align 8
+  %"rubyStr_block in <class:A>.i.i" = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 4), align 8, !invariant.load !5
+  %3 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <class:A>.i.i", i64 %"rubyId_block in <class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/sig_rewriter.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* %2, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %3, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>$block_1", align 8
   %rubyId_returns.i = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 7), align 8, !dbg !16, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !16
   %rubyId_extend.i = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 8), align 8, !dbg !19, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
-  %9 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !20
-  %10 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %9, i64 0, i32 18
-  %11 = load i64, i64* %10, align 8, !tbaa !22
-  %12 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !20
-  %13 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %12, i64 0, i32 2
-  %14 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %13, align 8, !tbaa !32
+  %4 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !20
+  %5 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %4, i64 0, i32 18
+  %6 = load i64, i64* %5, align 8, !tbaa !22
+  %7 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !20
+  %8 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %7, i64 0, i32 2
+  %9 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %8, align 8, !tbaa !32
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %15 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %14, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %15, align 8, !tbaa !35
-  %16 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %14, i64 0, i32 4
-  %17 = load i64*, i64** %16, align 8, !tbaa !37
-  %18 = load i64, i64* %17, align 8, !tbaa !6
-  %19 = and i64 %18, -33
-  store i64 %19, i64* %17, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %12, %struct.rb_control_frame_struct* %14, %struct.rb_iseq_struct* %stackFrame.i) #11
-  %20 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %14, i64 0, i32 0
-  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %20, align 8, !dbg !38, !tbaa !20
-  %21 = load i64, i64* @rb_cObject, align 8, !dbg !39
-  %22 = call i64 @rb_define_class(i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 56), i64 %21) #11, !dbg !39
-  %23 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %22) #11, !dbg !39
-  %stackFrame.i.i1 = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
-  %24 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !20
-  %25 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %24, i64 0, i32 2
-  %26 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %25, align 8, !tbaa !32
-  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i.i1, %struct.rb_iseq_struct** %27, align 8, !tbaa !35
-  %28 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 4
-  %29 = load i64*, i64** %28, align 8, !tbaa !37
-  %30 = load i64, i64* %29, align 8, !tbaa !6
-  %31 = and i64 %30, -33
-  store i64 %31, i64* %29, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %24, %struct.rb_control_frame_struct* %26, %struct.rb_iseq_struct* %stackFrame.i.i1) #11
-  %32 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 0
-  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %32, align 8, !dbg !40, !tbaa !20
+  %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %10, align 8, !tbaa !35
+  %11 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 4
+  %12 = load i64*, i64** %11, align 8, !tbaa !37
+  %13 = load i64, i64* %12, align 8, !tbaa !6
+  %14 = and i64 %13, -33
+  store i64 %14, i64* %12, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %7, %struct.rb_control_frame_struct* %9, %struct.rb_iseq_struct* %stackFrame.i) #11
+  %15 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 0
+  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %15, align 8, !dbg !38, !tbaa !20
+  %16 = load i64, i64* @rb_cObject, align 8, !dbg !39
+  %17 = call i64 @rb_define_class(i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 56), i64 %16) #11, !dbg !39
+  %18 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %17) #11, !dbg !39
+  %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.13<static-init>", align 8
+  %19 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !20
+  %20 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %19, i64 0, i32 2
+  %21 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %20, align 8, !tbaa !32
+  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %21, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %22, align 8, !tbaa !35
+  %23 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %21, i64 0, i32 4
+  %24 = load i64*, i64** %23, align 8, !tbaa !37
+  %25 = load i64, i64* %24, align 8, !tbaa !6
+  %26 = and i64 %25, -33
+  store i64 %26, i64* %24, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %19, %struct.rb_control_frame_struct* %21, %struct.rb_iseq_struct* %stackFrame.i.i) #11
+  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 0
+  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %27, align 8, !dbg !40, !tbaa !20
   %rawSym.i.i = call i64 @rb_id2sym(i64 %rubyId_foo.i) #11, !dbg !42
-  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym.i.i, i64 %22, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_A.13<static-init>L62$block_1") #11, !dbg !42
-  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %32, align 8, !dbg !42, !tbaa !20
+  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym.i.i, i64 %17, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_A.13<static-init>L62$block_1") #11, !dbg !42
+  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %27, align 8, !dbg !42, !tbaa !20
+  %28 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !43
+  %29 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !43, !tbaa !44
+  %needTakeSlowPath = icmp ne i64 %28, %29, !dbg !43
+  br i1 %needTakeSlowPath, label %30, label %31, !dbg !43, !prof !45
+
+30:                                               ; preds = %entry
+  call void @"const_recompute_T::Sig"(), !dbg !43
+  br label %31, !dbg !43
+
+31:                                               ; preds = %entry, %30
+  %32 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !43
   %33 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !43
   %34 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !43, !tbaa !44
-  %needTakeSlowPath = icmp ne i64 %33, %34, !dbg !43
-  br i1 %needTakeSlowPath, label %35, label %36, !dbg !43, !prof !45
-
-35:                                               ; preds = %entry
-  call void @"const_recompute_T::Sig"(), !dbg !43
-  br label %36, !dbg !43
-
-36:                                               ; preds = %entry, %35
-  %37 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !43
-  %38 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !43
-  %39 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !43, !tbaa !44
-  %guardUpdated = icmp eq i64 %38, %39, !dbg !43
+  %guardUpdated = icmp eq i64 %33, %34, !dbg !43
   call void @llvm.assume(i1 %guardUpdated), !dbg !43
-  %40 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %23, i64 0, i32 1, !dbg !43
-  %41 = load i64*, i64** %40, align 8, !dbg !43
-  store i64 %22, i64* %41, align 8, !dbg !43, !tbaa !6
-  %42 = getelementptr inbounds i64, i64* %41, i64 1, !dbg !43
-  store i64 %37, i64* %42, align 8, !dbg !43, !tbaa !6
-  %43 = getelementptr inbounds i64, i64* %42, i64 1, !dbg !43
-  store i64* %43, i64** %40, align 8, !dbg !43
+  %35 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %18, i64 0, i32 1, !dbg !43
+  %36 = load i64*, i64** %35, align 8, !dbg !43
+  store i64 %17, i64* %36, align 8, !dbg !43, !tbaa !6
+  %37 = getelementptr inbounds i64, i64* %36, i64 1, !dbg !43
+  store i64 %32, i64* %37, align 8, !dbg !43, !tbaa !6
+  %38 = getelementptr inbounds i64, i64* %37, i64 1, !dbg !43
+  store i64* %38, i64** %35, align 8, !dbg !43
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !43
-  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %32, align 8, !dbg !43, !tbaa !20
+  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %27, align 8, !dbg !43, !tbaa !20
+  %39 = load i64, i64* @guard_epoch_A, align 8, !dbg !46
+  %40 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !46, !tbaa !44
+  %needTakeSlowPath1 = icmp ne i64 %39, %40, !dbg !46
+  br i1 %needTakeSlowPath1, label %41, label %42, !dbg !46, !prof !45
+
+41:                                               ; preds = %31
+  call void @const_recompute_A(), !dbg !46
+  br label %42, !dbg !46
+
+42:                                               ; preds = %31, %41
+  %43 = load i64, i64* @guarded_const_A, align 8, !dbg !46
   %44 = load i64, i64* @guard_epoch_A, align 8, !dbg !46
   %45 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !46, !tbaa !44
-  %needTakeSlowPath2 = icmp ne i64 %44, %45, !dbg !46
-  br i1 %needTakeSlowPath2, label %46, label %47, !dbg !46, !prof !45
-
-46:                                               ; preds = %36
-  call void @const_recompute_A(), !dbg !46
-  br label %47, !dbg !46
-
-47:                                               ; preds = %36, %46
-  %48 = load i64, i64* @guarded_const_A, align 8, !dbg !46
-  %49 = load i64, i64* @guard_epoch_A, align 8, !dbg !46
-  %50 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !46, !tbaa !44
-  %guardUpdated3 = icmp eq i64 %49, %50, !dbg !46
-  call void @llvm.assume(i1 %guardUpdated3), !dbg !46
+  %guardUpdated2 = icmp eq i64 %44, %45, !dbg !46
+  call void @llvm.assume(i1 %guardUpdated2), !dbg !46
   %stackFrame42.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A#3foo", align 8, !dbg !46
-  %51 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !46
-  %52 = bitcast i8* %51 to i16*, !dbg !46
-  %53 = load i16, i16* %52, align 8, !dbg !46
-  %54 = and i16 %53, -384, !dbg !46
-  store i16 %54, i16* %52, align 8, !dbg !46
-  %55 = getelementptr inbounds i8, i8* %51, i64 4, !dbg !46
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %55, i8 0, i64 28, i1 false) #11, !dbg !46
-  call void @sorbet_vm_define_method(i64 %48, i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 80), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_A#3foo", i8* nonnull %51, %struct.rb_iseq_struct* %stackFrame42.i.i, i1 noundef zeroext false) #11, !dbg !46
+  %46 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #12, !dbg !46
+  %47 = bitcast i8* %46 to i16*, !dbg !46
+  %48 = load i16, i16* %47, align 8, !dbg !46
+  %49 = and i16 %48, -384, !dbg !46
+  store i16 %49, i16* %47, align 8, !dbg !46
+  %50 = getelementptr inbounds i8, i8* %46, i64 4, !dbg !46
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %50, i8 0, i64 28, i1 false) #11, !dbg !46
+  call void @sorbet_vm_define_method(i64 %43, i8* getelementptr inbounds ([175 x i8], [175 x i8]* @sorbet_moduleStringTable, i64 0, i64 80), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_A#3foo", i8* nonnull %46, %struct.rb_iseq_struct* %stackFrame42.i.i, i1 noundef zeroext false) #11, !dbg !46
   call void @sorbet_popFrame() #11, !dbg !39
-  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %20, align 8, !dbg !39, !tbaa !20
-  %56 = call i64 @sorbet_maybeAllocateObjectFastPath(i64 %48, %struct.FunctionInlineCache* noundef @ic_new) #11, !dbg !10
-  %57 = icmp eq i64 %56, 52, !dbg !10
-  br i1 %57, label %slowNew.i, label %fastNew.i, !dbg !10
+  store i64* getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %15, align 8, !dbg !39, !tbaa !20
+  %51 = call i64 @sorbet_maybeAllocateObjectFastPath(i64 %43, %struct.FunctionInlineCache* noundef @ic_new) #11, !dbg !10
+  %52 = icmp eq i64 %51, 52, !dbg !10
+  br i1 %52, label %slowNew.i, label %fastNew.i, !dbg !10
 
-slowNew.i:                                        ; preds = %47
-  %58 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %14, i64 0, i32 1, !dbg !10
-  %59 = load i64*, i64** %58, align 8, !dbg !10
-  store i64 %48, i64* %59, align 8, !dbg !10, !tbaa !6
-  %60 = getelementptr inbounds i64, i64* %59, i64 1, !dbg !10
-  store i64* %60, i64** %58, align 8, !dbg !10
-  %61 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_new, i64 noundef 0) #11, !dbg !10
+slowNew.i:                                        ; preds = %42
+  %53 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 1, !dbg !10
+  %54 = load i64*, i64** %53, align 8, !dbg !10
+  store i64 %43, i64* %54, align 8, !dbg !10, !tbaa !6
+  %55 = getelementptr inbounds i64, i64* %54, i64 1, !dbg !10
+  store i64* %55, i64** %53, align 8, !dbg !10
+  %56 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_new, i64 noundef 0) #11, !dbg !10
   br label %"func_<root>.17<static-init>$153.exit", !dbg !10
 
-fastNew.i:                                        ; preds = %47
-  %62 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %14, i64 0, i32 1, !dbg !10
-  %63 = load i64*, i64** %62, align 8, !dbg !10
-  store i64 %56, i64* %63, align 8, !dbg !10, !tbaa !6
-  %64 = getelementptr inbounds i64, i64* %63, i64 1, !dbg !10
-  store i64* %64, i64** %62, align 8, !dbg !10
-  %65 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 noundef 0) #11, !dbg !10
+fastNew.i:                                        ; preds = %42
+  %57 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 1, !dbg !10
+  %58 = load i64*, i64** %57, align 8, !dbg !10
+  store i64 %51, i64* %58, align 8, !dbg !10, !tbaa !6
+  %59 = getelementptr inbounds i64, i64* %58, i64 1, !dbg !10
+  store i64* %59, i64** %57, align 8, !dbg !10
+  %60 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 noundef 0) #11, !dbg !10
   br label %"func_<root>.17<static-init>$153.exit", !dbg !10
 
 "func_<root>.17<static-init>$153.exit":           ; preds = %slowNew.i, %fastNew.i
-  %initializedObject.i = phi i64 [ %61, %slowNew.i ], [ %56, %fastNew.i ], !dbg !10
-  %66 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %14, i64 0, i32 1, !dbg !10
-  %67 = load i64*, i64** %66, align 8, !dbg !10
-  store i64 %initializedObject.i, i64* %67, align 8, !dbg !10, !tbaa !6
-  %68 = getelementptr inbounds i64, i64* %67, i64 1, !dbg !10
-  store i64* %68, i64** %66, align 8, !dbg !10
-  %send5 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo, i64 0), !dbg !10
-  %69 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %14, i64 0, i32 1, !dbg !15
-  %70 = load i64*, i64** %69, align 8, !dbg !15
-  store i64 %11, i64* %70, align 8, !dbg !15, !tbaa !6
-  %71 = getelementptr inbounds i64, i64* %70, i64 1, !dbg !15
-  store i64 %send5, i64* %71, align 8, !dbg !15, !tbaa !6
-  %72 = getelementptr inbounds i64, i64* %71, i64 1, !dbg !15
-  store i64* %72, i64** %69, align 8, !dbg !15
-  %send7 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !15
+  %initializedObject.i = phi i64 [ %56, %slowNew.i ], [ %51, %fastNew.i ], !dbg !10
+  %61 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 1, !dbg !10
+  %62 = load i64*, i64** %61, align 8, !dbg !10
+  store i64 %initializedObject.i, i64* %62, align 8, !dbg !10, !tbaa !6
+  %63 = getelementptr inbounds i64, i64* %62, i64 1, !dbg !10
+  store i64* %63, i64** %61, align 8, !dbg !10
+  %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_foo, i64 0), !dbg !10
+  %64 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %9, i64 0, i32 1, !dbg !15
+  %65 = load i64*, i64** %64, align 8, !dbg !15
+  store i64 %6, i64* %65, align 8, !dbg !15, !tbaa !6
+  %66 = getelementptr inbounds i64, i64* %65, i64 1, !dbg !15
+  store i64 %send4, i64* %66, align 8, !dbg !15, !tbaa !6
+  %67 = getelementptr inbounds i64, i64* %66, i64 1, !dbg !15
+  store i64* %67, i64** %64, align 8, !dbg !15
+  %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !15
   ret void
 }
 

--- a/test/testdata/compiler/splat_assign.opt.ll.exp
+++ b/test/testdata/compiler/splat_assign.opt.ll.exp
@@ -81,8 +81,6 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"rubyStrFrozen_test/testdata/compiler/splat_assign.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [13 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
@@ -91,6 +89,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @sorbet_moduleStringTable = internal unnamed_addr constant [100 x i8] c"<top (required)>\00test/testdata/compiler/splat_assign.rb\00<build-array>\00<expand-splat>\00[]\00puts\00master\00", align 1
 @sorbet_moduleIDTable = internal unnamed_addr global [5 x i64] zeroinitializer, align 8
 @sorbet_moduleIDDescriptors = internal unnamed_addr constant [5 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 56, i32 13 }, %struct.rb_code_position_struct { i32 70, i32 14 }, %struct.rb_code_position_struct { i32 85, i32 2 }, %struct.rb_code_position_struct { i32 88, i32 4 }], align 8
+@sorbet_moduleRubyStringTable = internal unnamed_addr global [2 x i64] zeroinitializer, align 8
+@sorbet_moduleRubyStringDescriptors = internal unnamed_addr constant [2 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 17, i32 38 }], align 8
 
 declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
 
@@ -108,11 +108,9 @@ declare i64 @sorbet_vm_expandSplatIntrinsic(i64, i64, i64) local_unnamed_addr #0
 
 declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #0
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
+declare void @sorbet_vm_init_string_table(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #0
 
 declare i64 @rb_ary_new_from_values(i64, i64*) local_unnamed_addr #0
-
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
 
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #1
@@ -147,300 +145,295 @@ entry:
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
   tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([5 x %struct.rb_code_position_struct], [5 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 5, i8* noundef getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
-  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #7
-  tail call void @rb_gc_register_mark_object(i64 %0) #7
-  store i64 %0, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %1 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 38) #7
-  tail call void @rb_gc_register_mark_object(i64 %1) #7
-  store i64 %1, i64* @"rubyStrFrozen_test/testdata/compiler/splat_assign.rb", align 8
+  tail call void @sorbet_vm_init_string_table(i64* noundef getelementptr inbounds ([2 x i64], [2 x i64]* @sorbet_moduleRubyStringTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([2 x %struct.rb_code_position_struct], [2 x %struct.rb_code_position_struct]* @sorbet_moduleRubyStringDescriptors, i32 0, i32 0), i32 noundef 2, i8* noundef getelementptr inbounds ([100 x i8], [100 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 13)
   %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
-  %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/splat_assign.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/splat_assign.rb", align 8
-  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/splat_assign.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 8)
-  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %"rubyStr_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([2 x i64], [2 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 0), align 8, !invariant.load !5
+  %"rubyStr_test/testdata/compiler/splat_assign.rb.i.i" = load i64, i64* getelementptr inbounds ([2 x i64], [2 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
+  %0 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/splat_assign.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 8)
+  store %struct.rb_iseq_struct* %0, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
   %rubyId_puts.i = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !dbg !10, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !10
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.6, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.10, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !16
-  %3 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !17
-  %4 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %3, i64 0, i32 18
-  %5 = load i64, i64* %4, align 8, !tbaa !19
-  %6 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !17
-  %7 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %6, i64 0, i32 2
-  %8 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %7, align 8, !tbaa !29
-  %9 = bitcast [8 x i64]* %callArgs.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 64, i8* nonnull %9)
+  %1 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !17
+  %2 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %1, i64 0, i32 18
+  %3 = load i64, i64* %2, align 8, !tbaa !19
+  %4 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !17
+  %5 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %4, i64 0, i32 2
+  %6 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %5, align 8, !tbaa !29
+  %7 = bitcast [8 x i64]* %callArgs.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 64, i8* nonnull %7)
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %10 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %7, align 8, !tbaa !29
-  %11 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %10, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %11, align 8, !tbaa !32
-  %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %10, i64 0, i32 4
-  %13 = load i64*, i64** %12, align 8, !tbaa !34
-  %14 = load i64, i64* %13, align 8, !tbaa !6
-  %15 = and i64 %14, -33
-  store i64 %15, i64* %13, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %6, %struct.rb_control_frame_struct* %10, %struct.rb_iseq_struct* %stackFrame.i) #7
-  %16 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %8, i64 0, i32 0
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %16, align 8, !dbg !35, !tbaa !17
+  %8 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %5, align 8, !tbaa !29
+  %9 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %8, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %9, align 8, !tbaa !32
+  %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %8, i64 0, i32 4
+  %11 = load i64*, i64** %10, align 8, !tbaa !34
+  %12 = load i64, i64* %11, align 8, !tbaa !6
+  %13 = and i64 %12, -33
+  store i64 %13, i64* %11, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %4, %struct.rb_control_frame_struct* %8, %struct.rb_iseq_struct* %stackFrame.i) #7
+  %14 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %6, i64 0, i32 0
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %14, align 8, !dbg !35, !tbaa !17
   %callArgs0Addr.i = getelementptr [8 x i64], [8 x i64]* %callArgs.i, i64 0, i64 0, !dbg !36
   %callArgs1Addr.i = getelementptr [8 x i64], [8 x i64]* %callArgs.i, i64 0, i64 1, !dbg !36
   %callArgs2Addr.i = getelementptr [8 x i64], [8 x i64]* %callArgs.i, i64 0, i64 2, !dbg !36
-  %17 = bitcast i64* %callArgs0Addr.i to <4 x i64>*, !dbg !36
-  store <4 x i64> <i64 3, i64 5, i64 7, i64 9>, <4 x i64>* %17, align 8, !dbg !36
+  %15 = bitcast i64* %callArgs0Addr.i to <4 x i64>*, !dbg !36
+  store <4 x i64> <i64 3, i64 5, i64 7, i64 9>, <4 x i64>* %15, align 8, !dbg !36
   %callArgs4Addr.i = getelementptr [8 x i64], [8 x i64]* %callArgs.i, i64 0, i64 4, !dbg !36
-  %18 = bitcast i64* %callArgs4Addr.i to <2 x i64>*, !dbg !36
-  store <2 x i64> <i64 11, i64 13>, <2 x i64>* %18, align 8, !dbg !36
+  %16 = bitcast i64* %callArgs4Addr.i to <2 x i64>*, !dbg !36
+  store <2 x i64> <i64 11, i64 13>, <2 x i64>* %16, align 8, !dbg !36
   %callArgs6Addr.i = getelementptr [8 x i64], [8 x i64]* %callArgs.i, i64 0, i64 6, !dbg !36
   store i64 15, i64* %callArgs6Addr.i, align 8, !dbg !36
   call void @llvm.experimental.noalias.scope.decl(metadata !37) #7, !dbg !36
-  %19 = call i64 @rb_ary_new_from_values(i64 noundef 7, i64* noundef nonnull align 8 %callArgs0Addr.i) #7, !dbg !36
-  store i64 %19, i64* %callArgs0Addr.i, align 8, !dbg !40
-  %20 = bitcast i64* %callArgs1Addr.i to <2 x i64>*, !dbg !40
-  store <2 x i64> <i64 3, i64 5>, <2 x i64>* %20, align 8, !dbg !40
+  %17 = call i64 @rb_ary_new_from_values(i64 noundef 7, i64* noundef nonnull align 8 %callArgs0Addr.i) #7, !dbg !36
+  store i64 %17, i64* %callArgs0Addr.i, align 8, !dbg !40
+  %18 = bitcast i64* %callArgs1Addr.i to <2 x i64>*, !dbg !40
+  store <2 x i64> <i64 3, i64 5>, <2 x i64>* %18, align 8, !dbg !40
   call void @llvm.experimental.noalias.scope.decl(metadata !41) #7, !dbg !40
-  %21 = getelementptr inbounds i64, i64* %callArgs0Addr.i, i64 1, !dbg !40
-  %22 = getelementptr inbounds i64, i64* %callArgs0Addr.i, i64 2, !dbg !40
-  %23 = call i64 @sorbet_vm_expandSplatIntrinsic(i64 %19, i64 3, i64 5) #7, !dbg !40, !noalias !41
+  %19 = getelementptr inbounds i64, i64* %callArgs0Addr.i, i64 1, !dbg !40
+  %20 = getelementptr inbounds i64, i64* %callArgs0Addr.i, i64 2, !dbg !40
+  %21 = call i64 @sorbet_vm_expandSplatIntrinsic(i64 %17, i64 3, i64 5) #7, !dbg !40, !noalias !41
   store i64 1, i64* %callArgs0Addr.i, align 8, !dbg !40
   call void @llvm.experimental.noalias.scope.decl(metadata !44) #7, !dbg !40
-  %24 = call i64 @rb_ary_entry(i64 %23, i64 0) #7, !dbg !40
-  %25 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !40, !tbaa !17
-  %26 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %25, i64 0, i32 5, !dbg !40
-  %27 = load i32, i32* %26, align 8, !dbg !40, !tbaa !47
-  %28 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %25, i64 0, i32 6, !dbg !40
-  %29 = load i32, i32* %28, align 4, !dbg !40, !tbaa !48
-  %30 = xor i32 %29, -1, !dbg !40
-  %31 = and i32 %30, %27, !dbg !40
-  %32 = icmp eq i32 %31, 0, !dbg !40
-  br i1 %32, label %sorbet_rb_array_square_br.exit370.i, label %33, !dbg !40, !prof !49
+  %22 = call i64 @rb_ary_entry(i64 %21, i64 0) #7, !dbg !40
+  %23 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !40, !tbaa !17
+  %24 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %23, i64 0, i32 5, !dbg !40
+  %25 = load i32, i32* %24, align 8, !dbg !40, !tbaa !47
+  %26 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %23, i64 0, i32 6, !dbg !40
+  %27 = load i32, i32* %26, align 4, !dbg !40, !tbaa !48
+  %28 = xor i32 %27, -1, !dbg !40
+  %29 = and i32 %28, %25, !dbg !40
+  %30 = icmp eq i32 %29, 0, !dbg !40
+  br i1 %30, label %sorbet_rb_array_square_br.exit370.i, label %31, !dbg !40, !prof !49
 
-33:                                               ; preds = %entry
-  %34 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %25, i64 0, i32 8, !dbg !40
-  %35 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %34, align 8, !dbg !40, !tbaa !50
-  %36 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %35, i32 noundef 0) #7, !dbg !40
+31:                                               ; preds = %entry
+  %32 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %23, i64 0, i32 8, !dbg !40
+  %33 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %32, align 8, !dbg !40, !tbaa !50
+  %34 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %33, i32 noundef 0) #7, !dbg !40
   br label %sorbet_rb_array_square_br.exit370.i, !dbg !40
 
-sorbet_rb_array_square_br.exit370.i:              ; preds = %33, %entry
+sorbet_rb_array_square_br.exit370.i:              ; preds = %31, %entry
   store i64 -3, i64* %callArgs0Addr.i, align 8, !dbg !40
   call void @llvm.experimental.noalias.scope.decl(metadata !51) #7, !dbg !40
-  %37 = call i64 @rb_ary_entry(i64 %23, i64 -2) #7, !dbg !40
-  %38 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !40, !tbaa !17
-  %39 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %38, i64 0, i32 5, !dbg !40
-  %40 = load i32, i32* %39, align 8, !dbg !40, !tbaa !47
-  %41 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %38, i64 0, i32 6, !dbg !40
-  %42 = load i32, i32* %41, align 4, !dbg !40, !tbaa !48
-  %43 = xor i32 %42, -1, !dbg !40
-  %44 = and i32 %43, %40, !dbg !40
-  %45 = icmp eq i32 %44, 0, !dbg !40
-  br i1 %45, label %sorbet_rb_array_square_br.exit371.i, label %46, !dbg !40, !prof !49
+  %35 = call i64 @rb_ary_entry(i64 %21, i64 -2) #7, !dbg !40
+  %36 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !40, !tbaa !17
+  %37 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %36, i64 0, i32 5, !dbg !40
+  %38 = load i32, i32* %37, align 8, !dbg !40, !tbaa !47
+  %39 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %36, i64 0, i32 6, !dbg !40
+  %40 = load i32, i32* %39, align 4, !dbg !40, !tbaa !48
+  %41 = xor i32 %40, -1, !dbg !40
+  %42 = and i32 %41, %38, !dbg !40
+  %43 = icmp eq i32 %42, 0, !dbg !40
+  br i1 %43, label %sorbet_rb_array_square_br.exit371.i, label %44, !dbg !40, !prof !49
 
-46:                                               ; preds = %sorbet_rb_array_square_br.exit370.i
-  %47 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %38, i64 0, i32 8, !dbg !40
-  %48 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %47, align 8, !dbg !40, !tbaa !50
-  %49 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %48, i32 noundef 0) #7, !dbg !40
+44:                                               ; preds = %sorbet_rb_array_square_br.exit370.i
+  %45 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %36, i64 0, i32 8, !dbg !40
+  %46 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %45, align 8, !dbg !40, !tbaa !50
+  %47 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %46, i32 noundef 0) #7, !dbg !40
   br label %sorbet_rb_array_square_br.exit371.i, !dbg !40
 
-sorbet_rb_array_square_br.exit371.i:              ; preds = %46, %sorbet_rb_array_square_br.exit370.i
+sorbet_rb_array_square_br.exit371.i:              ; preds = %44, %sorbet_rb_array_square_br.exit370.i
   store i64 -1, i64* %callArgs0Addr.i, align 8, !dbg !40
   call void @llvm.experimental.noalias.scope.decl(metadata !54) #7, !dbg !40
-  %50 = call i64 @rb_ary_entry(i64 %23, i64 -1) #7, !dbg !40
-  %51 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !40, !tbaa !17
-  %52 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %51, i64 0, i32 5, !dbg !40
-  %53 = load i32, i32* %52, align 8, !dbg !40, !tbaa !47
-  %54 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %51, i64 0, i32 6, !dbg !40
-  %55 = load i32, i32* %54, align 4, !dbg !40, !tbaa !48
-  %56 = xor i32 %55, -1, !dbg !40
-  %57 = and i32 %56, %53, !dbg !40
-  %58 = icmp eq i32 %57, 0, !dbg !40
-  br i1 %58, label %sorbet_rb_array_square_br.exit372.i, label %59, !dbg !40, !prof !49
+  %48 = call i64 @rb_ary_entry(i64 %21, i64 -1) #7, !dbg !40
+  %49 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !40, !tbaa !17
+  %50 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %49, i64 0, i32 5, !dbg !40
+  %51 = load i32, i32* %50, align 8, !dbg !40, !tbaa !47
+  %52 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %49, i64 0, i32 6, !dbg !40
+  %53 = load i32, i32* %52, align 4, !dbg !40, !tbaa !48
+  %54 = xor i32 %53, -1, !dbg !40
+  %55 = and i32 %54, %51, !dbg !40
+  %56 = icmp eq i32 %55, 0, !dbg !40
+  br i1 %56, label %sorbet_rb_array_square_br.exit372.i, label %57, !dbg !40, !prof !49
 
-59:                                               ; preds = %sorbet_rb_array_square_br.exit371.i
-  %60 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %51, i64 0, i32 8, !dbg !40
-  %61 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %60, align 8, !dbg !40, !tbaa !50
-  %62 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %61, i32 noundef 0) #7, !dbg !40
+57:                                               ; preds = %sorbet_rb_array_square_br.exit371.i
+  %58 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %49, i64 0, i32 8, !dbg !40
+  %59 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %58, align 8, !dbg !40, !tbaa !50
+  %60 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %59, i32 noundef 0) #7, !dbg !40
   br label %sorbet_rb_array_square_br.exit372.i, !dbg !40
 
-sorbet_rb_array_square_br.exit372.i:              ; preds = %59, %sorbet_rb_array_square_br.exit371.i
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %16, align 8, !dbg !35, !tbaa !17
-  store i64 %24, i64* %callArgs0Addr.i, align 8, !dbg !57
-  store i64 %37, i64* %callArgs1Addr.i, align 8, !dbg !57
-  store i64 %50, i64* %callArgs2Addr.i, align 8, !dbg !57
+sorbet_rb_array_square_br.exit372.i:              ; preds = %57, %sorbet_rb_array_square_br.exit371.i
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %14, align 8, !dbg !35, !tbaa !17
+  store i64 %22, i64* %callArgs0Addr.i, align 8, !dbg !57
+  store i64 %35, i64* %callArgs1Addr.i, align 8, !dbg !57
+  store i64 %48, i64* %callArgs2Addr.i, align 8, !dbg !57
   call void @llvm.experimental.noalias.scope.decl(metadata !58) #7, !dbg !57
-  %63 = call i64 @rb_ary_new_from_values(i64 noundef 3, i64* noundef nonnull %callArgs0Addr.i) #7, !dbg !57
-  %64 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %8, i64 0, i32 1, !dbg !10
-  %65 = load i64*, i64** %64, align 8, !dbg !10
-  store i64 %5, i64* %65, align 8, !dbg !10, !tbaa !6
-  %66 = getelementptr inbounds i64, i64* %65, i64 1, !dbg !10
-  store i64 %63, i64* %66, align 8, !dbg !10, !tbaa !6
-  %67 = getelementptr inbounds i64, i64* %66, i64 1, !dbg !10
-  store i64* %67, i64** %64, align 8, !dbg !10
+  %61 = call i64 @rb_ary_new_from_values(i64 noundef 3, i64* noundef nonnull %callArgs0Addr.i) #7, !dbg !57
+  %62 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %6, i64 0, i32 1, !dbg !10
+  %63 = load i64*, i64** %62, align 8, !dbg !10
+  store i64 %3, i64* %63, align 8, !dbg !10, !tbaa !6
+  %64 = getelementptr inbounds i64, i64* %63, i64 1, !dbg !10
+  store i64 %61, i64* %64, align 8, !dbg !10, !tbaa !6
+  %65 = getelementptr inbounds i64, i64* %64, i64 1, !dbg !10
+  store i64* %65, i64** %62, align 8, !dbg !10
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !10
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %16, align 8, !dbg !10, !tbaa !17
-  %68 = bitcast i64* %callArgs0Addr.i to <2 x i64>*, !dbg !61
-  store <2 x i64> <i64 3, i64 5>, <2 x i64>* %68, align 8, !dbg !61
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %14, align 8, !dbg !10, !tbaa !17
+  %66 = bitcast i64* %callArgs0Addr.i to <2 x i64>*, !dbg !61
+  store <2 x i64> <i64 3, i64 5>, <2 x i64>* %66, align 8, !dbg !61
   call void @llvm.experimental.noalias.scope.decl(metadata !62) #7, !dbg !61
-  %69 = call i64 @rb_ary_new_from_values(i64 noundef 2, i64* noundef nonnull %callArgs0Addr.i) #7, !dbg !61
-  store i64 %69, i64* %callArgs0Addr.i, align 8, !dbg !65
-  store <2 x i64> <i64 3, i64 5>, <2 x i64>* %20, align 8, !dbg !65
+  %67 = call i64 @rb_ary_new_from_values(i64 noundef 2, i64* noundef nonnull %callArgs0Addr.i) #7, !dbg !61
+  store i64 %67, i64* %callArgs0Addr.i, align 8, !dbg !65
+  store <2 x i64> <i64 3, i64 5>, <2 x i64>* %18, align 8, !dbg !65
   call void @llvm.experimental.noalias.scope.decl(metadata !66) #7, !dbg !65
-  %70 = call i64 @sorbet_vm_expandSplatIntrinsic(i64 %69, i64 3, i64 5) #7, !dbg !65, !noalias !66
+  %68 = call i64 @sorbet_vm_expandSplatIntrinsic(i64 %67, i64 3, i64 5) #7, !dbg !65, !noalias !66
   store i64 1, i64* %callArgs0Addr.i, align 8, !dbg !65
   call void @llvm.experimental.noalias.scope.decl(metadata !69) #7, !dbg !65
-  %71 = call i64 @rb_ary_entry(i64 %70, i64 0) #7, !dbg !65
-  %72 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !65, !tbaa !17
-  %73 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %72, i64 0, i32 5, !dbg !65
-  %74 = load i32, i32* %73, align 8, !dbg !65, !tbaa !47
-  %75 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %72, i64 0, i32 6, !dbg !65
-  %76 = load i32, i32* %75, align 4, !dbg !65, !tbaa !48
-  %77 = xor i32 %76, -1, !dbg !65
-  %78 = and i32 %77, %74, !dbg !65
-  %79 = icmp eq i32 %78, 0, !dbg !65
-  br i1 %79, label %sorbet_rb_array_square_br.exit373.i, label %80, !dbg !65, !prof !49
+  %69 = call i64 @rb_ary_entry(i64 %68, i64 0) #7, !dbg !65
+  %70 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !65, !tbaa !17
+  %71 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %70, i64 0, i32 5, !dbg !65
+  %72 = load i32, i32* %71, align 8, !dbg !65, !tbaa !47
+  %73 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %70, i64 0, i32 6, !dbg !65
+  %74 = load i32, i32* %73, align 4, !dbg !65, !tbaa !48
+  %75 = xor i32 %74, -1, !dbg !65
+  %76 = and i32 %75, %72, !dbg !65
+  %77 = icmp eq i32 %76, 0, !dbg !65
+  br i1 %77, label %sorbet_rb_array_square_br.exit373.i, label %78, !dbg !65, !prof !49
 
-80:                                               ; preds = %sorbet_rb_array_square_br.exit372.i
-  %81 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %72, i64 0, i32 8, !dbg !65
-  %82 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %81, align 8, !dbg !65, !tbaa !50
-  %83 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %82, i32 noundef 0) #7, !dbg !65
+78:                                               ; preds = %sorbet_rb_array_square_br.exit372.i
+  %79 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %70, i64 0, i32 8, !dbg !65
+  %80 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %79, align 8, !dbg !65, !tbaa !50
+  %81 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %80, i32 noundef 0) #7, !dbg !65
   br label %sorbet_rb_array_square_br.exit373.i, !dbg !65
 
-sorbet_rb_array_square_br.exit373.i:              ; preds = %80, %sorbet_rb_array_square_br.exit372.i
+sorbet_rb_array_square_br.exit373.i:              ; preds = %78, %sorbet_rb_array_square_br.exit372.i
   store i64 -3, i64* %callArgs0Addr.i, align 8, !dbg !65
   call void @llvm.experimental.noalias.scope.decl(metadata !72) #7, !dbg !65
-  %84 = call i64 @rb_ary_entry(i64 %70, i64 -2) #7, !dbg !65
-  %85 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !65, !tbaa !17
-  %86 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %85, i64 0, i32 5, !dbg !65
-  %87 = load i32, i32* %86, align 8, !dbg !65, !tbaa !47
-  %88 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %85, i64 0, i32 6, !dbg !65
-  %89 = load i32, i32* %88, align 4, !dbg !65, !tbaa !48
-  %90 = xor i32 %89, -1, !dbg !65
-  %91 = and i32 %90, %87, !dbg !65
-  %92 = icmp eq i32 %91, 0, !dbg !65
-  br i1 %92, label %sorbet_rb_array_square_br.exit374.i, label %93, !dbg !65, !prof !49
+  %82 = call i64 @rb_ary_entry(i64 %68, i64 -2) #7, !dbg !65
+  %83 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !65, !tbaa !17
+  %84 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %83, i64 0, i32 5, !dbg !65
+  %85 = load i32, i32* %84, align 8, !dbg !65, !tbaa !47
+  %86 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %83, i64 0, i32 6, !dbg !65
+  %87 = load i32, i32* %86, align 4, !dbg !65, !tbaa !48
+  %88 = xor i32 %87, -1, !dbg !65
+  %89 = and i32 %88, %85, !dbg !65
+  %90 = icmp eq i32 %89, 0, !dbg !65
+  br i1 %90, label %sorbet_rb_array_square_br.exit374.i, label %91, !dbg !65, !prof !49
 
-93:                                               ; preds = %sorbet_rb_array_square_br.exit373.i
-  %94 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %85, i64 0, i32 8, !dbg !65
-  %95 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %94, align 8, !dbg !65, !tbaa !50
-  %96 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %95, i32 noundef 0) #7, !dbg !65
+91:                                               ; preds = %sorbet_rb_array_square_br.exit373.i
+  %92 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %83, i64 0, i32 8, !dbg !65
+  %93 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %92, align 8, !dbg !65, !tbaa !50
+  %94 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %93, i32 noundef 0) #7, !dbg !65
   br label %sorbet_rb_array_square_br.exit374.i, !dbg !65
 
-sorbet_rb_array_square_br.exit374.i:              ; preds = %93, %sorbet_rb_array_square_br.exit373.i
+sorbet_rb_array_square_br.exit374.i:              ; preds = %91, %sorbet_rb_array_square_br.exit373.i
   store i64 -1, i64* %callArgs0Addr.i, align 8, !dbg !65
   call void @llvm.experimental.noalias.scope.decl(metadata !75) #7, !dbg !65
-  %97 = call i64 @rb_ary_entry(i64 %70, i64 -1) #7, !dbg !65
-  %98 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !65, !tbaa !17
-  %99 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %98, i64 0, i32 5, !dbg !65
-  %100 = load i32, i32* %99, align 8, !dbg !65, !tbaa !47
-  %101 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %98, i64 0, i32 6, !dbg !65
-  %102 = load i32, i32* %101, align 4, !dbg !65, !tbaa !48
-  %103 = xor i32 %102, -1, !dbg !65
-  %104 = and i32 %103, %100, !dbg !65
-  %105 = icmp eq i32 %104, 0, !dbg !65
-  br i1 %105, label %sorbet_rb_array_square_br.exit375.i, label %106, !dbg !65, !prof !49
+  %95 = call i64 @rb_ary_entry(i64 %68, i64 -1) #7, !dbg !65
+  %96 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !65, !tbaa !17
+  %97 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %96, i64 0, i32 5, !dbg !65
+  %98 = load i32, i32* %97, align 8, !dbg !65, !tbaa !47
+  %99 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %96, i64 0, i32 6, !dbg !65
+  %100 = load i32, i32* %99, align 4, !dbg !65, !tbaa !48
+  %101 = xor i32 %100, -1, !dbg !65
+  %102 = and i32 %101, %98, !dbg !65
+  %103 = icmp eq i32 %102, 0, !dbg !65
+  br i1 %103, label %sorbet_rb_array_square_br.exit375.i, label %104, !dbg !65, !prof !49
 
-106:                                              ; preds = %sorbet_rb_array_square_br.exit374.i
-  %107 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %98, i64 0, i32 8, !dbg !65
-  %108 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %107, align 8, !dbg !65, !tbaa !50
-  %109 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %108, i32 noundef 0) #7, !dbg !65
+104:                                              ; preds = %sorbet_rb_array_square_br.exit374.i
+  %105 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %96, i64 0, i32 8, !dbg !65
+  %106 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %105, align 8, !dbg !65, !tbaa !50
+  %107 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %106, i32 noundef 0) #7, !dbg !65
   br label %sorbet_rb_array_square_br.exit375.i, !dbg !65
 
-sorbet_rb_array_square_br.exit375.i:              ; preds = %106, %sorbet_rb_array_square_br.exit374.i
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %16, align 8, !dbg !35, !tbaa !17
-  store i64 %71, i64* %callArgs0Addr.i, align 8, !dbg !78
-  store i64 %84, i64* %callArgs1Addr.i, align 8, !dbg !78
-  store i64 %97, i64* %callArgs2Addr.i, align 8, !dbg !78
+sorbet_rb_array_square_br.exit375.i:              ; preds = %104, %sorbet_rb_array_square_br.exit374.i
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %14, align 8, !dbg !35, !tbaa !17
+  store i64 %69, i64* %callArgs0Addr.i, align 8, !dbg !78
+  store i64 %82, i64* %callArgs1Addr.i, align 8, !dbg !78
+  store i64 %95, i64* %callArgs2Addr.i, align 8, !dbg !78
   call void @llvm.experimental.noalias.scope.decl(metadata !79) #7, !dbg !78
-  %110 = call i64 @rb_ary_new_from_values(i64 noundef 3, i64* noundef nonnull %callArgs0Addr.i) #7, !dbg !78
-  %111 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %8, i64 0, i32 1, !dbg !15
-  %112 = load i64*, i64** %111, align 8, !dbg !15
-  store i64 %5, i64* %112, align 8, !dbg !15, !tbaa !6
-  %113 = getelementptr inbounds i64, i64* %112, i64 1, !dbg !15
-  store i64 %110, i64* %113, align 8, !dbg !15, !tbaa !6
-  %114 = getelementptr inbounds i64, i64* %113, i64 1, !dbg !15
-  store i64* %114, i64** %111, align 8, !dbg !15
+  %108 = call i64 @rb_ary_new_from_values(i64 noundef 3, i64* noundef nonnull %callArgs0Addr.i) #7, !dbg !78
+  %109 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %6, i64 0, i32 1, !dbg !15
+  %110 = load i64*, i64** %109, align 8, !dbg !15
+  store i64 %3, i64* %110, align 8, !dbg !15, !tbaa !6
+  %111 = getelementptr inbounds i64, i64* %110, i64 1, !dbg !15
+  store i64 %108, i64* %111, align 8, !dbg !15, !tbaa !6
+  %112 = getelementptr inbounds i64, i64* %111, i64 1, !dbg !15
+  store i64* %112, i64** %109, align 8, !dbg !15
   %send2 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.6, i64 0), !dbg !15
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %16, align 8, !dbg !35, !tbaa !17
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %14, align 8, !dbg !35, !tbaa !17
   call void @llvm.experimental.noalias.scope.decl(metadata !82) #7, !dbg !85
-  %115 = call i64 @rb_ary_new() #7, !dbg !85
-  store i64 %115, i64* %callArgs0Addr.i, align 8, !dbg !86
-  store <2 x i64> <i64 3, i64 5>, <2 x i64>* %20, align 8, !dbg !86
+  %113 = call i64 @rb_ary_new() #7, !dbg !85
+  store i64 %113, i64* %callArgs0Addr.i, align 8, !dbg !86
+  store <2 x i64> <i64 3, i64 5>, <2 x i64>* %18, align 8, !dbg !86
   call void @llvm.experimental.noalias.scope.decl(metadata !87) #7, !dbg !86
-  %116 = call i64 @sorbet_vm_expandSplatIntrinsic(i64 %115, i64 3, i64 5) #7, !dbg !86, !noalias !87
+  %114 = call i64 @sorbet_vm_expandSplatIntrinsic(i64 %113, i64 3, i64 5) #7, !dbg !86, !noalias !87
   store i64 1, i64* %callArgs0Addr.i, align 8, !dbg !86
   call void @llvm.experimental.noalias.scope.decl(metadata !90) #7, !dbg !86
-  %117 = call i64 @rb_ary_entry(i64 %116, i64 0) #7, !dbg !86
-  %118 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !86, !tbaa !17
-  %119 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %118, i64 0, i32 5, !dbg !86
-  %120 = load i32, i32* %119, align 8, !dbg !86, !tbaa !47
-  %121 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %118, i64 0, i32 6, !dbg !86
-  %122 = load i32, i32* %121, align 4, !dbg !86, !tbaa !48
-  %123 = xor i32 %122, -1, !dbg !86
-  %124 = and i32 %123, %120, !dbg !86
-  %125 = icmp eq i32 %124, 0, !dbg !86
-  br i1 %125, label %sorbet_rb_array_square_br.exit368.i, label %126, !dbg !86, !prof !49
+  %115 = call i64 @rb_ary_entry(i64 %114, i64 0) #7, !dbg !86
+  %116 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !86, !tbaa !17
+  %117 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %116, i64 0, i32 5, !dbg !86
+  %118 = load i32, i32* %117, align 8, !dbg !86, !tbaa !47
+  %119 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %116, i64 0, i32 6, !dbg !86
+  %120 = load i32, i32* %119, align 4, !dbg !86, !tbaa !48
+  %121 = xor i32 %120, -1, !dbg !86
+  %122 = and i32 %121, %118, !dbg !86
+  %123 = icmp eq i32 %122, 0, !dbg !86
+  br i1 %123, label %sorbet_rb_array_square_br.exit368.i, label %124, !dbg !86, !prof !49
 
-126:                                              ; preds = %sorbet_rb_array_square_br.exit375.i
-  %127 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %118, i64 0, i32 8, !dbg !86
-  %128 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %127, align 8, !dbg !86, !tbaa !50
-  %129 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %128, i32 noundef 0) #7, !dbg !86
+124:                                              ; preds = %sorbet_rb_array_square_br.exit375.i
+  %125 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %116, i64 0, i32 8, !dbg !86
+  %126 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %125, align 8, !dbg !86, !tbaa !50
+  %127 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %126, i32 noundef 0) #7, !dbg !86
   br label %sorbet_rb_array_square_br.exit368.i, !dbg !86
 
-sorbet_rb_array_square_br.exit368.i:              ; preds = %126, %sorbet_rb_array_square_br.exit375.i
+sorbet_rb_array_square_br.exit368.i:              ; preds = %124, %sorbet_rb_array_square_br.exit375.i
   store i64 -3, i64* %callArgs0Addr.i, align 8, !dbg !86
   call void @llvm.experimental.noalias.scope.decl(metadata !93) #7, !dbg !86
-  %130 = call i64 @rb_ary_entry(i64 %116, i64 -2) #7, !dbg !86
-  %131 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !86, !tbaa !17
-  %132 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %131, i64 0, i32 5, !dbg !86
-  %133 = load i32, i32* %132, align 8, !dbg !86, !tbaa !47
-  %134 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %131, i64 0, i32 6, !dbg !86
-  %135 = load i32, i32* %134, align 4, !dbg !86, !tbaa !48
-  %136 = xor i32 %135, -1, !dbg !86
-  %137 = and i32 %136, %133, !dbg !86
-  %138 = icmp eq i32 %137, 0, !dbg !86
-  br i1 %138, label %sorbet_rb_array_square_br.exit.i, label %139, !dbg !86, !prof !49
+  %128 = call i64 @rb_ary_entry(i64 %114, i64 -2) #7, !dbg !86
+  %129 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !86, !tbaa !17
+  %130 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %129, i64 0, i32 5, !dbg !86
+  %131 = load i32, i32* %130, align 8, !dbg !86, !tbaa !47
+  %132 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %129, i64 0, i32 6, !dbg !86
+  %133 = load i32, i32* %132, align 4, !dbg !86, !tbaa !48
+  %134 = xor i32 %133, -1, !dbg !86
+  %135 = and i32 %134, %131, !dbg !86
+  %136 = icmp eq i32 %135, 0, !dbg !86
+  br i1 %136, label %sorbet_rb_array_square_br.exit.i, label %137, !dbg !86, !prof !49
 
-139:                                              ; preds = %sorbet_rb_array_square_br.exit368.i
-  %140 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %131, i64 0, i32 8, !dbg !86
-  %141 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %140, align 8, !dbg !86, !tbaa !50
-  %142 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %141, i32 noundef 0) #7, !dbg !86
+137:                                              ; preds = %sorbet_rb_array_square_br.exit368.i
+  %138 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %129, i64 0, i32 8, !dbg !86
+  %139 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %138, align 8, !dbg !86, !tbaa !50
+  %140 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %139, i32 noundef 0) #7, !dbg !86
   br label %sorbet_rb_array_square_br.exit.i, !dbg !86
 
-sorbet_rb_array_square_br.exit.i:                 ; preds = %139, %sorbet_rb_array_square_br.exit368.i
+sorbet_rb_array_square_br.exit.i:                 ; preds = %137, %sorbet_rb_array_square_br.exit368.i
   store i64 -1, i64* %callArgs0Addr.i, align 8, !dbg !86
   call void @llvm.experimental.noalias.scope.decl(metadata !96) #7, !dbg !86
-  %143 = call i64 @rb_ary_entry(i64 %116, i64 -1) #7, !dbg !86
-  %144 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !86, !tbaa !17
-  %145 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %144, i64 0, i32 5, !dbg !86
-  %146 = load i32, i32* %145, align 8, !dbg !86, !tbaa !47
-  %147 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %144, i64 0, i32 6, !dbg !86
-  %148 = load i32, i32* %147, align 4, !dbg !86, !tbaa !48
-  %149 = xor i32 %148, -1, !dbg !86
-  %150 = and i32 %149, %146, !dbg !86
-  %151 = icmp eq i32 %150, 0, !dbg !86
-  br i1 %151, label %"func_<root>.17<static-init>$153.exit", label %152, !dbg !86, !prof !49
+  %141 = call i64 @rb_ary_entry(i64 %114, i64 -1) #7, !dbg !86
+  %142 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !86, !tbaa !17
+  %143 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %142, i64 0, i32 5, !dbg !86
+  %144 = load i32, i32* %143, align 8, !dbg !86, !tbaa !47
+  %145 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %142, i64 0, i32 6, !dbg !86
+  %146 = load i32, i32* %145, align 4, !dbg !86, !tbaa !48
+  %147 = xor i32 %146, -1, !dbg !86
+  %148 = and i32 %147, %144, !dbg !86
+  %149 = icmp eq i32 %148, 0, !dbg !86
+  br i1 %149, label %"func_<root>.17<static-init>$153.exit", label %150, !dbg !86, !prof !49
 
-152:                                              ; preds = %sorbet_rb_array_square_br.exit.i
-  %153 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %144, i64 0, i32 8, !dbg !86
-  %154 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %153, align 8, !dbg !86, !tbaa !50
-  %155 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %154, i32 noundef 0) #7, !dbg !86
+150:                                              ; preds = %sorbet_rb_array_square_br.exit.i
+  %151 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %142, i64 0, i32 8, !dbg !86
+  %152 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %151, align 8, !dbg !86, !tbaa !50
+  %153 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %152, i32 noundef 0) #7, !dbg !86
   br label %"func_<root>.17<static-init>$153.exit", !dbg !86
 
-"func_<root>.17<static-init>$153.exit":           ; preds = %sorbet_rb_array_square_br.exit.i, %152
-  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %16, align 8, !dbg !35, !tbaa !17
-  store i64 %117, i64* %callArgs0Addr.i, align 8, !dbg !99
-  store i64 %130, i64* %callArgs1Addr.i, align 8, !dbg !99
-  store i64 %143, i64* %callArgs2Addr.i, align 8, !dbg !99
+"func_<root>.17<static-init>$153.exit":           ; preds = %sorbet_rb_array_square_br.exit.i, %150
+  store i64* getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %14, align 8, !dbg !35, !tbaa !17
+  store i64 %115, i64* %callArgs0Addr.i, align 8, !dbg !99
+  store i64 %128, i64* %callArgs1Addr.i, align 8, !dbg !99
+  store i64 %141, i64* %callArgs2Addr.i, align 8, !dbg !99
   call void @llvm.experimental.noalias.scope.decl(metadata !100) #7, !dbg !99
-  %156 = call i64 @rb_ary_new_from_values(i64 noundef 3, i64* noundef nonnull %callArgs0Addr.i) #7, !dbg !99
-  %157 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %8, i64 0, i32 1, !dbg !16
-  %158 = load i64*, i64** %157, align 8, !dbg !16
-  store i64 %5, i64* %158, align 8, !dbg !16, !tbaa !6
-  %159 = getelementptr inbounds i64, i64* %158, i64 1, !dbg !16
-  store i64 %156, i64* %159, align 8, !dbg !16, !tbaa !6
-  %160 = getelementptr inbounds i64, i64* %159, i64 1, !dbg !16
-  store i64* %160, i64** %157, align 8, !dbg !16
+  %154 = call i64 @rb_ary_new_from_values(i64 noundef 3, i64* noundef nonnull %callArgs0Addr.i) #7, !dbg !99
+  %155 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %6, i64 0, i32 1, !dbg !16
+  %156 = load i64*, i64** %155, align 8, !dbg !16
+  store i64 %3, i64* %156, align 8, !dbg !16, !tbaa !6
+  %157 = getelementptr inbounds i64, i64* %156, i64 1, !dbg !16
+  store i64 %154, i64* %157, align 8, !dbg !16, !tbaa !6
+  %158 = getelementptr inbounds i64, i64* %157, i64 1, !dbg !16
+  store i64* %158, i64** %155, align 8, !dbg !16
   %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts.10, i64 0), !dbg !16
-  call void @llvm.lifetime.end.p0i8(i64 64, i8* nonnull %9)
+  call void @llvm.lifetime.end.p0i8(i64 64, i8* nonnull %7)
   ret void
 }
 

--- a/test/testdata/compiler/unsafe.opt.ll.exp
+++ b/test/testdata/compiler/unsafe.opt.ll.exp
@@ -81,14 +81,14 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 @.str.9 = private unnamed_addr constant [95 x i8] c"sorbet_getBuildSCMRevision: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @.str.10 = private unnamed_addr constant [93 x i8] c"sorbet_getIsReleaseBuild: Shared objects compiled by sorbet_llvm must be run by sorbet_ruby.\00", align 1
 @"stackFramePrecomputed_func_<root>.17<static-init>$153" = internal unnamed_addr global %struct.rb_iseq_struct* null, align 8
-@"rubyStrFrozen_<top (required)>" = internal unnamed_addr global i64 0, align 8
-@"rubyStrFrozen_test/testdata/compiler/unsafe.rb" = internal unnamed_addr global i64 0, align 8
 @iseqEncodedArray = internal global [5 x i64] zeroinitializer
 @fileLineNumberInfo = internal global %struct.SorbetLineNumberInfo zeroinitializer
 @ic_puts = internal global %struct.FunctionInlineCache zeroinitializer
 @sorbet_moduleStringTable = internal unnamed_addr constant [71 x i8] c"<top (required)>\00test/testdata/compiler/unsafe.rb\00T\00unsafe\00puts\00master\00", align 1
 @sorbet_moduleIDTable = internal unnamed_addr global [3 x i64] zeroinitializer, align 8
 @sorbet_moduleIDDescriptors = internal unnamed_addr constant [3 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 52, i32 6 }, %struct.rb_code_position_struct { i32 59, i32 4 }], align 8
+@sorbet_moduleRubyStringTable = internal unnamed_addr global [2 x i64] zeroinitializer, align 8
+@sorbet_moduleRubyStringDescriptors = internal unnamed_addr constant [2 x %struct.rb_code_position_struct] [%struct.rb_code_position_struct { i32 0, i32 16 }, %struct.rb_code_position_struct { i32 17, i32 32 }], align 8
 
 declare %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64, i64, i64, i64, %struct.rb_iseq_struct*, i32, i32, %struct.SorbetLineNumberInfo*, i64*, i32, i32) local_unnamed_addr #0
 
@@ -104,9 +104,7 @@ declare void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct*, %
 
 declare void @sorbet_vm_intern_ids(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #0
 
-declare i64 @sorbet_vm_fstring_new(i8*, i64) local_unnamed_addr #0
-
-declare void @rb_gc_register_mark_object(i64) local_unnamed_addr #0
+declare void @sorbet_vm_init_string_table(i64*, %struct.rb_code_position_struct*, i32, i8*) local_unnamed_addr #0
 
 ; Function Attrs: noreturn
 declare void @rb_raise(i64, i8*, ...) local_unnamed_addr #1
@@ -136,62 +134,57 @@ entry:
   %locals.i.i = alloca i64, i32 0, align 8
   %realpath = tail call i64 @sorbet_readRealpath()
   tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([3 x %struct.rb_code_position_struct], [3 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 3, i8* noundef getelementptr inbounds ([71 x i8], [71 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
-  %0 = tail call i64 @sorbet_vm_fstring_new(i8* noundef getelementptr inbounds ([71 x i8], [71 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 noundef 16) #6
-  tail call void @rb_gc_register_mark_object(i64 %0) #6
-  store i64 %0, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %1 = tail call i64 @sorbet_vm_fstring_new(i8* getelementptr inbounds ([71 x i8], [71 x i8]* @sorbet_moduleStringTable, i64 0, i64 17), i64 noundef 32) #6
-  tail call void @rb_gc_register_mark_object(i64 %1) #6
-  store i64 %1, i64* @"rubyStrFrozen_test/testdata/compiler/unsafe.rb", align 8
+  tail call void @sorbet_vm_init_string_table(i64* noundef getelementptr inbounds ([2 x i64], [2 x i64]* @sorbet_moduleRubyStringTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([2 x %struct.rb_code_position_struct], [2 x %struct.rb_code_position_struct]* @sorbet_moduleRubyStringDescriptors, i32 0, i32 0), i32 noundef 2, i8* noundef getelementptr inbounds ([71 x i8], [71 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 5)
   %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
-  %"rubyStr_<top (required)>.i.i" = load i64, i64* @"rubyStrFrozen_<top (required)>", align 8
-  %"rubyStr_test/testdata/compiler/unsafe.rb.i.i" = load i64, i64* @"rubyStrFrozen_test/testdata/compiler/unsafe.rb", align 8
-  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/unsafe.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %"rubyStr_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([2 x i64], [2 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 0), align 8, !invariant.load !5
+  %"rubyStr_test/testdata/compiler/unsafe.rb.i.i" = load i64, i64* getelementptr inbounds ([2 x i64], [2 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
+  %0 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/unsafe.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %0, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
   %rubyId_puts.i = load i64, i64* getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !10, !invariant.load !5
   call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !10
-  %3 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !15
-  %4 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %3, i64 0, i32 18
-  %5 = load i64, i64* %4, align 8, !tbaa !17
-  %6 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
-  %7 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %6, i64 0, i32 2
-  %8 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %7, align 8, !tbaa !27
+  %1 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !15
+  %2 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %1, i64 0, i32 18
+  %3 = load i64, i64* %2, align 8, !tbaa !17
+  %4 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
+  %5 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %4, i64 0, i32 2
+  %6 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %5, align 8, !tbaa !27
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %9 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %8, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %9, align 8, !tbaa !30
-  %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %8, i64 0, i32 4
-  %11 = load i64*, i64** %10, align 8, !tbaa !32
-  %12 = load i64, i64* %11, align 8, !tbaa !6
-  %13 = and i64 %12, -33
-  store i64 %13, i64* %11, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %6, %struct.rb_control_frame_struct* %8, %struct.rb_iseq_struct* %stackFrame.i) #6
-  %14 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %8, i64 0, i32 0
-  store i64* getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %14, align 8, !dbg !33, !tbaa !15
+  %7 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %6, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %7, align 8, !tbaa !30
+  %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %6, i64 0, i32 4
+  %9 = load i64*, i64** %8, align 8, !tbaa !32
+  %10 = load i64, i64* %9, align 8, !tbaa !6
+  %11 = and i64 %10, -33
+  store i64 %11, i64* %9, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %4, %struct.rb_control_frame_struct* %6, %struct.rb_iseq_struct* %stackFrame.i) #6
+  %12 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %6, i64 0, i32 0
+  store i64* getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %12, align 8, !dbg !33, !tbaa !15
   call void @llvm.experimental.noalias.scope.decl(metadata !34) #6, !dbg !37
-  %15 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !37, !tbaa !15
-  %16 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %15, i64 0, i32 5, !dbg !37
-  %17 = load i32, i32* %16, align 8, !dbg !37, !tbaa !38
-  %18 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %15, i64 0, i32 6, !dbg !37
-  %19 = load i32, i32* %18, align 4, !dbg !37, !tbaa !39
-  %20 = xor i32 %19, -1, !dbg !37
-  %21 = and i32 %20, %17, !dbg !37
-  %22 = icmp eq i32 %21, 0, !dbg !37
-  br i1 %22, label %"func_<root>.17<static-init>$153.exit", label %23, !dbg !37, !prof !40
+  %13 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !37, !tbaa !15
+  %14 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %13, i64 0, i32 5, !dbg !37
+  %15 = load i32, i32* %14, align 8, !dbg !37, !tbaa !38
+  %16 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %13, i64 0, i32 6, !dbg !37
+  %17 = load i32, i32* %16, align 4, !dbg !37, !tbaa !39
+  %18 = xor i32 %17, -1, !dbg !37
+  %19 = and i32 %18, %15, !dbg !37
+  %20 = icmp eq i32 %19, 0, !dbg !37
+  br i1 %20, label %"func_<root>.17<static-init>$153.exit", label %21, !dbg !37, !prof !40
 
-23:                                               ; preds = %entry
-  %24 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %15, i64 0, i32 8, !dbg !37
-  %25 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %24, align 8, !dbg !37, !tbaa !41
-  %26 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %25, i32 noundef 0) #6, !dbg !37
+21:                                               ; preds = %entry
+  %22 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %13, i64 0, i32 8, !dbg !37
+  %23 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %22, align 8, !dbg !37, !tbaa !41
+  %24 = call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %23, i32 noundef 0) #6, !dbg !37
   br label %"func_<root>.17<static-init>$153.exit", !dbg !37
 
-"func_<root>.17<static-init>$153.exit":           ; preds = %entry, %23
-  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %8, i64 0, i32 1, !dbg !10
-  %28 = load i64*, i64** %27, align 8, !dbg !10
-  store i64 %5, i64* %28, align 8, !dbg !10, !tbaa !6
-  %29 = getelementptr inbounds i64, i64* %28, i64 1, !dbg !10
-  store i64 3, i64* %29, align 8, !dbg !10, !tbaa !6
-  %30 = getelementptr inbounds i64, i64* %29, i64 1, !dbg !10
-  store i64* %30, i64** %27, align 8, !dbg !10
+"func_<root>.17<static-init>$153.exit":           ; preds = %entry, %21
+  %25 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %6, i64 0, i32 1, !dbg !10
+  %26 = load i64*, i64** %25, align 8, !dbg !10
+  store i64 %3, i64* %26, align 8, !dbg !10, !tbaa !6
+  %27 = getelementptr inbounds i64, i64* %26, i64 1, !dbg !10
+  store i64 3, i64* %27, align 8, !dbg !10, !tbaa !6
+  %28 = getelementptr inbounds i64, i64* %27, i64 1, !dbg !10
+  store i64* %28, i64** %25, align 8, !dbg !10
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !10
   ret void
 }


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Following on to #5613 and #5646, we do the same thing for Ruby strings.

The main benefit here is less LLVM IR to optimize.  I think that this change also silently interacts more correctly with the compacting GC in Ruby 2.7+, since we're now marking the place(s) we store the Ruby string(s) rather than the strings themselves.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
