### PR TITLE
Add a counter for FoundDefinitionRefs

### DIFF
--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1791,6 +1791,7 @@ ast::ParsedFilesOrCancelled defineSymbols(core::GlobalState &gs, vector<SymbolFi
     const auto &epochManager = *gs.epochManager;
     uint32_t count = 0;
     for (auto &fileFoundDefinitions : allFoundDefinitions) {
+        prodCounterAdd("types.input.founddefs.total", fileFoundDefinitions.names->definitions().size());
         count++;
         // defineSymbols is really fast. Avoid this mildly expensive check for most turns of the loop.
         if (count % 250 == 0 && epochManager.wasTypecheckingCanceled()) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Lets us estimate memory pressure due to persisting FoundDefinitionRefs


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I tested with a manual `--counters` run on pay-server.