### PR TITLE
Format compile_commands.json with `jq` (if available)

### DIFF
--- a/tools/scripts/build_compilation_db.sh
+++ b/tools/scripts/build_compilation_db.sh
@@ -6,4 +6,8 @@ cd "$(dirname "$0")/../.."
 
 ./bazel build //tools:compdb --config=dbg
 
-cp bazel-bin/tools/compile_commands.json compile_commands.json
+if command -v jq &> /dev/null; then
+  jq . < bazel-bin/tools/compile_commands.json > compile_commands.json
+else
+  cp bazel-bin/tools/compile_commands.json compile_commands.json
+fi


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


A change a while back changed it so that the compile_commands.json file
is generated entirely on a single line. This makes it more difficult to
inspect manually, which I do from time to time to debug why it seems
like clangd isn't working correctly on a given file.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.