### PR TITLE
Fix redefined & overloaded methods on fast_path

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -927,7 +927,10 @@ constexpr decltype(GlobalState::STRINGS_PAGE_SIZE) GlobalState::STRINGS_PAGE_SIZ
 namespace {
 bool matchesArityHash(const GlobalState &gs, ArityHash arityHash, MethodRef method) {
     auto methodData = method.data(gs);
-    return methodData->methodArityHash(gs) == arityHash || (methodData->hasIntrinsic() && !methodData->hasSig());
+    // lookupMethodSymbolWithHash is called from namer, before resolver enters overloads.
+    // It wants to be able to find the "namer version" of the method, not the overload.
+    return !methodData->flags.isOverloaded &&
+           (methodData->methodArityHash(gs) == arityHash || (methodData->hasIntrinsic() && !methodData->hasSig()));
 }
 } // namespace
 

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -167,6 +167,7 @@ public:
     packages::UnfreezePackages unfreezePackages();
 
     void mangleRenameSymbol(SymbolRef what, NameRef origName);
+    void mangleRenameForOverload(SymbolRef what, NameRef origName);
     spdlog::logger &tracer() const;
     unsigned int namesUsedTotal() const;
     unsigned int utf8NamesUsed() const;
@@ -343,6 +344,8 @@ private:
 
     SymbolRef lookupSymbolWithKind(ClassOrModuleRef owner, NameRef name, SymbolRef::Kind kind,
                                    SymbolRef defaultReturnValue, bool ignoreKind = false) const;
+
+    void mangleRenameSymbolInternal(SymbolRef what, NameRef origName, UniqueNameKind kind);
 
     std::string toStringWithOptions(bool showFull, bool showRaw) const;
 };

--- a/core/Names.cc
+++ b/core/Names.cc
@@ -48,6 +48,9 @@ string NameRef::showRaw(const GlobalState &gs) const {
                 case UniqueNameKind::MangleRename:
                     kind = "M";
                     break;
+                case UniqueNameKind::MangleRenameOverload:
+                    kind = "V";
+                    break;
                 case UniqueNameKind::Singleton:
                     kind = "S";
                     break;
@@ -122,7 +125,8 @@ string NameRef::show(const GlobalState &gs) const {
                 return fmt::format("<Class:{}>", unique->original.show(gs));
             } else if (unique->uniqueNameKind == UniqueNameKind::Overload) {
                 return absl::StrCat(unique->original.show(gs), " (overload.", unique->num, ")");
-            } else if (unique->uniqueNameKind == UniqueNameKind::MangleRename) {
+            } else if (unique->uniqueNameKind == UniqueNameKind::MangleRename ||
+                       unique->uniqueNameKind == UniqueNameKind::MangleRenameOverload) {
                 return unique->original.show(gs);
             } else if (unique->uniqueNameKind == UniqueNameKind::TEnum) {
                 // The entire goal of UniqueNameKind::TEnum is to have Name::show print the name as if on the
@@ -180,6 +184,7 @@ bool NameRef::isClassName(const GlobalState &gs) const {
             switch (dataUnique(gs)->uniqueNameKind) {
                 case UniqueNameKind::Singleton:
                 case UniqueNameKind::MangleRename:
+                case UniqueNameKind::MangleRenameOverload:
                 case UniqueNameKind::TEnum:
                     return dataUnique(gs)->original.isClassName(gs);
                 case UniqueNameKind::ResolverMissingClass:
@@ -221,6 +226,7 @@ bool NameRef::isValidConstantName(const GlobalState &gs) const {
                 case UniqueNameKind::Desugar:
                 case UniqueNameKind::Namer:
                 case UniqueNameKind::MangleRename:
+                case UniqueNameKind::MangleRenameOverload:
                 case UniqueNameKind::Singleton:
                 case UniqueNameKind::Overload:
                 case UniqueNameKind::TypeVarName:

--- a/core/Names.h
+++ b/core/Names.h
@@ -23,6 +23,7 @@ enum class UniqueNameKind : uint8_t {
     Desugar,
     Namer,
     MangleRename,
+    MangleRenameOverload,
     Singleton,
     Overload,
     TypeVarName,

--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -36,6 +36,9 @@ com::stripe::rubytyper::Name Proto::toProto(const GlobalState &gs, NameRef name)
                 case UniqueNameKind::MangleRename:
                     protoName.set_unique(com::stripe::rubytyper::Name::MANGLE_RENAME);
                     break;
+                case UniqueNameKind::MangleRenameOverload:
+                    protoName.set_unique(com::stripe::rubytyper::Name::MANGLE_RENAME_OVERLOAD);
+                    break;
                 case UniqueNameKind::Singleton:
                     protoName.set_unique(com::stripe::rubytyper::Name::SINGLETON);
                     break;

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -916,7 +916,8 @@ vector<SimilarMethod> computeDedupedMethods(const core::GlobalState &gs, const c
 
     for (auto &[methodName, similarMethods] : similarMethodsByName) {
         if (methodName.kind() == core::NameKind::UNIQUE &&
-            methodName.dataUnique(gs)->uniqueNameKind == core::UniqueNameKind::MangleRename) {
+            (methodName.dataUnique(gs)->uniqueNameKind == core::UniqueNameKind::MangleRename ||
+             methodName.dataUnique(gs)->uniqueNameKind == core::UniqueNameKind::MangleRenameOverload)) {
             // It's possible we want to ignore more things here. But note that we *don't* want to ignore all
             // unique names, because we want each overload to show up but those use unique names.
             continue;

--- a/proto/Name.proto
+++ b/proto/Name.proto
@@ -26,6 +26,7 @@ message Name {
          DEFAULT_ARG = 12;
          PACKAGER = 13;
          // PACKAGER_PRIVATE = 14;
+         MANGLE_RENAME_OVERLOAD = 15;
     };
 
     Kind kind = 1;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3570,8 +3570,15 @@ public:
 
         bool isOverloaded = job.isOverloaded;
         auto originalName = mdef.symbol.data(ctx)->name;
-        if (isOverloaded) {
-            ctx.state.mangleRenameSymbol(mdef.symbol, originalName);
+
+        bool existingIsAlreadyMangled =
+            originalName.kind() == core::NameKind::UNIQUE &&
+            originalName.dataUnique(ctx)->uniqueNameKind == core::UniqueNameKind::MangleRenameOverload;
+        if (isOverloaded && !existingIsAlreadyMangled) {
+            ctx.state.mangleRenameForOverload(mdef.symbol, originalName);
+        }
+        if (existingIsAlreadyMangled) {
+            originalName = originalName.dataUnique(ctx)->original;
         }
 
         int i = -1;

--- a/test/testdata/infer/overloads_test.rb
+++ b/test/testdata/infer/overloads_test.rb
@@ -1,5 +1,4 @@
 # typed: true
-# disable-stress-incremental: true
 
 # MutableContext::permitOverloadDefinitions is aware of this file name. Don't rename this file.
 class HasOverloads

--- a/test/testdata/lsp/completion/overloads_test.A.rbedited
+++ b/test/testdata/lsp/completion/overloads_test.A.rbedited
@@ -1,5 +1,4 @@
 # typed: true
-# disable-stress-incremental: true
 
 class I; end
 class S; end
@@ -16,7 +15,7 @@ end
 # The order here doesn't particularly matter; if you're here because you made a
 # change to the order that broke this test, feel free to update the test.
 
-A.new.my_method(${1:S})${0} # error: does not exist
+A.new.my_method(${1:I})${0} # error: does not exist
 #             ^ completion: my_method, my_method
 #             ^ apply-completion: [A] item: 0
 #             ^ apply-completion: [B] item: 1

--- a/test/testdata/lsp/completion/overloads_test.B.rbedited
+++ b/test/testdata/lsp/completion/overloads_test.B.rbedited
@@ -1,5 +1,4 @@
 # typed: true
-# disable-stress-incremental: true
 
 class I; end
 class S; end
@@ -16,7 +15,7 @@ end
 # The order here doesn't particularly matter; if you're here because you made a
 # change to the order that broke this test, feel free to update the test.
 
-A.new.my_method(${1:I})${0} # error: does not exist
+A.new.my_method(${1:S})${0} # error: does not exist
 #             ^ completion: my_method, my_method
 #             ^ apply-completion: [A] item: 0
 #             ^ apply-completion: [B] item: 1

--- a/test/testdata/lsp/completion/overloads_test.rb
+++ b/test/testdata/lsp/completion/overloads_test.rb
@@ -1,5 +1,4 @@
 # typed: true
-# disable-stress-incremental: true
 
 class I; end
 class S; end

--- a/test/testdata/lsp/fast_path/overloads_test.1.rbupdate
+++ b/test/testdata/lsp/fast_path/overloads_test.1.rbupdate
@@ -1,0 +1,17 @@
+# typed: true
+
+class A
+  extend T::Sig
+
+  sig {params(x: Integer).void}
+  sig {params(x: Integer, y: String).void}
+  def self.example1(x, y='')
+  end
+end
+
+A.example(0) # error: Method `example` does not exist
+A.example(0, '') # error: Method `example` does not exist
+A.example # error: Method `example` does not exist
+A.example1(0)
+A.example1(0, '')
+A.example1 # error: Not enough arguments

--- a/test/testdata/lsp/fast_path/overloads_test.rb
+++ b/test/testdata/lsp/fast_path/overloads_test.rb
@@ -1,0 +1,17 @@
+# typed: true
+
+class A
+  extend T::Sig
+
+  sig {params(x: Integer).void}
+  sig {params(x: Integer, y: String).void}
+  def self.example(x, y='')
+  end
+end
+
+A.example(0)
+A.example(0, '')
+A.example # error: Not enough arguments
+A.example1(0) # error: Method `example1` does not exist
+A.example1(0, '') # error: Method `example1` does not exist
+A.example1 # error: Method `example1` does not exist

--- a/test/testdata/resolver/overloads_test.rb
+++ b/test/testdata/resolver/overloads_test.rb
@@ -1,6 +1,4 @@
 # typed: true
-# disable-fast-path: true
-# disable-stress-incremental: true
 extend T::Sig
 
 sig {params(s: Integer).void}
@@ -11,7 +9,7 @@ sig {params(s: Symbol).void}
 sig {params(s: Float).void}
 def f(s); end
 
-f(0)
-f('')
-f(:s)  # error: Expected `Integer`
-f(0.0) # error: Expected `Integer`
+f(0) # error: Expected `Symbol`
+f('') # error: Expected `Symbol`
+f(:s)
+f(0.0)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This unblocks #5808.


### Commit summary


- **pre-work: Add new UniqueNameKind::MangleRenameOverload** (9f808f349)

  The way that overloads works fundamentally requires mangle renaming the
  original method, so that there is still one method in the symbol table
  with all the ArgInfo's, that we can selectively copy onto each (derived)
  overload method.

  That means that it definitely needs the logic that mangleRenameSymbol
  does to rename things and erase things from the `members` vector.

  But I want to do it in a way that's more predictable, so that it's
  easier to map a name that was mangled in this way back to the original
  method, as justified in the next commit.

- **Add mangleRenameForOverload method** (95a89ec69)

  Now, instead of calling mangleRenameSymbol in resolver, we call
  mangleRenameForOverload. This lets us map back and forth between a
  method that was mangled only for the purpose of overloading (ignoring
  methods that have been mangle renamed in an attempt to recover from
  method redefinitions).

  This involves a slight trick in `lookupMethodSymbolWithHash`, because in
  addition to walking up the chain of MangleRename unique names, it must
  also look for a `MangleRenameOverload` at that step. In a picture:

  Before:

  ```
  <U example>
      │
      ▼
  <M <U example> $1>
      │
      ▼
  <M <U example> $2>
      │
      ▼
      ⋮
  ```

  Now:

  ```
  <U example>
      │
      ▼
  <M <U example> $1>  ─▶  <V <M <U example> $1> $1>
      ┌────────────────────────────┘
      ▼
  <M <U example> $2>  ─▶  <V <M <U example> $2> $1>
      ┌────────────────────────────┘
      ▼
      ⋮
  ```

  With this in place, we can relax/rework some assumptions in
  enterNewMethodOverload, namely: the method overload might already exist
  (because we're on the fast path). The new `ENFORCE`'s all combine to
  basically say that if there's already an method overload with the
  current name, that it must match exactly the arity we're expecting.

- **Two other edge cases** (5ccd7fa7a)


- **Fix a bunch of tests** (3c76998be)



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests become good, and added a new test