### PR TITLE
tighten conditions in LSP test runner

### DIFF
--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -255,7 +255,9 @@ void validateCodeActions(LSPWrapper &lspWrapper, Expectations &test, string file
             INFO(fmt::format(
                 "Did not receive code action matching assertion `{}` for error or selected code action `{}`...",
                 codeActionAssertion->toString(), codeActionDescription));
-            CHECK_NE(it2, receivedCodeActionsByTitle.end());
+            INFO("(If this was the expected behavior, add `# assert-no-code-action: $CODE_ACTION_KIND` to your "
+                 "testcase)");
+            REQUIRE_NE(it2, receivedCodeActionsByTitle.end());
         }
 
         // Ensure that the received code action applies correctly.
@@ -353,7 +355,7 @@ void testQuickFixCodeActions(LSPWrapper &lspWrapper, Expectations &test, const v
                 validateCodeActions(lspWrapper, test, fileUri, codeActionAssertion->range->copy(), nextId,
                                     selectedCodeActionKinds, ignoredCodeActionKinds, applyCodeActionAssertions,
                                     codeActionAssertion->toString(), true);
-                ENFORCE(applyCodeActionAssertions.size() < initialSize);
+                REQUIRE_LT(applyCodeActionAssertions.size(), initialSize);
             }
 
             // We've already removed any code action assertions that matches a received code action assertion.


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

When I made initial changes for #5801, I was greeted with a bunch of test timeouts, because some loops were not terminating.  One reason was the `ENFORCE` changed in this PR; the `ENFORCE` wasn't firing because I was initially testing in opt mode (yes, yes, this is not generally a good idea).  But the real culprit is that the `CHECK_NE` should have been a `REQUIRE_NE`; if it had been, we wouldn't have needed the `ENFORCE`.

I went ahead and changed both of them to always be active; then perhaps the next person who comes along won't be as confused as I was.  I also added an informative message that ideally will point people at how to assert "no code actions should be shown here", since it was not obvious to me.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
