### PR TITLE
Fix problem with aliased constants in VisibilityChecker

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -274,7 +274,7 @@ private:
             core::SymbolRef resolved = id->symbol.dealias(ctx);
             core::SymbolRef result;
             if (resolved.isClassOrModule()) {
-                result = resolved.asClassOrModuleRef().data(ctx)->findMember(ctx, c.cnst);
+                result = resolved.asClassOrModuleRef().data(ctx)->findMemberNoDealias(ctx, c.cnst);
             }
 
             // Private constants are allowed to be resolved, when there is no scope set (the scope is checked above),

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -737,8 +737,8 @@ private:
         return true;
     }
 
-    static bool resolveConstants(const core::GlobalState &gs, vector<ResolveItems<ResolutionItem>> &jobs,
-                                 WorkerPool &workers) {
+    static bool resolveResolutionItems(const core::GlobalState &gs, vector<ResolveItems<ResolutionItem>> &jobs,
+                                       WorkerPool &workers) {
         if (jobs.empty()) {
             return false;
         }
@@ -1609,7 +1609,7 @@ public:
                 }
                 {
                     Timer timeit(gs.tracer(), "resolver.resolve_constants.fixed_point.constants");
-                    bool resolvedSomeConstants = resolveConstants(gs, todo, workers);
+                    bool resolvedSomeConstants = resolveResolutionItems(gs, todo, workers);
                     progress = progress || resolvedSomeConstants;
                 }
                 {

--- a/test/testdata/packager/alias_constants/chalk/log/__package.rb
+++ b/test/testdata/packager/alias_constants/chalk/log/__package.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class Chalk::Log < PackageSpec
+  export Chalk::Log
+end

--- a/test/testdata/packager/alias_constants/chalk/log/lib/chalk_log.rb
+++ b/test/testdata/packager/alias_constants/chalk/log/lib/chalk_log.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+# typed: strict
+
+module Chalk
+  module Log
+    module CLevels
+      Sheddable = :sheddable
+      SheddablePlus = :sheddableplus
+      Critical = :critical
+      CriticalPlus = :criticalplus
+    end
+  end
+end

--- a/test/testdata/packager/alias_constants/emerald/__package.rb
+++ b/test/testdata/packager/alias_constants/emerald/__package.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Opus::Emerald < PackageSpec
+  import Opus::Log
+end

--- a/test/testdata/packager/alias_constants/emerald/migration/backfill.rb
+++ b/test/testdata/packager/alias_constants/emerald/migration/backfill.rb
@@ -1,0 +1,7 @@
+# typed: strict
+
+module Opus::Emerald
+  class Migration::BackfillEmeraldCategories
+    p(Opus::Log::CLevels::Sheddable)
+  end
+end

--- a/test/testdata/packager/alias_constants/lib/log/__package.rb
+++ b/test/testdata/packager/alias_constants/lib/log/__package.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Opus::Log < PackageSpec
+  import Chalk::Log
+
+  export Opus::Log
+end

--- a/test/testdata/packager/alias_constants/lib/log/log.rb
+++ b/test/testdata/packager/alias_constants/lib/log/log.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+# typed: strict
+
+module Opus; end
+class Opus::Log
+
+  module CLevels
+    Sheddable = Chalk::Log::CLevels::Sheddable
+    SheddablePlus = Chalk::Log::CLevels::SheddablePlus
+    Critical = Chalk::Log::CLevels::Critical
+    CriticalPlus = Chalk::Log::CLevels::CriticalPlus
+  end
+end

--- a/test/testdata/packager/alias_constants_cycle/devbox/__package.rb
+++ b/test/testdata/packager/alias_constants_cycle/devbox/__package.rb
@@ -1,0 +1,8 @@
+# typed: strict
+# enable-packager: true
+
+class Opus::Devbox < PackageSpec
+  import Opus::Devbox::Srv
+
+  export Opus::Devbox::Constants
+end

--- a/test/testdata/packager/alias_constants_cycle/devbox/assignment_client.rb
+++ b/test/testdata/packager/alias_constants_cycle/devbox/assignment_client.rb
@@ -2,5 +2,5 @@
 # enable-packager: true
 
 class Opus::Devbox::AssignmentClient
-  p(Opus::Devbox::Srv::Routes::UserFacing::Helpers::MAX_NUM_ADDITIONAL_DEVBOXES)
+  p(Opus::Devbox::Srv::Routes::UserFacing::Helpers::MAX_NUM_ADDITIONAL_DEVBOXES) # error: `Opus::Devbox::Srv::Routes::Helpers::MAX_NUM_ADDITIONAL_DEVBOXES` resolves but is not exported from `Opus::Devbox::Srv`
 end

--- a/test/testdata/packager/alias_constants_cycle/devbox/assignment_client.rb
+++ b/test/testdata/packager/alias_constants_cycle/devbox/assignment_client.rb
@@ -1,0 +1,6 @@
+# typed: strict
+# enable-packager: true
+
+class Opus::Devbox::AssignmentClient
+  p(Opus::Devbox::Srv::Routes::UserFacing::Helpers::MAX_NUM_ADDITIONAL_DEVBOXES)
+end

--- a/test/testdata/packager/alias_constants_cycle/devbox/constants.rb
+++ b/test/testdata/packager/alias_constants_cycle/devbox/constants.rb
@@ -1,0 +1,6 @@
+# typed: strict
+# enable-packager: true
+
+module Opus::Devbox::Constants
+  MAX_NUM_ADDITIONAL_DEVBOXES = 200
+end

--- a/test/testdata/packager/alias_constants_cycle/devbox/devbox_srv/__package.rb
+++ b/test/testdata/packager/alias_constants_cycle/devbox/devbox_srv/__package.rb
@@ -1,0 +1,8 @@
+# typed: strict
+# enable-packager: true
+
+class Opus::Devbox::Srv < PackageSpec
+  import Opus::Devbox
+
+  export Opus::Devbox::Srv::Routes::UserFacing
+end

--- a/test/testdata/packager/alias_constants_cycle/devbox/devbox_srv/helpers.rb
+++ b/test/testdata/packager/alias_constants_cycle/devbox/devbox_srv/helpers.rb
@@ -1,0 +1,6 @@
+# typed: strict
+# enable-packager: true
+
+module Opus::Devbox::Srv::Routes::Helpers
+  MAX_NUM_ADDITIONAL_DEVBOXES = Opus::Devbox::Constants::MAX_NUM_ADDITIONAL_DEVBOXES
+end

--- a/test/testdata/packager/alias_constants_cycle/devbox/devbox_srv/routes/user_facing.rb
+++ b/test/testdata/packager/alias_constants_cycle/devbox/devbox_srv/routes/user_facing.rb
@@ -1,0 +1,6 @@
+# typed: strict
+# enable-packager: true
+
+module Opus::Devbox::Srv::Routes::UserFacing
+  Helpers = Opus::Devbox::Srv::Routes::Helpers
+end

--- a/test/testdata/resolver/alias_chain.rb
+++ b/test/testdata/resolver/alias_chain.rb
@@ -1,0 +1,10 @@
+module Constants
+  MAX_NUM_ADDITIONAL_DEVBOXES = 200
+end
+module Routes::Helpers
+  MAX_NUM_ADDITIONAL_DEVBOXES = Constants::MAX_NUM_ADDITIONAL_DEVBOXES
+end
+module Routes::WillCollapseOut
+  Helpers = Routes::Helpers
+end
+Routes::WillCollapseOut::Helpers::MAX_NUM_ADDITIONAL_DEVBOXES

--- a/test/testdata/resolver/alias_chain.rb
+++ b/test/testdata/resolver/alias_chain.rb
@@ -1,3 +1,4 @@
+# typed: strict
 module Constants
   MAX_NUM_ADDITIONAL_DEVBOXES = 200
 end

--- a/test/testdata/resolver/alias_chain.rb.resolve-tree.exp
+++ b/test/testdata/resolver/alias_chain.rb.resolve-tree.exp
@@ -24,7 +24,7 @@ begin
       <emptyTree>
     end
 
-    ::Constants::MAX_NUM_ADDITIONAL_DEVBOXES
+    ::Routes::Helpers::MAX_NUM_ADDITIONAL_DEVBOXES
   end
   <emptyTree>
 end

--- a/test/testdata/resolver/alias_chain.rb.resolve-tree.exp
+++ b/test/testdata/resolver/alias_chain.rb.resolve-tree.exp
@@ -1,0 +1,30 @@
+begin
+  class <emptyTree><<C <root>>> < (::<todo sym>)
+    begin
+      module ::Constants<<C Constants>> < ()
+        ::Constants::MAX_NUM_ADDITIONAL_DEVBOXES = 200
+      end
+      ::Sorbet::Private::Static.keep_for_ide(::Constants)
+      <emptyTree>
+    end
+
+    begin
+      module ::Routes::Helpers<<C Helpers>> < ()
+        ::Routes::Helpers::MAX_NUM_ADDITIONAL_DEVBOXES = ::Constants::MAX_NUM_ADDITIONAL_DEVBOXES
+      end
+      ::Sorbet::Private::Static.keep_for_ide(::Routes::Helpers)
+      <emptyTree>
+    end
+
+    begin
+      module ::Routes::WillCollapseOut<<C WillCollapseOut>> < ()
+        ::Routes::WillCollapseOut::Helpers = ::Routes::Helpers
+      end
+      ::Sorbet::Private::Static.keep_for_ide(::Routes::WillCollapseOut)
+      <emptyTree>
+    end
+
+    ::Constants::MAX_NUM_ADDITIONAL_DEVBOXES
+  end
+  <emptyTree>
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

There were some errors on Stripe's codebase that only appeared in LSP mode
because the fast path contents of `GlobalState` differed, meaning that
`ResolveConstantsWalk` did the wrong thing on the second time through (e.g., in
`incrementalResolve`).

Weirdly, this test case didn't reproduce in `--stress-incremental-resolver`, but
did reproduce in our LSP test cases. I didn't spend a lot of time tracking down
what the differences are, but intuitively this change makes sense to me—we
shouldn't rely on constant aliases having been resolved yet, and also
`UnresolvedConstantLiterals` should resolve to their actual constant, and be
dealiased at the point where a dealias would be required (there is, in fact, a
dealias call immediately above, on the scope).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

In addition to the tests, we might want to check performance of this, as it
_could_ cause more constant literals to be deferred to `todo*` lists? But that's
just a guess, and it doesn't hurt to check.