### PR TITLE
split out changed definition statistics when only a single category changed

### DIFF
--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -148,6 +148,21 @@ bool LSPIndexer::canTakeFastPathInternal(
             const bool methodsDiffer = newHash.definitions.methodHash != oldHash.definitions.methodHash;
             const uint32_t differCount = int(classesDiffer) + int(typeArgumentsDiffer) + int(typeMembersDiffer) +
                                          int(fieldsDiffer) + int(methodsDiffer);
+            if (classesDiffer) {
+                prodCategoryCounterInc("lsp.slow_path_changed_def", "classmodule");
+            }
+            if (typeArgumentsDiffer) {
+                prodCategoryCounterInc("lsp.slow_path_changed_def", "typeargument");
+            }
+            if (typeMembersDiffer) {
+                prodCategoryCounterInc("lsp.slow_path_changed_def", "typemember");
+            }
+            if (fieldsDiffer) {
+                prodCategoryCounterInc("lsp.slow_path_changed_def", "field");
+            }
+            if (methodsDiffer) {
+                prodCategoryCounterInc("lsp.slow_path_changed_def", "method");
+            }
             if (differCount == 1) {
                 if (classesDiffer) {
                     prodCategoryCounterInc("lsp.slow_path_changed_def", "onlyclassmodule");
@@ -160,22 +175,6 @@ bool LSPIndexer::canTakeFastPathInternal(
                 } else {
                     ENFORCE(methodsDiffer);
                     prodCategoryCounterInc("lsp.slow_path_changed_def", "onlymethods");
-                }
-            } else {
-                if (classesDiffer) {
-                    prodCategoryCounterInc("lsp.slow_path_changed_def", "classmodule");
-                }
-                if (typeArgumentsDiffer) {
-                    prodCategoryCounterInc("lsp.slow_path_changed_def", "typeargument");
-                }
-                if (typeMembersDiffer) {
-                    prodCategoryCounterInc("lsp.slow_path_changed_def", "typemember");
-                }
-                if (fieldsDiffer) {
-                    prodCategoryCounterInc("lsp.slow_path_changed_def", "field");
-                }
-                if (methodsDiffer) {
-                    prodCategoryCounterInc("lsp.slow_path_changed_def", "method");
                 }
             }
             return false;

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -140,20 +140,43 @@ bool LSPIndexer::canTakeFastPathInternal(
             ENFORCE(newHash.definitions.methodHash != core::DefinitionHash::HASH_STATE_INVALID);
             prodCategoryCounterInc("lsp.slow_path_reason", "changed_definition");
             // Also record some information about what might have changed.
-            if (newHash.definitions.classModuleHash != oldHash.definitions.classModuleHash) {
-                prodCategoryCounterInc("lsp.slow_path_changed_def", "classmodule");
-            }
-            if (newHash.definitions.typeArgumentHash != oldHash.definitions.typeArgumentHash) {
-                prodCategoryCounterInc("lsp.slow_path_changed_def", "typeargument");
-            }
-            if (newHash.definitions.typeMemberHash != oldHash.definitions.typeMemberHash) {
-                prodCategoryCounterInc("lsp.slow_path_changed_def", "typemember");
-            }
-            if (newHash.definitions.fieldHash != oldHash.definitions.fieldHash) {
-                prodCategoryCounterInc("lsp.slow_path_changed_def", "field");
-            }
-            if (newHash.definitions.methodHash != oldHash.definitions.methodHash) {
-                prodCategoryCounterInc("lsp.slow_path_changed_def", "method");
+            const bool classesDiffer = newHash.definitions.classModuleHash != oldHash.definitions.classModuleHash;
+            const bool typeArgumentsDiffer =
+                newHash.definitions.typeArgumentHash != oldHash.definitions.typeArgumentHash;
+            const bool typeMembersDiffer = newHash.definitions.typeMemberHash != oldHash.definitions.typeMemberHash;
+            const bool fieldsDiffer = newHash.definitions.fieldHash != oldHash.definitions.fieldHash;
+            const bool methodsDiffer = newHash.definitions.methodHash != oldHash.definitions.methodHash;
+            const uint32_t differCount = int(classesDiffer) + int(typeArgumentsDiffer) + int(typeMembersDiffer) +
+                                         int(fieldsDiffer) + int(methodsDiffer);
+            if (differCount == 1) {
+                if (classesDiffer) {
+                    prodCategoryCounterInc("lsp.slow_path_changed_def", "onlyclassmodule");
+                } else if (typeArgumentsDiffer) {
+                    prodCategoryCounterInc("lsp.slow_path_changed_def", "onlytypeargument");
+                } else if (typeMembersDiffer) {
+                    prodCategoryCounterInc("lsp.slow_path_changed_def", "onlytypemembers");
+                } else if (fieldsDiffer) {
+                    prodCategoryCounterInc("lsp.slow_path_changed_def", "onlyfields");
+                } else {
+                    ENFORCE(methodsDiffer);
+                    prodCategoryCounterInc("lsp.slow_path_changed_def", "onlymethods");
+                }
+            } else {
+                if (classesDiffer) {
+                    prodCategoryCounterInc("lsp.slow_path_changed_def", "classmodule");
+                }
+                if (typeArgumentsDiffer) {
+                    prodCategoryCounterInc("lsp.slow_path_changed_def", "typeargument");
+                }
+                if (typeMembersDiffer) {
+                    prodCategoryCounterInc("lsp.slow_path_changed_def", "typemember");
+                }
+                if (fieldsDiffer) {
+                    prodCategoryCounterInc("lsp.slow_path_changed_def", "field");
+                }
+                if (methodsDiffer) {
+                    prodCategoryCounterInc("lsp.slow_path_changed_def", "method");
+                }
             }
             return false;
         }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I think the single category case is interesting, and even if it winds up not interesting, I think we get useful information from knowing "several things changed at once", which probably implies some sort of weird parse result that we could investigate.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
