### PR TITLE
Deduplicate serialized_val

### DIFF
--- a/gems/sorbet-runtime/lib/types/enum.rb
+++ b/gems/sorbet-runtime/lib/types/enum.rb
@@ -281,7 +281,7 @@ class T::Enum
     # Historical note: We convert to lowercase names because the majority of existing calls to
     # `make_accessible` were arrays of lowercase strings. Doing this conversion allowed for the
     # least amount of repetition in migrated declarations.
-    const_name.to_s.downcase.freeze
+    -const_name.to_s.downcase.freeze
   end
 
   sig {returns(T::Boolean)}


### PR DESCRIPTION
Since the string is frozen already, we can use `String#-@` instead.

This way two enum with similar values will re-use the same interned string.
