### PR TITLE
provide a better `TreeWalk` abstraction in addition to `TreeMap`

### DIFF
--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -206,6 +206,18 @@ private:
         } \
     }
 
+#define CALL_POST(member) \
+    if constexpr (Kind == TreeMapKind::Map) { \
+        if constexpr (Funcs::template HAS_MEMBER_postTransform##member<FUNC>()) { \
+            return Funcs::template CALL_MEMBER_postTransform##member<FUNC>::call(func, ctx, Funcs::pass(v)); \
+        } \
+        return v; \
+    } else if constexpr (Kind == TreeMapKind::Walk) {   \
+        if constexpr (Funcs::template HAS_MEMBER_postTransform##member<FUNC>()) { \
+            Funcs::template CALL_MEMBER_postTransform##member<FUNC>::call(func, ctx, Funcs::pass(v)); \
+        } \
+    }
+
     return_type mapClassDef(arg_type v, CTX ctx) {
         CALL_PRE(ClassDef);
 
@@ -225,10 +237,7 @@ private:
             def = mapIt(Funcs::pass(def), ctx.withOwner(cast_tree_nonnull<ClassDef>(v).symbol).withFile(ctx.file));
         }
 
-        if constexpr (Funcs::template HAS_MEMBER_postTransformClassDef<FUNC>()) {
-            return Funcs::template CALL_MEMBER_postTransformClassDef<FUNC>::call(func, ctx, Funcs::pass(v));
-        }
-        return v;
+        CALL_POST(ClassDef);
     }
 
     return_type mapMethodDef(arg_type v, CTX ctx) {
@@ -248,11 +257,7 @@ private:
                       ctx.withOwner(cast_tree_nonnull<MethodDef>(v).symbol).withFile(ctx.file));
         }
 
-        if constexpr (Funcs::template HAS_MEMBER_postTransformMethodDef<FUNC>()) {
-            return Funcs::template CALL_MEMBER_postTransformMethodDef<FUNC>::call(func, ctx, Funcs::pass(v));
-        }
-
-        return v;
+        CALL_POST(MethodDef);
     }
 
     return_type mapIf(arg_type v, CTX ctx) {
@@ -262,10 +267,7 @@ private:
         cast_tree_nonnull<If>(v).thenp = mapIt(Funcs::pass(cast_tree_nonnull<If>(v).thenp), ctx);
         cast_tree_nonnull<If>(v).elsep = mapIt(Funcs::pass(cast_tree_nonnull<If>(v).elsep), ctx);
 
-        if constexpr (Funcs::template HAS_MEMBER_postTransformIf<FUNC>()) {
-            return Funcs::template CALL_MEMBER_postTransformIf<FUNC>::call(func, ctx, Funcs::pass(v));
-        }
-        return v;
+        CALL_POST(If);
     }
 
     return_type mapWhile(arg_type v, CTX ctx) {
@@ -274,10 +276,7 @@ private:
         cast_tree_nonnull<While>(v).cond = mapIt(Funcs::pass(cast_tree_nonnull<While>(v).cond), ctx);
         cast_tree_nonnull<While>(v).body = mapIt(Funcs::pass(cast_tree_nonnull<While>(v).body), ctx);
 
-        if constexpr (Funcs::template HAS_MEMBER_postTransformWhile<FUNC>()) {
-            return Funcs::template CALL_MEMBER_postTransformWhile<FUNC>::call(func, ctx, Funcs::pass(v));
-        }
-        return v;
+        CALL_POST(While);
     }
 
     return_type mapBreak(arg_type v, CTX ctx) {
@@ -285,16 +284,10 @@ private:
 
         cast_tree_nonnull<Break>(v).expr = mapIt(Funcs::pass(cast_tree_nonnull<Break>(v).expr), ctx);
 
-        if constexpr (Funcs::template HAS_MEMBER_postTransformBreak<FUNC>()) {
-            return Funcs::template CALL_MEMBER_postTransformBreak<FUNC>::call(func, ctx, Funcs::pass(v));
-        }
-        return v;
+        CALL_POST(Break);
     }
     return_type mapRetry(arg_type v, CTX ctx) {
-        if constexpr (Funcs::template HAS_MEMBER_postTransformRetry<FUNC>()) {
-            return Funcs::template CALL_MEMBER_postTransformRetry<FUNC>::call(func, ctx, Funcs::pass(v));
-        }
-        return v;
+        CALL_POST(Retry);
     }
 
     return_type mapNext(arg_type v, CTX ctx) {
@@ -302,10 +295,7 @@ private:
 
         cast_tree_nonnull<Next>(v).expr = mapIt(Funcs::pass(cast_tree_nonnull<Next>(v).expr), ctx);
 
-        if constexpr (Funcs::template HAS_MEMBER_postTransformNext<FUNC>()) {
-            return Funcs::template CALL_MEMBER_postTransformNext<FUNC>::call(func, ctx, Funcs::pass(v));
-        }
-        return v;
+        CALL_POST(Next);
     }
 
     return_type mapReturn(arg_type v, CTX ctx) {
@@ -313,11 +303,7 @@ private:
 
         cast_tree_nonnull<Return>(v).expr = mapIt(Funcs::pass(cast_tree_nonnull<Return>(v).expr), ctx);
 
-        if constexpr (Funcs::template HAS_MEMBER_postTransformReturn<FUNC>()) {
-            return Funcs::template CALL_MEMBER_postTransformReturn<FUNC>::call(func, ctx, Funcs::pass(v));
-        }
-
-        return v;
+        CALL_POST(Return);
     }
 
     return_type mapRescueCase(arg_type v, CTX ctx) {
@@ -331,11 +317,7 @@ private:
 
         cast_tree_nonnull<RescueCase>(v).body = mapIt(Funcs::pass(cast_tree_nonnull<RescueCase>(v).body), ctx);
 
-        if constexpr (Funcs::template HAS_MEMBER_postTransformRescueCase<FUNC>()) {
-            return Funcs::template CALL_MEMBER_postTransformRescueCase<FUNC>::call(func, ctx, Funcs::pass(v));
-        }
-
-        return v;
+        CALL_POST(RescueCase);
     }
     return_type mapRescue(arg_type v, CTX ctx) {
         CALL_PRE(Rescue);
@@ -351,18 +333,11 @@ private:
         cast_tree_nonnull<Rescue>(v).else_ = mapIt(Funcs::pass(cast_tree_nonnull<Rescue>(v).else_), ctx);
         cast_tree_nonnull<Rescue>(v).ensure = mapIt(Funcs::pass(cast_tree_nonnull<Rescue>(v).ensure), ctx);
 
-        if constexpr (Funcs::template HAS_MEMBER_postTransformRescue<FUNC>()) {
-            return Funcs::template CALL_MEMBER_postTransformRescue<FUNC>::call(func, ctx, Funcs::pass(v));
-        }
-
-        return v;
+        CALL_POST(Rescue);
     }
 
     return_type mapUnresolvedIdent(arg_type v, CTX ctx) {
-        if constexpr (Funcs::template HAS_MEMBER_postTransformUnresolvedIdent<FUNC>()) {
-            return Funcs::template CALL_MEMBER_postTransformUnresolvedIdent<FUNC>::call(func, ctx, Funcs::pass(v));
-        }
-        return v;
+        CALL_POST(UnresolvedIdent);
     }
 
     return_type mapAssign(arg_type v, CTX ctx) {
@@ -371,11 +346,7 @@ private:
         cast_tree_nonnull<Assign>(v).lhs = mapIt(Funcs::pass(cast_tree_nonnull<Assign>(v).lhs), ctx);
         cast_tree_nonnull<Assign>(v).rhs = mapIt(Funcs::pass(cast_tree_nonnull<Assign>(v).rhs), ctx);
 
-        if constexpr (Funcs::template HAS_MEMBER_postTransformAssign<FUNC>()) {
-            return Funcs::template CALL_MEMBER_postTransformAssign<FUNC>::call(func, ctx, Funcs::pass(v));
-        }
-
-        return v;
+        CALL_POST(Assign);
     }
 
     return_type mapSend(arg_type v, CTX ctx) {
@@ -393,11 +364,7 @@ private:
             ENFORCE(cast_tree_nonnull<Send>(v).block() != nullptr, "block was mapped into not-a block");
         }
 
-        if constexpr (Funcs::template HAS_MEMBER_postTransformSend<FUNC>()) {
-            return Funcs::template CALL_MEMBER_postTransformSend<FUNC>::call(func, ctx, Funcs::pass(v));
-        }
-
-        return v;
+        CALL_POST(Send);
     }
 
     return_type mapHash(arg_type v, CTX ctx) {
@@ -411,10 +378,7 @@ private:
             value = mapIt(Funcs::pass(value), ctx);
         }
 
-        if constexpr (Funcs::template HAS_MEMBER_postTransformArray<FUNC>()) {
-            return Funcs::template CALL_MEMBER_postTransformHash<FUNC>::call(func, ctx, Funcs::pass(v));
-        }
-        return v;
+        CALL_POST(Hash);
     }
 
     return_type mapArray(arg_type v, CTX ctx) {
@@ -424,31 +388,19 @@ private:
             elem = mapIt(Funcs::pass(elem), ctx);
         }
 
-        if constexpr (Funcs::template HAS_MEMBER_postTransformArray<FUNC>()) {
-            return Funcs::template CALL_MEMBER_postTransformArray<FUNC>::call(func, ctx, Funcs::pass(v));
-        }
-        return v;
+        CALL_POST(Array);
     }
 
     return_type mapLiteral(arg_type v, CTX ctx) {
-        if constexpr (Funcs::template HAS_MEMBER_postTransformLiteral<FUNC>()) {
-            return Funcs::template CALL_MEMBER_postTransformLiteral<FUNC>::call(func, ctx, Funcs::pass(v));
-        }
-        return v;
+        CALL_POST(Literal);
     }
 
     return_type mapUnresolvedConstantLit(arg_type v, CTX ctx) {
-        if constexpr (Funcs::template HAS_MEMBER_postTransformUnresolvedConstantLit<FUNC>()) {
-            return Funcs::template CALL_MEMBER_postTransformUnresolvedConstantLit<FUNC>::call(func, ctx, Funcs::pass(v));
-        }
-        return v;
+        CALL_POST(UnresolvedConstantLit);
     }
 
     return_type mapConstantLit(arg_type v, CTX ctx) {
-        if constexpr (Funcs::template HAS_MEMBER_postTransformConstantLit<FUNC>()) {
-            return Funcs::template CALL_MEMBER_postTransformConstantLit<FUNC>::call(func, ctx, Funcs::pass(v));
-        }
-        return v;
+        CALL_POST(ConstantLit);
     }
 
     return_type mapBlock(arg_type v, CTX ctx) {
@@ -462,10 +414,7 @@ private:
         }
         cast_tree_nonnull<Block>(v).body = mapIt(Funcs::pass(cast_tree_nonnull<Block>(v).body), ctx);
 
-        if constexpr (Funcs::template HAS_MEMBER_postTransformBlock<FUNC>()) {
-            return Funcs::template CALL_MEMBER_postTransformBlock<FUNC>::call(func, ctx, Funcs::pass(v));
-        }
-        return v;
+        CALL_POST(Block);
     }
 
     return_type mapInsSeq(arg_type v, CTX ctx) {
@@ -477,18 +426,11 @@ private:
 
         cast_tree_nonnull<InsSeq>(v).expr = mapIt(Funcs::pass(cast_tree_nonnull<InsSeq>(v).expr), ctx);
 
-        if constexpr (Funcs::template HAS_MEMBER_postTransformInsSeq<FUNC>()) {
-            return Funcs::template CALL_MEMBER_postTransformInsSeq<FUNC>::call(func, ctx, Funcs::pass(v));
-        }
-
-        return v;
+        CALL_POST(InsSeq);
     }
 
     return_type mapLocal(arg_type v, CTX ctx) {
-        if constexpr (Funcs::template HAS_MEMBER_postTransformLocal<FUNC>()) {
-            return Funcs::template CALL_MEMBER_postTransformLocal<FUNC>::call(func, ctx, Funcs::pass(v));
-        }
-        return v;
+        CALL_POST(Local);
     }
 
     return_type mapCast(arg_type v, CTX ctx) {
@@ -496,19 +438,11 @@ private:
 
         cast_tree_nonnull<Cast>(v).arg = mapIt(Funcs::pass(cast_tree_nonnull<Cast>(v).arg), ctx);
 
-        if constexpr (Funcs::template HAS_MEMBER_postTransformCast<FUNC>()) {
-            return Funcs::template CALL_MEMBER_postTransformCast<FUNC>::call(func, ctx, Funcs::pass(v));
-        }
-
-        return v;
+        CALL_POST(Cast);
     }
 
     return_type mapRuntimeMethodDefinition(arg_type v, CTX ctx) {
-        if constexpr (Funcs::template HAS_MEMBER_postTransformRuntimeMethodDefinition<FUNC>()) {
-            return Funcs::template CALL_MEMBER_postTransformRuntimeMethodDefinition<FUNC>::call(func, ctx, Funcs::pass(v));
-        }
-
-        return v;
+        CALL_POST(RuntimeMethodDefinition);
     }
 
     return_type mapIt(arg_type what, CTX ctx) {
@@ -644,6 +578,7 @@ private:
     }
 
 #undef CALL_PRE
+#undef CALL_POST
 };
 
 class TreeMap {

--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -158,7 +158,7 @@ enum class TreeMapDepthKind {
  * FUNC may maintain internal state.
  * @tparam tree transformer, see FUNC_EXAMPLE
  */
-template <class FUNC, class CTX, TreeMapDepthKind Kind> class TreeMapper {
+template <class FUNC, class CTX, TreeMapDepthKind DepthKind> class TreeMapper {
 private:
     friend class TreeMap;
     friend class ShallowMap;
@@ -214,7 +214,7 @@ private:
             }
         }
 
-        if constexpr (Kind == TreeMapDepthKind::Full) {
+        if constexpr (DepthKind == TreeMapDepthKind::Full) {
             cast_tree_nonnull<MethodDef>(v).rhs =
                 mapIt(std::move(cast_tree_nonnull<MethodDef>(v).rhs),
                       ctx.withOwner(cast_tree_nonnull<MethodDef>(v).symbol).withFile(ctx.file));

--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -182,6 +182,7 @@ private:
     friend class TreeMap;
     friend class ShallowMap;
     friend class TreeWalk;
+    friend class ShallowWalk;
 
     using Funcs = MapFunctions<Kind>;
     using return_type = typename Funcs::return_type;
@@ -630,6 +631,22 @@ public:
         TreeMapper<FUNC, CTX, TreeMapKind::Map, TreeMapDepthKind::Shallow> walker(func);
         try {
             return walker.mapIt(std::move(to), ctx);
+        } catch (ReportedRubyException &exception) {
+            Exception::failInFuzzer();
+            if (auto e = ctx.beginError(exception.onLoc, core::errors::Internal::InternalError)) {
+                e.setHeader("Failed to process tree (backtrace is above)");
+            }
+            throw exception.reported;
+        }
+    }
+};
+
+class ShallowWalk {
+public:
+    template <typename CTX, typename FUNC> static void apply(CTX ctx, FUNC &func, ExpressionPtr &to) {
+        TreeMapper<FUNC, CTX, TreeMapKind::Walk, TreeMapDepthKind::Shallow> walker(func);
+        try {
+            walker.mapIt(to, ctx);
         } catch (ReportedRubyException &exception) {
             Exception::failInFuzzer();
             if (auto e = ctx.beginError(exception.onLoc, core::errors::Internal::InternalError)) {

--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -184,6 +184,7 @@ private:
 
     using Funcs = MapFunctions<Kind>;
     using return_type = typename Funcs::return_type;
+    using arg_type = typename Funcs::arg_type;
 
     FUNC &func;
 
@@ -223,7 +224,7 @@ private:
         return v;
     }
 
-    return_type mapMethodDef(ExpressionPtr v, CTX ctx) {
+    return_type mapMethodDef(arg_type v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_preTransformMethodDef<FUNC>()) {
             v = Funcs::template CALL_MEMBER_preTransformMethodDef<FUNC>::call(func, ctx, Funcs::pass(v));
         }
@@ -249,7 +250,7 @@ private:
         return v;
     }
 
-    return_type mapIf(ExpressionPtr v, CTX ctx) {
+    return_type mapIf(arg_type v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_preTransformIf<FUNC>()) {
             v = Funcs::template CALL_MEMBER_preTransformIf<FUNC>::call(func, ctx, Funcs::pass(v));
         }
@@ -263,7 +264,7 @@ private:
         return v;
     }
 
-    return_type mapWhile(ExpressionPtr v, CTX ctx) {
+    return_type mapWhile(arg_type v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_preTransformWhile<FUNC>()) {
             v = Funcs::template CALL_MEMBER_preTransformWhile<FUNC>::call(func, ctx, Funcs::pass(v));
         }
@@ -276,7 +277,7 @@ private:
         return v;
     }
 
-    return_type mapBreak(ExpressionPtr v, CTX ctx) {
+    return_type mapBreak(arg_type v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_preTransformBreak<FUNC>()) {
             return Funcs::template CALL_MEMBER_preTransformBreak<FUNC>::call(func, ctx, Funcs::pass(v));
         }
@@ -288,14 +289,14 @@ private:
         }
         return v;
     }
-    return_type mapRetry(ExpressionPtr v, CTX ctx) {
+    return_type mapRetry(arg_type v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_postTransformRetry<FUNC>()) {
             return Funcs::template CALL_MEMBER_postTransformRetry<FUNC>::call(func, ctx, Funcs::pass(v));
         }
         return v;
     }
 
-    return_type mapNext(ExpressionPtr v, CTX ctx) {
+    return_type mapNext(arg_type v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_preTransformNext<FUNC>()) {
             return Funcs::template CALL_MEMBER_preTransformNext<FUNC>::call(func, ctx, Funcs::pass(v));
         }
@@ -308,7 +309,7 @@ private:
         return v;
     }
 
-    return_type mapReturn(ExpressionPtr v, CTX ctx) {
+    return_type mapReturn(arg_type v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_preTransformReturn<FUNC>()) {
             v = Funcs::template CALL_MEMBER_preTransformReturn<FUNC>::call(func, ctx, Funcs::pass(v));
         }
@@ -321,7 +322,7 @@ private:
         return v;
     }
 
-    return_type mapRescueCase(ExpressionPtr v, CTX ctx) {
+    return_type mapRescueCase(arg_type v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_preTransformRescueCase<FUNC>()) {
             v = Funcs::template CALL_MEMBER_preTransformRescueCase<FUNC>::call(func, ctx, Funcs::pass(v));
         }
@@ -340,7 +341,7 @@ private:
 
         return v;
     }
-    return_type mapRescue(ExpressionPtr v, CTX ctx) {
+    return_type mapRescue(arg_type v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_preTransformRescue<FUNC>()) {
             v = Funcs::template CALL_MEMBER_preTransformRescue<FUNC>::call(func, ctx, Funcs::pass(v));
         }
@@ -363,14 +364,14 @@ private:
         return v;
     }
 
-    return_type mapUnresolvedIdent(ExpressionPtr v, CTX ctx) {
+    return_type mapUnresolvedIdent(arg_type v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_postTransformUnresolvedIdent<FUNC>()) {
             return Funcs::template CALL_MEMBER_postTransformUnresolvedIdent<FUNC>::call(func, ctx, Funcs::pass(v));
         }
         return v;
     }
 
-    return_type mapAssign(ExpressionPtr v, CTX ctx) {
+    return_type mapAssign(arg_type v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_preTransformAssign<FUNC>()) {
             v = Funcs::template CALL_MEMBER_preTransformAssign<FUNC>::call(func, ctx, Funcs::pass(v));
         }
@@ -385,7 +386,7 @@ private:
         return v;
     }
 
-    return_type mapSend(ExpressionPtr v, CTX ctx) {
+    return_type mapSend(arg_type v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_preTransformSend<FUNC>()) {
             v = Funcs::template CALL_MEMBER_preTransformSend<FUNC>::call(func, ctx, Funcs::pass(v));
         }
@@ -409,7 +410,7 @@ private:
         return v;
     }
 
-    return_type mapHash(ExpressionPtr v, CTX ctx) {
+    return_type mapHash(arg_type v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_preTransformHash<FUNC>()) {
             v = Funcs::template CALL_MEMBER_preTransformHash<FUNC>::call(func, ctx, Funcs::pass(v));
         }
@@ -427,7 +428,7 @@ private:
         return v;
     }
 
-    return_type mapArray(ExpressionPtr v, CTX ctx) {
+    return_type mapArray(arg_type v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_preTransformArray<FUNC>()) {
             v = Funcs::template CALL_MEMBER_preTransformArray<FUNC>::call(func, ctx, Funcs::pass(v));
         }
@@ -441,28 +442,28 @@ private:
         return v;
     }
 
-    return_type mapLiteral(ExpressionPtr v, CTX ctx) {
+    return_type mapLiteral(arg_type v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_postTransformLiteral<FUNC>()) {
             return Funcs::template CALL_MEMBER_postTransformLiteral<FUNC>::call(func, ctx, Funcs::pass(v));
         }
         return v;
     }
 
-    return_type mapUnresolvedConstantLit(ExpressionPtr v, CTX ctx) {
+    return_type mapUnresolvedConstantLit(arg_type v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_postTransformUnresolvedConstantLit<FUNC>()) {
             return Funcs::template CALL_MEMBER_postTransformUnresolvedConstantLit<FUNC>::call(func, ctx, Funcs::pass(v));
         }
         return v;
     }
 
-    return_type mapConstantLit(ExpressionPtr v, CTX ctx) {
+    return_type mapConstantLit(arg_type v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_postTransformConstantLit<FUNC>()) {
             return Funcs::template CALL_MEMBER_postTransformConstantLit<FUNC>::call(func, ctx, Funcs::pass(v));
         }
         return v;
     }
 
-    return_type mapBlock(ExpressionPtr v, CTX ctx) {
+    return_type mapBlock(arg_type v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_preTransformBlock<FUNC>()) {
             v = Funcs::template CALL_MEMBER_preTransformBlock<FUNC>::call(func, ctx, Funcs::pass(v));
         }
@@ -481,7 +482,7 @@ private:
         return v;
     }
 
-    return_type mapInsSeq(ExpressionPtr v, CTX ctx) {
+    return_type mapInsSeq(arg_type v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_preTransformInsSeq<FUNC>()) {
             v = Funcs::template CALL_MEMBER_preTransformInsSeq<FUNC>::call(func, ctx, Funcs::pass(v));
         }
@@ -499,14 +500,14 @@ private:
         return v;
     }
 
-    return_type mapLocal(ExpressionPtr v, CTX ctx) {
+    return_type mapLocal(arg_type v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_postTransformLocal<FUNC>()) {
             return Funcs::template CALL_MEMBER_postTransformLocal<FUNC>::call(func, ctx, Funcs::pass(v));
         }
         return v;
     }
 
-    return_type mapCast(ExpressionPtr v, CTX ctx) {
+    return_type mapCast(arg_type v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_preTransformCast<FUNC>()) {
             v = Funcs::template CALL_MEMBER_preTransformCast<FUNC>::call(func, ctx, Funcs::pass(v));
         }
@@ -519,7 +520,7 @@ private:
         return v;
     }
 
-    return_type mapRuntimeMethodDefinition(ExpressionPtr v, CTX ctx) {
+    return_type mapRuntimeMethodDefinition(arg_type v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_postTransformRuntimeMethodDefinition<FUNC>()) {
             return Funcs::template CALL_MEMBER_postTransformRuntimeMethodDefinition<FUNC>::call(func, ctx, Funcs::pass(v));
         }
@@ -527,7 +528,7 @@ private:
         return v;
     }
 
-    return_type mapIt(ExpressionPtr what, CTX ctx) {
+    return_type mapIt(arg_type what, CTX ctx) {
         if (what == nullptr) {
             return what;
         }

--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -147,7 +147,7 @@ struct ReportedRubyException {
     core::LocOffsets onLoc;
 };
 
-enum class TreeMapKind {
+enum class TreeMapDepthKind {
     Full,
     Shallow,
 };
@@ -158,7 +158,7 @@ enum class TreeMapKind {
  * FUNC may maintain internal state.
  * @tparam tree transformer, see FUNC_EXAMPLE
  */
-template <class FUNC, class CTX, TreeMapKind Kind> class TreeMapper {
+template <class FUNC, class CTX, TreeMapDepthKind Kind> class TreeMapper {
 private:
     friend class TreeMap;
     friend class ShallowMap;
@@ -214,7 +214,7 @@ private:
             }
         }
 
-        if constexpr (Kind == TreeMapKind::Full) {
+        if constexpr (Kind == TreeMapDepthKind::Full) {
             cast_tree_nonnull<MethodDef>(v).rhs =
                 mapIt(std::move(cast_tree_nonnull<MethodDef>(v).rhs),
                       ctx.withOwner(cast_tree_nonnull<MethodDef>(v).symbol).withFile(ctx.file));
@@ -625,7 +625,7 @@ private:
 class TreeMap {
 public:
     template <typename CTX, typename FUNC> static ExpressionPtr apply(CTX ctx, FUNC &func, ExpressionPtr to) {
-        TreeMapper<FUNC, CTX, TreeMapKind::Full> walker(func);
+        TreeMapper<FUNC, CTX, TreeMapDepthKind::Full> walker(func);
         try {
             return walker.mapIt(std::move(to), ctx);
         } catch (ReportedRubyException &exception) {
@@ -641,7 +641,7 @@ public:
 class ShallowMap {
 public:
     template <typename CTX, typename FUNC> static ExpressionPtr apply(CTX ctx, FUNC &func, ExpressionPtr to) {
-        TreeMapper<FUNC, CTX, TreeMapKind::Shallow> walker(func);
+        TreeMapper<FUNC, CTX, TreeMapDepthKind::Shallow> walker(func);
         try {
             return walker.mapIt(std::move(to), ctx);
         } catch (ReportedRubyException &exception) {

--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -74,70 +74,68 @@ public:
 
 // NOTE: Implementations must use a context type parameter that `MutableContext` is convertable to.
 // That is, either `Context` or `MutableContext`.
-#define GENERATE_HAS_MEMBER_VISITOR(X, arg_types...)                               \
-    GENERATE_HAS_MEMBER(X, arg_types)
+#define GENERATE_HAS_MEMBER_VISITOR(X, arg_types...) GENERATE_HAS_MEMBER(X, arg_types)
 
 // used to check for ABSENCE of method
 
-#define GENERATE_POSTPONE_PRECLASS(X, arg_types...)                                  \
+#define GENERATE_POSTPONE_PRECLASS(X, arg_types...)                                                              \
     GENERATE_CALL_MEMBER(preTransform##X, Exception::raise("should never be called. Incorrect use of TreeMap?"); \
                          return nullptr, arg_types)
 
-#define GENERATE_POSTPONE_POSTCLASS(X, arg_types...)                                 \
+#define GENERATE_POSTPONE_POSTCLASS(X, arg_types...)                                                              \
     GENERATE_CALL_MEMBER(postTransform##X, Exception::raise("should never be called. Incorrect use of TreeMap?"); \
                          return nullptr, arg_types)
 
-
-#define GENERATE_METAPROGRAMMING_FOR(arg_types...) \
-GENERATE_HAS_MEMBER_VISITOR(preTransformUnresolvedIdent, arg_types); \
-GENERATE_HAS_MEMBER_VISITOR(preTransformLocal, arg_types); \
-GENERATE_HAS_MEMBER_VISITOR(preTransformUnresolvedConstantLit, arg_types); \
-GENERATE_HAS_MEMBER_VISITOR(preTransformConstantLit, arg_types); \
-GENERATE_HAS_MEMBER_VISITOR(preTransformLiteral, arg_types); \
-GENERATE_HAS_MEMBER_VISITOR(preTransformRuntimeMethodDefinition, arg_types); \
- \
-GENERATE_POSTPONE_PRECLASS(Expression, arg_types); \
-GENERATE_POSTPONE_PRECLASS(ClassDef, arg_types); \
-GENERATE_POSTPONE_PRECLASS(MethodDef, arg_types); \
-GENERATE_POSTPONE_PRECLASS(If, arg_types); \
-GENERATE_POSTPONE_PRECLASS(While, arg_types); \
-GENERATE_POSTPONE_PRECLASS(Break, arg_types); \
-GENERATE_POSTPONE_PRECLASS(Retry, arg_types); \
-GENERATE_POSTPONE_PRECLASS(Next, arg_types); \
-GENERATE_POSTPONE_PRECLASS(Return, arg_types); \
-GENERATE_POSTPONE_PRECLASS(RescueCase, arg_types); \
-GENERATE_POSTPONE_PRECLASS(Rescue, arg_types); \
-GENERATE_POSTPONE_PRECLASS(Assign, arg_types); \
-GENERATE_POSTPONE_PRECLASS(Send, arg_types); \
-GENERATE_POSTPONE_PRECLASS(Hash, arg_types); \
-GENERATE_POSTPONE_PRECLASS(Array, arg_types); \
-GENERATE_POSTPONE_PRECLASS(Block, arg_types); \
-GENERATE_POSTPONE_PRECLASS(InsSeq, arg_types); \
-GENERATE_POSTPONE_PRECLASS(Cast, arg_types); \
-\
-GENERATE_POSTPONE_POSTCLASS(ClassDef, arg_types); \
-GENERATE_POSTPONE_POSTCLASS(MethodDef, arg_types); \
-GENERATE_POSTPONE_POSTCLASS(If, arg_types); \
-GENERATE_POSTPONE_POSTCLASS(While, arg_types); \
-GENERATE_POSTPONE_POSTCLASS(Break, arg_types); \
-GENERATE_POSTPONE_POSTCLASS(Retry, arg_types); \
-GENERATE_POSTPONE_POSTCLASS(Next, arg_types); \
-GENERATE_POSTPONE_POSTCLASS(Return, arg_types); \
-GENERATE_POSTPONE_POSTCLASS(RescueCase, arg_types); \
-GENERATE_POSTPONE_POSTCLASS(Rescue, arg_types); \
-GENERATE_POSTPONE_POSTCLASS(UnresolvedIdent, arg_types); \
-GENERATE_POSTPONE_POSTCLASS(Assign, arg_types); \
-GENERATE_POSTPONE_POSTCLASS(Send, arg_types); \
-GENERATE_POSTPONE_POSTCLASS(Hash, arg_types); \
-GENERATE_POSTPONE_POSTCLASS(Array, arg_types); \
-GENERATE_POSTPONE_POSTCLASS(Local, arg_types); \
-GENERATE_POSTPONE_POSTCLASS(Literal, arg_types); \
-GENERATE_POSTPONE_POSTCLASS(UnresolvedConstantLit, arg_types); \
-GENERATE_POSTPONE_POSTCLASS(ConstantLit, arg_types); \
-GENERATE_POSTPONE_POSTCLASS(Block, arg_types); \
-GENERATE_POSTPONE_POSTCLASS(InsSeq, arg_types); \
-GENERATE_POSTPONE_POSTCLASS(Cast, arg_types); \
-GENERATE_POSTPONE_POSTCLASS(RuntimeMethodDefinition, arg_types); \
+#define GENERATE_METAPROGRAMMING_FOR(arg_types...)                               \
+    GENERATE_HAS_MEMBER_VISITOR(preTransformUnresolvedIdent, arg_types);         \
+    GENERATE_HAS_MEMBER_VISITOR(preTransformLocal, arg_types);                   \
+    GENERATE_HAS_MEMBER_VISITOR(preTransformUnresolvedConstantLit, arg_types);   \
+    GENERATE_HAS_MEMBER_VISITOR(preTransformConstantLit, arg_types);             \
+    GENERATE_HAS_MEMBER_VISITOR(preTransformLiteral, arg_types);                 \
+    GENERATE_HAS_MEMBER_VISITOR(preTransformRuntimeMethodDefinition, arg_types); \
+                                                                                 \
+    GENERATE_POSTPONE_PRECLASS(Expression, arg_types);                           \
+    GENERATE_POSTPONE_PRECLASS(ClassDef, arg_types);                             \
+    GENERATE_POSTPONE_PRECLASS(MethodDef, arg_types);                            \
+    GENERATE_POSTPONE_PRECLASS(If, arg_types);                                   \
+    GENERATE_POSTPONE_PRECLASS(While, arg_types);                                \
+    GENERATE_POSTPONE_PRECLASS(Break, arg_types);                                \
+    GENERATE_POSTPONE_PRECLASS(Retry, arg_types);                                \
+    GENERATE_POSTPONE_PRECLASS(Next, arg_types);                                 \
+    GENERATE_POSTPONE_PRECLASS(Return, arg_types);                               \
+    GENERATE_POSTPONE_PRECLASS(RescueCase, arg_types);                           \
+    GENERATE_POSTPONE_PRECLASS(Rescue, arg_types);                               \
+    GENERATE_POSTPONE_PRECLASS(Assign, arg_types);                               \
+    GENERATE_POSTPONE_PRECLASS(Send, arg_types);                                 \
+    GENERATE_POSTPONE_PRECLASS(Hash, arg_types);                                 \
+    GENERATE_POSTPONE_PRECLASS(Array, arg_types);                                \
+    GENERATE_POSTPONE_PRECLASS(Block, arg_types);                                \
+    GENERATE_POSTPONE_PRECLASS(InsSeq, arg_types);                               \
+    GENERATE_POSTPONE_PRECLASS(Cast, arg_types);                                 \
+                                                                                 \
+    GENERATE_POSTPONE_POSTCLASS(ClassDef, arg_types);                            \
+    GENERATE_POSTPONE_POSTCLASS(MethodDef, arg_types);                           \
+    GENERATE_POSTPONE_POSTCLASS(If, arg_types);                                  \
+    GENERATE_POSTPONE_POSTCLASS(While, arg_types);                               \
+    GENERATE_POSTPONE_POSTCLASS(Break, arg_types);                               \
+    GENERATE_POSTPONE_POSTCLASS(Retry, arg_types);                               \
+    GENERATE_POSTPONE_POSTCLASS(Next, arg_types);                                \
+    GENERATE_POSTPONE_POSTCLASS(Return, arg_types);                              \
+    GENERATE_POSTPONE_POSTCLASS(RescueCase, arg_types);                          \
+    GENERATE_POSTPONE_POSTCLASS(Rescue, arg_types);                              \
+    GENERATE_POSTPONE_POSTCLASS(UnresolvedIdent, arg_types);                     \
+    GENERATE_POSTPONE_POSTCLASS(Assign, arg_types);                              \
+    GENERATE_POSTPONE_POSTCLASS(Send, arg_types);                                \
+    GENERATE_POSTPONE_POSTCLASS(Hash, arg_types);                                \
+    GENERATE_POSTPONE_POSTCLASS(Array, arg_types);                               \
+    GENERATE_POSTPONE_POSTCLASS(Local, arg_types);                               \
+    GENERATE_POSTPONE_POSTCLASS(Literal, arg_types);                             \
+    GENERATE_POSTPONE_POSTCLASS(UnresolvedConstantLit, arg_types);               \
+    GENERATE_POSTPONE_POSTCLASS(ConstantLit, arg_types);                         \
+    GENERATE_POSTPONE_POSTCLASS(Block, arg_types);                               \
+    GENERATE_POSTPONE_POSTCLASS(InsSeq, arg_types);                              \
+    GENERATE_POSTPONE_POSTCLASS(Cast, arg_types);                                \
+    GENERATE_POSTPONE_POSTCLASS(RuntimeMethodDefinition, arg_types);
 
 // Used to indicate that TreeMap has already reported location for this exception
 struct ReportedRubyException {
@@ -155,14 +153,18 @@ template <TreeMapKind> struct MapFunctions;
 template <> struct MapFunctions<TreeMapKind::Map> {
     using return_type = ExpressionPtr;
     using arg_type = ExpressionPtr;
-    static ExpressionPtr &&pass(ExpressionPtr &p) { return static_cast<ExpressionPtr &&>(p); }
+    static ExpressionPtr &&pass(ExpressionPtr &p) {
+        return static_cast<ExpressionPtr &&>(p);
+    }
     GENERATE_METAPROGRAMMING_FOR(std::declval<core::MutableContext>(), std::declval<ExpressionPtr>());
 };
 
 template <> struct MapFunctions<TreeMapKind::Walk> {
     using return_type = void;
     using arg_type = ExpressionPtr &;
-    static ExpressionPtr &pass(ExpressionPtr &p) { return p; }
+    static ExpressionPtr &pass(ExpressionPtr &p) {
+        return p;
+    }
     GENERATE_METAPROGRAMMING_FOR(std::declval<core::MutableContext>(), std::declval<ExpressionPtr &>());
 };
 
@@ -195,36 +197,37 @@ private:
     static_assert(!Funcs::template HAS_MEMBER_preTransformUnresolvedConstantLit<FUNC>(), "use post*Transform instead");
     static_assert(!Funcs::template HAS_MEMBER_preTransformConstantLit<FUNC>(), "use post*Transform instead");
     static_assert(!Funcs::template HAS_MEMBER_preTransformLocal<FUNC>(), "use post*Transform instead");
-    static_assert(!Funcs::template HAS_MEMBER_preTransformRuntimeMethodDefinition<FUNC>(), "use post*Transform instead");
+    static_assert(!Funcs::template HAS_MEMBER_preTransformRuntimeMethodDefinition<FUNC>(),
+                  "use post*Transform instead");
 
     TreeMapper(FUNC &func) : func(func) {}
 
-#define CALL_PRE(member) \
-    if constexpr (Funcs::template HAS_MEMBER_preTransform##member<FUNC>()) { \
-        if constexpr (Kind == TreeMapKind::Map) {                           \
+#define CALL_PRE(member)                                                                                 \
+    if constexpr (Funcs::template HAS_MEMBER_preTransform##member<FUNC>()) {                             \
+        if constexpr (Kind == TreeMapKind::Map) {                                                        \
             v = Funcs::template CALL_MEMBER_preTransform##member<FUNC>::call(func, ctx, Funcs::pass(v)); \
-        } else if (Kind == TreeMapKind::Walk) {                         \
-            Funcs::template CALL_MEMBER_preTransform##member<FUNC>::call(func, ctx, Funcs::pass(v)); \
-        } \
+        } else if (Kind == TreeMapKind::Walk) {                                                          \
+            Funcs::template CALL_MEMBER_preTransform##member<FUNC>::call(func, ctx, Funcs::pass(v));     \
+        }                                                                                                \
     }
 
-#define CALL_POST(member) \
-    if constexpr (Kind == TreeMapKind::Map) { \
-        if constexpr (Funcs::template HAS_MEMBER_postTransform##member<FUNC>()) { \
+#define CALL_POST(member)                                                                                    \
+    if constexpr (Kind == TreeMapKind::Map) {                                                                \
+        if constexpr (Funcs::template HAS_MEMBER_postTransform##member<FUNC>()) {                            \
             return Funcs::template CALL_MEMBER_postTransform##member<FUNC>::call(func, ctx, Funcs::pass(v)); \
-        } \
-        return v; \
-    } else if constexpr (Kind == TreeMapKind::Walk) {   \
-        if constexpr (Funcs::template HAS_MEMBER_postTransform##member<FUNC>()) { \
-            Funcs::template CALL_MEMBER_postTransform##member<FUNC>::call(func, ctx, Funcs::pass(v)); \
-        } \
+        }                                                                                                    \
+        return v;                                                                                            \
+    } else if constexpr (Kind == TreeMapKind::Walk) {                                                        \
+        if constexpr (Funcs::template HAS_MEMBER_postTransform##member<FUNC>()) {                            \
+            Funcs::template CALL_MEMBER_postTransform##member<FUNC>::call(func, ctx, Funcs::pass(v));        \
+        }                                                                                                    \
     }
 
-#define CALL_MAP(tree, ctx)           \
-    if constexpr (Kind == TreeMapKind::Map) { \
-        tree = mapIt(Funcs::pass(tree), ctx); \
+#define CALL_MAP(tree, ctx)                           \
+    if constexpr (Kind == TreeMapKind::Map) {         \
+        tree = mapIt(Funcs::pass(tree), ctx);         \
     } else if constexpr (Kind == TreeMapKind::Walk) { \
-        mapIt(Funcs::pass(tree), ctx); \
+        mapIt(Funcs::pass(tree), ctx);                \
     }
 
     return_type mapClassDef(arg_type v, CTX ctx) {

--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -139,7 +139,9 @@ GENERATE_POSTPONE_POSTCLASS(InsSeq, arg_types); \
 GENERATE_POSTPONE_POSTCLASS(Cast, arg_types); \
 GENERATE_POSTPONE_POSTCLASS(RuntimeMethodDefinition, arg_types); \
 
-GENERATE_METAPROGRAMMING_FOR(std::declval<core::MutableContext>(), std::declval<ExpressionPtr>());
+struct MapFunctions {
+    GENERATE_METAPROGRAMMING_FOR(std::declval<core::MutableContext>(), std::declval<ExpressionPtr>());
+};
 
 // Used to indicate that TreeMap has already reported location for this exception
 struct ReportedRubyException {
@@ -167,20 +169,22 @@ private:
     friend class TreeMap;
     friend class ShallowMap;
 
+    using Funcs = MapFunctions;
+
     FUNC &func;
 
-    static_assert(!HAS_MEMBER_preTransformUnresolvedIdent<FUNC>(), "use post*Transform instead");
-    static_assert(!HAS_MEMBER_preTransformLiteral<FUNC>(), "use post*Transform instead");
-    static_assert(!HAS_MEMBER_preTransformUnresolvedConstantLit<FUNC>(), "use post*Transform instead");
-    static_assert(!HAS_MEMBER_preTransformConstantLit<FUNC>(), "use post*Transform instead");
-    static_assert(!HAS_MEMBER_preTransformLocal<FUNC>(), "use post*Transform instead");
-    static_assert(!HAS_MEMBER_preTransformRuntimeMethodDefinition<FUNC>(), "use post*Transform instead");
+    static_assert(!Funcs::HAS_MEMBER_preTransformUnresolvedIdent<FUNC>(), "use post*Transform instead");
+    static_assert(!Funcs::HAS_MEMBER_preTransformLiteral<FUNC>(), "use post*Transform instead");
+    static_assert(!Funcs::HAS_MEMBER_preTransformUnresolvedConstantLit<FUNC>(), "use post*Transform instead");
+    static_assert(!Funcs::HAS_MEMBER_preTransformConstantLit<FUNC>(), "use post*Transform instead");
+    static_assert(!Funcs::HAS_MEMBER_preTransformLocal<FUNC>(), "use post*Transform instead");
+    static_assert(!Funcs::HAS_MEMBER_preTransformRuntimeMethodDefinition<FUNC>(), "use post*Transform instead");
 
     TreeMapper(FUNC &func) : func(func) {}
 
     ExpressionPtr mapClassDef(ExpressionPtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformClassDef<FUNC>()) {
-            v = CALL_MEMBER_preTransformClassDef<FUNC>::call(func, ctx, std::move(v));
+        if constexpr (Funcs::HAS_MEMBER_preTransformClassDef<FUNC>()) {
+            v = Funcs::CALL_MEMBER_preTransformClassDef<FUNC>::call(func, ctx, std::move(v));
         }
 
         // We intentionally do not walk v->ancestors nor v->singletonAncestors.
@@ -199,15 +203,15 @@ private:
             def = mapIt(std::move(def), ctx.withOwner(cast_tree_nonnull<ClassDef>(v).symbol).withFile(ctx.file));
         }
 
-        if constexpr (HAS_MEMBER_postTransformClassDef<FUNC>()) {
-            return CALL_MEMBER_postTransformClassDef<FUNC>::call(func, ctx, std::move(v));
+        if constexpr (Funcs::HAS_MEMBER_postTransformClassDef<FUNC>()) {
+            return Funcs::CALL_MEMBER_postTransformClassDef<FUNC>::call(func, ctx, std::move(v));
         }
         return v;
     }
 
     ExpressionPtr mapMethodDef(ExpressionPtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformMethodDef<FUNC>()) {
-            v = CALL_MEMBER_preTransformMethodDef<FUNC>::call(func, ctx, std::move(v));
+        if constexpr (Funcs::HAS_MEMBER_preTransformMethodDef<FUNC>()) {
+            v = Funcs::CALL_MEMBER_preTransformMethodDef<FUNC>::call(func, ctx, std::move(v));
         }
 
         for (auto &arg : cast_tree_nonnull<MethodDef>(v).args) {
@@ -224,88 +228,88 @@ private:
                       ctx.withOwner(cast_tree_nonnull<MethodDef>(v).symbol).withFile(ctx.file));
         }
 
-        if constexpr (HAS_MEMBER_postTransformMethodDef<FUNC>()) {
-            return CALL_MEMBER_postTransformMethodDef<FUNC>::call(func, ctx, std::move(v));
+        if constexpr (Funcs::HAS_MEMBER_postTransformMethodDef<FUNC>()) {
+            return Funcs::CALL_MEMBER_postTransformMethodDef<FUNC>::call(func, ctx, std::move(v));
         }
 
         return v;
     }
 
     ExpressionPtr mapIf(ExpressionPtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformIf<FUNC>()) {
-            v = CALL_MEMBER_preTransformIf<FUNC>::call(func, ctx, std::move(v));
+        if constexpr (Funcs::HAS_MEMBER_preTransformIf<FUNC>()) {
+            v = Funcs::CALL_MEMBER_preTransformIf<FUNC>::call(func, ctx, std::move(v));
         }
         cast_tree_nonnull<If>(v).cond = mapIt(std::move(cast_tree_nonnull<If>(v).cond), ctx);
         cast_tree_nonnull<If>(v).thenp = mapIt(std::move(cast_tree_nonnull<If>(v).thenp), ctx);
         cast_tree_nonnull<If>(v).elsep = mapIt(std::move(cast_tree_nonnull<If>(v).elsep), ctx);
 
-        if constexpr (HAS_MEMBER_postTransformIf<FUNC>()) {
-            return CALL_MEMBER_postTransformIf<FUNC>::call(func, ctx, std::move(v));
+        if constexpr (Funcs::HAS_MEMBER_postTransformIf<FUNC>()) {
+            return Funcs::CALL_MEMBER_postTransformIf<FUNC>::call(func, ctx, std::move(v));
         }
         return v;
     }
 
     ExpressionPtr mapWhile(ExpressionPtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformWhile<FUNC>()) {
-            v = CALL_MEMBER_preTransformWhile<FUNC>::call(func, ctx, std::move(v));
+        if constexpr (Funcs::HAS_MEMBER_preTransformWhile<FUNC>()) {
+            v = Funcs::CALL_MEMBER_preTransformWhile<FUNC>::call(func, ctx, std::move(v));
         }
         cast_tree_nonnull<While>(v).cond = mapIt(std::move(cast_tree_nonnull<While>(v).cond), ctx);
         cast_tree_nonnull<While>(v).body = mapIt(std::move(cast_tree_nonnull<While>(v).body), ctx);
 
-        if constexpr (HAS_MEMBER_postTransformWhile<FUNC>()) {
-            return CALL_MEMBER_postTransformWhile<FUNC>::call(func, ctx, std::move(v));
+        if constexpr (Funcs::HAS_MEMBER_postTransformWhile<FUNC>()) {
+            return Funcs::CALL_MEMBER_postTransformWhile<FUNC>::call(func, ctx, std::move(v));
         }
         return v;
     }
 
     ExpressionPtr mapBreak(ExpressionPtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformBreak<FUNC>()) {
-            return CALL_MEMBER_preTransformBreak<FUNC>::call(func, ctx, std::move(v));
+        if constexpr (Funcs::HAS_MEMBER_preTransformBreak<FUNC>()) {
+            return Funcs::CALL_MEMBER_preTransformBreak<FUNC>::call(func, ctx, std::move(v));
         }
 
         cast_tree_nonnull<Break>(v).expr = mapIt(std::move(cast_tree_nonnull<Break>(v).expr), ctx);
 
-        if constexpr (HAS_MEMBER_postTransformBreak<FUNC>()) {
-            return CALL_MEMBER_postTransformBreak<FUNC>::call(func, ctx, std::move(v));
+        if constexpr (Funcs::HAS_MEMBER_postTransformBreak<FUNC>()) {
+            return Funcs::CALL_MEMBER_postTransformBreak<FUNC>::call(func, ctx, std::move(v));
         }
         return v;
     }
     ExpressionPtr mapRetry(ExpressionPtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_postTransformRetry<FUNC>()) {
-            return CALL_MEMBER_postTransformRetry<FUNC>::call(func, ctx, std::move(v));
+        if constexpr (Funcs::HAS_MEMBER_postTransformRetry<FUNC>()) {
+            return Funcs::CALL_MEMBER_postTransformRetry<FUNC>::call(func, ctx, std::move(v));
         }
         return v;
     }
 
     ExpressionPtr mapNext(ExpressionPtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformNext<FUNC>()) {
-            return CALL_MEMBER_preTransformNext<FUNC>::call(func, ctx, std::move(v));
+        if constexpr (Funcs::HAS_MEMBER_preTransformNext<FUNC>()) {
+            return Funcs::CALL_MEMBER_preTransformNext<FUNC>::call(func, ctx, std::move(v));
         }
 
         cast_tree_nonnull<Next>(v).expr = mapIt(std::move(cast_tree_nonnull<Next>(v).expr), ctx);
 
-        if constexpr (HAS_MEMBER_postTransformNext<FUNC>()) {
-            return CALL_MEMBER_postTransformNext<FUNC>::call(func, ctx, std::move(v));
+        if constexpr (Funcs::HAS_MEMBER_postTransformNext<FUNC>()) {
+            return Funcs::CALL_MEMBER_postTransformNext<FUNC>::call(func, ctx, std::move(v));
         }
         return v;
     }
 
     ExpressionPtr mapReturn(ExpressionPtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformReturn<FUNC>()) {
-            v = CALL_MEMBER_preTransformReturn<FUNC>::call(func, ctx, std::move(v));
+        if constexpr (Funcs::HAS_MEMBER_preTransformReturn<FUNC>()) {
+            v = Funcs::CALL_MEMBER_preTransformReturn<FUNC>::call(func, ctx, std::move(v));
         }
         cast_tree_nonnull<Return>(v).expr = mapIt(std::move(cast_tree_nonnull<Return>(v).expr), ctx);
 
-        if constexpr (HAS_MEMBER_postTransformReturn<FUNC>()) {
-            return CALL_MEMBER_postTransformReturn<FUNC>::call(func, ctx, std::move(v));
+        if constexpr (Funcs::HAS_MEMBER_postTransformReturn<FUNC>()) {
+            return Funcs::CALL_MEMBER_postTransformReturn<FUNC>::call(func, ctx, std::move(v));
         }
 
         return v;
     }
 
     ExpressionPtr mapRescueCase(ExpressionPtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformRescueCase<FUNC>()) {
-            v = CALL_MEMBER_preTransformRescueCase<FUNC>::call(func, ctx, std::move(v));
+        if constexpr (Funcs::HAS_MEMBER_preTransformRescueCase<FUNC>()) {
+            v = Funcs::CALL_MEMBER_preTransformRescueCase<FUNC>::call(func, ctx, std::move(v));
         }
 
         for (auto &el : cast_tree_nonnull<RescueCase>(v).exceptions) {
@@ -316,15 +320,15 @@ private:
 
         cast_tree_nonnull<RescueCase>(v).body = mapIt(std::move(cast_tree_nonnull<RescueCase>(v).body), ctx);
 
-        if constexpr (HAS_MEMBER_postTransformRescueCase<FUNC>()) {
-            return CALL_MEMBER_postTransformRescueCase<FUNC>::call(func, ctx, std::move(v));
+        if constexpr (Funcs::HAS_MEMBER_postTransformRescueCase<FUNC>()) {
+            return Funcs::CALL_MEMBER_postTransformRescueCase<FUNC>::call(func, ctx, std::move(v));
         }
 
         return v;
     }
     ExpressionPtr mapRescue(ExpressionPtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformRescue<FUNC>()) {
-            v = CALL_MEMBER_preTransformRescue<FUNC>::call(func, ctx, std::move(v));
+        if constexpr (Funcs::HAS_MEMBER_preTransformRescue<FUNC>()) {
+            v = Funcs::CALL_MEMBER_preTransformRescue<FUNC>::call(func, ctx, std::move(v));
         }
 
         cast_tree_nonnull<Rescue>(v).body = mapIt(std::move(cast_tree_nonnull<Rescue>(v).body), ctx);
@@ -338,38 +342,38 @@ private:
         cast_tree_nonnull<Rescue>(v).else_ = mapIt(std::move(cast_tree_nonnull<Rescue>(v).else_), ctx);
         cast_tree_nonnull<Rescue>(v).ensure = mapIt(std::move(cast_tree_nonnull<Rescue>(v).ensure), ctx);
 
-        if constexpr (HAS_MEMBER_postTransformRescue<FUNC>()) {
-            return CALL_MEMBER_postTransformRescue<FUNC>::call(func, ctx, std::move(v));
+        if constexpr (Funcs::HAS_MEMBER_postTransformRescue<FUNC>()) {
+            return Funcs::CALL_MEMBER_postTransformRescue<FUNC>::call(func, ctx, std::move(v));
         }
 
         return v;
     }
 
     ExpressionPtr mapUnresolvedIdent(ExpressionPtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_postTransformUnresolvedIdent<FUNC>()) {
-            return CALL_MEMBER_postTransformUnresolvedIdent<FUNC>::call(func, ctx, std::move(v));
+        if constexpr (Funcs::HAS_MEMBER_postTransformUnresolvedIdent<FUNC>()) {
+            return Funcs::CALL_MEMBER_postTransformUnresolvedIdent<FUNC>::call(func, ctx, std::move(v));
         }
         return v;
     }
 
     ExpressionPtr mapAssign(ExpressionPtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformAssign<FUNC>()) {
-            v = CALL_MEMBER_preTransformAssign<FUNC>::call(func, ctx, std::move(v));
+        if constexpr (Funcs::HAS_MEMBER_preTransformAssign<FUNC>()) {
+            v = Funcs::CALL_MEMBER_preTransformAssign<FUNC>::call(func, ctx, std::move(v));
         }
 
         cast_tree_nonnull<Assign>(v).lhs = mapIt(std::move(cast_tree_nonnull<Assign>(v).lhs), ctx);
         cast_tree_nonnull<Assign>(v).rhs = mapIt(std::move(cast_tree_nonnull<Assign>(v).rhs), ctx);
 
-        if constexpr (HAS_MEMBER_postTransformAssign<FUNC>()) {
-            return CALL_MEMBER_postTransformAssign<FUNC>::call(func, ctx, std::move(v));
+        if constexpr (Funcs::HAS_MEMBER_postTransformAssign<FUNC>()) {
+            return Funcs::CALL_MEMBER_postTransformAssign<FUNC>::call(func, ctx, std::move(v));
         }
 
         return v;
     }
 
     ExpressionPtr mapSend(ExpressionPtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformSend<FUNC>()) {
-            v = CALL_MEMBER_preTransformSend<FUNC>::call(func, ctx, std::move(v));
+        if constexpr (Funcs::HAS_MEMBER_preTransformSend<FUNC>()) {
+            v = Funcs::CALL_MEMBER_preTransformSend<FUNC>::call(func, ctx, std::move(v));
         }
 
         cast_tree_nonnull<Send>(v).recv = mapIt(std::move(cast_tree_nonnull<Send>(v).recv), ctx);
@@ -384,16 +388,16 @@ private:
             ENFORCE(cast_tree_nonnull<Send>(v).block() != nullptr, "block was mapped into not-a block");
         }
 
-        if constexpr (HAS_MEMBER_postTransformSend<FUNC>()) {
-            return CALL_MEMBER_postTransformSend<FUNC>::call(func, ctx, std::move(v));
+        if constexpr (Funcs::HAS_MEMBER_postTransformSend<FUNC>()) {
+            return Funcs::CALL_MEMBER_postTransformSend<FUNC>::call(func, ctx, std::move(v));
         }
 
         return v;
     }
 
     ExpressionPtr mapHash(ExpressionPtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformHash<FUNC>()) {
-            v = CALL_MEMBER_preTransformHash<FUNC>::call(func, ctx, std::move(v));
+        if constexpr (Funcs::HAS_MEMBER_preTransformHash<FUNC>()) {
+            v = Funcs::CALL_MEMBER_preTransformHash<FUNC>::call(func, ctx, std::move(v));
         }
         for (auto &key : cast_tree_nonnull<Hash>(v).keys) {
             key = mapIt(std::move(key), ctx);
@@ -403,50 +407,50 @@ private:
             value = mapIt(std::move(value), ctx);
         }
 
-        if constexpr (HAS_MEMBER_postTransformArray<FUNC>()) {
-            return CALL_MEMBER_postTransformHash<FUNC>::call(func, ctx, std::move(v));
+        if constexpr (Funcs::HAS_MEMBER_postTransformArray<FUNC>()) {
+            return Funcs::CALL_MEMBER_postTransformHash<FUNC>::call(func, ctx, std::move(v));
         }
         return v;
     }
 
     ExpressionPtr mapArray(ExpressionPtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformArray<FUNC>()) {
-            v = CALL_MEMBER_preTransformArray<FUNC>::call(func, ctx, std::move(v));
+        if constexpr (Funcs::HAS_MEMBER_preTransformArray<FUNC>()) {
+            v = Funcs::CALL_MEMBER_preTransformArray<FUNC>::call(func, ctx, std::move(v));
         }
         for (auto &elem : cast_tree_nonnull<Array>(v).elems) {
             elem = mapIt(std::move(elem), ctx);
         }
 
-        if constexpr (HAS_MEMBER_postTransformArray<FUNC>()) {
-            return CALL_MEMBER_postTransformArray<FUNC>::call(func, ctx, std::move(v));
+        if constexpr (Funcs::HAS_MEMBER_postTransformArray<FUNC>()) {
+            return Funcs::CALL_MEMBER_postTransformArray<FUNC>::call(func, ctx, std::move(v));
         }
         return v;
     }
 
     ExpressionPtr mapLiteral(ExpressionPtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_postTransformLiteral<FUNC>()) {
-            return CALL_MEMBER_postTransformLiteral<FUNC>::call(func, ctx, std::move(v));
+        if constexpr (Funcs::HAS_MEMBER_postTransformLiteral<FUNC>()) {
+            return Funcs::CALL_MEMBER_postTransformLiteral<FUNC>::call(func, ctx, std::move(v));
         }
         return v;
     }
 
     ExpressionPtr mapUnresolvedConstantLit(ExpressionPtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_postTransformUnresolvedConstantLit<FUNC>()) {
-            return CALL_MEMBER_postTransformUnresolvedConstantLit<FUNC>::call(func, ctx, std::move(v));
+        if constexpr (Funcs::HAS_MEMBER_postTransformUnresolvedConstantLit<FUNC>()) {
+            return Funcs::CALL_MEMBER_postTransformUnresolvedConstantLit<FUNC>::call(func, ctx, std::move(v));
         }
         return v;
     }
 
     ExpressionPtr mapConstantLit(ExpressionPtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_postTransformConstantLit<FUNC>()) {
-            return CALL_MEMBER_postTransformConstantLit<FUNC>::call(func, ctx, std::move(v));
+        if constexpr (Funcs::HAS_MEMBER_postTransformConstantLit<FUNC>()) {
+            return Funcs::CALL_MEMBER_postTransformConstantLit<FUNC>::call(func, ctx, std::move(v));
         }
         return v;
     }
 
     ExpressionPtr mapBlock(ExpressionPtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformBlock<FUNC>()) {
-            v = CALL_MEMBER_preTransformBlock<FUNC>::call(func, ctx, std::move(v));
+        if constexpr (Funcs::HAS_MEMBER_preTransformBlock<FUNC>()) {
+            v = Funcs::CALL_MEMBER_preTransformBlock<FUNC>::call(func, ctx, std::move(v));
         }
 
         for (auto &arg : cast_tree_nonnull<Block>(v).args) {
@@ -457,15 +461,15 @@ private:
         }
         cast_tree_nonnull<Block>(v).body = mapIt(std::move(cast_tree_nonnull<Block>(v).body), ctx);
 
-        if constexpr (HAS_MEMBER_postTransformBlock<FUNC>()) {
-            return CALL_MEMBER_postTransformBlock<FUNC>::call(func, ctx, std::move(v));
+        if constexpr (Funcs::HAS_MEMBER_postTransformBlock<FUNC>()) {
+            return Funcs::CALL_MEMBER_postTransformBlock<FUNC>::call(func, ctx, std::move(v));
         }
         return v;
     }
 
     ExpressionPtr mapInsSeq(ExpressionPtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformInsSeq<FUNC>()) {
-            v = CALL_MEMBER_preTransformInsSeq<FUNC>::call(func, ctx, std::move(v));
+        if constexpr (Funcs::HAS_MEMBER_preTransformInsSeq<FUNC>()) {
+            v = Funcs::CALL_MEMBER_preTransformInsSeq<FUNC>::call(func, ctx, std::move(v));
         }
 
         for (auto &stat : cast_tree_nonnull<InsSeq>(v).stats) {
@@ -474,36 +478,36 @@ private:
 
         cast_tree_nonnull<InsSeq>(v).expr = mapIt(std::move(cast_tree_nonnull<InsSeq>(v).expr), ctx);
 
-        if constexpr (HAS_MEMBER_postTransformInsSeq<FUNC>()) {
-            return CALL_MEMBER_postTransformInsSeq<FUNC>::call(func, ctx, std::move(v));
+        if constexpr (Funcs::HAS_MEMBER_postTransformInsSeq<FUNC>()) {
+            return Funcs::CALL_MEMBER_postTransformInsSeq<FUNC>::call(func, ctx, std::move(v));
         }
 
         return v;
     }
 
     ExpressionPtr mapLocal(ExpressionPtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_postTransformLocal<FUNC>()) {
-            return CALL_MEMBER_postTransformLocal<FUNC>::call(func, ctx, std::move(v));
+        if constexpr (Funcs::HAS_MEMBER_postTransformLocal<FUNC>()) {
+            return Funcs::CALL_MEMBER_postTransformLocal<FUNC>::call(func, ctx, std::move(v));
         }
         return v;
     }
 
     ExpressionPtr mapCast(ExpressionPtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_preTransformCast<FUNC>()) {
-            v = CALL_MEMBER_preTransformCast<FUNC>::call(func, ctx, std::move(v));
+        if constexpr (Funcs::HAS_MEMBER_preTransformCast<FUNC>()) {
+            v = Funcs::CALL_MEMBER_preTransformCast<FUNC>::call(func, ctx, std::move(v));
         }
         cast_tree_nonnull<Cast>(v).arg = mapIt(std::move(cast_tree_nonnull<Cast>(v).arg), ctx);
 
-        if constexpr (HAS_MEMBER_postTransformCast<FUNC>()) {
-            return CALL_MEMBER_postTransformCast<FUNC>::call(func, ctx, std::move(v));
+        if constexpr (Funcs::HAS_MEMBER_postTransformCast<FUNC>()) {
+            return Funcs::CALL_MEMBER_postTransformCast<FUNC>::call(func, ctx, std::move(v));
         }
 
         return v;
     }
 
     ExpressionPtr mapRuntimeMethodDefinition(ExpressionPtr v, CTX ctx) {
-        if constexpr (HAS_MEMBER_postTransformRuntimeMethodDefinition<FUNC>()) {
-            return CALL_MEMBER_postTransformRuntimeMethodDefinition<FUNC>::call(func, ctx, std::move(v));
+        if constexpr (Funcs::HAS_MEMBER_postTransformRuntimeMethodDefinition<FUNC>()) {
+            return Funcs::CALL_MEMBER_postTransformRuntimeMethodDefinition<FUNC>::call(func, ctx, std::move(v));
         }
 
         return v;
@@ -517,8 +521,8 @@ private:
 
         try {
             // TODO: reorder by frequency
-            if constexpr (HAS_MEMBER_preTransformExpression<FUNC>()) {
-                what = CALL_MEMBER_preTransformExpression<FUNC>::call(func, ctx, std::move(what));
+            if constexpr (Funcs::HAS_MEMBER_preTransformExpression<FUNC>()) {
+                what = Funcs::CALL_MEMBER_preTransformExpression<FUNC>::call(func, ctx, std::move(what));
             }
 
             switch (what.tag()) {

--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -183,6 +183,7 @@ private:
     friend class ShallowMap;
 
     using Funcs = MapFunctions<Kind>;
+    using return_type = typename Funcs::return_type;
 
     FUNC &func;
 
@@ -195,7 +196,7 @@ private:
 
     TreeMapper(FUNC &func) : func(func) {}
 
-    ExpressionPtr mapClassDef(ExpressionPtr v, CTX ctx) {
+    return_type mapClassDef(ExpressionPtr v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_preTransformClassDef<FUNC>()) {
             v = Funcs::template CALL_MEMBER_preTransformClassDef<FUNC>::call(func, ctx, Funcs::pass(v));
         }
@@ -222,7 +223,7 @@ private:
         return v;
     }
 
-    ExpressionPtr mapMethodDef(ExpressionPtr v, CTX ctx) {
+    return_type mapMethodDef(ExpressionPtr v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_preTransformMethodDef<FUNC>()) {
             v = Funcs::template CALL_MEMBER_preTransformMethodDef<FUNC>::call(func, ctx, Funcs::pass(v));
         }
@@ -248,7 +249,7 @@ private:
         return v;
     }
 
-    ExpressionPtr mapIf(ExpressionPtr v, CTX ctx) {
+    return_type mapIf(ExpressionPtr v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_preTransformIf<FUNC>()) {
             v = Funcs::template CALL_MEMBER_preTransformIf<FUNC>::call(func, ctx, Funcs::pass(v));
         }
@@ -262,7 +263,7 @@ private:
         return v;
     }
 
-    ExpressionPtr mapWhile(ExpressionPtr v, CTX ctx) {
+    return_type mapWhile(ExpressionPtr v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_preTransformWhile<FUNC>()) {
             v = Funcs::template CALL_MEMBER_preTransformWhile<FUNC>::call(func, ctx, Funcs::pass(v));
         }
@@ -275,7 +276,7 @@ private:
         return v;
     }
 
-    ExpressionPtr mapBreak(ExpressionPtr v, CTX ctx) {
+    return_type mapBreak(ExpressionPtr v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_preTransformBreak<FUNC>()) {
             return Funcs::template CALL_MEMBER_preTransformBreak<FUNC>::call(func, ctx, Funcs::pass(v));
         }
@@ -287,14 +288,14 @@ private:
         }
         return v;
     }
-    ExpressionPtr mapRetry(ExpressionPtr v, CTX ctx) {
+    return_type mapRetry(ExpressionPtr v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_postTransformRetry<FUNC>()) {
             return Funcs::template CALL_MEMBER_postTransformRetry<FUNC>::call(func, ctx, Funcs::pass(v));
         }
         return v;
     }
 
-    ExpressionPtr mapNext(ExpressionPtr v, CTX ctx) {
+    return_type mapNext(ExpressionPtr v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_preTransformNext<FUNC>()) {
             return Funcs::template CALL_MEMBER_preTransformNext<FUNC>::call(func, ctx, Funcs::pass(v));
         }
@@ -307,7 +308,7 @@ private:
         return v;
     }
 
-    ExpressionPtr mapReturn(ExpressionPtr v, CTX ctx) {
+    return_type mapReturn(ExpressionPtr v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_preTransformReturn<FUNC>()) {
             v = Funcs::template CALL_MEMBER_preTransformReturn<FUNC>::call(func, ctx, Funcs::pass(v));
         }
@@ -320,7 +321,7 @@ private:
         return v;
     }
 
-    ExpressionPtr mapRescueCase(ExpressionPtr v, CTX ctx) {
+    return_type mapRescueCase(ExpressionPtr v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_preTransformRescueCase<FUNC>()) {
             v = Funcs::template CALL_MEMBER_preTransformRescueCase<FUNC>::call(func, ctx, Funcs::pass(v));
         }
@@ -339,7 +340,7 @@ private:
 
         return v;
     }
-    ExpressionPtr mapRescue(ExpressionPtr v, CTX ctx) {
+    return_type mapRescue(ExpressionPtr v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_preTransformRescue<FUNC>()) {
             v = Funcs::template CALL_MEMBER_preTransformRescue<FUNC>::call(func, ctx, Funcs::pass(v));
         }
@@ -362,14 +363,14 @@ private:
         return v;
     }
 
-    ExpressionPtr mapUnresolvedIdent(ExpressionPtr v, CTX ctx) {
+    return_type mapUnresolvedIdent(ExpressionPtr v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_postTransformUnresolvedIdent<FUNC>()) {
             return Funcs::template CALL_MEMBER_postTransformUnresolvedIdent<FUNC>::call(func, ctx, Funcs::pass(v));
         }
         return v;
     }
 
-    ExpressionPtr mapAssign(ExpressionPtr v, CTX ctx) {
+    return_type mapAssign(ExpressionPtr v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_preTransformAssign<FUNC>()) {
             v = Funcs::template CALL_MEMBER_preTransformAssign<FUNC>::call(func, ctx, Funcs::pass(v));
         }
@@ -384,7 +385,7 @@ private:
         return v;
     }
 
-    ExpressionPtr mapSend(ExpressionPtr v, CTX ctx) {
+    return_type mapSend(ExpressionPtr v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_preTransformSend<FUNC>()) {
             v = Funcs::template CALL_MEMBER_preTransformSend<FUNC>::call(func, ctx, Funcs::pass(v));
         }
@@ -408,7 +409,7 @@ private:
         return v;
     }
 
-    ExpressionPtr mapHash(ExpressionPtr v, CTX ctx) {
+    return_type mapHash(ExpressionPtr v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_preTransformHash<FUNC>()) {
             v = Funcs::template CALL_MEMBER_preTransformHash<FUNC>::call(func, ctx, Funcs::pass(v));
         }
@@ -426,7 +427,7 @@ private:
         return v;
     }
 
-    ExpressionPtr mapArray(ExpressionPtr v, CTX ctx) {
+    return_type mapArray(ExpressionPtr v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_preTransformArray<FUNC>()) {
             v = Funcs::template CALL_MEMBER_preTransformArray<FUNC>::call(func, ctx, Funcs::pass(v));
         }
@@ -440,28 +441,28 @@ private:
         return v;
     }
 
-    ExpressionPtr mapLiteral(ExpressionPtr v, CTX ctx) {
+    return_type mapLiteral(ExpressionPtr v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_postTransformLiteral<FUNC>()) {
             return Funcs::template CALL_MEMBER_postTransformLiteral<FUNC>::call(func, ctx, Funcs::pass(v));
         }
         return v;
     }
 
-    ExpressionPtr mapUnresolvedConstantLit(ExpressionPtr v, CTX ctx) {
+    return_type mapUnresolvedConstantLit(ExpressionPtr v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_postTransformUnresolvedConstantLit<FUNC>()) {
             return Funcs::template CALL_MEMBER_postTransformUnresolvedConstantLit<FUNC>::call(func, ctx, Funcs::pass(v));
         }
         return v;
     }
 
-    ExpressionPtr mapConstantLit(ExpressionPtr v, CTX ctx) {
+    return_type mapConstantLit(ExpressionPtr v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_postTransformConstantLit<FUNC>()) {
             return Funcs::template CALL_MEMBER_postTransformConstantLit<FUNC>::call(func, ctx, Funcs::pass(v));
         }
         return v;
     }
 
-    ExpressionPtr mapBlock(ExpressionPtr v, CTX ctx) {
+    return_type mapBlock(ExpressionPtr v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_preTransformBlock<FUNC>()) {
             v = Funcs::template CALL_MEMBER_preTransformBlock<FUNC>::call(func, ctx, Funcs::pass(v));
         }
@@ -480,7 +481,7 @@ private:
         return v;
     }
 
-    ExpressionPtr mapInsSeq(ExpressionPtr v, CTX ctx) {
+    return_type mapInsSeq(ExpressionPtr v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_preTransformInsSeq<FUNC>()) {
             v = Funcs::template CALL_MEMBER_preTransformInsSeq<FUNC>::call(func, ctx, Funcs::pass(v));
         }
@@ -498,14 +499,14 @@ private:
         return v;
     }
 
-    ExpressionPtr mapLocal(ExpressionPtr v, CTX ctx) {
+    return_type mapLocal(ExpressionPtr v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_postTransformLocal<FUNC>()) {
             return Funcs::template CALL_MEMBER_postTransformLocal<FUNC>::call(func, ctx, Funcs::pass(v));
         }
         return v;
     }
 
-    ExpressionPtr mapCast(ExpressionPtr v, CTX ctx) {
+    return_type mapCast(ExpressionPtr v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_preTransformCast<FUNC>()) {
             v = Funcs::template CALL_MEMBER_preTransformCast<FUNC>::call(func, ctx, Funcs::pass(v));
         }
@@ -518,7 +519,7 @@ private:
         return v;
     }
 
-    ExpressionPtr mapRuntimeMethodDefinition(ExpressionPtr v, CTX ctx) {
+    return_type mapRuntimeMethodDefinition(ExpressionPtr v, CTX ctx) {
         if constexpr (Funcs::template HAS_MEMBER_postTransformRuntimeMethodDefinition<FUNC>()) {
             return Funcs::template CALL_MEMBER_postTransformRuntimeMethodDefinition<FUNC>::call(func, ctx, Funcs::pass(v));
         }
@@ -526,7 +527,7 @@ private:
         return v;
     }
 
-    ExpressionPtr mapIt(ExpressionPtr what, CTX ctx) {
+    return_type mapIt(ExpressionPtr what, CTX ctx) {
         if (what == nullptr) {
             return what;
         }

--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -74,67 +74,72 @@ public:
 
 // NOTE: Implementations must use a context type parameter that `MutableContext` is convertable to.
 // That is, either `Context` or `MutableContext`.
-#define GENERATE_HAS_MEMBER_VISITOR(X) \
-    GENERATE_HAS_MEMBER(X, std::declval<core::MutableContext>(), std::declval<ExpressionPtr>())
+#define GENERATE_HAS_MEMBER_VISITOR(X, arg_types...)                               \
+    GENERATE_HAS_MEMBER(X, arg_types)
 
 // used to check for ABSENCE of method
-GENERATE_HAS_MEMBER_VISITOR(preTransformUnresolvedIdent);
-GENERATE_HAS_MEMBER_VISITOR(preTransformLocal);
-GENERATE_HAS_MEMBER_VISITOR(preTransformUnresolvedConstantLit);
-GENERATE_HAS_MEMBER_VISITOR(preTransformConstantLit);
-GENERATE_HAS_MEMBER_VISITOR(preTransformLiteral);
-GENERATE_HAS_MEMBER_VISITOR(preTransformRuntimeMethodDefinition);
 
-#define GENERATE_POSTPONE_PRECLASS(X)                                                                            \
+#define GENERATE_POSTPONE_PRECLASS(X, arg_types...)                                  \
     GENERATE_CALL_MEMBER(preTransform##X, Exception::raise("should never be called. Incorrect use of TreeMap?"); \
-                         return nullptr, std::declval<core::MutableContext>(), std::declval<ExpressionPtr>())
+                         return nullptr, arg_types)
 
-#define GENERATE_POSTPONE_POSTCLASS(X)                                                                            \
+#define GENERATE_POSTPONE_POSTCLASS(X, arg_types...)                                 \
     GENERATE_CALL_MEMBER(postTransform##X, Exception::raise("should never be called. Incorrect use of TreeMap?"); \
-                         return nullptr, std::declval<core::MutableContext>(), std::declval<ExpressionPtr>())
+                         return nullptr, arg_types)
 
-GENERATE_POSTPONE_PRECLASS(Expression);
-GENERATE_POSTPONE_PRECLASS(ClassDef);
-GENERATE_POSTPONE_PRECLASS(MethodDef);
-GENERATE_POSTPONE_PRECLASS(If);
-GENERATE_POSTPONE_PRECLASS(While);
-GENERATE_POSTPONE_PRECLASS(Break);
-GENERATE_POSTPONE_PRECLASS(Retry);
-GENERATE_POSTPONE_PRECLASS(Next);
-GENERATE_POSTPONE_PRECLASS(Return);
-GENERATE_POSTPONE_PRECLASS(RescueCase);
-GENERATE_POSTPONE_PRECLASS(Rescue);
-GENERATE_POSTPONE_PRECLASS(Assign);
-GENERATE_POSTPONE_PRECLASS(Send);
-GENERATE_POSTPONE_PRECLASS(Hash);
-GENERATE_POSTPONE_PRECLASS(Array);
-GENERATE_POSTPONE_PRECLASS(Block);
-GENERATE_POSTPONE_PRECLASS(InsSeq);
-GENERATE_POSTPONE_PRECLASS(Cast);
 
-GENERATE_POSTPONE_POSTCLASS(ClassDef);
-GENERATE_POSTPONE_POSTCLASS(MethodDef);
-GENERATE_POSTPONE_POSTCLASS(If);
-GENERATE_POSTPONE_POSTCLASS(While);
-GENERATE_POSTPONE_POSTCLASS(Break);
-GENERATE_POSTPONE_POSTCLASS(Retry);
-GENERATE_POSTPONE_POSTCLASS(Next);
-GENERATE_POSTPONE_POSTCLASS(Return);
-GENERATE_POSTPONE_POSTCLASS(RescueCase);
-GENERATE_POSTPONE_POSTCLASS(Rescue);
-GENERATE_POSTPONE_POSTCLASS(UnresolvedIdent);
-GENERATE_POSTPONE_POSTCLASS(Assign);
-GENERATE_POSTPONE_POSTCLASS(Send);
-GENERATE_POSTPONE_POSTCLASS(Hash);
-GENERATE_POSTPONE_POSTCLASS(Array);
-GENERATE_POSTPONE_POSTCLASS(Local);
-GENERATE_POSTPONE_POSTCLASS(Literal);
-GENERATE_POSTPONE_POSTCLASS(UnresolvedConstantLit);
-GENERATE_POSTPONE_POSTCLASS(ConstantLit);
-GENERATE_POSTPONE_POSTCLASS(Block);
-GENERATE_POSTPONE_POSTCLASS(InsSeq);
-GENERATE_POSTPONE_POSTCLASS(Cast);
-GENERATE_POSTPONE_POSTCLASS(RuntimeMethodDefinition);
+#define GENERATE_METAPROGRAMMING_FOR(arg_types...) \
+GENERATE_HAS_MEMBER_VISITOR(preTransformUnresolvedIdent, arg_types); \
+GENERATE_HAS_MEMBER_VISITOR(preTransformLocal, arg_types); \
+GENERATE_HAS_MEMBER_VISITOR(preTransformUnresolvedConstantLit, arg_types); \
+GENERATE_HAS_MEMBER_VISITOR(preTransformConstantLit, arg_types); \
+GENERATE_HAS_MEMBER_VISITOR(preTransformLiteral, arg_types); \
+GENERATE_HAS_MEMBER_VISITOR(preTransformRuntimeMethodDefinition, arg_types); \
+ \
+GENERATE_POSTPONE_PRECLASS(Expression, arg_types); \
+GENERATE_POSTPONE_PRECLASS(ClassDef, arg_types); \
+GENERATE_POSTPONE_PRECLASS(MethodDef, arg_types); \
+GENERATE_POSTPONE_PRECLASS(If, arg_types); \
+GENERATE_POSTPONE_PRECLASS(While, arg_types); \
+GENERATE_POSTPONE_PRECLASS(Break, arg_types); \
+GENERATE_POSTPONE_PRECLASS(Retry, arg_types); \
+GENERATE_POSTPONE_PRECLASS(Next, arg_types); \
+GENERATE_POSTPONE_PRECLASS(Return, arg_types); \
+GENERATE_POSTPONE_PRECLASS(RescueCase, arg_types); \
+GENERATE_POSTPONE_PRECLASS(Rescue, arg_types); \
+GENERATE_POSTPONE_PRECLASS(Assign, arg_types); \
+GENERATE_POSTPONE_PRECLASS(Send, arg_types); \
+GENERATE_POSTPONE_PRECLASS(Hash, arg_types); \
+GENERATE_POSTPONE_PRECLASS(Array, arg_types); \
+GENERATE_POSTPONE_PRECLASS(Block, arg_types); \
+GENERATE_POSTPONE_PRECLASS(InsSeq, arg_types); \
+GENERATE_POSTPONE_PRECLASS(Cast, arg_types); \
+\
+GENERATE_POSTPONE_POSTCLASS(ClassDef, arg_types); \
+GENERATE_POSTPONE_POSTCLASS(MethodDef, arg_types); \
+GENERATE_POSTPONE_POSTCLASS(If, arg_types); \
+GENERATE_POSTPONE_POSTCLASS(While, arg_types); \
+GENERATE_POSTPONE_POSTCLASS(Break, arg_types); \
+GENERATE_POSTPONE_POSTCLASS(Retry, arg_types); \
+GENERATE_POSTPONE_POSTCLASS(Next, arg_types); \
+GENERATE_POSTPONE_POSTCLASS(Return, arg_types); \
+GENERATE_POSTPONE_POSTCLASS(RescueCase, arg_types); \
+GENERATE_POSTPONE_POSTCLASS(Rescue, arg_types); \
+GENERATE_POSTPONE_POSTCLASS(UnresolvedIdent, arg_types); \
+GENERATE_POSTPONE_POSTCLASS(Assign, arg_types); \
+GENERATE_POSTPONE_POSTCLASS(Send, arg_types); \
+GENERATE_POSTPONE_POSTCLASS(Hash, arg_types); \
+GENERATE_POSTPONE_POSTCLASS(Array, arg_types); \
+GENERATE_POSTPONE_POSTCLASS(Local, arg_types); \
+GENERATE_POSTPONE_POSTCLASS(Literal, arg_types); \
+GENERATE_POSTPONE_POSTCLASS(UnresolvedConstantLit, arg_types); \
+GENERATE_POSTPONE_POSTCLASS(ConstantLit, arg_types); \
+GENERATE_POSTPONE_POSTCLASS(Block, arg_types); \
+GENERATE_POSTPONE_POSTCLASS(InsSeq, arg_types); \
+GENERATE_POSTPONE_POSTCLASS(Cast, arg_types); \
+GENERATE_POSTPONE_POSTCLASS(RuntimeMethodDefinition, arg_types); \
+
+GENERATE_METAPROGRAMMING_FOR(std::declval<core::MutableContext>(), std::declval<ExpressionPtr>());
 
 // Used to indicate that TreeMap has already reported location for this exception
 struct ReportedRubyException {

--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -147,6 +147,10 @@ struct ReportedRubyException {
     core::LocOffsets onLoc;
 };
 
+enum class TreeMapKind {
+    Map,
+};
+
 enum class TreeMapDepthKind {
     Full,
     Shallow,
@@ -158,7 +162,7 @@ enum class TreeMapDepthKind {
  * FUNC may maintain internal state.
  * @tparam tree transformer, see FUNC_EXAMPLE
  */
-template <class FUNC, class CTX, TreeMapDepthKind DepthKind> class TreeMapper {
+template <class FUNC, class CTX, TreeMapKind Kind, TreeMapDepthKind DepthKind> class TreeMapper {
 private:
     friend class TreeMap;
     friend class ShallowMap;
@@ -625,7 +629,7 @@ private:
 class TreeMap {
 public:
     template <typename CTX, typename FUNC> static ExpressionPtr apply(CTX ctx, FUNC &func, ExpressionPtr to) {
-        TreeMapper<FUNC, CTX, TreeMapDepthKind::Full> walker(func);
+        TreeMapper<FUNC, CTX, TreeMapKind::Map, TreeMapDepthKind::Full> walker(func);
         try {
             return walker.mapIt(std::move(to), ctx);
         } catch (ReportedRubyException &exception) {
@@ -641,7 +645,7 @@ public:
 class ShallowMap {
 public:
     template <typename CTX, typename FUNC> static ExpressionPtr apply(CTX ctx, FUNC &func, ExpressionPtr to) {
-        TreeMapper<FUNC, CTX, TreeMapDepthKind::Shallow> walker(func);
+        TreeMapper<FUNC, CTX, TreeMapKind::Map, TreeMapDepthKind::Shallow> walker(func);
         try {
             return walker.mapIt(std::move(to), ctx);
         } catch (ReportedRubyException &exception) {

--- a/ast/verifier/Verifier.cc
+++ b/ast/verifier/Verifier.cc
@@ -8,37 +8,31 @@ class VerifierWalker {
     uint32_t methodDepth = 0;
 
 public:
-    ExpressionPtr preTransformExpression(core::Context ctx, ExpressionPtr original) {
+    void preTransformExpression(core::Context ctx, ExpressionPtr &original) {
         if (!isa_tree<EmptyTree>(original)) {
             ENFORCE(original.loc().exists(), "location is unset");
         }
 
         original._sanityCheck();
-
-        return original;
     }
 
-    ExpressionPtr preTransformMethodDef(core::Context ctx, ExpressionPtr original) {
+    void preTransformMethodDef(core::Context ctx, ExpressionPtr &original) {
         methodDepth++;
-        return original;
     }
 
-    ExpressionPtr postTransformMethodDef(core::Context ctx, ExpressionPtr original) {
+    void postTransformMethodDef(core::Context ctx, ExpressionPtr &original) {
         methodDepth--;
-        return original;
     }
 
-    ExpressionPtr postTransformAssign(core::Context ctx, ExpressionPtr original) {
+    void postTransformAssign(core::Context ctx, ExpressionPtr &original) {
         auto *assign = cast_tree<Assign>(original);
         if (ast::isa_tree<ast::UnresolvedConstantLit>(assign->lhs)) {
             ENFORCE(methodDepth == 0, "Found constant definition inside method definition");
         }
-        return original;
     }
 
-    ExpressionPtr preTransformBlock(core::Context ctx, ExpressionPtr original) {
+    void preTransformBlock(core::Context ctx, ExpressionPtr &original) {
         original._sanityCheck();
-        return original;
     }
 };
 
@@ -47,7 +41,8 @@ ExpressionPtr Verifier::run(core::Context ctx, ExpressionPtr node) {
         return node;
     }
     VerifierWalker vw;
-    return TreeMap::apply(ctx, vw, move(node));
+    TreeWalk::apply(ctx, vw, node);
+    return node;
 }
 
 } // namespace sorbet::ast

--- a/class_flatten/class_flatten.cc
+++ b/class_flatten/class_flatten.cc
@@ -162,7 +162,7 @@ private:
     // them by their starts, so that `class A; class B; end; end` --> `class A;
     // end; class B; end`.
     //
-    // In order to make TreeMap work out, we can't remove them from the AST
+    // In order to make TreeWalk work out, we can't remove them from the AST
     // until the `postTransform*` hook. Appending them to a list at that point
     // would result in an "bottom-up" ordering, so instead we store a stack of
     // "where does the next definition belong" into `classStack`

--- a/class_flatten/class_flatten.cc
+++ b/class_flatten/class_flatten.cc
@@ -61,14 +61,12 @@ public:
         ENFORCE(classStack.empty());
     }
 
-    ast::ExpressionPtr preTransformClassDef(core::Context ctx, ast::ExpressionPtr tree) {
+    void preTransformClassDef(core::Context ctx, ast::ExpressionPtr &tree) {
         classStack.emplace_back(classes.size());
         classes.emplace_back();
-
-        return tree;
     }
 
-    ast::ExpressionPtr postTransformClassDef(core::Context ctx, ast::ExpressionPtr tree) {
+    void postTransformClassDef(core::Context ctx, ast::ExpressionPtr &tree) {
         ENFORCE(!classStack.empty());
         ENFORCE(classes.size() > classStack.back());
         ENFORCE(classes[classStack.back()] == nullptr);
@@ -124,7 +122,7 @@ public:
         classes[classStack.back()] = std::move(tree);
         classStack.pop_back();
 
-        return replacement;
+        tree = std::move(replacement);
     };
 
     ast::ExpressionPtr addClasses(core::Context ctx, ast::ExpressionPtr tree) {
@@ -175,7 +173,7 @@ private:
 
 ast::ParsedFile runOne(core::Context ctx, ast::ParsedFile tree) {
     ClassFlattenWalk flatten;
-    tree.tree = ast::TreeMap::apply(ctx, flatten, std::move(tree.tree));
+    ast::TreeWalk::apply(ctx, flatten, tree.tree);
     tree.tree = flatten.addClasses(ctx, std::move(tree.tree));
 
     return tree;

--- a/common/has_member.h
+++ b/common/has_member.h
@@ -19,14 +19,12 @@ template <class> struct sfinae_true : std::true_type {};
  *
  * Adapted from https://stackoverflow.com/a/9154394
  */
-#define GENERATE_HAS_MEMBER(name, arg_types...)                                                            \
-    namespace __HAS_MEMBER_##name {                                                                        \
-        template <class T>                                                                                 \
-        static constexpr auto __has_##name(int)->sfinae_true<decltype(std::declval<T>().name(arg_types))>; \
-        template <class> static constexpr auto __has_##name(long)->std::false_type;                        \
-    };                                                                                                     \
+#define GENERATE_HAS_MEMBER(name, arg_types...)                         \
+    template <class T>                                                  \
+    static constexpr auto __has_##name(int)->sfinae_true<decltype(std::declval<T>().name(arg_types))>; \
+    template <class> static constexpr auto __has_##name(long)->std::false_type; \
     template <class T> constexpr bool HAS_MEMBER_##name() {                                                \
-        return decltype(__HAS_MEMBER_##name::__has_##name<T>(0)){};                                        \
+        return decltype(__has_##name<T>(0)){};                                        \
     }
 
 /**

--- a/common/has_member.h
+++ b/common/has_member.h
@@ -23,7 +23,7 @@ template <class> struct sfinae_true : std::true_type {};
     template <class T>                                                  \
     static constexpr auto __has_##name(int)->sfinae_true<decltype(std::declval<T>().name(arg_types))>; \
     template <class> static constexpr auto __has_##name(long)->std::false_type; \
-    template <class T> constexpr bool HAS_MEMBER_##name() {                                                \
+    template <class T> static constexpr bool HAS_MEMBER_##name() {                                                \
         return decltype(__has_##name<T>(0)){};                                        \
     }
 

--- a/common/has_member.h
+++ b/common/has_member.h
@@ -19,12 +19,12 @@ template <class> struct sfinae_true : std::true_type {};
  *
  * Adapted from https://stackoverflow.com/a/9154394
  */
-#define GENERATE_HAS_MEMBER(name, arg_types...)                         \
-    template <class T>                                                  \
+#define GENERATE_HAS_MEMBER(name, arg_types...)                                                        \
+    template <class T>                                                                                 \
     static constexpr auto __has_##name(int)->sfinae_true<decltype(std::declval<T>().name(arg_types))>; \
-    template <class> static constexpr auto __has_##name(long)->std::false_type; \
-    template <class T> static constexpr bool HAS_MEMBER_##name() {                                                \
-        return decltype(__has_##name<T>(0)){};                                        \
+    template <class> static constexpr auto __has_##name(long)->std::false_type;                        \
+    template <class T> static constexpr bool HAS_MEMBER_##name() {                                     \
+        return decltype(__has_##name<T>(0)){};                                                         \
     }
 
 /**

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -767,7 +767,7 @@ private:
     }
 
 public:
-    ast::ExpressionPtr preTransformClassDef(core::Context ctx, ast::ExpressionPtr tree) {
+    void preTransformClassDef(core::Context ctx, ast::ExpressionPtr &tree) {
         auto &classDef = ast::cast_tree_nonnull<ast::ClassDef>(tree);
         auto sym = classDef.symbol;
         auto singleton = sym.data(ctx)->lookupSingletonClass(ctx);
@@ -789,10 +789,9 @@ public:
         if (ctx.state.requiresAncestorEnabled) {
             validateRequiredAncestors(ctx, singleton);
         }
-        return tree;
     }
 
-    ast::ExpressionPtr preTransformMethodDef(core::Context ctx, ast::ExpressionPtr tree) {
+    void preTransformMethodDef(core::Context ctx, ast::ExpressionPtr &tree) {
         auto &methodDef = ast::cast_tree_nonnull<ast::MethodDef>(tree);
         auto methodData = methodDef.symbol.data(ctx);
         auto ownerData = methodData->owner.data(ctx);
@@ -807,7 +806,6 @@ public:
         }
 
         validateOverriding(ctx, methodDef.symbol);
-        return tree;
     }
 };
 } // namespace
@@ -816,7 +814,7 @@ ast::ParsedFile runOne(core::Context ctx, ast::ParsedFile tree) {
     Timer timeit(ctx.state.tracer(), "validateSymbols");
 
     ValidateWalk validate;
-    tree.tree = ast::ShallowMap::apply(ctx, validate, std::move(tree.tree));
+    ast::ShallowWalk::apply(ctx, validate, tree.tree);
     return tree;
 }
 

--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -6,7 +6,7 @@
 using namespace std;
 namespace sorbet::realmain::lsp {
 
-ast::ExpressionPtr DefLocSaver::postTransformMethodDef(core::Context ctx, ast::ExpressionPtr tree) {
+void DefLocSaver::postTransformMethodDef(core::Context ctx, ast::ExpressionPtr &tree) {
     auto &methodDef = ast::cast_tree_nonnull<ast::MethodDef>(tree);
 
     const core::lsp::Query &lspQuery = ctx.state.lspQuery;
@@ -34,7 +34,7 @@ ast::ExpressionPtr DefLocSaver::postTransformMethodDef(core::Context ctx, ast::E
                 core::lsp::QueryResponse::pushQueryResponse(
                     ctx,
                     core::lsp::IdentResponse(ctx.locAt(localExp->loc), localExp->localVariable, tp, methodDef.symbol));
-                return tree;
+                return;
             }
         }
 
@@ -43,11 +43,9 @@ ast::ExpressionPtr DefLocSaver::postTransformMethodDef(core::Context ctx, ast::E
         core::lsp::QueryResponse::pushQueryResponse(
             ctx, core::lsp::MethodDefResponse(methodDef.symbol, ctx.locAt(methodDef.declLoc), methodDef.name, tp));
     }
-
-    return tree;
 }
 
-ast::ExpressionPtr DefLocSaver::postTransformUnresolvedIdent(core::Context ctx, ast::ExpressionPtr tree) {
+void DefLocSaver::postTransformUnresolvedIdent(core::Context ctx, ast::ExpressionPtr &tree) {
     auto &id = ast::cast_tree_nonnull<ast::UnresolvedIdent>(tree);
     if (id.kind == ast::UnresolvedIdent::Kind::Instance || id.kind == ast::UnresolvedIdent::Kind::Class) {
         core::ClassOrModuleRef klass;
@@ -75,7 +73,6 @@ ast::ExpressionPtr DefLocSaver::postTransformUnresolvedIdent(core::Context ctx, 
                 ctx, core::lsp::FieldResponse(field, ctx.locAt(id.loc), id.name, tp));
         }
     }
-    return tree;
 }
 
 namespace {
@@ -138,11 +135,10 @@ void matchesQuery(core::Context ctx, ast::ConstantLit *lit, const core::lsp::Que
 
 } // namespace
 
-ast::ExpressionPtr DefLocSaver::postTransformConstantLit(core::Context ctx, ast::ExpressionPtr tree) {
+void DefLocSaver::postTransformConstantLit(core::Context ctx, ast::ExpressionPtr &tree) {
     auto &lit = ast::cast_tree_nonnull<ast::ConstantLit>(tree);
     const core::lsp::Query &lspQuery = ctx.state.lspQuery;
     matchesQuery(ctx, &lit, lspQuery, lit.symbol);
-    return tree;
 }
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/DefLocSaver.h
+++ b/main/lsp/DefLocSaver.h
@@ -7,11 +7,11 @@ namespace sorbet::realmain::lsp {
 class DefLocSaver {
 public:
     // Handles loc and symbol requests for method definitions.
-    ast::ExpressionPtr postTransformMethodDef(core::Context ctx, ast::ExpressionPtr methodDef);
+    void postTransformMethodDef(core::Context ctx, ast::ExpressionPtr &methodDef);
     // Handles loc and symbol requests for instance variables.
-    ast::ExpressionPtr postTransformUnresolvedIdent(core::Context ctx, ast::ExpressionPtr id);
+    void postTransformUnresolvedIdent(core::Context ctx, ast::ExpressionPtr &id);
 
     // Handles loc and symbol requests for constants.
-    ast::ExpressionPtr postTransformConstantLit(core::Context ctx, ast::ExpressionPtr lit);
+    void postTransformConstantLit(core::Context ctx, ast::ExpressionPtr &lit);
 };
 }; // namespace sorbet::realmain::lsp

--- a/main/lsp/FieldFinder.cc
+++ b/main/lsp/FieldFinder.cc
@@ -11,41 +11,37 @@ FieldFinder::FieldFinder(core::ClassOrModuleRef target, ast::UnresolvedIdent::Ki
     ENFORCE(queryKind != ast::UnresolvedIdent::Kind::Local);
 }
 
-ast::ExpressionPtr FieldFinder::postTransformUnresolvedIdent(core::Context ctx, ast::ExpressionPtr tree) {
+void FieldFinder::postTransformUnresolvedIdent(core::Context ctx, ast::ExpressionPtr &tree) {
     ENFORCE(!this->classStack.empty());
 
     if (this->classStack.back() != this->targetClass) {
-        return tree;
+        return;
     }
 
     auto &ident = ast::cast_tree_nonnull<ast::UnresolvedIdent>(tree);
 
     if (ident.kind != this->queryKind) {
-        return tree;
+        return;
     }
 
     if (ident.name == core::Names::ivarNameMissing() || ident.name == core::Names::cvarNameMissing()) {
-        return tree;
+        return;
     }
 
     this->result_.emplace_back(ident.name);
-    return tree;
 }
 
-ast::ExpressionPtr FieldFinder::preTransformClassDef(core::Context ctx, ast::ExpressionPtr tree) {
+void FieldFinder::preTransformClassDef(core::Context ctx, ast::ExpressionPtr &tree) {
     auto &classDef = ast::cast_tree_nonnull<ast::ClassDef>(tree);
 
     ENFORCE(classDef.symbol.exists());
     ENFORCE(classDef.symbol != core::Symbols::todo());
 
     this->classStack.push_back(classDef.symbol);
-
-    return tree;
 }
 
-ast::ExpressionPtr FieldFinder::postTransformClassDef(core::Context ctx, ast::ExpressionPtr tree) {
+void FieldFinder::postTransformClassDef(core::Context ctx, ast::ExpressionPtr &tree) {
     this->classStack.pop_back();
-    return tree;
 }
 
 const vector<core::NameRef> &FieldFinder::result() const {

--- a/main/lsp/FieldFinder.h
+++ b/main/lsp/FieldFinder.h
@@ -18,9 +18,9 @@ private:
 public:
     FieldFinder(core::ClassOrModuleRef target, ast::UnresolvedIdent::Kind queryKind);
 
-    ast::ExpressionPtr postTransformUnresolvedIdent(core::Context ctx, ast::ExpressionPtr ident);
-    ast::ExpressionPtr preTransformClassDef(core::Context ctx, ast::ExpressionPtr classDef);
-    ast::ExpressionPtr postTransformClassDef(core::Context ctx, ast::ExpressionPtr classDef);
+    void postTransformUnresolvedIdent(core::Context ctx, ast::ExpressionPtr &ident);
+    void preTransformClassDef(core::Context ctx, ast::ExpressionPtr &classDef);
+    void postTransformClassDef(core::Context ctx, ast::ExpressionPtr &classDef);
 
     const std::vector<core::NameRef> &result() const;
 };

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -620,7 +620,7 @@ void tryApplyLocalVarSaver(const core::GlobalState &gs, vector<ast::ParsedFile> 
     for (auto &t : indexedCopies) {
         LocalVarSaver localVarSaver;
         core::Context ctx(gs, core::Symbols::root(), t.file);
-        t.tree = ast::TreeMap::apply(ctx, localVarSaver, move(t.tree));
+        ast::TreeWalk::apply(ctx, localVarSaver, t.tree);
     }
 }
 
@@ -631,7 +631,7 @@ void tryApplyDefLocSaver(const core::GlobalState &gs, vector<ast::ParsedFile> &i
     for (auto &t : indexedCopies) {
         DefLocSaver defLocSaver;
         core::Context ctx(gs, core::Symbols::root(), t.file);
-        t.tree = ast::TreeMap::apply(ctx, defLocSaver, move(t.tree));
+        ast::TreeWalk::apply(ctx, defLocSaver, t.tree);
     }
 }
 } // namespace

--- a/main/lsp/LocalVarFinder.cc
+++ b/main/lsp/LocalVarFinder.cc
@@ -6,46 +6,42 @@ using namespace std;
 
 namespace sorbet::realmain::lsp {
 
-ast::ExpressionPtr LocalVarFinder::preTransformBlock(core::Context ctx, ast::ExpressionPtr tree) {
+void LocalVarFinder::preTransformBlock(core::Context ctx, ast::ExpressionPtr &tree) {
     ENFORCE(!methodStack.empty());
 
     auto &block = ast::cast_tree_nonnull<ast::Block>(tree);
     auto loc = ctx.locAt(block.loc);
 
     if (methodStack.back() != this->targetMethod) {
-        return tree;
+        return;
     }
 
     if (!loc.contains(this->queryLoc)) {
-        return tree;
+        return;
     }
 
     auto parsedArgs = ast::ArgParsing::parseArgs(block.args);
     for (const auto &parsedArg : parsedArgs) {
         this->result_.emplace_back(parsedArg.local._name);
     }
-
-    return tree;
 }
 
-ast::ExpressionPtr LocalVarFinder::postTransformAssign(core::Context ctx, ast::ExpressionPtr tree) {
+void LocalVarFinder::postTransformAssign(core::Context ctx, ast::ExpressionPtr &tree) {
     ENFORCE(!methodStack.empty());
 
     auto &assign = ast::cast_tree_nonnull<ast::Assign>(tree);
 
     auto *local = ast::cast_tree<ast::Local>(assign.lhs);
     if (local == nullptr) {
-        return tree;
+        return;
     }
 
     if (methodStack.back() == this->targetMethod) {
         this->result_.emplace_back(local->localVariable._name);
     }
-
-    return tree;
 }
 
-ast::ExpressionPtr LocalVarFinder::preTransformMethodDef(core::Context ctx, ast::ExpressionPtr tree) {
+void LocalVarFinder::preTransformMethodDef(core::Context ctx, ast::ExpressionPtr &tree) {
     auto &methodDef = ast::cast_tree_nonnull<ast::MethodDef>(tree);
 
     ENFORCE(methodDef.symbol.exists());
@@ -61,16 +57,13 @@ ast::ExpressionPtr LocalVarFinder::preTransformMethodDef(core::Context ctx, ast:
     }
 
     this->methodStack.emplace_back(currentMethod);
-
-    return tree;
 }
 
-ast::ExpressionPtr LocalVarFinder::postTransformMethodDef(core::Context ctx, ast::ExpressionPtr tree) {
+void LocalVarFinder::postTransformMethodDef(core::Context ctx, ast::ExpressionPtr &tree) {
     this->methodStack.pop_back();
-    return tree;
 }
 
-ast::ExpressionPtr LocalVarFinder::preTransformClassDef(core::Context ctx, ast::ExpressionPtr tree) {
+void LocalVarFinder::preTransformClassDef(core::Context ctx, ast::ExpressionPtr &tree) {
     auto &classDef = ast::cast_tree_nonnull<ast::ClassDef>(tree);
     ENFORCE(classDef.symbol.exists());
     ENFORCE(classDef.symbol != core::Symbols::todo());
@@ -79,13 +72,10 @@ ast::ExpressionPtr LocalVarFinder::preTransformClassDef(core::Context ctx, ast::
                                                                   : ctx.state.lookupStaticInitForClass(classDef.symbol);
 
     this->methodStack.emplace_back(currentMethod);
-
-    return tree;
 }
 
-ast::ExpressionPtr LocalVarFinder::postTransformClassDef(core::Context ctx, ast::ExpressionPtr tree) {
+void LocalVarFinder::postTransformClassDef(core::Context ctx, ast::ExpressionPtr &tree) {
     this->methodStack.pop_back();
-    return tree;
 }
 
 const vector<core::NameRef> &LocalVarFinder::result() const {

--- a/main/lsp/LocalVarFinder.h
+++ b/main/lsp/LocalVarFinder.h
@@ -20,12 +20,12 @@ class LocalVarFinder {
 public:
     LocalVarFinder(core::MethodRef targetMethod, core::Loc queryLoc) : targetMethod(targetMethod), queryLoc(queryLoc) {}
 
-    ast::ExpressionPtr postTransformAssign(core::Context ctx, ast::ExpressionPtr assign);
-    ast::ExpressionPtr preTransformBlock(core::Context ctx, ast::ExpressionPtr block);
-    ast::ExpressionPtr preTransformMethodDef(core::Context ctx, ast::ExpressionPtr methodDef);
-    ast::ExpressionPtr postTransformMethodDef(core::Context ctx, ast::ExpressionPtr methodDef);
-    ast::ExpressionPtr preTransformClassDef(core::Context ctx, ast::ExpressionPtr classDef);
-    ast::ExpressionPtr postTransformClassDef(core::Context ctx, ast::ExpressionPtr classDef);
+    void postTransformAssign(core::Context ctx, ast::ExpressionPtr &assign);
+    void preTransformBlock(core::Context ctx, ast::ExpressionPtr &block);
+    void preTransformMethodDef(core::Context ctx, ast::ExpressionPtr &methodDef);
+    void postTransformMethodDef(core::Context ctx, ast::ExpressionPtr &methodDef);
+    void preTransformClassDef(core::Context ctx, ast::ExpressionPtr &classDef);
+    void postTransformClassDef(core::Context ctx, ast::ExpressionPtr &classDef);
 
     const std::vector<core::NameRef> &result() const;
 };

--- a/main/lsp/LocalVarSaver.cc
+++ b/main/lsp/LocalVarSaver.cc
@@ -21,7 +21,7 @@ core::MethodRef enclosingMethod(core::Context ctx) {
 }
 } // namespace
 
-ast::ExpressionPtr LocalVarSaver::postTransformBlock(core::Context ctx, ast::ExpressionPtr tree) {
+void LocalVarSaver::postTransformBlock(core::Context ctx, ast::ExpressionPtr &tree) {
     auto &block = ast::cast_tree_nonnull<ast::Block>(tree);
     auto method = enclosingMethod(ctx);
 
@@ -35,11 +35,9 @@ ast::ExpressionPtr LocalVarSaver::postTransformBlock(core::Context ctx, ast::Exp
             }
         }
     }
-
-    return tree;
 }
 
-ast::ExpressionPtr LocalVarSaver::postTransformLocal(core::Context ctx, ast::ExpressionPtr tree) {
+void LocalVarSaver::postTransformLocal(core::Context ctx, ast::ExpressionPtr &tree) {
     auto &local = ast::cast_tree_nonnull<ast::Local>(tree);
     auto method = enclosingMethod(ctx);
 
@@ -51,11 +49,9 @@ ast::ExpressionPtr LocalVarSaver::postTransformLocal(core::Context ctx, ast::Exp
         core::lsp::QueryResponse::pushQueryResponse(
             ctx, core::lsp::IdentResponse(ctx.locAt(local.loc), local.localVariable, tp, method));
     }
-
-    return tree;
 }
 
-ast::ExpressionPtr LocalVarSaver::postTransformMethodDef(core::Context ctx, ast::ExpressionPtr tree) {
+void LocalVarSaver::postTransformMethodDef(core::Context ctx, ast::ExpressionPtr &tree) {
     auto &methodDef = ast::cast_tree_nonnull<ast::MethodDef>(tree);
 
     // Check args.
@@ -72,7 +68,5 @@ ast::ExpressionPtr LocalVarSaver::postTransformMethodDef(core::Context ctx, ast:
             }
         }
     }
-
-    return tree;
 }
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/LocalVarSaver.h
+++ b/main/lsp/LocalVarSaver.h
@@ -9,9 +9,9 @@ namespace sorbet::realmain::lsp {
 
 class LocalVarSaver {
 public:
-    ast::ExpressionPtr postTransformBlock(core::Context ctx, ast::ExpressionPtr local);
-    ast::ExpressionPtr postTransformLocal(core::Context ctx, ast::ExpressionPtr local);
-    ast::ExpressionPtr postTransformMethodDef(core::Context ctx, ast::ExpressionPtr methodDef);
+    void postTransformBlock(core::Context ctx, ast::ExpressionPtr &local);
+    void postTransformLocal(core::Context ctx, ast::ExpressionPtr &local);
+    void postTransformMethodDef(core::Context ctx, ast::ExpressionPtr &methodDef);
 };
 }; // namespace sorbet::realmain::lsp
 

--- a/main/lsp/NextMethodFinder.h
+++ b/main/lsp/NextMethodFinder.h
@@ -24,9 +24,9 @@ public:
         : queryLoc(queryLoc), narrowestClassDefRange(core::Loc::none()), scopeContainsQueryLoc(std::vector<bool>{}),
           result_(core::Loc::none(), core::Symbols::noMethod()) {}
 
-    ast::ExpressionPtr preTransformClassDef(core::Context ctx, ast::ExpressionPtr tree);
-    ast::ExpressionPtr postTransformClassDef(core::Context ctx, ast::ExpressionPtr tree);
-    ast::ExpressionPtr preTransformMethodDef(core::Context ctx, ast::ExpressionPtr tree);
+    void preTransformClassDef(core::Context ctx, ast::ExpressionPtr &tree);
+    void postTransformClassDef(core::Context ctx, ast::ExpressionPtr &tree);
+    void preTransformMethodDef(core::Context ctx, ast::ExpressionPtr &tree);
 
     const core::MethodRef result() const;
 };

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -557,11 +557,11 @@ vector<core::NameRef> allSimilarFieldsForClass(LSPTypecheckerInterface &typechec
     if (!files.empty()) {
         auto resolved = typechecker.getResolved(files);
 
-        // Instantiate fieldFinder outside loop so that result accumulates over every time we TreeMap::apply
+        // Instantiate fieldFinder outside loop so that result accumulates over every time we TreeWalk::apply
         FieldFinder fieldFinder(klass, kind);
         for (auto &t : resolved) {
             auto ctx = core::Context(gs, core::Symbols::root(), t.file);
-            t.tree = ast::TreeMap::apply(ctx, fieldFinder, move(t.tree));
+            ast::TreeWalk::apply(ctx, fieldFinder, t.tree);
         }
         auto fields = fieldFinder.result();
 
@@ -596,11 +596,11 @@ vector<core::NameRef> localNamesForMethod(LSPTypecheckerInterface &typechecker, 
     }
     auto resolved = typechecker.getResolved(files);
 
-    // Instantiate localVarFinder outside loop so that result accumualates over every time we TreeMap::apply
+    // Instantiate localVarFinder outside loop so that result accumualates over every time we TreeWalk::apply
     LocalVarFinder localVarFinder(method, queryLoc);
     for (auto &t : resolved) {
         auto ctx = core::Context(gs, core::Symbols::root(), t.file);
-        t.tree = ast::TreeMap::apply(ctx, localVarFinder, move(t.tree));
+        ast::TreeWalk::apply(ctx, localVarFinder, t.tree);
     }
 
     auto result = localVarFinder.result();
@@ -627,7 +627,7 @@ core::MethodRef firstMethodAfterQuery(LSPTypecheckerInterface &typechecker, cons
     NextMethodFinder nextMethodFinder(queryLoc);
     for (auto &t : resolved) {
         auto ctx = core::Context(gs, core::Symbols::root(), t.file);
-        t.tree = ast::TreeMap::apply(ctx, nextMethodFinder, move(t.tree));
+        ast::TreeWalk::apply(ctx, nextMethodFinder, t.tree);
     }
 
     return nextMethodFinder.result();

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -142,7 +142,7 @@ public:
         return rv;
     }
 
-    ast::ExpressionPtr preTransformClassDef(core::Context ctx, ast::ExpressionPtr tree) {
+    void preTransformClassDef(core::Context ctx, ast::ExpressionPtr &tree) {
         auto &klass = ast::cast_tree_nonnull<ast::ClassDef>(tree);
 
         core::FoundClass found;
@@ -170,10 +170,9 @@ public:
 
         ownerStack.emplace_back(foundDefs->addClass(move(found)));
         methodVisiStack.emplace_back(nullopt);
-        return tree;
     }
 
-    ast::ExpressionPtr postTransformClassDef(core::Context ctx, ast::ExpressionPtr tree) {
+    void postTransformClassDef(core::Context ctx, ast::ExpressionPtr &tree) {
         auto &klass = ast::cast_tree_nonnull<ast::ClassDef>(tree);
 
         core::FoundDefinitionRef klassName = ownerStack.back();
@@ -183,21 +182,17 @@ public:
         for (auto &exp : klass.rhs) {
             findClassModifiers(ctx, klassName, exp);
         }
-
-        return tree;
     }
 
-    ast::ExpressionPtr preTransformBlock(core::Context ctx, ast::ExpressionPtr block) {
+    void preTransformBlock(core::Context ctx, ast::ExpressionPtr &block) {
         methodVisiStack.emplace_back(nullopt);
-        return block;
     }
 
-    ast::ExpressionPtr postTransformBlock(core::Context ctx, ast::ExpressionPtr block) {
+    void postTransformBlock(core::Context ctx, ast::ExpressionPtr &block) {
         methodVisiStack.pop_back();
-        return block;
     }
 
-    ast::ExpressionPtr preTransformMethodDef(core::Context ctx, ast::ExpressionPtr tree) {
+    void preTransformMethodDef(core::Context ctx, ast::ExpressionPtr &tree) {
         auto &method = ast::cast_tree_nonnull<ast::MethodDef>(tree);
         core::FoundMethod foundMethod;
         foundMethod.owner = getOwner();
@@ -212,10 +207,9 @@ public:
         // After flatten, method defs have been hoisted and reordered, so instead we look for the
         // keep_def / keep_self_def calls, which will still be ordered correctly relative to
         // visibility modifiers.
-        return tree;
     }
 
-    ast::ExpressionPtr postTransformSend(core::Context ctx, ast::ExpressionPtr tree) {
+    void postTransformSend(core::Context ctx, ast::ExpressionPtr &tree) {
         auto &original = ast::cast_tree_nonnull<ast::Send>(tree);
 
         switch (original.fun.rawId()) {
@@ -279,25 +273,23 @@ public:
                 break;
             }
         }
-        return tree;
     }
 
-    ast::ExpressionPtr postTransformRuntimeMethodDefinition(core::Context, ast::ExpressionPtr tree) {
+    void postTransformRuntimeMethodDefinition(core::Context, ast::ExpressionPtr &tree) {
         auto &original = ast::cast_tree_nonnull<ast::RuntimeMethodDefinition>(tree);
 
         // visibility toggle doesn't look at `self.*` methods, only instance methods
         // (need to use `class << self` to use nullary private with singleton class methods)
         if (original.isSelfMethod) {
-            return tree;
+            return;
         }
 
         ENFORCE(!methodVisiStack.empty());
         if (!methodVisiStack.back().has_value()) {
-            return tree;
+            return;
         }
 
         foundDefs->addModifier(methodVisiStack.back()->withTarget(original.name));
-        return tree;
     }
 
     void addMethodModifier(core::Context ctx, core::NameRef modifierName, const ast::ExpressionPtr &arg) {
@@ -480,12 +472,12 @@ public:
         return foundRef;
     }
 
-    ast::ExpressionPtr postTransformAssign(core::Context ctx, ast::ExpressionPtr tree) {
+    void postTransformAssign(core::Context ctx, ast::ExpressionPtr &tree) {
         auto &asgn = ast::cast_tree_nonnull<ast::Assign>(tree);
 
         auto *lhs = ast::cast_tree<ast::UnresolvedConstantLit>(asgn.lhs);
         if (lhs == nullptr) {
-            return tree;
+            return;
         }
 
         auto *send = ast::cast_tree<ast::Send>(asgn.rhs);
@@ -506,7 +498,6 @@ public:
                     break;
             }
         }
-        return tree;
     }
 };
 
@@ -1383,7 +1374,7 @@ class TreeSymbolizer {
 public:
     TreeSymbolizer(bool bestEffort) : bestEffort(bestEffort) {}
 
-    ast::ExpressionPtr preTransformClassDef(core::Context ctx, ast::ExpressionPtr tree) {
+    void preTransformClassDef(core::Context ctx, ast::ExpressionPtr &tree) {
         auto &klass = ast::cast_tree_nonnull<ast::ClassDef>(tree);
 
         auto *ident = ast::cast_tree<ast::UnresolvedIdent>(klass.name);
@@ -1412,7 +1403,6 @@ public:
                 ENFORCE(symbol == core::Symbols::root());
             }
         }
-        return tree;
     }
 
     // This decides if we need to keep a node around incase the current LSP query needs type information for it
@@ -1428,7 +1418,7 @@ public:
         return true;
     }
 
-    ast::ExpressionPtr postTransformClassDef(core::Context ctx, ast::ExpressionPtr tree) {
+    void postTransformClassDef(core::Context ctx, ast::ExpressionPtr &tree) {
         auto &klass = ast::cast_tree_nonnull<ast::ClassDef>(tree);
 
         if (klass.symbol == core::Symbols::todo()) {
@@ -1438,7 +1428,8 @@ public:
             // symbol in preTransformClassDef. Now that we're in postTransformClassDef, we're
             // allowed to return something that's not a ClassDef node, which we can use to delete
             // the tree.
-            return ast::MK::EmptyTree();
+            tree = ast::MK::EmptyTree();
+            return;
         }
 
         // NameDefiner should have forced this class's singleton class into existence.
@@ -1449,7 +1440,8 @@ public:
             ENFORCE(this->bestEffort);
             // Even though we found a symbol for this, we don't have a <static-init> for it, which is
             // an invariant that namer must introduce (all ClassDef's have `<static-init>` methods).
-            return ast::MK::EmptyTree();
+            tree = ast::MK::EmptyTree();
+            return;
         }
 
         for (auto &exp : klass.rhs) {
@@ -1489,7 +1481,7 @@ public:
         for (auto &stat : ideSeqs) {
             retSeqs.emplace_back(std::move(stat));
         }
-        return ast::MK::InsSeq(loc, std::move(retSeqs), ast::MK::EmptyTree());
+        tree = ast::MK::InsSeq(loc, std::move(retSeqs), ast::MK::EmptyTree());
     }
 
     ast::MethodDef::ARGS_store fillInArgs(vector<core::ParsedArg> parsedArgs, ast::MethodDef::ARGS_store oldArgs) {
@@ -1512,7 +1504,7 @@ public:
         return args;
     }
 
-    ast::ExpressionPtr preTransformMethodDef(core::Context ctx, ast::ExpressionPtr tree) {
+    void preTransformMethodDef(core::Context ctx, ast::ExpressionPtr &tree) {
         auto &method = ast::cast_tree_nonnull<ast::MethodDef>(tree);
 
         auto owner = methodOwner(ctx, method.flags);
@@ -1523,24 +1515,22 @@ public:
             // We're going to delete this tree when we get to the postTransformMethodDef.
             // Drop the RHS to make it get there faster.
             method.rhs = ast::MK::EmptyTree();
-            return tree;
+            return;
         }
         method.symbol = sym;
         method.args = fillInArgs(move(parsedArgs), std::move(method.args));
-
-        return tree;
     }
 
-    ast::ExpressionPtr postTransformMethodDef(core::Context ctx, ast::ExpressionPtr tree) {
+    void postTransformMethodDef(core::Context ctx, ast::ExpressionPtr &tree) {
         auto &method = ast::cast_tree_nonnull<ast::MethodDef>(tree);
         if (method.symbol == core::Symbols::todoMethod() && this->bestEffort) {
             // See the similar code in postTransformClassDef for an explanation.
-            return ast::MK::EmptyTree();
+            tree = ast::MK::EmptyTree();
+            return;
         }
 
         ENFORCE(method.args.size() == method.symbol.data(ctx)->arguments.size(), "{}: {} != {}",
                 method.name.showRaw(ctx), method.args.size(), method.symbol.data(ctx)->arguments.size());
-        return tree;
     }
 
     ast::ExpressionPtr handleAssignment(core::Context ctx, ast::ExpressionPtr tree) {
@@ -1768,29 +1758,35 @@ public:
         return tree;
     }
 
-    ast::ExpressionPtr postTransformAssign(core::Context ctx, ast::ExpressionPtr tree) {
+    void postTransformAssign(core::Context ctx, ast::ExpressionPtr &tree) {
         auto &asgn = ast::cast_tree_nonnull<ast::Assign>(tree);
 
         auto *lhs = ast::cast_tree<ast::UnresolvedConstantLit>(asgn.lhs);
         if (lhs == nullptr) {
-            return tree;
+            return;
         }
 
         auto *send = ast::cast_tree<ast::Send>(asgn.rhs);
         if (send == nullptr) {
-            return handleAssignment(ctx, std::move(tree));
+            tree = handleAssignment(ctx, std::move(tree));
+            return;
         }
 
         if (!send->recv.isSelfReference()) {
-            return handleAssignment(ctx, std::move(tree));
+            tree = handleAssignment(ctx, std::move(tree));
+            return;
         }
 
         switch (send->fun.rawId()) {
             case core::Names::typeTemplate().rawId():
-            case core::Names::typeMember().rawId():
-                return handleTypeMemberDefinition(ctx, send, std::move(tree), lhs);
-            default:
-                return handleAssignment(ctx, std::move(tree));
+            case core::Names::typeMember().rawId(): {
+                tree = handleTypeMemberDefinition(ctx, send, std::move(tree), lhs);
+                return;
+            }
+            default: {
+                tree = handleAssignment(ctx, std::move(tree));
+                return;
+            }
         }
     }
 
@@ -1817,7 +1813,7 @@ vector<SymbolFinderResult> findSymbols(const core::GlobalState &gs, vector<ast::
             if (result.gotItem()) {
                 Timer timeit(gs.tracer(), "naming.findSymbolsOne", {{"file", string(job.file.data(gs).path())}});
                 core::Context ctx(gs, core::Symbols::root(), job.file);
-                job.tree = ast::ShallowMap::apply(ctx, finder, std::move(job.tree));
+                ast::ShallowWalk::apply(ctx, finder, job.tree);
                 SymbolFinderResult jobOutput{move(job), finder.getAndClearFoundDefinitions()};
                 output.emplace_back(move(jobOutput));
             }
@@ -1941,7 +1937,7 @@ vector<ast::ParsedFile> symbolizeTrees(const core::GlobalState &gs, vector<ast::
             if (result.gotItem()) {
                 Timer timeit(gs.tracer(), "naming.symbolizeTreesOne", {{"file", string(job.file.data(gs).path())}});
                 core::Context ctx(gs, core::Symbols::root(), job.file);
-                job.tree = ast::ShallowMap::apply(ctx, inserter, std::move(job.tree));
+                ast::ShallowWalk::apply(ctx, inserter, job.tree);
                 output.trees.emplace_back(move(job));
             }
         }

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -69,7 +69,7 @@ core::ClassOrModuleRef contextClass(const core::GlobalState &gs, core::SymbolRef
 }
 
 /**
- * Used with TreeMap to locate all of the class, method, static field, and type member symbols defined in the tree.
+ * Used with TreeWalk to locate all of the class, method, static field, and type member symbols defined in the tree.
  * Does not mutate GlobalState, which allows us to parallelize this process.
  * Does not report any errors, which lets us cache its output.
  * Produces a vector of symbols to insert, and a vector of modifiers to those symbols.

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1635,7 +1635,7 @@ public:
                 {
                     Timer timeit(gs.tracer(), "resolver.resolve_constants.fixed_point.class_aliases");
                     // This is an optimization. The order should not matter semantically
-                    // This is done as a "pre-step" because the first iteration of this effectively ran in TreeMap.
+                    // This is done as a "pre-step" because the first iteration of this effectively ran in TreeWalk.
                     // every item in todoClassAliases implicitly depends on an item in item in todo
                     // there would be no point in running the todoClassAliases step before todo
 

--- a/rewriter/Flatten.cc
+++ b/rewriter/Flatten.cc
@@ -299,30 +299,29 @@ public:
         ENFORCE(classScopes.empty());
     }
 
-    ast::ExpressionPtr preTransformClassDef(core::Context ctx, ast::ExpressionPtr tree) {
+    void preTransformClassDef(core::Context ctx, ast::ExpressionPtr &tree) {
         if (!curMethodSet().stack.empty()) {
             curMethodSet().pushScope(computeScopeInfo(ScopeType::InstanceMethodScope));
         }
         newMethodSet();
-        return tree;
     }
 
-    ast::ExpressionPtr postTransformClassDef(core::Context ctx, ast::ExpressionPtr tree) {
+    void postTransformClassDef(core::Context ctx, ast::ExpressionPtr &tree) {
         auto &classDef = ast::cast_tree_nonnull<ast::ClassDef>(tree);
         classDef.rhs = addClassDefMethods(ctx, std::move(classDef.rhs), classDef.loc);
         auto &methods = curMethodSet();
         if (curMethodSet().stack.empty()) {
-            return tree;
+            return;
         }
         // if this class is dirrectly nested inside a method, we want to steal it
         auto md = methods.popScope();
         ENFORCE(md);
 
         methods.addExpr(*md, move(tree));
-        return ast::MK::EmptyTree();
+        tree = ast::MK::EmptyTree();
     };
 
-    ast::ExpressionPtr preTransformSend(core::Context ctx, ast::ExpressionPtr tree) {
+    void preTransformSend(core::Context ctx, ast::ExpressionPtr &tree) {
         auto &send = ast::cast_tree_nonnull<ast::Send>(tree);
         // we might want to move sigs, so we mostly use the same logic that we use for methods. The one exception is
         // that we don't know the 'staticness level' of a sig, as it depends on the method that follows it (whether that
@@ -330,34 +329,31 @@ public:
         if (send.fun == core::Names::sig()) {
             curMethodSet().pushScope(computeScopeInfo(ScopeType::StaticMethodScope));
         }
-
-        return tree;
     }
 
-    ast::ExpressionPtr postTransformSend(core::Context ctx, ast::ExpressionPtr tree) {
+    void postTransformSend(core::Context ctx, ast::ExpressionPtr &tree) {
         auto &send = ast::cast_tree_nonnull<ast::Send>(tree);
         auto &methods = curMethodSet();
         // if it's not a send, then we didn't make a stack frame for it
         if (send.fun != core::Names::sig()) {
-            return tree;
+            return;
         }
         // if we get a MethodData back, then we need to move this and replace it with an EmptyTree
         if (auto md = methods.popScope()) {
             methods.addExpr(*md, move(tree));
-            return ast::MK::EmptyTree();
+            tree = ast::MK::EmptyTree();
+            return;
         }
-        return tree;
     }
 
-    ast::ExpressionPtr preTransformMethodDef(core::Context ctx, ast::ExpressionPtr tree) {
+    void preTransformMethodDef(core::Context ctx, ast::ExpressionPtr &tree) {
         auto &methodDef = ast::cast_tree_nonnull<ast::MethodDef>(tree);
         // add a new scope for this method def
         curMethodSet().pushScope(computeScopeInfo(methodDef.flags.isSelfMethod ? ScopeType::StaticMethodScope
                                                                                : ScopeType::InstanceMethodScope));
-        return tree;
     }
 
-    ast::ExpressionPtr postTransformMethodDef(core::Context ctx, ast::ExpressionPtr tree) {
+    void postTransformMethodDef(core::Context ctx, ast::ExpressionPtr &tree) {
         auto &methodDef = ast::cast_tree_nonnull<ast::MethodDef>(tree);
         auto &methods = curMethodSet();
         // if we get a MethodData back, then we need to move this and replace it
@@ -372,19 +368,22 @@ public:
         methods.addExpr(*md, move(tree));
 
         if (discardable) {
-            return ast::MK::EmptyTree();
+            tree = ast::MK::EmptyTree();
+            return;
         } else if (!this->compiledFile) {
             // We need to return something here so things like `module_function` and method
             // visibility tracking can work correctly.
-            return ast::MK::RuntimeMethodDefinition(loc, name, methodDef.flags.isSelfMethod);
+            tree = ast::MK::RuntimeMethodDefinition(loc, name, methodDef.flags.isSelfMethod);
+            return;
         } else {
             auto keepName = methodDef.flags.isSelfMethod ? core::Names::keepSelfDef() : core::Names::keepDef();
             auto kind = methodDef.flags.genericPropGetter ? core::Names::genericPropGetter()
                         : methodDef.flags.isAttrReader    ? core::Names::attrReader()
                                                           : core::Names::normal();
-            return ast::MK::Send3(loc, ast::MK::Constant(loc, core::Symbols::Sorbet_Private_Static()), keepName,
+            tree = ast::MK::Send3(loc, ast::MK::Constant(loc, core::Symbols::Sorbet_Private_Static()), keepName,
                                   loc.copyWithZeroLength(), ast::MK::Self(loc), ast::MK::Symbol(loc, name),
                                   ast::MK::Symbol(loc, kind));
+            return;
         }
     };
 
@@ -417,7 +416,7 @@ public:
 
 ast::ExpressionPtr Flatten::run(core::Context ctx, ast::ExpressionPtr tree) {
     FlattenWalk flatten(ctx);
-    tree = ast::TreeMap::apply(ctx, flatten, std::move(tree));
+    ast::TreeWalk::apply(ctx, flatten, tree);
     tree = flatten.addTopLevelMethods(ctx, std::move(tree));
 
     return tree;

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -31,12 +31,13 @@ public:
         return ast::MK::Assign(asgn.loc, move(asgn.lhs), move(raiseUnimplemented));
     }
 
-    ast::ExpressionPtr postTransformAssign(core::MutableContext ctx, ast::ExpressionPtr tree) {
+    void postTransformAssign(core::MutableContext ctx, ast::ExpressionPtr &tree) {
         auto *asgn = ast::cast_tree<ast::Assign>(tree);
         if (auto *cnst = ast::cast_tree<ast::UnresolvedConstantLit>(asgn->lhs)) {
             if (ast::isa_tree<ast::UnresolvedConstantLit>(asgn->rhs)) {
                 movedConstants.emplace_back(move(tree));
-                return ast::MK::EmptyTree();
+                tree = ast::MK::EmptyTree();
+                return;
             }
             auto name = ast::MK::Symbol(cnst->loc, cnst->cnst);
 
@@ -44,49 +45,45 @@ public:
             movedConstants.emplace_back(createConstAssign(*asgn));
 
             auto module = ast::MK::Constant(asgn->loc, core::Symbols::Module());
-            return ast::MK::Send2(asgn->loc, move(module), core::Names::constSet(), asgn->loc.copyWithZeroLength(),
+            tree = ast::MK::Send2(asgn->loc, move(module), core::Names::constSet(), asgn->loc.copyWithZeroLength(),
                                   move(name), move(asgn->rhs));
+            return;
         }
-
-        return tree;
     }
 
     // classdefs define new constants, so we always move those if they're the "top-level" classdef (i.e. if we have
     // nested classdefs, we should only move the outermost one)
-    ast::ExpressionPtr preTransformClassDef(core::MutableContext ctx, ast::ExpressionPtr classDef) {
+    void preTransformClassDef(core::MutableContext ctx, ast::ExpressionPtr &classDef) {
         classDepth++;
-        return classDef;
     }
 
-    ast::ExpressionPtr postTransformClassDef(core::MutableContext ctx, ast::ExpressionPtr classDef) {
+    void postTransformClassDef(core::MutableContext ctx, ast::ExpressionPtr &classDef) {
         classDepth--;
         if (classDepth == 0) {
             movedConstants.emplace_back(move(classDef));
-            return ast::MK::EmptyTree();
+            classDef = ast::MK::EmptyTree();
         }
-        return classDef;
     }
 
     // we move sends if they are other minitest `describe` blocks, as those end up being classes anyway: consequently,
     // we treat those the same way we treat classes
-    ast::ExpressionPtr preTransformSend(core::MutableContext ctx, ast::ExpressionPtr tree) {
+    void preTransformSend(core::MutableContext ctx, ast::ExpressionPtr &tree) {
         auto *send = ast::cast_tree<ast::Send>(tree);
         if (send->recv.isSelfReference() && send->numPosArgs() == 1 && send->fun == core::Names::describe()) {
             classDepth++;
         }
-        return tree;
     }
 
-    ast::ExpressionPtr postTransformSend(core::MutableContext ctx, ast::ExpressionPtr tree) {
+    void postTransformSend(core::MutableContext ctx, ast::ExpressionPtr &tree) {
         auto *send = ast::cast_tree<ast::Send>(tree);
         if (send->recv.isSelfReference() && send->numPosArgs() == 1 && send->fun == core::Names::describe()) {
             classDepth--;
             if (classDepth == 0) {
                 movedConstants.emplace_back(move(tree));
-                return ast::MK::EmptyTree();
+                tree = ast::MK::EmptyTree();
+                return;
             }
         }
-        return tree;
     }
 
     vector<ast::ExpressionPtr> getMovedConstants() {
@@ -202,7 +199,7 @@ ast::ExpressionPtr runUnderEach(core::MutableContext ctx, core::NameRef eachName
             // pull constants out of the block
             ConstantMover constantMover;
             ast::ExpressionPtr body = move(send->block()->body);
-            body = ast::TreeMap::apply(ctx, constantMover, move(body));
+            ast::TreeWalk::apply(ctx, constantMover, body);
 
             // pull the arg and the iteratee in and synthesize `iterate.each { |arg| body }`
             ast::MethodDef::ARGS_store new_args;
@@ -358,7 +355,7 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, ast::Send *
     if (send->numPosArgs() == 0 && (send->fun == core::Names::before() || send->fun == core::Names::after())) {
         auto name = send->fun == core::Names::after() ? core::Names::afterAngles() : core::Names::initialize();
         ConstantMover constantMover;
-        block->body = ast::TreeMap::apply(ctx, constantMover, move(block->body));
+        ast::TreeWalk::apply(ctx, constantMover, block->body);
         auto method = addSigVoid(
             ast::MK::SyntheticMethod0(send->loc, send->loc, name, prepareBody(ctx, isClass, std::move(block->body))));
         return constantMover.addConstantsToExpression(send->loc, move(method));
@@ -387,7 +384,7 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, ast::Send *
         return ast::MK::Class(send->loc, send->loc, std::move(name), std::move(ancestors), std::move(rhs));
     } else if (send->fun == core::Names::it()) {
         ConstantMover constantMover;
-        block->body = ast::TreeMap::apply(ctx, constantMover, move(block->body));
+        ast::TreeWalk::apply(ctx, constantMover, block->body);
         auto name = ctx.state.enterNameUTF8("<it '" + argString + "'>");
         const bool bodyIsClass = false;
         auto method = addSigVoid(ast::MK::SyntheticMethod0(send->loc, send->loc, std::move(name),

--- a/test/hello-test.cc
+++ b/test/hello-test.cc
@@ -43,88 +43,71 @@ TEST_CASE("CountTrees") {
     class Counter {
     public:
         int count = 0;
-        ast::ExpressionPtr preTransformClassDef(core::MutableContext ctx, ast::ExpressionPtr original) {
+        void preTransformClassDef(core::MutableContext ctx, ast::ExpressionPtr &original) {
             count++;
-            return original;
         }
-        ast::ExpressionPtr preTransformMethodDef(core::MutableContext ctx, ast::ExpressionPtr original) {
+        void preTransformMethodDef(core::MutableContext ctx, ast::ExpressionPtr &original) {
             count++;
-            return original;
         }
 
-        ast::ExpressionPtr preTransformIf(core::MutableContext ctx, ast::ExpressionPtr original) {
+        void preTransformIf(core::MutableContext ctx, ast::ExpressionPtr &original) {
             count++;
-            return original;
         }
 
-        ast::ExpressionPtr preTransformWhile(core::MutableContext ctx, ast::ExpressionPtr original) {
+        void preTransformWhile(core::MutableContext ctx, ast::ExpressionPtr &original) {
             count++;
-            return original;
         }
 
-        ast::ExpressionPtr postTransformBreak(core::MutableContext ctx, ast::ExpressionPtr original) {
+        void postTransformBreak(core::MutableContext ctx, ast::ExpressionPtr &original) {
             count++;
-            return original;
         }
 
-        ast::ExpressionPtr postTransformNext(core::MutableContext ctx, ast::ExpressionPtr original) {
+        void postTransformNext(core::MutableContext ctx, ast::ExpressionPtr &original) {
             count++;
-            return original;
         }
 
-        ast::ExpressionPtr preTransformReturn(core::MutableContext ctx, ast::ExpressionPtr original) {
+        void preTransformReturn(core::MutableContext ctx, ast::ExpressionPtr &original) {
             count++;
-            return original;
         }
 
-        ast::ExpressionPtr preTransformRescue(core::MutableContext ctx, ast::ExpressionPtr original) {
+        void preTransformRescue(core::MutableContext ctx, ast::ExpressionPtr &original) {
             count++;
-            return original;
         }
 
-        ast::ExpressionPtr postTransformConstantLit(core::MutableContext ctx, ast::ExpressionPtr original) {
+        void postTransformConstantLit(core::MutableContext ctx, ast::ExpressionPtr &original) {
             count++;
-            return original;
         }
 
-        ast::ExpressionPtr preTransformAssign(core::MutableContext ctx, ast::ExpressionPtr original) {
+        void preTransformAssign(core::MutableContext ctx, ast::ExpressionPtr &original) {
             count++;
-            return original;
         }
 
-        ast::ExpressionPtr preTransformSend(core::MutableContext ctx, ast::ExpressionPtr original) {
+        void preTransformSend(core::MutableContext ctx, ast::ExpressionPtr &original) {
             count++;
-            return original;
         }
 
-        ast::ExpressionPtr preTransformHash(core::MutableContext ctx, ast::ExpressionPtr original) {
+        void preTransformHash(core::MutableContext ctx, ast::ExpressionPtr &original) {
             count++;
-            return original;
         }
 
-        ast::ExpressionPtr preTransformArray(core::MutableContext ctx, ast::ExpressionPtr original) {
+        void preTransformArray(core::MutableContext ctx, ast::ExpressionPtr &original) {
             count++;
-            return original;
         }
 
-        ast::ExpressionPtr postTransformLiteral(core::MutableContext ctx, ast::ExpressionPtr original) {
+        void postTransformLiteral(core::MutableContext ctx, ast::ExpressionPtr &original) {
             count++;
-            return original;
         }
 
-        ast::ExpressionPtr postTransformUnresolvedConstantLit(core::MutableContext ctx, ast::ExpressionPtr original) {
+        void postTransformUnresolvedConstantLit(core::MutableContext ctx, ast::ExpressionPtr &original) {
             count++;
-            return original;
         }
 
-        ast::ExpressionPtr preTransformBlock(core::MutableContext ctx, ast::ExpressionPtr original) {
+        void preTransformBlock(core::MutableContext ctx, ast::ExpressionPtr &original) {
             count++;
-            return original;
         }
 
-        ast::ExpressionPtr preTransformInsSeq(core::MutableContext ctx, ast::ExpressionPtr original) {
+        void preTransformInsSeq(core::MutableContext ctx, ast::ExpressionPtr &original) {
             count++;
-            return original;
         }
     };
 
@@ -166,7 +149,7 @@ TEST_CASE("CountTrees") {
     Counter c;
     sorbet::core::MutableContext ctx(cb, core::Symbols::root(), loc.file());
 
-    auto r = ast::TreeMap::apply(ctx, c, std::move(tree));
+    ast::TreeWalk::apply(ctx, c, tree);
     CHECK_EQ(c.count, 3);
 }
 


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

`TreeMap` is a nice abstraction, but its functional nature makes it relatively slow (though one can argue that the compiler really ought to be smart enough to eliminate the functional abstraction penalty; alas, it is not).  We can provide a better abstraction that doesn't have the functional abstraction penalties, and move things over incrementally.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
