### PR TITLE
Fix visibility checker for superclass declarations

### DIFF
--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -423,6 +423,16 @@ public:
         return tree;
     }
 
+    ast::ExpressionPtr preTransformClassDef(core::Context ctx, ast::ExpressionPtr tree) {
+        auto &original = ast::cast_tree_nonnull<ast::ClassDef>(tree);
+        if (original.kind == ast::ClassDef::Kind::Class && !original.ancestors.empty()) {
+            auto &superClass = original.ancestors[0];
+            superClass = ast::TreeMap::apply(ctx, *this, std::move(superClass));
+        }
+
+        return tree;
+    }
+
     static std::vector<ast::ParsedFile> run(const core::GlobalState &gs, WorkerPool &workers,
                                             std::vector<ast::ParsedFile> files) {
         Timer timeit(gs.tracer(), "visibility_checker.check_visibility");

--- a/test/cli/package-top-level-inheritance/__package.rb
+++ b/test/cli/package-top-level-inheritance/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class Main < PackageSpec
+  export Main::B
+end

--- a/test/cli/package-top-level-inheritance/a/__package.rb
+++ b/test/cli/package-top-level-inheritance/a/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class Main::A < PackageSpec
+end
+

--- a/test/cli/package-top-level-inheritance/a/foo.rb
+++ b/test/cli/package-top-level-inheritance/a/foo.rb
@@ -1,0 +1,8 @@
+# typed: strict
+
+module Main
+  module A
+    class Foo < Main::B
+    end
+  end
+end

--- a/test/cli/package-top-level-inheritance/b.rb
+++ b/test/cli/package-top-level-inheritance/b.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+class Main::B
+end

--- a/test/cli/package-top-level-inheritance/test.out
+++ b/test/cli/package-top-level-inheritance/test.out
@@ -1,0 +1,11 @@
+a/foo.rb:5: `Main::B` resolves but its package is not imported https://srb.help/3718
+     5 |    class Foo < Main::B
+                        ^^^^^^^
+    __package.rb:3: Exported from package here
+     3 |class Main < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    a/__package.rb:3: Insert `import Main`
+     3 |class Main::A < PackageSpec
+                                   ^
+Errors: 1

--- a/test/cli/package-top-level-inheritance/test.sh
+++ b/test/cli/package-top-level-inheritance/test.sh
@@ -1,0 +1,4 @@
+cd test/cli/package-top-level-inheritance || exit 1
+
+../../../main/sorbet --silence-dev-message --stripe-packages . 2>&1
+

--- a/test/testdata/packager/strict_nested/__package.rb
+++ b/test/testdata/packager/strict_nested/__package.rb
@@ -1,0 +1,8 @@
+# typed: strict
+# enable-packager: true
+
+class Root < PackageSpec
+  import Root::Nested
+
+  export Root::MyClass
+end

--- a/test/testdata/packager/strict_nested/my_class.rb
+++ b/test/testdata/packager/strict_nested/my_class.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+class Root::MyClass
+end

--- a/test/testdata/packager/strict_nested/nested/__package.rb
+++ b/test/testdata/packager/strict_nested/nested/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class Root::Nested < PackageSpec
+  # does not import Root
+end

--- a/test/testdata/packager/strict_nested/nested/example.rb
+++ b/test/testdata/packager/strict_nested/nested/example.rb
@@ -1,0 +1,22 @@
+# typed: strict
+
+module Root
+  module Nested
+    class Example
+      p(Root)
+      # ^^^^ error: resolves but its package is not imported
+      p(Root::MyClass)
+      # ^^^^^^^^^^^^^ error: resolves but its package is not imported
+    end
+
+    p(Root)
+    # ^^^^ error: resolves but its package is not imported
+    p(Root::MyClass)
+    # ^^^^^^^^^^^^^ error: resolves but its package is not imported
+  end
+end
+
+p(Root)
+# ^^^^ error: resolves but its package is not imported
+p(Root::MyClass)
+# ^^^^^^^^^^^^^ error: resolves but its package is not imported


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Fixes a bug in the new package enforcement which ends up ignoring constant references if they are used in a superclass declaration.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
The new package visibility checker has a bug -- it ignores references of the form:

```
class MyPackage::A < OtherPackage::B # OtherPackage::B is not checked!
```

This was tied to its handling of `keep_for_ide` declarations. We can safely remove this handling and simply ignore class definitions. Correct name-spacing of class declarations is already enforced by the packager pass.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Tested on Stripe codebase.
