### PR TITLE
Revert "Simplify test case rewriter (#5357)"

### DIFF
--- a/rewriter/TestCase.cc
+++ b/rewriter/TestCase.cc
@@ -7,9 +7,8 @@ namespace sorbet::rewriter {
 void TestCase::run(core::MutableContext ctx, ast::ClassDef *klass) {
     std::vector<ast::ExpressionPtr> stats;
 
-    // Go through all class definition statements and find all setups
-    std::vector<ast::ExpressionPtr> setups;
-    bool isTest = false;
+    // Go through all class definition statements and find all setups, tests and teardowns
+    std::vector<ast::ExpressionPtr> testSends, setupAndTeardownSends;
     for (auto &stat : klass->rhs) {
         if (auto *send = ast::cast_tree<ast::Send>(stat)) {
             if (send->fun == core::Names::test()) {
@@ -17,14 +16,14 @@ void TestCase::run(core::MutableContext ctx, ast::ClassDef *klass) {
                     auto *arg0 = ast::cast_tree<ast::Literal>(send->getPosArg(0));
 
                     if (arg0 && arg0->isString(ctx)) {
-                        isTest = true;
+                        testSends.push_back(std::move(stat));
                         continue;
                     }
                 }
-            } else if (send->fun == core::Names::setup()) {
+            } else if (send->fun == core::Names::setup() || send->fun == core::Names::teardown()) {
                 if (send->hasBlock() && !send->hasPosArgs() && !send->hasKwArgs()) {
                     // send->args only contains block.
-                    setups.push_back(std::move(stat));
+                    setupAndTeardownSends.push_back(std::move(stat));
                     continue;
                 }
             }
@@ -32,22 +31,38 @@ void TestCase::run(core::MutableContext ctx, ast::ClassDef *klass) {
         stats.emplace_back(std::move(stat));
     }
 
-    // If there are test definitions, then rewrite setup block invocations into initialize to avoid having the nilable
-    // instance variables issue
-    if (isTest) {
-        for (auto &stat : setups) {
+    // Rewrite all test sends as method definitions
+    for (auto &stat : testSends) {
+        auto *send = ast::cast_tree<ast::Send>(stat);
+        auto loc = send->loc;
+        auto *arg0 = ast::cast_tree<ast::Literal>(send->getPosArg(0));
+        auto *block = send->block();
+
+        auto snake_case_name = absl::StrReplaceAll(arg0->asString(ctx).toString(ctx), {{" ", "_"}});
+        auto name = ctx.state.enterNameUTF8("test_" + snake_case_name);
+        auto method = ast::MK::SyntheticMethod0(loc, loc, name, std::move(block->body));
+        auto method_with_sig = ast::MK::InsSeq1(method.loc(), ast::MK::SigVoid(method.loc(), {}), std::move(method));
+
+        stats.emplace_back(std::move(method_with_sig));
+    }
+
+    // If there are test definitions, then we can probably assume that the setup and teardown invocations are safe to
+    // rewrite as well. If there aren't any test sends, then emplace back the original statements into the class
+    if (!testSends.empty()) {
+        for (auto &stat : setupAndTeardownSends) {
             auto *send = ast::cast_tree<ast::Send>(stat);
             auto loc = send->loc;
             auto block = send->block();
+            auto method_name = send->fun == core::Names::setup() ? core::Names::initialize() : core::Names::teardown();
 
-            auto method = ast::MK::SyntheticMethod0(loc, loc, core::Names::initialize(), std::move(block->body));
+            auto method = ast::MK::SyntheticMethod0(loc, loc, method_name, std::move(block->body));
             auto method_with_sig =
                 ast::MK::InsSeq1(method.loc(), ast::MK::SigVoid(method.loc(), {}), std::move(method));
 
             stats.emplace_back(std::move(method_with_sig));
         }
     } else {
-        for (auto &stat : setups) {
+        for (auto &stat : setupAndTeardownSends) {
             stats.emplace_back(std::move(stat));
         }
     }

--- a/rewriter/TestCase.h
+++ b/rewriter/TestCase.h
@@ -24,15 +24,15 @@ namespace sorbet::rewriter {
  * into
  *
  *    class MyTest < AnyParent
- *      def initialize
+ *      def setup
  *        @a = 1
  *      end
  *
- *      test "the equality" do
+ *      def test_the_equality
  *        assert_equal 1, @a
  *      end
  *
- *      teardown do
+ *      def teardown
  *        @a = nil
  *      end
  *    end

--- a/test/testdata/rewriter/test_case.rb
+++ b/test/testdata/rewriter/test_case.rb
@@ -1,22 +1,20 @@
 # typed: strict
 
 class ActiveSupport::TestCase
+end
+
+class MyTest < ActiveSupport::TestCase
   extend T::Sig
-
-  # Helper method to direct calls to `test` instead of Kernel#test
-  sig { params(args: T.untyped, block: T.nilable(T.proc.bind(T.attached_class).void)).void }
-  def self.test(*args, &block)
-  end
-
   # Helper instance method
   sig { params(test: T.untyped).returns(T::Boolean) }
   def assert(test)
     test ? true : false
   end
-end
 
-class MyTest < ActiveSupport::TestCase
-  extend T::Sig
+  # Helper method to direct calls to `test` instead of Kernel#test
+  sig { params(args: T.untyped, block: T.nilable(T.proc.void)).void }
+  def self.test(*args, &block)
+  end
 
   setup do
     @a = T.let(1, Integer)
@@ -27,39 +25,67 @@ class MyTest < ActiveSupport::TestCase
     bar # error: Method `bar` does not exist on `MyTest`
   end
 
+  # Method calls that shouldn't be rewritten
+  tesst "invalid", "method name" do # error: Method `tesst` does not exist on `T.class_of(MyTest)`
+  end
+
+  test "invalid", "parameter count" do
+  end
+
+  test "no block argument"
+
+  test :not_a_string do
+  end
+
+  test :not_a_string do
+    assert true # error: Method `assert` does not exist on `T.class_of(MyTest)`
+  end
+  # end unmodified method calls
+
   test "valid method call" do
   end
 
   test "block is evaluated in the context of an instance" do
     assert true
   end
+
+  teardown do
+    fiz # error: Method `fiz` does not exist on `MyTest`
+  end
+
+  teardown do
+    baz # error: Method `baz` does not exist on `MyTest`
+  end
 end
 
 class NoMatchTest < ActiveSupport::TestCase
   extend T::Sig
 
-  sig { params(block: T.proc.bind(T.attached_class).void).void }
+  sig { params(block: T.proc.void).void }
   def self.setup(&block); end
 
+  sig { params(block: T.proc.void).void }
+  def self.teardown(&block); end
+
   setup do
-    @a = T.let(1, Integer)
-  # ^^ error: The instance variable `@a` must be declared inside `initialize` or declared nilable
     foo
-  # ^^^ error: Method `foo` does not exist on `NoMatchTest`
+  # ^^^ error: Method `foo` does not exist on `T.class_of(NoMatchTest)`
+  end
+
+  teardown do
+    bar
+  # ^^^ error: Method `bar` does not exist on `T.class_of(NoMatchTest)`
   end
 end
 
 class NoParentClass
   extend T::Sig
 
-  sig { params(block: T.proc.bind(T.attached_class).void).void }
+  sig { params(block: T.proc.void).void }
   def self.setup(&block); end
 
-  sig { params(block: T.proc.bind(T.attached_class).void).void }
+  sig { params(block: T.proc.void).void }
   def self.teardown(&block); end
-
-  sig { params(name: String, block: T.proc.bind(T.attached_class).void).void }
-  def self.test(name, &block); end
 
   sig { params(a: T.untyped, b: T.untyped).void }
   def assert_equal(a, b); end
@@ -69,6 +95,10 @@ class NoParentClass
   end
 
   test "it works" do
-    assert_equal(1, @a)
+    assert_equal 1, @a
+  end
+
+  teardown do
+    @a = 5
   end
 end

--- a/test/testdata/rewriter/test_case.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/test_case.rb.rewrite-tree.exp
@@ -1,13 +1,8 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C ActiveSupport>::<C TestCase><<C <todo sym>>> < (::<todo sym>)
-    ::Sorbet::Private::Static.sig(<self>) do ||
-      <self>.params(:args, <emptyTree>::<C T>.untyped(), :block, <emptyTree>::<C T>.nilable(<emptyTree>::<C T>.proc().bind(<emptyTree>::<C T>.attached_class()).void())).void()
-    end
+  end
 
-    def self.test<<todo method>>(*args, &block)
-      <emptyTree>
-    end
-
+  class <emptyTree>::<C MyTest><<C <todo sym>>> < (<emptyTree>::<C ActiveSupport>::<C TestCase>)
     ::Sorbet::Private::Static.sig(<self>) do ||
       <self>.params(:test, <emptyTree>::<C T>.untyped()).returns(<emptyTree>::<C T>::<C Boolean>)
     end
@@ -20,14 +15,30 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
     end
 
-    <self>.extend(<emptyTree>::<C T>::<C Sig>)
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.params(:args, <emptyTree>::<C T>.untyped(), :block, <emptyTree>::<C T>.nilable(<emptyTree>::<C T>.proc().void())).void()
+    end
 
-    <runtime method definition of self.test>
+    def self.test<<todo method>>(*args, &block)
+      <emptyTree>
+    end
 
-    <runtime method definition of assert>
-  end
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.void()
+    end
 
-  class <emptyTree>::<C MyTest><<C <todo sym>>> < (<emptyTree>::<C ActiveSupport>::<C TestCase>)
+    def test_valid_method_call<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.void()
+    end
+
+    def test_block_is_evaluated_in_the_context_of_an_instance<<todo method>>(&<blk>)
+      <self>.assert(true)
+    end
+
     ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
       <self>.void()
     end
@@ -47,19 +58,73 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.bar()
     end
 
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.void()
+    end
+
+    def teardown<<todo method>>(&<blk>)
+      <self>.fiz()
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.void()
+    end
+
+    def teardown<<todo method>>(&<blk>)
+      <self>.baz()
+    end
+
     <self>.extend(<emptyTree>::<C T>::<C Sig>)
 
+    <runtime method definition of assert>
+
+    <runtime method definition of self.test>
+
+    <self>.tesst("invalid", "method name") do ||
+      <emptyTree>
+    end
+
+    <self>.test("invalid", "parameter count") do ||
+      <emptyTree>
+    end
+
+    <self>.test("no block argument")
+
+    <self>.test(:not_a_string) do ||
+      <emptyTree>
+    end
+
+    <self>.test(:not_a_string) do ||
+      <self>.assert(true)
+    end
+
+    <runtime method definition of test_valid_method_call>
+
+    <runtime method definition of test_block_is_evaluated_in_the_context_of_an_instance>
+
     <runtime method definition of initialize>
 
     <runtime method definition of initialize>
+
+    <runtime method definition of teardown>
+
+    <runtime method definition of teardown>
   end
 
   class <emptyTree>::<C NoMatchTest><<C <todo sym>>> < (<emptyTree>::<C ActiveSupport>::<C TestCase>)
     ::Sorbet::Private::Static.sig(<self>) do ||
-      <self>.params(:block, <emptyTree>::<C T>.proc().bind(<emptyTree>::<C T>.attached_class()).void()).void()
+      <self>.params(:block, <emptyTree>::<C T>.proc().void()).void()
     end
 
     def self.setup<<todo method>>(&block)
+      <emptyTree>
+    end
+
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.params(:block, <emptyTree>::<C T>.proc().void()).void()
+    end
+
+    def self.teardown<<todo method>>(&block)
       <emptyTree>
     end
 
@@ -67,17 +132,20 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <runtime method definition of self.setup>
 
+    <runtime method definition of self.teardown>
+
     <self>.setup() do ||
-      begin
-        @a = <emptyTree>::<C T>.let(1, <emptyTree>::<C Integer>)
-        <self>.foo()
-      end
+      <self>.foo()
+    end
+
+    <self>.teardown() do ||
+      <self>.bar()
     end
   end
 
   class <emptyTree>::<C NoParentClass><<C <todo sym>>> < (::<todo sym>)
     ::Sorbet::Private::Static.sig(<self>) do ||
-      <self>.params(:block, <emptyTree>::<C T>.proc().bind(<emptyTree>::<C T>.attached_class()).void()).void()
+      <self>.params(:block, <emptyTree>::<C T>.proc().void()).void()
     end
 
     def self.setup<<todo method>>(&block)
@@ -85,18 +153,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     ::Sorbet::Private::Static.sig(<self>) do ||
-      <self>.params(:block, <emptyTree>::<C T>.proc().bind(<emptyTree>::<C T>.attached_class()).void()).void()
+      <self>.params(:block, <emptyTree>::<C T>.proc().void()).void()
     end
 
     def self.teardown<<todo method>>(&block)
-      <emptyTree>
-    end
-
-    ::Sorbet::Private::Static.sig(<self>) do ||
-      <self>.params(:name, <emptyTree>::<C String>, :block, <emptyTree>::<C T>.proc().bind(<emptyTree>::<C T>.attached_class()).void()).void()
-    end
-
-    def self.test<<todo method>>(name, &block)
       <emptyTree>
     end
 
@@ -112,8 +172,24 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
+    def test_it_works<<todo method>>(&<blk>)
+      <self>.assert_equal(1, @a)
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.void()
+    end
+
     def initialize<<todo method>>(&<blk>)
       @a = <emptyTree>::<C T>.let(1, <emptyTree>::<C Integer>)
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.void()
+    end
+
+    def teardown<<todo method>>(&<blk>)
+      @a = 5
     end
 
     <self>.extend(<emptyTree>::<C T>::<C Sig>)
@@ -122,10 +198,12 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <runtime method definition of self.teardown>
 
-    <runtime method definition of self.test>
-
     <runtime method definition of assert_equal>
 
+    <runtime method definition of test_it_works>
+
     <runtime method definition of initialize>
+
+    <runtime method definition of teardown>
   end
 end


### PR DESCRIPTION
### Motivation

This reverts commit ee5f895189c7e6c0ec24e69ec7f958ab2373f6c5 as the [fix forward](https://github.com/sorbet/sorbet/pull/5900) is going to be hard.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
