### PR TITLE
Adding, changing, or removing a method takes the fast path

### DIFF
--- a/ast/substitute/Substitute.cc
+++ b/ast/substitute/Substitute.cc
@@ -40,6 +40,21 @@ private:
         }
     }
 
+    core::NameRef unwrapLiteralToName(ExpressionPtr &arg) {
+        auto *literal = cast_tree<Literal>(arg);
+        if (literal == nullptr) {
+            return core::NameRef::noName();
+        }
+
+        if (literal->isString()) {
+            return literal->asString();
+        } else if (literal->isSymbol()) {
+            return literal->asSymbol();
+        } else {
+            return core::NameRef::noName();
+        }
+    }
+
 public:
     SubstWalk(T &subst) : subst(subst) {}
 
@@ -81,26 +96,49 @@ public:
     }
 
     void preTransformSend(core::MutableContext ctx, ExpressionPtr &original) {
-        cast_tree_nonnull<Send>(original).fun = subst.substituteSymbolName(cast_tree_nonnull<Send>(original).fun);
+        auto &send = cast_tree_nonnull<Send>(original);
+        if (send.fun == core::Names::aliasMethod()) {
+            // This is basically a MethodDef in disguise, so we have to do similar logic to record
+            // the names that the MethodDef case would.
+
+            // Discards the new name. We only care to do this for the side effect of recording the entry in
+            // acc.symbols in the NameSubstitution. When the tree traversal actually visits the arg
+            // nodes, they will get substituted like normal.
+            if (send.numPosArgs() > 0) {
+                auto name = unwrapLiteralToName(send.getPosArg(0));
+                if (name.exists()) {
+                    [[maybe_unused]] auto _substituted = subst.substituteSymbolName(name);
+                }
+            }
+            if (send.numPosArgs() > 1) {
+                auto name = unwrapLiteralToName(send.getPosArg(1));
+                if (name.exists()) {
+                    [[maybe_unused]] auto _substituted = subst.substituteSymbolName(name);
+                }
+            }
+        }
+
+        send.fun = subst.substituteSymbolName(send.fun);
     }
 
     void postTransformLiteral(core::MutableContext ctx, ExpressionPtr &tree) {
         auto &original = cast_tree_nonnull<Literal>(tree);
-        if (original.isString()) {
-            auto nameRef = original.asString();
-            auto newName = subst.substitute(nameRef);
-            if (nameRef != newName) {
-                original.value = core::make_type<core::NamedLiteralType>(core::Symbols::String(), newName);
-            }
+        auto nameRef = unwrapLiteralToName(tree);
+        if (!nameRef.exists()) {
             return;
         }
-        if (original.isSymbol()) {
-            auto nameRef = original.asSymbol();
-            auto newName = subst.substitute(nameRef);
-            if (newName != nameRef) {
-                original.value = core::make_type<core::NamedLiteralType>(core::Symbols::Symbol(), newName);
-            }
+        auto newName = subst.substitute(nameRef);
+
+        if (newName == nameRef) {
             return;
+        }
+
+        if (original.isString()) {
+            tree = MK::String(original.loc, newName);
+        } else if (original.isSymbol()) {
+            tree = MK::Symbol(original.loc, newName);
+        } else {
+            ENFORCE(false, "Should be guaranteed by unwrapLiteralToName");
         }
     }
 

--- a/ast/substitute/Substitute.cc
+++ b/ast/substitute/Substitute.cc
@@ -134,9 +134,9 @@ public:
         }
 
         if (original.isString()) {
-            tree = MK::String(original.loc, newName);
+            original.value = core::make_type<core::NamedLiteralType>(core::Symbols::String(), newName);
         } else if (original.isSymbol()) {
-            tree = MK::Symbol(original.loc, newName);
+            original.value = core::make_type<core::NamedLiteralType>(core::Symbols::Symbol(), newName);
         } else {
             ENFORCE(false, "Should be guaranteed by unwrapLiteralToName");
         }

--- a/core/FileHash.cc
+++ b/core/FileHash.cc
@@ -16,6 +16,13 @@ void ShortNameHash::sortAndDedupe(std::vector<core::ShortNameHash> &hashes) {
     hashes.resize(std::distance(hashes.begin(), std::unique(hashes.begin(), hashes.end())));
 }
 
+FullNameHash::FullNameHash(const GlobalState &gs, NameRef nm) : _hashValue(incZero(_hash(nm.shortName(gs)))){};
+
+void FullNameHash::sortAndDedupe(std::vector<core::FullNameHash> &hashes) {
+    fast_sort(hashes);
+    hashes.resize(std::distance(hashes.begin(), std::unique(hashes.begin(), hashes.end())));
+}
+
 FileHash::FileHash(LocalSymbolTableHashes &&localSymbolTableHashes, UsageHash &&usages)
     : localSymbolTableHashes(move(localSymbolTableHashes)), usages(move(usages)) {}
 

--- a/core/FileHash.cc
+++ b/core/FileHash.cc
@@ -6,9 +6,40 @@
 
 using namespace std;
 namespace sorbet::core {
+namespace {
+
+// We use 0 to signal whether the hash is defined (see isDefined in the header)
 uint32_t incZero(uint32_t a) {
     return a == 0 ? 1 : a;
 };
+
+uint32_t hashFullNameRef(const GlobalState &gs, NameRef nm) {
+    uint32_t result;
+    auto kind = nm.kind();
+
+    switch (kind) {
+        case NameKind::UTF8: {
+            result = _hash(nm.dataUtf8(gs)->utf8);
+            break;
+        }
+        case NameKind::CONSTANT: {
+            result = hashFullNameRef(gs, nm.dataCnst(gs)->original);
+            break;
+        }
+        case NameKind::UNIQUE: {
+            auto data = nm.dataUnique(gs);
+            auto hashedUniqueNameKind = static_cast<underlying_type<UniqueNameKind>::type>(data->uniqueNameKind);
+            result = mix(mix(hashFullNameRef(gs, data->original), data->num), hashedUniqueNameKind);
+            break;
+        }
+    }
+
+    auto hashedKind = static_cast<underlying_type<NameKind>::type>(kind);
+    return mix(result, hashedKind);
+}
+
+} // namespace
+
 ShortNameHash::ShortNameHash(const GlobalState &gs, NameRef nm) : _hashValue(incZero(_hash(nm.shortName(gs)))){};
 
 void ShortNameHash::sortAndDedupe(std::vector<core::ShortNameHash> &hashes) {
@@ -16,7 +47,7 @@ void ShortNameHash::sortAndDedupe(std::vector<core::ShortNameHash> &hashes) {
     hashes.resize(std::distance(hashes.begin(), std::unique(hashes.begin(), hashes.end())));
 }
 
-FullNameHash::FullNameHash(const GlobalState &gs, NameRef nm) : _hashValue(incZero(_hash(nm.shortName(gs)))){};
+FullNameHash::FullNameHash(const GlobalState &gs, NameRef nm) : _hashValue(incZero(hashFullNameRef(gs, nm))) {}
 
 void FullNameHash::sortAndDedupe(std::vector<core::FullNameHash> &hashes) {
     fast_sort(hashes);

--- a/core/FileHash.cc
+++ b/core/FileHash.cc
@@ -54,6 +54,15 @@ void FullNameHash::sortAndDedupe(std::vector<core::FullNameHash> &hashes) {
     hashes.resize(std::distance(hashes.begin(), std::unique(hashes.begin(), hashes.end())));
 }
 
+void FoundMethodHash::sanityCheck() const {
+    ENFORCE(nameHash.isDefined());
+}
+
+string FoundMethodHash::toString() const {
+    return fmt::format("FoundMethodHash {{ ownerIdx = {}, nameHash = {}, arityHash = {}, isSelfMethod = {} }}",
+                       nameHash._hashValue, arityHash._hashValue, isSelfMethod);
+}
+
 FileHash::FileHash(LocalSymbolTableHashes &&localSymbolTableHashes, UsageHash &&usages)
     : localSymbolTableHashes(move(localSymbolTableHashes)), usages(move(usages)) {}
 

--- a/core/FileHash.cc
+++ b/core/FileHash.cc
@@ -63,7 +63,9 @@ string FoundMethodHash::toString() const {
                        nameHash._hashValue, arityHash._hashValue, isSelfMethod);
 }
 
-FileHash::FileHash(LocalSymbolTableHashes &&localSymbolTableHashes, UsageHash &&usages)
-    : localSymbolTableHashes(move(localSymbolTableHashes)), usages(move(usages)) {}
+FileHash::FileHash(LocalSymbolTableHashes &&localSymbolTableHashes, UsageHash &&usages,
+                   FoundMethodHashes &&foundMethodHashes)
+    : localSymbolTableHashes(move(localSymbolTableHashes)), usages(move(usages)),
+      foundMethodHashes(move(foundMethodHashes)) {}
 
 } // namespace sorbet::core

--- a/core/FileHash.cc
+++ b/core/FileHash.cc
@@ -59,8 +59,9 @@ void FoundMethodHash::sanityCheck() const {
 }
 
 string FoundMethodHash::toString() const {
-    return fmt::format("FoundMethodHash {{ ownerIdx = {}, nameHash = {}, arityHash = {}, isSelfMethod = {} }}",
-                       nameHash._hashValue, arityHash._hashValue, isSelfMethod);
+    return fmt::format("FoundMethodHash {{ owner.idx = {}, owner.useSingletonClass = {}, nameHash = {}, "
+                       "arityHash = {}, isSelfMethod = {} }}",
+                       owner.idx, owner.useSingletonClass, nameHash._hashValue, arityHash._hashValue);
 }
 
 FileHash::FileHash(LocalSymbolTableHashes &&localSymbolTableHashes, UsageHash &&usages,

--- a/core/FileHash.h
+++ b/core/FileHash.h
@@ -36,6 +36,38 @@ template <typename H> H AbslHashValue(H h, const ShortNameHash &m) {
     return H::combine(std::move(h), m._hashValue);
 }
 
+class FullNameHash {
+public:
+    /** Sorts an array of ShortNameHashes and removes duplicates. */
+    static void sortAndDedupe(std::vector<core::FullNameHash> &hashes);
+
+    FullNameHash(const GlobalState &gs, NameRef nm);
+    inline bool isDefined() const {
+        return _hashValue != 0;
+    }
+    FullNameHash(const FullNameHash &nm) noexcept = default;
+    FullNameHash() noexcept : _hashValue(0){};
+    inline bool operator==(const FullNameHash &rhs) const noexcept {
+        ENFORCE(isDefined());
+        ENFORCE(rhs.isDefined());
+        return _hashValue == rhs._hashValue;
+    }
+
+    inline bool operator!=(const FullNameHash &rhs) const noexcept {
+        return !(rhs == *this);
+    }
+
+    inline bool operator<(const FullNameHash &rhs) const noexcept {
+        return this->_hashValue < rhs._hashValue;
+    }
+
+    uint32_t _hashValue;
+};
+
+template <typename H> H AbslHashValue(H h, const FullNameHash &m) {
+    return H::combine(std::move(h), m._hashValue);
+}
+
 struct SymbolHash {
     // The hash of the symbol's name. Note that symbols with the same name owned by different
     // symbols map to the same ShortNameHash. This is fine, because our strategy for deciding which

--- a/core/FileHash.h
+++ b/core/FileHash.h
@@ -118,6 +118,8 @@ struct FoundMethodHash {
 };
 CheckSize(FoundMethodHash, 16, 4);
 
+using FoundMethodHashes = std::vector<FoundMethodHash>;
+
 // When a file is edited, we run index and resolve it using an local (empty) GlobalState.
 // We then hash the symbols defined in that local GlobalState, and use the result to quickly decide
 // whether "something" changed, or whether nothing changed (and thus we can take the fast path).
@@ -239,9 +241,11 @@ struct UsageHash {
 struct FileHash {
     LocalSymbolTableHashes localSymbolTableHashes;
     UsageHash usages;
+    FoundMethodHashes foundMethodHashes;
 
     FileHash() = default;
-    FileHash(LocalSymbolTableHashes &&localSymbolTableHashes, UsageHash &&usages);
+    FileHash(LocalSymbolTableHashes &&localSymbolTableHashes, UsageHash &&usages,
+             FoundMethodHashes &&foundMethodHashes);
 };
 
 }; // namespace sorbet::core

--- a/core/FoundDefinitions.cc
+++ b/core/FoundDefinitions.cc
@@ -1,4 +1,5 @@
 #include "core/FoundDefinitions.h"
+#include "absl/base/casts.h"
 
 using namespace std;
 

--- a/core/FoundDefinitions.cc
+++ b/core/FoundDefinitions.cc
@@ -1,5 +1,4 @@
 #include "core/FoundDefinitions.h"
-#include "absl/base/casts.h"
 
 using namespace std;
 

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1736,10 +1736,6 @@ void GlobalState::deleteMethodSymbol(MethodRef what) {
     ENFORCE(fnd != ownerMembers.end());
     ENFORCE(fnd->second == what);
     ownerMembers.erase(fnd);
-    // TODO(jez) In the future, we could even store a "fake" core::Method that essentially tracks a
-    // free list of slots in `this->methods` that can be overridden to save space / prevent memory bloat
-    // TODO(jez) There are some places where we ask for the number of method symbols.
-    // We probably want specialized helpers depending on the context of what's being counted.
     this->methods[what.id()] = this->methods[0].deepCopy(*this);
 }
 

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2260,8 +2260,6 @@ unique_ptr<LocalSymbolTableHashes> GlobalState::hash() const {
         if (!sym.ignoreInHashing(*this)) {
             auto &target = methodHashesMap[ShortNameHash(*this, sym.name)];
             target = mix(target, sym.hash(*this));
-            // TODO(jez) Have to figure out whether all the flags do the right thing (maybe just
-            // reset them in namer?)
             if (sym.name == Names::unresolvedAncestors() || sym.name == Names::requiredAncestors() ||
                 sym.name == Names::requiredAncestorsLin()) {
                 uint32_t symhash = sym.methodShapeHash(*this);

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1915,6 +1915,7 @@ unique_ptr<GlobalState> GlobalState::deepCopy(bool keepId) const {
     result->censorForSnapshotTests = this->censorForSnapshotTests;
     result->sleepInSlowPathSeconds = this->sleepInSlowPathSeconds;
     result->requiresAncestorEnabled = this->requiresAncestorEnabled;
+    result->lspExperimentalFastPathEnabled = this->lspExperimentalFastPathEnabled;
 
     if (keepId) {
         result->globalStateId = this->globalStateId;
@@ -2007,6 +2008,7 @@ unique_ptr<GlobalState> GlobalState::copyForIndex() const {
     result->ensureCleanStrings = this->ensureCleanStrings;
     result->runningUnderAutogen = this->runningUnderAutogen;
     result->censorForSnapshotTests = this->censorForSnapshotTests;
+    result->lspExperimentalFastPathEnabled = this->lspExperimentalFastPathEnabled;
     result->sleepInSlowPathSeconds = this->sleepInSlowPathSeconds;
     result->requiresAncestorEnabled = this->requiresAncestorEnabled;
     result->kvstoreUuid = this->kvstoreUuid;
@@ -2260,8 +2262,12 @@ unique_ptr<LocalSymbolTableHashes> GlobalState::hash() const {
         if (!sym.ignoreInHashing(*this)) {
             auto &target = methodHashesMap[ShortNameHash(*this, sym.name)];
             target = mix(target, sym.hash(*this));
-            if (sym.name == Names::unresolvedAncestors() || sym.name == Names::requiredAncestors() ||
-                sym.name == Names::requiredAncestorsLin()) {
+            auto needMethodShapeHash =
+                this->lspExperimentalFastPathEnabled
+                    ? (sym.name == Names::unresolvedAncestors() || sym.name == Names::requiredAncestors() ||
+                       sym.name == Names::requiredAncestorsLin())
+                    : true;
+            if (needMethodShapeHash) {
                 uint32_t symhash = sym.methodShapeHash(*this);
                 hierarchyHash = mix(hierarchyHash, symhash);
                 methodHash = mix(methodHash, symhash);

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -168,6 +168,7 @@ public:
 
     void mangleRenameSymbol(SymbolRef what, NameRef origName);
     void mangleRenameForOverload(SymbolRef what, NameRef origName);
+    void deleteMethodSymbol(MethodRef what);
     spdlog::logger &tracer() const;
     unsigned int namesUsedTotal() const;
     unsigned int utf8NamesUsed() const;

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -286,6 +286,9 @@ public:
     // If 'true', enforce use of Ruby 3.0-style keyword args.
     bool ruby3KeywordArgs = false;
 
+    // If 'true', enable the experimental, symbol-deletion-based fast path mode
+    bool lspExperimentalFastPathEnabled = false;
+
     // When present, this indicates that single-package rbi generation is being performed, and contains metadata about
     // the packages that are imported by the one whose interface is being generated.
     std::optional<packages::ImportInfo> singlePackageImports;

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -168,6 +168,8 @@ public:
 
     void mangleRenameSymbol(SymbolRef what, NameRef origName);
     void mangleRenameForOverload(SymbolRef what, NameRef origName);
+    // NOTE: You likely want to use mangleRenameSymbol not deleteMethodSymbol, unless you know what you're doing.
+    // See the comment on the implementation for more.
     void deleteMethodSymbol(MethodRef what);
     spdlog::logger &tracer() const;
     unsigned int namesUsedTotal() const;

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -2200,7 +2200,6 @@ uint32_t ClassOrModule::hash(const GlobalState &gs) const {
     if (!members().empty()) {
         // Rather than use membersStableOrderSlow, which is... slow..., use an order dictated by symbol ref ID.
         // It's faster to sort, and SymbolRef IDs are stable during hashing.
-        // TODO(jez) Why is this necessary, if everything already hashes its owner?
         vector<core::SymbolRef> membersToHash;
         membersToHash.reserve(this->members().size());
         for (auto e : this->members()) {
@@ -2208,7 +2207,6 @@ uint32_t ClassOrModule::hash(const GlobalState &gs) const {
                 continue;
             }
 
-            // if (e.second.isMethod() && e.second.asMethodRef().data(gs)->ignoreInHashing(gs)) {
             if (e.second.isMethod()) {
                 continue;
             }

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -2283,10 +2283,8 @@ uint32_t TypeParameter::hash(const GlobalState &gs) const {
 
 uint32_t Method::methodShapeHash(const GlobalState &gs) const {
     uint32_t result = _hash(name.shortName(gs));
-    // TODO(jez) Some flags we can put into the shape, some flags we can't
     result = mix(result, this->flags.serialize());
     result = mix(result, this->owner.id());
-    // TODO(jez) I think we can probably drop rebind even without Namer::runIncremental?
     result = mix(result, this->rebind.id());
     result = mix(result, this->hasSig());
     result = mix(result, this->methodArityHash(gs)._hashValue);

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -2207,7 +2207,8 @@ uint32_t ClassOrModule::hash(const GlobalState &gs) const {
                 continue;
             }
 
-            if (e.second.isMethod()) {
+            if (e.second.isMethod() &&
+                (gs.lspExperimentalFastPathEnabled || e.second.asMethodRef().data(gs)->ignoreInHashing(gs))) {
                 continue;
             }
 

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -45,8 +45,13 @@ public:
     friend class serialize::SerializerImpl;
 
     Method(const Method &) = delete;
+    Method &operator=(Method &) = delete;
     Method() = default;
     Method(Method &&) noexcept = default;
+    // TODO(jez) Pretty sure we only want GlobalState to be able to call this.
+    // Maybe we make this method private, but give a fancy name to it so you can't accidentally do
+    // it with just a simple `=` sign?
+    Method &operator=(Method &&) noexcept = default;
     class Flags {
     public:
         // Synthesized by C++ code in a Rewriter pass
@@ -83,6 +88,7 @@ public:
     Loc loc() const;
     const InlinedVector<Loc, 2> &locs() const;
     void addLoc(const core::GlobalState &gs, core::Loc loc);
+    void removeLocsForFile(core::FileRef file);
     uint32_t hash(const GlobalState &gs) const;
     uint32_t methodShapeHash(const GlobalState &gs) const;
     ArityHash methodArityHash(const GlobalState &gs) const;

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -49,7 +49,7 @@ class Method final {
 
 public:
     Method(const Method &) = delete;
-    Method &operator=(Method &) = delete;
+    Method &operator=(const Method &) = delete;
     Method() = default;
     Method(Method &&) noexcept = default;
     class Flags {

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -40,18 +40,18 @@ enum class Visibility : uint8_t {
 };
 
 class Method final {
-public:
     friend class ClassOrModule;
+    friend class GlobalState;
     friend class serialize::SerializerImpl;
 
+    // This is to allow updating `GlobalState::methods` in place with a new method, over top of an existing method
+    Method &operator=(Method &&) = default;
+
+public:
     Method(const Method &) = delete;
     Method &operator=(Method &) = delete;
     Method() = default;
     Method(Method &&) noexcept = default;
-    // TODO(jez) Pretty sure we only want GlobalState to be able to call this.
-    // Maybe we make this method private, but give a fancy name to it so you can't accidentally do
-    // it with just a simple `=` sign?
-    Method &operator=(Method &&) noexcept = default;
     class Flags {
     public:
         // Synthesized by C++ code in a Rewriter pass

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -254,6 +254,13 @@ void SerializerImpl::pickle(Pickler &p, shared_ptr<const FileHash> fh) {
     for (const auto &e : fh->usages.nameHashes) {
         p.putU4(e._hashValue);
     }
+    p.putU4(fh->foundMethodHashes.size());
+    for (const auto &fdh : fh->foundMethodHashes) {
+        p.putU4(fdh.ownerIdx);
+        p.putU4(fdh.nameHash._hashValue);
+        p.putU4(fdh.arityHash._hashValue);
+        p.putU1(fdh.isSelfMethod);
+    }
 }
 
 unique_ptr<const FileHash> SerializerImpl::unpickleFileHash(UnPickler &p) {
@@ -284,6 +291,17 @@ unique_ptr<const FileHash> SerializerImpl::unpickleFileHash(UnPickler &p) {
         ShortNameHash key;
         key._hashValue = p.getU4();
         ret.usages.nameHashes.emplace_back(key);
+    }
+    auto foundMethodHashesSize = p.getU4();
+    ret.foundMethodHashes.reserve(foundMethodHashesSize);
+    for (int it = 0; it < foundMethodHashesSize; it++) {
+        auto ownerIdx = p.getU4();
+        FullNameHash fullNameHash;
+        fullNameHash._hashValue = p.getU4();
+        ArityHash arityHash;
+        arityHash._hashValue = p.getU4();
+        auto isSelfMethod = p.getU1();
+        ret.foundMethodHashes.emplace_back(ownerIdx, fullNameHash, arityHash, isSelfMethod);
     }
     return make_unique<const FileHash>(move(ret));
 }

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -256,10 +256,10 @@ void SerializerImpl::pickle(Pickler &p, shared_ptr<const FileHash> fh) {
     }
     p.putU4(fh->foundMethodHashes.size());
     for (const auto &fdh : fh->foundMethodHashes) {
-        p.putU4(fdh.ownerIdx);
+        p.putU4(fdh.owner.idx);
+        p.putU1(fdh.owner.useSingletonClass);
         p.putU4(fdh.nameHash._hashValue);
         p.putU4(fdh.arityHash._hashValue);
-        p.putU1(fdh.isSelfMethod);
     }
 }
 
@@ -296,12 +296,12 @@ unique_ptr<const FileHash> SerializerImpl::unpickleFileHash(UnPickler &p) {
     ret.foundMethodHashes.reserve(foundMethodHashesSize);
     for (int it = 0; it < foundMethodHashesSize; it++) {
         auto ownerIdx = p.getU4();
+        auto useSingletonClass = p.getU1();
         FullNameHash fullNameHash;
         fullNameHash._hashValue = p.getU4();
         ArityHash arityHash;
         arityHash._hashValue = p.getU4();
-        auto isSelfMethod = p.getU1();
-        ret.foundMethodHashes.emplace_back(ownerIdx, fullNameHash, arityHash, isSelfMethod);
+        ret.foundMethodHashes.emplace_back(ownerIdx, useSingletonClass, fullNameHash, arityHash);
     }
     return make_unique<const FileHash>(move(ret));
 }

--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -69,7 +69,8 @@ unique_ptr<core::FileHash> computeFileHashForAST(spdlog::logger &logger, unique_
             auto view = string_view{result.GetString(), result.GetLength()};
             logger.debug(view);
 
-            return make_unique<core::FileHash>(core::LocalSymbolTableHashes::invalidParse(), move(usageHash));
+            return make_unique<core::FileHash>(core::LocalSymbolTableHashes::invalidParse(), move(usageHash),
+                                               core::FoundMethodHashes{});
         }
     }
 
@@ -77,9 +78,10 @@ unique_ptr<core::FileHash> computeFileHashForAST(spdlog::logger &logger, unique_
     single.emplace_back(move(file));
 
     auto workers = WorkerPool::create(0, lgs->tracer());
-    realmain::pipeline::resolve(lgs, move(single), opts(), *workers);
+    core::FoundMethodHashes foundMethodHashes; // out parameter
+    realmain::pipeline::resolve(lgs, move(single), opts(), *workers, &foundMethodHashes);
 
-    return make_unique<core::FileHash>(move(*lgs->hash()), move(usageHash));
+    return make_unique<core::FileHash>(move(*lgs->hash()), move(usageHash), move(foundMethodHashes));
 }
 
 // Note: lgs is an outparameter.

--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -90,6 +90,7 @@ core::FileRef makeEmptyGlobalStateForFile(spdlog::logger &logger, shared_ptr<cor
                                           const realmain::options::Options &hashingOpts) {
     lgs = core::GlobalState::makeEmptyGlobalStateForHashing(logger);
     lgs->requiresAncestorEnabled = hashingOpts.requiresAncestorEnabled;
+    lgs->lspExperimentalFastPathEnabled = hashingOpts.lspExperimentalFastPathEnabled;
     {
         core::UnfreezeFileTable fileTableAccess(*lgs);
         auto fref = lgs->enterFile(forWhat);

--- a/infer/test/infer_test.cc
+++ b/infer/test/infer_test.cc
@@ -41,7 +41,8 @@ void processSource(core::GlobalState &cb, string str) {
     vector<ast::ParsedFile> trees;
     trees.emplace_back(move(tree));
     auto workers = WorkerPool::create(0, *logger);
-    trees = move(namer::Namer::run(cb, move(trees), *workers).result());
+    core::FoundMethodHashes foundMethodHashes; // compute this just for test coverage
+    trees = move(namer::Namer::run(cb, move(trees), *workers, &foundMethodHashes).result());
     auto resolved = resolver::Resolver::run(cb, move(trees), *workers);
     for (auto &tree : resolved.result()) {
         sorbet::core::MutableContext ctx(cb, core::Symbols::root(), tree.file);

--- a/main/cache/cache.cc
+++ b/main/cache/cache.cc
@@ -12,8 +12,10 @@ unique_ptr<OwnedKeyValueStore> maybeCreateKeyValueStore(const options::Options &
     if (opts.cacheDir.empty()) {
         return nullptr;
     }
-    return make_unique<OwnedKeyValueStore>(make_unique<KeyValueStore>(sorbet_full_version_string, opts.cacheDir,
-                                                                      opts.skipRewriterPasses ? "nodsl" : "default"));
+    auto flavor = fmt::format("{}-{}", opts.skipRewriterPasses ? "nodsl" : "dsl",
+                              opts.lspExperimentalFastPathEnabled ? "experimentalfastpath" : "normalfastpath");
+    return make_unique<OwnedKeyValueStore>(
+        make_unique<KeyValueStore>(sorbet_full_version_string, opts.cacheDir, move(flavor)));
 }
 
 unique_ptr<OwnedKeyValueStore> ownIfUnchanged(const core::GlobalState &gs, unique_ptr<KeyValueStore> kvstore) {

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -237,6 +237,7 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
     Timer timeit(config->logger, "fast_path");
     vector<core::FileRef> subset;
     vector<core::ShortNameHash> changedSymbolNameHashes;
+    UnorderedMap<core::FileRef, core::FoundMethodHashes> oldFoundMethodHashesForFiles;
     // Replace error queue with one that is owned by this thread.
     gs->errorQueue = make_shared<core::ErrorQueue>(gs->errorQueue->logger, gs->errorQueue->tracer, errorFlusher);
     {
@@ -262,14 +263,20 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
                 const auto &oldMethodHashes = oldSymbolHashes.methodHashes;
                 const auto &newMethodHashes = newSymbolHashes.methodHashes;
 
+                // TODO(jez) is this critical for the set_difference to work, or just a sanity check?
                 // Both oldHash and newHash should have the same methods, since this is the fast path!
-                ENFORCE(validateIdenticalFingerprints(oldMethodHashes, newMethodHashes),
+                ENFORCE(true || validateIdenticalFingerprints(oldMethodHashes, newMethodHashes),
                         "definitionHash should have failed");
 
                 // Find which hashes changed. Note: methodHashes are sorted, so set_difference should work.
                 // This will insert two entries into `changedMethodHashes` for each changed method, but they will get
                 // deduped later.
-                absl::c_set_difference(oldMethodHashes, newMethodHashes, std::back_inserter(changedMethodSymbolHashes));
+                absl::c_set_symmetric_difference(oldMethodHashes, newMethodHashes,
+                                                 std::back_inserter(changedMethodSymbolHashes));
+
+                // Okay to `move` here (steals component of getFileHash) because we're about to use
+                // replaceFile to clobber fref.data(*gs) anyways.
+                oldFoundMethodHashesForFiles.emplace(fref, move(fref.data(*gs).getFileHash()->foundMethodHashes));
 
                 const auto &oldFieldHashes = oldSymbolHashes.staticFieldHashes;
                 const auto &newFieldHashes = newSymbolHashes.staticFieldHashes;
@@ -331,10 +338,19 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
         auto t = pipeline::indexOne(config->opts, *gs, f);
         updatedIndexed.emplace_back(ast::ParsedFile{t.tree.deepCopy(), t.file});
         updates.updatedFinalGSFileIndexes.push_back(move(t));
+
+        if (oldFoundMethodHashesForFiles.find(f) == oldFoundMethodHashesForFiles.end()) {
+            // This is an extra file that we need to typecheck which was not part of the original
+            // edited files, so whatever it happens to have in foundMethodHashes is still "old"
+            // (but we can't use `move` to steal it like before, because we're not replacing the
+            // whole file).
+            oldFoundMethodHashesForFiles.emplace(f, f.data(*gs).getFileHash()->foundMethodHashes);
+        }
     }
 
     ENFORCE(gs->lspQuery.isEmpty());
-    auto resolved = pipeline::incrementalResolve(*gs, move(updatedIndexed), config->opts);
+    auto resolved =
+        pipeline::incrementalResolve(*gs, move(updatedIndexed), std::move(oldFoundMethodHashesForFiles), config->opts);
     auto sorted = sortParsedFiles(*gs, *errorReporter, move(resolved));
     const auto presorted = true;
     const auto cancelable = false;
@@ -699,7 +715,9 @@ vector<ast::ParsedFile> LSPTypechecker::getResolved(const vector<core::FileRef> 
             updatedIndexed.emplace_back(ast::ParsedFile{indexed.tree.deepCopy(), indexed.file});
         }
     }
-    return pipeline::incrementalResolve(*gs, move(updatedIndexed), config->opts);
+    // TODO(jez) I think it should be fine to not need a foundMethodHashesForFiles list...
+    // Makes the type signatures somewhat annoying but we can make it work.
+    return pipeline::incrementalResolve(*gs, move(updatedIndexed), nullopt, config->opts);
 }
 
 const core::GlobalState &LSPTypechecker::state() const {

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -479,7 +479,9 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates updates, WorkerPool &workers, bo
                 }
             }
         }
-        auto maybeResolved = pipeline::resolve(gs, move(indexedCopies), config->opts, workers);
+        // Only need to compute FoundMethodHashes when running to compute a FileHash
+        auto foundMethodHashes = nullptr;
+        auto maybeResolved = pipeline::resolve(gs, move(indexedCopies), config->opts, workers, foundMethodHashes);
         if (!maybeResolved.hasResult()) {
             return;
         }

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -263,15 +263,28 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
                 const auto &oldMethodHashes = oldSymbolHashes.methodHashes;
                 const auto &newMethodHashes = newSymbolHashes.methodHashes;
 
-                // Find which hashes changed. Note: methodHashes are sorted, so set_difference should work.
-                // This will insert two entries into `changedMethodHashes` for each changed method, but they will get
-                // deduped later.
-                absl::c_set_symmetric_difference(oldMethodHashes, newMethodHashes,
-                                                 std::back_inserter(changedMethodSymbolHashes));
+                if (config->opts.lspExperimentalFastPathEnabled) {
+                    // Find which hashes changed. Note: methodHashes are sorted, so set_difference should work.
+                    // This will insert two entries into `changedMethodHashes` for each changed method, but they will
+                    // get deduped later.
+                    absl::c_set_symmetric_difference(oldMethodHashes, newMethodHashes,
+                                                     std::back_inserter(changedMethodSymbolHashes));
 
-                // Okay to `move` here (steals component of getFileHash) because we're about to use
-                // replaceFile to clobber fref.data(*gs) anyways.
-                oldFoundMethodHashesForFiles.emplace(fref, move(fref.data(*gs).getFileHash()->foundMethodHashes));
+                    // Okay to `move` here (steals component of getFileHash) because we're about to use
+                    // replaceFile to clobber fref.data(*gs) anyways.
+                    oldFoundMethodHashesForFiles.emplace(fref, move(fref.data(*gs).getFileHash()->foundMethodHashes));
+
+                } else {
+                    // Both oldHash and newHash should have the same methods, since this is the fast path!
+                    ENFORCE(validateIdenticalFingerprints(oldMethodHashes, newMethodHashes),
+                            "definitionHash should have failed");
+
+                    // Find which hashes changed. Note: methodHashes are sorted, so set_difference should work.
+                    // This will insert two entries into `changedMethodHashes` for each changed method, but they will
+                    // get deduped later.
+                    absl::c_set_difference(oldMethodHashes, newMethodHashes,
+                                           std::back_inserter(changedMethodSymbolHashes));
+                }
 
                 const auto &oldFieldHashes = oldSymbolHashes.staticFieldHashes;
                 const auto &newFieldHashes = newSymbolHashes.staticFieldHashes;
@@ -334,7 +347,8 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
         updatedIndexed.emplace_back(ast::ParsedFile{t.tree.deepCopy(), t.file});
         updates.updatedFinalGSFileIndexes.push_back(move(t));
 
-        if (oldFoundMethodHashesForFiles.find(f) == oldFoundMethodHashesForFiles.end()) {
+        if (config->opts.lspExperimentalFastPathEnabled &&
+            oldFoundMethodHashesForFiles.find(f) == oldFoundMethodHashesForFiles.end()) {
             // This is an extra file that we need to typecheck which was not part of the original
             // edited files, so whatever it happens to have in foundMethodHashes is still "old"
             // (but we can't use `move` to steal it like before, because we're not replacing the
@@ -344,8 +358,10 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
     }
 
     ENFORCE(gs->lspQuery.isEmpty());
-    auto resolved =
-        pipeline::incrementalResolve(*gs, move(updatedIndexed), std::move(oldFoundMethodHashesForFiles), config->opts);
+    auto resolved = config->opts.lspExperimentalFastPathEnabled
+                        ? pipeline::incrementalResolve(*gs, move(updatedIndexed),
+                                                       std::move(oldFoundMethodHashesForFiles), config->opts)
+                        : pipeline::incrementalResolve(*gs, move(updatedIndexed), nullopt, config->opts);
     auto sorted = sortParsedFiles(*gs, *errorReporter, move(resolved));
     const auto presorted = true;
     const auto cancelable = false;

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -710,9 +710,13 @@ vector<ast::ParsedFile> LSPTypechecker::getResolved(const vector<core::FileRef> 
             updatedIndexed.emplace_back(ast::ParsedFile{indexed.tree.deepCopy(), indexed.file});
         }
     }
-    // TODO(jez) I think it should be fine to not need a foundMethodHashesForFiles list...
-    // Makes the type signatures somewhat annoying but we can make it work.
-    return pipeline::incrementalResolve(*gs, move(updatedIndexed), nullopt, config->opts);
+
+    // There are two incrementalResolve modes: one when running for the purpose of processing a file update,
+    // and one for running an LSP query on an already-resolved file.
+    // In getResolved, we want the LSP query behavior, not the file update behavior, which we get by passing nullopt.
+    auto foundMethodHashesForFiles = nullopt;
+
+    return pipeline::incrementalResolve(*gs, move(updatedIndexed), move(foundMethodHashesForFiles), config->opts);
 }
 
 const core::GlobalState &LSPTypechecker::state() const {

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -263,11 +263,6 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
                 const auto &oldMethodHashes = oldSymbolHashes.methodHashes;
                 const auto &newMethodHashes = newSymbolHashes.methodHashes;
 
-                // TODO(jez) is this critical for the set_difference to work, or just a sanity check?
-                // Both oldHash and newHash should have the same methods, since this is the fast path!
-                ENFORCE(true || validateIdenticalFingerprints(oldMethodHashes, newMethodHashes),
-                        "definitionHash should have failed");
-
                 // Find which hashes changed. Note: methodHashes are sorted, so set_difference should work.
                 // This will insert two entries into `changedMethodHashes` for each changed method, but they will get
                 // deduped later.

--- a/main/lsp/wrapper.cc
+++ b/main/lsp/wrapper.cc
@@ -25,6 +25,7 @@ void setRequiredLSPOptions(core::GlobalState &gs, options::Options &options) {
     }
 
     gs.requiresAncestorEnabled = options.requiresAncestorEnabled;
+    gs.lspExperimentalFastPathEnabled = options.lspExperimentalFastPathEnabled;
 
     // Ensure LSP is enabled.
     options.runLSP = true;
@@ -162,6 +163,7 @@ void LSPWrapper::enableAllExperimentalFeatures() {
     enableExperimentalFeature(LSPExperimentalFeature::DocumentSymbol);
     enableExperimentalFeature(LSPExperimentalFeature::SignatureHelp);
     enableExperimentalFeature(LSPExperimentalFeature::DocumentFormat);
+    enableExperimentalFeature(LSPExperimentalFeature::ExperimentalFastPath);
 }
 
 void LSPWrapper::enableExperimentalFeature(LSPExperimentalFeature feature) {
@@ -177,6 +179,9 @@ void LSPWrapper::enableExperimentalFeature(LSPExperimentalFeature feature) {
             break;
         case LSPExperimentalFeature::DocumentFormat:
             opts->lspDocumentFormatRubyfmtEnabled = true;
+            break;
+        case LSPExperimentalFeature::ExperimentalFastPath:
+            opts->lspExperimentalFastPathEnabled = true;
             break;
     }
 }

--- a/main/lsp/wrapper.h
+++ b/main/lsp/wrapper.h
@@ -52,6 +52,7 @@ public:
         SignatureHelp = 7,
         DocumentHighlight = 9,
         DocumentFormat = 10,
+        ExperimentalFastPath = 11,
     };
 
     // N.B.: Sorbet assumes we 'own' this object; keep it alive to avoid memory errors.

--- a/main/minimize/minimize.cc
+++ b/main/minimize/minimize.cc
@@ -419,7 +419,9 @@ void Minimize::indexAndResolveForMinimize(unique_ptr<core::GlobalState> &sourceG
         rbiGS->errorQueue->flushAllErrors(*rbiGS);
     }
 
-    rbiIndexed = move(pipeline::resolve(rbiGS, move(rbiIndexed), opts, workers).result());
+    // Only need to compute FoundMethodHashes when running to compute a FileHash
+    auto foundMethodHashes = nullptr;
+    rbiIndexed = move(pipeline::resolve(rbiGS, move(rbiIndexed), opts, workers, foundMethodHashes).result());
     if (rbiGS->hadCriticalError()) {
         rbiGS->errorQueue->flushAllErrors(*rbiGS);
     }

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -344,6 +344,8 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
     options.add_options("advanced")("enable-experimental-lsp-stale-state", "Enable experimental LSP feature: fast "
                                                                            "but approximate answers from stale "
                                                                            "typechecker state");
+    options.add_options("advanced")("enable-experimental-lsp-fast-path",
+                                    "Enable experimental LSP feature: a faster fast path using symbol deletions");
     options.add_options("advanced")("enable-experimental-requires-ancestor",
                                     "Enable experimental `requires_ancestor` annotation");
 
@@ -766,6 +768,9 @@ void readOptions(Options &opts,
         // until we get some other groundwork in place. Once things stabilize a bit more, we can slap
         // `enableAllLSPFeatures ||` onto the condition here.
         opts.lspStaleStateEnabled = raw["enable-experimental-lsp-stale-state"].as<bool>();
+
+        opts.lspExperimentalFastPathEnabled =
+            opts.lspAllBetaFeaturesEnabled || raw["enable-experimental-lsp-fast-path"].as<bool>();
 
         if (raw.count("lsp-directories-missing-from-client") > 0) {
             auto lspDirsMissingFromClient = raw["lsp-directories-missing-from-client"].as<vector<string>>();

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -247,6 +247,7 @@ struct Options {
     bool lspDocumentFormatRubyfmtEnabled = false;
     bool lspSignatureHelpEnabled = false;
     bool lspStaleStateEnabled = false;
+    bool lspExperimentalFastPathEnabled = false;
 
     // Experimental feature `requires_ancestor`
     bool requiresAncestorEnabled = false;

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -901,11 +901,7 @@ ast::ParsedFilesOrCancelled resolve(unique_ptr<core::GlobalState> &gs, vector<as
                     auto reIndexed = indexOne(opts, *gs, f.file);
                     vector<ast::ParsedFile> toBeReResolved;
                     toBeReResolved.emplace_back(move(reIndexed));
-                    // TODO(jez) It's an open question what we want the behavior of `--stress-incremental-resolver` to
-                    // be. On the one hand, LSPTypechecker::getResolved will _not_ use Namer::runIncremental.
-                    // On the other, if we don't test it in `--stress-incremental-resolver`, we'll have to write
-                    // extra tests to be sure of correctness, because pipeline tests won't test our feature for free.
-                    // TODO(jez) Once you've made a decision, explain what `nullopt` means here for posterity
+                    // We don't compute file hashes when running for incrementalResolve.
                     auto foundMethodHashesForFiles = nullopt;
                     auto reresolved =
                         pipeline::incrementalResolve(*gs, move(toBeReResolved), foundMethodHashesForFiles, opts);

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -5,6 +5,7 @@
 #include "common/common.h"
 #include "common/concurrency/WorkerPool.h"
 #include "common/kvstore/KeyValueStore.h"
+#include "core/FileHash.h"
 #include "main/options/options.h"
 
 namespace sorbet::core::lsp {
@@ -25,7 +26,8 @@ std::vector<ast::ParsedFile> package(core::GlobalState &gs, std::vector<ast::Par
                                      const options::Options &opts, WorkerPool &workers);
 
 ast::ParsedFilesOrCancelled resolve(std::unique_ptr<core::GlobalState> &gs, std::vector<ast::ParsedFile> what,
-                                    const options::Options &opts, WorkerPool &workers);
+                                    const options::Options &opts, WorkerPool &workers,
+                                    core::FoundMethodHashes *foundMethodHashes);
 
 std::vector<ast::ParsedFile> incrementalResolve(core::GlobalState &gs, std::vector<ast::ParsedFile> what,
                                                 const options::Options &opts);
@@ -35,7 +37,7 @@ std::vector<ast::ParsedFile> incrementalResolveBestEffort(const core::GlobalStat
                                                           const options::Options &opts);
 
 ast::ParsedFilesOrCancelled name(core::GlobalState &gs, std::vector<ast::ParsedFile> what, const options::Options &opts,
-                                 WorkerPool &workers);
+                                 WorkerPool &workers, core::FoundMethodHashes *foundMethodHashes);
 
 ast::ParsedFilesOrCancelled nameBestEffortConst(const core::GlobalState &gs, std::vector<ast::ParsedFile> what,
                                                 WorkerPool &workers);

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -29,9 +29,13 @@ ast::ParsedFilesOrCancelled resolve(std::unique_ptr<core::GlobalState> &gs, std:
                                     const options::Options &opts, WorkerPool &workers,
                                     core::FoundMethodHashes *foundMethodHashes);
 
-std::vector<ast::ParsedFile> incrementalResolve(core::GlobalState &gs, std::vector<ast::ParsedFile> what,
-                                                const options::Options &opts);
+std::vector<ast::ParsedFile>
+incrementalResolve(core::GlobalState &gs, std::vector<ast::ParsedFile> what,
+                   std::optional<UnorderedMap<core::FileRef, core::FoundMethodHashes>> &&foundMethodHashesForFiles,
+                   const options::Options &opts);
 
+// This function only calls Namer::symbolizeTreesBestEffort, not Namer::defineSymbols, which means
+// there's no point in taking any FoundMethodHashes.
 std::vector<ast::ParsedFile> incrementalResolveBestEffort(const core::GlobalState &gs,
                                                           std::vector<ast::ParsedFile> what,
                                                           const options::Options &opts);

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -29,6 +29,12 @@ ast::ParsedFilesOrCancelled resolve(std::unique_ptr<core::GlobalState> &gs, std:
                                     const options::Options &opts, WorkerPool &workers,
                                     core::FoundMethodHashes *foundMethodHashes);
 
+// If `foundMethodHashesForFiles` is non-nullopt, incrementalResolve invokes Namer in runIncremental mode.
+//
+// This is most useful when running incrementalResolve for the purpose of a file update.
+//
+// It's not required when running incrementalResolve just to turn an AST into a resolved AST, if
+// that AST has already been resolved once before on the fast path
 std::vector<ast::ParsedFile>
 incrementalResolve(core::GlobalState &gs, std::vector<ast::ParsedFile> what,
                    std::optional<UnorderedMap<core::FileRef, core::FoundMethodHashes>> &&foundMethodHashesForFiles,

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -751,7 +751,9 @@ int realmain(int argc, char *argv[]) {
             gs->suppressErrorClass(core::errors::Resolver::RecursiveTypeAlias.code);
 
             indexed = pipeline::package(*gs, move(indexed), opts, *workers);
-            indexed = move(pipeline::name(*gs, move(indexed), opts, *workers).result());
+            // Only need to compute FoundMethodHashes when running to compute a FileHash
+            auto foundMethodHashes = nullptr;
+            indexed = move(pipeline::name(*gs, move(indexed), opts, *workers, foundMethodHashes).result());
 
             autogen::AutoloaderConfig autoloaderCfg;
             {
@@ -765,7 +767,9 @@ int realmain(int argc, char *argv[]) {
             runAutogen(*gs, opts, autoloaderCfg, *workers, indexed);
 #endif
         } else {
-            indexed = move(pipeline::resolve(gs, move(indexed), opts, *workers).result());
+            // Only need to compute FoundMethodHashes when running to compute a FileHash
+            auto foundMethodHashes = nullptr;
+            indexed = move(pipeline::resolve(gs, move(indexed), opts, *workers, foundMethodHashes).result());
             if (gs->hadCriticalError()) {
                 gs->errorQueue->flushAllErrors(*gs);
             }

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -527,6 +527,7 @@ int realmain(int argc, char *argv[]) {
         gs->includeErrorSections = false;
     }
     gs->ruby3KeywordArgs = opts.ruby3KeywordArgs;
+    gs->lspExperimentalFastPathEnabled = opts.lspExperimentalFastPathEnabled;
     if (!opts.stripeMode) {
         // Definitions in multiple locations interact poorly with autoloader this error is enforced in Stripe code.
         if (opts.isolateErrorCode.empty()) {

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1218,6 +1218,7 @@ class SymbolDefiner {
             if (memberNameToHash.kind() == core::NameKind::UNIQUE) {
                 auto &uniqueData = memberNameToHash.dataUnique(ctx);
                 if (uniqueData->uniqueNameKind == core::UniqueNameKind::MangleRename ||
+                    uniqueData->uniqueNameKind == core::UniqueNameKind::MangleRenameOverload ||
                     uniqueData->uniqueNameKind == core::UniqueNameKind::Overload) {
                     memberNameToHash = uniqueData->original;
                 }

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -857,17 +857,6 @@ class SymbolDefiner {
 
     core::MethodRef insertMethod(core::MutableContext ctx, const core::FoundMethod &method) {
         auto symbol = defineMethod(ctx, method);
-        auto name = symbol.data(ctx)->name;
-        if (name.kind() == core::NameKind::UNIQUE &&
-            name.dataUnique(ctx)->uniqueNameKind == core::UniqueNameKind::MangleRenameOverload) {
-            // These name kinds are only created in resolver, which means that we must be running on
-            // the fast path with an existing GlobalState.
-            // When modifyMethod is called later, it won't be able to find the correct method entry.
-            // Let's leave the method visibility what it was.
-            // TODO(jez) After #5808 lands, can we delete this check?
-            return symbol;
-        }
-
         auto implicitlyPrivate = ctx.owner.enclosingClass(ctx) == core::Symbols::root();
         if (implicitlyPrivate) {
             // Methods defined at the top level default to private (on Object)

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -507,7 +507,10 @@ public:
  */
 class SymbolDefiner {
     const core::FoundDefinitions foundDefs;
+    const optional<core::FoundMethodHashes> oldFoundMethodHashes;
+    // See getOwnerSymbol
     vector<core::ClassOrModuleRef> definedClasses;
+    // See getOwnerSymbol
     vector<core::MethodRef> definedMethods;
 
     // Returns a symbol to the referenced name. Name must be a class or module.
@@ -1199,8 +1202,65 @@ class SymbolDefiner {
         }
     }
 
+    // TODO(jez) This is a lot of GlobalState-looking code. Should we move it there?
+    // TODO(jez) This no longer uses NameHash. Pick a different name?
+    // TODO(jez) This only needs to run once per unique owner, but we run it once per found definition
+    void deleteViaFullNameHash(core::MutableContext ctx, const core::FoundMethodHash &oldDefHash) {
+        auto ownerRef = core::FoundDefinitionRef(core::FoundDefinitionRef::Kind::Class, oldDefHash.ownerIdx);
+        ENFORCE(oldDefHash.nameHash.isDefined(), "Can't delete rename if old hash is not defined");
+
+        // TODO(jez) I don't think we really need the arityHash anymore now that we're only looking
+        // at the owner. Worth removing that? Or keep it in, on the chance we might need it later?
+        // Honestly, we don't even need the nameHash at this rate, just the ownerIdx
+
+        // Because a change to classes would have take the slow path, should be safe
+        // to look up old owner in current foundDefs.
+        auto ownerSymbol = getOwnerSymbol(ownerRef);
+        ENFORCE(ownerSymbol.isClassOrModule());
+        auto owner = methodOwner(ctx, ownerSymbol, oldDefHash.isSelfMethod);
+        vector<core::MethodRef> toDelete;
+        for (const auto &[memberName, memberSym] : owner.data(ctx)->members()) {
+            if (!memberSym.isMethod()) {
+                continue;
+            }
+            auto memberMethod = memberSym.asMethodRef();
+
+            auto memberNameToHash = memberName;
+            if (memberNameToHash.kind() == core::NameKind::UNIQUE) {
+                auto &uniqueData = memberNameToHash.dataUnique(ctx);
+                if (uniqueData->uniqueNameKind == core::UniqueNameKind::MangleRename ||
+                    uniqueData->uniqueNameKind == core::UniqueNameKind::Overload) {
+                    memberNameToHash = uniqueData->original;
+                }
+            }
+
+            auto memberFullNameHash = core::FullNameHash(ctx, memberNameToHash);
+            if (memberFullNameHash != oldDefHash.nameHash) {
+                continue;
+            }
+
+            toDelete.emplace_back(memberMethod);
+        }
+
+        // TODO(jez) Find somewhere appropriate for this comment
+        // Only delete if the thing we found had the hash we expected to find.
+        // If we found something else, it likely means that even though there was previously a FoundMethod
+        // that would have caused a method with this name to be defined, it was delete and a
+        // different method with the same name took its place (that other method might not have been deleted,
+        // but if it was, we'll get to delete it on some future iteration.)
+        for (auto oldMethod : toDelete) {
+            // TODO(jez) Double check that if you end up removing all references in all files on a
+            // fast path, that the method does in fact get deleted.
+            oldMethod.data(ctx)->removeLocsForFile(ctx.file);
+            if (oldMethod.data(ctx)->locs().empty()) {
+                ctx.state.deleteMethodSymbol(oldMethod);
+            }
+        }
+    }
+
 public:
-    SymbolDefiner(unique_ptr<core::FoundDefinitions> foundDefs) : foundDefs(move(*foundDefs)) {}
+    SymbolDefiner(unique_ptr<core::FoundDefinitions> foundDefs, optional<core::FoundMethodHashes> oldFoundMethodHashes)
+        : foundDefs(move(*foundDefs)), oldFoundMethodHashes(move(oldFoundMethodHashes)) {}
 
     void run(core::MutableContext ctx) {
         definedClasses.reserve(foundDefs.klasses().size());
@@ -1208,6 +1268,20 @@ public:
 
         for (auto ref : foundDefs.nonMethodDefinitions()) {
             defineNonMethodSingle(ctx, ref);
+        }
+
+        // TODO(jez) This currently interleaves deleting and defining across files.
+        // It's possible that this causes problems at some point? Though I haven't found a test case.
+        // That being said, if it does cause problems, we should be able to not interleave, and have
+        // all the `nonMethodDefinitions` from all files get defined, then delete all the old
+        // methods, then define all the methods.
+        if (oldFoundMethodHashes.has_value()) {
+            for (const auto &oldMethodHash : oldFoundMethodHashes.value()) {
+                // Since we've already processed all the non-method symbols (which includes classes), we now
+                // guarantee that deleteViaFullNameHash can use getOwnerSymbol to lookup an old owner
+                // ref in the new definedClasses vector.
+                deleteViaFullNameHash(ctx, oldMethodHash);
+            }
         }
 
         for (auto &method : foundDefs.methods()) {
@@ -1861,8 +1935,10 @@ vector<SymbolFinderResult> findSymbols(const core::GlobalState &gs, vector<ast::
     return allFoundDefinitions;
 }
 
-ast::ParsedFilesOrCancelled defineSymbols(core::GlobalState &gs, vector<SymbolFinderResult> allFoundDefinitions,
-                                          WorkerPool &workers, core::FoundMethodHashes *foundMethodHashesOut) {
+ast::ParsedFilesOrCancelled
+defineSymbols(core::GlobalState &gs, vector<SymbolFinderResult> allFoundDefinitions, WorkerPool &workers,
+              UnorderedMap<core::FileRef, core::FoundMethodHashes> &&oldFoundMethodHashesForFiles,
+              core::FoundMethodHashes *foundMethodHashesOut) {
     Timer timeit(gs.tracer(), "naming.defineSymbols");
     vector<ast::ParsedFile> output;
     output.reserve(allFoundDefinitions.size());
@@ -1879,8 +1955,12 @@ ast::ParsedFilesOrCancelled defineSymbols(core::GlobalState &gs, vector<SymbolFi
             }
             return ast::ParsedFilesOrCancelled::cancel(move(output), workers);
         }
-        core::MutableContext ctx(gs, core::Symbols::root(), fileFoundDefinitions.tree.file);
-        SymbolDefiner symbolDefiner(move(fileFoundDefinitions.names));
+        auto fref = fileFoundDefinitions.tree.file;
+        core::MutableContext ctx(gs, core::Symbols::root(), fref);
+        auto oldFoundMethodHashes = oldFoundMethodHashesForFiles.find(fref) == oldFoundMethodHashesForFiles.end()
+                                        ? optional<core::FoundMethodHashes>()
+                                        : std::move(oldFoundMethodHashesForFiles[fref]);
+        SymbolDefiner symbolDefiner(move(fileFoundDefinitions.names), move(oldFoundMethodHashes));
         output.emplace_back(move(fileFoundDefinitions.tree));
         symbolDefiner.run(ctx);
         if (foundMethodHashesOut != nullptr) {
@@ -2021,7 +2101,36 @@ ast::ParsedFilesOrCancelled Namer::run(core::GlobalState &gs, vector<ast::Parsed
         ENFORCE(foundDefs.size() == 1,
                 "Producing foundMethodHashes is meant to only happen when hashing a single file");
     }
-    auto result = defineSymbols(gs, move(foundDefs), workers, foundMethodHashesOut);
+    // There were no old FoundMethodHashes; just defineSymbols like normal.
+    auto oldFoundMethodHashesForFiles = UnorderedMap<core::FileRef, core::FoundMethodHashes>{};
+    auto result =
+        defineSymbols(gs, move(foundDefs), workers, std::move(oldFoundMethodHashesForFiles), foundMethodHashesOut);
+    if (!result.hasResult()) {
+        return result;
+    }
+    auto bestEffort = false;
+    trees = symbolizeTrees(gs, move(result.result()), workers, bestEffort);
+    return trees;
+}
+
+ast::ParsedFilesOrCancelled
+Namer::runIncremental(core::GlobalState &gs, std::vector<ast::ParsedFile> trees,
+                      UnorderedMap<core::FileRef, core::FoundMethodHashes> &&oldFoundMethodHashesForFiles,
+                      WorkerPool &workers) {
+    // TODO(jez) Clever way to de-dup this with Namer::run ?
+    auto foundDefs = findSymbols(gs, move(trees), workers);
+    if (gs.epochManager->wasTypecheckingCanceled()) {
+        trees.reserve(foundDefs.size());
+        for (auto &def : foundDefs) {
+            trees.emplace_back(move(def.tree));
+        }
+        return ast::ParsedFilesOrCancelled::cancel(move(trees), workers);
+    }
+
+    // We should never be combining Namer::runIncremental with the namer call that produces FileHashes
+    auto foundMethodHashesOut = nullptr;
+    auto result =
+        defineSymbols(gs, move(foundDefs), workers, std::move(oldFoundMethodHashesForFiles), foundMethodHashesOut);
     if (!result.hasResult()) {
         return result;
     }

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -857,6 +857,19 @@ class SymbolDefiner {
 
     core::MethodRef insertMethod(core::MutableContext ctx, const core::FoundMethod &method) {
         auto symbol = defineMethod(ctx, method);
+        if (!ctx.state.lspExperimentalFastPathEnabled) {
+            auto name = symbol.data(ctx)->name;
+            if (name.kind() == core::NameKind::UNIQUE &&
+                name.dataUnique(ctx)->uniqueNameKind == core::UniqueNameKind::MangleRenameOverload) {
+                // These name kinds are only created in resolver, which means that we must be running on
+                // the fast path with an existing GlobalState.
+                // When modifyMethod is called later, it won't be able to find the correct method entry.
+                // Let's leave the method visibility what it was.
+                // TODO(jez) After #5808 lands, can we delete this check?
+                return symbol;
+            }
+        }
+
         auto implicitlyPrivate = ctx.owner.enclosingClass(ctx) == core::Symbols::root();
         if (implicitlyPrivate) {
             // Methods defined at the top level default to private (on Object)

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1192,14 +1192,14 @@ class SymbolDefiner {
     }
 
     void deleteViaFullNameHash(core::MutableContext ctx, const core::FoundMethodHash &oldDefHash) {
-        auto ownerRef = core::FoundDefinitionRef(core::FoundDefinitionRef::Kind::Class, oldDefHash.ownerIdx);
+        auto ownerRef = core::FoundDefinitionRef(core::FoundDefinitionRef::Kind::Class, oldDefHash.owner.idx);
         ENFORCE(oldDefHash.nameHash.isDefined(), "Can't delete rename if old hash is not defined");
 
         // Because a change to classes would have take the slow path, should be safe
         // to look up old owner in current foundDefs.
         auto ownerSymbol = getOwnerSymbol(ownerRef);
         ENFORCE(ownerSymbol.isClassOrModule());
-        auto owner = methodOwner(ctx, ownerSymbol, oldDefHash.isSelfMethod);
+        auto owner = methodOwner(ctx, ownerSymbol, oldDefHash.owner.useSingletonClass);
 
         // We have to accumulate a list of methods to delete, instead of deleting them in the loop
         // below, because deleteing a method invalidates the members() iterator.
@@ -1295,7 +1295,7 @@ public:
         for (const auto &method : foundDefs.methods()) {
             auto owner = method.owner;
             auto fullNameHash = core::FullNameHash(ctx, method.name);
-            foundMethodHashesOut.emplace_back(owner.idx(), fullNameHash, method.arityHash, method.flags.isSelfMethod);
+            foundMethodHashesOut.emplace_back(owner.idx(), method.flags.isSelfMethod, fullNameHash, method.arityHash);
         }
     }
 };

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1258,7 +1258,7 @@ public:
             defineNonMethodSingle(ctx, ref);
         }
 
-        // TODO(jez) This currently interleaves deleting and defining across files.
+        // This currently interleaves deleting and defining across files.
         // It's possible that this causes problems at some point? Though I haven't found a test case.
         // That being said, if it does cause problems, we should be able to not interleave, and have
         // all the `nonMethodDefinitions` from all files get defined, then delete all the old
@@ -1274,8 +1274,9 @@ public:
 
         for (auto &method : foundDefs.methods()) {
             if (method.arityHash.isAliasMethod()) {
-                // TODO(jez) Update this comment on the fast path namer branch
-                // alias methods will be defined in resolver.
+                // We need alias methods in the FoundDefinitions list not so that we can actually
+                // create method symbols for them yet, but just so we can know which alias methods
+                // to delete on the fast path. Alias methods will be defined later, in resolver.
                 continue;
             }
             definedMethods.emplace_back(insertMethod(ctx.withOwner(getOwnerSymbol(method.owner)), method));

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1939,9 +1939,10 @@ defineSymbols(core::GlobalState &gs, vector<SymbolFinderResult> allFoundDefiniti
         }
         auto fref = fileFoundDefinitions.tree.file;
         core::MutableContext ctx(gs, core::Symbols::root(), fref);
-        auto oldFoundMethodHashes = oldFoundMethodHashesForFiles.find(fref) == oldFoundMethodHashesForFiles.end()
-                                        ? optional<core::FoundMethodHashes>()
-                                        : std::move(oldFoundMethodHashesForFiles[fref]);
+
+        auto frefIt = oldFoundMethodHashesForFiles.find(fref);
+        auto oldFoundMethodHashes = frefIt == oldFoundMethodHashesForFiles.end() ? optional<core::FoundMethodHashes>()
+                                                                                 : std::move(frefIt->second);
         SymbolDefiner symbolDefiner(move(fileFoundDefinitions.names), move(oldFoundMethodHashes));
         output.emplace_back(move(fileFoundDefinitions.tree));
         symbolDefiner.run(ctx);

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1202,7 +1202,7 @@ class SymbolDefiner {
         auto owner = methodOwner(ctx, ownerSymbol, oldDefHash.owner.useSingletonClass);
 
         // We have to accumulate a list of methods to delete, instead of deleting them in the loop
-        // below, because deleteing a method invalidates the members() iterator.
+        // below, because deleting a method invalidates the members() iterator.
         vector<core::MethodRef> toDelete;
 
         // Note: this loop is accidentally quadratic. We run deleteViaFullNameHash once per method
@@ -1292,6 +1292,8 @@ public:
     }
 
     void populateFoundMethodHashes(core::Context ctx, core::FoundMethodHashes &foundMethodHashesOut) {
+        ENFORCE(foundMethodHashesOut.empty());
+        foundMethodHashesOut.reserve(foundDefs.methods().size());
         for (const auto &method : foundDefs.methods()) {
             auto owner = method.owner;
             auto fullNameHash = core::FullNameHash(ctx, method.name);

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1239,8 +1239,6 @@ class SymbolDefiner {
         // different method with the same name took its place (that other method might not have been deleted,
         // but if it was, we'll get to delete it on some future iteration.)
         for (auto oldMethod : toDelete) {
-            // TODO(jez) Double check that if you end up removing all references in all files on a
-            // fast path, that the method does in fact get deleted.
             oldMethod.data(ctx)->removeLocsForFile(ctx.file);
             if (oldMethod.data(ctx)->locs().empty()) {
                 ctx.state.deleteMethodSymbol(oldMethod);

--- a/namer/namer.h
+++ b/namer/namer.h
@@ -23,6 +23,19 @@ public:
     static ast::ParsedFilesOrCancelled run(core::GlobalState &gs, std::vector<ast::ParsedFile> trees,
                                            WorkerPool &workers, core::FoundMethodHashes *foundMethodHashesOut);
 
+    // Version of Namer that accepts the old FoundMethodHashes for each file to run Namer, which
+    // it uses to figure out how to mutate the already-populated GlobalState into the right shape
+    // when considering that only the files in `trees` were edited.
+    //
+    // `trees` and `foundMethodHashesForFiles` should have the same number of elements, and
+    // `foundMethodHashesForFiles[i]` should be the `FoundMethodHashes` for `trees[i]`.
+    // (Done this way, instead of using something like a `std::pair`, to avoid intermidiate
+    // allocations for phases that don't actually need to operate on the `FoundMethodHashes`.)
+    static ast::ParsedFilesOrCancelled
+    runIncremental(core::GlobalState &gs, std::vector<ast::ParsedFile> trees,
+                   UnorderedMap<core::FileRef, core::FoundMethodHashes> &&oldFoundMethodHashesForFiles,
+                   WorkerPool &workers);
+
     Namer() = delete;
 };
 

--- a/namer/namer.h
+++ b/namer/namer.h
@@ -1,6 +1,7 @@
 #ifndef SORBET_NAMER_NAMER_H
 #define SORBET_NAMER_NAMER_H
 #include "ast/ast.h"
+#include "core/FileHash.h"
 #include <memory>
 
 namespace sorbet {
@@ -13,8 +14,14 @@ class Namer final {
 public:
     static ast::ParsedFilesOrCancelled
     symbolizeTreesBestEffort(const core::GlobalState &gs, std::vector<ast::ParsedFile> trees, WorkerPool &workers);
+
+    // Note: foundMethodHashes is an optional out parameter.
+    //
+    // Setting it to a non-nullptr requests that Namer compute a fingerprint of the FoundDefinitions
+    // it found while running. (Thus, it's usually nullptr except when pipeline::resolve is called
+    // for the purpose of computing a FileHash.)
     static ast::ParsedFilesOrCancelled run(core::GlobalState &gs, std::vector<ast::ParsedFile> trees,
-                                           WorkerPool &workers);
+                                           WorkerPool &workers, core::FoundMethodHashes *foundMethodHashesOut);
 
     Namer() = delete;
 };

--- a/namer/namer.h
+++ b/namer/namer.h
@@ -34,7 +34,7 @@ public:
     //
     // `trees` and `foundMethodHashesForFiles` should have the same number of elements, and
     // `foundMethodHashesForFiles[i]` should be the `FoundMethodHashes` for `trees[i]`.
-    // (Done this way, instead of using something like a `std::pair`, to avoid intermidiate
+    // (Done this way, instead of using something like a `std::pair`, to avoid intermediate
     // allocations for phases that don't actually need to operate on the `FoundMethodHashes`.)
     static ast::ParsedFilesOrCancelled
     runIncremental(core::GlobalState &gs, std::vector<ast::ParsedFile> trees,

--- a/namer/namer.h
+++ b/namer/namer.h
@@ -11,6 +11,11 @@ class WorkerPool;
 namespace sorbet::namer {
 
 class Namer final {
+    static ast::ParsedFilesOrCancelled
+    runInternal(core::GlobalState &gs, std::vector<ast::ParsedFile> trees, WorkerPool &workers,
+                UnorderedMap<core::FileRef, core::FoundMethodHashes> &&oldFoundMethodHashesForFiles,
+                core::FoundMethodHashes *foundMethodHashesOut);
+
 public:
     static ast::ParsedFilesOrCancelled
     symbolizeTreesBestEffort(const core::GlobalState &gs, std::vector<ast::ParsedFile> trees, WorkerPool &workers);

--- a/namer/test/namer_test.cc
+++ b/namer/test/namer_test.cc
@@ -47,7 +47,8 @@ vector<ast::ParsedFile> runNamer(core::GlobalState &gs, ast::ParsedFile tree) {
     vector<ast::ParsedFile> v;
     v.emplace_back(move(tree));
     auto workers = WorkerPool::create(0, *logger);
-    return move(namer::Namer::run(gs, move(v), *workers).result());
+    core::FoundMethodHashes foundMethodHashes; // compute this just for test coverage
+    return move(namer::Namer::run(gs, move(v), *workers, &foundMethodHashes).result());
 }
 
 } // namespace

--- a/test/lsp/ProtocolTest.cc
+++ b/test/lsp/ProtocolTest.cc
@@ -34,6 +34,7 @@ void ProtocolTest::resetState(std::shared_ptr<realmain::options::Options> opts) 
         }
         opts->cacheDir = cacheDir;
     }
+    opts->lspExperimentalFastPathEnabled = true;
 
     if (useMultithreading) {
         lspWrapper = MultiThreadedLSPWrapper::create(rootPath, opts);

--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -531,6 +531,7 @@ TEST_CASE("LSPTest") {
         }
         opts->disableWatchman = true;
         opts->rubyfmtPath = "test/testdata/lsp/rubyfmt-stub/rubyfmt";
+        opts->lspExperimentalFastPathEnabled = true;
 
         if (haveStaleUpdates) {
             opts->lspStaleStateEnabled = true;

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -478,7 +478,8 @@ TEST_CASE("PerPhaseTest") { // NOLINT
             {
                 core::UnfreezeNameTable nameTableAccess(*rbiGenGs);     // creates singletons and class names
                 core::UnfreezeSymbolTable symbolTableAccess(*rbiGenGs); // enters symbols
-                trees = move(namer::Namer::run(*rbiGenGs, move(trees), *workers).result());
+                auto foundMethodHashes = nullptr;
+                trees = move(namer::Namer::run(*rbiGenGs, move(trees), *workers, foundMethodHashes).result());
             }
 
             // Resolver
@@ -515,7 +516,8 @@ TEST_CASE("PerPhaseTest") { // NOLINT
             core::UnfreezeSymbolTable symbolTableAccess(*gs); // enters symbols
             vector<ast::ParsedFile> vTmp;
             vTmp.emplace_back(move(tree));
-            vTmp = move(namer::Namer::run(*gs, move(vTmp), *workers).result());
+            core::FoundMethodHashes foundMethodHashes; // compute this just for test coverage
+            vTmp = move(namer::Namer::run(*gs, move(vTmp), *workers, &foundMethodHashes).result());
             namedTree = testSerialize(*gs, move(vTmp[0]));
         }
 
@@ -838,7 +840,8 @@ TEST_CASE("PerPhaseTest") { // NOLINT
             core::UnfreezeSymbolTable symbolTableAccess(*gs);
             vector<ast::ParsedFile> vTmp;
             vTmp.emplace_back(move(tree));
-            vTmp = move(namer::Namer::run(*gs, move(vTmp), *workers).result());
+            core::FoundMethodHashes foundMethodHashes; // compute this just for test coverage
+            vTmp = move(namer::Namer::run(*gs, move(vTmp), *workers, &foundMethodHashes).result());
             tree = testSerialize(*gs, move(vTmp[0]));
 
             handler.addObserved(*gs, "name-tree", [&]() { return tree.tree.toString(*gs); });

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -840,7 +840,13 @@ TEST_CASE("PerPhaseTest") { // NOLINT
             core::UnfreezeSymbolTable symbolTableAccess(*gs);
             vector<ast::ParsedFile> vTmp;
             vTmp.emplace_back(move(tree));
-            core::FoundMethodHashes foundMethodHashes; // compute this just for test coverage
+            core::FoundMethodHashes foundMethodHashes; // out param, compute this just for test coverage
+            // The lsp_test_runner will turn every testdata test into a test of
+            // Namer::runIncremental by way of creating a file update with leading whitespace.
+            //
+            // Here, to complement those tests, we just run Namer::run (not Namer::runIncremental)
+            // to stress the codepath where Namer is not tasked with deleting anything when run for
+            // the fast path.
             vTmp = move(namer::Namer::run(*gs, move(vTmp), *workers, &foundMethodHashes).result());
             tree = testSerialize(*gs, move(vTmp[0]));
 

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -236,6 +236,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
     }
 
     gs->censorForSnapshotTests = true;
+    gs->lspExperimentalFastPathEnabled = true;
     auto workers = WorkerPool::create(0, gs->tracer());
 
     auto assertions = RangeAssertion::parseAssertions(test.sourceFileContents);

--- a/test/testdata/lsp/fast_path/alias_method.1.rbupdate
+++ b/test/testdata/lsp/fast_path/alias_method.1.rbupdate
@@ -1,0 +1,8 @@
+# typed: true
+# assert-fast-path: alias_method.rb
+
+class A
+  def pai; end
+
+  alias_method :paid?, :paid # error: Can't make method alias from `paid?` to non existing method `paid`
+end

--- a/test/testdata/lsp/fast_path/alias_method.2.rbupdate
+++ b/test/testdata/lsp/fast_path/alias_method.2.rbupdate
@@ -1,0 +1,8 @@
+# typed: true
+# assert-fast-path: alias_method.rb
+
+class A
+  def paid; end
+
+  alias_method :paid?, :paid
+end

--- a/test/testdata/lsp/fast_path/alias_method.rb
+++ b/test/testdata/lsp/fast_path/alias_method.rb
@@ -1,0 +1,7 @@
+# typed: true
+
+class A
+  def paid; end
+
+  alias_method :paid?, :paid
+end

--- a/test/testdata/lsp/fast_path/alias_method_chain.1.rbupdate
+++ b/test/testdata/lsp/fast_path/alias_method_chain.1.rbupdate
@@ -1,0 +1,9 @@
+# typed: true
+
+class A
+  def target; end
+
+  alias_method :inne, :target
+
+  alias_method :outer, :inner # error: Can't make method alias from `outer` to non existing method `inner`
+end

--- a/test/testdata/lsp/fast_path/alias_method_chain.2.rbupdate
+++ b/test/testdata/lsp/fast_path/alias_method_chain.2.rbupdate
@@ -1,0 +1,9 @@
+# typed: true
+
+class A
+  def target; end
+
+  alias_method :inner, :targe # error: Can't make method alias from `inner` to non existing method `targe`
+
+  alias_method :outer, :inner
+end

--- a/test/testdata/lsp/fast_path/alias_method_chain.rb
+++ b/test/testdata/lsp/fast_path/alias_method_chain.rb
@@ -1,0 +1,9 @@
+# typed: true
+
+class A
+  def target; end
+
+  alias_method :inner, :target
+
+  alias_method :outer, :inner
+end

--- a/test/testdata/lsp/fast_path/alias_method_change_type__1.1.rbupdate
+++ b/test/testdata/lsp/fast_path/alias_method_change_type__1.1.rbupdate
@@ -1,5 +1,5 @@
 # typed: true
-# assert-fast-path: alias_method_change_type__1.rb
+# assert-fast-path: alias_method_change_type__1.rb,alias_method_change_type__2.rb
 
 class A
   extend T::Sig

--- a/test/testdata/lsp/fast_path/alias_redefined_multi_file__1.1.rbupdate
+++ b/test/testdata/lsp/fast_path/alias_redefined_multi_file__1.1.rbupdate
@@ -1,0 +1,12 @@
+# typed: true
+# spacer for exclude from file update
+# assert-fast-path: alias_redefined_multi_file__1.rb,alias_redefined_multi_file__2.rb
+
+class A
+  def to_method_new; end
+end
+
+A.new.to_method # error: Method `to_method` does not exist on `A`
+A.new.to_method_new
+A.new.from_method
+A.new.from_method_new # error: Method `from_method_new` does not exist on `A`

--- a/test/testdata/lsp/fast_path/alias_redefined_multi_file__1.2.rbupdate
+++ b/test/testdata/lsp/fast_path/alias_redefined_multi_file__1.2.rbupdate
@@ -1,0 +1,12 @@
+# typed: true
+# exclude-from-file-update: true
+# assert-fast-path: alias_redefined_multi_file__1.rb,alias_redefined_multi_file__2.rb
+
+class A
+  def to_method_new; end
+end
+
+A.new.to_method # error: Method `to_method` does not exist on `A`
+A.new.to_method_new
+A.new.from_method
+A.new.from_method_new # error: Method `from_method_new` does not exist on `A`

--- a/test/testdata/lsp/fast_path/alias_redefined_multi_file__1.3.rbupdate
+++ b/test/testdata/lsp/fast_path/alias_redefined_multi_file__1.3.rbupdate
@@ -1,0 +1,12 @@
+# typed: true
+# exclude-from-file-update: true
+# assert-fast-path: alias_redefined_multi_file__1.rb,alias_redefined_multi_file__2.rb
+
+class A
+  def to_method_new; end
+end
+
+A.new.to_method # error: Method `to_method` does not exist on `A`
+A.new.to_method_new
+A.new.from_method # error: Method `from_method` does not exist on `A`
+A.new.from_method_new

--- a/test/testdata/lsp/fast_path/alias_redefined_multi_file__1.rb
+++ b/test/testdata/lsp/fast_path/alias_redefined_multi_file__1.rb
@@ -1,0 +1,12 @@
+# typed: true
+# spacer for exclude from file update
+# spacer for assert fast path
+
+class A
+  def to_method; end
+end
+
+A.new.to_method
+A.new.to_method_new # error: Method `to_method_new` does not exist on `A`
+A.new.from_method
+A.new.from_method_new # error: Method `from_method_new` does not exist on `A`

--- a/test/testdata/lsp/fast_path/alias_redefined_multi_file__2.1.rbupdate
+++ b/test/testdata/lsp/fast_path/alias_redefined_multi_file__2.1.rbupdate
@@ -1,0 +1,11 @@
+# typed: true
+# exclude-from-file-update: true
+
+class A
+  alias_method :from_method, :to_method # error: Can't make method alias from `from_method` to non existing method `to_method`
+end
+
+A.new.to_method # error: Method `to_method` does not exist on `A`
+A.new.to_method_new
+A.new.from_method
+A.new.from_method_new # error: Method `from_method_new` does not exist on `A`

--- a/test/testdata/lsp/fast_path/alias_redefined_multi_file__2.2.rbupdate
+++ b/test/testdata/lsp/fast_path/alias_redefined_multi_file__2.2.rbupdate
@@ -1,0 +1,11 @@
+# typed: true
+# spacer for exclude from file update
+
+class A
+  alias_method :from_method, :to_method_new
+end
+
+A.new.to_method # error: Method `to_method` does not exist on `A`
+A.new.to_method_new
+A.new.from_method
+A.new.from_method_new # error: Method `from_method_new` does not exist on `A`

--- a/test/testdata/lsp/fast_path/alias_redefined_multi_file__2.3.rbupdate
+++ b/test/testdata/lsp/fast_path/alias_redefined_multi_file__2.3.rbupdate
@@ -1,0 +1,11 @@
+# typed: true
+# spacer for exclude from file update
+
+class A
+  alias_method :from_method_new, :to_method_new
+end
+
+A.new.to_method # error: Method `to_method` does not exist on `A`
+A.new.to_method_new
+A.new.from_method # error: Method `from_method` does not exist on `A`
+A.new.from_method_new

--- a/test/testdata/lsp/fast_path/alias_redefined_multi_file__2.rb
+++ b/test/testdata/lsp/fast_path/alias_redefined_multi_file__2.rb
@@ -1,0 +1,11 @@
+# typed: true
+# spacer for exclude from file update
+
+class A
+  alias_method :from_method, :to_method
+end
+
+A.new.to_method
+A.new.to_method_new # error: Method `to_method_new` does not exist on `A`
+A.new.from_method
+A.new.from_method_new # error: Method `from_method_new` does not exist on `A`

--- a/test/testdata/lsp/fast_path/alias_to_nothing__1.1.rbupdate
+++ b/test/testdata/lsp/fast_path/alias_to_nothing__1.1.rbupdate
@@ -1,0 +1,11 @@
+# typed: true
+# assert-fast-path: alias_to_nothing__1.rb,alias_to_nothing__2.rb,alias_to_nothing__3.rb
+# Spacer to allow for exclude from file update assertion
+
+class A
+  extend T::Sig
+  sig {returns(String)}
+  def to_method_new
+    ''
+  end
+end

--- a/test/testdata/lsp/fast_path/alias_to_nothing__1.2.rbupdate
+++ b/test/testdata/lsp/fast_path/alias_to_nothing__1.2.rbupdate
@@ -1,0 +1,11 @@
+# typed: true
+# assert-fast-path: alias_to_nothing__2.rb,alias_to_nothing__3.rb
+# exclude-from-file-update: true
+
+class A
+  extend T::Sig
+  sig {returns(String)}
+  def to_method_new
+    ''
+  end
+end

--- a/test/testdata/lsp/fast_path/alias_to_nothing__1.rb
+++ b/test/testdata/lsp/fast_path/alias_to_nothing__1.rb
@@ -1,0 +1,11 @@
+# typed: true
+# Spacer for assert fast path
+# Spacer to allow for exclude from file update assertion
+
+class A
+  extend T::Sig
+  sig {returns(Integer)}
+  def to_method
+    0
+  end
+end

--- a/test/testdata/lsp/fast_path/alias_to_nothing__2.1.rbupdate
+++ b/test/testdata/lsp/fast_path/alias_to_nothing__2.1.rbupdate
@@ -1,0 +1,6 @@
+# typed: true
+# exclude-from-file-update: true
+
+class A
+  alias_method :from_method, :to_method # error: Can't make method alias from `from_method` to non existing method `to_method`
+end

--- a/test/testdata/lsp/fast_path/alias_to_nothing__2.2.rbupdate
+++ b/test/testdata/lsp/fast_path/alias_to_nothing__2.2.rbupdate
@@ -1,0 +1,6 @@
+# typed: true
+# Spacer to allow for exclude from file update assertion
+
+class A
+  alias_method :from_method, :to_method_new
+end

--- a/test/testdata/lsp/fast_path/alias_to_nothing__2.rb
+++ b/test/testdata/lsp/fast_path/alias_to_nothing__2.rb
@@ -1,0 +1,6 @@
+# typed: true
+# Spacer to allow for exclude from file update assertion
+
+class A
+  alias_method :from_method, :to_method
+end

--- a/test/testdata/lsp/fast_path/alias_to_nothing__3.1.rbupdate
+++ b/test/testdata/lsp/fast_path/alias_to_nothing__3.1.rbupdate
@@ -1,0 +1,9 @@
+# typed: true
+# exclude-from-file-update: true
+
+A.new.from_method
+A.new.from_method_new # error: Method `from_method_new` does not exist on `A`
+A.new.to_method # error: Method `to_method` does not exist on `A`
+A.new.to_method_new
+
+T.reveal_type(A.new.from_method) # error: `T.untyped`

--- a/test/testdata/lsp/fast_path/alias_to_nothing__3.2.rbupdate
+++ b/test/testdata/lsp/fast_path/alias_to_nothing__3.2.rbupdate
@@ -1,0 +1,9 @@
+# typed: true
+# exclude-from-file-update: true
+
+A.new.from_method
+A.new.from_method_new # error: Method `from_method_new` does not exist on `A`
+A.new.to_method # error: Method `to_method` does not exist on `A`
+A.new.to_method_new
+
+T.reveal_type(A.new.from_method) # error: `String`

--- a/test/testdata/lsp/fast_path/alias_to_nothing__3.rb
+++ b/test/testdata/lsp/fast_path/alias_to_nothing__3.rb
@@ -1,0 +1,9 @@
+# typed: true
+# Spacer to allow for exclude from file update assertion
+
+A.new.from_method
+A.new.from_method_new # error: Method `from_method_new` does not exist on `A`
+A.new.to_method
+A.new.to_method_new # error: Method `to_method_new` does not exist on `A`
+
+T.reveal_type(A.new.from_method) # error: `Integer`

--- a/test/testdata/lsp/fast_path/class_add_method.1.rbupdate
+++ b/test/testdata/lsp/fast_path/class_add_method.1.rbupdate
@@ -1,5 +1,5 @@
 # typed: true
-# assert-slow-path: true
+# assert-fast-path: class_add_method.rb
 
 class A extend T::Sig
   sig {params(x: Integer).returns(String)}

--- a/test/testdata/lsp/fast_path/class_remove_method.1.rbupdate
+++ b/test/testdata/lsp/fast_path/class_remove_method.1.rbupdate
@@ -1,5 +1,5 @@
 # typed: true
-# assert-slow-path: true
+# assert-fast-path: class_remove_method.rb
 
 class A extend T::Sig
   sig {params(x: Integer).returns(String)}

--- a/test/testdata/lsp/fast_path/method_add_argument.1.rbupdate
+++ b/test/testdata/lsp/fast_path/method_add_argument.1.rbupdate
@@ -1,5 +1,5 @@
 # typed: true
-# assert-slow-path: true
+# assert-fast-path: method_add_argument.rb
 
 class A extend T::Sig
   sig {params(x: Integer, y: Integer).returns(String)}

--- a/test/testdata/lsp/fast_path/method_add_argument.2.rbupdate
+++ b/test/testdata/lsp/fast_path/method_add_argument.2.rbupdate
@@ -1,0 +1,15 @@
+# typed: true
+# assert-fast-path: method_add_argument.rb
+
+class A extend T::Sig
+  sig {params(x: Integer, y: Integer).returns(String)} # error: Unknown argument name `y`
+  def bar(x)
+    res = x.to_s
+    puts(y) # error: Method `y` does not exist on `A`
+    res
+  end
+end
+
+A.new.bar # error: Expected: `1`, got: `0`
+A.new.bar(0)
+A.new.bar(0, 0) # error: Expected: `1`, got: `2`

--- a/test/testdata/lsp/fast_path/method_add_keyword_arg.1.rbupdate
+++ b/test/testdata/lsp/fast_path/method_add_keyword_arg.1.rbupdate
@@ -1,5 +1,5 @@
 # typed: true
-# assert-slow-path: true
+# assert-fast-path: method_add_keyword_arg.rb
 
 class A extend T::Sig
   sig {params(x: Integer, y: Integer).returns(String)}

--- a/test/testdata/lsp/fast_path/method_add_sig.1.rbupdate
+++ b/test/testdata/lsp/fast_path/method_add_sig.1.rbupdate
@@ -1,5 +1,5 @@
 # typed: true
-# assert-slow-path: true
+# assert-fast-path: method_add_sig.rb
 
 class A extend T::Sig
   sig {params(x: Integer).returns(String)}

--- a/test/testdata/lsp/fast_path/method_change_argument_kind.1.rbupdate
+++ b/test/testdata/lsp/fast_path/method_change_argument_kind.1.rbupdate
@@ -1,5 +1,5 @@
 # typed: true
-# assert-slow-path: true
+# assert-fast-path: method_change_argument_kind.rb
 
 class A extend T::Sig
   sig {params(x: Integer).returns(String)}

--- a/test/testdata/lsp/fast_path/method_change_kw_arg_name.1.rbupdate
+++ b/test/testdata/lsp/fast_path/method_change_kw_arg_name.1.rbupdate
@@ -1,5 +1,5 @@
 # typed: true
-# assert-slow-path: true
+# assert-fast-path: method_change_kw_arg_name.rb
 
 class A extend T::Sig
   sig {params(y: Integer).returns(String)}

--- a/test/testdata/lsp/fast_path/method_redefined_multi_file__1.1.rbupdate
+++ b/test/testdata/lsp/fast_path/method_redefined_multi_file__1.1.rbupdate
@@ -1,0 +1,8 @@
+# typed: true
+# assert-fast-path: method_redefined_multi_file__1.rb,method_redefined_multi_file__2.rb
+
+class A
+  def foo(x) # error: Method `A#foo` redefined without matching argument count. Expected: `0`, got: `1`
+    x
+  end
+end

--- a/test/testdata/lsp/fast_path/method_redefined_multi_file__1.rb
+++ b/test/testdata/lsp/fast_path/method_redefined_multi_file__1.rb
@@ -1,0 +1,7 @@
+# typed: true
+
+class A
+  def foo
+    x # error: Method `x` does not exist on `A`
+  end
+end

--- a/test/testdata/lsp/fast_path/method_redefined_multi_file__2.1.rbupdate
+++ b/test/testdata/lsp/fast_path/method_redefined_multi_file__2.1.rbupdate
@@ -1,0 +1,9 @@
+# typed: true
+# exclude-from-file-update: true
+
+# -- imagine that this file were an RBI --
+
+class A
+  def foo # error: Method `A#foo` redefined without matching argument count. Expected: `1`, got: `0`
+  end
+end

--- a/test/testdata/lsp/fast_path/method_redefined_multi_file__2.rb
+++ b/test/testdata/lsp/fast_path/method_redefined_multi_file__2.rb
@@ -1,0 +1,9 @@
+# typed: true
+# spacer for exclude from file update
+
+# -- imagine that this file were an RBI --
+
+class A
+  def foo
+  end
+end

--- a/test/testdata/lsp/fast_path/more_arguments.1.rbupdate
+++ b/test/testdata/lsp/fast_path/more_arguments.1.rbupdate
@@ -1,5 +1,5 @@
 # typed: true
-# assert-slow-path: true
+# assert-fast-path: more_arguments.rb
 
 class Foo
   extend T::Sig

--- a/test/testdata/lsp/fast_path/multi_file_deletion__1.1.rbupdate
+++ b/test/testdata/lsp/fast_path/multi_file_deletion__1.1.rbupdate
@@ -1,0 +1,7 @@
+# typed: true
+# assert-fast-path: multi_file_deletion__1.rb,multi_file_deletion__2.rb
+
+class A
+end
+
+A.new.foo # error: Method `foo` does not exist on `A`

--- a/test/testdata/lsp/fast_path/multi_file_deletion__1.rb
+++ b/test/testdata/lsp/fast_path/multi_file_deletion__1.rb
@@ -1,0 +1,7 @@
+# typed: true
+
+class A
+  def foo; end
+end
+
+A.new.foo

--- a/test/testdata/lsp/fast_path/multi_file_deletion__2.1.rbupdate
+++ b/test/testdata/lsp/fast_path/multi_file_deletion__2.1.rbupdate
@@ -1,0 +1,7 @@
+# typed: true
+# assert-fast-path: multi_file_deletion__1.rb,multi_file_deletion__2.rb
+
+class A
+end
+
+A.new.foo # error: Method `foo` does not exist on `A`

--- a/test/testdata/lsp/fast_path/multi_file_deletion__2.rb
+++ b/test/testdata/lsp/fast_path/multi_file_deletion__2.rb
@@ -1,0 +1,7 @@
+# typed: true
+
+class A
+  def foo; end
+end
+
+A.new.foo

--- a/test/testdata/lsp/fast_path/overloads_test.1.rbupdate
+++ b/test/testdata/lsp/fast_path/overloads_test.1.rbupdate
@@ -1,4 +1,5 @@
 # typed: true
+# assert-fast-path: overloads_test.rb
 
 class A
   extend T::Sig

--- a/test/testdata/lsp/fast_path/rename_singleton_method.1.rbupdate
+++ b/test/testdata/lsp/fast_path/rename_singleton_method.1.rbupdate
@@ -1,0 +1,10 @@
+# typed: true
+# assert-fast-path: rename_singleton_method.rb
+
+class A
+  def self.bar
+  end
+end
+
+A.foo # error: Method `foo` does not exist on `T.class_of(A)`
+A.bar

--- a/test/testdata/lsp/fast_path/rename_singleton_method.rb
+++ b/test/testdata/lsp/fast_path/rename_singleton_method.rb
@@ -1,0 +1,9 @@
+# typed: true
+
+class A
+  def self.foo
+  end
+end
+
+A.foo
+A.bar # error: Method `bar` does not exist on `T.class_of(A)`

--- a/test/testdata/lsp/fast_path/simple_hover.1.rbupdate
+++ b/test/testdata/lsp/fast_path/simple_hover.1.rbupdate
@@ -1,5 +1,5 @@
 # typed: true
-# assert-slow-path: true
+# assert-fast-path: simple_hover.rb
 
 class Foo
   extend T::Sig

--- a/test/testdata/lsp/sig_deletion.1.rbupdate
+++ b/test/testdata/lsp/sig_deletion.1.rbupdate
@@ -1,5 +1,5 @@
 # typed: true
-# assert-slow-path: true
+# assert-fast-path: sig_deletion.rb
 class Foo
   extend T::Sig
 

--- a/test/testdata/namer/redefinition_method.1.rbupdate
+++ b/test/testdata/namer/redefinition_method.1.rbupdate
@@ -1,0 +1,16 @@
+# typed: true
+# assert-fast-path: redefinition_method.rb
+class Main
+    extend T::Sig
+
+    sig {params(a: Integer).returns(Integer)}
+    def foo(a)
+        a
+    end
+
+    def foo(a, b, c) # error: Method `Main#foo` redefined without matching argument count. Expected: `1`, got: `3`
+    end
+
+    def foo(a, b) # error: Method `Main#foo` redefined without matching argument count. Expected: `3`, got: `2`
+    end
+end

--- a/test/testdata/namer/redefinition_method.rb
+++ b/test/testdata/namer/redefinition_method.rb
@@ -7,9 +7,9 @@ class Main
         a
     end
 
-    def foo(a, b) # error: redefined
+    def foo(a, b) # error: Method `Main#foo` redefined without matching argument count. Expected: `1`, got: `2`
     end
 
-    def foo(a, b, c) # error: redefined
+    def foo(a, b, c) # error: Method `Main#foo` redefined without matching argument count. Expected: `2`, got: `3`
     end
 end

--- a/test/testdata/resolver/redefined_and_overloaded/overloads_test.1.rbupdate
+++ b/test/testdata/resolver/redefined_and_overloaded/overloads_test.1.rbupdate
@@ -1,0 +1,26 @@
+# typed: true
+# assert-fast-path: overloads_test.rb
+
+class A
+  extend T::Sig
+
+  sig {params(x: Integer).void}
+  sig {params(x: Integer, y: String).void}
+  def self.example(x, y='')
+  end
+
+  sig {params(x: Integer).void}
+  sig {params(x: Integer, y: String).void}
+  sig {params(x: Integer, y: String, z: Float).void}
+  def self.example1(x, y='', z=0.0)
+  end
+end
+
+A.example # error: Not enough arguments
+A.example(0)
+A.example(0, '')
+A.example(0, '', 0.0) # error: Too many arguments provided
+A.example1 # error: Not enough arguments
+A.example1(0)
+A.example1(0, '')
+A.example1(0, '', 0.0)

--- a/test/testdata/resolver/redefined_and_overloaded/overloads_test.rb
+++ b/test/testdata/resolver/redefined_and_overloaded/overloads_test.rb
@@ -1,0 +1,25 @@
+# typed: true
+
+class A
+  extend T::Sig
+
+  sig {params(x: Integer).void}
+  sig {params(x: Integer, y: String).void}
+  def self.example(x, y='')
+  end
+
+  sig {params(x: Integer).void}
+  sig {params(x: Integer, y: String).void}
+  sig {params(x: Integer, y: String, z: Float).void}
+  def self.example(x, y='', z=0.0) # error: Method `A.example` redefined without matching argument count. Expected: `2`, got: `3`
+  end
+end
+
+A.example # error: Not enough arguments
+A.example(0)
+A.example(0, '')
+A.example(0, '', 0.0)
+A.example1 # error: Method `example1` does not exist
+A.example1(0) # error: Method `example1` does not exist
+A.example1(0, '') # error: Method `example1` does not exist
+A.example1(0, '', 0.0) # error: Method `example1` does not exist


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is a large change, and you are recommended to review by commit.

The general idea is that by threading information from a previous namer run to a current namer run, we can get enough information into namer to have it completely delete old symbols from the symbol table, so that when the current namer run enters methods, it appears to namer as if GlobalState is effectively empty (at least, empty w.r.t. to methods it's about to define).

We couple this with the existing logic to figure out which downstream files need to be retypechecked.

One key observation is that the set of files that is sent to namer is the same as the set of files that will be typechecked downstream.

This is good for some things (e.g., this makes it easy to have namer re-run on both the files that were edited as well as any downstream files that use `alias_method` on one of those methods) but is bad for others (it means that selectivity will be particularly bad.

For fast-path edits within a file, which do not modify any method symbols' hashes, this PR should not make anything slower.

But it will likely change the distribution of how many files are typechecked on the fast path, and so this may not actually be much of a speed improvement if adding/deleting a method that is used in many places. There are future projects (using package information? etc.) that we can build to limit the set of files that are retypechecked.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.