### PR TITLE
Move DB version check into each cache flavor

### DIFF
--- a/common/kvstore/KeyValueStore-emscripten.cc
+++ b/common/kvstore/KeyValueStore-emscripten.cc
@@ -49,7 +49,7 @@ KeyValueStoreValue OwnedKeyValueStore::read(string_view key) const {
     throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
 }
 
-void OwnedKeyValueStore::clearAll() {
+void OwnedKeyValueStore::checkVersions() {
     throw_mdb_error("creating databases isn't supported on emscripten"sv, 0);
 }
 

--- a/common/kvstore/KeyValueStore.cc
+++ b/common/kvstore/KeyValueStore.cc
@@ -170,7 +170,11 @@ int OwnedKeyValueStore::commit() {
 
     int rc = 0;
     for (auto &txn : txnState->readers) {
-        rc = mdb_txn_commit(txn.second) || rc;
+        auto rci = mdb_txn_commit(txn.second);
+        if (rc != 0) {
+            // Take the first non-zero rc
+            rc = rci;
+        }
     }
     txnState->readers.clear();
     txnState->txn = nullptr;

--- a/common/kvstore/KeyValueStore.cc
+++ b/common/kvstore/KeyValueStore.cc
@@ -23,7 +23,7 @@ struct OwnedKeyValueStore::TxnState {
 namespace {
 
 [[noreturn]] void throw_mdb_error(string_view what, int err, string_view path) {
-    fmt::print(stderr, "sorbet mdb error: what=\"{}\" mdb_error=\"{}\" cache_path=\"{}\"", what, mdb_strerror(err),
+    fmt::print(stderr, "sorbet mdb error: what=\"{}\" mdb_error=\"{}\" cache_path=\"{}\"\n", what, mdb_strerror(err),
                path);
     throw invalid_argument(string(what));
 }

--- a/common/kvstore/KeyValueStore.cc
+++ b/common/kvstore/KeyValueStore.cc
@@ -9,7 +9,6 @@
 
 using namespace std;
 namespace sorbet {
-constexpr string_view OLD_VERSION_KEY = "VERSION"sv;
 constexpr string_view VERSION_KEY = "DB_FORMAT_VERSION"sv;
 struct KeyValueStore::DBState {
     MDB_env *env;
@@ -131,9 +130,6 @@ OwnedKeyValueStore::OwnedKeyValueStore(unique_ptr<KeyValueStore> kvstore)
     // Writer thread may have changed; reset the primary transaction.
     refreshMainTransaction();
     {
-        if (read(OLD_VERSION_KEY).data != nullptr) { // remove databases that use old(non-string) versioning scheme.
-            clearAll();
-        }
         auto dbVersion = readString(VERSION_KEY);
         if (!dbVersion.has_value() || dbVersion != this->kvstore->version) {
             clearAll();

--- a/common/kvstore/KeyValueStore.h
+++ b/common/kvstore/KeyValueStore.h
@@ -68,7 +68,7 @@ class OwnedKeyValueStore final {
     mutable absl::Mutex readers_mtx;
 
     void writeInternal(std::string_view key, void *value, size_t len);
-    void clearAll();
+    void checkVersions();
     void refreshMainTransaction();
     int commit();
     void abort() const;

--- a/common/kvstore/test/kvstore_test.cc
+++ b/common/kvstore/test/kvstore_test.cc
@@ -1,13 +1,13 @@
 #include "doctest.h"
 // has to go first as it violates our requirements
 #include "spdlog/spdlog.h"
-// has to go above null_sink.h; this comment prevents reordering.
+// has to go above stdout_sinks.h; this comment prevents reordering.
 #include "absl/strings/str_split.h" // For StripAsciiWhitespace
 #include "absl/synchronization/notification.h"
 #include "common/FileOps.h"
 #include "common/common.h"
 #include "common/kvstore/KeyValueStore.h"
-#include "spdlog/sinks/null_sink.h"
+#include "spdlog/sinks/stdout_sinks.h"
 
 using namespace std;
 using namespace sorbet;
@@ -16,9 +16,11 @@ string exec(string cmd);
 
 TEST_CASE("kvstore") {
     const string directory(absl::StripAsciiWhitespace(exec("mktemp -d")));
-    const auto sink = make_shared<spdlog::sinks::null_sink_mt>();
-    const auto logger = make_shared<spdlog::logger>("null", sink);
-    auto maxSize = 4096 * 10;
+    const auto sink = make_shared<spdlog::sinks::stderr_sink_mt>();
+    const auto logger = make_shared<spdlog::logger>("test", sink);
+    // Uncomment this for debugging (or copy it into the test case you care about)
+    // logger->set_level(spdlog::level::trace);
+    auto maxSize = 4096 * 20;
 
     SUBCASE("CommitsChangesToDisk") {
         {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This means that two flavors with the current (correct) DB version can both
live in the cache at the same time.

It also means that we can't get into a situation like this, which happened
in the real world before this PR:

- sorbet v1: before all this (d02221d98)
- sorbet v2: bad beta change (fc3cf7a57)
- sorbet v3: bad beta change + evict all flavors (dca4abd96)
- sorbet v4: evict all flavors (a485c5966)

steps:

1.  sorbet runs using v4, populates `default` flavor to shared cache
2.  an old branch runs, using v2 specifically, no cache eviction
    happens because it wasn't implemented yet. the `dsl-normalfastpath`
    flavor is created.
3.  build runs using v4. it sees that `default` flavor has the expected
    version (v4) and doesn't evict `dsl-normalfastpath`

This new change makes it so that a cache will only ever be as big all the
flavors for the current sorbet version require it to be, making cache
eviction simpler to reason about because now any version change blows away
all other versions in the cache (this was our mental model of what happened
before but it wasn't quite right in the presence of multiple flavors in the
database, as listed above).

It _does_ mean that if a given Sorbet version attempts to store multiple
flavors concurrently, the database now has to make sure there's enough
space for _all_ flavors to coexist, whereas the changes in #5974 would have
only let a given Sorbet version have one flavor in the database
(there could still be multiple flavors if they were for different
versions).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

```bash
alias sbr="./bazel build //main:sorbet --config=release-linux"
echo "puts 'Hello, world'" > foo.rb

sbr && sorbet --cache-dir=jez-cache foo.rb
python -mlmdb --env jez-cache dump
less -f -F -X main.cdbmake
# +7,48:default->^@^@^@^@^@^@^A^@^@^@^@^@^@^@^@^@^A^@^@^@^@^@^@^@o^B^@^@^@^@^@^@^D^@^@^@^@^@^@^@^K^@^@^@^@^@^@^@
#

git checkout fc3cf7a57 # Adding, changing, or removing a method takes the fast path (#5808)

sbr && sorbet --cache-dir=jez-cache foo.rb
python -mlmdb --env jez-cache dump
less -f -F -X main.cdbmake
# +7,48:default->^@^@^@^@^@^@^A^@^@^@^@^@^@^@^@^@^A^@^@^@^@^@^@^@o^B^@^@^@^@^@^@^D^@^@^@^@^@^@^@^K^@^@^@^@^@^@^@
# +18,48:dsl-normalfastpath->^@^@^@^@^@^@^A^@^@^@^@^@^@^@^@^@^A^@^@^@^@^@^@^@<8A>^B^@^@^@^@^@^@^D^@^@^@^@^@^@^@^V^@^@^@^@^@^@^@
#

git checkout -

sbr && sorbet --cache-dir=jez-cache foo.rb
python -mlmdb --env jez-cache dump
less -f -F -X main.cdbmake
# +7,48:default->^@^@^@^@^@^@^A^@^@^@^@^@^@^@^@^@^A^@^@^@^@^@^@^@o^B^@^@^@^@^@^@^D^@^@^@^@^@^@^@^K^@^@^@^@^@^@^@
#
```

Before this change, this would not have deleted `dsl-normalfastpath`.

- - - - -

Not listed, but I also tested, using a similar method, that for a fixed release, both flavors are allowed to remain in the cache.