### PR TITLE
Add support for slash-munged "extra package paths" in --stripe-packages mode

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2138,6 +2138,7 @@ const packages::PackageDB &GlobalState::packageDB() const {
 
 void GlobalState::setPackagerOptions(const std::vector<std::string> &secondaryTestPackageNamespaces,
                                      const std::vector<std::string> &extraPackageFilesDirectoryUnderscorePrefixes,
+                                     const std::vector<std::string> &extraPackageFilesDirectorySlashPrefixes,
                                      const std::vector<std::string> &packageSkipRBIExportEnforcementDirs,
                                      std::string errorHint) {
     ENFORCE(packageDB_.secondaryTestPackageNamespaceRefs_.size() == 0);
@@ -2148,6 +2149,7 @@ void GlobalState::setPackagerOptions(const std::vector<std::string> &secondaryTe
     }
 
     packageDB_.extraPackageFilesDirectoryUnderscorePrefixes_ = extraPackageFilesDirectoryUnderscorePrefixes;
+    packageDB_.extraPackageFilesDirectorySlashPrefixes_ = extraPackageFilesDirectorySlashPrefixes;
     packageDB_.skipRBIExportEnforcementDirs_ = packageSkipRBIExportEnforcementDirs;
     packageDB_.errorHint_ = errorHint;
 }

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2137,7 +2137,7 @@ const packages::PackageDB &GlobalState::packageDB() const {
 }
 
 void GlobalState::setPackagerOptions(const std::vector<std::string> &secondaryTestPackageNamespaces,
-                                     const std::vector<std::string> &extraPackageFilesDirectoryPrefixes,
+                                     const std::vector<std::string> &extraPackageFilesDirectoryUnderscorePrefixes,
                                      const std::vector<std::string> &packageSkipRBIExportEnforcementDirs,
                                      std::string errorHint) {
     ENFORCE(packageDB_.secondaryTestPackageNamespaceRefs_.size() == 0);
@@ -2147,7 +2147,7 @@ void GlobalState::setPackagerOptions(const std::vector<std::string> &secondaryTe
         packageDB_.secondaryTestPackageNamespaceRefs_.emplace_back(enterNameConstant(ns));
     }
 
-    packageDB_.extraPackageFilesDirectoryPrefixes_ = extraPackageFilesDirectoryPrefixes;
+    packageDB_.extraPackageFilesDirectoryUnderscorePrefixes_ = extraPackageFilesDirectoryUnderscorePrefixes;
     packageDB_.skipRBIExportEnforcementDirs_ = packageSkipRBIExportEnforcementDirs;
     packageDB_.errorHint_ = errorHint;
 }

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -163,6 +163,7 @@ public:
     const packages::PackageDB &packageDB() const;
     void setPackagerOptions(const std::vector<std::string> &secondaryTestPackageNamespaces,
                             const std::vector<std::string> &extraPackageFilesDirectoryUnderscorePrefixes,
+                            const std::vector<std::string> &extraPackageFilesDirectorySlashPrefixes,
                             const std::vector<std::string> &packageSkipRBIExportEnforcementDirs, std::string errorHint);
     packages::UnfreezePackages unfreezePackages();
 

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -162,7 +162,7 @@ public:
 
     const packages::PackageDB &packageDB() const;
     void setPackagerOptions(const std::vector<std::string> &secondaryTestPackageNamespaces,
-                            const std::vector<std::string> &extraPackageFilesDirectoryPrefixes,
+                            const std::vector<std::string> &extraPackageFilesDirectoryUnderscorePrefixes,
                             const std::vector<std::string> &packageSkipRBIExportEnforcementDirs, std::string errorHint);
     packages::UnfreezePackages unfreezePackages();
 

--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -220,8 +220,8 @@ const std::vector<std::string> &PackageDB::skipRBIExportEnforcementDirs() const 
     return skipRBIExportEnforcementDirs_;
 }
 
-const std::vector<std::string> &PackageDB::extraPackageFilesDirectoryPrefixes() const {
-    return extraPackageFilesDirectoryPrefixes_;
+const std::vector<std::string> &PackageDB::extraPackageFilesDirectoryUnderscorePrefixes() const {
+    return extraPackageFilesDirectoryUnderscorePrefixes_;
 }
 
 const std::string_view PackageDB::errorHint() const {
@@ -236,7 +236,7 @@ PackageDB PackageDB::deepCopy() const {
         result.packages_[nr] = pkgInfo->deepCopy();
     }
     result.secondaryTestPackageNamespaceRefs_ = this->secondaryTestPackageNamespaceRefs_;
-    result.extraPackageFilesDirectoryPrefixes_ = this->extraPackageFilesDirectoryPrefixes_;
+    result.extraPackageFilesDirectoryUnderscorePrefixes_ = this->extraPackageFilesDirectoryUnderscorePrefixes_;
     result.packagesByPathPrefix = this->packagesByPathPrefix;
     result.mangledNames = this->mangledNames;
     result.errorHint_ = this->errorHint_;

--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -224,6 +224,10 @@ const std::vector<std::string> &PackageDB::extraPackageFilesDirectoryUnderscoreP
     return extraPackageFilesDirectoryUnderscorePrefixes_;
 }
 
+const std::vector<std::string> &PackageDB::extraPackageFilesDirectorySlashPrefixes() const {
+    return extraPackageFilesDirectorySlashPrefixes_;
+}
+
 const std::string_view PackageDB::errorHint() const {
     return errorHint_;
 }
@@ -237,6 +241,7 @@ PackageDB PackageDB::deepCopy() const {
     }
     result.secondaryTestPackageNamespaceRefs_ = this->secondaryTestPackageNamespaceRefs_;
     result.extraPackageFilesDirectoryUnderscorePrefixes_ = this->extraPackageFilesDirectoryUnderscorePrefixes_;
+    result.extraPackageFilesDirectorySlashPrefixes_ = this->extraPackageFilesDirectorySlashPrefixes_;
     result.packagesByPathPrefix = this->packagesByPathPrefix;
     result.mangledNames = this->mangledNames;
     result.errorHint_ = this->errorHint_;

--- a/core/packages/PackageDB.h
+++ b/core/packages/PackageDB.h
@@ -55,6 +55,7 @@ public:
 
     const std::vector<core::NameRef> &secondaryTestPackageNamespaceRefs() const;
     const std::vector<std::string> &extraPackageFilesDirectoryUnderscorePrefixes() const;
+    const std::vector<std::string> &extraPackageFilesDirectorySlashPrefixes() const;
     const std::vector<std::string> &skipRBIExportEnforcementDirs() const;
 
     const std::string_view errorHint() const;
@@ -62,6 +63,7 @@ public:
 private:
     std::vector<NameRef> secondaryTestPackageNamespaceRefs_;
     std::vector<std::string> extraPackageFilesDirectoryUnderscorePrefixes_;
+    std::vector<std::string> extraPackageFilesDirectorySlashPrefixes_;
     std::string errorHint_;
     std::vector<std::string> skipRBIExportEnforcementDirs_;
 

--- a/core/packages/PackageDB.h
+++ b/core/packages/PackageDB.h
@@ -54,14 +54,14 @@ public:
     PackageDB &operator=(PackageDB &&) = default;
 
     const std::vector<core::NameRef> &secondaryTestPackageNamespaceRefs() const;
-    const std::vector<std::string> &extraPackageFilesDirectoryPrefixes() const;
+    const std::vector<std::string> &extraPackageFilesDirectoryUnderscorePrefixes() const;
     const std::vector<std::string> &skipRBIExportEnforcementDirs() const;
 
     const std::string_view errorHint() const;
 
 private:
     std::vector<NameRef> secondaryTestPackageNamespaceRefs_;
-    std::vector<std::string> extraPackageFilesDirectoryPrefixes_;
+    std::vector<std::string> extraPackageFilesDirectoryUnderscorePrefixes_;
     std::string errorHint_;
     std::vector<std::string> skipRBIExportEnforcementDirs_;
 

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -377,8 +377,9 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
     options.add_options("advanced")("stripe-packages-hint-message",
                                     "Optional hint message to add to packaging related errors",
                                     cxxopts::value<string>()->default_value(""));
-    options.add_options("dev")("extra-package-files-directory-prefix",
-                               "Extra parent directories which contain package files. "
+    options.add_options("dev")("extra-package-files-directory-prefix-underscore",
+                               "Extra parent directories which contain package files. These paths use an underscore "
+                               "package-munging convention, i.e. 'Opus_Foo'."
                                "This option must be used in conjunction with --stripe-packages",
                                cxxopts::value<vector<string>>(), "string");
     options.add_options("dev")(
@@ -930,14 +931,14 @@ void readOptions(Options &opts,
         }
         opts.stripeMode = raw["stripe-mode"].as<bool>();
         opts.stripePackages = raw["stripe-packages"].as<bool>();
-        if (raw.count("extra-package-files-directory-prefix")) {
-            for (const string &dirName : raw["extra-package-files-directory-prefix"].as<vector<string>>()) {
+        if (raw.count("extra-package-files-directory-prefix-underscore")) {
+            for (const string &dirName : raw["extra-package-files-directory-prefix-underscore"].as<vector<string>>()) {
                 if (dirName.back() != '/') {
-                    logger->error(
-                        "--extra-package-files-directory-prefix directory path must have slash (/) at the end");
+                    logger->error("--extra-package-files-directory-prefix-underscore directory path must have slash "
+                                  "(/) at the end");
                     throw EarlyReturnWithCode(1);
                 }
-                opts.extraPackageFilesDirectoryPrefixes.emplace_back(dirName);
+                opts.extraPackageFilesDirectoryUnderscorePrefixes.emplace_back(dirName);
             }
         }
         if (raw.count("secondary-test-package-namespaces")) {

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -379,7 +379,12 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
                                     cxxopts::value<string>()->default_value(""));
     options.add_options("dev")("extra-package-files-directory-prefix-underscore",
                                "Extra parent directories which contain package files. These paths use an underscore "
-                               "package-munging convention, i.e. 'Opus_Foo'."
+                               "package-munging convention, i.e. 'Project_Foo'."
+                               "This option must be used in conjunction with --stripe-packages",
+                               cxxopts::value<vector<string>>(), "string");
+    options.add_options("dev")("extra-package-files-directory-prefix-slash",
+                               "Extra parent directories which contain package files. These paths use an underscore "
+                               "package-munging convention, i.e. 'project/foo'."
                                "This option must be used in conjunction with --stripe-packages",
                                cxxopts::value<vector<string>>(), "string");
     options.add_options("dev")(
@@ -939,6 +944,16 @@ void readOptions(Options &opts,
                     throw EarlyReturnWithCode(1);
                 }
                 opts.extraPackageFilesDirectoryUnderscorePrefixes.emplace_back(dirName);
+            }
+        }
+        if (raw.count("extra-package-files-directory-prefix-slash")) {
+            for (const string &dirName : raw["extra-package-files-directory-prefix-slash"].as<vector<string>>()) {
+                if (dirName.back() != '/') {
+                    logger->error("--extra-package-files-directory-prefix-slash directory path must have slash "
+                                  "(/) at the end");
+                    throw EarlyReturnWithCode(1);
+                }
+                opts.extraPackageFilesDirectorySlashPrefixes.emplace_back(dirName);
             }
         }
         if (raw.count("secondary-test-package-namespaces")) {

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -177,7 +177,7 @@ struct Options {
     bool stripeMode = false;
     bool stripePackages = false;
     std::string stripePackagesHint = "";
-    std::vector<std::string> extraPackageFilesDirectoryPrefixes;
+    std::vector<std::string> extraPackageFilesDirectoryUnderscorePrefixes;
     std::vector<std::string> secondaryTestPackageNamespaces;
     std::string typedSource = "";
     std::string cacheDir = "";

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -178,6 +178,7 @@ struct Options {
     bool stripePackages = false;
     std::string stripePackagesHint = "";
     std::vector<std::string> extraPackageFilesDirectoryUnderscorePrefixes;
+    std::vector<std::string> extraPackageFilesDirectorySlashPrefixes;
     std::vector<std::string> secondaryTestPackageNamespaces;
     std::string typedSource = "";
     std::string cacheDir = "";

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -731,7 +731,8 @@ vector<ast::ParsedFile> package(core::GlobalState &gs, vector<ast::ParsedFile> w
         {
             core::UnfreezeNameTable unfreezeToEnterPackagerOptionsGS(gs);
             core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = gs.unfreezePackages();
-            gs.setPackagerOptions(opts.secondaryTestPackageNamespaces, opts.extraPackageFilesDirectoryUnderscorePrefixes,
+            gs.setPackagerOptions(opts.secondaryTestPackageNamespaces,
+                                  opts.extraPackageFilesDirectoryUnderscorePrefixes,
                                   opts.extraPackageFilesDirectorySlashPrefixes,
                                   opts.packageSkipRBIExportEnforcementDirs, opts.stripePackagesHint);
         }

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -731,7 +731,7 @@ vector<ast::ParsedFile> package(core::GlobalState &gs, vector<ast::ParsedFile> w
         {
             core::UnfreezeNameTable unfreezeToEnterPackagerOptionsGS(gs);
             core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = gs.unfreezePackages();
-            gs.setPackagerOptions(opts.secondaryTestPackageNamespaces, opts.extraPackageFilesDirectoryPrefixes,
+            gs.setPackagerOptions(opts.secondaryTestPackageNamespaces, opts.extraPackageFilesDirectoryUnderscorePrefixes,
                                   opts.packageSkipRBIExportEnforcementDirs, opts.stripePackagesHint);
         }
         what = packager::Packager::run(gs, workers, move(what));

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -732,6 +732,7 @@ vector<ast::ParsedFile> package(core::GlobalState &gs, vector<ast::ParsedFile> w
             core::UnfreezeNameTable unfreezeToEnterPackagerOptionsGS(gs);
             core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = gs.unfreezePackages();
             gs.setPackagerOptions(opts.secondaryTestPackageNamespaces, opts.extraPackageFilesDirectoryUnderscorePrefixes,
+                                  opts.extraPackageFilesDirectorySlashPrefixes,
                                   opts.packageSkipRBIExportEnforcementDirs, opts.stripePackagesHint);
         }
         what = packager::Packager::run(gs, workers, move(what));

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -669,7 +669,9 @@ int realmain(int argc, char *argv[]) {
             {
                 core::UnfreezeNameTable unfreezeToEnterPackagerOptionsGS(*gs);
                 core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = gs->unfreezePackages();
-                gs->setPackagerOptions(opts.secondaryTestPackageNamespaces, opts.extraPackageFilesDirectoryUnderscorePrefixes, opts.extraPackageFilesDirectorySlashPrefixes,
+                gs->setPackagerOptions(opts.secondaryTestPackageNamespaces,
+                                       opts.extraPackageFilesDirectoryUnderscorePrefixes,
+                                       opts.extraPackageFilesDirectorySlashPrefixes,
                                        opts.packageSkipRBIExportEnforcementDirs, opts.stripePackagesHint);
             }
 

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -669,7 +669,7 @@ int realmain(int argc, char *argv[]) {
             {
                 core::UnfreezeNameTable unfreezeToEnterPackagerOptionsGS(*gs);
                 core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = gs->unfreezePackages();
-                gs->setPackagerOptions(opts.secondaryTestPackageNamespaces, opts.extraPackageFilesDirectoryPrefixes,
+                gs->setPackagerOptions(opts.secondaryTestPackageNamespaces, opts.extraPackageFilesDirectoryUnderscorePrefixes,
                                        opts.packageSkipRBIExportEnforcementDirs, opts.stripePackagesHint);
             }
 

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -669,7 +669,7 @@ int realmain(int argc, char *argv[]) {
             {
                 core::UnfreezeNameTable unfreezeToEnterPackagerOptionsGS(*gs);
                 core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = gs->unfreezePackages();
-                gs->setPackagerOptions(opts.secondaryTestPackageNamespaces, opts.extraPackageFilesDirectoryUnderscorePrefixes,
+                gs->setPackagerOptions(opts.secondaryTestPackageNamespaces, opts.extraPackageFilesDirectoryUnderscorePrefixes, opts.extraPackageFilesDirectorySlashPrefixes,
                                        opts.packageSkipRBIExportEnforcementDirs, opts.stripePackagesHint);
             }
 

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -13,6 +13,7 @@
 #include "core/Unfreeze.h"
 #include "core/errors/packager.h"
 #include "core/packages/PackageInfo.h"
+#include <cctype>
 #include <sys/stat.h>
 
 using namespace std;
@@ -1208,7 +1209,8 @@ struct PackageInfoFinder {
 template <typename ContextType>
 unique_ptr<PackageInfoImpl>
 runPackageInfoFinder(ContextType ctx, ast::ParsedFile &package,
-                     const vector<std::string> &extraPackageFilesDirectoryUnderscorePrefixes) {
+                     const vector<std::string> &extraPackageFilesDirectoryUnderscorePrefixes,
+                     const vector<std::string> &extraPackageFilesDirectorySlashPrefixes) {
     static_assert(is_same_v<ContextType, core::Context> || is_same_v<ContextType, core::MutableContext>);
     ENFORCE(package.file.exists());
     ENFORCE(package.file.data(ctx).isPackage());
@@ -1223,14 +1225,25 @@ runPackageInfoFinder(ContextType ctx, ast::ParsedFile &package,
     ast::TreeWalk::apply(ctx, finder, package.tree);
     finder.finalize(ctx);
     if (finder.info) {
-        const auto numPrefixes = extraPackageFilesDirectoryUnderscorePrefixes.size() + 1;
+        const auto numPrefixes =
+            extraPackageFilesDirectoryUnderscorePrefixes.size() + extraPackageFilesDirectorySlashPrefixes.size() + 1;
         finder.info->packagePathPrefixes.reserve(numPrefixes);
         finder.info->packagePathPrefixes.emplace_back(packageFilePath.substr(0, packageFilePath.find_last_of('/') + 1));
         const string_view shortName = finder.info->name.mangledName.shortName(ctx.state);
         const string_view dirNameFromShortName = shortName.substr(0, shortName.rfind(core::PACKAGE_SUFFIX));
 
         for (const string &prefix : extraPackageFilesDirectoryUnderscorePrefixes) {
+            // Project_Foo
             string additionalDirPath = absl::StrCat(prefix, dirNameFromShortName, "/");
+            finder.info->packagePathPrefixes.emplace_back(std::move(additionalDirPath));
+        }
+
+        for (const string &prefix : extraPackageFilesDirectorySlashPrefixes) {
+            // project/foo
+            auto slashMungedDirName = absl::StrReplaceAll(dirNameFromShortName, {{"_", "/"}});
+            std::transform(slashMungedDirName.begin(), slashMungedDirName.end(), slashMungedDirName.begin(),
+                           [](unsigned char c) { return std::tolower(c); });
+            string additionalDirPath = absl::StrCat(prefix, std::move(slashMungedDirName), "/");
             finder.info->packagePathPrefixes.emplace_back(std::move(additionalDirPath));
         }
     }
@@ -1305,7 +1318,8 @@ template <typename StateType> vector<ast::ParsedFile> rewriteFilesFast(StateType
             {
                 if constexpr (isMutableStateType) {
                     core::MutableContext ctx(gs, core::Symbols::root(), file.file);
-                    runPackageInfoFinder(ctx, file, gs.packageDB().extraPackageFilesDirectoryUnderscorePrefixes());
+                    runPackageInfoFinder(ctx, file, gs.packageDB().extraPackageFilesDirectoryUnderscorePrefixes(),
+                                         gs.packageDB().extraPackageFilesDirectorySlashPrefixes());
                 } else {
                     if (file.file.data(gs).strictLevel == core::StrictLevel::Ignore) {
                         // When we're running with an immutable GlobalState, we can't setIsPackage(false)
@@ -1313,7 +1327,8 @@ template <typename StateType> vector<ast::ParsedFile> rewriteFilesFast(StateType
                         continue;
                     }
                     core::Context ctx(gs, core::Symbols::root(), file.file);
-                    runPackageInfoFinder(ctx, file, gs.packageDB().extraPackageFilesDirectoryUnderscorePrefixes());
+                    runPackageInfoFinder(ctx, file, gs.packageDB().extraPackageFilesDirectoryUnderscorePrefixes(),
+                                         gs.packageDB().extraPackageFilesDirectorySlashPrefixes());
                 }
             }
             // Re-write imports and exports:
@@ -1356,7 +1371,8 @@ vector<ast::ParsedFile> Packager::findPackages(core::GlobalState &gs, WorkerPool
             }
 
             core::MutableContext ctx(gs, core::Symbols::root(), file.file);
-            auto pkg = runPackageInfoFinder(ctx, file, gs.packageDB().extraPackageFilesDirectoryUnderscorePrefixes());
+            auto pkg = runPackageInfoFinder(ctx, file, gs.packageDB().extraPackageFilesDirectoryUnderscorePrefixes(),
+                                            gs.packageDB().extraPackageFilesDirectorySlashPrefixes());
             if (pkg == nullptr) {
                 // There was an error creating a PackageInfoImpl for this file, and getPackageInfo has already
                 // surfaced that error to the user. Nothing to do here.

--- a/test/cli/rbi-gen-single/other/Family/belcher.rb
+++ b/test/cli/rbi-gen-single/other/Family/belcher.rb
@@ -3,7 +3,7 @@
 module Family
 
   # This class exists outside of the top-level family tree, but is present in
-  # that package via the use of `--extra-package-files-directory-prefix`.
+  # that package via the use of `--extra-package-files-directory-prefix-underscore`.
   class Belcher
   end
 

--- a/test/cli/rbi-gen-single/test.sh
+++ b/test/cli/rbi-gen-single/test.sh
@@ -14,7 +14,7 @@ echo "-- sanity-checking package with --stripe-packages"
   --stripe-packages \
   --max-threads=0 \
   --dump-package-info="$rbis/package-info.json" \
-  --extra-package-files-directory-prefix="${test_path}/other/" \
+  --extra-package-files-directory-prefix-underscore="${test_path}/other/" \
   "$test_path" 2>&1 || true
 
 show_output() {
@@ -38,7 +38,7 @@ find . -name __package.rb | sort | while read -r package; do
     --ignore=__package.rb \
     --package-rbi-generation \
     --package-rbi-dir="$rbis" \
-    --extra-package-files-directory-prefix="${test_path}/other/" \
+    --extra-package-files-directory-prefix-underscore="${test_path}/other/" \
     --single-package="$name" "$test_path" 2>&1 || true
 
   show_output "$name" "RBI"                   "package.rbi"

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -53,6 +53,7 @@ const UnorderedMap<
         {"symbol-search", SymbolSearchAssertion::make},
         {"apply-rename", ApplyRenameAssertion::make},
         {"extra-package-files-directory-prefix-underscore", StringPropertyAssertion::make},
+        {"extra-package-files-directory-prefix-slash", StringPropertyAssertion::make},
         {"implementation", ImplementationAssertion::make},
         {"find-implementation", FindImplementationAssertion::make},
         {"show-symbol", ShowSymbolAssertion::make},

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -52,7 +52,7 @@ const UnorderedMap<
         {"no-stdlib", BooleanPropertyAssertion::make},
         {"symbol-search", SymbolSearchAssertion::make},
         {"apply-rename", ApplyRenameAssertion::make},
-        {"extra-package-files-directory-prefix", StringPropertyAssertion::make},
+        {"extra-package-files-directory-prefix-underscore", StringPropertyAssertion::make},
         {"implementation", ImplementationAssertion::make},
         {"find-implementation", FindImplementationAssertion::make},
         {"show-symbol", ShowSymbolAssertion::make},

--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -526,10 +526,15 @@ TEST_CASE("LSPTest") {
             BooleanPropertyAssertion::getValue("enable-experimental-requires-ancestor", assertions).value_or(false);
         opts->stripePackages = BooleanPropertyAssertion::getValue("enable-packager", assertions).value_or(false);
         if (opts->stripePackages) {
-            auto extraDir =
+            auto extraDirUnderscore =
                 StringPropertyAssertion::getValue("extra-package-files-directory-prefix-underscore", assertions);
-            if (extraDir.has_value()) {
-                opts->extraPackageFilesDirectoryUnderscorePrefixes.emplace_back(extraDir.value());
+            if (extraDirUnderscore.has_value()) {
+                opts->extraPackageFilesDirectoryUnderscorePrefixes.emplace_back(extraDirUnderscore.value());
+            }
+            auto extraDirSlash =
+                StringPropertyAssertion::getValue("extra-package-files-directory-prefix-slash", assertions);
+            if (extraDirSlash.has_value()) {
+                opts->extraPackageFilesDirectorySlashPrefixes.emplace_back(extraDirSlash.value());
             }
             opts->secondaryTestPackageNamespaces.emplace_back("Critic");
         }

--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -526,9 +526,10 @@ TEST_CASE("LSPTest") {
             BooleanPropertyAssertion::getValue("enable-experimental-requires-ancestor", assertions).value_or(false);
         opts->stripePackages = BooleanPropertyAssertion::getValue("enable-packager", assertions).value_or(false);
         if (opts->stripePackages) {
-            auto extraDir = StringPropertyAssertion::getValue("extra-package-files-directory-prefix", assertions);
+            auto extraDir =
+                StringPropertyAssertion::getValue("extra-package-files-directory-prefix-underscore", assertions);
             if (extraDir.has_value()) {
-                opts->extraPackageFilesDirectoryPrefixes.emplace_back(extraDir.value());
+                opts->extraPackageFilesDirectoryUnderscorePrefixes.emplace_back(extraDir.value());
             }
             opts->secondaryTestPackageNamespaces.emplace_back("Critic");
         }

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -409,20 +409,26 @@ TEST_CASE("PerPhaseTest") { // NOLINT
     }
 
     if (enablePackager) {
-        vector<std::string> extraPackageFilesDirectoryPrefixes;
+        vector<std::string> extraPackageFilesDirectoryUnderscorePrefixes;
         vector<std::string> secondaryTestPackageNamespaces = {"Critic"};
         vector<std::string> skipRBIExportEnforcementDirs;
 
-        auto extraDir = StringPropertyAssertion::getValue("extra-package-files-directory-prefix", assertions);
+        auto extraDir =
+            StringPropertyAssertion::getValue("extra-package-files-directory-prefix-underscore", assertions);
         if (extraDir.has_value()) {
-            extraPackageFilesDirectoryPrefixes.emplace_back(extraDir.value());
+            extraPackageFilesDirectoryUnderscorePrefixes.emplace_back(extraDir.value());
         }
 
         {
             core::UnfreezeNameTable packageNS(*gs);
             core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = gs->unfreezePackages();
+<<<<<<< HEAD
             gs->setPackagerOptions(secondaryTestPackageNamespaces, extraPackageFilesDirectoryPrefixes,
                                    skipRBIExportEnforcementDirs, "PACKAGE_ERROR_HINT");
+=======
+            gs->setPackagerOptions(secondaryTestPackageNamespaces, extraPackageFilesDirectoryUnderscorePrefixes,
+                                   "PACKAGE_ERROR_HINT");
+>>>>>>> d9373953a (Change extra-package-paths-directory-prefix to extra-package-directory-paths-directory-prefix-underscore)
         }
 
         // Packager runs over all trees.

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -410,25 +410,27 @@ TEST_CASE("PerPhaseTest") { // NOLINT
 
     if (enablePackager) {
         vector<std::string> extraPackageFilesDirectoryUnderscorePrefixes;
+        vector<std::string> extraPackageFilesDirectorySlashPrefixes;
         vector<std::string> secondaryTestPackageNamespaces = {"Critic"};
         vector<std::string> skipRBIExportEnforcementDirs;
 
-        auto extraDir =
+        auto extraDirUnderscore =
             StringPropertyAssertion::getValue("extra-package-files-directory-prefix-underscore", assertions);
-        if (extraDir.has_value()) {
-            extraPackageFilesDirectoryUnderscorePrefixes.emplace_back(extraDir.value());
+        if (extraDirUnderscore.has_value()) {
+            extraPackageFilesDirectoryUnderscorePrefixes.emplace_back(extraDirUnderscore.value());
+        }
+
+        auto extraDirSlash =
+            StringPropertyAssertion::getValue("extra-package-files-directory-prefix-slash", assertions);
+        if (extraDirSlash.has_value()) {
+            extraPackageFilesDirectorySlashPrefixes.emplace_back(extraDirSlash.value());
         }
 
         {
             core::UnfreezeNameTable packageNS(*gs);
             core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = gs->unfreezePackages();
-<<<<<<< HEAD
-            gs->setPackagerOptions(secondaryTestPackageNamespaces, extraPackageFilesDirectoryPrefixes,
-                                   skipRBIExportEnforcementDirs, "PACKAGE_ERROR_HINT");
-=======
-            gs->setPackagerOptions(secondaryTestPackageNamespaces, extraPackageFilesDirectoryUnderscorePrefixes,
+            gs->setPackagerOptions(secondaryTestPackageNamespaces, extraPackageFilesDirectoryUnderscorePrefixes, extraPackageFilesDirectorySlashPrefixes,
                                    "PACKAGE_ERROR_HINT");
->>>>>>> d9373953a (Change extra-package-paths-directory-prefix to extra-package-directory-paths-directory-prefix-underscore)
         }
 
         // Packager runs over all trees.

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -429,8 +429,8 @@ TEST_CASE("PerPhaseTest") { // NOLINT
         {
             core::UnfreezeNameTable packageNS(*gs);
             core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = gs->unfreezePackages();
-            gs->setPackagerOptions(secondaryTestPackageNamespaces, extraPackageFilesDirectoryUnderscorePrefixes, extraPackageFilesDirectorySlashPrefixes, {},
-                                   "PACKAGE_ERROR_HINT");
+            gs->setPackagerOptions(secondaryTestPackageNamespaces, extraPackageFilesDirectoryUnderscorePrefixes,
+                                   extraPackageFilesDirectorySlashPrefixes, {}, "PACKAGE_ERROR_HINT");
         }
 
         // Packager runs over all trees.

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -429,7 +429,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
         {
             core::UnfreezeNameTable packageNS(*gs);
             core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = gs->unfreezePackages();
-            gs->setPackagerOptions(secondaryTestPackageNamespaces, extraPackageFilesDirectoryUnderscorePrefixes, extraPackageFilesDirectorySlashPrefixes,
+            gs->setPackagerOptions(secondaryTestPackageNamespaces, extraPackageFilesDirectoryUnderscorePrefixes, extraPackageFilesDirectorySlashPrefixes, {},
                                    "PACKAGE_ERROR_HINT");
         }
 

--- a/test/testdata/packager/extra_package_paths/bar/__package.rb
+++ b/test/testdata/packager/extra_package_paths/bar/__package.rb
@@ -3,6 +3,7 @@
 # typed: strict
 # enable-packager: true
 # extra-package-files-directory-prefix-underscore: test/testdata/packager/extra_package_paths/extra/
+# extra-package-files-directory-prefix-slash: test/testdata/packager/extra_package_paths/extra_slash/
 
 class Project::Bar < PackageSpec
   import Project::Foo

--- a/test/testdata/packager/extra_package_paths/bar/__package.rb
+++ b/test/testdata/packager/extra_package_paths/bar/__package.rb
@@ -2,7 +2,7 @@
 
 # typed: strict
 # enable-packager: true
-# extra-package-files-directory-prefix: test/testdata/packager/extra_package_paths/extra/
+# extra-package-files-directory-prefix-underscore: test/testdata/packager/extra_package_paths/extra/
 
 class Project::Bar < PackageSpec
   import Project::Foo

--- a/test/testdata/packager/extra_package_paths/bar/bar.rb
+++ b/test/testdata/packager/extra_package_paths/bar/bar.rb
@@ -8,10 +8,12 @@ class Project::Bar::Bar
   sig { void }
   def bar1
     Project::Foo::B.b
+    Project::Foo::D.d
   end
 
   sig { void }
   def bar2
     Project::Baz::Package::C.c
+    Project::Baz::Package::E.e
   end
 end

--- a/test/testdata/packager/extra_package_paths/baz/__package.rb
+++ b/test/testdata/packager/extra_package_paths/baz/__package.rb
@@ -4,4 +4,5 @@
 
 class Project::Baz::Package < PackageSpec
   export Project::Baz::Package::C
+  export Project::Baz::Package::E
 end

--- a/test/testdata/packager/extra_package_paths/extra_slash/project/baz/package/e.rb
+++ b/test/testdata/packager/extra_package_paths/extra_slash/project/baz/package/e.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# typed: strict
+
+module Project::Baz::Package
+  class E
+    extend T::Sig
+
+    sig { void }
+    def self.e; end
+  end
+end
+

--- a/test/testdata/packager/extra_package_paths/extra_slash/project/foo/d.rb
+++ b/test/testdata/packager/extra_package_paths/extra_slash/project/foo/d.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# typed: strict
+
+class Project::Foo::D
+  extend T::Sig
+
+  sig { void }
+  def self.d; end
+end
+

--- a/test/testdata/packager/extra_package_paths/foo/__package.rb
+++ b/test/testdata/packager/extra_package_paths/foo/__package.rb
@@ -4,4 +4,5 @@
 
 class Project::Foo < PackageSpec
   export Project::Foo::B
+  export Project::Foo::D
 end

--- a/test/testdata/packager/extra_package_paths/pass.package-tree.exp
+++ b/test/testdata/packager/extra_package_paths/pass.package-tree.exp
@@ -14,7 +14,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def bar1<<todo method>>(&<blk>)
-      <emptyTree>::<C Project>::<C Foo>::<C B>.b()
+      begin
+        <emptyTree>::<C Project>::<C Foo>::<C B>.b()
+        <emptyTree>::<C Project>::<C Foo>::<C D>.d()
+      end
     end
 
     ::Sorbet::Private::Static.sig(<self>) do ||
@@ -22,7 +25,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def bar2<<todo method>>(&<blk>)
-      <emptyTree>::<C Project>::<C Baz>::<C Package>::<C C>.c()
+      begin
+        <emptyTree>::<C Project>::<C Baz>::<C Package>::<C C>.c()
+        <emptyTree>::<C Project>::<C Baz>::<C Package>::<C E>.e()
+      end
     end
 
     <self>.extend(<emptyTree>::<C T>::<C Sig>)
@@ -36,6 +42,8 @@ end
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C <PackageSpecRegistry>>::<C Project>::<C Baz>::<C Package><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.export(::<root>::<C Project>::<C Baz>::<C Package>::<C C>)
+
+    <self>.export(::<root>::<C Project>::<C Baz>::<C Package>::<C E>)
   end
 end
 # -- test/testdata/packager/extra_package_paths/extra/Project_Baz_Package/c.rb --
@@ -72,9 +80,45 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <runtime method definition of self.b>
   end
 end
+# -- test/testdata/packager/extra_package_paths/extra_slash/project/baz/package/e.rb --
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C Project>::<C Baz>::<C Package><<C <todo sym>>> < ()
+    class <emptyTree>::<C E><<C <todo sym>>> < (::<todo sym>)
+      ::Sorbet::Private::Static.sig(<self>) do ||
+        <self>.void()
+      end
+
+      def self.e<<todo method>>(&<blk>)
+        <emptyTree>
+      end
+
+      <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+      <runtime method definition of self.e>
+    end
+  end
+end
+# -- test/testdata/packager/extra_package_paths/extra_slash/project/foo/d.rb --
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C Project>::<C Foo>::<C D><<C <todo sym>>> < (::<todo sym>)
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.void()
+    end
+
+    def self.d<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+    <runtime method definition of self.d>
+  end
+end
 # -- test/testdata/packager/extra_package_paths/foo/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C <PackageSpecRegistry>>::<C Project>::<C Foo><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.export(::<root>::<C Project>::<C Foo>::<C B>)
+
+    <self>.export(::<root>::<C Project>::<C Foo>::<C D>)
   end
 end

--- a/tools/scripts/update_testdata_exp.sh
+++ b/tools/scripts/update_testdata_exp.sh
@@ -131,10 +131,10 @@ for this_src in "${rb_src[@]}" DUMMY; do
         extra_prefixes=()
         while IFS='' read -r prefix; do
           extra_prefixes+=("$prefix")
-        done < <(grep '# extra-package-files-directory-prefix: ' "${srcs[@]}" | sort | awk -F': ' '{print $2}')
+        done < <(grep '# extra-package-files-directory-prefix-underscore: ' "${srcs[@]}" | sort | awk -F': ' '{print $2}')
         if [ "${#extra_prefixes[@]}" -gt 0 ]; then
           for prefix in "${extra_prefixes[@]}"; do
-            args+=("--extra-package-files-directory-prefix" "${prefix}")
+            args+=("--extra-package-files-directory-prefix-underscore" "${prefix}")
           done
         fi
       fi


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Adds support for slash-munged "extra package paths" (i.e. `.../project/foo/...`, as opposed to underscore-munged `.../Project_Foo/...` in `--stripe-packages` mode).

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Due to some changes we are making in the Stripe codebase, we need to support additional package paths which are lower case and munged with slashes instead of uppercase and munged with underscores.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Tested on Stripe codebase.
