### PR TITLE
Add error for test_each_hash without pos hash arg

### DIFF
--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -348,6 +348,10 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, ast::Send *
         auto errLoc = send->getKwKey(0).loc().join(send->getKwValue(send->numKwArgs() - 1).loc());
         if (auto e = ctx.beginError(errLoc, core::errors::Rewriter::BadTestEach)) {
             e.setHeader("`{}` expects a single `{}` argument, not keyword args", "test_each_hash", "Hash");
+            if (send->numPosArgs() == 0 && errLoc.exists()) {
+                auto replaceLoc = ctx.locAt(errLoc);
+                e.replaceWith("Wrap with curly braces", replaceLoc, "{{{}}}", replaceLoc.source(ctx).value());
+            }
         }
     }
 

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -344,6 +344,13 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, ast::Send *
             send->flags);
     }
 
+    if (send->fun == core::Names::testEachHash() && send->numKwArgs() > 0) {
+        auto errLoc = send->getKwKey(0).loc().join(send->getKwValue(send->numKwArgs() - 1).loc());
+        if (auto e = ctx.beginError(errLoc, core::errors::Rewriter::BadTestEach)) {
+            e.setHeader("`{}` expects a single `{}` argument, not keyword args", "test_each_hash", "Hash");
+        }
+    }
+
     if (send->numPosArgs() == 0 && (send->fun == core::Names::before() || send->fun == core::Names::after())) {
         auto name = send->fun == core::Names::after() ? core::Names::afterAngles() : core::Names::initialize();
         ConstantMover constantMover;

--- a/test/testdata/rewriter/test_each_hash.rb
+++ b/test/testdata/rewriter/test_each_hash.rb
@@ -1,0 +1,19 @@
+# typed: true
+
+class MyTest
+  def self.test_each_hash(hash, &blk)
+  end
+
+  def self.it(name, &blk)
+  end
+end
+
+class A < MyTest
+  test_each_hash(left: -1, right: 1) do |key, value|
+    #            ^^^^^^^^^^^^^^^^^^ error: `test_each_hash` expects a single `Hash` argument, not keyword args
+    it 'hello' do
+      p(key)
+      p(value)
+    end
+  end
+end

--- a/test/testdata/rewriter/test_each_hash.rb.autocorrects.exp
+++ b/test/testdata/rewriter/test_each_hash.rb.autocorrects.exp
@@ -10,7 +10,8 @@ class MyTest
 end
 
 class A < MyTest
-  test_each_hash(left: -1, right: 1) do |key, value|
+  test_each_hash({left: -1, right: 1}) do |key, value|
+    #            ^^^^^^^^^^^^^^^^^^ error: `test_each_hash` expects a single `Hash` argument, not keyword args
     it 'hello' do
       p(key)
       p(value)

--- a/test/testdata/rewriter/test_each_hash.rb.autocorrects.exp
+++ b/test/testdata/rewriter/test_each_hash.rb.autocorrects.exp
@@ -1,0 +1,20 @@
+# -- test/testdata/rewriter/test_each_hash.rb --
+# typed: true
+
+class MyTest
+  def self.test_each_hash(hash, &blk)
+  end
+
+  def self.it(name, &blk)
+  end
+end
+
+class A < MyTest
+  test_each_hash(left: -1, right: 1) do |key, value|
+    it 'hello' do
+      p(key)
+      p(value)
+    end
+  end
+end
+# ------------------------------


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

It was confusing that the Minitest rewriter did not fire without an error.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.