### PR TITLE
Resolve instance variables in blocks using the proc binding

### DIFF
--- a/rewriter/TestCase.cc
+++ b/rewriter/TestCase.cc
@@ -18,7 +18,6 @@ void TestCase::run(core::MutableContext ctx, ast::ClassDef *klass) {
 
                     if (arg0 && arg0->isString(ctx)) {
                         isTest = true;
-                        continue;
                     }
                 }
             } else if (send->fun == core::Names::setup()) {

--- a/test/testdata/rewriter/test_case.rb
+++ b/test/testdata/rewriter/test_case.rb
@@ -33,6 +33,10 @@ class MyTest < ActiveSupport::TestCase
   test "block is evaluated in the context of an instance" do
     assert true
   end
+
+  test "setup instance variables are declared" do
+    assert @a
+  end
 end
 
 class NoMatchTest < ActiveSupport::TestCase

--- a/test/testdata/rewriter/test_case.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/test_case.rb.rewrite-tree.exp
@@ -49,6 +49,18 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <self>.extend(<emptyTree>::<C T>::<C Sig>)
 
+    <self>.test("valid method call") do ||
+      <emptyTree>
+    end
+
+    <self>.test("block is evaluated in the context of an instance") do ||
+      <self>.assert(true)
+    end
+
+    <self>.test("setup instance variables are declared") do ||
+      <self>.assert(@a)
+    end
+
     <runtime method definition of initialize>
 
     <runtime method definition of initialize>
@@ -125,6 +137,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <runtime method definition of self.test>
 
     <runtime method definition of assert_equal>
+
+    <self>.test("it works") do ||
+      <self>.assert_equal(1, @a)
+    end
 
     <runtime method definition of initialize>
   end


### PR DESCRIPTION
### Motivation

This pull-request does two things:

1. Fix an error in the test_case rewriter logic leading to all `test` calls being rewritten out of the class
2. Fix instance variables resolution in blocks that are bound to another context (uncovered by fixing 1.)

#### Do not rewrite out `test` calls

The current implementation of the TestCase rewriter just [removes all the `test` calls from the file](https://sorbet.run/?arg=--print=rewrite-tree#%23%20typed%3A%20true%0A%0Aclass%20ActiveSupport%3A%3ATestCase%0Aend%0A%0Aclass%20MyTest%20%3C%20ActiveSupport%3A%3ATestCase%0A%20%20test%20%22foo%22%20do%0A%20%20%20%20puts%20%22here%22%0A%20%20end%0Aend%0A) (notice how the printed output doesn't have any mention of the `test` call). 

This is effectively [silencing type errors](https://sorbet.run/#%23%20typed%3A%20true%0A%0Aclass%20ActiveSupport%3A%3ATestCase%0Aend%0A%0Aclass%20MyTest%20%3C%20ActiveSupport%3A%3ATestCase%0A%20%20test%20%22foo%22%20do%0A%20%20%20%20SOME_UNDEFINED_CONSTANT.some_undefined_method%0A%20%20end%0Aend%0A).

#### Resolve instance variables in blocks using the proc binding

Once the previous problem was fixed, Sorbet started to report errors about instance variables resolution inside blocks because it didn't take into account the proc binding (especially when binding to `T.attached_class`):

```ruby
# typed: strict

class Foo
  extend T::Sig

  sig { void }
  def initialize
    @attr = T.let(42, Integer)
  end

  sig { params(block: T.proc.bind(T.attached_class).void).void }
  def self.foo(&block); end
    
  foo do
    T.reveal_type(self) # => Foo
    puts @attr # should work since @attr is defined on Foo
  end
end
```

[[sorbet.run](https://sorbet.run/#%23%20typed%3A%20strict%0A%0Aclass%20Foo%0A%20%20extend%20T%3A%3ASig%0A%0A%20%20sig%20%7B%20void%20%7D%0A%20%20def%20initialize%0A%20%20%20%20%40attr%20%3D%20T.let%2842%2C%20Integer%29%0A%20%20end%0A%0A%20%20sig%20%7B%20params%28block%3A%20T.proc.bind%28T.attached_class%29.void%29.void%20%7D%0A%20%20def%20self.foo%28%26block%29%3B%20end%0A%20%20%20%20%0A%20%20foo%20do%0A%20%20%20%20T.reveal_type%28self%29%20%23%20%3D%3E%20Foo%0A%20%20%20%20puts%20%40attr%20%23%20should%20work%0A%20%20end%0Aend)]

So this would work correctly:

```ruby
# typed: strict

class Foo
  extend T::Sig

  sig { params(block: T.proc.bind(T.attached_class).void).void }
  def self.setup(&block); end

  sig { params(name: String, block: T.proc.bind(T.attached_class).void).void }
  def self.test(name, &block); end

  setup do
    @attr = T.let(42, Integer)
  end
    
  test "some test" do
    T.reveal_type(self) # => Foo
    puts @attr # should work
  end
end
```

[[sorbet.run](https://sorbet.run/#%23%20typed%3A%20strict%0A%0Aclass%20Foo%0A%20%20extend%20T%3A%3ASig%0A%0A%20%20sig%20%7B%20params%28block%3A%20T.proc.bind%28T.attached_class%29.void%29.void%20%7D%0A%20%20def%20self.setup%28%26block%29%3B%20end%0A%0A%20%20sig%20%7B%20params%28name%3A%20String%2C%20block%3A%20T.proc.bind%28T.attached_class%29.void%29.void%20%7D%0A%20%20def%20self.test%28name%2C%20%26block%29%3B%20end%0A%0A%20%20setup%20do%0A%20%20%20%20%40attr%20%3D%20T.let%2842%2C%20Integer%29%0A%20%20end%0A%20%20%20%20%0A%20%20test%20%22some%20test%22%20do%0A%20%20%20%20T.reveal_type%28self%29%20%23%20%3D%3E%20Foo%0A%20%20%20%20puts%20%40attr%20%23%20should%20work%0A%20%20end%0Aend)] (note that it's currently working because the rewriter rewrites out the `test` calls)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
