### PR TITLE
tighten conditions for when we show move method code actions

### DIFF
--- a/test/testdata/lsp/code_actions/move_method/dsl_required.A.rbedited
+++ b/test/testdata/lsp/code_actions/move_method/dsl_required.A.rbedited
@@ -1,0 +1,10 @@
+# typed: strict
+# selective-apply-code-action: refactor.extract
+# assert-no-code-action: refactor.extract
+#
+# No code actions should be available for the props
+
+class TestDSLBuilder
+  dsl_required :example1, String
+  #                         ^ apply-code-action: [A] Move method to a new module
+end

--- a/test/testdata/lsp/code_actions/move_method/dsl_required.rb
+++ b/test/testdata/lsp/code_actions/move_method/dsl_required.rb
@@ -1,0 +1,10 @@
+# typed: strict
+# selective-apply-code-action: refactor.extract
+# assert-no-code-action: refactor.extract
+#
+# No code actions should be available for the props
+
+class TestDSLBuilder
+  dsl_required :example1, String
+  #                         ^ apply-code-action: [A] Move method to a new module
+end


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

As #5800 shows, we have a crash with move method requests on locations that are attributed to multiple methods.  The crash actually comes from looping over all relevant method definition responses that we can rename and then executing:

https://github.com/sorbet/sorbet/blob/772ce260c63bdd334a303c5174c70869a410785f/main/lsp/requests/code_action.cc#L156-L164
On the first such method, the first line of the region executes fine, but then we `std::move` data out of `params`.  On the second such method, we get a crash because `params` is now null.

I think the logic should be "is there a single method that we can handle at this location?".  If not, we can assume there's something weird going on with rewritten code, and abandon the attempt to move things.  Hence this PR.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included tests.