### PR TITLE
manually hoist data pointer accesses in `UIntSet` set methods

### DIFF
--- a/common/UIntSet.cc
+++ b/common/UIntSet.cc
@@ -28,15 +28,25 @@ bool UIntSet::contains(uint32_t item) const {
 
 void UIntSet::remove(const UIntSet &set) {
     ENFORCE_NO_TIMER(_members.size() == set._members.size());
+    // Manually lift the computation of the data pointer outside of the loop,
+    // since normal `InlinedVector` accesses branch on whether the vector is
+    // stored inline or not.
+    auto *ourptr = _members.data();
+    auto *setptr = set._members.data();
     for (int i = 0; i < _members.size(); i++) {
-        _members[i] &= ~set._members[i];
+        ourptr[i] &= ~setptr[i];
     }
 }
 
 void UIntSet::add(const UIntSet &set) {
     ENFORCE_NO_TIMER(_members.size() == set._members.size());
+    // Manually lift the computation of the data pointer outside of the loop,
+    // since normal `InlinedVector` accesses branch on whether the vector is
+    // stored inline or not.
+    auto *ourptr = _members.data();
+    auto *setptr = set._members.data();
     for (int i = 0; i < _members.size(); i++) {
-        _members[i] |= set._members[i];
+        ourptr[i] |= setptr[i];
     }
 }
 
@@ -51,8 +61,13 @@ bool UIntSet::empty() const {
 
 void UIntSet::intersect(const UIntSet &set) {
     ENFORCE_NO_TIMER(_members.size() == set._members.size());
+    // Manually lift the computation of the data pointer outside of the loop,
+    // since normal `InlinedVector` accesses branch on whether the vector is
+    // stored inline or not.
+    auto *ourptr = _members.data();
+    auto *setptr = set._members.data();
     for (int i = 0; i < _members.size(); i++) {
-        _members[i] &= set._members[i];
+        ourptr[i] &= setptr[i];
     }
 }
 


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The code for these methods was terrible because the compiler could not see that the branches to determine whether or not the data for the vectors were stored inline were actually loop invariant.  With this change, we get much better code generation (e.g. loop unrolling, vectorization, no branches in the loop body, etc.) and ~3% speedup on a pathological testcase derived from Stripe's codebase.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
