### PR TITLE
Fix `assert-slow-path`

### DIFF
--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -988,6 +988,11 @@ bool ErrorAssertion::checkAll(const UnorderedMap<string, shared_ptr<core::File>>
 shared_ptr<BooleanPropertyAssertion> BooleanPropertyAssertion::make(string_view filename, unique_ptr<Range> &range,
                                                                     int assertionLine, string_view assertionContents,
                                                                     string_view assertionType) {
+    {
+        INFO("Unrecognized boolean property assertion value: " << assertionContents);
+        auto trueOrFalse = assertionContents == "true" || assertionContents == "false";
+        CHECK(trueOrFalse);
+    }
     return make_shared<BooleanPropertyAssertion>(filename, range, assertionLine, assertionContents == "true",
                                                  assertionType);
 }

--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -873,9 +873,15 @@ TEST_CASE("LSPTest") {
                 verifyTypecheckRunInfo(
                     errorPrefix, responses, SorbetTypecheckRunStatus::Ended, ExpectDiagnosticMessages::Yes,
                     [&errorPrefix, assertSlowPath, &assertFastPath, &test, &version](auto &params) -> void {
-                        if (assertSlowPath.value_or(false)) {
-                            INFO(errorPrefix << "Expected Sorbet to take slow path, but it took the fast path.");
-                            CHECK_EQ(params->fastPath, false);
+                        if (assertSlowPath.has_value()) {
+                            if (params->fastPath && assertSlowPath.value()) {
+                                INFO(errorPrefix << "Expected Sorbet to take slow path, but it took the fast path.");
+                                CHECK_NE(params->fastPath, assertSlowPath.value());
+                            } else if (!params->fastPath && !assertSlowPath.value()) {
+                                INFO(errorPrefix
+                                     << "Expected Sorbet to not take slow path, but it took the slow path.");
+                                CHECK_NE(params->fastPath, assertSlowPath.value());
+                            }
                         }
                         if (assertFastPath.has_value()) {
                             (*assertFastPath)->check(*params, test.folder, version, errorPrefix);

--- a/test/testdata/lsp/fast_path/linearization.1.rbupdate
+++ b/test/testdata/lsp/fast_path/linearization.1.rbupdate
@@ -1,6 +1,6 @@
 # typed: true
 # frozen_string_literal: true
-# assert-slow-path: linearization.rb
+# assert-fast-path: linearization.rb
 
 module Base
 end

--- a/test/testdata/lsp/fast_path/linearization.2.rbupdate
+++ b/test/testdata/lsp/fast_path/linearization.2.rbupdate
@@ -1,6 +1,6 @@
 # typed: true
 # frozen_string_literal: true
-# assert-slow-path: linearization.rb
+# assert-fast-path: linearization.rb
 
 module Base
 end

--- a/test/testdata/lsp/fast_path/method_add_sig.1.rbupdate
+++ b/test/testdata/lsp/fast_path/method_add_sig.1.rbupdate
@@ -1,6 +1,5 @@
 # typed: true
-# assert-slow-path: method_add_sig.rb
-# TODO(jvilk): Can this be covered on the fast path?
+# assert-slow-path: true
 
 class A extend T::Sig
   sig {params(x: Integer).returns(String)}


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Previously:

- It would allow any string for the boolean, instead of only `true` or
  `false`.
- It would not actually check the `false` case.

Unblocks #5808


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.