### PR TITLE
Add `T::Enum#as_json` implementation

### DIFF
--- a/gems/sorbet-runtime/lib/types/enum.rb
+++ b/gems/sorbet-runtime/lib/types/enum.rb
@@ -160,7 +160,7 @@ class T::Enum
 
   sig {params(args: T.untyped).returns(T.untyped)}
   def as_json(*args)
-    serialize
+    serialize.as_json(*args)
   end
 
   sig {returns(String)}

--- a/gems/sorbet-runtime/lib/types/enum.rb
+++ b/gems/sorbet-runtime/lib/types/enum.rb
@@ -158,6 +158,11 @@ class T::Enum
     serialize.to_json(*args)
   end
 
+  sig {params(args: T.untyped).returns(T.untyped)}
+  def as_json(*args)
+    serialize
+  end
+
   sig {returns(String)}
   def to_s
     inspect

--- a/gems/sorbet-runtime/lib/types/enum.rb
+++ b/gems/sorbet-runtime/lib/types/enum.rb
@@ -160,7 +160,9 @@ class T::Enum
 
   sig {params(args: T.untyped).returns(T.untyped)}
   def as_json(*args)
-    serialize.as_json(*args)
+    serialized_val = serialize
+    return serialized_val unless serialized_val.respond_to?(:as_json)
+    serialized_val.as_json(*args)
   end
 
   sig {returns(String)}

--- a/gems/sorbet-runtime/test/types/enum.rb
+++ b/gems/sorbet-runtime/test/types/enum.rb
@@ -190,8 +190,24 @@ class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
   end
 
   describe 'as_json' do
-    it 'has a string JSON representation' do
+    class CustomSerializedValue
+      def as_json(*args)
+        1234
+      end
+    end
+
+    class CustomSerializationEnum < T::Enum
+      enums do
+        SPADE = new(CustomSerializedValue.new)
+      end
+    end
+
+    it 'has a JSON representation' do
       assert_equal("club", CardSuit::CLUB.as_json)
+    end
+
+    it 'asks for the JSON representation of the serialized value' do
+      assert_equal(1234, CustomSerializationEnum::SPADE.as_json)
     end
   end
 

--- a/gems/sorbet-runtime/test/types/enum.rb
+++ b/gems/sorbet-runtime/test/types/enum.rb
@@ -189,6 +189,12 @@ class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
     end
   end
 
+  describe 'as_json' do
+    it 'has a string JSON representation' do
+      assert_equal("club", CardSuit::CLUB.as_json)
+    end
+  end
+
   describe 'T::Props::CustomType integration' do
     it 'supports instance? checks on the Enum class' do
       assert_equal(true, CardSuit.instance?(CardSuit::SPADE))


### PR DESCRIPTION
### Motivation

Fixes https://github.com/sorbet/sorbet/issues/5775

Within Rails projects, it is very common to use `to_json` on objects to serialize for logging or HTTP responses. When using Sorbet enums in these objects, the default behavior serializes a very verbose representation. This PR implements `as_json` on `T::Enum` to return a simplified representation. See the linked issue for more details.

### Test plan

See included automated tests.

**Note:** While this issue is focused on interoperability with `ActiveSupport`, I didn't add any tests specific to it as it would require a new development dependency. Happy to change this approach if deemed necessary.
