### PR TITLE
strengthen fast path assertions in testing

### DIFF
--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -1083,6 +1083,12 @@ void FastPathAssertion::check(SorbetTypecheckRunInfo &info, string_view folder, 
                               errorPrefix
                                   << fmt::format("Expected file update to cause {} to also be typechecked.", f));
         }
+        vector<string> extraFiles;
+        absl::c_set_difference(info.filesTypechecked, expectedFilePaths, back_inserter(extraFiles));
+        for (auto &f : extraFiles) {
+            ADD_FAIL_CHECK_AT(updateFile.c_str(), assertionLine,
+                              errorPrefix << fmt::format("File update caused {} to be typechecked unexpectedly.", f));
+        }
     }
 }
 


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We should not only check that we checked everything that we asserted to be checked on the fast path, but we should also check that we didn't check any extra files beyond what we asserted.

(I guess there's a debate here that the fast path is necessarily heuristic and could check more things than expected, but given that this is a tightly controlled test framework, I think it's better to state the most complete set up front -- and then it's also interesting if the set of files changes for a given test because of hashing differences, etc.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
