### PR TITLE
add `Array` and `Hash` cfg instructions

### DIFF
--- a/cfg/CFG.cc
+++ b/cfg/CFG.cc
@@ -130,6 +130,14 @@ CFG::ReadsAndWrites CFG::findAllReadsAndWrites(core::Context ctx) {
                 blockReads.add(v->send.id());
             } else if (auto *v = cast_instruction<YieldLoadArg>(bind.value)) {
                 blockReads.add(v->yieldParam.variable.id());
+            } else if (auto *v = cast_instruction<Array>(bind.value)) {
+                for (auto elem : v->elems) {
+                    blockReads.add(elem.id());
+                }
+            } else if (auto *v = cast_instruction<Hash>(bind.value)) {
+                for (auto elem : v->elems) {
+                    blockReads.add(elem.id());
+                }
             }
 
             if (!blockReads.contains(bind.bind.variable.id())) {

--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -44,8 +44,8 @@ string spacesForTabLevel(int tabs) {
         CASE_STATEMENT(body, YieldLoadArg)        \
         CASE_STATEMENT(body, Cast)                \
         CASE_STATEMENT(body, TAbsurd)             \
-        CASE_STATEMENT(body, Array) \
-        CASE_STATEMENT(body, Hash) \
+        CASE_STATEMENT(body, Array)               \
+        CASE_STATEMENT(body, Hash)                \
     }
 
 std::string InstructionPtr::toString(const core::GlobalState &gs, const CFG &cfg) const {
@@ -316,8 +316,7 @@ string TAbsurd::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) c
 
 string Array::toString(const core::GlobalState &gs, const CFG &cfg) const {
     return fmt::format(
-        "[{}]",
-        fmt::map_join(this->elems, ", ", [&](const auto &elem) -> string { return elem.toString(gs, cfg); }));
+        "[{}]", fmt::map_join(this->elems, ", ", [&](const auto &elem) -> string { return elem.toString(gs, cfg); }));
 }
 
 string Array::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) const {
@@ -329,8 +328,7 @@ string Array::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) con
 // TODO: hash rocket syntax?
 string Hash::toString(const core::GlobalState &gs, const CFG &cfg) const {
     return fmt::format(
-        "{{{}}}",
-        fmt::map_join(this->elems, ", ", [&](const auto &elem) -> string { return elem.toString(gs, cfg); }));
+        "{{{}}}", fmt::map_join(this->elems, ", ", [&](const auto &elem) -> string { return elem.toString(gs, cfg); }));
 }
 
 string Hash::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) const {

--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -197,7 +197,7 @@ Alias::Alias(core::SymbolRef what, core::NameRef name) : what(what), name(name) 
     categoryCounterInc("cfg", "alias");
 }
 
-Array::Array(InlinedVector<LocalRef, 2> elems) : elems(std::move(elems)) {
+Array::Array(InlinedVector<LocalRef, 4> elems) : elems(std::move(elems)) {
     categoryCounterInc("cfg", "array");
 }
 

--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -197,11 +197,11 @@ Alias::Alias(core::SymbolRef what, core::NameRef name) : what(what), name(name) 
     categoryCounterInc("cfg", "alias");
 }
 
-Array::Array(InlinedVector<VariableUseSite, 2> elems) : elems(std::move(elems)) {
+Array::Array(InlinedVector<LocalRef, 2> elems) : elems(std::move(elems)) {
     categoryCounterInc("cfg", "array");
 }
 
-Hash::Hash(InlinedVector<VariableUseSite, 4> elems) : elems(std::move(elems)) {
+Hash::Hash(InlinedVector<LocalRef, 4> elems) : elems(std::move(elems)) {
     categoryCounterInc("cfg", "hash");
 }
 

--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -323,7 +323,7 @@ string Array::toString(const core::GlobalState &gs, const CFG &cfg) const {
 string Array::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) const {
     return fmt::format(
         "Array {{\n{0}&nbsp;elems = {1}\n{0}}}", spacesForTabLevel(tabs),
-        fmt::map_join(this->elems, ", ", [&](const auto &elem) -> string { return elem.showRaw(gs, cfg, tabs + 1); }));
+        fmt::map_join(this->elems, ", ", [&](const auto &elem) -> string { return elem.showRaw(gs, cfg); }));
 }
 
 // TODO: hash rocket syntax?
@@ -336,7 +336,7 @@ string Hash::toString(const core::GlobalState &gs, const CFG &cfg) const {
 string Hash::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) const {
     return fmt::format(
         "Hash {{\n{0}&nbsp;elems = {1}\n{0}}}", spacesForTabLevel(tabs),
-        fmt::map_join(this->elems, ", ", [&](const auto &elem) -> string { return elem.showRaw(gs, cfg, tabs + 1); }));
+        fmt::map_join(this->elems, ", ", [&](const auto &elem) -> string { return elem.showRaw(gs, cfg); }));
 }
 
 string VariableUseSite::toString(const core::GlobalState &gs, const CFG &cfg) const {

--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -44,6 +44,8 @@ string spacesForTabLevel(int tabs) {
         CASE_STATEMENT(body, YieldLoadArg)        \
         CASE_STATEMENT(body, Cast)                \
         CASE_STATEMENT(body, TAbsurd)             \
+        CASE_STATEMENT(body, Array) \
+        CASE_STATEMENT(body, Hash) \
     }
 
 std::string InstructionPtr::toString(const core::GlobalState &gs, const CFG &cfg) const {
@@ -195,6 +197,14 @@ Alias::Alias(core::SymbolRef what, core::NameRef name) : what(what), name(name) 
     categoryCounterInc("cfg", "alias");
 }
 
+Array::Array(InlinedVector<VariableUseSite, 2> elems) : elems(std::move(elems)) {
+    categoryCounterInc("cfg", "array");
+}
+
+Hash::Hash(InlinedVector<VariableUseSite, 4> elems) : elems(std::move(elems)) {
+    categoryCounterInc("cfg", "hash");
+}
+
 string Ident::toString(const core::GlobalState &gs, const CFG &cfg) const {
     return this->what.toString(gs, cfg);
 }
@@ -302,6 +312,31 @@ string TAbsurd::toString(const core::GlobalState &gs, const CFG &cfg) const {
 string TAbsurd::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) const {
     return fmt::format("TAbsurd {{\n{0}&nbsp;what = {1},\n{0}}}", spacesForTabLevel(tabs),
                        this->what.showRaw(gs, cfg, tabs + 1));
+}
+
+string Array::toString(const core::GlobalState &gs, const CFG &cfg) const {
+    return fmt::format(
+        "[{}]",
+        fmt::map_join(this->elems, ", ", [&](const auto &elem) -> string { return elem.toString(gs, cfg); }));
+}
+
+string Array::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) const {
+    return fmt::format(
+        "Array {{\n{0}&nbsp;elems = {1}\n{0}}}", spacesForTabLevel(tabs),
+        fmt::map_join(this->elems, ", ", [&](const auto &elem) -> string { return elem.showRaw(gs, cfg, tabs + 1); }));
+}
+
+// TODO: hash rocket syntax?
+string Hash::toString(const core::GlobalState &gs, const CFG &cfg) const {
+    return fmt::format(
+        "{{{}}}",
+        fmt::map_join(this->elems, ", ", [&](const auto &elem) -> string { return elem.toString(gs, cfg); }));
+}
+
+string Hash::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) const {
+    return fmt::format(
+        "Hash {{\n{0}&nbsp;elems = {1}\n{0}}}", spacesForTabLevel(tabs),
+        fmt::map_join(this->elems, ", ", [&](const auto &elem) -> string { return elem.showRaw(gs, cfg, tabs + 1); }));
 }
 
 string VariableUseSite::toString(const core::GlobalState &gs, const CFG &cfg) const {

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -277,6 +277,28 @@ public:
 };
 CheckSize(TAbsurd, 24, 8);
 
+INSN(Array) : public Instruction {
+public:
+    InlinedVector<VariableUseSite, 2> elems;
+
+    Array(InlinedVector<VariableUseSite, 2> elems);
+
+    std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
+    std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
+};
+CheckSize(Array, 56);
+
+INSN(Hash) : public Instruction {
+    // k0, v0, k1, v1, ..., kn, vn
+    InlinedVector<VariableUseSite, 4> elems;
+
+    Hash(InlinedVector<VariableUseSite, 4> elems);
+
+    std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
+    std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
+};
+CheckSize(Hash, 104);
+
 class InstructionPtr final {
     using tagged_storage = uint64_t;
 

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -288,9 +288,10 @@ public:
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(Array, 24);
+CheckSize(Array, 24, 8);
 
 INSN(Hash) : public Instruction {
+public:
     // k0, v0, k1, v1, ..., kn, vn
     InlinedVector<LocalRef, 4> elems;
 
@@ -299,7 +300,7 @@ INSN(Hash) : public Instruction {
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(Hash, 24);
+CheckSize(Hash, 24, 8);
 
 class InstructionPtr final {
     using tagged_storage = uint64_t;

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -46,6 +46,8 @@ enum class Tag : uint8_t {
     YieldLoadArg,
     Cast,
     TAbsurd,
+    Array,
+    Hash,
 };
 
 // A mapping from instruction type to its corresponding tag.

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -279,25 +279,25 @@ CheckSize(TAbsurd, 24, 8);
 
 INSN(Array) : public Instruction {
 public:
-    InlinedVector<VariableUseSite, 2> elems;
+    InlinedVector<LocalRef, 4> elems;
 
-    Array(InlinedVector<VariableUseSite, 2> elems);
+    Array(InlinedVector<LocalRef, 4> elems);
 
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(Array, 56);
+CheckSize(Array, 24);
 
 INSN(Hash) : public Instruction {
     // k0, v0, k1, v1, ..., kn, vn
-    InlinedVector<VariableUseSite, 4> elems;
+    InlinedVector<LocalRef, 4> elems;
 
-    Hash(InlinedVector<VariableUseSite, 4> elems);
+    Hash(InlinedVector<LocalRef, 4> elems);
 
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(Hash, 104);
+CheckSize(Hash, 24);
 
 class InstructionPtr final {
     using tagged_storage = uint64_t;

--- a/cfg/builder/builder.h
+++ b/cfg/builder/builder.h
@@ -26,7 +26,6 @@ private:
     static void unconditionalJump(BasicBlock *from, BasicBlock *to, CFG &inWhat, core::LocOffsets loc);
     static void jumpToDead(BasicBlock *from, CFG &inWhat, core::LocOffsets loc);
     static void synthesizeExpr(BasicBlock *bb, LocalRef var, core::LocOffsets loc, InstructionPtr inst);
-    static BasicBlock *walkHash(CFGContext cctx, ast::Hash &h, BasicBlock *current, core::NameRef method);
     static std::tuple<LocalRef, BasicBlock *, BasicBlock *>
     walkDefault(CFGContext cctx, int argIndex, const core::ArgInfo &argInfo, LocalRef argLocal, core::LocOffsets argLoc,
                 ast::ExpressionPtr &def, BasicBlock *presentCont, BasicBlock *defaultCont);

--- a/cfg/builder/builder_finalize.cc
+++ b/cfg/builder/builder_finalize.cc
@@ -219,6 +219,7 @@ void CFGBuilder::dealias(core::Context ctx, CFG &cfg) {
                 } else if (auto *v = cast_instruction<Return>(bind.value)) {
                     v->what = maybeDealias(ctx, cfg, v->what.variable, current);
                 }
+                // TODO: do `Array` and `Hash` need dealiasing treatment?
             }
 
             // record new aliases

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -752,8 +752,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                     elems.emplace_back(keyTmp);
                     elems.emplace_back(valTmp);
                 }
-                current->exprs.emplace_back(cctx.target, h.loc,
-                                            make_insn<cfg::Hash>(std::move(elems)));
+                current->exprs.emplace_back(cctx.target, h.loc, make_insn<cfg::Hash>(std::move(elems)));
                 ret = current;
             },
             [&](ast::Array &a) {
@@ -764,8 +763,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                     current = walk(cctx.withTarget(tmp), elem, current);
                     elems.emplace_back(tmp);
                 }
-                current->exprs.emplace_back(cctx.target, a.loc,
-                                            make_insn<cfg::Array>(std::move(elems)));
+                current->exprs.emplace_back(cctx.target, a.loc, make_insn<cfg::Array>(std::move(elems)));
                 ret = current;
             },
 

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -742,7 +742,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
             },
 
             [&](ast::Hash &h) {
-                InlinedVector<cfg::VariableUseSite, 4> elems;
+                InlinedVector<cfg::LocalRef, 4> elems;
                 elems.reserve(h.keys.size() * 2);
                 for (int i = 0; i < h.keys.size(); i++) {
                     LocalRef keyTmp = cctx.newTemporary(core::Names::hashTemp());
@@ -757,7 +757,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                 ret = current;
             },
             [&](ast::Array &a) {
-                InlinedVector<VariableUseSite, 2> elems;
+                InlinedVector<LocalRef, 4> elems;
                 elems.reserve(a.elems.size());
                 for (auto &elem : a.elems) {
                     LocalRef tmp = cctx.newTemporary(core::Names::arrayTemp());

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1420,8 +1420,8 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                     }
                 }
 
-                vector<TypePtr> keys;
-                vector<TypePtr> values;
+                vector<core::TypePtr> keys;
+                vector<core::TypePtr> values;
                 keys.reserve(h.elems.size() / 2);
                 values.reserve(h.elems.size() / 2);
                 for (int i = 0; i < h.elems.size(); i += 2) {
@@ -1430,7 +1430,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                     auto &valType = getTypeAndOrigin(ctx, h.elems[i+1]).type;
                     values.emplace_back(valType);
                 }
-                tp.type = res.returnType = make_type<ShapeType>(move(keys), move(values));
+                tp.type = res.returnType = core::make_type<core::ShapeType>(move(keys), move(values));
                 tp.origins.emplace_back(ctx.locAt(bind.loc));
             },
             [&](cfg::GetCurrentException &i) {

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1430,7 +1430,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                     auto &valType = getTypeAndOrigin(ctx, h.elems[i+1]).type;
                     values.emplace_back(valType);
                 }
-                tp.type = res.returnType = core::make_type<core::ShapeType>(move(keys), move(values));
+                tp.type = core::make_type<core::ShapeType>(move(keys), move(values));
                 tp.origins.emplace_back(ctx.locAt(bind.loc));
             },
             [&](cfg::GetCurrentException &i) {

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1412,8 +1412,12 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
             [&](cfg::Hash &h) {
                 ENFORCE(h.elems.size() % 2 == 0);
 
+                // TODO: we had this separate loop because it seemed to better to not
+                // allocate `keys` and `values` if we didn't have a `ShapeType`, but
+                // maybe allocating `keys` to not do lookups in `getTypeAndOrigin` twice
+                // would actually be better?
                 for (size_t i = 0; i < h.elems.size(); i += 2) {
-                    if (!core::isa_type<core::LiteralType>(h.elems[i].type)) {
+                    if (!core::isa_type<core::LiteralType>(getTypeAndOrigin(ctx, h.elems[i]).type)) {
                         tp.type = core::Types::hashOfUntyped();
                         tp.origins.emplace_back(ctx.locAt(bind.loc));
                         return;

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1431,7 +1431,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                 for (int i = 0; i < h.elems.size(); i += 2) {
                     auto &keyType = getTypeAndOrigin(ctx, h.elems[i]).type;
                     keys.emplace_back(keyType);
-                    auto &valType = getTypeAndOrigin(ctx, h.elems[i+1]).type;
+                    auto &valType = getTypeAndOrigin(ctx, h.elems[i + 1]).type;
                     values.emplace_back(valType);
                 }
                 tp.type = core::make_type<core::ShapeType>(move(keys), move(values));

--- a/test/testdata/cfg/array.rb.cfg-text.exp
+++ b/test/testdata/cfg/array.rb.cfg-text.exp
@@ -47,20 +47,16 @@ bb1[rubyRegionId=0, firstDead=-1]():
 
 method ::TestArray#test_arrays {
 
-bb0[rubyRegionId=0, firstDead=14]():
+bb0[rubyRegionId=0, firstDead=10]():
     <self>: TestArray = cast(<self>: NilClass, TestArray);
-    <magic>$4: T.class_of(<Magic>) = alias <C <Magic>>
-    <statTemp>$3: [] = <magic>$4: T.class_of(<Magic>).<build-array>()
-    <arrayTemp>$6: Integer(1) = 1
-    <arrayTemp>$7: Integer(2) = 2
-    <magic>$8: T.class_of(<Magic>) = alias <C <Magic>>
-    <statTemp>$5: [Integer(1), Integer(2)] = <magic>$8: T.class_of(<Magic>).<build-array>(<arrayTemp>$6: Integer(1), <arrayTemp>$7: Integer(2))
-    <arrayTemp>$9: Integer = <self>: TestArray.an_int()
-    <arrayTemp>$11: String = <self>: TestArray.a_string()
-    <magic>$14: T.class_of(<Magic>) = alias <C <Magic>>
-    <arrayTemp>$13: [] = <magic>$14: T.class_of(<Magic>).<build-array>()
-    <magic>$15: T.class_of(<Magic>) = alias <C <Magic>>
-    <returnMethodTemp>$2: [Integer, String, []] = <magic>$15: T.class_of(<Magic>).<build-array>(<arrayTemp>$9: Integer, <arrayTemp>$11: String, <arrayTemp>$13: [])
+    <statTemp>$3: [] = []
+    <arrayTemp>$5: Integer(1) = 1
+    <arrayTemp>$6: Integer(2) = 2
+    <statTemp>$4: [Integer(1), Integer(2)] = [<arrayTemp>$5, <arrayTemp>$6]
+    <arrayTemp>$7: Integer = <self>: TestArray.an_int()
+    <arrayTemp>$9: String = <self>: TestArray.a_string()
+    <arrayTemp>$11: [] = []
+    <returnMethodTemp>$2: [Integer, String, []] = [<arrayTemp>$7, <arrayTemp>$9, <arrayTemp>$11]
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: [Integer, String, []]
     <unconditional> -> bb1
 

--- a/test/testdata/cfg/break.rb.cfg-text.exp
+++ b/test/testdata/cfg/break.rb.cfg-text.exp
@@ -4,10 +4,9 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <arrayTemp>$5: Integer(1) = 1
     <arrayTemp>$6: Integer(2) = 2
-    <magic>$7: T.class_of(<Magic>) = alias <C <Magic>>
-    <statTemp>$4: [Integer(1), Integer(2)] = <magic>$7: T.class_of(<Magic>).<build-array>(<arrayTemp>$5: Integer(1), <arrayTemp>$6: Integer(2))
-    <block-pre-call-temp>$8: Sorbet::Private::Static::Void = <statTemp>$4: [Integer(1), Integer(2)].map()
-    <selfRestore>$9: Object = <self>
+    <statTemp>$4: [Integer(1), Integer(2)] = [<arrayTemp>$5, <arrayTemp>$6]
+    <block-pre-call-temp>$7: Sorbet::Private::Static::Void = <statTemp>$4: [Integer(1), Integer(2)].map()
+    <selfRestore>$8: Object = <self>
     <unconditional> -> bb2
 
 # backedges
@@ -17,37 +16,37 @@ bb1[rubyRegionId=0, firstDead=-1]():
 
 # backedges
 # - bb0(rubyRegionId=0)
-bb2[rubyRegionId=1, firstDead=-1](<self>: Object, <block-pre-call-temp>$8: Sorbet::Private::Static::Void, <selfRestore>$9: Object):
+bb2[rubyRegionId=1, firstDead=-1](<self>: Object, <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: Object):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$8: Sorbet::Private::Static::Void, <selfRestore>$9: Object):
-    target: T::Array[T.noreturn] = Solve<<block-pre-call-temp>$8, map>
+bb3[rubyRegionId=0, firstDead=-1](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: Object):
+    target: T::Array[T.noreturn] = Solve<<block-pre-call-temp>$7, map>
     <unconditional> -> bb4
 
 # backedges
 # - bb3(rubyRegionId=0)
 # - bb5(rubyRegionId=1)
-bb4[rubyRegionId=0, firstDead=3](target: T.any(T::Array[T.noreturn], Integer), <selfRestore>$9: Object):
-    <cfgAlias>$19: T.class_of(T) = alias <C T>
-    <returnMethodTemp>$2: T.any(T::Array[T.noreturn], Integer) = <cfgAlias>$19: T.class_of(T).reveal_type(target: T.any(T::Array[T.noreturn], Integer))
+bb4[rubyRegionId=0, firstDead=3](target: T.any(T::Array[T.noreturn], Integer), <selfRestore>$8: Object):
+    <cfgAlias>$18: T.class_of(T) = alias <C T>
+    <returnMethodTemp>$2: T.any(T::Array[T.noreturn], Integer) = <cfgAlias>$18: T.class_of(T).reveal_type(target: T.any(T::Array[T.noreturn], Integer))
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.any(T::Array[T.noreturn], Integer)
     <unconditional> -> bb1
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=-1](<self>: Object, <selfRestore>$9: Object):
+bb5[rubyRegionId=1, firstDead=-1](<self>: Object, <selfRestore>$8: Object):
     # outerLoops: 1
     <self>: Object = loadSelf(map)
-    <blk>$10: [Integer] = load_yield_params(map)
-    x$1: Integer = yield_load_arg(0, <blk>$10: [Integer])
-    <returnTemp>$14: Integer = x$1
-    <block-break-assign>$15: Integer = x$1
-    <magic>$16: T.class_of(<Magic>) = alias <C <Magic>>
-    <block-break>$17: T.untyped = <magic>$16: T.class_of(<Magic>).<block-break>(<returnTemp>$14: Integer)
-    target: Integer = <block-break-assign>$15
+    <blk>$9: [Integer] = load_yield_params(map)
+    x$1: Integer = yield_load_arg(0, <blk>$9: [Integer])
+    <returnTemp>$13: Integer = x$1
+    <block-break-assign>$14: Integer = x$1
+    <magic>$15: T.class_of(<Magic>) = alias <C <Magic>>
+    <block-break>$16: T.untyped = <magic>$15: T.class_of(<Magic>).<block-break>(<returnTemp>$13: Integer)
+    target: Integer = <block-break-assign>$14
     <unconditional> -> bb4
 
 }

--- a/test/testdata/cfg/hash.rb.cfg-text.exp
+++ b/test/testdata/cfg/hash.rb.cfg-text.exp
@@ -32,7 +32,7 @@ bb1[rubyRegionId=0, firstDead=-1]():
 
 method ::TestHash#test {
 
-bb0[rubyRegionId=0, firstDead=10]():
+bb0[rubyRegionId=0, firstDead=9]():
     <self>: TestHash = cast(<self>: NilClass, TestHash);
     <hashTemp>$3: T.untyped = <self>: TestHash.something()
     <hashTemp>$4: Symbol(:bar) = :bar
@@ -40,8 +40,7 @@ bb0[rubyRegionId=0, firstDead=10]():
     <statTemp>$9: Integer(2) = 2
     <hashTemp>$6: Integer = <statTemp>$8: Integer(1).+(<statTemp>$9: Integer(2))
     <hashTemp>$7: Integer(2) = 2
-    <magic>$10: T.class_of(<Magic>) = alias <C <Magic>>
-    <returnMethodTemp>$2: T::Hash[T.untyped, T.untyped] = <magic>$10: T.class_of(<Magic>).<build-hash>(<hashTemp>$3: T.untyped, <hashTemp>$4: Symbol(:bar), <hashTemp>$6: Integer, <hashTemp>$7: Integer(2))
+    <returnMethodTemp>$2: T::Hash[T.untyped, T.untyped] = {<hashTemp>$3, <hashTemp>$4, <hashTemp>$6, <hashTemp>$7}
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T::Hash[T.untyped, T.untyped]
     <unconditional> -> bb1
 
@@ -54,7 +53,7 @@ bb1[rubyRegionId=0, firstDead=-1]():
 
 method ::TestHash#test_shaped {
 
-bb0[rubyRegionId=0, firstDead=12]():
+bb0[rubyRegionId=0, firstDead=11]():
     <self>: TestHash = cast(<self>: NilClass, TestHash);
     <hashTemp>$3: Integer(1) = 1
     <hashTemp>$4: Integer(2) = 2
@@ -64,8 +63,7 @@ bb0[rubyRegionId=0, firstDead=12]():
     <hashTemp>$8: Symbol(:bar) = :bar
     <hashTemp>$9: Symbol(:baz) = :baz
     <hashTemp>$10: T.untyped = <self>: TestHash.something()
-    <magic>$12: T.class_of(<Magic>) = alias <C <Magic>>
-    <returnMethodTemp>$2: {Integer(1) => Integer(2), Integer(2) => Integer(3), foo: Symbol(:bar), baz: T.untyped} = <magic>$12: T.class_of(<Magic>).<build-hash>(<hashTemp>$3: Integer(1), <hashTemp>$4: Integer(2), <hashTemp>$5: Integer(2), <hashTemp>$6: Integer(3), <hashTemp>$7: Symbol(:foo), <hashTemp>$8: Symbol(:bar), <hashTemp>$9: Symbol(:baz), <hashTemp>$10: T.untyped)
+    <returnMethodTemp>$2: {Integer(1) => Integer(2), Integer(2) => Integer(3), foo: Symbol(:bar), baz: T.untyped} = {<hashTemp>$3, <hashTemp>$4, <hashTemp>$5, <hashTemp>$6, <hashTemp>$7, <hashTemp>$8, <hashTemp>$9, <hashTemp>$10}
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: {Integer(1) => Integer(2), Integer(2) => Integer(3), foo: Symbol(:bar), baz: T.untyped}
     <unconditional> -> bb1
 

--- a/test/testdata/cfg/next.rb.cfg-text.exp
+++ b/test/testdata/cfg/next.rb.cfg-text.exp
@@ -3,44 +3,43 @@ method ::Object#foo {
 bb0[rubyRegionId=0, firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     <arrayTemp>$4: Integer(1) = 1
-    <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
-    <statTemp>$3: [Integer(1)] = <magic>$5: T.class_of(<Magic>).<build-array>(<arrayTemp>$4: Integer(1))
-    <block-pre-call-temp>$6: Sorbet::Private::Static::Void = <statTemp>$3: [Integer(1)].map()
-    <selfRestore>$7: Object = <self>
+    <statTemp>$3: [Integer(1)] = [<arrayTemp>$4]
+    <block-pre-call-temp>$5: Sorbet::Private::Static::Void = <statTemp>$3: [Integer(1)].map()
+    <selfRestore>$6: Object = <self>
     <unconditional> -> bb2
 
 # backedges
 # - bb3(rubyRegionId=0)
 bb1[rubyRegionId=0, firstDead=-1](<self>):
-    <statTemp>$15 = <self>
-    <blockReturnTemp>$9 = <statTemp>$15.bad()
+    <statTemp>$14 = <self>
+    <blockReturnTemp>$8 = <statTemp>$14.bad()
     <unconditional> -> bb1
 
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb5(rubyRegionId=1)
-bb2[rubyRegionId=1, firstDead=-1](<self>: Object, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: Object):
+bb2[rubyRegionId=1, firstDead=-1](<self>: Object, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Object):
     # outerLoops: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb3[rubyRegionId=0, firstDead=3](<block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: Object):
-    <returnMethodTemp>$2: T::Array[Integer] = Solve<<block-pre-call-temp>$6, map>
-    <self>: Object = <selfRestore>$7
+bb3[rubyRegionId=0, firstDead=3](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Object):
+    <returnMethodTemp>$2: T::Array[Integer] = Solve<<block-pre-call-temp>$5, map>
+    <self>: Object = <selfRestore>$6
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T::Array[Integer]
     <unconditional> -> bb1
 
 # backedges
 # - bb2(rubyRegionId=1)
-bb5[rubyRegionId=1, firstDead=6](<self>: Object, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: Object):
+bb5[rubyRegionId=1, firstDead=6](<self>: Object, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Object):
     # outerLoops: 1
     <self>: Object = loadSelf(map)
-    <blk>$8: [Integer] = load_yield_params(map)
-    x$1: Integer = yield_load_arg(0, <blk>$8: [Integer])
-    <statTemp>$10: T.untyped = <self>: Object.good()
-    <nextTemp>$13: Integer = x$1
-    <nextTemp>$14: T.noreturn = blockreturn<map> <nextTemp>$13: Integer
+    <blk>$7: [Integer] = load_yield_params(map)
+    x$1: Integer = yield_load_arg(0, <blk>$7: [Integer])
+    <statTemp>$9: T.untyped = <self>: Object.good()
+    <nextTemp>$12: Integer = x$1
+    <nextTemp>$13: T.noreturn = blockreturn<map> <nextTemp>$12: Integer
     <unconditional> -> bb2
 
 }

--- a/test/testdata/cfg/textoutput.rb.cfg-text.exp
+++ b/test/testdata/cfg/textoutput.rb.cfg-text.exp
@@ -5,7 +5,7 @@ bb0[rubyRegionId=0, firstDead=-1]():
     <cfgAlias>$7: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <cfgAlias>$9: T.class_of(A) = alias <C A>
     <statTemp>$5: Sorbet::Private::Static::Void = <cfgAlias>$7: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$9: T.class_of(A))
-    <magic>$22: T.class_of(<Magic>) = alias <C <Magic>>
+    <magic>$21: T.class_of(<Magic>) = alias <C <Magic>>
     <exceptionValue>$11: T.untyped = <get-current-exception>
     <exceptionValue>$11 -> (T.untyped ? bb3 : bb4)
 
@@ -18,25 +18,24 @@ bb1[rubyRegionId=0, firstDead=-1]():
 # backedges
 # - bb0(rubyRegionId=0)
 # - bb4(rubyRegionId=1)
-bb3[rubyRegionId=2, firstDead=-1](<self>: T.class_of(<root>), <exceptionValue>$11: T.untyped, <magic>$22: T.class_of(<Magic>)):
+bb3[rubyRegionId=2, firstDead=-1](<self>: T.class_of(<root>), <exceptionValue>$11: T.untyped, <magic>$21: T.class_of(<Magic>)):
     e: T.untyped = <exceptionValue>$11
-    <cfgAlias>$25: T.class_of(StandardError) = alias <C StandardError>
-    <isaCheckTemp>$26: T.untyped = e: T.untyped.is_a?(<cfgAlias>$25: T.class_of(StandardError))
-    <isaCheckTemp>$26 -> (T.untyped ? bb7 : bb8)
+    <cfgAlias>$24: T.class_of(StandardError) = alias <C StandardError>
+    <isaCheckTemp>$25: T.untyped = e: T.untyped.is_a?(<cfgAlias>$24: T.class_of(StandardError))
+    <isaCheckTemp>$25 -> (T.untyped ? bb7 : bb8)
 
 # backedges
 # - bb0(rubyRegionId=0)
-bb4[rubyRegionId=1, firstDead=-1](<self>: T.class_of(<root>), <magic>$22: T.class_of(<Magic>)):
+bb4[rubyRegionId=1, firstDead=-1](<self>: T.class_of(<root>), <magic>$21: T.class_of(<Magic>)):
     <cfgAlias>$14: T.class_of(A) = alias <C A>
     <statTemp>$12: A = <cfgAlias>$14: T.class_of(A).new()
     <hashTemp>$16: Symbol(:z) = :z
     <hashTemp>$17: Integer(3) = 3
     <hashTemp>$18: Symbol(:w) = :w
     <hashTemp>$19: String("string") = "string"
-    <magic>$20: T.class_of(<Magic>) = alias <C <Magic>>
-    <statTemp>$15: {z: Integer(3), w: String("string")} = <magic>$20: T.class_of(<Magic>).<build-hash>(<hashTemp>$16: Symbol(:z), <hashTemp>$17: Integer(3), <hashTemp>$18: Symbol(:w), <hashTemp>$19: String("string"))
-    <statTemp>$21: TrueClass = true
-    <statTemp>$10: T.untyped = <statTemp>$12: A.f(<statTemp>$15: {z: Integer(3), w: String("string")}, <statTemp>$21: TrueClass)
+    <statTemp>$15: {z: Integer(3), w: String("string")} = {<hashTemp>$16, <hashTemp>$17, <hashTemp>$18, <hashTemp>$19}
+    <statTemp>$20: TrueClass = true
+    <statTemp>$10: T.untyped = <statTemp>$12: A.f(<statTemp>$15: {z: Integer(3), w: String("string")}, <statTemp>$20: TrueClass)
     <exceptionValue>$11: T.untyped = <get-current-exception>
     <exceptionValue>$11 -> (T.untyped ? bb3 : bb5)
 
@@ -49,24 +48,24 @@ bb5[rubyRegionId=4, firstDead=-1](<self>: T.class_of(<root>)):
 # - bb5(rubyRegionId=4)
 # - bb7(rubyRegionId=2)
 # - bb8(rubyRegionId=2)
-bb6[rubyRegionId=3, firstDead=-1](<self>: T.class_of(<root>), <gotoDeadTemp>$29: T.nilable(TrueClass)):
-    <statTemp>$32: String("done") = "done"
-    <throwAwayTemp>$30: NilClass = <self>: T.class_of(<root>).p(<statTemp>$32: String("done"))
-    <gotoDeadTemp>$29 -> (T.nilable(TrueClass) ? bb1 : bb9)
+bb6[rubyRegionId=3, firstDead=-1](<self>: T.class_of(<root>), <gotoDeadTemp>$28: T.nilable(TrueClass)):
+    <statTemp>$31: String("done") = "done"
+    <throwAwayTemp>$29: NilClass = <self>: T.class_of(<root>).p(<statTemp>$31: String("done"))
+    <gotoDeadTemp>$28 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
 # - bb3(rubyRegionId=2)
-bb7[rubyRegionId=2, firstDead=-1](<self>: T.class_of(<root>), <magic>$22: T.class_of(<Magic>)):
+bb7[rubyRegionId=2, firstDead=-1](<self>: T.class_of(<root>), <magic>$21: T.class_of(<Magic>)):
     <exceptionValue>$11: NilClass = nil
-    <keepForCfgTemp>$23: Sorbet::Private::Static::Void = <magic>$22: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$11: NilClass)
-    <statTemp>$28: String("whoops") = "whoops"
-    <statTemp>$10: NilClass = <self>: T.class_of(<root>).p(<statTemp>$28: String("whoops"))
+    <keepForCfgTemp>$22: Sorbet::Private::Static::Void = <magic>$21: T.class_of(<Magic>).<keep-for-cfg>(<exceptionValue>$11: NilClass)
+    <statTemp>$27: String("whoops") = "whoops"
+    <statTemp>$10: NilClass = <self>: T.class_of(<root>).p(<statTemp>$27: String("whoops"))
     <unconditional> -> bb6
 
 # backedges
 # - bb3(rubyRegionId=2)
 bb8[rubyRegionId=2, firstDead=-1](<self>: T.class_of(<root>)):
-    <gotoDeadTemp>$29: TrueClass = true
+    <gotoDeadTemp>$28: TrueClass = true
     <unconditional> -> bb6
 
 # backedges

--- a/test/testdata/infer/hashes.rb.cfg-text.exp
+++ b/test/testdata/infer/hashes.rb.cfg-text.exp
@@ -31,15 +31,13 @@ bb1[rubyRegionId=0, firstDead=-1](<returnMethodTemp>$2):
 # backedges
 # - bb0(rubyRegionId=0)
 bb2[rubyRegionId=0, firstDead=-1]():
-    <magic>$5: T.class_of(<Magic>) = alias <C <Magic>>
-    s: {} = <magic>$5: T.class_of(<Magic>).<build-hash>()
+    s: {} = {}
     <unconditional> -> bb4
 
 # backedges
 # - bb0(rubyRegionId=0)
 bb3[rubyRegionId=0, firstDead=-1]():
-    <magic>$6: T.class_of(<Magic>) = alias <C <Magic>>
-    s: {} = <magic>$6: T.class_of(<Magic>).<build-hash>()
+    s: {} = {}
     <unconditional> -> bb4
 
 # backedges

--- a/test/testdata/infer/isa_generic.rb.cfg-text.exp
+++ b/test/testdata/infer/isa_generic.rb.cfg-text.exp
@@ -269,9 +269,9 @@ bb5[rubyRegionId=1, firstDead=6](<self>: T.class_of(Concrete), <block-pre-call-t
     <self>: T.class_of(Concrete) = loadSelf(type_template)
     <hashTemp>$16: Symbol(:fixed) = :fixed
     <cfgAlias>$18: T.class_of(String) = alias <C String>
-    <magic>$19: T.class_of(<Magic>) = alias <C <Magic>>
-    <blockReturnTemp>$15: {fixed: T.class_of(String)} = <magic>$19: T.class_of(<Magic>).<build-hash>(<hashTemp>$16: Symbol(:fixed), <cfgAlias>$18: T.class_of(String))
-    <blockReturnTemp>$20: T.noreturn = blockreturn<type_template> <blockReturnTemp>$15: {fixed: T.class_of(String)}
+    <hashTemp>$17: T.class_of(String) = <cfgAlias>$18
+    <blockReturnTemp>$15: {fixed: T.class_of(String)} = {<hashTemp>$16, <hashTemp>$17}
+    <blockReturnTemp>$19: T.noreturn = blockreturn<type_template> <blockReturnTemp>$15: {fixed: T.class_of(String)}
     <unconditional> -> bb2
 
 }

--- a/test/testdata/infer/self_type.rb.cfg-text.exp
+++ b/test/testdata/infer/self_type.rb.cfg-text.exp
@@ -89,24 +89,24 @@ bb4[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>)):
     <statTemp>$95: Sorbet::Private::Static::Void = <cfgAlias>$97: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$99: T.class_of(Array))
     <cfgAlias>$103: T.class_of(Sorbet::Private::Static) = alias <C Static>
     <cfgAlias>$106: T.class_of(Integer) = alias <C Integer>
+    <arrayTemp>$105: T.class_of(Integer) = <cfgAlias>$106
     <cfgAlias>$108: T.class_of(Integer) = alias <C Integer>
-    <magic>$109: T.class_of(<Magic>) = alias <C <Magic>>
-    <statTemp>$104: [T.class_of(Integer), T.class_of(Integer)] = <magic>$109: T.class_of(<Magic>).<build-array>(<cfgAlias>$106: T.class_of(Integer), <cfgAlias>$108: T.class_of(Integer))
+    <arrayTemp>$107: T.class_of(Integer) = <cfgAlias>$108
+    <statTemp>$104: [T.class_of(Integer), T.class_of(Integer)] = [<arrayTemp>$105, <arrayTemp>$107]
     <statTemp>$101: Sorbet::Private::Static::Void = <cfgAlias>$103: T.class_of(Sorbet::Private::Static).keep_for_typechecking(<statTemp>$104: [T.class_of(Integer), T.class_of(Integer)])
-    <arrayTemp>$112: Integer(1) = 1
-    <arrayTemp>$113: Integer(2) = 2
-    <magic>$114: T.class_of(<Magic>) = alias <C <Magic>>
-    <statTemp>$111: [Integer(1), Integer(2)] = <magic>$114: T.class_of(<Magic>).<build-array>(<arrayTemp>$112: Integer(1), <arrayTemp>$113: Integer(2))
-    <castTemp>$110: [Integer(1), Integer(2)] = <statTemp>$111: [Integer(1), Integer(2)].returns_self()
-    <statTemp>$100: [Integer, Integer] = cast(<castTemp>$110: [Integer(1), Integer(2)], [Integer, Integer]);
-    <cfgAlias>$119: T.class_of(Sorbet::Private::Static) = alias <C Static>
-    <cfgAlias>$121: T.class_of(A) = alias <C A>
-    <statTemp>$117: Sorbet::Private::Static::Void = <cfgAlias>$119: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$121: T.class_of(A))
-    <cfgAlias>$126: T.class_of(Sorbet::Private::Static) = alias <C Static>
-    <cfgAlias>$128: T.class_of(B) = alias <C B>
-    <statTemp>$124: Sorbet::Private::Static::Void = <cfgAlias>$126: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$128: T.class_of(B))
-    <cfgAlias>$131: T.class_of(A) = alias <C A>
-    s: A = <cfgAlias>$131: T.class_of(A).new()
+    <arrayTemp>$111: Integer(1) = 1
+    <arrayTemp>$112: Integer(2) = 2
+    <statTemp>$110: [Integer(1), Integer(2)] = [<arrayTemp>$111, <arrayTemp>$112]
+    <castTemp>$109: [Integer(1), Integer(2)] = <statTemp>$110: [Integer(1), Integer(2)].returns_self()
+    <statTemp>$100: [Integer, Integer] = cast(<castTemp>$109: [Integer(1), Integer(2)], [Integer, Integer]);
+    <cfgAlias>$117: T.class_of(Sorbet::Private::Static) = alias <C Static>
+    <cfgAlias>$119: T.class_of(A) = alias <C A>
+    <statTemp>$115: Sorbet::Private::Static::Void = <cfgAlias>$117: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$119: T.class_of(A))
+    <cfgAlias>$124: T.class_of(Sorbet::Private::Static) = alias <C Static>
+    <cfgAlias>$126: T.class_of(B) = alias <C B>
+    <statTemp>$122: Sorbet::Private::Static::Void = <cfgAlias>$124: T.class_of(Sorbet::Private::Static).keep_for_ide(<cfgAlias>$126: T.class_of(B))
+    <cfgAlias>$129: T.class_of(A) = alias <C A>
+    s: A = <cfgAlias>$129: T.class_of(A).new()
     <unconditional> -> bb5
 
 # backedges
@@ -115,13 +115,13 @@ bb4[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>)):
 # - bb9(rubyRegionId=0)
 bb5[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>), s: A):
     # outerLoops: 1
-    <whileTemp>$134: T.untyped = <self>: T.class_of(<root>).rnd()
-    <whileTemp>$134 -> (T.untyped ? bb8 : bb7)
+    <whileTemp>$132: T.untyped = <self>: T.class_of(<root>).rnd()
+    <whileTemp>$132 -> (T.untyped ? bb8 : bb7)
 
 # backedges
 # - bb5(rubyRegionId=0)
 bb7[rubyRegionId=0, firstDead=2](<self>: T.class_of(<root>), s: A):
-    <statTemp>$142: NilClass = <self>: T.class_of(<root>).puts(s: A)
+    <statTemp>$140: NilClass = <self>: T.class_of(<root>).puts(s: A)
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
 
@@ -129,16 +129,16 @@ bb7[rubyRegionId=0, firstDead=2](<self>: T.class_of(<root>), s: A):
 # - bb5(rubyRegionId=0)
 bb8[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>), s: A):
     # outerLoops: 1
-    <cfgAlias>$140: T.class_of(B) = alias <C B>
-    <ifTemp>$137: T::Boolean = s: A.is_a?(<cfgAlias>$140: T.class_of(B))
-    <ifTemp>$137 -> (T::Boolean ? bb9 : bb5)
+    <cfgAlias>$138: T.class_of(B) = alias <C B>
+    <ifTemp>$135: T::Boolean = s: A.is_a?(<cfgAlias>$138: T.class_of(B))
+    <ifTemp>$135 -> (T::Boolean ? bb9 : bb5)
 
 # backedges
 # - bb8(rubyRegionId=0)
 bb9[rubyRegionId=0, firstDead=-1](<self>: T.class_of(<root>), s: T.all(A, B)):
     # outerLoops: 1
-    <statTemp>$141: T.all(A, B) = s
-    s: T.all(A, B) = <statTemp>$141: T.all(A, B).returns_self()
+    <statTemp>$139: T.all(A, B) = s
+    s: T.all(A, B) = <statTemp>$139: T.all(A, B).returns_self()
     <unconditional> -> bb5
 
 }


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

These instructions are significantly smaller than representing array and hash construction as `Send`s, require less information at construction, and require less upkeep during inference.  Should be a win all around!

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
