### PR TITLE
convert `sorbet_setupFunctionInlineCache` to use varargs

### DIFF
--- a/compiler/IREmitter/Payload/codegen-payload.c
+++ b/compiler/IREmitter/Payload/codegen-payload.c
@@ -97,8 +97,9 @@ SORBET_ALIVE(void, sorbet_pushBlockFrame, (const struct rb_captured_block *));
 SORBET_ALIVE(void, sorbet_popFrame, (void));
 
 SORBET_ALIVE(void, sorbet_vm_env_write_slowpath, (const VALUE *, int, VALUE));
+// Takes varargs of the IDs for keyword arguments, if any.
 SORBET_ALIVE(void, sorbet_setupFunctionInlineCache,
-             (struct FunctionInlineCache * cache, ID mid, unsigned int flags, int argc, int num_kwargs, VALUE *keys));
+             (struct FunctionInlineCache * cache, ID mid, unsigned int flags, int argc, int num_kwargs, ...));
 SORBET_ALIVE(VALUE, sorbet_callFuncWithCache, (struct FunctionInlineCache * cache, VALUE bh));
 SORBET_ALIVE(VALUE, sorbet_callSuperFuncWithCache, (struct FunctionInlineCache * cache, VALUE bh));
 SORBET_ALIVE(void, sorbet_vmMethodSearch, (struct FunctionInlineCache * cache, VALUE recv));

--- a/test/testdata/compiler/all_arguments.opt.ll.exp
+++ b/test/testdata/compiler/all_arguments.opt.ll.exp
@@ -134,7 +134,7 @@ declare i64 @sorbet_readRealpath() local_unnamed_addr #2
 
 declare void @sorbet_vm_env_write_slowpath(i64*, i32, i64) local_unnamed_addr #2
 
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #2
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) local_unnamed_addr #2
 
 declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #2
 
@@ -178,883 +178,753 @@ declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noa
 ; Function Attrs: nounwind ssp uwtable
 define weak i32 @sorbet_getIsReleaseBuild() local_unnamed_addr #6 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #9
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([93 x i8], [93 x i8]* @.str.10, i64 0, i64 0)) #10
   unreachable
 }
 
 ; Function Attrs: nounwind ssp uwtable
 define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #6 {
   %1 = load i64, i64* @rb_eRuntimeError, align 8, !tbaa !6
-  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #9
+  tail call void (i64, i8*, ...) @rb_raise(i64 %1, i8* noundef getelementptr inbounds ([95 x i8], [95 x i8]* @.str.9, i64 0, i64 0)) #10
   unreachable
 }
 
+define internal fastcc void @sorbet_globalConstructors(i64 %realpath) unnamed_addr {
+allocRubyIds:
+  tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([14 x %struct.rb_code_position_struct], [14 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 14, i8* noundef getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
+  tail call void @sorbet_vm_init_string_table(i64* noundef getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleRubyStringTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([3 x %struct.rb_code_position_struct], [3 x %struct.rb_code_position_struct]* @sorbet_moduleRubyStringDescriptors, i32 0, i32 0), i32 noundef 3, i8* noundef getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
+  tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 32)
+  tail call fastcc void @"Constr_stackFramePrecomputed_func_Object#14take_arguments"(i64 %realpath)
+  %rubyId_inspect = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 5), align 8, !dbg !10, !invariant.load !5
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_inspect, i64 %rubyId_inspect, i32 noundef 16, i32 noundef 0, i32 noundef 0), !dbg !10
+  %rubyId_puts = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 6), align 8, !dbg !15, !invariant.load !5
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !15
+  tail call fastcc void @"Constr_stackFramePrecomputed_func_<root>.17<static-init>$153"(i64 %realpath)
+  %rubyId_take_arguments = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !dbg !16, !invariant.load !5
+  %rubyId_d = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !16, !invariant.load !5
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments, i64 %rubyId_take_arguments, i32 noundef 68, i32 noundef 8, i32 noundef 1, i64 %rubyId_d), !dbg !16
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.1, i64 %rubyId_take_arguments, i32 noundef 68, i32 noundef 7, i32 noundef 1, i64 %rubyId_d), !dbg !18
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.2, i64 %rubyId_take_arguments, i32 noundef 68, i32 noundef 6, i32 noundef 1, i64 %rubyId_d), !dbg !19
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.3, i64 %rubyId_take_arguments, i32 noundef 68, i32 noundef 5, i32 noundef 1, i64 %rubyId_d), !dbg !20
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.4, i64 %rubyId_take_arguments, i32 noundef 68, i32 noundef 4, i32 noundef 1, i64 %rubyId_d), !dbg !21
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.5, i64 %rubyId_take_arguments, i32 noundef 68, i32 noundef 3, i32 noundef 1, i64 %rubyId_d), !dbg !22
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.6, i64 %rubyId_take_arguments, i32 noundef 68, i32 noundef 2, i32 noundef 1, i64 %rubyId_d), !dbg !23
+  %rubyId_e = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !24, !invariant.load !5
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.7, i64 %rubyId_take_arguments, i32 noundef 68, i32 noundef 9, i32 noundef 2, i64 %rubyId_d, i64 %rubyId_e), !dbg !24
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.8, i64 %rubyId_take_arguments, i32 noundef 68, i32 noundef 8, i32 noundef 2, i64 %rubyId_d, i64 %rubyId_e), !dbg !25
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.9, i64 %rubyId_take_arguments, i32 noundef 68, i32 noundef 7, i32 noundef 2, i64 %rubyId_d, i64 %rubyId_e), !dbg !26
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.10, i64 %rubyId_take_arguments, i32 noundef 68, i32 noundef 6, i32 noundef 2, i64 %rubyId_d, i64 %rubyId_e), !dbg !27
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.11, i64 %rubyId_take_arguments, i32 noundef 68, i32 noundef 5, i32 noundef 2, i64 %rubyId_d, i64 %rubyId_e), !dbg !28
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.12, i64 %rubyId_take_arguments, i32 noundef 68, i32 noundef 4, i32 noundef 2, i64 %rubyId_d, i64 %rubyId_e), !dbg !29
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.13, i64 %rubyId_take_arguments, i32 noundef 68, i32 noundef 3, i32 noundef 2, i64 %rubyId_d, i64 %rubyId_e), !dbg !30
+  %rubyId_baz = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 13), align 8, !dbg !31, !invariant.load !5
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.14, i64 %rubyId_take_arguments, i32 noundef 68, i32 noundef 10, i32 noundef 3, i64 %rubyId_d, i64 %rubyId_e, i64 %rubyId_baz), !dbg !31
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.15, i64 %rubyId_take_arguments, i32 noundef 68, i32 noundef 9, i32 noundef 3, i64 %rubyId_d, i64 %rubyId_e, i64 %rubyId_baz), !dbg !32
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.16, i64 %rubyId_take_arguments, i32 noundef 68, i32 noundef 8, i32 noundef 3, i64 %rubyId_d, i64 %rubyId_e, i64 %rubyId_baz), !dbg !33
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.17, i64 %rubyId_take_arguments, i32 noundef 68, i32 noundef 7, i32 noundef 3, i64 %rubyId_d, i64 %rubyId_e, i64 %rubyId_baz), !dbg !34
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.18, i64 %rubyId_take_arguments, i32 noundef 68, i32 noundef 6, i32 noundef 3, i64 %rubyId_d, i64 %rubyId_e, i64 %rubyId_baz), !dbg !35
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.19, i64 %rubyId_take_arguments, i32 noundef 68, i32 noundef 5, i32 noundef 3, i64 %rubyId_d, i64 %rubyId_e, i64 %rubyId_baz), !dbg !36
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.20, i64 %rubyId_take_arguments, i32 noundef 68, i32 noundef 4, i32 noundef 3, i64 %rubyId_d, i64 %rubyId_e, i64 %rubyId_baz), !dbg !37
+  ret void
+}
+
 ; Function Attrs: nounwind sspreq uwtable
-define internal i64 @"func_Object#14take_arguments"(i32 %argc, i64* %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #7 !dbg !10 {
+define internal i64 @"func_Object#14take_arguments"(i32 %argc, i64* %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #7 !dbg !11 {
 functionEntryInitializers:
   %callArgs = alloca [8 x i64], align 8
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %0, align 8, !tbaa !14
-  %1 = icmp slt i32 1, %argc, !dbg !16
-  br i1 %1, label %2, label %sorbet_determineKwSplatArg.exit, !dbg !16
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %0, align 8, !tbaa !38
+  %1 = icmp slt i32 1, %argc, !dbg !40
+  br i1 %1, label %2, label %sorbet_determineKwSplatArg.exit, !dbg !40
 
 2:                                                ; preds = %functionEntryInitializers
-  %3 = add nsw i32 %argc, -1, !dbg !16
+  %3 = add nsw i32 %argc, -1, !dbg !40
   %4 = zext i32 %3 to i64
-  %5 = getelementptr inbounds i64, i64* %argArray, i64 %4, !dbg !16
-  %6 = load i64, i64* %5, align 8, !dbg !16, !tbaa !6
-  %7 = and i64 %6, 7, !dbg !16
-  %8 = icmp ne i64 %7, 0, !dbg !16
-  %9 = and i64 %6, -9, !dbg !16
-  %10 = icmp eq i64 %9, 0, !dbg !16
-  %11 = or i1 %8, %10, !dbg !16
-  br i1 %11, label %sorbet_determineKwSplatArg.exit.thread77, label %sorbet_isa_Hash.exit, !dbg !16
+  %5 = getelementptr inbounds i64, i64* %argArray, i64 %4, !dbg !40
+  %6 = load i64, i64* %5, align 8, !dbg !40, !tbaa !6
+  %7 = and i64 %6, 7, !dbg !40
+  %8 = icmp ne i64 %7, 0, !dbg !40
+  %9 = and i64 %6, -9, !dbg !40
+  %10 = icmp eq i64 %9, 0, !dbg !40
+  %11 = or i1 %8, %10, !dbg !40
+  br i1 %11, label %sorbet_determineKwSplatArg.exit.thread77, label %sorbet_isa_Hash.exit, !dbg !40
 
 sorbet_isa_Hash.exit:                             ; preds = %2
-  %12 = inttoptr i64 %6 to %struct.iseq_inline_iv_cache_entry*, !dbg !16
-  %13 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %12, i64 0, i32 0, !dbg !16
-  %14 = load i64, i64* %13, align 8, !dbg !16, !tbaa !17
-  %15 = and i64 %14, 31, !dbg !16
-  %16 = icmp eq i64 %15, 8, !dbg !16
-  br i1 %16, label %fillRequiredArgs, label %sorbet_determineKwSplatArg.exit.thread77, !dbg !16
+  %12 = inttoptr i64 %6 to %struct.iseq_inline_iv_cache_entry*, !dbg !40
+  %13 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %12, i64 0, i32 0, !dbg !40
+  %14 = load i64, i64* %13, align 8, !dbg !40, !tbaa !41
+  %15 = and i64 %14, 31, !dbg !40
+  %16 = icmp eq i64 %15, 8, !dbg !40
+  br i1 %16, label %fillRequiredArgs, label %sorbet_determineKwSplatArg.exit.thread77, !dbg !40
 
 sorbet_determineKwSplatArg.exit.thread77:         ; preds = %sorbet_isa_Hash.exit, %2
-  br label %fillRequiredArgs, !dbg !16
+  br label %fillRequiredArgs, !dbg !40
 
 sorbet_determineKwSplatArg.exit:                  ; preds = %functionEntryInitializers
-  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !16
-  br i1 %tooFewArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !16, !prof !19
+  %tooFewArgs = icmp ult i32 %argc, 1, !dbg !40
+  br i1 %tooFewArgs, label %argCountFailBlock, label %fillRequiredArgs, !dbg !40, !prof !43
 
 argCountFailBlock:                                ; preds = %sorbet_determineKwSplatArg.exit
-  tail call void @sorbet_raiseArity(i32 noundef 0, i32 noundef 1, i32 noundef -1) #10, !dbg !16
-  unreachable, !dbg !16
+  tail call void @sorbet_raiseArity(i32 noundef 0, i32 noundef 1, i32 noundef -1) #11, !dbg !40
+  unreachable, !dbg !40
 
 fillFromDefaultBlockDone1:                        ; preds = %sorbet_writeLocal.exit
-  %17 = getelementptr i64, i64* %argArray, i32 1, !dbg !16
-  %rawArg_b = load i64, i64* %17, align 8, !dbg !16
-  %18 = icmp sgt i32 %30, 2, !dbg !16
-  br i1 %18, label %20, label %fillFromDefaultBlockDone1.thread, !dbg !16
+  %17 = getelementptr i64, i64* %argArray, i32 1, !dbg !40
+  %rawArg_b = load i64, i64* %17, align 8, !dbg !40
+  %18 = icmp sgt i32 %30, 2, !dbg !40
+  br i1 %18, label %20, label %fillFromDefaultBlockDone1.thread, !dbg !40
 
 fillFromDefaultBlockDone1.thread:                 ; preds = %sorbet_writeLocal.exit, %fillFromDefaultBlockDone1
   %"<argPresent>.sroa.0.084" = phi i64 [ 20, %fillFromDefaultBlockDone1 ], [ 0, %sorbet_writeLocal.exit ]
   %b.sroa.0.182 = phi i64 [ %rawArg_b, %fillFromDefaultBlockDone1 ], [ 8, %sorbet_writeLocal.exit ]
-  %19 = tail call i64 @rb_ary_new() #11, !dbg !16
-  br label %sorbet_readRestArgs.exit, !dbg !16
+  %19 = tail call i64 @rb_ary_new() #12, !dbg !40
+  br label %sorbet_readRestArgs.exit, !dbg !40
 
 20:                                               ; preds = %fillFromDefaultBlockDone1
-  %21 = sub nuw nsw i32 %30, 2, !dbg !16
+  %21 = sub nuw nsw i32 %30, 2, !dbg !40
   %22 = zext i32 %21 to i64
-  %23 = getelementptr inbounds i64, i64* %argArray, i64 2, !dbg !16
-  %24 = tail call i64 @rb_ary_new_from_values(i64 %22, i64* nonnull %23) #11, !dbg !16
-  br label %sorbet_readRestArgs.exit, !dbg !16
+  %23 = getelementptr inbounds i64, i64* %argArray, i64 2, !dbg !40
+  %24 = tail call i64 @rb_ary_new_from_values(i64 %22, i64* nonnull %23) #12, !dbg !40
+  br label %sorbet_readRestArgs.exit, !dbg !40
 
 sorbet_readRestArgs.exit:                         ; preds = %fillFromDefaultBlockDone1.thread, %20
   %"<argPresent>.sroa.0.083" = phi i64 [ %"<argPresent>.sroa.0.084", %fillFromDefaultBlockDone1.thread ], [ 20, %20 ]
   %b.sroa.0.181 = phi i64 [ %b.sroa.0.182, %fillFromDefaultBlockDone1.thread ], [ %rawArg_b, %20 ]
-  %25 = phi i64 [ %19, %fillFromDefaultBlockDone1.thread ], [ %24, %20 ], !dbg !16
-  %rubyId_d = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !16, !invariant.load !5
-  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_d), !dbg !16
-  %26 = icmp eq i64 %29, 52, !dbg !16
-  br i1 %26, label %kwArgContinue, label %sorbet_removeKWArg.exit74, !dbg !16
+  %25 = phi i64 [ %19, %fillFromDefaultBlockDone1.thread ], [ %24, %20 ], !dbg !40
+  %rubyId_d = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !40, !invariant.load !5
+  %rawSym = tail call i64 @rb_id2sym(i64 %rubyId_d), !dbg !40
+  %26 = icmp eq i64 %29, 52, !dbg !40
+  br i1 %26, label %kwArgContinue, label %sorbet_removeKWArg.exit74, !dbg !40
 
 sorbet_removeKWArg.exit74:                        ; preds = %sorbet_readRestArgs.exit
-  %27 = tail call i64 @rb_hash_delete_entry(i64 %29, i64 %rawSym) #11, !dbg !16
-  %28 = icmp eq i64 %27, 52, !dbg !16
-  br i1 %28, label %kwArgContinue, label %kwArgContinue.thread, !dbg !16
+  %27 = tail call i64 @rb_hash_delete_entry(i64 %29, i64 %rawSym) #12, !dbg !40
+  %28 = icmp eq i64 %27, 52, !dbg !40
+  br i1 %28, label %kwArgContinue, label %kwArgContinue.thread, !dbg !40
 
 kwArgContinue.thread:                             ; preds = %sorbet_removeKWArg.exit74
-  %rubyId_e87 = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !16, !invariant.load !5
-  %rawSym2088 = tail call i64 @rb_id2sym(i64 %rubyId_e87), !dbg !16
-  br label %sorbet_removeKWArg.exit.thread, !dbg !16
+  %rubyId_e87 = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !40, !invariant.load !5
+  %rawSym2088 = tail call i64 @rb_id2sym(i64 %rubyId_e87), !dbg !40
+  br label %sorbet_removeKWArg.exit.thread, !dbg !40
 
 fillRequiredArgs:                                 ; preds = %sorbet_isa_Hash.exit, %sorbet_determineKwSplatArg.exit.thread77, %sorbet_determineKwSplatArg.exit
   %29 = phi i64 [ 52, %sorbet_determineKwSplatArg.exit ], [ 52, %sorbet_determineKwSplatArg.exit.thread77 ], [ %6, %sorbet_isa_Hash.exit ]
   %30 = phi i32 [ %argc, %sorbet_determineKwSplatArg.exit ], [ %argc, %sorbet_determineKwSplatArg.exit.thread77 ], [ %3, %sorbet_isa_Hash.exit ]
-  %rawArg_a = load i64, i64* %argArray, align 8, !dbg !16
-  %31 = tail call i32 @rb_block_given_p() #11, !dbg !16
-  %32 = icmp eq i32 %31, 0, !dbg !16
-  br i1 %32, label %sorbet_getMethodBlockAsProc.exit, label %33, !dbg !16
+  %rawArg_a = load i64, i64* %argArray, align 8, !dbg !40
+  %31 = tail call i32 @rb_block_given_p() #12, !dbg !40
+  %32 = icmp eq i32 %31, 0, !dbg !40
+  br i1 %32, label %sorbet_getMethodBlockAsProc.exit, label %33, !dbg !40
 
 33:                                               ; preds = %fillRequiredArgs
-  %34 = tail call i64 @rb_block_proc() #11, !dbg !16
-  br label %sorbet_getMethodBlockAsProc.exit, !dbg !16
+  %34 = tail call i64 @rb_block_proc() #12, !dbg !40
+  br label %sorbet_getMethodBlockAsProc.exit, !dbg !40
 
 sorbet_getMethodBlockAsProc.exit:                 ; preds = %fillRequiredArgs, %33
-  %35 = phi i64 [ %34, %33 ], [ 8, %fillRequiredArgs ], !dbg !16
-  %36 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 4, !dbg !16
-  %37 = load i64*, i64** %36, align 8, !dbg !16, !tbaa !20
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !22), !dbg !16
-  %38 = load i64, i64* %37, align 8, !dbg !16, !tbaa !6
-  %39 = and i64 %38, 8, !dbg !16
-  %40 = icmp eq i64 %39, 0, !dbg !16
-  br i1 %40, label %41, label %43, !dbg !16, !prof !25
+  %35 = phi i64 [ %34, %33 ], [ 8, %fillRequiredArgs ], !dbg !40
+  %36 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 4, !dbg !40
+  %37 = load i64*, i64** %36, align 8, !dbg !40, !tbaa !44
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !46), !dbg !40
+  %38 = load i64, i64* %37, align 8, !dbg !40, !tbaa !6
+  %39 = and i64 %38, 8, !dbg !40
+  %40 = icmp eq i64 %39, 0, !dbg !40
+  br i1 %40, label %41, label %43, !dbg !40, !prof !49
 
 41:                                               ; preds = %sorbet_getMethodBlockAsProc.exit
-  %42 = getelementptr inbounds i64, i64* %37, i64 -3, !dbg !16
-  store i64 %35, i64* %42, align 8, !dbg !16, !tbaa !6
-  br label %sorbet_writeLocal.exit, !dbg !16
+  %42 = getelementptr inbounds i64, i64* %37, i64 -3, !dbg !40
+  store i64 %35, i64* %42, align 8, !dbg !40, !tbaa !6
+  br label %sorbet_writeLocal.exit, !dbg !40
 
 43:                                               ; preds = %sorbet_getMethodBlockAsProc.exit
-  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %37, i32 noundef -3, i64 %35) #11, !dbg !16
-  br label %sorbet_writeLocal.exit, !dbg !16
+  tail call void @sorbet_vm_env_write_slowpath(i64* nonnull align 8 dereferenceable(8) %37, i32 noundef -3, i64 %35) #12, !dbg !40
+  br label %sorbet_writeLocal.exit, !dbg !40
 
 sorbet_writeLocal.exit:                           ; preds = %41, %43
-  %default0 = icmp eq i32 %30, 1, !dbg !16
-  br i1 %default0, label %fillFromDefaultBlockDone1.thread, label %fillFromDefaultBlockDone1, !dbg !16, !prof !19
+  %default0 = icmp eq i32 %30, 1, !dbg !40
+  br i1 %default0, label %fillFromDefaultBlockDone1.thread, label %fillFromDefaultBlockDone1, !dbg !40, !prof !43
 
 kwArgContinue:                                    ; preds = %sorbet_readRestArgs.exit, %sorbet_removeKWArg.exit74
-  %44 = tail call i64 @sorbet_addMissingKWArg(i64 noundef 52, i64 %rawSym), !dbg !16
-  %rubyId_e = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !16, !invariant.load !5
-  %rawSym20 = tail call i64 @rb_id2sym(i64 %rubyId_e), !dbg !16
-  br i1 %26, label %sorbet_removeKWArg.exit, label %sorbet_removeKWArg.exit.thread, !dbg !16
+  %44 = tail call i64 @sorbet_addMissingKWArg(i64 noundef 52, i64 %rawSym), !dbg !40
+  %rubyId_e = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !40, !invariant.load !5
+  %rawSym20 = tail call i64 @rb_id2sym(i64 %rubyId_e), !dbg !40
+  br i1 %26, label %sorbet_removeKWArg.exit, label %sorbet_removeKWArg.exit.thread, !dbg !40
 
 sorbet_removeKWArg.exit:                          ; preds = %kwArgContinue
-  %45 = icmp eq i64 %44, 52, !dbg !16
-  br i1 %45, label %sorbet_readKWRestArgs.exit.thread, label %49, !dbg !16, !prof !25
+  %45 = icmp eq i64 %44, 52, !dbg !40
+  br i1 %45, label %sorbet_readKWRestArgs.exit.thread, label %49, !dbg !40, !prof !49
 
 sorbet_removeKWArg.exit.thread:                   ; preds = %kwArgContinue, %kwArgContinue.thread
   %rawSym2093 = phi i64 [ %rawSym2088, %kwArgContinue.thread ], [ %rawSym20, %kwArgContinue ]
   %missingArgsPhi91 = phi i64 [ 52, %kwArgContinue.thread ], [ %44, %kwArgContinue ]
   %d.sroa.0.089 = phi i64 [ %27, %kwArgContinue.thread ], [ 8, %kwArgContinue ]
-  %46 = tail call i64 @rb_hash_delete_entry(i64 %29, i64 %rawSym2093) #11, !dbg !16
-  %47 = icmp eq i64 %46, 52, !dbg !16
-  %e.sroa.0.196 = select i1 %47, i64 8, i64 %46, !dbg !16
-  %"<argPresent>9.sroa.0.097" = select i1 %47, i64 0, i64 20, !dbg !16
-  %48 = icmp eq i64 %missingArgsPhi91, 52, !dbg !16
-  br i1 %48, label %sorbet_readKWRestArgs.exit, label %49, !dbg !16, !prof !25
+  %46 = tail call i64 @rb_hash_delete_entry(i64 %29, i64 %rawSym2093) #12, !dbg !40
+  %47 = icmp eq i64 %46, 52, !dbg !40
+  %e.sroa.0.196 = select i1 %47, i64 8, i64 %46, !dbg !40
+  %"<argPresent>9.sroa.0.097" = select i1 %47, i64 0, i64 20, !dbg !40
+  %48 = icmp eq i64 %missingArgsPhi91, 52, !dbg !40
+  br i1 %48, label %sorbet_readKWRestArgs.exit, label %49, !dbg !40, !prof !49
 
 49:                                               ; preds = %sorbet_removeKWArg.exit.thread, %sorbet_removeKWArg.exit
   %missingArgsPhi9298 = phi i64 [ %missingArgsPhi91, %sorbet_removeKWArg.exit.thread ], [ %44, %sorbet_removeKWArg.exit ]
-  tail call void @sorbet_raiseMissingKeywords(i64 %missingArgsPhi9298) #9, !dbg !16
-  unreachable, !dbg !16
+  tail call void @sorbet_raiseMissingKeywords(i64 %missingArgsPhi9298) #10, !dbg !40
+  unreachable, !dbg !40
 
 sorbet_readKWRestArgs.exit.thread:                ; preds = %sorbet_removeKWArg.exit
-  %50 = tail call i64 @rb_hash_new() #11, !dbg !16
-  %51 = and i64 %"<argPresent>.sroa.0.083", -9, !dbg !26
-  %52 = icmp ne i64 %51, 0, !dbg !26
-  %b.sroa.0.0125 = select i1 %52, i64 %b.sroa.0.181, i64 3, !dbg !26
-  br label %58, !dbg !27
+  %50 = tail call i64 @rb_hash_new() #12, !dbg !40
+  %51 = and i64 %"<argPresent>.sroa.0.083", -9, !dbg !50
+  %52 = icmp ne i64 %51, 0, !dbg !50
+  %b.sroa.0.0125 = select i1 %52, i64 %b.sroa.0.181, i64 3, !dbg !50
+  br label %58, !dbg !51
 
 sorbet_readKWRestArgs.exit:                       ; preds = %sorbet_removeKWArg.exit.thread
-  %53 = tail call i64 @rb_hash_dup(i64 %29) #11, !dbg !16
-  %54 = and i64 %"<argPresent>.sroa.0.083", -9, !dbg !26
-  %55 = icmp ne i64 %54, 0, !dbg !26
-  %b.sroa.0.0 = select i1 %55, i64 %b.sroa.0.181, i64 3, !dbg !26
-  %56 = icmp ne i64 %"<argPresent>9.sroa.0.097", 0, !dbg !27
-  br i1 %56, label %57, label %58, !dbg !27
+  %53 = tail call i64 @rb_hash_dup(i64 %29) #12, !dbg !40
+  %54 = and i64 %"<argPresent>.sroa.0.083", -9, !dbg !50
+  %55 = icmp ne i64 %54, 0, !dbg !50
+  %b.sroa.0.0 = select i1 %55, i64 %b.sroa.0.181, i64 3, !dbg !50
+  %56 = icmp ne i64 %"<argPresent>9.sroa.0.097", 0, !dbg !51
+  br i1 %56, label %57, label %58, !dbg !51
 
 57:                                               ; preds = %sorbet_readKWRestArgs.exit
-  br label %58, !dbg !27
+  br label %58, !dbg !51
 
 58:                                               ; preds = %sorbet_readKWRestArgs.exit.thread, %sorbet_readKWRestArgs.exit, %57
   %b.sroa.0.0127 = phi i64 [ %b.sroa.0.0, %57 ], [ %b.sroa.0.0, %sorbet_readKWRestArgs.exit ], [ %b.sroa.0.0125, %sorbet_readKWRestArgs.exit.thread ]
   %59 = phi i64 [ %53, %57 ], [ %53, %sorbet_readKWRestArgs.exit ], [ %50, %sorbet_readKWRestArgs.exit.thread ]
   %d.sroa.0.09099109126 = phi i64 [ %d.sroa.0.089, %57 ], [ %d.sroa.0.089, %sorbet_readKWRestArgs.exit ], [ 8, %sorbet_readKWRestArgs.exit.thread ]
   %60 = phi i64 [ %e.sroa.0.196, %57 ], [ 5, %sorbet_readKWRestArgs.exit ], [ 5, %sorbet_readKWRestArgs.exit.thread ]
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %0, align 8, !dbg !28, !tbaa !14
-  %callArgs0Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i64 0, i64 0, !dbg !29
-  store i64 %rawArg_a, i64* %callArgs0Addr, align 8, !dbg !29
-  %callArgs1Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i64 0, i64 1, !dbg !29
-  store i64 %b.sroa.0.0127, i64* %callArgs1Addr, align 8, !dbg !29
-  %callArgs2Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i64 0, i64 2, !dbg !29
-  store i64 %25, i64* %callArgs2Addr, align 8, !dbg !29
-  %callArgs3Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i64 0, i64 3, !dbg !29
-  store i64 %d.sroa.0.09099109126, i64* %callArgs3Addr, align 8, !dbg !29
-  %callArgs4Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i64 0, i64 4, !dbg !29
-  store i64 %60, i64* %callArgs4Addr, align 8, !dbg !29
-  %callArgs5Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i64 0, i64 5, !dbg !29
-  store i64 %59, i64* %callArgs5Addr, align 8, !dbg !29
-  %61 = load i64*, i64** %36, align 8, !dbg !29, !tbaa !20
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !30), !dbg !29
-  %62 = getelementptr inbounds i64, i64* %61, i64 -3, !dbg !29
-  %63 = load i64, i64* %62, align 8, !dbg !29, !tbaa !6
-  %callArgs6Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i64 0, i64 6, !dbg !29
-  store i64 %63, i64* %callArgs6Addr, align 8, !dbg !29
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !33) #12, !dbg !29
-  %64 = call i64 @rb_ary_new_from_values(i64 noundef 7, i64* noundef nonnull %callArgs0Addr) #11, !dbg !29
-  %65 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !29
-  %66 = load i64*, i64** %65, align 8, !dbg !29
-  store i64 %64, i64* %66, align 8, !dbg !29, !tbaa !6
-  %67 = getelementptr inbounds i64, i64* %66, i64 1, !dbg !29
-  store i64* %67, i64** %65, align 8, !dbg !29
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_inspect, i64 0), !dbg !29
-  %68 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !36
-  %69 = load i64*, i64** %68, align 8, !dbg !36
-  store i64 %selfRaw, i64* %69, align 8, !dbg !36, !tbaa !6
-  %70 = getelementptr inbounds i64, i64* %69, i64 1, !dbg !36
-  store i64 %send, i64* %70, align 8, !dbg !36, !tbaa !6
-  %71 = getelementptr inbounds i64, i64* %70, i64 1, !dbg !36
-  store i64* %71, i64** %68, align 8, !dbg !36
-  %send121 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !36
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %0, align 8, !dbg !52, !tbaa !38
+  %callArgs0Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i64 0, i64 0, !dbg !10
+  store i64 %rawArg_a, i64* %callArgs0Addr, align 8, !dbg !10
+  %callArgs1Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i64 0, i64 1, !dbg !10
+  store i64 %b.sroa.0.0127, i64* %callArgs1Addr, align 8, !dbg !10
+  %callArgs2Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i64 0, i64 2, !dbg !10
+  store i64 %25, i64* %callArgs2Addr, align 8, !dbg !10
+  %callArgs3Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i64 0, i64 3, !dbg !10
+  store i64 %d.sroa.0.09099109126, i64* %callArgs3Addr, align 8, !dbg !10
+  %callArgs4Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i64 0, i64 4, !dbg !10
+  store i64 %60, i64* %callArgs4Addr, align 8, !dbg !10
+  %callArgs5Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i64 0, i64 5, !dbg !10
+  store i64 %59, i64* %callArgs5Addr, align 8, !dbg !10
+  %61 = load i64*, i64** %36, align 8, !dbg !10, !tbaa !44
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !53), !dbg !10
+  %62 = getelementptr inbounds i64, i64* %61, i64 -3, !dbg !10
+  %63 = load i64, i64* %62, align 8, !dbg !10, !tbaa !6
+  %callArgs6Addr = getelementptr [8 x i64], [8 x i64]* %callArgs, i64 0, i64 6, !dbg !10
+  store i64 %63, i64* %callArgs6Addr, align 8, !dbg !10
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !56) #13, !dbg !10
+  %64 = call i64 @rb_ary_new_from_values(i64 noundef 7, i64* noundef nonnull %callArgs0Addr) #12, !dbg !10
+  %65 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !10
+  %66 = load i64*, i64** %65, align 8, !dbg !10
+  store i64 %64, i64* %66, align 8, !dbg !10, !tbaa !6
+  %67 = getelementptr inbounds i64, i64* %66, i64 1, !dbg !10
+  store i64* %67, i64** %65, align 8, !dbg !10
+  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_inspect, i64 0), !dbg !10
+  %68 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !15
+  %69 = load i64*, i64** %68, align 8, !dbg !15
+  store i64 %selfRaw, i64* %69, align 8, !dbg !15, !tbaa !6
+  %70 = getelementptr inbounds i64, i64* %69, i64 1, !dbg !15
+  store i64 %send, i64* %70, align 8, !dbg !15, !tbaa !6
+  %71 = getelementptr inbounds i64, i64* %70, i64 1, !dbg !15
+  store i64* %71, i64** %68, align 8, !dbg !15
+  %send121 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_puts, i64 0), !dbg !15
   ret i64 %send121
 }
 
+; Function Attrs: ssp
+define internal fastcc void @"Constr_stackFramePrecomputed_func_Object#14take_arguments"(i64 %realpath) unnamed_addr #8 {
+entryInitializers:
+  %rubyId_take_arguments = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
+  %rubyStr_take_arguments = load i64, i64* getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 0), align 8, !invariant.load !5
+  %"rubyStr_test/testdata/compiler/all_arguments.rb" = load i64, i64* getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
+  %locals = alloca i64, align 8
+  %rubyId_g = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !invariant.load !5
+  store i64 %rubyId_g, i64* %locals, align 8
+  %0 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_take_arguments, i64 %rubyId_take_arguments, i64 %"rubyStr_test/testdata/compiler/all_arguments.rb", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals, i32 noundef 1, i32 noundef 8)
+  store %struct.rb_iseq_struct* %0, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#14take_arguments", align 8
+  ret void
+}
+
+; Function Attrs: ssp
+define internal fastcc void @"Constr_stackFramePrecomputed_func_<root>.17<static-init>$153"(i64 %realpath) unnamed_addr #8 {
+entryInitializers:
+  %"rubyId_<top (required)>" = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 7), align 8, !invariant.load !5
+  %"rubyStr_<top (required)>" = load i64, i64* getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 2), align 8, !invariant.load !5
+  %"rubyStr_test/testdata/compiler/all_arguments.rb" = load i64, i64* getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
+  %locals = alloca i64, i32 0, align 8
+  %0 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>", i64 %"rubyId_<top (required)>", i64 %"rubyStr_test/testdata/compiler/all_arguments.rb", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals, i32 noundef 0, i32 noundef 11)
+  store %struct.rb_iseq_struct* %0, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  ret void
+}
+
 ; Function Attrs: sspreq
-define void @Init_all_arguments() local_unnamed_addr #8 {
+define void @Init_all_arguments() local_unnamed_addr #9 {
 entry:
-  %positional_table.i = alloca i64, i32 4, align 8, !dbg !37
-  %keyword_table.i = alloca i64, i32 3, align 8, !dbg !37
-  %locals.i122.i = alloca i64, i32 0, align 8
-  %locals.i.i = alloca i64, align 8
-  %keywords.i = alloca i64, align 8, !dbg !39
-  %keywords2.i = alloca i64, align 8, !dbg !40
-  %keywords6.i = alloca i64, align 8, !dbg !41
-  %keywords10.i = alloca i64, align 8, !dbg !42
-  %keywords14.i = alloca i64, align 8, !dbg !43
-  %keywords18.i = alloca i64, align 8, !dbg !44
-  %keywords22.i = alloca i64, align 8, !dbg !45
-  %keywords26.i = alloca i64, i32 2, align 8, !dbg !46
-  %keywords31.i = alloca i64, i32 2, align 8, !dbg !47
-  %keywords37.i = alloca i64, i32 2, align 8, !dbg !48
-  %keywords43.i = alloca i64, i32 2, align 8, !dbg !49
-  %keywords49.i = alloca i64, i32 2, align 8, !dbg !50
-  %keywords55.i = alloca i64, i32 2, align 8, !dbg !51
-  %keywords61.i = alloca i64, i32 2, align 8, !dbg !52
-  %keywords67.i = alloca i64, i32 3, align 8, !dbg !53
-  %keywords74.i = alloca i64, i32 3, align 8, !dbg !54
-  %keywords82.i = alloca i64, i32 3, align 8, !dbg !55
-  %keywords90.i = alloca i64, i32 3, align 8, !dbg !56
-  %keywords98.i = alloca i64, i32 3, align 8, !dbg !57
-  %keywords106.i = alloca i64, i32 3, align 8, !dbg !58
-  %keywords114.i = alloca i64, i32 3, align 8, !dbg !59
+  %positional_table.i = alloca i64, i32 4, align 8, !dbg !59
+  %keyword_table.i = alloca i64, i32 3, align 8, !dbg !59
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = bitcast i64* %keywords.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %0)
-  %1 = bitcast i64* %keywords2.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %1)
-  %2 = bitcast i64* %keywords6.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %2)
-  %3 = bitcast i64* %keywords10.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %3)
-  %4 = bitcast i64* %keywords14.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %4)
-  %5 = bitcast i64* %keywords18.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %5)
-  %6 = bitcast i64* %keywords22.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %6)
-  %7 = bitcast i64* %keywords26.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %7)
-  %8 = bitcast i64* %keywords31.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %8)
-  %9 = bitcast i64* %keywords37.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %9)
-  %10 = bitcast i64* %keywords43.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %10)
-  %11 = bitcast i64* %keywords49.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %11)
-  %12 = bitcast i64* %keywords55.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %12)
-  %13 = bitcast i64* %keywords61.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %13)
-  %14 = bitcast i64* %keywords67.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %14)
-  %15 = bitcast i64* %keywords74.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %15)
-  %16 = bitcast i64* %keywords82.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %16)
-  %17 = bitcast i64* %keywords90.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %17)
-  %18 = bitcast i64* %keywords98.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %18)
-  %19 = bitcast i64* %keywords106.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %19)
-  %20 = bitcast i64* %keywords114.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %20)
-  tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([14 x %struct.rb_code_position_struct], [14 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 14, i8* noundef getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
-  tail call void @sorbet_vm_init_string_table(i64* noundef getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleRubyStringTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([3 x %struct.rb_code_position_struct], [3 x %struct.rb_code_position_struct]* @sorbet_moduleRubyStringDescriptors, i32 0, i32 0), i32 noundef 3, i8* noundef getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
-  tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 32)
-  %21 = bitcast i64* %locals.i.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %21)
-  %rubyId_take_arguments.i.i = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
-  %rubyStr_take_arguments.i.i = load i64, i64* getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 0), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/all_arguments.rb.i.i" = load i64, i64* getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
-  %rubyId_g.i.i = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !invariant.load !5
-  store i64 %rubyId_g.i.i, i64* %locals.i.i, align 8
-  %22 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_take_arguments.i.i, i64 %rubyId_take_arguments.i.i, i64 %"rubyStr_test/testdata/compiler/all_arguments.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i.i, i32 noundef 1, i32 noundef 8)
-  store %struct.rb_iseq_struct* %22, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#14take_arguments", align 8
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %21)
-  %rubyId_inspect.i = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 5), align 8, !dbg !29, !invariant.load !5
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_inspect, i64 %rubyId_inspect.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !29
-  %rubyId_puts.i = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 6), align 8, !dbg !36, !invariant.load !5
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !36
-  %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 7), align 8, !invariant.load !5
-  %"rubyStr_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 2), align 8, !invariant.load !5
-  %23 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/all_arguments.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i122.i, i32 noundef 0, i32 noundef 11)
-  store %struct.rb_iseq_struct* %23, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %rubyId_d.i = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !39, !invariant.load !5
-  %24 = call i64 @rb_id2sym(i64 %rubyId_d.i) #13, !dbg !39
-  store i64 %24, i64* %keywords.i, align 8, !dbg !39
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 8, i32 noundef 1, i64* noundef nonnull align 8 %keywords.i), !dbg !39
-  store i64 %24, i64* %keywords2.i, align 8, !dbg !40
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.1, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 7, i32 noundef 1, i64* noundef nonnull align 8 %keywords2.i), !dbg !40
-  store i64 %24, i64* %keywords6.i, align 8, !dbg !41
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.2, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 6, i32 noundef 1, i64* noundef nonnull align 8 %keywords6.i), !dbg !41
-  store i64 %24, i64* %keywords10.i, align 8, !dbg !42
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.3, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 5, i32 noundef 1, i64* noundef nonnull align 8 %keywords10.i), !dbg !42
-  store i64 %24, i64* %keywords14.i, align 8, !dbg !43
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.4, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 4, i32 noundef 1, i64* noundef nonnull align 8 %keywords14.i), !dbg !43
-  store i64 %24, i64* %keywords18.i, align 8, !dbg !44
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.5, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 3, i32 noundef 1, i64* noundef nonnull align 8 %keywords18.i), !dbg !44
-  store i64 %24, i64* %keywords22.i, align 8, !dbg !45
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.6, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 2, i32 noundef 1, i64* noundef nonnull align 8 %keywords22.i), !dbg !45
-  store i64 %24, i64* %keywords26.i, align 8, !dbg !46
-  %rubyId_e.i = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !46, !invariant.load !5
-  %25 = call i64 @rb_id2sym(i64 %rubyId_e.i) #13, !dbg !46
-  %26 = getelementptr i64, i64* %keywords26.i, i32 1, !dbg !46
-  store i64 %25, i64* %26, align 8, !dbg !46
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.7, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 9, i32 noundef 2, i64* noundef nonnull align 8 %keywords26.i), !dbg !46
-  store i64 %24, i64* %keywords31.i, align 8, !dbg !47
-  %27 = getelementptr i64, i64* %keywords31.i, i32 1, !dbg !47
-  store i64 %25, i64* %27, align 8, !dbg !47
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.8, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 8, i32 noundef 2, i64* noundef nonnull align 8 %keywords31.i), !dbg !47
-  store i64 %24, i64* %keywords37.i, align 8, !dbg !48
-  %28 = getelementptr i64, i64* %keywords37.i, i32 1, !dbg !48
-  store i64 %25, i64* %28, align 8, !dbg !48
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.9, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 7, i32 noundef 2, i64* noundef nonnull align 8 %keywords37.i), !dbg !48
-  store i64 %24, i64* %keywords43.i, align 8, !dbg !49
-  %29 = getelementptr i64, i64* %keywords43.i, i32 1, !dbg !49
-  store i64 %25, i64* %29, align 8, !dbg !49
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.10, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 6, i32 noundef 2, i64* noundef nonnull align 8 %keywords43.i), !dbg !49
-  store i64 %24, i64* %keywords49.i, align 8, !dbg !50
-  %30 = getelementptr i64, i64* %keywords49.i, i32 1, !dbg !50
-  store i64 %25, i64* %30, align 8, !dbg !50
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.11, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 5, i32 noundef 2, i64* noundef nonnull align 8 %keywords49.i), !dbg !50
-  store i64 %24, i64* %keywords55.i, align 8, !dbg !51
-  %31 = getelementptr i64, i64* %keywords55.i, i32 1, !dbg !51
-  store i64 %25, i64* %31, align 8, !dbg !51
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.12, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 4, i32 noundef 2, i64* noundef nonnull align 8 %keywords55.i), !dbg !51
-  store i64 %24, i64* %keywords61.i, align 8, !dbg !52
-  %32 = getelementptr i64, i64* %keywords61.i, i32 1, !dbg !52
-  store i64 %25, i64* %32, align 8, !dbg !52
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.13, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 3, i32 noundef 2, i64* noundef nonnull align 8 %keywords61.i), !dbg !52
-  store i64 %24, i64* %keywords67.i, align 8, !dbg !53
-  %33 = getelementptr i64, i64* %keywords67.i, i32 1, !dbg !53
-  store i64 %25, i64* %33, align 8, !dbg !53
-  %rubyId_baz.i = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 13), align 8, !dbg !53, !invariant.load !5
-  %34 = call i64 @rb_id2sym(i64 %rubyId_baz.i) #13, !dbg !53
-  %35 = getelementptr i64, i64* %keywords67.i, i32 2, !dbg !53
-  store i64 %34, i64* %35, align 8, !dbg !53
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.14, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 10, i32 noundef 3, i64* noundef nonnull align 8 %keywords67.i), !dbg !53
-  store i64 %24, i64* %keywords74.i, align 8, !dbg !54
-  %36 = getelementptr i64, i64* %keywords74.i, i32 1, !dbg !54
-  store i64 %25, i64* %36, align 8, !dbg !54
-  %37 = getelementptr i64, i64* %keywords74.i, i32 2, !dbg !54
-  store i64 %34, i64* %37, align 8, !dbg !54
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.15, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 9, i32 noundef 3, i64* noundef nonnull align 8 %keywords74.i), !dbg !54
-  store i64 %24, i64* %keywords82.i, align 8, !dbg !55
-  %38 = getelementptr i64, i64* %keywords82.i, i32 1, !dbg !55
-  store i64 %25, i64* %38, align 8, !dbg !55
-  %39 = getelementptr i64, i64* %keywords82.i, i32 2, !dbg !55
-  store i64 %34, i64* %39, align 8, !dbg !55
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.16, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 8, i32 noundef 3, i64* noundef nonnull align 8 %keywords82.i), !dbg !55
-  store i64 %24, i64* %keywords90.i, align 8, !dbg !56
-  %40 = getelementptr i64, i64* %keywords90.i, i32 1, !dbg !56
-  store i64 %25, i64* %40, align 8, !dbg !56
-  %41 = getelementptr i64, i64* %keywords90.i, i32 2, !dbg !56
-  store i64 %34, i64* %41, align 8, !dbg !56
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.17, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 7, i32 noundef 3, i64* noundef nonnull align 8 %keywords90.i), !dbg !56
-  store i64 %24, i64* %keywords98.i, align 8, !dbg !57
-  %42 = getelementptr i64, i64* %keywords98.i, i32 1, !dbg !57
-  store i64 %25, i64* %42, align 8, !dbg !57
-  %43 = getelementptr i64, i64* %keywords98.i, i32 2, !dbg !57
-  store i64 %34, i64* %43, align 8, !dbg !57
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.18, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 6, i32 noundef 3, i64* noundef nonnull align 8 %keywords98.i), !dbg !57
-  store i64 %24, i64* %keywords106.i, align 8, !dbg !58
-  %44 = getelementptr i64, i64* %keywords106.i, i32 1, !dbg !58
-  store i64 %25, i64* %44, align 8, !dbg !58
-  %45 = getelementptr i64, i64* %keywords106.i, i32 2, !dbg !58
-  store i64 %34, i64* %45, align 8, !dbg !58
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.19, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 5, i32 noundef 3, i64* noundef nonnull align 8 %keywords106.i), !dbg !58
-  store i64 %24, i64* %keywords114.i, align 8, !dbg !59
-  %46 = getelementptr i64, i64* %keywords114.i, i32 1, !dbg !59
-  store i64 %25, i64* %46, align 8, !dbg !59
-  %47 = getelementptr i64, i64* %keywords114.i, i32 2, !dbg !59
-  store i64 %34, i64* %47, align 8, !dbg !59
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_take_arguments.20, i64 %rubyId_take_arguments.i.i, i32 noundef 68, i32 noundef 4, i32 noundef 3, i64* noundef nonnull align 8 %keywords114.i), !dbg !59
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %0)
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %1)
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %2)
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %3)
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %4)
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %5)
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %6)
-  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %7)
-  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %8)
-  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %9)
-  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %10)
-  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %11)
-  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %12)
-  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %13)
-  call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %14)
-  call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %15)
-  call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %16)
-  call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %17)
-  call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %18)
-  call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %19)
-  call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %20)
-  %48 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
-  %49 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %48, i64 0, i32 18
-  %50 = load i64, i64* %49, align 8, !tbaa !60
-  %51 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %52 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %51, i64 0, i32 2
-  %53 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %52, align 8, !tbaa !70
-  %54 = bitcast i64* %positional_table.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 32, i8* nonnull %54)
-  %55 = bitcast i64* %keyword_table.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %55)
+  tail call fastcc void @sorbet_globalConstructors(i64 %realpath)
+  %0 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !38
+  %1 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %0, i64 0, i32 18
+  %2 = load i64, i64* %1, align 8, !tbaa !60
+  %3 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !38
+  %4 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %3, i64 0, i32 2
+  %5 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %4, align 8, !tbaa !70
+  %6 = bitcast i64* %positional_table.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 32, i8* nonnull %6)
+  %7 = bitcast i64* %keyword_table.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %7)
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %56 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %56, align 8, !tbaa !73
-  %57 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 4
-  %58 = load i64*, i64** %57, align 8, !tbaa !20
-  %59 = load i64, i64* %58, align 8, !tbaa !6
-  %60 = and i64 %59, -33
-  store i64 %60, i64* %58, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %51, %struct.rb_control_frame_struct* %53, %struct.rb_iseq_struct* %stackFrame.i) #11
-  %61 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 0
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %61, align 8, !dbg !74, !tbaa !14
-  %62 = load i64, i64* @rb_cObject, align 8, !dbg !37
-  %stackFrame386.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#14take_arguments", align 8, !dbg !37
-  %63 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #14, !dbg !37
-  %64 = bitcast i8* %63 to i16*, !dbg !37
-  %65 = load i16, i16* %64, align 8, !dbg !37
-  %66 = and i16 %65, -384, !dbg !37
-  %67 = or i16 %66, 119, !dbg !37
-  store i16 %67, i16* %64, align 8, !dbg !37
-  %68 = getelementptr inbounds i8, i8* %63, i64 8, !dbg !37
-  %69 = bitcast i8* %68 to i32*, !dbg !37
-  %70 = getelementptr inbounds i8, i8* %63, i64 12, !dbg !37
-  %71 = bitcast i8* %70 to i32*, !dbg !37
-  %72 = getelementptr inbounds i8, i8* %63, i64 16, !dbg !37
-  %73 = getelementptr inbounds i8, i8* %63, i64 20, !dbg !37
-  %74 = bitcast i8* %73 to i32*, !dbg !37
-  store i32 0, i32* %74, align 4, !dbg !37, !tbaa !75
-  %75 = getelementptr inbounds i8, i8* %63, i64 24, !dbg !37
-  %76 = bitcast i8* %75 to i32*, !dbg !37
-  store i32 0, i32* %76, align 8, !dbg !37, !tbaa !78
-  %77 = getelementptr inbounds i8, i8* %63, i64 28, !dbg !37
-  %78 = bitcast i8* %77 to i32*, !dbg !37
-  store i32 3, i32* %78, align 4, !dbg !37, !tbaa !79
-  %79 = getelementptr inbounds i8, i8* %63, i64 4, !dbg !37
-  %80 = bitcast i8* %79 to i32*, !dbg !37
-  %81 = bitcast i32* %80 to <4 x i32>*, !dbg !37
-  store <4 x i32> <i32 7, i32 1, i32 1, i32 2>, <4 x i32>* %81, align 4, !dbg !37, !tbaa !80
-  %82 = load <2 x i64>, <2 x i64>* bitcast (i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 9) to <2 x i64>*), align 8, !dbg !37, !invariant.load !5
-  %83 = bitcast i64* %positional_table.i to <2 x i64>*, !dbg !37
-  store <2 x i64> %82, <2 x i64>* %83, align 8, !dbg !37
-  %rubyId_c.i = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 11), align 8, !dbg !37, !invariant.load !5
-  %84 = getelementptr i64, i64* %positional_table.i, i32 2, !dbg !37
-  store i64 %rubyId_c.i, i64* %84, align 8, !dbg !37
-  %85 = getelementptr i64, i64* %positional_table.i, i32 3, !dbg !37
-  store i64 %rubyId_g.i.i, i64* %85, align 8, !dbg !37
-  %86 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 4, i64 noundef 8) #14, !dbg !37
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %86, i8* nocapture noundef nonnull readonly align 8 dereferenceable(24) %54, i64 noundef 32, i1 noundef false) #11, !dbg !37
-  %87 = getelementptr inbounds i8, i8* %63, i64 32, !dbg !37
-  %88 = bitcast i8* %87 to i8**, !dbg !37
-  store i8* %86, i8** %88, align 8, !dbg !37, !tbaa !81
-  store i64 %rubyId_d.i, i64* %keyword_table.i, align 8, !dbg !37
-  %89 = getelementptr i64, i64* %keyword_table.i, i32 1, !dbg !37
-  store i64 %rubyId_e.i, i64* %89, align 8, !dbg !37
-  %rubyId_f.i = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 12), align 8, !dbg !37, !invariant.load !5
-  %90 = getelementptr i64, i64* %keyword_table.i, i32 2, !dbg !37
-  store i64 %rubyId_f.i, i64* %90, align 8, !dbg !37
-  %91 = getelementptr inbounds i8, i8* %63, i64 40, !dbg !37
-  %92 = bitcast i8* %91 to i32*, !dbg !37
-  store i32 2, i32* %92, align 8, !dbg !37, !tbaa !82
-  %93 = getelementptr inbounds i8, i8* %63, i64 44, !dbg !37
-  %94 = bitcast i8* %93 to i32*, !dbg !37
-  store i32 1, i32* %94, align 4, !dbg !37, !tbaa !83
-  %95 = load i32, i32* %69, align 8, !dbg !37, !tbaa !84
-  %96 = load i32, i32* %71, align 4, !dbg !37, !tbaa !85
-  %97 = add i32 %95, 2, !dbg !37
-  %98 = add i32 %97, %96, !dbg !37
-  %99 = getelementptr inbounds i8, i8* %63, i64 48, !dbg !37
-  %100 = bitcast i8* %99 to i32*, !dbg !37
-  store i32 %98, i32* %100, align 8, !dbg !37, !tbaa !86
-  %101 = load i16, i16* %64, align 8, !dbg !37
-  %102 = and i16 %101, 32, !dbg !37
-  %103 = icmp eq i16 %102, 0, !dbg !37
-  br i1 %103, label %"func_<root>.17<static-init>$153.exit", label %104, !dbg !37
+  %8 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %8, align 8, !tbaa !73
+  %9 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 4
+  %10 = load i64*, i64** %9, align 8, !tbaa !44
+  %11 = load i64, i64* %10, align 8, !tbaa !6
+  %12 = and i64 %11, -33
+  store i64 %12, i64* %10, align 8, !tbaa !6
+  tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %3, %struct.rb_control_frame_struct* %5, %struct.rb_iseq_struct* %stackFrame.i) #12
+  %13 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 0
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 4), i64** %13, align 8, !dbg !74, !tbaa !38
+  %14 = load i64, i64* @rb_cObject, align 8, !dbg !59
+  %stackFrame386.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#14take_arguments", align 8, !dbg !59
+  %15 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #14, !dbg !59
+  %16 = bitcast i8* %15 to i16*, !dbg !59
+  %17 = load i16, i16* %16, align 8, !dbg !59
+  %18 = and i16 %17, -384, !dbg !59
+  %19 = or i16 %18, 119, !dbg !59
+  store i16 %19, i16* %16, align 8, !dbg !59
+  %20 = getelementptr inbounds i8, i8* %15, i64 8, !dbg !59
+  %21 = bitcast i8* %20 to i32*, !dbg !59
+  %22 = getelementptr inbounds i8, i8* %15, i64 12, !dbg !59
+  %23 = bitcast i8* %22 to i32*, !dbg !59
+  %24 = getelementptr inbounds i8, i8* %15, i64 16, !dbg !59
+  %25 = getelementptr inbounds i8, i8* %15, i64 20, !dbg !59
+  %26 = bitcast i8* %25 to i32*, !dbg !59
+  store i32 0, i32* %26, align 4, !dbg !59, !tbaa !75
+  %27 = getelementptr inbounds i8, i8* %15, i64 24, !dbg !59
+  %28 = bitcast i8* %27 to i32*, !dbg !59
+  store i32 0, i32* %28, align 8, !dbg !59, !tbaa !78
+  %29 = getelementptr inbounds i8, i8* %15, i64 28, !dbg !59
+  %30 = bitcast i8* %29 to i32*, !dbg !59
+  store i32 3, i32* %30, align 4, !dbg !59, !tbaa !79
+  %31 = getelementptr inbounds i8, i8* %15, i64 4, !dbg !59
+  %32 = bitcast i8* %31 to i32*, !dbg !59
+  %33 = bitcast i32* %32 to <4 x i32>*, !dbg !59
+  store <4 x i32> <i32 7, i32 1, i32 1, i32 2>, <4 x i32>* %33, align 4, !dbg !59, !tbaa !80
+  %34 = load <2 x i64>, <2 x i64>* bitcast (i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 9) to <2 x i64>*), align 8, !dbg !59, !invariant.load !5
+  %35 = bitcast i64* %positional_table.i to <2 x i64>*, !dbg !59
+  store <2 x i64> %34, <2 x i64>* %35, align 8, !dbg !59
+  %rubyId_c.i = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 11), align 8, !dbg !59, !invariant.load !5
+  %36 = getelementptr i64, i64* %positional_table.i, i32 2, !dbg !59
+  store i64 %rubyId_c.i, i64* %36, align 8, !dbg !59
+  %rubyId_g.i = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !dbg !59, !invariant.load !5
+  %37 = getelementptr i64, i64* %positional_table.i, i32 3, !dbg !59
+  store i64 %rubyId_g.i, i64* %37, align 8, !dbg !59
+  %38 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 4, i64 noundef 8) #14, !dbg !59
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %38, i8* nocapture noundef nonnull readonly align 8 dereferenceable(24) %6, i64 noundef 32, i1 noundef false) #12, !dbg !59
+  %39 = getelementptr inbounds i8, i8* %15, i64 32, !dbg !59
+  %40 = bitcast i8* %39 to i8**, !dbg !59
+  store i8* %38, i8** %40, align 8, !dbg !59, !tbaa !81
+  %41 = load <2 x i64>, <2 x i64>* bitcast (i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 2) to <2 x i64>*), align 8, !dbg !59, !invariant.load !5
+  %42 = bitcast i64* %keyword_table.i to <2 x i64>*, !dbg !59
+  store <2 x i64> %41, <2 x i64>* %42, align 8, !dbg !59
+  %rubyId_f.i = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 12), align 8, !dbg !59, !invariant.load !5
+  %43 = getelementptr i64, i64* %keyword_table.i, i32 2, !dbg !59
+  store i64 %rubyId_f.i, i64* %43, align 8, !dbg !59
+  %44 = getelementptr inbounds i8, i8* %15, i64 40, !dbg !59
+  %45 = bitcast i8* %44 to i32*, !dbg !59
+  store i32 2, i32* %45, align 8, !dbg !59, !tbaa !82
+  %46 = getelementptr inbounds i8, i8* %15, i64 44, !dbg !59
+  %47 = bitcast i8* %46 to i32*, !dbg !59
+  store i32 1, i32* %47, align 4, !dbg !59, !tbaa !83
+  %48 = load i32, i32* %21, align 8, !dbg !59, !tbaa !84
+  %49 = load i32, i32* %23, align 4, !dbg !59, !tbaa !85
+  %50 = add i32 %48, 2, !dbg !59
+  %51 = add i32 %50, %49, !dbg !59
+  %52 = getelementptr inbounds i8, i8* %15, i64 48, !dbg !59
+  %53 = bitcast i8* %52 to i32*, !dbg !59
+  store i32 %51, i32* %53, align 8, !dbg !59, !tbaa !86
+  %54 = load i16, i16* %16, align 8, !dbg !59
+  %55 = and i16 %54, 32, !dbg !59
+  %56 = icmp eq i16 %55, 0, !dbg !59
+  br i1 %56, label %"func_<root>.17<static-init>$153.exit", label %57, !dbg !59
 
-104:                                              ; preds = %entry
-  %105 = add nsw i32 %98, 1, !dbg !37
-  %106 = getelementptr inbounds i8, i8* %63, i64 52, !dbg !37
-  %107 = bitcast i8* %106 to i32*, !dbg !37
-  store i32 %105, i32* %107, align 4, !dbg !37, !tbaa !87
-  br label %"func_<root>.17<static-init>$153.exit", !dbg !37
+57:                                               ; preds = %entry
+  %58 = add nsw i32 %51, 1, !dbg !59
+  %59 = getelementptr inbounds i8, i8* %15, i64 52, !dbg !59
+  %60 = bitcast i8* %59 to i32*, !dbg !59
+  store i32 %58, i32* %60, align 4, !dbg !59, !tbaa !87
+  br label %"func_<root>.17<static-init>$153.exit", !dbg !59
 
-"func_<root>.17<static-init>$153.exit":           ; preds = %entry, %104
-  %108 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 3, i64 noundef 8) #14, !dbg !37
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %108, i8* nocapture noundef nonnull readonly align 8 dereferenceable(24) %55, i64 noundef 24, i1 noundef false) #11, !dbg !37
-  %109 = getelementptr inbounds i8, i8* %63, i64 56, !dbg !37
-  %110 = bitcast i8* %109 to i8**, !dbg !37
-  store i8* %108, i8** %110, align 8, !dbg !37, !tbaa !88
-  call void @sorbet_vm_define_method(i64 %62, i8* noundef getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#14take_arguments", i8* nonnull %63, %struct.rb_iseq_struct* %stackFrame386.i, i1 noundef zeroext false) #11, !dbg !37
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %61, align 8, !dbg !37, !tbaa !14
-  %111 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !39
-  %112 = load i64*, i64** %111, align 8, !dbg !39
-  store i64 %50, i64* %112, align 8, !dbg !39, !tbaa !6
-  %113 = getelementptr inbounds i64, i64* %112, i64 1, !dbg !39
-  %114 = getelementptr inbounds i64, i64* %113, i64 1, !dbg !39
-  %115 = getelementptr inbounds i64, i64* %114, i64 1, !dbg !39
-  %116 = getelementptr inbounds i64, i64* %115, i64 1, !dbg !39
-  %117 = bitcast i64* %113 to <4 x i64>*, !dbg !39
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %117, align 8, !dbg !39, !tbaa !6
-  %118 = getelementptr inbounds i64, i64* %116, i64 1, !dbg !39
-  %119 = getelementptr inbounds i64, i64* %118, i64 1, !dbg !39
-  %120 = bitcast i64* %118 to <2 x i64>*, !dbg !39
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %120, align 8, !dbg !39, !tbaa !6
-  %121 = getelementptr inbounds i64, i64* %119, i64 1, !dbg !39
-  store i64 -13, i64* %121, align 8, !dbg !39, !tbaa !6
-  %122 = getelementptr inbounds i64, i64* %121, i64 1, !dbg !39
-  store i64 -15, i64* %122, align 8, !dbg !39, !tbaa !6
-  %123 = getelementptr inbounds i64, i64* %122, i64 1, !dbg !39
-  store i64* %123, i64** %111, align 8, !dbg !39
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments, i64 0), !dbg !39
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %61, align 8, !dbg !39, !tbaa !14
-  %124 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !40
-  %125 = load i64*, i64** %124, align 8, !dbg !40
-  store i64 %50, i64* %125, align 8, !dbg !40, !tbaa !6
-  %126 = getelementptr inbounds i64, i64* %125, i64 1, !dbg !40
-  %127 = getelementptr inbounds i64, i64* %126, i64 1, !dbg !40
-  %128 = getelementptr inbounds i64, i64* %127, i64 1, !dbg !40
-  %129 = getelementptr inbounds i64, i64* %128, i64 1, !dbg !40
-  %130 = bitcast i64* %126 to <4 x i64>*, !dbg !40
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %130, align 8, !dbg !40, !tbaa !6
-  %131 = getelementptr inbounds i64, i64* %129, i64 1, !dbg !40
-  %132 = getelementptr inbounds i64, i64* %131, i64 1, !dbg !40
-  %133 = bitcast i64* %131 to <2 x i64>*, !dbg !40
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %133, align 8, !dbg !40, !tbaa !6
-  %134 = getelementptr inbounds i64, i64* %132, i64 1, !dbg !40
-  store i64 -15, i64* %134, align 8, !dbg !40, !tbaa !6
-  %135 = getelementptr inbounds i64, i64* %134, i64 1, !dbg !40
-  store i64* %135, i64** %124, align 8, !dbg !40
-  %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.1, i64 0), !dbg !40
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %61, align 8, !dbg !40, !tbaa !14
-  %136 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !41
-  %137 = load i64*, i64** %136, align 8, !dbg !41
-  store i64 %50, i64* %137, align 8, !dbg !41, !tbaa !6
-  %138 = getelementptr inbounds i64, i64* %137, i64 1, !dbg !41
-  %139 = getelementptr inbounds i64, i64* %138, i64 1, !dbg !41
-  %140 = getelementptr inbounds i64, i64* %139, i64 1, !dbg !41
-  %141 = getelementptr inbounds i64, i64* %140, i64 1, !dbg !41
-  %142 = bitcast i64* %138 to <4 x i64>*, !dbg !41
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %142, align 8, !dbg !41, !tbaa !6
-  %143 = getelementptr inbounds i64, i64* %141, i64 1, !dbg !41
-  %144 = getelementptr inbounds i64, i64* %143, i64 1, !dbg !41
-  %145 = bitcast i64* %143 to <2 x i64>*, !dbg !41
-  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %145, align 8, !dbg !41, !tbaa !6
-  %146 = getelementptr inbounds i64, i64* %144, i64 1, !dbg !41
-  store i64* %146, i64** %136, align 8, !dbg !41
-  %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.2, i64 0), !dbg !41
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %61, align 8, !dbg !41, !tbaa !14
-  %147 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !42
-  %148 = load i64*, i64** %147, align 8, !dbg !42
-  store i64 %50, i64* %148, align 8, !dbg !42, !tbaa !6
-  %149 = getelementptr inbounds i64, i64* %148, i64 1, !dbg !42
-  %150 = getelementptr inbounds i64, i64* %149, i64 1, !dbg !42
-  %151 = getelementptr inbounds i64, i64* %150, i64 1, !dbg !42
-  %152 = getelementptr inbounds i64, i64* %151, i64 1, !dbg !42
-  %153 = bitcast i64* %149 to <4 x i64>*, !dbg !42
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %153, align 8, !dbg !42, !tbaa !6
-  %154 = getelementptr inbounds i64, i64* %152, i64 1, !dbg !42
-  store i64 -15, i64* %154, align 8, !dbg !42, !tbaa !6
-  %155 = getelementptr inbounds i64, i64* %154, i64 1, !dbg !42
-  store i64* %155, i64** %147, align 8, !dbg !42
-  %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.3, i64 0), !dbg !42
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %61, align 8, !dbg !42, !tbaa !14
-  %156 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !43
-  %157 = load i64*, i64** %156, align 8, !dbg !43
-  store i64 %50, i64* %157, align 8, !dbg !43, !tbaa !6
-  %158 = getelementptr inbounds i64, i64* %157, i64 1, !dbg !43
-  %159 = getelementptr inbounds i64, i64* %158, i64 1, !dbg !43
-  %160 = getelementptr inbounds i64, i64* %159, i64 1, !dbg !43
-  %161 = getelementptr inbounds i64, i64* %160, i64 1, !dbg !43
-  %162 = bitcast i64* %158 to <4 x i64>*, !dbg !43
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %162, align 8, !dbg !43, !tbaa !6
-  %163 = getelementptr inbounds i64, i64* %161, i64 1, !dbg !43
-  store i64* %163, i64** %156, align 8, !dbg !43
-  %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.4, i64 0), !dbg !43
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %61, align 8, !dbg !43, !tbaa !14
-  %164 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !44
-  %165 = load i64*, i64** %164, align 8, !dbg !44
-  store i64 %50, i64* %165, align 8, !dbg !44, !tbaa !6
-  %166 = getelementptr inbounds i64, i64* %165, i64 1, !dbg !44
-  %167 = getelementptr inbounds i64, i64* %166, i64 1, !dbg !44
-  %168 = bitcast i64* %166 to <2 x i64>*, !dbg !44
-  store <2 x i64> <i64 -1, i64 -3>, <2 x i64>* %168, align 8, !dbg !44, !tbaa !6
-  %169 = getelementptr inbounds i64, i64* %167, i64 1, !dbg !44
-  store i64 -15, i64* %169, align 8, !dbg !44, !tbaa !6
-  %170 = getelementptr inbounds i64, i64* %169, i64 1, !dbg !44
-  store i64* %170, i64** %164, align 8, !dbg !44
-  %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.5, i64 0), !dbg !44
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %61, align 8, !dbg !44, !tbaa !14
-  %171 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !45
-  %172 = load i64*, i64** %171, align 8, !dbg !45
-  store i64 %50, i64* %172, align 8, !dbg !45, !tbaa !6
-  %173 = getelementptr inbounds i64, i64* %172, i64 1, !dbg !45
-  %174 = getelementptr inbounds i64, i64* %173, i64 1, !dbg !45
-  %175 = bitcast i64* %173 to <2 x i64>*, !dbg !45
-  store <2 x i64> <i64 -1, i64 -15>, <2 x i64>* %175, align 8, !dbg !45, !tbaa !6
-  %176 = getelementptr inbounds i64, i64* %174, i64 1, !dbg !45
-  store i64* %176, i64** %171, align 8, !dbg !45
-  %send14 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.6, i64 0), !dbg !45
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %61, align 8, !dbg !45, !tbaa !14
-  %177 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !46
-  %178 = load i64*, i64** %177, align 8, !dbg !46
-  store i64 %50, i64* %178, align 8, !dbg !46, !tbaa !6
-  %179 = getelementptr inbounds i64, i64* %178, i64 1, !dbg !46
-  %180 = getelementptr inbounds i64, i64* %179, i64 1, !dbg !46
-  %181 = getelementptr inbounds i64, i64* %180, i64 1, !dbg !46
-  %182 = getelementptr inbounds i64, i64* %181, i64 1, !dbg !46
-  %183 = bitcast i64* %179 to <4 x i64>*, !dbg !46
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %183, align 8, !dbg !46, !tbaa !6
-  %184 = getelementptr inbounds i64, i64* %182, i64 1, !dbg !46
-  %185 = getelementptr inbounds i64, i64* %184, i64 1, !dbg !46
-  %186 = bitcast i64* %184 to <2 x i64>*, !dbg !46
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %186, align 8, !dbg !46, !tbaa !6
-  %187 = getelementptr inbounds i64, i64* %185, i64 1, !dbg !46
-  store i64 -13, i64* %187, align 8, !dbg !46, !tbaa !6
-  %188 = getelementptr inbounds i64, i64* %187, i64 1, !dbg !46
-  store i64 -15, i64* %188, align 8, !dbg !46, !tbaa !6
-  %189 = getelementptr inbounds i64, i64* %188, i64 1, !dbg !46
-  store i64 -17, i64* %189, align 8, !dbg !46, !tbaa !6
-  %190 = getelementptr inbounds i64, i64* %189, i64 1, !dbg !46
-  store i64* %190, i64** %177, align 8, !dbg !46
-  %send16 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.7, i64 0), !dbg !46
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %61, align 8, !dbg !46, !tbaa !14
-  %191 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !47
-  %192 = load i64*, i64** %191, align 8, !dbg !47
-  store i64 %50, i64* %192, align 8, !dbg !47, !tbaa !6
-  %193 = getelementptr inbounds i64, i64* %192, i64 1, !dbg !47
-  %194 = getelementptr inbounds i64, i64* %193, i64 1, !dbg !47
-  %195 = getelementptr inbounds i64, i64* %194, i64 1, !dbg !47
-  %196 = getelementptr inbounds i64, i64* %195, i64 1, !dbg !47
-  %197 = bitcast i64* %193 to <4 x i64>*, !dbg !47
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %197, align 8, !dbg !47, !tbaa !6
-  %198 = getelementptr inbounds i64, i64* %196, i64 1, !dbg !47
-  %199 = getelementptr inbounds i64, i64* %198, i64 1, !dbg !47
-  %200 = bitcast i64* %198 to <2 x i64>*, !dbg !47
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %200, align 8, !dbg !47, !tbaa !6
-  %201 = getelementptr inbounds i64, i64* %199, i64 1, !dbg !47
-  store i64 -15, i64* %201, align 8, !dbg !47, !tbaa !6
-  %202 = getelementptr inbounds i64, i64* %201, i64 1, !dbg !47
-  store i64 -17, i64* %202, align 8, !dbg !47, !tbaa !6
-  %203 = getelementptr inbounds i64, i64* %202, i64 1, !dbg !47
-  store i64* %203, i64** %191, align 8, !dbg !47
-  %send18 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.8, i64 0), !dbg !47
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %61, align 8, !dbg !47, !tbaa !14
-  %204 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !48
-  %205 = load i64*, i64** %204, align 8, !dbg !48
-  store i64 %50, i64* %205, align 8, !dbg !48, !tbaa !6
-  %206 = getelementptr inbounds i64, i64* %205, i64 1, !dbg !48
-  %207 = getelementptr inbounds i64, i64* %206, i64 1, !dbg !48
-  %208 = getelementptr inbounds i64, i64* %207, i64 1, !dbg !48
-  %209 = getelementptr inbounds i64, i64* %208, i64 1, !dbg !48
-  %210 = bitcast i64* %206 to <4 x i64>*, !dbg !48
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %210, align 8, !dbg !48, !tbaa !6
-  %211 = getelementptr inbounds i64, i64* %209, i64 1, !dbg !48
-  %212 = getelementptr inbounds i64, i64* %211, i64 1, !dbg !48
-  %213 = bitcast i64* %211 to <2 x i64>*, !dbg !48
-  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %213, align 8, !dbg !48, !tbaa !6
-  %214 = getelementptr inbounds i64, i64* %212, i64 1, !dbg !48
-  store i64 -17, i64* %214, align 8, !dbg !48, !tbaa !6
-  %215 = getelementptr inbounds i64, i64* %214, i64 1, !dbg !48
-  store i64* %215, i64** %204, align 8, !dbg !48
-  %send20 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.9, i64 0), !dbg !48
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %61, align 8, !dbg !48, !tbaa !14
-  %216 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !49
-  %217 = load i64*, i64** %216, align 8, !dbg !49
-  store i64 %50, i64* %217, align 8, !dbg !49, !tbaa !6
-  %218 = getelementptr inbounds i64, i64* %217, i64 1, !dbg !49
-  %219 = getelementptr inbounds i64, i64* %218, i64 1, !dbg !49
-  %220 = getelementptr inbounds i64, i64* %219, i64 1, !dbg !49
-  %221 = getelementptr inbounds i64, i64* %220, i64 1, !dbg !49
-  %222 = bitcast i64* %218 to <4 x i64>*, !dbg !49
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %222, align 8, !dbg !49, !tbaa !6
-  %223 = getelementptr inbounds i64, i64* %221, i64 1, !dbg !49
-  %224 = getelementptr inbounds i64, i64* %223, i64 1, !dbg !49
-  %225 = bitcast i64* %223 to <2 x i64>*, !dbg !49
-  store <2 x i64> <i64 -15, i64 -17>, <2 x i64>* %225, align 8, !dbg !49, !tbaa !6
-  %226 = getelementptr inbounds i64, i64* %224, i64 1, !dbg !49
-  store i64* %226, i64** %216, align 8, !dbg !49
-  %send22 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.10, i64 0), !dbg !49
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 20), i64** %61, align 8, !dbg !49, !tbaa !14
-  %227 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !50
-  %228 = load i64*, i64** %227, align 8, !dbg !50
-  store i64 %50, i64* %228, align 8, !dbg !50, !tbaa !6
-  %229 = getelementptr inbounds i64, i64* %228, i64 1, !dbg !50
-  %230 = getelementptr inbounds i64, i64* %229, i64 1, !dbg !50
-  %231 = getelementptr inbounds i64, i64* %230, i64 1, !dbg !50
-  %232 = getelementptr inbounds i64, i64* %231, i64 1, !dbg !50
-  %233 = bitcast i64* %229 to <4 x i64>*, !dbg !50
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %233, align 8, !dbg !50, !tbaa !6
-  %234 = getelementptr inbounds i64, i64* %232, i64 1, !dbg !50
-  store i64 -17, i64* %234, align 8, !dbg !50, !tbaa !6
-  %235 = getelementptr inbounds i64, i64* %234, i64 1, !dbg !50
-  store i64* %235, i64** %227, align 8, !dbg !50
-  %send24 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.11, i64 0), !dbg !50
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %61, align 8, !dbg !50, !tbaa !14
-  %236 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !51
-  %237 = load i64*, i64** %236, align 8, !dbg !51
-  store i64 %50, i64* %237, align 8, !dbg !51, !tbaa !6
-  %238 = getelementptr inbounds i64, i64* %237, i64 1, !dbg !51
-  %239 = getelementptr inbounds i64, i64* %238, i64 1, !dbg !51
-  %240 = getelementptr inbounds i64, i64* %239, i64 1, !dbg !51
-  %241 = getelementptr inbounds i64, i64* %240, i64 1, !dbg !51
-  %242 = bitcast i64* %238 to <4 x i64>*, !dbg !51
-  store <4 x i64> <i64 -1, i64 -3, i64 -15, i64 -17>, <4 x i64>* %242, align 8, !dbg !51, !tbaa !6
-  %243 = getelementptr inbounds i64, i64* %241, i64 1, !dbg !51
-  store i64* %243, i64** %236, align 8, !dbg !51
-  %send26 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.12, i64 0), !dbg !51
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %61, align 8, !dbg !51, !tbaa !14
-  %244 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !52
-  %245 = load i64*, i64** %244, align 8, !dbg !52
-  store i64 %50, i64* %245, align 8, !dbg !52, !tbaa !6
-  %246 = getelementptr inbounds i64, i64* %245, i64 1, !dbg !52
-  %247 = getelementptr inbounds i64, i64* %246, i64 1, !dbg !52
-  %248 = bitcast i64* %246 to <2 x i64>*, !dbg !52
-  store <2 x i64> <i64 -1, i64 -15>, <2 x i64>* %248, align 8, !dbg !52, !tbaa !6
-  %249 = getelementptr inbounds i64, i64* %247, i64 1, !dbg !52
-  store i64 -17, i64* %249, align 8, !dbg !52, !tbaa !6
-  %250 = getelementptr inbounds i64, i64* %249, i64 1, !dbg !52
-  store i64* %250, i64** %244, align 8, !dbg !52
-  %send28 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.13, i64 0), !dbg !52
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %61, align 8, !dbg !52, !tbaa !14
-  %251 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !53
-  %252 = load i64*, i64** %251, align 8, !dbg !53
-  store i64 %50, i64* %252, align 8, !dbg !53, !tbaa !6
-  %253 = getelementptr inbounds i64, i64* %252, i64 1, !dbg !53
-  %254 = getelementptr inbounds i64, i64* %253, i64 1, !dbg !53
-  %255 = getelementptr inbounds i64, i64* %254, i64 1, !dbg !53
-  %256 = getelementptr inbounds i64, i64* %255, i64 1, !dbg !53
-  %257 = bitcast i64* %253 to <4 x i64>*, !dbg !53
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %257, align 8, !dbg !53, !tbaa !6
-  %258 = getelementptr inbounds i64, i64* %256, i64 1, !dbg !53
-  %259 = getelementptr inbounds i64, i64* %258, i64 1, !dbg !53
-  %260 = bitcast i64* %258 to <2 x i64>*, !dbg !53
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %260, align 8, !dbg !53, !tbaa !6
-  %261 = getelementptr inbounds i64, i64* %259, i64 1, !dbg !53
-  store i64 -13, i64* %261, align 8, !dbg !53, !tbaa !6
-  %262 = getelementptr inbounds i64, i64* %261, i64 1, !dbg !53
-  store i64 -15, i64* %262, align 8, !dbg !53, !tbaa !6
-  %263 = getelementptr inbounds i64, i64* %262, i64 1, !dbg !53
-  store i64 -17, i64* %263, align 8, !dbg !53, !tbaa !6
-  %264 = getelementptr inbounds i64, i64* %263, i64 1, !dbg !53
-  store i64 -19, i64* %264, align 8, !dbg !53, !tbaa !6
-  %265 = getelementptr inbounds i64, i64* %264, i64 1, !dbg !53
-  store i64* %265, i64** %251, align 8, !dbg !53
-  %send30 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.14, i64 0), !dbg !53
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %61, align 8, !dbg !53, !tbaa !14
-  %266 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !54
-  %267 = load i64*, i64** %266, align 8, !dbg !54
-  store i64 %50, i64* %267, align 8, !dbg !54, !tbaa !6
-  %268 = getelementptr inbounds i64, i64* %267, i64 1, !dbg !54
-  %269 = getelementptr inbounds i64, i64* %268, i64 1, !dbg !54
-  %270 = getelementptr inbounds i64, i64* %269, i64 1, !dbg !54
-  %271 = getelementptr inbounds i64, i64* %270, i64 1, !dbg !54
-  %272 = bitcast i64* %268 to <4 x i64>*, !dbg !54
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %272, align 8, !dbg !54, !tbaa !6
-  %273 = getelementptr inbounds i64, i64* %271, i64 1, !dbg !54
-  %274 = getelementptr inbounds i64, i64* %273, i64 1, !dbg !54
-  %275 = bitcast i64* %273 to <2 x i64>*, !dbg !54
-  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %275, align 8, !dbg !54, !tbaa !6
-  %276 = getelementptr inbounds i64, i64* %274, i64 1, !dbg !54
-  store i64 -15, i64* %276, align 8, !dbg !54, !tbaa !6
-  %277 = getelementptr inbounds i64, i64* %276, i64 1, !dbg !54
-  store i64 -17, i64* %277, align 8, !dbg !54, !tbaa !6
-  %278 = getelementptr inbounds i64, i64* %277, i64 1, !dbg !54
-  store i64 -19, i64* %278, align 8, !dbg !54, !tbaa !6
-  %279 = getelementptr inbounds i64, i64* %278, i64 1, !dbg !54
-  store i64* %279, i64** %266, align 8, !dbg !54
-  %send32 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.15, i64 0), !dbg !54
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %61, align 8, !dbg !54, !tbaa !14
-  %280 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !55
-  %281 = load i64*, i64** %280, align 8, !dbg !55
-  store i64 %50, i64* %281, align 8, !dbg !55, !tbaa !6
-  %282 = getelementptr inbounds i64, i64* %281, i64 1, !dbg !55
-  %283 = getelementptr inbounds i64, i64* %282, i64 1, !dbg !55
-  %284 = getelementptr inbounds i64, i64* %283, i64 1, !dbg !55
-  %285 = getelementptr inbounds i64, i64* %284, i64 1, !dbg !55
-  %286 = bitcast i64* %282 to <4 x i64>*, !dbg !55
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %286, align 8, !dbg !55, !tbaa !6
-  %287 = getelementptr inbounds i64, i64* %285, i64 1, !dbg !55
-  %288 = getelementptr inbounds i64, i64* %287, i64 1, !dbg !55
-  %289 = bitcast i64* %287 to <2 x i64>*, !dbg !55
-  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %289, align 8, !dbg !55, !tbaa !6
-  %290 = getelementptr inbounds i64, i64* %288, i64 1, !dbg !55
-  store i64 -17, i64* %290, align 8, !dbg !55, !tbaa !6
-  %291 = getelementptr inbounds i64, i64* %290, i64 1, !dbg !55
-  store i64 -19, i64* %291, align 8, !dbg !55, !tbaa !6
-  %292 = getelementptr inbounds i64, i64* %291, i64 1, !dbg !55
-  store i64* %292, i64** %280, align 8, !dbg !55
-  %send34 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.16, i64 0), !dbg !55
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %61, align 8, !dbg !55, !tbaa !14
-  %293 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !56
-  %294 = load i64*, i64** %293, align 8, !dbg !56
-  store i64 %50, i64* %294, align 8, !dbg !56, !tbaa !6
-  %295 = getelementptr inbounds i64, i64* %294, i64 1, !dbg !56
-  %296 = getelementptr inbounds i64, i64* %295, i64 1, !dbg !56
-  %297 = getelementptr inbounds i64, i64* %296, i64 1, !dbg !56
-  %298 = getelementptr inbounds i64, i64* %297, i64 1, !dbg !56
-  %299 = bitcast i64* %295 to <4 x i64>*, !dbg !56
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %299, align 8, !dbg !56, !tbaa !6
-  %300 = getelementptr inbounds i64, i64* %298, i64 1, !dbg !56
-  %301 = getelementptr inbounds i64, i64* %300, i64 1, !dbg !56
-  %302 = bitcast i64* %300 to <2 x i64>*, !dbg !56
-  store <2 x i64> <i64 -15, i64 -17>, <2 x i64>* %302, align 8, !dbg !56, !tbaa !6
-  %303 = getelementptr inbounds i64, i64* %301, i64 1, !dbg !56
-  store i64 -19, i64* %303, align 8, !dbg !56, !tbaa !6
-  %304 = getelementptr inbounds i64, i64* %303, i64 1, !dbg !56
-  store i64* %304, i64** %293, align 8, !dbg !56
-  %send36 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.17, i64 0), !dbg !56
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %61, align 8, !dbg !56, !tbaa !14
-  %305 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !57
-  %306 = load i64*, i64** %305, align 8, !dbg !57
-  store i64 %50, i64* %306, align 8, !dbg !57, !tbaa !6
-  %307 = getelementptr inbounds i64, i64* %306, i64 1, !dbg !57
-  %308 = getelementptr inbounds i64, i64* %307, i64 1, !dbg !57
-  %309 = getelementptr inbounds i64, i64* %308, i64 1, !dbg !57
-  %310 = getelementptr inbounds i64, i64* %309, i64 1, !dbg !57
-  %311 = bitcast i64* %307 to <4 x i64>*, !dbg !57
-  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %311, align 8, !dbg !57, !tbaa !6
-  %312 = getelementptr inbounds i64, i64* %310, i64 1, !dbg !57
-  %313 = getelementptr inbounds i64, i64* %312, i64 1, !dbg !57
-  %314 = bitcast i64* %312 to <2 x i64>*, !dbg !57
-  store <2 x i64> <i64 -17, i64 -19>, <2 x i64>* %314, align 8, !dbg !57, !tbaa !6
-  %315 = getelementptr inbounds i64, i64* %313, i64 1, !dbg !57
-  store i64* %315, i64** %305, align 8, !dbg !57
-  %send38 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.18, i64 0), !dbg !57
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 29), i64** %61, align 8, !dbg !57, !tbaa !14
-  %316 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !58
-  %317 = load i64*, i64** %316, align 8, !dbg !58
-  store i64 %50, i64* %317, align 8, !dbg !58, !tbaa !6
-  %318 = getelementptr inbounds i64, i64* %317, i64 1, !dbg !58
-  %319 = getelementptr inbounds i64, i64* %318, i64 1, !dbg !58
-  %320 = getelementptr inbounds i64, i64* %319, i64 1, !dbg !58
-  %321 = getelementptr inbounds i64, i64* %320, i64 1, !dbg !58
-  %322 = bitcast i64* %318 to <4 x i64>*, !dbg !58
-  store <4 x i64> <i64 -1, i64 -3, i64 -15, i64 -17>, <4 x i64>* %322, align 8, !dbg !58, !tbaa !6
-  %323 = getelementptr inbounds i64, i64* %321, i64 1, !dbg !58
-  store i64 -19, i64* %323, align 8, !dbg !58, !tbaa !6
-  %324 = getelementptr inbounds i64, i64* %323, i64 1, !dbg !58
-  store i64* %324, i64** %316, align 8, !dbg !58
-  %send40 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.19, i64 0), !dbg !58
-  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 30), i64** %61, align 8, !dbg !58, !tbaa !14
-  %325 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %53, i64 0, i32 1, !dbg !59
-  %326 = load i64*, i64** %325, align 8, !dbg !59
-  store i64 %50, i64* %326, align 8, !dbg !59, !tbaa !6
-  %327 = getelementptr inbounds i64, i64* %326, i64 1, !dbg !59
-  %328 = getelementptr inbounds i64, i64* %327, i64 1, !dbg !59
-  %329 = getelementptr inbounds i64, i64* %328, i64 1, !dbg !59
-  %330 = getelementptr inbounds i64, i64* %329, i64 1, !dbg !59
-  %331 = bitcast i64* %327 to <4 x i64>*, !dbg !59
-  store <4 x i64> <i64 -1, i64 -15, i64 -17, i64 -19>, <4 x i64>* %331, align 8, !dbg !59, !tbaa !6
-  %332 = getelementptr inbounds i64, i64* %330, i64 1, !dbg !59
-  store i64* %332, i64** %325, align 8, !dbg !59
-  %send42 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.20, i64 0), !dbg !59
-  call void @llvm.lifetime.end.p0i8(i64 32, i8* nonnull %54)
-  call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %55)
+"func_<root>.17<static-init>$153.exit":           ; preds = %entry, %57
+  %61 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 3, i64 noundef 8) #14, !dbg !59
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %61, i8* nocapture noundef nonnull readonly align 8 dereferenceable(24) %7, i64 noundef 24, i1 noundef false) #12, !dbg !59
+  %62 = getelementptr inbounds i8, i8* %15, i64 56, !dbg !59
+  %63 = bitcast i8* %62 to i8**, !dbg !59
+  store i8* %61, i8** %63, align 8, !dbg !59, !tbaa !88
+  tail call void @sorbet_vm_define_method(i64 %14, i8* noundef getelementptr inbounds ([138 x i8], [138 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#14take_arguments", i8* nonnull %15, %struct.rb_iseq_struct* %stackFrame386.i, i1 noundef zeroext false) #12, !dbg !59
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %13, align 8, !dbg !59, !tbaa !38
+  %64 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !16
+  %65 = load i64*, i64** %64, align 8, !dbg !16
+  store i64 %2, i64* %65, align 8, !dbg !16, !tbaa !6
+  %66 = getelementptr inbounds i64, i64* %65, i64 1, !dbg !16
+  %67 = getelementptr inbounds i64, i64* %66, i64 1, !dbg !16
+  %68 = getelementptr inbounds i64, i64* %67, i64 1, !dbg !16
+  %69 = getelementptr inbounds i64, i64* %68, i64 1, !dbg !16
+  %70 = bitcast i64* %66 to <4 x i64>*, !dbg !16
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %70, align 8, !dbg !16, !tbaa !6
+  %71 = getelementptr inbounds i64, i64* %69, i64 1, !dbg !16
+  %72 = getelementptr inbounds i64, i64* %71, i64 1, !dbg !16
+  %73 = bitcast i64* %71 to <2 x i64>*, !dbg !16
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %73, align 8, !dbg !16, !tbaa !6
+  %74 = getelementptr inbounds i64, i64* %72, i64 1, !dbg !16
+  store i64 -13, i64* %74, align 8, !dbg !16, !tbaa !6
+  %75 = getelementptr inbounds i64, i64* %74, i64 1, !dbg !16
+  store i64 -15, i64* %75, align 8, !dbg !16, !tbaa !6
+  %76 = getelementptr inbounds i64, i64* %75, i64 1, !dbg !16
+  store i64* %76, i64** %64, align 8, !dbg !16
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments, i64 0), !dbg !16
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %13, align 8, !dbg !16, !tbaa !38
+  %77 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !18
+  %78 = load i64*, i64** %77, align 8, !dbg !18
+  store i64 %2, i64* %78, align 8, !dbg !18, !tbaa !6
+  %79 = getelementptr inbounds i64, i64* %78, i64 1, !dbg !18
+  %80 = getelementptr inbounds i64, i64* %79, i64 1, !dbg !18
+  %81 = getelementptr inbounds i64, i64* %80, i64 1, !dbg !18
+  %82 = getelementptr inbounds i64, i64* %81, i64 1, !dbg !18
+  %83 = bitcast i64* %79 to <4 x i64>*, !dbg !18
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %83, align 8, !dbg !18, !tbaa !6
+  %84 = getelementptr inbounds i64, i64* %82, i64 1, !dbg !18
+  %85 = getelementptr inbounds i64, i64* %84, i64 1, !dbg !18
+  %86 = bitcast i64* %84 to <2 x i64>*, !dbg !18
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %86, align 8, !dbg !18, !tbaa !6
+  %87 = getelementptr inbounds i64, i64* %85, i64 1, !dbg !18
+  store i64 -15, i64* %87, align 8, !dbg !18, !tbaa !6
+  %88 = getelementptr inbounds i64, i64* %87, i64 1, !dbg !18
+  store i64* %88, i64** %77, align 8, !dbg !18
+  %send2 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.1, i64 0), !dbg !18
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 10), i64** %13, align 8, !dbg !18, !tbaa !38
+  %89 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !19
+  %90 = load i64*, i64** %89, align 8, !dbg !19
+  store i64 %2, i64* %90, align 8, !dbg !19, !tbaa !6
+  %91 = getelementptr inbounds i64, i64* %90, i64 1, !dbg !19
+  %92 = getelementptr inbounds i64, i64* %91, i64 1, !dbg !19
+  %93 = getelementptr inbounds i64, i64* %92, i64 1, !dbg !19
+  %94 = getelementptr inbounds i64, i64* %93, i64 1, !dbg !19
+  %95 = bitcast i64* %91 to <4 x i64>*, !dbg !19
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %95, align 8, !dbg !19, !tbaa !6
+  %96 = getelementptr inbounds i64, i64* %94, i64 1, !dbg !19
+  %97 = getelementptr inbounds i64, i64* %96, i64 1, !dbg !19
+  %98 = bitcast i64* %96 to <2 x i64>*, !dbg !19
+  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %98, align 8, !dbg !19, !tbaa !6
+  %99 = getelementptr inbounds i64, i64* %97, i64 1, !dbg !19
+  store i64* %99, i64** %89, align 8, !dbg !19
+  %send4 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.2, i64 0), !dbg !19
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 11), i64** %13, align 8, !dbg !19, !tbaa !38
+  %100 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !20
+  %101 = load i64*, i64** %100, align 8, !dbg !20
+  store i64 %2, i64* %101, align 8, !dbg !20, !tbaa !6
+  %102 = getelementptr inbounds i64, i64* %101, i64 1, !dbg !20
+  %103 = getelementptr inbounds i64, i64* %102, i64 1, !dbg !20
+  %104 = getelementptr inbounds i64, i64* %103, i64 1, !dbg !20
+  %105 = getelementptr inbounds i64, i64* %104, i64 1, !dbg !20
+  %106 = bitcast i64* %102 to <4 x i64>*, !dbg !20
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %106, align 8, !dbg !20, !tbaa !6
+  %107 = getelementptr inbounds i64, i64* %105, i64 1, !dbg !20
+  store i64 -15, i64* %107, align 8, !dbg !20, !tbaa !6
+  %108 = getelementptr inbounds i64, i64* %107, i64 1, !dbg !20
+  store i64* %108, i64** %100, align 8, !dbg !20
+  %send6 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.3, i64 0), !dbg !20
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %13, align 8, !dbg !20, !tbaa !38
+  %109 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !21
+  %110 = load i64*, i64** %109, align 8, !dbg !21
+  store i64 %2, i64* %110, align 8, !dbg !21, !tbaa !6
+  %111 = getelementptr inbounds i64, i64* %110, i64 1, !dbg !21
+  %112 = getelementptr inbounds i64, i64* %111, i64 1, !dbg !21
+  %113 = getelementptr inbounds i64, i64* %112, i64 1, !dbg !21
+  %114 = getelementptr inbounds i64, i64* %113, i64 1, !dbg !21
+  %115 = bitcast i64* %111 to <4 x i64>*, !dbg !21
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %115, align 8, !dbg !21, !tbaa !6
+  %116 = getelementptr inbounds i64, i64* %114, i64 1, !dbg !21
+  store i64* %116, i64** %109, align 8, !dbg !21
+  %send8 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.4, i64 0), !dbg !21
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %13, align 8, !dbg !21, !tbaa !38
+  %117 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !22
+  %118 = load i64*, i64** %117, align 8, !dbg !22
+  store i64 %2, i64* %118, align 8, !dbg !22, !tbaa !6
+  %119 = getelementptr inbounds i64, i64* %118, i64 1, !dbg !22
+  %120 = getelementptr inbounds i64, i64* %119, i64 1, !dbg !22
+  %121 = bitcast i64* %119 to <2 x i64>*, !dbg !22
+  store <2 x i64> <i64 -1, i64 -3>, <2 x i64>* %121, align 8, !dbg !22, !tbaa !6
+  %122 = getelementptr inbounds i64, i64* %120, i64 1, !dbg !22
+  store i64 -15, i64* %122, align 8, !dbg !22, !tbaa !6
+  %123 = getelementptr inbounds i64, i64* %122, i64 1, !dbg !22
+  store i64* %123, i64** %117, align 8, !dbg !22
+  %send10 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.5, i64 0), !dbg !22
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %13, align 8, !dbg !22, !tbaa !38
+  %124 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !23
+  %125 = load i64*, i64** %124, align 8, !dbg !23
+  store i64 %2, i64* %125, align 8, !dbg !23, !tbaa !6
+  %126 = getelementptr inbounds i64, i64* %125, i64 1, !dbg !23
+  %127 = getelementptr inbounds i64, i64* %126, i64 1, !dbg !23
+  %128 = bitcast i64* %126 to <2 x i64>*, !dbg !23
+  store <2 x i64> <i64 -1, i64 -15>, <2 x i64>* %128, align 8, !dbg !23, !tbaa !6
+  %129 = getelementptr inbounds i64, i64* %127, i64 1, !dbg !23
+  store i64* %129, i64** %124, align 8, !dbg !23
+  %send12 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.6, i64 0), !dbg !23
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 16), i64** %13, align 8, !dbg !23, !tbaa !38
+  %130 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !24
+  %131 = load i64*, i64** %130, align 8, !dbg !24
+  store i64 %2, i64* %131, align 8, !dbg !24, !tbaa !6
+  %132 = getelementptr inbounds i64, i64* %131, i64 1, !dbg !24
+  %133 = getelementptr inbounds i64, i64* %132, i64 1, !dbg !24
+  %134 = getelementptr inbounds i64, i64* %133, i64 1, !dbg !24
+  %135 = getelementptr inbounds i64, i64* %134, i64 1, !dbg !24
+  %136 = bitcast i64* %132 to <4 x i64>*, !dbg !24
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %136, align 8, !dbg !24, !tbaa !6
+  %137 = getelementptr inbounds i64, i64* %135, i64 1, !dbg !24
+  %138 = getelementptr inbounds i64, i64* %137, i64 1, !dbg !24
+  %139 = bitcast i64* %137 to <2 x i64>*, !dbg !24
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %139, align 8, !dbg !24, !tbaa !6
+  %140 = getelementptr inbounds i64, i64* %138, i64 1, !dbg !24
+  store i64 -13, i64* %140, align 8, !dbg !24, !tbaa !6
+  %141 = getelementptr inbounds i64, i64* %140, i64 1, !dbg !24
+  store i64 -15, i64* %141, align 8, !dbg !24, !tbaa !6
+  %142 = getelementptr inbounds i64, i64* %141, i64 1, !dbg !24
+  store i64 -17, i64* %142, align 8, !dbg !24, !tbaa !6
+  %143 = getelementptr inbounds i64, i64* %142, i64 1, !dbg !24
+  store i64* %143, i64** %130, align 8, !dbg !24
+  %send14 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.7, i64 0), !dbg !24
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %13, align 8, !dbg !24, !tbaa !38
+  %144 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !25
+  %145 = load i64*, i64** %144, align 8, !dbg !25
+  store i64 %2, i64* %145, align 8, !dbg !25, !tbaa !6
+  %146 = getelementptr inbounds i64, i64* %145, i64 1, !dbg !25
+  %147 = getelementptr inbounds i64, i64* %146, i64 1, !dbg !25
+  %148 = getelementptr inbounds i64, i64* %147, i64 1, !dbg !25
+  %149 = getelementptr inbounds i64, i64* %148, i64 1, !dbg !25
+  %150 = bitcast i64* %146 to <4 x i64>*, !dbg !25
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %150, align 8, !dbg !25, !tbaa !6
+  %151 = getelementptr inbounds i64, i64* %149, i64 1, !dbg !25
+  %152 = getelementptr inbounds i64, i64* %151, i64 1, !dbg !25
+  %153 = bitcast i64* %151 to <2 x i64>*, !dbg !25
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %153, align 8, !dbg !25, !tbaa !6
+  %154 = getelementptr inbounds i64, i64* %152, i64 1, !dbg !25
+  store i64 -15, i64* %154, align 8, !dbg !25, !tbaa !6
+  %155 = getelementptr inbounds i64, i64* %154, i64 1, !dbg !25
+  store i64 -17, i64* %155, align 8, !dbg !25, !tbaa !6
+  %156 = getelementptr inbounds i64, i64* %155, i64 1, !dbg !25
+  store i64* %156, i64** %144, align 8, !dbg !25
+  %send16 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.8, i64 0), !dbg !25
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %13, align 8, !dbg !25, !tbaa !38
+  %157 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !26
+  %158 = load i64*, i64** %157, align 8, !dbg !26
+  store i64 %2, i64* %158, align 8, !dbg !26, !tbaa !6
+  %159 = getelementptr inbounds i64, i64* %158, i64 1, !dbg !26
+  %160 = getelementptr inbounds i64, i64* %159, i64 1, !dbg !26
+  %161 = getelementptr inbounds i64, i64* %160, i64 1, !dbg !26
+  %162 = getelementptr inbounds i64, i64* %161, i64 1, !dbg !26
+  %163 = bitcast i64* %159 to <4 x i64>*, !dbg !26
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %163, align 8, !dbg !26, !tbaa !6
+  %164 = getelementptr inbounds i64, i64* %162, i64 1, !dbg !26
+  %165 = getelementptr inbounds i64, i64* %164, i64 1, !dbg !26
+  %166 = bitcast i64* %164 to <2 x i64>*, !dbg !26
+  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %166, align 8, !dbg !26, !tbaa !6
+  %167 = getelementptr inbounds i64, i64* %165, i64 1, !dbg !26
+  store i64 -17, i64* %167, align 8, !dbg !26, !tbaa !6
+  %168 = getelementptr inbounds i64, i64* %167, i64 1, !dbg !26
+  store i64* %168, i64** %157, align 8, !dbg !26
+  %send18 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.9, i64 0), !dbg !26
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %13, align 8, !dbg !26, !tbaa !38
+  %169 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !27
+  %170 = load i64*, i64** %169, align 8, !dbg !27
+  store i64 %2, i64* %170, align 8, !dbg !27, !tbaa !6
+  %171 = getelementptr inbounds i64, i64* %170, i64 1, !dbg !27
+  %172 = getelementptr inbounds i64, i64* %171, i64 1, !dbg !27
+  %173 = getelementptr inbounds i64, i64* %172, i64 1, !dbg !27
+  %174 = getelementptr inbounds i64, i64* %173, i64 1, !dbg !27
+  %175 = bitcast i64* %171 to <4 x i64>*, !dbg !27
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %175, align 8, !dbg !27, !tbaa !6
+  %176 = getelementptr inbounds i64, i64* %174, i64 1, !dbg !27
+  %177 = getelementptr inbounds i64, i64* %176, i64 1, !dbg !27
+  %178 = bitcast i64* %176 to <2 x i64>*, !dbg !27
+  store <2 x i64> <i64 -15, i64 -17>, <2 x i64>* %178, align 8, !dbg !27, !tbaa !6
+  %179 = getelementptr inbounds i64, i64* %177, i64 1, !dbg !27
+  store i64* %179, i64** %169, align 8, !dbg !27
+  %send20 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.10, i64 0), !dbg !27
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 20), i64** %13, align 8, !dbg !27, !tbaa !38
+  %180 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !28
+  %181 = load i64*, i64** %180, align 8, !dbg !28
+  store i64 %2, i64* %181, align 8, !dbg !28, !tbaa !6
+  %182 = getelementptr inbounds i64, i64* %181, i64 1, !dbg !28
+  %183 = getelementptr inbounds i64, i64* %182, i64 1, !dbg !28
+  %184 = getelementptr inbounds i64, i64* %183, i64 1, !dbg !28
+  %185 = getelementptr inbounds i64, i64* %184, i64 1, !dbg !28
+  %186 = bitcast i64* %182 to <4 x i64>*, !dbg !28
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %186, align 8, !dbg !28, !tbaa !6
+  %187 = getelementptr inbounds i64, i64* %185, i64 1, !dbg !28
+  store i64 -17, i64* %187, align 8, !dbg !28, !tbaa !6
+  %188 = getelementptr inbounds i64, i64* %187, i64 1, !dbg !28
+  store i64* %188, i64** %180, align 8, !dbg !28
+  %send22 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.11, i64 0), !dbg !28
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 21), i64** %13, align 8, !dbg !28, !tbaa !38
+  %189 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !29
+  %190 = load i64*, i64** %189, align 8, !dbg !29
+  store i64 %2, i64* %190, align 8, !dbg !29, !tbaa !6
+  %191 = getelementptr inbounds i64, i64* %190, i64 1, !dbg !29
+  %192 = getelementptr inbounds i64, i64* %191, i64 1, !dbg !29
+  %193 = getelementptr inbounds i64, i64* %192, i64 1, !dbg !29
+  %194 = getelementptr inbounds i64, i64* %193, i64 1, !dbg !29
+  %195 = bitcast i64* %191 to <4 x i64>*, !dbg !29
+  store <4 x i64> <i64 -1, i64 -3, i64 -15, i64 -17>, <4 x i64>* %195, align 8, !dbg !29, !tbaa !6
+  %196 = getelementptr inbounds i64, i64* %194, i64 1, !dbg !29
+  store i64* %196, i64** %189, align 8, !dbg !29
+  %send24 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.12, i64 0), !dbg !29
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %13, align 8, !dbg !29, !tbaa !38
+  %197 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !30
+  %198 = load i64*, i64** %197, align 8, !dbg !30
+  store i64 %2, i64* %198, align 8, !dbg !30, !tbaa !6
+  %199 = getelementptr inbounds i64, i64* %198, i64 1, !dbg !30
+  %200 = getelementptr inbounds i64, i64* %199, i64 1, !dbg !30
+  %201 = bitcast i64* %199 to <2 x i64>*, !dbg !30
+  store <2 x i64> <i64 -1, i64 -15>, <2 x i64>* %201, align 8, !dbg !30, !tbaa !6
+  %202 = getelementptr inbounds i64, i64* %200, i64 1, !dbg !30
+  store i64 -17, i64* %202, align 8, !dbg !30, !tbaa !6
+  %203 = getelementptr inbounds i64, i64* %202, i64 1, !dbg !30
+  store i64* %203, i64** %197, align 8, !dbg !30
+  %send26 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.13, i64 0), !dbg !30
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %13, align 8, !dbg !30, !tbaa !38
+  %204 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !31
+  %205 = load i64*, i64** %204, align 8, !dbg !31
+  store i64 %2, i64* %205, align 8, !dbg !31, !tbaa !6
+  %206 = getelementptr inbounds i64, i64* %205, i64 1, !dbg !31
+  %207 = getelementptr inbounds i64, i64* %206, i64 1, !dbg !31
+  %208 = getelementptr inbounds i64, i64* %207, i64 1, !dbg !31
+  %209 = getelementptr inbounds i64, i64* %208, i64 1, !dbg !31
+  %210 = bitcast i64* %206 to <4 x i64>*, !dbg !31
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %210, align 8, !dbg !31, !tbaa !6
+  %211 = getelementptr inbounds i64, i64* %209, i64 1, !dbg !31
+  %212 = getelementptr inbounds i64, i64* %211, i64 1, !dbg !31
+  %213 = bitcast i64* %211 to <2 x i64>*, !dbg !31
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %213, align 8, !dbg !31, !tbaa !6
+  %214 = getelementptr inbounds i64, i64* %212, i64 1, !dbg !31
+  store i64 -13, i64* %214, align 8, !dbg !31, !tbaa !6
+  %215 = getelementptr inbounds i64, i64* %214, i64 1, !dbg !31
+  store i64 -15, i64* %215, align 8, !dbg !31, !tbaa !6
+  %216 = getelementptr inbounds i64, i64* %215, i64 1, !dbg !31
+  store i64 -17, i64* %216, align 8, !dbg !31, !tbaa !6
+  %217 = getelementptr inbounds i64, i64* %216, i64 1, !dbg !31
+  store i64 -19, i64* %217, align 8, !dbg !31, !tbaa !6
+  %218 = getelementptr inbounds i64, i64* %217, i64 1, !dbg !31
+  store i64* %218, i64** %204, align 8, !dbg !31
+  %send28 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.14, i64 0), !dbg !31
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 25), i64** %13, align 8, !dbg !31, !tbaa !38
+  %219 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !32
+  %220 = load i64*, i64** %219, align 8, !dbg !32
+  store i64 %2, i64* %220, align 8, !dbg !32, !tbaa !6
+  %221 = getelementptr inbounds i64, i64* %220, i64 1, !dbg !32
+  %222 = getelementptr inbounds i64, i64* %221, i64 1, !dbg !32
+  %223 = getelementptr inbounds i64, i64* %222, i64 1, !dbg !32
+  %224 = getelementptr inbounds i64, i64* %223, i64 1, !dbg !32
+  %225 = bitcast i64* %221 to <4 x i64>*, !dbg !32
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %225, align 8, !dbg !32, !tbaa !6
+  %226 = getelementptr inbounds i64, i64* %224, i64 1, !dbg !32
+  %227 = getelementptr inbounds i64, i64* %226, i64 1, !dbg !32
+  %228 = bitcast i64* %226 to <2 x i64>*, !dbg !32
+  store <2 x i64> <i64 -9, i64 -11>, <2 x i64>* %228, align 8, !dbg !32, !tbaa !6
+  %229 = getelementptr inbounds i64, i64* %227, i64 1, !dbg !32
+  store i64 -15, i64* %229, align 8, !dbg !32, !tbaa !6
+  %230 = getelementptr inbounds i64, i64* %229, i64 1, !dbg !32
+  store i64 -17, i64* %230, align 8, !dbg !32, !tbaa !6
+  %231 = getelementptr inbounds i64, i64* %230, i64 1, !dbg !32
+  store i64 -19, i64* %231, align 8, !dbg !32, !tbaa !6
+  %232 = getelementptr inbounds i64, i64* %231, i64 1, !dbg !32
+  store i64* %232, i64** %219, align 8, !dbg !32
+  %send30 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.15, i64 0), !dbg !32
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 26), i64** %13, align 8, !dbg !32, !tbaa !38
+  %233 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !33
+  %234 = load i64*, i64** %233, align 8, !dbg !33
+  store i64 %2, i64* %234, align 8, !dbg !33, !tbaa !6
+  %235 = getelementptr inbounds i64, i64* %234, i64 1, !dbg !33
+  %236 = getelementptr inbounds i64, i64* %235, i64 1, !dbg !33
+  %237 = getelementptr inbounds i64, i64* %236, i64 1, !dbg !33
+  %238 = getelementptr inbounds i64, i64* %237, i64 1, !dbg !33
+  %239 = bitcast i64* %235 to <4 x i64>*, !dbg !33
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %239, align 8, !dbg !33, !tbaa !6
+  %240 = getelementptr inbounds i64, i64* %238, i64 1, !dbg !33
+  %241 = getelementptr inbounds i64, i64* %240, i64 1, !dbg !33
+  %242 = bitcast i64* %240 to <2 x i64>*, !dbg !33
+  store <2 x i64> <i64 -9, i64 -15>, <2 x i64>* %242, align 8, !dbg !33, !tbaa !6
+  %243 = getelementptr inbounds i64, i64* %241, i64 1, !dbg !33
+  store i64 -17, i64* %243, align 8, !dbg !33, !tbaa !6
+  %244 = getelementptr inbounds i64, i64* %243, i64 1, !dbg !33
+  store i64 -19, i64* %244, align 8, !dbg !33, !tbaa !6
+  %245 = getelementptr inbounds i64, i64* %244, i64 1, !dbg !33
+  store i64* %245, i64** %233, align 8, !dbg !33
+  %send32 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.16, i64 0), !dbg !33
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %13, align 8, !dbg !33, !tbaa !38
+  %246 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !34
+  %247 = load i64*, i64** %246, align 8, !dbg !34
+  store i64 %2, i64* %247, align 8, !dbg !34, !tbaa !6
+  %248 = getelementptr inbounds i64, i64* %247, i64 1, !dbg !34
+  %249 = getelementptr inbounds i64, i64* %248, i64 1, !dbg !34
+  %250 = getelementptr inbounds i64, i64* %249, i64 1, !dbg !34
+  %251 = getelementptr inbounds i64, i64* %250, i64 1, !dbg !34
+  %252 = bitcast i64* %248 to <4 x i64>*, !dbg !34
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -7>, <4 x i64>* %252, align 8, !dbg !34, !tbaa !6
+  %253 = getelementptr inbounds i64, i64* %251, i64 1, !dbg !34
+  %254 = getelementptr inbounds i64, i64* %253, i64 1, !dbg !34
+  %255 = bitcast i64* %253 to <2 x i64>*, !dbg !34
+  store <2 x i64> <i64 -15, i64 -17>, <2 x i64>* %255, align 8, !dbg !34, !tbaa !6
+  %256 = getelementptr inbounds i64, i64* %254, i64 1, !dbg !34
+  store i64 -19, i64* %256, align 8, !dbg !34, !tbaa !6
+  %257 = getelementptr inbounds i64, i64* %256, i64 1, !dbg !34
+  store i64* %257, i64** %246, align 8, !dbg !34
+  %send34 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.17, i64 0), !dbg !34
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %13, align 8, !dbg !34, !tbaa !38
+  %258 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !35
+  %259 = load i64*, i64** %258, align 8, !dbg !35
+  store i64 %2, i64* %259, align 8, !dbg !35, !tbaa !6
+  %260 = getelementptr inbounds i64, i64* %259, i64 1, !dbg !35
+  %261 = getelementptr inbounds i64, i64* %260, i64 1, !dbg !35
+  %262 = getelementptr inbounds i64, i64* %261, i64 1, !dbg !35
+  %263 = getelementptr inbounds i64, i64* %262, i64 1, !dbg !35
+  %264 = bitcast i64* %260 to <4 x i64>*, !dbg !35
+  store <4 x i64> <i64 -1, i64 -3, i64 -5, i64 -15>, <4 x i64>* %264, align 8, !dbg !35, !tbaa !6
+  %265 = getelementptr inbounds i64, i64* %263, i64 1, !dbg !35
+  %266 = getelementptr inbounds i64, i64* %265, i64 1, !dbg !35
+  %267 = bitcast i64* %265 to <2 x i64>*, !dbg !35
+  store <2 x i64> <i64 -17, i64 -19>, <2 x i64>* %267, align 8, !dbg !35, !tbaa !6
+  %268 = getelementptr inbounds i64, i64* %266, i64 1, !dbg !35
+  store i64* %268, i64** %258, align 8, !dbg !35
+  %send36 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.18, i64 0), !dbg !35
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 29), i64** %13, align 8, !dbg !35, !tbaa !38
+  %269 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !36
+  %270 = load i64*, i64** %269, align 8, !dbg !36
+  store i64 %2, i64* %270, align 8, !dbg !36, !tbaa !6
+  %271 = getelementptr inbounds i64, i64* %270, i64 1, !dbg !36
+  %272 = getelementptr inbounds i64, i64* %271, i64 1, !dbg !36
+  %273 = getelementptr inbounds i64, i64* %272, i64 1, !dbg !36
+  %274 = getelementptr inbounds i64, i64* %273, i64 1, !dbg !36
+  %275 = bitcast i64* %271 to <4 x i64>*, !dbg !36
+  store <4 x i64> <i64 -1, i64 -3, i64 -15, i64 -17>, <4 x i64>* %275, align 8, !dbg !36, !tbaa !6
+  %276 = getelementptr inbounds i64, i64* %274, i64 1, !dbg !36
+  store i64 -19, i64* %276, align 8, !dbg !36, !tbaa !6
+  %277 = getelementptr inbounds i64, i64* %276, i64 1, !dbg !36
+  store i64* %277, i64** %269, align 8, !dbg !36
+  %send38 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.19, i64 0), !dbg !36
+  store i64* getelementptr inbounds ([32 x i64], [32 x i64]* @iseqEncodedArray, i64 0, i64 30), i64** %13, align 8, !dbg !36, !tbaa !38
+  %278 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !37
+  %279 = load i64*, i64** %278, align 8, !dbg !37
+  store i64 %2, i64* %279, align 8, !dbg !37, !tbaa !6
+  %280 = getelementptr inbounds i64, i64* %279, i64 1, !dbg !37
+  %281 = getelementptr inbounds i64, i64* %280, i64 1, !dbg !37
+  %282 = getelementptr inbounds i64, i64* %281, i64 1, !dbg !37
+  %283 = getelementptr inbounds i64, i64* %282, i64 1, !dbg !37
+  %284 = bitcast i64* %280 to <4 x i64>*, !dbg !37
+  store <4 x i64> <i64 -1, i64 -15, i64 -17, i64 -19>, <4 x i64>* %284, align 8, !dbg !37, !tbaa !6
+  %285 = getelementptr inbounds i64, i64* %283, i64 1, !dbg !37
+  store i64* %285, i64** %278, align 8, !dbg !37
+  %send40 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_take_arguments.20, i64 0), !dbg !37
+  call void @llvm.lifetime.end.p0i8(i64 32, i8* nonnull %6)
+  call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %7)
   ret void
 }
 
@@ -1072,12 +942,12 @@ attributes #4 = { allocsize(0,1) "disable-tail-calls"="false" "frame-pointer"="a
 attributes #5 = { argmemonly nofree nosync nounwind willreturn }
 attributes #6 = { nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #7 = { nounwind sspreq uwtable }
-attributes #8 = { sspreq }
-attributes #9 = { noreturn nounwind }
-attributes #10 = { noreturn }
-attributes #11 = { nounwind }
-attributes #12 = { willreturn }
-attributes #13 = { nounwind readnone willreturn }
+attributes #8 = { ssp }
+attributes #9 = { sspreq }
+attributes #10 = { noreturn nounwind }
+attributes #11 = { noreturn }
+attributes #12 = { nounwind }
+attributes #13 = { willreturn }
 attributes #14 = { nounwind allocsize(0,1) }
 
 !llvm.module.flags = !{!0, !1, !2}
@@ -1093,82 +963,82 @@ attributes #14 = { nounwind allocsize(0,1) }
 !7 = !{!"long", !8, i64 0}
 !8 = !{!"omnipotent char", !9, i64 0}
 !9 = !{!"Simple C/C++ TBAA"}
-!10 = distinct !DISubprogram(name: "Object#take_arguments", linkageName: "func_Object#14take_arguments", scope: null, file: !4, line: 4, type: !11, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!11 = !DISubroutineType(types: !12)
-!12 = !{!13}
-!13 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
-!14 = !{!15, !15, i64 0}
-!15 = !{!"any pointer", !8, i64 0}
-!16 = !DILocation(line: 4, column: 1, scope: !10)
-!17 = !{!18, !7, i64 0}
-!18 = !{!"RBasic", !7, i64 0, !7, i64 8}
-!19 = !{!"branch_weights", i32 1, i32 2000}
-!20 = !{!21, !15, i64 32}
-!21 = !{!"rb_control_frame_struct", !15, i64 0, !15, i64 8, !15, i64 16, !7, i64 24, !15, i64 32, !15, i64 40, !15, i64 48}
-!22 = !{!23}
-!23 = distinct !{!23, !24, !"vm_get_ep: argument 0"}
-!24 = distinct !{!24, !"vm_get_ep"}
-!25 = !{!"branch_weights", i32 2000, i32 1}
-!26 = !DILocation(line: 4, column: 23, scope: !10)
-!27 = !DILocation(line: 4, column: 36, scope: !10)
-!28 = !DILocation(line: 0, scope: !10)
-!29 = !DILocation(line: 5, column: 10, scope: !10)
-!30 = !{!31}
-!31 = distinct !{!31, !32, !"vm_get_ep: argument 0"}
-!32 = distinct !{!32, !"vm_get_ep"}
-!33 = !{!34}
-!34 = distinct !{!34, !35, !"sorbet_buildArrayIntrinsic: argument 0"}
-!35 = distinct !{!35, !"sorbet_buildArrayIntrinsic"}
-!36 = !DILocation(line: 5, column: 5, scope: !10)
-!37 = !DILocation(line: 4, column: 1, scope: !38)
-!38 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$153", scope: null, file: !4, line: 4, type: !11, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!39 = !DILocation(line: 8, column: 1, scope: !38)
-!40 = !DILocation(line: 9, column: 1, scope: !38)
-!41 = !DILocation(line: 10, column: 1, scope: !38)
-!42 = !DILocation(line: 11, column: 1, scope: !38)
-!43 = !DILocation(line: 12, column: 1, scope: !38)
-!44 = !DILocation(line: 13, column: 1, scope: !38)
-!45 = !DILocation(line: 14, column: 1, scope: !38)
-!46 = !DILocation(line: 16, column: 1, scope: !38)
-!47 = !DILocation(line: 17, column: 1, scope: !38)
-!48 = !DILocation(line: 18, column: 1, scope: !38)
-!49 = !DILocation(line: 19, column: 1, scope: !38)
-!50 = !DILocation(line: 20, column: 1, scope: !38)
-!51 = !DILocation(line: 21, column: 1, scope: !38)
-!52 = !DILocation(line: 22, column: 1, scope: !38)
-!53 = !DILocation(line: 24, column: 1, scope: !38)
-!54 = !DILocation(line: 25, column: 1, scope: !38)
-!55 = !DILocation(line: 26, column: 1, scope: !38)
-!56 = !DILocation(line: 27, column: 1, scope: !38)
-!57 = !DILocation(line: 28, column: 1, scope: !38)
-!58 = !DILocation(line: 29, column: 1, scope: !38)
-!59 = !DILocation(line: 30, column: 1, scope: !38)
+!10 = !DILocation(line: 5, column: 10, scope: !11)
+!11 = distinct !DISubprogram(name: "Object#take_arguments", linkageName: "func_Object#14take_arguments", scope: null, file: !4, line: 4, type: !12, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!12 = !DISubroutineType(types: !13)
+!13 = !{!14}
+!14 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
+!15 = !DILocation(line: 5, column: 5, scope: !11)
+!16 = !DILocation(line: 8, column: 1, scope: !17)
+!17 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$153", scope: null, file: !4, line: 4, type: !12, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!18 = !DILocation(line: 9, column: 1, scope: !17)
+!19 = !DILocation(line: 10, column: 1, scope: !17)
+!20 = !DILocation(line: 11, column: 1, scope: !17)
+!21 = !DILocation(line: 12, column: 1, scope: !17)
+!22 = !DILocation(line: 13, column: 1, scope: !17)
+!23 = !DILocation(line: 14, column: 1, scope: !17)
+!24 = !DILocation(line: 16, column: 1, scope: !17)
+!25 = !DILocation(line: 17, column: 1, scope: !17)
+!26 = !DILocation(line: 18, column: 1, scope: !17)
+!27 = !DILocation(line: 19, column: 1, scope: !17)
+!28 = !DILocation(line: 20, column: 1, scope: !17)
+!29 = !DILocation(line: 21, column: 1, scope: !17)
+!30 = !DILocation(line: 22, column: 1, scope: !17)
+!31 = !DILocation(line: 24, column: 1, scope: !17)
+!32 = !DILocation(line: 25, column: 1, scope: !17)
+!33 = !DILocation(line: 26, column: 1, scope: !17)
+!34 = !DILocation(line: 27, column: 1, scope: !17)
+!35 = !DILocation(line: 28, column: 1, scope: !17)
+!36 = !DILocation(line: 29, column: 1, scope: !17)
+!37 = !DILocation(line: 30, column: 1, scope: !17)
+!38 = !{!39, !39, i64 0}
+!39 = !{!"any pointer", !8, i64 0}
+!40 = !DILocation(line: 4, column: 1, scope: !11)
+!41 = !{!42, !7, i64 0}
+!42 = !{!"RBasic", !7, i64 0, !7, i64 8}
+!43 = !{!"branch_weights", i32 1, i32 2000}
+!44 = !{!45, !39, i64 32}
+!45 = !{!"rb_control_frame_struct", !39, i64 0, !39, i64 8, !39, i64 16, !7, i64 24, !39, i64 32, !39, i64 40, !39, i64 48}
+!46 = !{!47}
+!47 = distinct !{!47, !48, !"vm_get_ep: argument 0"}
+!48 = distinct !{!48, !"vm_get_ep"}
+!49 = !{!"branch_weights", i32 2000, i32 1}
+!50 = !DILocation(line: 4, column: 23, scope: !11)
+!51 = !DILocation(line: 4, column: 36, scope: !11)
+!52 = !DILocation(line: 0, scope: !11)
+!53 = !{!54}
+!54 = distinct !{!54, !55, !"vm_get_ep: argument 0"}
+!55 = distinct !{!55, !"vm_get_ep"}
+!56 = !{!57}
+!57 = distinct !{!57, !58, !"sorbet_buildArrayIntrinsic: argument 0"}
+!58 = distinct !{!58, !"sorbet_buildArrayIntrinsic"}
+!59 = !DILocation(line: 4, column: 1, scope: !17)
 !60 = !{!61, !7, i64 400}
-!61 = !{!"rb_vm_struct", !7, i64 0, !62, i64 8, !15, i64 192, !15, i64 200, !15, i64 208, !66, i64 216, !8, i64 224, !63, i64 264, !63, i64 280, !63, i64 296, !63, i64 312, !7, i64 328, !65, i64 336, !65, i64 340, !65, i64 344, !65, i64 344, !65, i64 344, !65, i64 344, !65, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !15, i64 456, !15, i64 464, !67, i64 472, !68, i64 992, !15, i64 1016, !15, i64 1024, !65, i64 1032, !65, i64 1036, !63, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !65, i64 1136, !15, i64 1144, !15, i64 1152, !15, i64 1160, !15, i64 1168, !15, i64 1176, !15, i64 1184, !65, i64 1192, !69, i64 1200, !8, i64 1232}
-!62 = !{!"rb_global_vm_lock_struct", !15, i64 0, !8, i64 8, !63, i64 48, !15, i64 64, !65, i64 72, !8, i64 80, !8, i64 128, !65, i64 176, !65, i64 180}
+!61 = !{!"rb_vm_struct", !7, i64 0, !62, i64 8, !39, i64 192, !39, i64 200, !39, i64 208, !66, i64 216, !8, i64 224, !63, i64 264, !63, i64 280, !63, i64 296, !63, i64 312, !7, i64 328, !65, i64 336, !65, i64 340, !65, i64 344, !65, i64 344, !65, i64 344, !65, i64 344, !65, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !39, i64 456, !39, i64 464, !67, i64 472, !68, i64 992, !39, i64 1016, !39, i64 1024, !65, i64 1032, !65, i64 1036, !63, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !65, i64 1136, !39, i64 1144, !39, i64 1152, !39, i64 1160, !39, i64 1168, !39, i64 1176, !39, i64 1184, !65, i64 1192, !69, i64 1200, !8, i64 1232}
+!62 = !{!"rb_global_vm_lock_struct", !39, i64 0, !8, i64 8, !63, i64 48, !39, i64 64, !65, i64 72, !8, i64 80, !8, i64 128, !65, i64 176, !65, i64 180}
 !63 = !{!"list_head", !64, i64 0}
-!64 = !{!"list_node", !15, i64 0, !15, i64 8}
+!64 = !{!"list_node", !39, i64 0, !39, i64 8}
 !65 = !{!"int", !8, i64 0}
 !66 = !{!"long long", !8, i64 0}
 !67 = !{!"", !8, i64 0}
-!68 = !{!"rb_hook_list_struct", !15, i64 0, !65, i64 8, !65, i64 12, !65, i64 16}
+!68 = !{!"rb_hook_list_struct", !39, i64 0, !65, i64 8, !65, i64 12, !65, i64 16}
 !69 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
-!70 = !{!71, !15, i64 16}
-!71 = !{!"rb_execution_context_struct", !15, i64 0, !7, i64 8, !15, i64 16, !15, i64 24, !15, i64 32, !65, i64 40, !65, i64 44, !15, i64 48, !15, i64 56, !15, i64 64, !7, i64 72, !7, i64 80, !15, i64 88, !7, i64 96, !15, i64 104, !15, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !72, i64 152}
-!72 = !{!"", !15, i64 0, !15, i64 8, !7, i64 16, !8, i64 24}
-!73 = !{!21, !15, i64 16}
-!74 = !DILocation(line: 0, scope: !38)
+!70 = !{!71, !39, i64 16}
+!71 = !{!"rb_execution_context_struct", !39, i64 0, !7, i64 8, !39, i64 16, !39, i64 24, !39, i64 32, !65, i64 40, !65, i64 44, !39, i64 48, !39, i64 56, !39, i64 64, !7, i64 72, !7, i64 80, !39, i64 88, !7, i64 96, !39, i64 104, !39, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !72, i64 152}
+!72 = !{!"", !39, i64 0, !39, i64 8, !7, i64 16, !8, i64 24}
+!73 = !{!45, !39, i64 16}
+!74 = !DILocation(line: 0, scope: !17)
 !75 = !{!76, !65, i64 20}
-!76 = !{!"rb_sorbet_param_struct", !77, i64 0, !65, i64 4, !65, i64 8, !65, i64 12, !65, i64 16, !65, i64 20, !65, i64 24, !65, i64 28, !15, i64 32, !65, i64 40, !65, i64 44, !65, i64 48, !65, i64 52, !15, i64 56}
+!76 = !{!"rb_sorbet_param_struct", !77, i64 0, !65, i64 4, !65, i64 8, !65, i64 12, !65, i64 16, !65, i64 20, !65, i64 24, !65, i64 28, !39, i64 32, !65, i64 40, !65, i64 44, !65, i64 48, !65, i64 52, !39, i64 56}
 !77 = !{!"", !65, i64 0, !65, i64 0, !65, i64 0, !65, i64 0, !65, i64 0, !65, i64 0, !65, i64 0, !65, i64 0, !65, i64 1, !65, i64 1}
 !78 = !{!76, !65, i64 24}
 !79 = !{!76, !65, i64 28}
 !80 = !{!65, !65, i64 0}
-!81 = !{!76, !15, i64 32}
+!81 = !{!76, !39, i64 32}
 !82 = !{!76, !65, i64 40}
 !83 = !{!76, !65, i64 44}
 !84 = !{!76, !65, i64 8}
 !85 = !{!76, !65, i64 12}
 !86 = !{!76, !65, i64 48}
 !87 = !{!76, !65, i64 52}
-!88 = !{!76, !15, i64 56}
+!88 = !{!76, !39, i64 56}

--- a/test/testdata/compiler/block_arg_expand.opt.ll.exp
+++ b/test/testdata/compiler/block_arg_expand.opt.ll.exp
@@ -130,7 +130,7 @@ declare void @sorbet_pushBlockFrame(%struct.rb_captured_block*) local_unnamed_ad
 
 declare void @sorbet_popFrame() local_unnamed_addr #2
 
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #2
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) local_unnamed_addr #2
 
 declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #2
 
@@ -781,30 +781,30 @@ entry:
   %17 = call i64 @sorbet_globalConstRegister(i64 %16)
   store i64 %17, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8
   %"rubyId_+.i" = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 5), align 8, !dbg !30, !invariant.load !5
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_+", i64 %"rubyId_+.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !30
+  call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_+", i64 %"rubyId_+.i", i32 noundef 16, i32 noundef 1, i32 noundef 0), !dbg !30
   %18 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_2", i8* noundef null, i32 noundef 1, i32 noundef 1) #13
   %19 = ptrtoint %struct.vm_ifunc* %18 to i64
   %20 = call i64 @sorbet_globalConstRegister(i64 %19)
   store i64 %20, i64* @"func_<root>.17<static-init>$153$block_2_ifunc", align 8
   %rubyId_p.i = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 6), align 8, !dbg !45, !invariant.load !5
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !45
+  call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !45
   %21 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_3", i8* noundef null, i32 noundef 0, i32 noundef 1) #13
   %22 = ptrtoint %struct.vm_ifunc* %21 to i64
   %23 = call i64 @sorbet_globalConstRegister(i64 %22)
   store i64 %23, i64* @"func_<root>.17<static-init>$153$block_3_ifunc", align 8
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.5, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !52
+  call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.5, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !52
   %24 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_4", i8* noundef null, i32 noundef 0, i32 noundef 2) #13
   %25 = ptrtoint %struct.vm_ifunc* %24 to i64
   %26 = call i64 @sorbet_globalConstRegister(i64 %25)
   store i64 %26, i64* @"func_<root>.17<static-init>$153$block_4_ifunc", align 8
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.8, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !60
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.9, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !61
+  call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.8, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !60
+  call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.9, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !61
   %27 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_5", i8* noundef null, i32 noundef 1, i32 noundef 2) #13
   %28 = ptrtoint %struct.vm_ifunc* %27 to i64
   %29 = call i64 @sorbet_globalConstRegister(i64 %28)
   store i64 %29, i64* @"func_<root>.17<static-init>$153$block_5_ifunc", align 8
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.12, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !68
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.13, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !69
+  call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.12, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !68
+  call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.13, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !69
   %30 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
   %31 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %30, i64 0, i32 2
   %32 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %31, align 8, !tbaa !17

--- a/test/testdata/compiler/block_args.opt.ll.exp
+++ b/test/testdata/compiler/block_args.opt.ll.exp
@@ -114,7 +114,7 @@ declare void @sorbet_pushBlockFrame(%struct.rb_captured_block*) local_unnamed_ad
 
 declare void @sorbet_popFrame() local_unnamed_addr #0
 
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #0
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) local_unnamed_addr #0
 
 declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #0
 
@@ -294,9 +294,9 @@ entry:
   %6 = call i64 @sorbet_globalConstRegister(i64 %5)
   store i64 %6, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8
   %"rubyId_+.i" = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !dbg !26, !invariant.load !5
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_+", i64 %"rubyId_+.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !26
+  call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_+", i64 %"rubyId_+.i", i32 noundef 16, i32 noundef 1, i32 noundef 0), !dbg !26
   %rubyId_puts.i = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleIDTable, i64 0, i64 5), align 8, !dbg !38, !invariant.load !5
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !38
+  call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !38
   %7 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !15
   %8 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %7, i64 0, i32 18
   %9 = load i64, i64* %8, align 8, !tbaa !39

--- a/test/testdata/compiler/block_no_args.opt.ll.exp
+++ b/test/testdata/compiler/block_no_args.opt.ll.exp
@@ -105,7 +105,7 @@ declare void @sorbet_pushBlockFrame(%struct.rb_captured_block*) local_unnamed_ad
 
 declare void @sorbet_popFrame() local_unnamed_addr #0
 
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #0
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) local_unnamed_addr #0
 
 declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #0
 
@@ -192,7 +192,7 @@ entry:
   %4 = call i64 @sorbet_globalConstRegister(i64 %3)
   store i64 %4, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8
   %rubyId_puts.i = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !26, !invariant.load !5
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !26
+  call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 16, i32 noundef 1, i32 noundef 0), !dbg !26
   %5 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
   %6 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %5, i64 0, i32 2
   %7 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %6, align 8, !tbaa !17

--- a/test/testdata/compiler/block_no_args_capture.opt.ll.exp
+++ b/test/testdata/compiler/block_no_args_capture.opt.ll.exp
@@ -108,7 +108,7 @@ declare void @sorbet_popFrame() local_unnamed_addr #0
 
 declare void @sorbet_vm_env_write_slowpath(i64*, i32, i64) local_unnamed_addr #0
 
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #0
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) local_unnamed_addr #0
 
 declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #0
 
@@ -212,7 +212,7 @@ entry:
   %6 = call i64 @sorbet_globalConstRegister(i64 %5)
   store i64 %6, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8
   %rubyId_puts.i = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !dbg !24, !invariant.load !5
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !24
+  call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 16, i32 noundef 1, i32 noundef 0), !dbg !24
   %7 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
   %8 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %7, i64 0, i32 2
   %9 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %8, align 8, !tbaa !17

--- a/test/testdata/compiler/block_no_args_captures_constant.opt.ll.exp
+++ b/test/testdata/compiler/block_no_args_captures_constant.opt.ll.exp
@@ -120,7 +120,7 @@ declare void @sorbet_pushBlockFrame(%struct.rb_captured_block*) local_unnamed_ad
 
 declare void @sorbet_popFrame() local_unnamed_addr #1
 
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #1
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) local_unnamed_addr #1
 
 declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #1
 
@@ -333,17 +333,17 @@ entry:
   %1 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in foo.i.i", i64 %"rubyId_block in foo.i.i", i64 %"rubyStr_test/testdata/compiler/block_no_args_captures_constant.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* %0, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %1, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3foo$block_1", align 8
   %rubyId_puts.i = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !19, !invariant.load !5
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
+  call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 16, i32 noundef 1, i32 noundef 0), !dbg !19
   %2 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_Object#3foo$block_1", i8* noundef null, i32 noundef 0, i32 noundef 0) #12
   %3 = ptrtoint %struct.vm_ifunc* %2 to i64
   %4 = call i64 @sorbet_globalConstRegister(i64 %3)
   store i64 %4, i64* @"func_Object#3foo$block_1_ifunc", align 8
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !49
+  call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts.i, i32 noundef 16, i32 noundef 1, i32 noundef 0), !dbg !49
   %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !invariant.load !5
   %"rubyStr_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 3), align 8, !invariant.load !5
   %5 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_no_args_captures_constant.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 4, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i4.i, i32 noundef 0, i32 noundef 4)
   store %struct.rb_iseq_struct* %5, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !50
+  call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo.i.i, i32 noundef 20, i32 noundef 0, i32 noundef 0), !dbg !50
   %6 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
   %7 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %6, i64 0, i32 18
   %8 = load i64, i64* %7, align 8, !tbaa !52

--- a/test/testdata/compiler/block_type_checking.opt.ll.exp
+++ b/test/testdata/compiler/block_type_checking.opt.ll.exp
@@ -137,7 +137,7 @@ declare %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64) local_
 
 declare void @sorbet_popFrame() local_unnamed_addr #3
 
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #3
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) local_unnamed_addr #3
 
 declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #3
 
@@ -230,229 +230,220 @@ functionEntryInitializers:
 define void @Init_block_type_checking() local_unnamed_addr #10 {
 entry:
   %positional_table.i.i = alloca i64, i32 2, align 8, !dbg !26
-  %locals.i7.i = alloca i64, i32 0, align 8
-  %locals.i5.i = alloca i64, i32 0, align 8
+  %locals.i6.i = alloca i64, i32 0, align 8
+  %locals.i4.i = alloca i64, i32 0, align 8
   %locals.i.i = alloca i64, i32 0, align 8
-  %keywords.i = alloca i64, i32 2, align 8, !dbg !29
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = bitcast i64* %keywords.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %0)
   tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([16 x %struct.rb_code_position_struct], [16 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 16, i8* noundef getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
   tail call void @sorbet_vm_init_string_table(i64* noundef getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleRubyStringTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([6 x %struct.rb_code_position_struct], [6 x %struct.rb_code_position_struct]* @sorbet_moduleRubyStringDescriptors, i32 0, i32 0), i32 noundef 6, i8* noundef getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 19)
   %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
   %"rubyStr_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 0), align 8, !invariant.load !5
   %"rubyStr_test/testdata/compiler/block_type_checking.rb.i.i" = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
-  %1 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %1, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %0 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %0, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
   %"rubyId_block in <top (required)>.i.i" = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !invariant.load !5
   %"rubyStr_block in <top (required)>.i.i" = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 2), align 8, !invariant.load !5
-  %2 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i.i", i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* %1, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %2, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1", align 8
-  %rubyId_new.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !31, !invariant.load !5
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !31
-  %rubyId_initialize.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !31, !invariant.load !5
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 %rubyId_initialize.i, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !31
-  %rubyId_bar.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !dbg !31, !invariant.load !5
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_bar, i64 %rubyId_bar.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !31
-  %3 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_1", i8* noundef null, i32 noundef 0, i32 noundef 0) #17
-  %4 = ptrtoint %struct.vm_ifunc* %3 to i64
-  %5 = call i64 @sorbet_globalConstRegister(i64 %4)
-  store i64 %5, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8
-  %rubyId_p.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 5), align 8, !dbg !32, !invariant.load !5
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !32
+  %1 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i.i", i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* %0, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %1, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1", align 8
+  %rubyId_new.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !29, !invariant.load !5
+  call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new.i, i32 noundef 16, i32 noundef 0, i32 noundef 0), !dbg !29
+  %rubyId_initialize.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !29, !invariant.load !5
+  call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 %rubyId_initialize.i, i32 noundef 20, i32 noundef 0, i32 noundef 0), !dbg !29
+  %rubyId_bar.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !dbg !29, !invariant.load !5
+  call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_bar, i64 %rubyId_bar.i, i32 noundef 16, i32 noundef 1, i32 noundef 0), !dbg !29
+  %2 = call %struct.vm_ifunc* @rb_vm_ifunc_new(i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_1", i8* noundef null, i32 noundef 0, i32 noundef 0) #17
+  %3 = ptrtoint %struct.vm_ifunc* %2 to i64
+  %4 = call i64 @sorbet_globalConstRegister(i64 %3)
+  store i64 %4, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8
+  %rubyId_p.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 5), align 8, !dbg !30, !invariant.load !5
+  call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !30
   %rubyStr_bar.i.i = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 3), align 8, !invariant.load !5
-  %6 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_bar.i.i, i64 %rubyId_bar.i, i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 9, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i5.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %6, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo#3bar", align 8
+  %5 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_bar.i.i, i64 %rubyId_bar.i, i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 9, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i4.i, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %5, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo#3bar", align 8
   %"rubyId_<class:Foo>.i.i" = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 7), align 8, !invariant.load !5
   %"rubyStr_<class:Foo>.i.i" = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 4), align 8, !invariant.load !5
-  %7 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<class:Foo>.i.i", i64 %"rubyId_<class:Foo>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i7.i, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %7, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>", align 8
+  %6 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<class:Foo>.i.i", i64 %"rubyId_<class:Foo>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i6.i, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %6, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>", align 8
   %"rubyId_block in <class:Foo>.i.i" = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 8), align 8, !invariant.load !5
   %"rubyStr_block in <class:Foo>.i.i" = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 5), align 8, !invariant.load !5
-  %8 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <class:Foo>.i.i", i64 %"rubyId_block in <class:Foo>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* %7, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %8, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>$block_1", align 8
-  %rubyId_proc.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 11), align 8, !dbg !33, !invariant.load !5
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_proc, i64 %rubyId_proc.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !33
-  %rubyId_returns.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 12), align 8, !dbg !33, !invariant.load !5
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !33
-  %rubyId_params.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 13), align 8, !dbg !29, !invariant.load !5
-  %rubyId_x.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 9), align 8, !dbg !29, !invariant.load !5
-  %9 = call i64 @rb_id2sym(i64 %rubyId_x.i) #18, !dbg !29
-  store i64 %9, i64* %keywords.i, align 8, !dbg !29
-  %rubyId_blk.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 10), align 8, !dbg !29, !invariant.load !5
-  %10 = call i64 @rb_id2sym(i64 %rubyId_blk.i) #18, !dbg !29
-  %11 = getelementptr i64, i64* %keywords.i, i32 1, !dbg !29
-  store i64 %10, i64* %11, align 8, !dbg !29
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull align 8 %keywords.i), !dbg !29
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.1, i64 %rubyId_returns.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !29
+  %7 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <class:Foo>.i.i", i64 %"rubyId_block in <class:Foo>.i.i", i64 %"rubyStr_test/testdata/compiler/block_type_checking.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* %6, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %7, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>$block_1", align 8
+  %rubyId_proc.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 11), align 8, !dbg !31, !invariant.load !5
+  call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_proc, i64 %rubyId_proc.i, i32 noundef 16, i32 noundef 0, i32 noundef 0), !dbg !31
+  %rubyId_returns.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 12), align 8, !dbg !31, !invariant.load !5
+  call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns.i, i32 noundef 16, i32 noundef 1, i32 noundef 0), !dbg !31
+  %rubyId_params.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 13), align 8, !dbg !33, !invariant.load !5
+  %rubyId_x.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 9), align 8, !dbg !33, !invariant.load !5
+  %rubyId_blk.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 10), align 8, !dbg !33, !invariant.load !5
+  call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64 %rubyId_x.i, i64 %rubyId_blk.i), !dbg !33
+  call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.1, i64 %rubyId_returns.i, i32 noundef 16, i32 noundef 1, i32 noundef 0), !dbg !33
   %rubyId_extend.i = load i64, i64* getelementptr inbounds ([16 x i64], [16 x i64]* @sorbet_moduleIDTable, i64 0, i64 14), align 8, !dbg !34, !invariant.load !5
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !34
-  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %0)
-  %12 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !15
-  %13 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %12, i64 0, i32 18
-  %14 = load i64, i64* %13, align 8, !tbaa !35
-  %15 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
-  %16 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %15, i64 0, i32 2
-  %17 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %16, align 8, !tbaa !17
+  call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend.i, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !34
+  %8 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !15
+  %9 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %8, i64 0, i32 18
+  %10 = load i64, i64* %9, align 8, !tbaa !35
+  %11 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
+  %12 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %11, i64 0, i32 2
+  %13 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %12, align 8, !tbaa !17
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %18, align 8, !tbaa !21
-  %19 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 4
-  %20 = load i64*, i64** %19, align 8, !tbaa !23
-  %21 = load i64, i64* %20, align 8, !tbaa !6
-  %22 = and i64 %21, -33
-  store i64 %22, i64* %20, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %15, %struct.rb_control_frame_struct* %17, %struct.rb_iseq_struct* %stackFrame.i) #17
-  %23 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 0
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %23, align 8, !dbg !44, !tbaa !15
-  %24 = load i64, i64* @rb_cObject, align 8, !dbg !45
-  %25 = call i64 @rb_define_class(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 89), i64 %24) #17, !dbg !45
-  %26 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %25) #17, !dbg !45
-  %27 = bitcast i64* %positional_table.i.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %27) #17
+  %14 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %13, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %14, align 8, !tbaa !21
+  %15 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %13, i64 0, i32 4
+  %16 = load i64*, i64** %15, align 8, !tbaa !23
+  %17 = load i64, i64* %16, align 8, !tbaa !6
+  %18 = and i64 %17, -33
+  store i64 %18, i64* %16, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %11, %struct.rb_control_frame_struct* %13, %struct.rb_iseq_struct* %stackFrame.i) #17
+  %19 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %13, i64 0, i32 0
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %19, align 8, !dbg !44, !tbaa !15
+  %20 = load i64, i64* @rb_cObject, align 8, !dbg !45
+  %21 = call i64 @rb_define_class(i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 89), i64 %20) #17, !dbg !45
+  %22 = call %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64 %21) #17, !dbg !45
+  %23 = bitcast i64* %positional_table.i.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %23) #17
   %stackFrame.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo.13<static-init>", align 8
-  %28 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
-  %29 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %28, i64 0, i32 2
-  %30 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %29, align 8, !tbaa !17
-  %31 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %30, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %31, align 8, !tbaa !21
-  %32 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %30, i64 0, i32 4
-  %33 = load i64*, i64** %32, align 8, !tbaa !23
-  %34 = load i64, i64* %33, align 8, !tbaa !6
-  %35 = and i64 %34, -33
-  store i64 %35, i64* %33, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %28, %struct.rb_control_frame_struct* %30, %struct.rb_iseq_struct* %stackFrame.i.i) #17
-  %36 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 0
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %36, align 8, !dbg !46, !tbaa !15
+  %24 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
+  %25 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %24, i64 0, i32 2
+  %26 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %25, align 8, !tbaa !17
+  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i.i, %struct.rb_iseq_struct** %27, align 8, !tbaa !21
+  %28 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 4
+  %29 = load i64*, i64** %28, align 8, !tbaa !23
+  %30 = load i64, i64* %29, align 8, !tbaa !6
+  %31 = and i64 %30, -33
+  store i64 %31, i64* %29, align 8, !tbaa !6
+  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %24, %struct.rb_control_frame_struct* %26, %struct.rb_iseq_struct* %stackFrame.i.i) #17
+  %32 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %22, i64 0, i32 0
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %32, align 8, !dbg !46, !tbaa !15
   %rawSym.i.i = call i64 @rb_id2sym(i64 %rubyId_bar.i) #17, !dbg !47
-  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym.i.i, i64 %25, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_Foo.13<static-init>L62$block_1") #17, !dbg !47
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %36, align 8, !dbg !47, !tbaa !15
-  %37 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !48
-  %38 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !48, !tbaa !49
-  %needTakeSlowPath = icmp ne i64 %37, %38, !dbg !48
-  br i1 %needTakeSlowPath, label %39, label %40, !dbg !48, !prof !50
+  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym.i.i, i64 %21, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_Foo.13<static-init>L62$block_1") #17, !dbg !47
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 6), i64** %32, align 8, !dbg !47, !tbaa !15
+  %33 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !48
+  %34 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !48, !tbaa !49
+  %needTakeSlowPath = icmp ne i64 %33, %34, !dbg !48
+  br i1 %needTakeSlowPath, label %35, label %36, !dbg !48, !prof !50
 
-39:                                               ; preds = %entry
+35:                                               ; preds = %entry
   call void @"const_recompute_T::Sig"(), !dbg !48
-  br label %40, !dbg !48
+  br label %36, !dbg !48
 
-40:                                               ; preds = %entry, %39
-  %41 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !48
-  %42 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !48
-  %43 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !48, !tbaa !49
-  %guardUpdated = icmp eq i64 %42, %43, !dbg !48
+36:                                               ; preds = %entry, %35
+  %37 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !48
+  %38 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !48
+  %39 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !48, !tbaa !49
+  %guardUpdated = icmp eq i64 %38, %39, !dbg !48
   call void @llvm.assume(i1 %guardUpdated), !dbg !48
-  %44 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %26, i64 0, i32 1, !dbg !48
-  %45 = load i64*, i64** %44, align 8, !dbg !48
-  store i64 %25, i64* %45, align 8, !dbg !48, !tbaa !6
-  %46 = getelementptr inbounds i64, i64* %45, i64 1, !dbg !48
-  store i64 %41, i64* %46, align 8, !dbg !48, !tbaa !6
-  %47 = getelementptr inbounds i64, i64* %46, i64 1, !dbg !48
-  store i64* %47, i64** %44, align 8, !dbg !48
+  %40 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %22, i64 0, i32 1, !dbg !48
+  %41 = load i64*, i64** %40, align 8, !dbg !48
+  store i64 %21, i64* %41, align 8, !dbg !48, !tbaa !6
+  %42 = getelementptr inbounds i64, i64* %41, i64 1, !dbg !48
+  store i64 %37, i64* %42, align 8, !dbg !48, !tbaa !6
+  %43 = getelementptr inbounds i64, i64* %42, i64 1, !dbg !48
+  store i64* %43, i64** %40, align 8, !dbg !48
   %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !48
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %36, align 8, !dbg !48, !tbaa !15
-  %48 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !26
-  %49 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !26, !tbaa !49
-  %needTakeSlowPath1 = icmp ne i64 %48, %49, !dbg !26
-  br i1 %needTakeSlowPath1, label %50, label %51, !dbg !26, !prof !50
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %32, align 8, !dbg !48, !tbaa !15
+  %44 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !26
+  %45 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !26, !tbaa !49
+  %needTakeSlowPath1 = icmp ne i64 %44, %45, !dbg !26
+  br i1 %needTakeSlowPath1, label %46, label %47, !dbg !26, !prof !50
 
-50:                                               ; preds = %40
+46:                                               ; preds = %36
   call void @const_recompute_Foo(), !dbg !26
-  br label %51, !dbg !26
+  br label %47, !dbg !26
 
-51:                                               ; preds = %40, %50
-  %52 = load i64, i64* @guarded_const_Foo, align 8, !dbg !26
-  %53 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !26
-  %54 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !26, !tbaa !49
-  %guardUpdated2 = icmp eq i64 %53, %54, !dbg !26
+47:                                               ; preds = %36, %46
+  %48 = load i64, i64* @guarded_const_Foo, align 8, !dbg !26
+  %49 = load i64, i64* @guard_epoch_Foo, align 8, !dbg !26
+  %50 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !26, !tbaa !49
+  %guardUpdated2 = icmp eq i64 %49, %50, !dbg !26
   call void @llvm.assume(i1 %guardUpdated2), !dbg !26
   %stackFrame42.i.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Foo#3bar", align 8, !dbg !26
-  %55 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #19, !dbg !26
-  %56 = bitcast i8* %55 to i16*, !dbg !26
-  %57 = load i16, i16* %56, align 8, !dbg !26
-  %58 = and i16 %57, -384, !dbg !26
-  %59 = or i16 %58, 65, !dbg !26
-  store i16 %59, i16* %56, align 8, !dbg !26
-  %60 = getelementptr inbounds i8, i8* %55, i64 8, !dbg !26
-  %61 = bitcast i8* %60 to i32*, !dbg !26
-  store i32 1, i32* %61, align 8, !dbg !26, !tbaa !51
-  %62 = getelementptr inbounds i8, i8* %55, i64 12, !dbg !26
-  %63 = getelementptr inbounds i8, i8* %55, i64 28, !dbg !26
-  %64 = bitcast i8* %63 to i32*, !dbg !26
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %62, i8 0, i64 16, i1 false) #17, !dbg !26
-  store i32 1, i32* %64, align 4, !dbg !26, !tbaa !54
-  %65 = getelementptr inbounds i8, i8* %55, i64 4, !dbg !26
-  %66 = bitcast i8* %65 to i32*, !dbg !26
-  store i32 2, i32* %66, align 4, !dbg !26, !tbaa !55
+  %51 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !26
+  %52 = bitcast i8* %51 to i16*, !dbg !26
+  %53 = load i16, i16* %52, align 8, !dbg !26
+  %54 = and i16 %53, -384, !dbg !26
+  %55 = or i16 %54, 65, !dbg !26
+  store i16 %55, i16* %52, align 8, !dbg !26
+  %56 = getelementptr inbounds i8, i8* %51, i64 8, !dbg !26
+  %57 = bitcast i8* %56 to i32*, !dbg !26
+  store i32 1, i32* %57, align 8, !dbg !26, !tbaa !51
+  %58 = getelementptr inbounds i8, i8* %51, i64 12, !dbg !26
+  %59 = getelementptr inbounds i8, i8* %51, i64 28, !dbg !26
+  %60 = bitcast i8* %59 to i32*, !dbg !26
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %58, i8 0, i64 16, i1 false) #17, !dbg !26
+  store i32 1, i32* %60, align 4, !dbg !26, !tbaa !54
+  %61 = getelementptr inbounds i8, i8* %51, i64 4, !dbg !26
+  %62 = bitcast i8* %61 to i32*, !dbg !26
+  store i32 2, i32* %62, align 4, !dbg !26, !tbaa !55
   store i64 %rubyId_x.i, i64* %positional_table.i.i, align 8, !dbg !26
-  %67 = getelementptr i64, i64* %positional_table.i.i, i32 1, !dbg !26
-  store i64 %rubyId_blk.i, i64* %67, align 8, !dbg !26
-  %68 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #19, !dbg !26
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %68, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %27, i64 noundef 16, i1 noundef false) #17, !dbg !26
-  %69 = getelementptr inbounds i8, i8* %55, i64 32, !dbg !26
-  %70 = bitcast i8* %69 to i8**, !dbg !26
-  store i8* %68, i8** %70, align 8, !dbg !26, !tbaa !56
-  call void @sorbet_vm_define_method(i64 %52, i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 115), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Foo#3bar", i8* nonnull %55, %struct.rb_iseq_struct* %stackFrame42.i.i, i1 noundef zeroext false) #17, !dbg !26
-  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %27) #17
+  %63 = getelementptr i64, i64* %positional_table.i.i, i32 1, !dbg !26
+  store i64 %rubyId_blk.i, i64* %63, align 8, !dbg !26
+  %64 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #18, !dbg !26
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %64, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %23, i64 noundef 16, i1 noundef false) #17, !dbg !26
+  %65 = getelementptr inbounds i8, i8* %51, i64 32, !dbg !26
+  %66 = bitcast i8* %65 to i8**, !dbg !26
+  store i8* %64, i8** %66, align 8, !dbg !26, !tbaa !56
+  call void @sorbet_vm_define_method(i64 %48, i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 115), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Foo#3bar", i8* nonnull %51, %struct.rb_iseq_struct* %stackFrame42.i.i, i1 noundef zeroext false) #17, !dbg !26
+  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %23) #17
   call void @sorbet_popFrame() #17, !dbg !45
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 15), i64** %23, align 8, !dbg !45, !tbaa !15
-  %71 = call i64 @sorbet_maybeAllocateObjectFastPath(i64 %52, %struct.FunctionInlineCache* noundef @ic_new) #17, !dbg !31
-  %72 = icmp eq i64 %71, 52, !dbg !31
-  br i1 %72, label %slowNew.i, label %fastNew.i, !dbg !31
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 15), i64** %19, align 8, !dbg !45, !tbaa !15
+  %67 = call i64 @sorbet_maybeAllocateObjectFastPath(i64 %48, %struct.FunctionInlineCache* noundef @ic_new) #17, !dbg !29
+  %68 = icmp eq i64 %67, 52, !dbg !29
+  br i1 %68, label %slowNew.i, label %fastNew.i, !dbg !29
 
-slowNew.i:                                        ; preds = %51
-  %73 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 1, !dbg !31
-  %74 = load i64*, i64** %73, align 8, !dbg !31
-  store i64 %52, i64* %74, align 8, !dbg !31, !tbaa !6
-  %75 = getelementptr inbounds i64, i64* %74, i64 1, !dbg !31
-  store i64* %75, i64** %73, align 8, !dbg !31
-  %76 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_new, i64 noundef 0) #17, !dbg !31
-  br label %"func_<root>.17<static-init>$153.exit", !dbg !31
+slowNew.i:                                        ; preds = %47
+  %69 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %13, i64 0, i32 1, !dbg !29
+  %70 = load i64*, i64** %69, align 8, !dbg !29
+  store i64 %48, i64* %70, align 8, !dbg !29, !tbaa !6
+  %71 = getelementptr inbounds i64, i64* %70, i64 1, !dbg !29
+  store i64* %71, i64** %69, align 8, !dbg !29
+  %72 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_new, i64 noundef 0) #17, !dbg !29
+  br label %"func_<root>.17<static-init>$153.exit", !dbg !29
 
-fastNew.i:                                        ; preds = %51
-  %77 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 1, !dbg !31
-  %78 = load i64*, i64** %77, align 8, !dbg !31
-  store i64 %71, i64* %78, align 8, !dbg !31, !tbaa !6
-  %79 = getelementptr inbounds i64, i64* %78, i64 1, !dbg !31
-  store i64* %79, i64** %77, align 8, !dbg !31
-  %80 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 noundef 0) #17, !dbg !31
-  br label %"func_<root>.17<static-init>$153.exit", !dbg !31
+fastNew.i:                                        ; preds = %47
+  %73 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %13, i64 0, i32 1, !dbg !29
+  %74 = load i64*, i64** %73, align 8, !dbg !29
+  store i64 %67, i64* %74, align 8, !dbg !29, !tbaa !6
+  %75 = getelementptr inbounds i64, i64* %74, i64 1, !dbg !29
+  store i64* %75, i64** %73, align 8, !dbg !29
+  %76 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 noundef 0) #17, !dbg !29
+  br label %"func_<root>.17<static-init>$153.exit", !dbg !29
 
 "func_<root>.17<static-init>$153.exit":           ; preds = %slowNew.i, %fastNew.i
-  %initializedObject.i = phi i64 [ %76, %slowNew.i ], [ %71, %fastNew.i ], !dbg !31
-  %81 = load i64, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8, !dbg !31
-  %82 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %81) #17, !dbg !31
-  %83 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 1, !dbg !31
-  %84 = load i64*, i64** %83, align 8, !dbg !31
-  store i64 %initializedObject.i, i64* %84, align 8, !dbg !31, !tbaa !6
-  %85 = getelementptr inbounds i64, i64* %84, i64 1, !dbg !31
-  store i64 11, i64* %85, align 8, !dbg !31, !tbaa !6
-  %86 = getelementptr inbounds i64, i64* %85, i64 1, !dbg !31
-  store i64* %86, i64** %83, align 8, !dbg !31
-  %87 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !31, !tbaa !15
-  %88 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %87, i64 0, i32 2, !dbg !31
-  %89 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %88, align 8, !dbg !31, !tbaa !17
-  %90 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %89, i64 0, i32 3, !dbg !31
-  %91 = bitcast i64* %90 to %struct.rb_captured_block*, !dbg !31
-  %92 = getelementptr inbounds i64, i64* %90, i64 2, !dbg !31
-  %93 = bitcast i64* %92 to %struct.vm_ifunc**, !dbg !31
-  store %struct.vm_ifunc* %82, %struct.vm_ifunc** %93, align 8, !dbg !31, !tbaa !57
-  %94 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %87, i64 0, i32 17, !dbg !31
-  store i64 0, i64* %94, align 8, !dbg !31, !tbaa !58
-  call void @llvm.experimental.noalias.scope.decl(metadata !59) #17, !dbg !31
-  %95 = ptrtoint %struct.rb_captured_block* %91 to i64, !dbg !31
-  %96 = or i64 %95, 3, !dbg !31
-  %97 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_bar, i64 %96) #17, !dbg !31
-  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %23, align 8, !dbg !31, !tbaa !15
-  %98 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %17, i64 0, i32 1, !dbg !32
-  %99 = load i64*, i64** %98, align 8, !dbg !32
-  store i64 %14, i64* %99, align 8, !dbg !32, !tbaa !6
-  %100 = getelementptr inbounds i64, i64* %99, i64 1, !dbg !32
-  store i64 %97, i64* %100, align 8, !dbg !32, !tbaa !6
-  %101 = getelementptr inbounds i64, i64* %100, i64 1, !dbg !32
-  store i64* %101, i64** %98, align 8, !dbg !32
-  %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p, i64 0), !dbg !32
+  %initializedObject.i = phi i64 [ %72, %slowNew.i ], [ %67, %fastNew.i ], !dbg !29
+  %77 = load i64, i64* @"func_<root>.17<static-init>$153$block_1_ifunc", align 8, !dbg !29
+  %78 = call %struct.vm_ifunc* @sorbet_globalConstFetchIfunc(i64 %77) #17, !dbg !29
+  %79 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %13, i64 0, i32 1, !dbg !29
+  %80 = load i64*, i64** %79, align 8, !dbg !29
+  store i64 %initializedObject.i, i64* %80, align 8, !dbg !29, !tbaa !6
+  %81 = getelementptr inbounds i64, i64* %80, i64 1, !dbg !29
+  store i64 11, i64* %81, align 8, !dbg !29, !tbaa !6
+  %82 = getelementptr inbounds i64, i64* %81, i64 1, !dbg !29
+  store i64* %82, i64** %79, align 8, !dbg !29
+  %83 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !29, !tbaa !15
+  %84 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %83, i64 0, i32 2, !dbg !29
+  %85 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %84, align 8, !dbg !29, !tbaa !17
+  %86 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %85, i64 0, i32 3, !dbg !29
+  %87 = bitcast i64* %86 to %struct.rb_captured_block*, !dbg !29
+  %88 = getelementptr inbounds i64, i64* %86, i64 2, !dbg !29
+  %89 = bitcast i64* %88 to %struct.vm_ifunc**, !dbg !29
+  store %struct.vm_ifunc* %78, %struct.vm_ifunc** %89, align 8, !dbg !29, !tbaa !57
+  %90 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %83, i64 0, i32 17, !dbg !29
+  store i64 0, i64* %90, align 8, !dbg !29, !tbaa !58
+  call void @llvm.experimental.noalias.scope.decl(metadata !59) #17, !dbg !29
+  %91 = ptrtoint %struct.rb_captured_block* %87 to i64, !dbg !29
+  %92 = or i64 %91, 3, !dbg !29
+  %93 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_bar, i64 %92) #17, !dbg !29
+  store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %19, align 8, !dbg !29, !tbaa !15
+  %94 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %13, i64 0, i32 1, !dbg !30
+  %95 = load i64*, i64** %94, align 8, !dbg !30
+  store i64 %10, i64* %95, align 8, !dbg !30, !tbaa !6
+  %96 = getelementptr inbounds i64, i64* %95, i64 1, !dbg !30
+  store i64 %93, i64* %96, align 8, !dbg !30, !tbaa !6
+  %97 = getelementptr inbounds i64, i64* %96, i64 1, !dbg !30
+  store i64* %97, i64** %94, align 8, !dbg !30
+  %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p, i64 0), !dbg !30
   ret void
 }
 
@@ -467,7 +458,7 @@ functionEntryInitializers:
   br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !63, !prof !64
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #20, !dbg !63
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 1, i32 noundef 1) #19, !dbg !63
   unreachable, !dbg !63
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
@@ -504,7 +495,7 @@ typeTestSuccess:                                  ; preds = %fillRequiredArgs, %
 
 17:                                               ; preds = %typeTestSuccess
   %18 = add nsw i64 %rawBlockSendResult, -1, !dbg !75
-  %19 = tail call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %rawArg_x, i64 %18) #21, !dbg !75
+  %19 = tail call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %rawArg_x, i64 %18) #20, !dbg !75
   %20 = extractvalue { i64, i1 } %19, 1, !dbg !75
   %21 = extractvalue { i64, i1 } %19, 0, !dbg !75
   br i1 %20, label %22, label %sorbet_rb_int_plus.exit, !dbg !75
@@ -559,19 +550,19 @@ sorbet_isa_Integer.exit21:                        ; preds = %43
   br i1 %53, label %typeTestSuccess13, label %codeRepl, !prof !69
 
 codeRepl20:                                       ; preds = %3, %sorbet_isa_Integer.exit
-  tail call fastcc void @"func_Foo#3bar.cold.2"(i64 %rawArg_x) #22, !dbg !65
+  tail call fastcc void @"func_Foo#3bar.cold.2"(i64 %rawArg_x) #21, !dbg !65
   unreachable
 
 typeTestSuccess13:                                ; preds = %rb_vm_check_ints.exit, %sorbet_isa_Integer.exit21
   ret i64 %28
 
 codeRepl:                                         ; preds = %43, %sorbet_isa_Integer.exit21
-  tail call fastcc void @"func_Foo#3bar.cold.1"(i64 %28) #22, !dbg !79
+  tail call fastcc void @"func_Foo#3bar.cold.1"(i64 %28) #21, !dbg !79
   unreachable
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_Foo.13<static-init>L62$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #12 !dbg !30 {
+define internal i64 @"func_Foo.13<static-init>L62$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #12 !dbg !32 {
 functionEntryInitializers:
   %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !15
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
@@ -588,54 +579,54 @@ functionEntryInitializers:
   store i64 %9, i64* %7, align 8, !tbaa !6
   %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
   store i64* getelementptr inbounds ([19 x i64], [19 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %10, align 8, !tbaa !15
-  %11 = load i64, i64* @guard_epoch_T, align 8, !dbg !33
-  %12 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !33, !tbaa !49
-  %needTakeSlowPath = icmp ne i64 %11, %12, !dbg !33
-  br i1 %needTakeSlowPath, label %13, label %14, !dbg !33, !prof !50
+  %11 = load i64, i64* @guard_epoch_T, align 8, !dbg !31
+  %12 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !31, !tbaa !49
+  %needTakeSlowPath = icmp ne i64 %11, %12, !dbg !31
+  br i1 %needTakeSlowPath, label %13, label %14, !dbg !31, !prof !50
 
 13:                                               ; preds = %functionEntryInitializers
-  tail call void @const_recompute_T(), !dbg !33
-  br label %14, !dbg !33
+  tail call void @const_recompute_T(), !dbg !31
+  br label %14, !dbg !31
 
 14:                                               ; preds = %functionEntryInitializers, %13
-  %15 = load i64, i64* @guarded_const_T, align 8, !dbg !33
-  %16 = load i64, i64* @guard_epoch_T, align 8, !dbg !33
-  %17 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !33, !tbaa !49
-  %guardUpdated = icmp eq i64 %16, %17, !dbg !33
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !33
-  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !33
-  %19 = load i64*, i64** %18, align 8, !dbg !33
-  store i64 %15, i64* %19, align 8, !dbg !33, !tbaa !6
-  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !33
-  store i64* %20, i64** %18, align 8, !dbg !33
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_proc, i64 0), !dbg !33
-  %21 = load i64, i64* @rb_cInteger, align 8, !dbg !33
-  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !33
-  %23 = load i64*, i64** %22, align 8, !dbg !33
-  store i64 %send, i64* %23, align 8, !dbg !33, !tbaa !6
-  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !33
-  store i64 %21, i64* %24, align 8, !dbg !33, !tbaa !6
-  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !33
-  store i64* %25, i64** %22, align 8, !dbg !33
-  %send41 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns, i64 0), !dbg !33
-  %26 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !29
-  %27 = load i64*, i64** %26, align 8, !dbg !29
-  store i64 %4, i64* %27, align 8, !dbg !29, !tbaa !6
-  %28 = getelementptr inbounds i64, i64* %27, i64 1, !dbg !29
-  store i64 %21, i64* %28, align 8, !dbg !29, !tbaa !6
-  %29 = getelementptr inbounds i64, i64* %28, i64 1, !dbg !29
-  store i64 %send41, i64* %29, align 8, !dbg !29, !tbaa !6
-  %30 = getelementptr inbounds i64, i64* %29, i64 1, !dbg !29
-  store i64* %30, i64** %26, align 8, !dbg !29
-  %send43 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params, i64 0), !dbg !29
-  %31 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !29
-  %32 = load i64*, i64** %31, align 8, !dbg !29
-  store i64 %send43, i64* %32, align 8, !dbg !29, !tbaa !6
-  %33 = getelementptr inbounds i64, i64* %32, i64 1, !dbg !29
-  store i64 %21, i64* %33, align 8, !dbg !29, !tbaa !6
-  %34 = getelementptr inbounds i64, i64* %33, i64 1, !dbg !29
-  store i64* %34, i64** %31, align 8, !dbg !29
-  %send45 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns.1, i64 0), !dbg !29
+  %15 = load i64, i64* @guarded_const_T, align 8, !dbg !31
+  %16 = load i64, i64* @guard_epoch_T, align 8, !dbg !31
+  %17 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !31, !tbaa !49
+  %guardUpdated = icmp eq i64 %16, %17, !dbg !31
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !31
+  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !31
+  %19 = load i64*, i64** %18, align 8, !dbg !31
+  store i64 %15, i64* %19, align 8, !dbg !31, !tbaa !6
+  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !31
+  store i64* %20, i64** %18, align 8, !dbg !31
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_proc, i64 0), !dbg !31
+  %21 = load i64, i64* @rb_cInteger, align 8, !dbg !31
+  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !31
+  %23 = load i64*, i64** %22, align 8, !dbg !31
+  store i64 %send, i64* %23, align 8, !dbg !31, !tbaa !6
+  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !31
+  store i64 %21, i64* %24, align 8, !dbg !31, !tbaa !6
+  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !31
+  store i64* %25, i64** %22, align 8, !dbg !31
+  %send41 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns, i64 0), !dbg !31
+  %26 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !33
+  %27 = load i64*, i64** %26, align 8, !dbg !33
+  store i64 %4, i64* %27, align 8, !dbg !33, !tbaa !6
+  %28 = getelementptr inbounds i64, i64* %27, i64 1, !dbg !33
+  store i64 %21, i64* %28, align 8, !dbg !33, !tbaa !6
+  %29 = getelementptr inbounds i64, i64* %28, i64 1, !dbg !33
+  store i64 %send41, i64* %29, align 8, !dbg !33, !tbaa !6
+  %30 = getelementptr inbounds i64, i64* %29, i64 1, !dbg !33
+  store i64* %30, i64** %26, align 8, !dbg !33
+  %send43 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params, i64 0), !dbg !33
+  %31 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !33
+  %32 = load i64*, i64** %31, align 8, !dbg !33
+  store i64 %send43, i64* %32, align 8, !dbg !33, !tbaa !6
+  %33 = getelementptr inbounds i64, i64* %32, i64 1, !dbg !33
+  store i64 %21, i64* %33, align 8, !dbg !33, !tbaa !6
+  %34 = getelementptr inbounds i64, i64* %33, i64 1, !dbg !33
+  store i64* %34, i64** %31, align 8, !dbg !33
+  %send45 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns.1, i64 0), !dbg !33
   ret i64 %send45, !dbg !81
 }
 
@@ -645,14 +636,14 @@ declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
 define internal fastcc void @"func_Foo#3bar.cold.1"(i64 %0) unnamed_addr #14 !dbg !82 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %0, i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 152), i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 142)) #20
+  tail call void @sorbet_cast_failure(i64 %0, i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 152), i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 142)) #19
   unreachable
 }
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
 define internal fastcc void @"func_Foo#3bar.cold.2"(i64 %rawArg_x) unnamed_addr #14 !dbg !84 {
 newFuncRoot:
-  tail call void @sorbet_cast_failure(i64 %rawArg_x, i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 128), i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 142)) #20, !dbg !85
+  tail call void @sorbet_cast_failure(i64 %rawArg_x, i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 128), i8* getelementptr inbounds ([247 x i8], [247 x i8]* @sorbet_moduleStringTable, i64 0, i64 142)) #19, !dbg !85
   unreachable, !dbg !85
 }
 
@@ -704,11 +695,10 @@ attributes #14 = { cold minsize noreturn nounwind sspreq uwtable }
 attributes #15 = { nofree nosync nounwind willreturn }
 attributes #16 = { noreturn nounwind }
 attributes #17 = { nounwind }
-attributes #18 = { nounwind readnone willreturn }
-attributes #19 = { nounwind allocsize(0,1) }
-attributes #20 = { noreturn }
-attributes #21 = { nounwind willreturn }
-attributes #22 = { noinline }
+attributes #18 = { nounwind allocsize(0,1) }
+attributes #19 = { noreturn }
+attributes #20 = { nounwind willreturn }
+attributes #21 = { noinline }
 
 !llvm.module.flags = !{!0, !1, !2}
 !llvm.dbg.cu = !{!3}
@@ -742,11 +732,11 @@ attributes #22 = { noinline }
 !26 = !DILocation(line: 9, column: 3, scope: !27, inlinedAt: !28)
 !27 = distinct !DISubprogram(name: "Foo.<static-init>", linkageName: "func_Foo.13<static-init>L62", scope: null, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
 !28 = distinct !DILocation(line: 5, column: 1, scope: !11)
-!29 = !DILocation(line: 8, column: 8, scope: !30)
-!30 = distinct !DISubprogram(name: "Foo.<static-init>", linkageName: "func_Foo.13<static-init>L62$block_1", scope: !27, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!31 = !DILocation(line: 15, column: 10, scope: !11)
-!32 = !DILocation(line: 18, column: 1, scope: !11)
-!33 = !DILocation(line: 8, column: 32, scope: !30)
+!29 = !DILocation(line: 15, column: 10, scope: !11)
+!30 = !DILocation(line: 18, column: 1, scope: !11)
+!31 = !DILocation(line: 8, column: 32, scope: !32)
+!32 = distinct !DISubprogram(name: "Foo.<static-init>", linkageName: "func_Foo.13<static-init>L62$block_1", scope: !27, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!33 = !DILocation(line: 8, column: 8, scope: !32)
 !34 = !DILocation(line: 6, column: 3, scope: !27)
 !35 = !{!36, !7, i64 400}
 !36 = !{!"rb_vm_struct", !7, i64 0, !37, i64 8, !16, i64 192, !16, i64 200, !16, i64 208, !40, i64 216, !8, i64 224, !38, i64 264, !38, i64 280, !38, i64 296, !38, i64 312, !7, i64 328, !19, i64 336, !19, i64 340, !19, i64 344, !19, i64 344, !19, i64 344, !19, i64 344, !19, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !16, i64 456, !16, i64 464, !41, i64 472, !42, i64 992, !16, i64 1016, !16, i64 1024, !19, i64 1032, !19, i64 1036, !38, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !19, i64 1136, !16, i64 1144, !16, i64 1152, !16, i64 1160, !16, i64 1168, !16, i64 1176, !16, i64 1184, !19, i64 1192, !43, i64 1200, !8, i64 1232}
@@ -794,7 +784,7 @@ attributes #22 = { noinline }
 !78 = !{!18, !16, i64 56}
 !79 = !DILocation(line: 0, scope: !62)
 !80 = !{!22, !7, i64 24}
-!81 = !DILocation(line: 8, column: 3, scope: !30)
+!81 = !DILocation(line: 8, column: 3, scope: !32)
 !82 = distinct !DISubprogram(name: "func_Foo#3bar.cold.1", linkageName: "func_Foo#3bar.cold.1", scope: null, file: !4, type: !83, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
 !83 = !DISubroutineType(types: !5)
 !84 = distinct !DISubprogram(name: "func_Foo#3bar.cold.2", linkageName: "func_Foo#3bar.cold.2", scope: null, file: !4, type: !83, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)

--- a/test/testdata/compiler/boolean_ops.opt.ll.exp
+++ b/test/testdata/compiler/boolean_ops.opt.ll.exp
@@ -97,7 +97,7 @@ declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32
 
 declare i64 @sorbet_readRealpath() local_unnamed_addr #0
 
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #0
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) local_unnamed_addr #0
 
 declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #0
 
@@ -138,9 +138,9 @@ allocRubyIds:
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([6 x i64], [6 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 6)
   tail call fastcc void @"Constr_stackFramePrecomputed_func_<root>.17<static-init>$153"(i64 %realpath)
   %"rubyId_!" = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !10, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_!", i64 %"rubyId_!", i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !10
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_!", i64 %"rubyId_!", i32 noundef 16, i32 noundef 0, i32 noundef 0), !dbg !10
   %rubyId_puts = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !15, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !15
   ret void
 }
 

--- a/test/testdata/compiler/casts.opt.ll.exp
+++ b/test/testdata/compiler/casts.opt.ll.exp
@@ -122,7 +122,7 @@ declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32
 
 declare i64 @sorbet_readRealpath() local_unnamed_addr #3
 
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #3
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) local_unnamed_addr #3
 
 declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #3
 
@@ -186,21 +186,21 @@ allocRubyIds:
   tail call fastcc void @"Constr_stackFramePrecomputed_func_Object#8fooArray"(i64 %realpath)
   tail call fastcc void @"Constr_stackFramePrecomputed_func_<root>.17<static-init>$153"(i64 %realpath)
   %rubyId_fooInt = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !10, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooInt, i64 %rubyId_fooInt, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !10
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooInt, i64 %rubyId_fooInt, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !10
   %rubyId_puts = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 9), align 8, !dbg !15, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !15
   %rubyId_fooAny1 = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !dbg !16, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooAny1, i64 %rubyId_fooAny1, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !16
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !17
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooAny1, i64 %rubyId_fooAny1, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !16
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !17
   %rubyId_fooAny2 = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !18, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooAny2, i64 %rubyId_fooAny2, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !18
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooAny2, i64 %rubyId_fooAny2, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !18
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !19
   %rubyId_fooAll = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !dbg !20, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooAll, i64 %rubyId_fooAll, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !20
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !21
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooAll, i64 %rubyId_fooAll, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !20
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !21
   %rubyId_fooArray = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 5), align 8, !dbg !22, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooArray, i64 %rubyId_fooArray, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !22
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.4, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !23
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_fooArray, i64 %rubyId_fooArray, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !22
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.4, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !23
   ret void
 }
 

--- a/test/testdata/compiler/classfields.opt.ll.exp
+++ b/test/testdata/compiler/classfields.opt.ll.exp
@@ -121,7 +121,7 @@ declare %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64) local_
 
 declare void @sorbet_popFrame() local_unnamed_addr #1
 
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #1
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) local_unnamed_addr #1
 
 declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #1
 
@@ -180,19 +180,19 @@ allocRubyIds:
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([29 x i64], [29 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 29)
   tail call fastcc void @"Constr_stackFramePrecomputed_func_<root>.17<static-init>$153"(i64 %realpath)
   %rubyId_new = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !dbg !10, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !10
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new, i32 noundef 16, i32 noundef 0, i32 noundef 0), !dbg !10
   %rubyId_initialize = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !10, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 %rubyId_initialize, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !10
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 %rubyId_initialize, i32 noundef 20, i32 noundef 0, i32 noundef 0), !dbg !10
   %rubyId_write = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !10, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_write, i64 %rubyId_write, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !10
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_write, i64 %rubyId_write, i32 noundef 16, i32 noundef 1, i32 noundef 0), !dbg !10
   %rubyId_read = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !dbg !15, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_read, i64 %rubyId_read, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !15
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_read, i64 %rubyId_read, i32 noundef 16, i32 noundef 0, i32 noundef 0), !dbg !15
   %rubyId_puts = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 5), align 8, !dbg !16, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !16
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new.1, i64 %rubyId_new, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !17
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_initialize.2, i64 %rubyId_initialize, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !17
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_read.3, i64 %rubyId_read, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !17
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.4, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !18
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !16
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new.1, i64 %rubyId_new, i32 noundef 16, i32 noundef 0, i32 noundef 0), !dbg !17
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_initialize.2, i64 %rubyId_initialize, i32 noundef 20, i32 noundef 0, i32 noundef 0), !dbg !17
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_read.3, i64 %rubyId_read, i32 noundef 16, i32 noundef 0, i32 noundef 0), !dbg !17
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.4, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !18
   tail call fastcc void @"Constr_stackFramePrecomputed_func_B#5write"(i64 %realpath)
   tail call fastcc void @"Constr_stackFramePrecomputed_func_B#4read"(i64 %realpath)
   tail call fastcc void @Constr_stackFramePrecomputed_func_B.4read(i64 %realpath)

--- a/test/testdata/compiler/constant_cache.opt.ll.exp
+++ b/test/testdata/compiler/constant_cache.opt.ll.exp
@@ -115,7 +115,7 @@ declare %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64) local_
 
 declare void @sorbet_popFrame() local_unnamed_addr #1
 
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #1
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) local_unnamed_addr #1
 
 declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #1
 
@@ -156,13 +156,13 @@ allocRubyIds:
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 13)
   tail call fastcc void @"Constr_stackFramePrecomputed_func_Object#3foo"(i64 %realpath)
   %rubyId_puts = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !dbg !10, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !10
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !16
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !17
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !10
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !15
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !16
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !17
   tail call fastcc void @"Constr_stackFramePrecomputed_func_<root>.17<static-init>$153"(i64 %realpath)
   %rubyId_foo = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !dbg !18, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !18
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo, i32 noundef 20, i32 noundef 0, i32 noundef 0), !dbg !18
   tail call fastcc void @"Constr_stackFramePrecomputed_func_A.13<static-init>"(i64 %realpath)
   ret void
 }

--- a/test/testdata/compiler/custom_plus.opt.ll.exp
+++ b/test/testdata/compiler/custom_plus.opt.ll.exp
@@ -118,7 +118,7 @@ declare %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64) local_
 
 declare void @sorbet_popFrame() local_unnamed_addr #1
 
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #1
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) local_unnamed_addr #1
 
 declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #1
 
@@ -177,19 +177,19 @@ allocRubyIds:
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 23)
   tail call fastcc void @"Constr_stackFramePrecomputed_func_Object#8delegate"(i64 %realpath)
   %"rubyId_+" = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !dbg !10, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_+", i64 %"rubyId_+", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !10
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_+", i64 %"rubyId_+", i32 noundef 16, i32 noundef 1, i32 noundef 0), !dbg !10
   %"rubyId_==" = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !10, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_==", i64 %"rubyId_==", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !10
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_==", i64 %"rubyId_==", i32 noundef 16, i32 noundef 1, i32 noundef 0), !dbg !10
   %rubyId_puts = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !15, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !16
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !15
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !16
   tail call fastcc void @"Constr_stackFramePrecomputed_func_<root>.17<static-init>$153"(i64 %realpath)
   %rubyId_new = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 5), align 8, !dbg !17, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !17
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new, i32 noundef 16, i32 noundef 0, i32 noundef 0), !dbg !17
   %rubyId_initialize = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 6), align 8, !dbg !17, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 %rubyId_initialize, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !17
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 %rubyId_initialize, i32 noundef 20, i32 noundef 0, i32 noundef 0), !dbg !17
   %rubyId_delegate = load i64, i64* getelementptr inbounds ([11 x i64], [11 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !dbg !19, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_delegate, i64 %rubyId_delegate, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_delegate, i64 %rubyId_delegate, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !19
   tail call fastcc void @"Constr_stackFramePrecomputed_func_A#1+"(i64 %realpath)
   tail call fastcc void @"Constr_stackFramePrecomputed_func_A.13<static-init>"(i64 %realpath)
   ret void

--- a/test/testdata/compiler/direct_call.opt.ll.exp
+++ b/test/testdata/compiler/direct_call.opt.ll.exp
@@ -104,7 +104,7 @@ declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32
 
 declare i64 @sorbet_readRealpath() local_unnamed_addr #1
 
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #1
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) local_unnamed_addr #1
 
 declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #1
 
@@ -144,12 +144,12 @@ allocRubyIds:
   tail call fastcc void @"Constr_stackFramePrecomputed_func_Object#3foo"(i64 %realpath)
   tail call fastcc void @"Constr_stackFramePrecomputed_func_Object#3bar"(i64 %realpath)
   %rubyId_foo = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !dbg !10, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !10
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo, i32 noundef 20, i32 noundef 0, i32 noundef 0), !dbg !10
   tail call fastcc void @"Constr_stackFramePrecomputed_func_<root>.17<static-init>$153"(i64 %realpath)
   %rubyId_bar = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !dbg !15, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_bar, i64 %rubyId_bar, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !15
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_bar, i64 %rubyId_bar, i32 noundef 20, i32 noundef 0, i32 noundef 0), !dbg !15
   %rubyId_puts = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !dbg !17, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !17
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !17
   ret void
 }
 

--- a/test/testdata/compiler/exceptions/basic.opt.ll.exp
+++ b/test/testdata/compiler/exceptions/basic.opt.ll.exp
@@ -128,7 +128,7 @@ declare void @sorbet_popFrame() local_unnamed_addr #1
 
 declare void @sorbet_vm_env_write_slowpath(i64*, i32, i64) local_unnamed_addr #1
 
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #1
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) local_unnamed_addr #1
 
 declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #1
 
@@ -197,11 +197,11 @@ entry:
   %0 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %0, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
   %rubyId_puts.i = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !dbg !17, !invariant.load !5
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !17
+  call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !17
   %rubyId_test.i = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !18, !invariant.load !5
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test, i64 %rubyId_test.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !18
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test.2, i64 %rubyId_test.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !20
+  call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test, i64 %rubyId_test.i, i32 noundef 16, i32 noundef 1, i32 noundef 0), !dbg !18
+  call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !19
+  call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test.2, i64 %rubyId_test.i, i32 noundef 16, i32 noundef 1, i32 noundef 0), !dbg !20
   %1 = bitcast i64* %locals.i9.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 40, i8* nonnull %1)
   %rubyStr_test.i.i = load i64, i64* getelementptr inbounds ([12 x i64], [12 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 4), align 8, !invariant.load !5
@@ -225,15 +225,15 @@ entry:
   store %struct.rb_iseq_struct* %7, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_A.4test$block_3", align 8
   %8 = call i64 @sorbet_getConstant(i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @sorbet_getTRetry.retry, i64 0, i64 0), i64 noundef 25) #11
   store i64 %8, i64* @"<retry-singleton>", align 8
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !21
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.4, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !24
+  call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !21
+  call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.4, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !24
   %rubyId_raise.i = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 10), align 8, !dbg !25, !invariant.load !5
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_raise, i64 %rubyId_raise.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !25
+  call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_raise, i64 %rubyId_raise.i, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !25
   %"rubyId_is_a?.i" = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 11), align 8, !dbg !26, !invariant.load !5
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_is_a?", i64 %"rubyId_is_a?.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !26
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.5, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !28
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.6, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !29
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.7, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !31
+  call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_is_a?", i64 %"rubyId_is_a?.i", i32 noundef 16, i32 noundef 1, i32 noundef 0), !dbg !26
+  call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.5, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !28
+  call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.6, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !29
+  call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.7, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !31
   %"rubyId_<class:A>.i.i" = load i64, i64* getelementptr inbounds ([14 x i64], [14 x i64]* @sorbet_moduleIDTable, i64 0, i64 12), align 8, !invariant.load !5
   %"rubyStr_<class:A>.i.i" = load i64, i64* getelementptr inbounds ([12 x i64], [12 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 11), align 8, !invariant.load !5
   %9 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<class:A>.i.i", i64 %"rubyId_<class:A>.i.i", i64 %"rubyStr_test/testdata/compiler/exceptions/basic.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i14.i, i32 noundef 0, i32 noundef 4)

--- a/test/testdata/compiler/float-intrinsics.opt.ll.exp
+++ b/test/testdata/compiler/float-intrinsics.opt.ll.exp
@@ -187,7 +187,7 @@ declare i64 @sorbet_getConstant(i8*, i64) local_unnamed_addr #0
 
 declare i64 @sorbet_readRealpath() local_unnamed_addr #0
 
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #0
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) local_unnamed_addr #0
 
 declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #0
 
@@ -229,1287 +229,1348 @@ define weak i8* @sorbet_getBuildSCMRevision() local_unnamed_addr #6 {
   unreachable
 }
 
+define internal fastcc void @sorbet_globalConstructors(i64 %realpath) unnamed_addr {
+allocRubyIds:
+  tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([21 x %struct.rb_code_position_struct], [21 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 21, i8* noundef getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
+  tail call void @sorbet_vm_init_string_table(i64* noundef getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([13 x %struct.rb_code_position_struct], [13 x %struct.rb_code_position_struct]* @sorbet_moduleRubyStringDescriptors, i32 0, i32 0), i32 noundef 13, i8* noundef getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
+  tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 49)
+  tail call fastcc void @"Constr_stackFramePrecomputed_func_Object#4plus"(i64 %realpath)
+  tail call fastcc void @"Constr_stackFramePrecomputed_func_Object#5minus"(i64 %realpath)
+  %rubyId_- = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !10, !invariant.load !5
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_-, i64 %rubyId_-, i32 noundef 16, i32 noundef 1, i32 noundef 0), !dbg !10
+  tail call fastcc void @"Constr_stackFramePrecomputed_func_Object#2lt"(i64 %realpath)
+  tail call fastcc void @"Constr_stackFramePrecomputed_func_Object#3lte"(i64 %realpath)
+  tail call fastcc void @"Constr_stackFramePrecomputed_func_<root>.17<static-init>$153"(i64 %realpath)
+  tail call fastcc void @"Constr_stackFramePrecomputed_func_<root>.17<static-init>$153$block_1"(i64 %realpath)
+  tail call fastcc void @"Constr_stackFramePrecomputed_func_<root>.17<static-init>$153$block_2"(i64 %realpath)
+  tail call fastcc void @"Constr_stackFramePrecomputed_func_<root>.17<static-init>$153$block_3"(i64 %realpath)
+  tail call fastcc void @"Constr_stackFramePrecomputed_func_<root>.17<static-init>$153$block_4"(i64 %realpath)
+  %rubyId_untyped = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 13), align 8, !dbg !15, !invariant.load !5
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped, i64 %rubyId_untyped, i32 noundef 16, i32 noundef 0, i32 noundef 0), !dbg !15
+  %rubyId_params = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 14), align 8, !dbg !18, !invariant.load !5
+  %rubyId_x = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 11), align 8, !dbg !18, !invariant.load !5
+  %rubyId_y = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 12), align 8, !dbg !18, !invariant.load !5
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64 %rubyId_x, i64 %rubyId_y), !dbg !18
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.1, i64 %rubyId_untyped, i32 noundef 16, i32 noundef 0, i32 noundef 0), !dbg !19
+  %rubyId_returns = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 15), align 8, !dbg !18, !invariant.load !5
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns, i32 noundef 16, i32 noundef 1, i32 noundef 0), !dbg !18
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.2, i64 %rubyId_untyped, i32 noundef 16, i32 noundef 0, i32 noundef 0), !dbg !20
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params.3, i64 %rubyId_params, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64 %rubyId_x, i64 %rubyId_y), !dbg !22
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.4, i64 %rubyId_untyped, i32 noundef 16, i32 noundef 0, i32 noundef 0), !dbg !23
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.5, i64 %rubyId_returns, i32 noundef 16, i32 noundef 1, i32 noundef 0), !dbg !22
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.6, i64 %rubyId_untyped, i32 noundef 16, i32 noundef 0, i32 noundef 0), !dbg !24
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params.7, i64 %rubyId_params, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64 %rubyId_x, i64 %rubyId_y), !dbg !26
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.8, i64 %rubyId_returns, i32 noundef 16, i32 noundef 1, i32 noundef 0), !dbg !26
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.9, i64 %rubyId_untyped, i32 noundef 16, i32 noundef 0, i32 noundef 0), !dbg !27
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params.10, i64 %rubyId_params, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64 %rubyId_x, i64 %rubyId_y), !dbg !29
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.11, i64 %rubyId_returns, i32 noundef 16, i32 noundef 1, i32 noundef 0), !dbg !29
+  %rubyId_extend = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 16), align 8, !dbg !30, !invariant.load !5
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !30
+  %rubyId_plus = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !dbg !31, !invariant.load !5
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus, i64 %rubyId_plus, i32 noundef 20, i32 noundef 2, i32 noundef 0), !dbg !31
+  %rubyId_p = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 18), align 8, !dbg !32, !invariant.load !5
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p, i64 %rubyId_p, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !32
+  %rubyId_minus = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !33, !invariant.load !5
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus, i64 %rubyId_minus, i32 noundef 20, i32 noundef 2, i32 noundef 0), !dbg !33
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.12, i64 %rubyId_p, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !34
+  %rubyId_lt = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !dbg !35, !invariant.load !5
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt, i64 %rubyId_lt, i32 noundef 20, i32 noundef 2, i32 noundef 0), !dbg !35
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.13, i64 %rubyId_p, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !36
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt.14, i64 %rubyId_lt, i32 noundef 20, i32 noundef 2, i32 noundef 0), !dbg !37
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.15, i64 %rubyId_p, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !38
+  %rubyId_lte = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 6), align 8, !dbg !39, !invariant.load !5
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte, i64 %rubyId_lte, i32 noundef 20, i32 noundef 2, i32 noundef 0), !dbg !39
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.16, i64 %rubyId_p, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !40
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.17, i64 %rubyId_lte, i32 noundef 20, i32 noundef 2, i32 noundef 0), !dbg !41
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.18, i64 %rubyId_p, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !42
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.19, i64 %rubyId_lte, i32 noundef 20, i32 noundef 2, i32 noundef 0), !dbg !43
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.20, i64 %rubyId_p, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !44
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus.21, i64 %rubyId_plus, i32 noundef 20, i32 noundef 2, i32 noundef 0), !dbg !45
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.22, i64 %rubyId_p, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !46
+  %rubyId_Rational = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 19), align 8, !dbg !47, !invariant.load !5
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational, i64 %rubyId_Rational, i32 noundef 16, i32 noundef 1, i32 noundef 0), !dbg !47
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus.23, i64 %rubyId_plus, i32 noundef 20, i32 noundef 2, i32 noundef 0), !dbg !48
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.24, i64 %rubyId_p, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !49
+  %rubyId_Complex = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 20), align 8, !dbg !50, !invariant.load !5
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Complex, i64 %rubyId_Complex, i32 noundef 16, i32 noundef 2, i32 noundef 0), !dbg !50
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus.25, i64 %rubyId_plus, i32 noundef 20, i32 noundef 2, i32 noundef 0), !dbg !51
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.26, i64 %rubyId_p, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !52
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus.27, i64 %rubyId_minus, i32 noundef 20, i32 noundef 2, i32 noundef 0), !dbg !53
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.28, i64 %rubyId_p, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !54
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational.29, i64 %rubyId_Rational, i32 noundef 16, i32 noundef 1, i32 noundef 0), !dbg !55
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus.30, i64 %rubyId_minus, i32 noundef 20, i32 noundef 2, i32 noundef 0), !dbg !56
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.31, i64 %rubyId_p, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !57
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Complex.32, i64 %rubyId_Complex, i32 noundef 16, i32 noundef 2, i32 noundef 0), !dbg !58
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus.33, i64 %rubyId_minus, i32 noundef 20, i32 noundef 2, i32 noundef 0), !dbg !59
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.34, i64 %rubyId_p, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !60
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt.35, i64 %rubyId_lt, i32 noundef 20, i32 noundef 2, i32 noundef 0), !dbg !61
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.36, i64 %rubyId_p, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !62
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational.37, i64 %rubyId_Rational, i32 noundef 16, i32 noundef 1, i32 noundef 0), !dbg !63
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt.38, i64 %rubyId_lt, i32 noundef 20, i32 noundef 2, i32 noundef 0), !dbg !64
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.39, i64 %rubyId_p, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !65
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.40, i64 %rubyId_lte, i32 noundef 20, i32 noundef 2, i32 noundef 0), !dbg !66
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.41, i64 %rubyId_p, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !67
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational.42, i64 %rubyId_Rational, i32 noundef 16, i32 noundef 1, i32 noundef 0), !dbg !68
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.43, i64 %rubyId_lte, i32 noundef 20, i32 noundef 2, i32 noundef 0), !dbg !69
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.44, i64 %rubyId_p, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !70
+  ret void
+}
+
 ; Function Attrs: nounwind sspreq uwtable
-define internal i64 @"func_Object#4plus"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #7 !dbg !10 {
+define internal i64 @"func_Object#4plus"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #7 !dbg !71 {
 functionEntryInitializers:
   %callArgs = alloca [2 x i64], align 8
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !tbaa !14
-  %tooManyArgs = icmp ugt i32 %argc, 2, !dbg !16
-  %tooFewArgs = icmp ult i32 %argc, 2, !dbg !16
-  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !16
-  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !16, !prof !17
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %0, align 8, !tbaa !72
+  %tooManyArgs = icmp ugt i32 %argc, 2, !dbg !74
+  %tooFewArgs = icmp ult i32 %argc, 2, !dbg !74
+  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !74
+  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !74, !prof !75
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 2, i32 noundef 2) #15, !dbg !16
-  unreachable, !dbg !16
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 2, i32 noundef 2) #15, !dbg !74
+  unreachable, !dbg !74
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  %rawArg_x = load i64, i64* %argArray, align 8, !dbg !16
-  %1 = getelementptr i64, i64* %argArray, i32 1, !dbg !16
-  %rawArg_y = load i64, i64* %1, align 8, !dbg !16
-  %2 = and i64 %rawArg_x, 3, !dbg !18
-  %3 = icmp eq i64 %2, 2, !dbg !18
-  br i1 %3, label %typeTestSuccess6, label %4, !dbg !18
+  %rawArg_x = load i64, i64* %argArray, align 8, !dbg !74
+  %1 = getelementptr i64, i64* %argArray, i32 1, !dbg !74
+  %rawArg_y = load i64, i64* %1, align 8, !dbg !74
+  %2 = and i64 %rawArg_x, 3, !dbg !76
+  %3 = icmp eq i64 %2, 2, !dbg !76
+  br i1 %3, label %typeTestSuccess6, label %4, !dbg !76
 
 4:                                                ; preds = %fillRequiredArgs
-  %5 = and i64 %rawArg_x, 7, !dbg !18
-  %6 = icmp ne i64 %5, 0, !dbg !18
-  %7 = and i64 %rawArg_x, -9, !dbg !18
-  %8 = icmp eq i64 %7, 0, !dbg !18
-  %9 = or i1 %6, %8, !dbg !18
-  br i1 %9, label %codeRepl21, label %sorbet_isa_Float.exit, !dbg !18
+  %5 = and i64 %rawArg_x, 7, !dbg !76
+  %6 = icmp ne i64 %5, 0, !dbg !76
+  %7 = and i64 %rawArg_x, -9, !dbg !76
+  %8 = icmp eq i64 %7, 0, !dbg !76
+  %9 = or i1 %6, %8, !dbg !76
+  br i1 %9, label %codeRepl21, label %sorbet_isa_Float.exit, !dbg !76
 
 sorbet_isa_Float.exit:                            ; preds = %4
-  %10 = inttoptr i64 %rawArg_x to %struct.iseq_inline_iv_cache_entry*, !dbg !18
-  %11 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %10, i64 0, i32 0, !dbg !18
-  %12 = load i64, i64* %11, align 8, !dbg !18, !tbaa !19
-  %13 = and i64 %12, 31, !dbg !18
-  %14 = icmp eq i64 %13, 4, !dbg !18
-  br i1 %14, label %typeTestSuccess6, label %codeRepl21, !dbg !18, !prof !21
+  %10 = inttoptr i64 %rawArg_x to %struct.iseq_inline_iv_cache_entry*, !dbg !76
+  %11 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %10, i64 0, i32 0, !dbg !76
+  %12 = load i64, i64* %11, align 8, !dbg !76, !tbaa !77
+  %13 = and i64 %12, 31, !dbg !76
+  %14 = icmp eq i64 %13, 4, !dbg !76
+  br i1 %14, label %typeTestSuccess6, label %codeRepl21, !dbg !76, !prof !79
 
 codeRepl21:                                       ; preds = %4, %sorbet_isa_Float.exit
-  tail call fastcc void @"func_Object#2lt.cold.3"(i64 %rawArg_x) #16, !dbg !18
+  tail call fastcc void @"func_Object#2lt.cold.3"(i64 %rawArg_x) #16, !dbg !76
   unreachable
 
 typeTestSuccess6:                                 ; preds = %fillRequiredArgs, %sorbet_isa_Float.exit
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %0, align 8, !dbg !22, !tbaa !14
-  %callArgs0Addr = getelementptr [2 x i64], [2 x i64]* %callArgs, i64 0, i64 0, !dbg !23
-  store i64 %rawArg_y, i64* %callArgs0Addr, align 8, !dbg !23
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !24), !dbg !23
-  %15 = tail call i64 @rb_float_plus(i64 %rawArg_x, i64 %rawArg_y) #17, !dbg !23, !noalias !24
-  %16 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !23, !tbaa !14
-  %17 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 5, !dbg !23
-  %18 = load i32, i32* %17, align 8, !dbg !23, !tbaa !27
-  %19 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 6, !dbg !23
-  %20 = load i32, i32* %19, align 4, !dbg !23, !tbaa !31
-  %21 = xor i32 %20, -1, !dbg !23
-  %22 = and i32 %21, %18, !dbg !23
-  %23 = icmp eq i32 %22, 0, !dbg !23
-  br i1 %23, label %typeTestSuccess13, label %24, !dbg !23, !prof !21
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 9), i64** %0, align 8, !dbg !80, !tbaa !72
+  %callArgs0Addr = getelementptr [2 x i64], [2 x i64]* %callArgs, i64 0, i64 0, !dbg !81
+  store i64 %rawArg_y, i64* %callArgs0Addr, align 8, !dbg !81
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !82), !dbg !81
+  %15 = tail call i64 @rb_float_plus(i64 %rawArg_x, i64 %rawArg_y) #17, !dbg !81, !noalias !82
+  %16 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !81, !tbaa !72
+  %17 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 5, !dbg !81
+  %18 = load i32, i32* %17, align 8, !dbg !81, !tbaa !85
+  %19 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 6, !dbg !81
+  %20 = load i32, i32* %19, align 4, !dbg !81, !tbaa !89
+  %21 = xor i32 %20, -1, !dbg !81
+  %22 = and i32 %21, %18, !dbg !81
+  %23 = icmp eq i32 %22, 0, !dbg !81
+  br i1 %23, label %typeTestSuccess13, label %24, !dbg !81, !prof !79
 
 24:                                               ; preds = %typeTestSuccess6
-  %25 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 8, !dbg !23
-  %26 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %25, align 8, !dbg !23, !tbaa !32
-  %27 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %26, i32 noundef 0) #17, !dbg !23
-  br label %typeTestSuccess13, !dbg !23
+  %25 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 8, !dbg !81
+  %26 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %25, align 8, !dbg !81, !tbaa !90
+  %27 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %26, i32 noundef 0) #17, !dbg !81
+  br label %typeTestSuccess13, !dbg !81
 
 typeTestSuccess13:                                ; preds = %24, %typeTestSuccess6
   ret i64 %15
 }
 
+; Function Attrs: ssp
+define internal fastcc void @"Constr_stackFramePrecomputed_func_Object#4plus"(i64 %realpath) unnamed_addr #8 {
+entryInitializers:
+  %rubyId_plus = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
+  %rubyStr_plus = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 0), align 8, !invariant.load !5
+  %"rubyStr_test/testdata/compiler/float-intrinsics.rb" = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
+  %locals = alloca i64, i32 0, align 8
+  %0 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_plus, i64 %rubyId_plus, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %0, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#4plus", align 8
+  ret void
+}
+
 ; Function Attrs: nounwind sspreq uwtable
-define internal i64 @"func_Object#5minus"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #7 !dbg !33 {
+define internal i64 @"func_Object#5minus"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nonnull align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #7 !dbg !11 {
 functionEntryInitializers:
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %0, align 8, !tbaa !14
-  %tooManyArgs = icmp ugt i32 %argc, 2, !dbg !34
-  %tooFewArgs = icmp ult i32 %argc, 2, !dbg !34
-  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !34
-  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !34, !prof !17
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %0, align 8, !tbaa !72
+  %tooManyArgs = icmp ugt i32 %argc, 2, !dbg !91
+  %tooFewArgs = icmp ult i32 %argc, 2, !dbg !91
+  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !91
+  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !91, !prof !75
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 2, i32 noundef 2) #15, !dbg !34
-  unreachable, !dbg !34
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 2, i32 noundef 2) #15, !dbg !91
+  unreachable, !dbg !91
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  %1 = getelementptr i64, i64* %argArray, i32 1, !dbg !34
-  %2 = bitcast i64* %argArray to <2 x i64>*, !dbg !34
-  %3 = load <2 x i64>, <2 x i64>* %2, align 8, !dbg !34
-  %4 = extractelement <2 x i64> %3, i32 0, !dbg !35
-  %5 = and i64 %4, 3, !dbg !35
-  %6 = icmp eq i64 %5, 2, !dbg !35
-  br i1 %6, label %typeTestSuccess6, label %7, !dbg !35
+  %1 = getelementptr i64, i64* %argArray, i32 1, !dbg !91
+  %2 = bitcast i64* %argArray to <2 x i64>*, !dbg !91
+  %3 = load <2 x i64>, <2 x i64>* %2, align 8, !dbg !91
+  %4 = extractelement <2 x i64> %3, i32 0, !dbg !92
+  %5 = and i64 %4, 3, !dbg !92
+  %6 = icmp eq i64 %5, 2, !dbg !92
+  br i1 %6, label %typeTestSuccess6, label %7, !dbg !92
 
 7:                                                ; preds = %fillRequiredArgs
-  %8 = and i64 %4, 7, !dbg !35
-  %9 = icmp ne i64 %8, 0, !dbg !35
-  %10 = and i64 %4, -9, !dbg !35
-  %11 = icmp eq i64 %10, 0, !dbg !35
-  %12 = or i1 %9, %11, !dbg !35
-  br i1 %12, label %codeRepl19, label %sorbet_isa_Float.exit, !dbg !35
+  %8 = and i64 %4, 7, !dbg !92
+  %9 = icmp ne i64 %8, 0, !dbg !92
+  %10 = and i64 %4, -9, !dbg !92
+  %11 = icmp eq i64 %10, 0, !dbg !92
+  %12 = or i1 %9, %11, !dbg !92
+  br i1 %12, label %codeRepl19, label %sorbet_isa_Float.exit, !dbg !92
 
 sorbet_isa_Float.exit:                            ; preds = %7
-  %13 = inttoptr i64 %4 to %struct.iseq_inline_iv_cache_entry*, !dbg !35
-  %14 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %13, i64 0, i32 0, !dbg !35
-  %15 = load i64, i64* %14, align 8, !dbg !35, !tbaa !19
-  %16 = and i64 %15, 31, !dbg !35
-  %17 = icmp eq i64 %16, 4, !dbg !35
-  br i1 %17, label %typeTestSuccess6, label %codeRepl19, !dbg !35, !prof !21
+  %13 = inttoptr i64 %4 to %struct.iseq_inline_iv_cache_entry*, !dbg !92
+  %14 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %13, i64 0, i32 0, !dbg !92
+  %15 = load i64, i64* %14, align 8, !dbg !92, !tbaa !77
+  %16 = and i64 %15, 31, !dbg !92
+  %17 = icmp eq i64 %16, 4, !dbg !92
+  br i1 %17, label %typeTestSuccess6, label %codeRepl19, !dbg !92, !prof !79
 
 codeRepl19:                                       ; preds = %7, %sorbet_isa_Float.exit
-  tail call fastcc void @"func_Object#2lt.cold.3"(i64 %4) #16, !dbg !35
+  tail call fastcc void @"func_Object#2lt.cold.3"(i64 %4) #16, !dbg !92
   unreachable
 
 typeTestSuccess6:                                 ; preds = %fillRequiredArgs, %sorbet_isa_Float.exit
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %0, align 8, !dbg !36, !tbaa !14
-  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !37
-  %19 = load i64*, i64** %18, align 8, !dbg !37
-  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !37
-  %21 = bitcast i64* %19 to <2 x i64>*, !dbg !37
-  store <2 x i64> %3, <2 x i64>* %21, align 8, !dbg !37, !tbaa !6
-  %22 = getelementptr inbounds i64, i64* %20, i64 1, !dbg !37
-  store i64* %22, i64** %18, align 8, !dbg !37
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_-, i64 0), !dbg !37
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 14), i64** %0, align 8, !dbg !93, !tbaa !72
+  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 1, !dbg !10
+  %19 = load i64*, i64** %18, align 8, !dbg !10
+  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !10
+  %21 = bitcast i64* %19 to <2 x i64>*, !dbg !10
+  store <2 x i64> %3, <2 x i64>* %21, align 8, !dbg !10, !tbaa !6
+  %22 = getelementptr inbounds i64, i64* %20, i64 1, !dbg !10
+  store i64* %22, i64** %18, align 8, !dbg !10
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_-, i64 0), !dbg !10
   ret i64 %send
 }
 
-; Function Attrs: nounwind sspreq uwtable
-define internal i64 @"func_Object#2lt"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #7 !dbg !38 {
-functionEntryInitializers:
-  %callArgs = alloca [2 x i64], align 8
-  %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %0, align 8, !tbaa !14
-  %tooManyArgs = icmp ugt i32 %argc, 2, !dbg !39
-  %tooFewArgs = icmp ult i32 %argc, 2, !dbg !39
-  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !39
-  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !39, !prof !17
-
-argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 2, i32 noundef 2) #15, !dbg !39
-  unreachable, !dbg !39
-
-fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  %rawArg_x = load i64, i64* %argArray, align 8, !dbg !39
-  %1 = getelementptr i64, i64* %argArray, i32 1, !dbg !39
-  %rawArg_y = load i64, i64* %1, align 8, !dbg !39
-  %2 = and i64 %rawArg_x, 3, !dbg !40
-  %3 = icmp eq i64 %2, 2, !dbg !40
-  br i1 %3, label %typeTestSuccess6, label %4, !dbg !40
-
-4:                                                ; preds = %fillRequiredArgs
-  %5 = and i64 %rawArg_x, 7, !dbg !40
-  %6 = icmp ne i64 %5, 0, !dbg !40
-  %7 = and i64 %rawArg_x, -9, !dbg !40
-  %8 = icmp eq i64 %7, 0, !dbg !40
-  %9 = or i1 %6, %8, !dbg !40
-  br i1 %9, label %codeRepl21, label %sorbet_isa_Float.exit, !dbg !40
-
-sorbet_isa_Float.exit:                            ; preds = %4
-  %10 = inttoptr i64 %rawArg_x to %struct.iseq_inline_iv_cache_entry*, !dbg !40
-  %11 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %10, i64 0, i32 0, !dbg !40
-  %12 = load i64, i64* %11, align 8, !dbg !40, !tbaa !19
-  %13 = and i64 %12, 31, !dbg !40
-  %14 = icmp eq i64 %13, 4, !dbg !40
-  br i1 %14, label %typeTestSuccess6, label %codeRepl21, !dbg !40, !prof !21
-
-codeRepl21:                                       ; preds = %4, %sorbet_isa_Float.exit
-  tail call fastcc void @"func_Object#2lt.cold.3"(i64 %rawArg_x) #16, !dbg !40
-  unreachable
-
-typeTestSuccess6:                                 ; preds = %fillRequiredArgs, %sorbet_isa_Float.exit
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %0, align 8, !dbg !41, !tbaa !14
-  %callArgs0Addr = getelementptr [2 x i64], [2 x i64]* %callArgs, i64 0, i64 0, !dbg !42
-  store i64 %rawArg_y, i64* %callArgs0Addr, align 8, !dbg !42
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !43), !dbg !42
-  %15 = tail call i64 @sorbet_flo_lt(i64 %rawArg_x, i64 %rawArg_y) #17, !dbg !42, !noalias !43
-  %16 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !42, !tbaa !14
-  %17 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 5, !dbg !42
-  %18 = load i32, i32* %17, align 8, !dbg !42, !tbaa !27
-  %19 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 6, !dbg !42
-  %20 = load i32, i32* %19, align 4, !dbg !42, !tbaa !31
-  %21 = xor i32 %20, -1, !dbg !42
-  %22 = and i32 %21, %18, !dbg !42
-  %23 = icmp eq i32 %22, 0, !dbg !42
-  br i1 %23, label %rb_vm_check_ints.exit, label %24, !dbg !42, !prof !21
-
-24:                                               ; preds = %typeTestSuccess6
-  %25 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 8, !dbg !42
-  %26 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %25, align 8, !dbg !42, !tbaa !32
-  %27 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %26, i32 noundef 0) #17, !dbg !42
-  br label %rb_vm_check_ints.exit, !dbg !42
-
-rb_vm_check_ints.exit:                            ; preds = %typeTestSuccess6, %24
-  switch i64 %15, label %codeRepl [
-    i64 20, label %typeTestSuccess13
-    i64 0, label %typeTestSuccess13
-  ], !prof !46
-
-typeTestSuccess13:                                ; preds = %rb_vm_check_ints.exit, %rb_vm_check_ints.exit
-  ret i64 %15
-
-codeRepl:                                         ; preds = %rb_vm_check_ints.exit
-  tail call fastcc void @"func_Object#2lt.cold.1"(i64 %15) #16, !dbg !47
-  unreachable
+; Function Attrs: ssp
+define internal fastcc void @"Constr_stackFramePrecomputed_func_Object#5minus"(i64 %realpath) unnamed_addr #8 {
+entryInitializers:
+  %rubyId_minus = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !invariant.load !5
+  %rubyStr_minus = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 2), align 8, !invariant.load !5
+  %"rubyStr_test/testdata/compiler/float-intrinsics.rb" = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
+  %locals = alloca i64, i32 0, align 8
+  %0 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_minus, i64 %rubyId_minus, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 13, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %0, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#5minus", align 8
+  ret void
 }
 
 ; Function Attrs: nounwind sspreq uwtable
-define internal i64 @"func_Object#3lte"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #7 !dbg !48 {
+define internal i64 @"func_Object#2lt"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #7 !dbg !94 {
 functionEntryInitializers:
   %callArgs = alloca [2 x i64], align 8
   %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %0, align 8, !tbaa !14
-  %tooManyArgs = icmp ugt i32 %argc, 2, !dbg !49
-  %tooFewArgs = icmp ult i32 %argc, 2, !dbg !49
-  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !49
-  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !49, !prof !17
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %0, align 8, !tbaa !72
+  %tooManyArgs = icmp ugt i32 %argc, 2, !dbg !95
+  %tooFewArgs = icmp ult i32 %argc, 2, !dbg !95
+  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !95
+  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !95, !prof !75
 
 argCountFailBlock:                                ; preds = %functionEntryInitializers
-  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 2, i32 noundef 2) #15, !dbg !49
-  unreachable, !dbg !49
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 2, i32 noundef 2) #15, !dbg !95
+  unreachable, !dbg !95
 
 fillRequiredArgs:                                 ; preds = %functionEntryInitializers
-  %rawArg_x = load i64, i64* %argArray, align 8, !dbg !49
-  %1 = getelementptr i64, i64* %argArray, i32 1, !dbg !49
-  %rawArg_y = load i64, i64* %1, align 8, !dbg !49
-  %2 = and i64 %rawArg_x, 3, !dbg !50
-  %3 = icmp eq i64 %2, 2, !dbg !50
-  br i1 %3, label %typeTestSuccess6, label %4, !dbg !50
+  %rawArg_x = load i64, i64* %argArray, align 8, !dbg !95
+  %1 = getelementptr i64, i64* %argArray, i32 1, !dbg !95
+  %rawArg_y = load i64, i64* %1, align 8, !dbg !95
+  %2 = and i64 %rawArg_x, 3, !dbg !96
+  %3 = icmp eq i64 %2, 2, !dbg !96
+  br i1 %3, label %typeTestSuccess6, label %4, !dbg !96
 
 4:                                                ; preds = %fillRequiredArgs
-  %5 = and i64 %rawArg_x, 7, !dbg !50
-  %6 = icmp ne i64 %5, 0, !dbg !50
-  %7 = and i64 %rawArg_x, -9, !dbg !50
-  %8 = icmp eq i64 %7, 0, !dbg !50
-  %9 = or i1 %6, %8, !dbg !50
-  br i1 %9, label %codeRepl21, label %sorbet_isa_Float.exit, !dbg !50
+  %5 = and i64 %rawArg_x, 7, !dbg !96
+  %6 = icmp ne i64 %5, 0, !dbg !96
+  %7 = and i64 %rawArg_x, -9, !dbg !96
+  %8 = icmp eq i64 %7, 0, !dbg !96
+  %9 = or i1 %6, %8, !dbg !96
+  br i1 %9, label %codeRepl21, label %sorbet_isa_Float.exit, !dbg !96
 
 sorbet_isa_Float.exit:                            ; preds = %4
-  %10 = inttoptr i64 %rawArg_x to %struct.iseq_inline_iv_cache_entry*, !dbg !50
-  %11 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %10, i64 0, i32 0, !dbg !50
-  %12 = load i64, i64* %11, align 8, !dbg !50, !tbaa !19
-  %13 = and i64 %12, 31, !dbg !50
-  %14 = icmp eq i64 %13, 4, !dbg !50
-  br i1 %14, label %typeTestSuccess6, label %codeRepl21, !dbg !50, !prof !21
+  %10 = inttoptr i64 %rawArg_x to %struct.iseq_inline_iv_cache_entry*, !dbg !96
+  %11 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %10, i64 0, i32 0, !dbg !96
+  %12 = load i64, i64* %11, align 8, !dbg !96, !tbaa !77
+  %13 = and i64 %12, 31, !dbg !96
+  %14 = icmp eq i64 %13, 4, !dbg !96
+  br i1 %14, label %typeTestSuccess6, label %codeRepl21, !dbg !96, !prof !79
 
 codeRepl21:                                       ; preds = %4, %sorbet_isa_Float.exit
-  tail call fastcc void @"func_Object#2lt.cold.3"(i64 %rawArg_x) #16, !dbg !50
+  tail call fastcc void @"func_Object#2lt.cold.3"(i64 %rawArg_x) #16, !dbg !96
   unreachable
 
 typeTestSuccess6:                                 ; preds = %fillRequiredArgs, %sorbet_isa_Float.exit
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %0, align 8, !dbg !51, !tbaa !14
-  %callArgs0Addr = getelementptr [2 x i64], [2 x i64]* %callArgs, i64 0, i64 0, !dbg !52
-  store i64 %rawArg_y, i64* %callArgs0Addr, align 8, !dbg !52
-  tail call void @llvm.experimental.noalias.scope.decl(metadata !53), !dbg !52
-  %15 = tail call i64 @sorbet_flo_le(i64 %rawArg_x, i64 %rawArg_y) #17, !dbg !52, !noalias !53
-  %16 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !52, !tbaa !14
-  %17 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 5, !dbg !52
-  %18 = load i32, i32* %17, align 8, !dbg !52, !tbaa !27
-  %19 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 6, !dbg !52
-  %20 = load i32, i32* %19, align 4, !dbg !52, !tbaa !31
-  %21 = xor i32 %20, -1, !dbg !52
-  %22 = and i32 %21, %18, !dbg !52
-  %23 = icmp eq i32 %22, 0, !dbg !52
-  br i1 %23, label %rb_vm_check_ints.exit, label %24, !dbg !52, !prof !21
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 19), i64** %0, align 8, !dbg !97, !tbaa !72
+  %callArgs0Addr = getelementptr [2 x i64], [2 x i64]* %callArgs, i64 0, i64 0, !dbg !98
+  store i64 %rawArg_y, i64* %callArgs0Addr, align 8, !dbg !98
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !99), !dbg !98
+  %15 = tail call i64 @sorbet_flo_lt(i64 %rawArg_x, i64 %rawArg_y) #17, !dbg !98, !noalias !99
+  %16 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !98, !tbaa !72
+  %17 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 5, !dbg !98
+  %18 = load i32, i32* %17, align 8, !dbg !98, !tbaa !85
+  %19 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 6, !dbg !98
+  %20 = load i32, i32* %19, align 4, !dbg !98, !tbaa !89
+  %21 = xor i32 %20, -1, !dbg !98
+  %22 = and i32 %21, %18, !dbg !98
+  %23 = icmp eq i32 %22, 0, !dbg !98
+  br i1 %23, label %rb_vm_check_ints.exit, label %24, !dbg !98, !prof !79
 
 24:                                               ; preds = %typeTestSuccess6
-  %25 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 8, !dbg !52
-  %26 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %25, align 8, !dbg !52, !tbaa !32
-  %27 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %26, i32 noundef 0) #17, !dbg !52
-  br label %rb_vm_check_ints.exit, !dbg !52
+  %25 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 8, !dbg !98
+  %26 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %25, align 8, !dbg !98, !tbaa !90
+  %27 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %26, i32 noundef 0) #17, !dbg !98
+  br label %rb_vm_check_ints.exit, !dbg !98
 
 rb_vm_check_ints.exit:                            ; preds = %typeTestSuccess6, %24
   switch i64 %15, label %codeRepl [
     i64 20, label %typeTestSuccess13
     i64 0, label %typeTestSuccess13
-  ], !prof !46
+  ], !prof !102
 
 typeTestSuccess13:                                ; preds = %rb_vm_check_ints.exit, %rb_vm_check_ints.exit
   ret i64 %15
 
 codeRepl:                                         ; preds = %rb_vm_check_ints.exit
-  tail call fastcc void @"func_Object#2lt.cold.1"(i64 %15) #16, !dbg !56
+  tail call fastcc void @"func_Object#2lt.cold.1"(i64 %15) #16, !dbg !103
   unreachable
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_<root>.17<static-init>$153$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #8 !dbg !57 {
+define internal fastcc void @"Constr_stackFramePrecomputed_func_Object#2lt"(i64 %realpath) unnamed_addr #8 {
+entryInitializers:
+  %rubyId_lt = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !invariant.load !5
+  %rubyStr_lt = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 3), align 8, !invariant.load !5
+  %"rubyStr_test/testdata/compiler/float-intrinsics.rb" = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
+  %locals = alloca i64, i32 0, align 8
+  %0 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_lt, i64 %rubyId_lt, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 18, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %0, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#2lt", align 8
+  ret void
+}
+
+; Function Attrs: nounwind sspreq uwtable
+define internal i64 @"func_Object#3lte"(i32 %argc, i64* nocapture readonly %argArray, i64 %selfRaw, %struct.rb_control_frame_struct* nocapture nonnull writeonly align 8 dereferenceable(8) %cfp, i8* nocapture nofree readnone %calling, i8* nocapture nofree readnone %callData) #7 !dbg !104 {
 functionEntryInitializers:
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %callArgs = alloca [2 x i64], align 8
+  %0 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %cfp, i64 0, i32 0
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %0, align 8, !tbaa !72
+  %tooManyArgs = icmp ugt i32 %argc, 2, !dbg !105
+  %tooFewArgs = icmp ult i32 %argc, 2, !dbg !105
+  %or.cond = or i1 %tooManyArgs, %tooFewArgs, !dbg !105
+  br i1 %or.cond, label %argCountFailBlock, label %fillRequiredArgs, !dbg !105, !prof !75
+
+argCountFailBlock:                                ; preds = %functionEntryInitializers
+  tail call void @sorbet_raiseArity(i32 %argc, i32 noundef 2, i32 noundef 2) #15, !dbg !105
+  unreachable, !dbg !105
+
+fillRequiredArgs:                                 ; preds = %functionEntryInitializers
+  %rawArg_x = load i64, i64* %argArray, align 8, !dbg !105
+  %1 = getelementptr i64, i64* %argArray, i32 1, !dbg !105
+  %rawArg_y = load i64, i64* %1, align 8, !dbg !105
+  %2 = and i64 %rawArg_x, 3, !dbg !106
+  %3 = icmp eq i64 %2, 2, !dbg !106
+  br i1 %3, label %typeTestSuccess6, label %4, !dbg !106
+
+4:                                                ; preds = %fillRequiredArgs
+  %5 = and i64 %rawArg_x, 7, !dbg !106
+  %6 = icmp ne i64 %5, 0, !dbg !106
+  %7 = and i64 %rawArg_x, -9, !dbg !106
+  %8 = icmp eq i64 %7, 0, !dbg !106
+  %9 = or i1 %6, %8, !dbg !106
+  br i1 %9, label %codeRepl21, label %sorbet_isa_Float.exit, !dbg !106
+
+sorbet_isa_Float.exit:                            ; preds = %4
+  %10 = inttoptr i64 %rawArg_x to %struct.iseq_inline_iv_cache_entry*, !dbg !106
+  %11 = getelementptr inbounds %struct.iseq_inline_iv_cache_entry, %struct.iseq_inline_iv_cache_entry* %10, i64 0, i32 0, !dbg !106
+  %12 = load i64, i64* %11, align 8, !dbg !106, !tbaa !77
+  %13 = and i64 %12, 31, !dbg !106
+  %14 = icmp eq i64 %13, 4, !dbg !106
+  br i1 %14, label %typeTestSuccess6, label %codeRepl21, !dbg !106, !prof !79
+
+codeRepl21:                                       ; preds = %4, %sorbet_isa_Float.exit
+  tail call fastcc void @"func_Object#2lt.cold.3"(i64 %rawArg_x) #16, !dbg !106
+  unreachable
+
+typeTestSuccess6:                                 ; preds = %fillRequiredArgs, %sorbet_isa_Float.exit
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 24), i64** %0, align 8, !dbg !107, !tbaa !72
+  %callArgs0Addr = getelementptr [2 x i64], [2 x i64]* %callArgs, i64 0, i64 0, !dbg !108
+  store i64 %rawArg_y, i64* %callArgs0Addr, align 8, !dbg !108
+  tail call void @llvm.experimental.noalias.scope.decl(metadata !109), !dbg !108
+  %15 = tail call i64 @sorbet_flo_le(i64 %rawArg_x, i64 %rawArg_y) #17, !dbg !108, !noalias !109
+  %16 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !dbg !108, !tbaa !72
+  %17 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 5, !dbg !108
+  %18 = load i32, i32* %17, align 8, !dbg !108, !tbaa !85
+  %19 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 6, !dbg !108
+  %20 = load i32, i32* %19, align 4, !dbg !108, !tbaa !89
+  %21 = xor i32 %20, -1, !dbg !108
+  %22 = and i32 %21, %18, !dbg !108
+  %23 = icmp eq i32 %22, 0, !dbg !108
+  br i1 %23, label %rb_vm_check_ints.exit, label %24, !dbg !108, !prof !79
+
+24:                                               ; preds = %typeTestSuccess6
+  %25 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %16, i64 0, i32 8, !dbg !108
+  %26 = load %struct.rb_thread_struct*, %struct.rb_thread_struct** %25, align 8, !dbg !108, !tbaa !90
+  %27 = tail call i32 @rb_threadptr_execute_interrupts(%struct.rb_thread_struct* %26, i32 noundef 0) #17, !dbg !108
+  br label %rb_vm_check_ints.exit, !dbg !108
+
+rb_vm_check_ints.exit:                            ; preds = %typeTestSuccess6, %24
+  switch i64 %15, label %codeRepl [
+    i64 20, label %typeTestSuccess13
+    i64 0, label %typeTestSuccess13
+  ], !prof !102
+
+typeTestSuccess13:                                ; preds = %rb_vm_check_ints.exit, %rb_vm_check_ints.exit
+  ret i64 %15
+
+codeRepl:                                         ; preds = %rb_vm_check_ints.exit
+  tail call fastcc void @"func_Object#2lt.cold.1"(i64 %15) #16, !dbg !112
+  unreachable
+}
+
+; Function Attrs: ssp
+define internal fastcc void @"Constr_stackFramePrecomputed_func_Object#3lte"(i64 %realpath) unnamed_addr #8 {
+entryInitializers:
+  %rubyId_lte = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 6), align 8, !invariant.load !5
+  %rubyStr_lte = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 4), align 8, !invariant.load !5
+  %"rubyStr_test/testdata/compiler/float-intrinsics.rb" = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
+  %locals = alloca i64, i32 0, align 8
+  %0 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_lte, i64 %rubyId_lte, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 23, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals, i32 noundef 0, i32 noundef 2)
+  store %struct.rb_iseq_struct* %0, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3lte", align 8
+  ret void
+}
+
+; Function Attrs: ssp
+define internal i64 @"func_<root>.17<static-init>$153$block_1"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #8 !dbg !16 {
+functionEntryInitializers:
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !72
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !59
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !113
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !60
+  %4 = load i64, i64* %3, align 8, !tbaa !114
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1", align 8
   %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !62
+  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !116
   %6 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %7 = load i64*, i64** %6, align 8, !tbaa !63
+  %7 = load i64*, i64** %6, align 8, !tbaa !117
   %8 = load i64, i64* %7, align 8, !tbaa !6
   %9 = and i64 %8, -129
   store i64 %9, i64* %7, align 8, !tbaa !6
   %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %10, align 8, !tbaa !14
-  %11 = load i64, i64* @guard_epoch_T, align 8, !dbg !64
-  %12 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !64, !tbaa !65
-  %needTakeSlowPath = icmp ne i64 %11, %12, !dbg !64
-  br i1 %needTakeSlowPath, label %13, label %14, !dbg !64, !prof !67
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %10, align 8, !tbaa !72
+  %11 = load i64, i64* @guard_epoch_T, align 8, !dbg !15
+  %12 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !15, !tbaa !118
+  %needTakeSlowPath = icmp ne i64 %11, %12, !dbg !15
+  br i1 %needTakeSlowPath, label %13, label %14, !dbg !15, !prof !120
 
 13:                                               ; preds = %functionEntryInitializers
-  tail call void @const_recompute_T(), !dbg !64
-  br label %14, !dbg !64
+  tail call void @const_recompute_T(), !dbg !15
+  br label %14, !dbg !15
 
 14:                                               ; preds = %functionEntryInitializers, %13
-  %15 = load i64, i64* @guarded_const_T, align 8, !dbg !64
-  %16 = load i64, i64* @guard_epoch_T, align 8, !dbg !64
-  %17 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !64, !tbaa !65
-  %guardUpdated = icmp eq i64 %16, %17, !dbg !64
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !64
-  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !64
-  %19 = load i64*, i64** %18, align 8, !dbg !64
-  store i64 %15, i64* %19, align 8, !dbg !64, !tbaa !6
-  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !64
-  store i64* %20, i64** %18, align 8, !dbg !64
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped, i64 0), !dbg !64
-  %21 = load i64, i64* @rb_cFloat, align 8, !dbg !68
-  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !68
-  %23 = load i64*, i64** %22, align 8, !dbg !68
-  store i64 %4, i64* %23, align 8, !dbg !68, !tbaa !6
-  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !68
-  store i64 %21, i64* %24, align 8, !dbg !68, !tbaa !6
-  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !68
-  store i64 %send, i64* %25, align 8, !dbg !68, !tbaa !6
-  %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !68
-  store i64* %26, i64** %22, align 8, !dbg !68
-  %send38 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params, i64 0), !dbg !68
-  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !69
-  %28 = load i64*, i64** %27, align 8, !dbg !69
-  store i64 %15, i64* %28, align 8, !dbg !69, !tbaa !6
-  %29 = getelementptr inbounds i64, i64* %28, i64 1, !dbg !69
-  store i64* %29, i64** %27, align 8, !dbg !69
-  %send40 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.1, i64 0), !dbg !69
-  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !68
-  %31 = load i64*, i64** %30, align 8, !dbg !68
-  store i64 %send38, i64* %31, align 8, !dbg !68, !tbaa !6
-  %32 = getelementptr inbounds i64, i64* %31, i64 1, !dbg !68
-  store i64 %send40, i64* %32, align 8, !dbg !68, !tbaa !6
-  %33 = getelementptr inbounds i64, i64* %32, i64 1, !dbg !68
-  store i64* %33, i64** %30, align 8, !dbg !68
-  %send42 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns, i64 0), !dbg !68
-  ret i64 %send42, !dbg !70
+  %15 = load i64, i64* @guarded_const_T, align 8, !dbg !15
+  %16 = load i64, i64* @guard_epoch_T, align 8, !dbg !15
+  %17 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !15, !tbaa !118
+  %guardUpdated = icmp eq i64 %16, %17, !dbg !15
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !15
+  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !15
+  %19 = load i64*, i64** %18, align 8, !dbg !15
+  store i64 %15, i64* %19, align 8, !dbg !15, !tbaa !6
+  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !15
+  store i64* %20, i64** %18, align 8, !dbg !15
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped, i64 0), !dbg !15
+  %21 = load i64, i64* @rb_cFloat, align 8, !dbg !18
+  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !18
+  %23 = load i64*, i64** %22, align 8, !dbg !18
+  store i64 %4, i64* %23, align 8, !dbg !18, !tbaa !6
+  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !18
+  store i64 %21, i64* %24, align 8, !dbg !18, !tbaa !6
+  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !18
+  store i64 %send, i64* %25, align 8, !dbg !18, !tbaa !6
+  %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !18
+  store i64* %26, i64** %22, align 8, !dbg !18
+  %send38 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params, i64 0), !dbg !18
+  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !19
+  %28 = load i64*, i64** %27, align 8, !dbg !19
+  store i64 %15, i64* %28, align 8, !dbg !19, !tbaa !6
+  %29 = getelementptr inbounds i64, i64* %28, i64 1, !dbg !19
+  store i64* %29, i64** %27, align 8, !dbg !19
+  %send40 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.1, i64 0), !dbg !19
+  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !18
+  %31 = load i64*, i64** %30, align 8, !dbg !18
+  store i64 %send38, i64* %31, align 8, !dbg !18, !tbaa !6
+  %32 = getelementptr inbounds i64, i64* %31, i64 1, !dbg !18
+  store i64 %send40, i64* %32, align 8, !dbg !18, !tbaa !6
+  %33 = getelementptr inbounds i64, i64* %32, i64 1, !dbg !18
+  store i64* %33, i64** %30, align 8, !dbg !18
+  %send42 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns, i64 0), !dbg !18
+  ret i64 %send42, !dbg !121
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_<root>.17<static-init>$153$block_2"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #8 !dbg !71 {
+define internal i64 @"func_<root>.17<static-init>$153$block_2"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #8 !dbg !21 {
 functionEntryInitializers:
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !72
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !59
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !113
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !60
+  %4 = load i64, i64* %3, align 8, !tbaa !114
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_2", align 8
   %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !62
+  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !116
   %6 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %7 = load i64*, i64** %6, align 8, !tbaa !63
+  %7 = load i64*, i64** %6, align 8, !tbaa !117
   %8 = load i64, i64* %7, align 8, !tbaa !6
   %9 = and i64 %8, -129
   store i64 %9, i64* %7, align 8, !tbaa !6
   %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %10, align 8, !tbaa !14
-  %11 = load i64, i64* @guard_epoch_T, align 8, !dbg !72
-  %12 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !72, !tbaa !65
-  %needTakeSlowPath = icmp ne i64 %11, %12, !dbg !72
-  br i1 %needTakeSlowPath, label %13, label %14, !dbg !72, !prof !67
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %10, align 8, !tbaa !72
+  %11 = load i64, i64* @guard_epoch_T, align 8, !dbg !20
+  %12 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !20, !tbaa !118
+  %needTakeSlowPath = icmp ne i64 %11, %12, !dbg !20
+  br i1 %needTakeSlowPath, label %13, label %14, !dbg !20, !prof !120
 
 13:                                               ; preds = %functionEntryInitializers
-  tail call void @const_recompute_T(), !dbg !72
-  br label %14, !dbg !72
+  tail call void @const_recompute_T(), !dbg !20
+  br label %14, !dbg !20
 
 14:                                               ; preds = %functionEntryInitializers, %13
-  %15 = load i64, i64* @guarded_const_T, align 8, !dbg !72
-  %16 = load i64, i64* @guard_epoch_T, align 8, !dbg !72
-  %17 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !72, !tbaa !65
-  %guardUpdated = icmp eq i64 %16, %17, !dbg !72
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !72
-  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !72
-  %19 = load i64*, i64** %18, align 8, !dbg !72
-  store i64 %15, i64* %19, align 8, !dbg !72, !tbaa !6
-  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !72
-  store i64* %20, i64** %18, align 8, !dbg !72
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.2, i64 0), !dbg !72
-  %21 = load i64, i64* @rb_cFloat, align 8, !dbg !73
-  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !73
-  %23 = load i64*, i64** %22, align 8, !dbg !73
-  store i64 %4, i64* %23, align 8, !dbg !73, !tbaa !6
-  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !73
-  store i64 %21, i64* %24, align 8, !dbg !73, !tbaa !6
-  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !73
-  store i64 %send, i64* %25, align 8, !dbg !73, !tbaa !6
-  %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !73
-  store i64* %26, i64** %22, align 8, !dbg !73
-  %send38 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params.3, i64 0), !dbg !73
-  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !74
-  %28 = load i64*, i64** %27, align 8, !dbg !74
-  store i64 %15, i64* %28, align 8, !dbg !74, !tbaa !6
-  %29 = getelementptr inbounds i64, i64* %28, i64 1, !dbg !74
-  store i64* %29, i64** %27, align 8, !dbg !74
-  %send40 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.4, i64 0), !dbg !74
-  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !73
-  %31 = load i64*, i64** %30, align 8, !dbg !73
-  store i64 %send38, i64* %31, align 8, !dbg !73, !tbaa !6
-  %32 = getelementptr inbounds i64, i64* %31, i64 1, !dbg !73
-  store i64 %send40, i64* %32, align 8, !dbg !73, !tbaa !6
-  %33 = getelementptr inbounds i64, i64* %32, i64 1, !dbg !73
-  store i64* %33, i64** %30, align 8, !dbg !73
-  %send42 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns.5, i64 0), !dbg !73
-  ret i64 %send42, !dbg !75
+  %15 = load i64, i64* @guarded_const_T, align 8, !dbg !20
+  %16 = load i64, i64* @guard_epoch_T, align 8, !dbg !20
+  %17 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !20, !tbaa !118
+  %guardUpdated = icmp eq i64 %16, %17, !dbg !20
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !20
+  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !20
+  %19 = load i64*, i64** %18, align 8, !dbg !20
+  store i64 %15, i64* %19, align 8, !dbg !20, !tbaa !6
+  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !20
+  store i64* %20, i64** %18, align 8, !dbg !20
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.2, i64 0), !dbg !20
+  %21 = load i64, i64* @rb_cFloat, align 8, !dbg !22
+  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !22
+  %23 = load i64*, i64** %22, align 8, !dbg !22
+  store i64 %4, i64* %23, align 8, !dbg !22, !tbaa !6
+  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !22
+  store i64 %21, i64* %24, align 8, !dbg !22, !tbaa !6
+  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !22
+  store i64 %send, i64* %25, align 8, !dbg !22, !tbaa !6
+  %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !22
+  store i64* %26, i64** %22, align 8, !dbg !22
+  %send38 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params.3, i64 0), !dbg !22
+  %27 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !23
+  %28 = load i64*, i64** %27, align 8, !dbg !23
+  store i64 %15, i64* %28, align 8, !dbg !23, !tbaa !6
+  %29 = getelementptr inbounds i64, i64* %28, i64 1, !dbg !23
+  store i64* %29, i64** %27, align 8, !dbg !23
+  %send40 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.4, i64 0), !dbg !23
+  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !22
+  %31 = load i64*, i64** %30, align 8, !dbg !22
+  store i64 %send38, i64* %31, align 8, !dbg !22, !tbaa !6
+  %32 = getelementptr inbounds i64, i64* %31, i64 1, !dbg !22
+  store i64 %send40, i64* %32, align 8, !dbg !22, !tbaa !6
+  %33 = getelementptr inbounds i64, i64* %32, i64 1, !dbg !22
+  store i64* %33, i64** %30, align 8, !dbg !22
+  %send42 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns.5, i64 0), !dbg !22
+  ret i64 %send42, !dbg !122
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_<root>.17<static-init>$153$block_3"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #8 !dbg !76 {
+define internal i64 @"func_<root>.17<static-init>$153$block_3"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #8 !dbg !25 {
 functionEntryInitializers:
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !72
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !59
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !113
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !60
+  %4 = load i64, i64* %3, align 8, !tbaa !114
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_3", align 8
   %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !62
+  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !116
   %6 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %7 = load i64*, i64** %6, align 8, !tbaa !63
+  %7 = load i64*, i64** %6, align 8, !tbaa !117
   %8 = load i64, i64* %7, align 8, !tbaa !6
   %9 = and i64 %8, -129
   store i64 %9, i64* %7, align 8, !tbaa !6
   %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %10, align 8, !tbaa !14
-  %11 = load i64, i64* @guard_epoch_T, align 8, !dbg !77
-  %12 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !77, !tbaa !65
-  %needTakeSlowPath = icmp ne i64 %11, %12, !dbg !77
-  br i1 %needTakeSlowPath, label %13, label %14, !dbg !77, !prof !67
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %10, align 8, !tbaa !72
+  %11 = load i64, i64* @guard_epoch_T, align 8, !dbg !24
+  %12 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !24, !tbaa !118
+  %needTakeSlowPath = icmp ne i64 %11, %12, !dbg !24
+  br i1 %needTakeSlowPath, label %13, label %14, !dbg !24, !prof !120
 
 13:                                               ; preds = %functionEntryInitializers
-  tail call void @const_recompute_T(), !dbg !77
-  br label %14, !dbg !77
+  tail call void @const_recompute_T(), !dbg !24
+  br label %14, !dbg !24
 
 14:                                               ; preds = %functionEntryInitializers, %13
-  %15 = load i64, i64* @guarded_const_T, align 8, !dbg !77
-  %16 = load i64, i64* @guard_epoch_T, align 8, !dbg !77
-  %17 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !77, !tbaa !65
-  %guardUpdated = icmp eq i64 %16, %17, !dbg !77
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !77
-  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !77
-  %19 = load i64*, i64** %18, align 8, !dbg !77
-  store i64 %15, i64* %19, align 8, !dbg !77, !tbaa !6
-  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !77
-  store i64* %20, i64** %18, align 8, !dbg !77
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.6, i64 0), !dbg !77
-  %21 = load i64, i64* @rb_cFloat, align 8, !dbg !78
-  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !78
-  %23 = load i64*, i64** %22, align 8, !dbg !78
-  store i64 %4, i64* %23, align 8, !dbg !78, !tbaa !6
-  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !78
-  store i64 %21, i64* %24, align 8, !dbg !78, !tbaa !6
-  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !78
-  store i64 %send, i64* %25, align 8, !dbg !78, !tbaa !6
-  %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !78
-  store i64* %26, i64** %22, align 8, !dbg !78
-  %send34 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params.7, i64 0), !dbg !78
-  %27 = load i64, i64* @"guard_epoch_T::Boolean", align 8, !dbg !78
-  %28 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !78, !tbaa !65
-  %needTakeSlowPath31 = icmp ne i64 %27, %28, !dbg !78
-  br i1 %needTakeSlowPath31, label %29, label %30, !dbg !78, !prof !67
+  %15 = load i64, i64* @guarded_const_T, align 8, !dbg !24
+  %16 = load i64, i64* @guard_epoch_T, align 8, !dbg !24
+  %17 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !24, !tbaa !118
+  %guardUpdated = icmp eq i64 %16, %17, !dbg !24
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !24
+  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !24
+  %19 = load i64*, i64** %18, align 8, !dbg !24
+  store i64 %15, i64* %19, align 8, !dbg !24, !tbaa !6
+  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !24
+  store i64* %20, i64** %18, align 8, !dbg !24
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.6, i64 0), !dbg !24
+  %21 = load i64, i64* @rb_cFloat, align 8, !dbg !26
+  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !26
+  %23 = load i64*, i64** %22, align 8, !dbg !26
+  store i64 %4, i64* %23, align 8, !dbg !26, !tbaa !6
+  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !26
+  store i64 %21, i64* %24, align 8, !dbg !26, !tbaa !6
+  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !26
+  store i64 %send, i64* %25, align 8, !dbg !26, !tbaa !6
+  %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !26
+  store i64* %26, i64** %22, align 8, !dbg !26
+  %send34 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params.7, i64 0), !dbg !26
+  %27 = load i64, i64* @"guard_epoch_T::Boolean", align 8, !dbg !26
+  %28 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !26, !tbaa !118
+  %needTakeSlowPath31 = icmp ne i64 %27, %28, !dbg !26
+  br i1 %needTakeSlowPath31, label %29, label %30, !dbg !26, !prof !120
 
 29:                                               ; preds = %14
-  tail call void @"const_recompute_T::Boolean"(), !dbg !78
-  br label %30, !dbg !78
+  tail call void @"const_recompute_T::Boolean"(), !dbg !26
+  br label %30, !dbg !26
 
 30:                                               ; preds = %14, %29
-  %31 = load i64, i64* @"guarded_const_T::Boolean", align 8, !dbg !78
-  %32 = load i64, i64* @"guard_epoch_T::Boolean", align 8, !dbg !78
-  %33 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !78, !tbaa !65
-  %guardUpdated32 = icmp eq i64 %32, %33, !dbg !78
-  tail call void @llvm.assume(i1 %guardUpdated32), !dbg !78
-  %34 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !78
-  %35 = load i64*, i64** %34, align 8, !dbg !78
-  store i64 %send34, i64* %35, align 8, !dbg !78, !tbaa !6
-  %36 = getelementptr inbounds i64, i64* %35, i64 1, !dbg !78
-  store i64 %31, i64* %36, align 8, !dbg !78, !tbaa !6
-  %37 = getelementptr inbounds i64, i64* %36, i64 1, !dbg !78
-  store i64* %37, i64** %34, align 8, !dbg !78
-  %send36 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns.8, i64 0), !dbg !78
-  ret i64 %send36, !dbg !79
+  %31 = load i64, i64* @"guarded_const_T::Boolean", align 8, !dbg !26
+  %32 = load i64, i64* @"guard_epoch_T::Boolean", align 8, !dbg !26
+  %33 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !26, !tbaa !118
+  %guardUpdated32 = icmp eq i64 %32, %33, !dbg !26
+  tail call void @llvm.assume(i1 %guardUpdated32), !dbg !26
+  %34 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !26
+  %35 = load i64*, i64** %34, align 8, !dbg !26
+  store i64 %send34, i64* %35, align 8, !dbg !26, !tbaa !6
+  %36 = getelementptr inbounds i64, i64* %35, i64 1, !dbg !26
+  store i64 %31, i64* %36, align 8, !dbg !26, !tbaa !6
+  %37 = getelementptr inbounds i64, i64* %36, i64 1, !dbg !26
+  store i64* %37, i64** %34, align 8, !dbg !26
+  %send36 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns.8, i64 0), !dbg !26
+  ret i64 %send36, !dbg !123
 }
 
 ; Function Attrs: ssp
-define internal i64 @"func_<root>.17<static-init>$153$block_4"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #8 !dbg !80 {
+define internal i64 @"func_<root>.17<static-init>$153$block_4"(i64 %firstYieldArgRaw, i64 %localsOffset, i32 %argc, i64* nocapture nofree readnone %argArray, i64 %blockArg) #8 !dbg !28 {
 functionEntryInitializers:
-  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
+  %0 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !72
   %1 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %0, i64 0, i32 2
-  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !59
+  %2 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %1, align 8, !tbaa !113
   %3 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 3
-  %4 = load i64, i64* %3, align 8, !tbaa !60
+  %4 = load i64, i64* %3, align 8, !tbaa !114
   %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_4", align 8
   %5 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !62
+  store %struct.rb_iseq_struct* %stackFrame, %struct.rb_iseq_struct** %5, align 8, !tbaa !116
   %6 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 4
-  %7 = load i64*, i64** %6, align 8, !tbaa !63
+  %7 = load i64*, i64** %6, align 8, !tbaa !117
   %8 = load i64, i64* %7, align 8, !tbaa !6
   %9 = and i64 %8, -129
   store i64 %9, i64* %7, align 8, !tbaa !6
   %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 0
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %10, align 8, !tbaa !14
-  %11 = load i64, i64* @guard_epoch_T, align 8, !dbg !81
-  %12 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !81, !tbaa !65
-  %needTakeSlowPath = icmp ne i64 %11, %12, !dbg !81
-  br i1 %needTakeSlowPath, label %13, label %14, !dbg !81, !prof !67
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %10, align 8, !tbaa !72
+  %11 = load i64, i64* @guard_epoch_T, align 8, !dbg !27
+  %12 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !27, !tbaa !118
+  %needTakeSlowPath = icmp ne i64 %11, %12, !dbg !27
+  br i1 %needTakeSlowPath, label %13, label %14, !dbg !27, !prof !120
 
 13:                                               ; preds = %functionEntryInitializers
-  tail call void @const_recompute_T(), !dbg !81
-  br label %14, !dbg !81
+  tail call void @const_recompute_T(), !dbg !27
+  br label %14, !dbg !27
 
 14:                                               ; preds = %functionEntryInitializers, %13
-  %15 = load i64, i64* @guarded_const_T, align 8, !dbg !81
-  %16 = load i64, i64* @guard_epoch_T, align 8, !dbg !81
-  %17 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !81, !tbaa !65
-  %guardUpdated = icmp eq i64 %16, %17, !dbg !81
-  tail call void @llvm.assume(i1 %guardUpdated), !dbg !81
-  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !81
-  %19 = load i64*, i64** %18, align 8, !dbg !81
-  store i64 %15, i64* %19, align 8, !dbg !81, !tbaa !6
-  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !81
-  store i64* %20, i64** %18, align 8, !dbg !81
-  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.9, i64 0), !dbg !81
-  %21 = load i64, i64* @rb_cFloat, align 8, !dbg !82
-  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !82
-  %23 = load i64*, i64** %22, align 8, !dbg !82
-  store i64 %4, i64* %23, align 8, !dbg !82, !tbaa !6
-  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !82
-  store i64 %21, i64* %24, align 8, !dbg !82, !tbaa !6
-  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !82
-  store i64 %send, i64* %25, align 8, !dbg !82, !tbaa !6
-  %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !82
-  store i64* %26, i64** %22, align 8, !dbg !82
-  %send34 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params.10, i64 0), !dbg !82
-  %27 = load i64, i64* @"guard_epoch_T::Boolean", align 8, !dbg !82
-  %28 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !82, !tbaa !65
-  %needTakeSlowPath31 = icmp ne i64 %27, %28, !dbg !82
-  br i1 %needTakeSlowPath31, label %29, label %30, !dbg !82, !prof !67
+  %15 = load i64, i64* @guarded_const_T, align 8, !dbg !27
+  %16 = load i64, i64* @guard_epoch_T, align 8, !dbg !27
+  %17 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !27, !tbaa !118
+  %guardUpdated = icmp eq i64 %16, %17, !dbg !27
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !27
+  %18 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !27
+  %19 = load i64*, i64** %18, align 8, !dbg !27
+  store i64 %15, i64* %19, align 8, !dbg !27, !tbaa !6
+  %20 = getelementptr inbounds i64, i64* %19, i64 1, !dbg !27
+  store i64* %20, i64** %18, align 8, !dbg !27
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_untyped.9, i64 0), !dbg !27
+  %21 = load i64, i64* @rb_cFloat, align 8, !dbg !29
+  %22 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !29
+  %23 = load i64*, i64** %22, align 8, !dbg !29
+  store i64 %4, i64* %23, align 8, !dbg !29, !tbaa !6
+  %24 = getelementptr inbounds i64, i64* %23, i64 1, !dbg !29
+  store i64 %21, i64* %24, align 8, !dbg !29, !tbaa !6
+  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !29
+  store i64 %send, i64* %25, align 8, !dbg !29, !tbaa !6
+  %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !29
+  store i64* %26, i64** %22, align 8, !dbg !29
+  %send34 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_params.10, i64 0), !dbg !29
+  %27 = load i64, i64* @"guard_epoch_T::Boolean", align 8, !dbg !29
+  %28 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !29, !tbaa !118
+  %needTakeSlowPath31 = icmp ne i64 %27, %28, !dbg !29
+  br i1 %needTakeSlowPath31, label %29, label %30, !dbg !29, !prof !120
 
 29:                                               ; preds = %14
-  tail call void @"const_recompute_T::Boolean"(), !dbg !82
-  br label %30, !dbg !82
+  tail call void @"const_recompute_T::Boolean"(), !dbg !29
+  br label %30, !dbg !29
 
 30:                                               ; preds = %14, %29
-  %31 = load i64, i64* @"guarded_const_T::Boolean", align 8, !dbg !82
-  %32 = load i64, i64* @"guard_epoch_T::Boolean", align 8, !dbg !82
-  %33 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !82, !tbaa !65
-  %guardUpdated32 = icmp eq i64 %32, %33, !dbg !82
-  tail call void @llvm.assume(i1 %guardUpdated32), !dbg !82
-  %34 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !82
-  %35 = load i64*, i64** %34, align 8, !dbg !82
-  store i64 %send34, i64* %35, align 8, !dbg !82, !tbaa !6
-  %36 = getelementptr inbounds i64, i64* %35, i64 1, !dbg !82
-  store i64 %31, i64* %36, align 8, !dbg !82, !tbaa !6
-  %37 = getelementptr inbounds i64, i64* %36, i64 1, !dbg !82
-  store i64* %37, i64** %34, align 8, !dbg !82
-  %send36 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns.11, i64 0), !dbg !82
-  ret i64 %send36, !dbg !83
+  %31 = load i64, i64* @"guarded_const_T::Boolean", align 8, !dbg !29
+  %32 = load i64, i64* @"guard_epoch_T::Boolean", align 8, !dbg !29
+  %33 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !29, !tbaa !118
+  %guardUpdated32 = icmp eq i64 %32, %33, !dbg !29
+  tail call void @llvm.assume(i1 %guardUpdated32), !dbg !29
+  %34 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %2, i64 0, i32 1, !dbg !29
+  %35 = load i64*, i64** %34, align 8, !dbg !29
+  store i64 %send34, i64* %35, align 8, !dbg !29, !tbaa !6
+  %36 = getelementptr inbounds i64, i64* %35, i64 1, !dbg !29
+  store i64 %31, i64* %36, align 8, !dbg !29, !tbaa !6
+  %37 = getelementptr inbounds i64, i64* %36, i64 1, !dbg !29
+  store i64* %37, i64** %34, align 8, !dbg !29
+  %send36 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_returns.11, i64 0), !dbg !29
+  ret i64 %send36, !dbg !124
+}
+
+; Function Attrs: ssp
+define internal fastcc void @"Constr_stackFramePrecomputed_func_<root>.17<static-init>$153"(i64 %realpath) unnamed_addr #8 {
+entryInitializers:
+  %"rubyId_<top (required)>" = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 8), align 8, !invariant.load !5
+  %"rubyStr_<top (required)>" = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 5), align 8, !invariant.load !5
+  %"rubyStr_test/testdata/compiler/float-intrinsics.rb" = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
+  %locals = alloca i64, align 8
+  %"rubyId_<block-call>" = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 9), align 8, !invariant.load !5
+  store i64 %"rubyId_<block-call>", i64* %locals, align 8
+  %0 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>", i64 %"rubyId_<top (required)>", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals, i32 noundef 1, i32 noundef 4)
+  store %struct.rb_iseq_struct* %0, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  ret void
+}
+
+; Function Attrs: ssp
+define internal fastcc void @"Constr_stackFramePrecomputed_func_<root>.17<static-init>$153$block_1"(i64 %realpath) unnamed_addr #8 {
+entryInitializers:
+  %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %"rubyId_block in <top (required)>" = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 10), align 8, !invariant.load !5
+  %"rubyStr_block in <top (required)>" = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 6), align 8, !invariant.load !5
+  %"rubyStr_test/testdata/compiler/float-intrinsics.rb" = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
+  %0 = tail call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>", i64 %"rubyId_block in <top (required)>", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb", i64 %realpath, %struct.rb_iseq_struct* %stackFrame, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %0, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1", align 8
+  ret void
+}
+
+; Function Attrs: ssp
+define internal fastcc void @"Constr_stackFramePrecomputed_func_<root>.17<static-init>$153$block_2"(i64 %realpath) unnamed_addr #8 {
+entryInitializers:
+  %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %"rubyId_block in <top (required)>" = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 10), align 8, !invariant.load !5
+  %"rubyStr_block in <top (required)>" = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 6), align 8, !invariant.load !5
+  %"rubyStr_test/testdata/compiler/float-intrinsics.rb" = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
+  %0 = tail call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>", i64 %"rubyId_block in <top (required)>", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb", i64 %realpath, %struct.rb_iseq_struct* %stackFrame, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %0, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_2", align 8
+  ret void
+}
+
+; Function Attrs: ssp
+define internal fastcc void @"Constr_stackFramePrecomputed_func_<root>.17<static-init>$153$block_3"(i64 %realpath) unnamed_addr #8 {
+entryInitializers:
+  %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %"rubyId_block in <top (required)>" = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 10), align 8, !invariant.load !5
+  %"rubyStr_block in <top (required)>" = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 6), align 8, !invariant.load !5
+  %"rubyStr_test/testdata/compiler/float-intrinsics.rb" = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
+  %0 = tail call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>", i64 %"rubyId_block in <top (required)>", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb", i64 %realpath, %struct.rb_iseq_struct* %stackFrame, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %0, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_3", align 8
+  ret void
+}
+
+; Function Attrs: ssp
+define internal fastcc void @"Constr_stackFramePrecomputed_func_<root>.17<static-init>$153$block_4"(i64 %realpath) unnamed_addr #8 {
+entryInitializers:
+  %stackFrame = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
+  %"rubyId_block in <top (required)>" = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 10), align 8, !invariant.load !5
+  %"rubyStr_block in <top (required)>" = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 6), align 8, !invariant.load !5
+  %"rubyStr_test/testdata/compiler/float-intrinsics.rb" = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
+  %0 = tail call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>", i64 %"rubyId_block in <top (required)>", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb", i64 %realpath, %struct.rb_iseq_struct* %stackFrame, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
+  store %struct.rb_iseq_struct* %0, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_4", align 8
+  ret void
 }
 
 ; Function Attrs: sspreq
 define void @Init_float-intrinsics() local_unnamed_addr #9 {
 entry:
-  %positional_table.i = alloca i64, i32 2, align 8, !dbg !84
-  %positional_table320.i = alloca i64, i32 2, align 8, !dbg !85
-  %positional_table334.i = alloca i64, i32 2, align 8, !dbg !86
-  %positional_table348.i = alloca i64, i32 2, align 8, !dbg !87
-  %locals.i68.i = alloca i64, align 8
-  %locals.i66.i = alloca i64, i32 0, align 8
-  %locals.i64.i = alloca i64, i32 0, align 8
-  %locals.i62.i = alloca i64, i32 0, align 8
-  %locals.i.i = alloca i64, i32 0, align 8
-  %keywords.i = alloca i64, i32 2, align 8, !dbg !68
-  %keywords5.i = alloca i64, i32 2, align 8, !dbg !73
-  %keywords14.i = alloca i64, i32 2, align 8, !dbg !78
-  %keywords22.i = alloca i64, i32 2, align 8, !dbg !82
+  %positional_table.i = alloca i64, i32 2, align 8, !dbg !125
+  %positional_table320.i = alloca i64, i32 2, align 8, !dbg !126
+  %positional_table334.i = alloca i64, i32 2, align 8, !dbg !127
+  %positional_table348.i = alloca i64, i32 2, align 8, !dbg !128
   %realpath = tail call i64 @sorbet_readRealpath()
-  %0 = bitcast i64* %keywords.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %0)
-  %1 = bitcast i64* %keywords5.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %1)
-  %2 = bitcast i64* %keywords14.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %2)
-  %3 = bitcast i64* %keywords22.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %3)
-  tail call void @sorbet_vm_intern_ids(i64* noundef getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([21 x %struct.rb_code_position_struct], [21 x %struct.rb_code_position_struct]* @sorbet_moduleIDDescriptors, i32 0, i32 0), i32 noundef 21, i8* noundef getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
-  tail call void @sorbet_vm_init_string_table(i64* noundef getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i32 0, i32 0), %struct.rb_code_position_struct* noundef getelementptr inbounds ([13 x %struct.rb_code_position_struct], [13 x %struct.rb_code_position_struct]* @sorbet_moduleRubyStringDescriptors, i32 0, i32 0), i32 noundef 13, i8* noundef getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i32 0, i32 0))
-  tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 49)
-  %rubyId_plus.i.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !invariant.load !5
-  %rubyStr_plus.i.i = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 0), align 8, !invariant.load !5
-  %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i.i" = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 1), align 8, !invariant.load !5
-  %4 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_plus.i.i, i64 %rubyId_plus.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 8, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %4, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#4plus", align 8
-  %rubyId_minus.i.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !invariant.load !5
-  %rubyStr_minus.i.i = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 2), align 8, !invariant.load !5
-  %5 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_minus.i.i, i64 %rubyId_minus.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 13, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i62.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %5, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#5minus", align 8
-  %rubyId_-.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !37, !invariant.load !5
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_-, i64 %rubyId_-.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !37
-  %rubyId_lt.i.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !invariant.load !5
-  %rubyStr_lt.i.i = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 3), align 8, !invariant.load !5
-  %6 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_lt.i.i, i64 %rubyId_lt.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 18, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i64.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %6, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#2lt", align 8
-  %rubyId_lte.i.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 6), align 8, !invariant.load !5
-  %rubyStr_lte.i.i = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 4), align 8, !invariant.load !5
-  %7 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %rubyStr_lte.i.i, i64 %rubyId_lte.i.i, i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 1, i32 noundef 23, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i66.i, i32 noundef 0, i32 noundef 2)
-  store %struct.rb_iseq_struct* %7, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3lte", align 8
-  %8 = bitcast i64* %locals.i68.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %8)
-  %"rubyId_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 8), align 8, !invariant.load !5
-  %"rubyStr_<top (required)>.i.i" = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 5), align 8, !invariant.load !5
-  %"rubyId_<block-call>.i.i" = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 9), align 8, !invariant.load !5
-  store i64 %"rubyId_<block-call>.i.i", i64* %locals.i68.i, align 8
-  %9 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull align 8 %locals.i68.i, i32 noundef 1, i32 noundef 4)
-  store %struct.rb_iseq_struct* %9, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %8)
-  %"rubyId_block in <top (required)>.i.i" = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 10), align 8, !invariant.load !5
-  %"rubyStr_block in <top (required)>.i.i" = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 6), align 8, !invariant.load !5
-  %10 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i.i", i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* %9, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %10, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_1", align 8
-  %stackFrame.i70.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %11 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i.i", i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i70.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %11, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_2", align 8
-  %stackFrame.i74.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %12 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i.i", i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i74.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %12, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_3", align 8
-  %stackFrame.i78.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %13 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_block in <top (required)>.i.i", i64 %"rubyId_block in <top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/float-intrinsics.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i78.i, i32 noundef 2, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 4)
-  store %struct.rb_iseq_struct* %13, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153$block_4", align 8
-  %rubyId_untyped.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 13), align 8, !dbg !64, !invariant.load !5
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped, i64 %rubyId_untyped.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !64
-  %rubyId_params.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 14), align 8, !dbg !68, !invariant.load !5
-  %rubyId_x.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 11), align 8, !dbg !68, !invariant.load !5
-  %14 = call i64 @rb_id2sym(i64 %rubyId_x.i) #18, !dbg !68
-  store i64 %14, i64* %keywords.i, align 8, !dbg !68
-  %rubyId_y.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 12), align 8, !dbg !68, !invariant.load !5
-  %15 = call i64 @rb_id2sym(i64 %rubyId_y.i) #18, !dbg !68
-  %16 = getelementptr i64, i64* %keywords.i, i32 1, !dbg !68
-  store i64 %15, i64* %16, align 8, !dbg !68
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull align 8 %keywords.i), !dbg !68
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.1, i64 %rubyId_untyped.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !69
-  %rubyId_returns.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 15), align 8, !dbg !68, !invariant.load !5
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !68
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.2, i64 %rubyId_untyped.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !72
-  store i64 %14, i64* %keywords5.i, align 8, !dbg !73
-  %17 = getelementptr i64, i64* %keywords5.i, i32 1, !dbg !73
-  store i64 %15, i64* %17, align 8, !dbg !73
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params.3, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull align 8 %keywords5.i), !dbg !73
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.4, i64 %rubyId_untyped.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !74
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.5, i64 %rubyId_returns.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !73
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.6, i64 %rubyId_untyped.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !77
-  store i64 %14, i64* %keywords14.i, align 8, !dbg !78
-  %18 = getelementptr i64, i64* %keywords14.i, i32 1, !dbg !78
-  store i64 %15, i64* %18, align 8, !dbg !78
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params.7, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull align 8 %keywords14.i), !dbg !78
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.8, i64 %rubyId_returns.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !78
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_untyped.9, i64 %rubyId_untyped.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !81
-  store i64 %14, i64* %keywords22.i, align 8, !dbg !82
-  %19 = getelementptr i64, i64* %keywords22.i, i32 1, !dbg !82
-  store i64 %15, i64* %19, align 8, !dbg !82
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_params.10, i64 %rubyId_params.i, i32 noundef 68, i32 noundef 2, i32 noundef 2, i64* noundef nonnull align 8 %keywords22.i), !dbg !82
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns.11, i64 %rubyId_returns.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !82
-  %rubyId_extend.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 16), align 8, !dbg !88, !invariant.load !5
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !88
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus, i64 %rubyId_plus.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !89
-  %rubyId_p.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 18), align 8, !dbg !90, !invariant.load !5
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !90
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus, i64 %rubyId_minus.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !91
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.12, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !92
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt, i64 %rubyId_lt.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !93
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.13, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !94
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt.14, i64 %rubyId_lt.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !95
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.15, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !96
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte, i64 %rubyId_lte.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !97
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.16, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !98
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.17, i64 %rubyId_lte.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !99
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.18, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !100
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.19, i64 %rubyId_lte.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !101
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.20, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !102
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus.21, i64 %rubyId_plus.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !103
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.22, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !104
-  %rubyId_Rational.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 19), align 8, !dbg !105, !invariant.load !5
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational, i64 %rubyId_Rational.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !105
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus.23, i64 %rubyId_plus.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !106
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.24, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !107
-  %rubyId_Complex.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 20), align 8, !dbg !108, !invariant.load !5
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Complex, i64 %rubyId_Complex.i, i32 noundef 16, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !108
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_plus.25, i64 %rubyId_plus.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !109
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.26, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !110
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus.27, i64 %rubyId_minus.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !111
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.28, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !112
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational.29, i64 %rubyId_Rational.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !113
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus.30, i64 %rubyId_minus.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !114
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.31, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !115
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Complex.32, i64 %rubyId_Complex.i, i32 noundef 16, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !116
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_minus.33, i64 %rubyId_minus.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !117
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.34, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !118
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt.35, i64 %rubyId_lt.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !119
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.36, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !120
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational.37, i64 %rubyId_Rational.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !121
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lt.38, i64 %rubyId_lt.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !122
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.39, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !123
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.40, i64 %rubyId_lte.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !124
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.41, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !125
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_Rational.42, i64 %rubyId_Rational.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !126
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_lte.43, i64 %rubyId_lte.i.i, i32 noundef 20, i32 noundef 2, i32 noundef 0, i64* noundef null), !dbg !127
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_p.44, i64 %rubyId_p.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !128
-  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %0)
-  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %1)
-  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %2)
-  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %3)
-  %20 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !14
-  %21 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %20, i64 0, i32 18
-  %22 = load i64, i64* %21, align 8, !tbaa !129
-  %23 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !14
-  %24 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %23, i64 0, i32 2
-  %25 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %24, align 8, !tbaa !59
-  %26 = bitcast i64* %positional_table.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %26)
-  %27 = bitcast i64* %positional_table320.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %27)
-  %28 = bitcast i64* %positional_table334.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %28)
-  %29 = bitcast i64* %positional_table348.i to i8*
-  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %29)
+  tail call fastcc void @sorbet_globalConstructors(i64 %realpath)
+  %0 = load %struct.rb_vm_struct*, %struct.rb_vm_struct** @ruby_current_vm_ptr, align 8, !tbaa !72
+  %1 = getelementptr inbounds %struct.rb_vm_struct, %struct.rb_vm_struct* %0, i64 0, i32 18
+  %2 = load i64, i64* %1, align 8, !tbaa !129
+  %3 = load %struct.rb_execution_context_struct*, %struct.rb_execution_context_struct** @ruby_current_execution_context_ptr, align 8, !tbaa !72
+  %4 = getelementptr inbounds %struct.rb_execution_context_struct, %struct.rb_execution_context_struct* %3, i64 0, i32 2
+  %5 = load %struct.rb_control_frame_struct*, %struct.rb_control_frame_struct** %4, align 8, !tbaa !113
+  %6 = bitcast i64* %positional_table.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %6)
+  %7 = bitcast i64* %positional_table320.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %7)
+  %8 = bitcast i64* %positional_table334.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %8)
+  %9 = bitcast i64* %positional_table348.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %9)
   %stackFrame.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
-  %30 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 2
-  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %30, align 8, !tbaa !62
-  %31 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 4
-  %32 = load i64*, i64** %31, align 8, !tbaa !63
-  %33 = load i64, i64* %32, align 8, !tbaa !6
-  %34 = and i64 %33, -33
-  store i64 %34, i64* %32, align 8, !tbaa !6
-  call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %23, %struct.rb_control_frame_struct* %25, %struct.rb_iseq_struct* %stackFrame.i) #17
-  %35 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 0
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %35, align 8, !dbg !137, !tbaa !14
-  %rawSym.i = call i64 @rb_id2sym(i64 %rubyId_plus.i.i) #17, !dbg !138
-  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym.i, i64 %22, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_1") #17, !dbg !138
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %35, align 8, !dbg !138, !tbaa !14
-  %rawSym257.i = call i64 @rb_id2sym(i64 %rubyId_minus.i.i) #17, !dbg !139
-  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym257.i, i64 %22, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_2") #17, !dbg !139
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %35, align 8, !dbg !139, !tbaa !14
-  %rawSym271.i = call i64 @rb_id2sym(i64 %rubyId_lt.i.i) #17, !dbg !140
-  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym271.i, i64 %22, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_3") #17, !dbg !140
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %35, align 8, !dbg !140, !tbaa !14
-  %rawSym285.i = call i64 @rb_id2sym(i64 %rubyId_lte.i.i) #17, !dbg !141
-  call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym285.i, i64 %22, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_4") #17, !dbg !141
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %35, align 8, !dbg !141, !tbaa !14
-  %36 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !88
-  %37 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !88, !tbaa !65
-  %needTakeSlowPath = icmp ne i64 %36, %37, !dbg !88
-  br i1 %needTakeSlowPath, label %38, label %39, !dbg !88, !prof !67
+  %10 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 2
+  store %struct.rb_iseq_struct* %stackFrame.i, %struct.rb_iseq_struct** %10, align 8, !tbaa !116
+  %11 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 4
+  %12 = load i64*, i64** %11, align 8, !tbaa !117
+  %13 = load i64, i64* %12, align 8, !tbaa !6
+  %14 = and i64 %13, -33
+  store i64 %14, i64* %12, align 8, !tbaa !6
+  tail call void @sorbet_setMethodStackFrame(%struct.rb_execution_context_struct* %3, %struct.rb_control_frame_struct* %5, %struct.rb_iseq_struct* %stackFrame.i) #17
+  %15 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 0
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 7), i64** %15, align 8, !dbg !137, !tbaa !72
+  %rubyId_plus.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 0), align 8, !dbg !138, !invariant.load !5
+  %rawSym.i = tail call i64 @rb_id2sym(i64 %rubyId_plus.i) #17, !dbg !138
+  tail call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym.i, i64 %2, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_1") #17, !dbg !138
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 12), i64** %15, align 8, !dbg !138, !tbaa !72
+  %rubyId_minus.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !139, !invariant.load !5
+  %rawSym257.i = tail call i64 @rb_id2sym(i64 %rubyId_minus.i) #17, !dbg !139
+  tail call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym257.i, i64 %2, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_2") #17, !dbg !139
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 17), i64** %15, align 8, !dbg !139, !tbaa !72
+  %rubyId_lt.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !dbg !140, !invariant.load !5
+  %rawSym271.i = tail call i64 @rb_id2sym(i64 %rubyId_lt.i) #17, !dbg !140
+  tail call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym271.i, i64 %2, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_3") #17, !dbg !140
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 22), i64** %15, align 8, !dbg !140, !tbaa !72
+  %rubyId_lte.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 6), align 8, !dbg !141, !invariant.load !5
+  %rawSym285.i = tail call i64 @rb_id2sym(i64 %rubyId_lte.i) #17, !dbg !141
+  tail call void @sorbet_vm_register_sig(i64 noundef 0, i64 %rawSym285.i, i64 %2, i64 noundef 8, i64 (i64, i64, i32, i64*, i64)* noundef @"func_<root>.17<static-init>$153$block_4") #17, !dbg !141
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 5), i64** %15, align 8, !dbg !141, !tbaa !72
+  %16 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !30
+  %17 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !30, !tbaa !118
+  %needTakeSlowPath = icmp ne i64 %16, %17, !dbg !30
+  br i1 %needTakeSlowPath, label %18, label %19, !dbg !30, !prof !120
 
-38:                                               ; preds = %entry
-  call void @"const_recompute_T::Sig"(), !dbg !88
-  br label %39, !dbg !88
+18:                                               ; preds = %entry
+  tail call void @"const_recompute_T::Sig"(), !dbg !30
+  br label %19, !dbg !30
 
-39:                                               ; preds = %entry, %38
-  %40 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !88
-  %41 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !88
-  %42 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !88, !tbaa !65
-  %guardUpdated = icmp eq i64 %41, %42, !dbg !88
-  call void @llvm.assume(i1 %guardUpdated), !dbg !88
-  %43 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !88
-  %44 = load i64*, i64** %43, align 8, !dbg !88
-  store i64 %22, i64* %44, align 8, !dbg !88, !tbaa !6
-  %45 = getelementptr inbounds i64, i64* %44, i64 1, !dbg !88
-  store i64 %40, i64* %45, align 8, !dbg !88, !tbaa !6
-  %46 = getelementptr inbounds i64, i64* %45, i64 1, !dbg !88
-  store i64* %46, i64** %43, align 8, !dbg !88
-  %send = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !88
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %35, align 8, !dbg !88, !tbaa !14
-  %47 = load i64, i64* @rb_cObject, align 8, !dbg !84
-  %stackFrame308.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#4plus", align 8, !dbg !84
-  %48 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #19, !dbg !84
-  %49 = bitcast i8* %48 to i16*, !dbg !84
-  %50 = load i16, i16* %49, align 8, !dbg !84
-  %51 = and i16 %50, -384, !dbg !84
-  %52 = or i16 %51, 1, !dbg !84
-  store i16 %52, i16* %49, align 8, !dbg !84
-  %53 = getelementptr inbounds i8, i8* %48, i64 8, !dbg !84
-  %54 = bitcast i8* %53 to i32*, !dbg !84
-  store i32 2, i32* %54, align 8, !dbg !84, !tbaa !142
-  %55 = getelementptr inbounds i8, i8* %48, i64 12, !dbg !84
-  %56 = getelementptr inbounds i8, i8* %48, i64 4, !dbg !84
-  %57 = bitcast i8* %56 to i32*, !dbg !84
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %55, i8 0, i64 20, i1 false) #17, !dbg !84
-  store i32 2, i32* %57, align 4, !dbg !84, !tbaa !145
-  store i64 %rubyId_x.i, i64* %positional_table.i, align 8, !dbg !84
-  %58 = getelementptr i64, i64* %positional_table.i, i32 1, !dbg !84
-  store i64 %rubyId_y.i, i64* %58, align 8, !dbg !84
-  %59 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #19, !dbg !84
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %59, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %26, i64 noundef 16, i1 noundef false) #17, !dbg !84
-  %60 = getelementptr inbounds i8, i8* %48, i64 32, !dbg !84
-  %61 = bitcast i8* %60 to i8**, !dbg !84
-  store i8* %59, i8** %61, align 8, !dbg !84, !tbaa !146
-  call void @sorbet_vm_define_method(i64 %47, i8* noundef getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#4plus", i8* nonnull %48, %struct.rb_iseq_struct* %stackFrame308.i, i1 noundef zeroext false) #17, !dbg !84
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %35, align 8, !dbg !84, !tbaa !14
-  %stackFrame318.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#5minus", align 8, !dbg !85
-  %62 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #19, !dbg !85
-  %63 = bitcast i8* %62 to i16*, !dbg !85
-  %64 = load i16, i16* %63, align 8, !dbg !85
-  %65 = and i16 %64, -384, !dbg !85
-  %66 = or i16 %65, 1, !dbg !85
-  store i16 %66, i16* %63, align 8, !dbg !85
-  %67 = getelementptr inbounds i8, i8* %62, i64 8, !dbg !85
-  %68 = bitcast i8* %67 to i32*, !dbg !85
-  store i32 2, i32* %68, align 8, !dbg !85, !tbaa !142
-  %69 = getelementptr inbounds i8, i8* %62, i64 12, !dbg !85
-  %70 = getelementptr inbounds i8, i8* %62, i64 4, !dbg !85
-  %71 = bitcast i8* %70 to i32*, !dbg !85
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %69, i8 0, i64 20, i1 false) #17, !dbg !85
-  store i32 2, i32* %71, align 4, !dbg !85, !tbaa !145
-  store i64 %rubyId_x.i, i64* %positional_table320.i, align 8, !dbg !85
-  %72 = getelementptr i64, i64* %positional_table320.i, i32 1, !dbg !85
-  store i64 %rubyId_y.i, i64* %72, align 8, !dbg !85
-  %73 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #19, !dbg !85
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %73, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %27, i64 noundef 16, i1 noundef false) #17, !dbg !85
-  %74 = getelementptr inbounds i8, i8* %62, i64 32, !dbg !85
-  %75 = bitcast i8* %74 to i8**, !dbg !85
-  store i8* %73, i8** %75, align 8, !dbg !85, !tbaa !146
-  call void @sorbet_vm_define_method(i64 %47, i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 107), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#5minus", i8* nonnull %62, %struct.rb_iseq_struct* %stackFrame318.i, i1 noundef zeroext false) #17, !dbg !85
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %35, align 8, !dbg !85, !tbaa !14
-  %stackFrame332.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#2lt", align 8, !dbg !86
-  %76 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #19, !dbg !86
-  %77 = bitcast i8* %76 to i16*, !dbg !86
-  %78 = load i16, i16* %77, align 8, !dbg !86
-  %79 = and i16 %78, -384, !dbg !86
-  %80 = or i16 %79, 1, !dbg !86
-  store i16 %80, i16* %77, align 8, !dbg !86
-  %81 = getelementptr inbounds i8, i8* %76, i64 8, !dbg !86
-  %82 = bitcast i8* %81 to i32*, !dbg !86
-  store i32 2, i32* %82, align 8, !dbg !86, !tbaa !142
-  %83 = getelementptr inbounds i8, i8* %76, i64 12, !dbg !86
-  %84 = getelementptr inbounds i8, i8* %76, i64 4, !dbg !86
-  %85 = bitcast i8* %84 to i32*, !dbg !86
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %83, i8 0, i64 20, i1 false) #17, !dbg !86
-  store i32 2, i32* %85, align 4, !dbg !86, !tbaa !145
-  store i64 %rubyId_x.i, i64* %positional_table334.i, align 8, !dbg !86
-  %86 = getelementptr i64, i64* %positional_table334.i, i32 1, !dbg !86
-  store i64 %rubyId_y.i, i64* %86, align 8, !dbg !86
-  %87 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #19, !dbg !86
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %87, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %28, i64 noundef 16, i1 noundef false) #17, !dbg !86
-  %88 = getelementptr inbounds i8, i8* %76, i64 32, !dbg !86
-  %89 = bitcast i8* %88 to i8**, !dbg !86
-  store i8* %87, i8** %89, align 8, !dbg !86, !tbaa !146
-  call void @sorbet_vm_define_method(i64 %47, i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 115), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#2lt", i8* nonnull %76, %struct.rb_iseq_struct* %stackFrame332.i, i1 noundef zeroext false) #17, !dbg !86
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %35, align 8, !dbg !86, !tbaa !14
-  %stackFrame346.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3lte", align 8, !dbg !87
-  %90 = call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #19, !dbg !87
-  %91 = bitcast i8* %90 to i16*, !dbg !87
-  %92 = load i16, i16* %91, align 8, !dbg !87
-  %93 = and i16 %92, -384, !dbg !87
-  %94 = or i16 %93, 1, !dbg !87
-  store i16 %94, i16* %91, align 8, !dbg !87
-  %95 = getelementptr inbounds i8, i8* %90, i64 8, !dbg !87
-  %96 = bitcast i8* %95 to i32*, !dbg !87
-  store i32 2, i32* %96, align 8, !dbg !87, !tbaa !142
-  %97 = getelementptr inbounds i8, i8* %90, i64 12, !dbg !87
-  %98 = getelementptr inbounds i8, i8* %90, i64 4, !dbg !87
-  %99 = bitcast i8* %98 to i32*, !dbg !87
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %97, i8 0, i64 20, i1 false) #17, !dbg !87
-  store i32 2, i32* %99, align 4, !dbg !87, !tbaa !145
-  store i64 %rubyId_x.i, i64* %positional_table348.i, align 8, !dbg !87
-  %100 = getelementptr i64, i64* %positional_table348.i, i32 1, !dbg !87
-  store i64 %rubyId_y.i, i64* %100, align 8, !dbg !87
-  %101 = call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #19, !dbg !87
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %101, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %29, i64 noundef 16, i1 noundef false) #17, !dbg !87
-  %102 = getelementptr inbounds i8, i8* %90, i64 32, !dbg !87
-  %103 = bitcast i8* %102 to i8**, !dbg !87
-  store i8* %101, i8** %103, align 8, !dbg !87, !tbaa !146
-  call void @sorbet_vm_define_method(i64 %47, i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 131), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#3lte", i8* nonnull %90, %struct.rb_iseq_struct* %stackFrame346.i, i1 noundef zeroext false) #17, !dbg !87
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %35, align 8, !dbg !87, !tbaa !14
-  %104 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !89
-  %105 = load i64*, i64** %104, align 8, !dbg !89
-  store i64 %22, i64* %105, align 8, !dbg !89, !tbaa !6
-  %106 = getelementptr inbounds i64, i64* %105, i64 1, !dbg !89
-  %107 = getelementptr inbounds i64, i64* %106, i64 1, !dbg !89
-  %108 = bitcast i64* %106 to <2 x i64>*, !dbg !89
-  store <2 x i64> <i64 45035996273704962, i64 54043195528445954>, <2 x i64>* %108, align 8, !dbg !89, !tbaa !6
-  %109 = getelementptr inbounds i64, i64* %107, i64 1, !dbg !89
-  store i64* %109, i64** %104, align 8, !dbg !89
-  %send4 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus, i64 0), !dbg !89
-  %110 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !90
-  %111 = load i64*, i64** %110, align 8, !dbg !90
-  store i64 %22, i64* %111, align 8, !dbg !90, !tbaa !6
-  %112 = getelementptr inbounds i64, i64* %111, i64 1, !dbg !90
-  store i64 %send4, i64* %112, align 8, !dbg !90, !tbaa !6
-  %113 = getelementptr inbounds i64, i64* %112, i64 1, !dbg !90
-  store i64* %113, i64** %110, align 8, !dbg !90
-  %send6 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p, i64 0), !dbg !90
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %35, align 8, !dbg !90, !tbaa !14
-  %114 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !91
-  %115 = load i64*, i64** %114, align 8, !dbg !91
-  store i64 %22, i64* %115, align 8, !dbg !91, !tbaa !6
-  %116 = getelementptr inbounds i64, i64* %115, i64 1, !dbg !91
-  %117 = getelementptr inbounds i64, i64* %116, i64 1, !dbg !91
-  %118 = bitcast i64* %116 to <2 x i64>*, !dbg !91
-  store <2 x i64> <i64 146704757861593906, i64 194442913911721170>, <2 x i64>* %118, align 8, !dbg !91, !tbaa !6
-  %119 = getelementptr inbounds i64, i64* %117, i64 1, !dbg !91
-  store i64* %119, i64** %114, align 8, !dbg !91
-  %send8 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus, i64 0), !dbg !91
-  %120 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !92
-  %121 = load i64*, i64** %120, align 8, !dbg !92
-  store i64 %22, i64* %121, align 8, !dbg !92, !tbaa !6
-  %122 = getelementptr inbounds i64, i64* %121, i64 1, !dbg !92
-  store i64 %send8, i64* %122, align 8, !dbg !92, !tbaa !6
-  %123 = getelementptr inbounds i64, i64* %122, i64 1, !dbg !92
-  store i64* %123, i64** %120, align 8, !dbg !92
-  %send10 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.12, i64 0), !dbg !92
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 29), i64** %35, align 8, !dbg !92, !tbaa !14
-  %124 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !93
-  %125 = load i64*, i64** %124, align 8, !dbg !93
-  store i64 %22, i64* %125, align 8, !dbg !93, !tbaa !6
-  %126 = getelementptr inbounds i64, i64* %125, i64 1, !dbg !93
-  %127 = getelementptr inbounds i64, i64* %126, i64 1, !dbg !93
-  %128 = bitcast i64* %126 to <2 x i64>*, !dbg !93
-  store <2 x i64> <i64 193204424014194282, i64 53142475602971858>, <2 x i64>* %128, align 8, !dbg !93, !tbaa !6
-  %129 = getelementptr inbounds i64, i64* %127, i64 1, !dbg !93
-  store i64* %129, i64** %124, align 8, !dbg !93
-  %send12 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt, i64 0), !dbg !93
-  %130 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !94
-  %131 = load i64*, i64** %130, align 8, !dbg !94
-  store i64 %22, i64* %131, align 8, !dbg !94, !tbaa !6
-  %132 = getelementptr inbounds i64, i64* %131, i64 1, !dbg !94
-  store i64 %send12, i64* %132, align 8, !dbg !94, !tbaa !6
-  %133 = getelementptr inbounds i64, i64* %132, i64 1, !dbg !94
-  store i64* %133, i64** %130, align 8, !dbg !94
-  %send14 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.13, i64 0), !dbg !94
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 30), i64** %35, align 8, !dbg !94, !tbaa !14
-  %134 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !95
-  %135 = load i64*, i64** %134, align 8, !dbg !95
-  store i64 %22, i64* %135, align 8, !dbg !95, !tbaa !6
-  %136 = getelementptr inbounds i64, i64* %135, i64 1, !dbg !95
-  %137 = getelementptr inbounds i64, i64* %136, i64 1, !dbg !95
-  %138 = bitcast i64* %136 to <2 x i64>*, !dbg !95
-  store <2 x i64> <i64 61248954932238746, i64 133982088914272258>, <2 x i64>* %138, align 8, !dbg !95, !tbaa !6
-  %139 = getelementptr inbounds i64, i64* %137, i64 1, !dbg !95
-  store i64* %139, i64** %134, align 8, !dbg !95
-  %send16 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt.14, i64 0), !dbg !95
-  %140 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !96
-  %141 = load i64*, i64** %140, align 8, !dbg !96
-  store i64 %22, i64* %141, align 8, !dbg !96, !tbaa !6
-  %142 = getelementptr inbounds i64, i64* %141, i64 1, !dbg !96
-  store i64 %send16, i64* %142, align 8, !dbg !96, !tbaa !6
-  %143 = getelementptr inbounds i64, i64* %142, i64 1, !dbg !96
-  store i64* %143, i64** %140, align 8, !dbg !96
-  %send18 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.15, i64 0), !dbg !96
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 31), i64** %35, align 8, !dbg !96, !tbaa !14
-  %144 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !97
-  %145 = load i64*, i64** %144, align 8, !dbg !97
-  store i64 %22, i64* %145, align 8, !dbg !97, !tbaa !6
-  %146 = getelementptr inbounds i64, i64* %145, i64 1, !dbg !97
-  %147 = getelementptr inbounds i64, i64* %146, i64 1, !dbg !97
-  %148 = bitcast i64* %146 to <2 x i64>*, !dbg !97
-  store <2 x i64> <i64 180200280090161970, i64 155261597153597850>, <2 x i64>* %148, align 8, !dbg !97, !tbaa !6
-  %149 = getelementptr inbounds i64, i64* %147, i64 1, !dbg !97
-  store i64* %149, i64** %144, align 8, !dbg !97
-  %send20 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte, i64 0), !dbg !97
-  %150 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !98
-  %151 = load i64*, i64** %150, align 8, !dbg !98
-  store i64 %22, i64* %151, align 8, !dbg !98, !tbaa !6
-  %152 = getelementptr inbounds i64, i64* %151, i64 1, !dbg !98
-  store i64 %send20, i64* %152, align 8, !dbg !98, !tbaa !6
-  %153 = getelementptr inbounds i64, i64* %152, i64 1, !dbg !98
-  store i64* %153, i64** %150, align 8, !dbg !98
-  %send22 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.16, i64 0), !dbg !98
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 32), i64** %35, align 8, !dbg !98, !tbaa !14
-  %154 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !99
-  %155 = load i64*, i64** %154, align 8, !dbg !99
-  store i64 %22, i64* %155, align 8, !dbg !99, !tbaa !6
-  %156 = getelementptr inbounds i64, i64* %155, i64 1, !dbg !99
-  %157 = getelementptr inbounds i64, i64* %156, i64 1, !dbg !99
-  %158 = bitcast i64* %156 to <2 x i64>*, !dbg !99
-  store <2 x i64> <i64 57646075230342354, i64 155261597153597850>, <2 x i64>* %158, align 8, !dbg !99, !tbaa !6
-  %159 = getelementptr inbounds i64, i64* %157, i64 1, !dbg !99
-  store i64* %159, i64** %154, align 8, !dbg !99
-  %send24 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.17, i64 0), !dbg !99
-  %160 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !100
-  %161 = load i64*, i64** %160, align 8, !dbg !100
-  store i64 %22, i64* %161, align 8, !dbg !100, !tbaa !6
-  %162 = getelementptr inbounds i64, i64* %161, i64 1, !dbg !100
-  store i64 %send24, i64* %162, align 8, !dbg !100, !tbaa !6
-  %163 = getelementptr inbounds i64, i64* %162, i64 1, !dbg !100
-  store i64* %163, i64** %160, align 8, !dbg !100
-  %send26 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.18, i64 0), !dbg !100
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 33), i64** %35, align 8, !dbg !100, !tbaa !14
-  %164 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !101
-  %165 = load i64*, i64** %164, align 8, !dbg !101
-  store i64 %22, i64* %165, align 8, !dbg !101, !tbaa !6
-  %166 = getelementptr inbounds i64, i64* %165, i64 1, !dbg !101
-  %167 = getelementptr inbounds i64, i64* %166, i64 1, !dbg !101
-  %168 = bitcast i64* %166 to <2 x i64>*, !dbg !101
-  store <2 x i64> <i64 75660473739824338, i64 75660473739824338>, <2 x i64>* %168, align 8, !dbg !101, !tbaa !6
-  %169 = getelementptr inbounds i64, i64* %167, i64 1, !dbg !101
-  store i64* %169, i64** %164, align 8, !dbg !101
-  %send28 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.19, i64 0), !dbg !101
-  %170 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !102
-  %171 = load i64*, i64** %170, align 8, !dbg !102
-  store i64 %22, i64* %171, align 8, !dbg !102, !tbaa !6
-  %172 = getelementptr inbounds i64, i64* %171, i64 1, !dbg !102
-  store i64 %send28, i64* %172, align 8, !dbg !102, !tbaa !6
-  %173 = getelementptr inbounds i64, i64* %172, i64 1, !dbg !102
-  store i64* %173, i64** %170, align 8, !dbg !102
-  %send30 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.20, i64 0), !dbg !102
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 36), i64** %35, align 8, !dbg !102, !tbaa !14
-  %174 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !103
-  %175 = load i64*, i64** %174, align 8, !dbg !103
-  store i64 %22, i64* %175, align 8, !dbg !103, !tbaa !6
-  %176 = getelementptr inbounds i64, i64* %175, i64 1, !dbg !103
-  %177 = getelementptr inbounds i64, i64* %176, i64 1, !dbg !103
-  %178 = bitcast i64* %176 to <2 x i64>*, !dbg !103
-  store <2 x i64> <i64 45035996273704962, i64 17>, <2 x i64>* %178, align 8, !dbg !103, !tbaa !6
-  %179 = getelementptr inbounds i64, i64* %177, i64 1, !dbg !103
-  store i64* %179, i64** %174, align 8, !dbg !103
-  %send32 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus.21, i64 0), !dbg !103
-  %180 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !104
-  %181 = load i64*, i64** %180, align 8, !dbg !104
-  store i64 %22, i64* %181, align 8, !dbg !104, !tbaa !6
-  %182 = getelementptr inbounds i64, i64* %181, i64 1, !dbg !104
-  store i64 %send32, i64* %182, align 8, !dbg !104, !tbaa !6
-  %183 = getelementptr inbounds i64, i64* %182, i64 1, !dbg !104
-  store i64* %183, i64** %180, align 8, !dbg !104
-  %send34 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.22, i64 0), !dbg !104
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 37), i64** %35, align 8, !dbg !104, !tbaa !14
-  %rubyStr_8.9.i = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 7), align 8, !dbg !105, !invariant.load !5
-  %184 = load i64, i64* @rb_mKernel, align 8, !dbg !105
-  %185 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !105
-  %186 = load i64*, i64** %185, align 8, !dbg !105
-  store i64 %184, i64* %186, align 8, !dbg !105, !tbaa !6
-  %187 = getelementptr inbounds i64, i64* %186, i64 1, !dbg !105
-  store i64 %rubyStr_8.9.i, i64* %187, align 8, !dbg !105, !tbaa !6
-  %188 = getelementptr inbounds i64, i64* %187, i64 1, !dbg !105
-  store i64* %188, i64** %185, align 8, !dbg !105
-  %send36 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational, i64 0), !dbg !105
-  %189 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !106
-  %190 = load i64*, i64** %189, align 8, !dbg !106
-  store i64 %22, i64* %190, align 8, !dbg !106, !tbaa !6
-  %191 = getelementptr inbounds i64, i64* %190, i64 1, !dbg !106
-  store i64 36028797018963970, i64* %191, align 8, !dbg !106, !tbaa !6
-  %192 = getelementptr inbounds i64, i64* %191, i64 1, !dbg !106
-  store i64 %send36, i64* %192, align 8, !dbg !106, !tbaa !6
-  %193 = getelementptr inbounds i64, i64* %192, i64 1, !dbg !106
-  store i64* %193, i64** %189, align 8, !dbg !106
-  %send38 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus.23, i64 0), !dbg !106
-  %194 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !107
-  %195 = load i64*, i64** %194, align 8, !dbg !107
-  store i64 %22, i64* %195, align 8, !dbg !107, !tbaa !6
-  %196 = getelementptr inbounds i64, i64* %195, i64 1, !dbg !107
-  store i64 %send38, i64* %196, align 8, !dbg !107, !tbaa !6
-  %197 = getelementptr inbounds i64, i64* %196, i64 1, !dbg !107
-  store i64* %197, i64** %194, align 8, !dbg !107
-  %send40 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.24, i64 0), !dbg !107
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 38), i64** %35, align 8, !dbg !107, !tbaa !14
-  %rubyStr_5.i = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 8), align 8, !dbg !108, !invariant.load !5
-  %198 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !108
-  %199 = load i64*, i64** %198, align 8, !dbg !108
-  store i64 %184, i64* %199, align 8, !dbg !108, !tbaa !6
-  %200 = getelementptr inbounds i64, i64* %199, i64 1, !dbg !108
-  store i64 1, i64* %200, align 8, !dbg !108, !tbaa !6
-  %201 = getelementptr inbounds i64, i64* %200, i64 1, !dbg !108
-  store i64 %rubyStr_5.i, i64* %201, align 8, !dbg !108, !tbaa !6
-  %202 = getelementptr inbounds i64, i64* %201, i64 1, !dbg !108
-  store i64* %202, i64** %198, align 8, !dbg !108
-  %send42 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Complex, i64 0), !dbg !108
-  %203 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !109
-  %204 = load i64*, i64** %203, align 8, !dbg !109
-  store i64 %22, i64* %204, align 8, !dbg !109, !tbaa !6
-  %205 = getelementptr inbounds i64, i64* %204, i64 1, !dbg !109
-  store i64 36028797018963970, i64* %205, align 8, !dbg !109, !tbaa !6
-  %206 = getelementptr inbounds i64, i64* %205, i64 1, !dbg !109
-  store i64 %send42, i64* %206, align 8, !dbg !109, !tbaa !6
-  %207 = getelementptr inbounds i64, i64* %206, i64 1, !dbg !109
-  store i64* %207, i64** %203, align 8, !dbg !109
-  %send44 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus.25, i64 0), !dbg !109
-  %208 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !110
-  %209 = load i64*, i64** %208, align 8, !dbg !110
-  store i64 %22, i64* %209, align 8, !dbg !110, !tbaa !6
-  %210 = getelementptr inbounds i64, i64* %209, i64 1, !dbg !110
-  store i64 %send44, i64* %210, align 8, !dbg !110, !tbaa !6
-  %211 = getelementptr inbounds i64, i64* %210, i64 1, !dbg !110
-  store i64* %211, i64** %208, align 8, !dbg !110
-  %send46 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.26, i64 0), !dbg !110
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 40), i64** %35, align 8, !dbg !110, !tbaa !14
-  %212 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !111
-  %213 = load i64*, i64** %212, align 8, !dbg !111
-  store i64 %22, i64* %213, align 8, !dbg !111, !tbaa !6
-  %214 = getelementptr inbounds i64, i64* %213, i64 1, !dbg !111
-  %215 = getelementptr inbounds i64, i64* %214, i64 1, !dbg !111
-  %216 = bitcast i64* %214 to <2 x i64>*, !dbg !111
-  store <2 x i64> <i64 199678348478539370, i64 7>, <2 x i64>* %216, align 8, !dbg !111, !tbaa !6
-  %217 = getelementptr inbounds i64, i64* %215, i64 1, !dbg !111
-  store i64* %217, i64** %212, align 8, !dbg !111
-  %send48 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus.27, i64 0), !dbg !111
-  %218 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !112
-  %219 = load i64*, i64** %218, align 8, !dbg !112
-  store i64 %22, i64* %219, align 8, !dbg !112, !tbaa !6
-  %220 = getelementptr inbounds i64, i64* %219, i64 1, !dbg !112
-  store i64 %send48, i64* %220, align 8, !dbg !112, !tbaa !6
-  %221 = getelementptr inbounds i64, i64* %220, i64 1, !dbg !112
-  store i64* %221, i64** %218, align 8, !dbg !112
-  %send50 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.28, i64 0), !dbg !112
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 41), i64** %35, align 8, !dbg !112, !tbaa !14
-  %rubyStr_15.4.i = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 9), align 8, !dbg !113, !invariant.load !5
-  %222 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !113
-  %223 = load i64*, i64** %222, align 8, !dbg !113
-  store i64 %184, i64* %223, align 8, !dbg !113, !tbaa !6
-  %224 = getelementptr inbounds i64, i64* %223, i64 1, !dbg !113
-  store i64 %rubyStr_15.4.i, i64* %224, align 8, !dbg !113, !tbaa !6
-  %225 = getelementptr inbounds i64, i64* %224, i64 1, !dbg !113
-  store i64* %225, i64** %222, align 8, !dbg !113
-  %send52 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational.29, i64 0), !dbg !113
-  %226 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !114
-  %227 = load i64*, i64** %226, align 8, !dbg !114
-  store i64 %22, i64* %227, align 8, !dbg !114, !tbaa !6
-  %228 = getelementptr inbounds i64, i64* %227, i64 1, !dbg !114
-  store i64 199622053483197234, i64* %228, align 8, !dbg !114, !tbaa !6
-  %229 = getelementptr inbounds i64, i64* %228, i64 1, !dbg !114
-  store i64 %send52, i64* %229, align 8, !dbg !114, !tbaa !6
-  %230 = getelementptr inbounds i64, i64* %229, i64 1, !dbg !114
-  store i64* %230, i64** %226, align 8, !dbg !114
-  %send54 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus.30, i64 0), !dbg !114
-  %231 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !115
-  %232 = load i64*, i64** %231, align 8, !dbg !115
-  store i64 %22, i64* %232, align 8, !dbg !115, !tbaa !6
-  %233 = getelementptr inbounds i64, i64* %232, i64 1, !dbg !115
-  store i64 %send54, i64* %233, align 8, !dbg !115, !tbaa !6
-  %234 = getelementptr inbounds i64, i64* %233, i64 1, !dbg !115
-  store i64* %234, i64** %231, align 8, !dbg !115
-  %send56 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.31, i64 0), !dbg !115
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 42), i64** %35, align 8, !dbg !115, !tbaa !14
-  %rubyStr_18.i = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 10), align 8, !dbg !116, !invariant.load !5
-  %235 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !116
-  %236 = load i64*, i64** %235, align 8, !dbg !116
-  store i64 %184, i64* %236, align 8, !dbg !116, !tbaa !6
-  %237 = getelementptr inbounds i64, i64* %236, i64 1, !dbg !116
-  store i64 1, i64* %237, align 8, !dbg !116, !tbaa !6
-  %238 = getelementptr inbounds i64, i64* %237, i64 1, !dbg !116
-  store i64 %rubyStr_18.i, i64* %238, align 8, !dbg !116, !tbaa !6
-  %239 = getelementptr inbounds i64, i64* %238, i64 1, !dbg !116
-  store i64* %239, i64** %235, align 8, !dbg !116
-  %send58 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Complex.32, i64 0), !dbg !116
-  %240 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !117
-  %241 = load i64*, i64** %240, align 8, !dbg !117
-  store i64 %22, i64* %241, align 8, !dbg !117, !tbaa !6
-  %242 = getelementptr inbounds i64, i64* %241, i64 1, !dbg !117
-  store i64 199565758487855106, i64* %242, align 8, !dbg !117, !tbaa !6
-  %243 = getelementptr inbounds i64, i64* %242, i64 1, !dbg !117
-  store i64 %send58, i64* %243, align 8, !dbg !117, !tbaa !6
-  %244 = getelementptr inbounds i64, i64* %243, i64 1, !dbg !117
-  store i64* %244, i64** %240, align 8, !dbg !117
-  %send60 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus.33, i64 0), !dbg !117
-  %245 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !118
-  %246 = load i64*, i64** %245, align 8, !dbg !118
-  store i64 %22, i64* %246, align 8, !dbg !118, !tbaa !6
-  %247 = getelementptr inbounds i64, i64* %246, i64 1, !dbg !118
-  store i64 %send60, i64* %247, align 8, !dbg !118, !tbaa !6
-  %248 = getelementptr inbounds i64, i64* %247, i64 1, !dbg !118
-  store i64* %248, i64** %245, align 8, !dbg !118
-  %send62 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.34, i64 0), !dbg !118
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 44), i64** %35, align 8, !dbg !118, !tbaa !14
-  %249 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !119
-  %250 = load i64*, i64** %249, align 8, !dbg !119
-  store i64 %22, i64* %250, align 8, !dbg !119, !tbaa !6
-  %251 = getelementptr inbounds i64, i64* %250, i64 1, !dbg !119
-  %252 = getelementptr inbounds i64, i64* %251, i64 1, !dbg !119
-  %253 = bitcast i64* %251 to <2 x i64>*, !dbg !119
-  store <2 x i64> <i64 113040350646999450, i64 13>, <2 x i64>* %253, align 8, !dbg !119, !tbaa !6
-  %254 = getelementptr inbounds i64, i64* %252, i64 1, !dbg !119
-  store i64* %254, i64** %249, align 8, !dbg !119
-  %send64 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt.35, i64 0), !dbg !119
-  %255 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !120
-  %256 = load i64*, i64** %255, align 8, !dbg !120
-  store i64 %22, i64* %256, align 8, !dbg !120, !tbaa !6
-  %257 = getelementptr inbounds i64, i64* %256, i64 1, !dbg !120
-  store i64 %send64, i64* %257, align 8, !dbg !120, !tbaa !6
-  %258 = getelementptr inbounds i64, i64* %257, i64 1, !dbg !120
-  store i64* %258, i64** %255, align 8, !dbg !120
-  %send66 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.36, i64 0), !dbg !120
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 45), i64** %35, align 8, !dbg !120, !tbaa !14
-  %rubyStr_25.4.i = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 11), align 8, !dbg !121, !invariant.load !5
-  %259 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !121
-  %260 = load i64*, i64** %259, align 8, !dbg !121
-  store i64 %184, i64* %260, align 8, !dbg !121, !tbaa !6
-  %261 = getelementptr inbounds i64, i64* %260, i64 1, !dbg !121
-  store i64 %rubyStr_25.4.i, i64* %261, align 8, !dbg !121, !tbaa !6
-  %262 = getelementptr inbounds i64, i64* %261, i64 1, !dbg !121
-  store i64* %262, i64** %259, align 8, !dbg !121
-  %send68 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational.37, i64 0), !dbg !121
-  %263 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !122
-  %264 = load i64*, i64** %263, align 8, !dbg !122
-  store i64 %22, i64* %264, align 8, !dbg !122, !tbaa !6
-  %265 = getelementptr inbounds i64, i64* %264, i64 1, !dbg !122
-  store i64 113040350646999450, i64* %265, align 8, !dbg !122, !tbaa !6
-  %266 = getelementptr inbounds i64, i64* %265, i64 1, !dbg !122
-  store i64 %send68, i64* %266, align 8, !dbg !122, !tbaa !6
-  %267 = getelementptr inbounds i64, i64* %266, i64 1, !dbg !122
-  store i64* %267, i64** %263, align 8, !dbg !122
-  %send70 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt.38, i64 0), !dbg !122
-  %268 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !123
-  %269 = load i64*, i64** %268, align 8, !dbg !123
-  store i64 %22, i64* %269, align 8, !dbg !123, !tbaa !6
-  %270 = getelementptr inbounds i64, i64* %269, i64 1, !dbg !123
-  store i64 %send70, i64* %270, align 8, !dbg !123, !tbaa !6
-  %271 = getelementptr inbounds i64, i64* %270, i64 1, !dbg !123
-  store i64* %271, i64** %268, align 8, !dbg !123
-  %send72 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.39, i64 0), !dbg !123
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 47), i64** %35, align 8, !dbg !123, !tbaa !14
-  %272 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !124
-  %273 = load i64*, i64** %272, align 8, !dbg !124
-  store i64 %22, i64* %273, align 8, !dbg !124, !tbaa !6
-  %274 = getelementptr inbounds i64, i64* %273, i64 1, !dbg !124
-  %275 = getelementptr inbounds i64, i64* %274, i64 1, !dbg !124
-  %276 = bitcast i64* %274 to <2 x i64>*, !dbg !124
-  store <2 x i64> <i64 113040350646999450, i64 41>, <2 x i64>* %276, align 8, !dbg !124, !tbaa !6
-  %277 = getelementptr inbounds i64, i64* %275, i64 1, !dbg !124
-  store i64* %277, i64** %272, align 8, !dbg !124
-  %send74 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.40, i64 0), !dbg !124
-  %278 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !125
-  %279 = load i64*, i64** %278, align 8, !dbg !125
-  store i64 %22, i64* %279, align 8, !dbg !125, !tbaa !6
-  %280 = getelementptr inbounds i64, i64* %279, i64 1, !dbg !125
-  store i64 %send74, i64* %280, align 8, !dbg !125, !tbaa !6
-  %281 = getelementptr inbounds i64, i64* %280, i64 1, !dbg !125
-  store i64* %281, i64** %278, align 8, !dbg !125
-  %send76 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.41, i64 0), !dbg !125
-  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 48), i64** %35, align 8, !dbg !125, !tbaa !14
-  %rubyStr_5.923.i = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 12), align 8, !dbg !126, !invariant.load !5
-  %282 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !126
-  %283 = load i64*, i64** %282, align 8, !dbg !126
-  store i64 %184, i64* %283, align 8, !dbg !126, !tbaa !6
-  %284 = getelementptr inbounds i64, i64* %283, i64 1, !dbg !126
-  store i64 %rubyStr_5.923.i, i64* %284, align 8, !dbg !126, !tbaa !6
-  %285 = getelementptr inbounds i64, i64* %284, i64 1, !dbg !126
-  store i64* %285, i64** %282, align 8, !dbg !126
-  %send78 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational.42, i64 0), !dbg !126
-  %286 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !127
-  %287 = load i64*, i64** %286, align 8, !dbg !127
-  store i64 %22, i64* %287, align 8, !dbg !127, !tbaa !6
-  %288 = getelementptr inbounds i64, i64* %287, i64 1, !dbg !127
-  store i64 113040350646999450, i64* %288, align 8, !dbg !127, !tbaa !6
-  %289 = getelementptr inbounds i64, i64* %288, i64 1, !dbg !127
-  store i64 %send78, i64* %289, align 8, !dbg !127, !tbaa !6
-  %290 = getelementptr inbounds i64, i64* %289, i64 1, !dbg !127
-  store i64* %290, i64** %286, align 8, !dbg !127
-  %send80 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.43, i64 0), !dbg !127
-  %291 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %25, i64 0, i32 1, !dbg !128
-  %292 = load i64*, i64** %291, align 8, !dbg !128
-  store i64 %22, i64* %292, align 8, !dbg !128, !tbaa !6
-  %293 = getelementptr inbounds i64, i64* %292, i64 1, !dbg !128
-  store i64 %send80, i64* %293, align 8, !dbg !128, !tbaa !6
-  %294 = getelementptr inbounds i64, i64* %293, i64 1, !dbg !128
-  store i64* %294, i64** %291, align 8, !dbg !128
-  %send82 = call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.44, i64 0), !dbg !128
-  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %26)
-  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %27)
-  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %28)
-  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %29)
+19:                                               ; preds = %entry, %18
+  %20 = load i64, i64* @"guarded_const_T::Sig", align 8, !dbg !30
+  %21 = load i64, i64* @"guard_epoch_T::Sig", align 8, !dbg !30
+  %22 = load i64, i64* @ruby_vm_global_constant_state, align 8, !dbg !30, !tbaa !118
+  %guardUpdated = icmp eq i64 %21, %22, !dbg !30
+  tail call void @llvm.assume(i1 %guardUpdated), !dbg !30
+  %23 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !30
+  %24 = load i64*, i64** %23, align 8, !dbg !30
+  store i64 %2, i64* %24, align 8, !dbg !30, !tbaa !6
+  %25 = getelementptr inbounds i64, i64* %24, i64 1, !dbg !30
+  store i64 %20, i64* %25, align 8, !dbg !30, !tbaa !6
+  %26 = getelementptr inbounds i64, i64* %25, i64 1, !dbg !30
+  store i64* %26, i64** %23, align 8, !dbg !30
+  %send = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_extend, i64 0), !dbg !30
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 8), i64** %15, align 8, !dbg !30, !tbaa !72
+  %27 = load i64, i64* @rb_cObject, align 8, !dbg !125
+  %stackFrame308.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#4plus", align 8, !dbg !125
+  %28 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !125
+  %29 = bitcast i8* %28 to i16*, !dbg !125
+  %30 = load i16, i16* %29, align 8, !dbg !125
+  %31 = and i16 %30, -384, !dbg !125
+  %32 = or i16 %31, 1, !dbg !125
+  store i16 %32, i16* %29, align 8, !dbg !125
+  %33 = getelementptr inbounds i8, i8* %28, i64 8, !dbg !125
+  %34 = bitcast i8* %33 to i32*, !dbg !125
+  store i32 2, i32* %34, align 8, !dbg !125, !tbaa !142
+  %35 = getelementptr inbounds i8, i8* %28, i64 12, !dbg !125
+  %36 = getelementptr inbounds i8, i8* %28, i64 4, !dbg !125
+  %37 = bitcast i8* %36 to i32*, !dbg !125
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %35, i8 0, i64 20, i1 false) #17, !dbg !125
+  store i32 2, i32* %37, align 4, !dbg !125, !tbaa !145
+  %rubyId_x.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 11), align 8, !dbg !125, !invariant.load !5
+  store i64 %rubyId_x.i, i64* %positional_table.i, align 8, !dbg !125
+  %rubyId_y.i = load i64, i64* getelementptr inbounds ([21 x i64], [21 x i64]* @sorbet_moduleIDTable, i64 0, i64 12), align 8, !dbg !125, !invariant.load !5
+  %38 = getelementptr i64, i64* %positional_table.i, i32 1, !dbg !125
+  store i64 %rubyId_y.i, i64* %38, align 8, !dbg !125
+  %39 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #18, !dbg !125
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %39, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %6, i64 noundef 16, i1 noundef false) #17, !dbg !125
+  %40 = getelementptr inbounds i8, i8* %28, i64 32, !dbg !125
+  %41 = bitcast i8* %40 to i8**, !dbg !125
+  store i8* %39, i8** %41, align 8, !dbg !125, !tbaa !146
+  tail call void @sorbet_vm_define_method(i64 %27, i8* noundef getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 0), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#4plus", i8* nonnull %28, %struct.rb_iseq_struct* %stackFrame308.i, i1 noundef zeroext false) #17, !dbg !125
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 13), i64** %15, align 8, !dbg !125, !tbaa !72
+  %stackFrame318.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#5minus", align 8, !dbg !126
+  %42 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !126
+  %43 = bitcast i8* %42 to i16*, !dbg !126
+  %44 = load i16, i16* %43, align 8, !dbg !126
+  %45 = and i16 %44, -384, !dbg !126
+  %46 = or i16 %45, 1, !dbg !126
+  store i16 %46, i16* %43, align 8, !dbg !126
+  %47 = getelementptr inbounds i8, i8* %42, i64 8, !dbg !126
+  %48 = bitcast i8* %47 to i32*, !dbg !126
+  store i32 2, i32* %48, align 8, !dbg !126, !tbaa !142
+  %49 = getelementptr inbounds i8, i8* %42, i64 12, !dbg !126
+  %50 = getelementptr inbounds i8, i8* %42, i64 4, !dbg !126
+  %51 = bitcast i8* %50 to i32*, !dbg !126
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %49, i8 0, i64 20, i1 false) #17, !dbg !126
+  store i32 2, i32* %51, align 4, !dbg !126, !tbaa !145
+  store i64 %rubyId_x.i, i64* %positional_table320.i, align 8, !dbg !126
+  %52 = getelementptr i64, i64* %positional_table320.i, i32 1, !dbg !126
+  store i64 %rubyId_y.i, i64* %52, align 8, !dbg !126
+  %53 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #18, !dbg !126
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %53, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %7, i64 noundef 16, i1 noundef false) #17, !dbg !126
+  %54 = getelementptr inbounds i8, i8* %42, i64 32, !dbg !126
+  %55 = bitcast i8* %54 to i8**, !dbg !126
+  store i8* %53, i8** %55, align 8, !dbg !126, !tbaa !146
+  tail call void @sorbet_vm_define_method(i64 %27, i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 107), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#5minus", i8* nonnull %42, %struct.rb_iseq_struct* %stackFrame318.i, i1 noundef zeroext false) #17, !dbg !126
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 18), i64** %15, align 8, !dbg !126, !tbaa !72
+  %stackFrame332.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#2lt", align 8, !dbg !127
+  %56 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !127
+  %57 = bitcast i8* %56 to i16*, !dbg !127
+  %58 = load i16, i16* %57, align 8, !dbg !127
+  %59 = and i16 %58, -384, !dbg !127
+  %60 = or i16 %59, 1, !dbg !127
+  store i16 %60, i16* %57, align 8, !dbg !127
+  %61 = getelementptr inbounds i8, i8* %56, i64 8, !dbg !127
+  %62 = bitcast i8* %61 to i32*, !dbg !127
+  store i32 2, i32* %62, align 8, !dbg !127, !tbaa !142
+  %63 = getelementptr inbounds i8, i8* %56, i64 12, !dbg !127
+  %64 = getelementptr inbounds i8, i8* %56, i64 4, !dbg !127
+  %65 = bitcast i8* %64 to i32*, !dbg !127
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %63, i8 0, i64 20, i1 false) #17, !dbg !127
+  store i32 2, i32* %65, align 4, !dbg !127, !tbaa !145
+  store i64 %rubyId_x.i, i64* %positional_table334.i, align 8, !dbg !127
+  %66 = getelementptr i64, i64* %positional_table334.i, i32 1, !dbg !127
+  store i64 %rubyId_y.i, i64* %66, align 8, !dbg !127
+  %67 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #18, !dbg !127
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %67, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %8, i64 noundef 16, i1 noundef false) #17, !dbg !127
+  %68 = getelementptr inbounds i8, i8* %56, i64 32, !dbg !127
+  %69 = bitcast i8* %68 to i8**, !dbg !127
+  store i8* %67, i8** %69, align 8, !dbg !127, !tbaa !146
+  tail call void @sorbet_vm_define_method(i64 %27, i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 115), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#2lt", i8* nonnull %56, %struct.rb_iseq_struct* %stackFrame332.i, i1 noundef zeroext false) #17, !dbg !127
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 23), i64** %15, align 8, !dbg !127, !tbaa !72
+  %stackFrame346.i = load %struct.rb_iseq_struct*, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Object#3lte", align 8, !dbg !128
+  %70 = tail call noalias nonnull i8* @ruby_xcalloc(i64 noundef 1, i64 noundef 64) #18, !dbg !128
+  %71 = bitcast i8* %70 to i16*, !dbg !128
+  %72 = load i16, i16* %71, align 8, !dbg !128
+  %73 = and i16 %72, -384, !dbg !128
+  %74 = or i16 %73, 1, !dbg !128
+  store i16 %74, i16* %71, align 8, !dbg !128
+  %75 = getelementptr inbounds i8, i8* %70, i64 8, !dbg !128
+  %76 = bitcast i8* %75 to i32*, !dbg !128
+  store i32 2, i32* %76, align 8, !dbg !128, !tbaa !142
+  %77 = getelementptr inbounds i8, i8* %70, i64 12, !dbg !128
+  %78 = getelementptr inbounds i8, i8* %70, i64 4, !dbg !128
+  %79 = bitcast i8* %78 to i32*, !dbg !128
+  tail call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %77, i8 0, i64 20, i1 false) #17, !dbg !128
+  store i32 2, i32* %79, align 4, !dbg !128, !tbaa !145
+  store i64 %rubyId_x.i, i64* %positional_table348.i, align 8, !dbg !128
+  %80 = getelementptr i64, i64* %positional_table348.i, i32 1, !dbg !128
+  store i64 %rubyId_y.i, i64* %80, align 8, !dbg !128
+  %81 = tail call noalias nonnull i8* @ruby_xmalloc2(i64 noundef 2, i64 noundef 8) #18, !dbg !128
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture nonnull writeonly align 1 %81, i8* nocapture noundef nonnull readonly align 8 dereferenceable(16) %9, i64 noundef 16, i1 noundef false) #17, !dbg !128
+  %82 = getelementptr inbounds i8, i8* %70, i64 32, !dbg !128
+  %83 = bitcast i8* %82 to i8**, !dbg !128
+  store i8* %81, i8** %83, align 8, !dbg !128, !tbaa !146
+  tail call void @sorbet_vm_define_method(i64 %27, i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 131), i64 (i32, i64*, i64, %struct.rb_control_frame_struct*, i8*, i8*)* noundef @"func_Object#3lte", i8* nonnull %70, %struct.rb_iseq_struct* %stackFrame346.i, i1 noundef zeroext false) #17, !dbg !128
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 27), i64** %15, align 8, !dbg !128, !tbaa !72
+  %84 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !31
+  %85 = load i64*, i64** %84, align 8, !dbg !31
+  store i64 %2, i64* %85, align 8, !dbg !31, !tbaa !6
+  %86 = getelementptr inbounds i64, i64* %85, i64 1, !dbg !31
+  %87 = getelementptr inbounds i64, i64* %86, i64 1, !dbg !31
+  %88 = bitcast i64* %86 to <2 x i64>*, !dbg !31
+  store <2 x i64> <i64 45035996273704962, i64 54043195528445954>, <2 x i64>* %88, align 8, !dbg !31, !tbaa !6
+  %89 = getelementptr inbounds i64, i64* %87, i64 1, !dbg !31
+  store i64* %89, i64** %84, align 8, !dbg !31
+  %send2 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus, i64 0), !dbg !31
+  %90 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !32
+  %91 = load i64*, i64** %90, align 8, !dbg !32
+  store i64 %2, i64* %91, align 8, !dbg !32, !tbaa !6
+  %92 = getelementptr inbounds i64, i64* %91, i64 1, !dbg !32
+  store i64 %send2, i64* %92, align 8, !dbg !32, !tbaa !6
+  %93 = getelementptr inbounds i64, i64* %92, i64 1, !dbg !32
+  store i64* %93, i64** %90, align 8, !dbg !32
+  %send4 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p, i64 0), !dbg !32
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 28), i64** %15, align 8, !dbg !32, !tbaa !72
+  %94 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !33
+  %95 = load i64*, i64** %94, align 8, !dbg !33
+  store i64 %2, i64* %95, align 8, !dbg !33, !tbaa !6
+  %96 = getelementptr inbounds i64, i64* %95, i64 1, !dbg !33
+  %97 = getelementptr inbounds i64, i64* %96, i64 1, !dbg !33
+  %98 = bitcast i64* %96 to <2 x i64>*, !dbg !33
+  store <2 x i64> <i64 146704757861593906, i64 194442913911721170>, <2 x i64>* %98, align 8, !dbg !33, !tbaa !6
+  %99 = getelementptr inbounds i64, i64* %97, i64 1, !dbg !33
+  store i64* %99, i64** %94, align 8, !dbg !33
+  %send6 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus, i64 0), !dbg !33
+  %100 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !34
+  %101 = load i64*, i64** %100, align 8, !dbg !34
+  store i64 %2, i64* %101, align 8, !dbg !34, !tbaa !6
+  %102 = getelementptr inbounds i64, i64* %101, i64 1, !dbg !34
+  store i64 %send6, i64* %102, align 8, !dbg !34, !tbaa !6
+  %103 = getelementptr inbounds i64, i64* %102, i64 1, !dbg !34
+  store i64* %103, i64** %100, align 8, !dbg !34
+  %send8 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.12, i64 0), !dbg !34
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 29), i64** %15, align 8, !dbg !34, !tbaa !72
+  %104 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !35
+  %105 = load i64*, i64** %104, align 8, !dbg !35
+  store i64 %2, i64* %105, align 8, !dbg !35, !tbaa !6
+  %106 = getelementptr inbounds i64, i64* %105, i64 1, !dbg !35
+  %107 = getelementptr inbounds i64, i64* %106, i64 1, !dbg !35
+  %108 = bitcast i64* %106 to <2 x i64>*, !dbg !35
+  store <2 x i64> <i64 193204424014194282, i64 53142475602971858>, <2 x i64>* %108, align 8, !dbg !35, !tbaa !6
+  %109 = getelementptr inbounds i64, i64* %107, i64 1, !dbg !35
+  store i64* %109, i64** %104, align 8, !dbg !35
+  %send10 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt, i64 0), !dbg !35
+  %110 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !36
+  %111 = load i64*, i64** %110, align 8, !dbg !36
+  store i64 %2, i64* %111, align 8, !dbg !36, !tbaa !6
+  %112 = getelementptr inbounds i64, i64* %111, i64 1, !dbg !36
+  store i64 %send10, i64* %112, align 8, !dbg !36, !tbaa !6
+  %113 = getelementptr inbounds i64, i64* %112, i64 1, !dbg !36
+  store i64* %113, i64** %110, align 8, !dbg !36
+  %send12 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.13, i64 0), !dbg !36
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 30), i64** %15, align 8, !dbg !36, !tbaa !72
+  %114 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !37
+  %115 = load i64*, i64** %114, align 8, !dbg !37
+  store i64 %2, i64* %115, align 8, !dbg !37, !tbaa !6
+  %116 = getelementptr inbounds i64, i64* %115, i64 1, !dbg !37
+  %117 = getelementptr inbounds i64, i64* %116, i64 1, !dbg !37
+  %118 = bitcast i64* %116 to <2 x i64>*, !dbg !37
+  store <2 x i64> <i64 61248954932238746, i64 133982088914272258>, <2 x i64>* %118, align 8, !dbg !37, !tbaa !6
+  %119 = getelementptr inbounds i64, i64* %117, i64 1, !dbg !37
+  store i64* %119, i64** %114, align 8, !dbg !37
+  %send14 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt.14, i64 0), !dbg !37
+  %120 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !38
+  %121 = load i64*, i64** %120, align 8, !dbg !38
+  store i64 %2, i64* %121, align 8, !dbg !38, !tbaa !6
+  %122 = getelementptr inbounds i64, i64* %121, i64 1, !dbg !38
+  store i64 %send14, i64* %122, align 8, !dbg !38, !tbaa !6
+  %123 = getelementptr inbounds i64, i64* %122, i64 1, !dbg !38
+  store i64* %123, i64** %120, align 8, !dbg !38
+  %send16 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.15, i64 0), !dbg !38
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 31), i64** %15, align 8, !dbg !38, !tbaa !72
+  %124 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !39
+  %125 = load i64*, i64** %124, align 8, !dbg !39
+  store i64 %2, i64* %125, align 8, !dbg !39, !tbaa !6
+  %126 = getelementptr inbounds i64, i64* %125, i64 1, !dbg !39
+  %127 = getelementptr inbounds i64, i64* %126, i64 1, !dbg !39
+  %128 = bitcast i64* %126 to <2 x i64>*, !dbg !39
+  store <2 x i64> <i64 180200280090161970, i64 155261597153597850>, <2 x i64>* %128, align 8, !dbg !39, !tbaa !6
+  %129 = getelementptr inbounds i64, i64* %127, i64 1, !dbg !39
+  store i64* %129, i64** %124, align 8, !dbg !39
+  %send18 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte, i64 0), !dbg !39
+  %130 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !40
+  %131 = load i64*, i64** %130, align 8, !dbg !40
+  store i64 %2, i64* %131, align 8, !dbg !40, !tbaa !6
+  %132 = getelementptr inbounds i64, i64* %131, i64 1, !dbg !40
+  store i64 %send18, i64* %132, align 8, !dbg !40, !tbaa !6
+  %133 = getelementptr inbounds i64, i64* %132, i64 1, !dbg !40
+  store i64* %133, i64** %130, align 8, !dbg !40
+  %send20 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.16, i64 0), !dbg !40
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 32), i64** %15, align 8, !dbg !40, !tbaa !72
+  %134 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !41
+  %135 = load i64*, i64** %134, align 8, !dbg !41
+  store i64 %2, i64* %135, align 8, !dbg !41, !tbaa !6
+  %136 = getelementptr inbounds i64, i64* %135, i64 1, !dbg !41
+  %137 = getelementptr inbounds i64, i64* %136, i64 1, !dbg !41
+  %138 = bitcast i64* %136 to <2 x i64>*, !dbg !41
+  store <2 x i64> <i64 57646075230342354, i64 155261597153597850>, <2 x i64>* %138, align 8, !dbg !41, !tbaa !6
+  %139 = getelementptr inbounds i64, i64* %137, i64 1, !dbg !41
+  store i64* %139, i64** %134, align 8, !dbg !41
+  %send22 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.17, i64 0), !dbg !41
+  %140 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !42
+  %141 = load i64*, i64** %140, align 8, !dbg !42
+  store i64 %2, i64* %141, align 8, !dbg !42, !tbaa !6
+  %142 = getelementptr inbounds i64, i64* %141, i64 1, !dbg !42
+  store i64 %send22, i64* %142, align 8, !dbg !42, !tbaa !6
+  %143 = getelementptr inbounds i64, i64* %142, i64 1, !dbg !42
+  store i64* %143, i64** %140, align 8, !dbg !42
+  %send24 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.18, i64 0), !dbg !42
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 33), i64** %15, align 8, !dbg !42, !tbaa !72
+  %144 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !43
+  %145 = load i64*, i64** %144, align 8, !dbg !43
+  store i64 %2, i64* %145, align 8, !dbg !43, !tbaa !6
+  %146 = getelementptr inbounds i64, i64* %145, i64 1, !dbg !43
+  %147 = getelementptr inbounds i64, i64* %146, i64 1, !dbg !43
+  %148 = bitcast i64* %146 to <2 x i64>*, !dbg !43
+  store <2 x i64> <i64 75660473739824338, i64 75660473739824338>, <2 x i64>* %148, align 8, !dbg !43, !tbaa !6
+  %149 = getelementptr inbounds i64, i64* %147, i64 1, !dbg !43
+  store i64* %149, i64** %144, align 8, !dbg !43
+  %send26 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.19, i64 0), !dbg !43
+  %150 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !44
+  %151 = load i64*, i64** %150, align 8, !dbg !44
+  store i64 %2, i64* %151, align 8, !dbg !44, !tbaa !6
+  %152 = getelementptr inbounds i64, i64* %151, i64 1, !dbg !44
+  store i64 %send26, i64* %152, align 8, !dbg !44, !tbaa !6
+  %153 = getelementptr inbounds i64, i64* %152, i64 1, !dbg !44
+  store i64* %153, i64** %150, align 8, !dbg !44
+  %send28 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.20, i64 0), !dbg !44
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 36), i64** %15, align 8, !dbg !44, !tbaa !72
+  %154 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !45
+  %155 = load i64*, i64** %154, align 8, !dbg !45
+  store i64 %2, i64* %155, align 8, !dbg !45, !tbaa !6
+  %156 = getelementptr inbounds i64, i64* %155, i64 1, !dbg !45
+  %157 = getelementptr inbounds i64, i64* %156, i64 1, !dbg !45
+  %158 = bitcast i64* %156 to <2 x i64>*, !dbg !45
+  store <2 x i64> <i64 45035996273704962, i64 17>, <2 x i64>* %158, align 8, !dbg !45, !tbaa !6
+  %159 = getelementptr inbounds i64, i64* %157, i64 1, !dbg !45
+  store i64* %159, i64** %154, align 8, !dbg !45
+  %send30 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus.21, i64 0), !dbg !45
+  %160 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !46
+  %161 = load i64*, i64** %160, align 8, !dbg !46
+  store i64 %2, i64* %161, align 8, !dbg !46, !tbaa !6
+  %162 = getelementptr inbounds i64, i64* %161, i64 1, !dbg !46
+  store i64 %send30, i64* %162, align 8, !dbg !46, !tbaa !6
+  %163 = getelementptr inbounds i64, i64* %162, i64 1, !dbg !46
+  store i64* %163, i64** %160, align 8, !dbg !46
+  %send32 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.22, i64 0), !dbg !46
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 37), i64** %15, align 8, !dbg !46, !tbaa !72
+  %rubyStr_8.9.i = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 7), align 8, !dbg !47, !invariant.load !5
+  %164 = load i64, i64* @rb_mKernel, align 8, !dbg !47
+  %165 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !47
+  %166 = load i64*, i64** %165, align 8, !dbg !47
+  store i64 %164, i64* %166, align 8, !dbg !47, !tbaa !6
+  %167 = getelementptr inbounds i64, i64* %166, i64 1, !dbg !47
+  store i64 %rubyStr_8.9.i, i64* %167, align 8, !dbg !47, !tbaa !6
+  %168 = getelementptr inbounds i64, i64* %167, i64 1, !dbg !47
+  store i64* %168, i64** %165, align 8, !dbg !47
+  %send34 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational, i64 0), !dbg !47
+  %169 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !48
+  %170 = load i64*, i64** %169, align 8, !dbg !48
+  store i64 %2, i64* %170, align 8, !dbg !48, !tbaa !6
+  %171 = getelementptr inbounds i64, i64* %170, i64 1, !dbg !48
+  store i64 36028797018963970, i64* %171, align 8, !dbg !48, !tbaa !6
+  %172 = getelementptr inbounds i64, i64* %171, i64 1, !dbg !48
+  store i64 %send34, i64* %172, align 8, !dbg !48, !tbaa !6
+  %173 = getelementptr inbounds i64, i64* %172, i64 1, !dbg !48
+  store i64* %173, i64** %169, align 8, !dbg !48
+  %send36 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus.23, i64 0), !dbg !48
+  %174 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !49
+  %175 = load i64*, i64** %174, align 8, !dbg !49
+  store i64 %2, i64* %175, align 8, !dbg !49, !tbaa !6
+  %176 = getelementptr inbounds i64, i64* %175, i64 1, !dbg !49
+  store i64 %send36, i64* %176, align 8, !dbg !49, !tbaa !6
+  %177 = getelementptr inbounds i64, i64* %176, i64 1, !dbg !49
+  store i64* %177, i64** %174, align 8, !dbg !49
+  %send38 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.24, i64 0), !dbg !49
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 38), i64** %15, align 8, !dbg !49, !tbaa !72
+  %rubyStr_5.i = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 8), align 8, !dbg !50, !invariant.load !5
+  %178 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !50
+  %179 = load i64*, i64** %178, align 8, !dbg !50
+  store i64 %164, i64* %179, align 8, !dbg !50, !tbaa !6
+  %180 = getelementptr inbounds i64, i64* %179, i64 1, !dbg !50
+  store i64 1, i64* %180, align 8, !dbg !50, !tbaa !6
+  %181 = getelementptr inbounds i64, i64* %180, i64 1, !dbg !50
+  store i64 %rubyStr_5.i, i64* %181, align 8, !dbg !50, !tbaa !6
+  %182 = getelementptr inbounds i64, i64* %181, i64 1, !dbg !50
+  store i64* %182, i64** %178, align 8, !dbg !50
+  %send40 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Complex, i64 0), !dbg !50
+  %183 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !51
+  %184 = load i64*, i64** %183, align 8, !dbg !51
+  store i64 %2, i64* %184, align 8, !dbg !51, !tbaa !6
+  %185 = getelementptr inbounds i64, i64* %184, i64 1, !dbg !51
+  store i64 36028797018963970, i64* %185, align 8, !dbg !51, !tbaa !6
+  %186 = getelementptr inbounds i64, i64* %185, i64 1, !dbg !51
+  store i64 %send40, i64* %186, align 8, !dbg !51, !tbaa !6
+  %187 = getelementptr inbounds i64, i64* %186, i64 1, !dbg !51
+  store i64* %187, i64** %183, align 8, !dbg !51
+  %send42 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_plus.25, i64 0), !dbg !51
+  %188 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !52
+  %189 = load i64*, i64** %188, align 8, !dbg !52
+  store i64 %2, i64* %189, align 8, !dbg !52, !tbaa !6
+  %190 = getelementptr inbounds i64, i64* %189, i64 1, !dbg !52
+  store i64 %send42, i64* %190, align 8, !dbg !52, !tbaa !6
+  %191 = getelementptr inbounds i64, i64* %190, i64 1, !dbg !52
+  store i64* %191, i64** %188, align 8, !dbg !52
+  %send44 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.26, i64 0), !dbg !52
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 40), i64** %15, align 8, !dbg !52, !tbaa !72
+  %192 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !53
+  %193 = load i64*, i64** %192, align 8, !dbg !53
+  store i64 %2, i64* %193, align 8, !dbg !53, !tbaa !6
+  %194 = getelementptr inbounds i64, i64* %193, i64 1, !dbg !53
+  %195 = getelementptr inbounds i64, i64* %194, i64 1, !dbg !53
+  %196 = bitcast i64* %194 to <2 x i64>*, !dbg !53
+  store <2 x i64> <i64 199678348478539370, i64 7>, <2 x i64>* %196, align 8, !dbg !53, !tbaa !6
+  %197 = getelementptr inbounds i64, i64* %195, i64 1, !dbg !53
+  store i64* %197, i64** %192, align 8, !dbg !53
+  %send46 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus.27, i64 0), !dbg !53
+  %198 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !54
+  %199 = load i64*, i64** %198, align 8, !dbg !54
+  store i64 %2, i64* %199, align 8, !dbg !54, !tbaa !6
+  %200 = getelementptr inbounds i64, i64* %199, i64 1, !dbg !54
+  store i64 %send46, i64* %200, align 8, !dbg !54, !tbaa !6
+  %201 = getelementptr inbounds i64, i64* %200, i64 1, !dbg !54
+  store i64* %201, i64** %198, align 8, !dbg !54
+  %send48 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.28, i64 0), !dbg !54
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 41), i64** %15, align 8, !dbg !54, !tbaa !72
+  %rubyStr_15.4.i = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 9), align 8, !dbg !55, !invariant.load !5
+  %202 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !55
+  %203 = load i64*, i64** %202, align 8, !dbg !55
+  store i64 %164, i64* %203, align 8, !dbg !55, !tbaa !6
+  %204 = getelementptr inbounds i64, i64* %203, i64 1, !dbg !55
+  store i64 %rubyStr_15.4.i, i64* %204, align 8, !dbg !55, !tbaa !6
+  %205 = getelementptr inbounds i64, i64* %204, i64 1, !dbg !55
+  store i64* %205, i64** %202, align 8, !dbg !55
+  %send50 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational.29, i64 0), !dbg !55
+  %206 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !56
+  %207 = load i64*, i64** %206, align 8, !dbg !56
+  store i64 %2, i64* %207, align 8, !dbg !56, !tbaa !6
+  %208 = getelementptr inbounds i64, i64* %207, i64 1, !dbg !56
+  store i64 199622053483197234, i64* %208, align 8, !dbg !56, !tbaa !6
+  %209 = getelementptr inbounds i64, i64* %208, i64 1, !dbg !56
+  store i64 %send50, i64* %209, align 8, !dbg !56, !tbaa !6
+  %210 = getelementptr inbounds i64, i64* %209, i64 1, !dbg !56
+  store i64* %210, i64** %206, align 8, !dbg !56
+  %send52 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus.30, i64 0), !dbg !56
+  %211 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !57
+  %212 = load i64*, i64** %211, align 8, !dbg !57
+  store i64 %2, i64* %212, align 8, !dbg !57, !tbaa !6
+  %213 = getelementptr inbounds i64, i64* %212, i64 1, !dbg !57
+  store i64 %send52, i64* %213, align 8, !dbg !57, !tbaa !6
+  %214 = getelementptr inbounds i64, i64* %213, i64 1, !dbg !57
+  store i64* %214, i64** %211, align 8, !dbg !57
+  %send54 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.31, i64 0), !dbg !57
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 42), i64** %15, align 8, !dbg !57, !tbaa !72
+  %rubyStr_18.i = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 10), align 8, !dbg !58, !invariant.load !5
+  %215 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !58
+  %216 = load i64*, i64** %215, align 8, !dbg !58
+  store i64 %164, i64* %216, align 8, !dbg !58, !tbaa !6
+  %217 = getelementptr inbounds i64, i64* %216, i64 1, !dbg !58
+  store i64 1, i64* %217, align 8, !dbg !58, !tbaa !6
+  %218 = getelementptr inbounds i64, i64* %217, i64 1, !dbg !58
+  store i64 %rubyStr_18.i, i64* %218, align 8, !dbg !58, !tbaa !6
+  %219 = getelementptr inbounds i64, i64* %218, i64 1, !dbg !58
+  store i64* %219, i64** %215, align 8, !dbg !58
+  %send56 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Complex.32, i64 0), !dbg !58
+  %220 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !59
+  %221 = load i64*, i64** %220, align 8, !dbg !59
+  store i64 %2, i64* %221, align 8, !dbg !59, !tbaa !6
+  %222 = getelementptr inbounds i64, i64* %221, i64 1, !dbg !59
+  store i64 199565758487855106, i64* %222, align 8, !dbg !59, !tbaa !6
+  %223 = getelementptr inbounds i64, i64* %222, i64 1, !dbg !59
+  store i64 %send56, i64* %223, align 8, !dbg !59, !tbaa !6
+  %224 = getelementptr inbounds i64, i64* %223, i64 1, !dbg !59
+  store i64* %224, i64** %220, align 8, !dbg !59
+  %send58 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_minus.33, i64 0), !dbg !59
+  %225 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !60
+  %226 = load i64*, i64** %225, align 8, !dbg !60
+  store i64 %2, i64* %226, align 8, !dbg !60, !tbaa !6
+  %227 = getelementptr inbounds i64, i64* %226, i64 1, !dbg !60
+  store i64 %send58, i64* %227, align 8, !dbg !60, !tbaa !6
+  %228 = getelementptr inbounds i64, i64* %227, i64 1, !dbg !60
+  store i64* %228, i64** %225, align 8, !dbg !60
+  %send60 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.34, i64 0), !dbg !60
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 44), i64** %15, align 8, !dbg !60, !tbaa !72
+  %229 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !61
+  %230 = load i64*, i64** %229, align 8, !dbg !61
+  store i64 %2, i64* %230, align 8, !dbg !61, !tbaa !6
+  %231 = getelementptr inbounds i64, i64* %230, i64 1, !dbg !61
+  %232 = getelementptr inbounds i64, i64* %231, i64 1, !dbg !61
+  %233 = bitcast i64* %231 to <2 x i64>*, !dbg !61
+  store <2 x i64> <i64 113040350646999450, i64 13>, <2 x i64>* %233, align 8, !dbg !61, !tbaa !6
+  %234 = getelementptr inbounds i64, i64* %232, i64 1, !dbg !61
+  store i64* %234, i64** %229, align 8, !dbg !61
+  %send62 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt.35, i64 0), !dbg !61
+  %235 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !62
+  %236 = load i64*, i64** %235, align 8, !dbg !62
+  store i64 %2, i64* %236, align 8, !dbg !62, !tbaa !6
+  %237 = getelementptr inbounds i64, i64* %236, i64 1, !dbg !62
+  store i64 %send62, i64* %237, align 8, !dbg !62, !tbaa !6
+  %238 = getelementptr inbounds i64, i64* %237, i64 1, !dbg !62
+  store i64* %238, i64** %235, align 8, !dbg !62
+  %send64 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.36, i64 0), !dbg !62
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 45), i64** %15, align 8, !dbg !62, !tbaa !72
+  %rubyStr_25.4.i = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 11), align 8, !dbg !63, !invariant.load !5
+  %239 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !63
+  %240 = load i64*, i64** %239, align 8, !dbg !63
+  store i64 %164, i64* %240, align 8, !dbg !63, !tbaa !6
+  %241 = getelementptr inbounds i64, i64* %240, i64 1, !dbg !63
+  store i64 %rubyStr_25.4.i, i64* %241, align 8, !dbg !63, !tbaa !6
+  %242 = getelementptr inbounds i64, i64* %241, i64 1, !dbg !63
+  store i64* %242, i64** %239, align 8, !dbg !63
+  %send66 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational.37, i64 0), !dbg !63
+  %243 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !64
+  %244 = load i64*, i64** %243, align 8, !dbg !64
+  store i64 %2, i64* %244, align 8, !dbg !64, !tbaa !6
+  %245 = getelementptr inbounds i64, i64* %244, i64 1, !dbg !64
+  store i64 113040350646999450, i64* %245, align 8, !dbg !64, !tbaa !6
+  %246 = getelementptr inbounds i64, i64* %245, i64 1, !dbg !64
+  store i64 %send66, i64* %246, align 8, !dbg !64, !tbaa !6
+  %247 = getelementptr inbounds i64, i64* %246, i64 1, !dbg !64
+  store i64* %247, i64** %243, align 8, !dbg !64
+  %send68 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lt.38, i64 0), !dbg !64
+  %248 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !65
+  %249 = load i64*, i64** %248, align 8, !dbg !65
+  store i64 %2, i64* %249, align 8, !dbg !65, !tbaa !6
+  %250 = getelementptr inbounds i64, i64* %249, i64 1, !dbg !65
+  store i64 %send68, i64* %250, align 8, !dbg !65, !tbaa !6
+  %251 = getelementptr inbounds i64, i64* %250, i64 1, !dbg !65
+  store i64* %251, i64** %248, align 8, !dbg !65
+  %send70 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.39, i64 0), !dbg !65
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 47), i64** %15, align 8, !dbg !65, !tbaa !72
+  %252 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !66
+  %253 = load i64*, i64** %252, align 8, !dbg !66
+  store i64 %2, i64* %253, align 8, !dbg !66, !tbaa !6
+  %254 = getelementptr inbounds i64, i64* %253, i64 1, !dbg !66
+  %255 = getelementptr inbounds i64, i64* %254, i64 1, !dbg !66
+  %256 = bitcast i64* %254 to <2 x i64>*, !dbg !66
+  store <2 x i64> <i64 113040350646999450, i64 41>, <2 x i64>* %256, align 8, !dbg !66, !tbaa !6
+  %257 = getelementptr inbounds i64, i64* %255, i64 1, !dbg !66
+  store i64* %257, i64** %252, align 8, !dbg !66
+  %send72 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.40, i64 0), !dbg !66
+  %258 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !67
+  %259 = load i64*, i64** %258, align 8, !dbg !67
+  store i64 %2, i64* %259, align 8, !dbg !67, !tbaa !6
+  %260 = getelementptr inbounds i64, i64* %259, i64 1, !dbg !67
+  store i64 %send72, i64* %260, align 8, !dbg !67, !tbaa !6
+  %261 = getelementptr inbounds i64, i64* %260, i64 1, !dbg !67
+  store i64* %261, i64** %258, align 8, !dbg !67
+  %send74 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.41, i64 0), !dbg !67
+  store i64* getelementptr inbounds ([49 x i64], [49 x i64]* @iseqEncodedArray, i64 0, i64 48), i64** %15, align 8, !dbg !67, !tbaa !72
+  %rubyStr_5.923.i = load i64, i64* getelementptr inbounds ([13 x i64], [13 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 12), align 8, !dbg !68, !invariant.load !5
+  %262 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !68
+  %263 = load i64*, i64** %262, align 8, !dbg !68
+  store i64 %164, i64* %263, align 8, !dbg !68, !tbaa !6
+  %264 = getelementptr inbounds i64, i64* %263, i64 1, !dbg !68
+  store i64 %rubyStr_5.923.i, i64* %264, align 8, !dbg !68, !tbaa !6
+  %265 = getelementptr inbounds i64, i64* %264, i64 1, !dbg !68
+  store i64* %265, i64** %262, align 8, !dbg !68
+  %send76 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_Rational.42, i64 0), !dbg !68
+  %266 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !69
+  %267 = load i64*, i64** %266, align 8, !dbg !69
+  store i64 %2, i64* %267, align 8, !dbg !69, !tbaa !6
+  %268 = getelementptr inbounds i64, i64* %267, i64 1, !dbg !69
+  store i64 113040350646999450, i64* %268, align 8, !dbg !69, !tbaa !6
+  %269 = getelementptr inbounds i64, i64* %268, i64 1, !dbg !69
+  store i64 %send76, i64* %269, align 8, !dbg !69, !tbaa !6
+  %270 = getelementptr inbounds i64, i64* %269, i64 1, !dbg !69
+  store i64* %270, i64** %266, align 8, !dbg !69
+  %send78 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_lte.43, i64 0), !dbg !69
+  %271 = getelementptr inbounds %struct.rb_control_frame_struct, %struct.rb_control_frame_struct* %5, i64 0, i32 1, !dbg !70
+  %272 = load i64*, i64** %271, align 8, !dbg !70
+  store i64 %2, i64* %272, align 8, !dbg !70, !tbaa !6
+  %273 = getelementptr inbounds i64, i64* %272, i64 1, !dbg !70
+  store i64 %send78, i64* %273, align 8, !dbg !70, !tbaa !6
+  %274 = getelementptr inbounds i64, i64* %273, i64 1, !dbg !70
+  store i64* %274, i64** %271, align 8, !dbg !70
+  %send80 = tail call i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache* @ic_p.44, i64 0), !dbg !70
+  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %6)
+  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %7)
+  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %8)
+  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %9)
   ret void
 }
 
 ; Function Attrs: inaccessiblememonly nofree nosync nounwind willreturn
 declare void @llvm.experimental.noalias.scope.decl(metadata) #10
 
+; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #11
+
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #5
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #5
-
-; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #11
 
 ; Function Attrs: cold minsize noreturn nounwind sspreq uwtable
 define internal fastcc void @"func_Object#2lt.cold.1"(i64 %0) unnamed_addr #12 !dbg !147 {
@@ -1532,7 +1593,7 @@ declare void @llvm.assume(i1 noundef) #13
 define linkonce void @const_recompute_T() local_unnamed_addr #8 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 206), i64 1)
   store i64 %1, i64* @guarded_const_T, align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !65
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !118
   store i64 %2, i64* @guard_epoch_T, align 8
   ret void
 }
@@ -1541,7 +1602,7 @@ define linkonce void @const_recompute_T() local_unnamed_addr #8 {
 define linkonce void @"const_recompute_T::Boolean"() local_unnamed_addr #8 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 120), i64 10)
   store i64 %1, i64* @"guarded_const_T::Boolean", align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !65
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !118
   store i64 %2, i64* @"guard_epoch_T::Boolean", align 8
   ret void
 }
@@ -1550,7 +1611,7 @@ define linkonce void @"const_recompute_T::Boolean"() local_unnamed_addr #8 {
 define linkonce void @"const_recompute_T::Sig"() local_unnamed_addr #8 {
   %1 = tail call i64 @sorbet_getConstant(i8* getelementptr inbounds ([309 x i8], [309 x i8]* @sorbet_moduleStringTable, i64 0, i64 223), i64 6)
   store i64 %1, i64* @"guarded_const_T::Sig", align 8
-  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !65
+  %2 = load i64, i64* @ruby_vm_global_constant_state, align 8, !tbaa !118
   store i64 %2, i64* @"guard_epoch_T::Sig", align 8
   ret void
 }
@@ -1573,8 +1634,7 @@ attributes #14 = { noreturn nounwind }
 attributes #15 = { noreturn }
 attributes #16 = { noinline }
 attributes #17 = { nounwind }
-attributes #18 = { nounwind readnone willreturn }
-attributes #19 = { nounwind allocsize(0,1) }
+attributes #18 = { nounwind allocsize(0,1) }
 
 !llvm.module.flags = !{!0, !1, !2}
 !llvm.dbg.cu = !{!3}
@@ -1589,143 +1649,143 @@ attributes #19 = { nounwind allocsize(0,1) }
 !7 = !{!"long", !8, i64 0}
 !8 = !{!"omnipotent char", !9, i64 0}
 !9 = !{!"Simple C/C++ TBAA"}
-!10 = distinct !DISubprogram(name: "Object#plus", linkageName: "func_Object#4plus", scope: null, file: !4, line: 8, type: !11, scopeLine: 8, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!11 = !DISubroutineType(types: !12)
-!12 = !{!13}
-!13 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
-!14 = !{!15, !15, i64 0}
-!15 = !{!"any pointer", !8, i64 0}
-!16 = !DILocation(line: 8, column: 1, scope: !10)
-!17 = !{!"branch_weights", i32 4001, i32 4000000}
-!18 = !DILocation(line: 8, column: 10, scope: !10)
-!19 = !{!20, !7, i64 0}
-!20 = !{!"RBasic", !7, i64 0, !7, i64 8}
-!21 = !{!"branch_weights", i32 2000, i32 1}
-!22 = !DILocation(line: 8, column: 13, scope: !10)
-!23 = !DILocation(line: 9, column: 3, scope: !10)
-!24 = !{!25}
-!25 = distinct !{!25, !26, !"sorbet_int_rb_float_plus: argument 0"}
-!26 = distinct !{!26, !"sorbet_int_rb_float_plus"}
-!27 = !{!28, !29, i64 40}
-!28 = !{!"rb_execution_context_struct", !15, i64 0, !7, i64 8, !15, i64 16, !15, i64 24, !15, i64 32, !29, i64 40, !29, i64 44, !15, i64 48, !15, i64 56, !15, i64 64, !7, i64 72, !7, i64 80, !15, i64 88, !7, i64 96, !15, i64 104, !15, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !30, i64 152}
-!29 = !{!"int", !8, i64 0}
-!30 = !{!"", !15, i64 0, !15, i64 8, !7, i64 16, !8, i64 24}
-!31 = !{!28, !29, i64 44}
-!32 = !{!28, !15, i64 56}
-!33 = distinct !DISubprogram(name: "Object#minus", linkageName: "func_Object#5minus", scope: null, file: !4, line: 13, type: !11, scopeLine: 13, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!34 = !DILocation(line: 13, column: 1, scope: !33)
-!35 = !DILocation(line: 13, column: 11, scope: !33)
-!36 = !DILocation(line: 13, column: 14, scope: !33)
-!37 = !DILocation(line: 14, column: 3, scope: !33)
-!38 = distinct !DISubprogram(name: "Object#lt", linkageName: "func_Object#2lt", scope: null, file: !4, line: 18, type: !11, scopeLine: 18, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!39 = !DILocation(line: 18, column: 1, scope: !38)
-!40 = !DILocation(line: 18, column: 8, scope: !38)
-!41 = !DILocation(line: 18, column: 11, scope: !38)
-!42 = !DILocation(line: 19, column: 3, scope: !38)
-!43 = !{!44}
-!44 = distinct !{!44, !45, !"sorbet_int_flo_lt: argument 0"}
-!45 = distinct !{!45, !"sorbet_int_flo_lt"}
-!46 = !{!"branch_weights", i32 1, i32 2001, i32 2000}
-!47 = !DILocation(line: 0, scope: !38)
-!48 = distinct !DISubprogram(name: "Object#lte", linkageName: "func_Object#3lte", scope: null, file: !4, line: 23, type: !11, scopeLine: 23, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!49 = !DILocation(line: 23, column: 1, scope: !48)
-!50 = !DILocation(line: 23, column: 9, scope: !48)
-!51 = !DILocation(line: 23, column: 12, scope: !48)
-!52 = !DILocation(line: 24, column: 3, scope: !48)
-!53 = !{!54}
-!54 = distinct !{!54, !55, !"sorbet_int_flo_le: argument 0"}
-!55 = distinct !{!55, !"sorbet_int_flo_le"}
-!56 = !DILocation(line: 0, scope: !48)
-!57 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$153$block_1", scope: !58, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!58 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$153", scope: null, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!59 = !{!28, !15, i64 16}
-!60 = !{!61, !7, i64 24}
-!61 = !{!"rb_control_frame_struct", !15, i64 0, !15, i64 8, !15, i64 16, !7, i64 24, !15, i64 32, !15, i64 40, !15, i64 48}
-!62 = !{!61, !15, i64 16}
-!63 = !{!61, !15, i64 32}
-!64 = !DILocation(line: 7, column: 26, scope: !57)
-!65 = !{!66, !66, i64 0}
-!66 = !{!"long long", !8, i64 0}
-!67 = !{!"branch_weights", i32 1, i32 10000}
-!68 = !DILocation(line: 7, column: 6, scope: !57)
-!69 = !DILocation(line: 7, column: 45, scope: !57)
-!70 = !DILocation(line: 7, column: 1, scope: !57)
-!71 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$153$block_2", scope: !58, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!72 = !DILocation(line: 12, column: 26, scope: !71)
-!73 = !DILocation(line: 12, column: 6, scope: !71)
-!74 = !DILocation(line: 12, column: 45, scope: !71)
-!75 = !DILocation(line: 12, column: 1, scope: !71)
-!76 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$153$block_3", scope: !58, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!77 = !DILocation(line: 17, column: 26, scope: !76)
-!78 = !DILocation(line: 17, column: 6, scope: !76)
-!79 = !DILocation(line: 17, column: 1, scope: !76)
-!80 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$153$block_4", scope: !58, file: !4, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
-!81 = !DILocation(line: 22, column: 26, scope: !80)
-!82 = !DILocation(line: 22, column: 6, scope: !80)
-!83 = !DILocation(line: 22, column: 1, scope: !80)
-!84 = !DILocation(line: 8, column: 1, scope: !58)
-!85 = !DILocation(line: 13, column: 1, scope: !58)
-!86 = !DILocation(line: 18, column: 1, scope: !58)
-!87 = !DILocation(line: 23, column: 1, scope: !58)
-!88 = !DILocation(line: 5, column: 1, scope: !58)
-!89 = !DILocation(line: 27, column: 3, scope: !58)
-!90 = !DILocation(line: 27, column: 1, scope: !58)
-!91 = !DILocation(line: 28, column: 3, scope: !58)
-!92 = !DILocation(line: 28, column: 1, scope: !58)
-!93 = !DILocation(line: 29, column: 3, scope: !58)
-!94 = !DILocation(line: 29, column: 1, scope: !58)
-!95 = !DILocation(line: 30, column: 3, scope: !58)
-!96 = !DILocation(line: 30, column: 1, scope: !58)
-!97 = !DILocation(line: 31, column: 3, scope: !58)
-!98 = !DILocation(line: 31, column: 1, scope: !58)
-!99 = !DILocation(line: 32, column: 3, scope: !58)
-!100 = !DILocation(line: 32, column: 1, scope: !58)
-!101 = !DILocation(line: 33, column: 3, scope: !58)
-!102 = !DILocation(line: 33, column: 1, scope: !58)
-!103 = !DILocation(line: 36, column: 3, scope: !58)
-!104 = !DILocation(line: 36, column: 1, scope: !58)
-!105 = !DILocation(line: 37, column: 13, scope: !58)
-!106 = !DILocation(line: 37, column: 3, scope: !58)
-!107 = !DILocation(line: 37, column: 1, scope: !58)
-!108 = !DILocation(line: 38, column: 13, scope: !58)
-!109 = !DILocation(line: 38, column: 3, scope: !58)
-!110 = !DILocation(line: 38, column: 1, scope: !58)
-!111 = !DILocation(line: 40, column: 3, scope: !58)
-!112 = !DILocation(line: 40, column: 1, scope: !58)
-!113 = !DILocation(line: 41, column: 15, scope: !58)
-!114 = !DILocation(line: 41, column: 3, scope: !58)
-!115 = !DILocation(line: 41, column: 1, scope: !58)
-!116 = !DILocation(line: 42, column: 15, scope: !58)
-!117 = !DILocation(line: 42, column: 3, scope: !58)
-!118 = !DILocation(line: 42, column: 1, scope: !58)
-!119 = !DILocation(line: 44, column: 3, scope: !58)
-!120 = !DILocation(line: 44, column: 1, scope: !58)
-!121 = !DILocation(line: 45, column: 12, scope: !58)
-!122 = !DILocation(line: 45, column: 3, scope: !58)
-!123 = !DILocation(line: 45, column: 1, scope: !58)
-!124 = !DILocation(line: 47, column: 3, scope: !58)
-!125 = !DILocation(line: 47, column: 1, scope: !58)
-!126 = !DILocation(line: 48, column: 13, scope: !58)
-!127 = !DILocation(line: 48, column: 3, scope: !58)
-!128 = !DILocation(line: 48, column: 1, scope: !58)
+!10 = !DILocation(line: 14, column: 3, scope: !11)
+!11 = distinct !DISubprogram(name: "Object#minus", linkageName: "func_Object#5minus", scope: null, file: !4, line: 13, type: !12, scopeLine: 13, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!12 = !DISubroutineType(types: !13)
+!13 = !{!14}
+!14 = !DIBasicType(name: "VALUE", size: 64, encoding: DW_ATE_signed)
+!15 = !DILocation(line: 7, column: 26, scope: !16)
+!16 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$153$block_1", scope: !17, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!17 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$153", scope: null, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!18 = !DILocation(line: 7, column: 6, scope: !16)
+!19 = !DILocation(line: 7, column: 45, scope: !16)
+!20 = !DILocation(line: 12, column: 26, scope: !21)
+!21 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$153$block_2", scope: !17, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!22 = !DILocation(line: 12, column: 6, scope: !21)
+!23 = !DILocation(line: 12, column: 45, scope: !21)
+!24 = !DILocation(line: 17, column: 26, scope: !25)
+!25 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$153$block_3", scope: !17, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!26 = !DILocation(line: 17, column: 6, scope: !25)
+!27 = !DILocation(line: 22, column: 26, scope: !28)
+!28 = distinct !DISubprogram(name: "<root>.<static-init>", linkageName: "func_<root>.17<static-init>$153$block_4", scope: !17, file: !4, line: 5, type: !12, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!29 = !DILocation(line: 22, column: 6, scope: !28)
+!30 = !DILocation(line: 5, column: 1, scope: !17)
+!31 = !DILocation(line: 27, column: 3, scope: !17)
+!32 = !DILocation(line: 27, column: 1, scope: !17)
+!33 = !DILocation(line: 28, column: 3, scope: !17)
+!34 = !DILocation(line: 28, column: 1, scope: !17)
+!35 = !DILocation(line: 29, column: 3, scope: !17)
+!36 = !DILocation(line: 29, column: 1, scope: !17)
+!37 = !DILocation(line: 30, column: 3, scope: !17)
+!38 = !DILocation(line: 30, column: 1, scope: !17)
+!39 = !DILocation(line: 31, column: 3, scope: !17)
+!40 = !DILocation(line: 31, column: 1, scope: !17)
+!41 = !DILocation(line: 32, column: 3, scope: !17)
+!42 = !DILocation(line: 32, column: 1, scope: !17)
+!43 = !DILocation(line: 33, column: 3, scope: !17)
+!44 = !DILocation(line: 33, column: 1, scope: !17)
+!45 = !DILocation(line: 36, column: 3, scope: !17)
+!46 = !DILocation(line: 36, column: 1, scope: !17)
+!47 = !DILocation(line: 37, column: 13, scope: !17)
+!48 = !DILocation(line: 37, column: 3, scope: !17)
+!49 = !DILocation(line: 37, column: 1, scope: !17)
+!50 = !DILocation(line: 38, column: 13, scope: !17)
+!51 = !DILocation(line: 38, column: 3, scope: !17)
+!52 = !DILocation(line: 38, column: 1, scope: !17)
+!53 = !DILocation(line: 40, column: 3, scope: !17)
+!54 = !DILocation(line: 40, column: 1, scope: !17)
+!55 = !DILocation(line: 41, column: 15, scope: !17)
+!56 = !DILocation(line: 41, column: 3, scope: !17)
+!57 = !DILocation(line: 41, column: 1, scope: !17)
+!58 = !DILocation(line: 42, column: 15, scope: !17)
+!59 = !DILocation(line: 42, column: 3, scope: !17)
+!60 = !DILocation(line: 42, column: 1, scope: !17)
+!61 = !DILocation(line: 44, column: 3, scope: !17)
+!62 = !DILocation(line: 44, column: 1, scope: !17)
+!63 = !DILocation(line: 45, column: 12, scope: !17)
+!64 = !DILocation(line: 45, column: 3, scope: !17)
+!65 = !DILocation(line: 45, column: 1, scope: !17)
+!66 = !DILocation(line: 47, column: 3, scope: !17)
+!67 = !DILocation(line: 47, column: 1, scope: !17)
+!68 = !DILocation(line: 48, column: 13, scope: !17)
+!69 = !DILocation(line: 48, column: 3, scope: !17)
+!70 = !DILocation(line: 48, column: 1, scope: !17)
+!71 = distinct !DISubprogram(name: "Object#plus", linkageName: "func_Object#4plus", scope: null, file: !4, line: 8, type: !12, scopeLine: 8, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!72 = !{!73, !73, i64 0}
+!73 = !{!"any pointer", !8, i64 0}
+!74 = !DILocation(line: 8, column: 1, scope: !71)
+!75 = !{!"branch_weights", i32 4001, i32 4000000}
+!76 = !DILocation(line: 8, column: 10, scope: !71)
+!77 = !{!78, !7, i64 0}
+!78 = !{!"RBasic", !7, i64 0, !7, i64 8}
+!79 = !{!"branch_weights", i32 2000, i32 1}
+!80 = !DILocation(line: 8, column: 13, scope: !71)
+!81 = !DILocation(line: 9, column: 3, scope: !71)
+!82 = !{!83}
+!83 = distinct !{!83, !84, !"sorbet_int_rb_float_plus: argument 0"}
+!84 = distinct !{!84, !"sorbet_int_rb_float_plus"}
+!85 = !{!86, !87, i64 40}
+!86 = !{!"rb_execution_context_struct", !73, i64 0, !7, i64 8, !73, i64 16, !73, i64 24, !73, i64 32, !87, i64 40, !87, i64 44, !73, i64 48, !73, i64 56, !73, i64 64, !7, i64 72, !7, i64 80, !73, i64 88, !7, i64 96, !73, i64 104, !73, i64 112, !7, i64 120, !7, i64 128, !8, i64 136, !8, i64 137, !7, i64 144, !88, i64 152}
+!87 = !{!"int", !8, i64 0}
+!88 = !{!"", !73, i64 0, !73, i64 8, !7, i64 16, !8, i64 24}
+!89 = !{!86, !87, i64 44}
+!90 = !{!86, !73, i64 56}
+!91 = !DILocation(line: 13, column: 1, scope: !11)
+!92 = !DILocation(line: 13, column: 11, scope: !11)
+!93 = !DILocation(line: 13, column: 14, scope: !11)
+!94 = distinct !DISubprogram(name: "Object#lt", linkageName: "func_Object#2lt", scope: null, file: !4, line: 18, type: !12, scopeLine: 18, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!95 = !DILocation(line: 18, column: 1, scope: !94)
+!96 = !DILocation(line: 18, column: 8, scope: !94)
+!97 = !DILocation(line: 18, column: 11, scope: !94)
+!98 = !DILocation(line: 19, column: 3, scope: !94)
+!99 = !{!100}
+!100 = distinct !{!100, !101, !"sorbet_int_flo_lt: argument 0"}
+!101 = distinct !{!101, !"sorbet_int_flo_lt"}
+!102 = !{!"branch_weights", i32 1, i32 2001, i32 2000}
+!103 = !DILocation(line: 0, scope: !94)
+!104 = distinct !DISubprogram(name: "Object#lte", linkageName: "func_Object#3lte", scope: null, file: !4, line: 23, type: !12, scopeLine: 23, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !5)
+!105 = !DILocation(line: 23, column: 1, scope: !104)
+!106 = !DILocation(line: 23, column: 9, scope: !104)
+!107 = !DILocation(line: 23, column: 12, scope: !104)
+!108 = !DILocation(line: 24, column: 3, scope: !104)
+!109 = !{!110}
+!110 = distinct !{!110, !111, !"sorbet_int_flo_le: argument 0"}
+!111 = distinct !{!111, !"sorbet_int_flo_le"}
+!112 = !DILocation(line: 0, scope: !104)
+!113 = !{!86, !73, i64 16}
+!114 = !{!115, !7, i64 24}
+!115 = !{!"rb_control_frame_struct", !73, i64 0, !73, i64 8, !73, i64 16, !7, i64 24, !73, i64 32, !73, i64 40, !73, i64 48}
+!116 = !{!115, !73, i64 16}
+!117 = !{!115, !73, i64 32}
+!118 = !{!119, !119, i64 0}
+!119 = !{!"long long", !8, i64 0}
+!120 = !{!"branch_weights", i32 1, i32 10000}
+!121 = !DILocation(line: 7, column: 1, scope: !16)
+!122 = !DILocation(line: 12, column: 1, scope: !21)
+!123 = !DILocation(line: 17, column: 1, scope: !25)
+!124 = !DILocation(line: 22, column: 1, scope: !28)
+!125 = !DILocation(line: 8, column: 1, scope: !17)
+!126 = !DILocation(line: 13, column: 1, scope: !17)
+!127 = !DILocation(line: 18, column: 1, scope: !17)
+!128 = !DILocation(line: 23, column: 1, scope: !17)
 !129 = !{!130, !7, i64 400}
-!130 = !{!"rb_vm_struct", !7, i64 0, !131, i64 8, !15, i64 192, !15, i64 200, !15, i64 208, !66, i64 216, !8, i64 224, !132, i64 264, !132, i64 280, !132, i64 296, !132, i64 312, !7, i64 328, !29, i64 336, !29, i64 340, !29, i64 344, !29, i64 344, !29, i64 344, !29, i64 344, !29, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !15, i64 456, !15, i64 464, !134, i64 472, !135, i64 992, !15, i64 1016, !15, i64 1024, !29, i64 1032, !29, i64 1036, !132, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !29, i64 1136, !15, i64 1144, !15, i64 1152, !15, i64 1160, !15, i64 1168, !15, i64 1176, !15, i64 1184, !29, i64 1192, !136, i64 1200, !8, i64 1232}
-!131 = !{!"rb_global_vm_lock_struct", !15, i64 0, !8, i64 8, !132, i64 48, !15, i64 64, !29, i64 72, !8, i64 80, !8, i64 128, !29, i64 176, !29, i64 180}
+!130 = !{!"rb_vm_struct", !7, i64 0, !131, i64 8, !73, i64 192, !73, i64 200, !73, i64 208, !119, i64 216, !8, i64 224, !132, i64 264, !132, i64 280, !132, i64 296, !132, i64 312, !7, i64 328, !87, i64 336, !87, i64 340, !87, i64 344, !87, i64 344, !87, i64 344, !87, i64 344, !87, i64 348, !7, i64 352, !8, i64 360, !7, i64 400, !7, i64 408, !7, i64 416, !7, i64 424, !7, i64 432, !7, i64 440, !7, i64 448, !73, i64 456, !73, i64 464, !134, i64 472, !135, i64 992, !73, i64 1016, !73, i64 1024, !87, i64 1032, !87, i64 1036, !132, i64 1040, !8, i64 1056, !7, i64 1096, !7, i64 1104, !7, i64 1112, !7, i64 1120, !7, i64 1128, !87, i64 1136, !73, i64 1144, !73, i64 1152, !73, i64 1160, !73, i64 1168, !73, i64 1176, !73, i64 1184, !87, i64 1192, !136, i64 1200, !8, i64 1232}
+!131 = !{!"rb_global_vm_lock_struct", !73, i64 0, !8, i64 8, !132, i64 48, !73, i64 64, !87, i64 72, !8, i64 80, !8, i64 128, !87, i64 176, !87, i64 180}
 !132 = !{!"list_head", !133, i64 0}
-!133 = !{!"list_node", !15, i64 0, !15, i64 8}
+!133 = !{!"list_node", !73, i64 0, !73, i64 8}
 !134 = !{!"", !8, i64 0}
-!135 = !{!"rb_hook_list_struct", !15, i64 0, !29, i64 8, !29, i64 12, !29, i64 16}
+!135 = !{!"rb_hook_list_struct", !73, i64 0, !87, i64 8, !87, i64 12, !87, i64 16}
 !136 = !{!"", !7, i64 0, !7, i64 8, !7, i64 16, !7, i64 24}
-!137 = !DILocation(line: 0, scope: !58)
-!138 = !DILocation(line: 7, column: 1, scope: !58)
-!139 = !DILocation(line: 12, column: 1, scope: !58)
-!140 = !DILocation(line: 17, column: 1, scope: !58)
-!141 = !DILocation(line: 22, column: 1, scope: !58)
-!142 = !{!143, !29, i64 8}
-!143 = !{!"rb_sorbet_param_struct", !144, i64 0, !29, i64 4, !29, i64 8, !29, i64 12, !29, i64 16, !29, i64 20, !29, i64 24, !29, i64 28, !15, i64 32, !29, i64 40, !29, i64 44, !29, i64 48, !29, i64 52, !15, i64 56}
-!144 = !{!"", !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 0, !29, i64 1, !29, i64 1}
-!145 = !{!143, !29, i64 4}
-!146 = !{!143, !15, i64 32}
+!137 = !DILocation(line: 0, scope: !17)
+!138 = !DILocation(line: 7, column: 1, scope: !17)
+!139 = !DILocation(line: 12, column: 1, scope: !17)
+!140 = !DILocation(line: 17, column: 1, scope: !17)
+!141 = !DILocation(line: 22, column: 1, scope: !17)
+!142 = !{!143, !87, i64 8}
+!143 = !{!"rb_sorbet_param_struct", !144, i64 0, !87, i64 4, !87, i64 8, !87, i64 12, !87, i64 16, !87, i64 20, !87, i64 24, !87, i64 28, !73, i64 32, !87, i64 40, !87, i64 44, !87, i64 48, !87, i64 52, !73, i64 56}
+!144 = !{!"", !87, i64 0, !87, i64 0, !87, i64 0, !87, i64 0, !87, i64 0, !87, i64 0, !87, i64 0, !87, i64 0, !87, i64 1, !87, i64 1}
+!145 = !{!143, !87, i64 4}
+!146 = !{!143, !73, i64 32}
 !147 = distinct !DISubprogram(name: "func_Object#2lt.cold.1", linkageName: "func_Object#2lt.cold.1", scope: null, file: !4, type: !148, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)
 !148 = !DISubroutineType(types: !5)
 !149 = distinct !DISubprogram(name: "func_Object#2lt.cold.3", linkageName: "func_Object#2lt.cold.3", scope: null, file: !4, type: !148, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !3, retainedNodes: !5)

--- a/test/testdata/compiler/globalfields.opt.ll.exp
+++ b/test/testdata/compiler/globalfields.opt.ll.exp
@@ -123,7 +123,7 @@ declare %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64) local_
 
 declare void @sorbet_popFrame() local_unnamed_addr #1
 
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #1
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) local_unnamed_addr #1
 
 declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #1
 
@@ -184,18 +184,18 @@ allocRubyIds:
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([20 x i64], [20 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 20)
   tail call fastcc void @"Constr_stackFramePrecomputed_func_<root>.17<static-init>$153"(i64 %realpath)
   %rubyId_new = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !dbg !10, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !10
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new, i32 noundef 16, i32 noundef 0, i32 noundef 0), !dbg !10
   %rubyId_initialize = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !10, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 %rubyId_initialize, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !10
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 %rubyId_initialize, i32 noundef 20, i32 noundef 0, i32 noundef 0), !dbg !10
   %rubyId_read = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !15, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_read, i64 %rubyId_read, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !15
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_read, i64 %rubyId_read, i32 noundef 16, i32 noundef 0, i32 noundef 0), !dbg !15
   %rubyId_puts = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !dbg !16, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !16
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !16
   %rubyId_write = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 5), align 8, !dbg !17, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_write, i64 %rubyId_write, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !17
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_read.1, i64 %rubyId_read, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !18
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !20
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_write, i64 %rubyId_write, i32 noundef 16, i32 noundef 1, i32 noundef 0), !dbg !17
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_read.1, i64 %rubyId_read, i32 noundef 16, i32 noundef 0, i32 noundef 0), !dbg !18
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !19
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !20
   tail call fastcc void @"Constr_stackFramePrecomputed_func_A#5write"(i64 %realpath)
   tail call fastcc void @"Constr_stackFramePrecomputed_func_A#4read"(i64 %realpath)
   tail call fastcc void @"Constr_stackFramePrecomputed_func_A.13<static-init>"(i64 %realpath)

--- a/test/testdata/compiler/hello.opt.ll.exp
+++ b/test/testdata/compiler/hello.opt.ll.exp
@@ -96,7 +96,7 @@ declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32
 
 declare i64 @sorbet_readRealpath() local_unnamed_addr #0
 
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #0
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) local_unnamed_addr #0
 
 declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #0
 
@@ -130,7 +130,7 @@ allocRubyIds:
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 5)
   tail call fastcc void @"Constr_stackFramePrecomputed_func_<root>.17<static-init>$153"(i64 %realpath)
   %rubyId_puts = load i64, i64* getelementptr inbounds ([2 x i64], [2 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !dbg !10, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !10
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !10
   ret void
 }
 

--- a/test/testdata/compiler/intrinsics/bang.opt.ll.exp
+++ b/test/testdata/compiler/intrinsics/bang.opt.ll.exp
@@ -127,7 +127,7 @@ declare %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64) local_
 
 declare void @sorbet_popFrame() local_unnamed_addr #1
 
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #1
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) local_unnamed_addr #1
 
 declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #1
 
@@ -174,27 +174,27 @@ allocRubyIds:
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([23 x i64], [23 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 23)
   tail call fastcc void @"Constr_stackFramePrecomputed_func_<root>.17<static-init>$153"(i64 %realpath)
   %rubyId_test = load i64, i64* getelementptr inbounds ([9 x i64], [9 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !dbg !10, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test, i64 %rubyId_test, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !10
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test, i64 %rubyId_test, i32 noundef 16, i32 noundef 0, i32 noundef 0), !dbg !10
   tail call fastcc void @"Constr_stackFramePrecomputed_func_Bad#1!"(i64 %realpath)
   %rubyId_puts = load i64, i64* getelementptr inbounds ([9 x i64], [9 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !15, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !15
   tail call fastcc void @"Constr_stackFramePrecomputed_func_Bad.13<static-init>"(i64 %realpath)
   tail call fastcc void @Constr_stackFramePrecomputed_func_Main.4test(i64 %realpath)
   %"rubyId_!" = load i64, i64* getelementptr inbounds ([9 x i64], [9 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !17, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_!", i64 %"rubyId_!", i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !17
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_!.2", i64 %"rubyId_!", i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !20
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !21
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_!.4", i64 %"rubyId_!", i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !22
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.5, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !23
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_!.6", i64 %"rubyId_!", i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !24
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.7, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !25
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_!", i64 %"rubyId_!", i32 noundef 16, i32 noundef 0, i32 noundef 0), !dbg !17
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !19
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_!.2", i64 %"rubyId_!", i32 noundef 16, i32 noundef 0, i32 noundef 0), !dbg !20
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !21
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_!.4", i64 %"rubyId_!", i32 noundef 16, i32 noundef 0, i32 noundef 0), !dbg !22
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.5, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !23
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_!.6", i64 %"rubyId_!", i32 noundef 16, i32 noundef 0, i32 noundef 0), !dbg !24
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.7, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !25
   %rubyId_new = load i64, i64* getelementptr inbounds ([9 x i64], [9 x i64]* @sorbet_moduleIDTable, i64 0, i64 6), align 8, !dbg !26, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !26
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new, i32 noundef 16, i32 noundef 0, i32 noundef 0), !dbg !26
   %rubyId_initialize = load i64, i64* getelementptr inbounds ([9 x i64], [9 x i64]* @sorbet_moduleIDTable, i64 0, i64 7), align 8, !dbg !26, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 %rubyId_initialize, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !26
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_!.8", i64 %"rubyId_!", i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !27
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.9, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !28
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 %rubyId_initialize, i32 noundef 20, i32 noundef 0, i32 noundef 0), !dbg !26
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_!.8", i64 %"rubyId_!", i32 noundef 16, i32 noundef 0, i32 noundef 0), !dbg !27
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.9, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !28
   tail call fastcc void @"Constr_stackFramePrecomputed_func_Main.13<static-init>"(i64 %realpath)
   ret void
 }

--- a/test/testdata/compiler/intrinsics/t_must.opt.ll.exp
+++ b/test/testdata/compiler/intrinsics/t_must.opt.ll.exp
@@ -129,7 +129,7 @@ declare void @sorbet_popFrame() local_unnamed_addr #1
 
 declare void @sorbet_vm_env_write_slowpath(i64*, i32, i64) local_unnamed_addr #1
 
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #1
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) local_unnamed_addr #1
 
 declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #1
 
@@ -206,11 +206,11 @@ entry:
   %0 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<top (required)>.i.i", i64 %"rubyId_<top (required)>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 0, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i.i, i32 noundef 0, i32 noundef 2)
   store %struct.rb_iseq_struct* %0, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_<root>.17<static-init>$153", align 8
   %rubyId_test_known_nil.i = load i64, i64* getelementptr inbounds ([18 x i64], [18 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !dbg !17, !invariant.load !5
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test_known_nil, i64 %rubyId_test_known_nil.i, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !17
+  call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test_known_nil, i64 %rubyId_test_known_nil.i, i32 noundef 16, i32 noundef 0, i32 noundef 0), !dbg !17
   %rubyId_test_nilable_arg.i = load i64, i64* getelementptr inbounds ([18 x i64], [18 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !18, !invariant.load !5
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test_nilable_arg, i64 %rubyId_test_nilable_arg.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !18
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test_nilable_arg.1, i64 %rubyId_test_nilable_arg.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test_nilable_arg.2, i64 %rubyId_test_nilable_arg.i, i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !20
+  call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test_nilable_arg, i64 %rubyId_test_nilable_arg.i, i32 noundef 16, i32 noundef 1, i32 noundef 0), !dbg !18
+  call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test_nilable_arg.1, i64 %rubyId_test_nilable_arg.i, i32 noundef 16, i32 noundef 1, i32 noundef 0), !dbg !19
+  call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_test_nilable_arg.2, i64 %rubyId_test_nilable_arg.i, i32 noundef 16, i32 noundef 1, i32 noundef 0), !dbg !20
   %1 = bitcast i64* %locals.i7.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 32, i8* nonnull %1)
   %rubyStr_test_known_nil.i.i = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 2), align 8, !invariant.load !5
@@ -240,9 +240,9 @@ entry:
   %8 = call i64 @sorbet_getConstant(i8* noundef getelementptr inbounds ([25 x i8], [25 x i8]* @sorbet_getTRetry.retry, i64 0, i64 0), i64 noundef 25) #14
   store i64 %8, i64* @"<retry-singleton>", align 8
   %"rubyId_is_a?.i" = load i64, i64* getelementptr inbounds ([18 x i64], [18 x i64]* @sorbet_moduleIDTable, i64 0, i64 10), align 8, !dbg !21, !invariant.load !5
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_is_a?", i64 %"rubyId_is_a?.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !21
+  call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_is_a?", i64 %"rubyId_is_a?.i", i32 noundef 16, i32 noundef 1, i32 noundef 0), !dbg !21
   %rubyId_puts.i = load i64, i64* getelementptr inbounds ([18 x i64], [18 x i64]* @sorbet_moduleIDTable, i64 0, i64 11), align 8, !dbg !24, !invariant.load !5
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !24
+  call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !24
   %9 = bitcast i64* %locals.i12.i to i8*
   call void @llvm.lifetime.start.p0i8(i64 40, i8* nonnull %9)
   %rubyStr_test_nilable_arg.i.i = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 5), align 8, !invariant.load !5
@@ -268,9 +268,9 @@ entry:
   %"rubyStr_ensure in test_nilable_arg.i.i" = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 7), align 8, !invariant.load !5
   %16 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_ensure in test_nilable_arg.i.i", i64 %"rubyId_ensure in test_nilable_arg.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* %stackFrame.i19.i, i32 noundef 5, i32 noundef 14, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef null, i32 noundef 0, i32 noundef 3)
   store %struct.rb_iseq_struct* %16, %struct.rb_iseq_struct** @"stackFramePrecomputed_func_Test.16test_nilable_arg$block_3", align 8
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !25
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_is_a?.4", i64 %"rubyId_is_a?.i", i32 noundef 16, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !28
-  call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.5, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !30
+  call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !25
+  call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @"ic_is_a?.4", i64 %"rubyId_is_a?.i", i32 noundef 16, i32 noundef 1, i32 noundef 0), !dbg !28
+  call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.5, i64 %rubyId_puts.i, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !30
   %"rubyId_<module:Test>.i.i" = load i64, i64* getelementptr inbounds ([18 x i64], [18 x i64]* @sorbet_moduleIDTable, i64 0, i64 16), align 8, !invariant.load !5
   %"rubyStr_<module:Test>.i.i" = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleRubyStringTable, i64 0, i64 9), align 8, !invariant.load !5
   %17 = call %struct.rb_iseq_struct* @sorbet_allocateRubyStackFrame(i64 %"rubyStr_<module:Test>.i.i", i64 %"rubyId_<module:Test>.i.i", i64 %"rubyStr_test/testdata/compiler/intrinsics/t_must.rb.i.i", i64 %realpath, %struct.rb_iseq_struct* noundef null, i32 noundef 3, i32 noundef 5, %struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef nonnull %locals.i22.i, i32 noundef 0, i32 noundef 4)

--- a/test/testdata/compiler/literal_hash.opt.ll.exp
+++ b/test/testdata/compiler/literal_hash.opt.ll.exp
@@ -106,7 +106,7 @@ declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32
 
 declare i64 @sorbet_readRealpath() local_unnamed_addr #1
 
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #1
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) local_unnamed_addr #1
 
 declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #1
 
@@ -155,7 +155,7 @@ allocRubyIds:
   tail call fastcc void @Constr_ruby_hashLiteral6() #8
   tail call fastcc void @Constr_ruby_hashLiteral7() #8
   %rubyId_puts = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !10, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts, i32 noundef 20, i32 noundef 7, i32 noundef 0, i64* noundef null), !dbg !10
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts, i32 noundef 20, i32 noundef 7, i32 noundef 0), !dbg !10
   ret void
 }
 

--- a/test/testdata/compiler/literals.opt.ll.exp
+++ b/test/testdata/compiler/literals.opt.ll.exp
@@ -105,7 +105,7 @@ declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32
 
 declare i64 @sorbet_readRealpath() local_unnamed_addr #1
 
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #1
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) local_unnamed_addr #1
 
 declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #1
 
@@ -139,13 +139,13 @@ allocRubyIds:
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([11 x i64], [11 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 11)
   tail call fastcc void @"Constr_stackFramePrecomputed_func_<root>.17<static-init>$153"(i64 %realpath)
   %rubyId_puts = load i64, i64* getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !dbg !10, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !10
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !16
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !17
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.4, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !18
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.5, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.6, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !20
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !10
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.1, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !15
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.2, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !16
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.3, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !17
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.4, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !18
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.5, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !19
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.6, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !20
   ret void
 }
 

--- a/test/testdata/compiler/repeated_casts.opt.ll.exp
+++ b/test/testdata/compiler/repeated_casts.opt.ll.exp
@@ -118,7 +118,7 @@ declare %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64) local_
 
 declare void @sorbet_popFrame() local_unnamed_addr #3
 
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #3
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) local_unnamed_addr #3
 
 declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #3
 
@@ -171,8 +171,8 @@ allocRubyIds:
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([12 x i64], [12 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 12)
   tail call fastcc void @"Constr_stackFramePrecomputed_func_Object#10doubleCast"(i64 %realpath)
   %rubyId_foo = load i64, i64* getelementptr inbounds ([6 x i64], [6 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !dbg !10, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !10
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo.1, i64 %rubyId_foo, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !15
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo, i32 noundef 16, i32 noundef 0, i32 noundef 0), !dbg !10
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo.1, i64 %rubyId_foo, i32 noundef 16, i32 noundef 0, i32 noundef 0), !dbg !15
   tail call fastcc void @"Constr_stackFramePrecomputed_func_<root>.17<static-init>$153"(i64 %realpath)
   tail call fastcc void @"Constr_stackFramePrecomputed_func_A#3foo"(i64 %realpath)
   tail call fastcc void @"Constr_stackFramePrecomputed_func_A.13<static-init>"(i64 %realpath)

--- a/test/testdata/compiler/send_with_block_param.opt.ll.exp
+++ b/test/testdata/compiler/send_with_block_param.opt.ll.exp
@@ -100,7 +100,7 @@ declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32
 
 declare i64 @sorbet_readRealpath() local_unnamed_addr #0
 
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #0
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) local_unnamed_addr #0
 
 declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #0
 
@@ -154,9 +154,9 @@ allocRubyIds:
   tail call fastcc void @"Constr_stackFramePrecomputed_func_<root>.17<static-init>$153"(i64 %realpath)
   tail call fastcc void @Constr_ruby_hashLiteral1() #9
   %rubyId_map = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !10, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_map, i64 %rubyId_map, i32 noundef 18, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !10
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_map, i64 %rubyId_map, i32 noundef 18, i32 noundef 0, i32 noundef 0), !dbg !10
   %rubyId_puts = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !dbg !15, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !15
   ret void
 }
 

--- a/test/testdata/compiler/sig_rewriter.opt.ll.exp
+++ b/test/testdata/compiler/sig_rewriter.opt.ll.exp
@@ -123,7 +123,7 @@ declare %struct.rb_control_frame_struct* @sorbet_pushStaticInitFrame(i64) local_
 
 declare void @sorbet_popFrame() local_unnamed_addr #2
 
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #2
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) local_unnamed_addr #2
 
 declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #2
 
@@ -168,20 +168,20 @@ allocRubyIds:
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([14 x i64], [14 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 14)
   tail call fastcc void @"Constr_stackFramePrecomputed_func_<root>.17<static-init>$153"(i64 %realpath)
   %rubyId_new = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 1), align 8, !dbg !10, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !10
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_new, i64 %rubyId_new, i32 noundef 16, i32 noundef 0, i32 noundef 0), !dbg !10
   %rubyId_initialize = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !10, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 %rubyId_initialize, i32 noundef 20, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !10
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_initialize, i64 %rubyId_initialize, i32 noundef 20, i32 noundef 0, i32 noundef 0), !dbg !10
   %rubyId_foo = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 3), align 8, !dbg !10, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo, i32 noundef 16, i32 noundef 0, i32 noundef 0, i64* noundef null), !dbg !10
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_foo, i64 %rubyId_foo, i32 noundef 16, i32 noundef 0, i32 noundef 0), !dbg !10
   %rubyId_puts = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !dbg !15, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !15
   tail call fastcc void @"Constr_stackFramePrecomputed_func_A#3foo"(i64 %realpath)
   tail call fastcc void @"Constr_stackFramePrecomputed_func_A.13<static-init>"(i64 %realpath)
   tail call fastcc void @"Constr_stackFramePrecomputed_func_A.13<static-init>$block_1"(i64 %realpath)
   %rubyId_returns = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 7), align 8, !dbg !16, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !16
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_returns, i64 %rubyId_returns, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !16
   %rubyId_extend = load i64, i64* getelementptr inbounds ([10 x i64], [10 x i64]* @sorbet_moduleIDTable, i64 0, i64 8), align 8, !dbg !19, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !19
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_extend, i64 %rubyId_extend, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !19
   ret void
 }
 

--- a/test/testdata/compiler/splat_assign.opt.ll.exp
+++ b/test/testdata/compiler/splat_assign.opt.ll.exp
@@ -98,7 +98,7 @@ declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32
 
 declare i64 @sorbet_readRealpath() local_unnamed_addr #0
 
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #0
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) local_unnamed_addr #0
 
 declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #0
 
@@ -145,9 +145,9 @@ allocRubyIds:
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([13 x i64], [13 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 13)
   tail call fastcc void @"Constr_stackFramePrecomputed_func_<root>.17<static-init>$153"(i64 %realpath)
   %rubyId_puts = load i64, i64* getelementptr inbounds ([5 x i64], [5 x i64]* @sorbet_moduleIDTable, i64 0, i64 4), align 8, !dbg !10, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !10
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.6, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !15
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.10, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !16
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !10
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.6, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !15
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts.10, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !16
   ret void
 }
 

--- a/test/testdata/compiler/unsafe.opt.ll.exp
+++ b/test/testdata/compiler/unsafe.opt.ll.exp
@@ -96,7 +96,7 @@ declare void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo*, i64*, i32
 
 declare i64 @sorbet_readRealpath() local_unnamed_addr #0
 
-declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, i64*) local_unnamed_addr #0
+declare void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) local_unnamed_addr #0
 
 declare i64 @sorbet_callFuncWithCache(%struct.FunctionInlineCache*, i64) local_unnamed_addr #0
 
@@ -135,7 +135,7 @@ allocRubyIds:
   tail call void @sorbet_initLineNumberInfo(%struct.SorbetLineNumberInfo* noundef @fileLineNumberInfo, i64* noundef getelementptr inbounds ([5 x i64], [5 x i64]* @iseqEncodedArray, i32 0, i32 0), i32 noundef 5)
   tail call fastcc void @"Constr_stackFramePrecomputed_func_<root>.17<static-init>$153"(i64 %realpath)
   %rubyId_puts = load i64, i64* getelementptr inbounds ([3 x i64], [3 x i64]* @sorbet_moduleIDTable, i64 0, i64 2), align 8, !dbg !10, !invariant.load !5
-  tail call void @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0, i64* noundef null), !dbg !10
+  tail call void (%struct.FunctionInlineCache*, i64, i32, i32, i32, ...) @sorbet_setupFunctionInlineCache(%struct.FunctionInlineCache* noundef @ic_puts, i64 %rubyId_puts, i32 noundef 20, i32 noundef 1, i32 noundef 0), !dbg !10
   ret void
 }
 


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

One step on the way to making function cache setup take a single call during module initialization, just like ID and Ruby string setup.  But this is beneficial on its own, as it moves all of the `ID2SYM` calls into the VM, so there's a little less LLVM IR to optimize.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
