### PR TITLE
don't copy `FileHash` when determining the fast path

### DIFF
--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -116,8 +116,8 @@ bool LSPIndexer::canTakeFastPathInternal(
         }
         ENFORCE(oldFile.getFileHash() != nullptr);
         ENFORCE(f->getFileHash() != nullptr);
-        auto oldHash = *oldFile.getFileHash();
-        auto newHash = *f->getFileHash();
+        const auto &oldHash = *oldFile.getFileHash();
+        const auto &newHash = *f->getFileHash();
         ENFORCE(oldHash.definitions.hierarchyHash != core::GlobalStateHash::HASH_STATE_NOT_COMPUTED);
         if (newHash.definitions.hierarchyHash == core::GlobalStateHash::HASH_STATE_INVALID) {
             logger.debug("Taking slow path because {} has a syntax error", f->path());


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

`FileHash` objects can be pretty large, and there's no good reason to copy them here.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
