### PR TITLE
Run document formatting requests on preprocessor thread

### DIFF
--- a/main/lsp/LSPPreprocessor.h
+++ b/main/lsp/LSPPreprocessor.h
@@ -105,6 +105,12 @@ class LSPPreprocessor final {
     std::unique_ptr<SorbetWorkspaceEditParams>
     canonicalizeEdits(uint32_t v, std::unique_ptr<WatchmanQueryResponse> queryResponse) const;
 
+    /**
+     * Get the current contents of the file at the given path. Returns "" (empty string view) if file does not yet
+     * exist.
+     */
+    std::string_view getFileContents(std::string_view path) const;
+
     bool ensureInitialized(const LSPMethod forMethod, const LSPMessage &msg) const;
 
     std::unique_ptr<LSPTask> getTaskForMessage(LSPMessage &msg);
@@ -150,10 +156,9 @@ public:
     void exit(int exitCode);
 
     /**
-     * Get the current contents of the file at the given path. Returns "" (empty string view) if file does not yet
-     * exist.
+     * Get the current contents of the file at the given path if it is in `openFiles`.
      */
-    std::string_view getFileContents(std::string_view path, bool enforceFileExists) const;
+    std::optional<std::string_view> maybeGetFileContents(std::string_view path) const;
 
     std::unique_ptr<Joinable> runPreprocessor(MessageQueueState &messageQueue, absl::Mutex &messageQueueMutex);
 };

--- a/main/lsp/LSPPreprocessor.h
+++ b/main/lsp/LSPPreprocessor.h
@@ -105,12 +105,6 @@ class LSPPreprocessor final {
     std::unique_ptr<SorbetWorkspaceEditParams>
     canonicalizeEdits(uint32_t v, std::unique_ptr<WatchmanQueryResponse> queryResponse) const;
 
-    /**
-     * Get the current contents of the file at the given path. Returns "" (empty string view) if file does not yet
-     * exist.
-     */
-    std::string_view getFileContents(std::string_view path) const;
-
     bool ensureInitialized(const LSPMethod forMethod, const LSPMessage &msg) const;
 
     std::unique_ptr<LSPTask> getTaskForMessage(LSPMessage &msg);
@@ -154,6 +148,12 @@ public:
      * Suspend preprocessing indefinitely. Is called before the language server shuts down.
      */
     void exit(int exitCode);
+
+    /**
+     * Get the current contents of the file at the given path. Returns "" (empty string view) if file does not yet
+     * exist.
+     */
+    std::string_view getFileContents(std::string_view path, bool enforceFileExists) const;
 
     std::unique_ptr<Joinable> runPreprocessor(MessageQueueState &messageQueue, absl::Mutex &messageQueueMutex);
 };

--- a/main/lsp/requests/document_formatting.cc
+++ b/main/lsp/requests/document_formatting.cc
@@ -102,9 +102,8 @@ void DocumentFormattingTask::preprocess(LSPPreprocessor &preprocessor) {
                 response->result = move(result);
                 break;
             case RubyfmtStatus::SYNTAX_ERROR:
-                response->error = make_unique<ResponseError>(
-                    (int)LSPErrorCodes::RequestFailed,
-                    fmt::format("`rubyfmt` could not format {} because it contains syntax errors.", path));
+                // result is already JSONNullObject, so return null
+                response->result = move(result);
                 break;
             case RubyfmtStatus::RIPPER_PARSE_FAILURE:
                 displayError(fmt::format("`rubyfmt` failed to deserialize the parse tree from Ripper for {}.\n"

--- a/main/lsp/requests/document_formatting.cc
+++ b/main/lsp/requests/document_formatting.cc
@@ -1,4 +1,6 @@
 #include "main/lsp/requests/document_formatting.h"
+#include "common/FileOps.h"
+#include "common/common.h"
 #include "main/lsp/LSPOutput.h"
 #include "main/lsp/json_types.h"
 #include "main/lsp/lsp.h"
@@ -11,9 +13,9 @@ DocumentFormattingTask::DocumentFormattingTask(const LSPConfiguration &config, M
                                                std::unique_ptr<DocumentFormattingParams> params)
     : LSPRequestTask(config, move(id), LSPMethod::TextDocumentFormatting), params(move(params)) {}
 
-// Processed on the index thread so it doesn't wait for typechecking.
+// Processed on the preprocess thread so it doesn't wait for typechecking.
 LSPTask::Phase DocumentFormattingTask::finalPhase() const {
-    return Phase::INDEX;
+    return Phase::PREPROCESS;
 }
 
 enum RubyfmtStatus {
@@ -53,7 +55,7 @@ void DocumentFormattingTask::displayError(string errorMessage, unique_ptr<Respon
         "2.0", LSPMethod::WindowShowMessage, make_unique<ShowMessageParams>(MessageType::Error, errorMessage)));
 }
 
-void DocumentFormattingTask::index(LSPIndexer &index) {
+void DocumentFormattingTask::preprocess(LSPPreprocessor &preprocessor) {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::TextDocumentFormatting);
     if (!config.opts.lspDocumentFormatRubyfmtEnabled) {
         response->error = make_unique<ResponseError>(
@@ -64,12 +66,13 @@ void DocumentFormattingTask::index(LSPIndexer &index) {
     }
 
     variant<JSONNullObject, vector<unique_ptr<TextEdit>>> result = JSONNullObject();
+    vector<unique_ptr<TextEdit>> edits;
 
-    auto fref = index.uri2FileRef(params->textDocument->uri);
-    if (fref.exists()) {
-        vector<unique_ptr<TextEdit>> edits;
+    auto path = config.remoteName2Local(params->textDocument->uri);
+    auto sourceView = readFile(preprocessor, path);
 
-        auto sourceView = index.getFile(fref).source();
+    if (!sourceView.empty()) {
+        auto originalLineCount = findLineBreaks(sourceView).size() - 1;
         auto process = subprocess::Popen({config.opts.rubyfmtPath}, subprocess::output{subprocess::PIPE},
                                          subprocess::input{subprocess::PIPE});
         auto processResponse = process.communicate(vector<char>(sourceView.begin(), sourceView.end()));
@@ -83,34 +86,33 @@ void DocumentFormattingTask::index(LSPIndexer &index) {
                 // Construct text edit to replace entire document.
                 // Note: VS Code uses 0-indexed lines, so the lineCount will be one more line than the size of the
                 // doc.
-                edits.emplace_back(
-                    make_unique<TextEdit>(make_unique<Range>(make_unique<Position>(0, 0),
-                                                             make_unique<Position>(index.getFile(fref).lineCount(), 0)),
-                                          formattedContents));
+                edits.emplace_back(make_unique<TextEdit>(
+                    make_unique<Range>(make_unique<Position>(0, 0), make_unique<Position>(originalLineCount, 0)),
+                    formattedContents));
                 result = move(edits);
                 response->result = move(result);
                 break;
             case RubyfmtStatus::SYNTAX_ERROR:
                 response->error = make_unique<ResponseError>(
                     (int)LSPErrorCodes::RequestFailed,
-                    fmt::format("`rubyfmt` could not format {} because it contains syntax errors."));
+                    fmt::format("`rubyfmt` could not format {} because it contains syntax errors.", path));
                 break;
             case RubyfmtStatus::RIPPER_PARSE_FAILURE:
                 displayError(fmt::format("`rubyfmt` failed to deserialize the parse tree from Ripper for {}.\n"
                                          "This is valid Ruby but represents a bug in `rubyfmt`.",
-                                         index.getFile(fref).path()),
+                                         path),
                              response);
                 break;
             case RubyfmtStatus::IO_ERROR:
                 displayError(fmt::format("`rubyfmt` encountered an IO error while writing {}.\n"
                                          "This is likely a bug in `rubyfmt`.",
-                                         index.getFile(fref).path()),
+                                         path),
                              response);
                 break;
             case RubyfmtStatus::OTHER_RUBY_ERROR:
                 displayError(fmt::format("`rubyfmt` encountered a ruby error while writing {}.\n"
                                          "This is likely a bug in `rubyfmt`.",
-                                         index.getFile(fref).path()),
+                                         path),
                              response);
                 break;
             case RubyfmtStatus::INITIALIZE_ERROR:
@@ -126,8 +128,20 @@ void DocumentFormattingTask::index(LSPIndexer &index) {
                 break;
         }
     }
+
     config.output->write(move(response));
     return;
+}
+
+string_view DocumentFormattingTask::readFile(LSPPreprocessor &preprocessor, string_view uri) {
+    auto contents = preprocessor.getFileContents(uri, false);
+    // `getFileContents` uses `openFiles` from the preprocessor, but technically
+    // the LSP can send formatting requests for unopened files, so in that case
+    // we read from disk
+    if (contents.empty()) {
+        return std::move(sorbet::FileOps::read(uri));
+    }
+    return contents;
 }
 
 // Since finalPhase is `preprocess`, this method should never be called.

--- a/main/lsp/requests/document_formatting.cc
+++ b/main/lsp/requests/document_formatting.cc
@@ -91,9 +91,9 @@ void DocumentFormattingTask::index(LSPIndexer &index) {
                 response->result = move(result);
                 break;
             case RubyfmtStatus::SYNTAX_ERROR:
-                displayError(fmt::format("`rubyfmt` could not format {} because it contains syntax errors.",
-                                         index.getFile(fref).path()),
-                             response);
+                response->error = make_unique<ResponseError>(
+                    (int)LSPErrorCodes::RequestFailed,
+                    fmt::format("`rubyfmt` could not format {} because it contains syntax errors."));
                 break;
             case RubyfmtStatus::RIPPER_PARSE_FAILURE:
                 displayError(fmt::format("`rubyfmt` failed to deserialize the parse tree from Ripper for {}.\n"

--- a/main/lsp/requests/document_formatting.h
+++ b/main/lsp/requests/document_formatting.h
@@ -14,11 +14,13 @@ public:
 
     Phase finalPhase() const override;
 
-    void index(LSPIndexer &index) override;
+    void preprocess(LSPPreprocessor &preprocessor) override;
 
     std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerInterface &typechecker) override;
 
 private:
+    std::string_view readFile(LSPPreprocessor &preprocessor, std::string_view uri);
+
     void displayError(std::string errorMessage, std::unique_ptr<ResponseMessage> &response);
 };
 

--- a/main/lsp/requests/document_formatting.h
+++ b/main/lsp/requests/document_formatting.h
@@ -19,8 +19,6 @@ public:
     std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerInterface &typechecker) override;
 
 private:
-    std::string_view readFile(LSPPreprocessor &preprocessor, std::string_view uri);
-
     void displayError(std::string errorMessage, std::unique_ptr<ResponseMessage> &response);
 };
 

--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -428,6 +428,14 @@ void testDocumentFormatting(LSPWrapper &lspWrapper, Expectations &test, int &nex
         auto &msg = responses.at(0);
         REQUIRE(msg->isResponse());
         auto &response = msg->asResponse();
+        if (response.error) {
+            // If we're here, this is a syntax error response, which is an error
+            // but doesn't create a notification response like other error types
+            auto &receivedErrorResponse = *response.error;
+            auto expectedOutput = FileOps::read(test.folder + expectationFileName);
+            REQUIRE_EQ(expectedOutput, receivedErrorResponse->message);
+            return;
+        }
         REQUIRE_MESSAGE(response.result, "Document formatting request returned error: " << msg->toJSON());
         auto &receivedFormattingResponse = get<variant<JSONNullObject, vector<unique_ptr<TextEdit>>>>(*response.result);
         if (auto *edits = get_if<vector<unique_ptr<TextEdit>>>(&receivedFormattingResponse)) {

--- a/test/testdata/lsp/syntax_error_formatting.rb.document-formatting-rubyfmt.exp
+++ b/test/testdata/lsp/syntax_error_formatting.rb.document-formatting-rubyfmt.exp
@@ -1,1 +1,0 @@
-`rubyfmt` could not format test/testdata/lsp/syntax_error_formatting.rb because it contains syntax errors.


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

On the tin -- running on the index thread means that document formatting can be forced to wait for certain slow-path Sorbet operations, but document formatting has no relation to what Sorbet does and really only cares about the raw source, so running it on preprocessor should improve response times.

Another smaller change is rolled into this PR, which is that formatting errors failing due to syntax errors now longer show a notification and instead just log an error -- this is more of a UX improvement, since users don't want to manually have to close VSCode notifications.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This should be covered by existing automated tests, since it's functionally the same, but I've also manually tested this on Stripe's codebase.
