### PR TITLE
Make sleep-in-slow-path configurable & cancellable

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1832,7 +1832,7 @@ unique_ptr<GlobalState> GlobalState::deepCopy(bool keepId) const {
     result->ensureCleanStrings = this->ensureCleanStrings;
     result->runningUnderAutogen = this->runningUnderAutogen;
     result->censorForSnapshotTests = this->censorForSnapshotTests;
-    result->sleepInSlowPath = this->sleepInSlowPath;
+    result->sleepInSlowPathSeconds = this->sleepInSlowPathSeconds;
     result->requiresAncestorEnabled = this->requiresAncestorEnabled;
 
     if (keepId) {
@@ -1926,7 +1926,7 @@ unique_ptr<GlobalState> GlobalState::copyForIndex() const {
     result->ensureCleanStrings = this->ensureCleanStrings;
     result->runningUnderAutogen = this->runningUnderAutogen;
     result->censorForSnapshotTests = this->censorForSnapshotTests;
-    result->sleepInSlowPath = this->sleepInSlowPath;
+    result->sleepInSlowPathSeconds = this->sleepInSlowPathSeconds;
     result->requiresAncestorEnabled = this->requiresAncestorEnabled;
     result->kvstoreUuid = this->kvstoreUuid;
     result->errorUrlBase = this->errorUrlBase;

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -232,7 +232,7 @@ public:
     bool runningUnderAutogen = false;
     bool censorForSnapshotTests = false;
 
-    bool sleepInSlowPath = false;
+    std::optional<int> sleepInSlowPathSeconds = std::nullopt;
 
     std::unique_ptr<GlobalState> deepCopy(bool keepId = false) const;
     mutable std::shared_ptr<ErrorQueue> errorQueue;

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -459,8 +459,14 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates updates, WorkerPool &workers, bo
                 +[](bool *slowPathBlocked) -> bool { return !*slowPathBlocked; }, &slowPathBlocked));
         }
 
-        if (gs->sleepInSlowPath) {
-            Timer::timedSleep(3000ms, *logger, "slow_path.resolve.sleep");
+        if (gs->sleepInSlowPathSeconds.has_value()) {
+            auto sleepDuration = gs->sleepInSlowPathSeconds.value();
+            for (int i = 0; i < sleepDuration * 10; i++) {
+                Timer::timedSleep(100ms, *logger, "slow_path.resolve.sleep");
+                if (epochManager.wasTypecheckingCanceled()) {
+                    break;
+                }
+            }
         }
         auto maybeResolved = pipeline::resolve(gs, move(indexedCopies), config->opts, workers);
         if (!maybeResolved.hasResult()) {
@@ -471,8 +477,14 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates updates, WorkerPool &workers, bo
         for (auto &tree : resolved) {
             ENFORCE(tree.file.exists());
         }
-        if (gs->sleepInSlowPath) {
-            Timer::timedSleep(3000ms, *logger, "slow_path.typecheck.sleep");
+        if (gs->sleepInSlowPathSeconds.has_value()) {
+            auto sleepDuration = gs->sleepInSlowPathSeconds.value();
+            for (int i = 0; i < sleepDuration * 10; i++) {
+                Timer::timedSleep(100ms, *logger, "slow_path.resolve.sleep");
+                if (epochManager.wasTypecheckingCanceled()) {
+                    break;
+                }
+            }
         }
 
         // Inform the fast path that this global state is OK for typechecking as resolution has completed.

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -440,7 +440,8 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
     options.add_options("dev")("wait-for-dbg", "Wait for debugger on start");
     options.add_options("dev")("stress-incremental-resolver",
                                "Force incremental updates to discover resolver & namer bugs");
-    options.add_options("dev")("sleep-in-slow-path", "Add some sleeps to slow path to artificially slow it down");
+    options.add_options("dev")("sleep-in-slow-path", "Add some sleeps to slow path to artificially slow it down",
+                               cxxopts::value<int>()->implicit_value("3"));
     options.add_options("dev")("simulate-crash", "Crash on start");
     options.add_options("dev")("silence-dev-message", "Silence \"You are running a development build\" message");
     options.add_options("dev")("censor-for-snapshot-tests",
@@ -869,7 +870,9 @@ void readOptions(Options &opts,
         opts.traceLexer = raw["trace-lexer"].as<bool>();
         opts.traceParser = raw["trace-parser"].as<bool>();
         opts.stressIncrementalResolver = raw["stress-incremental-resolver"].as<bool>();
-        opts.sleepInSlowPath = raw["sleep-in-slow-path"].as<bool>();
+        if (raw.count("sleep-in-slow-path") > 0) {
+            opts.sleepInSlowPathSeconds = raw["sleep-in-slow-path"].as<int>();
+        }
         opts.enableCounters = raw["counters"].as<bool>();
         opts.silenceDevMessage = raw["silence-dev-message"].as<bool>();
         opts.censorForSnapshotTests = raw["censor-for-snapshot-tests"].as<bool>();

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -144,7 +144,7 @@ struct Options {
     bool disableWatchman = false;
     std::string watchmanPath = "watchman";
     bool stressIncrementalResolver = false;
-    bool sleepInSlowPath = false;
+    std::optional<int> sleepInSlowPathSeconds = std::nullopt;
     bool traceLexer = false;
     bool traceParser = false;
     bool noErrorCount = false;

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -505,9 +505,7 @@ int realmain(int argc, char *argv[]) {
     if (opts.censorForSnapshotTests) {
         gs->censorForSnapshotTests = true;
     }
-    if (opts.sleepInSlowPath) {
-        gs->sleepInSlowPath = true;
-    }
+    gs->sleepInSlowPathSeconds = opts.sleepInSlowPathSeconds;
     gs->preallocateTables(opts.reserveClassTableCapacity, opts.reserveMethodTableCapacity,
                           opts.reserveFieldTableCapacity, opts.reserveTypeArgumentTableCapacity,
                           opts.reserveTypeMemberTableCapacity, opts.reserveUtf8NameTableCapacity,


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

`--sleep-in-slow-path` is meant to simulate the kind of user pain that people
would experience using Sorbet in an editor on a non-trivial codebase size.

It was overestimating that pain because the sleeps did not respect slow path
cancellation. Even if a subsequent edit would come in that allowed for taking
the fast path, the sleeps would run to completion.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tested in my editor. There are no tests for this feature, but also ~no users 🙃