### PR TITLE
Create T::ImmutableStruct

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -227,6 +227,7 @@ NameDef names[] = {
     {"computedBy", "computed_by"},
     {"factory"},
     {"InexactStruct", "InexactStruct", true},
+    {"ImmutableStruct", "ImmutableStruct", true},
     {"Chalk", "Chalk", true},
     {"ODM", "ODM", true},
     {"Document", "Document", true},

--- a/gems/sorbet-runtime/lib/types/struct.rb
+++ b/gems/sorbet-runtime/lib/types/struct.rb
@@ -16,3 +16,36 @@ class T::Struct < T::InexactStruct
     end
   end
 end
+
+class T::ImmutableStruct < T::InexactStruct
+  extend T::Sig
+
+  def self.inherited(subclass)
+    super(subclass)
+
+    T::Private::ClassUtils.replace_method(subclass.singleton_class, :inherited) do |s|
+      super(s)
+      raise "#{self.name} is a subclass of T::ImmutableStruct and cannot be subclassed"
+    end
+  end
+
+  # Matches the one in WeakConstructor, but freezes the object
+  sig {params(hash: T::Hash[Symbol, T.untyped]).void.checked(:never)}
+  def initialize(hash={})
+    super
+
+    freeze
+  end
+
+  # Matches the signature in Props, but raises since this is an immutable struct and only const is allowed
+  sig {params(name: Symbol, cls: T.untyped, rules: T.untyped).void}
+  def self.prop(name, cls, rules={})
+    return super if (cls.is_a?(Hash) && cls[:immutable]) || rules[:immutable]
+
+    raise "Cannot use `prop` in #{self.name} because it is an immutable struct. Use `const` instead"
+  end
+
+  def with(changed_props)
+    raise "Cannot use `with` in #{self.class.name} because it is an immutable struct"
+  end
+end

--- a/gems/sorbet-runtime/test/types/struct.rb
+++ b/gems/sorbet-runtime/test/types/struct.rb
@@ -44,4 +44,36 @@ class Opus::Types::Test::StructValidationTest < Critic::Unit::UnitTest
       end
     end
   end
+
+  describe "immutable structs" do
+    it "errors when using prop" do
+      assert_raises(RuntimeError) do
+        Class.new(T::ImmutableStruct) do
+          prop :foo, Integer
+        end
+      end
+    end
+
+    it "errors when using with" do
+      klass = Class.new(T::ImmutableStruct) do
+        const :foo, Integer
+      end
+
+      assert_raises(RuntimeError) do
+        klass.new(foo: 1).with({foo: 5})
+      end
+    end
+
+    it "produces frozen objects" do
+      klass = Class.new(T::ImmutableStruct) do
+        const :foo, Integer
+      end
+
+      object = klass.new(foo: 5)
+
+      assert_raises(FrozenError) do
+        object.instance_variable_set(:@foo, 3)
+      end
+    end
+  end
 end

--- a/rbi/sorbet/tprops.rbi
+++ b/rbi/sorbet/tprops.rbi
@@ -12,6 +12,9 @@ end
 class T::Struct < T::InexactStruct
 end
 
+class T::ImmutableStruct < T::InexactStruct
+end
+
 module T::Props
   extend T::Helpers
   mixes_in_class_methods(T::Props::ClassMethods)

--- a/test/testdata/lsp/completion/constants_t.rb
+++ b/test/testdata/lsp/completion/constants_t.rb
@@ -3,7 +3,7 @@
 class A
   # TODO(jez) We should sort exact prefix matches ahead of fuzzy matches
   extend T::S # error-with-dupes: Unable to resolve
-  #          ^ completion: InexactStruct, Set, Sig, Struct
+  #          ^ completion: ImmutableStruct, InexactStruct, Set, Sig, Struct
   extend T::H # error-with-dupes: Unable to resolve
   #          ^ completion: Hash, Helpers
   extend T::G # error-with-dupes: Unable to resolve

--- a/test/testdata/rewriter/struct.rb
+++ b/test/testdata/rewriter/struct.rb
@@ -120,3 +120,19 @@ class FullyQualifiedStructUsages
   Foo.new.a
   Bar.new.a
 end
+
+class Immutable < T::ImmutableStruct
+  prop :a, Integer
+# ^^^^^^^^^^^^^^^^ error: Cannot use `prop` in an immutable struct
+
+  const :b, String
+end
+
+class ImmutableTest
+  Immutable.new(a: 1, b: "foo")
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Unrecognized keyword argument `a` passed for method `Immutable#initialize`
+
+  obj = Immutable.new(b: "foo")
+  obj.b = "bar"
+    # ^^^ error: Method `b=` does not exist on `Immutable`
+end

--- a/test/testdata/rewriter/struct.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/struct.rb.rewrite-tree.exp
@@ -456,4 +456,41 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <emptyTree>::<C Bar>.new().a()
   end
+
+  class <emptyTree>::<C Immutable><<C <todo sym>>> < (<emptyTree>::<C T>::<C ImmutableStruct>)
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.params(:b, <emptyTree>::<C String>).void()
+    end
+
+    def initialize<<todo method>>(b:, &<blk>)
+      begin
+        @b = ::T.let(b, <emptyTree>::<C String>)
+        nil
+      end
+    end
+
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.returns(<emptyTree>::<C String>)
+    end
+
+    def b<<todo method>>(&<blk>)
+      @b
+    end
+
+    <runtime method definition of initialize>
+
+    <self>.prop(:a, <emptyTree>::<C Integer>)
+
+    <self>.const(:b, <emptyTree>::<C String>, :without_accessors, true)
+
+    <runtime method definition of b>
+  end
+
+  class <emptyTree>::<C ImmutableTest><<C <todo sym>>> < (::<todo sym>)
+    <emptyTree>::<C Immutable>.new(:a, 1, :b, "foo")
+
+    obj = <emptyTree>::<C Immutable>.new(:b, "foo")
+
+    obj.b=("bar")
+  end
 end

--- a/test/testdata/rewriter/struct.rb.symbol-table-raw.exp
+++ b/test/testdata/rewriter/struct.rb.symbol-table-raw.exp
@@ -1,6 +1,6 @@
 class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
-    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=2:1 end=122:4}
+    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=2:1 end=138:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
   class <C <U AccidentallyStruct>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=37:1 end=37:25}
     class <C <U AccidentallyStruct>>::<C <U A>> < <C <U Struct>> () @ Loc {file=test/testdata/rewriter/struct.rb start=42:5 end=42:31}
@@ -85,6 +85,22 @@ class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U FullyQualifiedStructUsages>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=115:7 end=115:33}
     type-member(+) <S <C <U FullyQualifiedStructUsages>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U FullyQualifiedStructUsages>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=FullyQualifiedStructUsages) @ Loc {file=test/testdata/rewriter/struct.rb start=115:7 end=115:33}
     method <S <C <U FullyQualifiedStructUsages>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=115:1 end=122:4}
+      argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+  class <C <U Immutable>> < <C <U T>>::<C <U ImmutableStruct>> () @ Loc {file=test/testdata/rewriter/struct.rb start=124:1 end=124:37}
+    field <C <U Immutable>>#<U @b> -> String @ Loc {file=test/testdata/rewriter/struct.rb start=128:10 end=128:11}
+    method <C <U Immutable>>#<U b> (<blk>) -> String @ Loc {file=test/testdata/rewriter/struct.rb start=128:3 end=128:19}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+    method <C <U Immutable>>#<U initialize> (b, <blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/rewriter/struct.rb start=124:1 end=124:37}
+      argument b<keyword> -> String @ Loc {file=test/testdata/rewriter/struct.rb start=128:3 end=128:19}
+      argument <blk><block> -> T.untyped @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+  class <S <C <U Immutable>> $1>[<C <U <AttachedClass>>>] < <C <U T>>::<S <C <U ImmutableStruct>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=124:7 end=124:16}
+    type-member(+) <S <C <U Immutable>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U Immutable>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=Immutable) @ Loc {file=test/testdata/rewriter/struct.rb start=124:7 end=124:16}
+    method <S <C <U Immutable>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=124:1 end=129:4}
+      argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
+  class <C <U ImmutableTest>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=131:1 end=131:20}
+  class <S <C <U ImmutableTest>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/struct.rb start=131:7 end=131:20}
+    type-member(+) <S <C <U ImmutableTest>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U ImmutableTest>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=ImmutableTest) @ Loc {file=test/testdata/rewriter/struct.rb start=131:7 end=131:20}
+    method <S <C <U ImmutableTest>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/struct.rb start=131:1 end=138:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/struct.rb start=??? end=???}
   class <C <U InvalidMember>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/struct.rb start=45:1 end=45:20}
     class <C <U InvalidMember>>::<C <U A>> < <C <U Struct>> () @ Loc {file=test/testdata/rewriter/struct.rb start=46:3 end=46:24}


### PR DESCRIPTION
Please see #5650 and the discussions on that PR.

This PR is an alternative implementation of the `T::ImmutableStruct` with the goal to avoid any breaking changes.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.