### PR TITLE
Single threaded for rbi-gen-single test

### DIFF
--- a/test/cli/rbi-gen-single/test.sh
+++ b/test/cli/rbi-gen-single/test.sh
@@ -12,6 +12,7 @@ trap "rm -rf $rbis" EXIT
 echo "-- sanity-checking package with --stripe-packages"
 "$sorbet" --silence-dev-message \
   --stripe-packages \
+  --max-threads=0 \
   --dump-package-info="$rbis/package-info.json" \
   --extra-package-files-directory-prefix="${test_path}/other/" \
   "$test_path" 2>&1 || true


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Before the changes in 4a225c2d4, this test did not generate any errors to the
output.

There are enough files in this CLI test to push it over the threshold at which
it starts using multiple threads (pretty sure that once it gets to 4 input files
it'll use 2 threads).

So before it didn't matter that it was running in multi-threaded mode, because
the error output was deterministic. After the change to start capturing errors
from all files into a single log, they now start showing up in different orders.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This failed on master a few times:

- <https://buildkite.com/sorbet/sorbet/builds/22310#dc0608e1-a8d0-47f5-bad7-e3996f1cf96a/256-258>
- <https://buildkite.com/sorbet/sorbet/builds/22307#50564e12-b79c-4571-9a8b-bd3f85e84e7d/254-257>

Hopefully this will remove the flakiness.