### PR TITLE
Convert Histogram to log line

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -323,8 +323,7 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
     fast_sort(subset);
     subset.resize(std::distance(subset.begin(), std::unique(subset.begin(), subset.end())));
 
-    config->logger->debug("Running fast path");
-    prodHistogramInc("lsp.fast_path_files_retypechecked", subset.size());
+    config->logger->debug("Running fast path over num_files={}", subset.size());
     ENFORCE(gs->errorQueue->isEmpty());
     vector<ast::ParsedFile> updatedIndexed;
     for (auto &f : subset) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Stripe's metrics tooling isn't handling histograms like this quite the way we'd
like them to. Converting to a log line which will be slightly less automatic to
consume, but easier to do one-off analyses.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a