### PR TITLE
make `ExpressionPtr` `trivial_abi` for faster argument passing

### DIFF
--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -71,7 +71,7 @@ template <typename T> struct ExpressionToTag;
 
 class EmptyTree;
 
-class ExpressionPtr {
+class __attribute__((trivial_abi)) ExpressionPtr final {
 public:
     // We store tagged pointers as 64-bit values.
     using tagged_storage = uint64_t;

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -71,7 +71,16 @@ template <typename T> struct ExpressionToTag;
 
 class EmptyTree;
 
-class __attribute__((trivial_abi)) ExpressionPtr final {
+// When we added trivial_abi support, the version of Emscripten that we used did not
+// support trivial_abi.  Even if we upgraded to a version that did, the performance
+// gains of trivial_abi are not super-important for Emscripten'd Sorbet.
+#ifdef __EMSCRIPTEN__
+#define TRIVIAL_ABI
+#else
+#define TRIVIAL_ABI __attribute__((trivial_abi))
+#endif
+
+class TRIVIAL_ABI ExpressionPtr final {
 public:
     // We store tagged pointers as 64-bit values.
     using tagged_storage = uint64_t;


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

`ExpressionPtr`, due to ABI rules, needs to be passed in memory even though it is small enough that we could pass it in a register.  And since we do a lot of unnecessary passing of `ExpressionPtr` values due to treemap, this change should be beneficial.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
