### PR TITLE
wip: Failing test for change to `initialize` on fast path

### DIFF
--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -59,8 +59,10 @@ const UnorderedMap<
 };
 
 // Ignore any comments that have these labels (e.g. `# typed: true`).
-const UnorderedSet<string> ignoredAssertionLabels = {"typed", "TODO", "linearization", "commented-out-error",
-                                                     "Note",  "See",  "packaged",      "rubyfmt-force-exit"};
+const UnorderedSet<string> ignoredAssertionLabels = {
+    "typed", "TODO",     "linearization",      "commented-out-error",      "Note",
+    "See",   "packaged", "rubyfmt-force-exit", "exclude-from-file-update",
+};
 
 constexpr string_view NOTHING_LABEL = "(nothing)"sv;
 constexpr string_view NULL_LABEL = "null"sv;

--- a/test/testdata/lsp/fast_path/initialize_types__1.1.rbupdate
+++ b/test/testdata/lsp/fast_path/initialize_types__1.1.rbupdate
@@ -1,0 +1,14 @@
+# typed: true
+# assert-fast-path: initialize_types__1.rb,initialize_types__2.rb
+
+class A
+  extend T::Sig
+
+  sig {params(x: String).void}
+  def initialize(x)
+    T.reveal_type(x) # error: `String`
+  end
+end
+
+A.new(0) # error: Expected `String` but found `Integer(0)`
+A.new('')

--- a/test/testdata/lsp/fast_path/initialize_types__1.rb
+++ b/test/testdata/lsp/fast_path/initialize_types__1.rb
@@ -1,0 +1,14 @@
+# typed: true
+# Spacer so error assertions are on same line
+
+class A
+  extend T::Sig
+
+  sig {params(x: Integer).void}
+  def initialize(x)
+    T.reveal_type(x) # error: `Integer`
+  end
+end
+
+A.new(0)
+A.new('') # error: Expected `Integer` but found `String("")`

--- a/test/testdata/lsp/fast_path/initialize_types__2.1.rbupdate
+++ b/test/testdata/lsp/fast_path/initialize_types__2.1.rbupdate
@@ -1,0 +1,5 @@
+# typed: true
+# exclude-from-file-update: true
+
+A.new(0) # error: Expected `String` but found `Integer(0)`
+A.new('')

--- a/test/testdata/lsp/fast_path/initialize_types__2.rb
+++ b/test/testdata/lsp/fast_path/initialize_types__2.rb
@@ -1,0 +1,5 @@
+# typed: true
+# Spacer so error assertions are on same line
+
+A.new(0)
+A.new('') # error: Expected `Integer` but found `String("")`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The fast path currently typechecks too few files right now when changing a
method signature for `initialize`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.