### PR TITLE
Properly initialize rubyfmt-path

### DIFF
--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -742,6 +742,7 @@ void readOptions(Options &opts,
         opts.lspSignatureHelpEnabled = enableAllLSPFeatures || raw["enable-experimental-lsp-signature-help"].as<bool>();
         opts.lspDocumentFormatRubyfmtEnabled =
             enableAllLSPFeatures || raw["enable-experimental-lsp-document-formatting-rubyfmt"].as<bool>();
+        opts.rubyfmtPath = raw["rubyfmt-path"].as<string>();
 
         // TODO(aprocter): For the moment, we are not including this flag in the "enableAllLSPFeatures" bundle, because
         // it's likely to be even less stable than a typical experimental flag, and will be producing stub answers


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

This flag was added to the list of options in #5857, but it wasn't properly read off of the raw parameters, so it was a no-op. This passes it to the cleaned `opts` struct so that it's usable from the command line.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

https://github.com/sorbet/sorbet/pull/5857#discussion_r887355630

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

