### PR TITLE
Move `FoundDefinitions` to core

### DIFF
--- a/ast/ArgParsing.cc
+++ b/ast/ArgParsing.cc
@@ -8,8 +8,8 @@ using namespace std;
 namespace sorbet::ast {
 
 namespace {
-ParsedArg parseArg(const ast::ExpressionPtr &arg) {
-    ParsedArg parsedArg;
+core::ParsedArg parseArg(const ast::ExpressionPtr &arg) {
+    core::ParsedArg parsedArg;
 
     typecase(
         arg,
@@ -58,8 +58,8 @@ ExpressionPtr getDefaultValue(ExpressionPtr arg) {
 
 } // namespace
 
-vector<ParsedArg> ArgParsing::parseArgs(const ast::MethodDef::ARGS_store &args) {
-    vector<ParsedArg> parsedArgs;
+vector<core::ParsedArg> ArgParsing::parseArgs(const ast::MethodDef::ARGS_store &args) {
+    vector<core::ParsedArg> parsedArgs;
     for (auto &arg : args) {
         if (!ast::isa_reference(arg)) {
             Exception::raise("Must be a reference!");
@@ -70,7 +70,7 @@ vector<ParsedArg> ArgParsing::parseArgs(const ast::MethodDef::ARGS_store &args) 
     return parsedArgs;
 }
 
-std::vector<uint32_t> ArgParsing::hashArgs(core::Context ctx, const std::vector<ParsedArg> &args) {
+std::vector<uint32_t> ArgParsing::hashArgs(core::Context ctx, const std::vector<core::ParsedArg> &args) {
     std::vector<uint32_t> result;
     result.reserve(args.size());
     for (const auto &e : args) {
@@ -103,7 +103,7 @@ std::vector<uint32_t> ArgParsing::hashArgs(core::Context ctx, const std::vector<
     return result;
 }
 
-ExpressionPtr ArgParsing::getDefault(const ParsedArg &parsedArg, ExpressionPtr arg) {
+ExpressionPtr ArgParsing::getDefault(const core::ParsedArg &parsedArg, ExpressionPtr arg) {
     if (!parsedArg.flags.isDefault) {
         return nullptr;
     }

--- a/ast/ArgParsing.h
+++ b/ast/ArgParsing.h
@@ -2,17 +2,12 @@
 #define SORBET_AST_ARG_PARSING_H
 #include "ast/ast.h"
 namespace sorbet::ast {
-struct ParsedArg {
-    core::LocOffsets loc;
-    core::LocalVariable local;
-    core::ArgInfo::ArgFlags flags;
-};
 class ArgParsing {
 public:
-    static std::vector<ParsedArg> parseArgs(const ast::MethodDef::ARGS_store &args);
-    static std::vector<uint32_t> hashArgs(core::Context ctx, const std::vector<ParsedArg> &args);
+    static std::vector<core::ParsedArg> parseArgs(const ast::MethodDef::ARGS_store &args);
+    static std::vector<uint32_t> hashArgs(core::Context ctx, const std::vector<core::ParsedArg> &args);
     // Returns the default argument value for the given argument, or nullptr if not specified. Mutates arg.
-    static ExpressionPtr getDefault(const ParsedArg &parsedArg, ExpressionPtr arg);
+    static ExpressionPtr getDefault(const core::ParsedArg &parsedArg, ExpressionPtr arg);
 };
 }; // namespace sorbet::ast
 

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -3,6 +3,7 @@
 
 #include "common/common.h"
 #include "core/Context.h"
+#include "core/FoundDefinitions.h"
 #include "core/LocalVariable.h"
 #include "core/SymbolRef.h"
 #include "core/Types.h"
@@ -324,10 +325,7 @@ public:
     core::LocOffsets declLoc;
     core::ClassOrModuleRef symbol;
 
-    enum class Kind : uint8_t {
-        Module,
-        Class,
-    };
+    using Kind = core::FoundClass::Kind;
     Kind kind;
     static constexpr int EXPECTED_RHS_COUNT = 4;
     using RHS_store = InlinedVector<ExpressionPtr, EXPECTED_RHS_COUNT>;
@@ -368,20 +366,7 @@ public:
 
     core::NameRef name;
 
-    struct Flags {
-        bool isSelfMethod : 1;
-        bool isRewriterSynthesized : 1;
-        bool isAttrReader : 1;
-        bool discardDef : 1;
-        bool genericPropGetter : 1;
-
-        // In C++20 we can replace this with bit field initialzers
-        Flags()
-            : isSelfMethod(false), isRewriterSynthesized(false), isAttrReader(false), discardDef(false),
-              genericPropGetter(false) {}
-    };
-    CheckSize(Flags, 1, 1);
-
+    using Flags = core::FoundMethod::Flags;
     Flags flags;
 
     MethodDef(core::LocOffsets loc, core::LocOffsets declLoc, core::MethodRef symbol, core::NameRef name,

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -434,7 +434,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                 if (auto *block = s.block()) {
                     auto newRubyRegionId = ++cctx.inWhat.maxRubyRegionId;
                     auto &blockArgs = block->args;
-                    vector<ast::ParsedArg> blockArgFlags = ast::ArgParsing::parseArgs(blockArgs);
+                    vector<core::ParsedArg> blockArgFlags = ast::ArgParsing::parseArgs(blockArgs);
                     vector<core::ArgInfo::ArgFlags> argFlags;
                     for (auto &e : blockArgFlags) {
                         argFlags.emplace_back(e.flags);

--- a/core/FoundDefinitions.cc
+++ b/core/FoundDefinitions.cc
@@ -1,0 +1,5 @@
+#include "core/FoundDefinitions.h"
+
+using namespace std;
+
+namespace sorbet::core {} // namespace sorbet::core

--- a/core/FoundDefinitions.cc
+++ b/core/FoundDefinitions.cc
@@ -2,4 +2,66 @@
 
 using namespace std;
 
-namespace sorbet::core {} // namespace sorbet::core
+namespace sorbet::core {
+
+FoundClassRef &FoundDefinitionRef::klassRef(FoundDefinitions &foundDefs) {
+    ENFORCE(kind() == FoundDefinitionRef::Kind::ClassRef);
+    ENFORCE(foundDefs._klassRefs.size() > idx());
+    return foundDefs._klassRefs[idx()];
+}
+const FoundClassRef &FoundDefinitionRef::klassRef(const FoundDefinitions &foundDefs) const {
+    ENFORCE(kind() == FoundDefinitionRef::Kind::ClassRef);
+    ENFORCE(foundDefs._klassRefs.size() > idx());
+    return foundDefs._klassRefs[idx()];
+}
+
+FoundClass &FoundDefinitionRef::klass(FoundDefinitions &foundDefs) {
+    ENFORCE(kind() == FoundDefinitionRef::Kind::Class);
+    ENFORCE(foundDefs._klasses.size() > idx());
+    return foundDefs._klasses[idx()];
+}
+const FoundClass &FoundDefinitionRef::klass(const FoundDefinitions &foundDefs) const {
+    ENFORCE(kind() == FoundDefinitionRef::Kind::Class);
+    ENFORCE(foundDefs._klasses.size() > idx());
+    return foundDefs._klasses[idx()];
+}
+
+FoundMethod &FoundDefinitionRef::method(FoundDefinitions &foundDefs) {
+    ENFORCE(kind() == FoundDefinitionRef::Kind::Method);
+    ENFORCE(foundDefs._methods.size() > idx());
+    return foundDefs._methods[idx()];
+}
+const FoundMethod &FoundDefinitionRef::method(const FoundDefinitions &foundDefs) const {
+    ENFORCE(kind() == FoundDefinitionRef::Kind::Method);
+    ENFORCE(foundDefs._methods.size() > idx());
+    return foundDefs._methods[idx()];
+}
+
+FoundStaticField &FoundDefinitionRef::staticField(FoundDefinitions &foundDefs) {
+    ENFORCE(kind() == FoundDefinitionRef::Kind::StaticField);
+    ENFORCE(foundDefs._staticFields.size() > idx());
+    return foundDefs._staticFields[idx()];
+}
+const FoundStaticField &FoundDefinitionRef::staticField(const FoundDefinitions &foundDefs) const {
+    ENFORCE(kind() == FoundDefinitionRef::Kind::StaticField);
+    ENFORCE(foundDefs._staticFields.size() > idx());
+    return foundDefs._staticFields[idx()];
+}
+
+FoundTypeMember &FoundDefinitionRef::typeMember(FoundDefinitions &foundDefs) {
+    ENFORCE(kind() == FoundDefinitionRef::Kind::TypeMember);
+    ENFORCE(foundDefs._typeMembers.size() > idx());
+    return foundDefs._typeMembers[idx()];
+}
+const FoundTypeMember &FoundDefinitionRef::typeMember(const FoundDefinitions &foundDefs) const {
+    ENFORCE(kind() == FoundDefinitionRef::Kind::TypeMember);
+    ENFORCE(foundDefs._typeMembers.size() > idx());
+    return foundDefs._typeMembers[idx()];
+}
+
+core::SymbolRef FoundDefinitionRef::symbol() const {
+    ENFORCE(kind() == FoundDefinitionRef::Kind::Symbol);
+    return core::SymbolRef::fromRaw(_storage.id);
+}
+
+} // namespace sorbet::core

--- a/core/FoundDefinitions.h
+++ b/core/FoundDefinitions.h
@@ -1,0 +1,335 @@
+#ifndef SORBET_FOUND_DEFINITIONS_H
+#define SORBET_FOUND_DEFINITIONS_H
+
+#include "common/common.h"
+#include "core/Loc.h"
+#include "core/NameRef.h"
+#include "core/ParsedArg.h"
+#include "core/SymbolRef.h"
+#include <vector>
+
+namespace sorbet::core {
+
+class FoundDefinitions;
+
+struct FoundClassRef;
+struct FoundClass;
+struct FoundStaticField;
+struct FoundTypeMember;
+struct FoundMethod;
+
+class FoundDefinitionRef final {
+public:
+    enum class Kind : uint8_t {
+        Empty = 0,
+        Class = 1,
+        ClassRef = 2,
+        Method = 3,
+        StaticField = 4,
+        TypeMember = 5,
+        Symbol = 6,
+    };
+    CheckSize(Kind, 1, 1);
+
+private:
+    struct Storage {
+        Kind kind;
+        uint32_t id : 24; // We only support 2^24 (≈ 16M) definitions of any kind in a single file.
+    } _storage;
+    CheckSize(Storage, 4, 4);
+
+public:
+    FoundDefinitionRef(FoundDefinitionRef::Kind kind, uint32_t idx) : _storage({kind, idx}) {}
+    FoundDefinitionRef() : FoundDefinitionRef(FoundDefinitionRef::Kind::Empty, 0) {}
+    FoundDefinitionRef(const FoundDefinitionRef &nm) = default;
+    FoundDefinitionRef(FoundDefinitionRef &&nm) = default;
+    FoundDefinitionRef &operator=(const FoundDefinitionRef &rhs) = default;
+
+    static FoundDefinitionRef root() {
+        return FoundDefinitionRef(FoundDefinitionRef::Kind::Symbol, core::SymbolRef(core::Symbols::root()).rawId());
+    }
+
+    FoundDefinitionRef::Kind kind() const {
+        return _storage.kind;
+    }
+
+    bool exists() const {
+        return _storage.id > 0;
+    }
+
+    uint32_t idx() const {
+        return _storage.id;
+    }
+
+    FoundClassRef &klassRef(FoundDefinitions &foundDefs);
+    const FoundClassRef &klassRef(const FoundDefinitions &foundDefs) const;
+
+    FoundClass &klass(FoundDefinitions &foundDefs);
+    const FoundClass &klass(const FoundDefinitions &foundDefs) const;
+
+    FoundMethod &method(FoundDefinitions &foundDefs);
+    const FoundMethod &method(const FoundDefinitions &foundDefs) const;
+
+    FoundStaticField &staticField(FoundDefinitions &foundDefs);
+    const FoundStaticField &staticField(const FoundDefinitions &foundDefs) const;
+
+    FoundTypeMember &typeMember(FoundDefinitions &foundDefs);
+    const FoundTypeMember &typeMember(const FoundDefinitions &foundDefs) const;
+
+    core::SymbolRef symbol() const;
+};
+CheckSize(FoundDefinitionRef, 4, 4);
+
+struct FoundClassRef final {
+    core::NameRef name;
+    core::LocOffsets loc;
+    // If !owner.exists(), owner is determined by reference site.
+    FoundDefinitionRef owner;
+};
+CheckSize(FoundClassRef, 16, 4);
+
+struct FoundClass final {
+    FoundDefinitionRef owner;
+    FoundDefinitionRef klass;
+    core::LocOffsets loc;
+    core::LocOffsets declLoc;
+
+    enum class Kind : uint8_t {
+        Module,
+        Class,
+    };
+    Kind classKind;
+};
+CheckSize(FoundClass, 28, 4);
+
+struct FoundStaticField final {
+    FoundDefinitionRef owner;
+    FoundDefinitionRef klass;
+    core::NameRef name;
+    core::LocOffsets asgnLoc;
+    core::LocOffsets lhsLoc;
+    bool isTypeAlias = false;
+};
+CheckSize(FoundStaticField, 32, 4);
+
+struct FoundTypeMember final {
+    FoundDefinitionRef owner;
+    core::NameRef name;
+    core::LocOffsets asgnLoc;
+    core::LocOffsets nameLoc;
+    core::LocOffsets litLoc;
+    core::NameRef varianceName;
+    bool isFixed = false;
+    bool isTypeTemplete = false;
+};
+CheckSize(FoundTypeMember, 40, 4);
+
+struct FoundMethod final {
+    FoundDefinitionRef owner;
+    core::NameRef name;
+    core::LocOffsets loc;
+    core::LocOffsets declLoc;
+    struct Flags {
+        bool isSelfMethod : 1;
+        bool isRewriterSynthesized : 1;
+        bool isAttrReader : 1;
+        bool discardDef : 1;
+        bool genericPropGetter : 1;
+
+        // In C++20 we can replace this with bit field initialzers
+        Flags()
+            : isSelfMethod(false), isRewriterSynthesized(false), isAttrReader(false), discardDef(false),
+              genericPropGetter(false) {}
+    };
+    Flags flags;
+    CheckSize(Flags, 1, 1);
+    std::vector<core::ParsedArg> parsedArgs;
+    std::vector<uint32_t> argsHash;
+};
+CheckSize(FoundMethod, 80, 8);
+
+struct FoundModifier {
+    enum class Kind : uint8_t {
+        Class = 0,
+        Method = 1,
+        ClassOrStaticField = 2,
+    };
+    Kind kind;
+    FoundDefinitionRef owner;
+    core::LocOffsets loc;
+    // The name of the modification.
+    core::NameRef name;
+    // For methods: The name of the method being modified.
+    // For constants: The name of the constant being modified.
+    core::NameRef target;
+
+    FoundModifier withTarget(core::NameRef target) {
+        return FoundModifier{this->kind, this->owner, this->loc, this->name, target};
+    }
+};
+CheckSize(FoundModifier, 24, 4);
+
+class FoundDefinitions final {
+    // Contains references to items in _klasses, _methods, _staticFields, and _typeMembers.
+    // Used to determine the order in which symbols are defined in SymbolDefiner.
+    std::vector<FoundDefinitionRef> _definitions;
+    // Contains references to classes in general. Separate from `FoundClass` because we sometimes need to define class
+    // Symbols for classes that are referenced from but not present in the given file.
+    std::vector<FoundClassRef> _klassRefs;
+    // Contains all classes defined in the file.
+    std::vector<FoundClass> _klasses;
+    // Contains all methods defined in the file.
+    std::vector<FoundMethod> _methods;
+    // Contains all static fields defined in the file.
+    std::vector<FoundStaticField> _staticFields;
+    // Contains all type members defined in the file.
+    std::vector<FoundTypeMember> _typeMembers;
+    // Contains all method and class modifiers (e.g. private/public/protected).
+    std::vector<FoundModifier> _modifiers;
+
+    FoundDefinitionRef addDefinition(FoundDefinitionRef ref) {
+        DEBUG_ONLY(switch (ref.kind()) {
+            case FoundDefinitionRef::Kind::Class:
+            case FoundDefinitionRef::Kind::Method:
+            case FoundDefinitionRef::Kind::StaticField:
+            case FoundDefinitionRef::Kind::TypeMember:
+                break;
+            case FoundDefinitionRef::Kind::ClassRef:
+            case FoundDefinitionRef::Kind::Empty:
+            case FoundDefinitionRef::Kind::Symbol:
+                ENFORCE(false, "Attempted to give unexpected FoundDefinitionRef kind to addDefinition");
+        });
+        _definitions.emplace_back(ref);
+        return ref;
+    }
+
+public:
+    FoundDefinitions() = default;
+    FoundDefinitions(FoundDefinitions &&names) = default;
+    FoundDefinitions(const FoundDefinitions &names) = delete;
+    ~FoundDefinitions() = default;
+
+    FoundDefinitionRef addClass(FoundClass &&klass) {
+        const uint32_t idx = _klasses.size();
+        _klasses.emplace_back(std::move(klass));
+        return addDefinition(FoundDefinitionRef(FoundDefinitionRef::Kind::Class, idx));
+    }
+
+    FoundDefinitionRef addClassRef(FoundClassRef &&klassRef) {
+        const uint32_t idx = _klassRefs.size();
+        _klassRefs.emplace_back(std::move(klassRef));
+        return FoundDefinitionRef(FoundDefinitionRef::Kind::ClassRef, idx);
+    }
+
+    FoundDefinitionRef addMethod(FoundMethod &&method) {
+        const uint32_t idx = _methods.size();
+        _methods.emplace_back(std::move(method));
+        return addDefinition(FoundDefinitionRef(FoundDefinitionRef::Kind::Method, idx));
+    }
+
+    FoundDefinitionRef addStaticField(FoundStaticField &&staticField) {
+        const uint32_t idx = _staticFields.size();
+        _staticFields.emplace_back(std::move(staticField));
+        return addDefinition(FoundDefinitionRef(FoundDefinitionRef::Kind::StaticField, idx));
+    }
+
+    FoundDefinitionRef addTypeMember(FoundTypeMember &&typeMember) {
+        const uint32_t idx = _typeMembers.size();
+        _typeMembers.emplace_back(std::move(typeMember));
+        return addDefinition(FoundDefinitionRef(FoundDefinitionRef::Kind::TypeMember, idx));
+    }
+
+    FoundDefinitionRef addSymbol(core::SymbolRef symbol) {
+        return FoundDefinitionRef(FoundDefinitionRef::Kind::Symbol, symbol.rawId());
+    }
+
+    void addModifier(FoundModifier &&mod) {
+        _modifiers.emplace_back(std::move(mod));
+    }
+
+    // See documentation on _definitions
+    const std::vector<FoundDefinitionRef> &definitions() const {
+        return _definitions;
+    }
+
+    // See documentation on _klasses
+    const std::vector<FoundClass> &klasses() const {
+        return _klasses;
+    }
+
+    // See documentation on _methods
+    const std::vector<FoundMethod> &methods() const {
+        return _methods;
+    }
+
+    // See documentation on _modifiers
+    const std::vector<FoundModifier> &modifiers() const {
+        return _modifiers;
+    }
+
+    friend FoundDefinitionRef;
+};
+
+FoundClassRef &FoundDefinitionRef::klassRef(FoundDefinitions &foundDefs) {
+    ENFORCE(kind() == FoundDefinitionRef::Kind::ClassRef);
+    ENFORCE(foundDefs._klassRefs.size() > idx());
+    return foundDefs._klassRefs[idx()];
+}
+const FoundClassRef &FoundDefinitionRef::klassRef(const FoundDefinitions &foundDefs) const {
+    ENFORCE(kind() == FoundDefinitionRef::Kind::ClassRef);
+    ENFORCE(foundDefs._klassRefs.size() > idx());
+    return foundDefs._klassRefs[idx()];
+}
+
+FoundClass &FoundDefinitionRef::klass(FoundDefinitions &foundDefs) {
+    ENFORCE(kind() == FoundDefinitionRef::Kind::Class);
+    ENFORCE(foundDefs._klasses.size() > idx());
+    return foundDefs._klasses[idx()];
+}
+const FoundClass &FoundDefinitionRef::klass(const FoundDefinitions &foundDefs) const {
+    ENFORCE(kind() == FoundDefinitionRef::Kind::Class);
+    ENFORCE(foundDefs._klasses.size() > idx());
+    return foundDefs._klasses[idx()];
+}
+
+FoundMethod &FoundDefinitionRef::method(FoundDefinitions &foundDefs) {
+    ENFORCE(kind() == FoundDefinitionRef::Kind::Method);
+    ENFORCE(foundDefs._methods.size() > idx());
+    return foundDefs._methods[idx()];
+}
+const FoundMethod &FoundDefinitionRef::method(const FoundDefinitions &foundDefs) const {
+    ENFORCE(kind() == FoundDefinitionRef::Kind::Method);
+    ENFORCE(foundDefs._methods.size() > idx());
+    return foundDefs._methods[idx()];
+}
+
+FoundStaticField &FoundDefinitionRef::staticField(FoundDefinitions &foundDefs) {
+    ENFORCE(kind() == FoundDefinitionRef::Kind::StaticField);
+    ENFORCE(foundDefs._staticFields.size() > idx());
+    return foundDefs._staticFields[idx()];
+}
+const FoundStaticField &FoundDefinitionRef::staticField(const FoundDefinitions &foundDefs) const {
+    ENFORCE(kind() == FoundDefinitionRef::Kind::StaticField);
+    ENFORCE(foundDefs._staticFields.size() > idx());
+    return foundDefs._staticFields[idx()];
+}
+
+FoundTypeMember &FoundDefinitionRef::typeMember(FoundDefinitions &foundDefs) {
+    ENFORCE(kind() == FoundDefinitionRef::Kind::TypeMember);
+    ENFORCE(foundDefs._typeMembers.size() > idx());
+    return foundDefs._typeMembers[idx()];
+}
+const FoundTypeMember &FoundDefinitionRef::typeMember(const FoundDefinitions &foundDefs) const {
+    ENFORCE(kind() == FoundDefinitionRef::Kind::TypeMember);
+    ENFORCE(foundDefs._typeMembers.size() > idx());
+    return foundDefs._typeMembers[idx()];
+}
+
+core::SymbolRef FoundDefinitionRef::symbol() const {
+    ENFORCE(kind() == FoundDefinitionRef::Kind::Symbol);
+    return core::SymbolRef::fromRaw(_storage.id);
+}
+
+} // namespace sorbet::core
+
+#endif

--- a/core/FoundDefinitions.h
+++ b/core/FoundDefinitions.h
@@ -270,66 +270,6 @@ public:
     friend FoundDefinitionRef;
 };
 
-FoundClassRef &FoundDefinitionRef::klassRef(FoundDefinitions &foundDefs) {
-    ENFORCE(kind() == FoundDefinitionRef::Kind::ClassRef);
-    ENFORCE(foundDefs._klassRefs.size() > idx());
-    return foundDefs._klassRefs[idx()];
-}
-const FoundClassRef &FoundDefinitionRef::klassRef(const FoundDefinitions &foundDefs) const {
-    ENFORCE(kind() == FoundDefinitionRef::Kind::ClassRef);
-    ENFORCE(foundDefs._klassRefs.size() > idx());
-    return foundDefs._klassRefs[idx()];
-}
-
-FoundClass &FoundDefinitionRef::klass(FoundDefinitions &foundDefs) {
-    ENFORCE(kind() == FoundDefinitionRef::Kind::Class);
-    ENFORCE(foundDefs._klasses.size() > idx());
-    return foundDefs._klasses[idx()];
-}
-const FoundClass &FoundDefinitionRef::klass(const FoundDefinitions &foundDefs) const {
-    ENFORCE(kind() == FoundDefinitionRef::Kind::Class);
-    ENFORCE(foundDefs._klasses.size() > idx());
-    return foundDefs._klasses[idx()];
-}
-
-FoundMethod &FoundDefinitionRef::method(FoundDefinitions &foundDefs) {
-    ENFORCE(kind() == FoundDefinitionRef::Kind::Method);
-    ENFORCE(foundDefs._methods.size() > idx());
-    return foundDefs._methods[idx()];
-}
-const FoundMethod &FoundDefinitionRef::method(const FoundDefinitions &foundDefs) const {
-    ENFORCE(kind() == FoundDefinitionRef::Kind::Method);
-    ENFORCE(foundDefs._methods.size() > idx());
-    return foundDefs._methods[idx()];
-}
-
-FoundStaticField &FoundDefinitionRef::staticField(FoundDefinitions &foundDefs) {
-    ENFORCE(kind() == FoundDefinitionRef::Kind::StaticField);
-    ENFORCE(foundDefs._staticFields.size() > idx());
-    return foundDefs._staticFields[idx()];
-}
-const FoundStaticField &FoundDefinitionRef::staticField(const FoundDefinitions &foundDefs) const {
-    ENFORCE(kind() == FoundDefinitionRef::Kind::StaticField);
-    ENFORCE(foundDefs._staticFields.size() > idx());
-    return foundDefs._staticFields[idx()];
-}
-
-FoundTypeMember &FoundDefinitionRef::typeMember(FoundDefinitions &foundDefs) {
-    ENFORCE(kind() == FoundDefinitionRef::Kind::TypeMember);
-    ENFORCE(foundDefs._typeMembers.size() > idx());
-    return foundDefs._typeMembers[idx()];
-}
-const FoundTypeMember &FoundDefinitionRef::typeMember(const FoundDefinitions &foundDefs) const {
-    ENFORCE(kind() == FoundDefinitionRef::Kind::TypeMember);
-    ENFORCE(foundDefs._typeMembers.size() > idx());
-    return foundDefs._typeMembers[idx()];
-}
-
-core::SymbolRef FoundDefinitionRef::symbol() const {
-    ENFORCE(kind() == FoundDefinitionRef::Kind::Symbol);
-    return core::SymbolRef::fromRaw(_storage.id);
-}
-
 } // namespace sorbet::core
 
 #endif

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2173,6 +2173,10 @@ unique_ptr<LocalSymbolTableHashes> GlobalState::hash() const {
         if (!sym.ignoreInHashing(*this)) {
             auto &target = methodHashesMap[NameHash(*this, sym.name)];
             target = mix(target, sym.hash(*this));
+
+            // TODO(jez) Remember that if you stop calling methodShapeHash here you'll still have to
+            // handle unresolvedAncestors somehow.
+            // TODO(jez) Ignore method flags for now (private, abstrct, final, etc.)
             uint32_t symhash = sym.methodShapeHash(*this);
             hierarchyHash = mix(hierarchyHash, symhash);
             methodHash = mix(methodHash, symhash);

--- a/core/ParsedArg.h
+++ b/core/ParsedArg.h
@@ -1,0 +1,34 @@
+#ifndef SORBET_PARSED_ARG_H
+#define SORBET_PARSED_ARG_H
+
+#include "core/Loc.h"
+#include "core/LocalVariable.h"
+
+namespace sorbet::core {
+
+struct ParsedArg {
+    struct ArgFlags {
+        bool isKeyword : 1;
+        bool isRepeated : 1;
+        bool isDefault : 1;
+        bool isShadow : 1;
+        bool isBlock : 1;
+
+        // In C++20 we can replace this with bit field initialzers
+        ArgFlags() : isKeyword(false), isRepeated(false), isDefault(false), isShadow(false), isBlock(false) {}
+
+    private:
+        friend class Method;
+        friend class serialize::SerializerImpl;
+
+        void setFromU1(uint8_t flags);
+        uint8_t toU1() const;
+    };
+    core::LocOffsets loc;
+    core::LocalVariable local;
+    ArgFlags flags;
+};
+
+} // namespace sorbet::core
+
+#endif

--- a/core/Types.h
+++ b/core/Types.h
@@ -6,6 +6,7 @@
 #include "common/Counters.h"
 #include "core/Context.h"
 #include "core/Error.h"
+#include "core/ParsedArg.h"
 #include "core/ShowOptions.h"
 #include "core/SymbolRef.h"
 #include "core/TypeConstraint.h"
@@ -29,23 +30,7 @@ class TypeAndOrigins;
 
 class ArgInfo {
 public:
-    struct ArgFlags {
-        bool isKeyword : 1;
-        bool isRepeated : 1;
-        bool isDefault : 1;
-        bool isShadow : 1;
-        bool isBlock : 1;
-
-        // In C++20 we can replace this with bit field initialzers
-        ArgFlags() : isKeyword(false), isRepeated(false), isDefault(false), isShadow(false), isBlock(false) {}
-
-    private:
-        friend class Method;
-        friend class serialize::SerializerImpl;
-
-        void setFromU1(uint8_t flags);
-        uint8_t toU1() const;
-    };
+    using ArgFlags = core::ParsedArg::ArgFlags;
     ArgFlags flags;
     NameRef name;
     // Stores the `.bind(...)` symbol if the `&blk` arg's type had one

--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -78,6 +78,7 @@ unique_ptr<core::FileHash> computeFileHashForAST(spdlog::logger &logger, unique_
 
     core::Context ctx(*lgs, core::Symbols::root(), single[0].file);
     auto workers = WorkerPool::create(0, lgs->tracer());
+    // TODO(jez)
     realmain::pipeline::resolve(lgs, move(single), opts(), *workers);
 
     return make_unique<core::FileHash>(move(*lgs->hash()), move(usageHash));

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -865,7 +865,7 @@ class SymbolDefiner {
         return existing;
     }
 
-    void defineArg(core::MutableContext ctx, core::MethodData &methodData, int pos, const ast::ParsedArg &parsedArg) {
+    void defineArg(core::MutableContext ctx, core::MethodData &methodData, int pos, const core::ParsedArg &parsedArg) {
         if (pos < methodData->arguments.size()) {
             // TODO: check that flags match;
             if (parsedArg.loc.exists()) {
@@ -910,7 +910,7 @@ class SymbolDefiner {
         argInfo.flags = parsedArg.flags;
     }
 
-    void defineArgs(core::MutableContext ctx, const vector<ast::ParsedArg> &parsedArgs) {
+    void defineArgs(core::MutableContext ctx, const vector<core::ParsedArg> &parsedArgs) {
         auto methodData = ctx.owner.asMethodRef().data(ctx);
         bool inShadows = false;
         bool intrinsic = isIntrinsic(methodData);
@@ -943,7 +943,7 @@ class SymbolDefiner {
         }
     }
 
-    bool paramsMatch(core::MutableContext ctx, core::MethodRef method, const vector<ast::ParsedArg> &parsedArgs) {
+    bool paramsMatch(core::MutableContext ctx, core::MethodRef method, const vector<core::ParsedArg> &parsedArgs) {
         auto sym = method.data(ctx)->dealiasMethod(ctx);
         if (sym.data(ctx)->arguments.size() != parsedArgs.size()) {
             return false;
@@ -963,7 +963,7 @@ class SymbolDefiner {
         return true;
     }
 
-    void paramMismatchErrors(core::MutableContext ctx, core::Loc loc, const vector<ast::ParsedArg> &parsedArgs) {
+    void paramMismatchErrors(core::MutableContext ctx, core::Loc loc, const vector<core::ParsedArg> &parsedArgs) {
         auto sym = ctx.owner.dealias(ctx);
         if (!sym.isMethod()) {
             return;
@@ -1532,7 +1532,7 @@ class TreeSymbolizer {
         return result.exists() ? make_optional<core::SymbolRef>(result) : nullopt;
     }
 
-    ast::ExpressionPtr arg2Symbol(int pos, ast::ParsedArg parsedArg, ast::ExpressionPtr arg) {
+    ast::ExpressionPtr arg2Symbol(int pos, core::ParsedArg parsedArg, ast::ExpressionPtr arg) {
         ast::ExpressionPtr localExpr = ast::make_expression<ast::Local>(parsedArg.loc, parsedArg.local);
         if (parsedArg.flags.isDefault) {
             localExpr =
@@ -1725,7 +1725,7 @@ public:
         return ast::MK::InsSeq(loc, std::move(retSeqs), ast::MK::EmptyTree());
     }
 
-    ast::MethodDef::ARGS_store fillInArgs(vector<ast::ParsedArg> parsedArgs, ast::MethodDef::ARGS_store oldArgs) {
+    ast::MethodDef::ARGS_store fillInArgs(vector<core::ParsedArg> parsedArgs, ast::MethodDef::ARGS_store oldArgs) {
         ast::MethodDef::ARGS_store args;
         int i = -1;
         for (auto &arg : parsedArgs) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I want to be able to depend on most of the contents of this file from
`core/FileHash.h`. I don't want to incur a dependency on `namer` from `core`, so
I'm moving most of the things relating specifically to `FoundDefinitions` into
`core`.

### Commit summary

Review by commit. This PR is based on top of #5813.

- **DefinitionKind -> FoundDefinitionRef::Kind** (b34bd6f2f)


- **Move ParsedArg to core** (d4977635e)

  The ArgFlags were already in core (because they were shared with
  ArgInfo, which is basically Symbol but for arguments).

  The other two fields were also just a core::LocOffsets and a
  core::LocalVariable.

  I moved the ArgFlags to here so that I didn't have to depend on
  `core/Types.h` from `core/ParsedArg.h`

- **Modifier -> FoundModifier** (a46098974)


- **Move all of FoundDefinitions to core** (26e5a773b)


- **Move some FoundDefinitionRef methods to cc file** (cc5ba37e9)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No functionality change; covered by existing tests.