### PR TITLE
add some more histograms for type fields

### DIFF
--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -379,6 +379,7 @@ TypePtr LiteralType::underlying(const GlobalState &gs) const {
 
 TupleType::TupleType(vector<TypePtr> elements) : elems(move(elements)) {
     categoryCounterInc("types.allocated", "tupletype");
+    histogramInc("tupletype.elems", this->elems.size());
 }
 
 AndType::AndType(const TypePtr &left, const TypePtr &right) : left(move(left)), right(move(right)) {
@@ -419,6 +420,7 @@ void TupleType::_sanityCheck(const GlobalState &gs) const {
 ShapeType::ShapeType(vector<TypePtr> keys, vector<TypePtr> values) : keys(move(keys)), values(move(values)) {
     DEBUG_ONLY(for (auto &k : this->keys) { ENFORCE(isa_type<LiteralType>(k)); };);
     categoryCounterInc("types.allocated", "shapetype");
+    histogramInc("shapetype.keys", this->keys.size());
 }
 
 TypePtr ShapeType::underlying(const GlobalState &gs) const {
@@ -726,6 +728,7 @@ SelfType::SelfType() {
 };
 AppliedType::AppliedType(ClassOrModuleRef klass, vector<TypePtr> targs) : klass(klass), targs(std::move(targs)) {
     categoryCounterInc("types.allocated", "appliedtype");
+    histogramInc("appliedtype.targs", this->targs.size());
 }
 
 bool SelfType::derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Was curious what these were, specifically if `AppliedType` might be better off using inline vector storage.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
