### PR TITLE
wip: POC Suggest arguments after typing method def

### DIFF
--- a/main/sig_finder/sig_finder.cc
+++ b/main/sig_finder/sig_finder.cc
@@ -59,7 +59,7 @@ void SigFinder::postTransformClassDef(core::Context ctx, ast::ExpressionPtr &tre
 void SigFinder::preTransformMethodDef(core::Context ctx, ast::ExpressionPtr &tree) {
     if (this->result_.has_value()) {
         if (this->result_->origSend->loc.endPos() <= tree.loc().beginPos() &&
-            tree.loc().endPos() <= queryLoc.beginPos()) {
+            tree.loc().endPos() < queryLoc.beginPos()) {
             // There is a method definition between the current result sig and the queryLoc,
             // so the sig we found is not for the right method.
             this->result_ = nullopt;
@@ -70,7 +70,7 @@ void SigFinder::preTransformMethodDef(core::Context ctx, ast::ExpressionPtr &tre
 void SigFinder::postTransformRuntimeMethodDefinition(core::Context ctx, ast::ExpressionPtr &tree) {
     if (this->result_.has_value()) {
         if (this->result_->origSend->loc.endPos() <= tree.loc().beginPos() &&
-            tree.loc().endPos() <= queryLoc.beginPos()) {
+            tree.loc().endPos() < queryLoc.beginPos()) {
             // There is a method definition between the current result sig and the queryLoc,
             // so the sig we found is not for the right method.
             this->result_ = nullopt;

--- a/test/testdata/lsp/completion/suggest_arguments.A.rbedited
+++ b/test/testdata/lsp/completion/suggest_arguments.A.rbedited
@@ -1,0 +1,11 @@
+# typed: true
+
+class A # error: Hint: this "class" token is not closed before the end of the file
+  extend T::Sig
+  sig {params(x: Integer, y: Integer).void}
+  #           ^ error: Unknown argument name `x`
+  #                       ^ error: Unknown argument name `y`
+  def foo(x, y) # error: Hint: this "def" token is not closed before the end of the file
+    #    ^ completion: foo
+    #    ^ apply-completion: [A] item: 0
+    # error: unexpected token "end of file"

--- a/test/testdata/lsp/completion/suggest_arguments.A.rbedited
+++ b/test/testdata/lsp/completion/suggest_arguments.A.rbedited
@@ -6,6 +6,6 @@ class A # error: Hint: this "class" token is not closed before the end of the fi
   #           ^ error: Unknown argument name `x`
   #                       ^ error: Unknown argument name `y`
   def foo(x, y) # error: Hint: this "def" token is not closed before the end of the file
-    #    ^ completion: foo
+    #    ^ completion: (sorbet) Suggested params
     #    ^ apply-completion: [A] item: 0
     # error: unexpected token "end of file"

--- a/test/testdata/lsp/completion/suggest_arguments.rb
+++ b/test/testdata/lsp/completion/suggest_arguments.rb
@@ -1,0 +1,11 @@
+# typed: true
+
+class A # error: Hint: this "class" token is not closed before the end of the file
+  extend T::Sig
+  sig {params(x: Integer, y: Integer).void}
+  #           ^ error: Unknown argument name `x`
+  #                       ^ error: Unknown argument name `y`
+  def foo # error: Hint: this "def" token is not closed before the end of the file
+    #    ^ completion: foo
+    #    ^ apply-completion: [A] item: 0
+    # error: unexpected token "end of file"

--- a/test/testdata/lsp/completion/suggest_arguments.rb
+++ b/test/testdata/lsp/completion/suggest_arguments.rb
@@ -6,6 +6,6 @@ class A # error: Hint: this "class" token is not closed before the end of the fi
   #           ^ error: Unknown argument name `x`
   #                       ^ error: Unknown argument name `y`
   def foo # error: Hint: this "def" token is not closed before the end of the file
-    #    ^ completion: foo
+    #    ^ completion: (sorbet) Suggested params
     #    ^ apply-completion: [A] item: 0
     # error: unexpected token "end of file"


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Once we have adding methods taking the fast path, we can do cool things like
this.

- [ ] @jez Build a second option like "(sorbet) Suggest keyword params" to let the user choose whether they want one or the other. Don't set the sort text on the result, so that VS Code can learn the user's preference over time.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

- [ ] @jez Test this

![Screenshot from 2022-06-04 17-16-36](https://user-images.githubusercontent.com/5544532/172029741-3d2cd481-d57e-4579-ad1c-5afc6d4433b8.png)
