### PR TITLE
avoid reallocating nodes for `UnresolvedConstantLit` in `SubstWalk`

### DIFF
--- a/ast/substitute/Substitute.cc
+++ b/ast/substitute/Substitute.cc
@@ -20,10 +20,10 @@ private:
             return TreeMap::apply(ctx, *this, std::move(node));
         }
 
-        auto scope = substClassName(ctx, std::move(constLit->scope));
-        auto cnst = subst.substituteSymbolName(constLit->cnst);
+        constLit->scope = substClassName(ctx, std::move(constLit->scope));
+        constLit->cnst = subst.substituteSymbolName(constLit->cnst);
 
-        return make_expression<UnresolvedConstantLit>(constLit->loc, std::move(scope), cnst);
+        return node;
     }
 
     ExpressionPtr substArg(core::MutableContext ctx, ExpressionPtr argp) {


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

There's no need to allocate a new node here when we have a perfectly good one all ready to be operated on.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
