### PR TITLE
Foo in sorbet/rbi/shims/foo.rbi should be a class

### DIFF
--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -1824,7 +1824,7 @@ our definitions as RBI under `sorbet/rbi/shims/foo.rbi`:
 # sorbet/rbi/shims/foo.rbi
 # typed: true
 
-module Foo
+class Foo
   def foo; end
 end
 ```


### PR DESCRIPTION
Just a typo I found while looking at the documentation.