### PR TITLE
Change pipeline.sh to account for change in env vars

### DIFF
--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -4,13 +4,19 @@ set -euo pipefail
 
 whitelisted=0
 
+echo "BUILDKITE_PULL_REQUEST=$BUILDKITE_PULL_REQUEST"
+echo "BUILDKITE_PULL_REQUEST_REPO=$BUILDKITE_PULL_REQUEST_REPO"
+
 if [[ "$BUILDKITE_PULL_REQUEST" == "false" ]]; then
-  # whitelist commits that are triggered in branch builds of github.com/stripe/sorbet
+  # whitelist commits that are triggered in branch builds of github.com/sorbet/sorbet
+  echo "Automatically running build for non-PR commit pushed to sorbet/sorbet"
   whitelisted=1
 fi
 
-if [[ "$BUILDKITE_PULL_REQUEST_REPO" == "git://github.com/sorbet/sorbet.git" ]]; then
+if [[ "$BUILDKITE_PULL_REQUEST_REPO" == "git://github.com/sorbet/sorbet.git" ]] ||
+  [[ "$BUILDKITE_PULL_REQUEST_REPO" == "https://github.com/sorbet/sorbet.git" ]]; then
   # whitelist folks with write access to github.com/sorbet/sorbet
+  echo "Automatically running build for non-fork PR created against sorbet/sorbet"
   whitelisted=1
 fi
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

It seems like sometimes we get
`BUILDKITE_PULL_REQUEST_REPO=https://github.com/sorbet/sorbet.git`,
whereas before we would always get `git://` URLs. Idk why this happened,
maybe GitHub changed something?


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

To roll this out, we need to update the pipeline.sh checksum on the build runner
machine (not in source control).