### PR TITLE
wip: Remove beta flag from fast path methods change

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1915,7 +1915,6 @@ unique_ptr<GlobalState> GlobalState::deepCopy(bool keepId) const {
     result->censorForSnapshotTests = this->censorForSnapshotTests;
     result->sleepInSlowPathSeconds = this->sleepInSlowPathSeconds;
     result->requiresAncestorEnabled = this->requiresAncestorEnabled;
-    result->lspExperimentalFastPathEnabled = this->lspExperimentalFastPathEnabled;
 
     if (keepId) {
         result->globalStateId = this->globalStateId;
@@ -2008,7 +2007,6 @@ unique_ptr<GlobalState> GlobalState::copyForIndex() const {
     result->ensureCleanStrings = this->ensureCleanStrings;
     result->runningUnderAutogen = this->runningUnderAutogen;
     result->censorForSnapshotTests = this->censorForSnapshotTests;
-    result->lspExperimentalFastPathEnabled = this->lspExperimentalFastPathEnabled;
     result->sleepInSlowPathSeconds = this->sleepInSlowPathSeconds;
     result->requiresAncestorEnabled = this->requiresAncestorEnabled;
     result->kvstoreUuid = this->kvstoreUuid;
@@ -2262,12 +2260,8 @@ unique_ptr<LocalSymbolTableHashes> GlobalState::hash() const {
         if (!sym.ignoreInHashing(*this)) {
             auto &target = methodHashesMap[ShortNameHash(*this, sym.name)];
             target = mix(target, sym.hash(*this));
-            auto needMethodShapeHash =
-                this->lspExperimentalFastPathEnabled
-                    ? (sym.name == Names::unresolvedAncestors() || sym.name == Names::requiredAncestors() ||
-                       sym.name == Names::requiredAncestorsLin())
-                    : true;
-            if (needMethodShapeHash) {
+            if (sym.name == Names::unresolvedAncestors() || sym.name == Names::requiredAncestors() ||
+                sym.name == Names::requiredAncestorsLin()) {
                 uint32_t symhash = sym.methodShapeHash(*this);
                 hierarchyHash = mix(hierarchyHash, symhash);
                 methodHash = mix(methodHash, symhash);

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -286,9 +286,6 @@ public:
     // If 'true', enforce use of Ruby 3.0-style keyword args.
     bool ruby3KeywordArgs = false;
 
-    // If 'true', enable the experimental, symbol-deletion-based fast path mode
-    bool lspExperimentalFastPathEnabled = false;
-
     // When present, this indicates that single-package rbi generation is being performed, and contains metadata about
     // the packages that are imported by the one whose interface is being generated.
     std::optional<packages::ImportInfo> singlePackageImports;

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -2207,8 +2207,7 @@ uint32_t ClassOrModule::hash(const GlobalState &gs) const {
                 continue;
             }
 
-            if (e.second.isMethod() &&
-                (gs.lspExperimentalFastPathEnabled || e.second.asMethodRef().data(gs)->ignoreInHashing(gs))) {
+            if (e.second.isMethod()) {
                 continue;
             }
 

--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -90,7 +90,6 @@ core::FileRef makeEmptyGlobalStateForFile(spdlog::logger &logger, shared_ptr<cor
                                           const realmain::options::Options &hashingOpts) {
     lgs = core::GlobalState::makeEmptyGlobalStateForHashing(logger);
     lgs->requiresAncestorEnabled = hashingOpts.requiresAncestorEnabled;
-    lgs->lspExperimentalFastPathEnabled = hashingOpts.lspExperimentalFastPathEnabled;
     {
         core::UnfreezeFileTable fileTableAccess(*lgs);
         auto fref = lgs->enterFile(forWhat);

--- a/main/cache/cache.cc
+++ b/main/cache/cache.cc
@@ -12,10 +12,8 @@ unique_ptr<OwnedKeyValueStore> maybeCreateKeyValueStore(const options::Options &
     if (opts.cacheDir.empty()) {
         return nullptr;
     }
-    auto flavor = fmt::format("{}-{}", opts.skipRewriterPasses ? "nodsl" : "dsl",
-                              opts.lspExperimentalFastPathEnabled ? "experimentalfastpath" : "normalfastpath");
-    return make_unique<OwnedKeyValueStore>(
-        make_unique<KeyValueStore>(sorbet_full_version_string, opts.cacheDir, move(flavor)));
+    return make_unique<OwnedKeyValueStore>(make_unique<KeyValueStore>(sorbet_full_version_string, opts.cacheDir,
+                                                                      opts.skipRewriterPasses ? "nodsl" : "default"));
 }
 
 unique_ptr<OwnedKeyValueStore> ownIfUnchanged(const core::GlobalState &gs, unique_ptr<KeyValueStore> kvstore) {

--- a/main/lsp/wrapper.cc
+++ b/main/lsp/wrapper.cc
@@ -25,7 +25,6 @@ void setRequiredLSPOptions(core::GlobalState &gs, options::Options &options) {
     }
 
     gs.requiresAncestorEnabled = options.requiresAncestorEnabled;
-    gs.lspExperimentalFastPathEnabled = options.lspExperimentalFastPathEnabled;
 
     // Ensure LSP is enabled.
     options.runLSP = true;
@@ -163,7 +162,6 @@ void LSPWrapper::enableAllExperimentalFeatures() {
     enableExperimentalFeature(LSPExperimentalFeature::DocumentSymbol);
     enableExperimentalFeature(LSPExperimentalFeature::SignatureHelp);
     enableExperimentalFeature(LSPExperimentalFeature::DocumentFormat);
-    enableExperimentalFeature(LSPExperimentalFeature::ExperimentalFastPath);
 }
 
 void LSPWrapper::enableExperimentalFeature(LSPExperimentalFeature feature) {
@@ -179,9 +177,6 @@ void LSPWrapper::enableExperimentalFeature(LSPExperimentalFeature feature) {
             break;
         case LSPExperimentalFeature::DocumentFormat:
             opts->lspDocumentFormatRubyfmtEnabled = true;
-            break;
-        case LSPExperimentalFeature::ExperimentalFastPath:
-            opts->lspExperimentalFastPathEnabled = true;
             break;
     }
 }

--- a/main/lsp/wrapper.h
+++ b/main/lsp/wrapper.h
@@ -52,7 +52,6 @@ public:
         SignatureHelp = 7,
         DocumentHighlight = 9,
         DocumentFormat = 10,
-        ExperimentalFastPath = 11,
     };
 
     // N.B.: Sorbet assumes we 'own' this object; keep it alive to avoid memory errors.

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -344,8 +344,6 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
     options.add_options("advanced")("enable-experimental-lsp-stale-state", "Enable experimental LSP feature: fast "
                                                                            "but approximate answers from stale "
                                                                            "typechecker state");
-    options.add_options("advanced")("enable-experimental-lsp-fast-path",
-                                    "Enable experimental LSP feature: a faster fast path using symbol deletions");
     options.add_options("advanced")("enable-experimental-requires-ancestor",
                                     "Enable experimental `requires_ancestor` annotation");
 
@@ -768,9 +766,6 @@ void readOptions(Options &opts,
         // until we get some other groundwork in place. Once things stabilize a bit more, we can slap
         // `enableAllLSPFeatures ||` onto the condition here.
         opts.lspStaleStateEnabled = raw["enable-experimental-lsp-stale-state"].as<bool>();
-
-        opts.lspExperimentalFastPathEnabled =
-            opts.lspAllBetaFeaturesEnabled || raw["enable-experimental-lsp-fast-path"].as<bool>();
 
         if (raw.count("lsp-directories-missing-from-client") > 0) {
             auto lspDirsMissingFromClient = raw["lsp-directories-missing-from-client"].as<vector<string>>();

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -247,7 +247,6 @@ struct Options {
     bool lspDocumentFormatRubyfmtEnabled = false;
     bool lspSignatureHelpEnabled = false;
     bool lspStaleStateEnabled = false;
-    bool lspExperimentalFastPathEnabled = false;
 
     // Experimental feature `requires_ancestor`
     bool requiresAncestorEnabled = false;

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -527,7 +527,6 @@ int realmain(int argc, char *argv[]) {
         gs->includeErrorSections = false;
     }
     gs->ruby3KeywordArgs = opts.ruby3KeywordArgs;
-    gs->lspExperimentalFastPathEnabled = opts.lspExperimentalFastPathEnabled;
     if (!opts.stripeMode) {
         // Definitions in multiple locations interact poorly with autoloader this error is enforced in Stripe code.
         if (opts.isolateErrorCode.empty()) {

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -857,19 +857,6 @@ class SymbolDefiner {
 
     core::MethodRef insertMethod(core::MutableContext ctx, const core::FoundMethod &method) {
         auto symbol = defineMethod(ctx, method);
-        if (!ctx.state.lspExperimentalFastPathEnabled) {
-            auto name = symbol.data(ctx)->name;
-            if (name.kind() == core::NameKind::UNIQUE &&
-                name.dataUnique(ctx)->uniqueNameKind == core::UniqueNameKind::MangleRenameOverload) {
-                // These name kinds are only created in resolver, which means that we must be running on
-                // the fast path with an existing GlobalState.
-                // When modifyMethod is called later, it won't be able to find the correct method entry.
-                // Let's leave the method visibility what it was.
-                // TODO(jez) After #5808 lands, can we delete this check?
-                return symbol;
-            }
-        }
-
         auto implicitlyPrivate = ctx.owner.enclosingClass(ctx) == core::Symbols::root();
         if (implicitlyPrivate) {
             // Methods defined at the top level default to private (on Object)

--- a/test/lsp/ProtocolTest.cc
+++ b/test/lsp/ProtocolTest.cc
@@ -34,7 +34,6 @@ void ProtocolTest::resetState(std::shared_ptr<realmain::options::Options> opts) 
         }
         opts->cacheDir = cacheDir;
     }
-    opts->lspExperimentalFastPathEnabled = true;
 
     if (useMultithreading) {
         lspWrapper = MultiThreadedLSPWrapper::create(rootPath, opts);

--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -531,7 +531,6 @@ TEST_CASE("LSPTest") {
         }
         opts->disableWatchman = true;
         opts->rubyfmtPath = "test/testdata/lsp/rubyfmt-stub/rubyfmt";
-        opts->lspExperimentalFastPathEnabled = true;
 
         if (haveStaleUpdates) {
             opts->lspStaleStateEnabled = true;

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -236,7 +236,6 @@ TEST_CASE("PerPhaseTest") { // NOLINT
     }
 
     gs->censorForSnapshotTests = true;
-    gs->lspExperimentalFastPathEnabled = true;
     auto workers = WorkerPool::create(0, gs->tracer());
 
     auto assertions = RangeAssertion::parseAssertions(test.sourceFileContents);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I just wanted somewhere to store this commit, which is the revert of b55c259a9
from #5808.

We may want to keep this flag around for some of the future changes we have
planned, so maybe this PR won't be landed in its current form but at least we
have a reference of all the things that can be deleted once the flag is gone.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

- [ ] @jez should be tested on Stripe's codebase