### PR TITLE
methodArgumentHash: vector<uint32_t> -> uint32_t

### DIFF
--- a/ast/ArgParsing.cc
+++ b/ast/ArgParsing.cc
@@ -70,21 +70,20 @@ vector<core::ParsedArg> ArgParsing::parseArgs(const ast::MethodDef::ARGS_store &
     return parsedArgs;
 }
 
-std::vector<uint32_t> ArgParsing::hashArgs(core::Context ctx, const std::vector<core::ParsedArg> &args) {
-    std::vector<uint32_t> result;
-    result.reserve(args.size());
+// This has to match the implementation of Method::methodArgumentHash
+uint32_t ArgParsing::hashArgs(core::Context ctx, const std::vector<core::ParsedArg> &args) {
+    uint32_t result = 0;
     for (const auto &e : args) {
-        uint32_t arg = 0;
         if (e.flags.isKeyword) {
             if (e.flags.isRepeated && e.local._name != core::Names::fwdKwargs()) {
                 auto name = core::Names::kwargs();
-                arg = core::mix(arg, core::_hash(name.shortName(ctx)));
+                result = core::mix(result, core::_hash(name.shortName(ctx)));
             } else {
-                arg = core::mix(arg, core::_hash(e.local._name.shortName(ctx)));
+                result = core::mix(result, core::_hash(e.local._name.shortName(ctx)));
             }
         }
 
-        result.push_back(core::mix(arg, e.flags.toU1()));
+        result = core::mix(result, e.flags.toU1());
     }
     return result;
 }

--- a/ast/ArgParsing.cc
+++ b/ast/ArgParsing.cc
@@ -75,7 +75,6 @@ std::vector<uint32_t> ArgParsing::hashArgs(core::Context ctx, const std::vector<
     result.reserve(args.size());
     for (const auto &e : args) {
         uint32_t arg = 0;
-        uint8_t flags = 0;
         if (e.flags.isKeyword) {
             if (e.flags.isRepeated && e.local._name != core::Names::fwdKwargs()) {
                 auto name = core::Names::kwargs();
@@ -83,22 +82,9 @@ std::vector<uint32_t> ArgParsing::hashArgs(core::Context ctx, const std::vector<
             } else {
                 arg = core::mix(arg, core::_hash(e.local._name.shortName(ctx)));
             }
-            flags += 1;
-        }
-        if (e.flags.isRepeated) {
-            flags += 2;
-        }
-        if (e.flags.isDefault) {
-            flags += 4;
-        }
-        if (e.flags.isShadow) {
-            flags += 8;
-        }
-        if (e.flags.isBlock) {
-            flags += 16;
         }
 
-        result.push_back(core::mix(arg, flags));
+        result.push_back(core::mix(arg, e.flags.toU1()));
     }
     return result;
 }

--- a/ast/ArgParsing.cc
+++ b/ast/ArgParsing.cc
@@ -73,6 +73,7 @@ vector<core::ParsedArg> ArgParsing::parseArgs(const ast::MethodDef::ARGS_store &
 // This has to match the implementation of Method::methodArgumentHash
 uint32_t ArgParsing::hashArgs(core::Context ctx, const std::vector<core::ParsedArg> &args) {
     uint32_t result = 0;
+    result = core::mix(result, args.size());
     for (const auto &e : args) {
         if (e.flags.isKeyword) {
             if (e.flags.isRepeated && e.local._name != core::Names::fwdKwargs()) {

--- a/ast/ArgParsing.h
+++ b/ast/ArgParsing.h
@@ -5,7 +5,7 @@ namespace sorbet::ast {
 class ArgParsing {
 public:
     static std::vector<core::ParsedArg> parseArgs(const ast::MethodDef::ARGS_store &args);
-    static std::vector<uint32_t> hashArgs(core::Context ctx, const std::vector<core::ParsedArg> &args);
+    static uint32_t hashArgs(core::Context ctx, const std::vector<core::ParsedArg> &args);
     // Returns the default argument value for the given argument, or nullptr if not specified. Mutates arg.
     static ExpressionPtr getDefault(const core::ParsedArg &parsedArg, ExpressionPtr arg);
 };

--- a/core/FoundDefinitions.h
+++ b/core/FoundDefinitions.h
@@ -156,7 +156,7 @@ struct FoundMethod final {
     Flags flags;
     CheckSize(Flags, 1, 1);
     std::vector<core::ParsedArg> parsedArgs;
-    std::vector<uint32_t> argsHash;
+    uint32_t argsHash;
 
     std::string toString(const core::GlobalState &gs, const FoundDefinitions &foundDefs, uint32_t id) const;
 };

--- a/core/FoundDefinitions.h
+++ b/core/FoundDefinitions.h
@@ -160,7 +160,7 @@ struct FoundMethod final {
 
     std::string toString(const core::GlobalState &gs, const FoundDefinitions &foundDefs, uint32_t id) const;
 };
-CheckSize(FoundMethod, 80, 8);
+CheckSize(FoundMethod, 64, 8);
 
 struct FoundModifier {
     enum class Kind : uint8_t {

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -924,8 +924,7 @@ void GlobalState::preallocateTables(uint32_t classAndModulesSize, uint32_t metho
 
 constexpr decltype(GlobalState::STRINGS_PAGE_SIZE) GlobalState::STRINGS_PAGE_SIZE;
 
-MethodRef GlobalState::lookupMethodSymbolWithHash(ClassOrModuleRef owner, NameRef name,
-                                                  const vector<uint32_t> &methodHash) const {
+MethodRef GlobalState::lookupMethodSymbolWithHash(ClassOrModuleRef owner, NameRef name, uint32_t methodHash) const {
     ENFORCE(owner.exists(), "looking up symbol from non-existing owner");
     ENFORCE(name.exists(), "looking up symbol with non-existing name");
     auto ownerScope = owner.dataAllowingNone(*this);

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -124,8 +124,7 @@ public:
     MethodRef lookupMethodSymbol(ClassOrModuleRef owner, NameRef name) const {
         return lookupSymbolWithKind(owner, name, SymbolRef::Kind::Method, Symbols::noMethod()).asMethodRef();
     }
-    MethodRef lookupMethodSymbolWithHash(ClassOrModuleRef owner, NameRef name,
-                                         const std::vector<uint32_t> &methodHash) const;
+    MethodRef lookupMethodSymbolWithHash(ClassOrModuleRef owner, NameRef name, uint32_t methodHash) const;
     FieldRef lookupStaticFieldSymbol(ClassOrModuleRef owner, NameRef name) const {
         // N.B.: Fields and static fields have entirely different types of names, so this should be unambiguous.
         return lookupSymbolWithKind(owner, name, SymbolRef::Kind::FieldOrStaticField, Symbols::noField()).asFieldRef();

--- a/core/ParsedArg.h
+++ b/core/ParsedArg.h
@@ -17,10 +17,6 @@ struct ParsedArg {
         // In C++20 we can replace this with bit field initialzers
         ArgFlags() : isKeyword(false), isRepeated(false), isDefault(false), isShadow(false), isBlock(false) {}
 
-    private:
-        friend class Method;
-        friend class serialize::SerializerImpl;
-
         void setFromU1(uint8_t flags);
         uint8_t toU1() const;
     };

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -2281,9 +2281,7 @@ uint32_t Method::methodShapeHash(const GlobalState &gs) const {
     result = mix(result, this->owner.id());
     result = mix(result, this->rebind.id());
     result = mix(result, this->hasSig());
-    for (auto &arg : this->methodArgumentHash(gs)) {
-        result = mix(result, arg);
-    }
+    result = mix(result, this->methodArgumentHash(gs));
 
     if (name == core::Names::unresolvedAncestors()) {
         // This is a synthetic method that encodes the superclasses of its owning class in its return type.
@@ -2295,17 +2293,16 @@ uint32_t Method::methodShapeHash(const GlobalState &gs) const {
     return result;
 }
 
-vector<uint32_t> Method::methodArgumentHash(const GlobalState &gs) const {
-    vector<uint32_t> result;
-    result.reserve(arguments.size());
+// This has to match the implementation of ArgParsing::hashArgs
+uint32_t Method::methodArgumentHash(const GlobalState &gs) const {
+    uint32_t result = 0;
     for (const auto &e : arguments) {
-        uint32_t arg = 0;
         // Changing name of keyword arg is a shape change.
         if (e.flags.isKeyword) {
-            arg = mix(arg, _hash(e.name.shortName(gs)));
+            result = mix(result, _hash(e.name.shortName(gs)));
         }
         // Changing an argument from e.g. keyword to position-based is a shape change.
-        result.push_back(mix(arg, e.flags.toU1()));
+        result = mix(result, e.flags.toU1());
     }
     return result;
 }

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -2296,6 +2296,7 @@ uint32_t Method::methodShapeHash(const GlobalState &gs) const {
 // This has to match the implementation of ArgParsing::hashArgs
 uint32_t Method::methodArgumentHash(const GlobalState &gs) const {
     uint32_t result = 0;
+    result = mix(result, arguments.size());
     for (const auto &e : arguments) {
         // Changing name of keyword arg is a shape change.
         if (e.flags.isKeyword) {

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -84,7 +84,7 @@ public:
     void addLoc(const core::GlobalState &gs, core::Loc loc);
     uint32_t hash(const GlobalState &gs) const;
     uint32_t methodShapeHash(const GlobalState &gs) const;
-    std::vector<uint32_t> methodArgumentHash(const GlobalState &gs) const;
+    uint32_t methodArgumentHash(const GlobalState &gs) const;
 
     inline void setMethodPublic() {
         flags.isPrivate = false;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Despite this being a vector, we were never using it as a vector really. We
were always just using it as a single hash value.

It will be convenient for #5808 if I can just call this method and get a 
uint32_t, and since that already works for all the current use cases, I've
pulled it out as a pre-work change.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests