### PR TITLE
improve comparison methods for `{Expression,Instruction}Ptr`

### DIFF
--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -112,6 +112,11 @@ bool ExpressionPtr::isSelfReference() const {
     return false;
 }
 
+void ExpressionPtr::resetToEmpty(EmptyTree *expr) noexcept {
+    ENFORCE(expr != nullptr);
+    resetTagged(tagPtr(ExpressionToTag<EmptyTree>::value, expr));
+}
+
 bool isa_reference(const ExpressionPtr &what) {
     return isa_tree<Local>(what) || isa_tree<UnresolvedIdent>(what) || isa_tree<RestArg>(what) ||
            isa_tree<KeywordArg>(what) || isa_tree<OptionalArg>(what) || isa_tree<BlockArg>(what) ||
@@ -373,7 +378,7 @@ EmptyTree singletonEmptyTree{};
 
 template <> ExpressionPtr make_expression<EmptyTree>() {
     ExpressionPtr result = nullptr;
-    result.reset(&singletonEmptyTree);
+    result.resetToEmpty(&singletonEmptyTree);
     return result;
 }
 

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -91,6 +91,9 @@ private:
     template <typename E, typename... Args> friend ExpressionPtr make_expression(Args &&...);
 
     static tagged_storage tagPtr(Tag tag, void *expr) {
+        ENFORCE(static_cast<size_t>(tag) != 0);
+        ENFORCE(expr != nullptr);
+
         // Store the tag in the lower 16 bits of the pointer, regardless of size.
         auto val = static_cast<tagged_storage>(tag);
         auto maskedPtr = reinterpret_cast<tagged_storage>(expr) << 16;

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -194,15 +194,23 @@ public:
     }
 
     explicit operator bool() const noexcept {
-        return get() != nullptr;
+        return ptr != 0;
     }
 
     bool operator==(const ExpressionPtr &other) const noexcept {
-        return get() == other.get();
+        return ptr == other.ptr;
+    }
+
+    bool operator==(std::nullptr_t) const noexcept {
+        return ptr == 0;
     }
 
     bool operator!=(const ExpressionPtr &other) const noexcept {
-        return get() != other.get();
+        return ptr != other.ptr;
+    }
+
+    bool operator!=(std::nullptr_t) const noexcept {
+        return ptr != 0;
     }
 
     ExpressionPtr deepCopy() const;

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -69,6 +69,8 @@ enum class Tag {
 // A mapping from tree type to its corresponding tag.
 template <typename T> struct ExpressionToTag;
 
+class EmptyTree;
+
 class ExpressionPtr {
 public:
     // We store tagged pointers as 64-bit values.
@@ -174,9 +176,7 @@ public:
         resetTagged(0);
     }
 
-    template <typename T> void reset(T *expr = nullptr) noexcept {
-        resetTagged(tagPtr(ExpressionToTag<T>::value, expr));
-    }
+    void resetToEmpty(EmptyTree *expr) noexcept;
 
     Tag tag() const noexcept {
         ENFORCE(ptr != 0);

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -362,14 +362,20 @@ public:
     }
 
     explicit operator bool() const noexcept {
-        return get() != nullptr;
+        return ptr != 0;
     }
 
     bool operator==(const InstructionPtr &other) const noexcept {
-        return get() == other.get();
+        return ptr == other.ptr;
+    }
+    bool operator==(std::nullptr_t) const noexcept {
+        return ptr == 0;
     }
     bool operator!=(const InstructionPtr &other) const noexcept {
-        return get() != other.get();
+        return ptr != other.ptr;
+    }
+    bool operator!=(std::nullptr_t) const noexcept {
+        return ptr != 0;
     }
 
     Tag tag() const noexcept {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

There's no need to add extraneous shifts in these methods, because if the pointers are the same (resp. different) they will have the same (resp. different) tags, so we can just compare the whole tagged pointer.  Note that this argument also works for `nullptr` being stored in these (i.e. 0), because our tags start at 1, so any tagged thing will compare not-equal to `nullptr`.

This change enables `typecase` over the pointers to be compiled as a jump table, which wasn't happening before (!).  I think this is because the `nullptr_t` overloads enable things inside clang to be smarter?  (I didn't test if the jump tables happened without the `nullptr_t` overloads, but I think they are pretty common for smart pointers and consistency is a good thing.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
