### PR TITLE
fix unnecessary copying of `TypePtr`s in `environment.cc`

### DIFF
--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -170,7 +170,7 @@ KnowledgeRef KnowledgeRef::under(core::Context ctx, const Environment &env, cfg:
             // would be otherwise; Many of the performance optimizations in this
             // file effectively exist to support this feature.
 
-            auto type = state.typeAndOrigins.type;
+            auto &type = state.typeAndOrigins.type;
             if (isNeeded && !type.isUntyped() && !core::isa_type<core::MetaType>(type)) {
                 // Direct mutation of `yesTypeTests` rather than going through `addYesTypeTest`.
                 // This is fine since `copy` is unmoored from a particular environment.
@@ -756,7 +756,7 @@ void Environment::assumeKnowledge(core::Context ctx, bool isTrue, cfg::LocalRef 
         auto glbbed = core::Types::all(ctx, tp.type, typeTested.second);
         if (tp.type != glbbed) {
             tp.origins.emplace_back(loc);
-            tp.type = glbbed;
+            tp.type = std::move(glbbed);
         }
         setTypeAndOrigin(typeTested.first, tp);
         if (tp.type.isBottom()) {


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

These are actually kind of hot for some of Stripe's biggest files.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
