### PR TITLE
desugar `NthRef` into a form that doesn't lose information

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1584,9 +1584,9 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                 result = std::move(res);
             },
             [&](parser::NthRef *var) {
-                ExpressionPtr res = make_expression<UnresolvedIdent>(loc, UnresolvedIdent::Kind::Global,
-                                                                     dctx.ctx.state.enterNameUTF8(to_string(var->ref)));
-                result = std::move(res);
+                auto recv = MK::Constant(loc, core::Symbols::Magic());
+                auto arg = MK::Int(var->loc, var->ref);
+                result = MK::Send1(loc, std::move(recv), core::Names::regexBackref(), locZeroLen, std::move(arg));
             },
             [&](parser::Super *super) {
                 // Desugar super into a call to a normal method named `super`;

--- a/test/testdata/desugar/backref.rb
+++ b/test/testdata/desugar/backref.rb
@@ -16,10 +16,10 @@ x5 = $+ # contains last capture group;
 T.reveal_type(x5) # error: Revealed type: `T.nilable(String)`
 
 x6 = $1 # contains the first match group;
-T.reveal_type(x6) # error: Revealed type: `T.untyped`
+T.reveal_type(x6) # error: Revealed type: `T.nilable(String)`
 
 x7 = $9 # contains the 9th match group;
-T.reveal_type(x7) # error: Revealed type: `T.untyped`
+T.reveal_type(x7) # error: Revealed type: `T.nilable(String)`
 
 class TestNotPinningBackrefs
   /foo/.match("foo") do |m|

--- a/test/testdata/desugar/nthref.rb.desugar-tree-raw.exp
+++ b/test/testdata/desugar/nthref.rb.desugar-tree-raw.exp
@@ -7,14 +7,32 @@ ClassDef{
       orig = nullptr
     }]
   rhs = [
-    UnresolvedIdent{
-      kind = Global
-      name = <U 1>
+    Send{
+      flags = {}
+      recv = ConstantLit{
+        symbol = (class ::<Magic>)
+        orig = nullptr
+      }
+      fun = <U <regex-backref>>
+      block = nullptr
+      pos_args = 1
+      args = [
+        Literal{ value = 1 }
+      ]
     }
 
-    UnresolvedIdent{
-      kind = Global
-      name = <U 314159>
+    Send{
+      flags = {}
+      recv = ConstantLit{
+        symbol = (class ::<Magic>)
+        orig = nullptr
+      }
+      fun = <U <regex-backref>>
+      block = nullptr
+      pos_args = 1
+      args = [
+        Literal{ value = 314159 }
+      ]
     }
   ]
 }

--- a/test/testdata/parser/misc.rb.desugar-tree.exp
+++ b/test/testdata/parser/misc.rb.desugar-tree.exp
@@ -164,7 +164,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <assignTemp>$9
   end
 
-  4
+  ::<Magic>.<regex-backref>(4)
 
   def optfoo<<todo method>>(x = 1, *y, &<blk>)
     <emptyTree>


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The current desugaring of `NthRef` turns it into a global.  I guess you could handle this in the compiler by translating certain globals specially, but it makes slightly more sense to me to translate it to a send to `<Magic>`.  Open to bikeshedding on whether it should be `<regex-backref>` or a new method, but in either case, it's nice that the typing is slightly more accurate in this representation.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
