### PR TITLE
Fix bug with alias_method and the fast path

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -2096,9 +2096,12 @@ void Method::sanityCheck(const GlobalState &gs) const {
                                           " corresponds to a core::Symbols::noTypeArgument()");
     }
     if (isa_type<AliasType>(this->resultType)) {
-        // If we have an alias method, we should never look at it's arguments;
-        // we should instead look at the arguments of whatever we're aliasing.
-        ENFORCE_NO_TIMER(this->arguments.empty(), ref(gs).show(gs));
+        // The arguments of an alias method don't mean anything. When calling a method alias,
+        // we dealias the symbol and use those arguments.
+        //
+        // This leaves the alias method's arguments vector free for us to stash some information. See resolver.
+        ENFORCE_NO_TIMER(absl::c_all_of(this->arguments, [](const auto &arg) { return arg.flags.isKeyword; }),
+                         ref(gs).show(gs));
     } else {
         ENFORCE_NO_TIMER(!this->arguments.empty(), ref(gs).show(gs));
     }

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -2095,6 +2095,10 @@ void Method::sanityCheck(const GlobalState &gs) const {
         ENFORCE_NO_TIMER(tp.exists(), name.toString(gs) + "." + tp.data(gs)->name.toString(gs) +
                                           " corresponds to a core::Symbols::noTypeArgument()");
     }
+
+    // There should always either be a block argument at the end, or the method should be an alias
+    ENFORCE_NO_TIMER(!this->arguments.empty(), ref(gs).show(gs));
+
     if (isa_type<AliasType>(this->resultType)) {
         // The arguments of an alias method don't mean anything. When calling a method alias,
         // we dealias the symbol and use those arguments.
@@ -2102,8 +2106,8 @@ void Method::sanityCheck(const GlobalState &gs) const {
         // This leaves the alias method's arguments vector free for us to stash some information. See resolver.
         ENFORCE_NO_TIMER(absl::c_all_of(this->arguments, [](const auto &arg) { return arg.flags.isKeyword; }),
                          ref(gs).show(gs));
-    } else {
-        ENFORCE_NO_TIMER(!this->arguments.empty(), ref(gs).show(gs));
+        ENFORCE_NO_TIMER(absl::c_all_of(this->arguments, [](const auto &arg) { return arg.flags.isKeyword; }),
+                         ref(gs).show(gs));
     }
 }
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2362,6 +2362,11 @@ class ResolveTypeMembersAndFieldsWalk {
                     e.addErrorLine(fromMethod.data(ctx)->loc(), "Previous alias definition");
                     e.addErrorLine(dealiased.data(ctx)->loc(), "Previous alias pointed to");
                     e.addErrorLine(toMethod.data(ctx)->loc(), "Redefining alias to");
+
+                    // Add a fake keyword argument to remember the toName (for fast path hashing).
+                    // It has to be a keyword arg, because names of positional args are ignored in hashing.
+                    auto &arg = ctx.state.enterMethodArgumentSymbol(ctx.locAt(job.toNameLoc), fromMethod, job.toName);
+                    arg.flags.isKeyword = true;
                 }
             }
             return;
@@ -2374,6 +2379,11 @@ class ResolveTypeMembersAndFieldsWalk {
 
         auto alias = ctx.state.enterMethodSymbol(ctx.locAt(job.loc), job.owner, job.fromName);
         alias.data(ctx)->resultType = core::make_type<core::AliasType>(core::SymbolRef(toMethod));
+
+        // Add a fake keyword argument to remember the toName (for fast path hashing).
+        // It has to be a keyword arg, because names of positional args are ignored in hashing.
+        auto &arg = ctx.state.enterMethodArgumentSymbol(ctx.locAt(job.toNameLoc), alias, job.toName);
+        arg.flags.isKeyword = true;
     }
 
     // Returns `true` if `asgn` is a field declaration.

--- a/test/testdata/lsp/fast_path/alias_fixed_multi_file__1.rb
+++ b/test/testdata/lsp/fast_path/alias_fixed_multi_file__1.rb
@@ -1,0 +1,8 @@
+# typed: true
+
+class A
+  extend T::Sig
+
+  sig {returns(Integer)}
+  def to; 0; end
+end

--- a/test/testdata/lsp/fast_path/alias_fixed_multi_file__2.1.rbupdate
+++ b/test/testdata/lsp/fast_path/alias_fixed_multi_file__2.1.rbupdate
@@ -1,0 +1,5 @@
+# typed: true
+
+class A
+  alias_method :from, :to
+end

--- a/test/testdata/lsp/fast_path/alias_fixed_multi_file__2.rb
+++ b/test/testdata/lsp/fast_path/alias_fixed_multi_file__2.rb
@@ -1,0 +1,5 @@
+# typed: true
+
+class A
+  alias_method :from, :to_bad # error: Can't make method alias from `from` to non existing method `to_bad`
+end

--- a/test/testdata/lsp/fast_path/alias_fixed_multi_file__3.1.rbupdate
+++ b/test/testdata/lsp/fast_path/alias_fixed_multi_file__3.1.rbupdate
@@ -1,0 +1,3 @@
+# typed: true
+
+T.reveal_type(A.new.from) # error: `Integer`

--- a/test/testdata/lsp/fast_path/alias_fixed_multi_file__3.rb
+++ b/test/testdata/lsp/fast_path/alias_fixed_multi_file__3.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+T.reveal_type(A.new.from) # error: `T.untyped`

--- a/test/testdata/namer/alias_method.rb.symbol-table-raw.exp
+++ b/test/testdata/namer/alias_method.rb.symbol-table-raw.exp
@@ -5,11 +5,14 @@ class <C <U <root>>> < <C <U Object>> ()
   module <C <U Alias>> < <C <U Sorbet>>::<C <U Private>>::<C <U Static>>::<C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/namer/alias_method.rb start=2:1 end=2:13}
     method <C <U Alias>>#<U alias_user> (<blk>) @ Loc {file=test/testdata/namer/alias_method.rb start=16:3 end=16:17}
       argument <blk><block> @ Loc {file=test/testdata/namer/alias_method.rb start=??? end=???}
-    method <C <U Alias>>#<U bad_alias> () -> AliasType { symbol = <C <U Sorbet>>::<C <U Private>>::<C <U Static>>#<U <bad-method-alias-stub>> } @ Loc {file=test/testdata/namer/alias_method.rb start=13:3 end=13:47}
+    method <C <U Alias>>#<U bad_alias> (nonexistant_method) -> AliasType { symbol = <C <U Sorbet>>::<C <U Private>>::<C <U Static>>#<U <bad-method-alias-stub>> } @ Loc {file=test/testdata/namer/alias_method.rb start=13:3 end=13:47}
+      argument nonexistant_method<keyword> @ Loc {file=test/testdata/namer/alias_method.rb start=13:28 end=13:47}
     method <C <U Alias>>#<U f> (<blk>) @ Loc {file=test/testdata/namer/alias_method.rb start=3:3 end=3:8}
       argument <blk><block> @ Loc {file=test/testdata/namer/alias_method.rb start=??? end=???}
-    method <C <U Alias>>#<U f_alias> () -> AliasType { symbol = <C <U Alias>>#<U f> } @ Loc {file=test/testdata/namer/alias_method.rb start=6:3 end=6:18}
-    method <C <U Alias>>#<U f_alias_1> () -> AliasType { symbol = <C <U Alias>>#<U f> } @ Loc {file=test/testdata/namer/alias_method.rb start=7:3 end=7:30}
+    method <C <U Alias>>#<U f_alias> (f) -> AliasType { symbol = <C <U Alias>>#<U f> } @ Loc {file=test/testdata/namer/alias_method.rb start=6:3 end=6:18}
+      argument f<keyword> @ Loc {file=test/testdata/namer/alias_method.rb start=6:17 end=6:18}
+    method <C <U Alias>>#<U f_alias_1> (f) -> AliasType { symbol = <C <U Alias>>#<U f> } @ Loc {file=test/testdata/namer/alias_method.rb start=7:3 end=7:30}
+      argument f<keyword> @ Loc {file=test/testdata/namer/alias_method.rb start=7:28 end=7:30}
   class <S <C <U Alias>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> () @ Loc {file=test/testdata/namer/alias_method.rb start=2:8 end=2:13}
     type-member(+) <S <C <U Alias>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U Alias>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=Alias) @ Loc {file=test/testdata/namer/alias_method.rb start=2:8 end=2:13}
     method <S <C <U Alias>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/namer/alias_method.rb start=2:1 end=21:4}

--- a/test/testdata/resolver/multi_alias_method.rb
+++ b/test/testdata/resolver/multi_alias_method.rb
@@ -1,0 +1,13 @@
+# typed: true
+
+class A
+  def to; end
+
+  alias_method :from, :to
+  alias_method :from, :to_bad # error: Redefining method alias `A#from` from `A#to` to `Sorbet::Private::Static#<bad-method-alias-stub>`
+end
+
+class B
+  alias_method :from, :does_not_exist1 # error: Can't make method alias from `from` to non existing method `does_not_exist1`
+  alias_method :from, :does_not_exist2 # error: Can't make method alias from `from` to non existing method `does_not_exist2`
+end

--- a/test/testdata/resolver/multi_alias_method.rb
+++ b/test/testdata/resolver/multi_alias_method.rb
@@ -4,7 +4,9 @@ class A
   def to; end
 
   alias_method :from, :to
-  alias_method :from, :to_bad # error: Redefining method alias `A#from` from `A#to` to `Sorbet::Private::Static#<bad-method-alias-stub>`
+  alias_method :from, :to_bad
+  #                   ^^^^^^^ error: Can't make method alias from `from` to non existing method `to_bad`
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Redefining method alias `A#from` from `A#to` to `Sorbet::Private::Static#<bad-method-alias-stub>`
 end
 
 class B

--- a/test/testdata/resolver/multi_alias_method.rb.symbol-table.exp
+++ b/test/testdata/resolver/multi_alias_method.rb.symbol-table.exp
@@ -12,12 +12,12 @@ class ::<root> < ::Object ()
     type-member(+) ::<Class:A>::<AttachedClass> -> T.attached_class (of A) @ test/testdata/resolver/multi_alias_method.rb:3
     method ::<Class:A>#<static-init> (<blk>) @ test/testdata/resolver/multi_alias_method.rb:3
       argument <blk><block> @ Loc {file=test/testdata/resolver/multi_alias_method.rb start=??? end=???}
-  class ::B < ::Object () @ test/testdata/resolver/multi_alias_method.rb:10
-    method ::B#from (does_not_exist1, does_not_exist2) -> <Alias: ::Sorbet::Private::Static#<bad-method-alias-stub> > @ test/testdata/resolver/multi_alias_method.rb:11
-      argument does_not_exist1<keyword> @ Loc {file=test/testdata/resolver/multi_alias_method.rb start=11:23 end=11:39}
-      argument does_not_exist2<keyword> @ Loc {file=test/testdata/resolver/multi_alias_method.rb start=12:23 end=12:39}
-  class ::<Class:B>[<AttachedClass>] < ::<Class:Object> () @ test/testdata/resolver/multi_alias_method.rb:10
-    type-member(+) ::<Class:B>::<AttachedClass> -> T.attached_class (of B) @ test/testdata/resolver/multi_alias_method.rb:10
-    method ::<Class:B>#<static-init> (<blk>) @ test/testdata/resolver/multi_alias_method.rb:10
+  class ::B < ::Object () @ test/testdata/resolver/multi_alias_method.rb:12
+    method ::B#from (does_not_exist1, does_not_exist2) -> <Alias: ::Sorbet::Private::Static#<bad-method-alias-stub> > @ test/testdata/resolver/multi_alias_method.rb:13
+      argument does_not_exist1<keyword> @ Loc {file=test/testdata/resolver/multi_alias_method.rb start=13:23 end=13:39}
+      argument does_not_exist2<keyword> @ Loc {file=test/testdata/resolver/multi_alias_method.rb start=14:23 end=14:39}
+  class ::<Class:B>[<AttachedClass>] < ::<Class:Object> () @ test/testdata/resolver/multi_alias_method.rb:12
+    type-member(+) ::<Class:B>::<AttachedClass> -> T.attached_class (of B) @ test/testdata/resolver/multi_alias_method.rb:12
+    method ::<Class:B>#<static-init> (<blk>) @ test/testdata/resolver/multi_alias_method.rb:12
       argument <blk><block> @ Loc {file=test/testdata/resolver/multi_alias_method.rb start=??? end=???}
 

--- a/test/testdata/resolver/multi_alias_method.rb.symbol-table.exp
+++ b/test/testdata/resolver/multi_alias_method.rb.symbol-table.exp
@@ -3,7 +3,9 @@ class ::<root> < ::Object ()
     method ::<Class:<root>>#<static-init> (<blk>) @ test/testdata/resolver/multi_alias_method.rb:3
       argument <blk><block> @ Loc {file=test/testdata/resolver/multi_alias_method.rb start=??? end=???}
   class ::A < ::Object () @ test/testdata/resolver/multi_alias_method.rb:3
-    method ::A#from () -> <Alias: ::A#to > @ test/testdata/resolver/multi_alias_method.rb:6
+    method ::A#from (to, to_bad) -> <Alias: ::A#to > @ test/testdata/resolver/multi_alias_method.rb:6
+      argument to<keyword> @ Loc {file=test/testdata/resolver/multi_alias_method.rb start=6:23 end=6:26}
+      argument to_bad<keyword> @ Loc {file=test/testdata/resolver/multi_alias_method.rb start=7:23 end=7:30}
     method ::A#to (<blk>) @ test/testdata/resolver/multi_alias_method.rb:4
       argument <blk><block> @ Loc {file=test/testdata/resolver/multi_alias_method.rb start=??? end=???}
   class ::<Class:A>[<AttachedClass>] < ::<Class:Object> () @ test/testdata/resolver/multi_alias_method.rb:3
@@ -11,7 +13,9 @@ class ::<root> < ::Object ()
     method ::<Class:A>#<static-init> (<blk>) @ test/testdata/resolver/multi_alias_method.rb:3
       argument <blk><block> @ Loc {file=test/testdata/resolver/multi_alias_method.rb start=??? end=???}
   class ::B < ::Object () @ test/testdata/resolver/multi_alias_method.rb:10
-    method ::B#from () -> <Alias: ::Sorbet::Private::Static#<bad-method-alias-stub> > @ test/testdata/resolver/multi_alias_method.rb:11
+    method ::B#from (does_not_exist1, does_not_exist2) -> <Alias: ::Sorbet::Private::Static#<bad-method-alias-stub> > @ test/testdata/resolver/multi_alias_method.rb:11
+      argument does_not_exist1<keyword> @ Loc {file=test/testdata/resolver/multi_alias_method.rb start=11:23 end=11:39}
+      argument does_not_exist2<keyword> @ Loc {file=test/testdata/resolver/multi_alias_method.rb start=12:23 end=12:39}
   class ::<Class:B>[<AttachedClass>] < ::<Class:Object> () @ test/testdata/resolver/multi_alias_method.rb:10
     type-member(+) ::<Class:B>::<AttachedClass> -> T.attached_class (of B) @ test/testdata/resolver/multi_alias_method.rb:10
     method ::<Class:B>#<static-init> (<blk>) @ test/testdata/resolver/multi_alias_method.rb:10

--- a/test/testdata/resolver/multi_alias_method.rb.symbol-table.exp
+++ b/test/testdata/resolver/multi_alias_method.rb.symbol-table.exp
@@ -1,0 +1,19 @@
+class ::<root> < ::Object ()
+  class ::<Class:<root>>[<AttachedClass>] < ::<Class:Object> ()
+    method ::<Class:<root>>#<static-init> (<blk>) @ test/testdata/resolver/multi_alias_method.rb:3
+      argument <blk><block> @ Loc {file=test/testdata/resolver/multi_alias_method.rb start=??? end=???}
+  class ::A < ::Object () @ test/testdata/resolver/multi_alias_method.rb:3
+    method ::A#from () -> <Alias: ::A#to > @ test/testdata/resolver/multi_alias_method.rb:6
+    method ::A#to (<blk>) @ test/testdata/resolver/multi_alias_method.rb:4
+      argument <blk><block> @ Loc {file=test/testdata/resolver/multi_alias_method.rb start=??? end=???}
+  class ::<Class:A>[<AttachedClass>] < ::<Class:Object> () @ test/testdata/resolver/multi_alias_method.rb:3
+    type-member(+) ::<Class:A>::<AttachedClass> -> T.attached_class (of A) @ test/testdata/resolver/multi_alias_method.rb:3
+    method ::<Class:A>#<static-init> (<blk>) @ test/testdata/resolver/multi_alias_method.rb:3
+      argument <blk><block> @ Loc {file=test/testdata/resolver/multi_alias_method.rb start=??? end=???}
+  class ::B < ::Object () @ test/testdata/resolver/multi_alias_method.rb:10
+    method ::B#from () -> <Alias: ::Sorbet::Private::Static#<bad-method-alias-stub> > @ test/testdata/resolver/multi_alias_method.rb:11
+  class ::<Class:B>[<AttachedClass>] < ::<Class:Object> () @ test/testdata/resolver/multi_alias_method.rb:10
+    type-member(+) ::<Class:B>::<AttachedClass> -> T.attached_class (of B) @ test/testdata/resolver/multi_alias_method.rb:10
+    method ::<Class:B>#<static-init> (<blk>) @ test/testdata/resolver/multi_alias_method.rb:10
+      argument <blk><block> @ Loc {file=test/testdata/resolver/multi_alias_method.rb start=??? end=???}
+


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I thought that this was a bug unique to my changes in #5808 (method changess
taking the fast path), but it turned out to be a bug that reproduces on master.

I'd like to fix it so that I can write some tests that I think should be able to
pass on my other PR.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

If you want to see what the failing behavior looked like:
<https://buildkite.com/sorbet/sorbet/builds/22823#01813b92-0ffb-4b4b-9ffb-94bc8abb80f6/139-193>