### PR TITLE
gather more statistics on definition changes that force the slow path in LSP

### DIFF
--- a/core/NameHash.h
+++ b/core/NameHash.h
@@ -42,11 +42,23 @@ struct GlobalStateHash {
     static constexpr int HASH_STATE_INVALID = 2;
     static constexpr int HASH_STATE_INVALID_COLLISION_AVOID = 3;
     uint32_t hierarchyHash = HASH_STATE_NOT_COMPUTED;
+    uint32_t classModuleHash = HASH_STATE_NOT_COMPUTED;
+    uint32_t typeArgumentHash = HASH_STATE_NOT_COMPUTED;
+    uint32_t typeMemberHash = HASH_STATE_NOT_COMPUTED;
+    // TODO(froydnj) would maybe be interesting to split this out into separate
+    // field/static field hashes, or even finer subdivisions on static fields.
+    uint32_t fieldHash = HASH_STATE_NOT_COMPUTED;
+    uint32_t methodHash = HASH_STATE_NOT_COMPUTED;
     std::vector<std::pair<NameHash, uint32_t>> methodHashes;
 
     static GlobalStateHash invalid() {
         GlobalStateHash ret;
         ret.hierarchyHash = HASH_STATE_INVALID;
+        ret.classModuleHash = HASH_STATE_INVALID;
+        ret.typeArgumentHash = HASH_STATE_INVALID;
+        ret.typeMemberHash = HASH_STATE_INVALID;
+        ret.fieldHash = HASH_STATE_INVALID;
+        ret.methodHash = HASH_STATE_INVALID;
         return ret;
     }
 };

--- a/core/NameHash.h
+++ b/core/NameHash.h
@@ -43,6 +43,12 @@ struct GlobalStateHash {
     static constexpr int HASH_STATE_INVALID_COLLISION_AVOID = 3;
     uint32_t hierarchyHash = HASH_STATE_NOT_COMPUTED;
     std::vector<std::pair<NameHash, uint32_t>> methodHashes;
+
+    static GlobalStateHash invalid() {
+        GlobalStateHash ret;
+        ret.hierarchyHash = HASH_STATE_INVALID;
+        return ret;
+    }
 };
 
 struct UsageHash {

--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -69,9 +69,7 @@ unique_ptr<core::FileHash> computeFileHashForAST(spdlog::logger &logger, unique_
             auto view = string_view{result.GetString(), result.GetLength()};
             logger.debug(view);
 
-            core::GlobalStateHash invalid;
-            invalid.hierarchyHash = core::GlobalStateHash::HASH_STATE_INVALID;
-            return make_unique<core::FileHash>(move(invalid), move(usageHash));
+            return make_unique<core::FileHash>(core::GlobalStateHash::invalid(), move(usageHash));
         }
     }
 

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -120,6 +120,11 @@ bool LSPIndexer::canTakeFastPathInternal(
         const auto &newHash = *f->getFileHash();
         ENFORCE(oldHash.definitions.hierarchyHash != core::GlobalStateHash::HASH_STATE_NOT_COMPUTED);
         if (newHash.definitions.hierarchyHash == core::GlobalStateHash::HASH_STATE_INVALID) {
+            ENFORCE(newHash.definitions.classModuleHash == core::GlobalStateHash::HASH_STATE_INVALID);
+            ENFORCE(newHash.definitions.typeArgumentHash == core::GlobalStateHash::HASH_STATE_INVALID);
+            ENFORCE(newHash.definitions.typeMemberHash == core::GlobalStateHash::HASH_STATE_INVALID);
+            ENFORCE(newHash.definitions.fieldHash == core::GlobalStateHash::HASH_STATE_INVALID);
+            ENFORCE(newHash.definitions.methodHash == core::GlobalStateHash::HASH_STATE_INVALID);
             logger.debug("Taking slow path because {} has a syntax error", f->path());
             prodCategoryCounterInc("lsp.slow_path_reason", "syntax_error");
             return false;
@@ -128,7 +133,28 @@ bool LSPIndexer::canTakeFastPathInternal(
         if (newHash.definitions.hierarchyHash != core::GlobalStateHash::HASH_STATE_INVALID &&
             newHash.definitions.hierarchyHash != oldHash.definitions.hierarchyHash) {
             logger.debug("Taking slow path because {} has changed definitions", f->path());
+            ENFORCE(newHash.definitions.classModuleHash != core::GlobalStateHash::HASH_STATE_INVALID);
+            ENFORCE(newHash.definitions.typeArgumentHash != core::GlobalStateHash::HASH_STATE_INVALID);
+            ENFORCE(newHash.definitions.typeMemberHash != core::GlobalStateHash::HASH_STATE_INVALID);
+            ENFORCE(newHash.definitions.fieldHash != core::GlobalStateHash::HASH_STATE_INVALID);
+            ENFORCE(newHash.definitions.methodHash != core::GlobalStateHash::HASH_STATE_INVALID);
             prodCategoryCounterInc("lsp.slow_path_reason", "changed_definition");
+            // Also record some information about what might have changed.
+            if (newHash.definitions.classModuleHash != oldHash.definitions.classModuleHash) {
+                prodCategoryCounterInc("lsp.slow_path_changed_def", "classmodule");
+            }
+            if (newHash.definitions.typeArgumentHash != oldHash.definitions.typeArgumentHash) {
+                prodCategoryCounterInc("lsp.slow_path_changed_def", "typeargument");
+            }
+            if (newHash.definitions.typeMemberHash != oldHash.definitions.typeMemberHash) {
+                prodCategoryCounterInc("lsp.slow_path_changed_def", "typemember");
+            }
+            if (newHash.definitions.fieldHash != oldHash.definitions.fieldHash) {
+                prodCategoryCounterInc("lsp.slow_path_changed_def", "field");
+            }
+            if (newHash.definitions.methodHash != oldHash.definitions.methodHash) {
+                prodCategoryCounterInc("lsp.slow_path_changed_def", "method");
+            }
             return false;
         }
     }


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Stripe's statistics show that something like 50-60% of the reasons for taking the slow path (i.e. typecheck the entire world) in LSP are related to changed definitions.  We'd like to try and understand what sort of changes are triggering this.  Ideally we can get enough information that we can decide the best plan for driving that number down and taking the fast path more often.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.  I have not benchmarked this, but I am guessing that tossing a few more arithmetic operations into `GlobalState::hash` (especially since they could be computed in parallel with `hierarchyHash`, subject to functional units) is not going to have that big of an impact.  Totally willing to revert after we gather some data, too.
