### PR TITLE
reorder class flattening and definition validation in tests, too

### DIFF
--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -198,8 +198,8 @@ void immutableNamerResolver(const core::GlobalState &gs, vector<ast::ParsedFile>
         auto file = resolvedTree.file;
 
         core::Context ctx(gs, core::Symbols::root(), file);
-        resolvedTree = definition_validator::runOne(ctx, move(resolvedTree));
         resolvedTree = class_flatten::runOne(ctx, move(resolvedTree));
+        resolvedTree = definition_validator::runOne(ctx, move(resolvedTree));
 
         // Don't run typecheck on RBI files.
         if (resolvedTree.file.data(gs).isRBI()) {
@@ -606,10 +606,10 @@ TEST_CASE("PerPhaseTest") { // NOLINT
         auto file = resolvedTree.file;
 
         core::Context ctx(*gs, core::Symbols::root(), file);
+        resolvedTree = class_flatten::runOne(ctx, move(resolvedTree));
+
         resolvedTree = definition_validator::runOne(ctx, move(resolvedTree));
         handler.drainErrors(*gs);
-
-        resolvedTree = class_flatten::runOne(ctx, move(resolvedTree));
 
         handler.addObserved(*gs, "flatten-tree", [&]() { return resolvedTree.tree.toString(*gs); });
         handler.addObserved(*gs, "flatten-tree-raw", [&]() { return resolvedTree.tree.showRaw(*gs); });


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Following up on #5921, we should make the same change to our test harnesses that we made to our pipeline so that we're actually testing (something close to) what we ship.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
