### PR TITLE
enforce that non-inlined types cannot be inadvertently copied.

### DIFF
--- a/core/TypePtr.cc
+++ b/core/TypePtr.cc
@@ -315,6 +315,14 @@ TypePtr TypePtr::_instantiate(const GlobalState &gs, absl::Span<const TypeMember
 }
 
 void TypePtr::_sanityCheck(const GlobalState &gs) const {
+    // Not really a dynamic check, but this is a convenient place to put this to
+    // ensure that all relevant types get checked.
+#define SANITY_CHECK(T) \
+    static_assert(TypePtr::TypeToIsInlined<T>::value || !std::is_copy_constructible<T>::value, \
+                  "non-inline types must not be copy-constructible");   \
+    break;
+    GENERATE_TAG_SWITCH(tag(), SANITY_CHECK)
+#undef SANITY_CHECK
 #define SANITY_CHECK(T) return cast_type_nonnull<T>(*this)._sanityCheck(gs);
     GENERATE_TAG_SWITCH(tag(), SANITY_CHECK)
 #undef SANITY_CHECK

--- a/core/TypePtr.cc
+++ b/core/TypePtr.cc
@@ -317,9 +317,9 @@ TypePtr TypePtr::_instantiate(const GlobalState &gs, absl::Span<const TypeMember
 void TypePtr::_sanityCheck(const GlobalState &gs) const {
     // Not really a dynamic check, but this is a convenient place to put this to
     // ensure that all relevant types get checked.
-#define SANITY_CHECK(T) \
+#define SANITY_CHECK(T)                                                                        \
     static_assert(TypePtr::TypeToIsInlined<T>::value || !std::is_copy_constructible<T>::value, \
-                  "non-inline types must not be copy-constructible");   \
+                  "non-inline types must not be copy-constructible");                          \
     break;
     GENERATE_TAG_SWITCH(tag(), SANITY_CHECK)
 #undef SANITY_CHECK

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -65,9 +65,9 @@ public:
     template <class To>
     static typename TypeToCastType<To, TypeToIsInlined<To>::value>::type cast(TypePtr &&what) = delete;
 
-    template <class To> static auto cast(TypePtr &what) {
-        return const_cast_type<To>(cast<To>(static_cast<const TypePtr &>(what)));
-    }
+    // Disallowing this and requiring people to cast to `const TypePtr &` is simplier
+    // than creating a parallel `TypeToCastType` for non-const argument types.
+    template <class To> static auto cast(TypePtr &what) = delete;
 
     static std::string tagToString(Tag tag);
 

--- a/core/Types.h
+++ b/core/Types.h
@@ -381,6 +381,8 @@ public:
     TypePtr upperBound;
 
     LambdaParam(TypeMemberRef definition, TypePtr lower, TypePtr upper);
+    LambdaParam(const LambdaParam &) = delete;
+    LambdaParam &operator=(const LambdaParam &) = delete;
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const {
         return show(gs, {});
@@ -580,6 +582,8 @@ TYPE(TypeVar) final {
 public:
     TypeArgumentRef sym;
     TypeVar(TypeArgumentRef sym);
+    TypeVar(const TypeVar &) = delete;
+    TypeVar &operator=(const TypeVar &) = delete;
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const {
         return show(gs, {});
@@ -600,6 +604,8 @@ public:
     TypePtr left;
     TypePtr right;
 
+    OrType(const OrType &) = delete;
+    OrType &operator=(const OrType &) = delete;
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const {
         return show(gs, {});
@@ -654,6 +660,8 @@ public:
     TypePtr left;
     TypePtr right;
 
+    AndType(const AndType &) = delete;
+    AndType &operator=(const AndType &) = delete;
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const {
         return show(gs, {});
@@ -699,6 +707,8 @@ public:
     std::vector<TypePtr> keys; // TODO: store sorted by whatever
     std::vector<TypePtr> values;
     ShapeType(std::vector<TypePtr> keys, std::vector<TypePtr> values);
+    ShapeType(const ShapeType &) = delete;
+    ShapeType &operator=(const ShapeType &) = delete;
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const {
@@ -729,6 +739,8 @@ public:
     std::vector<TypePtr> elems;
 
     TupleType(std::vector<TypePtr> elements);
+    TupleType(const TupleType &) = delete;
+    TupleType &operator=(const TupleType &) = delete;
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const {
@@ -756,6 +768,8 @@ public:
     ClassOrModuleRef klass;
     std::vector<TypePtr> targs;
     AppliedType(ClassOrModuleRef klass, std::vector<TypePtr> targs);
+    AppliedType(const AppliedType &) = delete;
+    AppliedType &operator=(const AppliedType &) = delete;
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const {
@@ -789,6 +803,8 @@ public:
     TypePtr wrapped;
 
     MetaType(const TypePtr &wrapped);
+    MetaType(const MetaType &) = delete;
+    MetaType &operator=(const MetaType &) = delete;
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const {
@@ -981,6 +997,8 @@ public:
     const std::vector<core::NameRef> names;
     UnresolvedClassType(SymbolRef scope, std::vector<core::NameRef> names)
         : ClassType(core::Symbols::untyped()), scope(scope), names(std::move(names)){};
+    UnresolvedClassType(const UnresolvedClassType &) = delete;
+    UnresolvedClassType &operator=(const UnresolvedClassType &) = delete;
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const {
         return show(gs, {});
@@ -995,6 +1013,8 @@ public:
     const std::vector<TypePtr> targs;
     UnresolvedAppliedType(ClassOrModuleRef klass, std::vector<TypePtr> targs)
         : ClassType(core::Symbols::untyped()), klass(klass), targs(std::move(targs)){};
+    UnresolvedAppliedType(const UnresolvedAppliedType &) = delete;
+    UnresolvedAppliedType &operator=(const UnresolvedAppliedType &) = delete;
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const {
         return show(gs, {});

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -212,7 +212,7 @@ DispatchResult SelfTypeParam::dispatchCall(const GlobalState &gs, const Dispatch
     } else {
         ENFORCE(this->definition.isTypeMember());
         auto typeMember = this->definition.asTypeMemberRef();
-        auto lambdaParam = cast_type_nonnull<LambdaParam>(typeMember.data(gs)->resultType);
+        auto &lambdaParam = cast_type_nonnull<LambdaParam>(typeMember.data(gs)->resultType);
         auto upperBound = lambdaParam.upperBound;
         if (upperBound.isTop()) {
             if (args.suppressErrors) {
@@ -1085,7 +1085,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                 }
             } else if (hasKwParam) {
                 auto hashType = isa_type<ShapeType>(kwSplatType) ? kwSplatType.underlying(gs) : kwSplatType;
-                auto appliedType = cast_type_nonnull<AppliedType>(hashType);
+                auto &appliedType = cast_type_nonnull<AppliedType>(hashType);
                 auto kwSplatKeyType = appliedType.targs[0];
                 auto kwSplatValueType = appliedType.targs[1];
 
@@ -1652,7 +1652,7 @@ ClassOrModuleRef unwrapSymbol(const GlobalState &gs, const TypePtr &type, bool m
     bool breakOut = false;
     while (!result.exists() && !breakOut) {
         typecase(
-            typePtr,
+		 (const TypePtr &)typePtr,
 
             [&](const ClassType &klass) { result = klass.symbol; },
 

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1653,7 +1653,7 @@ ClassOrModuleRef unwrapSymbol(const GlobalState &gs, const TypePtr &type, bool m
     while (!result.exists() && !breakOut) {
         const TypePtr &ptrForTypecase = typePtr;
         typecase(
-	    ptrForTypecase,
+            ptrForTypecase,
 
             [&](const ClassType &klass) { result = klass.symbol; },
 

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1651,8 +1651,9 @@ ClassOrModuleRef unwrapSymbol(const GlobalState &gs, const TypePtr &type, bool m
     TypePtr typePtr = type;
     bool breakOut = false;
     while (!result.exists() && !breakOut) {
+        const TypePtr &ptrForTypecase = typePtr;
         typecase(
-		 (const TypePtr &)typePtr,
+	    ptrForTypecase,
 
             [&](const ClassType &klass) { result = klass.symbol; },
 

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -604,7 +604,7 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
                 auto c = core::cast_type_nonnull<core::ClassType>(argType);
                 argSymbol = c.symbol;
             } else if (core::isa_type<core::AppliedType>(argType)) {
-                auto a = core::cast_type_nonnull<core::AppliedType>(argType);
+                auto &a = core::cast_type_nonnull<core::AppliedType>(argType);
                 argSymbol = a.klass;
             }
             if (argSymbol.exists() && isSingleton(ctx, argSymbol)) {
@@ -620,7 +620,7 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
                 auto c = core::cast_type_nonnull<core::ClassType>(recvType);
                 recvSymbol = c.symbol;
             } else if (core::isa_type<core::AppliedType>(recvType)) {
-                auto a = core::cast_type_nonnull<core::AppliedType>(recvType);
+                auto &a = core::cast_type_nonnull<core::AppliedType>(recvType);
                 recvSymbol = a.klass;
             }
             if (recvSymbol.exists() && isSingleton(ctx, recvSymbol)) {


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Noticed this while working on #5614 and it seemed worth pulling into a separate PR.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
