### PR TITLE
Add test that used to crash us

### DIFF
--- a/test/cli/packager_export_self/__package.rb
+++ b/test/cli/packager_export_self/__package.rb
@@ -1,0 +1,4 @@
+# typed: strict
+class Opus::Deploy < PackageSpec
+  export_for_test Opus::Deploy
+end

--- a/test/cli/packager_export_self/test.out
+++ b/test/cli/packager_export_self/test.out
@@ -1,0 +1,17 @@
+Exception::raise(): core/Symbols.cc:247 enforced condition this->exists() has failed: (no message provided)
+
+Backtrace:
+  #3 0xb17042 
+  #4 0x19841e2 sorbet::core::ClassOrModuleRef::data()
+  #5 0x1988d16 sorbet::core::SymbolRef::dealias()
+  #6 0x1398ab4 sorbet::resolver::(anonymous namespace)::ResolveConstantsWalk::constantResolutionFailed<>()
+  #7 0x138c9b9 sorbet::resolver::(anonymous namespace)::ResolveConstantsWalk::resolveConstants<>()
+  #8 0x1392815 sorbet::resolver::Resolver::run()
+  #9 0xee8c7b sorbet::realmain::pipeline::resolve()
+  #10 0xb09214 sorbet::realmain::realmain()
+  #11 0xb03ee2 main
+  #12 0x7f6744ae10b3 __libc_start_main
+  #13 0xb03dee _start
+
+???: Exception resolving (backtrace is above) https://srb.help/1001
+Errors: 1

--- a/test/cli/packager_export_self/test.out
+++ b/test/cli/packager_export_self/test.out
@@ -1,17 +1,19 @@
-Exception::raise(): core/Symbols.cc:247 enforced condition this->exists() has failed: (no message provided)
+test/cli/packager_export_self/__package.rb:3: Invalid expression in package: Arguments to functions must be literals https://srb.help/3710
+     3 |  export_for_test Opus::Deploy
+                          ^^^^^^^^^^^^
 
-Backtrace:
-  #3 0xb17042 
-  #4 0x19841e2 sorbet::core::ClassOrModuleRef::data()
-  #5 0x1988d16 sorbet::core::SymbolRef::dealias()
-  #6 0x1398ab4 sorbet::resolver::(anonymous namespace)::ResolveConstantsWalk::constantResolutionFailed<>()
-  #7 0x138c9b9 sorbet::resolver::(anonymous namespace)::ResolveConstantsWalk::resolveConstants<>()
-  #8 0x1392815 sorbet::resolver::Resolver::run()
-  #9 0xee8c7b sorbet::realmain::pipeline::resolve()
-  #10 0xb09214 sorbet::realmain::realmain()
-  #11 0xb03ee2 main
-  #12 0x7f6744ae10b3 __libc_start_main
-  #13 0xb03dee _start
+test/cli/packager_export_self/__package.rb:3: Unable to resolve constant `Opus` https://srb.help/5002
+     3 |  export_for_test Opus::Deploy
+                          ^^^^
+  Did you mean `Opus`? Use `-a` to autocorrect
+    test/cli/packager_export_self/__package.rb:3: Replace with `Opus`
+     3 |  export_for_test Opus::Deploy
+                          ^^^^
+    test/cli/packager_export_self/__package.rb:2: `Opus` defined here
+     2 |class Opus::Deploy < PackageSpec
+              ^^^^
 
-???: Exception resolving (backtrace is above) https://srb.help/1001
-Errors: 1
+test/cli/packager_export_self/__package.rb:3: Method `export_for_test` does not exist on `T.class_of(Opus::Deploy)` https://srb.help/7003
+     3 |  export_for_test Opus::Deploy
+          ^^^^^^^^^^^^^^^
+Errors: 3

--- a/test/cli/packager_export_self/test.sh
+++ b/test/cli/packager_export_self/test.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+main/sorbet --silence-dev-message --stripe-packages . 2>&1

--- a/test/cli/packager_suggest_nested_crash/consumer_auth/__package.rb
+++ b/test/cli/packager_suggest_nested_crash/consumer_auth/__package.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class Project::ConsumerAuth < PackageSpec
+  import Project::ConsumerAuth::Data
+end

--- a/test/cli/packager_suggest_nested_crash/consumer_auth/data/__package.rb
+++ b/test/cli/packager_suggest_nested_crash/consumer_auth/data/__package.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Project::ConsumerAuth::Data < PackageSpec
+  export Project::ConsumerAuth::Data::IdentifierStruct
+end

--- a/test/cli/packager_suggest_nested_crash/consumer_auth/data/identifier_struct.rb
+++ b/test/cli/packager_suggest_nested_crash/consumer_auth/data/identifier_struct.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Project::ConsumerAuth::Data
+  class IdentifierStruct
+    puts(Project::ConsumerAuth::IdentifierType)
+  end
+end

--- a/test/cli/packager_suggest_nested_crash/consumer_auth/identity_type.rb
+++ b/test/cli/packager_suggest_nested_crash/consumer_auth/identity_type.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Project::ConsumerAuth
+  class IdentifierType
+  end
+end

--- a/test/cli/packager_suggest_nested_crash/test.out
+++ b/test/cli/packager_suggest_nested_crash/test.out
@@ -1,44 +1,19 @@
-Exception::raise(): core/Symbols.cc:247 enforced condition this->exists() has failed: (no message provided)
-
-Backtrace:
-  #3 0xb17042 
-  #4 0x19841e2 sorbet::core::ClassOrModuleRef::data()
-  #5 0x1988d16 sorbet::core::SymbolRef::dealias()
-  #6 0x1398ab4 sorbet::resolver::(anonymous namespace)::ResolveConstantsWalk::constantResolutionFailed<>()
-  #7 0x138c9b9 sorbet::resolver::(anonymous namespace)::ResolveConstantsWalk::resolveConstants<>()
-  #8 0x1392815 sorbet::resolver::Resolver::run()
-  #9 0xee8c7b sorbet::realmain::pipeline::resolve()
-  #10 0xb09214 sorbet::realmain::realmain()
-  #11 0xb03ee2 main
-  #12 0x7fe755e670b3 __libc_start_main
-  #13 0xb03dee _start
-
-test/cli/packager_suggest_nested_crash/consumer_auth/data/identifier_struct.rb:4: `Project::ConsumerAuth::Data` was previously defined as a `module` https://srb.help/4012
-     4 |class Project::ConsumerAuth::Data
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    test/cli/packager_suggest_nested_crash/consumer_auth/data/__package.rb:4: Previous definition
-     4 |class Project::ConsumerAuth::Data < PackageSpec
-     5 |  export Project::ConsumerAuth::Data::IdentifierStruct
-     6 |end
-
-test/cli/packager_suggest_nested_crash/consumer_auth/data/identifier_struct.rb:5: Redefining constant `Project::ConsumerAuth::Data::IdentifierStruct` https://srb.help/4012
-     5 |  class IdentifierStruct
-     6 |    puts(Project::ConsumerAuth::IdentifierType)
-     7 |  end
-    test/cli/packager_suggest_nested_crash/consumer_auth/data/__package.rb: Previous definition
-
 test/cli/packager_suggest_nested_crash/consumer_auth/data/identifier_struct.rb:4: Class or method definition must match enclosing package namespace `Test::Project::ConsumerAuth::Data` https://srb.help/3713
      4 |class Project::ConsumerAuth::Data
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-test/cli/packager_suggest_nested_crash/consumer_auth/identity_type.rb:4: `Project::ConsumerAuth` was previously defined as a `module` https://srb.help/4012
-     4 |class Project::ConsumerAuth
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    test/cli/packager_suggest_nested_crash/consumer_auth/__package.rb: Previous definition
+test/cli/packager_suggest_nested_crash/consumer_auth/data/identifier_struct.rb:6: No import provides `Project::ConsumerAuth::IdentifierType` https://srb.help/3718
+     6 |    puts(Project::ConsumerAuth::IdentifierType)
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    test/cli/packager_suggest_nested_crash/consumer_auth/data/__package.rb:4: Insert `test_import Project::ConsumerAuth`
+     4 |class Project::ConsumerAuth::Data < PackageSpec
+                                                       ^
+    test/cli/packager_suggest_nested_crash/consumer_auth/__package.rb:5: Defined here
+     5 |class Project::ConsumerAuth < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 test/cli/packager_suggest_nested_crash/consumer_auth/identity_type.rb:4: Class or method definition must match enclosing package namespace `Test::Project::ConsumerAuth` https://srb.help/3713
      4 |class Project::ConsumerAuth
               ^^^^^^^^^^^^^^^^^^^^^
-
-???: Exception resolving (backtrace is above) https://srb.help/1001
-Errors: 6
+Errors: 3

--- a/test/cli/packager_suggest_nested_crash/test.out
+++ b/test/cli/packager_suggest_nested_crash/test.out
@@ -1,0 +1,44 @@
+Exception::raise(): core/Symbols.cc:247 enforced condition this->exists() has failed: (no message provided)
+
+Backtrace:
+  #3 0xb17042 
+  #4 0x19841e2 sorbet::core::ClassOrModuleRef::data()
+  #5 0x1988d16 sorbet::core::SymbolRef::dealias()
+  #6 0x1398ab4 sorbet::resolver::(anonymous namespace)::ResolveConstantsWalk::constantResolutionFailed<>()
+  #7 0x138c9b9 sorbet::resolver::(anonymous namespace)::ResolveConstantsWalk::resolveConstants<>()
+  #8 0x1392815 sorbet::resolver::Resolver::run()
+  #9 0xee8c7b sorbet::realmain::pipeline::resolve()
+  #10 0xb09214 sorbet::realmain::realmain()
+  #11 0xb03ee2 main
+  #12 0x7fe755e670b3 __libc_start_main
+  #13 0xb03dee _start
+
+test/cli/packager_suggest_nested_crash/consumer_auth/data/identifier_struct.rb:4: `Project::ConsumerAuth::Data` was previously defined as a `module` https://srb.help/4012
+     4 |class Project::ConsumerAuth::Data
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    test/cli/packager_suggest_nested_crash/consumer_auth/data/__package.rb:4: Previous definition
+     4 |class Project::ConsumerAuth::Data < PackageSpec
+     5 |  export Project::ConsumerAuth::Data::IdentifierStruct
+     6 |end
+
+test/cli/packager_suggest_nested_crash/consumer_auth/data/identifier_struct.rb:5: Redefining constant `Project::ConsumerAuth::Data::IdentifierStruct` https://srb.help/4012
+     5 |  class IdentifierStruct
+     6 |    puts(Project::ConsumerAuth::IdentifierType)
+     7 |  end
+    test/cli/packager_suggest_nested_crash/consumer_auth/data/__package.rb: Previous definition
+
+test/cli/packager_suggest_nested_crash/consumer_auth/data/identifier_struct.rb:4: Class or method definition must match enclosing package namespace `Test::Project::ConsumerAuth::Data` https://srb.help/3713
+     4 |class Project::ConsumerAuth::Data
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+test/cli/packager_suggest_nested_crash/consumer_auth/identity_type.rb:4: `Project::ConsumerAuth` was previously defined as a `module` https://srb.help/4012
+     4 |class Project::ConsumerAuth
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    test/cli/packager_suggest_nested_crash/consumer_auth/__package.rb: Previous definition
+
+test/cli/packager_suggest_nested_crash/consumer_auth/identity_type.rb:4: Class or method definition must match enclosing package namespace `Test::Project::ConsumerAuth` https://srb.help/3713
+     4 |class Project::ConsumerAuth
+              ^^^^^^^^^^^^^^^^^^^^^
+
+???: Exception resolving (backtrace is above) https://srb.help/1001
+Errors: 6

--- a/test/cli/packager_suggest_nested_crash/test.sh
+++ b/test/cli/packager_suggest_nested_crash/test.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+main/sorbet --silence-dev-message --stripe-packages . 2>&1

--- a/test/cli/packager_suggest_nested_crash/test.sh
+++ b/test/cli/packager_suggest_nested_crash/test.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-main/sorbet --silence-dev-message --stripe-packages --max-threads=0. 2>&1
+main/sorbet --silence-dev-message --stripe-packages --max-threads=0 2>&1

--- a/test/cli/packager_suggest_nested_crash/test.sh
+++ b/test/cli/packager_suggest_nested_crash/test.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-main/sorbet --silence-dev-message --stripe-packages --max-threads=0 2>&1
+main/sorbet --silence-dev-message --stripe-packages --max-threads=0 . 2>&1

--- a/test/cli/packager_suggest_nested_crash/test.sh
+++ b/test/cli/packager_suggest_nested_crash/test.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-main/sorbet --silence-dev-message --stripe-packages . 2>&1
+main/sorbet --silence-dev-message --stripe-packages --max-threads=0. 2>&1


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I originally reported this crash based on 14b71b2fa. At some point with the
recent changes to the packager pass, this no longer causes us to crash. I wasn't
100% that this exact test case had been committed, so I figured I may as well
submit it.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

test-only change