### PR TITLE
Move #itself and #object_id to Kernel

### DIFF
--- a/gems/sorbet/test/hidden-method-finder/simple/sorbet_ruby_2_7_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/simple/sorbet_ruby_2_7_hidden.rbi.exp
@@ -2818,12 +2818,6 @@ JSON::State = JSON::Ext::Generator::State
 JSON::UnparserError = JSON::GeneratorError
 
 module Kernel
-  def itself(); end
-
-  def object_id(); end
-end
-
-module Kernel
   def self.at_exit(); end
 end
 

--- a/gems/sorbet/test/hidden-method-finder/simple/sorbet_ruby_3_0_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/simple/sorbet_ruby_3_0_hidden.rbi.exp
@@ -2871,12 +2871,6 @@ module JSON
 end
 
 module Kernel
-  def itself(); end
-
-  def object_id(); end
-end
-
-module Kernel
   def self.at_exit(); end
 end
 

--- a/gems/sorbet/test/hidden-method-finder/thorough/sorbet_ruby_2_7_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/thorough/sorbet_ruby_2_7_hidden.rbi.exp
@@ -2836,12 +2836,6 @@ JSON::State = JSON::Ext::Generator::State
 JSON::UnparserError = JSON::GeneratorError
 
 module Kernel
-  def itself(); end
-
-  def object_id(); end
-end
-
-module Kernel
   def self.at_exit(); end
 end
 

--- a/gems/sorbet/test/hidden-method-finder/thorough/sorbet_ruby_3_0_hidden.rbi.exp
+++ b/gems/sorbet/test/hidden-method-finder/thorough/sorbet_ruby_3_0_hidden.rbi.exp
@@ -2889,12 +2889,6 @@ module JSON
 end
 
 module Kernel
-  def itself(); end
-
-  def object_id(); end
-end
-
-module Kernel
   def self.at_exit(); end
 end
 

--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -2976,4 +2976,37 @@ module Kernel
       .returns(T.type_parameter(:X))
   end
   def then(&blk); end
+
+  # Returns an integer identifier for `obj`.
+  #
+  # The same number will be returned on all calls to `object_id` for a given
+  # object, and no two active objects will share an id.
+  #
+  # Note: that some objects of builtin classes are reused for optimization. This
+  # is the case for immediate values and frozen string literals.
+  #
+  # [`BasicObject`](https://docs.ruby-lang.org/en/2.7.0/BasicObject.html)
+  # implements +\_\_id\_\_+,
+  # [`Kernel`](https://docs.ruby-lang.org/en/2.7.0/Kernel.html) implements
+  # `object_id`.
+  #
+  # Immediate values are not passed by reference but are passed by value: `nil`,
+  # `true`, `false`, Fixnums, Symbols, and some Floats.
+  #
+  # ```ruby
+  # Object.new.object_id  == Object.new.object_id  # => false
+  # (21 * 2).object_id    == (21 * 2).object_id    # => true
+  # "hello".object_id     == "hello".object_id     # => false
+  # "hi".freeze.object_id == "hi".freeze.object_id # => true
+  # ```
+  sig {returns(Integer)}
+  def object_id(); end
+
+  # Returns the receiver `obj`.
+  #
+  # ```ruby
+  # obj = Object.new; obj.itself.object_id == o.object_id # => true
+  # ```
+  sig {returns(T.self_type)}
+  def itself(); end
 end

--- a/rbi/core/object.rbi
+++ b/rbi/core/object.rbi
@@ -27,36 +27,4 @@
 class Object < BasicObject
   include Kernel
 
-  # Returns an integer identifier for `obj`.
-  #
-  # The same number will be returned on all calls to `object_id` for a given
-  # object, and no two active objects will share an id.
-  #
-  # Note: that some objects of builtin classes are reused for optimization. This
-  # is the case for immediate values and frozen string literals.
-  #
-  # [`BasicObject`](https://docs.ruby-lang.org/en/2.7.0/BasicObject.html)
-  # implements +\_\_id\_\_+,
-  # [`Kernel`](https://docs.ruby-lang.org/en/2.7.0/Kernel.html) implements
-  # `object_id`.
-  #
-  # Immediate values are not passed by reference but are passed by value: `nil`,
-  # `true`, `false`, Fixnums, Symbols, and some Floats.
-  #
-  # ```ruby
-  # Object.new.object_id  == Object.new.object_id  # => false
-  # (21 * 2).object_id    == (21 * 2).object_id    # => true
-  # "hello".object_id     == "hello".object_id     # => false
-  # "hi".freeze.object_id == "hi".freeze.object_id # => true
-  # ```
-  sig {returns(Integer)}
-  def object_id(); end
-
-  # Returns the receiver `obj`.
-  #
-  # ```ruby
-  # obj = Object.new; obj.itself.object_id == o.object_id # => true
-  # ```
-  sig {returns(T.self_type)}
-  def itself(); end
 end

--- a/test/testdata/rbi/kernel.rb
+++ b/test/testdata/rbi/kernel.rb
@@ -57,6 +57,14 @@ obj = T.let("foo", String)
 # Object#then, with a block
 T.reveal_type(obj.then(&:to_i)) # error: Revealed type: `T.untyped`
 
+# object_id
+obj = T.let("foo", String)
+T.assert_type!(obj.object_id, Integer)
+
+# itself
+obj = T.let("foo", String)
+T.assert_type!(obj.itself, String)
+
 y = loop do
 end
 puts y # error: This code is unreachable


### PR DESCRIPTION
Follow up to https://github.com/sorbet/sorbet/pull/5849

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
As I was moving `then/yield_self` it was pointed out that `#object_id` and `#itself` also belongs to `Kernel` as per Ruby specs.

 - [object_id](https://github.com/ruby/ruby/blob/1177665e6224f8491db82997c8774e9485564e41/gc.c#L14065)
 - [itself](https://github.com/ruby/ruby/blob/1177665e6224f8491db82997c8774e9485564e41/object.c#L4318)

### Test plan
I've updated the kernel test data as well the expectations for the hidden method finders.
