### PR TITLE
pack `ConstantLit` down to 16 bytes

### DIFF
--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -449,12 +449,12 @@ public:
             return true;
         }
         auto root = ast::cast_tree<ast::ConstantLit>(scope);
-        return root != nullptr && root->symbol == core::Symbols::root();
+        return root != nullptr && root->symbol() == core::Symbols::root();
     }
 
     static bool isMagicClass(ExpressionPtr &expr) {
         if (auto *recv = cast_tree<ConstantLit>(expr)) {
-            return recv->symbol == core::Symbols::Magic();
+            return recv->symbol() == core::Symbols::Magic();
         } else {
             return false;
         }

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -91,9 +91,9 @@ public:
         return make_expression<ast::Literal>(loc, core::Types::nilClass());
     }
 
-    static ExpressionPtr Constant(core::LocOffsets loc, core::SymbolRef symbol) {
+    static ExpressionPtr Constant(core::SymbolRef symbol) {
         ENFORCE(symbol.exists());
-        return make_expression<ConstantLit>(loc, symbol, nullptr);
+        return make_expression<ConstantLit>(symbol, nullptr);
     }
 
     static ExpressionPtr Local(core::LocOffsets loc, core::NameRef name) {
@@ -184,12 +184,12 @@ public:
     }
 
     static ExpressionPtr Splat(core::LocOffsets loc, ExpressionPtr arg) {
-        return Send1(loc, Constant(loc, core::Symbols::Magic()), core::Names::splat(), loc, std::move(arg));
+        return Send1(loc, Constant(core::Symbols::Magic()), core::Names::splat(), loc, std::move(arg));
     }
 
     static ExpressionPtr CallWithSplat(core::LocOffsets loc, ExpressionPtr recv, core::NameRef name,
                                        ExpressionPtr args) {
-        return Send3(loc, Constant(loc, core::Symbols::Magic()), core::Names::callWithSplat(), loc, std::move(recv),
+        return Send3(loc, Constant(core::Symbols::Magic()), core::Names::callWithSplat(), loc, std::move(recv),
                      MK::Symbol(loc, name), std::move(args));
     }
 
@@ -324,8 +324,8 @@ public:
     static ExpressionPtr Sig(core::LocOffsets loc, Send::ARGS_store args, ExpressionPtr ret) {
         auto params = Params(loc, Self(loc), std::move(args));
         auto returns = Send1(loc, std::move(params), core::Names::returns(), loc, std::move(ret));
-        auto sig = Send1(loc, Constant(loc, core::Symbols::Sorbet_Private_Static()), core::Names::sig(), loc,
-                         Constant(loc, core::Symbols::T_Sig_WithoutRuntime()));
+        auto sig = Send1(loc, Constant(core::Symbols::Sorbet_Private_Static()), core::Names::sig(), loc,
+                         Constant(core::Symbols::T_Sig_WithoutRuntime()));
         auto sigSend = ast::cast_tree<ast::Send>(sig);
         sigSend->setBlock(Block0(loc, std::move(returns)));
         sigSend->flags.isRewriterSynthesized = true;
@@ -335,8 +335,8 @@ public:
     static ExpressionPtr SigVoid(core::LocOffsets loc, Send::ARGS_store args) {
         auto params = Params(loc, Self(loc), std::move(args));
         auto void_ = Send0(loc, std::move(params), core::Names::void_(), loc);
-        auto sig = Send1(loc, Constant(loc, core::Symbols::Sorbet_Private_Static()), core::Names::sig(), loc,
-                         Constant(loc, core::Symbols::T_Sig_WithoutRuntime()));
+        auto sig = Send1(loc, Constant(core::Symbols::Sorbet_Private_Static()), core::Names::sig(), loc,
+                         Constant(core::Symbols::T_Sig_WithoutRuntime()));
         auto sigSend = ast::cast_tree<ast::Send>(sig);
         sigSend->setBlock(Block0(loc, std::move(void_)));
         sigSend->flags.isRewriterSynthesized = true;
@@ -345,8 +345,8 @@ public:
 
     static ExpressionPtr Sig0(core::LocOffsets loc, ExpressionPtr ret) {
         auto returns = Send1(loc, Self(loc), core::Names::returns(), loc, std::move(ret));
-        auto sig = Send1(loc, Constant(loc, core::Symbols::Sorbet_Private_Static()), core::Names::sig(), loc,
-                         Constant(loc, core::Symbols::T_Sig_WithoutRuntime()));
+        auto sig = Send1(loc, Constant(core::Symbols::Sorbet_Private_Static()), core::Names::sig(), loc,
+                         Constant(core::Symbols::T_Sig_WithoutRuntime()));
         auto sigSend = ast::cast_tree<ast::Send>(sig);
         sigSend->setBlock(Block0(loc, std::move(returns)));
         sigSend->flags.isRewriterSynthesized = true;
@@ -358,7 +358,7 @@ public:
     }
 
     static ExpressionPtr T(core::LocOffsets loc) {
-        return Constant(loc, core::Symbols::T());
+        return Constant(core::Symbols::T());
     }
 
     static ExpressionPtr Bind(core::LocOffsets loc, ExpressionPtr value, ExpressionPtr type) {
@@ -399,13 +399,13 @@ public:
     }
 
     static ExpressionPtr KeepForIDE(core::LocOffsets loc, ExpressionPtr arg) {
-        return Send1(loc, Constant(loc, core::Symbols::Sorbet_Private_Static()), core::Names::keepForIde(), loc,
+        return Send1(loc, Constant(core::Symbols::Sorbet_Private_Static()), core::Names::keepForIde(), loc,
                      std::move(arg));
     }
 
     static ExpressionPtr KeepForTypechecking(ExpressionPtr arg) {
         auto loc = core::LocOffsets::none();
-        return Send1(loc, Constant(loc, core::Symbols::Sorbet_Private_Static()), core::Names::keepForTypechecking(),
+        return Send1(loc, Constant(core::Symbols::Sorbet_Private_Static()), core::Names::keepForTypechecking(),
                      loc, std::move(arg));
     }
 
@@ -418,17 +418,17 @@ public:
 
     static ExpressionPtr SelfNew(core::LocOffsets loc, core::LocOffsets funLoc, int numPosArgs,
                                  ast::Send::ARGS_store args, Send::Flags flags = {}) {
-        auto magic = Constant(loc, core::Symbols::Magic());
+        auto magic = Constant(core::Symbols::Magic());
         return Send(loc, std::move(magic), core::Names::selfNew(), funLoc, numPosArgs, std::move(args), flags);
     }
 
     static ExpressionPtr DefineTopClassOrModule(core::LocOffsets loc, core::ClassOrModuleRef klass) {
-        auto magic = Constant(loc, core::Symbols::Magic());
+        auto magic = Constant(core::Symbols::Magic());
         Send::Flags flags;
         flags.isRewriterSynthesized = true;
         // Use a 0-sized loc so that LSP queries for "what is at this location" do not return this synthetic send.
         return Send(core::LocOffsets{loc.beginLoc, loc.beginLoc}, std::move(magic),
-                    core::Names::defineTopClassOrModule(), loc, 1, SendArgs(Constant(loc, klass)), flags);
+                    core::Names::defineTopClassOrModule(), loc, 1, SendArgs(Constant(klass)), flags);
     }
 
     static ExpressionPtr RuntimeMethodDefinition(core::LocOffsets loc, core::NameRef name, bool isSelfMethod) {
@@ -436,7 +436,7 @@ public:
     }
 
     static ExpressionPtr RaiseUnimplemented(core::LocOffsets loc) {
-        auto kernel = Constant(loc, core::Symbols::Kernel());
+        auto kernel = Constant(core::Symbols::Kernel());
         auto msg = String(loc, core::Names::rewriterRaiseUnimplemented());
         // T.unsafe so that Sorbet doesn't know this unconditionally raises (avoids introducing dead code errors)
         auto ret = Send1(loc, Unsafe(loc, std::move(kernel)), core::Names::raise(), loc, std::move(msg));

--- a/ast/TreeCopying.cc
+++ b/ast/TreeCopying.cc
@@ -163,7 +163,7 @@ ExpressionPtr deepCopy(const void *avoid, const Tag tag, const void *tree, bool 
             if (exp->original) {
                 originalC = deepCopy(avoid, exp->original);
             }
-            return make_expression<ConstantLit>(exp->loc, exp->symbol(), move(originalC));
+            return make_expression<ConstantLit>(exp->symbol(), move(originalC));
         }
 
         case Tag::ZSuperArgs: {

--- a/ast/TreeCopying.cc
+++ b/ast/TreeCopying.cc
@@ -163,7 +163,7 @@ ExpressionPtr deepCopy(const void *avoid, const Tag tag, const void *tree, bool 
             if (exp->original) {
                 originalC = deepCopy(avoid, exp->original);
             }
-            return make_expression<ConstantLit>(exp->loc, exp->symbol, move(originalC));
+            return make_expression<ConstantLit>(exp->loc, exp->symbol(), move(originalC));
         }
 
         case Tag::ZSuperArgs: {

--- a/ast/TreeSanityChecks.cc
+++ b/ast/TreeSanityChecks.cc
@@ -98,7 +98,7 @@ void UnresolvedConstantLit::_sanityCheck() {
 }
 
 void ConstantLit::_sanityCheck() {
-    ENFORCE(resolutionScopes == nullptr || !resolutionScopes->empty());
+    ENFORCE(resolutionScopes() == nullptr || !resolutionScopes()->empty());
 }
 
 void EmptyTree::_sanityCheck() {}

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -1053,16 +1053,121 @@ public:
 };
 CheckSize(UnresolvedConstantLit, 24, 8);
 
+// For constants that failed resolution, this class will contain resolutionScopes
+// set to whatever nesting scope we estimate the constant could have been defined in.
+// For constants that resolve properly, this class will contain the resolved symbol.
+class ResolutionScopesOrSymbol final {
+public:
+    // We store tagged pointers as 64-bit values.
+    using tagged_storage = uint64_t;
+
+private:
+    enum class Tag {
+        Symbol = 1,
+        ResolutionScopes = 2,
+    };
+
+    static constexpr tagged_storage TAG_MASK = 0xffff;
+
+    static constexpr tagged_storage PTR_MASK = ~TAG_MASK;
+
+    tagged_storage ptr;
+
+    static tagged_storage tagPtr(Tag tag, tagged_storage ptr) {
+        // Store the tag in the lower 16 bits of the pointer, regardless of size.
+        auto val = static_cast<tagged_storage>(tag);
+        auto maskedPtr = ptr << 16;
+
+        return maskedPtr | val;
+    }
+
+    static tagged_storage tagSymbol(core::SymbolRef symbol) {
+        return tagPtr(Tag::Symbol, static_cast<tagged_storage>(symbol.rawId()));
+    }
+
+    static tagged_storage allocateResolutionScopes() {
+        return tagPtr(Tag::ResolutionScopes, reinterpret_cast<tagged_storage>(new std::vector<core::SymbolRef>()));
+    }
+
+    Tag tag() const {
+        ENFORCE(ptr != 0);
+        auto value = reinterpret_cast<tagged_storage>(ptr) & TAG_MASK;
+        return static_cast<Tag>(value);
+    }
+
+    tagged_storage untaggedPtr() const noexcept {
+        auto val = ptr & PTR_MASK;
+        return val >> 16;
+    }
+
+public:
+    ResolutionScopesOrSymbol() noexcept : ptr(tagSymbol(core::Symbols::noSymbol())) {}
+    ResolutionScopesOrSymbol(core::SymbolRef symbol) noexcept : ptr(tagSymbol(symbol)) {}
+
+    ResolutionScopesOrSymbol(const ResolutionScopesOrSymbol &) = delete;
+    ResolutionScopesOrSymbol &operator=(const ResolutionScopesOrSymbol &) = delete;
+    ResolutionScopesOrSymbol(ResolutionScopesOrSymbol &&other) = delete;
+
+    ResolutionScopesOrSymbol &operator=(ResolutionScopesOrSymbol &&other) noexcept {
+        if (tag() == Tag::ResolutionScopes) {
+            delete resolutionScopes();
+        }
+        this->ptr = other.ptr;
+        other.ptr = tagSymbol(core::Symbols::noSymbol());
+        return *this;
+    }
+
+    ~ResolutionScopesOrSymbol() {
+        if (tag() == Tag::ResolutionScopes) {
+            delete resolutionScopes();
+        }
+    }
+
+    void markUnresolved() {
+        if (tag() != Tag::ResolutionScopes) {
+            ptr = allocateResolutionScopes();
+        }
+    }
+
+    // Returns nullptr if this is a resolved symbol.
+    std::vector<core::SymbolRef> *resolutionScopes() {
+        if (tag() != Tag::ResolutionScopes) {
+            return nullptr;
+        }
+
+        auto ptr = untaggedPtr();
+        return reinterpret_cast<std::vector<core::SymbolRef> *>(ptr);
+    }
+
+    // Returns nullptr if this is a resolved symbol.
+    const std::vector<core::SymbolRef> *resolutionScopes() const {
+        if (tag() != Tag::ResolutionScopes) {
+            return nullptr;
+        }
+
+        auto ptr = untaggedPtr();
+        return reinterpret_cast<std::vector<core::SymbolRef> *>(ptr);
+    }
+
+    // Returns StubModule if this is an unresolved symbol.
+    core::SymbolRef symbol() const {
+        if (tag() != Tag::Symbol) {
+            return core::Symbols::StubModule();
+        }
+        auto symbolId = untaggedPtr();
+        return core::SymbolRef::fromRaw(static_cast<uint32_t>(symbolId));
+    }
+};
+CheckSize(ResolutionScopesOrSymbol, 8, 8);
+
 EXPRESSION(ConstantLit) {
 public:
     const core::LocOffsets loc;
 
-    core::SymbolRef symbol; // If this is a normal constant. This symbol may be already dealiased.
-    // For constants that failed resolution, symbol will be set to StubModule and resolutionScopes
-    // will be set to whatever nesting scope we estimate the constant could have been defined in.
-    // For resolved symbols, `resolutionScopes` is null.
-    using ResolutionScopes = InlinedVector<core::SymbolRef, 1>;
-    std::unique_ptr<ResolutionScopes> resolutionScopes;
+private:
+    ResolutionScopesOrSymbol resolutionScopesOrSymbol;
+
+public:
     ExpressionPtr original;
 
     ConstantLit(core::LocOffsets loc, core::SymbolRef symbol, ExpressionPtr original);
@@ -1075,9 +1180,30 @@ public:
     std::optional<std::pair<core::SymbolRef, std::vector<core::NameRef>>> fullUnresolvedPath(
         const core::GlobalState &gs) const;
 
+    core::SymbolRef symbol() const {
+        return resolutionScopesOrSymbol.symbol();
+    }
+
+    void setSymbol(core::SymbolRef symbol) {
+        resolutionScopesOrSymbol = symbol;
+    }
+
+    std::vector<core::SymbolRef> *resolutionScopes() {
+        return resolutionScopesOrSymbol.resolutionScopes();
+    }
+
+    const std::vector<core::SymbolRef> *resolutionScopes() const {
+        return resolutionScopesOrSymbol.resolutionScopes();
+    }
+
+    // Marks this constant as unresolved and allocates a vector for `resolutionScopes`.
+    void markUnresolved() {
+        return resolutionScopesOrSymbol.markUnresolved();
+    }
+
     void _sanityCheck();
 };
-CheckSize(ConstantLit, 32, 8);
+CheckSize(ConstantLit, 24, 8);
 
 EXPRESSION(ZSuperArgs) {
 public:

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -1161,17 +1161,15 @@ public:
 CheckSize(ResolutionScopesOrSymbol, 8, 8);
 
 EXPRESSION(ConstantLit) {
-public:
-    const core::LocOffsets loc;
-
 private:
     ResolutionScopesOrSymbol resolutionScopesOrSymbol;
 
 public:
     ExpressionPtr original;
 
-    ConstantLit(core::LocOffsets loc, core::SymbolRef symbol, ExpressionPtr original);
+    ConstantLit(core::SymbolRef symbol, ExpressionPtr original);
 
+    core::LocOffsets loc() const;
     ExpressionPtr deepCopy() const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
@@ -1203,7 +1201,7 @@ public:
 
     void _sanityCheck();
 };
-CheckSize(ConstantLit, 24, 8);
+CheckSize(ConstantLit, 16, 8);
 
 EXPRESSION(ZSuperArgs) {
 public:

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -237,7 +237,7 @@ ExpressionPtr desugarDString(DesugarContext dctx, core::LocOffsets loc, parser::
     if (allStringsSoFar) {
         return mergeStrings(dctx, loc, std::move(stringsAccumulated));
     } else {
-        auto recv = MK::Constant(loc, core::Symbols::Magic());
+        auto recv = MK::Constant(core::Symbols::Magic());
         return MK::Send(loc, std::move(recv), core::Names::stringInterpolate(), loc.copyWithZeroLength(),
                         interpArgs.size(), std::move(interpArgs));
     }
@@ -374,7 +374,7 @@ ExpressionPtr desugarMlhs(DesugarContext dctx, core::LocOffsets loc, parser::Mlh
                 }
                 auto lhloc = lh.loc();
                 auto zlhloc = lhloc.copyWithZeroLength();
-                auto index = MK::Send3(lhloc, MK::Constant(lhloc, core::Symbols::Range()), core::Names::new_(), zlhloc,
+                auto index = MK::Send3(lhloc, MK::Constant(core::Symbols::Range()), core::Names::new_(), zlhloc,
                                        MK::Int(lhloc, left), MK::Int(lhloc, -right), std::move(exclusive));
                 stats.emplace_back(MK::Assign(
                     lhloc, std::move(lh),
@@ -409,7 +409,7 @@ ExpressionPtr desugarMlhs(DesugarContext dctx, core::LocOffsets loc, parser::Mlh
     }
 
     auto expanded =
-        MK::Send3(loc, MK::Constant(loc, core::Symbols::Magic()), core::Names::expandSplat(), loc.copyWithZeroLength(),
+        MK::Send3(loc, MK::Constant(core::Symbols::Magic()), core::Names::expandSplat(), loc.copyWithZeroLength(),
                   MK::Local(loc, tempRhs), MK::Int(loc, before), MK::Int(loc, after));
     stats.insert(stats.begin(), MK::Assign(loc, tempExpanded, std::move(expanded)));
     stats.insert(stats.begin(), MK::Assign(loc, tempRhs, std::move(rhs)));
@@ -756,7 +756,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                             MK::Send1(loc, std::move(args), core::Names::concat(), locZeroLen, std::move(argsSplat));
 
                         auto fwdKwargs = MK::Local(loc, core::Names::fwdKwargs());
-                        auto kwargsSplat = MK::Send1(loc, MK::Constant(loc, core::Symbols::Magic()),
+                        auto kwargsSplat = MK::Send1(loc, MK::Constant(core::Symbols::Magic()),
                                                      core::Names::toHashDup(), locZeroLen, std::move(fwdKwargs));
 
                         Array::ENTRY_store kwargsEntries;
@@ -784,7 +784,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                     sendargs.emplace_back(std::move(kwargs));
                     ExpressionPtr res;
                     if (block == nullptr && !anonymousBlockPass) {
-                        res = MK::Send(loc, MK::Constant(loc, core::Symbols::Magic()), core::Names::callWithSplat(),
+                        res = MK::Send(loc, MK::Constant(core::Symbols::Magic()), core::Names::callWithSplat(),
                                        locZeroLen, 4, std::move(sendargs), flags);
                     } else {
                         ExpressionPtr convertedBlock;
@@ -796,13 +796,13 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                         }
                         Literal *lit;
                         if ((lit = cast_tree<Literal>(convertedBlock)) && lit->isSymbol(dctx.ctx)) {
-                            res = MK::Send(loc, MK::Constant(loc, core::Symbols::Magic()), core::Names::callWithSplat(),
+                            res = MK::Send(loc, MK::Constant(core::Symbols::Magic()), core::Names::callWithSplat(),
                                            locZeroLen, 4, std::move(sendargs), flags);
                             ast::cast_tree_nonnull<ast::Send>(res).setBlock(
                                 symbol2Proc(dctx, std::move(convertedBlock)));
                         } else {
                             sendargs.emplace_back(std::move(convertedBlock));
-                            res = MK::Send(loc, MK::Constant(loc, core::Symbols::Magic()),
+                            res = MK::Send(loc, MK::Constant(core::Symbols::Magic()),
                                            core::Names::callWithSplatAndBlock(), locZeroLen, 5, std::move(sendargs),
                                            flags);
                         }
@@ -899,7 +899,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                                 sendargs.emplace_back(std::move(arg));
                             }
 
-                            res = MK::Send(loc, MK::Constant(loc, core::Symbols::Magic()), core::Names::callWithBlock(),
+                            res = MK::Send(loc, MK::Constant(core::Symbols::Magic()), core::Names::callWithBlock(),
                                            locZeroLen, numPosArgs, std::move(sendargs), flags);
                         }
                     }
@@ -993,7 +993,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                         } else {
                             int numPosArgs = mergeValues.size();
                             updateStmts.emplace_back(MK::Assign(loc, acc,
-                                                                MK::Send(loc, MK::Constant(loc, core::Symbols::Magic()),
+                                                                MK::Send(loc, MK::Constant(core::Symbols::Magic()),
                                                                          core::Names::mergeHashValues(), locZeroLen,
                                                                          numPosArgs, std::move(mergeValues))));
                         }
@@ -1009,14 +1009,14 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                     if (updateStmts.empty()) {
                         updateStmts.emplace_back(
                             MK::Assign(loc, acc,
-                                       MK::Send1(loc, MK::Constant(loc, core::Symbols::Magic()),
+                                       MK::Send1(loc, MK::Constant(core::Symbols::Magic()),
                                                  core::Names::toHashDup(), locZeroLen, std::move(expr))));
                     } else {
                         updateStmts.emplace_back(
                             MK::Assign(loc, acc,
-                                       MK::Send2(loc, MK::Constant(loc, core::Symbols::Magic()),
+                                       MK::Send2(loc, MK::Constant(core::Symbols::Magic()),
                                                  core::Names::mergeHash(), locZeroLen, MK::Local(loc, acc),
-                                                 MK::Send1(loc, MK::Constant(loc, core::Symbols::Magic()),
+                                                 MK::Send1(loc, MK::Constant(core::Symbols::Magic()),
                                                            core::Names::toHashNoDup(), locZeroLen, std::move(expr)))));
                     }
                 };
@@ -1032,7 +1032,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                     // through to the rest of the processing
                     int numPosArgs = mergeValues.size();
                     updateStmts.emplace_back(MK::Assign(loc, acc,
-                                                        MK::Send(loc, MK::Constant(loc, core::Symbols::Magic()),
+                                                        MK::Send(loc, MK::Constant(core::Symbols::Magic()),
                                                                  core::Names::mergeHashValues(), locZeroLen, numPosArgs,
                                                                  std::move(mergeValues))));
                 }
@@ -1107,7 +1107,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                             rhsSend->insertPosArg(0, std::move(rhsSend->recv));
                             rhsSend->insertPosArg(1, MK::Local(loc.copyWithZeroLength(), andAndTemp));
                             rhsSend->insertPosArg(2, MK::Symbol(rhsSend->funLoc.copyWithZeroLength(), rhsSend->fun));
-                            rhsSend->recv = MK::Constant(loc.copyWithZeroLength(), core::Symbols::Magic());
+                            rhsSend->recv = MK::Constant(core::Symbols::Magic());
                             rhsSend->fun = core::Names::checkAndAnd();
                             thenp = std::move(rhs);
                         } else {
@@ -1355,7 +1355,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
 
                 // Just compare with `NilClass` to avoid potentially calling into a class-defined `==`
                 auto cond =
-                    MK::Send1(zeroLengthLoc, ast::MK::Constant(zeroLengthRecvLoc, core::Symbols::NilClass()),
+                    MK::Send1(zeroLengthLoc, ast::MK::Constant(core::Symbols::NilClass()),
                               core::Names::tripleEq(), zeroLengthRecvLoc, MK::Local(zeroLengthRecvLoc, tempRecv));
 
                 unique_ptr<parser::Node> sendNode =
@@ -1364,7 +1364,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                 auto send = node2TreeImpl(dctx, std::move(sendNode));
 
                 ExpressionPtr nil =
-                    MK::Send1(recvLoc.copyEndWithZeroLength(), ast::MK::Constant(zeroLengthLoc, core::Symbols::Magic()),
+                    MK::Send1(recvLoc.copyEndWithZeroLength(), ast::MK::Constant(core::Symbols::Magic()),
                               core::Names::nilForSafeNavigation(), zeroLengthLoc, MK::Local(csendLoc, tempRecv));
                 auto iff = MK::If(zeroLengthLoc, std::move(cond), std::move(nil), std::move(send));
                 auto res = MK::InsSeq1(csend->loc, std::move(assgn), std::move(iff));
@@ -1396,7 +1396,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                 result = std::move(res);
             },
             [&](parser::Cbase *cbase) {
-                ExpressionPtr res = MK::Constant(loc, core::Symbols::root());
+                ExpressionPtr res = MK::Constant(core::Symbols::root());
                 result = std::move(res);
             },
             [&](parser::Kwbegin *kwbegin) {
@@ -1430,7 +1430,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                 ClassDef::RHS_store body = scopeNodeToBody(dctx, std::move(claz->body));
                 ClassDef::ANCESTORS_store ancestors;
                 if (claz->superclass == nullptr) {
-                    ancestors.emplace_back(MK::Constant(loc, core::Symbols::todo()));
+                    ancestors.emplace_back(MK::Constant(core::Symbols::todo()));
                 } else {
                     ancestors.emplace_back(node2TreeImpl(dctx, std::move(claz->superclass)));
                 }
@@ -1690,7 +1690,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                 result = std::move(res);
             },
             [&](parser::Complex *complex) {
-                auto kernel = MK::Constant(loc, core::Symbols::Kernel());
+                auto kernel = MK::Constant(core::Symbols::Kernel());
                 core::NameRef complex_name = core::Names::Constants::Complex().dataCnst(dctx.ctx)->original;
                 core::NameRef value = dctx.ctx.state.enterNameUTF8(complex->value);
                 auto send = MK::Send2(loc, std::move(kernel), complex_name, locZeroLen, MK::Int(loc, 0),
@@ -1698,7 +1698,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                 result = std::move(send);
             },
             [&](parser::Rational *complex) {
-                auto kernel = MK::Constant(loc, core::Symbols::Kernel());
+                auto kernel = MK::Constant(core::Symbols::Kernel());
                 core::NameRef complex_name = core::Names::Constants::Rational().dataCnst(dctx.ctx)->original;
                 core::NameRef value = dctx.ctx.state.enterNameUTF8(complex->val);
                 auto send = MK::Send1(loc, std::move(kernel), complex_name, locZeroLen, MK::String(loc, value));
@@ -1757,7 +1757,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                 result = std::move(res);
             },
             [&](parser::IRange *ret) {
-                auto recv = MK::Constant(loc, core::Symbols::Magic());
+                auto recv = MK::Constant(core::Symbols::Magic());
                 auto from = node2TreeImpl(dctx, std::move(ret->from));
                 auto to = node2TreeImpl(dctx, std::move(ret->to));
                 auto excludeEnd = MK::False(loc);
@@ -1766,7 +1766,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                 result = std::move(send);
             },
             [&](parser::ERange *ret) {
-                auto recv = MK::Constant(loc, core::Symbols::Magic());
+                auto recv = MK::Constant(core::Symbols::Magic());
                 auto from = node2TreeImpl(dctx, std::move(ret->from));
                 auto to = node2TreeImpl(dctx, std::move(ret->to));
                 auto excludeEnd = MK::True(loc);
@@ -1775,7 +1775,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                 result = std::move(send);
             },
             [&](parser::Regexp *regexpNode) {
-                ExpressionPtr cnst = MK::Constant(loc, core::Symbols::Regexp());
+                ExpressionPtr cnst = MK::Constant(core::Symbols::Regexp());
                 auto pattern = desugarDString(dctx, loc, std::move(regexpNode->regex));
                 auto opts = node2TreeImpl(dctx, std::move(regexpNode->opts));
                 auto send = MK::Send2(loc, std::move(cnst), core::Names::new_(), locZeroLen, std::move(pattern),
@@ -2055,7 +2055,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                         ExpressionPtr test;
                         if (parser::isa_node<parser::Splat>(cnode.get())) {
                             ENFORCE(temp.exists(), "splats need something to test against");
-                            auto recv = MK::Constant(loc, core::Symbols::Magic());
+                            auto recv = MK::Constant(core::Symbols::Magic());
                             auto local = MK::Local(cloc, temp);
                             // TODO(froydnj): use the splat's var directly so we can elide the
                             // coercion to an array where possible.
@@ -2109,7 +2109,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                     auto methodName = ident->kind == UnresolvedIdent::Kind::Instance ? core::Names::definedInstanceVar()
                                                                                      : core::Names::definedClassVar();
                     auto sym = MK::Symbol(loc, ident->name);
-                    auto res = MK::Send1(loc, MK::Constant(loc, core::Symbols::Magic()), methodName, locZeroLen,
+                    auto res = MK::Send1(loc, MK::Constant(core::Symbols::Magic()), methodName, locZeroLen,
                                          std::move(sym));
                     result = std::move(res);
                     return;
@@ -2128,7 +2128,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                 absl::c_reverse(args);
 
                 auto numPosArgs = args.size();
-                auto res = MK::Send(loc, MK::Constant(loc, core::Symbols::Magic()), core::Names::defined_p(),
+                auto res = MK::Send(loc, MK::Constant(core::Symbols::Magic()), core::Names::defined_p(),
                                     locZeroLen, numPosArgs, std::move(args));
                 result = std::move(res);
             },
@@ -2160,7 +2160,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                     args.emplace_back(node2TreeImpl(dctx, move(expr)));
                 }
                 auto numPosArgs = args.size();
-                auto res = MK::Send(loc, MK::Constant(loc, core::Symbols::Kernel()), core::Names::undef(), locZeroLen,
+                auto res = MK::Send(loc, MK::Constant(core::Symbols::Kernel()), core::Names::undef(), locZeroLen,
                                     numPosArgs, std::move(args));
                 // It wasn't a Send to begin with--there's no way this could result in a private
                 // method call error.
@@ -2201,7 +2201,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                 result = std::move(res);
             },
             [&](parser::Backref *backref) {
-                auto recv = MK::Constant(loc, core::Symbols::Magic());
+                auto recv = MK::Constant(core::Symbols::Magic());
                 auto arg = MK::Symbol(backref->loc, backref->name);
                 result = MK::Send1(loc, std::move(recv), core::Names::regexBackref(), locZeroLen, std::move(arg));
             },
@@ -2222,7 +2222,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
                 result = std::move(res);
             },
             [&](parser::EncodingLiteral *encodingLiteral) {
-                auto recv = MK::Constant(loc, core::Symbols::Magic());
+                auto recv = MK::Constant(core::Symbols::Magic());
                 result = MK::Send0(loc, std::move(recv), core::Names::getEncoding(), locZeroLen);
             },
             [&](parser::MatchPattern *pattern) {
@@ -2253,7 +2253,7 @@ ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> what) 
 ExpressionPtr liftTopLevel(DesugarContext dctx, core::LocOffsets loc, ExpressionPtr what) {
     ClassDef::RHS_store rhs;
     ClassDef::ANCESTORS_store ancestors;
-    ancestors.emplace_back(MK::Constant(loc, core::Symbols::todo()));
+    ancestors.emplace_back(MK::Constant(core::Symbols::todo()));
     auto insSeq = cast_tree<InsSeq>(what);
     if (insSeq) {
         rhs.reserve(insSeq->stats.size() + 1);

--- a/ast/verifier/Verifier.cc
+++ b/ast/verifier/Verifier.cc
@@ -9,7 +9,7 @@ class VerifierWalker {
 
 public:
     ExpressionPtr preTransformExpression(core::Context ctx, ExpressionPtr original) {
-        if (!isa_tree<EmptyTree>(original)) {
+        if (!isa_tree<EmptyTree>(original) && !isa_tree<ConstantLit>(original)) {
             ENFORCE(original.loc().exists(), "location is unset");
         }
 

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -291,10 +291,10 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
             },
             [&](ast::ConstantLit &a) {
                 auto aliasName = cctx.newTemporary(core::Names::cfgAlias());
-                if (a.symbol == core::Symbols::StubModule()) {
+                if (a.symbol() == core::Symbols::StubModule()) {
                     current->exprs.emplace_back(aliasName, a.loc, make_insn<Alias>(core::Symbols::untyped()));
                 } else {
-                    current->exprs.emplace_back(aliasName, a.loc, make_insn<Alias>(a.symbol));
+                    current->exprs.emplace_back(aliasName, a.loc, make_insn<Alias>(a.symbol()));
                 }
 
                 synthesizeExpr(current, cctx.target, a.loc, make_insn<Ident>(aliasName));
@@ -323,7 +323,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
             [&](ast::Assign &a) {
                 LocalRef lhs;
                 if (auto lhsIdent = ast::cast_tree<ast::ConstantLit>(a.lhs)) {
-                    lhs = global2Local(cctx, lhsIdent->symbol);
+                    lhs = global2Local(cctx, lhsIdent->symbol());
                 } else if (auto lhsLocal = ast::cast_tree<ast::Local>(a.lhs)) {
                     lhs = cctx.inWhat.enterLocal(lhsLocal->localVariable);
                 } else if (auto ident = ast::cast_tree<ast::UnresolvedIdent>(a.lhs)) {
@@ -349,7 +349,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
 
                 if (s.fun == core::Names::absurd()) {
                     if (auto cnst = ast::cast_tree<ast::ConstantLit>(s.recv)) {
-                        if (cnst->symbol == core::Symbols::T()) {
+                        if (cnst->symbol() == core::Symbols::T()) {
                             if (s.hasKwArgs()) {
                                 if (auto e = cctx.ctx.beginError(s.loc, core::errors::CFG::MalformedTAbsurd)) {
                                     e.setHeader("`{}` does not accept keyword arguments", "T.absurd");

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -292,12 +292,12 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
             [&](ast::ConstantLit &a) {
                 auto aliasName = cctx.newTemporary(core::Names::cfgAlias());
                 if (a.symbol() == core::Symbols::StubModule()) {
-                    current->exprs.emplace_back(aliasName, a.loc, make_insn<Alias>(core::Symbols::untyped()));
+                    current->exprs.emplace_back(aliasName, a.loc(), make_insn<Alias>(core::Symbols::untyped()));
                 } else {
-                    current->exprs.emplace_back(aliasName, a.loc, make_insn<Alias>(a.symbol()));
+                    current->exprs.emplace_back(aliasName, a.loc(), make_insn<Alias>(a.symbol()));
                 }
 
-                synthesizeExpr(current, cctx.target, a.loc, make_insn<Ident>(aliasName));
+                synthesizeExpr(current, cctx.target, a.loc(), make_insn<Ident>(aliasName));
 
                 if (a.original) {
                     auto *orig = ast::cast_tree<ast::UnresolvedConstantLit>(a.original);
@@ -720,7 +720,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                     if (exceptions.empty()) {
                         // rescue without a class catches StandardError
                         exceptions.emplace_back(
-                            ast::MK::Constant(rescueCase->var.loc(), core::Symbols::StandardError()));
+                            ast::MK::Constant(core::Symbols::StandardError()));
                         added = true;
                     }
                     for (auto &ex : exceptions) {

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -1321,7 +1321,6 @@ void SerializerImpl::pickle(Pickler &p, const ast::ExpressionPtr &what) {
 
         case ast::Tag::ConstantLit: {
             auto &a = ast::cast_tree_nonnull<ast::ConstantLit>(what);
-            pickle(p, a.loc);
             p.putU4(a.symbol().rawId());
             pickle(p, a.original);
             break;
@@ -1590,10 +1589,9 @@ ast::ExpressionPtr SerializerImpl::unpickleExpr(serialize::UnPickler &p, const G
             return ast::make_expression<ast::UnresolvedIdent>(loc, kind, name);
         }
         case ast::Tag::ConstantLit: {
-            auto loc = unpickleLocOffsets(p);
             auto sym = SymbolRef::fromRaw(p.getU4());
             auto orig = unpickleExpr(p, gs);
-            return ast::make_expression<ast::ConstantLit>(loc, sym, std::move(orig));
+            return ast::make_expression<ast::ConstantLit>(sym, std::move(orig));
         }
         case ast::Tag::RuntimeMethodDefinition: {
             auto loc = unpickleLocOffsets(p);

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -1322,7 +1322,7 @@ void SerializerImpl::pickle(Pickler &p, const ast::ExpressionPtr &what) {
         case ast::Tag::ConstantLit: {
             auto &a = ast::cast_tree_nonnull<ast::ConstantLit>(what);
             pickle(p, a.loc);
-            p.putU4(a.symbol.rawId());
+            p.putU4(a.symbol().rawId());
             pickle(p, a.original);
             break;
         }

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -360,13 +360,13 @@ core::LocOffsets getAncestorLoc(const core::GlobalState &gs, const ast::ClassDef
                                 const core::ClassOrModuleRef ancestor) {
     for (const auto &anc : classDef.ancestors) {
         const auto ancConst = ast::cast_tree<ast::ConstantLit>(anc);
-        if (ancConst != nullptr && ancConst->symbol.dealias(gs) == ancestor) {
+        if (ancConst != nullptr && ancConst->symbol().dealias(gs) == ancestor) {
             return anc.loc();
         }
     }
     for (const auto &anc : classDef.singletonAncestors) {
         const auto ancConst = ast::cast_tree<ast::ConstantLit>(anc);
-        if (ancConst != nullptr && ancConst->symbol.dealias(gs) == ancestor) {
+        if (ancConst != nullptr && ancConst->symbol().dealias(gs) == ancestor) {
             return anc.loc();
         }
     }
@@ -551,7 +551,7 @@ void validateSuperClass(core::Context ctx, const core::ClassOrModuleRef sym, con
     }
 
     if (auto *cnst = ast::cast_tree<ast::ConstantLit>(classDef.ancestors.front())) {
-        if (cnst->symbol == core::Symbols::todo()) {
+        if (cnst->symbol() == core::Symbols::todo()) {
             return;
         }
     }

--- a/local_vars/local_vars.cc
+++ b/local_vars/local_vars.cc
@@ -299,7 +299,7 @@ class LocalNameInserter {
                 ENFORCE(kwArgsHash == nullptr, "Saw multiple keyword splats");
 
                 // TODO(aprocter): is it necessary to duplicate the hash here?
-                kwArgsHash = ast::MK::Send1(original.loc, ast::MK::Constant(original.loc, core::Symbols::Magic()),
+                kwArgsHash = ast::MK::Send1(original.loc, ast::MK::Constant(core::Symbols::Magic()),
                                             core::Names::toHashDup(), original.loc.copyWithZeroLength(),
                                             ast::make_expression<ast::Local>(original.loc, arg.arg));
                 if (!kwArgKeyEntries.empty()) {
@@ -372,7 +372,7 @@ class LocalNameInserter {
             }
             original.addPosArg(std::move(boxedKwArgs));
 
-            original.recv = ast::MK::Constant(original.loc, core::Symbols::Magic());
+            original.recv = ast::MK::Constant(core::Symbols::Magic());
 
             if (originalBlock != nullptr) {
                 // <call-with-splat> and "do"
@@ -408,7 +408,7 @@ class LocalNameInserter {
             kwArgKeyEntries.clear();
             kwArgValueEntries.clear();
 
-            original.recv = ast::MK::Constant(original.loc, core::Symbols::Magic());
+            original.recv = ast::MK::Constant(core::Symbols::Magic());
             original.fun = core::Names::callWithBlock();
         } else {
             // No positional splat and we have a "do", so we can synthesize an ordinary send.

--- a/main/autogen/autogen.cc
+++ b/main/autogen/autogen.cc
@@ -212,12 +212,12 @@ public:
             ref.nesting.pop_back();
             ref.scope = nesting.back();
         }
-        ref.loc = original.loc;
+        ref.loc = original.loc();
 
         // the reference location is the location of constant, but this might get updated if the reference corresponds
         // to the definition of the constant, because in that case we'll later on extend the location to cover the whole
         // class or assignment
-        ref.definitionLoc = original.loc;
+        ref.definitionLoc = original.loc();
         ref.name = QualifiedName::fromFullName(constantName(ctx, original));
         auto sym = original.symbol();
         if (!sym.isClassOrModule() || sym != core::Symbols::StubModule()) {

--- a/main/autogen/autogen.cc
+++ b/main/autogen/autogen.cc
@@ -179,7 +179,7 @@ public:
             auto &original = ast::cast_tree_nonnull<ast::UnresolvedConstantLit>(cnst->original);
             cnst = ast::cast_tree<ast::ConstantLit>(original.scope);
         }
-        if (cnst && cnst->symbol == core::Symbols::root()) {
+        if (cnst && cnst->symbol() == core::Symbols::root()) {
             return true;
         }
         return false;
@@ -219,7 +219,7 @@ public:
         // class or assignment
         ref.definitionLoc = original.loc;
         ref.name = QualifiedName::fromFullName(constantName(ctx, original));
-        auto sym = original.symbol;
+        auto sym = original.symbol();
         if (!sym.isClassOrModule() || sym != core::Symbols::StubModule()) {
             ref.resolved = QualifiedName::fromFullName(symbolName(ctx, sym));
         }
@@ -257,13 +257,13 @@ public:
 
         // if the RHS is _also_ a constant, then this is an alias
         auto *rhs = ast::cast_tree<ast::ConstantLit>(original.rhs);
-        if (rhs && rhs->symbol.exists() && !rhs->symbol.isTypeAlias(ctx)) {
+        if (rhs && rhs->symbol().exists() && !rhs->symbol().isTypeAlias(ctx)) {
             def.type = Definition::Type::Alias;
             // since this is a `post`- method, then we've already created a `Reference` for the constant on the
             // RHS. Mark this `Definition` as an alias for it.
             ENFORCE(refMap.count(original.rhs.get()));
             def.aliased_ref = refMap[original.rhs.get()];
-        } else if (lhs->symbol.exists() && lhs->symbol.isTypeAlias(ctx)) {
+        } else if (lhs->symbol().exists() && lhs->symbol().isTypeAlias(ctx)) {
             // if the LHS has already been annotated as a type alias by the namer, the definition is (by definition,
             // hah) a type alias.
             def.type = Definition::Type::TypeAlias;

--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -118,8 +118,8 @@ void matchesQuery(core::Context ctx, ast::ConstantLit *lit, const core::lsp::Que
 
             core::lsp::ConstantResponse::Scopes scopes;
             if (symbol == core::Symbols::StubModule()) {
-                auto resolutionScopes = lit->resolutionScopes();
-                std::copy(resolutionScopes->begin(), resolutionScopes->end(), scopes.begin());
+                auto *resolutionScopes = lit->resolutionScopes();
+                scopes.insert(scopes.end(), resolutionScopes->begin(), resolutionScopes->end());
             } else {
                 scopes = {symbol.owner(ctx)};
             }

--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -103,7 +103,7 @@ void matchesQuery(core::Context ctx, ast::ConstantLit *lit, const core::lsp::Que
     auto symbol = symbolBeforeDealias.dealias(ctx);
     while (lit && symbol.exists() && lit->original) {
         auto &unresolved = ast::cast_tree_nonnull<ast::UnresolvedConstantLit>(lit->original);
-        if (lspQuery.matchesLoc(ctx.locAt(lit->loc)) || lspQuery.matchesSymbol(symbol) ||
+        if (lspQuery.matchesLoc(ctx.locAt(lit->loc())) || lspQuery.matchesSymbol(symbol) ||
             lspQuery.matchesSymbol(symbolBeforeDealias)) {
             // This basically approximates the cfg::Alias case from Environment::processBinding.
             core::TypeAndOrigins tp;
@@ -125,7 +125,7 @@ void matchesQuery(core::Context ctx, ast::ConstantLit *lit, const core::lsp::Que
             }
 
             auto enclosingMethod = enclosingMethodFromContext(ctx);
-            auto resp = core::lsp::ConstantResponse(symbol, symbolBeforeDealias, ctx.locAt(lit->loc), scopes,
+            auto resp = core::lsp::ConstantResponse(symbol, symbolBeforeDealias, ctx.locAt(lit->loc()), scopes,
                                                     unresolved.cnst, tp, enclosingMethod);
             core::lsp::QueryResponse::pushQueryResponse(ctx, resp);
         }

--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -118,7 +118,8 @@ void matchesQuery(core::Context ctx, ast::ConstantLit *lit, const core::lsp::Que
 
             core::lsp::ConstantResponse::Scopes scopes;
             if (symbol == core::Symbols::StubModule()) {
-                scopes = *lit->resolutionScopes;
+                auto resolutionScopes = lit->resolutionScopes();
+                std::copy(resolutionScopes->begin(), resolutionScopes->end(), scopes.begin());
             } else {
                 scopes = {symbol.owner(ctx)};
             }
@@ -130,7 +131,7 @@ void matchesQuery(core::Context ctx, ast::ConstantLit *lit, const core::lsp::Que
         }
         lit = ast::cast_tree<ast::ConstantLit>(unresolved.scope);
         if (lit) {
-            symbolBeforeDealias = lit->symbol;
+            symbolBeforeDealias = lit->symbol();
             symbol = symbolBeforeDealias.dealias(ctx);
         }
     }
@@ -141,7 +142,7 @@ void matchesQuery(core::Context ctx, ast::ConstantLit *lit, const core::lsp::Que
 ast::ExpressionPtr DefLocSaver::postTransformConstantLit(core::Context ctx, ast::ExpressionPtr tree) {
     auto &lit = ast::cast_tree_nonnull<ast::ConstantLit>(tree);
     const core::lsp::Query &lspQuery = ctx.state.lspQuery;
-    matchesQuery(ctx, &lit, lspQuery, lit.symbol);
+    matchesQuery(ctx, &lit, lspQuery, lit.symbol());
     return tree;
 }
 

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1292,7 +1292,7 @@ class TreeSymbolizer {
             return core::Symbols::noSymbol();
         }
 
-        node = ast::make_expression<ast::ConstantLit>(constLit->loc, existing, std::move(node));
+        node = ast::make_expression<ast::ConstantLit>(existing, std::move(node));
         return existing;
     }
 
@@ -1568,8 +1568,7 @@ public:
             ENFORCE(this->bestEffort);
             return ast::MK::EmptyTree();
         }
-        auto loc = lhs.loc;
-        asgn.lhs = ast::make_expression<ast::ConstantLit>(loc, cnst, std::move(asgn.lhs));
+        asgn.lhs = ast::make_expression<ast::ConstantLit>(cnst, std::move(asgn.lhs));
 
         return tree;
     }
@@ -1739,7 +1738,7 @@ public:
 
                 // one of fixed or bounds were provided
                 if (fixed != bounded) {
-                    asgn.lhs = ast::MK::Constant(asgn.lhs.loc(), sym);
+                    asgn.lhs = ast::MK::Constant(sym);
 
                     // Leave it in the tree for the resolver to chew on.
                     return tree;

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -118,7 +118,7 @@ class SymbolFinder {
     core::FoundDefinitionRef squashNames(core::Context ctx, const ast::ExpressionPtr &node) {
         if (auto *id = ast::cast_tree<ast::ConstantLit>(node)) {
             // Already defined. Insert a foundname so we can reference it.
-            auto sym = id->symbol.dealias(ctx);
+            auto sym = id->symbol().dealias(ctx);
             ENFORCE(sym.exists());
             return foundDefs->addSymbol(sym);
         } else if (auto constLit = ast::cast_tree<ast::UnresolvedConstantLit>(node)) {
@@ -265,7 +265,7 @@ public:
                 }
 
                 auto recv = ast::cast_tree<ast::ConstantLit>(original.recv);
-                if (recv == nullptr || recv->symbol != core::Symbols::Sorbet_Private_Static()) {
+                if (recv == nullptr || recv->symbol() != core::Symbols::Sorbet_Private_Static()) {
                     break;
                 }
 
@@ -389,7 +389,7 @@ public:
                 return core::NameRef::noName();
             }
 
-            if (recv->symbol != core::Symbols::Sorbet_Private_Static()) {
+            if (recv->symbol() != core::Symbols::Sorbet_Private_Static()) {
                 return core::NameRef::noName();
             }
 
@@ -1249,7 +1249,7 @@ class TreeSymbolizer {
         auto constLit = ast::cast_tree<ast::UnresolvedConstantLit>(node);
         if (constLit == nullptr) {
             if (auto *id = ast::cast_tree<ast::ConstantLit>(node)) {
-                return id->symbol.dealias(ctx);
+                return id->symbol().dealias(ctx);
             }
             if (auto *uid = ast::cast_tree<ast::UnresolvedIdent>(node)) {
                 if (uid->kind != ast::UnresolvedIdent::Kind::Class || uid->name != core::Names::singleton()) {
@@ -1422,7 +1422,7 @@ public:
             return false;
         }
         auto rcl = ast::cast_tree<ast::ConstantLit>(anc);
-        if (rcl && rcl->symbol == core::Symbols::todo()) {
+        if (rcl && rcl->symbol() == core::Symbols::todo()) {
             return false;
         }
         return true;

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -338,7 +338,7 @@ public:
 
         // If the imported symbol comes from the test namespace, we must also be in the test namespace.
         if (otherFile.data(ctx).isPackagedTest() && !this->insideTestFile) {
-            if (auto e = ctx.beginError(lit.loc, core::errors::Packager::UsedTestOnlyName)) {
+            if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::UsedTestOnlyName)) {
                 e.setHeader("`{}` is defined in a test namespace and cannot be referenced in a non-test file",
                             litSymbol.show(ctx));
             }
@@ -361,7 +361,7 @@ public:
 
         // Did we use a constant that wasn't exported?
         if (!isExported) {
-            if (auto e = ctx.beginError(lit.loc, core::errors::Packager::UsedPackagePrivateName)) {
+            if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::UsedPackagePrivateName)) {
                 auto &pkg = ctx.state.packageDB().getPackageInfo(otherPackage);
                 e.setHeader("`{}` resolves but is not exported from `{}`", litSymbol.show(ctx), pkg.show(ctx));
                 auto definedHereLoc = litSymbol.loc(ctx);
@@ -388,7 +388,7 @@ public:
         auto importType = this->package.importsPackage(otherPackage);
         if (!importType.has_value()) {
             // We failed to import the package that defines the symbol
-            if (auto e = ctx.beginError(lit.loc, core::errors::Packager::MissingImport)) {
+            if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::MissingImport)) {
                 auto &pkg = ctx.state.packageDB().getPackageInfo(otherPackage);
                 e.setHeader("`{}` resolves but its package is not imported", litSymbol.show(ctx));
                 bool isTestImport = otherFile.data(ctx).isPackagedTest();
@@ -410,7 +410,7 @@ public:
             }
         } else if (*importType == core::packages::ImportType::Test && !this->insideTestFile) {
             // We used a symbol from a `test_import` in a non-test context
-            if (auto e = ctx.beginError(lit.loc, core::errors::Packager::UsedTestOnlyName)) {
+            if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::UsedTestOnlyName)) {
                 e.setHeader("Used `{}` constant `{}` in non-test file", "test_import", litSymbol.show(ctx));
                 auto &pkg = ctx.state.packageDB().getPackageInfo(otherPackage);
                 if (auto exp = this->package.addImport(ctx, pkg, false)) {

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -486,8 +486,7 @@ ast::ExpressionPtr prependRoot(ast::ExpressionPtr scope) {
     while (auto constLit = ast::cast_tree<ast::UnresolvedConstantLit>(lastConstLit->scope)) {
         lastConstLit = constLit;
     }
-    auto loc = lastConstLit->scope.loc();
-    lastConstLit->scope = ast::MK::Constant(loc, core::Symbols::root());
+    lastConstLit->scope = ast::MK::Constant(core::Symbols::root());
     return scope;
 }
 

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -861,7 +861,7 @@ private:
             lit = ast::cast_tree<ast::UnresolvedConstantLit>(lit->scope);
             if (scope != nullptr) {
                 ENFORCE(lit == nullptr);
-                ENFORCE(scope->symbol == core::Symbols::root());
+                ENFORCE(scope->symbol() == core::Symbols::root());
                 rootConsts++;
             }
         }
@@ -888,7 +888,7 @@ private:
             lit = ast::cast_tree<ast::UnresolvedConstantLit>(lit->scope);
             if (scope != nullptr) {
                 ENFORCE(lit == nullptr);
-                ENFORCE(scope->symbol == core::Symbols::root());
+                ENFORCE(scope->symbol() == core::Symbols::root());
                 rootConsts--;
             }
         }

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -1070,7 +1070,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx,
 
             if (recvi->symbol() == core::Symbols::Magic() && s.fun == core::Names::callWithSplat()) {
                 // TODO(pay-server) remove this block
-                if (auto e = ctx.beginError(recvi->loc(), core::errors::Resolver::InvalidTypeDeclaration)) {
+                if (auto e = ctx.beginError(s.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                     e.setHeader("Malformed type declaration: splats cannot be used in types");
                 }
                 result.type = core::Types::untypedUntracked();

--- a/rewriter/AttrReader.cc
+++ b/rewriter/AttrReader.cc
@@ -196,7 +196,7 @@ ast::ExpressionPtr toWriterSigForName(ast::Send *sharedSig, const core::NameRef 
     ast::Send *cur = body;
     while (cur != nullptr) {
         auto recv = ast::cast_tree<ast::ConstantLit>(cur->recv);
-        if ((cur->recv.isSelfReference()) || (recv && recv->symbol == core::Symbols::Sorbet())) {
+        if ((cur->recv.isSelfReference()) || (recv && recv->symbol() == core::Symbols::Sorbet())) {
             auto loc = resultType.loc();
             auto params = ast::MK::Send0(loc, move(cur->recv), core::Names::params(), loc.copyWithZeroLength());
             ast::cast_tree_nonnull<ast::Send>(params).addKwArg(ast::MK::Symbol(nameLoc, name), move(resultType));

--- a/rewriter/ClassNew.cc
+++ b/rewriter/ClassNew.cc
@@ -91,7 +91,7 @@ vector<ast::ExpressionPtr> ClassNew::run(core::MutableContext ctx, ast::Assign *
     if (argc == 1) {
         ancestors.emplace_back(move(send->getPosArg(0)));
     } else {
-        ancestors.emplace_back(ast::MK::Constant(send->loc, core::Symbols::todo()));
+        ancestors.emplace_back(ast::MK::Constant(core::Symbols::todo()));
     }
 
     auto loc = asgn->loc;
@@ -129,7 +129,7 @@ bool ClassNew::run(core::MutableContext ctx, ast::Send *send) {
     ast::ExpressionPtr type;
 
     if (argc == 0) {
-        type = ast::MK::Constant(send->loc, core::Symbols::Class());
+        type = ast::MK::Constant(core::Symbols::Class());
     } else {
         auto target = send->getPosArg(0).deepCopy();
         type = ast::MK::ClassOf(send->loc, std::move(target));

--- a/rewriter/Concern.cc
+++ b/rewriter/Concern.cc
@@ -133,7 +133,7 @@ void Concern::run(core::MutableContext ctx, ast::ClassDef *klass) {
 
     if (classMethodsNode) {
         // Generate a Send { Magic.mixes_in_class_methods(ClassMethods) }
-        auto magic = ast::MK::Constant(klass->loc, core::Symbols::Magic());
+        auto magic = ast::MK::Constant(core::Symbols::Magic());
         auto classMethods =
             ast::MK::UnresolvedConstant(klass->loc, ast::MK::EmptyTree(), core::Names::Constants::ClassMethods());
         auto sendForMixes =

--- a/rewriter/DSLBuilder.cc
+++ b/rewriter/DSLBuilder.cc
@@ -87,7 +87,7 @@ vector<ast::ExpressionPtr> DSLBuilder::run(core::MutableContext ctx, ast::Send *
     // def self.<prop>
     if (!skipSetter) {
         stats.emplace_back(ast::MK::Sig1(loc, ast::MK::Symbol(nameLoc, name), ASTUtil::dupType(type),
-                                         ast::MK::Constant(loc, core::Symbols::NilClass())));
+                                         ast::MK::Constant(core::Symbols::NilClass())));
         auto arg = ast::MK::Local(nameLoc, name);
         if (implied) {
             auto default_ = ast::MK::UntypedNil(loc);

--- a/rewriter/DefDelegator.cc
+++ b/rewriter/DefDelegator.cc
@@ -14,7 +14,7 @@ void generateStub(vector<ast::ExpressionPtr> &methodStubs, const core::LocOffset
     // sig {params(arg0: T.untyped, blk: Proc).returns(T.untyped)}
     auto sigArgs = ast::MK::SendArgs(ast::MK::Symbol(loc, core::Names::arg0()), ast::MK::Untyped(loc),
                                      ast::MK::Symbol(loc, core::Names::blkArg()),
-                                     ast::MK::Nilable(loc, ast::MK::Constant(loc, core::Symbols::Proc())));
+                                     ast::MK::Nilable(loc, ast::MK::Constant(core::Symbols::Proc())));
 
     methodStubs.push_back(ast::MK::Sig(loc, std::move(sigArgs), ast::MK::Untyped(loc)));
 

--- a/rewriter/Delegate.cc
+++ b/rewriter/Delegate.cc
@@ -108,7 +108,7 @@ vector<ast::ExpressionPtr> Delegate::run(core::MutableContext ctx, const ast::Se
         // sig {params(arg0: T.untyped, blk: Proc).returns(T.untyped)}
         auto sigArgs = ast::MK::SendArgs(ast::MK::Symbol(loc, core::Names::arg0()), ast::MK::Untyped(loc),
                                          ast::MK::Symbol(loc, core::Names::blkArg()),
-                                         ast::MK::Nilable(loc, ast::MK::Constant(loc, core::Symbols::Proc())));
+                                         ast::MK::Nilable(loc, ast::MK::Constant(core::Symbols::Proc())));
 
         methodStubs.push_back(ast::MK::Sig(loc, std::move(sigArgs), ast::MK::Untyped(loc)));
 

--- a/rewriter/Flatten.cc
+++ b/rewriter/Flatten.cc
@@ -382,7 +382,7 @@ public:
             auto kind = methodDef.flags.genericPropGetter ? core::Names::genericPropGetter()
                         : methodDef.flags.isAttrReader    ? core::Names::attrReader()
                                                           : core::Names::normal();
-            return ast::MK::Send3(loc, ast::MK::Constant(loc, core::Symbols::Sorbet_Private_Static()), keepName,
+            return ast::MK::Send3(loc, ast::MK::Constant(core::Symbols::Sorbet_Private_Static()), keepName,
                                   loc.copyWithZeroLength(), ast::MK::Self(loc), ast::MK::Symbol(loc, name),
                                   ast::MK::Symbol(loc, kind));
         }

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -43,7 +43,7 @@ public:
             // if the constant is already in a T.let, preserve it, otherwise decay it to unsafe
             movedConstants.emplace_back(createConstAssign(*asgn));
 
-            auto module = ast::MK::Constant(asgn->loc, core::Symbols::Module());
+            auto module = ast::MK::Constant(core::Symbols::Module());
             return ast::MK::Send2(asgn->loc, move(module), core::Names::constSet(), asgn->loc.copyWithZeroLength(),
                                   move(name), move(asgn->rhs));
         }

--- a/rewriter/MixinEncryptedProp.cc
+++ b/rewriter/MixinEncryptedProp.cc
@@ -22,7 +22,7 @@ ast::ExpressionPtr mkNilableEncryptedValue(core::MutableContext ctx, core::LocOf
 }
 
 ast::ExpressionPtr mkNilableString(core::LocOffsets loc) {
-    return ASTUtil::mkNilable(loc, ast::MK::Constant(loc, core::Symbols::String()));
+    return ASTUtil::mkNilable(loc, ast::MK::Constant(core::Symbols::String()));
 }
 
 } // namespace

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -145,14 +145,14 @@ optional<PropInfo> parseProp(core::MutableContext ctx, const ast::Send *send) {
             ret.name = core::Names::token();
             auto beginPos = send->loc.beginPos() + (send->fun == core::Names::timestampedTokenProp() ? 12 : 0);
             ret.nameLoc = core::LocOffsets{beginPos, beginPos + 5}; // get the 'token' part of it
-            ret.type = ast::MK::Constant(send->loc, core::Symbols::String());
+            ret.type = ast::MK::Constant(core::Symbols::String());
             break;
         }
         case core::Names::createdProp().rawId():
             ret.name = core::Names::created();
             // 5 is the length of the _prop suffix
             ret.nameLoc = core::LocOffsets{send->loc.beginPos(), send->loc.endPos() - 5};
-            ret.type = ast::MK::Constant(send->loc, core::Symbols::Float());
+            ret.type = ast::MK::Constant(core::Symbols::Float());
             break;
         case core::Names::updatedProp().rawId(): {
             ret.name = send->fun == core::Names::createdProp() ? core::Names::created() : core::Names::updated();
@@ -172,7 +172,7 @@ optional<PropInfo> parseProp(core::MutableContext ctx, const ast::Send *send) {
             ret.name = core::Names::merchant();
             // 5 is the length of the _prop suffix
             ret.nameLoc = core::LocOffsets{send->loc.beginPos(), send->loc.endPos() - 5};
-            ret.type = ast::MK::Constant(send->loc, core::Symbols::String());
+            ret.type = ast::MK::Constant(core::Symbols::String());
             break;
         case core::Names::merchantTokenProp().rawId():
             ret.isImmutable = true;
@@ -444,7 +444,7 @@ vector<ast::ExpressionPtr> processProp(core::MutableContext ctx, PropInfo &ret, 
                 auto ivarSet =
                     ast::MK::Send2(loc, ast::MK::Self(loc), core::Names::instanceVariableSet(), locZero,
                                    ast::MK::Symbol(nameLoc, ivarName), ast::MK::Local(nameLoc, core::Names::arg0()));
-                auto tConfig = ast::MK::Constant(loc, core::Symbols::T_Configuration());
+                auto tConfig = ast::MK::Constant(core::Symbols::T_Configuration());
                 auto propFreezeHandler =
                     ast::MK::Send0(loc, std::move(tConfig), core::Names::propFreezeHandler(), locZero);
                 auto propFreezeLogic = ast::MK::Send2(loc, std::move(propFreezeHandler), core::Names::call(), locZero,

--- a/rewriter/Regexp.cc
+++ b/rewriter/Regexp.cc
@@ -27,7 +27,7 @@ vector<ast::ExpressionPtr> Regexp::run(core::MutableContext ctx, ast::Assign *as
     }
 
     vector<ast::ExpressionPtr> stats;
-    auto type = ast::MK::Constant(send->loc, core::Symbols::Regexp());
+    auto type = ast::MK::Constant(core::Symbols::Regexp());
     auto newRhs = ast::MK::Let(send->loc, std::move(asgn->rhs), std::move(type));
     stats.emplace_back(ast::MK::Assign(asgn->loc, std::move(asgn->lhs), std::move(newRhs)));
     return stats;

--- a/rewriter/Regexp.cc
+++ b/rewriter/Regexp.cc
@@ -22,7 +22,7 @@ vector<ast::ExpressionPtr> Regexp::run(core::MutableContext ctx, ast::Assign *as
     }
 
     auto recv = ast::cast_tree<ast::ConstantLit>(send->recv);
-    if (recv == nullptr || recv->symbol != core::Symbols::Regexp()) {
+    if (recv == nullptr || recv->symbol() != core::Symbols::Regexp()) {
         return {};
     }
 

--- a/rewriter/SelfNew.cc
+++ b/rewriter/SelfNew.cc
@@ -53,7 +53,7 @@ bool isSelfNewCallWithSplat(core::MutableContext ctx, ast::Send *send) {
 }
 
 ast::ExpressionPtr convertSelfNewCallWithSplat(core::MutableContext ctx, ast::Send *send) {
-    auto magic = ast::MK::Constant(send->loc, core::Symbols::Magic());
+    auto magic = ast::MK::Constant(core::Symbols::Magic());
     auto &arg0 = send->getPosArg(0);
     arg0 = std::move(magic);
 

--- a/rewriter/SigRewriter.cc
+++ b/rewriter/SigRewriter.cc
@@ -51,7 +51,7 @@ bool SigRewriter::run(core::MutableContext &ctx, ast::Send *send) {
     // Keep track of old receiver at this point so that we can report whether a method called
     // sig with the right arity even existed at this point.
     auto oldRecv = std::move(send->recv);
-    send->recv = ast::MK::Constant(send->loc, core::Symbols::Sorbet_Private_Static());
+    send->recv = ast::MK::Constant(core::Symbols::Sorbet_Private_Static());
     send->insertPosArg(0, std::move(oldRecv));
     return true;
 }

--- a/rewriter/SigRewriter.cc
+++ b/rewriter/SigRewriter.cc
@@ -9,7 +9,7 @@ namespace {
 
 bool isTSigWithoutRuntime(ast::ExpressionPtr &expr) {
     if (auto *cnst = ast::cast_tree<ast::ConstantLit>(expr)) {
-        return cnst->symbol == core::Symbols::T_Sig_WithoutRuntime();
+        return cnst->symbol() == core::Symbols::T_Sig_WithoutRuntime();
     } else {
         auto *withoutRuntime = ast::cast_tree<ast::UnresolvedConstantLit>(expr);
         if (withoutRuntime == nullptr || withoutRuntime->cnst != core::Names::Constants::WithoutRuntime()) {

--- a/rewriter/Struct.cc
+++ b/rewriter/Struct.cc
@@ -132,7 +132,7 @@ vector<ast::ExpressionPtr> Struct::run(core::MutableContext ctx, ast::Assign *as
         }
 
         sigArgs.emplace_back(ast::MK::Symbol(symLoc, name));
-        sigArgs.emplace_back(ast::MK::Constant(symLoc, core::Symbols::BasicObject()));
+        sigArgs.emplace_back(ast::MK::Constant(core::Symbols::BasicObject()));
         auto argName = ast::MK::Local(symLoc, name);
         if (keywordInit) {
             argName = ast::make_expression<ast::KeywordArg>(symLoc, move(argName));
@@ -176,7 +176,7 @@ vector<ast::ExpressionPtr> Struct::run(core::MutableContext ctx, ast::Assign *as
     }
 
     ast::ClassDef::ANCESTORS_store ancestors;
-    ancestors.emplace_back(ast::MK::UnresolvedConstant(loc, ast::MK::Constant(loc, core::Symbols::root()),
+    ancestors.emplace_back(ast::MK::UnresolvedConstant(loc, ast::MK::Constant(core::Symbols::root()),
                                                        core::Names::Constants::Struct()));
 
     vector<ast::ExpressionPtr> stats;

--- a/rewriter/TEnum.cc
+++ b/rewriter/TEnum.cc
@@ -131,7 +131,7 @@ vector<ast::ExpressionPtr> processStat(core::MutableContext ctx, ast::ClassDef *
     flags.isPrivateOk = true;
     auto singletonAsgn = ast::MK::Assign(
         stat.loc(), std::move(asgn->lhs),
-        ast::MK::Send2(stat.loc(), ast::MK::Constant(stat.loc(), core::Symbols::T()), core::Names::uncheckedLet(),
+        ast::MK::Send2(stat.loc(), ast::MK::Constant(core::Symbols::T()), core::Names::uncheckedLet(),
                        stat.loc().copyWithZeroLength(),
                        rhs->withNewBody(stat.loc(), classCnst.deepCopy(), core::Names::new_()), std::move(classCnst)));
     vector<ast::ExpressionPtr> result;
@@ -169,7 +169,7 @@ void TEnum::run(core::MutableContext ctx, ast::ClassDef *klass) {
     auto loc = klass->declLoc;
     auto locZero = loc.copyWithZeroLength();
     klass->rhs.emplace_back(ast::MK::Send1(loc, ast::MK::Self(loc), core::Names::extend(), locZero,
-                                           ast::MK::Constant(loc, core::Symbols::T_Helpers())));
+                                           ast::MK::Constant(core::Symbols::T_Helpers())));
     klass->rhs.emplace_back(ast::MK::Send0(loc, ast::MK::Self(loc), core::Names::declareAbstract(), locZero));
     klass->rhs.emplace_back(ast::MK::Send0(loc, ast::MK::Self(loc), core::Names::declareSealed(), locZero));
     for (auto &stat : oldRHS) {

--- a/rewriter/Util.cc
+++ b/rewriter/Util.cc
@@ -61,7 +61,7 @@ ast::ExpressionPtr ASTUtil::dupType(const ast::ExpressionPtr &orig) {
         if (ident->original && !orig) {
             return nullptr;
         }
-        return ast::make_expression<ast::ConstantLit>(ident->loc, ident->symbol(), std::move(orig));
+        return ast::make_expression<ast::ConstantLit>(ident->symbol(), std::move(orig));
     }
 
     auto *arrayLit = ast::cast_tree<ast::Array>(orig);

--- a/rewriter/Util.cc
+++ b/rewriter/Util.cc
@@ -61,7 +61,7 @@ ast::ExpressionPtr ASTUtil::dupType(const ast::ExpressionPtr &orig) {
         if (ident->original && !orig) {
             return nullptr;
         }
-        return ast::make_expression<ast::ConstantLit>(ident->loc, ident->symbol, std::move(orig));
+        return ast::make_expression<ast::ConstantLit>(ident->loc, ident->symbol(), std::move(orig));
     }
 
     auto *arrayLit = ast::cast_tree<ast::Array>(orig);
@@ -119,7 +119,7 @@ ast::ExpressionPtr ASTUtil::dupType(const ast::ExpressionPtr &orig) {
         if (id == nullptr) {
             return nullptr;
         }
-        ENFORCE(id->symbol == core::Symbols::root());
+        ENFORCE(id->symbol() == core::Symbols::root());
         return ast::MK::UnresolvedConstant(cons->loc, dupType(cons->scope), cons->cnst);
     }
     auto scope = dupType(cons->scope);


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is an extension of #4954, which removed 8 bytes from `ConstantLit`...but unfortunately didn't change very much as far as memory usage goes because 24 bytes and 32 bytes all go into the 32-byte bucket in jemalloc.  To see savings, we need to reduce `ConstantLit` down to 16 bytes.

We can do that by observing that `ConstantLit`'s loc is exactly the same as the original `UnresolvedConstantLit`'s loc.  And in cases where we don't have an `original`, we're synthesizing a constant literal from something that didn't appear in the user's source code, and therefore we probably shouldn't be giving it a loc anyway.  So we can redirect all requests for the loc of a `ConstantLit` to its original unresolved constant literal, and just say the `ConstantLit` doesn't have a loc if the original doesn't exist.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
