### PR TITLE
make static field changes take the fast path

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1068,6 +1068,13 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
             [&](parser::Assign *asgn) {
                 auto lhs = node2TreeImpl(dctx, std::move(asgn->lhs));
                 auto rhs = node2TreeImpl(dctx, std::move(asgn->rhs));
+                if (isa_tree<UnresolvedConstantLit>(lhs) && isa_tree<UnresolvedConstantLit>(rhs)) {
+                    auto &rhsConst = cast_tree_nonnull<UnresolvedConstantLit>(rhs);
+                    if (rhsConst.cnst == core::Names::Constants::ErrorNode()) {
+                        auto rhsLocZero = rhs.loc().copyWithZeroLength();
+                        rhs = MK::Let(rhsLocZero, std::move(rhs), MK::Untyped(rhsLocZero));
+                    }
+                }
                 auto res = MK::Assign(loc, std::move(lhs), std::move(rhs));
                 result = std::move(res);
             },

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1068,6 +1068,11 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
             [&](parser::Assign *asgn) {
                 auto lhs = node2TreeImpl(dctx, std::move(asgn->lhs));
                 auto rhs = node2TreeImpl(dctx, std::move(asgn->rhs));
+                // Ensure that X = <ErrorNode> always looks like a proper static field, rather
+                // than a class alias.  Leaving it as a class alias would require taking the
+                // slow path; turning it into a proper static field gives us a chance to take
+                // the fast path.  T.let(<ErrorNode>, T.untyped) ensures that we don't get
+                // warnings in `typed: strict` files.
                 if (isa_tree<UnresolvedConstantLit>(lhs) && isa_tree<UnresolvedConstantLit>(rhs)) {
                     auto &rhsConst = cast_tree_nonnull<UnresolvedConstantLit>(rhs);
                     if (rhsConst.cnst == core::Names::Constants::ErrorNode()) {

--- a/core/FileHash.h
+++ b/core/FileHash.h
@@ -104,6 +104,7 @@ struct LocalSymbolTableHashes {
     // things like types for the fast/slow path decision), this stores the complete method symbol
     // hash, so that if anything including types change for a method we know what their names are.
     std::vector<SymbolHash> methodHashes;
+    std::vector<SymbolHash> staticFieldHashes;
 
     static uint32_t patchHash(uint32_t hash) {
         if (hash == LocalSymbolTableHashes::HASH_STATE_NOT_COMPUTED) {

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2158,9 +2158,12 @@ unique_ptr<LocalSymbolTableHashes> GlobalState::hash() const {
     for (const auto &field : this->fields) {
         counter++;
         // No fields are ignored in hashing.
+        // TODO(jez) We're abusing methodHashes--after this change, the name is no longer accurate.
+        auto &target = methodHashes[NameHash(*this, field.name)];
         uint32_t symhash = field.hash(*this);
-        hierarchyHash = mix(hierarchyHash, symhash);
+        hierarchyHash = mix(hierarchyHash, field.fieldShapeHash(*this));
         fieldHash = mix(fieldHash, symhash);
+        target = mix(target, symhash);
 
         if (DEBUG_HASHING_TAIL && counter > this->fields.size() - 15) {
             errorQueue->logger.info("Hashing symbols: {}, {}", hierarchyHash, field.name.show(*this));

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2116,6 +2116,7 @@ unique_ptr<LocalSymbolTableHashes> GlobalState::hash() const {
     uint32_t fieldHash = 0;
     uint32_t methodHash = 0;
     UnorderedMap<ShortNameHash, uint32_t> methodHashesMap;
+    UnorderedMap<ShortNameHash, uint32_t> staticFieldHashesMap;
     int counter = 0;
 
     for (const auto &sym : this->classAndModules) {
@@ -2158,12 +2159,13 @@ unique_ptr<LocalSymbolTableHashes> GlobalState::hash() const {
     for (const auto &field : this->fields) {
         counter++;
         // No fields are ignored in hashing.
-        // TODO(jez) We're abusing methodHashes--after this change, the name is no longer accurate.
-        auto &target = methodHashes[NameHash(*this, field.name)];
         uint32_t symhash = field.hash(*this);
+        if (field.flags.isStaticField) {
+            auto &target = staticFieldHashesMap[ShortNameHash(*this, field.name)];
+            target = mix(target, symhash);
+        }
         hierarchyHash = mix(hierarchyHash, field.fieldShapeHash(*this));
         fieldHash = mix(fieldHash, symhash);
-        target = mix(target, symhash);
 
         if (DEBUG_HASHING_TAIL && counter > this->fields.size() - 15) {
             errorQueue->logger.info("Hashing symbols: {}, {}", hierarchyHash, field.name.show(*this));
@@ -2188,11 +2190,16 @@ unique_ptr<LocalSymbolTableHashes> GlobalState::hash() const {
 
     unique_ptr<LocalSymbolTableHashes> result = make_unique<LocalSymbolTableHashes>();
     result->methodHashes.reserve(methodHashesMap.size());
+    result->staticFieldHashes.reserve(staticFieldHashesMap.size());
     for (const auto &[nameHash, symbolHash] : methodHashesMap) {
         result->methodHashes.emplace_back(nameHash, LocalSymbolTableHashes::patchHash(symbolHash));
     }
+    for (const auto &[nameHash, symbolHash] : staticFieldHashesMap) {
+        result->staticFieldHashes.emplace_back(nameHash, LocalSymbolTableHashes::patchHash(symbolHash));
+    }
     // Sort the hashes. Semantically important for quickly diffing hashes.
     fast_sort(result->methodHashes);
+    fast_sort(result->staticFieldHashes);
 
     result->hierarchyHash = LocalSymbolTableHashes::patchHash(hierarchyHash);
     result->classModuleHash = LocalSymbolTableHashes::patchHash(classModuleHash);

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -2302,8 +2302,10 @@ uint32_t Field::fieldShapeHash(const GlobalState &gs) const {
     // literally mention the name of this type alias. Add a test for this.
     // (also maybe double check this logic?)
     auto canSkipType =
-        // All fields are ok (don't participate in constant resolution)
-        this->flags.isField ||
+        // Only consider static fields for the fast path at the moment.  It is probably
+        // straightforward to take the fast path for changes to regular fields by changing
+        // this and the corresponding code in GlobalState, but one step at a time.
+        !this->flags.isField &&
         // Only normal static fields are ok (no class aliases, no type aliases).
         (!this->flags.isStaticFieldTypeAlias && !isa_type<AliasType>(this->resultType));
 

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -2306,7 +2306,7 @@ uint32_t Field::fieldShapeHash(const GlobalState &gs) const {
         // straightforward to take the fast path for changes to regular fields by changing
         // this and the corresponding code in GlobalState, but one step at a time.
         !this->flags.isField &&
-        // Only normal static fields are ok (no class aliases, no type aliases).
+        // Only normal static fields are ok (no type aliases, no class aliases/type templates).
         (!this->flags.isStaticFieldTypeAlias && !isa_type<AliasType>(this->resultType));
 
     if (!canSkipType) {

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -2301,9 +2301,6 @@ uint32_t Field::fieldShapeHash(const GlobalState &gs) const {
     // point, which could probably make something start to resolve in a file that doesn't
     // literally mention the name of this type alias. Add a test for this.
     // (also maybe double check this logic?)
-    // TODO(jez) There's actually some non-trivial logic in resolver to handle constant fields.
-    // They're no longer handled by resolveSigs; they're handled by ResolveTypeMembersAndFieldsWalk
-    // now. Stare at that code to see if this whole idea is not going to work.
     auto canSkipType =
         // All fields are ok (don't participate in constant resolution)
         this->flags.isField ||

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -2297,10 +2297,6 @@ uint32_t Method::methodShapeHash(const GlobalState &gs) const {
 uint32_t Field::fieldShapeHash(const GlobalState &gs) const {
     uint32_t result = _hash(name.shortName(gs));
 
-    // TODO(jez) type aliases and class aliases participate in the constant resolution fixed
-    // point, which could probably make something start to resolve in a file that doesn't
-    // literally mention the name of this type alias. Add a test for this.
-    // (also maybe double check this logic?)
     auto canSkipType =
         // Only consider static fields for the fast path at the moment.  It is probably
         // straightforward to take the fast path for changes to regular fields by changing

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -226,6 +226,7 @@ public:
     void addLoc(const core::GlobalState &gs, core::Loc loc);
 
     uint32_t hash(const GlobalState &gs) const;
+    uint32_t fieldShapeHash(const GlobalState &gs) const;
 
     void sanityCheck(const GlobalState &gs) const;
 

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -245,6 +245,11 @@ void SerializerImpl::pickle(Pickler &p, shared_ptr<const FileHash> fh) {
         p.putU4(key._hashValue);
         p.putU4(value);
     }
+    p.putU4(fh->localSymbolTableHashes.staticFieldHashes.size());
+    for (const auto &[key, value] : fh->localSymbolTableHashes.staticFieldHashes) {
+        p.putU4(key._hashValue);
+        p.putU4(value);
+    }
     p.putU4(fh->usages.symbols.size());
     for (const auto &e : fh->usages.symbols) {
         p.putU4(e._hashValue);
@@ -269,6 +274,13 @@ unique_ptr<const FileHash> SerializerImpl::unpickleFileHash(UnPickler &p) {
         ShortNameHash key;
         key._hashValue = p.getU4();
         ret.localSymbolTableHashes.methodHashes.emplace_back(key, p.getU4());
+    }
+    auto staticFieldHashSize = p.getU4();
+    ret.localSymbolTableHashes.staticFieldHashes.reserve(staticFieldHashSize);
+    for (int it = 0; it < staticFieldHashSize; it++) {
+        ShortNameHash key;
+        key._hashValue = p.getU4();
+        ret.localSymbolTableHashes.staticFieldHashes.emplace_back(key, p.getU4());
     }
     auto constantsSize = p.getU4();
     ret.usages.symbols.reserve(constantsSize);

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -240,7 +240,7 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
     // Replace error queue with one that is owned by this thread.
     gs->errorQueue = make_shared<core::ErrorQueue>(gs->errorQueue->logger, gs->errorQueue->tracer, errorFlusher);
     {
-        vector<core::SymbolHash> changedMethodHashes;
+        vector<core::SymbolHash> changedMethodSymbolHashes;
         for (auto &updatedFile : updates.updatedFiles) {
             auto fref = gs->findFileByPath(updatedFile->path());
             // We don't support new files on the fast path. This enforce failing indicates a bug in our fast/slow
@@ -267,7 +267,7 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
                 // This will insert two entries into `changedMethodHashes` for each changed method, but they will get
                 // deduped later.
                 set_difference(oldMethodHashes.begin(), oldMethodHashes.end(), newMethodHashes.begin(),
-                               newMethodHashes.end(), std::back_inserter(changedMethodHashes));
+                               newMethodHashes.end(), std::back_inserter(changedMethodSymbolHashes));
 
                 gs->replaceFile(fref, updatedFile);
                 // If file doesn't have a typed: sigil, then we need to ensure it's typechecked using typed: false.
@@ -276,9 +276,9 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
             }
         }
 
-        changedHashes.reserve(changedMethodHashes.size());
-        for (auto &changedMethodHash : changedMethodHashes) {
-            changedHashes.push_back(changedMethodHash.nameHash);
+        changedHashes.reserve(changedMethodSymbolHashes.size());
+        for (auto &changedMethodHash : changedMethodSymbolHashes) {
+            changedHashes.push_back(changedMethodSymbolHashes.nameHash);
         }
         core::ShortNameHash::sortAndDedupe(changedHashes);
     }

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -43,8 +43,7 @@ void sendTypecheckInfo(const LSPConfiguration &config, const core::GlobalState &
 
 // In debug builds, asserts that we have not accidentally taken the fast path after a change to the set of
 // methods in a file.
-bool validateMethodHashesHaveSameMethods(const std::vector<core::SymbolHash> &a,
-                                         const std::vector<core::SymbolHash> &b) {
+bool validateIdenticalFingerprints(const std::vector<core::SymbolHash> &a, const std::vector<core::SymbolHash> &b) {
     if (a.size() != b.size()) {
         return false;
     }
@@ -261,7 +260,7 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
                 const auto &newMethodHashes = updatedFile->getFileHash()->localSymbolTableHashes.methodHashes;
 
                 // Both oldHash and newHash should have the same methods, since this is the fast path!
-                ENFORCE(validateMethodHashesHaveSameMethods(oldMethodHashes, newMethodHashes),
+                ENFORCE(validateIdenticalFingerprints(oldMethodHashes, newMethodHashes),
                         "definitionHash should have failed");
 
                 // Find which hashes changed. Note: methodHashes are sorted, so set_difference should work.

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -270,8 +270,7 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
                 // Find which hashes changed. Note: methodHashes are sorted, so set_difference should work.
                 // This will insert two entries into `changedMethodHashes` for each changed method, but they will get
                 // deduped later.
-                absl::c_set_difference(oldMethodHashes, newMethodHashes,
-                                       std::back_inserter(changedMethodSymbolHashes));
+                absl::c_set_difference(oldMethodHashes, newMethodHashes, std::back_inserter(changedMethodSymbolHashes));
 
                 const auto &oldFieldHashes = oldSymbolHashes.staticFieldHashes;
                 const auto &newFieldHashes = newSymbolHashes.staticFieldHashes;
@@ -279,8 +278,7 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
                 ENFORCE(validateIdenticalFingerprints(oldFieldHashes, newFieldHashes),
                         "definitionHash should have failed");
 
-                absl::c_set_difference(oldFieldHashes, newFieldHashes,
-                                       std::back_inserter(changedFieldSymbolHashes));
+                absl::c_set_difference(oldFieldHashes, newFieldHashes, std::back_inserter(changedFieldSymbolHashes));
 
                 gs->replaceFile(fref, updatedFile);
                 // If file doesn't have a typed: sigil, then we need to ensure it's typechecked using typed: false.
@@ -314,8 +312,7 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
         ENFORCE(oldFile->getFileHash() != nullptr);
         const auto &oldHash = *oldFile->getFileHash();
         vector<core::ShortNameHash> intersection;
-        absl::c_set_intersection(changedMethodHashes, oldHash.usages.sends,
-                                 std::back_inserter(intersection));
+        absl::c_set_intersection(changedMethodHashes, oldHash.usages.sends, std::back_inserter(intersection));
         if (!intersection.empty()) {
             auto ref = core::FileRef(i);
             config->logger->debug("Added {} to update set as used a changed method",
@@ -324,8 +321,7 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
             continue;
         }
 
-        absl::c_set_intersection(changedFieldHashes, oldHash.usages.symbols,
-                                 std::back_inserter(intersection));
+        absl::c_set_intersection(changedFieldHashes, oldHash.usages.symbols, std::back_inserter(intersection));
         if (!intersection.empty()) {
             auto ref = core::FileRef(i);
             config->logger->debug("Added {} to update set as used a changed field symbol",

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -236,7 +236,7 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
 
     Timer timeit(config->logger, "fast_path");
     vector<core::FileRef> subset;
-    vector<core::ShortNameHash> changedHashes;
+    vector<core::ShortNameHash> changedMethodHashes;
     // Replace error queue with one that is owned by this thread.
     gs->errorQueue = make_shared<core::ErrorQueue>(gs->errorQueue->logger, gs->errorQueue->tracer, errorFlusher);
     {
@@ -276,11 +276,11 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
             }
         }
 
-        changedHashes.reserve(changedMethodSymbolHashes.size());
+        changedMethodHashes.reserve(changedMethodSymbolHashes.size());
         for (auto &changedMethodHash : changedMethodSymbolHashes) {
-            changedHashes.push_back(changedMethodSymbolHashes.nameHash);
+            changedMethodHashes.push_back(changedMethodSymbolHashes.nameHash);
         }
-        core::ShortNameHash::sortAndDedupe(changedHashes);
+        core::ShortNameHash::sortAndDedupe(changedMethodHashes);
     }
 
     int i = -1;
@@ -298,7 +298,7 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
         ENFORCE(oldFile->getFileHash() != nullptr);
         const auto &oldHash = *oldFile->getFileHash();
         vector<core::ShortNameHash> intersection;
-        std::set_intersection(changedHashes.begin(), changedHashes.end(), oldHash.usages.sends.begin(),
+        std::set_intersection(changedMethodHashes.begin(), changedMethodHashes.end(), oldHash.usages.sends.begin(),
                               oldHash.usages.sends.end(), std::back_inserter(intersection));
         if (!intersection.empty()) {
             auto ref = core::FileRef(i);

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2080,6 +2080,8 @@ class ResolveTypeMembersAndFieldsWalk {
                 return resultType;
             }
         }
+        // resultType was already set. We may be running on the incremental path. Force this field to be resolved in
+        // `resolvedStaticField`, which may produce an error message.
         return core::Types::todo();
     }
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2080,8 +2080,6 @@ class ResolveTypeMembersAndFieldsWalk {
                 return resultType;
             }
         }
-        // resultType was already set. We may be running on the incremental path. Force this field to be resolved in
-        // `resolveStaticField`, which may produce an error message.
         return core::Types::todo();
     }
 
@@ -2106,10 +2104,9 @@ class ResolveTypeMembersAndFieldsWalk {
                 job.asgn->rhs = ast::MK::Send1(loc, ast::MK::Constant(loc, core::Symbols::Magic()),
                                                core::Names::suggestType(), loc.copyWithZeroLength(), move(rhs));
             }
-            return resultType;
         }
-
-        return data->resultType;
+        // Always return the re-derived type, even on the fast path.
+        return resultType;
     }
 
     static void resolveTypeMember(core::MutableContext ctx, core::TypeMemberRef lhs, ast::Send *rhs,

--- a/test/testdata/lsp/fast_path/class_superclass_static_field__child.1.rbupdate
+++ b/test/testdata/lsp/fast_path/class_superclass_static_field__child.1.rbupdate
@@ -1,0 +1,6 @@
+# typed: true
+# assert-slow-path: true
+
+class A < TestThing
+  puts(Inner)
+end

--- a/test/testdata/lsp/fast_path/class_superclass_static_field__child.rb
+++ b/test/testdata/lsp/fast_path/class_superclass_static_field__child.rb
@@ -1,0 +1,5 @@
+# typed: true
+
+class A < TestThing # error: Superclasses and mixins may only use class aliases
+  puts(Inner) # error: Unable to resolve constant `Inner`
+end

--- a/test/testdata/lsp/fast_path/class_superclass_static_field__parent.1.rbupdate
+++ b/test/testdata/lsp/fast_path/class_superclass_static_field__parent.1.rbupdate
@@ -1,0 +1,10 @@
+# typed: true
+# assert-slow-path: true
+
+class Parent
+  module Inner; end
+end
+
+ParentAlias = Parent
+
+TestThing = ParentAlias

--- a/test/testdata/lsp/fast_path/class_superclass_static_field__parent.rb
+++ b/test/testdata/lsp/fast_path/class_superclass_static_field__parent.rb
@@ -1,0 +1,9 @@
+# typed: true
+
+class Parent
+  module Inner; end
+end
+
+ParentAlias = 1
+
+TestThing = ParentAlias

--- a/test/testdata/lsp/fast_path/method_and_static_field_change__def.1.rbupdate
+++ b/test/testdata/lsp/fast_path/method_and_static_field_change__def.1.rbupdate
@@ -1,0 +1,13 @@
+# typed: true
+# assert-fast-path: method_and_static_field_change__def.rb,method_and_static_field_change__method_use.rb
+
+module HoldingContainer
+  extend T::Sig
+
+  MEMBER_FIELD = T.let("", String)
+
+  sig {returns(Integer)}
+  def self.fancy_function
+    1729
+  end
+end

--- a/test/testdata/lsp/fast_path/method_and_static_field_change__def.2.rbupdate
+++ b/test/testdata/lsp/fast_path/method_and_static_field_change__def.2.rbupdate
@@ -1,0 +1,13 @@
+# typed: true
+# assert-fast-path: method_and_static_field_change__def.rb,method_and_static_field_change__field_use.rb
+
+module HoldingContainer
+  extend T::Sig
+
+  MEMBER_FIELD = T.let(1, Integer)
+
+  sig {returns(Integer)}
+  def self.fancy_function
+    1729
+  end
+end

--- a/test/testdata/lsp/fast_path/method_and_static_field_change__def.rb
+++ b/test/testdata/lsp/fast_path/method_and_static_field_change__def.rb
@@ -1,0 +1,12 @@
+# typed: true
+
+module HoldingContainer
+  extend T::Sig
+
+  MEMBER_FIELD = T.let("", String)
+
+  sig {returns(String)}
+  def self.fancy_function
+    "shiny"
+  end
+end

--- a/test/testdata/lsp/fast_path/method_and_static_field_change__field_use.rb
+++ b/test/testdata/lsp/fast_path/method_and_static_field_change__field_use.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+puts(HoldingContainer::MEMBER_FIELD)

--- a/test/testdata/lsp/fast_path/method_and_static_field_change__method_use.rb
+++ b/test/testdata/lsp/fast_path/method_and_static_field_change__method_use.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+puts(HoldingContainer.fancy_function)

--- a/test/testdata/lsp/fast_path/static_field_change_type__def.1.rbupdate
+++ b/test/testdata/lsp/fast_path/static_field_change_type__def.1.rbupdate
@@ -1,0 +1,5 @@
+# typed: strict
+# assert-fast-path: static_field_change_type__def.rb,static_field_change_type__use.rb
+
+STATIC_FIELD = T.let({}, T::Hash[Symbol, ]) # error-with-dupes: Not enough arguments provided
+                               # ^^^^^^ error-with-dupes: Wrong number of type parameters

--- a/test/testdata/lsp/fast_path/static_field_change_type__def.2.rbupdate
+++ b/test/testdata/lsp/fast_path/static_field_change_type__def.2.rbupdate
@@ -1,0 +1,4 @@
+# typed: strict
+# assert-fast-path: static_field_change_type__def.rb,static_field_change_type__use.rb
+
+STATIC_FIELD = T.let({}, T::Hash[Symbol, Integer])

--- a/test/testdata/lsp/fast_path/static_field_change_type__def.rb
+++ b/test/testdata/lsp/fast_path/static_field_change_type__def.rb
@@ -1,0 +1,3 @@
+# typed: strict
+
+STATIC_FIELD = T.let({}, T::Hash[Symbol, String])

--- a/test/testdata/lsp/fast_path/static_field_change_type__extra.rb
+++ b/test/testdata/lsp/fast_path/static_field_change_type__extra.rb
@@ -1,0 +1,3 @@
+# typed: strict
+
+DIFFERENT_FIELD = T.let(1, Integer)

--- a/test/testdata/lsp/fast_path/static_field_change_type__use.1.rbupdate
+++ b/test/testdata/lsp/fast_path/static_field_change_type__use.1.rbupdate
@@ -4,5 +4,6 @@ extend T::Sig
 
 sig {returns(String)}
 def foo
+  T.reveal_type(STATIC_FIELD) # error: Revealed type: `T::Hash[Symbol, T.untyped]`
   STATIC_FIELD.fetch(:key, "default") + "suffix"
 end

--- a/test/testdata/lsp/fast_path/static_field_change_type__use.1.rbupdate
+++ b/test/testdata/lsp/fast_path/static_field_change_type__use.1.rbupdate
@@ -1,0 +1,8 @@
+# typed: strict
+# assert-fast-path: static_field_change_type__def.rb,static_field_change_type__use.rb
+extend T::Sig
+
+sig {returns(String)}
+def foo
+  STATIC_FIELD.fetch(:key, "default") + "suffix"
+end

--- a/test/testdata/lsp/fast_path/static_field_change_type__use.2.rbupdate
+++ b/test/testdata/lsp/fast_path/static_field_change_type__use.2.rbupdate
@@ -4,6 +4,7 @@ extend T::Sig
 
 sig {returns(String)}
 def foo
+  T.reveal_type(STATIC_FIELD) # error: Revealed type: `T::Hash[Symbol, Integer]`
   STATIC_FIELD.fetch(:key, "default") + "suffix" # error: Expected `String` but found `T.any(Integer, String)`
                                       # ^^^^^^^^ error: Expected `Integer`
 end

--- a/test/testdata/lsp/fast_path/static_field_change_type__use.2.rbupdate
+++ b/test/testdata/lsp/fast_path/static_field_change_type__use.2.rbupdate
@@ -1,0 +1,9 @@
+# typed: strict
+# assert-fast-path: static_field_change_type__def.rb,static_field_change_type__use.rb
+extend T::Sig
+
+sig {returns(String)}
+def foo
+  STATIC_FIELD.fetch(:key, "default") + "suffix" # error: Expected `String` but found `T.any(Integer, String)`
+                                      # ^^^^^^^^ error: Expected `Integer`
+end

--- a/test/testdata/lsp/fast_path/static_field_change_type__use.rb
+++ b/test/testdata/lsp/fast_path/static_field_change_type__use.rb
@@ -1,0 +1,7 @@
+# typed: strict
+extend T::Sig
+
+sig {returns(String)}
+def foo
+  STATIC_FIELD.fetch(:key, "default") + "suffix"
+end

--- a/test/testdata/lsp/fast_path/static_field_enum_let.1.rbupdate
+++ b/test/testdata/lsp/fast_path/static_field_enum_let.1.rbupdate
@@ -1,0 +1,14 @@
+# typed: true
+# assert-fast-path: static_field_enum_let.rb
+
+class MyEnum < T::Enum
+  enums do
+    Field1 = new
+    Field2 = new
+  end
+end
+
+MyEnum_Field1 = MyEnum::Field1
+
+Alias = T.let(MyEnum::Field1, MyEnum_) # error: Unable to resolve constant
+T.reveal_type(Alias) # error: Revealed type: `<root>::MyEnum_ (unresolved)`

--- a/test/testdata/lsp/fast_path/static_field_enum_let.1.rbupdate
+++ b/test/testdata/lsp/fast_path/static_field_enum_let.1.rbupdate
@@ -10,5 +10,5 @@ end
 
 MyEnum_Field1 = MyEnum::Field1
 
-Alias = T.let(MyEnum::Field1, MyEnum_) # error: Unable to resolve constant
-T.reveal_type(Alias) # error: Revealed type: `<root>::MyEnum_ (unresolved)`
+TestAlias = T.let(MyEnum::Field1, MyEnum_) # error: Unable to resolve constant
+T.reveal_type(TestAlias) # error: Revealed type: `<root>::MyEnum_ (unresolved)`

--- a/test/testdata/lsp/fast_path/static_field_enum_let.2.rbupdate
+++ b/test/testdata/lsp/fast_path/static_field_enum_let.2.rbupdate
@@ -10,5 +10,5 @@ end
 
 MyEnum_Field1 = MyEnum::Field1
 
-Alias = T.let(MyEnum::Field1, MyEnum_F) # error: Unable to resolve constant
-T.reveal_type(Alias) # error: Revealed type: `<root>::MyEnum_F (unresolved)`
+TestAlias = T.let(MyEnum::Field1, MyEnum_F) # error: Unable to resolve constant
+T.reveal_type(TestAlias) # error: Revealed type: `<root>::MyEnum_F (unresolved)`

--- a/test/testdata/lsp/fast_path/static_field_enum_let.2.rbupdate
+++ b/test/testdata/lsp/fast_path/static_field_enum_let.2.rbupdate
@@ -1,0 +1,14 @@
+# typed: true
+# assert-fast-path: static_field_enum_let.rb
+
+class MyEnum < T::Enum
+  enums do
+    Field1 = new
+    Field2 = new
+  end
+end
+
+MyEnum_Field1 = MyEnum::Field1
+
+Alias = T.let(MyEnum::Field1, MyEnum_F) # error: Unable to resolve constant
+T.reveal_type(Alias) # error: Revealed type: `<root>::MyEnum_F (unresolved)`

--- a/test/testdata/lsp/fast_path/static_field_enum_let.3.rbupdate
+++ b/test/testdata/lsp/fast_path/static_field_enum_let.3.rbupdate
@@ -1,0 +1,14 @@
+# typed: true
+# assert-slow-path: true
+
+class MyEnum < T::Enum
+  enums do
+    Field1 = new
+    Field2 = new
+  end
+end
+
+MyEnum_Field1 = MyEnum::Field1
+
+Alias = T.let(MyEnum::Field1, MyEnum_Field1) # error: Constant `MyEnum_Field1` is not a class or type alias
+T.reveal_type(Alias) # error: Revealed type: `T.untyped`

--- a/test/testdata/lsp/fast_path/static_field_enum_let.3.rbupdate
+++ b/test/testdata/lsp/fast_path/static_field_enum_let.3.rbupdate
@@ -1,5 +1,5 @@
 # typed: true
-# assert-slow-path: true
+# assert-fast-path: static_field_enum_let.rb
 
 class MyEnum < T::Enum
   enums do
@@ -10,5 +10,5 @@ end
 
 MyEnum_Field1 = MyEnum::Field1
 
-Alias = T.let(MyEnum::Field1, MyEnum_Field1) # error: Constant `MyEnum_Field1` is not a class or type alias
-T.reveal_type(Alias) # error: Revealed type: `T.untyped`
+TestAlias = T.let(MyEnum::Field1, MyEnum_Field1) # error: Constant `MyEnum_Field1` is not a class or type alias
+T.reveal_type(TestAlias) # error: Revealed type: `T.untyped`

--- a/test/testdata/lsp/fast_path/static_field_enum_let.rb
+++ b/test/testdata/lsp/fast_path/static_field_enum_let.rb
@@ -1,0 +1,12 @@
+# typed: true
+
+class MyEnum < T::Enum
+  enums do
+    Field1 = new
+    Field2 = new
+  end
+end
+
+MyEnum_Field1 = MyEnum::Field1
+
+Alias = T.let(MyEnum::Field1, MyEnum)

--- a/test/testdata/lsp/fast_path/static_field_enum_let.rb
+++ b/test/testdata/lsp/fast_path/static_field_enum_let.rb
@@ -9,4 +9,4 @@ end
 
 MyEnum_Field1 = MyEnum::Field1
 
-Alias = T.let(MyEnum::Field1, MyEnum)
+TestAlias = T.let(MyEnum::Field1, MyEnum)

--- a/test/testdata/lsp/fast_path/static_field_superclass_resolution__def.rb
+++ b/test/testdata/lsp/fast_path/static_field_superclass_resolution__def.rb
@@ -1,0 +1,9 @@
+# typed: true
+
+class FieldContainerA
+  MEMBER_FIELD = T.let(6, Integer)
+end
+
+class FieldContainerB
+  MEMBER_FIELD = T.let("", String)
+end

--- a/test/testdata/lsp/fast_path/static_field_superclass_resolution__use.1.rbupdate
+++ b/test/testdata/lsp/fast_path/static_field_superclass_resolution__use.1.rbupdate
@@ -1,0 +1,10 @@
+# typed: true
+# assert-slow-path: true
+
+class ChildContainer < FieldContainer # error-with-dupes: Unable to resolve constant `FieldContainer`
+  def helper_method
+    x = 6 + MEMBER_FIELD # error: Unable to resolve constant `MEMBER_FIELD`
+    T.reveal_type(x) # error: Revealed type: `Integer`
+    puts x # error: Method `puts` does not exist on `ChildContainer`
+  end
+end

--- a/test/testdata/lsp/fast_path/static_field_superclass_resolution__use.2.rbupdate
+++ b/test/testdata/lsp/fast_path/static_field_superclass_resolution__use.2.rbupdate
@@ -1,0 +1,10 @@
+# typed: true
+# assert-slow-path: true
+
+class ChildContainer < FieldContainerB
+  def helper_method
+    x = 6 + MEMBER_FIELD # error: Expected `Integer` but found `String` for argument `arg0`
+    T.reveal_type(x) # error: Revealed type: `Integer`
+    puts x
+  end
+end

--- a/test/testdata/lsp/fast_path/static_field_superclass_resolution__use.3.rbupdate
+++ b/test/testdata/lsp/fast_path/static_field_superclass_resolution__use.3.rbupdate
@@ -1,0 +1,10 @@
+# typed: true
+# assert-slow-path: true
+
+class ChildContainer < FieldContainerA
+  def helper_method
+    x = 6 + MEMBER_FIELD
+    T.reveal_type(x) # error: Revealed type: `Integer`
+    puts x
+  end
+end

--- a/test/testdata/lsp/fast_path/static_field_superclass_resolution__use.rb
+++ b/test/testdata/lsp/fast_path/static_field_superclass_resolution__use.rb
@@ -1,0 +1,9 @@
+# typed: true
+
+class ChildContainer < FieldContainerA
+  def helper_method
+    x = 6 + MEMBER_FIELD
+    T.reveal_type(x) # error: Revealed type: `Integer`
+    puts x
+  end
+end

--- a/test/testdata/lsp/fast_path/static_field_type.1.rbupdate
+++ b/test/testdata/lsp/fast_path/static_field_type.1.rbupdate
@@ -1,0 +1,10 @@
+# typed: true
+# assert-fast-path: static_field_type.rb
+
+class A
+  def foo(x); end
+
+  X =
+end # error: unexpected token "end"
+
+T.reveal_type(A::X) # error: `T.untyped`

--- a/test/testdata/lsp/fast_path/static_field_type.2.rbupdate
+++ b/test/testdata/lsp/fast_path/static_field_type.2.rbupdate
@@ -1,0 +1,10 @@
+# typed: true
+# assert-fast-path: static_field_type.rb
+
+class A
+  def foo(x); end
+
+  X = ''
+end
+
+T.reveal_type(A::X) # error: `String`

--- a/test/testdata/lsp/fast_path/static_field_type.rb
+++ b/test/testdata/lsp/fast_path/static_field_type.rb
@@ -1,0 +1,9 @@
+# typed: true
+
+class A
+  def foo(x); end
+
+  X = 1
+end
+
+T.reveal_type(A::X) # error: `Integer`

--- a/test/testdata/lsp/fast_path/static_field_type_alias.1.rbupdate
+++ b/test/testdata/lsp/fast_path/static_field_type_alias.1.rbupdate
@@ -1,0 +1,6 @@
+# typed: true
+# assert-slow-path: true
+
+class AliasContainer
+  ContainedThing = T.type_alias {T.any(Float, Integer)}
+end

--- a/test/testdata/lsp/fast_path/static_field_type_alias.rb
+++ b/test/testdata/lsp/fast_path/static_field_type_alias.rb
@@ -1,0 +1,5 @@
+# typed: true
+
+class AliasContainer
+  ContainedThing = T.type_alias {T.any(Float, Symbol)}
+end

--- a/test/testdata/lsp/fast_path/static_field_type_template.1.rbupdate
+++ b/test/testdata/lsp/fast_path/static_field_type_template.1.rbupdate
@@ -1,0 +1,9 @@
+# typed: true
+# assert-slow-path: true
+
+class GenericPlaceholder
+  extend T::Helpers
+  extend T::Generic
+
+  ElementPlaceholder = type_template {{fixed: Integer}}
+end

--- a/test/testdata/lsp/fast_path/static_field_type_template.rb
+++ b/test/testdata/lsp/fast_path/static_field_type_template.rb
@@ -1,0 +1,8 @@
+# typed: true
+
+class GenericPlaceholder
+  extend T::Helpers
+  extend T::Generic
+
+  ElementPlaceholder = type_template {{fixed: String}}
+end

--- a/test/testdata/lsp/stale_state/static_field_type.1.rbstaleupdate
+++ b/test/testdata/lsp/stale_state/static_field_type.1.rbstaleupdate
@@ -1,6 +1,0 @@
-# typed: true
-
-AA = 123
-#^ hover: NilClass
-puts AA
-#    ^ hover: NilClass

--- a/test/testdata/lsp/stale_state/static_field_type.rb
+++ b/test/testdata/lsp/stale_state/static_field_type.rb
@@ -1,6 +1,0 @@
-# typed: true
-
-AA = nil
-#^ hover: NilClass
-puts AA
-#    ^ hover: NilClass

--- a/test/testdata/namer/fuzz_type_member.rb
+++ b/test/testdata/namer/fuzz_type_member.rb
@@ -1,4 +1,4 @@
 # typed: true
 
-A=3 # error: Expected `Runtime object representing type: T.untyped` but found `Integer(3)` for field
+A=3 # error: Expected `Runtime object representing type: Integer` but found `Integer(3)` for field
 A=type_member # error: `type_member` cannot be used at the top-level

--- a/test/testdata/namer/fuzz_type_template_overwrite.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/fuzz_type_template_overwrite.rb.symbol-table-raw.exp
@@ -3,7 +3,7 @@ class <C <U <root>>> < <C <U Object>> ()
     method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/namer/fuzz_type_template_overwrite.rb start=3:1 end=6:4}
       argument <blk><block> @ Loc {file=test/testdata/namer/fuzz_type_template_overwrite.rb start=??? end=???}
   class <C <U A>> < <C <U Object>> () @ Loc {file=test/testdata/namer/fuzz_type_template_overwrite.rb start=3:1 end=3:8}
-    static-field <C <U A>>::<C <U B>> -> AliasType { symbol = <S <C <U A>> $1>::<C <U B>> } @ Loc {file=test/testdata/namer/fuzz_type_template_overwrite.rb start=5:3 end=5:20}
+    static-field <C <U A>>::<C <U B>> -> Integer @ Loc {file=test/testdata/namer/fuzz_type_template_overwrite.rb start=5:3 end=5:20}
     static-field <C <U A>>::<M <C <U B>> $1> @ Loc {file=test/testdata/namer/fuzz_type_template_overwrite.rb start=4:3 end=4:4}
   class <S <C <U A>> $1>[<C <U <AttachedClass>>>, <C <U B>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/namer/fuzz_type_template_overwrite.rb start=3:7 end=3:8}
     type-member(+) <S <C <U A>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U A>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=A) @ Loc {file=test/testdata/namer/fuzz_type_template_overwrite.rb start=3:7 end=3:8}


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Static fields appear to be one of the most common things developers change.  It would be a huge help if changes to such things took the fast path.

The easiest way for me to think about them is that static fields are essentially zero-argument methods that magically get called.  And since changes to the static fields are essentially changes to the method's return type (changes to which already take the fast path, thx to @.jez for the explanation), we should be able to make such changes take the fast path just like methods.

Like #5589, but farther along.  There probably need to be some more tests; I could imagine there are some issues lurking.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
