### PR TITLE
delay accessing tree locs in `TreeMapper::mapIt`

### DIFF
--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -467,7 +467,6 @@ private:
                 return;
             }
         }
-        auto loc = what.loc();
 
         try {
             // TODO: reorder by frequency
@@ -585,6 +584,8 @@ private:
                     return mapRuntimeMethodDefinition(Funcs::pass(what), ctx);
             }
         } catch (SorbetException &e) {
+            auto loc = what.loc();
+
             Exception::failInFuzzer();
 
             throw ReportedRubyException{e, loc};

--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -137,12 +137,6 @@ public:
     GENERATE_POSTPONE_POSTCLASS(Cast, arg_types);                                \
     GENERATE_POSTPONE_POSTCLASS(RuntimeMethodDefinition, arg_types);
 
-// Used to indicate that TreeMap has already reported location for this exception
-struct ReportedRubyException {
-    SorbetException reported;
-    core::LocOffsets onLoc;
-};
-
 enum class TreeMapKind {
     Map,
     Walk,
@@ -593,15 +587,7 @@ class TreeMap {
 public:
     template <typename CTX, typename FUNC> static ExpressionPtr apply(CTX ctx, FUNC &func, ExpressionPtr to) {
         TreeMapper<FUNC, CTX, TreeMapKind::Map, TreeMapDepthKind::Full> walker(func);
-        try {
-            return walker.mapIt(std::move(to), ctx);
-        } catch (ReportedRubyException &exception) {
-            Exception::failInFuzzer();
-            if (auto e = ctx.beginError(exception.onLoc, core::errors::Internal::InternalError)) {
-                e.setHeader("Failed to process tree (backtrace is above)");
-            }
-            throw exception.reported;
-        }
+        return walker.mapIt(std::move(to), ctx);
     }
 };
 
@@ -609,15 +595,7 @@ class TreeWalk {
 public:
     template <typename CTX, typename FUNC> static void apply(CTX ctx, FUNC &func, ExpressionPtr &to) {
         TreeMapper<FUNC, CTX, TreeMapKind::Walk, TreeMapDepthKind::Full> walker(func);
-        try {
-            walker.mapIt(to, ctx);
-        } catch (ReportedRubyException &exception) {
-            Exception::failInFuzzer();
-            if (auto e = ctx.beginError(exception.onLoc, core::errors::Internal::InternalError)) {
-                e.setHeader("Failed to process tree (backtrace is above)");
-            }
-            throw exception.reported;
-        }
+        walker.mapIt(to, ctx);
     }
 };
 
@@ -625,15 +603,7 @@ class ShallowMap {
 public:
     template <typename CTX, typename FUNC> static ExpressionPtr apply(CTX ctx, FUNC &func, ExpressionPtr to) {
         TreeMapper<FUNC, CTX, TreeMapKind::Map, TreeMapDepthKind::Shallow> walker(func);
-        try {
-            return walker.mapIt(std::move(to), ctx);
-        } catch (ReportedRubyException &exception) {
-            Exception::failInFuzzer();
-            if (auto e = ctx.beginError(exception.onLoc, core::errors::Internal::InternalError)) {
-                e.setHeader("Failed to process tree (backtrace is above)");
-            }
-            throw exception.reported;
-        }
+        return walker.mapIt(std::move(to), ctx);
     }
 };
 
@@ -641,15 +611,7 @@ class ShallowWalk {
 public:
     template <typename CTX, typename FUNC> static void apply(CTX ctx, FUNC &func, ExpressionPtr &to) {
         TreeMapper<FUNC, CTX, TreeMapKind::Walk, TreeMapDepthKind::Shallow> walker(func);
-        try {
-            walker.mapIt(to, ctx);
-        } catch (ReportedRubyException &exception) {
-            Exception::failInFuzzer();
-            if (auto e = ctx.beginError(exception.onLoc, core::errors::Internal::InternalError)) {
-                e.setHeader("Failed to process tree (backtrace is above)");
-            }
-            throw exception.reported;
-        }
+        walker.mapIt(to, ctx);
     }
 };
 

--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -467,7 +467,9 @@ private:
                 return;
             }
         }
+        auto loc = what.loc();
 
+        try {
             // TODO: reorder by frequency
             if constexpr (Funcs::template HAS_MEMBER_preTransformExpression<FUNC>()) {
                 if constexpr (Kind == TreeMapKind::Map) {
@@ -582,6 +584,11 @@ private:
                 case Tag::RuntimeMethodDefinition:
                     return mapRuntimeMethodDefinition(Funcs::pass(what), ctx);
             }
+        } catch (SorbetException &e) {
+            Exception::failInFuzzer();
+
+            throw ReportedRubyException{e, loc};
+        }
     }
 
 #undef CALL_PRE

--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -137,6 +137,12 @@ public:
     GENERATE_POSTPONE_POSTCLASS(Cast, arg_types);                                \
     GENERATE_POSTPONE_POSTCLASS(RuntimeMethodDefinition, arg_types);
 
+// Used to indicate that TreeMap has already reported location for this exception
+struct ReportedRubyException {
+    SorbetException reported;
+    core::LocOffsets onLoc;
+};
+
 enum class TreeMapKind {
     Map,
     Walk,
@@ -587,7 +593,15 @@ class TreeMap {
 public:
     template <typename CTX, typename FUNC> static ExpressionPtr apply(CTX ctx, FUNC &func, ExpressionPtr to) {
         TreeMapper<FUNC, CTX, TreeMapKind::Map, TreeMapDepthKind::Full> walker(func);
-        return walker.mapIt(std::move(to), ctx);
+        try {
+            return walker.mapIt(std::move(to), ctx);
+        } catch (ReportedRubyException &exception) {
+            Exception::failInFuzzer();
+            if (auto e = ctx.beginError(exception.onLoc, core::errors::Internal::InternalError)) {
+                e.setHeader("Failed to process tree (backtrace is above)");
+            }
+            throw exception.reported;
+        }
     }
 };
 
@@ -595,7 +609,15 @@ class TreeWalk {
 public:
     template <typename CTX, typename FUNC> static void apply(CTX ctx, FUNC &func, ExpressionPtr &to) {
         TreeMapper<FUNC, CTX, TreeMapKind::Walk, TreeMapDepthKind::Full> walker(func);
-        walker.mapIt(to, ctx);
+        try {
+            walker.mapIt(to, ctx);
+        } catch (ReportedRubyException &exception) {
+            Exception::failInFuzzer();
+            if (auto e = ctx.beginError(exception.onLoc, core::errors::Internal::InternalError)) {
+                e.setHeader("Failed to process tree (backtrace is above)");
+            }
+            throw exception.reported;
+        }
     }
 };
 
@@ -603,7 +625,15 @@ class ShallowMap {
 public:
     template <typename CTX, typename FUNC> static ExpressionPtr apply(CTX ctx, FUNC &func, ExpressionPtr to) {
         TreeMapper<FUNC, CTX, TreeMapKind::Map, TreeMapDepthKind::Shallow> walker(func);
-        return walker.mapIt(std::move(to), ctx);
+        try {
+            return walker.mapIt(std::move(to), ctx);
+        } catch (ReportedRubyException &exception) {
+            Exception::failInFuzzer();
+            if (auto e = ctx.beginError(exception.onLoc, core::errors::Internal::InternalError)) {
+                e.setHeader("Failed to process tree (backtrace is above)");
+            }
+            throw exception.reported;
+        }
     }
 };
 
@@ -611,7 +641,15 @@ class ShallowWalk {
 public:
     template <typename CTX, typename FUNC> static void apply(CTX ctx, FUNC &func, ExpressionPtr &to) {
         TreeMapper<FUNC, CTX, TreeMapKind::Walk, TreeMapDepthKind::Shallow> walker(func);
-        walker.mapIt(to, ctx);
+        try {
+            walker.mapIt(to, ctx);
+        } catch (ReportedRubyException &exception) {
+            Exception::failInFuzzer();
+            if (auto e = ctx.beginError(exception.onLoc, core::errors::Internal::InternalError)) {
+                e.setHeader("Failed to process tree (backtrace is above)");
+            }
+            throw exception.reported;
+        }
     }
 };
 

--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -467,9 +467,7 @@ private:
                 return;
             }
         }
-        auto loc = what.loc();
 
-        try {
             // TODO: reorder by frequency
             if constexpr (Funcs::template HAS_MEMBER_preTransformExpression<FUNC>()) {
                 if constexpr (Kind == TreeMapKind::Map) {
@@ -584,11 +582,6 @@ private:
                 case Tag::RuntimeMethodDefinition:
                     return mapRuntimeMethodDefinition(Funcs::pass(what), ctx);
             }
-        } catch (SorbetException &e) {
-            Exception::failInFuzzer();
-
-            throw ReportedRubyException{e, loc};
-        }
     }
 
 #undef CALL_PRE


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

For every recursive call to `TreeMapper::mapIt`, we fetch the loc of the tree we're mapping over, so we can throw a nicer exception in the error case.  We only ever use the loc in the error case: an error case that is extremely rare, not just error cases where the user wrote some unparseable code or something like that.  I assume we're fetching the loc early in the case that memory might have been corrupted by the time we catch the exception.

(Full disclosure: there is a selfish reason for getting rid of this and that's with the current form of #5931, `ExpressionPtr::loc` is no longer inlining, which makes the runtime cost of that PR somewhat high.  It'd be nice to not have to make `TreeMapper::mapIt` slower in that PR, but I think getting rid of the extraneous code here is worthwhile on its own.)

This PR proposes getting rid of this exception handling and just living with whatever `SorbetException` we threw, without the nicer error message of exactly which tree we were in the process of handling.  My sense is that we can figure out in the debugger what's going on and/or that the cases which this error was helpful are vanishingly rare nowadays and/or our `ENFORCE`s are much better and the corresponding backtraces from those more useful than the handling here would have been.

I can't recall ever seeing this fire, but I admit that my memory may not be the best.  Leaving this in for debug builds is also a possibility.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
