### PR TITLE
do a better job of constructing `TypeAndOrigins`

### DIFF
--- a/core/Types.h
+++ b/core/Types.h
@@ -876,6 +876,7 @@ public:
 
     ~TypeAndOrigins() noexcept;
     TypeAndOrigins() = default;
+    TypeAndOrigins(TypePtr type, Loc origin);
     TypeAndOrigins(TypePtr type, InlinedVector<Loc, 1> origins) : type(type), origins(origins) {}
     TypeAndOrigins(const TypeAndOrigins &) = default;
     TypeAndOrigins(TypeAndOrigins &&) = default;

--- a/core/Types.h
+++ b/core/Types.h
@@ -877,7 +877,7 @@ public:
     ~TypeAndOrigins() noexcept;
     TypeAndOrigins() = default;
     TypeAndOrigins(TypePtr type, Loc origin);
-    TypeAndOrigins(TypePtr type, InlinedVector<Loc, 1> origins) : type(type), origins(origins) {}
+    TypeAndOrigins(TypePtr type, InlinedVector<Loc, 1> origins) : type(std::move(type)), origins(std::move(origins)) {}
     TypeAndOrigins(const TypeAndOrigins &) = default;
     TypeAndOrigins(TypeAndOrigins &&) = default;
     TypeAndOrigins &operator=(const TypeAndOrigins &) = default;

--- a/core/TypesAndOrigins.cc
+++ b/core/TypesAndOrigins.cc
@@ -84,6 +84,9 @@ optional<ErrorSection> TypeAndOrigins::explainGot(const GlobalState &gs, Loc ori
     }
 }
 
+TypeAndOrigins::TypeAndOrigins(TypePtr type, Loc origin) :
+    type(std::move(type)), origins(1, origin) {}
+
 TypeAndOrigins::~TypeAndOrigins() noexcept {
     histogramInc("TypeAndOrigins.origins.size", origins.size());
 }

--- a/core/TypesAndOrigins.cc
+++ b/core/TypesAndOrigins.cc
@@ -84,8 +84,7 @@ optional<ErrorSection> TypeAndOrigins::explainGot(const GlobalState &gs, Loc ori
     }
 }
 
-TypeAndOrigins::TypeAndOrigins(TypePtr type, Loc origin) :
-    type(std::move(type)), origins(1, origin) {}
+TypeAndOrigins::TypeAndOrigins(TypePtr type, Loc origin) : type(std::move(type)), origins(1, origin) {}
 
 TypeAndOrigins::~TypeAndOrigins() noexcept {
     histogramInc("TypeAndOrigins.origins.size", origins.size());

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2221,15 +2221,13 @@ private:
         sendArgStore.reserve(posTuple->elems.size() + numKwArgs);
 
         for (auto &arg : posTuple->elems) {
-            TypeAndOrigins tao{arg, argsLoc};
-            sendArgStore.emplace_back(std::move(tao));
+            sendArgStore.emplace_back(arg, argsLoc);
         }
 
         // kwTuple is a nullptr when there are no keyword args present
         if (kwTuple != nullptr) {
             for (auto &arg : kwTuple->elems) {
-                TypeAndOrigins tao{arg, argsLoc};
-                sendArgStore.emplace_back(std::move(tao));
+                sendArgStore.emplace_back(arg, argsLoc);
             }
         }
 

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -3360,7 +3360,7 @@ class Magic_mergeHashValues : public IntrinsicMethod {
         InlinedVector<const TypeAndOrigins *, 2> sendArgs;
         InlinedVector<LocOffsets, 2> sendArgLocs;
 
-        TypeAndOrigins argument{argType, {}};
+        TypeAndOrigins argument{argType, InlinedVector<Loc, 1>{}};
         sendArgs.emplace_back(&argument);
 
         auto hashLoc = args.locs.args[1].join(args.locs.args.back());

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -919,7 +919,7 @@ core::TypePtr flatmapHack(core::Context ctx, const core::TypePtr &receiver, cons
     int64_t flattenDepth = 1;
     auto mapType = core::Types::arrayOf(ctx, returnType);
 
-    const core::TypeAndOrigins recvType = {mapType, {loc}};
+    const core::TypeAndOrigins recvType{mapType, loc};
     core::TypeAndOrigins arg{core::make_type<core::IntegerLiteralType>((int64_t)flattenDepth), recvType.origins};
     InlinedVector<const core::TypeAndOrigins *, 2> args{&arg};
 
@@ -1277,9 +1277,7 @@ core::TypePtr Environment::processBinding(core::Context ctx, const cfg::CFG &inW
                 const core::TypeAndOrigins &recvType = getAndFillTypeAndOrigin(ctx, i.yieldParam);
                 core::TypePtr argType = core::make_type<core::IntegerLiteralType>((int64_t)i.argId);
 
-                core::TypeAndOrigins arg;
-                arg.type = argType;
-                arg.origins = recvType.origins;
+                core::TypeAndOrigins arg{argType, recvType.origins};
                 InlinedVector<const core::TypeAndOrigins *, 2> args;
                 args.emplace_back(&arg);
 
@@ -1674,9 +1672,7 @@ core::TypeAndOrigins nilTypesWithOriginWithLoc(core::Loc loc) {
     // I'd love to have this, but keepForIDE intentionally has Loc::none() and
     // sometimes ends up here...
     // ENFORCE(loc.exists());
-    core::TypeAndOrigins ret;
-    ret.type = core::Types::nilClass();
-    ret.origins.emplace_back(loc);
+    core::TypeAndOrigins ret{core::Types::nilClass(), loc};
     return ret;
 }
 } // namespace

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -1085,8 +1085,8 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx,
             holders.reserve(argSize);
 
             for (auto &arg : s.posArgs()) {
-                auto type = core::make_type<core::MetaType>(getResultTypeWithSelfTypeParams(
-                                                 ctx, arg, sigBeingParsed, args.withoutSelfType()));
+                auto type = core::make_type<core::MetaType>(
+                    getResultTypeWithSelfTypeParams(ctx, arg, sigBeingParsed, args.withoutSelfType()));
                 auto &argtao = holders.emplace_back(std::move(type), ctx.locAt(arg.loc()));
                 targs.emplace_back(&argtao);
                 argLocs.emplace_back(arg.loc());

--- a/resolver/type_syntax.cc
+++ b/resolver/type_syntax.cc
@@ -796,9 +796,7 @@ core::TypePtr getResultTypeWithSelfTypeParams(core::Context ctx, const ast::Expr
 }
 
 unique_ptr<core::TypeAndOrigins> makeTypeAndOrigins(core::Context ctx, core::LocOffsets origin, core::TypePtr type) {
-    auto ty = make_unique<core::TypeAndOrigins>();
-    ty->origins.emplace_back(ctx.locAt(origin));
-    ty->type = move(type);
+    auto ty = make_unique<core::TypeAndOrigins>(move(type), ctx.locAt(origin));
     return ty;
 }
 
@@ -1172,7 +1170,7 @@ TypeSyntax::ResultType getResultTypeAndBindWithSelfTypeParams(core::Context ctx,
             auto correctedSingleton = corrected.asClassOrModuleRef().data(ctx)->lookupSingletonClass(ctx);
             ENFORCE_NO_TIMER(correctedSingleton.exists());
             auto ctype = core::make_type<core::ClassType>(correctedSingleton);
-            auto ctypeAndOrigins = core::TypeAndOrigins{ctype, {ctx.locAt(s.loc)}};
+            core::TypeAndOrigins ctypeAndOrigins{ctype, ctx.locAt(s.loc)};
             // In `dispatchArgs` this is ordinarily used to specify the origin tag for
             // uninitialized variables. Inside of a signature we shouldn't need this:
             auto originForUninitialized = core::Loc::none();


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This started out as :disappointed: in the extra allocations being done when resolving send nodes in `type_syntax.cc`, and mushroomed into a slightly broader cleanup.

You should be able to review commit by commit.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
