### PR TITLE
don't transitively lookup instance/class variables in CFG building

### DIFF
--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -80,7 +80,7 @@ LocalRef unresolvedIdent2Local(CFGContext cctx, const ast::UnresolvedIdent &id) 
             Exception::notImplemented();
     }
 
-    auto sym = klass.data(cctx.ctx)->findMemberTransitive(cctx.ctx, id.name);
+    auto sym = klass.data(cctx.ctx)->findMember(cctx.ctx, id.name);
     if (!sym.exists()) {
         auto fnd = cctx.discoveredUndeclaredFields.find(id.name);
         if (fnd == cctx.discoveredUndeclaredFields.end()) {


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

How many things break if we tried to implement something like this?

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
