### PR TITLE
Don't short circuit in isSubType if other half might want to record bounds

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -275,9 +275,6 @@ unique_ptr<Error> matchArgType(const GlobalState &gs, TypeConstraint &constr, Lo
     expectedType = Types::replaceSelfType(gs, expectedType, selfType);
 
     if (Types::isSubTypeUnderConstraint(gs, constr, argTpe.type, expectedType, UntypedMode::AlwaysCompatible)) {
-        // if (method.data(gs)->name.shortName(gs) == "refute_nil") {
-        //     fmt::print(stderr, "{}\n", constr.toString(gs));
-        // }
         return nullptr;
     }
 
@@ -687,9 +684,6 @@ const ShapeType *fromKwargsHash(const GlobalState &gs, const TypePtr &ty) {
 //    (with a subtype check on the key type, once we have generics)
 DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &args, core::ClassOrModuleRef symbol,
                                   const vector<TypePtr> &targs) {
-    if (args.name.shortName(gs) == "refute_nil") {
-        stopInDebugger();
-    }
     auto funLoc = args.funLoc();
     auto errLoc = (funLoc.exists() && !funLoc.empty()) ? funLoc : args.callLoc();
     if (symbol == core::Symbols::untyped()) {

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -275,6 +275,9 @@ unique_ptr<Error> matchArgType(const GlobalState &gs, TypeConstraint &constr, Lo
     expectedType = Types::replaceSelfType(gs, expectedType, selfType);
 
     if (Types::isSubTypeUnderConstraint(gs, constr, argTpe.type, expectedType, UntypedMode::AlwaysCompatible)) {
+        // if (method.data(gs)->name.shortName(gs) == "refute_nil") {
+        //     fmt::print(stderr, "{}\n", constr.toString(gs));
+        // }
         return nullptr;
     }
 
@@ -684,6 +687,9 @@ const ShapeType *fromKwargsHash(const GlobalState &gs, const TypePtr &ty) {
 //    (with a subtype check on the key type, once we have generics)
 DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &args, core::ClassOrModuleRef symbol,
                                   const vector<TypePtr> &targs) {
+    if (args.name.shortName(gs) == "refute_nil") {
+        stopInDebugger();
+    }
     auto funLoc = args.funLoc();
     auto errLoc = (funLoc.exists() && !funLoc.empty()) ? funLoc : args.callLoc();
     if (symbol == core::Symbols::untyped()) {

--- a/test/testdata/infer/double_type_param.rb
+++ b/test/testdata/infer/double_type_param.rb
@@ -1,0 +1,114 @@
+# typed: true
+extend T::Sig
+
+# Not all of the behaviors in this file are necessarily desired.
+# This test serves more as a mirror to tell you how the change you've made to
+# TypeConstraints works on some examples you might have not thought of.
+# If you make a change that causes this test to fail, you and your reviewer
+# will have to decide on your own whether that change is an improvement or a
+# regression.
+
+untyped = T.unsafe(nil)
+integer = T.let(0, Integer)
+string = T.let('', String)
+int_or_string = T.let(0, T.any(Integer, String))
+string_or_int = T.let(0, T.any(String, Integer))
+
+sig do
+  type_parameters(:U, :V)
+  .params(
+    u_or_v: T.any(T.type_parameter(:U), T.type_parameter(:V)),
+    u: T.type_parameter(:U),
+    v: T.type_parameter(:V),
+  )
+    .returns([T.type_parameter(:U), T.type_parameter(:V)])
+end
+def u_or_v__u__v(u_or_v, u, v)
+  T.reveal_type(u_or_v) # error: `T.any(T.type_parameter(:U) (of Object#u_or_v__u__v), T.type_parameter(:V) (of Object#u_or_v__u__v))`
+  T.reveal_type(u) # error: `T.type_parameter(:U) (of Object#u_or_v__u__v)`
+  T.reveal_type(v) # error: `T.type_parameter(:V) (of Object#u_or_v__u__v)`
+  [u, v]
+end
+
+sig do
+  type_parameters(:U, :V)
+  .params(
+    u: T.type_parameter(:U),
+    u_or_v: T.any(T.type_parameter(:U), T.type_parameter(:V)),
+    v: T.type_parameter(:V),
+  )
+    .returns([T.type_parameter(:U), T.type_parameter(:V)])
+end
+def u__u_or_v__v(u, u_or_v, v)
+  T.reveal_type(u_or_v) # error: `T.any(T.type_parameter(:U) (of Object#u__u_or_v__v), T.type_parameter(:V) (of Object#u__u_or_v__v))`
+  T.reveal_type(u) # error: `T.type_parameter(:U) (of Object#u__u_or_v__v)`
+  T.reveal_type(v) # error: `T.type_parameter(:V) (of Object#u__u_or_v__v)`
+  [u, v]
+end
+
+sig do
+  type_parameters(:U, :V)
+  .params(
+    u: T.type_parameter(:U),
+    v: T.type_parameter(:V),
+    u_or_v: T.any(T.type_parameter(:U), T.type_parameter(:V)),
+  )
+    .returns([T.type_parameter(:U), T.type_parameter(:V)])
+end
+def u__v__u_or_v(u, v, u_or_v)
+  T.reveal_type(u_or_v) # error: `T.any(T.type_parameter(:U) (of Object#u__v__u_or_v), T.type_parameter(:V) (of Object#u__v__u_or_v))`
+  T.reveal_type(u) # error: `T.type_parameter(:U) (of Object#u__v__u_or_v)`
+  T.reveal_type(v) # error: `T.type_parameter(:V) (of Object#u__v__u_or_v)`
+  [u, v]
+end
+
+
+x = u_or_v__u__v(integer, integer, string)
+T.reveal_type(x) # error: `[Integer, String] (2-tuple)`
+x = u__u_or_v__v(integer, integer, string)
+T.reveal_type(x) # error: `[Integer, String] (2-tuple)`
+x = u__v__u_or_v(integer, string, integer)
+T.reveal_type(x) # error: `[Integer, String] (2-tuple)`
+
+x = u_or_v__u__v(untyped, integer, string)
+T.reveal_type(x) # error: `[T.untyped, String] (2-tuple)`
+x = u__u_or_v__v(integer, untyped, string)
+T.reveal_type(x) # error: `[T.untyped, String] (2-tuple)`
+x = u__v__u_or_v(integer, string, untyped)
+T.reveal_type(x) # error: `[T.untyped, String] (2-tuple)`
+
+x = u_or_v__u__v(untyped, false, string)
+T.reveal_type(x) # error: `[T.untyped, String] (2-tuple)`
+x = u__u_or_v__v(false, untyped, string)
+T.reveal_type(x) # error: `[T.untyped, String] (2-tuple)`
+x = u__v__u_or_v(false, string, untyped)
+T.reveal_type(x) # error: `[T.untyped, String] (2-tuple)`
+
+x = u_or_v__u__v(untyped, integer, false)
+T.reveal_type(x) # error: `[T.untyped, FalseClass] (2-tuple)`
+x = u__u_or_v__v(integer, untyped, false)
+T.reveal_type(x) # error: `[T.untyped, FalseClass] (2-tuple)`
+x = u__v__u_or_v(integer, false, untyped)
+T.reveal_type(x) # error: `[T.untyped, FalseClass] (2-tuple)`
+
+x = u_or_v__u__v(int_or_string, integer, false)
+T.reveal_type(x) # error: `[T.any(Integer, String), FalseClass] (2-tuple)`
+x = u__u_or_v__v(integer, int_or_string, false)
+T.reveal_type(x) # error: `[T.any(Integer, String), FalseClass] (2-tuple)`
+x = u__v__u_or_v(integer, false, int_or_string)
+T.reveal_type(x) # error: `[T.any(Integer, String), FalseClass] (2-tuple)`
+
+x = u_or_v__u__v(string_or_int, integer, false)
+T.reveal_type(x) # error: `[T.any(String, Integer), FalseClass] (2-tuple)`
+x = u__u_or_v__v(integer, string_or_int, false)
+T.reveal_type(x) # error: `[T.any(Integer, String), FalseClass] (2-tuple)`
+x = u__v__u_or_v(integer, false, string_or_int)
+T.reveal_type(x) # error: `[T.any(Integer, String), FalseClass] (2-tuple)`
+
+x = u_or_v__u__v(int_or_string, false, false)
+T.reveal_type(x) # error: `[T.any(Integer, String, FalseClass), FalseClass] (2-tuple)`
+x = u__u_or_v__v(false, int_or_string, false)
+T.reveal_type(x) # error: `[T.any(FalseClass, Integer, String), FalseClass] (2-tuple)`
+x = u__v__u_or_v(false, false, int_or_string)
+T.reveal_type(x) # error: `[T.any(FalseClass, Integer, String), FalseClass] (2-tuple)`
+

--- a/test/testdata/infer/no_short_circuit_type_constraint.rb
+++ b/test/testdata/infer/no_short_circuit_type_constraint.rb
@@ -1,0 +1,62 @@
+# typed: true
+extend T::Sig
+
+sig do
+  type_parameters(:T)
+  .params(x: T.nilable(T.type_parameter(:T)))
+  .returns(T.type_parameter(:T))
+end
+def refute_nil(x)
+  T.reveal_type(x) # error: `T.nilable(T.type_parameter(:T) (of Object#refute_nil))`
+  case x
+  when NilClass then raise "was not nil"
+  else
+    T.reveal_type(x) # error: `T.type_parameter(:T) (of Object#refute_nil)`
+    x
+  end
+end
+
+nilable_integer = T.let(0, T.nilable(Integer))
+integer_or_nilclass = T.let(0, T.any(Integer, NilClass))
+untyped = T.unsafe(0)
+
+x = refute_nil(nilable_integer)
+T.reveal_type(x) # error: `Integer`
+
+x = refute_nil(integer_or_nilclass)
+T.reveal_type(x) # error: `Integer`
+
+x = refute_nil(untyped)
+T.reveal_type(x) # error: `T.untyped`
+
+
+sig do
+  type_parameters(:T)
+  # Even if we write the parameters this way, they'll currently get re-ordered.
+  # This happens because we sort the arguments to `lub` based on the value of
+  # `TypePtr::kind` to cut the implementation in half.
+  #
+  # If that ever stopped happening, we'd likely have to change
+  # isSubTypeUnderConstraint to be able to pass the tests below, or decide that
+  # we can't support the behavior below anymore.
+  .params(x: T.any(T.type_parameter(:T), NilClass))
+  .returns(T.type_parameter(:T))
+end
+def refute_nil_opposite_order(x)
+  T.reveal_type(x) # error: `T.nilable(T.type_parameter(:T) (of Object#refute_nil_opposite_order))`
+  case x
+  when NilClass then raise "was not nil"
+  else
+    T.reveal_type(x) # error: `T.type_parameter(:T) (of Object#refute_nil_opposite_order)`
+    x
+  end
+end
+
+x = refute_nil_opposite_order(nilable_integer)
+T.reveal_type(x) # error: `Integer`
+
+x = refute_nil_opposite_order(integer_or_nilclass)
+T.reveal_type(x) # error: `Integer`
+
+x = refute_nil_opposite_order(untyped)
+T.reveal_type(x) # error: `T.untyped`

--- a/test/testdata/infer/no_short_circuit_type_constraint.rb
+++ b/test/testdata/infer/no_short_circuit_type_constraint.rb
@@ -1,6 +1,68 @@
 # typed: true
 extend T::Sig
 
+# This is a comment I wrote to myself while I was working on the original
+# change that "fixed" the behavior in this test. It's super verbose, so I don't
+# think it belongs in the source code, but I was pretty sure I'd want to be
+# able to refer back to it at some point in the future.
+#
+# It basically walks through how Sorbet's isSubTypeUnderConstraint algorithm
+# worked at a point in time, on a handful of the examples in this test.
+#
+# It shows how the greedy nature of Sorbet's constraint solving algorithm
+# (instead of doing proper constraint generation and constraint resolution) can
+# break down, so that we don't have enough information to know what we'd like
+# to do until later.
+
+# (1)
+# T.nilable(Integer) <: T.nilable(T.type_parameter(:T))
+#
+# ==> NilClass <: T.nilable(T.type_parameter(:T)) &&
+#     Integer <: T.nilable(T.type_parameter(:T))
+#
+# ==> (NilClass <: NilClass ||
+#      NilClass <: T.type_parameter(:T)) &&      This should ideally not remember `NilClass` as lower bound
+#     (Integer <: NilClass ||
+#      Integer <: T.type_parameter(:T))          This should ideally remember `Integer` as lower bound
+
+# (2)
+# T.any(Integer, NilClass) <: T.any(T.type_paramater(:T), NilClass)
+#
+# ==> Integer <: T.any(T.type_parameter(:T), NilClass) &&
+#     NilClass <: T.any(T.type_parameter(:T), NilClass)
+#
+# ==> (Integer <: T.type_parameter(:T) ||        This should ideally remember `Integer` as a lower bound
+#      Integer <: NilClass) &&
+#     (NilClass <: T.type_parameter(:T) ||       This should ideally not remember `NilClass` as a lower bound
+#      NilClass <: NilClass)
+#
+# Compare this with the previous case. Ideally we want to implement
+# isSubTypeUnderConstraint such that it's agnostic of the order of things in a
+# union type. To get this test to pass, I did not do that--this test at time of
+# writing only works because the order is currently always
+# `T.nilable(T.type_parameter(:U))`. This is sort of an accident, because the
+# `TypePtr::kind` for `T.type_parameter` is greater than the kind for
+# `ClassType`, and we sort the arguments to `lub` on construction based on the
+# value of `TypePtr::kind`.
+
+# (3)
+# T.any(Integer, NilClass) <: T.nilable(T.type_parameter(:T))
+#
+# ==> Integer <: T.nilable(T.type_parameter(:T)) &&
+#     NilClass <: T.nilable(T.type_parameter(:T))
+#
+# ==> (Integer <: NilClass ||
+#      Integer <: T.type_parameter(:T)) &&
+#     (NilClass <: NilClass ||
+#      NilClass <: T.type_paramater(:T))
+
+# (4)
+# T.untyped <: T.nilable(T.type_parameter(:T))
+#
+# ==> T.untyped <: NilClass ||                   This is already true, so technically we know enough to
+#                                                answer isSubTypeUnderConstraint by short circuiting.
+#     T.untyped <: T.type_parameter(:T)          This should also remember `T.untyped` as lower bound
+
 sig do
   type_parameters(:T)
   .params(x: T.nilable(T.type_parameter(:T)))
@@ -32,13 +94,6 @@ T.reveal_type(x) # error: `T.untyped`
 
 sig do
   type_parameters(:T)
-  # Even if we write the parameters this way, they'll currently get re-ordered.
-  # This happens because we sort the arguments to `lub` based on the value of
-  # `TypePtr::kind` to cut the implementation in half.
-  #
-  # If that ever stopped happening, we'd likely have to change
-  # isSubTypeUnderConstraint to be able to pass the tests below, or decide that
-  # we can't support the behavior below anymore.
   .params(x: T.any(T.type_parameter(:T), NilClass))
   .returns(T.type_parameter(:T))
 end

--- a/test/testdata/infer/no_short_circuit_type_constraint.rb
+++ b/test/testdata/infer/no_short_circuit_type_constraint.rb
@@ -115,3 +115,27 @@ T.reveal_type(x) # error: `Integer`
 
 x = refute_nil_opposite_order(untyped)
 T.reveal_type(x) # error: `T.untyped`
+
+# -----------------------------------------------------------------------------
+# This is the thing, but flipped.
+# So it's T.all(...) <: T.untyped instead of T.untyped <: T.any(...)
+
+module IFoo
+end
+class Foo; include IFoo; end
+
+sig do
+  type_parameters(:U)
+    .params(
+      f: T.proc.params(x: T.all(IFoo, T.type_parameter(:U))).void,
+    )
+    .returns(T.proc.params(x: T.all(IFoo, T.type_parameter(:U))).void)
+end
+def example(f)
+  f
+end
+
+f = T.cast(nil, T.proc.params(x: T.untyped).void)
+res = example(f)
+T.reveal_type(res) # error: `T.proc.params(arg0: IFoo).void`
+res.call(Foo.new)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is best explained by reading the comments in the code and tests.

When it works:

Fixes #5308
Fixes #5468
Fixes #5620

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

- [x] @jez it appears that this might rely on ordering of type kind tags? w.r.t. #5614, see if you can write a test that would break if the literal type kinds were at the end of the list, instead of up above `TypeVar` etc.
  - I haven't been able to find a test case for this. I figure if it happens in practice, we can figure out a solution with the test case in hand. Nothing should crash, it will just maybe be a confusing type error (or lack thereof).