### PR TITLE
avoid inner loop allocations in block-private variable computation

### DIFF
--- a/cfg/CFG.cc
+++ b/cfg/CFG.cc
@@ -147,9 +147,9 @@ CFG::ReadsAndWrites CFG::findAllReadsAndWrites(core::Context ctx) {
     {
         Timer timeit(ctx.state.tracer(), "privates1");
 
+        UIntSet blockReadsAndWrites(this->numLocalVariables());
         for (auto blockId = 0; blockId < maxBasicBlockId; blockId++) {
-            UIntSet blockReadsAndWrites = target.reads[blockId];
-            blockReadsAndWrites.add(target.writes[blockId]);
+            blockReadsAndWrites.overwriteWithUnion(target.reads[blockId], target.writes[blockId]);
             blockReadsAndWrites.forEach([&usageCounts, blockId](uint32_t local) -> void {
                 if (usageCounts[local].first == 0) {
                     usageCounts[local].second = blockId;

--- a/common/UIntSet.cc
+++ b/common/UIntSet.cc
@@ -71,6 +71,20 @@ void UIntSet::intersect(const UIntSet &set) {
     }
 }
 
+void UIntSet::overwriteWithUnion(const UIntSet &a, const UIntSet &b) {
+    ENFORCE_NO_TIMER(_members.size() == a._members.size());
+    ENFORCE_NO_TIMER(_members.size() == b._members.size());
+    // Manually lift the computation of the data pointer outside of the loop,
+    // since normal `InlinedVector` accesses branch on whether the vector is
+    // stored inline or not.
+    auto *ourptr = _members.data();
+    auto *aptr = a._members.data();
+    auto *bptr = b._members.data();
+    for (int i = 0; i < _members.size(); i++) {
+        ourptr[i] = aptr[i] | bptr[i];
+    }
+}
+
 size_t UIntSet::size() const {
     size_t sz = 0;
     for (auto member : _members) {

--- a/common/UIntSet.h
+++ b/common/UIntSet.h
@@ -33,6 +33,9 @@ public:
     // Mutates the set to contain the intersection of this set and the passed-in set.
     void intersect(const UIntSet &set);
 
+    // Mutates the set to contain the union of the given sets.
+    void overwriteWithUnion(const UIntSet &a, const UIntSet &b);
+
     // Returns true if the set is empty.
     bool empty() const;
 


### PR DESCRIPTION

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We shouldn't need to repeatedly allocate this set, which should be a win on large CFGs.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
