### PR TITLE
don't copy unnecessarily in `unsafeComputeExternalType`

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -163,7 +163,7 @@ TypePtr ClassOrModule::unsafeComputeExternalType(GlobalState &gs) {
             }
         }
 
-        resultType = make_type<AppliedType>(ref, targs);
+        resultType = make_type<AppliedType>(ref, std::move(targs));
     }
     return resultType;
 }


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Less copying here would be good.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
