### PR TITLE
Raise error for packaged const used from unpackged

### DIFF
--- a/core/errors/packager.h
+++ b/core/errors/packager.h
@@ -23,10 +23,9 @@ constexpr ErrorClass ImportConflict{3714, StrictLevel::False};
 constexpr ErrorClass ExportConflict{3716, StrictLevel::False};
 constexpr ErrorClass UsedPackagePrivateName{3717, StrictLevel::False};
 constexpr ErrorClass MissingImport{3718, StrictLevel::False};
-// 3719 PackagedSymbolInUnpackagedContext
+// constexpr ErrorClass PackagedSymbolInUnpackagedContext{3719, StrictLevel::False};
 constexpr ErrorClass UsedTestOnlyName{3720, StrictLevel::False};
 constexpr ErrorClass InvalidExport{3721, StrictLevel::False};
 // constexpr ErrorClass ExportingTypeAlias{3722, StrictLevel::False};
-constexpr ErrorClass PackagedSymbolInUnpackagedContext{3723, StrictLevel::False};
 } // namespace sorbet::core::errors::Packager
 #endif

--- a/core/errors/packager.h
+++ b/core/errors/packager.h
@@ -27,5 +27,6 @@ constexpr ErrorClass MissingImport{3718, StrictLevel::False};
 constexpr ErrorClass UsedTestOnlyName{3720, StrictLevel::False};
 constexpr ErrorClass InvalidExport{3721, StrictLevel::False};
 // constexpr ErrorClass ExportingTypeAlias{3722, StrictLevel::False};
+constexpr ErrorClass PackagedSymbolInUnpackagedContext{3723, StrictLevel::False};
 } // namespace sorbet::core::errors::Packager
 #endif

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -388,6 +388,13 @@ public:
                     e.addAutocorrect(std::move(exp.value()));
                 }
 
+                if (!ctx.file.data(ctx).isPackaged()) {
+                    e.addErrorNote(
+                        "A `{}` file is allowed to define constants outside of the package's namespace,\n    "
+                        "but must still respect its enclosing package's imports.",
+                        "# packaged: false");
+                }
+
                 if (!db.errorHint().empty()) {
                     e.addErrorNote("{}", db.errorHint());
                 }

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -421,7 +421,7 @@ public:
         workers.multiplexJob("VisibilityChecker", [&gs, fileq, resultq]() {
             ast::ParsedFile f;
             for (auto result = fileq->try_pop(f); !result.done(); result = fileq->try_pop(f)) {
-                if (!f.file.data(gs).isPackage() && f.file.data(gs).isPackaged()) {
+                if (!f.file.data(gs).isPackage()) {
                     auto pkgName = gs.packageDB().getPackageNameForFile(f.file);
                     if (pkgName.exists()) {
                         core::Context ctx{gs, core::Symbols::root(), f.file};

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -352,6 +352,13 @@ public:
             return tree;
         }
 
+        if (!this->package.exists()) {
+            if (auto e = ctx.beginError(lit.loc, core::errors::Packager::PackagedSymbolInUnpackagedContext)) {
+                e.setHeader("Packaged constant `{}` used in an unpackaged context", lit.symbol.show(ctx));
+            }
+            return tree;
+        }
+
         bool isExported = false;
         if (lit.symbol.isClassOrModule()) {
             isExported = lit.symbol.asClassOrModuleRef().data(ctx)->flags.isExported;

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -352,13 +352,6 @@ public:
             return tree;
         }
 
-        if (!this->package.exists()) {
-            if (auto e = ctx.beginError(lit.loc, core::errors::Packager::PackagedSymbolInUnpackagedContext)) {
-                e.setHeader("Packaged constant `{}` used in an unpackaged context", lit.symbol.show(ctx));
-            }
-            return tree;
-        }
-
         bool isExported = false;
         if (lit.symbol.isClassOrModule()) {
             isExported = lit.symbol.asClassOrModuleRef().data(ctx)->flags.isExported;

--- a/test/testdata/packager/unpackaged-error/other_package_imported/__package.rb
+++ b/test/testdata/packager/unpackaged-error/other_package_imported/__package.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+# typed: strict
+
+class OtherPackageImported < PackageSpec
+  export OtherPackageImported::ExportedClass
+end

--- a/test/testdata/packager/unpackaged-error/other_package_imported/exported_class.rb
+++ b/test/testdata/packager/unpackaged-error/other_package_imported/exported_class.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+class OtherPackageImported::ExportedClass
+end

--- a/test/testdata/packager/unpackaged-error/other_package_not_imported/__package.rb
+++ b/test/testdata/packager/unpackaged-error/other_package_not_imported/__package.rb
@@ -1,0 +1,7 @@
+
+# frozen_string_literal: true
+# typed: strict
+
+class OtherPackageNotImported < PackageSpec
+  export OtherPackageNotImported::ExportedClass
+end

--- a/test/testdata/packager/unpackaged-error/other_package_not_imported/exported_class.rb
+++ b/test/testdata/packager/unpackaged-error/other_package_not_imported/exported_class.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+class OtherPackageNotImported::ExportedClass
+end

--- a/test/testdata/packager/unpackaged-error/packaged/__package.rb
+++ b/test/testdata/packager/unpackaged-error/packaged/__package.rb
@@ -5,4 +5,5 @@
 
 class MyPackage < PackageSpec
   # No imports or exports.
+  import OtherPackageImported
 end

--- a/test/testdata/packager/unpackaged-error/packaged/unpackaged-file.rb
+++ b/test/testdata/packager/unpackaged-error/packaged/unpackaged-file.rb
@@ -6,7 +6,8 @@
 class ::UnpackagedTheSequel
   def test
 
-    # This reference should be an error.
     puts MyPackage::MyClass.new
+    puts OtherPackageImported::ExportedClass.new
+    puts OtherPackageNotImported::ExportedClass.new
   end
 end

--- a/test/testdata/packager/unpackaged-error/packaged/unpackaged-file.rb
+++ b/test/testdata/packager/unpackaged-error/packaged/unpackaged-file.rb
@@ -9,5 +9,6 @@ class ::UnpackagedTheSequel
     puts MyPackage::MyClass.new
     puts OtherPackageImported::ExportedClass.new
     puts OtherPackageNotImported::ExportedClass.new
+    #    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `OtherPackageNotImported::ExportedClass` resolves but its package is not imported
   end
 end

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -805,6 +805,10 @@ class A::B < PackageSpec
 end
 ```
 
+## 3723
+
+TODO(jez)
+
 ## 4001
 
 Sorbet parses the syntax of `include` and `extend` declarations, even in

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -805,10 +805,6 @@ class A::B < PackageSpec
 end
 ```
 
-## 3723
-
-TODO(jez)
-
 ## 4001
 
 Sorbet parses the syntax of `include` and `extend` declarations, even in


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This gets us to parity with the old packager behavior.

The key insight that makes this easy is that a `# packaged: false` file still technically belongs to the enclosing package (it seems that trevor had maybe overlooked that?)

So e.g., `extn/` can have a `__package.rb` file like

```ruby
class ExtnDONOTUSE < PackageSpec
  import Opus::LSpace
end
```

and all the files in `extn/` can mention e.g. `Opus::LSpace`, but those files are allowed to re-open stdlib classes.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.