### PR TITLE
Allow packages to specify their visibility

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -577,6 +577,9 @@ void GlobalState::initEmpty() {
         enterMethod(*this, Symbols::PackageSpecSingleton(), Names::restrict_to_service()).arg(Names::arg0()).build();
     ENFORCE(method == Symbols::PackageSpec_restrict_to_service());
 
+    method = enterMethod(*this, Symbols::PackageSpecSingleton(), Names::visible_to()).arg(Names::arg0()).build();
+    ENFORCE(method == Symbols::PackageSpec_visible_to());
+
     klass = synthesizeClass(core::Names::Constants::Encoding());
     ENFORCE(klass == Symbols::Encoding());
 

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -577,9 +577,6 @@ void GlobalState::initEmpty() {
         enterMethod(*this, Symbols::PackageSpecSingleton(), Names::restrict_to_service()).arg(Names::arg0()).build();
     ENFORCE(method == Symbols::PackageSpec_restrict_to_service());
 
-    method = enterMethod(*this, Symbols::PackageSpecSingleton(), Names::visible_to()).arg(Names::arg0()).build();
-    ENFORCE(method == Symbols::PackageSpec_visible_to());
-
     klass = synthesizeClass(core::Names::Constants::Encoding());
     ENFORCE(klass == Symbols::Encoding());
 
@@ -601,6 +598,9 @@ void GlobalState::initEmpty() {
                  .arg(Names::arg0())
                  .build();
     ENFORCE(method == Symbols::PackageSpec_autoloader_compatibility());
+
+    method = enterMethod(*this, Symbols::PackageSpecSingleton(), Names::visible_to()).arg(Names::arg0()).build();
+    ENFORCE(method == Symbols::PackageSpec_visible_to());
 
     klass = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::ResolvedSig());
     ENFORCE(klass == Symbols::Sorbet_Private_Static_ResolvedSig());

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -1004,6 +1004,10 @@ public:
         return MethodRef::fromRaw(9);
     }
 
+    static MethodRef PackageSpec_visible_to() {
+        return MethodRef::fromRaw(10);
+    }
+
     static ClassOrModuleRef Encoding() {
         return ClassOrModuleRef::fromRaw(86);
     }
@@ -1013,19 +1017,19 @@ public:
     }
 
     static MethodRef Class_new() {
-        return MethodRef::fromRaw(10);
-    }
-
-    static MethodRef todoMethod() {
         return MethodRef::fromRaw(11);
     }
 
-    static MethodRef rootStaticInit() {
+    static MethodRef todoMethod() {
         return MethodRef::fromRaw(12);
     }
 
     static MethodRef PackageSpec_autoloader_compatibility() {
         return MethodRef::fromRaw(13);
+    }
+
+    static MethodRef rootStaticInit() {
+        return MethodRef::fromRaw(14);
     }
 
     static ClassOrModuleRef Sorbet_Private_Static_ResolvedSig() {

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -1004,10 +1004,6 @@ public:
         return MethodRef::fromRaw(9);
     }
 
-    static MethodRef PackageSpec_visible_to() {
-        return MethodRef::fromRaw(10);
-    }
-
     static ClassOrModuleRef Encoding() {
         return ClassOrModuleRef::fromRaw(86);
     }
@@ -1017,10 +1013,14 @@ public:
     }
 
     static MethodRef Class_new() {
-        return MethodRef::fromRaw(11);
+        return MethodRef::fromRaw(10);
     }
 
     static MethodRef todoMethod() {
+        return MethodRef::fromRaw(11);
+    }
+
+    static MethodRef rootStaticInit() {
         return MethodRef::fromRaw(12);
     }
 
@@ -1028,7 +1028,7 @@ public:
         return MethodRef::fromRaw(13);
     }
 
-    static MethodRef rootStaticInit() {
+    static MethodRef PackageSpec_visible_to() {
         return MethodRef::fromRaw(14);
     }
 

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -23,7 +23,7 @@ namespace sorbet::core {
 using namespace std;
 
 const int Symbols::MAX_SYNTHETIC_CLASS_SYMBOLS = 209;
-const int Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS = 48;
+const int Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS = 49;
 const int Symbols::MAX_SYNTHETIC_FIELD_SYMBOLS = 4;
 const int Symbols::MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 4;
 const int Symbols::MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 107;

--- a/core/errors/packager.h
+++ b/core/errors/packager.h
@@ -27,5 +27,6 @@ constexpr ErrorClass MissingImport{3718, StrictLevel::False};
 constexpr ErrorClass UsedTestOnlyName{3720, StrictLevel::False};
 constexpr ErrorClass InvalidExport{3721, StrictLevel::False};
 // constexpr ErrorClass ExportingTypeAlias{3722, StrictLevel::False};
+constexpr ErrorClass ImportNotVisible{3723, StrictLevel::False};
 } // namespace sorbet::core::errors::Packager
 #endif

--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -72,6 +72,9 @@ public:
     std::vector<std::vector<core::NameRef>> testImports() const {
         return vector<vector<core::NameRef>>();
     }
+    std::vector<std::vector<core::NameRef>> visibleTo() const {
+        return vector<vector<core::NameRef>>();
+    }
 
     std::optional<ImportType> importsPackage(core::NameRef mangledName) const {
         notImplemented();

--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -29,6 +29,7 @@ public:
     virtual std::vector<std::vector<core::NameRef>> exports() const = 0;
     virtual std::vector<std::vector<core::NameRef>> imports() const = 0;
     virtual std::vector<std::vector<core::NameRef>> testImports() const = 0;
+    virtual std::vector<std::vector<core::NameRef>> visibleTo() const = 0;
     virtual std::unique_ptr<PackageInfo> deepCopy() const = 0;
     virtual core::Loc fullLoc() const = 0;
     virtual core::Loc declLoc() const = 0;

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -451,6 +451,7 @@ NameDef names[] = {
     {"autoloader_compatibility"},
     {"legacy"},
     {"strict"},
+    {"visible_to"},
     {"PackageSpec", "PackageSpec", true},
     {"PackageSpecRegistry", "<PackageSpecRegistry>", true},
 

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1032,6 +1032,8 @@ struct PackageInfoFinder {
 
             if (compatibilityAnnotation == core::Names::strict()) {
                 info->strictAutoloaderCompatibility_ = true;
+            }
+        }
 
         if (send.fun == core::Names::visible_to() && send.numPosArgs() == 1) {
             if (auto target = verifyConstant(ctx, send.fun, send.getPosArg(0))) {

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -208,6 +208,9 @@ public:
     // Whether the code in this package is compatible for path-based autoloading.
     bool strictAutoloaderCompatibility_;
 
+    // The other packages to which this package is visible.
+    vector<PackageName> visibleTo_;
+
     // PackageInfoImpl is the only implementation of PackageInfoImpl
     const static PackageInfoImpl &from(const core::packages::PackageInfo &pkg) {
         ENFORCE(pkg.exists());
@@ -351,6 +354,13 @@ public:
             if (i.type == ImportType::Test) {
                 rv.emplace_back(i.name.fullName.parts);
             }
+        }
+        return rv;
+    }
+    vector<vector<core::NameRef>> visibleTo() const {
+        vector<vector<core::NameRef>> rv;
+        for (auto &v : visibleTo_) {
+            rv.emplace_back(v.fullName.parts);
         }
         return rv;
     }
@@ -1022,6 +1032,28 @@ struct PackageInfoFinder {
 
             if (compatibilityAnnotation == core::Names::strict()) {
                 info->strictAutoloaderCompatibility_ = true;
+
+        if (send.fun == core::Names::visible_to() && send.numPosArgs() == 1) {
+            if (auto target = verifyConstant(ctx, send.fun, send.getPosArg(0))) {
+                auto name = getPackageName(ctx, target);
+                if (!name.has_value()) {
+                    ENFORCE(!isMutableContext);
+                    return;
+                }
+
+                if (name.value().mangledName == info->name.mangledName) {
+                    if (auto e = ctx.beginError(target->loc, core::errors::Packager::NoSelfImport)) {
+                        e.setHeader("Useless `{}`, because {} cannot import itself, ", "visible_to",
+                                    info->name.toString(ctx));
+                    }
+                }
+
+                auto importArg = move(send.getPosArg(0));
+                send.removePosArg(0);
+                ENFORCE(send.numPosArgs() == 0);
+                send.addPosArg(prependName(move(importArg), core::Names::Constants::PackageSpecRegistry()));
+
+                info->visibleTo_.emplace_back(move(name.value()));
             }
         }
     }
@@ -1130,6 +1162,7 @@ struct PackageInfoFinder {
             case core::Names::export_().rawId():
             case core::Names::restrict_to_service().rawId():
             case core::Names::autoloader_compatibility().rawId():
+            case core::Names::visible_to().rawId():
                 return true;
             default:
                 return false;
@@ -1282,7 +1315,38 @@ ast::ParsedFile validatePackage(core::Context ctx, ast::ParsedFile file) {
     if (!absPkg.exists()) {
         // We already produced an error on this package when producing its package info.
         // The correct course of action is to abort the transform.
+
         return file;
+    }
+
+    auto &pkgInfo = PackageInfoImpl::from(absPkg);
+    for (auto &i : pkgInfo.importedPackageNames) {
+        auto &otherPkg = packageDB.getPackageInfo(i.name.mangledName);
+
+        // this might mean the other package doesn't exist, but that
+        // should have been caught already
+        if (!otherPkg.exists()) {
+            continue;
+        }
+
+        if (!otherPkg.visibleTo().empty()) {
+            bool allowed = false;
+            for (auto &other : otherPkg.visibleTo()) {
+                if (other == absPkg.fullName()) {
+                    allowed = true;
+                }
+            }
+
+            if (!allowed) {
+                if (auto e = ctx.beginError(i.name.loc, core::errors::Packager::ImportNotVisible)) {
+                    e.setHeader(
+                        "Package `{}` includes explicit visibility modifiers and does not allow imports from `{}`",
+                        otherPkg.show(ctx), absPkg.show(ctx));
+                    e.addErrorNote("Please consult with the owning team before adding a `{}` line to the package `{}`",
+                                   "visible_to", otherPkg.show(ctx));
+                }
+            }
+        }
     }
 
     // Sanity check: __package.rb files _must_ be typed: strict

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1038,12 +1038,9 @@ struct PackageInfoFinder {
         if (send.fun == core::Names::visible_to() && send.numPosArgs() == 1) {
             if (auto target = verifyConstant(ctx, send.fun, send.getPosArg(0))) {
                 auto name = getPackageName(ctx, target);
-                if (!name.has_value()) {
-                    ENFORCE(!isMutableContext);
-                    return;
-                }
+                ENFORCE(name.mangledName.exists());
 
-                if (name.value().mangledName == info->name.mangledName) {
+                if (name.mangledName == info->name.mangledName) {
                     if (auto e = ctx.beginError(target->loc, core::errors::Packager::NoSelfImport)) {
                         e.setHeader("Useless `{}`, because {} cannot import itself, ", "visible_to",
                                     info->name.toString(ctx));
@@ -1055,7 +1052,7 @@ struct PackageInfoFinder {
                 ENFORCE(send.numPosArgs() == 0);
                 send.addPosArg(prependName(move(importArg), core::Names::Constants::PackageSpecRegistry()));
 
-                info->visibleTo_.emplace_back(move(name.value()));
+                info->visibleTo_.emplace_back(move(name));
             }
         }
     }

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1328,7 +1328,10 @@ ast::ParsedFile validatePackage(core::Context ctx, ast::ParsedFile file) {
             continue;
         }
 
-        if (!otherPkg.visibleTo().empty()) {
+        const auto &visibleTo = otherPkg.visibleTo();
+        if (visibleTo.empty()) {
+            continue;
+        }
             bool allowed = absl::c_any_of(otherPkg.visibleTo(), [&absPkg](const auto &other) { return other == absPkg.fullName(); });
 
             if (!allowed) {

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1332,16 +1332,16 @@ ast::ParsedFile validatePackage(core::Context ctx, ast::ParsedFile file) {
         if (visibleTo.empty()) {
             continue;
         }
-            bool allowed = absl::c_any_of(otherPkg.visibleTo(), [&absPkg](const auto &other) { return other == absPkg.fullName(); });
 
-            if (!allowed) {
-                if (auto e = ctx.beginError(i.name.loc, core::errors::Packager::ImportNotVisible)) {
-                    e.setHeader(
-                        "Package `{}` includes explicit visibility modifiers and does not allow imports from `{}`",
-                        otherPkg.show(ctx), absPkg.show(ctx));
-                    e.addErrorNote("Please consult with the owning team before adding a `{}` line to the package `{}`",
-                                   "visible_to", otherPkg.show(ctx));
-                }
+        bool allowed = absl::c_any_of(otherPkg.visibleTo(), [&absPkg](const auto &other) { return other == absPkg.fullName(); });
+
+        if (!allowed) {
+            if (auto e = ctx.beginError(i.name.loc, core::errors::Packager::ImportNotVisible)) {
+                e.setHeader(
+                    "Package `{}` includes explicit visibility modifiers and does not allow imports from `{}`",
+                    otherPkg.show(ctx), absPkg.show(ctx));
+                e.addErrorNote("Please consult with the owning team before adding a `{}` line to the package `{}`",
+                               "visible_to", otherPkg.show(ctx));
             }
         }
     }

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -208,7 +208,8 @@ public:
     // Whether the code in this package is compatible for path-based autoloading.
     bool strictAutoloaderCompatibility_;
 
-    // The other packages to which this package is visible.
+    // The other packages to which this package is visible. If this vector is empty, then it means
+    // the package is fully public and can be imported by anything.
     vector<PackageName> visibleTo_;
 
     // PackageInfoImpl is the only implementation of PackageInfoImpl
@@ -1314,7 +1315,6 @@ ast::ParsedFile validatePackage(core::Context ctx, ast::ParsedFile file) {
     if (!absPkg.exists()) {
         // We already produced an error on this package when producing its package info.
         // The correct course of action is to abort the transform.
-
         return file;
     }
 
@@ -1338,7 +1338,7 @@ ast::ParsedFile validatePackage(core::Context ctx, ast::ParsedFile file) {
         if (!allowed) {
             if (auto e = ctx.beginError(i.name.loc, core::errors::Packager::ImportNotVisible)) {
                 e.setHeader(
-                    "Package `{}` includes explicit visibility modifiers and does not allow imports from `{}`",
+                    "Package `{}` includes explicit visibility modifiers and cannot be imported from `{}`",
                     otherPkg.show(ctx), absPkg.show(ctx));
                 e.addErrorNote("Please consult with the owning team before adding a `{}` line to the package `{}`",
                                "visible_to", otherPkg.show(ctx));

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1329,12 +1329,7 @@ ast::ParsedFile validatePackage(core::Context ctx, ast::ParsedFile file) {
         }
 
         if (!otherPkg.visibleTo().empty()) {
-            bool allowed = false;
-            for (auto &other : otherPkg.visibleTo()) {
-                if (other == absPkg.fullName()) {
-                    allowed = true;
-                }
-            }
+            bool allowed = absl::c_any_of(otherPkg.visibleTo(), [&absPkg](const auto &other) { return other == absPkg.fullName(); });
 
             if (!allowed) {
                 if (auto e = ctx.beginError(i.name.loc, core::errors::Packager::ImportNotVisible)) {

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1333,13 +1333,13 @@ ast::ParsedFile validatePackage(core::Context ctx, ast::ParsedFile file) {
             continue;
         }
 
-        bool allowed = absl::c_any_of(otherPkg.visibleTo(), [&absPkg](const auto &other) { return other == absPkg.fullName(); });
+        bool allowed =
+            absl::c_any_of(otherPkg.visibleTo(), [&absPkg](const auto &other) { return other == absPkg.fullName(); });
 
         if (!allowed) {
             if (auto e = ctx.beginError(i.name.loc, core::errors::Packager::ImportNotVisible)) {
-                e.setHeader(
-                    "Package `{}` includes explicit visibility modifiers and cannot be imported from `{}`",
-                    otherPkg.show(ctx), absPkg.show(ctx));
+                e.setHeader("Package `{}` includes explicit visibility modifiers and cannot be imported from `{}`",
+                            otherPkg.show(ctx), absPkg.show(ctx));
                 e.addErrorNote("Please consult with the owning team before adding a `{}` line to the package `{}`",
                                "visible_to", otherPkg.show(ctx));
             }

--- a/test/testdata/packager/visibility/bar/__package.rb
+++ b/test/testdata/packager/visibility/bar/__package.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class Bar < PackageSpec
+  import Foo
+end

--- a/test/testdata/packager/visibility/baz/__package.rb
+++ b/test/testdata/packager/visibility/baz/__package.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class Baz < PackageSpec
+  import Foo # error: Package `Foo` includes explicit visibility modifiers and does not allow imports from `Baz`
+end

--- a/test/testdata/packager/visibility/baz/__package.rb
+++ b/test/testdata/packager/visibility/baz/__package.rb
@@ -3,5 +3,5 @@
 # enable-packager: true
 
 class Baz < PackageSpec
-  import Foo # error: Package `Foo` includes explicit visibility modifiers and does not allow imports from `Baz`
+  import Foo # error: Package `Foo` includes explicit visibility modifiers and cannot be imported from `Baz`
 end

--- a/test/testdata/packager/visibility/foo/__package.rb
+++ b/test/testdata/packager/visibility/foo/__package.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class Foo < PackageSpec
+  visible_to Bar
+end

--- a/test/testdata/packager/visibility/foo/__package.rb
+++ b/test/testdata/packager/visibility/foo/__package.rb
@@ -4,4 +4,6 @@
 
 class Foo < PackageSpec
   visible_to Bar
+  visible_to Quux
+           # ^^^^ error: Unable to resolve constant `Quux`
 end

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -844,6 +844,23 @@ class A::B < PackageSpec
 end
 ```
 
+## 3723
+
+> This error is specific to Stripe's custom `--stripe-packages` mode. If you are
+> at Stripe, please see [go/modularity](http://go/modularity) for more.
+
+The `--stripe-packages` mdoe allows packages to explicitly enumerate which other
+packages are allowed to import them by using the `visible_to` directive. If a
+package uses one or more `visible_to` lines, and is imported by a package _not_
+referenced by a `visible_to` line, then Sorbet will raise an error pointing to
+that import.
+
+Often, if you're running across this error, it means that you're trying to rely
+on an implementation detail that was deliberately made private. However, if
+you're sure that it should be okay to import this package, then you can add an
+additional `visible_to` directive in order to allow the import you're trying to
+add.
+
 ## 4001
 
 Sorbet parses the syntax of `include` and `extend` declarations, even in


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
This is a prototype of a new packaging feature where packages can explicitly describe themselves as `visible_to` another package; if a package uses this, then any imports from a package not explicitly listed becomes an error.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
