### PR TITLE
link to public Sorbet docs for `T::Helpers`

### DIFF
--- a/gems/sorbet-runtime/lib/types/helpers.rb
+++ b/gems/sorbet-runtime/lib/types/helpers.rb
@@ -2,7 +2,7 @@
 # typed: true
 
 # Use as a mixin with extend (`extend T::Helpers`).
-# Docs at https://confluence.corp.stripe.com/display/PRODINFRA/Ruby+Types
+# Docs at https://sorbet.org/docs/
 module T::Helpers
   extend T::Sig
 


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We shouldn't be linking to internal Stripe things for public docs, as this docstring gets reflected into www.rubydocs.info.
### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
