### PR TITLE
bring `Kernel.fail` and `Kernel.raise` sigs more closely in line with each other

### DIFF
--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -1217,7 +1217,7 @@ module Kernel
   end
   sig do
     params(
-        arg0: Class,
+        arg0: Exception,
         arg1: String,
         arg2: T::Array[String],
     )

--- a/test/testdata/rbi/kernel.rb
+++ b/test/testdata/rbi/kernel.rb
@@ -68,3 +68,18 @@ T.assert_type!(obj.itself, String)
 y = loop do
 end
 puts y # error: This code is unreachable
+
+class CustomError < StandardError
+  def initialize(cause, team)
+    @cause = cause
+    @team = team
+  end
+end
+
+def raises_fail
+  fail CustomError.new("Problem", "DevOops")
+end
+
+def raises_raise
+  raise CustomError.new("Problem", "DevOops")
+end


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

These are implemented by the same function in Ruby underneath the hood, so they should take roughly the same arguments.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.  I left the slightly looser typing for `Kernel.raise`'s `arg1` and `arg2` for now and didn't both to try and sync things up.
