### PR TITLE
Revert "Revert "Adding, changing, or removing a method takes the fast path (#5808)" (#5978)"

### DIFF
--- a/core/FileHash.cc
+++ b/core/FileHash.cc
@@ -6,9 +6,40 @@
 
 using namespace std;
 namespace sorbet::core {
+namespace {
+
+// We use 0 to signal whether the hash is defined (see isDefined in the header)
 uint32_t incZero(uint32_t a) {
     return a == 0 ? 1 : a;
 };
+
+uint32_t hashFullNameRef(const GlobalState &gs, NameRef nm) {
+    uint32_t result;
+    auto kind = nm.kind();
+
+    switch (kind) {
+        case NameKind::UTF8: {
+            result = _hash(nm.dataUtf8(gs)->utf8);
+            break;
+        }
+        case NameKind::CONSTANT: {
+            result = hashFullNameRef(gs, nm.dataCnst(gs)->original);
+            break;
+        }
+        case NameKind::UNIQUE: {
+            auto data = nm.dataUnique(gs);
+            auto hashedUniqueNameKind = static_cast<underlying_type<UniqueNameKind>::type>(data->uniqueNameKind);
+            result = mix(mix(hashFullNameRef(gs, data->original), data->num), hashedUniqueNameKind);
+            break;
+        }
+    }
+
+    auto hashedKind = static_cast<underlying_type<NameKind>::type>(kind);
+    return mix(result, hashedKind);
+}
+
+} // namespace
+
 ShortNameHash::ShortNameHash(const GlobalState &gs, NameRef nm) : _hashValue(incZero(_hash(nm.shortName(gs)))){};
 
 void ShortNameHash::sortAndDedupe(std::vector<core::ShortNameHash> &hashes) {
@@ -16,7 +47,26 @@ void ShortNameHash::sortAndDedupe(std::vector<core::ShortNameHash> &hashes) {
     hashes.resize(std::distance(hashes.begin(), std::unique(hashes.begin(), hashes.end())));
 }
 
-FileHash::FileHash(LocalSymbolTableHashes &&localSymbolTableHashes, UsageHash &&usages)
-    : localSymbolTableHashes(move(localSymbolTableHashes)), usages(move(usages)) {}
+FullNameHash::FullNameHash(const GlobalState &gs, NameRef nm) : _hashValue(incZero(hashFullNameRef(gs, nm))) {}
+
+void FullNameHash::sortAndDedupe(std::vector<core::FullNameHash> &hashes) {
+    fast_sort(hashes);
+    hashes.resize(std::distance(hashes.begin(), std::unique(hashes.begin(), hashes.end())));
+}
+
+void FoundMethodHash::sanityCheck() const {
+    ENFORCE(nameHash.isDefined());
+}
+
+string FoundMethodHash::toString() const {
+    return fmt::format("FoundMethodHash {{ owner.idx = {}, owner.useSingletonClass = {}, nameHash = {}, "
+                       "arityHash = {}, isSelfMethod = {} }}",
+                       owner.idx, owner.useSingletonClass, nameHash._hashValue, arityHash._hashValue);
+}
+
+FileHash::FileHash(LocalSymbolTableHashes &&localSymbolTableHashes, UsageHash &&usages,
+                   FoundMethodHashes &&foundMethodHashes)
+    : localSymbolTableHashes(move(localSymbolTableHashes)), usages(move(usages)),
+      foundMethodHashes(move(foundMethodHashes)) {}
 
 } // namespace sorbet::core

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -169,6 +169,9 @@ public:
 
     void mangleRenameSymbol(SymbolRef what, NameRef origName);
     void mangleRenameForOverload(SymbolRef what, NameRef origName);
+    // NOTE: You likely want to use mangleRenameSymbol not deleteMethodSymbol, unless you know what you're doing.
+    // See the comment on the implementation for more.
+    void deleteMethodSymbol(MethodRef what);
     spdlog::logger &tracer() const;
     unsigned int namesUsedTotal() const;
     unsigned int utf8NamesUsed() const;
@@ -283,6 +286,9 @@ public:
 
     // If 'true', enforce use of Ruby 3.0-style keyword args.
     bool ruby3KeywordArgs = false;
+
+    // If 'true', enable the experimental, symbol-deletion-based fast path mode
+    bool lspExperimentalFastPathEnabled = false;
 
     // When present, this indicates that single-package rbi generation is being performed, and contains metadata about
     // the packages that are imported by the one whose interface is being generated.

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -2207,7 +2207,8 @@ uint32_t ClassOrModule::hash(const GlobalState &gs) const {
                 continue;
             }
 
-            if (e.second.isMethod() && e.second.asMethodRef().data(gs)->ignoreInHashing(gs)) {
+            if (e.second.isMethod() &&
+                (gs.lspExperimentalFastPathEnabled || e.second.asMethodRef().data(gs)->ignoreInHashing(gs))) {
                 continue;
             }
 
@@ -2416,6 +2417,11 @@ void Method::addLoc(const core::GlobalState &gs, core::Loc loc) {
     }
 
     addLocInternal(gs, loc, this->loc(), locs_);
+}
+
+void Method::removeLocsForFile(core::FileRef file) {
+    auto it = remove_if(locs_.begin(), locs_.end(), [&](const auto loc) { return loc.file() == file; });
+    locs_.erase(it, locs_.end());
 }
 
 void Field::addLoc(const core::GlobalState &gs, core::Loc loc) {

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -40,11 +40,16 @@ enum class Visibility : uint8_t {
 };
 
 class Method final {
-public:
     friend class ClassOrModule;
+    friend class GlobalState;
     friend class serialize::SerializerImpl;
 
+    // This is to allow updating `GlobalState::methods` in place with a new method, over top of an existing method
+    Method &operator=(Method &&) = default;
+
+public:
     Method(const Method &) = delete;
+    Method &operator=(const Method &) = delete;
     Method() = default;
     Method(Method &&) noexcept = default;
     class Flags {
@@ -83,6 +88,7 @@ public:
     Loc loc() const;
     const InlinedVector<Loc, 2> &locs() const;
     void addLoc(const core::GlobalState &gs, core::Loc loc);
+    void removeLocsForFile(core::FileRef file);
     uint32_t hash(const GlobalState &gs) const;
     uint32_t methodShapeHash(const GlobalState &gs) const;
     ArityHash methodArityHash(const GlobalState &gs) const;

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -254,6 +254,13 @@ void SerializerImpl::pickle(Pickler &p, shared_ptr<const FileHash> fh) {
     for (const auto &e : fh->usages.nameHashes) {
         p.putU4(e._hashValue);
     }
+    p.putU4(fh->foundMethodHashes.size());
+    for (const auto &fdh : fh->foundMethodHashes) {
+        p.putU4(fdh.owner.idx);
+        p.putU1(fdh.owner.useSingletonClass);
+        p.putU4(fdh.nameHash._hashValue);
+        p.putU4(fdh.arityHash._hashValue);
+    }
 }
 
 unique_ptr<const FileHash> SerializerImpl::unpickleFileHash(UnPickler &p) {
@@ -284,6 +291,17 @@ unique_ptr<const FileHash> SerializerImpl::unpickleFileHash(UnPickler &p) {
         ShortNameHash key;
         key._hashValue = p.getU4();
         ret.usages.nameHashes.emplace_back(key);
+    }
+    auto foundMethodHashesSize = p.getU4();
+    ret.foundMethodHashes.reserve(foundMethodHashesSize);
+    for (int it = 0; it < foundMethodHashesSize; it++) {
+        auto ownerIdx = p.getU4();
+        auto useSingletonClass = p.getU1();
+        FullNameHash fullNameHash;
+        fullNameHash._hashValue = p.getU4();
+        ArityHash arityHash;
+        arityHash._hashValue = p.getU4();
+        ret.foundMethodHashes.emplace_back(ownerIdx, useSingletonClass, fullNameHash, arityHash);
     }
     return make_unique<const FileHash>(move(ret));
 }

--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -69,7 +69,8 @@ unique_ptr<core::FileHash> computeFileHashForAST(spdlog::logger &logger, unique_
             auto view = string_view{result.GetString(), result.GetLength()};
             logger.debug(view);
 
-            return make_unique<core::FileHash>(core::LocalSymbolTableHashes::invalidParse(), move(usageHash));
+            return make_unique<core::FileHash>(core::LocalSymbolTableHashes::invalidParse(), move(usageHash),
+                                               core::FoundMethodHashes{});
         }
     }
 
@@ -77,9 +78,10 @@ unique_ptr<core::FileHash> computeFileHashForAST(spdlog::logger &logger, unique_
     single.emplace_back(move(file));
 
     auto workers = WorkerPool::create(0, lgs->tracer());
-    realmain::pipeline::resolve(lgs, move(single), opts(), *workers);
+    core::FoundMethodHashes foundMethodHashes; // out parameter
+    realmain::pipeline::resolve(lgs, move(single), opts(), *workers, &foundMethodHashes);
 
-    return make_unique<core::FileHash>(move(*lgs->hash()), move(usageHash));
+    return make_unique<core::FileHash>(move(*lgs->hash()), move(usageHash), move(foundMethodHashes));
 }
 
 // Note: lgs is an outparameter.
@@ -88,6 +90,7 @@ core::FileRef makeEmptyGlobalStateForFile(spdlog::logger &logger, shared_ptr<cor
                                           const realmain::options::Options &hashingOpts) {
     lgs = core::GlobalState::makeEmptyGlobalStateForHashing(logger);
     lgs->requiresAncestorEnabled = hashingOpts.requiresAncestorEnabled;
+    lgs->lspExperimentalFastPathEnabled = hashingOpts.lspExperimentalFastPathEnabled;
     {
         core::UnfreezeFileTable fileTableAccess(*lgs);
         auto fref = lgs->enterFile(forWhat);

--- a/infer/test/infer_test.cc
+++ b/infer/test/infer_test.cc
@@ -41,7 +41,8 @@ void processSource(core::GlobalState &cb, string str) {
     vector<ast::ParsedFile> trees;
     trees.emplace_back(move(tree));
     auto workers = WorkerPool::create(0, *logger);
-    trees = move(namer::Namer::run(cb, move(trees), *workers).result());
+    core::FoundMethodHashes foundMethodHashes; // compute this just for test coverage
+    trees = move(namer::Namer::run(cb, move(trees), *workers, &foundMethodHashes).result());
     auto resolved = resolver::Resolver::run(cb, move(trees), *workers);
     for (auto &tree : resolved.result()) {
         sorbet::core::MutableContext ctx(cb, core::Symbols::root(), tree.file);

--- a/main/cache/cache.cc
+++ b/main/cache/cache.cc
@@ -13,9 +13,10 @@ unique_ptr<OwnedKeyValueStore> maybeCreateKeyValueStore(shared_ptr<::spdlog::log
     if (opts.cacheDir.empty()) {
         return nullptr;
     }
+    auto flavor = fmt::format("{}-{}", opts.skipRewriterPasses ? "nodsl" : "dsl",
+                              opts.lspExperimentalFastPathEnabled ? "experimentalfastpath" : "normalfastpath");
     return make_unique<OwnedKeyValueStore>(make_unique<KeyValueStore>(logger, sorbet_full_version_string, opts.cacheDir,
-                                                                      opts.skipRewriterPasses ? "nodsl" : "default",
-                                                                      opts.maxCacheSizeBytes));
+                                                                      move(flavor), opts.maxCacheSizeBytes));
 }
 
 unique_ptr<OwnedKeyValueStore> ownIfUnchanged(const core::GlobalState &gs, unique_ptr<KeyValueStore> kvstore) {

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -241,103 +241,108 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
     // Replace error queue with one that is owned by this thread.
     gs->errorQueue = make_shared<core::ErrorQueue>(gs->errorQueue->logger, gs->errorQueue->tracer, errorFlusher);
     {
-        vector<core::SymbolHash> changedMethodSymbolHashes;
-        vector<core::SymbolHash> changedFieldSymbolHashes;
-        for (auto &updatedFile : updates.updatedFiles) {
-            auto fref = gs->findFileByPath(updatedFile->path());
-            // We don't support new files on the fast path. This enforce failing indicates a bug in our fast/slow
-            // path logic in LSPPreprocessor.
-            ENFORCE(fref.exists());
-            ENFORCE(updatedFile->getFileHash() != nullptr);
-            if (this->config->opts.stripePackages && updatedFile->isPackage()) {
-                // Only relevant in --stripe-packages mode. Package declarations do not have method
-                // hashes. Instead we rely on recomputing packages if any __package.rb source
-                // changes.
-                continue;
-            }
-            if (fref.exists()) {
-                // Update to existing file on fast path
-                ENFORCE(fref.data(*gs).getFileHash() != nullptr);
-                const auto &oldSymbolHashes = fref.data(*gs).getFileHash()->localSymbolTableHashes;
-                const auto &newSymbolHashes = updatedFile->getFileHash()->localSymbolTableHashes;
-                const auto &oldMethodHashes = oldSymbolHashes.methodHashes;
-                const auto &newMethodHashes = newSymbolHashes.methodHashes;
+        Timer timeit(config->logger, "compute_fast_path_file_set");
+        {
+            vector<core::SymbolHash> changedMethodSymbolHashes;
+            vector<core::SymbolHash> changedFieldSymbolHashes;
+            for (auto &updatedFile : updates.updatedFiles) {
+                auto fref = gs->findFileByPath(updatedFile->path());
+                // We don't support new files on the fast path. This enforce failing indicates a bug in our fast/slow
+                // path logic in LSPPreprocessor.
+                ENFORCE(fref.exists());
+                ENFORCE(updatedFile->getFileHash() != nullptr);
+                if (this->config->opts.stripePackages && updatedFile->isPackage()) {
+                    // Only relevant in --stripe-packages mode. Package declarations do not have method
+                    // hashes. Instead we rely on recomputing packages if any __package.rb source
+                    // changes.
+                    continue;
+                }
+                if (fref.exists()) {
+                    // Update to existing file on fast path
+                    ENFORCE(fref.data(*gs).getFileHash() != nullptr);
+                    const auto &oldSymbolHashes = fref.data(*gs).getFileHash()->localSymbolTableHashes;
+                    const auto &newSymbolHashes = updatedFile->getFileHash()->localSymbolTableHashes;
+                    const auto &oldMethodHashes = oldSymbolHashes.methodHashes;
+                    const auto &newMethodHashes = newSymbolHashes.methodHashes;
 
-                if (config->opts.lspExperimentalFastPathEnabled) {
-                    // Find which hashes changed. Note: methodHashes are sorted, so set_difference should work.
-                    // This will insert two entries into `changedMethodHashes` for each changed method, but they will
-                    // get deduped later.
-                    absl::c_set_symmetric_difference(oldMethodHashes, newMethodHashes,
-                                                     std::back_inserter(changedMethodSymbolHashes));
+                    if (config->opts.lspExperimentalFastPathEnabled) {
+                        // Find which hashes changed. Note: methodHashes are sorted, so set_difference should work.
+                        // This will insert two entries into `changedMethodHashes` for each changed method, but they
+                        // will get deduped later.
+                        absl::c_set_symmetric_difference(oldMethodHashes, newMethodHashes,
+                                                         std::back_inserter(changedMethodSymbolHashes));
 
-                    // Okay to `move` here (steals component of getFileHash) because we're about to use
-                    // replaceFile to clobber fref.data(*gs) anyways.
-                    oldFoundMethodHashesForFiles.emplace(fref, move(fref.data(*gs).getFileHash()->foundMethodHashes));
+                        // Okay to `move` here (steals component of getFileHash) because we're about to use
+                        // replaceFile to clobber fref.data(*gs) anyways.
+                        oldFoundMethodHashesForFiles.emplace(fref,
+                                                             move(fref.data(*gs).getFileHash()->foundMethodHashes));
 
-                } else {
-                    // Both oldHash and newHash should have the same methods, since this is the fast path!
-                    ENFORCE(validateIdenticalFingerprints(oldMethodHashes, newMethodHashes),
+                    } else {
+                        // Both oldHash and newHash should have the same methods, since this is the fast path!
+                        ENFORCE(validateIdenticalFingerprints(oldMethodHashes, newMethodHashes),
+                                "definitionHash should have failed");
+
+                        // Find which hashes changed. Note: methodHashes are sorted, so set_difference should work.
+                        // This will insert two entries into `changedMethodHashes` for each changed method, but they
+                        // will get deduped later.
+                        absl::c_set_difference(oldMethodHashes, newMethodHashes,
+                                               std::back_inserter(changedMethodSymbolHashes));
+                    }
+
+                    const auto &oldFieldHashes = oldSymbolHashes.staticFieldHashes;
+                    const auto &newFieldHashes = newSymbolHashes.staticFieldHashes;
+
+                    ENFORCE(validateIdenticalFingerprints(oldFieldHashes, newFieldHashes),
                             "definitionHash should have failed");
 
-                    // Find which hashes changed. Note: methodHashes are sorted, so set_difference should work.
-                    // This will insert two entries into `changedMethodHashes` for each changed method, but they will
-                    // get deduped later.
-                    absl::c_set_difference(oldMethodHashes, newMethodHashes,
-                                           std::back_inserter(changedMethodSymbolHashes));
+                    absl::c_set_difference(oldFieldHashes, newFieldHashes,
+                                           std::back_inserter(changedFieldSymbolHashes));
+
+                    gs->replaceFile(fref, updatedFile);
+                    // If file doesn't have a typed: sigil, then we need to ensure it's typechecked using typed: false.
+                    fref.data(*gs).strictLevel = pipeline::decideStrictLevel(*gs, fref, config->opts);
+                    subset.emplace_back(fref);
                 }
-
-                const auto &oldFieldHashes = oldSymbolHashes.staticFieldHashes;
-                const auto &newFieldHashes = newSymbolHashes.staticFieldHashes;
-
-                ENFORCE(validateIdenticalFingerprints(oldFieldHashes, newFieldHashes),
-                        "definitionHash should have failed");
-
-                absl::c_set_difference(oldFieldHashes, newFieldHashes, std::back_inserter(changedFieldSymbolHashes));
-
-                gs->replaceFile(fref, updatedFile);
-                // If file doesn't have a typed: sigil, then we need to ensure it's typechecked using typed: false.
-                fref.data(*gs).strictLevel = pipeline::decideStrictLevel(*gs, fref, config->opts);
-                subset.emplace_back(fref);
             }
+
+            changedSymbolNameHashes.reserve(changedMethodSymbolHashes.size() + changedFieldSymbolHashes.size());
+            absl::c_transform(changedMethodSymbolHashes, std::back_inserter(changedSymbolNameHashes),
+                              [](const auto &symhash) { return symhash.nameHash; });
+            absl::c_transform(changedFieldSymbolHashes, std::back_inserter(changedSymbolNameHashes),
+                              [](const auto &symhash) { return symhash.nameHash; });
+            core::ShortNameHash::sortAndDedupe(changedSymbolNameHashes);
         }
 
-        changedSymbolNameHashes.reserve(changedMethodSymbolHashes.size() + changedFieldSymbolHashes.size());
-        absl::c_transform(changedMethodSymbolHashes, std::back_inserter(changedSymbolNameHashes),
-                          [](const auto &symhash) { return symhash.nameHash; });
-        absl::c_transform(changedFieldSymbolHashes, std::back_inserter(changedSymbolNameHashes),
-                          [](const auto &symhash) { return symhash.nameHash; });
-        core::ShortNameHash::sortAndDedupe(changedSymbolNameHashes);
+        int i = -1;
+        // N.B.: We'll iterate over the changed files, too, but it's benign if we re-add them since we dedupe `subset`.
+        for (auto &oldFile : gs->getFiles()) {
+            i++;
+            if (oldFile == nullptr) {
+                continue;
+            }
+
+            if (this->config->opts.stripePackages && oldFile->isPackage()) {
+                continue; // See note above about --stripe-packages.
+            }
+
+            ENFORCE(oldFile->getFileHash() != nullptr);
+            const auto &oldHash = *oldFile->getFileHash();
+            vector<core::ShortNameHash> intersection;
+            absl::c_set_intersection(changedSymbolNameHashes, oldHash.usages.nameHashes,
+                                     std::back_inserter(intersection));
+            if (intersection.empty()) {
+                continue;
+            }
+
+            auto ref = core::FileRef(i);
+            config->logger->debug("Added {} to update set as used a changed symbol",
+                                  !ref.exists() ? "" : ref.data(*gs).path());
+            subset.emplace_back(ref);
+        }
+        // Remove any duplicate files.
+        fast_sort(subset);
+        subset.resize(std::distance(subset.begin(), std::unique(subset.begin(), subset.end())));
     }
-
-    int i = -1;
-    // N.B.: We'll iterate over the changed files, too, but it's benign if we re-add them since we dedupe `subset`.
-    for (auto &oldFile : gs->getFiles()) {
-        i++;
-        if (oldFile == nullptr) {
-            continue;
-        }
-
-        if (this->config->opts.stripePackages && oldFile->isPackage()) {
-            continue; // See note above about --stripe-packages.
-        }
-
-        ENFORCE(oldFile->getFileHash() != nullptr);
-        const auto &oldHash = *oldFile->getFileHash();
-        vector<core::ShortNameHash> intersection;
-        absl::c_set_intersection(changedSymbolNameHashes, oldHash.usages.nameHashes, std::back_inserter(intersection));
-        if (intersection.empty()) {
-            continue;
-        }
-
-        auto ref = core::FileRef(i);
-        config->logger->debug("Added {} to update set as used a changed symbol",
-                              !ref.exists() ? "" : ref.data(*gs).path());
-        subset.emplace_back(ref);
-    }
-    // Remove any duplicate files.
-    fast_sort(subset);
-    subset.resize(std::distance(subset.begin(), std::unique(subset.begin(), subset.end())));
-
     config->logger->debug("Running fast path over num_files={}", subset.size());
     ENFORCE(gs->errorQueue->isEmpty());
     vector<ast::ParsedFile> updatedIndexed;

--- a/main/lsp/notifications/sorbet_workspace_edit.cc
+++ b/main/lsp/notifications/sorbet_workspace_edit.cc
@@ -144,7 +144,11 @@ bool SorbetWorkspaceEditTask::canTakeFastPath(const LSPIndexer &index) const {
 }
 
 bool SorbetWorkspaceEditTask::canPreempt(const LSPIndexer &index) const {
-    return canTakeFastPath(index);
+    if (config.opts.lspExperimentalFastPathEnabled) {
+        return false;
+    } else {
+        return canTakeFastPath(index);
+    }
 }
 
 bool SorbetWorkspaceEditTask::needsMultithreading(const LSPIndexer &index) const {

--- a/main/lsp/wrapper.cc
+++ b/main/lsp/wrapper.cc
@@ -25,6 +25,7 @@ void setRequiredLSPOptions(core::GlobalState &gs, options::Options &options) {
     }
 
     gs.requiresAncestorEnabled = options.requiresAncestorEnabled;
+    gs.lspExperimentalFastPathEnabled = options.lspExperimentalFastPathEnabled;
 
     // Ensure LSP is enabled.
     options.runLSP = true;
@@ -162,6 +163,7 @@ void LSPWrapper::enableAllExperimentalFeatures() {
     enableExperimentalFeature(LSPExperimentalFeature::DocumentSymbol);
     enableExperimentalFeature(LSPExperimentalFeature::SignatureHelp);
     enableExperimentalFeature(LSPExperimentalFeature::DocumentFormat);
+    enableExperimentalFeature(LSPExperimentalFeature::ExperimentalFastPath);
 }
 
 void LSPWrapper::enableExperimentalFeature(LSPExperimentalFeature feature) {
@@ -177,6 +179,9 @@ void LSPWrapper::enableExperimentalFeature(LSPExperimentalFeature feature) {
             break;
         case LSPExperimentalFeature::DocumentFormat:
             opts->lspDocumentFormatRubyfmtEnabled = true;
+            break;
+        case LSPExperimentalFeature::ExperimentalFastPath:
+            opts->lspExperimentalFastPathEnabled = true;
             break;
     }
 }

--- a/main/lsp/wrapper.h
+++ b/main/lsp/wrapper.h
@@ -52,6 +52,7 @@ public:
         SignatureHelp = 7,
         DocumentHighlight = 9,
         DocumentFormat = 10,
+        ExperimentalFastPath = 11,
     };
 
     // N.B.: Sorbet assumes we 'own' this object; keep it alive to avoid memory errors.

--- a/main/minimize/minimize.cc
+++ b/main/minimize/minimize.cc
@@ -419,7 +419,9 @@ void Minimize::indexAndResolveForMinimize(unique_ptr<core::GlobalState> &sourceG
         rbiGS->errorQueue->flushAllErrors(*rbiGS);
     }
 
-    rbiIndexed = move(pipeline::resolve(rbiGS, move(rbiIndexed), opts, workers).result());
+    // Only need to compute FoundMethodHashes when running to compute a FileHash
+    auto foundMethodHashes = nullptr;
+    rbiIndexed = move(pipeline::resolve(rbiGS, move(rbiIndexed), opts, workers, foundMethodHashes).result());
     if (rbiGS->hadCriticalError()) {
         rbiGS->errorQueue->flushAllErrors(*rbiGS);
     }

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -344,6 +344,8 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
     options.add_options("advanced")("enable-experimental-lsp-stale-state", "Enable experimental LSP feature: fast "
                                                                            "but approximate answers from stale "
                                                                            "typechecker state");
+    options.add_options("advanced")("enable-experimental-lsp-fast-path",
+                                    "Enable experimental LSP feature: a faster fast path using symbol deletions");
     options.add_options("advanced")("enable-experimental-requires-ancestor",
                                     "Enable experimental `requires_ancestor` annotation");
 
@@ -776,6 +778,9 @@ void readOptions(Options &opts,
         // until we get some other groundwork in place. Once things stabilize a bit more, we can slap
         // `enableAllLSPFeatures ||` onto the condition here.
         opts.lspStaleStateEnabled = raw["enable-experimental-lsp-stale-state"].as<bool>();
+
+        opts.lspExperimentalFastPathEnabled =
+            opts.lspAllBetaFeaturesEnabled || raw["enable-experimental-lsp-fast-path"].as<bool>();
 
         if (raw.count("lsp-directories-missing-from-client") > 0) {
             auto lspDirsMissingFromClient = raw["lsp-directories-missing-from-client"].as<vector<string>>();

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -262,6 +262,7 @@ struct Options {
     bool lspDocumentFormatRubyfmtEnabled = false;
     bool lspSignatureHelpEnabled = false;
     bool lspStaleStateEnabled = false;
+    bool lspExperimentalFastPathEnabled = false;
 
     // Experimental feature `requires_ancestor`
     bool requiresAncestorEnabled = false;

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -223,8 +223,10 @@ ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, c
     }
 }
 
-vector<ast::ParsedFile> incrementalResolve(core::GlobalState &gs, vector<ast::ParsedFile> what,
-                                           const options::Options &opts) {
+vector<ast::ParsedFile>
+incrementalResolve(core::GlobalState &gs, vector<ast::ParsedFile> what,
+                   optional<UnorderedMap<core::FileRef, core::FoundMethodHashes>> &&foundMethodHashesForFiles,
+                   const options::Options &opts) {
     try {
 #ifndef SORBET_REALMAIN_MIN
         if (opts.stripePackages) {
@@ -238,7 +240,11 @@ vector<ast::ParsedFile> incrementalResolve(core::GlobalState &gs, vector<ast::Pa
             core::UnfreezeNameTable nameTable(gs);
             auto emptyWorkers = WorkerPool::create(0, gs.tracer());
 
-            auto result = sorbet::namer::Namer::run(gs, move(what), *emptyWorkers);
+            auto result = foundMethodHashesForFiles.has_value()
+                              ? sorbet::namer::Namer::runIncremental(
+                                    gs, move(what), std::move(foundMethodHashesForFiles.value()), *emptyWorkers)
+                              : sorbet::namer::Namer::run(gs, move(what), *emptyWorkers, nullptr);
+
             // Cancellation cannot occur during incremental namer.
             ENFORCE(result.hasResult());
             what = move(result.result());
@@ -757,11 +763,11 @@ ast::ParsedFilesOrCancelled nameBestEffortConst(const core::GlobalState &gs, vec
 }
 
 ast::ParsedFilesOrCancelled name(core::GlobalState &gs, vector<ast::ParsedFile> what, const options::Options &opts,
-                                 WorkerPool &workers) {
+                                 WorkerPool &workers, core::FoundMethodHashes *foundMethodHashes) {
     Timer timeit(gs.tracer(), "name");
     core::UnfreezeNameTable nameTableAccess(gs);     // creates singletons and class names
     core::UnfreezeSymbolTable symbolTableAccess(gs); // enters symbols
-    auto result = namer::Namer::run(gs, move(what), workers);
+    auto result = namer::Namer::run(gs, move(what), workers, foundMethodHashes);
 
     return result;
 }
@@ -842,12 +848,13 @@ ast::ParsedFile checkNoDefinitionsInsideProhibitedLines(core::GlobalState &gs, a
 }
 
 ast::ParsedFilesOrCancelled resolve(unique_ptr<core::GlobalState> &gs, vector<ast::ParsedFile> what,
-                                    const options::Options &opts, WorkerPool &workers) {
+                                    const options::Options &opts, WorkerPool &workers,
+                                    core::FoundMethodHashes *foundMethodHashes) {
     try {
         // packager intentionally runs outside of rewriter so that its output does not get cached.
         what = package(*gs, move(what), opts, workers);
 
-        auto result = name(*gs, move(what), opts, workers);
+        auto result = name(*gs, move(what), opts, workers, foundMethodHashes);
         if (!result.hasResult()) {
             return result;
         }
@@ -896,7 +903,10 @@ ast::ParsedFilesOrCancelled resolve(unique_ptr<core::GlobalState> &gs, vector<as
                     auto reIndexed = indexOne(opts, *gs, f.file);
                     vector<ast::ParsedFile> toBeReResolved;
                     toBeReResolved.emplace_back(move(reIndexed));
-                    auto reresolved = pipeline::incrementalResolve(*gs, move(toBeReResolved), opts);
+                    // We don't compute file hashes when running for incrementalResolve.
+                    auto foundMethodHashesForFiles = nullopt;
+                    auto reresolved =
+                        pipeline::incrementalResolve(*gs, move(toBeReResolved), foundMethodHashesForFiles, opts);
                     ENFORCE(reresolved.size() == 1);
                     f = checkNoDefinitionsInsideProhibitedLines(*gs, move(reresolved[0]), 0, prohibitedLines);
                 }

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -527,6 +527,7 @@ int realmain(int argc, char *argv[]) {
         gs->includeErrorSections = false;
     }
     gs->ruby3KeywordArgs = opts.ruby3KeywordArgs;
+    gs->lspExperimentalFastPathEnabled = opts.lspExperimentalFastPathEnabled;
     if (!opts.stripeMode) {
         // Definitions in multiple locations interact poorly with autoloader this error is enforced in Stripe code.
         if (opts.isolateErrorCode.empty()) {
@@ -753,7 +754,9 @@ int realmain(int argc, char *argv[]) {
             gs->suppressErrorClass(core::errors::Resolver::RecursiveTypeAlias.code);
 
             indexed = pipeline::package(*gs, move(indexed), opts, *workers);
-            indexed = move(pipeline::name(*gs, move(indexed), opts, *workers).result());
+            // Only need to compute FoundMethodHashes when running to compute a FileHash
+            auto foundMethodHashes = nullptr;
+            indexed = move(pipeline::name(*gs, move(indexed), opts, *workers, foundMethodHashes).result());
 
             autogen::AutoloaderConfig autoloaderCfg;
             {
@@ -767,7 +770,9 @@ int realmain(int argc, char *argv[]) {
             runAutogen(*gs, opts, autoloaderCfg, *workers, indexed);
 #endif
         } else {
-            indexed = move(pipeline::resolve(gs, move(indexed), opts, *workers).result());
+            // Only need to compute FoundMethodHashes when running to compute a FileHash
+            auto foundMethodHashes = nullptr;
+            indexed = move(pipeline::resolve(gs, move(indexed), opts, *workers, foundMethodHashes).result());
             if (gs->hadCriticalError()) {
                 gs->errorQueue->flushAllErrors(*gs);
             }

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -857,17 +857,17 @@ class SymbolDefiner {
 
     core::MethodRef insertMethod(core::MutableContext ctx, const core::FoundMethod &method) {
         auto symbol = defineMethod(ctx, method);
-        if (!ctx.state.lspExperimentalFastPathEnabled) {
-            auto name = symbol.data(ctx)->name;
-            if (name.kind() == core::NameKind::UNIQUE &&
-                name.dataUnique(ctx)->uniqueNameKind == core::UniqueNameKind::MangleRenameOverload) {
-                // These name kinds are only created in resolver, which means that we must be running on
-                // the fast path with an existing GlobalState.
-                // When modifyMethod is called later, it won't be able to find the correct method entry.
-                // Let's leave the method visibility what it was.
-                // TODO(jez) After #5808 lands, can we delete this check?
-                return symbol;
-            }
+        auto name = symbol.data(ctx)->name;
+        if (name.kind() == core::NameKind::UNIQUE &&
+            name.dataUnique(ctx)->uniqueNameKind == core::UniqueNameKind::MangleRenameOverload) {
+            // These name kinds are only created in resolver, which means that we must be running on
+            // the fast path with an existing GlobalState.
+            // When modifyMethod is called later, it won't be able to find the correct method entry.
+            // Let's leave the method visibility what it was.
+            // TODO(jez) After #5808 lands, can we delete this check?
+            // TODO(jez) The change to only populate oldFoundMethodHashesForFiles means that no, we
+            // actually can't remove this quite yet.
+            return symbol;
         }
 
         auto implicitlyPrivate = ctx.owner.enclosingClass(ctx) == core::Symbols::root();

--- a/namer/namer.h
+++ b/namer/namer.h
@@ -1,6 +1,7 @@
 #ifndef SORBET_NAMER_NAMER_H
 #define SORBET_NAMER_NAMER_H
 #include "ast/ast.h"
+#include "core/FileHash.h"
 #include <memory>
 
 namespace sorbet {
@@ -10,11 +11,35 @@ class WorkerPool;
 namespace sorbet::namer {
 
 class Namer final {
+    static ast::ParsedFilesOrCancelled
+    runInternal(core::GlobalState &gs, std::vector<ast::ParsedFile> trees, WorkerPool &workers,
+                UnorderedMap<core::FileRef, core::FoundMethodHashes> &&oldFoundMethodHashesForFiles,
+                core::FoundMethodHashes *foundMethodHashesOut);
+
 public:
     static ast::ParsedFilesOrCancelled
     symbolizeTreesBestEffort(const core::GlobalState &gs, std::vector<ast::ParsedFile> trees, WorkerPool &workers);
+
+    // Note: foundMethodHashes is an optional out parameter.
+    //
+    // Setting it to a non-nullptr requests that Namer compute a fingerprint of the FoundDefinitions
+    // it found while running. (Thus, it's usually nullptr except when pipeline::resolve is called
+    // for the purpose of computing a FileHash.)
     static ast::ParsedFilesOrCancelled run(core::GlobalState &gs, std::vector<ast::ParsedFile> trees,
-                                           WorkerPool &workers);
+                                           WorkerPool &workers, core::FoundMethodHashes *foundMethodHashesOut);
+
+    // Version of Namer that accepts the old FoundMethodHashes for each file to run Namer, which
+    // it uses to figure out how to mutate the already-populated GlobalState into the right shape
+    // when considering that only the files in `trees` were edited.
+    //
+    // `trees` and `foundMethodHashesForFiles` should have the same number of elements, and
+    // `foundMethodHashesForFiles[i]` should be the `FoundMethodHashes` for `trees[i]`.
+    // (Done this way, instead of using something like a `std::pair`, to avoid intermediate
+    // allocations for phases that don't actually need to operate on the `FoundMethodHashes`.)
+    static ast::ParsedFilesOrCancelled
+    runIncremental(core::GlobalState &gs, std::vector<ast::ParsedFile> trees,
+                   UnorderedMap<core::FileRef, core::FoundMethodHashes> &&oldFoundMethodHashesForFiles,
+                   WorkerPool &workers);
 
     Namer() = delete;
 };

--- a/namer/test/namer_test.cc
+++ b/namer/test/namer_test.cc
@@ -47,7 +47,8 @@ vector<ast::ParsedFile> runNamer(core::GlobalState &gs, ast::ParsedFile tree) {
     vector<ast::ParsedFile> v;
     v.emplace_back(move(tree));
     auto workers = WorkerPool::create(0, *logger);
-    return move(namer::Namer::run(gs, move(v), *workers).result());
+    core::FoundMethodHashes foundMethodHashes; // compute this just for test coverage
+    return move(namer::Namer::run(gs, move(v), *workers, &foundMethodHashes).result());
 }
 
 } // namespace

--- a/test/lsp/ProtocolTest.cc
+++ b/test/lsp/ProtocolTest.cc
@@ -34,6 +34,7 @@ void ProtocolTest::resetState(std::shared_ptr<realmain::options::Options> opts) 
         }
         opts->cacheDir = cacheDir;
     }
+    opts->lspExperimentalFastPathEnabled = true;
 
     if (useMultithreading) {
         lspWrapper = MultiThreadedLSPWrapper::create(rootPath, opts);

--- a/test/lsp/multithreaded_protocol_test_corpus.cc
+++ b/test/lsp/multithreaded_protocol_test_corpus.cc
@@ -464,7 +464,7 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "CanPreemptSlowPathWithFastPath") {
     sendAsync(*changeFile("foo.rb",
                           "# typed: true\nclass Foo\nextend T::Sig\nsig{returns(Integer)}\ndef "
                           "bar\nbaz\nend\nsig{returns(Float)}\ndef baz\n'not a float'\nend\nend\n",
-                          2, false, 1));
+                          2, false, 0));
     sendAsync(*changeFile(
         "bar.rb", "# typed: true\nclass Bar\nextend T::Sig\nsig{returns(String)}\ndef branch\n1\nend\nend\n", 3));
     sendAsync(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::RESUME, nullopt)));
@@ -509,7 +509,7 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "CanPreemptSlowPathWithFastPathThat
     sendAsync(*changeFile("foo.rb",
                           "# typed: true\nclass Foo\nextend T::Sig\nsig{returns(Integer)}\ndef "
                           "bar\n'hello'\nend\nend\n",
-                          2, false, 1));
+                          2, false, 0));
     sendAsync(*changeFile(
         "bar.rb", "# typed: true\nclass Bar\nextend T::Sig\nsig{returns(String)}\ndef str\nFoo.new.bar\nend\nend\n",
         3));
@@ -537,7 +537,7 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "CanPreemptSlowPathWithFastPathThat
     //                      /* assertUniqueStartTimes */ false);
 }
 
-TEST_CASE_FIXTURE(MultithreadedProtocolTest, "CanPreemptSlowPathWithFastPathAndThenCancelBoth") {
+TEST_CASE_FIXTURE(MultithreadedProtocolTest, "CanPreemptSlowPathWithFastPathAndThenCancelBoth" * doctest::skip()) {
     auto initOptions = make_unique<SorbetInitializationOptions>();
     initOptions->enableTypecheckInfo = true;
     assertDiagnostics(
@@ -615,7 +615,7 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "CanPreemptSlowPathWithFastPathAndB
                           "# typed: true\n"
                           "class Foo\n"
                           "extend(T::Sig",
-                          2, false, 1));
+                          2, false, 0));
 
     // Wait for typechecking to begin to avoid races.
     {
@@ -691,7 +691,7 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "CanCancelSlowPathWithFastPathThatR
                          /* assertUniqueStartTimes */ false);
 }
 
-TEST_CASE_FIXTURE(MultithreadedProtocolTest, "CanCancelSlowPathEvenIfAddsFile") {
+TEST_CASE_FIXTURE(MultithreadedProtocolTest, "CanCancelSlowPathEvenIfAddsFile" * doctest::skip()) {
     auto initOptions = make_unique<SorbetInitializationOptions>();
     initOptions->enableTypecheckInfo = true;
     assertDiagnostics(
@@ -779,7 +779,8 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "CanceledRequestsDontReportLatencyM
                          /* assertUniqueStartTimes */ false);
 }
 
-TEST_CASE_FIXTURE(MultithreadedProtocolTest, "ErrorIntroducedInSlowPathPreemptionByFastPathClearedByNewSlowPath") {
+TEST_CASE_FIXTURE(MultithreadedProtocolTest,
+                  "ErrorIntroducedInSlowPathPreemptionByFastPathClearedByNewSlowPath" * doctest::skip()) {
     auto initOptions = make_unique<SorbetInitializationOptions>();
     initOptions->enableTypecheckInfo = true;
     assertDiagnostics(

--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -540,6 +540,7 @@ TEST_CASE("LSPTest") {
         }
         opts->disableWatchman = true;
         opts->rubyfmtPath = "test/testdata/lsp/rubyfmt-stub/rubyfmt";
+        opts->lspExperimentalFastPathEnabled = true;
 
         if (haveStaleUpdates) {
             opts->lspStaleStateEnabled = true;

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -236,6 +236,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
     }
 
     gs->censorForSnapshotTests = true;
+    gs->lspExperimentalFastPathEnabled = true;
     auto workers = WorkerPool::create(0, gs->tracer());
 
     auto assertions = RangeAssertion::parseAssertions(test.sourceFileContents);
@@ -486,7 +487,8 @@ TEST_CASE("PerPhaseTest") { // NOLINT
             {
                 core::UnfreezeNameTable nameTableAccess(*rbiGenGs);     // creates singletons and class names
                 core::UnfreezeSymbolTable symbolTableAccess(*rbiGenGs); // enters symbols
-                trees = move(namer::Namer::run(*rbiGenGs, move(trees), *workers).result());
+                auto foundMethodHashes = nullptr;
+                trees = move(namer::Namer::run(*rbiGenGs, move(trees), *workers, foundMethodHashes).result());
             }
 
             // Resolver
@@ -523,7 +525,8 @@ TEST_CASE("PerPhaseTest") { // NOLINT
             core::UnfreezeSymbolTable symbolTableAccess(*gs); // enters symbols
             vector<ast::ParsedFile> vTmp;
             vTmp.emplace_back(move(tree));
-            vTmp = move(namer::Namer::run(*gs, move(vTmp), *workers).result());
+            core::FoundMethodHashes foundMethodHashes; // compute this just for test coverage
+            vTmp = move(namer::Namer::run(*gs, move(vTmp), *workers, &foundMethodHashes).result());
             namedTree = testSerialize(*gs, move(vTmp[0]));
         }
 
@@ -846,7 +849,14 @@ TEST_CASE("PerPhaseTest") { // NOLINT
             core::UnfreezeSymbolTable symbolTableAccess(*gs);
             vector<ast::ParsedFile> vTmp;
             vTmp.emplace_back(move(tree));
-            vTmp = move(namer::Namer::run(*gs, move(vTmp), *workers).result());
+            core::FoundMethodHashes foundMethodHashes; // out param, compute this just for test coverage
+            // The lsp_test_runner will turn every testdata test into a test of
+            // Namer::runIncremental by way of creating a file update with leading whitespace.
+            //
+            // Here, to complement those tests, we just run Namer::run (not Namer::runIncremental)
+            // to stress the codepath where Namer is not tasked with deleting anything when run for
+            // the fast path.
+            vTmp = move(namer::Namer::run(*gs, move(vTmp), *workers, &foundMethodHashes).result());
             tree = testSerialize(*gs, move(vTmp[0]));
 
             handler.addObserved(*gs, "name-tree", [&]() { return tree.tree.toString(*gs); });

--- a/test/testdata/lsp/fast_path/alias_method.1.rbupdate
+++ b/test/testdata/lsp/fast_path/alias_method.1.rbupdate
@@ -1,0 +1,8 @@
+# typed: true
+# assert-fast-path: alias_method.rb
+
+class A
+  def pai; end
+
+  alias_method :paid?, :paid # error: Can't make method alias from `paid?` to non existing method `paid`
+end

--- a/test/testdata/lsp/fast_path/alias_method.2.rbupdate
+++ b/test/testdata/lsp/fast_path/alias_method.2.rbupdate
@@ -1,0 +1,8 @@
+# typed: true
+# assert-fast-path: alias_method.rb
+
+class A
+  def paid; end
+
+  alias_method :paid?, :paid
+end

--- a/test/testdata/lsp/fast_path/alias_method.rb
+++ b/test/testdata/lsp/fast_path/alias_method.rb
@@ -1,0 +1,7 @@
+# typed: true
+
+class A
+  def paid; end
+
+  alias_method :paid?, :paid
+end

--- a/test/testdata/lsp/fast_path/alias_method_chain.1.rbupdate
+++ b/test/testdata/lsp/fast_path/alias_method_chain.1.rbupdate
@@ -1,0 +1,9 @@
+# typed: true
+
+class A
+  def target; end
+
+  alias_method :inne, :target
+
+  alias_method :outer, :inner # error: Can't make method alias from `outer` to non existing method `inner`
+end

--- a/test/testdata/lsp/fast_path/alias_method_chain.2.rbupdate
+++ b/test/testdata/lsp/fast_path/alias_method_chain.2.rbupdate
@@ -1,0 +1,9 @@
+# typed: true
+
+class A
+  def target; end
+
+  alias_method :inner, :targe # error: Can't make method alias from `inner` to non existing method `targe`
+
+  alias_method :outer, :inner
+end

--- a/test/testdata/lsp/fast_path/alias_method_chain.rb
+++ b/test/testdata/lsp/fast_path/alias_method_chain.rb
@@ -1,0 +1,9 @@
+# typed: true
+
+class A
+  def target; end
+
+  alias_method :inner, :target
+
+  alias_method :outer, :inner
+end

--- a/test/testdata/lsp/fast_path/alias_method_change_type__1.1.rbupdate
+++ b/test/testdata/lsp/fast_path/alias_method_change_type__1.1.rbupdate
@@ -1,5 +1,5 @@
 # typed: true
-# assert-fast-path: alias_method_change_type__1.rb
+# assert-fast-path: alias_method_change_type__1.rb,alias_method_change_type__2.rb
 
 class A
   extend T::Sig

--- a/test/testdata/lsp/fast_path/alias_redefined_multi_file__1.1.rbupdate
+++ b/test/testdata/lsp/fast_path/alias_redefined_multi_file__1.1.rbupdate
@@ -1,0 +1,12 @@
+# typed: true
+# spacer for exclude from file update
+# assert-fast-path: alias_redefined_multi_file__1.rb,alias_redefined_multi_file__2.rb
+
+class A
+  def to_method_new; end
+end
+
+A.new.to_method # error: Method `to_method` does not exist on `A`
+A.new.to_method_new
+A.new.from_method
+A.new.from_method_new # error: Method `from_method_new` does not exist on `A`

--- a/test/testdata/lsp/fast_path/alias_redefined_multi_file__1.2.rbupdate
+++ b/test/testdata/lsp/fast_path/alias_redefined_multi_file__1.2.rbupdate
@@ -1,0 +1,12 @@
+# typed: true
+# exclude-from-file-update: true
+# assert-fast-path: alias_redefined_multi_file__1.rb,alias_redefined_multi_file__2.rb
+
+class A
+  def to_method_new; end
+end
+
+A.new.to_method # error: Method `to_method` does not exist on `A`
+A.new.to_method_new
+A.new.from_method
+A.new.from_method_new # error: Method `from_method_new` does not exist on `A`

--- a/test/testdata/lsp/fast_path/alias_redefined_multi_file__1.3.rbupdate
+++ b/test/testdata/lsp/fast_path/alias_redefined_multi_file__1.3.rbupdate
@@ -1,0 +1,12 @@
+# typed: true
+# exclude-from-file-update: true
+# assert-fast-path: alias_redefined_multi_file__1.rb,alias_redefined_multi_file__2.rb
+
+class A
+  def to_method_new; end
+end
+
+A.new.to_method # error: Method `to_method` does not exist on `A`
+A.new.to_method_new
+A.new.from_method # error: Method `from_method` does not exist on `A`
+A.new.from_method_new

--- a/test/testdata/lsp/fast_path/alias_redefined_multi_file__1.rb
+++ b/test/testdata/lsp/fast_path/alias_redefined_multi_file__1.rb
@@ -1,0 +1,12 @@
+# typed: true
+# spacer for exclude from file update
+# spacer for assert fast path
+
+class A
+  def to_method; end
+end
+
+A.new.to_method
+A.new.to_method_new # error: Method `to_method_new` does not exist on `A`
+A.new.from_method
+A.new.from_method_new # error: Method `from_method_new` does not exist on `A`

--- a/test/testdata/lsp/fast_path/alias_redefined_multi_file__2.1.rbupdate
+++ b/test/testdata/lsp/fast_path/alias_redefined_multi_file__2.1.rbupdate
@@ -1,0 +1,11 @@
+# typed: true
+# exclude-from-file-update: true
+
+class A
+  alias_method :from_method, :to_method # error: Can't make method alias from `from_method` to non existing method `to_method`
+end
+
+A.new.to_method # error: Method `to_method` does not exist on `A`
+A.new.to_method_new
+A.new.from_method
+A.new.from_method_new # error: Method `from_method_new` does not exist on `A`

--- a/test/testdata/lsp/fast_path/alias_redefined_multi_file__2.2.rbupdate
+++ b/test/testdata/lsp/fast_path/alias_redefined_multi_file__2.2.rbupdate
@@ -1,0 +1,11 @@
+# typed: true
+# spacer for exclude from file update
+
+class A
+  alias_method :from_method, :to_method_new
+end
+
+A.new.to_method # error: Method `to_method` does not exist on `A`
+A.new.to_method_new
+A.new.from_method
+A.new.from_method_new # error: Method `from_method_new` does not exist on `A`

--- a/test/testdata/lsp/fast_path/alias_redefined_multi_file__2.3.rbupdate
+++ b/test/testdata/lsp/fast_path/alias_redefined_multi_file__2.3.rbupdate
@@ -1,0 +1,11 @@
+# typed: true
+# spacer for exclude from file update
+
+class A
+  alias_method :from_method_new, :to_method_new
+end
+
+A.new.to_method # error: Method `to_method` does not exist on `A`
+A.new.to_method_new
+A.new.from_method # error: Method `from_method` does not exist on `A`
+A.new.from_method_new

--- a/test/testdata/lsp/fast_path/alias_redefined_multi_file__2.rb
+++ b/test/testdata/lsp/fast_path/alias_redefined_multi_file__2.rb
@@ -1,0 +1,11 @@
+# typed: true
+# spacer for exclude from file update
+
+class A
+  alias_method :from_method, :to_method
+end
+
+A.new.to_method
+A.new.to_method_new # error: Method `to_method_new` does not exist on `A`
+A.new.from_method
+A.new.from_method_new # error: Method `from_method_new` does not exist on `A`

--- a/test/testdata/lsp/fast_path/alias_to_nothing__1.1.rbupdate
+++ b/test/testdata/lsp/fast_path/alias_to_nothing__1.1.rbupdate
@@ -1,0 +1,11 @@
+# typed: true
+# assert-fast-path: alias_to_nothing__1.rb,alias_to_nothing__2.rb,alias_to_nothing__3.rb
+# Spacer to allow for exclude from file update assertion
+
+class A
+  extend T::Sig
+  sig {returns(String)}
+  def to_method_new
+    ''
+  end
+end

--- a/test/testdata/lsp/fast_path/alias_to_nothing__1.2.rbupdate
+++ b/test/testdata/lsp/fast_path/alias_to_nothing__1.2.rbupdate
@@ -1,0 +1,11 @@
+# typed: true
+# assert-fast-path: alias_to_nothing__2.rb,alias_to_nothing__3.rb
+# exclude-from-file-update: true
+
+class A
+  extend T::Sig
+  sig {returns(String)}
+  def to_method_new
+    ''
+  end
+end

--- a/test/testdata/lsp/fast_path/alias_to_nothing__1.rb
+++ b/test/testdata/lsp/fast_path/alias_to_nothing__1.rb
@@ -1,0 +1,11 @@
+# typed: true
+# Spacer for assert fast path
+# Spacer to allow for exclude from file update assertion
+
+class A
+  extend T::Sig
+  sig {returns(Integer)}
+  def to_method
+    0
+  end
+end

--- a/test/testdata/lsp/fast_path/alias_to_nothing__2.1.rbupdate
+++ b/test/testdata/lsp/fast_path/alias_to_nothing__2.1.rbupdate
@@ -1,0 +1,6 @@
+# typed: true
+# exclude-from-file-update: true
+
+class A
+  alias_method :from_method, :to_method # error: Can't make method alias from `from_method` to non existing method `to_method`
+end

--- a/test/testdata/lsp/fast_path/alias_to_nothing__2.2.rbupdate
+++ b/test/testdata/lsp/fast_path/alias_to_nothing__2.2.rbupdate
@@ -1,0 +1,6 @@
+# typed: true
+# Spacer to allow for exclude from file update assertion
+
+class A
+  alias_method :from_method, :to_method_new
+end

--- a/test/testdata/lsp/fast_path/alias_to_nothing__2.rb
+++ b/test/testdata/lsp/fast_path/alias_to_nothing__2.rb
@@ -1,0 +1,6 @@
+# typed: true
+# Spacer to allow for exclude from file update assertion
+
+class A
+  alias_method :from_method, :to_method
+end

--- a/test/testdata/lsp/fast_path/alias_to_nothing__3.1.rbupdate
+++ b/test/testdata/lsp/fast_path/alias_to_nothing__3.1.rbupdate
@@ -1,0 +1,9 @@
+# typed: true
+# exclude-from-file-update: true
+
+A.new.from_method
+A.new.from_method_new # error: Method `from_method_new` does not exist on `A`
+A.new.to_method # error: Method `to_method` does not exist on `A`
+A.new.to_method_new
+
+T.reveal_type(A.new.from_method) # error: `T.untyped`

--- a/test/testdata/lsp/fast_path/alias_to_nothing__3.2.rbupdate
+++ b/test/testdata/lsp/fast_path/alias_to_nothing__3.2.rbupdate
@@ -1,0 +1,9 @@
+# typed: true
+# exclude-from-file-update: true
+
+A.new.from_method
+A.new.from_method_new # error: Method `from_method_new` does not exist on `A`
+A.new.to_method # error: Method `to_method` does not exist on `A`
+A.new.to_method_new
+
+T.reveal_type(A.new.from_method) # error: `String`

--- a/test/testdata/lsp/fast_path/alias_to_nothing__3.rb
+++ b/test/testdata/lsp/fast_path/alias_to_nothing__3.rb
@@ -1,0 +1,9 @@
+# typed: true
+# Spacer to allow for exclude from file update assertion
+
+A.new.from_method
+A.new.from_method_new # error: Method `from_method_new` does not exist on `A`
+A.new.to_method
+A.new.to_method_new # error: Method `to_method_new` does not exist on `A`
+
+T.reveal_type(A.new.from_method) # error: `Integer`

--- a/test/testdata/lsp/fast_path/class_add_method.1.rbupdate
+++ b/test/testdata/lsp/fast_path/class_add_method.1.rbupdate
@@ -1,5 +1,5 @@
 # typed: true
-# assert-slow-path: true
+# assert-fast-path: class_add_method.rb
 
 class A extend T::Sig
   sig {params(x: Integer).returns(String)}

--- a/test/testdata/lsp/fast_path/class_remove_method.1.rbupdate
+++ b/test/testdata/lsp/fast_path/class_remove_method.1.rbupdate
@@ -1,5 +1,5 @@
 # typed: true
-# assert-slow-path: true
+# assert-fast-path: class_remove_method.rb
 
 class A extend T::Sig
   sig {params(x: Integer).returns(String)}

--- a/test/testdata/lsp/fast_path/method_add_argument.1.rbupdate
+++ b/test/testdata/lsp/fast_path/method_add_argument.1.rbupdate
@@ -1,5 +1,5 @@
 # typed: true
-# assert-slow-path: true
+# assert-fast-path: method_add_argument.rb
 
 class A extend T::Sig
   sig {params(x: Integer, y: Integer).returns(String)}

--- a/test/testdata/lsp/fast_path/method_add_argument.2.rbupdate
+++ b/test/testdata/lsp/fast_path/method_add_argument.2.rbupdate
@@ -1,0 +1,15 @@
+# typed: true
+# assert-fast-path: method_add_argument.rb
+
+class A extend T::Sig
+  sig {params(x: Integer, y: Integer).returns(String)} # error: Unknown argument name `y`
+  def bar(x)
+    res = x.to_s
+    puts(y) # error: Method `y` does not exist on `A`
+    res
+  end
+end
+
+A.new.bar # error: Expected: `1`, got: `0`
+A.new.bar(0)
+A.new.bar(0, 0) # error: Expected: `1`, got: `2`

--- a/test/testdata/lsp/fast_path/method_add_keyword_arg.1.rbupdate
+++ b/test/testdata/lsp/fast_path/method_add_keyword_arg.1.rbupdate
@@ -1,5 +1,5 @@
 # typed: true
-# assert-slow-path: true
+# assert-fast-path: method_add_keyword_arg.rb
 
 class A extend T::Sig
   sig {params(x: Integer, y: Integer).returns(String)}

--- a/test/testdata/lsp/fast_path/method_add_sig.1.rbupdate
+++ b/test/testdata/lsp/fast_path/method_add_sig.1.rbupdate
@@ -1,5 +1,5 @@
 # typed: true
-# assert-slow-path: true
+# assert-fast-path: method_add_sig.rb
 
 class A extend T::Sig
   sig {params(x: Integer).returns(String)}

--- a/test/testdata/lsp/fast_path/method_change_argument_kind.1.rbupdate
+++ b/test/testdata/lsp/fast_path/method_change_argument_kind.1.rbupdate
@@ -1,5 +1,5 @@
 # typed: true
-# assert-slow-path: true
+# assert-fast-path: method_change_argument_kind.rb
 
 class A extend T::Sig
   sig {params(x: Integer).returns(String)}

--- a/test/testdata/lsp/fast_path/method_change_kw_arg_name.1.rbupdate
+++ b/test/testdata/lsp/fast_path/method_change_kw_arg_name.1.rbupdate
@@ -1,5 +1,5 @@
 # typed: true
-# assert-slow-path: true
+# assert-fast-path: method_change_kw_arg_name.rb
 
 class A extend T::Sig
   sig {params(y: Integer).returns(String)}

--- a/test/testdata/lsp/fast_path/method_redefined_multi_file__1.1.rbupdate
+++ b/test/testdata/lsp/fast_path/method_redefined_multi_file__1.1.rbupdate
@@ -1,0 +1,8 @@
+# typed: true
+# assert-fast-path: method_redefined_multi_file__1.rb,method_redefined_multi_file__2.rb
+
+class A
+  def foo(x) # error: Method `A#foo` redefined without matching argument count. Expected: `0`, got: `1`
+    x
+  end
+end

--- a/test/testdata/lsp/fast_path/method_redefined_multi_file__1.rb
+++ b/test/testdata/lsp/fast_path/method_redefined_multi_file__1.rb
@@ -1,0 +1,7 @@
+# typed: true
+
+class A
+  def foo
+    x # error: Method `x` does not exist on `A`
+  end
+end

--- a/test/testdata/lsp/fast_path/method_redefined_multi_file__2.1.rbupdate
+++ b/test/testdata/lsp/fast_path/method_redefined_multi_file__2.1.rbupdate
@@ -1,0 +1,9 @@
+# typed: true
+# exclude-from-file-update: true
+
+# -- imagine that this file were an RBI --
+
+class A
+  def foo # error: Method `A#foo` redefined without matching argument count. Expected: `1`, got: `0`
+  end
+end

--- a/test/testdata/lsp/fast_path/method_redefined_multi_file__2.rb
+++ b/test/testdata/lsp/fast_path/method_redefined_multi_file__2.rb
@@ -1,0 +1,9 @@
+# typed: true
+# spacer for exclude from file update
+
+# -- imagine that this file were an RBI --
+
+class A
+  def foo
+  end
+end

--- a/test/testdata/lsp/fast_path/more_arguments.1.rbupdate
+++ b/test/testdata/lsp/fast_path/more_arguments.1.rbupdate
@@ -1,5 +1,5 @@
 # typed: true
-# assert-slow-path: true
+# assert-fast-path: more_arguments.rb
 
 class Foo
   extend T::Sig

--- a/test/testdata/lsp/fast_path/multi_file_deletion__1.1.rbupdate
+++ b/test/testdata/lsp/fast_path/multi_file_deletion__1.1.rbupdate
@@ -1,0 +1,7 @@
+# typed: true
+# assert-fast-path: multi_file_deletion__1.rb,multi_file_deletion__2.rb
+
+class A
+end
+
+A.new.foo # error: Method `foo` does not exist on `A`

--- a/test/testdata/lsp/fast_path/multi_file_deletion__1.rb
+++ b/test/testdata/lsp/fast_path/multi_file_deletion__1.rb
@@ -1,0 +1,7 @@
+# typed: true
+
+class A
+  def foo; end
+end
+
+A.new.foo

--- a/test/testdata/lsp/fast_path/multi_file_deletion__2.1.rbupdate
+++ b/test/testdata/lsp/fast_path/multi_file_deletion__2.1.rbupdate
@@ -1,0 +1,7 @@
+# typed: true
+# assert-fast-path: multi_file_deletion__1.rb,multi_file_deletion__2.rb
+
+class A
+end
+
+A.new.foo # error: Method `foo` does not exist on `A`

--- a/test/testdata/lsp/fast_path/multi_file_deletion__2.rb
+++ b/test/testdata/lsp/fast_path/multi_file_deletion__2.rb
@@ -1,0 +1,7 @@
+# typed: true
+
+class A
+  def foo; end
+end
+
+A.new.foo

--- a/test/testdata/lsp/fast_path/overloads_test.1.rbupdate
+++ b/test/testdata/lsp/fast_path/overloads_test.1.rbupdate
@@ -1,4 +1,5 @@
 # typed: true
+# assert-fast-path: overloads_test.rb
 
 class A
   extend T::Sig

--- a/test/testdata/lsp/fast_path/rename_singleton_method.1.rbupdate
+++ b/test/testdata/lsp/fast_path/rename_singleton_method.1.rbupdate
@@ -1,0 +1,10 @@
+# typed: true
+# assert-fast-path: rename_singleton_method.rb
+
+class A
+  def self.bar
+  end
+end
+
+A.foo # error: Method `foo` does not exist on `T.class_of(A)`
+A.bar

--- a/test/testdata/lsp/fast_path/rename_singleton_method.rb
+++ b/test/testdata/lsp/fast_path/rename_singleton_method.rb
@@ -1,0 +1,9 @@
+# typed: true
+
+class A
+  def self.foo
+  end
+end
+
+A.foo
+A.bar # error: Method `bar` does not exist on `T.class_of(A)`

--- a/test/testdata/lsp/fast_path/simple_hover.1.rbupdate
+++ b/test/testdata/lsp/fast_path/simple_hover.1.rbupdate
@@ -1,5 +1,5 @@
 # typed: true
-# assert-slow-path: true
+# assert-fast-path: simple_hover.rb
 
 class Foo
   extend T::Sig

--- a/test/testdata/lsp/sig_deletion.1.rbupdate
+++ b/test/testdata/lsp/sig_deletion.1.rbupdate
@@ -1,5 +1,5 @@
 # typed: true
-# assert-slow-path: true
+# assert-fast-path: sig_deletion.rb
 class Foo
   extend T::Sig
 

--- a/test/testdata/namer/redefinition_method.1.rbupdate
+++ b/test/testdata/namer/redefinition_method.1.rbupdate
@@ -1,0 +1,16 @@
+# typed: true
+# assert-fast-path: redefinition_method.rb
+class Main
+    extend T::Sig
+
+    sig {params(a: Integer).returns(Integer)}
+    def foo(a)
+        a
+    end
+
+    def foo(a, b, c) # error: Method `Main#foo` redefined without matching argument count. Expected: `1`, got: `3`
+    end
+
+    def foo(a, b) # error: Method `Main#foo` redefined without matching argument count. Expected: `3`, got: `2`
+    end
+end

--- a/test/testdata/namer/redefinition_method.rb
+++ b/test/testdata/namer/redefinition_method.rb
@@ -7,9 +7,9 @@ class Main
         a
     end
 
-    def foo(a, b) # error: redefined
+    def foo(a, b) # error: Method `Main#foo` redefined without matching argument count. Expected: `1`, got: `2`
     end
 
-    def foo(a, b, c) # error: redefined
+    def foo(a, b, c) # error: Method `Main#foo` redefined without matching argument count. Expected: `2`, got: `3`
     end
 end

--- a/test/testdata/resolver/redefined_and_overloaded/overloads_test.1.rbupdate
+++ b/test/testdata/resolver/redefined_and_overloaded/overloads_test.1.rbupdate
@@ -1,0 +1,26 @@
+# typed: true
+# assert-fast-path: overloads_test.rb
+
+class A
+  extend T::Sig
+
+  sig {params(x: Integer).void}
+  sig {params(x: Integer, y: String).void}
+  def self.example(x, y='')
+  end
+
+  sig {params(x: Integer).void}
+  sig {params(x: Integer, y: String).void}
+  sig {params(x: Integer, y: String, z: Float).void}
+  def self.example1(x, y='', z=0.0)
+  end
+end
+
+A.example # error: Not enough arguments
+A.example(0)
+A.example(0, '')
+A.example(0, '', 0.0) # error: Too many arguments provided
+A.example1 # error: Not enough arguments
+A.example1(0)
+A.example1(0, '')
+A.example1(0, '', 0.0)

--- a/test/testdata/resolver/redefined_and_overloaded/overloads_test.rb
+++ b/test/testdata/resolver/redefined_and_overloaded/overloads_test.rb
@@ -1,0 +1,25 @@
+# typed: true
+
+class A
+  extend T::Sig
+
+  sig {params(x: Integer).void}
+  sig {params(x: Integer, y: String).void}
+  def self.example(x, y='')
+  end
+
+  sig {params(x: Integer).void}
+  sig {params(x: Integer, y: String).void}
+  sig {params(x: Integer, y: String, z: Float).void}
+  def self.example(x, y='', z=0.0) # error: Method `A.example` redefined without matching argument count. Expected: `2`, got: `3`
+  end
+end
+
+A.example # error: Not enough arguments
+A.example(0)
+A.example(0, '')
+A.example(0, '', 0.0)
+A.example1 # error: Method `example1` does not exist
+A.example1(0) # error: Method `example1` does not exist
+A.example1(0, '') # error: Method `example1` does not exist
+A.example1(0, '', 0.0) # error: Method `example1` does not exist


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

These change originally landed in #5808.

We have since landed a series of changes to the cache and done more beta testing, fixing a handful of remaining crashes that surfaced after landing that original PR.

The first three commits in this branch are just a roundabout way of reverting #5978 (it was easier to do it with 3 commits instead of 1 because of merge conflicts).

The remaining commits represent bug fixes.




### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

One of the bugs we caught from beta testing was actually caught by our test suite, except the test failure were being silenced (39d924e3f, fixed in efb539dce). That is fixed, so crashes in the tests do actually cause the test to fail. The other bug caught in beta testing did not have a test so I added one (1741271f7, fixed in 21e8b575d).
