### PR TITLE
Drop core::FoundMethod to 56 bytes

### DIFF
--- a/core/FoundDefinitions.h
+++ b/core/FoundDefinitions.h
@@ -141,6 +141,8 @@ struct FoundMethod final {
     core::NameRef name;
     core::LocOffsets loc;
     core::LocOffsets declLoc;
+    std::vector<core::ParsedArg> parsedArgs;
+    uint32_t argsHash;
     struct Flags {
         bool isSelfMethod : 1;
         bool isRewriterSynthesized : 1;
@@ -155,12 +157,10 @@ struct FoundMethod final {
     };
     Flags flags;
     CheckSize(Flags, 1, 1);
-    std::vector<core::ParsedArg> parsedArgs;
-    uint32_t argsHash;
 
     std::string toString(const core::GlobalState &gs, const FoundDefinitions &foundDefs, uint32_t id) const;
 };
-CheckSize(FoundMethod, 64, 8);
+CheckSize(FoundMethod, 56, 8);
 
 struct FoundModifier {
     enum class Kind : uint8_t {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Followup to #5860 as suggested by froydnj.

I had mistakenly judged NameRef to take 8 bytes (because clangd was
running in debug mode in my editor). NameRef is 4 bytes in prod builds.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.