### PR TITLE
Store a `NameRef` directly in `LiteralType`

### DIFF
--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -1325,32 +1325,32 @@ string Literal::nodeName() {
     return "Literal";
 }
 
-core::NameRef Literal::asString(const core::GlobalState &gs) const {
-    ENFORCE(isString(gs));
+core::NameRef Literal::asString() const {
+    ENFORCE(isString());
     auto t = core::cast_type_nonnull<core::LiteralType>(value);
-    core::NameRef res = t.asName(gs);
+    core::NameRef res = t.asName();
     return res;
 }
 
-core::NameRef Literal::asSymbol(const core::GlobalState &gs) const {
-    ENFORCE(isSymbol(gs));
+core::NameRef Literal::asSymbol() const {
+    ENFORCE(isSymbol());
     auto t = core::cast_type_nonnull<core::LiteralType>(value);
-    core::NameRef res = t.asName(gs);
+    core::NameRef res = t.asName();
     return res;
 }
 
-bool Literal::isSymbol(const core::GlobalState &gs) const {
+bool Literal::isSymbol() const {
     return core::isa_type<core::LiteralType>(value) &&
-           core::cast_type_nonnull<core::LiteralType>(value).derivesFrom(gs, core::Symbols::Symbol());
+           core::cast_type_nonnull<core::LiteralType>(value).literalKind == core::LiteralType::LiteralTypeKind::Symbol;
 }
 
 bool Literal::isNil(const core::GlobalState &gs) const {
     return value.derivesFrom(gs, core::Symbols::NilClass());
 }
 
-bool Literal::isString(const core::GlobalState &gs) const {
+bool Literal::isString() const {
     return core::isa_type<core::LiteralType>(value) &&
-           core::cast_type_nonnull<core::LiteralType>(value).derivesFrom(gs, core::Symbols::String());
+           core::cast_type_nonnull<core::LiteralType>(value).literalKind == core::LiteralType::LiteralTypeKind::String;
 }
 
 bool Literal::isTrue(const core::GlobalState &gs) const {

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -1022,11 +1022,11 @@ public:
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0);
     std::string nodeName();
-    bool isString(const core::GlobalState &gs) const;
-    bool isSymbol(const core::GlobalState &gs) const;
+    bool isString() const;
+    bool isSymbol() const;
     bool isNil(const core::GlobalState &gs) const;
-    core::NameRef asString(const core::GlobalState &gs) const;
-    core::NameRef asSymbol(const core::GlobalState &gs) const;
+    core::NameRef asString() const;
+    core::NameRef asSymbol() const;
     bool isTrue(const core::GlobalState &gs) const;
     bool isFalse(const core::GlobalState &gs) const;
 

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -332,7 +332,7 @@ ExpressionPtr symbol2Proc(DesugarContext dctx, ExpressionPtr expr) {
     ENFORCE(lit && lit->isSymbol());
 
     // &:foo => {|temp| temp.foo() }
-    core::NameRef name = core::cast_type_nonnull<core::LiteralType>(lit->value).asName(dctx.ctx);
+    core::NameRef name = core::cast_type_nonnull<core::LiteralType>(lit->value).asName();
     // `temp` does not refer to any specific source text, so give it a 0-length Loc so LSP ignores it.
     auto zeroLengthLoc = loc.copyWithZeroLength();
     ExpressionPtr recv = MK::Local(zeroLengthLoc, temp);

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -179,7 +179,7 @@ ExpressionPtr desugarBlock(DesugarContext dctx, core::LocOffsets loc, core::LocO
 
 bool isStringLit(DesugarContext dctx, ExpressionPtr &expr) {
     Literal *lit;
-    return (lit = cast_tree<Literal>(expr)) && lit->isString(dctx.ctx);
+    return (lit = cast_tree<Literal>(expr)) && lit->isString();
 }
 
 ExpressionPtr mergeStrings(DesugarContext dctx, core::LocOffsets loc,
@@ -192,7 +192,7 @@ ExpressionPtr mergeStrings(DesugarContext dctx, core::LocOffsets loc,
                                        if (isa_tree<EmptyTree>(expr)) {
                                            return ""sv;
                                        } else {
-                                           return cast_tree<Literal>(expr)->asString(dctx.ctx).shortName(dctx.ctx);
+                                           return cast_tree<Literal>(expr)->asString().shortName(dctx.ctx);
                                        }
                                    }))));
     }
@@ -329,7 +329,7 @@ ExpressionPtr symbol2Proc(DesugarContext dctx, ExpressionPtr expr) {
     auto loc = expr.loc();
     core::NameRef temp = dctx.freshNameUnique(core::Names::blockPassTemp());
     Literal *lit = cast_tree<Literal>(expr);
-    ENFORCE(lit && lit->isSymbol(dctx.ctx));
+    ENFORCE(lit && lit->isSymbol());
 
     // &:foo => {|temp| temp.foo() }
     core::NameRef name = core::cast_type_nonnull<core::LiteralType>(lit->value).asName(dctx.ctx);
@@ -567,15 +567,15 @@ public:
             return;
         }
 
-        auto isSymbol = lit->isSymbol(gs);
+        auto isSymbol = lit->isSymbol();
         core::NameRef nameRef;
         if (!lit) {
             return;
         }
         if (isSymbol) {
-            nameRef = lit->asSymbol(gs);
-        } else if (lit->isString(gs)) {
-            nameRef = lit->asString(gs);
+            nameRef = lit->asSymbol();
+        } else if (lit->isString()) {
+            nameRef = lit->asString();
         } else {
             return;
         }
@@ -795,7 +795,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                             convertedBlock = node2TreeImpl(dctx, std::move(block));
                         }
                         Literal *lit;
-                        if ((lit = cast_tree<Literal>(convertedBlock)) && lit->isSymbol(dctx.ctx)) {
+                        if ((lit = cast_tree<Literal>(convertedBlock)) && lit->isSymbol()) {
                             res = MK::Send(loc, MK::Constant(loc, core::Symbols::Magic()), core::Names::callWithSplat(),
                                            locZeroLen, 4, std::move(sendargs), flags);
                             ast::cast_tree_nonnull<ast::Send>(res).setBlock(
@@ -882,7 +882,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                             convertedBlock = node2TreeImpl(dctx, std::move(block));
                         }
                         Literal *lit;
-                        if ((lit = cast_tree<Literal>(convertedBlock)) && lit->isSymbol(dctx.ctx)) {
+                        if ((lit = cast_tree<Literal>(convertedBlock)) && lit->isSymbol()) {
                             res = MK::Send(loc, std::move(rec), send->method, send->methodLoc, numPosArgs,
                                            std::move(args), flags);
                             ast::cast_tree_nonnull<ast::Send>(res).setBlock(

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -187,14 +187,14 @@ ExpressionPtr mergeStrings(DesugarContext dctx, core::LocOffsets loc,
     if (stringsAccumulated.size() == 1) {
         return move(stringsAccumulated[0]);
     } else {
-        return MK::String(loc, dctx.ctx.state.enterNameUTF8(fmt::format(
-                                   "{}", fmt::map_join(stringsAccumulated, "", [&](const auto &expr) {
-                                       if (isa_tree<EmptyTree>(expr)) {
-                                           return ""sv;
-                                       } else {
-                                           return cast_tree<Literal>(expr)->asString().shortName(dctx.ctx);
-                                       }
-                                   }))));
+        return MK::String(loc, dctx.ctx.state.enterNameUTF8(
+                                   fmt::format("{}", fmt::map_join(stringsAccumulated, "", [&](const auto &expr) {
+                                                   if (isa_tree<EmptyTree>(expr)) {
+                                                       return ""sv;
+                                                   } else {
+                                                       return cast_tree<Literal>(expr)->asString().shortName(dctx.ctx);
+                                                   }
+                                               }))));
     }
 }
 

--- a/ast/substitute/Substitute.cc
+++ b/ast/substitute/Substitute.cc
@@ -94,8 +94,8 @@ public:
 
     ExpressionPtr postTransformLiteral(core::MutableContext ctx, ExpressionPtr tree) {
         auto &original = cast_tree_nonnull<Literal>(tree);
-        if (original.isString(ctx)) {
-            auto nameRef = original.asString(ctx);
+        if (original.isString()) {
+            auto nameRef = original.asString();
             // The 'from' and 'to' GlobalState in this substitution will always be the same,
             // because the newly created nameRef reuses our current GlobalState id
             bool allowSameFromTo = true;
@@ -105,8 +105,8 @@ public:
             }
             return MK::String(original.loc, newName);
         }
-        if (original.isSymbol(ctx)) {
-            auto nameRef = original.asSymbol(ctx);
+        if (original.isSymbol()) {
+            auto nameRef = original.asSymbol();
             // The 'from' and 'to' GlobalState in this substitution will always be the same,
             // because the newly created nameRef reuses our current GlobalState id
             bool allowSameFromTo = true;

--- a/compiler/IREmitter/IREmitterContext.cc
+++ b/compiler/IREmitter/IREmitterContext.cc
@@ -37,7 +37,7 @@ optional<string_view> isSymbol(const core::GlobalState &gs, const cfg::Instructi
         return std::nullopt;
     }
 
-    return lit.asName(gs).shortName(gs);
+    return lit.asName().shortName(gs);
 }
 
 struct AliasesAndKeywords {

--- a/compiler/IREmitter/IREmitterHelpers.cc
+++ b/compiler/IREmitter/IREmitterHelpers.cc
@@ -331,14 +331,14 @@ llvm::Value *IREmitterHelpers::emitLiteralish(CompilerState &cs, llvm::IRBuilder
             return value;
         }
         case core::LiteralType::LiteralTypeKind::Symbol: {
-            auto str = litType.asName(cs).shortName(cs);
+            auto str = litType.asName().shortName(cs);
             auto rawId = Payload::idIntern(cs, builder, str);
             auto *value = builder.CreateCall(cs.getFunction("rb_id2sym"), {rawId}, "rawSym");
             Payload::assumeType(cs, builder, value, core::Symbols::Symbol());
             return value;
         }
         case core::LiteralType::LiteralTypeKind::String: {
-            auto str = litType.asName(cs).shortName(cs);
+            auto str = litType.asName().shortName(cs);
             auto *value = Payload::cPtrToRubyString(cs, builder, str, true);
             Payload::assumeType(cs, builder, value, core::Symbols::String());
             return value;

--- a/compiler/IREmitter/NameBasedIntrinsics.cc
+++ b/compiler/IREmitter/NameBasedIntrinsics.cc
@@ -165,7 +165,7 @@ public:
         auto recv = send->args[0].variable;
         auto lit = core::cast_type_nonnull<core::LiteralType>(send->args[1].type);
         ENFORCE(lit.literalKind == core::LiteralType::LiteralTypeKind::Symbol);
-        auto methodName = lit.asName(cs);
+        auto methodName = lit.asName();
 
         llvm::Value *blockHandler = prepareBlockHandler(mcctx, send->args[2]);
 
@@ -467,7 +467,7 @@ public:
 
         auto lit = core::cast_type_nonnull<core::LiteralType>(send->args[1].type);
         ENFORCE(lit.literalKind == core::LiteralType::LiteralTypeKind::Symbol);
-        auto methodName = lit.asName(cs);
+        auto methodName = lit.asName();
 
         // setup the inline cache
         // Note that in the case of calling `super`, the VM's search mechanism will
@@ -528,7 +528,7 @@ public:
 
         auto lit = core::cast_type_nonnull<core::LiteralType>(send->args[1].type);
         ENFORCE(lit.literalKind == core::LiteralType::LiteralTypeKind::Symbol);
-        auto methodName = lit.asName(cs);
+        auto methodName = lit.asName();
 
         // setup the inline cache
         // Note that in the case of calling `super`, the VM's search mechanism will
@@ -677,7 +677,7 @@ public:
             return IREmitterHelpers::emitMethodCallViaRubyVM(mcctx);
         }
 
-        auto varName = lit.asName(cs);
+        auto varName = lit.asName();
         auto varNameStr = varName.shortName(cs);
 
         auto *callCache = mcctx.getInlineCache();
@@ -715,7 +715,7 @@ public:
             return IREmitterHelpers::emitMethodCallViaRubyVM(mcctx);
         }
 
-        auto varName = lit.asName(cs);
+        auto varName = lit.asName();
         auto varNameStr = varName.shortName(cs);
 
         auto *callCache = mcctx.getInlineCache();

--- a/compiler/IREmitter/SymbolBasedIntrinsics.cc
+++ b/compiler/IREmitter/SymbolBasedIntrinsics.cc
@@ -474,13 +474,13 @@ public:
         // Second arg: name of method to define
         auto litName = core::cast_type_nonnull<core::LiteralType>(send->args[1].type);
         ENFORCE(litName.literalKind == core::LiteralType::LiteralTypeKind::Symbol);
-        auto funcNameRef = litName.asName(cs);
+        auto funcNameRef = litName.asName();
         auto name = Payload::toCString(cs, funcNameRef.show(cs), builder);
 
         // Third arg: method kind (normal, attr_reader, or genericPropGetter)
         auto litMethodKind = core::cast_type_nonnull<core::LiteralType>(send->args[2].type);
         ENFORCE(litMethodKind.literalKind == core::LiteralType::LiteralTypeKind::Symbol);
-        auto methodKind = litMethodKind.asName(cs);
+        auto methodKind = litMethodKind.asName();
 
         auto lookupSym = isSelf ? ownerSym : ownerSym.data(cs)->attachedClass(cs);
         if (ownerSym == core::Symbols::Object() && !isSelf) {
@@ -708,7 +708,7 @@ public:
             return IREmitterHelpers::emitMethodCallViaRubyVM(mcctx);
         }
         auto &builder = mcctx.builder;
-        auto str = literal.asName(cs).shortName(cs);
+        auto str = literal.asName().shortName(cs);
         return Payload::cPtrToRubyRegexp(cs, builder, str, options);
     };
 

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -237,20 +237,20 @@ InlinedVector<core::ClassOrModuleRef, 4> ParentLinearizationInformation::fullLin
 
 } // namespace
 
-ClassOrModuleRef GlobalState::synthesizeClass(NameRef nameId, uint32_t superclass, bool isModule) {
+ClassOrModuleRef GlobalState::synthesizeClass(NameRef name, uint32_t superclass, bool isModule) {
     // This can't use enterClass since there is a chicken and egg problem.
     // These will be added to Symbols::root().members later.
     ClassOrModuleRef symRef = ClassOrModuleRef(*this, classAndModules.size());
     classAndModules.emplace_back();
     ClassOrModuleData data =
         symRef.dataAllowingNone(*this); // allowing noSymbol is needed because this enters noSymbol.
-    data->name = nameId;
+    data->name = name;
     data->owner = Symbols::root();
     data->setIsModule(isModule);
     data->setSuperClass(ClassOrModuleRef(*this, superclass));
 
     if (symRef.id() > Symbols::root().id()) {
-        Symbols::root().data(*this)->members()[nameId] = symRef;
+        Symbols::root().data(*this)->members()[name] = symRef;
     }
     return symRef;
 }

--- a/core/Types.h
+++ b/core/Types.h
@@ -477,7 +477,7 @@ TYPE_INLINED(LiteralType) final {
     union {
         const int64_t value;
         const double floatval;
-        const uint32_t nameId;
+        const NameRef name;
     };
 
 public:
@@ -491,7 +491,7 @@ public:
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
     int64_t asInteger() const;
     double asFloat() const;
-    core::NameRef asName(const core::GlobalState &gs) const;
+    core::NameRef asName() const;
     core::NameRef unsafeAsName() const;
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;

--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -169,11 +169,11 @@ com::stripe::rubytyper::Type::Literal Proto::toProto(const GlobalState &gs, cons
             break;
         case LiteralType::LiteralTypeKind::String:
             proto.set_kind(com::stripe::rubytyper::Type::Literal::STRING);
-            proto.set_string(lit.asName(gs).show(gs));
+            proto.set_string(lit.asName().show(gs));
             break;
         case LiteralType::LiteralTypeKind::Symbol:
             proto.set_kind(com::stripe::rubytyper::Type::Literal::SYMBOL);
-            proto.set_symbol(lit.asName(gs).show(gs));
+            proto.set_symbol(lit.asName().show(gs));
             break;
         case LiteralType::LiteralTypeKind::Float:
             proto.set_kind(com::stripe::rubytyper::Type::Literal::FLOAT);

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1213,7 +1213,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                             continue;
                         }
 
-                        NameRef arg = key.asName(gs);
+                        NameRef arg = key.asName();
                         if (consumed.contains(arg)) {
                             continue;
                         }
@@ -1240,7 +1240,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                     auto lit = cast_type_nonnull<LiteralType>(litType);
                     auto underlying = lit.underlying(gs);
                     return cast_type_nonnull<ClassType>(underlying).symbol == Symbols::Symbol() &&
-                           lit.asName(gs) == spec.name;
+                           lit.asName() == spec.name;
                 });
                 if (arg == hash->keys.end()) {
                     if (!spec.flags.isDefault) {
@@ -1293,10 +1293,10 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                 auto key = cast_type_nonnull<LiteralType>(keyType);
                 auto underlying = key.underlying(gs);
                 ClassOrModuleRef klass = cast_type_nonnull<ClassType>(underlying).symbol;
-                if (klass == Symbols::Symbol() && consumed.find(key.asName(gs)) != consumed.end()) {
+                if (klass == Symbols::Symbol() && consumed.find(key.asName()) != consumed.end()) {
                     continue;
                 }
-                NameRef arg = key.asName(gs);
+                NameRef arg = key.asName();
 
                 if (auto e = gs.beginError(args.callLoc(), errors::Infer::MethodArgumentCountMismatch)) {
                     e.setHeader("Unrecognized keyword argument `{}` passed for method `{}`", arg.show(gs),
@@ -2258,7 +2258,7 @@ public:
             return;
         }
 
-        NameRef fn = lit.asName(gs);
+        NameRef fn = lit.asName();
         if (args.args[2]->type.isUntyped()) {
             res.returnType = args.args[2]->type;
             return;
@@ -2507,7 +2507,7 @@ public:
             return;
         }
 
-        NameRef fn = lit.asName(gs);
+        NameRef fn = lit.asName();
 
         uint16_t numPosArgs = args.numPosArgs - 3;
         InlinedVector<TypeAndOrigins, 2> sendArgStore;
@@ -2577,7 +2577,7 @@ public:
             return;
         }
 
-        NameRef fn = lit.asName(gs);
+        NameRef fn = lit.asName();
 
         if (args.args[2]->type.isUntyped()) {
             res.returnType = args.args[2]->type;
@@ -2752,7 +2752,7 @@ public:
         if (!lit.derivesFrom(gs, Symbols::Symbol())) {
             return;
         }
-        auto fun = lit.asName(gs);
+        auto fun = lit.asName();
 
         uint16_t numPosArgs = args.numPosArgs - 3;
 
@@ -3138,7 +3138,7 @@ public:
 
                     if (args.fullType.origins.size() == 1 &&
                         argLit.literalKind == LiteralType::LiteralTypeKind::Symbol) {
-                        auto key = argLit.asName(gs);
+                        auto key = argLit.asName();
                         auto loc = locOfValueForKey(gs, args.fullType.origins[0], key, expectedType);
 
                         if (loc.has_value() && loc->exists()) {

--- a/core/types/hashing.cc
+++ b/core/types/hashing.cc
@@ -37,7 +37,7 @@ uint32_t LiteralType::hash(const GlobalState &gs) const {
     switch (literalKind) {
         case LiteralType::LiteralTypeKind::String:
         case LiteralType::LiteralTypeKind::Symbol:
-            return mix(result, _hash(asName(gs).shortName(gs)));
+            return mix(result, _hash(asName().shortName(gs)));
         case LiteralType::LiteralTypeKind::Float:
             rawValue = absl::bit_cast<uint64_t>(asFloat());
             break;

--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -88,9 +88,9 @@ string LiteralType::show(const GlobalState &gs, ShowOptions options) const {
 string LiteralType::showValue(const GlobalState &gs) const {
     switch (literalKind) {
         case LiteralType::LiteralTypeKind::String:
-            return fmt::format("\"{}\"", absl::CEscape(asName(gs).show(gs)));
+            return fmt::format("\"{}\"", absl::CEscape(asName().show(gs)));
         case LiteralType::LiteralTypeKind::Symbol: {
-            auto shown = asName(gs).show(gs);
+            auto shown = asName().show(gs);
             if (absl::StrContains(shown, " ")) {
                 return fmt::format(":\"{}\"", absl::CEscape(shown));
             } else {
@@ -159,8 +159,8 @@ string ShapeType::show(const GlobalState &gs, ShowOptions options) const {
 
         // properties beginning with $ need to be printed as :$prop => type.
         if (keyLiteral.literalKind == core::LiteralType::LiteralTypeKind::Symbol &&
-            !absl::StartsWith(keyLiteral.asName(gs).shortName(gs), "$")) {
-            fmt::format_to(std::back_inserter(buf), "{}: {}", keyLiteral.asName(gs).show(gs), value.show(gs, options));
+            !absl::StartsWith(keyLiteral.asName().shortName(gs), "$")) {
+            fmt::format_to(std::back_inserter(buf), "{}: {}", keyLiteral.asName().show(gs), value.show(gs, options));
         } else {
             fmt::format_to(std::back_inserter(buf), "{} => {}",
                            options.showForRBI ? keyLiteral.showValue(gs) : keyLiteral.show(gs, options),

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -318,7 +318,7 @@ LiteralType::LiteralType(double val) : floatval(val), literalKind(LiteralTypeKin
 }
 
 LiteralType::LiteralType(ClassOrModuleRef klass, NameRef val)
-    : nameId(val.rawId()), literalKind(klass == Symbols::String() ? LiteralTypeKind::String : LiteralTypeKind::Symbol) {
+    : name(val), literalKind(klass == Symbols::String() ? LiteralTypeKind::String : LiteralTypeKind::Symbol) {
     if (klass == Symbols::String()) {
         categoryCounterInc("types.allocated", "literaltype.string");
     } else {
@@ -337,14 +337,14 @@ double LiteralType::asFloat() const {
     return floatval;
 }
 
-core::NameRef LiteralType::asName(const core::GlobalState &gs) const {
+core::NameRef LiteralType::asName() const {
     ENFORCE_NO_TIMER(literalKind == LiteralTypeKind::Symbol || literalKind == LiteralTypeKind::String);
-    return NameRef::fromRaw(gs, nameId);
+    return name;
 }
 
 core::NameRef LiteralType::unsafeAsName() const {
     ENFORCE_NO_TIMER(literalKind == LiteralTypeKind::Symbol || literalKind == LiteralTypeKind::String);
-    return NameRef::fromRawUnchecked(nameId);
+    return name;
 }
 
 TypePtr LiteralType::underlying(const GlobalState &gs) const {
@@ -385,7 +385,7 @@ bool LiteralType::equals(const LiteralType &rhs) const {
             return this->value == rhs.value;
         case LiteralTypeKind::Symbol:
         case LiteralTypeKind::String:
-            return this->nameId == rhs.nameId;
+            return this->name == rhs.name;
     }
 }
 

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -145,7 +145,7 @@ void extractSendArgumentKnowledge(core::Context ctx, core::LocOffsets bindLoc, c
             if (core::isa_type<core::LiteralType>(snd->args[i].type)) {
                 auto lit = core::cast_type_nonnull<core::LiteralType>(snd->args[i].type);
                 if (lit.literalKind == core::LiteralType::LiteralTypeKind::Symbol) {
-                    keyword = lit.asName(ctx);
+                    keyword = lit.asName();
                 }
             }
 

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1063,7 +1063,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                     if (fun == core::Names::checkAndAnd() && core::isa_type<core::LiteralType>(args[2]->type)) {
                         auto lit = core::cast_type_nonnull<core::LiteralType>(args[2]->type);
                         if (lit.derivesFrom(ctx, core::Symbols::Symbol())) {
-                            fun = lit.asName(ctx);
+                            fun = lit.asName();
                         }
                     }
                     core::lsp::QueryResponse::pushQueryResponse(

--- a/main/autogen/autogen.cc
+++ b/main/autogen/autogen.cc
@@ -303,8 +303,8 @@ public:
         // This means it's a `require`; mark it as such
         if (original->flags.isPrivateOk && original->fun == core::Names::require() && original->numPosArgs() == 1) {
             auto *lit = ast::cast_tree<ast::Literal>(original->getPosArg(0));
-            if (lit && lit->isString(ctx)) {
-                requireStatements.emplace_back(lit->asString(ctx));
+            if (lit && lit->isString()) {
+                requireStatements.emplace_back(lit->asString());
             }
         }
         return tree;

--- a/main/autogen/constant_hash.cc
+++ b/main/autogen/constant_hash.cc
@@ -63,8 +63,8 @@ struct ConstantHashWalk {
             hashSoFar = core::mix(hashSoFar, core::_hash("(r"));
             if (send.hasPosArgs()) {
                 if (auto str = ast::cast_tree<ast::Literal>(send.posArgs().front())) {
-                    if (str->isString(ctx)) {
-                        hashSoFar = core::mix(hashSoFar, core::_hash(str->asString(ctx).shortName(ctx)));
+                    if (str->isString()) {
+                        hashSoFar = core::mix(hashSoFar, core::_hash(str->asString().shortName(ctx)));
                     }
                 }
             }

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1722,8 +1722,8 @@ public:
                             default:
                                 if (auto e =
                                         ctx.beginError(keyExpr.loc(), core::errors::Namer::InvalidTypeDefinition)) {
-                                    e.setHeader("Unknown key `{}` provided in block to `{}`",
-                                                key->asSymbol().show(ctx), send->fun.show(ctx));
+                                    e.setHeader("Unknown key `{}` provided in block to `{}`", key->asSymbol().show(ctx),
+                                                send->fun.show(ctx));
                                 }
                                 return tree;
                         }

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -326,10 +326,10 @@ public:
 
         for (const auto &arg : send.posArgs()) {
             auto lit = ast::cast_tree<ast::Literal>(arg);
-            if (lit == nullptr || !lit->isSymbol(ctx)) {
+            if (lit == nullptr || !lit->isSymbol()) {
                 continue;
             }
-            core::NameRef name = lit->asSymbol(ctx);
+            core::NameRef name = lit->asSymbol();
 
             parsedArgs.emplace_back(name);
         }
@@ -352,10 +352,10 @@ public:
     void addConstantModifier(core::Context ctx, core::NameRef modifierName, const ast::ExpressionPtr &arg) {
         auto target = core::NameRef::noName();
         if (auto sym = ast::cast_tree<ast::Literal>(arg)) {
-            if (sym->isSymbol(ctx)) {
-                target = sym->asSymbol(ctx);
-            } else if (sym->isString(ctx)) {
-                target = sym->asString(ctx);
+            if (sym->isSymbol()) {
+                target = sym->asSymbol();
+            } else if (sym->isString()) {
+                target = sym->asString();
             }
         }
 
@@ -373,10 +373,10 @@ public:
     core::NameRef unwrapLiteralToMethodName(core::Context ctx, const ast::ExpressionPtr &expr) {
         if (auto sym = ast::cast_tree<ast::Literal>(expr)) {
             // this handles the `private :foo` case
-            if (!sym->isSymbol(ctx)) {
+            if (!sym->isSymbol()) {
                 return core::NameRef::noName();
             }
-            return sym->asSymbol(ctx);
+            return sym->asSymbol();
         } else if (auto *def = ast::cast_tree<ast::RuntimeMethodDefinition>(expr)) {
             return def->name;
         } else if (auto send = ast::cast_tree<ast::Send>(expr)) {
@@ -447,8 +447,8 @@ public:
             // If there are positional arguments, there might be a variance annotation
             if (send->numPosArgs() > 0) {
                 auto *lit = ast::cast_tree<ast::Literal>(send->getPosArg(0));
-                if (lit != nullptr && lit->isSymbol(ctx)) {
-                    found.varianceName = lit->asSymbol(ctx);
+                if (lit != nullptr && lit->isSymbol()) {
+                    found.varianceName = lit->asSymbol();
                     found.litLoc = lit->loc;
                 }
             }
@@ -457,8 +457,8 @@ public:
                 if (const auto *hash = ast::cast_tree<ast::Hash>(send->block()->body)) {
                     for (const auto &keyExpr : hash->keys) {
                         const auto *key = ast::cast_tree<ast::Literal>(keyExpr);
-                        if (key != nullptr && key->isSymbol(ctx)) {
-                            switch (key->asSymbol(ctx).rawId()) {
+                        if (key != nullptr && key->isSymbol()) {
+                            switch (key->asSymbol().rawId()) {
                                 case core::Names::fixed().rawId():
                                     found.isFixed = true;
                                     break;
@@ -1701,7 +1701,7 @@ public:
                 if (const auto *hash = ast::cast_tree<ast::Hash>(send->block()->body)) {
                     for (const auto &keyExpr : hash->keys) {
                         const auto *key = ast::cast_tree<ast::Literal>(keyExpr);
-                        if (key == nullptr || !key->isSymbol(ctx)) {
+                        if (key == nullptr || !key->isSymbol()) {
                             if (auto e = ctx.beginError(keyExpr.loc(), core::errors::Namer::InvalidTypeDefinition)) {
                                 e.setHeader("Hash provided in block to `{}` must have symbol keys",
                                             send->fun.show(ctx));
@@ -1709,7 +1709,7 @@ public:
                             return tree;
                         }
 
-                        switch (key->asSymbol(ctx).rawId()) {
+                        switch (key->asSymbol().rawId()) {
                             case core::Names::fixed().rawId():
                                 fixed = true;
                                 break;
@@ -1723,7 +1723,7 @@ public:
                                 if (auto e =
                                         ctx.beginError(keyExpr.loc(), core::errors::Namer::InvalidTypeDefinition)) {
                                     e.setHeader("Unknown key `{}` provided in block to `{}`",
-                                                key->asSymbol(ctx).show(ctx), send->fun.show(ctx));
+                                                key->asSymbol().show(ctx), send->fun.show(ctx));
                                 }
                                 return tree;
                         }
@@ -1757,7 +1757,7 @@ public:
 
             if (send->numPosArgs() > 0) {
                 auto *lit = ast::cast_tree<ast::Literal>(send->getPosArg(0));
-                if (!lit || !lit->isSymbol(ctx)) {
+                if (!lit || !lit->isSymbol()) {
                     if (auto e = ctx.beginError(send->loc, core::errors::Namer::InvalidTypeDefinition)) {
                         e.setHeader("Invalid param, must be a :symbol");
                     }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2501,7 +2501,7 @@ class ResolveTypeMembersAndFieldsWalk {
         // if we got keyword args, then package should be non-null
         ENFORCE((!send.hasKwArgs() && !packageType) || (send.hasKwArgs() && packageType));
 
-        auto name = literal.asName(ctx);
+        auto name = literal.asName();
         auto shortName = name.shortName(ctx);
         if (shortName.empty()) {
             if (auto e = ctx.beginError(stringLoc, core::errors::Resolver::LazyResolve)) {
@@ -2532,7 +2532,7 @@ class ResolveTypeMembersAndFieldsWalk {
                 return;
             }
             auto package = core::cast_type_nonnull<core::LiteralType>(packageType);
-            auto name = package.asName(ctx).shortName(ctx);
+            auto name = package.asName().shortName(ctx);
             vector<string> pkgParts = absl::StrSplit(name, "::");
             // add the initial empty string to mimic the leading `::`
             if (ctx.state.packageDB().empty()) {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2156,7 +2156,7 @@ class ResolveTypeMembersAndFieldsWalk {
                 for (const auto &keyExpr : hash->keys) {
                     i++;
                     const auto *key = ast::cast_tree<ast::Literal>(keyExpr);
-                    if (key == nullptr || !key->isSymbol(ctx)) {
+                    if (key == nullptr || !key->isSymbol()) {
                         // Namer reported an error already
                         continue;
                     }
@@ -2170,7 +2170,7 @@ class ResolveTypeMembersAndFieldsWalk {
                     core::TypePtr resTy = TypeSyntax::getResultType(
                         ctx, value, emptySig, TypeSyntaxArgs{allowSelfType, allowRebind, allowTypeMember, lhs});
 
-                    switch (key->asSymbol(ctx).rawId()) {
+                    switch (key->asSymbol().rawId()) {
                         case core::Names::fixed().rawId():
                             memberType->lowerBound = resTy;
                             memberType->upperBound = resTy;
@@ -2476,7 +2476,7 @@ class ResolveTypeMembersAndFieldsWalk {
         if (send.hasKwArgs()) {
             // this means we got the third package arg
             auto *key = ast::cast_tree<ast::Literal>(send.getKwKey(0));
-            if (!key || !key->isSymbol(ctx) || key->asSymbol(ctx) != ctx.state.lookupNameUTF8("package")) {
+            if (!key || !key->isSymbol() || key->asSymbol() != ctx.state.lookupNameUTF8("package")) {
                 return;
             }
 
@@ -2843,10 +2843,10 @@ public:
             for (auto i = 0; i < numPosArgs; ++i) {
                 auto &arg = send.getPosArg(i);
                 auto lit = ast::cast_tree<ast::Literal>(arg);
-                if (lit == nullptr || !lit->isSymbol(ctx)) {
+                if (lit == nullptr || !lit->isSymbol()) {
                     continue;
                 }
-                core::NameRef name = lit->asSymbol(ctx);
+                core::NameRef name = lit->asSymbol();
 
                 args.emplace_back(name);
             }

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -193,7 +193,7 @@ ParsedSig parseSigWithSelfTypeParams(core::Context ctx, const ast::Send &sigSend
 
     if (sigSend.numPosArgs() == 2) {
         auto lit = ast::cast_tree<ast::Literal>(sigSend.getPosArg(1));
-        if (lit != nullptr && lit->isSymbol(ctx) && lit->asSymbol(ctx) == core::Names::final_()) {
+        if (lit != nullptr && lit->isSymbol() && lit->asSymbol() == core::Names::final_()) {
             sig.seen.final = true;
         }
     }
@@ -217,14 +217,14 @@ ParsedSig parseSigWithSelfTypeParams(core::Context ctx, const ast::Send &sigSend
                     continue;
                 }
 
-                if (!c->isSymbol(ctx)) {
+                if (!c->isSymbol()) {
                     if (auto e = ctx.beginError(arg.loc(), core::errors::Resolver::InvalidMethodSignature)) {
                         e.setHeader("Malformed `{}`: Type parameters are specified with symbols", "sig");
                     }
                     continue;
                 }
 
-                auto name = c->asSymbol(ctx);
+                auto name = c->asSymbol();
                 auto &typeArgSpec = sig.enterTypeArgByName(name);
                 if (typeArgSpec.type) {
                     if (auto e = ctx.beginError(arg.loc(), core::errors::Resolver::InvalidMethodSignature)) {
@@ -371,8 +371,8 @@ ParsedSig parseSigWithSelfTypeParams(core::Context ctx, const ast::Send &sigSend
                     auto &key = send->getKwKey(i);
                     auto &value = send->getKwValue(i);
                     auto *lit = ast::cast_tree<ast::Literal>(key);
-                    if (lit && lit->isSymbol(ctx)) {
-                        core::NameRef name = lit->asSymbol(ctx);
+                    if (lit && lit->isSymbol()) {
+                        core::NameRef name = lit->asSymbol();
                         TypeSyntax::ResultType resultAndBind;
 
                         if (isProc) {
@@ -426,8 +426,8 @@ ParsedSig parseSigWithSelfTypeParams(core::Context ctx, const ast::Send &sigSend
                         auto &key = send->getKwKey(i);
                         auto &value = send->getKwValue(i);
                         auto lit = ast::cast_tree<ast::Literal>(key);
-                        if (lit && lit->isSymbol(ctx)) {
-                            if (lit->asSymbol(ctx) == core::Names::allowIncompatible()) {
+                        if (lit && lit->isSymbol()) {
+                            if (lit->asSymbol() == core::Names::allowIncompatible()) {
                                 auto val = ast::cast_tree<ast::Literal>(value);
                                 if (val && val->isTrue(ctx)) {
                                     sig.seen.incompatibleOverride = true;
@@ -628,13 +628,13 @@ TypeSyntax::ResultType interpretTCombinator(core::Context ctx, const ast::Send &
                 return TypeSyntax::ResultType{core::Types::untypedUntracked(), core::Symbols::noClassOrModule()};
             }
             auto arr = ast::cast_tree<ast::Literal>(send.getPosArg(0));
-            if (!arr || !arr->isSymbol(ctx)) {
+            if (!arr || !arr->isSymbol()) {
                 if (auto e = ctx.beginError(send.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                     e.setHeader("type_parameter requires a symbol");
                 }
                 return TypeSyntax::ResultType{core::Types::untypedUntracked(), core::Symbols::noClassOrModule()};
             }
-            auto fnd = sig.findTypeArgByName(arr->asSymbol(ctx));
+            auto fnd = sig.findTypeArgByName(arr->asSymbol());
             if (!fnd.type) {
                 if (auto e = ctx.beginError(arr->loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                     e.setHeader("Unspecified type parameter");
@@ -826,7 +826,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx,
                 auto &vtree = hash.values[&ktree - &hash.keys.front()];
                 auto val = getResultTypeWithSelfTypeParams(ctx, vtree, sigBeingParsed, args.withoutSelfType());
                 auto lit = ast::cast_tree<ast::Literal>(ktree);
-                if (lit && (lit->isSymbol(ctx) || lit->isString(ctx))) {
+                if (lit && (lit->isSymbol() || lit->isString())) {
                     ENFORCE(core::isa_type<core::LiteralType>(lit->value));
                     keys.emplace_back(lit->value);
                     values.emplace_back(val);

--- a/rewriter/AttrReader.cc
+++ b/rewriter/AttrReader.cc
@@ -19,14 +19,14 @@ pair<core::NameRef, core::LocOffsets> getName(core::MutableContext ctx, ast::Exp
     core::LocOffsets loc;
     core::NameRef res;
     if (auto *lit = ast::cast_tree<ast::Literal>(name)) {
-        if (lit->isSymbol(ctx)) {
-            res = lit->asSymbol(ctx);
+        if (lit->isSymbol()) {
+            res = lit->asSymbol();
             loc = lit->loc;
             ENFORCE(ctx.locAt(loc).exists());
             ENFORCE(ctx.locAt(loc).source(ctx).value().size() > 1 && ctx.locAt(loc).source(ctx).value()[0] == ':');
             loc = core::LocOffsets{loc.beginPos() + 1, loc.endPos()};
-        } else if (lit->isString(ctx)) {
-            core::NameRef nameRef = lit->asString(ctx);
+        } else if (lit->isString()) {
+            core::NameRef nameRef = lit->asString();
             auto shortName = nameRef.shortName(ctx);
             bool validAttr = (isalpha(shortName.front()) || shortName.front() == '_') &&
                              absl::c_all_of(shortName, [](char c) { return isalnum(c) || c == '_'; });
@@ -166,14 +166,14 @@ bool sigIsUnchecked(core::MutableContext ctx, ast::Send *sig) {
     }
 
     auto lit = ast::cast_tree<ast::Literal>(checked->getPosArg(0));
-    if (lit == nullptr || !lit->isSymbol(ctx)) {
+    if (lit == nullptr || !lit->isSymbol()) {
         // Unknown: default to false
         return false;
     }
 
     // Treats `.checked(:tests)` as unknown, therefore not unchecked.
     // Also treats `.checked(:compiled)` as unknown, therefore not unchecked.
-    return lit->asSymbol(ctx) == core::Names::never();
+    return lit->asSymbol() == core::Names::never();
 }
 
 // To convert a sig into a writer sig with argument `name`, we copy the `returns(...)`

--- a/rewriter/DSLBuilder.cc
+++ b/rewriter/DSLBuilder.cc
@@ -44,10 +44,10 @@ vector<ast::ExpressionPtr> DSLBuilder::run(core::MutableContext ctx, ast::Send *
         return empty;
     }
     auto *sym = ast::cast_tree<ast::Literal>(send->getPosArg(0));
-    if (sym == nullptr || !sym->isSymbol(ctx)) {
+    if (sym == nullptr || !sym->isSymbol()) {
         return empty;
     }
-    name = sym->asSymbol(ctx);
+    name = sym->asSymbol();
 
     ENFORCE(ctx.locAt(sym->loc).exists());
     ENFORCE(!ctx.locAt(sym->loc).source(ctx).value().empty() && ctx.locAt(sym->loc).source(ctx).value()[0] == ':');

--- a/rewriter/DefDelegator.cc
+++ b/rewriter/DefDelegator.cc
@@ -43,24 +43,24 @@ vector<ast::ExpressionPtr> runDefDelegator(core::MutableContext ctx, const ast::
     }
 
     auto *accessor = ast::cast_tree<ast::Literal>(send->getPosArg(0));
-    if (!accessor || !(accessor->isSymbol(ctx) || accessor->isString(ctx))) {
+    if (!accessor || !(accessor->isSymbol() || accessor->isString())) {
         return methodStubs;
     }
 
     auto *method = ast::cast_tree<ast::Literal>(send->getPosArg(1));
-    if (!method || !method->isSymbol(ctx)) {
+    if (!method || !method->isSymbol()) {
         return methodStubs;
     }
 
-    core::NameRef methodName = method->asSymbol(ctx);
+    core::NameRef methodName = method->asSymbol();
 
     if (send->numPosArgs() == 3) {
         auto *alias = ast::cast_tree<ast::Literal>(send->getPosArg(2));
-        if (!alias || !alias->isSymbol(ctx)) {
+        if (!alias || !alias->isSymbol()) {
             return methodStubs;
         }
 
-        methodName = alias->asSymbol(ctx);
+        methodName = alias->asSymbol();
     }
 
     generateStub(methodStubs, loc, methodName);
@@ -88,7 +88,7 @@ vector<ast::ExpressionPtr> runDefDelegators(core::MutableContext ctx, const ast:
     }
 
     auto *accessor = ast::cast_tree<ast::Literal>(send->getPosArg(0));
-    if (!accessor || !(accessor->isSymbol(ctx) || accessor->isString(ctx))) {
+    if (!accessor || !(accessor->isSymbol() || accessor->isString())) {
         return methodStubs;
     }
 
@@ -96,11 +96,11 @@ vector<ast::ExpressionPtr> runDefDelegators(core::MutableContext ctx, const ast:
         auto *method = ast::cast_tree<ast::Literal>(send->getPosArg(i));
         // Skip method names that we don't understand, but continue to emit
         // desugared calls for the ones we do.
-        if (!method || !method->isSymbol(ctx)) {
+        if (!method || !method->isSymbol()) {
             continue;
         }
 
-        generateStub(methodStubs, loc, method->asSymbol(ctx));
+        generateStub(methodStubs, loc, method->asSymbol());
     }
 
     // Include the original call to def_delegators so sorbet will still type-check it

--- a/rewriter/Delegate.cc
+++ b/rewriter/Delegate.cc
@@ -10,7 +10,7 @@ namespace sorbet::rewriter {
 
 static bool literalSymbolEqual(const core::GlobalState &gs, const ast::ExpressionPtr &node, core::NameRef name) {
     if (auto lit = ast::cast_tree<ast::Literal>(node)) {
-        return lit->isSymbol(gs) && lit->asSymbol(gs) == name;
+        return lit->isSymbol() && lit->asSymbol() == name;
     }
     return false;
 }
@@ -27,10 +27,10 @@ static optional<core::NameRef> stringOrSymbolNameRef(const core::GlobalState &gs
     if (!lit) {
         return nullopt;
     }
-    if (lit->isSymbol(gs)) {
-        return lit->asSymbol(gs);
-    } else if (lit->isString(gs)) {
-        return lit->asString(gs);
+    if (lit->isSymbol()) {
+        return lit->asSymbol();
+    } else if (lit->isString()) {
+        return lit->asString();
     } else {
         return nullopt;
     }
@@ -91,7 +91,7 @@ vector<ast::ExpressionPtr> Delegate::run(core::MutableContext ctx, const ast::Se
     vector<ast::ExpressionPtr> methodStubs;
     for (int i = 0; i < send->numPosArgs(); i++) {
         auto *lit = ast::cast_tree<ast::Literal>(send->getPosArg(i));
-        if (!lit || !lit->isSymbol(ctx)) {
+        if (!lit || !lit->isSymbol()) {
             return empty;
         }
         core::NameRef methodName;
@@ -101,9 +101,9 @@ vector<ast::ExpressionPtr> Delegate::run(core::MutableContext ctx, const ast::Se
                 return empty;
             }
             methodName =
-                ctx.state.enterNameUTF8(fmt::format("{}_{}", beforeUnderscore, lit->asSymbol(ctx).shortName(ctx)));
+                ctx.state.enterNameUTF8(fmt::format("{}_{}", beforeUnderscore, lit->asSymbol().shortName(ctx)));
         } else {
-            methodName = lit->asSymbol(ctx);
+            methodName = lit->asSymbol();
         }
         // sig {params(arg0: T.untyped, blk: Proc).returns(T.untyped)}
         auto sigArgs = ast::MK::SendArgs(ast::MK::Symbol(loc, core::Names::arg0()), ast::MK::Untyped(loc),

--- a/rewriter/Flatfiles.cc
+++ b/rewriter/Flatfiles.cc
@@ -12,14 +12,14 @@ using namespace std;
 namespace sorbet::rewriter {
 optional<core::NameRef> getFieldName(core::MutableContext ctx, ast::Send &send) {
     if (auto propLit = ast::cast_tree<ast::Literal>(send.getPosArg(0))) {
-        if (propLit->isSymbol(ctx)) {
-            return propLit->asSymbol(ctx);
+        if (propLit->isSymbol()) {
+            return propLit->asSymbol();
         }
     }
     if (send.numPosArgs() >= 2) {
         if (auto propLit = ast::cast_tree<ast::Literal>(send.getPosArg(1))) {
-            if (propLit->isSymbol(ctx)) {
-                return propLit->asSymbol(ctx);
+            if (propLit->isSymbol()) {
+                return propLit->asSymbol();
             }
         }
     }

--- a/rewriter/Initializer.cc
+++ b/rewriter/Initializer.cc
@@ -151,8 +151,8 @@ void Initializer::run(core::MutableContext ctx, ast::MethodDef *methodDef, ast::
     for (int i = 0; i < numKwArgs; ++i) {
         auto *argName = ast::cast_tree<ast::Literal>(params->getKwKey(i));
         auto *argVal = &params->getKwValue(i);
-        if (argName->isSymbol(ctx)) {
-            argTypeMap[argName->asSymbol(ctx)] = argVal;
+        if (argName->isSymbol()) {
+            argTypeMap[argName->asSymbol()] = argVal;
         }
     }
 

--- a/rewriter/Mattr.cc
+++ b/rewriter/Mattr.cc
@@ -9,7 +9,7 @@ namespace sorbet::rewriter {
 
 static bool literalSymbolEqual(const core::GlobalState &gs, const ast::ExpressionPtr &node, core::NameRef name) {
     if (auto lit = ast::cast_tree<ast::Literal>(node)) {
-        return lit->isSymbol(gs) && lit->asSymbol(gs) == name;
+        return lit->isSymbol() && lit->asSymbol() == name;
     }
     return false;
 }
@@ -89,13 +89,13 @@ vector<ast::ExpressionPtr> Mattr::run(core::MutableContext ctx, const ast::Send 
     vector<ast::ExpressionPtr> result;
     for (int i = 0; i < symbolArgsBound; i++) {
         auto *lit = ast::cast_tree<ast::Literal>(send->getPosArg(i));
-        if (!lit || !lit->isSymbol(ctx)) {
+        if (!lit || !lit->isSymbol()) {
             return empty;
         }
         auto loc = lit->loc;
         if (doReaders) {
             auto sig = ast::MK::Sig0(loc, ast::MK::Untyped(loc));
-            auto def = ast::MK::SyntheticMethod0(loc, loc, lit->asSymbol(ctx), ast::MK::EmptyTree());
+            auto def = ast::MK::SyntheticMethod0(loc, loc, lit->asSymbol(), ast::MK::EmptyTree());
             ast::cast_tree_nonnull<ast::MethodDef>(def).flags.isSelfMethod = true;
             if (instanceReader) {
                 addInstanceCounterPart(result, sig, def);
@@ -106,7 +106,7 @@ vector<ast::ExpressionPtr> Mattr::run(core::MutableContext ctx, const ast::Send 
         if (doWriters) {
             auto sig = ast::MK::Sig1(loc, ast::MK::Symbol(loc, core::Names::arg0()), ast::MK::Untyped(loc),
                                      ast::MK::Untyped(loc));
-            auto def = ast::MK::SyntheticMethod1(loc, loc, lit->asSymbol(ctx).addEq(ctx),
+            auto def = ast::MK::SyntheticMethod1(loc, loc, lit->asSymbol().addEq(ctx),
                                                  ast::MK::Local(loc, core::Names::arg0()), ast::MK::EmptyTree());
             ast::cast_tree_nonnull<ast::MethodDef>(def).flags.isSelfMethod = true;
             if (instanceWriter) {
@@ -120,7 +120,7 @@ vector<ast::ExpressionPtr> Mattr::run(core::MutableContext ctx, const ast::Send 
             // from being generated.
             auto sig = ast::MK::Sig0(
                 loc, ast::MK::UnresolvedConstant(loc, ast::MK::T(loc), core::Names::Constants::Boolean()));
-            auto def = ast::MK::SyntheticMethod0(loc, loc, lit->asSymbol(ctx).addQuestion(ctx), ast::MK::False(loc));
+            auto def = ast::MK::SyntheticMethod0(loc, loc, lit->asSymbol().addQuestion(ctx), ast::MK::False(loc));
             ast::cast_tree_nonnull<ast::MethodDef>(def).flags.isSelfMethod = true;
             if (instanceReader && instancePredicate) {
                 addInstanceCounterPart(result, sig, def);

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -134,10 +134,10 @@ string to_s(core::Context ctx, ast::ExpressionPtr &arg) {
     auto argLit = ast::cast_tree<ast::Literal>(arg);
     string argString;
     if (argLit != nullptr) {
-        if (argLit->isString(ctx)) {
-            return argLit->asString(ctx).show(ctx);
-        } else if (argLit->isSymbol(ctx)) {
-            return argLit->asSymbol(ctx).show(ctx);
+        if (argLit->isString()) {
+            return argLit->asString().show(ctx);
+        } else if (argLit->isSymbol()) {
+            return argLit->asSymbol().show(ctx);
         }
     }
     auto argConstant = ast::cast_tree<ast::UnresolvedConstantLit>(arg);

--- a/rewriter/MixinEncryptedProp.cc
+++ b/rewriter/MixinEncryptedProp.cc
@@ -47,10 +47,10 @@ vector<ast::ExpressionPtr> MixinEncryptedProp::run(core::MutableContext ctx, ast
 
     auto loc = send->loc;
     auto *sym = ast::cast_tree<ast::Literal>(send->getPosArg(0));
-    if (!sym || !sym->isSymbol(ctx)) {
+    if (!sym || !sym->isSymbol()) {
         return empty;
     }
-    name = sym->asSymbol(ctx);
+    name = sym->asSymbol();
     ENFORCE(ctx.locAt(sym->loc).exists());
     ENFORCE(ctx.locAt(sym->loc).source(ctx).value().size() > 1 && ctx.locAt(sym->loc).source(ctx).value()[0] == ':');
     auto nameLoc = core::LocOffsets{sym->loc.beginPos() + 1, sym->loc.endPos()};

--- a/rewriter/ModuleFunction.cc
+++ b/rewriter/ModuleFunction.cc
@@ -117,10 +117,10 @@ vector<ast::ExpressionPtr> ModuleFunction::run(core::MutableContext ctx, ast::Se
         } else if (auto lit = ast::cast_tree<ast::Literal>(arg)) {
             core::NameRef methodName;
             auto loc = send->loc;
-            if (lit->isSymbol(ctx)) {
-                methodName = lit->asSymbol(ctx);
-            } else if (lit->isString(ctx)) {
-                core::NameRef nameRef = lit->asString(ctx);
+            if (lit->isSymbol()) {
+                methodName = lit->asSymbol();
+            } else if (lit->isString()) {
+                core::NameRef nameRef = lit->asString();
                 auto shortName = nameRef.shortName(ctx);
                 bool validAttr = (isalpha(shortName.front()) || shortName.front() == '_') &&
                                  absl::c_all_of(shortName, [](char c) { return isalnum(c) || c == '_'; });

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -214,10 +214,10 @@ optional<PropInfo> parseProp(core::MutableContext ctx, const ast::Send *send) {
             return nullopt;
         }
         auto *sym = ast::cast_tree<ast::Literal>(send->getPosArg(0));
-        if (!sym || !sym->isSymbol(ctx)) {
+        if (!sym || !sym->isSymbol()) {
             return nullopt;
         }
-        ret.name = sym->asSymbol(ctx);
+        ret.name = sym->asSymbol();
         ENFORCE(ctx.locAt(sym->loc).exists());
         ENFORCE(!ctx.locAt(sym->loc).source(ctx).value().empty() && ctx.locAt(sym->loc).source(ctx).value()[0] == ':');
         ret.nameLoc = core::LocOffsets{sym->loc.beginPos() + 1, sym->loc.endPos()};
@@ -292,9 +292,9 @@ optional<PropInfo> parseProp(core::MutableContext ctx, const ast::Send *send) {
         if (ASTUtil::hasTruthyHashValue(ctx, *rules, core::Names::computedBy())) {
             auto [key, val] = ASTUtil::extractHashValue(ctx, *rules, core::Names::computedBy());
             auto lit = ast::cast_tree<ast::Literal>(val);
-            if (lit != nullptr && lit->isSymbol(ctx)) {
+            if (lit != nullptr && lit->isSymbol()) {
                 ret.computedByMethodNameLoc = lit->loc;
-                ret.computedByMethodName = lit->asSymbol(ctx);
+                ret.computedByMethodName = lit->asSymbol();
             } else {
                 if (auto e = ctx.beginError(val.loc(), core::errors::Rewriter::ComputedBySymbol)) {
                     e.setHeader("Value for `{}` must be a symbol literal", "computed_by");

--- a/rewriter/SelfNew.cc
+++ b/rewriter/SelfNew.cc
@@ -45,7 +45,7 @@ bool isSelfNewCallWithSplat(core::MutableContext ctx, ast::Send *send) {
         return false;
     }
 
-    if (litType.asName(ctx) != core::Names::new_()) {
+    if (litType.asName() != core::Names::new_()) {
         return false;
     }
 

--- a/rewriter/Struct.cc
+++ b/rewriter/Struct.cc
@@ -17,7 +17,7 @@ namespace {
 
 bool isKeywordInitKey(const core::GlobalState &gs, const ast::ExpressionPtr &node) {
     if (auto *lit = ast::cast_tree<ast::Literal>(node)) {
-        return lit->isSymbol(gs) && lit->asSymbol(gs) == core::Names::keywordInit();
+        return lit->isSymbol() && lit->asSymbol() == core::Names::keywordInit();
     }
     return false;
 }
@@ -114,10 +114,10 @@ vector<ast::ExpressionPtr> Struct::run(core::MutableContext ctx, ast::Assign *as
 
     for (int i = 0; i < send->numPosArgs(); i++) {
         auto *sym = ast::cast_tree<ast::Literal>(send->getPosArg(i));
-        if (!sym || !sym->isSymbol(ctx)) {
+        if (!sym || !sym->isSymbol()) {
             return empty;
         }
-        core::NameRef name = sym->asSymbol(ctx);
+        core::NameRef name = sym->asSymbol();
         auto symLoc = sym->loc;
         auto strname = name.shortName(ctx);
         if (!strname.empty() && strname.back() == '=') {

--- a/rewriter/TestCase.cc
+++ b/rewriter/TestCase.cc
@@ -15,7 +15,7 @@ void TestCase::run(core::MutableContext ctx, ast::ClassDef *klass) {
                 if (send->numPosArgs() == 1 && !send->hasKwArgs() && send->hasBlock()) {
                     auto *arg0 = ast::cast_tree<ast::Literal>(send->getPosArg(0));
 
-                    if (arg0 && arg0->isString(ctx)) {
+                    if (arg0 && arg0->isString()) {
                         testSends.push_back(std::move(stat));
                         continue;
                     }
@@ -38,7 +38,7 @@ void TestCase::run(core::MutableContext ctx, ast::ClassDef *klass) {
         auto *arg0 = ast::cast_tree<ast::Literal>(send->getPosArg(0));
         auto *block = send->block();
 
-        auto snake_case_name = absl::StrReplaceAll(arg0->asString(ctx).toString(ctx), {{" ", "_"}});
+        auto snake_case_name = absl::StrReplaceAll(arg0->asString().toString(ctx), {{" ", "_"}});
         auto name = ctx.state.enterNameUTF8("test_" + snake_case_name);
         auto method = ast::MK::SyntheticMethod0(loc, loc, name, std::move(block->body));
         auto method_with_sig = ast::MK::InsSeq1(method.loc(), ast::MK::SigVoid(method.loc(), {}), std::move(method));

--- a/rewriter/Util.cc
+++ b/rewriter/Util.cc
@@ -132,7 +132,7 @@ ast::ExpressionPtr ASTUtil::dupType(const ast::ExpressionPtr &orig) {
 bool ASTUtil::hasHashValue(core::MutableContext ctx, const ast::Hash &hash, core::NameRef name) {
     for (const auto &keyExpr : hash.keys) {
         auto *key = ast::cast_tree<ast::Literal>(keyExpr);
-        if (key && key->isSymbol(ctx) && key->asSymbol(ctx) == name) {
+        if (key && key->isSymbol() && key->asSymbol() == name) {
             return true;
         }
     }
@@ -144,7 +144,7 @@ bool ASTUtil::hasTruthyHashValue(core::MutableContext ctx, const ast::Hash &hash
     for (const auto &keyExpr : hash.keys) {
         i++;
         auto *key = ast::cast_tree<ast::Literal>(keyExpr);
-        if (key && key->isSymbol(ctx) && key->asSymbol(ctx) == name) {
+        if (key && key->isSymbol() && key->asSymbol() == name) {
             auto *val = ast::cast_tree<ast::Literal>(hash.values[i]);
             if (!val) {
                 // All non-literals are truthy
@@ -165,7 +165,7 @@ pair<ast::ExpressionPtr, ast::ExpressionPtr> ASTUtil::extractHashValue(core::Mut
     for (auto &keyExpr : hash.keys) {
         i++;
         auto *key = ast::cast_tree<ast::Literal>(keyExpr);
-        if (key && key->isSymbol(ctx) && key->asSymbol(ctx) == name) {
+        if (key && key->isSymbol() && key->asSymbol() == name) {
             auto key = std::move(keyExpr);
             auto value = std::move(hash.values[i]);
             hash.keys.erase(hash.keys.begin() + i);


### PR DESCRIPTION
In the union for `LiteralType` storage, instead of storing a `uint32_t` we
simply store a `NameRef`. This means that in debug builds, we can store extra
information to track the `GlobalState` ID that created the `NameRef`.

This also lets us remove the `GlobalState` parameter from `isString`,
`isSymbol`, `asString`, `asSymbol`, and `asName` (previously, the `gs`)
parameter was only being used for the sake of attributing a `GlobalState` to the
freshly minted `NameRef` (but there were no checks to make sure that the
`uint32_t` stored in the `LiteralType` union was actually created by the
`GlobalState` that had been passed into `asName`, so it was possible to misuse).



<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Pre-work for #5808


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

no-op change, covered by existing tests

(if you want a slightly better guarantee that this change is ok, know that it enables the changes in #5928, which on its own would fail ENFORCEs when building Sorbet's payload if not for the changes in this PR)