### PR TITLE
reorder class flattening and definition validation for speed

### DIFF
--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -662,9 +662,9 @@ void typecheckOne(core::Context ctx, ast::ParsedFile resolved, const options::Op
         return;
     }
 
-    resolved = definition_validator::runOne(ctx, std::move(resolved));
-
     resolved = class_flatten::runOne(ctx, move(resolved));
+
+    resolved = definition_validator::runOne(ctx, std::move(resolved));
 
     if (opts.print.FlattenTree.enabled || opts.print.AST.enabled) {
         opts.print.FlattenTree.fmt("{}\n", resolved.tree.toString(ctx));


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We should run definition validation after class flattening, so definition validation doesn't have to wade through a bunch of top-level stuff in classes.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
