### PR TITLE
fix spelling of `isTypeTemplate` field

### DIFF
--- a/core/FoundDefinitions.h
+++ b/core/FoundDefinitions.h
@@ -131,7 +131,7 @@ struct FoundTypeMember final {
     core::LocOffsets litLoc;
     core::NameRef varianceName;
     bool isFixed = false;
-    bool isTypeTemplete = false;
+    bool isTypeTemplate = false;
 
     std::string toString(const core::GlobalState &gs, const FoundDefinitions &foundDefs, uint32_t id) const;
 };

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -422,7 +422,7 @@ public:
         found.name = typeName->cnst;
         // Store name rather than core::Variance type so that we can defer reporting an error until later.
         found.varianceName = core::NameRef();
-        found.isTypeTemplete = send->fun == core::Names::typeTemplate();
+        found.isTypeTemplate = send->fun == core::Names::typeTemplate();
 
         if (send->numPosArgs() > 1) {
             // Too many arguments. Define a static field that we'll use for this type åmember later.
@@ -1085,7 +1085,7 @@ class SymbolDefiner {
         }
 
         core::Variance variance = core::Variance::Invariant;
-        const bool isTypeTemplate = typeMember.isTypeTemplete;
+        const bool isTypeTemplate = typeMember.isTypeTemplate;
 
         auto onSymbol = isTypeTemplate ? ctx.owner.asClassOrModuleRef().data(ctx)->singletonClass(ctx)
                                        : ctx.owner.asClassOrModuleRef();


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Misspellings in comments I can mostly handle; misspellings of actual fields not so much.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
