### PR TITLE
Report histogram of how many files per fast path

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -334,6 +334,7 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
     subset.resize(std::distance(subset.begin(), std::unique(subset.begin(), subset.end())));
 
     config->logger->debug("Running fast path");
+    prodHistogramInc("lsp.fast_path_files_retypechecked", subset.size());
     ENFORCE(gs->errorQueue->isEmpty());
     vector<ast::ParsedFile> updatedIndexed;
     for (auto &f : subset) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The fast path could run on a single file or on tens of thousands of
files because of how our naive, name-based approach works.

We are going to be taking the fast path for more and more edits, which
will drive up the likelihood that we encounter worst-case edits that
typecheck many files on the fast path.

I want this metric so that we can get a sense of the magnitude.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I haven't tested this because it's a metric change. If we feel strongly, I can
try to write a test, but I would rather test on Stripe's metrics gathering
infrastructure after updating, and revert or fix forward as needed.