### PR TITLE
Pack FoundDefinitionRef into 4 bytes

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -102,7 +102,7 @@ template <typename ToCheck, std::size_t ExpectedAlign, std::size_t RealAlign = a
 #endif
 
 #define CheckSize(T, ExpSize, ExpAlign)                                              \
-    inline void _##T##is##ExpSize##_bytes_long_() {                                  \
+    [[maybe_unused]] inline void _##T##is##ExpSize##_bytes_long_() {                 \
         sorbet::check_size<T, ExpSize> UNUSED(_##T##is##ExpSize##_bytes_long);       \
         sorbet::check_align<T, ExpAlign> UNUSED(_##T##is##ExpAlign##_bytes_aligned); \
     }

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -2223,6 +2223,11 @@ uint32_t ClassOrModule::hash(const GlobalState &gs) const {
     return result;
 }
 
+// Tracks whether _anything_ changed about the method, but unlike the other things, this hash is not
+// used for the fast path decision. This is just used to figure out the names of the method symbols
+// that changed, so that _if_ we took the fast path (determined using methodShapeHash), we know
+// which methods might have been updated on the fast path, so we can then figure out which files to
+// type check after the fast path resolver finishes.
 uint32_t Method::hash(const GlobalState &gs) const {
     uint32_t result = _hash(name.shortName(gs));
     result = mix(result, !this->resultType ? 0 : this->resultType.hash(gs));

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -40,6 +40,7 @@ enum class DefinitionKind : uint8_t {
     TypeMember = 5,
     Symbol = 6,
 };
+CheckSize(DefinitionKind, 1, 1);
 
 class FoundDefinitionRef final {
     DefinitionKind _kind;
@@ -85,6 +86,7 @@ public:
 
     core::SymbolRef symbol() const;
 };
+CheckSize(FoundDefinitionRef, 8, 4);
 
 struct FoundClassRef final {
     core::NameRef name;
@@ -92,6 +94,7 @@ struct FoundClassRef final {
     // If !owner.exists(), owner is determined by reference site.
     FoundDefinitionRef owner;
 };
+CheckSize(FoundClassRef, 20, 4);
 
 struct FoundClass final {
     FoundDefinitionRef owner;
@@ -100,6 +103,7 @@ struct FoundClass final {
     core::LocOffsets declLoc;
     ast::ClassDef::Kind classKind;
 };
+CheckSize(FoundClass, 36, 4);
 
 struct FoundStaticField final {
     FoundDefinitionRef owner;
@@ -109,6 +113,7 @@ struct FoundStaticField final {
     core::LocOffsets lhsLoc;
     bool isTypeAlias = false;
 };
+CheckSize(FoundStaticField, 40, 4);
 
 struct FoundTypeMember final {
     FoundDefinitionRef owner;
@@ -120,6 +125,7 @@ struct FoundTypeMember final {
     bool isFixed = false;
     bool isTypeTemplete = false;
 };
+CheckSize(FoundTypeMember, 44, 4);
 
 struct FoundMethod final {
     FoundDefinitionRef owner;
@@ -130,6 +136,7 @@ struct FoundMethod final {
     vector<ast::ParsedArg> parsedArgs;
     vector<uint32_t> argsHash;
 };
+CheckSize(FoundMethod, 80, 8);
 
 struct Modifier {
     enum class Kind : uint8_t {
@@ -150,6 +157,7 @@ struct Modifier {
         return Modifier{this->kind, this->owner, this->loc, this->name, target};
     }
 };
+CheckSize(Modifier, 28, 4);
 
 class FoundDefinitions final {
     // Contains references to items in _klasses, _methods, _staticFields, and _typeMembers.

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -178,6 +178,17 @@ class FoundDefinitions final {
     vector<Modifier> _modifiers;
 
     FoundDefinitionRef addDefinition(FoundDefinitionRef ref) {
+        DEBUG_ONLY(switch (ref.kind()) {
+            case DefinitionKind::Class:
+            case DefinitionKind::Method:
+            case DefinitionKind::StaticField:
+            case DefinitionKind::TypeMember:
+                break;
+            case DefinitionKind::ClassRef:
+            case DefinitionKind::Empty:
+            case DefinitionKind::Symbol:
+                ENFORCE(false, "Attempted to give unexpected FoundDefinitionRef kind to addDefinition");
+        });
         _definitions.emplace_back(ref);
         return ref;
     }
@@ -226,18 +237,22 @@ public:
         _modifiers.emplace_back(move(mod));
     }
 
+    // See documentation on _definitions
     const vector<FoundDefinitionRef> &definitions() const {
         return _definitions;
     }
 
+    // See documentation on _klasses
     const vector<FoundClass> &klasses() const {
         return _klasses;
     }
 
+    // See documentation on _methods
     const vector<FoundMethod> &methods() const {
         return _methods;
     }
 
+    // See documentation on _modifiers
     const vector<Modifier> &modifiers() const {
         return _modifiers;
     }


### PR DESCRIPTION
I don't think we should be optimizing for the case where there are 16M+
definitions in a single file, so this seems fine to me.


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I'm working on some changes that will in essence persist the FoundDefinitionRef
lists longer than they currently live.

Out of paranoia, I'd like to cut the size of a FoundDefinitionRef before doing
that.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.