### PR TITLE
Fix example in override-checking.md

### DIFF
--- a/website/docs/override-checking.md
+++ b/website/docs/override-checking.md
@@ -54,12 +54,12 @@ class Parent
   extend T::Sig
 
   sig {overridable.params(x: T.any(Integer, String)).void}
-  def takes_integer_or_string; end
+  def takes_integer_or_string(x); end
 end
 
 class Child < Parent
   sig {override.params(x: Integer).void}
-  def takes_integer_or_string; end # error
+  def takes_integer_or_string(x); end # error
 end
 ```
 


### PR DESCRIPTION

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The example on that page was incorrect.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

The [new version](https://sorbet.run/#%23%20typed%3A%20true%0Aextend%20T%3A%3ASig%0A%0Aclass%20Parent%0A%20%20extend%20T%3A%3ASig%0A%0A%20%20sig%20%7Boverridable.params%28x%3A%20T.any%28Integer%2C%20String%29%29.void%7D%0A%20%20def%20takes_integer_or_string%28x%29%3B%20end%0Aend%0A%0Aclass%20Child%20%3C%20Parent%0A%20%20sig%20%7Boverride.params%28x%3A%20Integer%29.void%7D%0A%20%20def%20takes_integer_or_string%28x%29%3B%20end%20%23%20error%0Aend) works as expected, the [old one](https://sorbet.run/#%23%20typed%3A%20true%0Aextend%20T%3A%3ASig%0A%0Aclass%20Parent%0A%20%20extend%20T%3A%3ASig%0A%0A%20%20sig%20%7Boverridable.params%28x%3A%20T.any%28Integer%2C%20String%29%29.void%7D%0A%20%20def%20takes_integer_or_string%3B%20end%0Aend%0A%0Aclass%20Child%20%3C%20Parent%0A%20%20sig%20%7Boverride.params%28x%3A%20Integer%29.void%7D%0A%20%20def%20takes_integer_or_string%3B%20end%20%23%20error%0Aend) doesn't.
