### PR TITLE
Use snake-case for slash-munged paths in packager

### DIFF
--- a/test/testdata/packager/extra_package_paths/bar/__package.rb
+++ b/test/testdata/packager/extra_package_paths/bar/__package.rb
@@ -8,4 +8,5 @@
 class Project::Bar < PackageSpec
   import Project::Foo
   import Project::Baz::Package
+  import Project::FooBar
 end

--- a/test/testdata/packager/extra_package_paths/bar/bar.rb
+++ b/test/testdata/packager/extra_package_paths/bar/bar.rb
@@ -9,6 +9,7 @@ class Project::Bar::Bar
   def bar1
     Project::Foo::B.b
     Project::Foo::D.d
+    Project::FooBar::Z.z
   end
 
   sig { void }

--- a/test/testdata/packager/extra_package_paths/extra_slash/project/foo_bar/z.rb
+++ b/test/testdata/packager/extra_package_paths/extra_slash/project/foo_bar/z.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# typed: strict
+
+class Project::FooBar::Z
+  extend T::Sig
+
+  sig { void }
+  def self.z; end
+end
+

--- a/test/testdata/packager/extra_package_paths/foo_bar/__package.rb
+++ b/test/testdata/packager/extra_package_paths/foo_bar/__package.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# typed: strict
+
+class Project::FooBar < PackageSpec
+  export Project::FooBar::Z
+end
+

--- a/test/testdata/packager/extra_package_paths/pass.package-tree.exp
+++ b/test/testdata/packager/extra_package_paths/pass.package-tree.exp
@@ -4,6 +4,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <self>.import(<emptyTree>::<C <PackageSpecRegistry>>::<C Project>::<C Foo>)
 
     <self>.import(<emptyTree>::<C <PackageSpecRegistry>>::<C Project>::<C Baz>::<C Package>)
+
+    <self>.import(<emptyTree>::<C <PackageSpecRegistry>>::<C Project>::<C FooBar>)
   end
 end
 # -- test/testdata/packager/extra_package_paths/bar/bar.rb --
@@ -17,6 +19,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       begin
         <emptyTree>::<C Project>::<C Foo>::<C B>.b()
         <emptyTree>::<C Project>::<C Foo>::<C D>.d()
+        <emptyTree>::<C Project>::<C FooBar>::<C Z>.z()
       end
     end
 
@@ -114,11 +117,33 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <runtime method definition of self.d>
   end
 end
+# -- test/testdata/packager/extra_package_paths/extra_slash/project/foo_bar/z.rb --
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C Project>::<C FooBar>::<C Z><<C <todo sym>>> < (::<todo sym>)
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.void()
+    end
+
+    def self.z<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+    <runtime method definition of self.z>
+  end
+end
 # -- test/testdata/packager/extra_package_paths/foo/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C <PackageSpecRegistry>>::<C Project>::<C Foo><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
     <self>.export(::<root>::<C Project>::<C Foo>::<C B>)
 
     <self>.export(::<root>::<C Project>::<C Foo>::<C D>)
+  end
+end
+# -- test/testdata/packager/extra_package_paths/foo_bar/__package.rb --
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C <PackageSpecRegistry>>::<C Project>::<C FooBar><<C <todo sym>>> < (<emptyTree>::<C PackageSpec>)
+    <self>.export(::<root>::<C Project>::<C FooBar>::<C Z>)
   end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
For the newly added "slash-munged" package paths in #5987 , we need to also snake-case the path names in addition to lower-casing, so that `Project_FooBar` transforms to `project/foo_bar`. Previously it was just `project/foobar`.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
In the Stripe codebase, we are working on introducing path-based autoloading based on [Zeitwerk](https://github.com/fxn/zeitwerk)'s convention, which is used in Rails codebases.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Tested on Stripe codebase.
