### PR TITLE
Improve document formatting performance with `posix_spawn`

### DIFF
--- a/common/Subprocess.cc
+++ b/common/Subprocess.cc
@@ -3,7 +3,6 @@
 #include <array>
 #include <spawn.h>
 #include <sstream>
-#include <string.h>
 #include <string>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -101,7 +100,7 @@ optional<sorbet::Subprocess::Result> sorbet::Subprocess::spawnAndPipeInput(strin
 
         // Write contents to child process stdin
         vector<char> contents(stdinContents.begin(), stdinContents.end());
-        ret = write(stdinPipe[1], contents.data(), strlen(contents.data()));
+        ret = write(stdinPipe[1], contents.data(), contents.size());
         if (ret < 0) {
             return nullopt;
         }
@@ -143,5 +142,5 @@ optional<sorbet::Subprocess::Result> sorbet::Subprocess::spawnAndPipeInput(strin
         return nullopt;
     }
 
-    return sorbet::Subprocess::Result{sink.str(), childStatus};
+    return sorbet::Subprocess::Result{sink.str(), WEXITSTATUS(childStatus)};
 }

--- a/common/Subprocess.h
+++ b/common/Subprocess.h
@@ -9,7 +9,12 @@ class Subprocess {
     Subprocess() = delete;
 
 public:
-    static std::optional<std::string> spawn(std::string executable, std::vector<std::string> arguments);
+    typedef struct {
+        std::string output;
+        int status;
+    } Result;
+
+    static std::optional<Subprocess::Result> spawnAndPipeInput(std::string executable, std::string stdinContents);
 };
 
 } // namespace sorbet

--- a/common/Subprocess.h
+++ b/common/Subprocess.h
@@ -14,7 +14,8 @@ public:
         int status;
     } Result;
 
-    static std::optional<Subprocess::Result> spawnAndPipeInput(std::string executable, std::string stdinContents);
+    static std::optional<Subprocess::Result> spawn(std::string executable, std::vector<std::string> arguments,
+                                                   std::optional<std::string> stdinContents);
 };
 
 } // namespace sorbet

--- a/compiler/Linker/Linker.cc
+++ b/compiler/Linker/Linker.cc
@@ -34,7 +34,7 @@ bool Linker::run(spdlog::logger &log, vector<string> objectFiles, string outputF
     for (auto &of : objectFiles) {
         commandLineArgs.emplace_back(move(of));
     }
-    auto ldOutput = Subprocess::spawn(executable, commandLineArgs);
+    auto ldOutput = Subprocess::spawn(executable, commandLineArgs, nullopt);
     return ldOutput != nullopt;
 };
 

--- a/main/lsp/requests/document_formatting.cc
+++ b/main/lsp/requests/document_formatting.cc
@@ -1,10 +1,10 @@
 #include "main/lsp/requests/document_formatting.h"
 #include "common/FileOps.h"
+#include "common/Subprocess.h"
 #include "common/common.h"
 #include "main/lsp/LSPOutput.h"
 #include "main/lsp/json_types.h"
 #include "main/lsp/lsp.h"
-#include "subprocess.hpp"
 
 using namespace std;
 
@@ -82,13 +82,11 @@ void DocumentFormattingTask::preprocess(LSPPreprocessor &preprocessor) {
 
     if (!sourceView.empty()) {
         auto originalLineCount = findLineBreaks(sourceView).size() - 1;
-        auto process = subprocess::Popen({config.opts.rubyfmtPath}, subprocess::output{subprocess::PIPE},
-                                         subprocess::input{subprocess::PIPE});
-        auto processResponse = process.communicate(vector<char>(sourceView.begin(), sourceView.end()));
-        process.wait();
-        auto returnCode = process.retcode();
+        auto processResponse = sorbet::Subprocess::spawnAndPipeInput(config.opts.rubyfmtPath,
+                                                                     std::string(sourceView.begin(), sourceView.end()));
 
-        std::string formattedContents(processResponse.first.buf.begin(), processResponse.first.buf.end());
+        auto returnCode = processResponse->status;
+        auto formattedContents = processResponse->output;
 
         switch (returnCode) {
             case RubyfmtStatus::OK:

--- a/main/lsp/requests/document_formatting.cc
+++ b/main/lsp/requests/document_formatting.cc
@@ -82,8 +82,8 @@ void DocumentFormattingTask::preprocess(LSPPreprocessor &preprocessor) {
 
     if (!sourceView.empty()) {
         auto originalLineCount = findLineBreaks(sourceView).size() - 1;
-        auto processResponse = sorbet::Subprocess::spawnAndPipeInput(config.opts.rubyfmtPath,
-                                                                     std::string(sourceView.begin(), sourceView.end()));
+        auto processResponse = sorbet::Subprocess::spawn(config.opts.rubyfmtPath, vector<string>(),
+                                                         string(sourceView.begin(), sourceView.end()));
 
         auto returnCode = processResponse->status;
         auto formattedContents = processResponse->output;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

The `subprocess` library currently used for document formatting is horribly slow for our use case. I did some profiling, and about 150-300ms are spent just calling `fork` [here](https://github.com/arun11299/cpp-subprocess/blob/master/subprocess.hpp#L1602), since `fork` copies the memory space of the parent process into the child process. That coupled with the time spent e.g. configuring file descriptors meant that _just starting the process_ for `rubyfmt` took more than half a second, which is unacceptably slow for a code formatter.

This change updates the document formatter to use an existing utility that uses [`posix_spawn`](https://man7.org/linux/man-pages/man3/posix_spawn.3.html) for the process creation, which gets us down from half a second to <20ms (including the call to `rubyfmt` itself) on a quiet machine. 

(cc @jvilk-stripe)


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Performance! Since this could block file saves for users with `formatOnSave` on, it should be sufficiently fast that it's almost unnoticed.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This should be functionally equivalent to the existing implementation, so existing tests should cover it. I also manually ran this in the Stripe VSCode setup.
