### PR TITLE
use tree locs directly rather than indirecting through `loc()`

### DIFF
--- a/local_vars/local_vars.cc
+++ b/local_vars/local_vars.cc
@@ -55,37 +55,37 @@ class LocalNameInserter {
             [&](ast::UnresolvedIdent &nm) {
                 named.name = nm.name;
                 named.local = enterLocal(named.name);
-                named.loc = arg.loc();
-                named.expr = ast::make_expression<ast::Local>(arg.loc(), named.local);
+                named.loc = nm.loc;
+                named.expr = ast::make_expression<ast::Local>(nm.loc, named.local);
             },
             [&](ast::RestArg &rest) {
                 named = nameArg(move(rest.expr));
-                named.expr = ast::MK::RestArg(arg.loc(), move(named.expr));
+                named.expr = ast::MK::RestArg(rest.loc, move(named.expr));
                 named.flags.repeated = true;
             },
             [&](ast::KeywordArg &kw) {
                 named = nameArg(move(kw.expr));
-                named.expr = ast::make_expression<ast::KeywordArg>(arg.loc(), move(named.expr));
+                named.expr = ast::make_expression<ast::KeywordArg>(kw.loc, move(named.expr));
                 named.flags.keyword = true;
             },
             [&](ast::OptionalArg &opt) {
                 named = nameArg(move(opt.expr));
-                named.expr = ast::MK::OptionalArg(arg.loc(), move(named.expr), move(opt.default_));
+                named.expr = ast::MK::OptionalArg(opt.loc, move(named.expr), move(opt.default_));
             },
             [&](ast::BlockArg &blk) {
                 named = nameArg(move(blk.expr));
-                named.expr = ast::MK::BlockArg(arg.loc(), move(named.expr));
+                named.expr = ast::MK::BlockArg(blk.loc, move(named.expr));
                 named.flags.block = true;
             },
             [&](ast::ShadowArg &shadow) {
                 named = nameArg(move(shadow.expr));
-                named.expr = ast::MK::ShadowArg(arg.loc(), move(named.expr));
+                named.expr = ast::MK::ShadowArg(shadow.loc, move(named.expr));
                 named.flags.shadow = true;
             },
             [&](const ast::Local &local) {
                 named.name = local.localVariable._name;
                 named.local = enterLocal(named.name);
-                named.loc = arg.loc();
+                named.loc = local.loc;
                 named.expr = ast::make_expression<ast::Local>(local.loc, named.local);
             });
 


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We already have the concrete tree in hand at these locations, we don't need to redirect back through the `ExpressionPtr`.  This is slightly smaller code-wise and should be ever-so-slightly faster.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
