### PR TITLE
Fix crash on mixes_in_class_methods for undeclared

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -997,7 +997,6 @@ private:
             return;
         }
 
-        auto encounteredError = false;
         for (auto i = 0; i < numPosArgs; ++i) {
             auto &arg = send->getPosArg(i);
             if (arg.isSelfReference()) {
@@ -1017,28 +1016,31 @@ private:
                 }
                 continue;
             }
+            auto idLoc = core::Loc(todo.file, id->loc);
             if (!id->symbol.isClassOrModule()) {
-                if (auto e =
-                        gs.beginError(core::Loc(todo.file, id->loc), core::errors::Resolver::InvalidMixinDeclaration)) {
+                if (auto e = gs.beginError(idLoc, core::errors::Resolver::InvalidMixinDeclaration)) {
                     e.setHeader("Argument to `{}` must be statically resolvable to a module", send->fun.show(gs));
                 }
                 continue;
             }
-            if (id->symbol.asClassOrModuleRef().data(gs)->isClass()) {
-                if (auto e =
-                        gs.beginError(core::Loc(todo.file, id->loc), core::errors::Resolver::InvalidMixinDeclaration)) {
+            auto idSymbol = id->symbol.asClassOrModuleRef();
+            if (idSymbol.data(gs)->isUndeclared()) {
+                if (auto e = gs.beginError(idLoc, core::errors::Resolver::InvalidMixinDeclaration)) {
+                    e.setHeader("Could not determine that `{}` was a module, not a class", id->symbol.show(gs));
+                    e.addErrorLine(idSymbol.data(gs)->loc(), "Defined here");
+                }
+                continue;
+            }
+            if (idSymbol.data(gs)->isClass()) {
+                if (auto e = gs.beginError(idLoc, core::errors::Resolver::InvalidMixinDeclaration)) {
                     e.setHeader("`{}` is a class, not a module; Only modules may be mixins", id->symbol.show(gs));
                 }
-                encounteredError = true;
+                continue;
             }
             if (id->symbol == owner) {
-                if (auto e =
-                        gs.beginError(core::Loc(todo.file, id->loc), core::errors::Resolver::InvalidMixinDeclaration)) {
+                if (auto e = gs.beginError(idLoc, core::errors::Resolver::InvalidMixinDeclaration)) {
                     e.setHeader("Must not pass your self to `{}`", send->fun.show(gs));
                 }
-                encounteredError = true;
-            }
-            if (encounteredError) {
                 continue;
             }
 
@@ -1057,7 +1059,7 @@ private:
                     arg.flags.isBlock = true;
                 }
 
-                auto type = core::make_type<core::ClassType>(id->symbol.asClassOrModuleRef());
+                auto type = core::make_type<core::ClassType>(idSymbol);
                 auto &elems = (core::cast_type<core::TupleType>(mixMethod.data(gs)->resultType))->elems;
                 // Make sure we are not adding existing symbols to our tuple
                 if (absl::c_find(elems, type) == elems.end()) {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1026,8 +1026,11 @@ private:
             auto idSymbol = id->symbol.asClassOrModuleRef();
             if (idSymbol.data(gs)->isUndeclared()) {
                 if (auto e = gs.beginError(idLoc, core::errors::Resolver::InvalidMixinDeclaration)) {
-                    e.setHeader("Could not determine that `{}` was a module, not a class", id->symbol.show(gs));
-                    e.addErrorLine(idSymbol.data(gs)->loc(), "Defined here");
+                    e.setHeader("`{}` is declared implicitly, but must be defined as a `{}` explicitly",
+                                id->symbol.show(gs), "module");
+                    e.addErrorLine(idSymbol.data(gs)->loc(), "Defined implicitly here");
+                    e.addErrorNote("`{}` has the potential to be a `{}`, which is not allowed with `{}`",
+                                   id->symbol.show(gs), "class", send->fun.show(gs));
                 }
                 continue;
             }

--- a/test/testdata/resolver/mixes_in_class_module_not_set.rb
+++ b/test/testdata/resolver/mixes_in_class_module_not_set.rb
@@ -3,5 +3,5 @@
 module A::B
   extend T::Helpers
 
-  mixes_in_class_methods(A) # error: Could not determine that `A` was a module, not a class
+  mixes_in_class_methods(A) # error: `A` is declared implicitly, but must be defined as a `module` explicitly
 end

--- a/test/testdata/resolver/mixes_in_class_module_not_set.rb
+++ b/test/testdata/resolver/mixes_in_class_module_not_set.rb
@@ -1,0 +1,7 @@
+# typed: strict
+
+module A::B
+  extend T::Helpers
+
+  mixes_in_class_methods(A) # error: Could not determine that `A` was a module, not a class
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The crash looked like this:

    Exception::raise(): Should never happen

    Backtrace:
      #3 0xccda75 sorbet::core::ClassOrModule::isClass()
      #4 0x13de160 sorbet::resolver::(anonymous namespace)::ResolveConstantsWalk::resolveClassMethodsJob<>()
      #5 0x13d2407 sorbet::resolver::(anonymous namespace)::ResolveConstantsWalk::resolveConstants<>()
      #6 0x13d0a15 sorbet::resolver::Resolver::run()
      #7 0xeaf34b sorbet::realmain::pipeline::resolve()
      #8 0xb1b1ae sorbet::realmain::realmain()
      #9 0xb15a22 main
      #10 0x7ffff7c65083 __libc_start_main
      #11 0xb1592e _start


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.