### PR TITLE
be less verbose when naming entry classes for the compiler's tables

### DIFF
--- a/compiler/Core/CompilerState.h
+++ b/compiler/Core/CompilerState.h
@@ -9,12 +9,12 @@
 namespace sorbet::compiler {
 
 struct StringTable {
-    struct StringTableEntry {
+    struct Entry {
         uint32_t offset = 0;
         llvm::GlobalVariable *addrVar = nullptr;
     };
 
-    UnorderedMap<std::string, StringTableEntry> map;
+    UnorderedMap<std::string, Entry> map;
     uint32_t size = 0;
 
     void clear() {
@@ -26,14 +26,14 @@ struct StringTable {
 };
 
 struct IDTable {
-    struct IDTableEntry {
+    struct Entry {
         uint32_t offset;
         uint32_t stringTableOffset = 0;
         uint32_t stringLength = 0;
         llvm::GlobalVariable *addrVar = nullptr;
     };
 
-    UnorderedMap<std::string, IDTableEntry> map;
+    UnorderedMap<std::string, Entry> map;
 
     void clear() {
         this->map.clear();
@@ -43,14 +43,14 @@ struct IDTable {
 };
 
 struct RubyStringTable {
-    struct RubyStringTableEntry {
+    struct Entry {
         uint32_t offset;
         uint32_t stringTableOffset = 0;
         uint32_t stringLength = 0;
         llvm::GlobalVariable *addrVar = nullptr;
     };
 
-    UnorderedMap<std::string, RubyStringTableEntry> map;
+    UnorderedMap<std::string, Entry> map;
 
     void clear() {
         this->map.clear();
@@ -90,7 +90,7 @@ public:
     RubyStringTable &rubyStringTable;
 
 private:
-    StringTable::StringTableEntry insertIntoStringTable(std::string_view str);
+    StringTable::Entry insertIntoStringTable(std::string_view str);
 
 public:
     llvm::Value *stringTableRef(std::string_view str);


### PR DESCRIPTION

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

C++ classes provide fine scoping rules; we don't need to repeat ourselves.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
