### PR TITLE
Make error fail with better message

### DIFF
--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -1046,6 +1046,12 @@ shared_ptr<FastPathAssertion> FastPathAssertion::make(string_view filename, uniq
                                                       string_view assertionContents, string_view assertionType) {
     optional<vector<string>> expectedFiles;
     if (!assertionContents.empty()) {
+        if (assertionContents == "true") {
+            auto filenameStr = string(filename);
+            ADD_FAIL_CHECK_AT(filenameStr.c_str(), assertionLine,
+                              "Unlike assert-slow-path, assert-fast-path takes a comma-separated list of file "
+                              "basenames which should be typechecked on the fast path");
+        }
         expectedFiles = absl::StrSplit(assertionContents, ',');
         fast_sort(*expectedFiles);
     }

--- a/test/testdata/lsp/fast_path/parse_errors.3.rbupdate
+++ b/test/testdata/lsp/fast_path/parse_errors.3.rbupdate
@@ -1,5 +1,5 @@
 # typed: true
-# assert-fast-path: parse_errors.rb
+# assert-fast-path: true
 class A
   def foo; end
 end

--- a/test/testdata/lsp/fast_path/parse_errors.3.rbupdate
+++ b/test/testdata/lsp/fast_path/parse_errors.3.rbupdate
@@ -1,5 +1,5 @@
 # typed: true
-# assert-fast-path: true
+# assert-fast-path: parse_errors.rb
 class A
   def foo; end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The error output looks like this:

    test/lsp_test_runner.cc:491:
    TEST CASE:  LSPTest

    test/testdata/lsp/fast_path/parse_errors.rb:1: ERROR: Unlike assert-slow-path, assert-fast-path takes a comma-separated list of file basenames which should be typechecked on the fast path

    test/testdata/lsp/fast_path/parse_errors.rb.3.rbupdate:1: ERROR: [*.3.rbupdate] Expected file update to cause test/testdata/lsp/fast_path/true to also be typechecked.

    test/testdata/lsp/fast_path/parse_errors.rb.3.rbupdate:1: ERROR: [*.3.rbupdate] File update caused test/testdata/lsp/fast_path/parse_errors.rb to be typechecked unexpectedly.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.