### PR TITLE
Clean up `document/formatting` LSP requests

### DIFF
--- a/main/lsp/json_enums.h
+++ b/main/lsp/json_enums.h
@@ -18,6 +18,7 @@ enum class LSPErrorCodes {
 
     // Defined by the LSP
     RequestCancelled = -32800,
+    RequestFailed = -32803,
 };
 
 // Is not an enum, but is as simple as one. Putting it here reduces dependencies on json_types.h.

--- a/main/lsp/requests/document_formatting.cc
+++ b/main/lsp/requests/document_formatting.cc
@@ -113,7 +113,7 @@ void DocumentFormattingTask::index(LSPIndexer &index) {
                              response);
                 break;
             case RubyfmtStatus::INITIALIZE_ERROR:
-                displayError(fmt::format("`rubyfmt` failed to initialize."), response);
+                displayError("`rubyfmt` failed to initialize.", response);
                 break;
             case RubyfmtStatus::RUBYFMT_NOT_IN_PATH:
                 displayError("`rubyfmt` could not be found. Ensure that it is properly configured in your PATH.",

--- a/main/lsp/requests/document_formatting.h
+++ b/main/lsp/requests/document_formatting.h
@@ -17,6 +17,9 @@ public:
     void index(LSPIndexer &index) override;
 
     std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerInterface &typechecker) override;
+
+private:
+    void displayError(std::string errorMessage, std::unique_ptr<ResponseMessage> &response);
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -321,6 +321,10 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
                                     "Enable experimental LSP feature: Document Symbol");
     options.add_options("advanced")("enable-experimental-lsp-document-formatting-rubyfmt",
                                     "Enable experimental LSP feature: Document Formatting with Rubyfmt");
+    options.add_options("advanced")(
+        "rubyfmt-path",
+        "Path to the rubyfmt executable used for document formatting. Defaults to using `rubyfmt` on your PATH.",
+        cxxopts::value<string>()->default_value(empty.rubyfmtPath));
     options.add_options("advanced")("enable-experimental-lsp-document-highlight",
                                     "Enable experimental LSP feature: Document Highlight");
     options.add_options("advanced")("enable-experimental-lsp-signature-help",

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -232,6 +232,8 @@ struct Options {
     // List of directories not available editor-side. References to files in these directories should be sent via
     // sorbet: URIs to clients that support them.
     std::vector<std::string> lspDirsMissingFromClient;
+    // Path to the executable used for document formatting
+    std::string rubyfmtPath = "rubyfmt";
     // Enable stable-but-not-yet-shipped features suitable for late-stage beta-testing.
     bool lspAllBetaFeaturesEnabled = false;
     // Booleans enabling various experimental LSP features. Each will be removed once corresponding feature stabilizes.

--- a/main/options/test/options_test.cc
+++ b/main/options/test/options_test.cc
@@ -73,6 +73,7 @@ TEST_CASE("DefaultConstructorMatchesReadOptions") {
     CHECK_EQ(empty.lspDocumentHighlightEnabled, opts.lspDocumentHighlightEnabled);
     CHECK_EQ(empty.lspSignatureHelpEnabled, opts.lspSignatureHelpEnabled);
     CHECK_EQ(empty.lspDocumentFormatRubyfmtEnabled, opts.lspDocumentFormatRubyfmtEnabled);
+    CHECK_EQ(empty.rubyfmtPath, opts.rubyfmtPath);
     CHECK_EQ(empty.inlineInput, opts.inlineInput);
     CHECK_EQ(empty.debugLogFile, opts.debugLogFile);
     CHECK_EQ(empty.webTraceFile, opts.webTraceFile);

--- a/test/BUILD
+++ b/test/BUILD
@@ -264,6 +264,7 @@ pipeline_tests(
         ],
     ),
     "LSPTests",
+    extra_files = ["testdata/lsp/rubyfmt-stub/rubyfmt"],
 )
 
 test_suite(

--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -405,8 +405,6 @@ void testDocumentSymbols(LSPWrapper &lspWrapper, Expectations &test, int &nextId
                   "Mismatch on: " + expectedSymbolsPath);
 }
 
-static string RUBYFMT_TEST_FLAG = "# rubyfmt-force-exit";
-
 void testDocumentFormatting(LSPWrapper &lspWrapper, Expectations &test, int &nextId, string_view uri,
                             string_view testFile) {
     auto expectationFileName = test.expectations["document-formatting-rubyfmt"][testFile];

--- a/test/pipeline_test.bzl
+++ b/test/pipeline_test.bzl
@@ -104,7 +104,7 @@ _TEST_RUNNERS = {
     "PackagerTests": ":pipeline_test_runner",
 }
 
-def pipeline_tests(suite_name, all_paths, test_name_prefix, extra_args = [], tags = []):
+def pipeline_tests(suite_name, all_paths, test_name_prefix, extra_files = [], tags = []):
     tests = {}  # test_name-> {"path": String, "prefix": String, "sentinel": String}
 
     # The packager step needs folder-based steps since folder structure dictates package membership.
@@ -172,6 +172,7 @@ def pipeline_tests(suite_name, all_paths, test_name_prefix, extra_args = [], tag
             enabled_tests.append(test_name)
 
         data = []
+        data += extra_files
         if tests[name]["isDirectory"]:
             data += native.glob(["{}**/*".format(prefix)])
         elif tests[name]["isMultiFile"]:

--- a/test/testdata/lsp/ripper_parse_error_formatting.rb
+++ b/test/testdata/lsp/ripper_parse_error_formatting.rb
@@ -1,0 +1,1 @@
+# rubyfmt-force-exit 2

--- a/test/testdata/lsp/ripper_parse_error_formatting.rb
+++ b/test/testdata/lsp/ripper_parse_error_formatting.rb
@@ -1,1 +1,2 @@
+# typed: strict
 # rubyfmt-force-exit 2

--- a/test/testdata/lsp/ripper_parse_error_formatting.rb.document-formatting-rubyfmt.exp
+++ b/test/testdata/lsp/ripper_parse_error_formatting.rb.document-formatting-rubyfmt.exp
@@ -1,0 +1,2 @@
+`rubyfmt` failed to deserialize the parse tree from Ripper for test/testdata/lsp/ripper_parse_error_formatting.rb.
+This is valid Ruby but represents a bug in `rubyfmt`.

--- a/test/testdata/lsp/rubyfmt-stub/rubyfmt
+++ b/test/testdata/lsp/rubyfmt-stub/rubyfmt
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+exit_code=$(grep 'rubyfmt-force-exit' < "$1" | grep -Eow "[0-9]+")
+
+if [ "$exit_code" == 0 ]; then
+    echo "Stub output formatted by rubyfmt"
+fi
+
+exit "$exit_code"

--- a/test/testdata/lsp/rubyfmt_init_error.rb
+++ b/test/testdata/lsp/rubyfmt_init_error.rb
@@ -1,1 +1,2 @@
+# typed: strict
 # rubyfmt-force-exit 101

--- a/test/testdata/lsp/rubyfmt_init_error.rb
+++ b/test/testdata/lsp/rubyfmt_init_error.rb
@@ -1,0 +1,1 @@
+# rubyfmt-force-exit 101

--- a/test/testdata/lsp/rubyfmt_init_error.rb.document-formatting-rubyfmt.exp
+++ b/test/testdata/lsp/rubyfmt_init_error.rb.document-formatting-rubyfmt.exp
@@ -1,0 +1,1 @@
+`rubyfmt` failed to initialize.

--- a/test/testdata/lsp/rubyfmt_io_error_formatting.rb
+++ b/test/testdata/lsp/rubyfmt_io_error_formatting.rb
@@ -1,0 +1,1 @@
+# rubyfmt-force-exit 3

--- a/test/testdata/lsp/rubyfmt_io_error_formatting.rb
+++ b/test/testdata/lsp/rubyfmt_io_error_formatting.rb
@@ -1,1 +1,2 @@
+# typed: strict
 # rubyfmt-force-exit 3

--- a/test/testdata/lsp/rubyfmt_io_error_formatting.rb.document-formatting-rubyfmt.exp
+++ b/test/testdata/lsp/rubyfmt_io_error_formatting.rb.document-formatting-rubyfmt.exp
@@ -1,0 +1,2 @@
+`rubyfmt` encountered an IO error while writing test/testdata/lsp/rubyfmt_io_error_formatting.rb.
+This is likely a bug in `rubyfmt`.

--- a/test/testdata/lsp/rubyfmt_ruby_error.rb
+++ b/test/testdata/lsp/rubyfmt_ruby_error.rb
@@ -1,1 +1,2 @@
+# typed: strict
 # rubyfmt-force-exit 4

--- a/test/testdata/lsp/rubyfmt_ruby_error.rb
+++ b/test/testdata/lsp/rubyfmt_ruby_error.rb
@@ -1,0 +1,1 @@
+# rubyfmt-force-exit 4

--- a/test/testdata/lsp/rubyfmt_ruby_error.rb.document-formatting-rubyfmt.exp
+++ b/test/testdata/lsp/rubyfmt_ruby_error.rb.document-formatting-rubyfmt.exp
@@ -1,0 +1,2 @@
+`rubyfmt` encountered a ruby error while writing test/testdata/lsp/rubyfmt_ruby_error.rb.
+This is likely a bug in `rubyfmt`.

--- a/test/testdata/lsp/rubyfmt_unknown_error.rb
+++ b/test/testdata/lsp/rubyfmt_unknown_error.rb
@@ -1,1 +1,2 @@
+# typed: strict
 # rubyfmt-force-exit 111

--- a/test/testdata/lsp/rubyfmt_unknown_error.rb
+++ b/test/testdata/lsp/rubyfmt_unknown_error.rb
@@ -1,0 +1,1 @@
+# rubyfmt-force-exit 111

--- a/test/testdata/lsp/rubyfmt_unknown_error.rb.document-formatting-rubyfmt.exp
+++ b/test/testdata/lsp/rubyfmt_unknown_error.rb.document-formatting-rubyfmt.exp
@@ -1,0 +1,1 @@
+`rubyfmt` encountered an unknown exception (exit code 111).

--- a/test/testdata/lsp/successful_formatting.rb
+++ b/test/testdata/lsp/successful_formatting.rb
@@ -1,1 +1,2 @@
+# typed: strict
 # rubyfmt-force-exit 0

--- a/test/testdata/lsp/successful_formatting.rb
+++ b/test/testdata/lsp/successful_formatting.rb
@@ -1,0 +1,1 @@
+# rubyfmt-force-exit 0

--- a/test/testdata/lsp/successful_formatting.rb.document-formatting-rubyfmt.exp
+++ b/test/testdata/lsp/successful_formatting.rb.document-formatting-rubyfmt.exp
@@ -1,0 +1,1 @@
+Stub output formatted by rubyfmt

--- a/test/testdata/lsp/syntax_error_formatting.rb
+++ b/test/testdata/lsp/syntax_error_formatting.rb
@@ -1,1 +1,2 @@
+# typed: strict
 # rubyfmt-force-exit 1

--- a/test/testdata/lsp/syntax_error_formatting.rb
+++ b/test/testdata/lsp/syntax_error_formatting.rb
@@ -1,0 +1,1 @@
+# rubyfmt-force-exit 1

--- a/test/testdata/lsp/syntax_error_formatting.rb.document-formatting-rubyfmt.exp
+++ b/test/testdata/lsp/syntax_error_formatting.rb.document-formatting-rubyfmt.exp
@@ -1,1 +1,1 @@
-`rubyfmt` could not format test/testdata/lsp/parse_error_formatting.rb because it contains syntax errors.
+`rubyfmt` could not format test/testdata/lsp/syntax_error_formatting.rb because it contains syntax errors.

--- a/test/testdata/lsp/syntax_error_formatting.rb.document-formatting-rubyfmt.exp
+++ b/test/testdata/lsp/syntax_error_formatting.rb.document-formatting-rubyfmt.exp
@@ -1,0 +1,1 @@
+`rubyfmt` could not format test/testdata/lsp/parse_error_formatting.rb because it contains syntax errors.


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

This PR adds tests for the `rubyfmt` LSP implementation. As part of this, I also added an option to pass a rubyfmt executable path, since relying on the user's `PATH` was a pain to test and is probably a nice thing to have anyways, since relying on the `PATH` is a lot of action-at-a-distance.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Follow up to discussions from #5831 (cc @jez). Once this is merged, this feature can likely be stabilized for broader use, although I'll do that in a follow-up PR.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

(Well, this is almost _entirely_ tests.)
