### PR TITLE
fix issues with method return types incorrectly resolving on the fast path

### DIFF
--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -201,15 +201,16 @@ public:
         // Static Field flags
         bool isStaticFieldTypeAlias : 1;
         bool isStaticFieldPrivate : 1;
+        bool isStaticFieldTypeTemplate : 1;
 
         bool isExported : 1;
 
-        constexpr static uint8_t NUMBER_OF_FLAGS = 5;
+        constexpr static uint8_t NUMBER_OF_FLAGS = 6;
         constexpr static uint8_t VALID_BITS_MASK = (1 << NUMBER_OF_FLAGS) - 1;
 
         Flags() noexcept
             : isField(false), isStaticField(false), isStaticFieldTypeAlias(false), isStaticFieldPrivate(false),
-              isExported(false) {}
+              isStaticFieldTypeTemplate(false), isExported(false) {}
 
         uint8_t serialize() const {
             ENFORCE(sizeof(Flags) == sizeof(uint8_t));

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -201,16 +201,15 @@ public:
         // Static Field flags
         bool isStaticFieldTypeAlias : 1;
         bool isStaticFieldPrivate : 1;
-        bool isStaticFieldTypeTemplate : 1;
 
         bool isExported : 1;
 
-        constexpr static uint8_t NUMBER_OF_FLAGS = 6;
+        constexpr static uint8_t NUMBER_OF_FLAGS = 5;
         constexpr static uint8_t VALID_BITS_MASK = (1 << NUMBER_OF_FLAGS) - 1;
 
         Flags() noexcept
             : isField(false), isStaticField(false), isStaticFieldTypeAlias(false), isStaticFieldPrivate(false),
-              isStaticFieldTypeTemplate(false), isExported(false) {}
+              isExported(false) {}
 
         uint8_t serialize() const {
             ENFORCE(sizeof(Flags) == sizeof(uint8_t));

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1096,10 +1096,11 @@ class SymbolDefiner {
                                                oldSym.loc(ctx));
                     ctx.state.mangleRenameSymbol(oldSym, typeMember.name);
                 }
+                // This static field with an AliasType is how we get `MyTypeTemplate` to resolve,
+                // because resolver does not usually look on the singleton class to resolve constant
+                // literals, but type_template's are only ever entered on the singleton class.
                 auto alias = ctx.state.enterStaticFieldSymbol(ctx.locAt(typeMember.asgnLoc), context, typeMember.name);
-                auto aliasData = alias.data(ctx);
-                aliasData->flags.isStaticFieldTypeTemplate = true;
-                aliasData->resultType = core::make_type<core::AliasType>(core::SymbolRef(sym));
+                alias.data(ctx)->resultType = core::make_type<core::AliasType>(core::SymbolRef(sym));
             }
         }
 

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1097,7 +1097,9 @@ class SymbolDefiner {
                     ctx.state.mangleRenameSymbol(oldSym, typeMember.name);
                 }
                 auto alias = ctx.state.enterStaticFieldSymbol(ctx.locAt(typeMember.asgnLoc), context, typeMember.name);
-                alias.data(ctx)->resultType = core::make_type<core::AliasType>(core::SymbolRef(sym));
+                auto aliasData = alias.data(ctx);
+                aliasData->flags.isStaticFieldTypeTemplate = true;
+                aliasData->resultType = core::make_type<core::AliasType>(core::SymbolRef(sym));
             }
         }
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -212,7 +212,7 @@ private:
         Nesting *scope = nesting.get();
         while (scope != nullptr) {
             if (scope->scope.isClassOrModule()) {
-                auto lookup = scope->scope.asClassOrModuleRef().data(ctx)->findMember(ctx, name);
+                auto lookup = scope->scope.asClassOrModuleRef().data(ctx)->findMemberNoDealias(ctx, name);
                 if (lookup.exists()) {
                     return lookup;
                 }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -216,8 +216,19 @@ private:
                 // fast path in LSP, but we do need to explicitly look through type template
                 // static fields to find the field on the singleton class.
                 auto lookup = scope->scope.asClassOrModuleRef().data(ctx)->findMemberNoDealias(ctx, name);
-                if (lookup.isFieldOrStaticField() && lookup.asFieldRef().data(ctx)->flags.isStaticFieldTypeTemplate) {
-                    lookup = lookup.dealias(ctx);
+                if (lookup.isStaticField(ctx)) {
+                    const auto &resultType = lookup.asFieldRef().data(ctx)->resultType;
+                    if (core::isa_type<core::AliasType>(resultType)) {
+                        auto dealiased = lookup.dealias(ctx);
+                        if (dealiased.isTypeMember() &&
+                            dealiased.asTypeMemberRef().data(ctx)->owner ==
+                                lookup.owner(ctx).asClassOrModuleRef().data(ctx)->lookupSingletonClass(ctx)) {
+                            // This static field is a shim that exists only so that `MyTypeTemplate` resolves as normal
+                            // constant literal by looking for the thing with that name on the singleton class.
+                            // Should never be leaked externally, so in this case we forcibly dealias.
+                            lookup = dealiased;
+                        }
+                    }
                 }
                 if (lookup.exists()) {
                     return lookup;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -212,7 +212,13 @@ private:
         Nesting *scope = nesting.get();
         while (scope != nullptr) {
             if (scope->scope.isClassOrModule()) {
+                // We don't want to rely on existing information in the symbol table for the
+                // fast path in LSP, but we do need to explicitly look through type template
+                // static fields to find the field on the singleton class.
                 auto lookup = scope->scope.asClassOrModuleRef().data(ctx)->findMemberNoDealias(ctx, name);
+                if (lookup.isFieldOrStaticField() && lookup.asFieldRef().data(ctx)->flags.isStaticFieldTypeTemplate) {
+                    lookup = lookup.dealias(ctx);
+                }
                 if (lookup.exists()) {
                     return lookup;
                 }

--- a/test/testdata/lsp/fast_path/method_aliased_result_type.1.rbupdate
+++ b/test/testdata/lsp/fast_path/method_aliased_result_type.1.rbupdate
@@ -1,0 +1,16 @@
+# typed: true
+extend T::Sig
+
+class MyEnum < T::Enum
+  enums do
+    X = new
+    Y = new
+  end
+end
+
+MyEnum_X = MyEnum::X
+
+sig {returns(MyEnum_X)} # error: Constant `MyEnum_X` is not a class or type alias
+def example
+  MyEnum::X
+end

--- a/test/testdata/lsp/fast_path/method_aliased_result_type.1.rbupdate
+++ b/test/testdata/lsp/fast_path/method_aliased_result_type.1.rbupdate
@@ -1,4 +1,5 @@
 # typed: true
+# assert-fast-path: method_aliased_result_type.rb
 extend T::Sig
 
 class MyEnum < T::Enum

--- a/test/testdata/lsp/fast_path/method_aliased_result_type.rb
+++ b/test/testdata/lsp/fast_path/method_aliased_result_type.rb
@@ -1,0 +1,16 @@
+# typed: true
+extend T::Sig
+
+class MyEnum < T::Enum
+  enums do
+    X = new
+    Y = new
+  end
+end
+
+MyEnum_X = MyEnum::X
+
+sig {returns(MyEnum)}
+def example
+  MyEnum::X
+end


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Inspired by work in #5828 and tests in #5805, this fixes one more case where we shouldn't be using existing information in the symbol table.  I said in #5828 that this location would need some kind of context-aware lookup, and this seemed to be the right way to address it.  (The other alternative I could see was to add a `TypeTemplateAliasType` and have a separate dealiasing through that, but that seemed like a lot of work for epsilon gain, if that.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
