### PR TITLE
Better indentation-aware recovery for class & module

### DIFF
--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -612,6 +612,14 @@ int yylex(parser::semantic_type *lval, ruby_parser::location *lloc, ruby_parser:
                 | stmts terms stmt_or_begin
                     {
                       auto *result = $1;
+                      if (result->inner->empty()) {
+                        // This set of stmts started with a leading tNL (common after e.g. class and module defs)
+                        // Since an empty stmts reduces without any tokens, it uses the begin/end location of the
+                        // most recently lexed token, despite that token not being included in the stmts.
+                        // Manually fix up the locations here.
+                        @$.begin = @3.begin;
+                        @$.end = @3.end;
+                      }
                       result->inner->emplace_back($3);
                       $$ = result;
 

--- a/parser/parser/include/ruby_parser/driver.hh
+++ b/parser/parser/include/ruby_parser/driver.hh
@@ -26,6 +26,10 @@ struct node_list {
         return nodes.size();
     }
 
+    inline bool empty() const {
+        return nodes.empty();
+    }
+
     inline void emplace_back(const ForeignPtr &ptr) {
         nodes.emplace_back(ptr);
     }

--- a/test/testdata/parser/error_recovery/class_indent_2.rb.desugar-tree.exp
+++ b/test/testdata/parser/error_recovery/class_indent_2.rb.desugar-tree.exp
@@ -1,12 +1,10 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C B><<C <todo sym>>> < (::<todo sym>)
     class <emptyTree>::<C Inner><<C <todo sym>>> < (::<todo sym>)
-      <emptyTree>
+      <self>.puts("hello")
+
+      <self>.puts("hello")
     end
-
-    <self>.puts("hello")
-
-    <self>.puts("hello")
 
     def method2<<todo method>>(&<blk>)
       <emptyTree>

--- a/test/testdata/parser/error_recovery/class_indent_4.rb.desugar-tree.exp
+++ b/test/testdata/parser/error_recovery/class_indent_4.rb.desugar-tree.exp
@@ -1,10 +1,8 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C D><<C <todo sym>>> < (::<todo sym>)
     class <emptyTree>::<C Inner><<C <todo sym>>> < (::<todo sym>)
-      <emptyTree>
+      <self>.puts("hello")
     end
-
-    <self>.puts("hello")
 
     <self>.sig() do ||
       <self>.void()

--- a/test/testdata/parser/error_recovery/class_indent_6.rb.desugar-tree.exp
+++ b/test/testdata/parser/error_recovery/class_indent_6.rb.desugar-tree.exp
@@ -9,9 +9,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     class <emptyTree>::<C Inner><<C <todo sym>>> < (::<todo sym>)
-      <emptyTree>
+      <self>.puts("hello")
     end
-
-    <self>.puts("hello")
   end
 end

--- a/test/testdata/parser/error_recovery/module_indent_2.rb.desugar-tree.exp
+++ b/test/testdata/parser/error_recovery/module_indent_2.rb.desugar-tree.exp
@@ -1,12 +1,10 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C B><<C <todo sym>>> < (::<todo sym>)
     module <emptyTree>::<C Inner><<C <todo sym>>> < ()
-      <emptyTree>
+      <self>.puts("hello")
+
+      <self>.puts("hello")
     end
-
-    <self>.puts("hello")
-
-    <self>.puts("hello")
 
     def method2<<todo method>>(&<blk>)
       <emptyTree>

--- a/test/testdata/parser/error_recovery/module_indent_4.rb.desugar-tree.exp
+++ b/test/testdata/parser/error_recovery/module_indent_4.rb.desugar-tree.exp
@@ -1,10 +1,8 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C D><<C <todo sym>>> < (::<todo sym>)
     module <emptyTree>::<C Inner><<C <todo sym>>> < ()
-      <emptyTree>
+      <self>.puts("hello")
     end
-
-    <self>.puts("hello")
 
     <self>.sig() do ||
       <self>.void()

--- a/test/testdata/parser/error_recovery/module_indent_6.rb.desugar-tree.exp
+++ b/test/testdata/parser/error_recovery/module_indent_6.rb.desugar-tree.exp
@@ -9,9 +9,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     module <emptyTree>::<C Inner><<C <todo sym>>> < ()
-      <emptyTree>
+      <self>.puts("hello")
     end
-
-    <self>.puts("hello")
   end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #5841.

The comment in the parser is the best explanation of what was going on.

The key difference between class/module defs and method defs is that
method defs don't emit a tNL after the arguments end, while classe and
modules do. That means that classes and modules have their stmts list
constructed by starting from empty, reducing the `tNL`, and appending
the first element. Meanwhile methods start from the singleton
production, with no leading `tNL`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.