### PR TITLE
Fix metrics counter for singleton classes

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1616,7 +1616,6 @@ ClassOrModuleRef ClassOrModule::singletonClass(GlobalState &gs) {
     singleton = gs.enterClassSymbol(this->loc(), this->owner, singletonName);
     ClassOrModuleData singletonInfo = singleton.data(gs);
 
-    prodCounterInc("types.input.singleton_classes.total");
     singletonInfo->members()[Names::attached()] = selfRef;
     singletonInfo->setSuperClass(Symbols::todo());
     singletonInfo->setIsModule(false);

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -190,6 +190,7 @@ void Resolver::finalizeAncestors(core::GlobalState &gs) {
     Timer timer(gs.tracer(), "resolver.finalize_ancestors");
     int methodCount = 0;
     int classCount = 0;
+    int singletonClassCount = 0;
     int moduleCount = 0;
     for (size_t i = 1; i < gs.methodsUsed(); ++i) {
         auto ref = core::MethodRef(gs, i);
@@ -229,6 +230,7 @@ void Resolver::finalizeAncestors(core::GlobalState &gs) {
         auto attached = ref.data(gs)->attachedClass(gs);
         bool isSingleton = attached.exists() && attached != core::Symbols::untyped();
         if (isSingleton) {
+            singletonClassCount++;
             if (attached == core::Symbols::BasicObject()) {
                 ref.data(gs)->setSuperClass(core::Symbols::Class());
             } else if (attached.data(gs)->superClass() ==
@@ -256,6 +258,7 @@ void Resolver::finalizeAncestors(core::GlobalState &gs) {
 
     prodCounterAdd("types.input.modules.total", moduleCount);
     prodCounterAdd("types.input.classes.total", classCount);
+    prodCounterAdd("types.input.singleton_classes.total", singletonClassCount);
     prodCounterAdd("types.input.methods.total", methodCount);
 }
 

--- a/test/cli/metrics-file/files_for_metrics/test1.rb
+++ b/test/cli/metrics-file/files_for_metrics/test1.rb
@@ -1,0 +1,11 @@
+# typed: true
+
+# Metrics:
+#  * 1 module     M
+#  * 1 class      T.class_of(M)
+#  * 1 singleton  T.class_of(M)
+#  * 3 methods    <root>.static_init, M1.foo, M1.static_init
+
+module M1
+  def self.foo; end
+end

--- a/test/cli/metrics-file/files_for_metrics/test2.rb
+++ b/test/cli/metrics-file/files_for_metrics/test2.rb
@@ -1,0 +1,11 @@
+# typed: true
+
+# Metrics:
+#  * 0 module
+#  * 2 classes    C1, T.class_of(C1)
+#  * 1 singleton  T.class_of(C1)
+#  * 3 methods    <root>.static_init, C1#foo, C1.static_init
+
+class C1
+  def foo; end
+end

--- a/test/cli/metrics-file/files_for_metrics/test3.rb
+++ b/test/cli/metrics-file/files_for_metrics/test3.rb
@@ -1,0 +1,13 @@
+# typed: true
+
+# Metrics:
+#  * 0 module
+#  * 3 classes    C2, T.class_of(C2), T.class_of(T.class_of(C2))
+#  * 2 singleton  T.class_of(C2), T.class_of(T.class_of(C2))
+#  * 4 methods    <root>.static_init, C2.static_init, T.class_of(C2)#foo, T.class_of(C2).static_init
+
+class C2
+  class << self
+    def foo; end
+  end
+end

--- a/test/cli/metrics-file/test.out
+++ b/test/cli/metrics-file/test.out
@@ -9,3 +9,13 @@ Cannot write metrics file at `baz/metrics3.json`
 ------------------------------
 No errors! Great job.
 No error metrics reported.
+------------------------------
+No errors! Great job.
+   "name": "ruby_typer.unknown..types.input.modules.total",
+   "value": 1
+   "name": "ruby_typer.unknown..types.input.classes.total",
+   "value": 6
+   "name": "ruby_typer.unknown..types.input.singleton_classes.total",
+   "value": 4
+   "name": "ruby_typer.unknown..types.input.methods.total",
+   "value": 10

--- a/test/cli/metrics-file/test.sh
+++ b/test/cli/metrics-file/test.sh
@@ -19,8 +19,7 @@ echo ------------------------------
 # Sorbet will not count errors that are created but end up being
 # ignored by other branches, e.g. when a type error is found in one
 # branch of a T.all but ends up being made irrelevant by the other
-main/sorbet --silence-dev-message \
-            --metrics-file=metrics5.json \
-            test/cli/metrics-file/with-error-branching.rb 2>&1
+main/sorbet --silence-dev-message --metrics-file=metrics4.json test/cli/metrics-file/with-error-branching.rb 2>&1
+grep -A1 "\"ruby_typer.unknown..error.total\"" metrics4.json || echo "No error metrics reported."
 
 grep -A1 "\"ruby_typer.unknown..error.total\"" metrics5.json || echo "No error metrics reported."

--- a/test/cli/metrics-file/test.sh
+++ b/test/cli/metrics-file/test.sh
@@ -22,4 +22,12 @@ echo ------------------------------
 main/sorbet --silence-dev-message --metrics-file=metrics4.json test/cli/metrics-file/with-error-branching.rb 2>&1
 grep -A1 "\"ruby_typer.unknown..error.total\"" metrics4.json || echo "No error metrics reported."
 
-grep -A1 "\"ruby_typer.unknown..error.total\"" metrics5.json || echo "No error metrics reported."
+echo ------------------------------
+
+# Compute metrics for classes, modules and methods
+
+main/sorbet --silence-dev-message --metrics-file=metrics5.json test/cli/metrics-file/files_for_metrics/ 2>&1
+grep -A1 "\"ruby_typer.unknown..types.input.modules.total\"" metrics5.json
+grep -A1 "\"ruby_typer.unknown..types.input.classes.total\"" metrics5.json
+grep -A1 "\"ruby_typer.unknown..types.input.singleton_classes.total\"" metrics5.json
+grep -A1 "\"ruby_typer.unknown..types.input.methods.total\"" metrics5.json


### PR DESCRIPTION
### Motivation

With the previous behavior, this metrics was incremented for each singleton class of each synthetic class created at GlobalState initialization. This was giving >100 singleton classes for an empty set of files.

An interesting fact is that the GlobalState is initialized with all the synthetic classes only when passing more than 2 files so
it needs an index. So we need at least 3 empty files to reproduce this.

### Test plan

See included automated tests.
