### PR TITLE
Show when there's a blocking fast path operation

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -329,6 +329,10 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
         subset.resize(std::distance(subset.begin(), std::unique(subset.begin(), subset.end())));
     }
     config->logger->debug("Running fast path over num_files={}", subset.size());
+    unique_ptr<ShowOperation> op;
+    if (subset.size() > 100) {
+        op = make_unique<ShowOperation>(*config, ShowOperation::Kind::FastPath);
+    }
     ENFORCE(gs->errorQueue->isEmpty());
     vector<ast::ParsedFile> updatedIndexed;
     for (auto &f : subset) {

--- a/main/lsp/ShowOperation.cc
+++ b/main/lsp/ShowOperation.cc
@@ -24,6 +24,8 @@ string_view kindToOperationName(ShowOperation::Kind kind) {
             return "SlowPathBlocking";
         case ShowOperation::Kind::SlowPathNonBlocking:
             return "SlowPathNonBlocking";
+        case ShowOperation::Kind::FastPath:
+            return "FastPath";
         case ShowOperation::Kind::References:
             return "References";
         case ShowOperation::Kind::SymbolSearch:
@@ -43,6 +45,8 @@ string_view kindToDescription(ShowOperation::Kind kind) {
             return "Typechecking...";
         case ShowOperation::Kind::SlowPathNonBlocking:
             return "Typechecking in background";
+        case ShowOperation::Kind::FastPath:
+            return "Typechecking in foreground...";
         case ShowOperation::Kind::References:
             return "Finding all references...";
         case ShowOperation::Kind::SymbolSearch:

--- a/main/lsp/ShowOperation.h
+++ b/main/lsp/ShowOperation.h
@@ -21,6 +21,7 @@ public:
         Indexing = 1,
         SlowPathBlocking,
         SlowPathNonBlocking,
+        FastPath,
         References,
         SymbolSearch,
         Rename,


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


Most fast path operations are fast, but some are quite slow. As a
heuristic, choose to report when the fast path is about to run on 100+
files. We may want to adjust this up or down, depending on how much it
causes flickering.

By my estimation, this will affect `0.08%` of fast path edits, or 8 in 10,000.
Given that there are hundreds of thousands of fast path operations daily,
this should be visible to people but not burdensome.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I have tested this on Stripe's codebase:

<img width="380" alt="Screen Shot 2022-07-14 at 1 57 26 PM" src="https://user-images.githubusercontent.com/5544532/179311572-6c2d5333-4546-4883-8e99-c19139e83a7d.png">

I do not want to build an LSP test that has 101 files in it to test that this works as expected.