### PR TITLE
devirtualize `parser::Node`

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -2234,7 +2234,8 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, parser::NodePtr what) {
                 result = std::move(res);
             },
 
-            [&](parser::BlockPass &blockPass) { Exception::raise("Send should have already handled the BlockPass"); });
+            [&](parser::BlockPass &blockPass) { Exception::raise("Send should have already handled the BlockPass"); },
+            [&](parser::NodePtr &node) { Exception::raise("Unimplemented Parser Node: {}", node->nodeName()); });
         ENFORCE(result.get() != nullptr, "desugar result unset");
         return result;
     } catch (SorbetException &) {

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -145,8 +145,7 @@ ExpressionPtr desugarBody(DesugarContext dctx, core::LocOffsets loc, parser::Nod
 }
 
 ExpressionPtr desugarBlock(DesugarContext dctx, core::LocOffsets loc, core::LocOffsets blockLoc,
-                           parser::NodePtr &blockSend, parser::NodePtr &blockArgs,
-                           parser::NodePtr &blockBody) {
+                           parser::NodePtr &blockSend, parser::NodePtr &blockArgs, parser::NodePtr &blockBody) {
     blockSend->loc = loc;
     auto recv = node2TreeImpl(dctx, std::move(blockSend));
     Send *send;
@@ -649,8 +648,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, parser::NodePtr what) {
                 }
 
                 if (absl::c_any_of(send.args, [](auto &arg) {
-                        return parser::isa_node<parser::Splat>(arg) ||
-                               parser::isa_node<parser::ForwardedArgs>(arg);
+                        return parser::isa_node<parser::Splat>(arg) || parser::isa_node<parser::ForwardedArgs>(arg);
                     })) {
                     // Build up an array that represents the keyword args for the send. When there is a Kwsplat, treat
                     // all keyword arguments as a single argument.
@@ -724,8 +722,8 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, parser::NodePtr what) {
                     auto argnodes = std::move(send.args);
                     bool anonymousBlockPass = false;
                     core::LocOffsets bpLoc;
-                    auto it = absl::c_find_if(argnodes,
-                                              [](auto &arg) { return parser::isa_node<parser::BlockPass>(arg); });
+                    auto it =
+                        absl::c_find_if(argnodes, [](auto &arg) { return parser::isa_node<parser::BlockPass>(arg); });
                     if (it != argnodes.end()) {
                         auto *bp = parser::cast_node<parser::BlockPass>(it->get());
                         if (bp->block == nullptr) {
@@ -1359,8 +1357,8 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, parser::NodePtr what) {
                               core::Names::tripleEq(), zeroLengthRecvLoc, MK::Local(zeroLengthRecvLoc, tempRecv));
 
                 parser::NodePtr sendNode =
-                    parser::make_node<parser::Send>(loc, parser::make_node<parser::LVar>(recvLoc, tempRecv), csend.method,
-                                              csend.methodLoc, std::move(csend.args));
+                    parser::make_node<parser::Send>(loc, parser::make_node<parser::LVar>(recvLoc, tempRecv),
+                                                    csend.method, csend.methodLoc, std::move(csend.args));
                 auto send = node2TreeImpl(dctx, std::move(sendNode));
 
                 ExpressionPtr nil =
@@ -1421,9 +1419,8 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, parser::NodePtr what) {
             [&](parser::Module &module) {
                 ClassDef::RHS_store body = scopeNodeToBody(dctx, std::move(module.body));
                 ClassDef::ANCESTORS_store ancestors;
-                ExpressionPtr res =
-                    MK::Module(module.loc, module.declLoc, node2TreeImpl(dctx, std::move(module.name)),
-                               std::move(ancestors), std::move(body));
+                ExpressionPtr res = MK::Module(module.loc, module.declLoc, node2TreeImpl(dctx, std::move(module.name)),
+                                               std::move(ancestors), std::move(body));
                 result = std::move(res);
             },
             [&](parser::Class &claz) {
@@ -1593,7 +1590,8 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, parser::NodePtr what) {
                 // Do this by synthesizing a `Send` parse node and letting our
                 // Send desugar handle it.
                 auto method = core::Names::super();
-                auto send = parser::make_node<parser::Send>(super.loc, nullptr, method, super.loc, std::move(super.args));
+                auto send =
+                    parser::make_node<parser::Send>(super.loc, nullptr, method, super.loc, std::move(super.args));
                 auto res = node2TreeImpl(dctx, std::move(send));
                 result = std::move(res);
             },
@@ -1634,8 +1632,8 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, parser::NodePtr what) {
                 } else {
                     auto temp = dctx.freshNameUnique(core::Names::forTemp());
 
-                    parser::NodePtr masgn =
-                        parser::make_node<parser::Masgn>(loc, std::move(mlhsNode), parser::make_node<parser::LVar>(loc, temp));
+                    parser::NodePtr masgn = parser::make_node<parser::Masgn>(
+                        loc, std::move(mlhsNode), parser::make_node<parser::LVar>(loc, temp));
 
                     body = MK::InsSeq1(loc, node2TreeImpl(dctx, std::move(masgn)), move(body));
                     block = MK::Block(loc, std::move(body), std::move(args));

--- a/ast/desugar/Desugar.h
+++ b/ast/desugar/Desugar.h
@@ -7,7 +7,7 @@
 
 namespace sorbet::ast::desugar {
 
-ExpressionPtr node2Tree(core::MutableContext ctx, std::unique_ptr<parser::Node> what);
+ExpressionPtr node2Tree(core::MutableContext ctx, std::unique_ptr<parser::Node, parser::NodeDeleter> what);
 } // namespace sorbet::ast::desugar
 
 #endif // SORBET_DESUGAR_H

--- a/ast/desugar/Desugar.h
+++ b/ast/desugar/Desugar.h
@@ -7,7 +7,7 @@
 
 namespace sorbet::ast::desugar {
 
-ExpressionPtr node2Tree(core::MutableContext ctx, std::unique_ptr<parser::Node, parser::NodeDeleter> what);
+ExpressionPtr node2Tree(core::MutableContext ctx, parser::NodePtr what);
 } // namespace sorbet::ast::desugar
 
 #endif // SORBET_DESUGAR_H

--- a/common/typecase.h
+++ b/common/typecase.h
@@ -94,7 +94,7 @@ template <typename Base, typename... Subclasses> void typecase(Base &base, Subcl
         if (!base) {
             sorbet::Exception::raise("nullptr passed to typecase");
         }
-        sorbet::Exception::raise("not handled typecase case: {}", base.tag());
+        sorbet::Exception::raise("not handled tagged reference case: {}", base.tag());
     }
 }
 

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -109,10 +109,10 @@ ast::ExpressionPtr fetchTreeFromCache(core::GlobalState &gs, core::FileRef fref,
     return nullptr;
 }
 
-unique_ptr<parser::Node> runParser(core::GlobalState &gs, core::FileRef file, const options::Printers &print,
+unique_ptr<parser::Node, parser::NodeDeleter> runParser(core::GlobalState &gs, core::FileRef file, const options::Printers &print,
                                    bool traceLexer, bool traceParser) {
     Timer timeit(gs.tracer(), "runParser", {{"file", string(file.data(gs).path())}});
-    unique_ptr<parser::Node> nodes;
+    unique_ptr<parser::Node, parser::NodeDeleter> nodes;
     {
         core::UnfreezeNameTable nameTableAccess(gs); // enters strings from source code as names
         auto indentationAware = false;               // Don't start in indentation-aware error recovery mode
@@ -134,7 +134,7 @@ unique_ptr<parser::Node> runParser(core::GlobalState &gs, core::FileRef file, co
     return nodes;
 }
 
-ast::ExpressionPtr runDesugar(core::GlobalState &gs, core::FileRef file, unique_ptr<parser::Node> parseTree,
+ast::ExpressionPtr runDesugar(core::GlobalState &gs, core::FileRef file, unique_ptr<parser::Node, parser::NodeDeleter> parseTree,
                               const options::Printers &print) {
     Timer timeit(gs.tracer(), "runDesugar", {{"file", string(file.data(gs).path())}});
     ast::ExpressionPtr ast;

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -109,8 +109,8 @@ ast::ExpressionPtr fetchTreeFromCache(core::GlobalState &gs, core::FileRef fref,
     return nullptr;
 }
 
-parser::NodePtr runParser(core::GlobalState &gs, core::FileRef file, const options::Printers &print,
-                                   bool traceLexer, bool traceParser) {
+parser::NodePtr runParser(core::GlobalState &gs, core::FileRef file, const options::Printers &print, bool traceLexer,
+                          bool traceParser) {
     Timer timeit(gs.tracer(), "runParser", {{"file", string(file.data(gs).path())}});
     parser::NodePtr nodes;
     {

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -109,10 +109,10 @@ ast::ExpressionPtr fetchTreeFromCache(core::GlobalState &gs, core::FileRef fref,
     return nullptr;
 }
 
-unique_ptr<parser::Node, parser::NodeDeleter> runParser(core::GlobalState &gs, core::FileRef file, const options::Printers &print,
+parser::NodePtr runParser(core::GlobalState &gs, core::FileRef file, const options::Printers &print,
                                    bool traceLexer, bool traceParser) {
     Timer timeit(gs.tracer(), "runParser", {{"file", string(file.data(gs).path())}});
-    unique_ptr<parser::Node, parser::NodeDeleter> nodes;
+    parser::NodePtr nodes;
     {
         core::UnfreezeNameTable nameTableAccess(gs); // enters strings from source code as names
         auto indentationAware = false;               // Don't start in indentation-aware error recovery mode
@@ -134,7 +134,7 @@ unique_ptr<parser::Node, parser::NodeDeleter> runParser(core::GlobalState &gs, c
     return nodes;
 }
 
-ast::ExpressionPtr runDesugar(core::GlobalState &gs, core::FileRef file, unique_ptr<parser::Node, parser::NodeDeleter> parseTree,
+ast::ExpressionPtr runDesugar(core::GlobalState &gs, core::FileRef file, parser::NodePtr parseTree,
                               const options::Printers &print) {
     Timer timeit(gs.tracer(), "runDesugar", {{"file", string(file.data(gs).path())}});
     ast::ExpressionPtr ast;

--- a/parser/BUILD
+++ b/parser/BUILD
@@ -45,10 +45,11 @@ genrule(
     outs = [
         "Node_gen.h",
         "Node_gen.cc",
+        "Node_gen_case.h",
         "Node_gen_tag.h",
     ],
-    cmd = "$(location :generate_ast) $(location Node_gen_tag.h) $(location Node_gen.h) $(location Node_gen.cc) && \
-             $(location //tools:clang-format) -i $(location Node_gen.cc) $(location Node_gen.h) $(location Node_gen_tag.h)",
+    cmd = "$(location :generate_ast) $(location Node_gen_tag.h) $(location Node_gen_case.h) $(location Node_gen.h) $(location Node_gen.cc) && \
+             $(location //tools:clang-format) -i $(location Node_gen.cc) $(location Node_gen.h) $(location Node_gen_tag.h) $(location Node_gen_case.h)",
     tools = [
         ":generate_ast",
         "//tools:clang-format",

--- a/parser/BUILD
+++ b/parser/BUILD
@@ -8,6 +8,7 @@ cc_library(
         "Node.h",
         "Node_gen.cc",
         "Node_gen.h",
+        "Node_gen_case.h",
         "Node_gen_tag.h",
         "Parser.cc",
         "diagnostics.cc",

--- a/parser/BUILD
+++ b/parser/BUILD
@@ -8,6 +8,7 @@ cc_library(
         "Node.h",
         "Node_gen.cc",
         "Node_gen.h",
+        "Node_gen_tag.h",
         "Parser.cc",
         "diagnostics.cc",
         "parser.h",
@@ -44,9 +45,10 @@ genrule(
     outs = [
         "Node_gen.h",
         "Node_gen.cc",
+        "Node_gen_tag.h",
     ],
-    cmd = "$(location :generate_ast) $(location Node_gen.h) $(location Node_gen.cc) && \
-             $(location //tools:clang-format) -i $(location Node_gen.cc) $(location Node_gen.h)",
+    cmd = "$(location :generate_ast) $(location Node_gen_tag.h) $(location Node_gen.h) $(location Node_gen.cc) && \
+             $(location //tools:clang-format) -i $(location Node_gen.cc) $(location Node_gen.h) $(location Node_gen_tag.h)",
     tools = [
         ":generate_ast",
         "//tools:clang-format",

--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -893,7 +893,7 @@ public:
         core::LocOffsets declLoc = head->loc.join(maybe_loc(args));
         core::LocOffsets loc = head->loc.join(tokLoc(end));
 
-        if (isLiteralNode(*(head->definee.get()))) {
+        if (isLiteralNode(head->definee)) {
             error(ruby_parser::dclass::SingletonLiteral, head->definee->loc);
         }
         checkReservedForNumberedParameters(head->name.toString(gs_), declLoc);
@@ -1796,11 +1796,11 @@ public:
         return (name[0] != '_');
     }
 
-    bool isLiteralNode(parser::Node &node) {
-        return parser::isa_node<Integer>(&node) || parser::isa_node<String>(&node) ||
-               parser::isa_node<DString>(&node) || parser::isa_node<Symbol>(&node) ||
-               parser::isa_node<DSymbol>(&node) || parser::isa_node<Regexp>(&node) || parser::isa_node<Array>(&node) ||
-               parser::isa_node<Hash>(&node);
+    bool isLiteralNode(parser::NodePtr &node) {
+        return parser::isa_node<Integer>(node) || parser::isa_node<String>(node) ||
+               parser::isa_node<DString>(node) || parser::isa_node<Symbol>(node) ||
+               parser::isa_node<DSymbol>(node) || parser::isa_node<Regexp>(node) || parser::isa_node<Array>(node) ||
+               parser::isa_node<Hash>(node);
     }
 
     void checkAssignmentToNumberedParameters(std::string_view name, core::LocOffsets loc) {

--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -166,10 +166,10 @@ public:
             o->right = transformCondition(std::move(o->right));
         } else if (auto *ir = parser::cast_node<IRange>(cond.get())) {
             return make_node<IFlipflop>(ir->loc, transformCondition(std::move(ir->from)),
-                                          transformCondition(std::move(ir->to)));
+                                        transformCondition(std::move(ir->to)));
         } else if (auto *er = parser::cast_node<ERange>(cond.get())) {
             return make_node<EFlipflop>(er->loc, transformCondition(std::move(er->from)),
-                                          transformCondition(std::move(er->to)));
+                                        transformCondition(std::move(er->to)));
         } else if (auto *re = parser::cast_node<Regexp>(cond.get())) {
             return make_node<MatchCurLine>(re->loc, std::move(cond));
         }
@@ -323,11 +323,11 @@ public:
         if (auto *s = parser::cast_node<Send>(lhs.get())) {
             s->args.emplace_back(std::move(rhs));
             return make_node<Send>(loc, std::move(s->receiver), s->method, s->methodLoc.join(tokLoc(eql)),
-                                     std::move(s->args));
+                                   std::move(s->args));
         } else if (auto *s = parser::cast_node<CSend>(lhs.get())) {
             s->args.emplace_back(std::move(rhs));
             return make_node<CSend>(loc, std::move(s->receiver), s->method, s->methodLoc.join(tokLoc(eql)),
-                                      std::move(s->args));
+                                    std::move(s->args));
         } else {
             return make_node<Assign>(loc, std::move(lhs), std::move(rhs));
         }
@@ -433,15 +433,15 @@ public:
         return make_node<Begin>(loc, std::move(stmts));
     }
 
-    NodePtr beginBody(NodePtr body, sorbet::parser::NodeVec rescueBodies, const token *elseTok,
-                               NodePtr else_, const token *ensure_tok, NodePtr ensure) {
+    NodePtr beginBody(NodePtr body, sorbet::parser::NodeVec rescueBodies, const token *elseTok, NodePtr else_,
+                      const token *ensure_tok, NodePtr ensure) {
         if (!rescueBodies.empty()) {
             if (else_ == nullptr) {
                 body = make_node<Rescue>(maybe_loc(body).join(rescueBodies.back()->loc), std::move(body),
-                                           std::move(rescueBodies), nullptr);
+                                         std::move(rescueBodies), nullptr);
             } else {
                 body = make_node<Rescue>(maybe_loc(body).join(else_->loc), std::move(body), std::move(rescueBodies),
-                                           std::move(else_));
+                                         std::move(else_));
             }
         } else if (elseTok != nullptr) {
             sorbet::parser::NodeVec stmts;
@@ -495,11 +495,10 @@ public:
         args.emplace_back(std::move(arg));
 
         return make_node<Send>(loc, std::move(receiver), gs_.enterNameUTF8(oper->view()), tokLoc(oper),
-                                 std::move(args));
+                               std::move(args));
     }
 
-    NodePtr block(NodePtr methodCall, const token *begin, NodePtr args,
-                           NodePtr body, const token *end) {
+    NodePtr block(NodePtr methodCall, const token *begin, NodePtr args, NodePtr body, const token *end) {
         if (auto *y = parser::cast_node<Yield>(methodCall.get())) {
             error(ruby_parser::dclass::BlockGivenToYield, y->loc);
             return make_node<Yield>(y->loc, sorbet::parser::NodeVec());
@@ -528,16 +527,14 @@ public:
             isNumblock = true;
         }
 
-        if (parser::isa_node<parser::Send>(methodCall) ||
-            parser::isa_node<CSend>(methodCall) ||
-            parser::isa_node<Super>(methodCall) ||
-            parser::isa_node<ZSuper>(methodCall)) {
+        if (parser::isa_node<parser::Send>(methodCall) || parser::isa_node<CSend>(methodCall) ||
+            parser::isa_node<Super>(methodCall) || parser::isa_node<ZSuper>(methodCall)) {
             if (isNumblock) {
                 return make_node<NumBlock>(methodCall->loc.join(tokLoc(end)), std::move(methodCall), std::move(args),
-                                             std::move(body));
+                                           std::move(body));
             }
             return make_node<Block>(methodCall->loc.join(tokLoc(end)), std::move(methodCall), std::move(args),
-                                      std::move(body));
+                                    std::move(body));
         }
 
         sorbet::parser::NodeVec *exprs;
@@ -592,8 +589,8 @@ public:
         return make_node<Send>(loc, std::move(kernel), core::Names::lambda(), loc, NodeVec());
     }
 
-    NodePtr call_method(NodePtr receiver, const token *dot, const token *selector,
-                                 const token *lparen, sorbet::parser::NodeVec args, const token *rparen) {
+    NodePtr call_method(NodePtr receiver, const token *dot, const token *selector, const token *lparen,
+                        sorbet::parser::NodeVec args, const token *rparen) {
         core::LocOffsets selectorLoc, startLoc;
         if (selector != nullptr) {
             selectorLoc = tokLoc(selector);
@@ -646,10 +643,10 @@ public:
         }
     }
 
-    NodePtr case_(const token *case_, NodePtr expr, sorbet::parser::NodeVec whenBodies,
-                           const token *elseTok, NodePtr elseBody, const token *end) {
+    NodePtr case_(const token *case_, NodePtr expr, sorbet::parser::NodeVec whenBodies, const token *elseTok,
+                  NodePtr elseBody, const token *end) {
         return make_node<Case>(tokLoc(case_).join(tokLoc(end)), std::move(expr), std::move(whenBodies),
-                                 std::move(elseBody));
+                               std::move(elseBody));
     }
 
     NodePtr case_error(const token *case_, NodePtr cond, const token *end) {
@@ -665,13 +662,13 @@ public:
         return make_node<Case>(loc, std::move(cond), std::move(whens), nullptr);
     }
 
-    NodePtr case_match(const token *case_, NodePtr expr, sorbet::parser::NodeVec inBodies,
-                                const token *elseTok, NodePtr elseBody, const token *end) {
+    NodePtr case_match(const token *case_, NodePtr expr, sorbet::parser::NodeVec inBodies, const token *elseTok,
+                       NodePtr elseBody, const token *end) {
         if (elseTok != nullptr && elseBody == nullptr) {
             elseBody = empty_else(elseTok);
         }
         return make_node<CaseMatch>(tokLoc(case_).join(tokLoc(end)), std::move(expr), std::move(inBodies),
-                                      std::move(elseBody));
+                                    std::move(elseBody));
     }
 
     NodePtr character(const token *char_) {
@@ -693,8 +690,8 @@ public:
         }
     }
 
-    NodePtr condition(const token *cond_tok, NodePtr cond, const token *then, NodePtr ifTrue,
-                               const token *else_, NodePtr ifFalse, const token *end) {
+    NodePtr condition(const token *cond_tok, NodePtr cond, const token *then, NodePtr ifTrue, const token *else_,
+                      NodePtr ifFalse, const token *end) {
         core::LocOffsets loc = tokLoc(cond_tok).join(cond->loc);
         if (then != nullptr) {
             loc = loc.join(tokLoc(then));
@@ -728,8 +725,7 @@ public:
         return make_node<Const>(tokLoc(name), nullptr, gs_.enterNameConstant(name->view()));
     }
 
-    NodePtr const_pattern(NodePtr const_, const token *begin, NodePtr pattern,
-                                   const token *end) {
+    NodePtr const_pattern(NodePtr const_, const token *begin, NodePtr pattern, const token *end) {
         return make_node<ConstPattern>(tokLoc(begin).join(tokLoc(end)), std::move(const_), std::move(pattern));
     }
 
@@ -739,12 +735,12 @@ public:
 
     NodePtr constFetchError(NodePtr scope, const token *colon) {
         return make_node<Const>(scope->loc.join(tokLoc(colon)), std::move(scope),
-                                  core::Names::Constants::ConstantNameMissing());
+                                core::Names::Constants::ConstantNameMissing());
     }
 
     NodePtr constGlobal(const token *colon, const token *name) {
         return make_node<Const>(tokLoc(colon).join(tokLoc(name)), make_node<Cbase>(tokLoc(colon)),
-                                  gs_.enterNameConstant(name->view()));
+                                gs_.enterNameConstant(name->view()));
     }
 
     NodePtr constOpAssignable(NodePtr node) {
@@ -786,8 +782,7 @@ public:
                         if (dedented && dedented->empty()) {
                             continue;
                         }
-                        NodePtr newstr =
-                            make_node<String>(s->loc, dedented ? gs_.enterNameUTF8(*dedented) : s->val);
+                        NodePtr newstr = make_node<String>(s->loc, dedented ? gs_.enterNameUTF8(*dedented) : s->val);
                         parts.emplace_back(std::move(newstr));
                     } else {
                         dedenter.interrupt();
@@ -809,8 +804,7 @@ public:
                         if (dedented && dedented->empty()) {
                             continue;
                         }
-                        NodePtr newstr =
-                            make_node<String>(s->loc, dedented ? gs_.enterNameUTF8(*dedented) : s->val);
+                        NodePtr newstr = make_node<String>(s->loc, dedented ? gs_.enterNameUTF8(*dedented) : s->val);
                         parts.emplace_back(std::move(newstr));
                     } else {
                         dedenter.interrupt();
@@ -825,16 +819,15 @@ public:
         return result;
     }
 
-    NodePtr def_class(const token *class_, NodePtr name, const token *lt_,
-                               NodePtr superclass, NodePtr body, const token *end_) {
+    NodePtr def_class(const token *class_, NodePtr name, const token *lt_, NodePtr superclass, NodePtr body,
+                      const token *end_) {
         core::LocOffsets declLoc = tokLoc(class_).join(maybe_loc(name)).join(maybe_loc(superclass));
         core::LocOffsets loc = tokLoc(class_, end_);
 
         return make_node<Class>(loc, declLoc, std::move(name), std::move(superclass), std::move(body));
     }
 
-    NodePtr defEndlessMethod(const token *def, const token *tname, NodePtr args, const token *equal,
-                                      NodePtr body) {
+    NodePtr defEndlessMethod(const token *def, const token *tname, NodePtr args, const token *equal, NodePtr body) {
         core::LocOffsets declLoc = tokLoc(def, tname).join(maybe_loc(args));
         core::LocOffsets loc = tokLoc(def).join(body->loc);
         std::string name{tname->view()};
@@ -845,8 +838,7 @@ public:
         return make_node<DefMethod>(loc, declLoc, gs_.enterNameUTF8(name), std::move(args), std::move(body));
     }
 
-    NodePtr defEndlessSingleton(NodePtr defHead, NodePtr args, const token *equal,
-                                         NodePtr body) {
+    NodePtr defEndlessSingleton(NodePtr defHead, NodePtr args, const token *equal, NodePtr body) {
         auto *head = parser::cast_node<DefsHead>(defHead.get());
         core::LocOffsets declLoc = head->loc.join(maybe_loc(args));
         core::LocOffsets loc = head->loc.join(body->loc);
@@ -858,8 +850,7 @@ public:
         return make_node<DefS>(loc, declLoc, std::move(head->definee), head->name, std::move(args), std::move(body));
     }
 
-    NodePtr defMethod(const token *def, const token *name, NodePtr args, NodePtr body,
-                               const token *end) {
+    NodePtr defMethod(const token *def, const token *name, NodePtr args, NodePtr body, const token *end) {
         core::LocOffsets declLoc = tokLoc(def, name).join(maybe_loc(args));
         core::LocOffsets loc = tokLoc(def, end);
 
@@ -874,8 +865,7 @@ public:
         return make_node<Module>(loc, declLoc, std::move(name), std::move(body));
     }
 
-    NodePtr def_sclass(const token *class_, const token *lshft_, NodePtr expr, NodePtr body,
-                                const token *end_) {
+    NodePtr def_sclass(const token *class_, const token *lshft_, NodePtr expr, NodePtr body, const token *end_) {
         core::LocOffsets declLoc = tokLoc(class_);
         core::LocOffsets loc = tokLoc(class_, end_);
         return make_node<SClass>(loc, declLoc, std::move(expr), std::move(body));
@@ -887,8 +877,7 @@ public:
         return make_node<DefsHead>(declLoc, std::move(definee), gs_.enterNameUTF8(name->view()));
     }
 
-    NodePtr defSingleton(NodePtr defHead, NodePtr args, NodePtr body,
-                                  const token *end) {
+    NodePtr defSingleton(NodePtr defHead, NodePtr args, NodePtr body, const token *end) {
         auto *head = parser::cast_node<DefsHead>(defHead.get());
         core::LocOffsets declLoc = head->loc.join(maybe_loc(args));
         core::LocOffsets loc = head->loc.join(tokLoc(end));
@@ -943,10 +932,10 @@ public:
         return make_node<Complex>(tokLoc(tok), tok->view());
     }
 
-    NodePtr for_(const token *for_, NodePtr iterator, const token *in_, NodePtr iteratee,
-                          const token *do_, NodePtr body, const token *end) {
+    NodePtr for_(const token *for_, NodePtr iterator, const token *in_, NodePtr iteratee, const token *do_,
+                 NodePtr body, const token *end) {
         return make_node<For>(tokLoc(for_).join(tokLoc(end)), std::move(iterator), std::move(iteratee),
-                                std::move(body));
+                              std::move(body));
     }
 
     NodePtr forward_arg(const token *begin, const token *dots, const token *end) {
@@ -985,23 +974,19 @@ public:
         return make_node<IfGuard>(tokLoc(tok).join(if_body->loc), std::move(if_body));
     }
 
-    NodePtr in_pattern(const token *inTok, NodePtr pattern, NodePtr guard,
-                                const token *thenTok, NodePtr body) {
+    NodePtr in_pattern(const token *inTok, NodePtr pattern, NodePtr guard, const token *thenTok, NodePtr body) {
         return make_node<InPattern>(tokLoc(inTok).join(maybe_loc(body)), std::move(pattern), std::move(guard),
-                                      std::move(body));
+                                    std::move(body));
     }
 
-    NodePtr index(NodePtr receiver, const token *lbrack, sorbet::parser::NodeVec indexes,
-                           const token *rbrack) {
+    NodePtr index(NodePtr receiver, const token *lbrack, sorbet::parser::NodeVec indexes, const token *rbrack) {
         return make_node<Send>(receiver->loc.join(tokLoc(rbrack)), std::move(receiver), core::Names::squareBrackets(),
-                                 tokLoc(lbrack).copyWithZeroLength(), std::move(indexes));
+                               tokLoc(lbrack).copyWithZeroLength(), std::move(indexes));
     }
 
-    NodePtr indexAsgn(NodePtr receiver, const token *lbrack, sorbet::parser::NodeVec indexes,
-                               const token *rbrack) {
-        return make_node<Send>(receiver->loc.join(tokLoc(rbrack)), std::move(receiver),
-                                 core::Names::squareBracketsEq(), tokLoc(lbrack).copyWithZeroLength(),
-                                 std::move(indexes));
+    NodePtr indexAsgn(NodePtr receiver, const token *lbrack, sorbet::parser::NodeVec indexes, const token *rbrack) {
+        return make_node<Send>(receiver->loc.join(tokLoc(rbrack)), std::move(receiver), core::Names::squareBracketsEq(),
+                               tokLoc(lbrack).copyWithZeroLength(), std::move(indexes));
     }
 
     NodePtr integer(const token *tok) {
@@ -1014,8 +999,7 @@ public:
         return make_node<IVar>(tokLoc(tok), name);
     }
 
-    NodePtr keywordBreak(const token *keyword, const token *lparen, sorbet::parser::NodeVec args,
-                                  const token *rparen) {
+    NodePtr keywordBreak(const token *keyword, const token *lparen, sorbet::parser::NodeVec args, const token *rparen) {
         core::LocOffsets loc = tokLoc(keyword).join(collectionLoc(lparen, args, rparen));
         return make_node<Break>(loc, std::move(args));
     }
@@ -1024,8 +1008,7 @@ public:
         return make_node<Defined>(tokLoc(keyword).join(arg->loc), std::move(arg));
     }
 
-    NodePtr keywordNext(const token *keyword, const token *lparen, sorbet::parser::NodeVec args,
-                                 const token *rparen) {
+    NodePtr keywordNext(const token *keyword, const token *lparen, sorbet::parser::NodeVec args, const token *rparen) {
         return make_node<Next>(tokLoc(keyword).join(collectionLoc(lparen, args, rparen)), std::move(args));
     }
 
@@ -1038,13 +1021,12 @@ public:
     }
 
     NodePtr keywordReturn(const token *keyword, const token *lparen, sorbet::parser::NodeVec args,
-                                   const token *rparen) {
+                          const token *rparen) {
         core::LocOffsets loc = tokLoc(keyword).join(collectionLoc(lparen, args, rparen));
         return make_node<Return>(loc, std::move(args));
     }
 
-    NodePtr keywordSuper(const token *keyword, const token *lparen, sorbet::parser::NodeVec args,
-                                  const token *rparen) {
+    NodePtr keywordSuper(const token *keyword, const token *lparen, sorbet::parser::NodeVec args, const token *rparen) {
         core::LocOffsets loc = tokLoc(keyword);
         core::LocOffsets argloc = collectionLoc(lparen, args, rparen);
         if (argloc.exists()) {
@@ -1053,8 +1035,7 @@ public:
         return make_node<Super>(loc, std::move(args));
     }
 
-    NodePtr keywordYield(const token *keyword, const token *lparen, sorbet::parser::NodeVec args,
-                                  const token *rparen) {
+    NodePtr keywordYield(const token *keyword, const token *lparen, sorbet::parser::NodeVec args, const token *rparen) {
         core::LocOffsets loc = tokLoc(keyword).join(collectionLoc(lparen, args, rparen));
         if (!args.empty() && parser::isa_node<BlockPass>(args.back().get())) {
             error(ruby_parser::dclass::BlockGivenToYield, loc);
@@ -1078,7 +1059,7 @@ public:
         checkReservedForNumberedParameters(name->view(), loc);
 
         return make_node<Kwoptarg>(loc.join(value->loc), gs_.enterNameUTF8(name->view()), tokLoc(name),
-                                     std::move(value));
+                                   std::move(value));
     }
 
     NodePtr kwnilarg(const token *dstar, const token *nil) {
@@ -1117,8 +1098,7 @@ public:
         return make_node<Or>(lhs->loc.join(rhs->loc), std::move(lhs), std::move(rhs));
     }
 
-    NodePtr loopUntil(const token *keyword, NodePtr cond, const token *do_, NodePtr body,
-                               const token *end) {
+    NodePtr loopUntil(const token *keyword, NodePtr cond, const token *do_, NodePtr body, const token *end) {
         return make_node<Until>(tokLoc(keyword).join(tokLoc(end)), std::move(cond), std::move(body));
     }
 
@@ -1130,8 +1110,7 @@ public:
         return make_node<Until>(body->loc.join(cond->loc), std::move(cond), std::move(body));
     }
 
-    NodePtr loop_while(const token *keyword, NodePtr cond, const token *do_, NodePtr body,
-                                const token *end) {
+    NodePtr loop_while(const token *keyword, NodePtr cond, const token *do_, NodePtr body, const token *end) {
         return make_node<While>(tokLoc(keyword).join(tokLoc(end)), std::move(cond), std::move(body));
     }
 
@@ -1175,7 +1154,7 @@ public:
         sorbet::parser::NodeVec args;
         args.emplace_back(std::move(arg));
         return make_node<Send>(loc, std::move(receiver), gs_.enterNameUTF8(oper->view()), tokLoc(oper),
-                                 std::move(args));
+                               std::move(args));
     }
 
     NodePtr match_pattern(NodePtr lhs, const token *tok, NodePtr rhs) {
@@ -1280,13 +1259,13 @@ public:
                 loc = notLoc.join(receiver->loc);
             }
             return make_node<Send>(loc, transformCondition(std::move(receiver)), core::Names::bang(), notLoc,
-                                     sorbet::parser::NodeVec());
+                                   sorbet::parser::NodeVec());
         }
 
         ENFORCE(begin != nullptr && end != nullptr);
         auto body = make_node<Begin>(tokLoc(begin).join(tokLoc(end)), sorbet::parser::NodeVec());
         return make_node<Send>(notLoc.join(body->loc), std::move(body), core::Names::bang(),
-                                 notLoc.copyWithZeroLength(), sorbet::parser::NodeVec());
+                               notLoc.copyWithZeroLength(), sorbet::parser::NodeVec());
     }
 
     NodePtr nth_ref(const token *tok) {
@@ -1316,15 +1295,14 @@ public:
             return make_node<OrAsgn>(lhs->loc.join(rhs->loc), std::move(lhs), std::move(rhs));
         }
         return make_node<OpAsgn>(lhs->loc.join(rhs->loc), std::move(lhs), gs_.enterNameUTF8(op->view()), tokLoc(op),
-                                   std::move(rhs));
+                                 std::move(rhs));
     }
 
     NodePtr optarg_(const token *name, const token *eql, NodePtr value) {
         core::LocOffsets loc = tokLoc(name);
         checkReservedForNumberedParameters(name->view(), loc);
 
-        return make_node<Optarg>(loc.join(value->loc), gs_.enterNameUTF8(name->view()), tokLoc(name),
-                                   std::move(value));
+        return make_node<Optarg>(loc.join(value->loc), gs_.enterNameUTF8(name->view()), tokLoc(name), std::move(value));
     }
 
     NodePtr p_ident(const token *tok) {
@@ -1351,7 +1329,7 @@ public:
         auto keyLoc = core::LocOffsets{start, end};
 
         return make_node<Pair>(tokLoc(key).join(maybe_loc(value)),
-                                 make_node<Symbol>(keyLoc, gs_.enterNameUTF8(key->view())), std::move(value));
+                               make_node<Symbol>(keyLoc, gs_.enterNameUTF8(key->view())), std::move(value));
     }
 
     NodePtr pair_label(const token *key) {
@@ -1366,15 +1344,13 @@ public:
             core::LocOffsets{clamp((uint32_t)key->start()), clamp((uint32_t)key->end() - 1)}; // drop the trailing :
         auto accessible_value = accessible(std::move(value));
         return make_node<Pair>(tokLoc(key).join(maybe_loc(accessible_value)),
-                                 make_node<Symbol>(keyLoc, gs_.enterNameUTF8(key->view())),
-                                 std::move(accessible_value));
+                               make_node<Symbol>(keyLoc, gs_.enterNameUTF8(key->view())), std::move(accessible_value));
     }
 
-    NodePtr pair_quoted(const token *begin, sorbet::parser::NodeVec parts, const token *end,
-                                 NodePtr value) {
+    NodePtr pair_quoted(const token *begin, sorbet::parser::NodeVec parts, const token *end, NodePtr value) {
         auto key = symbol_compose(begin, std::move(parts), end);
         return make_node<Pair>(tokLoc(begin).join(tokLoc(end)).join(maybe_loc(value)), std::move(key),
-                                 std::move(value));
+                               std::move(value));
     }
 
     NodePtr pin(const token *tok, NodePtr var) {
@@ -1413,8 +1389,7 @@ public:
         return make_node<Complex>(tokLoc(tok), tok->view());
     }
 
-    NodePtr regexp_compose(const token *begin, sorbet::parser::NodeVec parts, const token *end,
-                                    NodePtr options) {
+    NodePtr regexp_compose(const token *begin, sorbet::parser::NodeVec parts, const token *end, NodePtr options) {
         core::LocOffsets loc = tokLoc(begin).join(tokLoc(end)).join(maybe_loc(options));
         return make_node<Regexp>(loc, std::move(parts), std::move(options));
     }
@@ -1423,8 +1398,8 @@ public:
         return make_node<Regopt>(tokLoc(regopt), regopt->view());
     }
 
-    NodePtr rescue_body(const token *rescue, NodePtr excList, const token *assoc,
-                                 NodePtr excVar, const token *then, NodePtr body) {
+    NodePtr rescue_body(const token *rescue, NodePtr excList, const token *assoc, NodePtr excVar, const token *then,
+                        NodePtr body) {
         core::LocOffsets loc = tokLoc(rescue);
         if (excList != nullptr) {
             loc = loc.join(excList->loc);
@@ -1545,8 +1520,7 @@ public:
         return make_node<Array>(loc, std::move(outParts));
     }
 
-    NodePtr ternary(NodePtr cond, const token *question, NodePtr ifTrue, const token *colon,
-                             NodePtr ifFalse) {
+    NodePtr ternary(NodePtr cond, const token *question, NodePtr ifTrue, const token *colon, NodePtr ifFalse) {
         core::LocOffsets loc = cond->loc.join(ifFalse->loc);
         return make_node<If>(loc, transformCondition(std::move(cond)), std::move(ifTrue), std::move(ifFalse));
     }
@@ -1612,8 +1586,7 @@ public:
         return make_node<UnlessGuard>(tokLoc(tok).join(unless_body->loc), std::move(unless_body));
     }
 
-    NodePtr when(const token *when, sorbet::parser::NodeVec patterns, const token *then,
-                          NodePtr body) {
+    NodePtr when(const token *when, sorbet::parser::NodeVec patterns, const token *then, NodePtr body) {
         core::LocOffsets loc = tokLoc(when);
         if (body != nullptr) {
             loc = loc.join(body->loc);
@@ -1797,10 +1770,9 @@ public:
     }
 
     bool isLiteralNode(parser::NodePtr &node) {
-        return parser::isa_node<Integer>(node) || parser::isa_node<String>(node) ||
-               parser::isa_node<DString>(node) || parser::isa_node<Symbol>(node) ||
-               parser::isa_node<DSymbol>(node) || parser::isa_node<Regexp>(node) || parser::isa_node<Array>(node) ||
-               parser::isa_node<Hash>(node);
+        return parser::isa_node<Integer>(node) || parser::isa_node<String>(node) || parser::isa_node<DString>(node) ||
+               parser::isa_node<Symbol>(node) || parser::isa_node<DSymbol>(node) || parser::isa_node<Regexp>(node) ||
+               parser::isa_node<Array>(node) || parser::isa_node<Hash>(node);
     }
 
     void checkAssignmentToNumberedParameters(std::string_view name, core::LocOffsets loc) {

--- a/parser/Builder.h
+++ b/parser/Builder.h
@@ -11,6 +11,7 @@
 namespace sorbet::parser {
 
 class Node;
+struct NodeDeleter;
 
 class Builder final {
 public:
@@ -21,7 +22,7 @@ public:
 
     // Marked `const` so that `Parser::run` can confidently reuse one `Builder` object across
     // multiple parses.
-    std::unique_ptr<Node> build(ruby_parser::base_driver *driver, bool trace) const;
+    std::unique_ptr<Node, NodeDeleter> build(ruby_parser::base_driver *driver, bool trace) const;
 
     class Impl;
 

--- a/parser/Builder.h
+++ b/parser/Builder.h
@@ -10,8 +10,7 @@
 
 namespace sorbet::parser {
 
-class Node;
-struct NodeDeleter;
+class NodePtr;
 
 class Builder final {
 public:

--- a/parser/Builder.h
+++ b/parser/Builder.h
@@ -22,7 +22,7 @@ public:
 
     // Marked `const` so that `Parser::run` can confidently reuse one `Builder` object across
     // multiple parses.
-    std::unique_ptr<Node, NodeDeleter> build(ruby_parser::base_driver *driver, bool trace) const;
+    NodePtr build(ruby_parser::base_driver *driver, bool trace) const;
 
     class Impl;
 

--- a/parser/Node.cc
+++ b/parser/Node.cc
@@ -54,7 +54,7 @@ void Node::printTabs(fmt::memory_buffer &to, int count) const {
     }
 }
 
-void Node::printNode(fmt::memory_buffer &to, const unique_ptr<Node, NodeDeleter> &node, const core::GlobalState &gs,
+void Node::printNode(fmt::memory_buffer &to, const NodePtr &node, const core::GlobalState &gs,
                      int tabs) const {
     if (node) {
         fmt::format_to(std::back_inserter(to), "{}\n", node->toStringWithTabs(gs, tabs));
@@ -63,7 +63,7 @@ void Node::printNode(fmt::memory_buffer &to, const unique_ptr<Node, NodeDeleter>
     }
 }
 
-void Node::printNodeJSON(fmt::memory_buffer &to, const unique_ptr<Node, NodeDeleter> &node, const core::GlobalState &gs,
+void Node::printNodeJSON(fmt::memory_buffer &to, const NodePtr &node, const core::GlobalState &gs,
                          int tabs) const {
     if (node) {
         fmt::format_to(std::back_inserter(to), "{}", node->toJSON(gs, tabs));
@@ -72,7 +72,7 @@ void Node::printNodeJSON(fmt::memory_buffer &to, const unique_ptr<Node, NodeDele
     }
 }
 
-void Node::printNodeJSONWithLocs(fmt::memory_buffer &to, const unique_ptr<Node, NodeDeleter> &node, const core::GlobalState &gs,
+void Node::printNodeJSONWithLocs(fmt::memory_buffer &to, const NodePtr &node, const core::GlobalState &gs,
                                  core::FileRef file, int tabs) const {
     if (node) {
         fmt::format_to(std::back_inserter(to), "{}", node->toJSONWithLocs(gs, file, tabs));
@@ -81,7 +81,7 @@ void Node::printNodeJSONWithLocs(fmt::memory_buffer &to, const unique_ptr<Node, 
     }
 }
 
-void Node::printNodeWhitequark(fmt::memory_buffer &to, const unique_ptr<Node, NodeDeleter> &node, const core::GlobalState &gs,
+void Node::printNodeWhitequark(fmt::memory_buffer &to, const NodePtr &node, const core::GlobalState &gs,
                                int tabs) const {
     if (node) {
         fmt::format_to(std::back_inserter(to), "{}", node->toWhitequark(gs, tabs));

--- a/parser/Node.cc
+++ b/parser/Node.cc
@@ -1,5 +1,5 @@
-#include "parser/parser.h"
 #include "parser/Node_gen_case.h"
+#include "parser/parser.h"
 #include <algorithm>
 #include <iterator>
 
@@ -54,8 +54,7 @@ void Node::printTabs(fmt::memory_buffer &to, int count) const {
     }
 }
 
-void Node::printNode(fmt::memory_buffer &to, const NodePtr &node, const core::GlobalState &gs,
-                     int tabs) const {
+void Node::printNode(fmt::memory_buffer &to, const NodePtr &node, const core::GlobalState &gs, int tabs) const {
     if (node) {
         fmt::format_to(std::back_inserter(to), "{}\n", node->toStringWithTabs(gs, tabs));
     } else {
@@ -63,8 +62,7 @@ void Node::printNode(fmt::memory_buffer &to, const NodePtr &node, const core::Gl
     }
 }
 
-void Node::printNodeJSON(fmt::memory_buffer &to, const NodePtr &node, const core::GlobalState &gs,
-                         int tabs) const {
+void Node::printNodeJSON(fmt::memory_buffer &to, const NodePtr &node, const core::GlobalState &gs, int tabs) const {
     if (node) {
         fmt::format_to(std::back_inserter(to), "{}", node->toJSON(gs, tabs));
     } else {

--- a/parser/Node.cc
+++ b/parser/Node.cc
@@ -16,6 +16,36 @@ void Node::deleteTagged() {
 #undef DELETE_NODE
 }
 
+string Node::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
+#define TOSTRING(name) return static_cast<const name *>(this)->toStringWithTabs(gs, tabs);
+    GENERATE_TAG_SWITCH(this->tag, TOSTRING);
+#undef TOSTRING
+}
+
+string Node::toJSON(const core::GlobalState &gs, int tabs) {
+#define TOJSON(name) return static_cast<name *>(this)->toJSON(gs, tabs);
+    GENERATE_TAG_SWITCH(this->tag, TOJSON);
+#undef TOJSON
+}
+
+string Node::toJSONWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs) {
+#define TOJSON(name) return static_cast<name *>(this)->toJSONWithLocs(gs, file, tabs);
+    GENERATE_TAG_SWITCH(this->tag, TOJSON);
+#undef TOJSON
+}
+
+string Node::toWhitequark(const core::GlobalState &gs, int tabs) {
+#define TOWHITEQUARK(name) return static_cast<name *>(this)->toWhitequark(gs, tabs);
+    GENERATE_TAG_SWITCH(this->tag, TOWHITEQUARK);
+#undef TOWHITEQUARK
+}
+
+string Node::nodeName() const {
+#define NODENAME(name) return static_cast<const name *>(this)->nodeName();
+    GENERATE_TAG_SWITCH(this->tag, NODENAME);
+#undef NODENAME
+}
+
 void Node::printTabs(fmt::memory_buffer &to, int count) const {
     int i = 0;
     while (i < count) {

--- a/parser/Node.cc
+++ b/parser/Node.cc
@@ -1,13 +1,20 @@
 #include "parser/parser.h"
+#include "parser/Node_gen_case.h"
 #include <algorithm>
 #include <iterator>
 
 // makes lldb work. Do not remove please
-template class std::unique_ptr<sorbet::parser::Node>;
+template class std::unique_ptr<sorbet::parser::Node, sorbet::parser::NodeDeleter>;
 
 using namespace std;
 
 namespace sorbet::parser {
+
+void Node::deleteTagged() {
+#define DELETE_NODE(name) delete static_cast<name *>(this);
+    GENERATE_TAG_SWITCH(this->tag, DELETE_NODE);
+#undef DELETE_NODE
+}
 
 void Node::printTabs(fmt::memory_buffer &to, int count) const {
     int i = 0;
@@ -17,7 +24,7 @@ void Node::printTabs(fmt::memory_buffer &to, int count) const {
     }
 }
 
-void Node::printNode(fmt::memory_buffer &to, const unique_ptr<Node> &node, const core::GlobalState &gs,
+void Node::printNode(fmt::memory_buffer &to, const unique_ptr<Node, NodeDeleter> &node, const core::GlobalState &gs,
                      int tabs) const {
     if (node) {
         fmt::format_to(std::back_inserter(to), "{}\n", node->toStringWithTabs(gs, tabs));
@@ -26,7 +33,7 @@ void Node::printNode(fmt::memory_buffer &to, const unique_ptr<Node> &node, const
     }
 }
 
-void Node::printNodeJSON(fmt::memory_buffer &to, const unique_ptr<Node> &node, const core::GlobalState &gs,
+void Node::printNodeJSON(fmt::memory_buffer &to, const unique_ptr<Node, NodeDeleter> &node, const core::GlobalState &gs,
                          int tabs) const {
     if (node) {
         fmt::format_to(std::back_inserter(to), "{}", node->toJSON(gs, tabs));
@@ -35,7 +42,7 @@ void Node::printNodeJSON(fmt::memory_buffer &to, const unique_ptr<Node> &node, c
     }
 }
 
-void Node::printNodeJSONWithLocs(fmt::memory_buffer &to, const unique_ptr<Node> &node, const core::GlobalState &gs,
+void Node::printNodeJSONWithLocs(fmt::memory_buffer &to, const unique_ptr<Node, NodeDeleter> &node, const core::GlobalState &gs,
                                  core::FileRef file, int tabs) const {
     if (node) {
         fmt::format_to(std::back_inserter(to), "{}", node->toJSONWithLocs(gs, file, tabs));
@@ -44,7 +51,7 @@ void Node::printNodeJSONWithLocs(fmt::memory_buffer &to, const unique_ptr<Node> 
     }
 }
 
-void Node::printNodeWhitequark(fmt::memory_buffer &to, const unique_ptr<Node> &node, const core::GlobalState &gs,
+void Node::printNodeWhitequark(fmt::memory_buffer &to, const unique_ptr<Node, NodeDeleter> &node, const core::GlobalState &gs,
                                int tabs) const {
     if (node) {
         fmt::format_to(std::back_inserter(to), "{}", node->toWhitequark(gs, tabs));

--- a/parser/Node.h
+++ b/parser/Node.h
@@ -11,6 +11,7 @@ namespace sorbet::parser {
 #include "parser/Node_gen_tag.h"
 
 struct NodeDeleter;
+class NodePtr;
 
 class Node {
     friend NodeDeleter;
@@ -33,13 +34,13 @@ public:
 
 protected:
     void printTabs(fmt::memory_buffer &to, int count) const;
-    void printNode(fmt::memory_buffer &to, const std::unique_ptr<Node, NodeDeleter> &node, const core::GlobalState &gs,
+    void printNode(fmt::memory_buffer &to, const NodePtr &node, const core::GlobalState &gs,
                    int tabs) const;
-    void printNodeJSON(fmt::memory_buffer &to, const std::unique_ptr<Node, NodeDeleter> &node, const core::GlobalState &gs,
+    void printNodeJSON(fmt::memory_buffer &to, const NodePtr &node, const core::GlobalState &gs,
                        int tabs) const;
-    void printNodeJSONWithLocs(fmt::memory_buffer &to, const std::unique_ptr<Node, NodeDeleter> &node, const core::GlobalState &gs,
+    void printNodeJSONWithLocs(fmt::memory_buffer &to, const NodePtr &node, const core::GlobalState &gs,
                                core::FileRef file, int tabs) const;
-    void printNodeWhitequark(fmt::memory_buffer &to, const std::unique_ptr<Node, NodeDeleter> &node, const core::GlobalState &gs,
+    void printNodeWhitequark(fmt::memory_buffer &to, const NodePtr &node, const core::GlobalState &gs,
                              int tabs) const;
 };
 

--- a/parser/Node.h
+++ b/parser/Node.h
@@ -60,10 +60,6 @@ template <class To> To *cast_node(Node *what) {
     return static_cast<To *>(what);
 }
 
-template <class To> bool isa_node(Node *what) {
-    return cast_node<To>(what) != nullptr;
-}
-
 class NodePtr : public std::unique_ptr<Node, NodeDeleter> {
     using Base = std::unique_ptr<Node, NodeDeleter>;
 
@@ -136,8 +132,16 @@ template <class To> inline bool NodePtr::isa(const NodePtr &what) {
     return isa_node<To>(what);
 }
 
+template <> inline bool NodePtr::isa<NodePtr>(const NodePtr &what) {
+    return true;
+}
+
 template <class To> inline const To &NodePtr::cast(const NodePtr &what) {
     return cast_node_nonnull<To>(what);
+}
+
+template <> inline const NodePtr &NodePtr::cast<NodePtr>(const NodePtr &what) {
+    return what;
 }
 
 using NodeVec = InlinedVector<NodePtr, 4>;

--- a/parser/Node.h
+++ b/parser/Node.h
@@ -37,15 +37,9 @@ protected:
 };
 
 template <class To> To *cast_node(Node *what) {
-    static_assert(!std::is_pointer<To>::value, "To has to be a pointer");
-    static_assert(std::is_assignable<Node *&, To *>::value, "Ill Formed To, has to be a subclass of Expression");
-#if __cplusplus >= 201402L
+    static_assert(!std::is_pointer<To>::value, "To must not be a pointer");
+    static_assert(std::is_assignable<Node *&, To *>::value, "Ill Formed To, has to be a subclass of Node");
     static_assert(std::is_final<To>::value, "To is not final");
-#elif __has_feature(is_final)
-    static_assert(__is_final(To), "To is not final");
-#else
-    static_assert(false);
-#endif
     return fast_cast<Node, To>(what);
 }
 

--- a/parser/Node.h
+++ b/parser/Node.h
@@ -34,14 +34,11 @@ public:
 
 protected:
     void printTabs(fmt::memory_buffer &to, int count) const;
-    void printNode(fmt::memory_buffer &to, const NodePtr &node, const core::GlobalState &gs,
-                   int tabs) const;
-    void printNodeJSON(fmt::memory_buffer &to, const NodePtr &node, const core::GlobalState &gs,
-                       int tabs) const;
+    void printNode(fmt::memory_buffer &to, const NodePtr &node, const core::GlobalState &gs, int tabs) const;
+    void printNodeJSON(fmt::memory_buffer &to, const NodePtr &node, const core::GlobalState &gs, int tabs) const;
     void printNodeJSONWithLocs(fmt::memory_buffer &to, const NodePtr &node, const core::GlobalState &gs,
                                core::FileRef file, int tabs) const;
-    void printNodeWhitequark(fmt::memory_buffer &to, const NodePtr &node, const core::GlobalState &gs,
-                             int tabs) const;
+    void printNodeWhitequark(fmt::memory_buffer &to, const NodePtr &node, const core::GlobalState &gs, int tabs) const;
 };
 
 struct NodeDeleter {
@@ -73,8 +70,7 @@ public:
     }
 };
 
-template <class N, typename... Args>
-NodePtr make_node(Args &&... args) {
+template <class N, typename... Args> NodePtr make_node(Args &&...args) {
     return NodePtr(new N(std::forward<Args>(args)...));
 }
 
@@ -84,7 +80,7 @@ template <class To> bool isa_node(const NodePtr &what) {
 
 template <class To> bool isa_node(const Node *what) {
     return what != nullptr && what->tag == NodeToTag<To>::value;
- }
+}
 
 // We disallow casting on temporary values because the lifetime of the returned value is
 // tied to the temporary, but it is possible for the temporary to be destroyed at the end

--- a/parser/Node.h
+++ b/parser/Node.h
@@ -63,12 +63,24 @@ template <class To> bool isa_node(Node *what) {
     return cast_node<To>(what) != nullptr;
 }
 
+class NodePtr : public std::unique_ptr<Node, NodeDeleter> {
+    using Base = std::unique_ptr<Node, NodeDeleter>;
+
+public:
+    NodePtr() = default;
+    NodePtr(std::nullptr_t) : Base(nullptr) {}
+    NodePtr(Node *node) : Base(node) {}
+
+    NodePtr(NodePtr &&p) = default;
+    NodePtr &operator=(NodePtr &&p) = default;
+};
+
 template <class N, typename... Args>
-std::unique_ptr<Node, NodeDeleter> make_node(Args &&... args) {
-    return std::unique_ptr<Node, NodeDeleter>(new N(std::forward<Args>(args)...));
+NodePtr make_node(Args &&... args) {
+    return NodePtr(new N(std::forward<Args>(args)...));
 }
 
-using NodeVec = InlinedVector<std::unique_ptr<Node, NodeDeleter>, 4>;
+using NodeVec = InlinedVector<NodePtr, 4>;
 
 #include "parser/Node_gen.h"
 }; // namespace sorbet::parser

--- a/parser/Node.h
+++ b/parser/Node.h
@@ -8,9 +8,11 @@
 
 namespace sorbet::parser {
 
+#include "parser/Node_gen_tag.h"
+
 class Node {
 public:
-    Node(core::LocOffsets loc) : loc(loc) {
+    Node(NodeTag tag, core::LocOffsets loc) : tag(tag), loc(loc) {
         ENFORCE(loc.exists(), "Location of parser node is none");
     }
     virtual ~Node() = default;
@@ -22,6 +24,7 @@ public:
     virtual std::string toJSONWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs = 0) = 0;
     virtual std::string toWhitequark(const core::GlobalState &gs, int tabs = 0) = 0;
     virtual std::string nodeName() = 0;
+    NodeTag tag;
     core::LocOffsets loc;
 
 protected:

--- a/parser/Node.h
+++ b/parser/Node.h
@@ -20,15 +20,14 @@ public:
     Node(NodeTag tag, core::LocOffsets loc) : tag(tag), loc(loc) {
         ENFORCE(loc.exists(), "Location of parser node is none");
     }
-    virtual ~Node() = default;
-    virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const = 0;
+    std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string toString(const core::GlobalState &gs) const {
         return toStringWithTabs(gs);
     }
-    virtual std::string toJSON(const core::GlobalState &gs, int tabs = 0) = 0;
-    virtual std::string toJSONWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs = 0) = 0;
-    virtual std::string toWhitequark(const core::GlobalState &gs, int tabs = 0) = 0;
-    virtual std::string nodeName() = 0;
+    std::string toJSON(const core::GlobalState &gs, int tabs = 0);
+    std::string toJSONWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs = 0);
+    std::string toWhitequark(const core::GlobalState &gs, int tabs = 0);
+    std::string nodeName() const;
     NodeTag tag;
     core::LocOffsets loc;
 

--- a/parser/Node.h
+++ b/parser/Node.h
@@ -53,7 +53,10 @@ template <class To> To *cast_node(Node *what) {
     static_assert(!std::is_pointer<To>::value, "To must not be a pointer");
     static_assert(std::is_assignable<Node *&, To *>::value, "Ill Formed To, has to be a subclass of Node");
     static_assert(std::is_final<To>::value, "To is not final");
-    return fast_cast<Node, To>(what);
+    if (what == nullptr || what->tag != NodeToTag<To>::value) {
+        return nullptr;
+    }
+    return static_cast<To *>(what);
 }
 
 template <class To> bool isa_node(Node *what) {

--- a/parser/Parser.cc
+++ b/parser/Parser.cc
@@ -118,7 +118,7 @@ unique_ptr<ruby_parser::base_driver> makeDriver(Parser::Settings settings, strin
 } // namespace
 
 NodePtr Parser::run(core::GlobalState &gs, core::FileRef file, Parser::Settings settings,
-                                          vector<string> initialLocals) {
+                    vector<string> initialLocals) {
     // Marked `const` so that we can re-use across multiple `build()` invocations
     const Builder builder(gs, file);
 

--- a/parser/Parser.cc
+++ b/parser/Parser.cc
@@ -117,7 +117,7 @@ unique_ptr<ruby_parser::base_driver> makeDriver(Parser::Settings settings, strin
 
 } // namespace
 
-unique_ptr<Node, NodeDeleter> Parser::run(core::GlobalState &gs, core::FileRef file, Parser::Settings settings,
+NodePtr Parser::run(core::GlobalState &gs, core::FileRef file, Parser::Settings settings,
                                           vector<string> initialLocals) {
     // Marked `const` so that we can re-use across multiple `build()` invocations
     const Builder builder(gs, file);

--- a/parser/Parser.cc
+++ b/parser/Parser.cc
@@ -6,7 +6,7 @@
 #include "ruby_parser/driver.hh"
 #include <algorithm>
 
-template class std::unique_ptr<sorbet::parser::Node>;
+template class std::unique_ptr<sorbet::parser::Node, sorbet::parser::NodeDeleter>;
 
 using namespace std;
 
@@ -117,8 +117,8 @@ unique_ptr<ruby_parser::base_driver> makeDriver(Parser::Settings settings, strin
 
 } // namespace
 
-unique_ptr<Node> Parser::run(core::GlobalState &gs, core::FileRef file, Parser::Settings settings,
-                             vector<string> initialLocals) {
+unique_ptr<Node, NodeDeleter> Parser::run(core::GlobalState &gs, core::FileRef file, Parser::Settings settings,
+                                          vector<string> initialLocals) {
     // Marked `const` so that we can re-use across multiple `build()` invocations
     const Builder builder(gs, file);
 
@@ -162,7 +162,7 @@ unique_ptr<Node> Parser::run(core::GlobalState &gs, core::FileRef file, Parser::
 
     if (astRetry == nullptr) {
         // Retry did not produce a parse result
-        return make_unique<Begin>(core::LocOffsets{0, 0}, NodeVec{});
+        return make_node<Begin>(core::LocOffsets{0, 0}, NodeVec{});
     }
 
     ENFORCE(absl::c_any_of(driverRetry->diagnostics,

--- a/parser/parser.h
+++ b/parser/parser.h
@@ -22,7 +22,7 @@ public:
     };
 
     static NodePtr run(core::GlobalState &gs, core::FileRef file, Settings settings,
-                                                  std::vector<std::string> initialLocals = {});
+                       std::vector<std::string> initialLocals = {});
 };
 
 } // namespace sorbet::parser

--- a/parser/parser.h
+++ b/parser/parser.h
@@ -21,8 +21,8 @@ public:
         }
     };
 
-    static std::unique_ptr<Node> run(core::GlobalState &gs, core::FileRef file, Settings settings,
-                                     std::vector<std::string> initialLocals = {});
+    static std::unique_ptr<Node, NodeDeleter> run(core::GlobalState &gs, core::FileRef file, Settings settings,
+                                                  std::vector<std::string> initialLocals = {});
 };
 
 } // namespace sorbet::parser

--- a/parser/parser.h
+++ b/parser/parser.h
@@ -21,7 +21,7 @@ public:
         }
     };
 
-    static std::unique_ptr<Node, NodeDeleter> run(core::GlobalState &gs, core::FileRef file, Settings settings,
+    static NodePtr run(core::GlobalState &gs, core::FileRef file, Settings settings,
                                                   std::vector<std::string> initialLocals = {});
 };
 

--- a/parser/tools/generate_ast.cc
+++ b/parser/tools/generate_ast.cc
@@ -774,7 +774,7 @@ string constructorArgType(FieldType arg) {
         case FieldType::Name:
             return "core::NameRef";
         case FieldType::Node:
-            return "std::unique_ptr<Node, NodeDeleter>";
+            return "NodePtr";
         case FieldType::NodeVec:
             return "NodeVec";
         case FieldType::String:
@@ -793,7 +793,7 @@ string fieldType(FieldType arg) {
         case FieldType::Name:
             return "core::NameRef";
         case FieldType::Node:
-            return "std::unique_ptr<Node, NodeDeleter>";
+            return "NodePtr";
         case FieldType::NodeVec:
             return "NodeVec";
         case FieldType::String:

--- a/parser/tools/generate_ast.cc
+++ b/parser/tools/generate_ast.cc
@@ -1120,6 +1120,13 @@ int main(int argc, char **argv) {
             cerr << "unable to open " << argv[1] << '\n';
             return 1;
         }
+        header << "enum class NodeTag : uint32_t {" << '\n';
+        bool first = true;
+        for (auto &node : nodes) {
+            header << "    " << node.name << (first ? " = 1" : "") << ',' << '\n';
+            first = false;
+        }
+        header << "};" << '\n' << '\n';
         for (auto &node : nodes) {
             emitNodeHeader(header, node);
         }

--- a/parser/tools/generate_ast.cc
+++ b/parser/tools/generate_ast.cc
@@ -819,7 +819,7 @@ void emitNodeHeader(ostream &out, NodeDef &node) {
         out << ", " << constructorArgType(arg.type) << " " << arg.name;
     }
     out << ")" << '\n';
-    out << "        : Node(loc)";
+    out << "        : Node(NodeTag::" << node.name << ", loc)";
     for (auto &arg : node.fields) {
         out << ", " << arg.name << "(";
         if (arg.type == FieldType::Node || arg.type == FieldType::NodeVec) {

--- a/parser/tools/generate_ast.cc
+++ b/parser/tools/generate_ast.cc
@@ -842,19 +842,19 @@ void emitNodeHeader(ostream &out, NodeDef &node) {
         out << "    " << fieldType(arg.type) << " " << arg.name << ";" << '\n';
     }
     out << '\n';
-    out << "  virtual std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;" << '\n';
-    out << "  virtual std::string toJSON(const core::GlobalState &gs, int tabs = 0);" << '\n';
-    out << "  virtual std::string toJSONWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs = 0);"
+    out << "  std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;" << '\n';
+    out << "  std::string toJSON(const core::GlobalState &gs, int tabs = 0);" << '\n';
+    out << "  std::string toJSONWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs = 0);"
         << '\n';
-    out << "  virtual std::string toWhitequark(const core::GlobalState &gs, int tabs = 0);" << '\n';
-    out << "  virtual std::string nodeName();" << '\n';
+    out << "  std::string toWhitequark(const core::GlobalState &gs, int tabs = 0);" << '\n';
+    out << "  std::string nodeName() const;" << '\n';
 
     out << "};" << '\n';
     out << '\n';
 }
 
 void emitNodeClassfile(ostream &out, NodeDef &node) {
-    out << "  std::string " << node.name << "::nodeName() {" << '\n';
+    out << "  std::string " << node.name << "::nodeName() const {" << '\n';
     out << "    return \"" << node.name << "\";" << '\n';
     out << "  };" << '\n' << '\n';
 

--- a/parser/tools/generate_ast.cc
+++ b/parser/tools/generate_ast.cc
@@ -1115,7 +1115,7 @@ void emitNodeClassfile(ostream &out, NodeDef &node) {
 }
 
 int main(int argc, char **argv) {
-    // emit headef file
+
     {
         ofstream header(argv[1], ios::trunc);
         if (!header.good()) {
@@ -1130,15 +1130,24 @@ int main(int argc, char **argv) {
         }
         header << "};" << '\n' << '\n';
         header << "template <typename T> struct NodeToTag;" << '\n' << '\n';
+    }
+
+    // emit header file
+    {
+        ofstream header(argv[2], ios::trunc);
+        if (!header.good()) {
+            cerr << "unable to open " << argv[2] << '\n';
+            return 1;
+        }
         for (auto &node : nodes) {
             emitNodeHeader(header, node);
         }
     }
 
     {
-        ofstream classfile(argv[2], ios::trunc);
+        ofstream classfile(argv[3], ios::trunc);
         if (!classfile.good()) {
-            cerr << "unable to open " << argv[2] << '\n';
+            cerr << "unable to open " << argv[3] << '\n';
             return 1;
         }
         classfile << "#include \"parser/Node.h\"" << '\n' << '\n';

--- a/parser/tools/generate_ast.cc
+++ b/parser/tools/generate_ast.cc
@@ -808,6 +808,8 @@ string fieldType(FieldType arg) {
 }
 
 void emitNodeHeader(ostream &out, NodeDef &node) {
+    out << "class " << node.name << ";" << '\n';
+    out << "template <> struct NodeToTag<" << node.name << "> { static constexpr NodeTag value = NodeTag::" << node.name << "; };" << '\n';
     out << "class " << node.name << " final : public Node {" << '\n';
     out << "public:" << '\n';
 
@@ -1127,6 +1129,7 @@ int main(int argc, char **argv) {
             first = false;
         }
         header << "};" << '\n' << '\n';
+        header << "template <typename T> struct NodeToTag;" << '\n' << '\n';
         for (auto &node : nodes) {
             emitNodeHeader(header, node);
         }

--- a/parser/tools/generate_ast.cc
+++ b/parser/tools/generate_ast.cc
@@ -809,7 +809,8 @@ string fieldType(FieldType arg) {
 
 void emitNodeHeader(ostream &out, NodeDef &node) {
     out << "class " << node.name << ";" << '\n';
-    out << "template <> struct NodeToTag<" << node.name << "> { static constexpr NodeTag value = NodeTag::" << node.name << "; };" << '\n';
+    out << "template <> struct NodeToTag<" << node.name << "> { static constexpr NodeTag value = NodeTag::" << node.name
+        << "; };" << '\n';
     out << "class " << node.name << " final : public Node {" << '\n';
     out << "public:" << '\n';
 
@@ -844,8 +845,7 @@ void emitNodeHeader(ostream &out, NodeDef &node) {
     out << '\n';
     out << "  std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;" << '\n';
     out << "  std::string toJSON(const core::GlobalState &gs, int tabs = 0);" << '\n';
-    out << "  std::string toJSONWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs = 0);"
-        << '\n';
+    out << "  std::string toJSONWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs = 0);" << '\n';
     out << "  std::string toWhitequark(const core::GlobalState &gs, int tabs = 0);" << '\n';
     out << "  std::string nodeName() const;" << '\n';
 
@@ -1115,7 +1115,6 @@ void emitNodeClassfile(ostream &out, NodeDef &node) {
 }
 
 int main(int argc, char **argv) {
-
     {
         ofstream header(argv[1], ios::trunc);
         if (!header.good()) {

--- a/parser/tools/generate_ast.cc
+++ b/parser/tools/generate_ast.cc
@@ -831,7 +831,7 @@ void emitNodeHeader(ostream &out, NodeDef &node) {
     }
     out << '\n';
     out << "{";
-    out << R"(    categoryCounterInc("nodes", ")" << node.name << "\");" << '\n';
+    out << "    categoryCounterInc(\"nodes\", \"" << node.name << "\");" << '\n';
     out << "}" << '\n';
     out << '\n';
 
@@ -918,7 +918,7 @@ void emitNodeClassfile(ostream &out, NodeDef &node) {
     if (!node.fields.empty()) {
         maybeComma = ",";
     }
-    out << R"(    fmt::format_to(std::back_inserter(buf),  "\"type\" : \")" << node.name << "\\\"" << maybeComma
+    out << "    fmt::format_to(std::back_inserter(buf),  \"\\\"type\\\" : \\\"" << node.name << "\\\"" << maybeComma
         << "\\n\");\n";
     int i = -1;
     // Generate fields
@@ -965,7 +965,7 @@ void emitNodeClassfile(ostream &out, NodeDef &node) {
                     << maybeComma << "\\n\", " << arg.name << ");\n";
                 break;
             case FieldType::Uint:
-                out << R"(    fmt::format_to(std::back_inserter(buf),  "\")" << arg.name << R"(\" : \"{}\")"
+                out << "    fmt::format_to(std::back_inserter(buf),  \"\\\"" << arg.name << "\\\" : \\\"{}\\\""
                     << maybeComma << "\\n\", " << arg.name << ");\n";
                 break;
             case FieldType::Loc:
@@ -993,8 +993,8 @@ void emitNodeClassfile(ostream &out, NodeDef &node) {
     if (!node.fields.empty()) {
         maybeComma = ",";
     }
-    out << R"(    fmt::format_to(std::back_inserter(buf),  "\"type\" : \")" << node.name << "\\\"" << maybeComma
-        << "\\n\");\n";
+    out << "    fmt::format_to(std::back_inserter(buf),  \"\\\"type\\\" : \\\"" << node.name << "\\\"" << maybeComma
+        << "\");\n";
     i = -1;
     // Generate fields
     for (auto &arg : node.fields) {
@@ -1034,17 +1034,17 @@ void emitNodeClassfile(ostream &out, NodeDef &node) {
                     << maybeComma << "\\n\", " << arg.name << ");\n";
                 break;
             case FieldType::Uint:
-                out << R"(    fmt::format_to(std::back_inserter(buf),  "\")" << arg.name << R"(\" : \"{}\")"
+                out << "    fmt::format_to(std::back_inserter(buf),  \"\\\"" << arg.name << "\\\" : \\\"{}\\\""
                     << maybeComma << "\\n\", " << arg.name << ");\n";
                 break;
             case FieldType::Loc:
                 out << "      bool showFull = true;";
-                out << R"(    fmt::format_to(std::back_inserter(buf),  "\")" << arg.name << R"(\" : \"{}\")"
+                out << "      fmt::format_to(std::back_inserter(buf),  \"\\\"" << arg.name << "\\\" : \\\"{}\\\""
                     << maybeComma << "\\n\", "
                     << "core::Loc(file, " << arg.name << ").filePosToString(gs, showFull));\n";
                 break;
             case FieldType::Bool:
-                out << R"(    fmt::format_to(std::back_inserter(buf),  "\")" << arg.name << R"(\" : \"{}\")"
+                out << "    fmt::format_to(std::back_inserter(buf),  \"\\\"" << arg.name << "\\\" : \\\"{}\\\""
                     << maybeComma << "\\n\", " << arg.name << ");\n";
                 break;
         }

--- a/parser/tools/generate_ast.cc
+++ b/parser/tools/generate_ast.cc
@@ -774,7 +774,7 @@ string constructorArgType(FieldType arg) {
         case FieldType::Name:
             return "core::NameRef";
         case FieldType::Node:
-            return "std::unique_ptr<Node>";
+            return "std::unique_ptr<Node, NodeDeleter>";
         case FieldType::NodeVec:
             return "NodeVec";
         case FieldType::String:
@@ -793,7 +793,7 @@ string fieldType(FieldType arg) {
         case FieldType::Name:
             return "core::NameRef";
         case FieldType::Node:
-            return "std::unique_ptr<Node>";
+            return "std::unique_ptr<Node, NodeDeleter>";
         case FieldType::NodeVec:
             return "NodeVec";
         case FieldType::String:

--- a/parser/tools/generate_ast.cc
+++ b/parser/tools/generate_ast.cc
@@ -1132,11 +1132,31 @@ int main(int argc, char **argv) {
         header << "template <typename T> struct NodeToTag;" << '\n' << '\n';
     }
 
-    // emit header file
     {
         ofstream header(argv[2], ios::trunc);
         if (!header.good()) {
             cerr << "unable to open " << argv[2] << '\n';
+            return 1;
+        }
+        header << "#define CASE_STATEMENT(CASE_BODY, T) \\" << '\n';
+        header << "    case NodeTag::T: { \\" << '\n';
+        header << "        CASE_BODY(T)   \\" << '\n';
+        header << "        break; \\" << '\n';
+        header << "}" << '\n' << '\n';
+
+        header << "#define GENERATE_TAG_SWITCH(tag, CASE_BODY) \\" << '\n';
+        header << "    switch (tag) { \\" << '\n';
+        for (auto &node : nodes) {
+            header << "        CASE_STATEMENT(CASE_BODY, " << node.name << ") \\" << '\n';
+        }
+        header << "}" << '\n' << '\n';
+    }
+
+    // emit header file
+    {
+        ofstream header(argv[3], ios::trunc);
+        if (!header.good()) {
+            cerr << "unable to open " << argv[3] << '\n';
             return 1;
         }
         for (auto &node : nodes) {
@@ -1145,9 +1165,9 @@ int main(int argc, char **argv) {
     }
 
     {
-        ofstream classfile(argv[3], ios::trunc);
+        ofstream classfile(argv[4], ios::trunc);
         if (!classfile.good()) {
-            cerr << "unable to open " << argv[3] << '\n';
+            cerr << "unable to open " << argv[4] << '\n';
             return 1;
         }
         classfile << "#include \"parser/Node.h\"" << '\n' << '\n';

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -297,7 +297,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
             continue;
         }
 
-        unique_ptr<parser::Node> nodes;
+        parser::NodePtr nodes;
         {
             core::UnfreezeNameTable nameTableAccess(*gs); // enters original strings
 


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Was curious how much of a difference this would make, especially since we get to turn desugar into a jump table...or at least we would if clang was a little smarter.  Will have to look into that later.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
