### PR TITLE
Find behavior conflicts across threads

### DIFF
--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1819,7 +1819,7 @@ void mergeClassBehaviorLocs(const core::GlobalState &gs, ClassBehaviorLocs &merg
     }
     for (auto [ref, loc] : threadRes) {
         auto &mergedLoc = merged[ref];
-        if (mergedLoc.empty()) {
+        if (!mergedLoc.exists()) {
             mergedLoc = loc;
         } else if (mergedLoc.file() != loc.file()) {
             core::Context ctx(gs, core::Symbols::root(), loc.file());

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1837,12 +1837,7 @@ void findConflictingClassDefs(const core::GlobalState &gs, ClassBehaviorLocsMap 
     }
     map.clear();
 
-    fast_sort(conflicts, [](const auto &lhs, const auto &rhs) -> bool {
-        if (lhs.first != rhs.first) {
-            return lhs.first.id() < rhs.first.id();
-        }
-        return lhs.second[0].file() < rhs.second[0].file();
-    });
+    fast_sort(conflicts, [](const auto &lhs, const auto &rhs) -> bool { return lhs.first.id() < rhs.first.id(); });
     for (const auto &[ref, locs] : conflicts) {
         core::Loc mainLoc = locs[0];
         core::Context ctx(gs, core::Symbols::root(), mainLoc.file());

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1824,7 +1824,7 @@ void findConflictingClassDefs(const core::GlobalState &gs, ClassBehaviorLocsMap 
         if (locs.size() < 2) {
             continue;
         }
-        fast_sort(locs, [](const auto &lhs, const auto &rhs) -> bool { return lhs.file().id() < rhs.file().id(); });
+        fast_sort(locs, [](const auto &lhs, const auto &rhs) -> bool { return lhs.file() < rhs.file(); });
         // In rare cases we see multiple defs in same file. Ignore them.
         auto last = unique(locs.begin(), locs.end(),
                            [](const auto &lhs, const auto &rhs) -> bool { return lhs.file() == rhs.file(); });

--- a/test/cli/conflicting-definition-multithread/a.rb
+++ b/test/cli/conflicting-definition-multithread/a.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+# typed: true
+
+class A
+  def x; end
+end
+
+class B
+  def x; end
+end
+
+class C
+  def x; end
+end
+
+class D
+  def x; end
+end
+
+class E
+  def x; end
+end
+
+class F
+  def x; end
+end
+
+class G
+  def x; end
+end
+
+class H
+  def x; end
+end
+
+class I
+  def x; end
+end
+
+class J
+  def x; end
+end

--- a/test/cli/conflicting-definition-multithread/b.rb
+++ b/test/cli/conflicting-definition-multithread/b.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+# typed: true
+
+class A
+  def x; end
+end
+
+class B
+  def x; end
+end
+
+class C
+  def x; end
+end
+
+class D
+  def x; end
+end
+
+class E
+  def x; end
+end
+
+class F
+  def x; end
+end
+
+class G
+  def x; end
+end
+
+class H
+  def x; end
+end
+
+class I
+  def x; end
+end
+
+class J
+  def x; end
+end

--- a/test/cli/conflicting-definition-multithread/c.rb
+++ b/test/cli/conflicting-definition-multithread/c.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+# typed: true
+
+class A
+  def x; end
+end
+
+class B
+  def x; end
+end
+
+class C
+  def x; end
+end
+
+class D
+  def x; end
+end
+
+class E
+  def x; end
+end
+
+class F
+  def x; end
+end
+
+class G
+  def x; end
+end
+
+class H
+  def x; end
+end
+
+class I
+  def x; end
+end
+
+class J
+  def x; end
+end

--- a/test/cli/conflicting-definition-multithread/d.rb
+++ b/test/cli/conflicting-definition-multithread/d.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+# typed: true
+
+class A
+  def x; end
+end
+
+class B
+  def x; end
+end
+
+class C
+  def x; end
+end
+
+class D
+  def x; end
+end
+
+class E
+  def x; end
+end
+
+class F
+  def x; end
+end
+
+class G
+  def x; end
+end
+
+class H
+  def x; end
+end
+
+class I
+  def x; end
+end
+
+class J
+  def x; end
+end

--- a/test/cli/conflicting-definition-multithread/e.rb
+++ b/test/cli/conflicting-definition-multithread/e.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+# typed: true
+
+class A
+  def x; end
+end
+
+class B
+  def x; end
+end
+
+class C
+  def x; end
+end
+
+class D
+  def x; end
+end
+
+class E
+  def x; end
+end
+
+class F
+  def x; end
+end
+
+class G
+  def x; end
+end
+
+class H
+  def x; end
+end
+
+class I
+  def x; end
+end
+
+class J
+  def x; end
+end

--- a/test/cli/conflicting-definition-multithread/f.rb
+++ b/test/cli/conflicting-definition-multithread/f.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+# typed: true
+
+class A
+  def x; end
+end
+
+class B
+  def x; end
+end
+
+class C
+  def x; end
+end
+
+class D
+  def x; end
+end
+
+class E
+  def x; end
+end
+
+class F
+  def x; end
+end
+
+class G
+  def x; end
+end
+
+class H
+  def x; end
+end
+
+class I
+  def x; end
+end
+
+class J
+  def x; end
+end

--- a/test/cli/conflicting-definition-multithread/h.rb
+++ b/test/cli/conflicting-definition-multithread/h.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+# typed: true
+
+class A
+  def x; end
+end
+
+class B
+  def x; end
+end
+
+class C
+  def x; end
+end
+
+class D
+  def x; end
+end
+
+class E
+  def x; end
+end
+
+class F
+  def x; end
+end
+
+class G
+  def x; end
+end
+
+class H
+  def x; end
+end
+
+class I
+  def x; end
+end
+
+class J
+  def x; end
+end

--- a/test/cli/conflicting-definition-multithread/i.rb
+++ b/test/cli/conflicting-definition-multithread/i.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+# typed: true
+
+class A
+  def x; end
+end
+
+class B
+  def x; end
+end
+
+class C
+  def x; end
+end
+
+class D
+  def x; end
+end
+
+class E
+  def x; end
+end
+
+class F
+  def x; end
+end
+
+class G
+  def x; end
+end
+
+class H
+  def x; end
+end
+
+class I
+  def x; end
+end
+
+class J
+  def x; end
+end

--- a/test/cli/conflicting-definition-multithread/j.rb
+++ b/test/cli/conflicting-definition-multithread/j.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+# typed: true
+
+class A
+  def x; end
+end
+
+class B
+  def x; end
+end
+
+class C
+  def x; end
+end
+
+class D
+  def x; end
+end
+
+class E
+  def x; end
+end
+
+class F
+  def x; end
+end
+
+class G
+  def x; end
+end
+
+class H
+  def x; end
+end
+
+class I
+  def x; end
+end
+
+class J
+  def x; end
+end

--- a/test/cli/conflicting-definition-multithread/test.out
+++ b/test/cli/conflicting-definition-multithread/test.out
@@ -1,92 +1,280 @@
-test/cli/conflicting-definition-multithread/a.rb:12: `C` has behavior defined in multiple files https://srb.help/4019
-test/cli/conflicting-definition-multithread/a.rb:16: `D` has behavior defined in multiple files https://srb.help/4019
-test/cli/conflicting-definition-multithread/a.rb:20: `E` has behavior defined in multiple files https://srb.help/4019
-test/cli/conflicting-definition-multithread/a.rb:24: `F` has behavior defined in multiple files https://srb.help/4019
-test/cli/conflicting-definition-multithread/a.rb:28: `G` has behavior defined in multiple files https://srb.help/4019
-test/cli/conflicting-definition-multithread/a.rb:32: `H` has behavior defined in multiple files https://srb.help/4019
-test/cli/conflicting-definition-multithread/a.rb:36: `I` has behavior defined in multiple files https://srb.help/4019
-test/cli/conflicting-definition-multithread/a.rb:40: `J` has behavior defined in multiple files https://srb.help/4019
 test/cli/conflicting-definition-multithread/a.rb:4: `A` has behavior defined in multiple files https://srb.help/4019
-test/cli/conflicting-definition-multithread/a.rb:8: `B` has behavior defined in multiple files https://srb.help/4019
-
-== Previous definitions ==
-    test/cli/conflicting-definition-multithread/b.rb:12: Previous definition
-    test/cli/conflicting-definition-multithread/b.rb:16: Previous definition
-    test/cli/conflicting-definition-multithread/b.rb:20: Previous definition
-    test/cli/conflicting-definition-multithread/b.rb:24: Previous definition
-    test/cli/conflicting-definition-multithread/b.rb:28: Previous definition
-    test/cli/conflicting-definition-multithread/b.rb:32: Previous definition
-    test/cli/conflicting-definition-multithread/b.rb:36: Previous definition
-    test/cli/conflicting-definition-multithread/b.rb:40: Previous definition
+     4 |class A
+        ^^^^^^^
     test/cli/conflicting-definition-multithread/b.rb:4: Previous definition
-    test/cli/conflicting-definition-multithread/b.rb:8: Previous definition
-    test/cli/conflicting-definition-multithread/c.rb:12: Previous definition
-    test/cli/conflicting-definition-multithread/c.rb:16: Previous definition
-    test/cli/conflicting-definition-multithread/c.rb:20: Previous definition
-    test/cli/conflicting-definition-multithread/c.rb:24: Previous definition
-    test/cli/conflicting-definition-multithread/c.rb:28: Previous definition
-    test/cli/conflicting-definition-multithread/c.rb:32: Previous definition
-    test/cli/conflicting-definition-multithread/c.rb:36: Previous definition
-    test/cli/conflicting-definition-multithread/c.rb:40: Previous definition
+     4 |class A
+        ^^^^^^^
     test/cli/conflicting-definition-multithread/c.rb:4: Previous definition
-    test/cli/conflicting-definition-multithread/c.rb:8: Previous definition
-    test/cli/conflicting-definition-multithread/d.rb:12: Previous definition
-    test/cli/conflicting-definition-multithread/d.rb:16: Previous definition
-    test/cli/conflicting-definition-multithread/d.rb:20: Previous definition
-    test/cli/conflicting-definition-multithread/d.rb:24: Previous definition
-    test/cli/conflicting-definition-multithread/d.rb:28: Previous definition
-    test/cli/conflicting-definition-multithread/d.rb:32: Previous definition
-    test/cli/conflicting-definition-multithread/d.rb:36: Previous definition
-    test/cli/conflicting-definition-multithread/d.rb:40: Previous definition
+     4 |class A
+        ^^^^^^^
     test/cli/conflicting-definition-multithread/d.rb:4: Previous definition
-    test/cli/conflicting-definition-multithread/d.rb:8: Previous definition
-    test/cli/conflicting-definition-multithread/e.rb:12: Previous definition
-    test/cli/conflicting-definition-multithread/e.rb:16: Previous definition
-    test/cli/conflicting-definition-multithread/e.rb:20: Previous definition
-    test/cli/conflicting-definition-multithread/e.rb:24: Previous definition
-    test/cli/conflicting-definition-multithread/e.rb:28: Previous definition
-    test/cli/conflicting-definition-multithread/e.rb:32: Previous definition
-    test/cli/conflicting-definition-multithread/e.rb:36: Previous definition
-    test/cli/conflicting-definition-multithread/e.rb:40: Previous definition
+     4 |class A
+        ^^^^^^^
     test/cli/conflicting-definition-multithread/e.rb:4: Previous definition
-    test/cli/conflicting-definition-multithread/e.rb:8: Previous definition
-    test/cli/conflicting-definition-multithread/f.rb:12: Previous definition
-    test/cli/conflicting-definition-multithread/f.rb:16: Previous definition
-    test/cli/conflicting-definition-multithread/f.rb:20: Previous definition
-    test/cli/conflicting-definition-multithread/f.rb:24: Previous definition
-    test/cli/conflicting-definition-multithread/f.rb:28: Previous definition
-    test/cli/conflicting-definition-multithread/f.rb:32: Previous definition
-    test/cli/conflicting-definition-multithread/f.rb:36: Previous definition
-    test/cli/conflicting-definition-multithread/f.rb:40: Previous definition
+     4 |class A
+        ^^^^^^^
     test/cli/conflicting-definition-multithread/f.rb:4: Previous definition
-    test/cli/conflicting-definition-multithread/f.rb:8: Previous definition
-    test/cli/conflicting-definition-multithread/h.rb:12: Previous definition
-    test/cli/conflicting-definition-multithread/h.rb:16: Previous definition
-    test/cli/conflicting-definition-multithread/h.rb:20: Previous definition
-    test/cli/conflicting-definition-multithread/h.rb:24: Previous definition
-    test/cli/conflicting-definition-multithread/h.rb:28: Previous definition
-    test/cli/conflicting-definition-multithread/h.rb:32: Previous definition
-    test/cli/conflicting-definition-multithread/h.rb:36: Previous definition
-    test/cli/conflicting-definition-multithread/h.rb:40: Previous definition
+     4 |class A
+        ^^^^^^^
     test/cli/conflicting-definition-multithread/h.rb:4: Previous definition
-    test/cli/conflicting-definition-multithread/h.rb:8: Previous definition
-    test/cli/conflicting-definition-multithread/i.rb:12: Previous definition
-    test/cli/conflicting-definition-multithread/i.rb:16: Previous definition
-    test/cli/conflicting-definition-multithread/i.rb:20: Previous definition
-    test/cli/conflicting-definition-multithread/i.rb:24: Previous definition
-    test/cli/conflicting-definition-multithread/i.rb:28: Previous definition
-    test/cli/conflicting-definition-multithread/i.rb:32: Previous definition
-    test/cli/conflicting-definition-multithread/i.rb:36: Previous definition
-    test/cli/conflicting-definition-multithread/i.rb:40: Previous definition
+     4 |class A
+        ^^^^^^^
     test/cli/conflicting-definition-multithread/i.rb:4: Previous definition
-    test/cli/conflicting-definition-multithread/i.rb:8: Previous definition
-    test/cli/conflicting-definition-multithread/j.rb:12: Previous definition
-    test/cli/conflicting-definition-multithread/j.rb:16: Previous definition
-    test/cli/conflicting-definition-multithread/j.rb:20: Previous definition
-    test/cli/conflicting-definition-multithread/j.rb:24: Previous definition
-    test/cli/conflicting-definition-multithread/j.rb:28: Previous definition
-    test/cli/conflicting-definition-multithread/j.rb:32: Previous definition
-    test/cli/conflicting-definition-multithread/j.rb:36: Previous definition
-    test/cli/conflicting-definition-multithread/j.rb:40: Previous definition
+     4 |class A
+        ^^^^^^^
     test/cli/conflicting-definition-multithread/j.rb:4: Previous definition
+     4 |class A
+        ^^^^^^^
+
+test/cli/conflicting-definition-multithread/a.rb:8: `B` has behavior defined in multiple files https://srb.help/4019
+     8 |class B
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/b.rb:8: Previous definition
+     8 |class B
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/c.rb:8: Previous definition
+     8 |class B
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/d.rb:8: Previous definition
+     8 |class B
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/e.rb:8: Previous definition
+     8 |class B
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/f.rb:8: Previous definition
+     8 |class B
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/h.rb:8: Previous definition
+     8 |class B
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/i.rb:8: Previous definition
+     8 |class B
+        ^^^^^^^
     test/cli/conflicting-definition-multithread/j.rb:8: Previous definition
+     8 |class B
+        ^^^^^^^
+
+test/cli/conflicting-definition-multithread/a.rb:12: `C` has behavior defined in multiple files https://srb.help/4019
+    12 |class C
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/b.rb:12: Previous definition
+    12 |class C
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/c.rb:12: Previous definition
+    12 |class C
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/d.rb:12: Previous definition
+    12 |class C
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/e.rb:12: Previous definition
+    12 |class C
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/f.rb:12: Previous definition
+    12 |class C
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/h.rb:12: Previous definition
+    12 |class C
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/i.rb:12: Previous definition
+    12 |class C
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/j.rb:12: Previous definition
+    12 |class C
+        ^^^^^^^
+
+test/cli/conflicting-definition-multithread/a.rb:16: `D` has behavior defined in multiple files https://srb.help/4019
+    16 |class D
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/b.rb:16: Previous definition
+    16 |class D
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/c.rb:16: Previous definition
+    16 |class D
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/d.rb:16: Previous definition
+    16 |class D
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/e.rb:16: Previous definition
+    16 |class D
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/f.rb:16: Previous definition
+    16 |class D
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/h.rb:16: Previous definition
+    16 |class D
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/i.rb:16: Previous definition
+    16 |class D
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/j.rb:16: Previous definition
+    16 |class D
+        ^^^^^^^
+
+test/cli/conflicting-definition-multithread/a.rb:20: `E` has behavior defined in multiple files https://srb.help/4019
+    20 |class E
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/b.rb:20: Previous definition
+    20 |class E
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/c.rb:20: Previous definition
+    20 |class E
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/d.rb:20: Previous definition
+    20 |class E
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/e.rb:20: Previous definition
+    20 |class E
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/f.rb:20: Previous definition
+    20 |class E
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/h.rb:20: Previous definition
+    20 |class E
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/i.rb:20: Previous definition
+    20 |class E
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/j.rb:20: Previous definition
+    20 |class E
+        ^^^^^^^
+
+test/cli/conflicting-definition-multithread/a.rb:24: `F` has behavior defined in multiple files https://srb.help/4019
+    24 |class F
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/b.rb:24: Previous definition
+    24 |class F
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/c.rb:24: Previous definition
+    24 |class F
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/d.rb:24: Previous definition
+    24 |class F
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/e.rb:24: Previous definition
+    24 |class F
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/f.rb:24: Previous definition
+    24 |class F
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/h.rb:24: Previous definition
+    24 |class F
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/i.rb:24: Previous definition
+    24 |class F
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/j.rb:24: Previous definition
+    24 |class F
+        ^^^^^^^
+
+test/cli/conflicting-definition-multithread/a.rb:28: `G` has behavior defined in multiple files https://srb.help/4019
+    28 |class G
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/b.rb:28: Previous definition
+    28 |class G
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/c.rb:28: Previous definition
+    28 |class G
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/d.rb:28: Previous definition
+    28 |class G
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/e.rb:28: Previous definition
+    28 |class G
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/f.rb:28: Previous definition
+    28 |class G
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/h.rb:28: Previous definition
+    28 |class G
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/i.rb:28: Previous definition
+    28 |class G
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/j.rb:28: Previous definition
+    28 |class G
+        ^^^^^^^
+
+test/cli/conflicting-definition-multithread/a.rb:32: `H` has behavior defined in multiple files https://srb.help/4019
+    32 |class H
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/b.rb:32: Previous definition
+    32 |class H
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/c.rb:32: Previous definition
+    32 |class H
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/d.rb:32: Previous definition
+    32 |class H
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/e.rb:32: Previous definition
+    32 |class H
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/f.rb:32: Previous definition
+    32 |class H
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/h.rb:32: Previous definition
+    32 |class H
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/i.rb:32: Previous definition
+    32 |class H
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/j.rb:32: Previous definition
+    32 |class H
+        ^^^^^^^
+
+test/cli/conflicting-definition-multithread/a.rb:36: `I` has behavior defined in multiple files https://srb.help/4019
+    36 |class I
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/b.rb:36: Previous definition
+    36 |class I
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/c.rb:36: Previous definition
+    36 |class I
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/d.rb:36: Previous definition
+    36 |class I
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/e.rb:36: Previous definition
+    36 |class I
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/f.rb:36: Previous definition
+    36 |class I
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/h.rb:36: Previous definition
+    36 |class I
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/i.rb:36: Previous definition
+    36 |class I
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/j.rb:36: Previous definition
+    36 |class I
+        ^^^^^^^
+
+test/cli/conflicting-definition-multithread/a.rb:40: `J` has behavior defined in multiple files https://srb.help/4019
+    40 |class J
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/b.rb:40: Previous definition
+    40 |class J
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/c.rb:40: Previous definition
+    40 |class J
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/d.rb:40: Previous definition
+    40 |class J
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/e.rb:40: Previous definition
+    40 |class J
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/f.rb:40: Previous definition
+    40 |class J
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/h.rb:40: Previous definition
+    40 |class J
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/i.rb:40: Previous definition
+    40 |class J
+        ^^^^^^^
+    test/cli/conflicting-definition-multithread/j.rb:40: Previous definition
+    40 |class J
+        ^^^^^^^
+Errors: 10

--- a/test/cli/conflicting-definition-multithread/test.out
+++ b/test/cli/conflicting-definition-multithread/test.out
@@ -1,0 +1,92 @@
+test/cli/conflicting-definition-multithread/a.rb:12: `C` has behavior defined in multiple files https://srb.help/4019
+test/cli/conflicting-definition-multithread/a.rb:16: `D` has behavior defined in multiple files https://srb.help/4019
+test/cli/conflicting-definition-multithread/a.rb:20: `E` has behavior defined in multiple files https://srb.help/4019
+test/cli/conflicting-definition-multithread/a.rb:24: `F` has behavior defined in multiple files https://srb.help/4019
+test/cli/conflicting-definition-multithread/a.rb:28: `G` has behavior defined in multiple files https://srb.help/4019
+test/cli/conflicting-definition-multithread/a.rb:32: `H` has behavior defined in multiple files https://srb.help/4019
+test/cli/conflicting-definition-multithread/a.rb:36: `I` has behavior defined in multiple files https://srb.help/4019
+test/cli/conflicting-definition-multithread/a.rb:40: `J` has behavior defined in multiple files https://srb.help/4019
+test/cli/conflicting-definition-multithread/a.rb:4: `A` has behavior defined in multiple files https://srb.help/4019
+test/cli/conflicting-definition-multithread/a.rb:8: `B` has behavior defined in multiple files https://srb.help/4019
+
+== Previous definitions ==
+    test/cli/conflicting-definition-multithread/b.rb:12: Previous definition
+    test/cli/conflicting-definition-multithread/b.rb:16: Previous definition
+    test/cli/conflicting-definition-multithread/b.rb:20: Previous definition
+    test/cli/conflicting-definition-multithread/b.rb:24: Previous definition
+    test/cli/conflicting-definition-multithread/b.rb:28: Previous definition
+    test/cli/conflicting-definition-multithread/b.rb:32: Previous definition
+    test/cli/conflicting-definition-multithread/b.rb:36: Previous definition
+    test/cli/conflicting-definition-multithread/b.rb:40: Previous definition
+    test/cli/conflicting-definition-multithread/b.rb:4: Previous definition
+    test/cli/conflicting-definition-multithread/b.rb:8: Previous definition
+    test/cli/conflicting-definition-multithread/c.rb:12: Previous definition
+    test/cli/conflicting-definition-multithread/c.rb:16: Previous definition
+    test/cli/conflicting-definition-multithread/c.rb:20: Previous definition
+    test/cli/conflicting-definition-multithread/c.rb:24: Previous definition
+    test/cli/conflicting-definition-multithread/c.rb:28: Previous definition
+    test/cli/conflicting-definition-multithread/c.rb:32: Previous definition
+    test/cli/conflicting-definition-multithread/c.rb:36: Previous definition
+    test/cli/conflicting-definition-multithread/c.rb:40: Previous definition
+    test/cli/conflicting-definition-multithread/c.rb:4: Previous definition
+    test/cli/conflicting-definition-multithread/c.rb:8: Previous definition
+    test/cli/conflicting-definition-multithread/d.rb:12: Previous definition
+    test/cli/conflicting-definition-multithread/d.rb:16: Previous definition
+    test/cli/conflicting-definition-multithread/d.rb:20: Previous definition
+    test/cli/conflicting-definition-multithread/d.rb:24: Previous definition
+    test/cli/conflicting-definition-multithread/d.rb:28: Previous definition
+    test/cli/conflicting-definition-multithread/d.rb:32: Previous definition
+    test/cli/conflicting-definition-multithread/d.rb:36: Previous definition
+    test/cli/conflicting-definition-multithread/d.rb:40: Previous definition
+    test/cli/conflicting-definition-multithread/d.rb:4: Previous definition
+    test/cli/conflicting-definition-multithread/d.rb:8: Previous definition
+    test/cli/conflicting-definition-multithread/e.rb:12: Previous definition
+    test/cli/conflicting-definition-multithread/e.rb:16: Previous definition
+    test/cli/conflicting-definition-multithread/e.rb:20: Previous definition
+    test/cli/conflicting-definition-multithread/e.rb:24: Previous definition
+    test/cli/conflicting-definition-multithread/e.rb:28: Previous definition
+    test/cli/conflicting-definition-multithread/e.rb:32: Previous definition
+    test/cli/conflicting-definition-multithread/e.rb:36: Previous definition
+    test/cli/conflicting-definition-multithread/e.rb:40: Previous definition
+    test/cli/conflicting-definition-multithread/e.rb:4: Previous definition
+    test/cli/conflicting-definition-multithread/e.rb:8: Previous definition
+    test/cli/conflicting-definition-multithread/f.rb:12: Previous definition
+    test/cli/conflicting-definition-multithread/f.rb:16: Previous definition
+    test/cli/conflicting-definition-multithread/f.rb:20: Previous definition
+    test/cli/conflicting-definition-multithread/f.rb:24: Previous definition
+    test/cli/conflicting-definition-multithread/f.rb:28: Previous definition
+    test/cli/conflicting-definition-multithread/f.rb:32: Previous definition
+    test/cli/conflicting-definition-multithread/f.rb:36: Previous definition
+    test/cli/conflicting-definition-multithread/f.rb:40: Previous definition
+    test/cli/conflicting-definition-multithread/f.rb:4: Previous definition
+    test/cli/conflicting-definition-multithread/f.rb:8: Previous definition
+    test/cli/conflicting-definition-multithread/h.rb:12: Previous definition
+    test/cli/conflicting-definition-multithread/h.rb:16: Previous definition
+    test/cli/conflicting-definition-multithread/h.rb:20: Previous definition
+    test/cli/conflicting-definition-multithread/h.rb:24: Previous definition
+    test/cli/conflicting-definition-multithread/h.rb:28: Previous definition
+    test/cli/conflicting-definition-multithread/h.rb:32: Previous definition
+    test/cli/conflicting-definition-multithread/h.rb:36: Previous definition
+    test/cli/conflicting-definition-multithread/h.rb:40: Previous definition
+    test/cli/conflicting-definition-multithread/h.rb:4: Previous definition
+    test/cli/conflicting-definition-multithread/h.rb:8: Previous definition
+    test/cli/conflicting-definition-multithread/i.rb:12: Previous definition
+    test/cli/conflicting-definition-multithread/i.rb:16: Previous definition
+    test/cli/conflicting-definition-multithread/i.rb:20: Previous definition
+    test/cli/conflicting-definition-multithread/i.rb:24: Previous definition
+    test/cli/conflicting-definition-multithread/i.rb:28: Previous definition
+    test/cli/conflicting-definition-multithread/i.rb:32: Previous definition
+    test/cli/conflicting-definition-multithread/i.rb:36: Previous definition
+    test/cli/conflicting-definition-multithread/i.rb:40: Previous definition
+    test/cli/conflicting-definition-multithread/i.rb:4: Previous definition
+    test/cli/conflicting-definition-multithread/i.rb:8: Previous definition
+    test/cli/conflicting-definition-multithread/j.rb:12: Previous definition
+    test/cli/conflicting-definition-multithread/j.rb:16: Previous definition
+    test/cli/conflicting-definition-multithread/j.rb:20: Previous definition
+    test/cli/conflicting-definition-multithread/j.rb:24: Previous definition
+    test/cli/conflicting-definition-multithread/j.rb:28: Previous definition
+    test/cli/conflicting-definition-multithread/j.rb:32: Previous definition
+    test/cli/conflicting-definition-multithread/j.rb:36: Previous definition
+    test/cli/conflicting-definition-multithread/j.rb:40: Previous definition
+    test/cli/conflicting-definition-multithread/j.rb:4: Previous definition
+    test/cli/conflicting-definition-multithread/j.rb:8: Previous definition

--- a/test/cli/conflicting-definition-multithread/test.sh
+++ b/test/cli/conflicting-definition-multithread/test.sh
@@ -1,15 +1,5 @@
 #!/bin/bash
 set -u
 
-out=$(mktemp)
-trap 'rm -f $out' EXIT
-
 main/sorbet --silence-dev-message --stripe-mode \
-  test/cli/conflicting-definition-multithread/*.rb >"$out" 2>&1
-
-grep "^test/cli/conflicting-definition-multithread/a.* has behavior defined in multiple files https://srb.help/4019$" "$out" |
-  sort
-
-echo
-echo "== Previous definitions =="
-grep ": Previous definition" "$out" | sort
+  test/cli/conflicting-definition-multithread/*.rb 2>&1

--- a/test/cli/conflicting-definition-multithread/test.sh
+++ b/test/cli/conflicting-definition-multithread/test.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -u
+
+out=$(mktemp)
+trap 'rm -f $out' EXIT
+
+main/sorbet --silence-dev-message --stripe-mode \
+  test/cli/conflicting-definition-multithread/*.rb >"$out" 2>&1
+
+grep "^test/cli/conflicting-definition-multithread/a.* has behavior defined in multiple files https://srb.help/4019$" "$out" |
+  sort
+
+echo
+echo "== Previous definitions =="
+grep ": Previous definition" "$out" | sort

--- a/test/cli/conflicting-definition/test.out
+++ b/test/cli/conflicting-definition/test.out
@@ -1,7 +1,7 @@
-test/cli/conflicting-definition/b.rb:3: `Foo` has behavior defined in multiple files https://srb.help/4019
+test/cli/conflicting-definition/a.rb:3: `Foo` has behavior defined in multiple files https://srb.help/4019
      3 |module Foo
         ^^^^^^^^^^
-    test/cli/conflicting-definition/a.rb:3: Previous definition
+    test/cli/conflicting-definition/b.rb:3: Previous definition
      3 |module Foo
         ^^^^^^^^^^
 Errors: 1


### PR DESCRIPTION
Adds a merge step for maps of class to "behavior" loc in `Namer::symbolizeTrees`. This ensures conflicts are found even if they are processed by different workers.

### Motivation
This check was broken if the conflicting defs were processed by different workers.
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

Introduced a conflict in Stripe's codebase and ensured this caught it.

Added timing. The merge ops are fast enough on the codebase that they don't appear in timing data.
