### PR TITLE
Stabilize document formatting LSP functionality

### DIFF
--- a/main/lsp/requests/document_formatting.cc
+++ b/main/lsp/requests/document_formatting.cc
@@ -55,13 +55,6 @@ void DocumentFormattingTask::displayError(string errorMessage, unique_ptr<Respon
 
 void DocumentFormattingTask::index(LSPIndexer &index) {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentFormatting);
-    if (!config.opts.lspDocumentFormatRubyfmtEnabled) {
-        response->error = make_unique<ResponseError>(
-            (int)LSPErrorCodes::InvalidRequest,
-            "The `Document Formatting` LSP feature is experimental and disabled by default.");
-        config.output->write(move(response));
-        return;
-    }
 
     variant<JSONNullObject, vector<unique_ptr<TextEdit>>> result = JSONNullObject();
 

--- a/main/lsp/requests/initialize.cc
+++ b/main/lsp/requests/initialize.cc
@@ -31,7 +31,7 @@ unique_ptr<ResponseMessage> InitializeTask::runRequest(LSPTypecheckerInterface &
     serverCap->hoverProvider = true;
     serverCap->referencesProvider = true;
     serverCap->implementationProvider = true;
-    serverCap->documentFormattingProvider = opts.lspDocumentFormatRubyfmtEnabled;
+    serverCap->documentFormattingProvider = true;
     serverCap->sorbetShowSymbolProvider = true;
 
     auto codeActionProvider = make_unique<CodeActionOptions>();

--- a/main/lsp/wrapper.cc
+++ b/main/lsp/wrapper.cc
@@ -161,7 +161,6 @@ void LSPWrapper::enableAllExperimentalFeatures() {
     enableExperimentalFeature(LSPExperimentalFeature::DocumentHighlight);
     enableExperimentalFeature(LSPExperimentalFeature::DocumentSymbol);
     enableExperimentalFeature(LSPExperimentalFeature::SignatureHelp);
-    enableExperimentalFeature(LSPExperimentalFeature::DocumentFormat);
 }
 
 void LSPWrapper::enableExperimentalFeature(LSPExperimentalFeature feature) {
@@ -174,9 +173,6 @@ void LSPWrapper::enableExperimentalFeature(LSPExperimentalFeature feature) {
             break;
         case LSPExperimentalFeature::SignatureHelp:
             opts->lspSignatureHelpEnabled = true;
-            break;
-        case LSPExperimentalFeature::DocumentFormat:
-            opts->lspDocumentFormatRubyfmtEnabled = true;
             break;
     }
 }

--- a/main/lsp/wrapper.h
+++ b/main/lsp/wrapper.h
@@ -51,7 +51,6 @@ public:
         DocumentSymbol = 6,
         SignatureHelp = 7,
         DocumentHighlight = 9,
-        DocumentFormat = 10,
     };
 
     // N.B.: Sorbet assumes we 'own' this object; keep it alive to avoid memory errors.

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -319,8 +319,6 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
                                     cxxopts::value<string>()->default_value(empty.watchmanPath));
     options.add_options("advanced")("enable-experimental-lsp-document-symbol",
                                     "Enable experimental LSP feature: Document Symbol");
-    options.add_options("advanced")("enable-experimental-lsp-document-formatting-rubyfmt",
-                                    "Enable experimental LSP feature: Document Formatting with Rubyfmt");
     options.add_options("advanced")(
         "rubyfmt-path",
         "Path to the rubyfmt executable used for document formatting. Defaults to using `rubyfmt` on your PATH.",
@@ -740,8 +738,6 @@ void readOptions(Options &opts,
         opts.lspDocumentHighlightEnabled =
             enableAllLSPFeatures || raw["enable-experimental-lsp-document-highlight"].as<bool>();
         opts.lspSignatureHelpEnabled = enableAllLSPFeatures || raw["enable-experimental-lsp-signature-help"].as<bool>();
-        opts.lspDocumentFormatRubyfmtEnabled =
-            enableAllLSPFeatures || raw["enable-experimental-lsp-document-formatting-rubyfmt"].as<bool>();
 
         // TODO(aprocter): For the moment, we are not including this flag in the "enableAllLSPFeatures" bundle, because
         // it's likely to be even less stable than a typical experimental flag, and will be producing stub answers

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -239,7 +239,6 @@ struct Options {
     // Booleans enabling various experimental LSP features. Each will be removed once corresponding feature stabilizes.
     bool lspDocumentHighlightEnabled = false;
     bool lspDocumentSymbolEnabled = false;
-    bool lspDocumentFormatRubyfmtEnabled = false;
     bool lspSignatureHelpEnabled = false;
     bool lspStaleStateEnabled = false;
 

--- a/main/options/test/options_test.cc
+++ b/main/options/test/options_test.cc
@@ -72,7 +72,6 @@ TEST_CASE("DefaultConstructorMatchesReadOptions") {
     CHECK_EQ(empty.lspDocumentSymbolEnabled, opts.lspDocumentSymbolEnabled);
     CHECK_EQ(empty.lspDocumentHighlightEnabled, opts.lspDocumentHighlightEnabled);
     CHECK_EQ(empty.lspSignatureHelpEnabled, opts.lspSignatureHelpEnabled);
-    CHECK_EQ(empty.lspDocumentFormatRubyfmtEnabled, opts.lspDocumentFormatRubyfmtEnabled);
     CHECK_EQ(empty.rubyfmtPath, opts.rubyfmtPath);
     CHECK_EQ(empty.inlineInput, opts.inlineInput);
     CHECK_EQ(empty.debugLogFile, opts.debugLogFile);

--- a/test/cli/lsp-common-case-exit/test.out
+++ b/test/cli/lsp-common-case-exit/test.out
@@ -1,5 +1,5 @@
-Content-Length: 597
+Content-Length: 596
 
-{"jsonrpc":"2.0","id":0,"requestMethod":"initialize","result":{"capabilities":{"textDocumentSync":1,"hoverProvider":true,"completionProvider":{"triggerCharacters":[".",":","@","#"]},"definitionProvider":true,"typeDefinitionProvider":true,"implementationProvider":true,"referencesProvider":true,"documentHighlightProvider":false,"documentSymbolProvider":false,"workspaceSymbolProvider":true,"codeActionProvider":{"codeActionKinds":["quickfix","source.fixAll.sorbet","refactor.extract"]},"documentFormattingProvider":false,"renameProvider":{"prepareProvider":true},"sorbetShowSymbolProvider":true}}}Content-Length: 65
+{"jsonrpc":"2.0","id":0,"requestMethod":"initialize","result":{"capabilities":{"textDocumentSync":1,"hoverProvider":true,"completionProvider":{"triggerCharacters":[".",":","@","#"]},"definitionProvider":true,"typeDefinitionProvider":true,"implementationProvider":true,"referencesProvider":true,"documentHighlightProvider":false,"documentSymbolProvider":false,"workspaceSymbolProvider":true,"codeActionProvider":{"codeActionKinds":["quickfix","source.fixAll.sorbet","refactor.extract"]},"documentFormattingProvider":true,"renameProvider":{"prepareProvider":true},"sorbetShowSymbolProvider":true}}}Content-Length: 65
 
 {"jsonrpc":"2.0","id":1,"requestMethod":"shutdown","result":null}

--- a/test/helpers/lsp.cc
+++ b/test/helpers/lsp.cc
@@ -232,7 +232,7 @@ void checkServerCapabilities(const ServerCapabilities &capabilities) {
     CHECK(capabilities.codeActionProvider.has_value());
     CHECK(capabilities.renameProvider.has_value());
     CHECK_FALSE(capabilities.codeLensProvider.has_value());
-    CHECK(capabilities.documentFormattingProvider.value_or(false));
+    CHECK(capabilities.documentFormattingProvider.has_value());
     CHECK_FALSE(capabilities.documentRangeFormattingProvider.has_value());
     CHECK_FALSE(capabilities.documentRangeFormattingProvider.has_value());
     CHECK_FALSE(capabilities.documentOnTypeFormattingProvider.has_value());


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

The final installment (for now) of my `rubyfmt` journey: this enables document formatting as a stable feature in the LSP. This is mostly removing the config flags that disable formatting and updating any tests

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This will be gradually rolled out as a default formatter at Stripe, so this will need to be on the stable configuration.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
