### PR TITLE
Add an experimental error to catch "common prefix" collisions

### DIFF
--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -276,6 +276,9 @@ public:
     // The error code is appended to this string.
     std::string errorUrlBase;
 
+    // If 'true', check for common prefix namespace collisions (experimental)
+    bool checkNamespaceCollisions = false;
+
     // If 'true', print error sections
     bool includeErrorSections = true;
 

--- a/core/errors/namer.h
+++ b/core/errors/namer.h
@@ -24,6 +24,7 @@ constexpr ErrorClass RootTypeMember{4016, StrictLevel::False};
 constexpr ErrorClass MultipleBehaviorDefs{4019, StrictLevel::False};
 // constexpr ErrorClass YAMLSyntaxError{4020, StrictLevel::False};
 constexpr ErrorClass OldTypeMemberSyntax{4021, StrictLevel::False};
+constexpr ErrorClass ConflictingCommonPrefix{4022, StrictLevel::False};
 } // namespace sorbet::core::errors::Namer
 
 #endif

--- a/main/lsp/wrapper.cc
+++ b/main/lsp/wrapper.cc
@@ -22,6 +22,7 @@ void setRequiredLSPOptions(core::GlobalState &gs, options::Options &options) {
         // Definitions in multiple locations interact poorly with autoloader this error is enforced
         // in Stripe code.
         gs.suppressErrorClass(sorbet::core::errors::Namer::MultipleBehaviorDefs.code);
+        gs.suppressErrorClass(sorbet::core::errors::Namer::ConflictingCommonPrefix.code);
     }
 
     gs.requiresAncestorEnabled = options.requiresAncestorEnabled;

--- a/main/lsp/wrapper.cc
+++ b/main/lsp/wrapper.cc
@@ -22,7 +22,10 @@ void setRequiredLSPOptions(core::GlobalState &gs, options::Options &options) {
         // Definitions in multiple locations interact poorly with autoloader this error is enforced
         // in Stripe code.
         gs.suppressErrorClass(sorbet::core::errors::Namer::MultipleBehaviorDefs.code);
-        gs.suppressErrorClass(sorbet::core::errors::Namer::ConflictingCommonPrefix.code);
+    } else {
+        if (options.stripeModeNamespaceCollisionCheck) {
+            gs.checkNamespaceCollisions = true;
+        }
     }
 
     gs.requiresAncestorEnabled = options.requiresAncestorEnabled;

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -356,6 +356,9 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
     options.add_options("advanced")("no-error-count", "Do not print the error count summary line");
     options.add_options("advanced")("autogen-version", "Autogen version to output", cxxopts::value<int>());
     options.add_options("advanced")("stripe-mode", "Enable Stripe specific error enforcement", cxxopts::value<bool>());
+    options.add_options("advanced")("stripe-mode-namespace-collision-check-experimental",
+                                    "Enable Stripe specific error enforcement for file-based namespace collisions",
+                                    cxxopts::value<bool>());
     options.add_options("advanced")("stripe-packages", "Enable support for Stripe's internal Ruby package system",
                                     cxxopts::value<bool>());
     options.add_options("advanced")("stripe-packages-hint-message",
@@ -903,6 +906,12 @@ void readOptions(Options &opts,
             opts.autogenVersion = raw["autogen-version"].as<int>();
         }
         opts.stripeMode = raw["stripe-mode"].as<bool>();
+        opts.stripeModeNamespaceCollisionCheck = raw["stripe-mode-namespace-collision-check-experimental"].as<bool>();
+        if (opts.stripeModeNamespaceCollisionCheck && !opts.stripeMode) {
+            logger->error("--stripe-mode-namespace-collision-check-experimental is only valid in --stripe-mode");
+            throw EarlyReturnWithCode(1);
+        }
+
         opts.stripePackages = raw["stripe-packages"].as<bool>();
         if (raw.count("extra-package-files-directory-prefix")) {
             for (const string &dirName : raw["extra-package-files-directory-prefix"].as<vector<string>>()) {

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -157,6 +157,7 @@ struct Options {
     int logLevel = 0; // number of time -v was passed
     int autogenVersion = 0;
     bool stripeMode = false;
+    bool stripeModeNamespaceCollisionCheck = false;
     bool stripePackages = false;
     std::string stripePackagesHint = "";
     std::vector<std::string> extraPackageFilesDirectoryPrefixes;

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -526,7 +526,10 @@ int realmain(int argc, char *argv[]) {
         // Definitions in multiple locations interact poorly with autoloader this error is enforced in Stripe code.
         if (opts.isolateErrorCode.empty()) {
             gs->suppressErrorClass(core::errors::Namer::MultipleBehaviorDefs.code);
-            gs->suppressErrorClass(core::errors::Namer::ConflictingCommonPrefix.code);
+        }
+    } else {
+        if (opts.stripeModeNamespaceCollisionCheck) {
+            gs->checkNamespaceCollisions = true;
         }
     }
     if (opts.suggestTyped) {
@@ -534,7 +537,6 @@ int realmain(int argc, char *argv[]) {
         gs->ignoreErrorClassForSuggestTyped(core::errors::Resolver::SigInFileWithoutSigil.code);
         if (!opts.stripeMode) {
             gs->ignoreErrorClassForSuggestTyped(core::errors::Namer::MultipleBehaviorDefs.code);
-            gs->ignoreErrorClassForSuggestTyped(core::errors::Namer::ConflictingCommonPrefix.code);
         }
     }
     gs->suggestUnsafe = opts.suggestUnsafe;

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -526,6 +526,7 @@ int realmain(int argc, char *argv[]) {
         // Definitions in multiple locations interact poorly with autoloader this error is enforced in Stripe code.
         if (opts.isolateErrorCode.empty()) {
             gs->suppressErrorClass(core::errors::Namer::MultipleBehaviorDefs.code);
+            gs->suppressErrorClass(core::errors::Namer::ConflictingCommonPrefix.code);
         }
     }
     if (opts.suggestTyped) {
@@ -533,6 +534,7 @@ int realmain(int argc, char *argv[]) {
         gs->ignoreErrorClassForSuggestTyped(core::errors::Resolver::SigInFileWithoutSigil.code);
         if (!opts.stripeMode) {
             gs->ignoreErrorClassForSuggestTyped(core::errors::Namer::MultipleBehaviorDefs.code);
+            gs->ignoreErrorClassForSuggestTyped(core::errors::Namer::ConflictingCommonPrefix.code);
         }
     }
     gs->suggestUnsafe = opts.suggestUnsafe;

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1442,6 +1442,8 @@ class TreeSymbolizer {
 
     bool bestEffort;
 
+    core::ClassOrModuleRef commonPrefix;
+
     core::SymbolRef squashNamesInner(core::Context ctx, core::SymbolRef owner, ast::ExpressionPtr &node,
                                      bool firstName) {
         auto constLit = ast::cast_tree<ast::UnresolvedConstantLit>(node);
@@ -1581,6 +1583,14 @@ class TreeSymbolizer {
 public:
     TreeSymbolizer(bool bestEffort) : bestEffort(bestEffort) {}
 
+    const core::ClassOrModuleRef getCommonPrefix() const {
+        return commonPrefix;
+    }
+
+    void clearCommonPrefix() {
+        commonPrefix = core::Symbols::noClassOrModule();
+    }
+
     ast::ExpressionPtr preTransformClassDef(core::Context ctx, ast::ExpressionPtr tree) {
         auto &klass = ast::cast_tree_nonnull<ast::ClassDef>(tree);
 
@@ -1687,6 +1697,50 @@ public:
                     e.addErrorLine(prevLoc->second, "Previous definition");
                 }
             }
+
+            if (!commonPrefix.exists()) {
+                // Initialize common prefix to the current symbol
+                commonPrefix = klass.symbol;
+            } else if (commonPrefix != core::Symbols::root()) {
+                // Find common prefix.
+                // Say the current common prefix is Foo -> Bar -> Baz, and the current symbol is Foo -> Bar -> Bat
+                // We iterate backwards over both symbols to find the first prefix that matches
+                // in both symbols: this will be the new common prefix.
+
+                core::ClassOrModuleRef foundPrefix;
+
+                auto curSym = klass.symbol;
+                int curSymLen = symbolLength(ctx, curSym);
+
+                auto prefixSym = commonPrefix;
+                int prefixSymLen = symbolLength(ctx, prefixSym);
+
+                while (curSymLen != prefixSymLen) {
+                    if (curSymLen > prefixSymLen) {
+                        curSym = curSym.data(ctx)->owner;
+                        curSymLen--;
+                    } else {
+                        prefixSym = prefixSym.data(ctx)->owner;
+                        prefixSymLen--;
+                    }
+                }
+
+                while (!foundPrefix.exists() && curSym != core::Symbols::root()) {
+                    if (curSym == prefixSym) {
+                        foundPrefix = curSym;
+                    } else {
+                        curSym = curSym.data(ctx)->owner;
+                        prefixSym = prefixSym.data(ctx)->owner;
+                    }
+                }
+
+                if (foundPrefix.exists()) {
+                    commonPrefix = foundPrefix;
+                } else {
+                    // set to root symbol if common prefix is not found
+                    commonPrefix = core::Symbols::root();
+                }
+            }
         }
 
         ast::InsSeq::STATS_store retSeqs;
@@ -1695,6 +1749,16 @@ public:
             retSeqs.emplace_back(std::move(stat));
         }
         return ast::MK::InsSeq(loc, std::move(retSeqs), ast::MK::EmptyTree());
+    }
+
+    int symbolLength(core::Context ctx, core::ClassOrModuleRef sym) {
+        int len = 0;
+        while (sym != core::Symbols::root()) {
+            len++;
+            sym = sym.data(ctx)->owner;
+        }
+
+        return len;
     }
 
     ast::MethodDef::ARGS_store fillInArgs(vector<ast::ParsedArg> parsedArgs, ast::MethodDef::ARGS_store oldArgs) {
@@ -2084,7 +2148,13 @@ vector<ast::ParsedFile> symbolizeTrees(const core::GlobalState &gs, vector<ast::
         fileq->push(move(tree), 1);
     }
 
-    workers.multiplexJob("symbolizeTrees", [&gs, fileq, resultq, bestEffort]() {
+    // Store a map of common prefix -> file where that prefix is seen.
+    UnorderedMap<core::ClassOrModuleRef, core::FileRef> commonPrefixes;
+
+    // Mutex for safe concurrent updates of map.
+    std::mutex prefixMutex;
+
+    workers.multiplexJob("symbolizeTrees", [&gs, fileq, resultq, bestEffort, &commonPrefixes, &prefixMutex]() {
         Timer timeit(gs.tracer(), "naming.symbolizeTreesWorker");
         TreeSymbolizer inserter(bestEffort);
         vector<ast::ParsedFile> output;
@@ -2094,6 +2164,30 @@ vector<ast::ParsedFile> symbolizeTrees(const core::GlobalState &gs, vector<ast::
                 Timer timeit(gs.tracer(), "naming.symbolizeTreesOne", {{"file", string(job.file.data(gs).path())}});
                 core::Context ctx(gs, core::Symbols::root(), job.file);
                 job.tree = ast::ShallowMap::apply(ctx, inserter, std::move(job.tree));
+
+                // Grab the common prefix that was found by the TreeSymbolizer walk
+                const auto commonPrefix = inserter.getCommonPrefix();
+
+                // Update the map
+                prefixMutex.lock();
+                if (commonPrefix.exists() && commonPrefix != core::Symbols::root()) {
+                    const auto &it = commonPrefixes.find(commonPrefix);
+                    if (it != commonPrefixes.end()) {
+                        // Report error if common prefix is already found in another file
+                        if (auto e = ctx.beginError(commonPrefix.data(gs)->loc().offsets(),
+                                                    core::errors::Namer::ConflictingCommonPrefix)) {
+                            e.setHeader("`{}` is a common prefix in multiple files", commonPrefix.show(ctx));
+                            e.addErrorNote("Additional file: `{}`", it->second.data(gs).path());
+                        }
+                    } else {
+                        commonPrefixes[commonPrefix] = job.file;
+                    }
+                }
+                prefixMutex.unlock();
+
+                // Reset the common prefix for the next walk
+                inserter.clearCommonPrefix();
+
                 output.emplace_back(move(job));
             }
         }

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1698,48 +1698,8 @@ public:
                 }
             }
 
-            if (!commonPrefix.exists()) {
-                // Initialize common prefix to the current symbol
-                commonPrefix = klass.symbol;
-            } else if (commonPrefix != core::Symbols::root()) {
-                // Find common prefix.
-                // Say the current common prefix is Foo -> Bar -> Baz, and the current symbol is Foo -> Bar -> Bat
-                // We iterate backwards over both symbols to find the first prefix that matches
-                // in both symbols: this will be the new common prefix.
-
-                core::ClassOrModuleRef foundPrefix;
-
-                auto curSym = klass.symbol;
-                int curSymLen = symbolLength(ctx, curSym);
-
-                auto prefixSym = commonPrefix;
-                int prefixSymLen = symbolLength(ctx, prefixSym);
-
-                while (curSymLen != prefixSymLen) {
-                    if (curSymLen > prefixSymLen) {
-                        curSym = curSym.data(ctx)->owner;
-                        curSymLen--;
-                    } else {
-                        prefixSym = prefixSym.data(ctx)->owner;
-                        prefixSymLen--;
-                    }
-                }
-
-                while (!foundPrefix.exists() && curSym != core::Symbols::root()) {
-                    if (curSym == prefixSym) {
-                        foundPrefix = curSym;
-                    } else {
-                        curSym = curSym.data(ctx)->owner;
-                        prefixSym = prefixSym.data(ctx)->owner;
-                    }
-                }
-
-                if (foundPrefix.exists()) {
-                    commonPrefix = foundPrefix;
-                } else {
-                    // set to root symbol if common prefix is not found
-                    commonPrefix = core::Symbols::root();
-                }
+            if (ctx.state.checkNamespaceCollisions) {
+                updateCommonPrefix(ctx, klass.symbol);
             }
         }
 
@@ -1749,6 +1709,52 @@ public:
             retSeqs.emplace_back(std::move(stat));
         }
         return ast::MK::InsSeq(loc, std::move(retSeqs), ast::MK::EmptyTree());
+    }
+
+    void updateCommonPrefix(core::Context ctx, core::ClassOrModuleRef klassSymbol) {
+        if (!commonPrefix.exists()) {
+            // Initialize common prefix to the current symbol
+            commonPrefix = klassSymbol;
+        } else if (commonPrefix != core::Symbols::root()) {
+            // Find common prefix.
+            // Say the current common prefix is Foo -> Bar -> Baz, and the current symbol is Foo -> Bar -> Bat
+            // We iterate backwards over both symbols to find the first prefix that matches
+            // in both symbols: this will be the new common prefix.
+
+            core::ClassOrModuleRef foundPrefix;
+
+            auto curSym = klassSymbol;
+            int curSymLen = symbolLength(ctx, curSym);
+
+            auto prefixSym = commonPrefix;
+            int prefixSymLen = symbolLength(ctx, prefixSym);
+
+            while (curSymLen != prefixSymLen) {
+                if (curSymLen > prefixSymLen) {
+                    curSym = curSym.data(ctx)->owner;
+                    curSymLen--;
+                } else {
+                    prefixSym = prefixSym.data(ctx)->owner;
+                    prefixSymLen--;
+                }
+            }
+
+            while (!foundPrefix.exists() && curSym != core::Symbols::root()) {
+                if (curSym == prefixSym) {
+                    foundPrefix = curSym;
+                } else {
+                    curSym = curSym.data(ctx)->owner;
+                    prefixSym = prefixSym.data(ctx)->owner;
+                }
+            }
+
+            if (foundPrefix.exists()) {
+                commonPrefix = foundPrefix;
+            } else {
+                // set to root symbol if common prefix is not found
+                commonPrefix = core::Symbols::root();
+            }
+        }
     }
 
     int symbolLength(core::Context ctx, core::ClassOrModuleRef sym) {
@@ -2165,28 +2171,30 @@ vector<ast::ParsedFile> symbolizeTrees(const core::GlobalState &gs, vector<ast::
                 core::Context ctx(gs, core::Symbols::root(), job.file);
                 job.tree = ast::ShallowMap::apply(ctx, inserter, std::move(job.tree));
 
-                // Grab the common prefix that was found by the TreeSymbolizer walk
-                const auto commonPrefix = inserter.getCommonPrefix();
+                if (gs.checkNamespaceCollisions) {
+                    // Grab the common prefix that was found by the TreeSymbolizer walk
+                    const auto commonPrefix = inserter.getCommonPrefix();
 
-                // Update the map
-                prefixMutex.lock();
-                if (commonPrefix.exists() && commonPrefix != core::Symbols::root()) {
-                    const auto &it = commonPrefixes.find(commonPrefix);
-                    if (it != commonPrefixes.end()) {
-                        // Report error if common prefix is already found in another file
-                        if (auto e = ctx.beginError(commonPrefix.data(gs)->loc().offsets(),
-                                                    core::errors::Namer::ConflictingCommonPrefix)) {
-                            e.setHeader("`{}` is a common prefix in multiple files", commonPrefix.show(ctx));
-                            e.addErrorNote("Additional file: `{}`", it->second.data(gs).path());
+                    // Update the map
+                    prefixMutex.lock();
+                    if (commonPrefix.exists() && commonPrefix != core::Symbols::root()) {
+                        const auto &it = commonPrefixes.find(commonPrefix);
+                        if (it != commonPrefixes.end()) {
+                            // Report error if common prefix is already found in another file
+                            if (auto e = ctx.beginError(commonPrefix.data(gs)->loc().offsets(),
+                                                        core::errors::Namer::ConflictingCommonPrefix)) {
+                                e.setHeader("`{}` is a common prefix in multiple files", commonPrefix.show(ctx));
+                                e.addErrorNote("Additional file: `{}`", it->second.data(gs).path());
+                            }
+                        } else {
+                            commonPrefixes[commonPrefix] = job.file;
                         }
-                    } else {
-                        commonPrefixes[commonPrefix] = job.file;
                     }
-                }
-                prefixMutex.unlock();
+                    prefixMutex.unlock();
 
-                // Reset the common prefix for the next walk
-                inserter.clearCommonPrefix();
+                    // Reset the common prefix for the next walk
+                    inserter.clearCommonPrefix();
+                }
 
                 output.emplace_back(move(job));
             }

--- a/test/cli/conflicting-namespace/a.rb
+++ b/test/cli/conflicting-namespace/a.rb
@@ -1,0 +1,15 @@
+# typed: true
+
+module Foo
+  module Bar
+    class A
+      def bar
+      end
+    end
+  end
+
+  class Bar::B
+    def baz
+    end
+  end
+end

--- a/test/cli/conflicting-namespace/b.rb
+++ b/test/cli/conflicting-namespace/b.rb
@@ -1,0 +1,13 @@
+# typed: true
+
+module Foo
+  module Bar
+    def self.mod_method
+    end
+
+    class C
+      def bat
+      end
+    end
+  end
+end

--- a/test/cli/conflicting-namespace/test.out
+++ b/test/cli/conflicting-namespace/test.out
@@ -1,0 +1,8 @@
+test/cli/conflicting-namespace/b.rb:4: `Foo::Bar` is a common prefix in multiple files https://srb.help/4022
+     4 |  module Bar
+          ^^^^^^^^^^
+  Note:
+    Additional file: `test/cli/conflicting-namespace/a.rb`
+Errors: 1
+without --stripe-mode-namespace-collision-check-experimental
+No errors! Great job.

--- a/test/cli/conflicting-namespace/test.sh
+++ b/test/cli/conflicting-namespace/test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -eu
+
+set +e
+main/sorbet --silence-dev-message --stripe-mode --stripe-mode-namespace-collision-check-experimental \
+  test/cli/conflicting-namespace/{a,b}.rb 2>&1
+set -e
+
+echo "without --stripe-mode-namespace-collision-check-experimental"
+main/sorbet --silence-dev-message --stripe-mode \
+  test/cli/conflicting-namespace/{a,b}.rb 2>&1

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -1131,6 +1131,35 @@ new syntax:
 srb tc --isolate-error-code=4021 --autocorrect
 ```
 
+## 4022
+
+This error is experimental, currently reported only when running with
+--stripe-mode and --stripe-mode-namespace-collision-check-experimental flags.
+
+A "namespace" or "common prefix" in this context is defined as the lowest common
+prefix of all behavior-defining (see error 4019) classes/modules in a file. This
+error is reported when 2 files have the same lowest common prefix.
+
+```ruby
+# -- file1.rb --
+module A::B
+  class C
+    def foo; end
+  end
+
+  class D
+    def bar; end
+  end
+end
+
+# -- file2.rb --
+module A::B
+  def bar; end
+end
+```
+
+In this case, both files have the same lowest common prefix A::B.
+
 ## 5001
 
 Sorbet cannot resolve references to dynamic constants. The common case occurs


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Adds a new error that is reported when there is a "common prefix" collision. Currently performs the check only when running with `--stripe-mode` and `--stripe-mode-namespace-collision-check-experimental` flags.

A "namespace" or "common prefix" in this context is defined as the lowest common prefix of
all behavior-defining (see error 4019) classes/modules in a file. This error is reported when 2 files have the
same lowest common prefix.

```
# -- file1.rb --
module A::B
  class C
    def foo; end
  end

  class D
    def bar; end
  end
end

# -- file2.rb --
module A::B
  def bar; end
end
```

In this case, both files have the same lowest common prefix A::B.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

In the Stripe codebase, we are exploring migrating to an implicit path-based autoloading solution like [zeitwerk](https://github.com/fxn/zeitwerk). One requirement is that every file maps to a unique constant to autoload, which we would like to eagerly catch violations of and fix them in the codebase.

Stripe employees can see the results of this error at https://go/gist/aadi/d404cec430493748621032e31428e5b6

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Tested on Stripe codebase.