### PR TITLE
don't side-effectually access TLS variables for non-prod counters

### DIFF
--- a/common/Counters.cc
+++ b/common/Counters.cc
@@ -144,7 +144,9 @@ void counterConsume(CounterState cs) {
 }
 
 void counterAdd(ConstExprStr counter, unsigned long value) {
-    counterState.counterAdd(counter.str, value);
+    if constexpr (enable_counters) {
+        counterState.counterAdd(counter.str, value);
+    }
 }
 
 void counterInc(ConstExprStr counter) {
@@ -168,7 +170,9 @@ void prodCategoryCounterInc(ConstExprStr category, ConstExprStr counter) {
 }
 
 void categoryCounterAdd(ConstExprStr category, ConstExprStr counter, unsigned long value) {
-    counterState.categoryCounterAdd(category.str, counter.str, value);
+    if constexpr (enable_counters) {
+        counterState.categoryCounterAdd(category.str, counter.str, value);
+    }
 }
 
 int genThreadId() {
@@ -254,7 +258,9 @@ void histogramInc(ConstExprStr histogram, int key) {
 }
 
 void histogramAdd(ConstExprStr histogram, int key, unsigned long value) {
-    counterState.histogramAdd(histogram.str, key, value);
+    if constexpr (enable_counters) {
+        counterState.histogramAdd(histogram.str, key, value);
+    }
 }
 
 void prodHistogramInc(ConstExprStr histogram, int key) {


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Since these functions were accessing `counterState`, even though we ultimately wound up compiling the method call to nothing, the compiler still considered the access to the TLS variable as a possible initialization of said variable.  And that initialization could not be folded away, since it is side-effectual.  So we were inserting compares and jumps + initialization code wherever we called these functions.

This change makes a release-linux binary ~200K smaller and eliminates several billion (!) instructions from a run of Sorbet on Stripe's codebase.  Whether that impacts runtime...I haven't measured, but such a change cannot be a bad thing.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
