### PR TITLE
Get rid of ripper errors

### DIFF
--- a/third_party/ruby/build-ruby.bzl
+++ b/third_party/ruby/build-ruby.bzl
@@ -111,15 +111,6 @@ run_cmd make V=1 install
 
 ruby_version=$(./miniruby -r ./rbconfig.rb -e 'puts "#{{RbConfig::CONFIG["MAJOR"]}}.#{{RbConfig::CONFIG["MINOR"]}}"')
 
-static_libs="$base/{static_libs}"
-mkdir -p "$static_libs"
-
-cp libruby*-static.a "$static_libs/libruby-static.a"
-
-# from https://github.com/penelopezone/rubyfmt/blob/3051835cc28db04e9d9caf0c8430407ca0347e83/librubyfmt/build.rs#L34
-ar crs "libripper-static.a" ext/ripper/ripper.o
-cp "libripper-static.a" "$static_libs"
-
 internal_incdir="$base/{internal_incdir}"
 
 mkdir -p "$internal_incdir"
@@ -254,11 +245,8 @@ def _build_ruby_impl(ctx):
     sharedir = ctx.actions.declare_directory("toolchain/share")
 
     internal_incdir = ctx.actions.declare_directory("toolchain/internal_include")
-    static_libs = ctx.actions.declare_file("toolchain/static_libs")
-    static_lib_ruby = ctx.actions.declare_file("toolchain/static_libs/libruby-static.a")
-    static_lib_ripper = ctx.actions.declare_file("toolchain/static_libs/libripper-static.a")
 
-    outputs = binaries + [libdir, incdir, sharedir, internal_incdir, static_libs, static_lib_ruby, static_lib_ripper]
+    outputs = binaries + [libdir, incdir, sharedir, internal_incdir]
 
     install_extra_srcs = []
     extra_srcs_object_files = []
@@ -302,9 +290,6 @@ def _build_ruby_impl(ctx):
             toolchain = libdir.dirname,
             src_dir = src_dir,
             internal_incdir = internal_incdir.path,
-            static_libs = static_libs.path,
-            static_lib_ruby = static_lib_ruby.path,
-            static_lib_ripper = static_lib_ripper.path,
             hdrs = " ".join(hdrs),
             libs = " ".join(libs),
             rubygems = ctx.files.rubygems[0].path,
@@ -326,9 +311,6 @@ def _build_ruby_impl(ctx):
             internal_includes = internal_incdir,
             lib = libdir,
             share = sharedir,
-            static_libs = static_libs,
-            static_lib_ruby = static_lib_ruby,
-            static_lib_ripper = static_lib_ripper,
         ),
         DefaultInfo(
             files = depset(outputs),


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I'm tired of looking at these errors

```
[3 / 7] BuildRuby external/sorbet_ruby_2_7/toolchain/bin/ruby; Downloading external/sorbet_ruby_2_7/toolchain/static_libs/libruby-static.a; 8s remote-cache ... (2 actions, 0 running)
[3 / 7] BuildRuby external/sorbet_ruby_2_7/toolchain/bin/ruby; Downloading external/sorbet_ruby_2_7/toolchain/static_libs/libruby-static.a; 17s remote-cache ... (2 actions, 0 running)
[3 / 7] BuildRuby external/sorbet_ruby_2_7/toolchain/bin/ruby; Downloading external/sorbet_ruby_2_7/toolchain/static_libs/libruby-static.a.tmp; 22s remote-cache ... (2 actions, 0 running)
[3 / 7] BuildRuby external/sorbet_ruby_2_7/toolchain/bin/ruby; Downloading external/sorbet_ruby_2_7/toolchain/static_libs/libruby-static.a.tmp; 30s remote-cache ... (2 actions, 0 running)
WARNING: Remote Cache: 
java.io.FileNotFoundException: /mnt/tmpfs/BAZEL_OUTPUT/execroot/com_stripe_ruby_typer/bazel-out/k8-opt/bin/external/sorbet_ruby_2_7_unpatched/toolchain/static_libs/libripper-static.a.tmp (No such file or directory)
	at com.google.devtools.build.lib.unix.NativePosixFiles.lstat(Native Method)
	at com.google.devtools.build.lib.unix.UnixFileSystem.statInternal(UnixFileSystem.java:185)
	at com.google.devtools.build.lib.unix.UnixFileSystem.stat(UnixFileSystem.java:174)
	at com.google.devtools.build.lib.vfs.Path.stat(Path.java:319)
	at com.google.devtools.build.lib.vfs.FileSystemUtils.moveFile(FileSystemUtils.java:456)
	at com.google.devtools.build.lib.remote.RemoteExecutionService.moveOutputsToFinalLocation(RemoteExecutionService.java:738)
	at com.google.devtools.build.lib.remote.RemoteExecutionService.downloadOutputs(RemoteExecutionService.java:1069)
	at com.google.devtools.build.lib.remote.RemoteSpawnCache.lookup(RemoteSpawnCache.java:116)
	at com.google.devtools.build.lib.exec.AbstractSpawnStrategy.exec(AbstractSpawnStrategy.java:141)
	at com.google.devtools.build.lib.exec.AbstractSpawnStrategy.exec(AbstractSpawnStrategy.java:108)
	at com.google.devtools.build.lib.actions.SpawnStrategy.beginExecution(SpawnStrategy.java:47)
	at com.google.devtools.build.lib.exec.SpawnStrategyResolver.beginExecution(SpawnStrategyResolver.java:68)
	at com.google.devtools.build.lib.analysis.actions.SpawnAction.beginExecution(SpawnAction.java:328)
	at com.google.devtools.build.lib.actions.Action.execute(Action.java:133)
	at com.google.devtools.build.lib.skyframe.SkyframeActionExecutor$5.execute(SkyframeActionExecutor.java:907)
	at com.google.devtools.build.lib.skyframe.SkyframeActionExecutor$ActionRunner.continueAction(SkyframeActionExecutor.java:1076)
	at com.google.devtools.build.lib.skyframe.SkyframeActionExecutor$ActionRunner.run(SkyframeActionExecutor.java:1031)
	at com.google.devtools.build.lib.skyframe.ActionExecutionState.runStateMachine(ActionExecutionState.java:152)
	at com.google.devtools.build.lib.skyframe.ActionExecutionState.getResultOrDependOnFuture(ActionExecutionState.java:91)
	at com.google.devtools.build.lib.skyframe.SkyframeActionExecutor.executeAction(SkyframeActionExecutor.java:492)
	at com.google.devtools.build.lib.skyframe.ActionExecutionFunction.checkCacheAndExecuteIfNeeded(ActionExecutionFunction.java:856)
	at com.google.devtools.build.lib.skyframe.ActionExecutionFunction.computeInternal(ActionExecutionFunction.java:349)
	at com.google.devtools.build.lib.skyframe.ActionExecutionFunction.compute(ActionExecutionFunction.java:169)
	at com.google.devtools.build.skyframe.AbstractParallelEvaluator$Evaluate.run(AbstractParallelEvaluator.java:590)
	at com.google.devtools.build.lib.concurrent.AbstractQueueVisitor$WrappedRunnable.run(AbstractQueueVisitor.java:382)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)
[3 / 7] BuildRuby external/sorbet_ruby_2_7/toolchain/bin/ruby; Downloading external/sorbet_ruby_2_7/toolchain/static_libs/libruby-static.a.tmp.tmp.tmp.tmp.tmp.tmp.tmp.tmp.tmp.tmp.tmp.tmp.tmp; 35s remote-cache ... (2 actions, 1 running)
WARNING: Remote Cache: 
java.io.FileNotFoundException: /mnt/tmpfs/BAZEL_OUTPUT/execroot/com_stripe_ruby_typer/bazel-out/k8-opt/bin/external/sorbet_ruby_2_7/toolchain/static_libs/libripper-static.a.tmp (No such file or directory)
	at com.google.devtools.build.lib.unix.NativePosixFiles.lstat(Native Method)
	at com.google.devtools.build.lib.unix.UnixFileSystem.statInternal(UnixFileSystem.java:185)
	at com.google.devtools.build.lib.unix.UnixFileSystem.stat(UnixFileSystem.java:174)
	at com.google.devtools.build.lib.vfs.Path.stat(Path.java:319)
	at com.google.devtools.build.lib.vfs.FileSystemUtils.moveFile(FileSystemUtils.java:456)
	at com.google.devtools.build.lib.remote.RemoteExecutionService.moveOutputsToFinalLocation(RemoteExecutionService.java:738)
	at com.google.devtools.build.lib.remote.RemoteExecutionService.downloadOutputs(RemoteExecutionService.java:1069)
	at com.google.devtools.build.lib.remote.RemoteSpawnCache.lookup(RemoteSpawnCache.java:116)
	at com.google.devtools.build.lib.exec.AbstractSpawnStrategy.exec(AbstractSpawnStrategy.java:141)
	at com.google.devtools.build.lib.exec.AbstractSpawnStrategy.exec(AbstractSpawnStrategy.java:108)
	at com.google.devtools.build.lib.actions.SpawnStrategy.beginExecution(SpawnStrategy.java:47)
	at com.google.devtools.build.lib.exec.SpawnStrategyResolver.beginExecution(SpawnStrategyResolver.java:68)
	at com.google.devtools.build.lib.analysis.actions.SpawnAction.beginExecution(SpawnAction.java:328)
	at com.google.devtools.build.lib.actions.Action.execute(Action.java:133)
	at com.google.devtools.build.lib.skyframe.SkyframeActionExecutor$5.execute(SkyframeActionExecutor.java:907)
	at com.google.devtools.build.lib.skyframe.SkyframeActionExecutor$ActionRunner.continueAction(SkyframeActionExecutor.java:1076)
	at com.google.devtools.build.lib.skyframe.SkyframeActionExecutor$ActionRunner.run(SkyframeActionExecutor.java:1031)
	at com.google.devtools.build.lib.skyframe.ActionExecutionState.runStateMachine(ActionExecutionState.java:152)
	at com.google.devtools.build.lib.skyframe.ActionExecutionState.getResultOrDependOnFuture(ActionExecutionState.java:91)
	at com.google.devtools.build.lib.skyframe.SkyframeActionExecutor.executeAction(SkyframeActionExecutor.java:492)
	at com.google.devtools.build.lib.skyframe.ActionExecutionFunction.checkCacheAndExecuteIfNeeded(ActionExecutionFunction.java:856)
	at com.google.devtools.build.lib.skyframe.ActionExecutionFunction.computeInternal(ActionExecutionFunction.java:349)
	at com.google.devtools.build.lib.skyframe.ActionExecutionFunction.compute(ActionExecutionFunction.java:169)
	at com.google.devtools.build.skyframe.AbstractParallelEvaluator$Evaluate.run(AbstractParallelEvaluator.java:590)
	at com.google.devtools.build.lib.concurrent.AbstractQueueVisitor$WrappedRunnable.run(AbstractQueueVisitor.java:382)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)
```


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.