### PR TITLE
add commentary and real names for hashing-related things

### DIFF
--- a/core/Files.h
+++ b/core/Files.h
@@ -12,7 +12,7 @@
 
 namespace sorbet::core {
 class GlobalState;
-struct GlobalStateHash;
+struct DefinitionHash;
 struct FileHash;
 namespace serialize {
 class SerializerImpl;

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2109,15 +2109,15 @@ unique_ptr<GlobalState> GlobalState::markFileAsTombStone(unique_ptr<GlobalState>
 }
 
 uint32_t patchHash(uint32_t hash) {
-    if (hash == GlobalStateHash::HASH_STATE_NOT_COMPUTED) {
-        hash = GlobalStateHash::HASH_STATE_NOT_COMPUTED_COLLISION_AVOID;
-    } else if (hash == GlobalStateHash::HASH_STATE_INVALID) {
-        hash = GlobalStateHash::HASH_STATE_INVALID_COLLISION_AVOID;
+    if (hash == DefinitionHash::HASH_STATE_NOT_COMPUTED) {
+        hash = DefinitionHash::HASH_STATE_NOT_COMPUTED_COLLISION_AVOID;
+    } else if (hash == DefinitionHash::HASH_STATE_INVALID) {
+        hash = DefinitionHash::HASH_STATE_INVALID_COLLISION_AVOID;
     }
     return hash;
 }
 
-unique_ptr<GlobalStateHash> GlobalState::hash() const {
+unique_ptr<DefinitionHash> GlobalState::hash() const {
     constexpr bool DEBUG_HASHING_TAIL = false;
     uint32_t hierarchyHash = 0;
     uint32_t classModuleHash = 0;
@@ -2192,7 +2192,7 @@ unique_ptr<GlobalStateHash> GlobalState::hash() const {
         }
     }
 
-    unique_ptr<GlobalStateHash> result = make_unique<GlobalStateHash>();
+    unique_ptr<DefinitionHash> result = make_unique<DefinitionHash>();
     result->methodHashes.reserve(methodHashes.size());
     for (const auto &e : methodHashes) {
         result->methodHashes.emplace_back(e.first, patchHash(e.second));

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -26,7 +26,7 @@ class TypeArgumentRef;
 class TypeMemberRef;
 class NameSubstitution;
 class ErrorQueue;
-struct GlobalStateHash;
+struct DefinitionHash;
 
 namespace lsp {
 class Task;
@@ -269,7 +269,7 @@ public:
 
     void trace(std::string_view msg) const;
 
-    std::unique_ptr<GlobalStateHash> hash() const;
+    std::unique_ptr<DefinitionHash> hash() const;
     const std::vector<std::shared_ptr<File>> &getFiles() const;
 
     // Contains a string to be used as the base of the error URL.

--- a/core/NameHash.cc
+++ b/core/NameHash.cc
@@ -16,7 +16,7 @@ void NameHash::sortAndDedupe(std::vector<core::NameHash> &hashes) {
     hashes.resize(std::distance(hashes.begin(), std::unique(hashes.begin(), hashes.end())));
 }
 
-FileHash::FileHash(GlobalStateHash &&definitions, UsageHash &&usages)
+FileHash::FileHash(DefinitionHash &&definitions, UsageHash &&usages)
     : definitions(move(definitions)), usages(move(usages)) {}
 
 } // namespace sorbet::core

--- a/core/NameHash.h
+++ b/core/NameHash.h
@@ -63,8 +63,16 @@ struct DefinitionHash {
     }
 };
 
+// This structure represents all the uses of various constructs contained in a single file.
 struct UsageHash {
+    // A sorted, deduplicated list of the hashes of all the method names called
+    // by this file.
     std::vector<core::NameHash> sends;
+    // A sorted, deduplicated list of the hashes of all the names referenced in this
+    // file that will wind up referencing `core::Symbol` structures.  This includes
+    // the obvious constant names (`T::Hash` counts as two constant names), but also
+    // the names of the classes/methods defined in the file as well as any
+    // @instance/@@class variables.
     std::vector<core::NameHash> symbols;
 };
 

--- a/core/NameHash.h
+++ b/core/NameHash.h
@@ -13,19 +13,19 @@ public:
     inline bool isDefined() const {
         return _hashValue != 0;
     }
-    NameHash(const NameHash &nm) = default;
-    NameHash() : _hashValue(0){};
-    inline bool operator==(const NameHash &rhs) const {
+    NameHash(const NameHash &nm) noexcept = default;
+    NameHash() noexcept : _hashValue(0){};
+    inline bool operator==(const NameHash &rhs) const noexcept {
         ENFORCE(isDefined());
         ENFORCE(rhs.isDefined());
         return _hashValue == rhs._hashValue;
     }
 
-    inline bool operator!=(const NameHash &rhs) const {
+    inline bool operator!=(const NameHash &rhs) const noexcept {
         return !(rhs == *this);
     }
 
-    inline bool operator<(const NameHash &rhs) const {
+    inline bool operator<(const NameHash &rhs) const noexcept {
         return this->_hashValue < rhs._hashValue;
     }
 

--- a/core/NameHash.h
+++ b/core/NameHash.h
@@ -36,7 +36,7 @@ template <typename H> H AbslHashValue(H h, const NameHash &m) {
     return H::combine(std::move(h), m._hashValue);
 }
 
-struct GlobalStateHash {
+struct DefinitionHash {
     static constexpr int HASH_STATE_NOT_COMPUTED = 0;
     static constexpr int HASH_STATE_NOT_COMPUTED_COLLISION_AVOID = 1;
     static constexpr int HASH_STATE_INVALID = 2;
@@ -51,8 +51,8 @@ struct GlobalStateHash {
     uint32_t methodHash = HASH_STATE_NOT_COMPUTED;
     std::vector<std::pair<NameHash, uint32_t>> methodHashes;
 
-    static GlobalStateHash invalid() {
-        GlobalStateHash ret;
+    static DefinitionHash invalid() {
+        DefinitionHash ret;
         ret.hierarchyHash = HASH_STATE_INVALID;
         ret.classModuleHash = HASH_STATE_INVALID;
         ret.typeArgumentHash = HASH_STATE_INVALID;
@@ -69,11 +69,11 @@ struct UsageHash {
 };
 
 struct FileHash {
-    GlobalStateHash definitions;
+    DefinitionHash definitions;
     UsageHash usages;
 
     FileHash() = default;
-    FileHash(GlobalStateHash &&definitions, UsageHash &&usages);
+    FileHash(DefinitionHash &&definitions, UsageHash &&usages);
 };
 
 }; // namespace sorbet::core

--- a/core/NameHash.h
+++ b/core/NameHash.h
@@ -50,8 +50,8 @@ struct DefinitionFingerprint {
         : nameHash(nameHash), definitionHash(definitionHash) {}
 
     inline bool operator<(const DefinitionFingerprint &h) const noexcept {
-        return this->nameHash < h.nameHash
-            || (!(h.nameHash < this->nameHash) && this->definitionHash < h.definitionHash);
+        return this->nameHash < h.nameHash ||
+               (!(h.nameHash < this->nameHash) && this->definitionHash < h.definitionHash);
     }
 };
 

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -13,7 +13,7 @@
 namespace sorbet::core {
 class ClassOrModule;
 class GlobalState;
-struct GlobalStateHash;
+struct DefinitionHash;
 class Type;
 class MutableContext;
 class Context;

--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -69,7 +69,7 @@ unique_ptr<core::FileHash> computeFileHashForAST(spdlog::logger &logger, unique_
             auto view = string_view{result.GetString(), result.GetLength()};
             logger.debug(view);
 
-            return make_unique<core::FileHash>(core::GlobalStateHash::invalid(), move(usageHash));
+            return make_unique<core::FileHash>(core::DefinitionHash::invalid(), move(usageHash));
         }
     }
 

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -133,11 +133,11 @@ bool LSPIndexer::canTakeFastPathInternal(
         if (newHash.definitions.hierarchyHash != core::DefinitionHash::HASH_STATE_INVALID &&
             newHash.definitions.hierarchyHash != oldHash.definitions.hierarchyHash) {
             logger.debug("Taking slow path because {} has changed definitions", f->path());
-            ENFORCE(newHash.definitions.classModuleHash != core::GlobalStateHash::HASH_STATE_INVALID);
-            ENFORCE(newHash.definitions.typeArgumentHash != core::GlobalStateHash::HASH_STATE_INVALID);
-            ENFORCE(newHash.definitions.typeMemberHash != core::GlobalStateHash::HASH_STATE_INVALID);
-            ENFORCE(newHash.definitions.fieldHash != core::GlobalStateHash::HASH_STATE_INVALID);
-            ENFORCE(newHash.definitions.methodHash != core::GlobalStateHash::HASH_STATE_INVALID);
+            ENFORCE(newHash.definitions.classModuleHash != core::DefinitionHash::HASH_STATE_INVALID);
+            ENFORCE(newHash.definitions.typeArgumentHash != core::DefinitionHash::HASH_STATE_INVALID);
+            ENFORCE(newHash.definitions.typeMemberHash != core::DefinitionHash::HASH_STATE_INVALID);
+            ENFORCE(newHash.definitions.fieldHash != core::DefinitionHash::HASH_STATE_INVALID);
+            ENFORCE(newHash.definitions.methodHash != core::DefinitionHash::HASH_STATE_INVALID);
             prodCategoryCounterInc("lsp.slow_path_reason", "changed_definition");
             // Also record some information about what might have changed.
             if (newHash.definitions.classModuleHash != oldHash.definitions.classModuleHash) {

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -118,19 +118,19 @@ bool LSPIndexer::canTakeFastPathInternal(
         ENFORCE(f->getFileHash() != nullptr);
         const auto &oldHash = *oldFile.getFileHash();
         const auto &newHash = *f->getFileHash();
-        ENFORCE(oldHash.definitions.hierarchyHash != core::GlobalStateHash::HASH_STATE_NOT_COMPUTED);
-        if (newHash.definitions.hierarchyHash == core::GlobalStateHash::HASH_STATE_INVALID) {
-            ENFORCE(newHash.definitions.classModuleHash == core::GlobalStateHash::HASH_STATE_INVALID);
-            ENFORCE(newHash.definitions.typeArgumentHash == core::GlobalStateHash::HASH_STATE_INVALID);
-            ENFORCE(newHash.definitions.typeMemberHash == core::GlobalStateHash::HASH_STATE_INVALID);
-            ENFORCE(newHash.definitions.fieldHash == core::GlobalStateHash::HASH_STATE_INVALID);
-            ENFORCE(newHash.definitions.methodHash == core::GlobalStateHash::HASH_STATE_INVALID);
+        ENFORCE(oldHash.definitions.hierarchyHash != core::DefinitionHash::HASH_STATE_NOT_COMPUTED);
+        if (newHash.definitions.hierarchyHash == core::DefinitionHash::HASH_STATE_INVALID) {
+            ENFORCE(newHash.definitions.classModuleHash == core::DefinitionHash::HASH_STATE_INVALID);
+            ENFORCE(newHash.definitions.typeArgumentHash == core::DefinitionHash::HASH_STATE_INVALID);
+            ENFORCE(newHash.definitions.typeMemberHash == core::DefinitionHash::HASH_STATE_INVALID);
+            ENFORCE(newHash.definitions.fieldHash == core::DefinitionHash::HASH_STATE_INVALID);
+            ENFORCE(newHash.definitions.methodHash == core::DefinitionHash::HASH_STATE_INVALID);
             logger.debug("Taking slow path because {} has a syntax error", f->path());
             prodCategoryCounterInc("lsp.slow_path_reason", "syntax_error");
             return false;
         }
 
-        if (newHash.definitions.hierarchyHash != core::GlobalStateHash::HASH_STATE_INVALID &&
+        if (newHash.definitions.hierarchyHash != core::DefinitionHash::HASH_STATE_INVALID &&
             newHash.definitions.hierarchyHash != oldHash.definitions.hierarchyHash) {
             logger.debug("Taking slow path because {} has changed definitions", f->path());
             ENFORCE(newHash.definitions.classModuleHash != core::GlobalStateHash::HASH_STATE_INVALID);


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

1. A little `std::pair` is OK; `std::pair` usage spread across three different files demands a real structure.
2. The name `GlobalStateHash` is...not great.  I think it's really weird that `GlobalState::hash` only really applies to the things contained in a single file, but at least this change makes it (ideally) clearer how things work.
3. Comments are helpful things, let's have some more of those.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
