### PR TITLE
Fix hang when running document formatting on large files

### DIFF
--- a/common/Subprocess.cc
+++ b/common/Subprocess.cc
@@ -1,14 +1,13 @@
 #include "common/Subprocess.h"
 #include "common/common.h"
 #include <array>
+#include <fcntl.h>
 #include <spawn.h>
 #include <sstream>
 #include <string>
 #include <sys/wait.h>
 #include <unistd.h>
 #include <vector>
-#include <fcntl.h>
-#include "spdlog/spdlog.h"
 
 using namespace std;
 
@@ -58,7 +57,7 @@ private:
 // Spawns a new child process, pipes `stdinContents` into the new processes's stdin,
 // and returns the child's stdout and status code
 optional<sorbet::Subprocess::Result> sorbet::Subprocess::spawn(string executable, vector<string> arguments,
-                                                               optional<string> stdinContents) {
+                                                               optional<string_view> stdinContents) {
     if (emscripten_build) {
         return nullopt;
     }
@@ -119,8 +118,7 @@ optional<sorbet::Subprocess::Result> sorbet::Subprocess::spawn(string executable
 
         // Write contents to child process stdin
         if (stdinContents.has_value()) {
-            vector<char> contents(stdinContents->begin(), stdinContents->end());
-            ret = write(stdinPipe[1], contents.data(), contents.size());
+            ret = write(stdinPipe[1], stdinContents->data(), stdinContents->size());
             if (ret < 0) {
                 return nullopt;
             }

--- a/common/Subprocess.h
+++ b/common/Subprocess.h
@@ -15,7 +15,7 @@ public:
     } Result;
 
     static std::optional<Subprocess::Result> spawn(std::string executable, std::vector<std::string> arguments,
-                                                   std::optional<std::string> stdinContents);
+                                                   std::optional<std::string_view> stdinContents);
 };
 
 } // namespace sorbet

--- a/main/lsp/requests/document_formatting.cc
+++ b/main/lsp/requests/document_formatting.cc
@@ -82,8 +82,7 @@ void DocumentFormattingTask::preprocess(LSPPreprocessor &preprocessor) {
 
     if (!sourceView.empty()) {
         auto originalLineCount = findLineBreaks(sourceView).size() - 1;
-        auto processResponse = sorbet::Subprocess::spawn(config.opts.rubyfmtPath, vector<string>(),
-                                                         string(sourceView.begin(), sourceView.end()));
+        auto processResponse = sorbet::Subprocess::spawn(config.opts.rubyfmtPath, vector<string>(), sourceView);
 
         auto returnCode = processResponse->status;
         auto formattedContents = processResponse->output;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

This fixes a bug introduced in #6003. That PR incorrectly writes to the `stdin` pipe _before_ running the spawned process, when writing should happen after the process starts. The reason is that pipes have a fixed size buffer, and if we format a document larger than the pipe buffer without the process running, the `write` call to the buffer will hang indefinitely.


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Document formatting is currently broken for large files.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Automated tests should cover existing functionality -- I also manually tested this on an 82K file in the Stripe codebase (that was previously hanging) to ensure that it formatted properly.
