### PR TITLE
be more correct in passing parameters to `pipeline::typecheck` from LSP

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -325,7 +325,9 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
     ENFORCE(gs->lspQuery.isEmpty());
     auto resolved = pipeline::incrementalResolve(*gs, move(updatedIndexed), config->opts);
     auto sorted = sortParsedFiles(*gs, *errorReporter, move(resolved));
-    pipeline::typecheck(*gs, move(sorted), config->opts, workers, /*presorted*/ true);
+    const auto presorted = true;
+    const auto cancelable = false;
+    pipeline::typecheck(*gs, move(sorted), config->opts, workers, cancelable, std::nullopt, presorted);
     gs->lspTypecheckCount++;
 
     return subset;
@@ -504,7 +506,8 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates updates, WorkerPool &workers, bo
         }
 
         auto sorted = sortParsedFiles(*gs, *errorReporter, move(resolved));
-        pipeline::typecheck(*gs, move(sorted), config->opts, workers, cancelable, preemptManager, /*presorted*/ true);
+        const auto presorted = true;
+        pipeline::typecheck(*gs, move(sorted), config->opts, workers, cancelable, preemptManager, presorted);
     });
 
     // Note: `gs` now holds the value of `finalGS`.
@@ -621,7 +624,8 @@ LSPQueryResult LSPTypechecker::query(const core::lsp::Query &q, const std::vecto
     tryApplyDefLocSaver(*gs, resolved);
     tryApplyLocalVarSaver(*gs, resolved);
 
-    pipeline::typecheck(*gs, move(resolved), config->opts, workers, /*presorted*/ true);
+    const auto cancelable = true;
+    pipeline::typecheck(*gs, move(resolved), config->opts, workers, cancelable);
     gs->lspTypecheckCount++;
     gs->lspQuery = core::lsp::Query::noQuery();
     return LSPQueryResult{queryCollector->drainQueryResponses(), nullptr};
@@ -794,7 +798,8 @@ LSPQueryResult LSPStaleTypechecker::query(const core::lsp::Query &q,
     tryApplyDefLocSaver(*gs, resolved);
     tryApplyLocalVarSaver(*gs, resolved);
 
-    pipeline::typecheck(*gs, move(resolved), config->opts, *emptyWorkers, /*presorted*/ true);
+    const auto cancelable = true;
+    pipeline::typecheck(*gs, move(resolved), config->opts, *emptyWorkers, cancelable);
     gs->lspTypecheckCount++;
     gs->lspQuery = core::lsp::Query::noQuery();
     return LSPQueryResult{queryCollector->drainQueryResponses(), nullptr};


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

There were a couple of places in `LSPTypechecker.cc` that passed `/*presorted*/ true` to `pipeline::typecheck`, not realizing that at some point, the prototype of `pipeline::typecheck` had changed and the parameter that was actually being passed was `cancelable`.

This seems particularly bad because the fast path is not supposed to be cancelable, cf.

https://github.com/sorbet/sorbet/blob/912faf475735a624b1490f3b9112ab2a5530a81c/main/lsp/LSPTypechecker.cc#L533-L535

so I think we could have been in the position of running the fast path, canceling it (I think?), but recording that those files were properly typechecked anyway.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I don't think we even have a way to write tests for this, cf.

https://github.com/sorbet/sorbet/blob/912faf475735a624b1490f3b9112ab2a5530a81c/main/lsp/LSPTypechecker.cc#L225-L236

tests don't have a cancelation path for the fast path because the fast path was never meant to be cancelable.

I do not know what this does for the feel of LSP.
