### PR TITLE
Thread (currently unused) logger argument to KeyValueStore

### DIFF
--- a/common/kvstore/KeyValueStore-emscripten.cc
+++ b/common/kvstore/KeyValueStore-emscripten.cc
@@ -12,8 +12,9 @@ struct OwnedKeyValueStore::TxnState {};
     throw invalid_argument(string(what));
 }
 
-KeyValueStore::KeyValueStore(string version, string path, string flavor, size_t maxSize)
-    : version(move(version)), path(move(path)), flavor(move(flavor)), dbState(make_unique<DBState>()) {
+KeyValueStore::KeyValueStore(shared_ptr<spdlog::logger> logger, string version, string path, string flavor,
+                             size_t maxSize)
+    : version(move(version)), path(move(path)), flavor(move(flavor)), dbState(make_unique<DBState>()), logger(logger) {
     throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
 }
 KeyValueStore::~KeyValueStore() noexcept(false) {

--- a/common/kvstore/KeyValueStore.cc
+++ b/common/kvstore/KeyValueStore.cc
@@ -73,7 +73,7 @@ bool hasNoOutstandingReaders(MDB_env *env, string_view path) {
 
 KeyValueStore::KeyValueStore(shared_ptr<spdlog::logger> logger, string version, string path, string flavor,
                              size_t maxSize)
-    : version(move(version)), path(move(path)), flavor(move(flavor)), dbState(make_unique<DBState>()), logger(logger) {
+    : version(move(version)), path(move(path)), flavor(move(flavor)), dbState(make_unique<DBState>()), logger(move(logger)) {
     ENFORCE(!this->version.empty());
     bool expected = false;
     if (!kvstoreInUse.compare_exchange_strong(expected, true)) {

--- a/common/kvstore/KeyValueStore.cc
+++ b/common/kvstore/KeyValueStore.cc
@@ -73,7 +73,8 @@ bool hasNoOutstandingReaders(MDB_env *env, string_view path) {
 
 KeyValueStore::KeyValueStore(shared_ptr<spdlog::logger> logger, string version, string path, string flavor,
                              size_t maxSize)
-    : version(move(version)), path(move(path)), flavor(move(flavor)), dbState(make_unique<DBState>()), logger(move(logger)) {
+    : version(move(version)), path(move(path)), flavor(move(flavor)), dbState(make_unique<DBState>()),
+      logger(move(logger)) {
     ENFORCE(!this->version.empty());
     bool expected = false;
     if (!kvstoreInUse.compare_exchange_strong(expected, true)) {

--- a/common/kvstore/KeyValueStore.cc
+++ b/common/kvstore/KeyValueStore.cc
@@ -71,8 +71,9 @@ bool hasNoOutstandingReaders(MDB_env *env, string_view path) {
 }
 } // namespace
 
-KeyValueStore::KeyValueStore(string version, string path, string flavor, size_t maxSize)
-    : version(move(version)), path(move(path)), flavor(move(flavor)), dbState(make_unique<DBState>()) {
+KeyValueStore::KeyValueStore(shared_ptr<spdlog::logger> logger, string version, string path, string flavor,
+                             size_t maxSize)
+    : version(move(version)), path(move(path)), flavor(move(flavor)), dbState(make_unique<DBState>()), logger(logger) {
     ENFORCE(!this->version.empty());
     bool expected = false;
     if (!kvstoreInUse.compare_exchange_strong(expected, true)) {

--- a/common/kvstore/KeyValueStore.h
+++ b/common/kvstore/KeyValueStore.h
@@ -22,6 +22,7 @@ class KeyValueStore final {
     const std::string flavor;
     struct DBState;
     const std::unique_ptr<DBState> dbState;
+    const std::shared_ptr<spdlog::logger> logger;
 
 public:
     /**
@@ -41,7 +42,8 @@ public:
      * `KeyValueStore`s opened with different `flavor`s will not share
      * any entries, but each will see their own set of values.
      */
-    KeyValueStore(std::string version, std::string path, std::string flavor, size_t maxSize);
+    KeyValueStore(std::shared_ptr<spdlog::logger> logger, std::string version, std::string path, std::string flavor,
+                  size_t maxSize);
     ~KeyValueStore() noexcept(false);
 
     // Used in tests to assert that OwnedKeyValueStore cleans up reader transactions.

--- a/common/kvstore/test/kvstore_test.cc
+++ b/common/kvstore/test/kvstore_test.cc
@@ -22,14 +22,14 @@ TEST_CASE("kvstore") {
 
     SUBCASE("CommitsChangesToDisk") {
         {
-            auto kvstore = make_unique<KeyValueStore>("1", directory, "vanilla", maxSize);
+            auto kvstore = make_unique<KeyValueStore>(logger, "1", directory, "vanilla", maxSize);
             auto owned = make_unique<OwnedKeyValueStore>(move(kvstore));
             owned->writeString("hello", "testing");
             CHECK_EQ(owned->readString("hello"), "testing");
             OwnedKeyValueStore::bestEffortCommit(*logger, move(owned));
         }
         {
-            auto kvstore = make_unique<KeyValueStore>("1", directory, "vanilla", maxSize);
+            auto kvstore = make_unique<KeyValueStore>(logger, "1", directory, "vanilla", maxSize);
             auto owned = make_unique<OwnedKeyValueStore>(move(kvstore));
             CHECK_EQ(owned->readString("hello"), "testing");
         }
@@ -37,20 +37,20 @@ TEST_CASE("kvstore") {
 
     SUBCASE("AbortsChangesByDefault") {
         {
-            auto kvstore = make_unique<KeyValueStore>("1", directory, "vanilla", maxSize);
+            auto kvstore = make_unique<KeyValueStore>(logger, "1", directory, "vanilla", maxSize);
             auto owned = make_unique<OwnedKeyValueStore>(move(kvstore));
             owned->writeString("hello", "testing");
             CHECK_EQ(owned->readString("hello"), "testing");
         }
         {
-            auto kvstore = make_unique<KeyValueStore>("1", directory, "vanilla", maxSize);
+            auto kvstore = make_unique<KeyValueStore>(logger, "1", directory, "vanilla", maxSize);
             auto owned = make_unique<OwnedKeyValueStore>(move(kvstore));
             CHECK_EQ(owned->readString("hello"), nullopt);
         }
     }
 
     SUBCASE("CanBeReowned") {
-        auto kvstore = make_unique<KeyValueStore>("1", directory, "vanilla", maxSize);
+        auto kvstore = make_unique<KeyValueStore>(logger, "1", directory, "vanilla", maxSize);
         auto owned = make_unique<OwnedKeyValueStore>(move(kvstore));
         owned->writeString("hello", "testing");
         CHECK_EQ(owned->readString("hello"), "testing");
@@ -60,7 +60,7 @@ TEST_CASE("kvstore") {
     }
 
     SUBCASE("AbortsChangesWhenAborted") {
-        auto kvstore = make_unique<KeyValueStore>("1", directory, "vanilla", maxSize);
+        auto kvstore = make_unique<KeyValueStore>(logger, "1", directory, "vanilla", maxSize);
         auto owned = make_unique<OwnedKeyValueStore>(move(kvstore));
         owned->writeString("hello", "testing");
         CHECK_EQ(owned->readString("hello"), "testing");
@@ -71,14 +71,14 @@ TEST_CASE("kvstore") {
 
     SUBCASE("ClearsChangesOnVersionChange") {
         {
-            auto kvstore = make_unique<KeyValueStore>("1", directory, "vanilla", maxSize);
+            auto kvstore = make_unique<KeyValueStore>(logger, "1", directory, "vanilla", maxSize);
             auto owned = make_unique<OwnedKeyValueStore>(move(kvstore));
             owned->writeString("hello", "testing");
             CHECK_EQ(owned->readString("hello"), "testing");
             OwnedKeyValueStore::bestEffortCommit(*logger, move(owned));
         }
         {
-            auto kvstore = make_unique<KeyValueStore>("2", directory, "vanilla", maxSize);
+            auto kvstore = make_unique<KeyValueStore>(logger, "2", directory, "vanilla", maxSize);
             auto owned = make_unique<OwnedKeyValueStore>(move(kvstore));
             CHECK_EQ(owned->readString("hello"), nullopt);
         }
@@ -86,26 +86,27 @@ TEST_CASE("kvstore") {
 
     SUBCASE("FlavorsHaveDifferentContents") {
         {
-            auto kvstore = make_unique<KeyValueStore>("1", directory, "vanilla", maxSize);
+            auto kvstore = make_unique<KeyValueStore>(logger, "1", directory, "vanilla", maxSize);
             auto owned = make_unique<OwnedKeyValueStore>(move(kvstore));
             owned->writeString("hello", "testing");
             CHECK_EQ(owned->readString("hello"), "testing");
             OwnedKeyValueStore::bestEffortCommit(*logger, move(owned));
         }
         {
-            auto kvstore = make_unique<KeyValueStore>("1", directory, "coldbrewcoffeewithchocolateflakes", maxSize);
+            auto kvstore =
+                make_unique<KeyValueStore>(logger, "1", directory, "coldbrewcoffeewithchocolateflakes", maxSize);
             auto owned = make_unique<OwnedKeyValueStore>(move(kvstore));
             CHECK_EQ(owned->readString("hello"), nullopt);
         }
     }
 
     SUBCASE("CannotCreateTwoKvstores") {
-        auto kvstore1 = make_unique<KeyValueStore>("1", directory, "vanilla", maxSize);
-        CHECK_THROWS_AS(make_unique<KeyValueStore>("1", directory, "vanilla", maxSize), std::invalid_argument);
+        auto kvstore1 = make_unique<KeyValueStore>(logger, "1", directory, "vanilla", maxSize);
+        CHECK_THROWS_AS(make_unique<KeyValueStore>(logger, "1", directory, "vanilla", maxSize), std::invalid_argument);
     }
 
     SUBCASE("LeavesNoStaleTransactions") {
-        auto kvstore = make_unique<KeyValueStore>("1", directory, "vanilla", maxSize);
+        auto kvstore = make_unique<KeyValueStore>(logger, "1", directory, "vanilla", maxSize);
         auto owned = make_unique<OwnedKeyValueStore>(move(kvstore));
         absl::Notification readFinished;
         absl::Notification testFinished;

--- a/main/cache/cache-orig.cc
+++ b/main/cache/cache-orig.cc
@@ -3,7 +3,8 @@
 using namespace std;
 
 namespace sorbet::realmain::cache {
-unique_ptr<OwnedKeyValueStore> maybeCreateKeyValueStore(const options::Options &opts) {
+unique_ptr<OwnedKeyValueStore> maybeCreateKeyValueStore(shared_ptr<::spdlog::logger> logger,
+                                                        const options::Options &opts) {
     return nullptr;
 }
 

--- a/main/cache/cache.cc
+++ b/main/cache/cache.cc
@@ -8,11 +8,12 @@
 using namespace std;
 
 namespace sorbet::realmain::cache {
-unique_ptr<OwnedKeyValueStore> maybeCreateKeyValueStore(const options::Options &opts) {
+unique_ptr<OwnedKeyValueStore> maybeCreateKeyValueStore(shared_ptr<::spdlog::logger> logger,
+                                                        const options::Options &opts) {
     if (opts.cacheDir.empty()) {
         return nullptr;
     }
-    return make_unique<OwnedKeyValueStore>(make_unique<KeyValueStore>(sorbet_full_version_string, opts.cacheDir,
+    return make_unique<OwnedKeyValueStore>(make_unique<KeyValueStore>(logger, sorbet_full_version_string, opts.cacheDir,
                                                                       opts.skipRewriterPasses ? "nodsl" : "default",
                                                                       opts.maxCacheSizeBytes));
 }

--- a/main/cache/cache.h
+++ b/main/cache/cache.h
@@ -3,6 +3,10 @@
 
 #include <memory>
 
+namespace spdlog {
+class logger;
+}
+
 namespace sorbet {
 class KeyValueStore;
 class OwnedKeyValueStore;
@@ -20,7 +24,8 @@ struct Options;
 
 namespace sorbet::realmain::cache {
 // If cacheDir is specified, creates a KeyValueStore. Otherwise, returns nullptr.
-std::unique_ptr<OwnedKeyValueStore> maybeCreateKeyValueStore(const options::Options &opts);
+std::unique_ptr<OwnedKeyValueStore> maybeCreateKeyValueStore(std::shared_ptr<::spdlog::logger> logger,
+                                                             const options::Options &opts);
 
 // Returns an owned key value store if kvstore is unchanged since gs was created, or false otherwise.
 std::unique_ptr<OwnedKeyValueStore> ownIfUnchanged(const core::GlobalState &gs, std::unique_ptr<KeyValueStore> kvstore);

--- a/main/lsp/wrapper.cc
+++ b/main/lsp/wrapper.cc
@@ -44,7 +44,7 @@ createGlobalStateAndOtherObjects(string_view rootPath, options::Options &options
     typeErrorsConsoleOut->set_pattern("%v");
     auto gs = make_unique<core::GlobalState>(make_shared<core::ErrorQueue>(*typeErrorsConsoleOut, *loggerOut));
 
-    unique_ptr<const OwnedKeyValueStore> kvstore = cache::maybeCreateKeyValueStore(options);
+    unique_ptr<const OwnedKeyValueStore> kvstore = cache::maybeCreateKeyValueStore(loggerOut, options);
     payload::createInitialGlobalState(gs, options, kvstore);
     setRequiredLSPOptions(*gs, options);
     return make_pair(move(gs), OwnedKeyValueStore::abort(move(kvstore)));

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -498,7 +498,7 @@ int realmain(int argc, char *argv[]) {
     gs->requiresAncestorEnabled = opts.requiresAncestorEnabled;
 
     logger->trace("building initial global state");
-    unique_ptr<const OwnedKeyValueStore> kvstore = cache::maybeCreateKeyValueStore(opts);
+    unique_ptr<const OwnedKeyValueStore> kvstore = cache::maybeCreateKeyValueStore(logger, opts);
     payload::createInitialGlobalState(gs, opts, kvstore);
     if (opts.silenceErrors) {
         gs->silenceErrors = true;

--- a/test/lsp/cache_protocol_test_corpus.cc
+++ b/test/lsp/cache_protocol_test_corpus.cc
@@ -81,14 +81,14 @@ TEST_CASE_FIXTURE(CacheProtocolTest, "LSPUsesCache") {
         // Release cache lock.
         lspWrapper = nullptr;
 
-        unique_ptr<const OwnedKeyValueStore> kvstore = realmain::cache::maybeCreateKeyValueStore(*opts);
+        auto sink = std::make_shared<spdlog::sinks::null_sink_mt>();
+        auto logger = std::make_shared<spdlog::logger>("null", sink);
+        unique_ptr<const OwnedKeyValueStore> kvstore = realmain::cache::maybeCreateKeyValueStore(logger, *opts);
         CHECK_EQ(kvstore->read(updatedKey).data, nullptr);
 
         auto contents = kvstore->read(key);
         REQUIRE_NE(contents.data, nullptr);
 
-        auto sink = std::make_shared<spdlog::sinks::null_sink_mt>();
-        auto logger = std::make_shared<spdlog::logger>("null", sink);
         auto gs = make_unique<core::GlobalState>(make_shared<core::ErrorQueue>(*logger, *logger));
         payload::createInitialGlobalState(gs, *opts, kvstore);
 
@@ -138,12 +138,12 @@ TEST_CASE_FIXTURE(CacheProtocolTest, "LSPUsesCache") {
 
         // Release cache lock.
         lspWrapper = nullptr;
-        unique_ptr<const OwnedKeyValueStore> kvstore = realmain::cache::maybeCreateKeyValueStore(*opts);
+        auto sink = std::make_shared<spdlog::sinks::null_sink_mt>();
+        auto logger = std::make_shared<spdlog::logger>("null", sink);
+        unique_ptr<const OwnedKeyValueStore> kvstore = realmain::cache::maybeCreateKeyValueStore(logger, *opts);
         auto updatedFileData = kvstore->read(updatedKey);
         REQUIRE_NE(updatedFileData.data, nullptr);
 
-        auto sink = std::make_shared<spdlog::sinks::null_sink_mt>();
-        auto logger = std::make_shared<spdlog::logger>("null", sink);
         auto gs = make_unique<core::GlobalState>(make_shared<core::ErrorQueue>(*logger, *logger));
         payload::createInitialGlobalState(gs, *opts, kvstore);
 
@@ -187,7 +187,7 @@ TEST_CASE_FIXTURE(CacheProtocolTest, "LSPDoesNotUseCacheIfModified") {
         // Release cache lock.
         lspWrapper = nullptr;
 
-        unique_ptr<const OwnedKeyValueStore> kvstore = realmain::cache::maybeCreateKeyValueStore(*opts);
+        unique_ptr<const OwnedKeyValueStore> kvstore = realmain::cache::maybeCreateKeyValueStore(nullLogger, *opts);
         auto contents = kvstore->read(key);
         REQUIRE_NE(contents.data, nullptr);
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I'm going to follow up with some more changes to the caching code. When I do,
I'll make use of this new logger argument.

I recall wanting this to exist so that I could have written log statements when
implementing #5974, because it's otherwise tricky to debug (the cache version
checking logic depends on being compiled in release mode, which makes for poor
debugger symbols).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing build