### PR TITLE
Allow `T.type_parameter` used in invariant position to match anything

### DIFF
--- a/core/Types.h
+++ b/core/Types.h
@@ -86,10 +86,14 @@ public:
     /** is every instance of  t1 an  instance of t2 when not allowed to modify constraint */
     static bool isSubType(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
     static bool equiv(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
+    static bool equivUnderConstraint(const GlobalState &gs, TypeConstraint &constr, const TypePtr &t1,
+                                     const TypePtr &t2);
 
     /** check that t1 <: t2, but do not consider `T.untyped` as super type or a subtype of all other types */
     static bool isAsSpecificAs(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
     static bool equivNoUntyped(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
+    static bool equivNoUntypedUnderConstraint(const GlobalState &gs, TypeConstraint &constr, const TypePtr &t1,
+                                              const TypePtr &t2);
 
     static TypePtr top();
     static TypePtr bottom();

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -1202,9 +1202,13 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
                     auto &a = a1->targs[i];
                     auto &b = a2->targs[j];
                     if (mode == UntypedMode::AlwaysCompatible) {
-                        result = Types::equiv(gs, a, b);
+                        result = Types::equivUnderConstraint(gs, constr, a, b);
                     } else {
-                        result = Types::equivNoUntyped(gs, a, b);
+                        // At the time of writing, we never set mode == UntypedMode::AlwaysIncompatible
+                        // except when `constr` is EmptyFrozenConstraint, so there's no observable
+                        // difference whether we use equivNoUntyped or equivNoUntypedUnderConstraint here.
+                        // May as well do it for symmetry though.
+                        result = Types::equivNoUntypedUnderConstraint(gs, constr, a, b);
                     }
                 } else if (idxTypeMember.data(gs)->flags.isContravariant) {
                     result = Types::isSubTypeUnderConstraint(gs, constr, a2->targs[j], a1->targs[i], mode);
@@ -1439,8 +1443,19 @@ bool Types::equiv(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) {
     return isSubType(gs, t1, t2) && isSubType(gs, t2, t1);
 }
 
+bool Types::equivUnderConstraint(const GlobalState &gs, TypeConstraint &constr, const TypePtr &t1, const TypePtr &t2) {
+    auto mode = UntypedMode::AlwaysCompatible;
+    return isSubTypeUnderConstraint(gs, constr, t1, t2, mode) && isSubTypeUnderConstraint(gs, constr, t2, t1, mode);
+}
+
 bool Types::equivNoUntyped(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) {
     return isAsSpecificAs(gs, t1, t2) && isAsSpecificAs(gs, t2, t1);
+}
+
+bool Types::equivNoUntypedUnderConstraint(const GlobalState &gs, TypeConstraint &constr, const TypePtr &t1,
+                                          const TypePtr &t2) {
+    auto mode = UntypedMode::AlwaysIncompatible;
+    return isSubTypeUnderConstraint(gs, constr, t1, t2, mode) && isSubTypeUnderConstraint(gs, constr, t2, t1, mode);
 }
 
 } // namespace sorbet::core

--- a/test/cli/invariant_type_parameter/test.out
+++ b/test/cli/invariant_type_parameter/test.out
@@ -1,0 +1,130 @@
+test/cli/invariant_type_parameter/test.rb:58: Expected `Box[T.type_parameter(:U)]` but found `Box[Integer]` for argument `box` https://srb.help/7002
+    58 |box_example(Box[Integer].new, takes_box_string) do |box|
+                    ^^^^^^^^^^^^^^^^
+  Expected `Box[T.type_parameter(:U)]` for argument `box` of method `Object#box_example`:
+    test/cli/invariant_type_parameter/test.rb:21:
+    21 |      box: Box[T.type_parameter(:U)],
+              ^^^
+  Got `Box[Integer]` originating from:
+    test/cli/invariant_type_parameter/test.rb:58:
+    58 |box_example(Box[Integer].new, takes_box_string) do |box|
+                    ^^^^^^^^^^^^^^^^
+
+test/cli/invariant_type_parameter/test.rb:58: Expected `T.proc.params(arg0: Box[T.type_parameter(:U)]).void` but found `T.proc.params(arg0: Box[String]).void` for argument `f` https://srb.help/7002
+    58 |box_example(Box[Integer].new, takes_box_string) do |box|
+                                      ^^^^^^^^^^^^^^^^
+  Expected `T.proc.params(arg0: Box[T.type_parameter(:U)]).void` for argument `f` of method `Object#box_example`:
+    test/cli/invariant_type_parameter/test.rb:22:
+    22 |      f: T.proc.params(box: Box[T.type_parameter(:U)]).void,
+              ^
+  Got `T.proc.params(arg0: Box[String]).void` originating from:
+    test/cli/invariant_type_parameter/test.rb:44:
+    44 |takes_box_string = T.let(->(box) {}, T.proc.params(box: Box[String]).void)
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+test/cli/invariant_type_parameter/test.rb:60: Revealed type: `Box[<top>]` https://srb.help/7014
+    60 |  T.reveal_type(box)
+          ^^^^^^^^^^^^^^^^^^
+  Got `Box[<top>]` originating from:
+    test/cli/invariant_type_parameter/test.rb:58:
+    58 |box_example(Box[Integer].new, takes_box_string) do |box|
+                                                            ^^^
+
+test/cli/invariant_type_parameter/test.rb:68: Expected `Box[T.type_parameter(:U)]` but found `Box[M]` for argument `box` https://srb.help/7002
+    68 |box_example(Box[M].new, takes_box_n) do |box|
+                    ^^^^^^^^^^
+  Expected `Box[T.type_parameter(:U)]` for argument `box` of method `Object#box_example`:
+    test/cli/invariant_type_parameter/test.rb:21:
+    21 |      box: Box[T.type_parameter(:U)],
+              ^^^
+  Got `Box[M]` originating from:
+    test/cli/invariant_type_parameter/test.rb:68:
+    68 |box_example(Box[M].new, takes_box_n) do |box|
+                    ^^^^^^^^^^
+
+test/cli/invariant_type_parameter/test.rb:68: Expected `T.proc.params(arg0: Box[T.type_parameter(:U)]).void` but found `T.proc.params(arg0: Box[N]).void` for argument `f` https://srb.help/7002
+    68 |box_example(Box[M].new, takes_box_n) do |box|
+                                ^^^^^^^^^^^
+  Expected `T.proc.params(arg0: Box[T.type_parameter(:U)]).void` for argument `f` of method `Object#box_example`:
+    test/cli/invariant_type_parameter/test.rb:22:
+    22 |      f: T.proc.params(box: Box[T.type_parameter(:U)]).void,
+              ^
+  Got `T.proc.params(arg0: Box[N]).void` originating from:
+    test/cli/invariant_type_parameter/test.rb:45:
+    45 |takes_box_n = T.let(->(box) {}, T.proc.params(box: Box[N]).void)
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+test/cli/invariant_type_parameter/test.rb:75: Expected `Box[T.type_parameter(:U)]` but found `IBox[M]` for argument `box` https://srb.help/7002
+    75 |box_example(ibox_m, takes_ibox_n) do |box|
+                    ^^^^^^
+  Expected `Box[T.type_parameter(:U)]` for argument `box` of method `Object#box_example`:
+    test/cli/invariant_type_parameter/test.rb:21:
+    21 |      box: Box[T.type_parameter(:U)],
+              ^^^
+  Got `IBox[M]` originating from:
+    test/cli/invariant_type_parameter/test.rb:71:
+    71 |ibox_m = T.let(Box[M].new, IBox[M])
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+test/cli/invariant_type_parameter/test.rb:76: Revealed type: `Box[N]` https://srb.help/7014
+    76 |  T.reveal_type(box)
+          ^^^^^^^^^^^^^^^^^^
+  Got `Box[N]` originating from:
+    test/cli/invariant_type_parameter/test.rb:75:
+    75 |box_example(ibox_m, takes_ibox_n) do |box|
+                                              ^^^
+
+test/cli/invariant_type_parameter/test.rb:82: Revealed type: `IBox[N]` https://srb.help/7014
+    82 |  T.reveal_type(box)
+          ^^^^^^^^^^^^^^^^^^
+  Got `IBox[N]` originating from:
+    test/cli/invariant_type_parameter/test.rb:81:
+    81 |ibox_example(Box[String].new, takes_ibox_n) do |box|
+                                                        ^^^
+
+test/cli/invariant_type_parameter/test.rb:81: Could not find valid instantiation of type parameters for `Object#ibox_example` https://srb.help/7020
+    81 |ibox_example(Box[String].new, takes_ibox_n) do |box|
+    82 |  T.reveal_type(box)
+    83 |end
+    test/cli/invariant_type_parameter/test.rb:40: `Object#ibox_example` defined here
+    40 |def ibox_example(box, f, &blk)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Found no solution for these constraints:
+    `String` must be a subtype of `T.type_parameter(:U)` which must be a subtype of `N`
+
+test/cli/invariant_type_parameter/test.rb:85: Revealed type: `IBox[N]` https://srb.help/7014
+    85 |  T.reveal_type(box)
+          ^^^^^^^^^^^^^^^^^^
+  Got `IBox[N]` originating from:
+    test/cli/invariant_type_parameter/test.rb:84:
+    84 |ibox_example(ibox_m, takes_ibox_n) do |box|
+                                               ^^^
+
+test/cli/invariant_type_parameter/test.rb:84: Could not find valid instantiation of type parameters for `Object#ibox_example` https://srb.help/7020
+    84 |ibox_example(ibox_m, takes_ibox_n) do |box|
+    85 |  T.reveal_type(box)
+    86 |end
+    test/cli/invariant_type_parameter/test.rb:40: `Object#ibox_example` defined here
+    40 |def ibox_example(box, f, &blk)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Found no solution for these constraints:
+    `M` must be a subtype of `T.type_parameter(:U)` which must be a subtype of `N`
+
+test/cli/invariant_type_parameter/test.rb:88: Revealed type: `IBox[N]` https://srb.help/7014
+    88 |  T.reveal_type(box)
+          ^^^^^^^^^^^^^^^^^^
+  Got `IBox[N]` originating from:
+    test/cli/invariant_type_parameter/test.rb:87:
+    87 |ibox_example(ibox_integer, takes_ibox_string) do |box|
+                                                          ^^^
+
+test/cli/invariant_type_parameter/test.rb:87: Could not find valid instantiation of type parameters for `Object#ibox_example` https://srb.help/7020
+    87 |ibox_example(ibox_integer, takes_ibox_string) do |box|
+    88 |  T.reveal_type(box)
+    89 |end
+    test/cli/invariant_type_parameter/test.rb:40: `Object#ibox_example` defined here
+    40 |def ibox_example(box, f, &blk)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Found no solution for these constraints:
+    `Integer` must be a subtype of `T.type_parameter(:U)` which must be a subtype of `N`
+Errors: 13

--- a/test/cli/invariant_type_parameter/test.out
+++ b/test/cli/invariant_type_parameter/test.out
@@ -1,58 +1,30 @@
-test/cli/invariant_type_parameter/test.rb:58: Expected `Box[T.type_parameter(:U)]` but found `Box[Integer]` for argument `box` https://srb.help/7002
-    58 |box_example(Box[Integer].new, takes_box_string) do |box|
-                    ^^^^^^^^^^^^^^^^
-  Expected `Box[T.type_parameter(:U)]` for argument `box` of method `Object#box_example`:
-    test/cli/invariant_type_parameter/test.rb:21:
-    21 |      box: Box[T.type_parameter(:U)],
-              ^^^
-  Got `Box[Integer]` originating from:
-    test/cli/invariant_type_parameter/test.rb:58:
-    58 |box_example(Box[Integer].new, takes_box_string) do |box|
-                    ^^^^^^^^^^^^^^^^
-
-test/cli/invariant_type_parameter/test.rb:58: Expected `T.proc.params(arg0: Box[T.type_parameter(:U)]).void` but found `T.proc.params(arg0: Box[String]).void` for argument `f` https://srb.help/7002
-    58 |box_example(Box[Integer].new, takes_box_string) do |box|
-                                      ^^^^^^^^^^^^^^^^
-  Expected `T.proc.params(arg0: Box[T.type_parameter(:U)]).void` for argument `f` of method `Object#box_example`:
-    test/cli/invariant_type_parameter/test.rb:22:
-    22 |      f: T.proc.params(box: Box[T.type_parameter(:U)]).void,
-              ^
-  Got `T.proc.params(arg0: Box[String]).void` originating from:
-    test/cli/invariant_type_parameter/test.rb:44:
-    44 |takes_box_string = T.let(->(box) {}, T.proc.params(box: Box[String]).void)
-                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-test/cli/invariant_type_parameter/test.rb:60: Revealed type: `Box[<top>]` https://srb.help/7014
+test/cli/invariant_type_parameter/test.rb:60: Revealed type: `Box[T.noreturn]` https://srb.help/7014
     60 |  T.reveal_type(box)
           ^^^^^^^^^^^^^^^^^^
-  Got `Box[<top>]` originating from:
+  Got `Box[T.noreturn]` originating from:
     test/cli/invariant_type_parameter/test.rb:58:
     58 |box_example(Box[Integer].new, takes_box_string) do |box|
                                                             ^^^
 
-test/cli/invariant_type_parameter/test.rb:68: Expected `Box[T.type_parameter(:U)]` but found `Box[M]` for argument `box` https://srb.help/7002
-    68 |box_example(Box[M].new, takes_box_n) do |box|
-                    ^^^^^^^^^^
-  Expected `Box[T.type_parameter(:U)]` for argument `box` of method `Object#box_example`:
-    test/cli/invariant_type_parameter/test.rb:21:
-    21 |      box: Box[T.type_parameter(:U)],
-              ^^^
-  Got `Box[M]` originating from:
-    test/cli/invariant_type_parameter/test.rb:68:
-    68 |box_example(Box[M].new, takes_box_n) do |box|
-                    ^^^^^^^^^^
+test/cli/invariant_type_parameter/test.rb:58: Could not find valid instantiation of type parameters for `Object#box_example` https://srb.help/7020
+    58 |box_example(Box[Integer].new, takes_box_string) do |box|
+    59 |  # Solution takes the upper bound, regardless of whether it solves, I guess?
+    60 |  T.reveal_type(box)
+    61 |end
+    test/cli/invariant_type_parameter/test.rb:27: `Object#box_example` defined here
+    27 |def box_example(box, f, &blk)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Found no solution for these constraints:
+    `T.any(Integer, String)` must be a subtype of `T.type_parameter(:U)` which must be a subtype of `T.noreturn`
 
-test/cli/invariant_type_parameter/test.rb:68: Expected `T.proc.params(arg0: Box[T.type_parameter(:U)]).void` but found `T.proc.params(arg0: Box[N]).void` for argument `f` https://srb.help/7002
+test/cli/invariant_type_parameter/test.rb:68: Could not find valid instantiation of type parameters for `Object#box_example` https://srb.help/7020
     68 |box_example(Box[M].new, takes_box_n) do |box|
-                                ^^^^^^^^^^^
-  Expected `T.proc.params(arg0: Box[T.type_parameter(:U)]).void` for argument `f` of method `Object#box_example`:
-    test/cli/invariant_type_parameter/test.rb:22:
-    22 |      f: T.proc.params(box: Box[T.type_parameter(:U)]).void,
-              ^
-  Got `T.proc.params(arg0: Box[N]).void` originating from:
-    test/cli/invariant_type_parameter/test.rb:45:
-    45 |takes_box_n = T.let(->(box) {}, T.proc.params(box: Box[N]).void)
-                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    69 |end
+    test/cli/invariant_type_parameter/test.rb:27: `Object#box_example` defined here
+    27 |def box_example(box, f, &blk)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Found no solution for these constraints:
+    `T.any(M, N)` must be a subtype of `T.type_parameter(:U)` which must be a subtype of `T.all(M, N)`
 
 test/cli/invariant_type_parameter/test.rb:75: Expected `Box[T.type_parameter(:U)]` but found `IBox[M]` for argument `box` https://srb.help/7002
     75 |box_example(ibox_m, takes_ibox_n) do |box|
@@ -127,4 +99,4 @@ test/cli/invariant_type_parameter/test.rb:87: Could not find valid instantiation
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Found no solution for these constraints:
     `Integer` must be a subtype of `T.type_parameter(:U)` which must be a subtype of `N`
-Errors: 13
+Errors: 11

--- a/test/cli/invariant_type_parameter/test.rb
+++ b/test/cli/invariant_type_parameter/test.rb
@@ -1,0 +1,89 @@
+# typed: true
+extend T::Sig
+
+module IBox
+  extend T::Generic
+  Elem = type_member(:out)
+end
+
+class Box
+  include IBox
+  extend T::Generic
+  Elem = type_member
+end
+
+module M; end
+module N; end
+
+sig do
+  type_parameters(:U)
+    .params(
+      box: Box[T.type_parameter(:U)],
+      f: T.proc.params(box: Box[T.type_parameter(:U)]).void,
+      blk: T.proc.params(box: Box[T.type_parameter(:U)]).void
+    )
+    .void
+end
+def box_example(box, f, &blk)
+  yield box
+end
+
+sig do
+  type_parameters(:U)
+    .params(
+      box: IBox[T.type_parameter(:U)],
+      f: T.proc.params(box: IBox[T.type_parameter(:U)]).void,
+      blk: T.proc.params(box: IBox[T.type_parameter(:U)]).void
+    )
+    .void
+end
+def ibox_example(box, f, &blk)
+  yield box
+end
+
+takes_box_string = T.let(->(box) {}, T.proc.params(box: Box[String]).void)
+takes_box_n = T.let(->(box) {}, T.proc.params(box: Box[N]).void)
+takes_ibox_n = T.let(->(box) {}, T.proc.params(box: IBox[N]).void)
+takes_ibox_string = T.let(->(box) {}, T.proc.params(box: IBox[N]).void)
+
+# The error message here is terrible
+#   `T.any(Integer, String)` must be a subtype of `T.type_parameter(:U)` which must be a subtype of `T.noreturn`
+# because what happens is that checking the first arg places the bounds
+#   Integer <: T.type_parameter(:U) (of Object#box_example) <: Integer
+# on the constraint, then the second argument places does a Types::lub (T.any)
+# on the lower bound, and a Types::glb (T.all) on the upperbound, both with
+# `String`, thus producing
+#   T.any(Integer, String) <: T.type_parameter(:U) (of Object#box_example) <: T.noreturn
+# because `T.all(Integer, String)` collapses to `T.noreturn`
+box_example(Box[Integer].new, takes_box_string) do |box|
+  # Solution takes the upper bound, regardless of whether it solves, I guess?
+  T.reveal_type(box)
+end
+
+# For a similar reason, even if we switch to modules (to avoid the `T.all`
+# collapsing to `T.noreturn`), this doesn't escape the fact that the lower
+# bound is still `T.any(M, N)`, which is not a subtype of `T.all(M, N)`. So the
+# error is slightly better here, but still doesn't fully explain how it arrived
+# at this constraint.
+box_example(Box[M].new, takes_box_n) do |box|
+end
+
+ibox_m = T.let(Box[M].new, IBox[M])
+ibox_integer = T.let(Box[Integer].new, IBox[Integer])
+# This error is easy to get right, doesn't even involve generics, just
+# inheritance, but it's a good test anyways.
+box_example(ibox_m, takes_ibox_n) do |box|
+  T.reveal_type(box)
+end
+
+# Changing to covarint just takes the `equiv` to a one-sided `isSubType`, which
+# still doesn't solve, regardless of class or module.
+ibox_example(Box[String].new, takes_ibox_n) do |box|
+  T.reveal_type(box)
+end
+ibox_example(ibox_m, takes_ibox_n) do |box|
+  T.reveal_type(box)
+end
+ibox_example(ibox_integer, takes_ibox_string) do |box|
+  T.reveal_type(box)
+end

--- a/test/cli/invariant_type_parameter/test.sh
+++ b/test/cli/invariant_type_parameter/test.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+main/sorbet --silence-dev-message test/cli/invariant_type_parameter/test.rb 2>&1

--- a/test/testdata/infer/invariant_type_parameter.rb
+++ b/test/testdata/infer/invariant_type_parameter.rb
@@ -10,7 +10,7 @@ sig {type_parameters(:U).params(box: Box[T.type_parameter(:U)]).void}
 def example(box)
 end
 
-example(Box[Integer].new) # error: Expected `Box[T.type_parameter(:U)]` but found `Box[Integer]` for argument `box`
+example(Box[Integer].new)
 
 sig do
   type_parameters(:U)
@@ -25,4 +25,4 @@ def example_complicated(x, f, box)
 end
 
 takes_int = T.let(->(x){}, T.proc.params(y: Integer).void)
-example_complicated(0, takes_int, Box[String].new) # error: Expected `Box[T.type_parameter(:U)]` but found `Box[String]` for argument `box`
+example_complicated(0, takes_int, Box[String].new) # error: Could not find valid instantiation of type parameters for `Object#example_complicated`

--- a/test/testdata/infer/invariant_type_parameter.rb
+++ b/test/testdata/infer/invariant_type_parameter.rb
@@ -1,0 +1,28 @@
+# typed: true
+extend T::Sig
+
+class Box
+  extend T::Generic
+  Elem = type_member
+end
+
+sig {type_parameters(:U).params(box: Box[T.type_parameter(:U)]).void}
+def example(box)
+end
+
+example(Box[Integer].new) # error: Expected `Box[T.type_parameter(:U)]` but found `Box[Integer]` for argument `box`
+
+sig do
+  type_parameters(:U)
+    .params(
+      x: T.type_parameter(:U),
+      f: T.proc.params(arg0: T.type_parameter(:U)).void,
+      box: Box[T.type_parameter(:U)]
+    )
+    .void
+end
+def example_complicated(x, f, box)
+end
+
+takes_int = T.let(->(x){}, T.proc.params(y: Integer).void)
+example_complicated(0, takes_int, Box[String].new) # error: Expected `Box[T.type_parameter(:U)]` but found `Box[String]` for argument `box`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Fixes #1718
Fixes #5268

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Previously when checking `Box[Integer] <: Box[T.type_parameter(:U)]`, because
the `type_member` is invariant, we required that `Integer` be equivalent to (sub
and super type of) `T.type_parameter(:U)`. But since we were using the empty
frozen constraint, neither `isSubType` call would be able to record an upper or
lower bound, so the subtyping check would simply fail upon reaching the
`TypeVar` case.

By threading through the `constr` that we have in scope, recursive calls to
`isSubTypeUnderConstraint` by way of `Types::equivUnderConstraint` will be able
to update bounds to pass the checks.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.