### PR TITLE
Drop everything in the database

### DIFF
--- a/common/kvstore/KeyValueStore-emscripten.cc
+++ b/common/kvstore/KeyValueStore-emscripten.cc
@@ -52,7 +52,7 @@ void OwnedKeyValueStore::clear() {
     throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
 }
 
-string_view OwnedKeyValueStore::readString(string_view key) const {
+optional<string_view> OwnedKeyValueStore::readString(string_view key) const {
     throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
 }
 

--- a/common/kvstore/KeyValueStore.cc
+++ b/common/kvstore/KeyValueStore.cc
@@ -134,14 +134,16 @@ OwnedKeyValueStore::OwnedKeyValueStore(unique_ptr<KeyValueStore> kvstore)
             clearAll();
         }
         auto dbVersion = readString(VERSION_KEY);
-        if (!dbVersion.has_value()) {
-            // Probably new
-            fmt::print("writing version, not has value\n");
-            writeString(VERSION_KEY, this->kvstore->version);
-        } else if (dbVersion != this->kvstore->version) {
+        if (dbVersion.has_value() && dbVersion != this->kvstore->version) {
+            fmt::print("clearing all databases\n");
             clearAll();
-            fmt::print("writing version, has value but not right version\n");
+        }
+
+        if (!dbVersion.has_value() || dbVersion != this->kvstore->version) {
+            fmt::print("writing version\n");
             writeString(VERSION_KEY, this->kvstore->version);
+            commit();
+            refreshMainTransaction();
         }
         return;
     }

--- a/common/kvstore/KeyValueStore.cc
+++ b/common/kvstore/KeyValueStore.cc
@@ -137,8 +137,6 @@ OwnedKeyValueStore::OwnedKeyValueStore(unique_ptr<KeyValueStore> kvstore)
         if (!dbVersion.has_value() || dbVersion != this->kvstore->version) {
             clearAll();
             writeString(VERSION_KEY, this->kvstore->version);
-            // commit();
-            // refreshMainTransaction();
         }
         return;
     }

--- a/common/kvstore/KeyValueStore.cc
+++ b/common/kvstore/KeyValueStore.cc
@@ -136,9 +136,11 @@ OwnedKeyValueStore::OwnedKeyValueStore(unique_ptr<KeyValueStore> kvstore)
         auto dbVersion = readString(VERSION_KEY);
         if (!dbVersion.has_value()) {
             // Probably new
+            fmt::format("writing version, not has value");
             writeString(VERSION_KEY, this->kvstore->version);
         } else if (dbVersion != this->kvstore->version) {
             clearAll();
+            fmt::format("writing version, has value but not right version");
             writeString(VERSION_KEY, this->kvstore->version);
         }
         return;
@@ -251,6 +253,8 @@ void OwnedKeyValueStore::clearAll() {
     if (writerId != this_thread::get_id()) {
         throw_mdb_error("KeyValueStore can only write from thread that created it"sv, 0);
     }
+
+    fmt::print("clearing all\n");
 
     // -- Clear the open database --
     int rc = mdb_drop(txnState->txn, txnState->dbi, 0);

--- a/common/kvstore/KeyValueStore.cc
+++ b/common/kvstore/KeyValueStore.cc
@@ -308,7 +308,8 @@ void OwnedKeyValueStore::clearAll() {
                 goto fail;
             }
 
-            rc = mdb_drop(txnState->txn, txnState->dbi, 0);
+            int del = 1;
+            rc = mdb_drop(txnState->txn, txnState->dbi, del);
             fmt::print("drop\n");
             if (rc != 0) {
                 goto fail;

--- a/common/kvstore/KeyValueStore.cc
+++ b/common/kvstore/KeyValueStore.cc
@@ -137,8 +137,8 @@ OwnedKeyValueStore::OwnedKeyValueStore(unique_ptr<KeyValueStore> kvstore)
         if (!dbVersion.has_value() || dbVersion != this->kvstore->version) {
             clearAll();
             writeString(VERSION_KEY, this->kvstore->version);
-            commit();
-            refreshMainTransaction();
+            // commit();
+            // refreshMainTransaction();
         }
         return;
     }

--- a/common/kvstore/KeyValueStore.cc
+++ b/common/kvstore/KeyValueStore.cc
@@ -12,7 +12,7 @@ namespace sorbet {
 constexpr string_view OLD_VERSION_KEY = "VERSION"sv;
 constexpr string_view VERSION_KEY = "DB_FORMAT_VERSION"sv;
 // This configured both maximum filesystem db size and max virtual memory usage
-// Needs to be a multiple of getpagesize(2) which is 4906 by default on macOS and Linux
+// Needs to be a multiple of getpagesize(2) which is 4096 by default on macOS and Linux
 constexpr size_t MAX_DB_SIZE_BYTES = 4L * 1024 * 1024 * 1024; // 4 GiB
 struct KeyValueStore::DBState {
     MDB_env *env;

--- a/common/kvstore/KeyValueStore.cc
+++ b/common/kvstore/KeyValueStore.cc
@@ -136,11 +136,11 @@ OwnedKeyValueStore::OwnedKeyValueStore(unique_ptr<KeyValueStore> kvstore)
         auto dbVersion = readString(VERSION_KEY);
         if (!dbVersion.has_value()) {
             // Probably new
-            fmt::format("writing version, not has value");
+            fmt::print("writing version, not has value\n");
             writeString(VERSION_KEY, this->kvstore->version);
         } else if (dbVersion != this->kvstore->version) {
             clearAll();
-            fmt::format("writing version, has value but not right version");
+            fmt::print("writing version, has value but not right version\n");
             writeString(VERSION_KEY, this->kvstore->version);
         }
         return;

--- a/common/kvstore/KeyValueStore.h
+++ b/common/kvstore/KeyValueStore.h
@@ -79,7 +79,7 @@ public:
     KeyValueStoreValue read(std::string_view key) const;
     /** Reads a string from the key value store. Lifetime of string is tied to the lifetime of the database. Returns an
      * empty string_view if the key does not exist. */
-    std::string_view readString(std::string_view key) const;
+    std::optional<std::string_view> readString(std::string_view key) const;
     void writeString(std::string_view key, std::string_view value);
     /** can only be called from owning thread */
     void write(std::string_view key, const std::vector<uint8_t> &value);

--- a/common/kvstore/KeyValueStore.h
+++ b/common/kvstore/KeyValueStore.h
@@ -66,7 +66,7 @@ class OwnedKeyValueStore final {
     mutable absl::Mutex readers_mtx;
 
     void writeInternal(std::string_view key, void *value, size_t len);
-    void clear();
+    void clearAll();
     void refreshMainTransaction();
     int commit();
     void abort() const;

--- a/common/kvstore/test/kvstore_test.cc
+++ b/common/kvstore/test/kvstore_test.cc
@@ -44,7 +44,7 @@ TEST_CASE("kvstore") {
         {
             auto kvstore = make_unique<KeyValueStore>("1", directory, "vanilla");
             auto owned = make_unique<OwnedKeyValueStore>(move(kvstore));
-            CHECK_EQ(owned->readString("hello"), "");
+            CHECK_EQ(owned->readString("hello"), nullopt);
         }
     }
 
@@ -65,7 +65,7 @@ TEST_CASE("kvstore") {
         CHECK_EQ(owned->readString("hello"), "testing");
         kvstore = OwnedKeyValueStore::abort(move(owned));
         owned = make_unique<OwnedKeyValueStore>(move(kvstore));
-        CHECK_EQ(owned->readString("hello"), "");
+        CHECK_EQ(owned->readString("hello"), nullopt);
     }
 
     SUBCASE("ClearsChangesOnVersionChange") {
@@ -79,7 +79,7 @@ TEST_CASE("kvstore") {
         {
             auto kvstore = make_unique<KeyValueStore>("2", directory, "vanilla");
             auto owned = make_unique<OwnedKeyValueStore>(move(kvstore));
-            CHECK_EQ(owned->readString("hello"), "");
+            CHECK_EQ(owned->readString("hello"), nullopt);
         }
     }
 
@@ -94,7 +94,7 @@ TEST_CASE("kvstore") {
         {
             auto kvstore = make_unique<KeyValueStore>("1", directory, "coldbrewcoffeewithchocolateflakes");
             auto owned = make_unique<OwnedKeyValueStore>(move(kvstore));
-            CHECK_EQ(owned->readString("hello"), "");
+            CHECK_EQ(owned->readString("hello"), nullopt);
         }
     }
 


### PR DESCRIPTION
### Motivation

We were not sufficiently purging the disk cache, which meant that we effectively
leaked cache space.

I would like to clean this change up in a follow up PR, but this should solve
the immediate problem.


### Test plan

I tested this manually by switching back and forth between new and old branches,
and dumped the databases using commands like these:

```
sorbet --cache-dir=jez-cache foo.rb
sorbet --cache-dir=jez-cache --skip-rewriter-passes foo.rb
sorbet --cache-dir=jez-cache --enable-experimental-lsp-fast-path foo.rb
sorbet --cache-dir=jez-cache --skip-rewriter-passes --enable-experimental-lsp-fast-path foo.rb
sorbet --cache-dir=master-cache foo.rb
sorbet --cache-dir=master-cache foo.rb bar.rb
sorbet --cache-dir=jez-cache foo.rb bar.rb

pip install lmdb

python -mlmdb --env jez-cache dump default=foo.txt
python -mlmdb --env jez-cache dump nodsl=foo.txt
python -mlmdb --env jez-cache dump dsl-experimentalfastpath=bar.txt
python -mlmdb --env jez-cache dump
python -mlmdb --env jez-cache dump dsl-experimentalfastpath=foo.txt
python -mlmdb --env master-cache dump default=bar.txt
python -mlmdb --env jez-cache dump default=bar.txt
python -mlmdb --env jez-cache dump dsl-normalfastpath=foo.txt
```

in various orders and combinations and branches.