### PR TITLE
RBI: `Thread#fetch` accepts a block

### DIFF
--- a/rbi/core/thread.rbi
+++ b/rbi/core/thread.rbi
@@ -402,7 +402,7 @@ class Thread < Object
   # [`Hash#fetch`](https://docs.ruby-lang.org/en/2.7.0/Hash.html#method-i-fetch).
   sig {params(sym: T.untyped).returns(T.untyped)}
   sig {params(sym: T.untyped, blk: T.proc.returns(T.untyped)).returns(T.untyped)}
-  def fetch(*sym); end
+  def fetch(*sym, &blk); end
 
   # Returns the
   # [`ThreadGroup`](https://docs.ruby-lang.org/en/2.7.0/ThreadGroup.html) which


### PR DESCRIPTION
This matches how `Hash#fetch` works.

```ruby
2.7.3 :002 > Thread.current[:foo] = "bar"
 => "bar"
2.7.3 :003 > Thread.current.fetch(:foo)
 => "bar"
2.7.3 :004 > Thread.current.fetch(:foo) { "bar2" }
 => "bar"
2.7.3 :005 > Thread.current.fetch(:foo2) { "bar2" }
 => "bar2"
```
