### PR TITLE
Normalize for leading `./` in autogen constant cache

### DIFF
--- a/main/autogen/cache.h
+++ b/main/autogen/cache.h
@@ -17,7 +17,7 @@ public:
     static bool canSkipAutogen(core::GlobalState &gs, std::string_view cachePath,
                                const std::vector<std::string> &changedFiles);
 
-    static AutogenCache unpackForFiles(std::string_view path, const UnorderedSet<std::string> &changedFiles);
+    static AutogenCache unpackForFiles(std::string_view path, const UnorderedSet<std::string_view> &changedFiles);
 
     AutogenCache(UnorderedMap<std::string, unsigned int> constantHashMap) : _constantHashMap(constantHashMap){};
     AutogenCache() = default;

--- a/test/cli/autogen-constant-cache/test.out
+++ b/test/cli/autogen-constant-cache/test.out
@@ -5,6 +5,10 @@ Running autogen with no changes: should exit early
 Checking 1 changed files
 All constant hashes unchanged; exiting
 
+Running autogen with no changes (and './' path): should exit early
+Checking 1 changed files
+All constant hashes unchanged; exiting
+
 Running autogen with non-constant-related changes: should exit early
 Checking 1 changed files
 All constant hashes unchanged; exiting
@@ -14,3 +18,6 @@ Checking 1 changed files
 Rerunning autogen: constant hash for file `example.rb` does not match stored hash
 Autogen still needs rerunning
 No errors! Great job.
+
+Producing a new constant cache with './' paths should produce the same cache file:
+Same!

--- a/test/cli/autogen-constant-cache/test.sh
+++ b/test/cli/autogen-constant-cache/test.sh
@@ -12,6 +12,10 @@ echo "Running autogen with no changes: should exit early"
 ../../../main/sorbet --silence-dev-message -p autogen-msgpack --autogen-version=2 --stop-after=namer --skip-rewriter-passes --autogen-constant-cache-file cache.msgpack foo.rb --autogen-changed-files example.rb 2>&1 >/dev/null
 
 echo
+echo "Running autogen with no changes (and './' path): should exit early"
+../../../main/sorbet --silence-dev-message -p autogen-msgpack --autogen-version=2 --stop-after=namer --skip-rewriter-passes --autogen-constant-cache-file cache.msgpack foo.rb --autogen-changed-files ./example.rb 2>&1 >/dev/null
+
+echo
 echo "Running autogen with non-constant-related changes: should exit early"
 cat >>example.rb <<EOF
 def new_method
@@ -28,3 +32,12 @@ module NewModule
 end
 EOF
 ../../../main/sorbet --silence-dev-message -p autogen-msgpack --autogen-version=2 --stop-after=namer --skip-rewriter-passes --autogen-constant-cache-file cache.msgpack example.rb --autogen-changed-files example.rb 2>&1 >/dev/null
+
+echo
+echo "Producing a new constant cache with './' paths should produce the same cache file:"
+../../../main/sorbet --silence-dev-message -p autogen-msgpack --autogen-version=2 --stop-after=namer --skip-rewriter-passes --autogen-constant-cache-file abs-cache.msgpack ./example.rb >/dev/null 2>&1
+if $(diff cache.msgpack abs-cache.msgpack >/dev/null); then
+    echo "Same!"
+else
+    echo "Not same!"
+fi


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Previously we'd be kind of finicky about the presence of leading `./` in the constant cache. This will now always strip it out so it doesn't matter if we use it anywhere in particular.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Added tests to ensure that lookup doesn't care about `./` and the we produce the same msgpack file regardless of leading `./`.
