### PR TITLE
Create newtype wrapper for method arity hashes

### DIFF
--- a/ast/ArgParsing.cc
+++ b/ast/ArgParsing.cc
@@ -70,8 +70,8 @@ vector<core::ParsedArg> ArgParsing::parseArgs(const ast::MethodDef::ARGS_store &
     return parsedArgs;
 }
 
-// This has to match the implementation of Method::methodArgumentHash
-uint32_t ArgParsing::hashArgs(core::Context ctx, const std::vector<core::ParsedArg> &args) {
+// This has to match the implementation of Method::methodArityHash
+core::ArityHash ArgParsing::hashArgs(core::Context ctx, const std::vector<core::ParsedArg> &args) {
     uint32_t result = 0;
     result = core::mix(result, args.size());
     for (const auto &e : args) {
@@ -86,7 +86,7 @@ uint32_t ArgParsing::hashArgs(core::Context ctx, const std::vector<core::ParsedA
 
         result = core::mix(result, e.flags.toU1());
     }
-    return result;
+    return core::ArityHash(result);
 }
 
 ExpressionPtr ArgParsing::getDefault(const core::ParsedArg &parsedArg, ExpressionPtr arg) {

--- a/ast/ArgParsing.h
+++ b/ast/ArgParsing.h
@@ -1,11 +1,12 @@
 #ifndef SORBET_AST_ARG_PARSING_H
 #define SORBET_AST_ARG_PARSING_H
 #include "ast/ast.h"
+#include "core/ArityHash.h"
 namespace sorbet::ast {
 class ArgParsing {
 public:
     static std::vector<core::ParsedArg> parseArgs(const ast::MethodDef::ARGS_store &args);
-    static uint32_t hashArgs(core::Context ctx, const std::vector<core::ParsedArg> &args);
+    static core::ArityHash hashArgs(core::Context ctx, const std::vector<core::ParsedArg> &args);
     // Returns the default argument value for the given argument, or nullptr if not specified. Mutates arg.
     static ExpressionPtr getDefault(const core::ParsedArg &parsedArg, ExpressionPtr arg);
 };

--- a/core/ArityHash.cc
+++ b/core/ArityHash.cc
@@ -1,0 +1,15 @@
+#include "core/ArityHash.h"
+
+using namespace std;
+
+namespace sorbet::core {
+
+ArityHash::ArityHash(uint32_t _hashValue) {
+    if (_hashValue == UNDEFINED) {
+        this->_hashValue = UNDEFINED_COLLISION_AVOID;
+    } else {
+        this->_hashValue = _hashValue;
+    }
+}
+
+} // namespace sorbet::core

--- a/core/ArityHash.h
+++ b/core/ArityHash.h
@@ -1,0 +1,42 @@
+#ifndef SORBET_ARITY_HASH_H
+#define SORBET_ARITY_HASH_H
+
+#include "common/common.h"
+
+namespace sorbet::core {
+
+class ArityHash {
+    constexpr static uint32_t UNDEFINED = 0;
+    // In case something naturally hashed to a value of `0`, we force it to collide with things that
+    // hashed to `1` instead, to reserve `0` as a special constant (checking for isDefined())
+    constexpr static uint32_t UNDEFINED_COLLISION_AVOID = 1;
+
+public:
+    ArityHash() noexcept : _hashValue(0) {}
+    explicit ArityHash(uint32_t _hashValue);
+
+    inline bool isDefined() const {
+        return _hashValue != UNDEFINED;
+    }
+
+    inline bool operator==(const ArityHash &rhs) const noexcept {
+        ENFORCE(isDefined());
+        ENFORCE(rhs.isDefined());
+        return _hashValue == rhs._hashValue;
+    }
+
+    inline bool operator!=(const ArityHash &rhs) const noexcept {
+        return !(rhs == *this);
+    }
+
+    inline bool operator<(const ArityHash &rhs) const noexcept {
+        return this->_hashValue < rhs._hashValue;
+    }
+
+    // Pseudo-private, only public for serialization
+    uint32_t _hashValue;
+};
+
+} // namespace sorbet::core
+
+#endif

--- a/core/FoundDefinitions.h
+++ b/core/FoundDefinitions.h
@@ -2,6 +2,7 @@
 #define SORBET_FOUND_DEFINITIONS_H
 
 #include "common/common.h"
+#include "core/ArityHash.h"
 #include "core/Loc.h"
 #include "core/NameRef.h"
 #include "core/ParsedArg.h"
@@ -142,7 +143,7 @@ struct FoundMethod final {
     core::LocOffsets loc;
     core::LocOffsets declLoc;
     std::vector<core::ParsedArg> parsedArgs;
-    uint32_t argsHash;
+    core::ArityHash arityHash;
     struct Flags {
         bool isSelfMethod : 1;
         bool isRewriterSynthesized : 1;

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -924,7 +924,7 @@ void GlobalState::preallocateTables(uint32_t classAndModulesSize, uint32_t metho
 
 constexpr decltype(GlobalState::STRINGS_PAGE_SIZE) GlobalState::STRINGS_PAGE_SIZE;
 
-MethodRef GlobalState::lookupMethodSymbolWithHash(ClassOrModuleRef owner, NameRef name, uint32_t methodHash) const {
+MethodRef GlobalState::lookupMethodSymbolWithHash(ClassOrModuleRef owner, NameRef name, ArityHash arityHash) const {
     ENFORCE(owner.exists(), "looking up symbol from non-existing owner");
     ENFORCE(name.exists(), "looking up symbol with non-existing name");
     auto ownerScope = owner.dataAllowingNone(*this);
@@ -938,8 +938,7 @@ MethodRef GlobalState::lookupMethodSymbolWithHash(ClassOrModuleRef owner, NameRe
         auto resSym = res->second;
         if (resSym.isMethod()) {
             auto resMethod = resSym.asMethodRef().data(*this);
-            if (resMethod->methodArgumentHash(*this) == methodHash ||
-                (resMethod->hasIntrinsic() && !resMethod->hasSig())) {
+            if (resMethod->methodArityHash(*this) == arityHash || (resMethod->hasIntrinsic() && !resMethod->hasSig())) {
                 return resSym.asMethodRef();
             }
         }

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -124,7 +124,7 @@ public:
     MethodRef lookupMethodSymbol(ClassOrModuleRef owner, NameRef name) const {
         return lookupSymbolWithKind(owner, name, SymbolRef::Kind::Method, Symbols::noMethod()).asMethodRef();
     }
-    MethodRef lookupMethodSymbolWithHash(ClassOrModuleRef owner, NameRef name, uint32_t methodHash) const;
+    MethodRef lookupMethodSymbolWithHash(ClassOrModuleRef owner, NameRef name, ArityHash arityHash) const;
     FieldRef lookupStaticFieldSymbol(ClassOrModuleRef owner, NameRef name) const {
         // N.B.: Fields and static fields have entirely different types of names, so this should be unambiguous.
         return lookupSymbolWithKind(owner, name, SymbolRef::Kind::FieldOrStaticField, Symbols::noField()).asFieldRef();

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -2281,7 +2281,7 @@ uint32_t Method::methodShapeHash(const GlobalState &gs) const {
     result = mix(result, this->owner.id());
     result = mix(result, this->rebind.id());
     result = mix(result, this->hasSig());
-    result = mix(result, this->methodArgumentHash(gs));
+    result = mix(result, this->methodArityHash(gs)._hashValue);
 
     if (name == Names::unresolvedAncestors() || name == Names::requiredAncestors() ||
         name == Names::requiredAncestorsLin()) {
@@ -2314,7 +2314,7 @@ uint32_t Field::fieldShapeHash(const GlobalState &gs) const {
 }
 
 // This has to match the implementation of ArgParsing::hashArgs
-uint32_t Method::methodArgumentHash(const GlobalState &gs) const {
+ArityHash Method::methodArityHash(const GlobalState &gs) const {
     uint32_t result = 0;
     result = mix(result, arguments.size());
     for (const auto &e : arguments) {
@@ -2325,7 +2325,7 @@ uint32_t Method::methodArgumentHash(const GlobalState &gs) const {
         // Changing an argument from e.g. keyword to position-based is a shape change.
         result = mix(result, e.flags.toU1());
     }
-    return result;
+    return ArityHash(result);
 }
 
 bool ClassOrModule::ignoreInHashing(const GlobalState &gs) const {

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -2,6 +2,7 @@
 #define SORBET_SYMBOLS_H
 
 #include "common/common.h"
+#include "core/ArityHash.h"
 #include "core/Loc.h"
 #include "core/Names.h"
 #include "core/SymbolRef.h"
@@ -84,7 +85,7 @@ public:
     void addLoc(const core::GlobalState &gs, core::Loc loc);
     uint32_t hash(const GlobalState &gs) const;
     uint32_t methodShapeHash(const GlobalState &gs) const;
-    uint32_t methodArgumentHash(const GlobalState &gs) const;
+    ArityHash methodArityHash(const GlobalState &gs) const;
 
     inline void setMethodPublic() {
         flags.isPrivate = false;

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -201,7 +201,7 @@ public:
         foundMethod.declLoc = method.declLoc;
         foundMethod.flags = method.flags;
         foundMethod.parsedArgs = ast::ArgParsing::parseArgs(method.args);
-        foundMethod.argsHash = ast::ArgParsing::hashArgs(ctx, foundMethod.parsedArgs);
+        foundMethod.arityHash = ast::ArgParsing::hashArgs(ctx, foundMethod.parsedArgs);
         foundDefs->addMethod(move(foundMethod));
 
         // After flatten, method defs have been hoisted and reordered, so instead we look for the
@@ -759,7 +759,7 @@ class SymbolDefiner {
         const bool isNewSymbol = symTableSize != ctx.state.methodsUsed();
         if (!isNewSymbol) {
             // See if this is == to the method we're defining now, or if we have a redefinition error.
-            auto matchingSym = ctx.state.lookupMethodSymbolWithHash(owner, method.name, method.argsHash);
+            auto matchingSym = ctx.state.lookupMethodSymbolWithHash(owner, method.name, method.arityHash);
             if (!matchingSym.exists()) {
                 // we don't have a method definition with the right argument structure, so we need to mangle the
                 // existing one and create a new one
@@ -790,7 +790,7 @@ class SymbolDefiner {
         if (method.flags.isRewriterSynthesized) {
             sym.data(ctx)->flags.isRewriterSynthesized = true;
         }
-        ENFORCE(ctx.state.lookupMethodSymbolWithHash(owner, method.name, method.argsHash).exists());
+        ENFORCE(ctx.state.lookupMethodSymbolWithHash(owner, method.name, method.arityHash).exists());
         return sym;
     }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I also took the chance to rename this to arityHash not argument hash,
because first of all, it's hashing parameters, not arguments (arguments
are the things at the call site). We do a pretty terrible job with that
convention throughout the codebase and I've considered taking a whole
pass over the codebase to fix this but I usually end up giving up.
Anyways, one fewer misuse of `args` is good.

I also called it "arity" instead of "parameters" to make it more clear
that this has nothing to do with hashing the parameter types as well,
only with which parameters exist.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No-op change. Covered by existing tests.