### PR TITLE
Track, but don't use, alias methods in namer

### DIFF
--- a/core/ArityHash.cc
+++ b/core/ArityHash.cc
@@ -7,9 +7,17 @@ namespace sorbet::core {
 ArityHash::ArityHash(uint32_t _hashValue) {
     if (_hashValue == UNDEFINED) {
         this->_hashValue = UNDEFINED_COLLISION_AVOID;
+    } else if (_hashValue == ALIAS_METHOD) {
+        this->_hashValue = ALIAS_METHOD_COLLISION_AVOID;
     } else {
         this->_hashValue = _hashValue;
     }
+}
+
+ArityHash ArityHash::aliasMethodHash() {
+    ArityHash result;
+    result._hashValue = ALIAS_METHOD;
+    return result;
 }
 
 } // namespace sorbet::core

--- a/core/ArityHash.h
+++ b/core/ArityHash.h
@@ -6,17 +6,31 @@
 namespace sorbet::core {
 
 class ArityHash {
+    // For use with isDefined
     constexpr static uint32_t UNDEFINED = 0;
     // In case something naturally hashed to a value of `0`, we force it to collide with things that
     // hashed to `1` instead, to reserve `0` as a special constant (checking for isDefined())
     constexpr static uint32_t UNDEFINED_COLLISION_AVOID = 1;
 
+    // To be able to implement isAliasMethod
+    //
+    // Asking for the arity of an alias method (not the arity of the method it dealiases to) doesn't
+    // make sense, as there are no parameters in an alias method definition.
+    constexpr static uint32_t ALIAS_METHOD = 2;
+    // Same as UNDEFINED_COLLISION_AVOID above, but for alias methods.
+    constexpr static uint32_t ALIAS_METHOD_COLLISION_AVOID = 3;
+
 public:
     ArityHash() noexcept : _hashValue(0) {}
     explicit ArityHash(uint32_t _hashValue);
+    static ArityHash aliasMethodHash();
 
     inline bool isDefined() const {
         return _hashValue != UNDEFINED;
+    }
+    inline bool isAliasMethod() const {
+        ENFORCE(isDefined());
+        return _hashValue == ALIAS_METHOD;
     }
 
     inline bool operator==(const ArityHash &rhs) const noexcept {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This will let us have a better sense of which methods we'll need to
delete on the fast path methods change (#5808).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

As written, this should not have any behavior changes.

I will be testing that this has the desired effect by including this commit in
my fast path methods PR.