### PR TITLE
give a better error message for incorrect {instance,class} variable declarations

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2405,7 +2405,8 @@ class ResolveTypeMembersAndFieldsWalk {
 
         if (cast->cast != core::Names::let()) {
             if (auto e = ctx.beginError(cast->loc, core::errors::Resolver::ConstantAssertType)) {
-                e.setHeader("Use `{}` to specify the type of constants", "T.let");
+                string desc = uid->kind == ast::UnresolvedIdent::Kind::Instance ? "instance" : "class";
+                e.setHeader("Use `{}` to specify the type of {} variables", "T.let", desc);
                 auto rhsLoc = ctx.locAt(asgn.rhs.loc());
                 auto argSource = ctx.locAt(cast->arg.loc()).source(ctx).value();
                 e.replaceWith("Replace with `T.let`", rhsLoc, "T.let({}, {})", argSource, cast->type.show(ctx));

--- a/test/cli/ivar-with-cast/test.out
+++ b/test/cli/ivar-with-cast/test.out
@@ -1,4 +1,4 @@
-test/cli/ivar-with-cast/ivar-with-cast.rb:6: Use `T.let` to specify the type of constants https://srb.help/5013
+test/cli/ivar-with-cast/ivar-with-cast.rb:6: Use `T.let` to specify the type of instance variables https://srb.help/5013
      6 |    @val = T.cast(0, Integer)
                    ^^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect

--- a/test/testdata/resolver/let_errors.rb
+++ b/test/testdata/resolver/let_errors.rb
@@ -1,5 +1,7 @@
 # typed: true
 class LetErrors
+  @@topvar = T.cast(nil, Integer) # error: Use `T.let` to specify the type of constants
+
   def initialize
     @@cvar = T.let(0, Integer) # error: The class variable `@@cvar` must be declared at class scope
     @ivar = T.cast(nil, Integer) # error: Use `T.let` to specify the type of constants

--- a/test/testdata/resolver/let_errors.rb
+++ b/test/testdata/resolver/let_errors.rb
@@ -1,10 +1,10 @@
 # typed: true
 class LetErrors
-  @@topvar = T.cast(nil, Integer) # error: Use `T.let` to specify the type of constants
+  @@topvar = T.cast(nil, Integer) # error: Use `T.let` to specify the type of class variables
 
   def initialize
     @@cvar = T.let(0, Integer) # error: The class variable `@@cvar` must be declared at class scope
-    @ivar = T.cast(nil, Integer) # error: Use `T.let` to specify the type of constants
+    @ivar = T.cast(nil, Integer) # error: Use `T.let` to specify the type of instance variables
   end
 
   def not_initialize

--- a/test/testdata/resolver/let_errors.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/let_errors.rb.symbol-table-raw.exp
@@ -1,21 +1,22 @@
 class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
-    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/let_errors.rb start=2:1 end=23:4}
+    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/let_errors.rb start=2:1 end=25:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/let_errors.rb start=??? end=???}
   class <C <U LetErrors>> < <C <U Object>> () @ Loc {file=test/testdata/resolver/let_errors.rb start=2:1 end=2:16}
-    static-field <C <U LetErrors>>::<U @@cv> -> Symbol @ Loc {file=test/testdata/resolver/let_errors.rb start=15:3 end=15:7}
-    static-field <C <U LetErrors>>::<U @@cvar> -> Integer @ Loc {file=test/testdata/resolver/let_errors.rb start=4:5 end=4:11}
-    static-field <C <U LetErrors>>::<U @@dv> -> Symbol @ Loc {file=test/testdata/resolver/let_errors.rb start=21:3 end=21:7}
-    field <C <U LetErrors>>#<U @a> -> Integer @ Loc {file=test/testdata/resolver/let_errors.rb start=9:5 end=9:7}
-    field <C <U LetErrors>>#<U @ivar> -> Integer @ Loc {file=test/testdata/resolver/let_errors.rb start=5:5 end=5:10}
-    method <C <U LetErrors>>#<U initialize> (<blk>) @ Loc {file=test/testdata/resolver/let_errors.rb start=3:3 end=3:17}
+    static-field <C <U LetErrors>>::<U @@cv> -> Symbol @ Loc {file=test/testdata/resolver/let_errors.rb start=17:3 end=17:7}
+    static-field <C <U LetErrors>>::<U @@cvar> -> Integer @ Loc {file=test/testdata/resolver/let_errors.rb start=6:5 end=6:11}
+    static-field <C <U LetErrors>>::<U @@dv> -> Symbol @ Loc {file=test/testdata/resolver/let_errors.rb start=23:3 end=23:7}
+    static-field <C <U LetErrors>>::<U @@topvar> -> Integer @ Loc {file=test/testdata/resolver/let_errors.rb start=3:3 end=3:11}
+    field <C <U LetErrors>>#<U @a> -> Integer @ Loc {file=test/testdata/resolver/let_errors.rb start=11:5 end=11:7}
+    field <C <U LetErrors>>#<U @ivar> -> Integer @ Loc {file=test/testdata/resolver/let_errors.rb start=7:5 end=7:10}
+    method <C <U LetErrors>>#<U initialize> (<blk>) @ Loc {file=test/testdata/resolver/let_errors.rb start=5:3 end=5:17}
       argument <blk><block> @ Loc {file=test/testdata/resolver/let_errors.rb start=??? end=???}
-    method <C <U LetErrors>>#<U not_initialize> (<blk>) @ Loc {file=test/testdata/resolver/let_errors.rb start=8:3 end=8:21}
+    method <C <U LetErrors>>#<U not_initialize> (<blk>) @ Loc {file=test/testdata/resolver/let_errors.rb start=10:3 end=10:21}
       argument <blk><block> @ Loc {file=test/testdata/resolver/let_errors.rb start=??? end=???}
   class <S <C <U LetErrors>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/resolver/let_errors.rb start=2:7 end=2:16}
     type-member(+) <S <C <U LetErrors>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U LetErrors>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=LetErrors) @ Loc {file=test/testdata/resolver/let_errors.rb start=2:7 end=2:16}
-    method <S <C <U LetErrors>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/let_errors.rb start=2:1 end=23:4}
+    method <S <C <U LetErrors>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/let_errors.rb start=2:1 end=25:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/let_errors.rb start=??? end=???}
-    field <S <C <U LetErrors>> $1>#<U @b> -> String @ Loc {file=test/testdata/resolver/let_errors.rb start=12:3 end=12:5}
-    field <S <C <U LetErrors>> $1>#<U @d> -> String @ Loc {file=test/testdata/resolver/let_errors.rb start=18:3 end=18:5}
+    field <S <C <U LetErrors>> $1>#<U @b> -> String @ Loc {file=test/testdata/resolver/let_errors.rb start=14:3 end=14:5}
+    field <S <C <U LetErrors>> $1>#<U @d> -> String @ Loc {file=test/testdata/resolver/let_errors.rb start=20:3 end=20:5}
 


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I think somebody copy/pasted the error message from the constant case and forgot to change it?  This message is clearer.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
