### PR TITLE
Don't let `T.all` silently instantiate bad bounds

### DIFF
--- a/test/testdata/infer/glb_in_bounds.rb
+++ b/test/testdata/infer/glb_in_bounds.rb
@@ -1,0 +1,49 @@
+# typed: true
+extend T::Sig
+
+class Parent
+  extend T::Generic
+  A = type_member
+end
+
+class Child1 < Parent
+  A = type_member {{upper: Integer}}
+end
+
+class Child2 < Parent
+  A = type_member {{lower: Integer}}
+end
+
+sig {
+  params(
+    x: T.all(
+      Parent[String],
+      Child1[T.untyped]
+    ),
+    y: T.any(
+      Parent[String],
+      Child1[T.untyped]
+    ),
+  ).void
+}
+def example1(x, y)
+  T.reveal_type(x) # error: `Child1[String]`
+  T.reveal_type(y) # error: `Parent[T.untyped]`
+end
+
+sig {
+  params(
+    x: T.all(
+      Parent[String],
+      Child2[T.untyped]
+    ),
+    y: T.any(
+      Parent[String],
+      Child2[T.untyped]
+    ),
+  ).void
+}
+def example2(x, y)
+  T.reveal_type(x) # error: `Child2[String]`
+  T.reveal_type(y) # error: `Parent[T.untyped]`
+end

--- a/test/testdata/infer/glb_in_bounds.rb
+++ b/test/testdata/infer/glb_in_bounds.rb
@@ -27,7 +27,7 @@ sig {
   ).void
 }
 def example1(x, y)
-  T.reveal_type(x) # error: `Child1[String]`
+  T.reveal_type(x) # error: `Child1[T.untyped]`
   T.reveal_type(y) # error: `Parent[T.untyped]`
 end
 
@@ -44,6 +44,6 @@ sig {
   ).void
 }
 def example2(x, y)
-  T.reveal_type(x) # error: `Child2[String]`
+  T.reveal_type(x) # error: `Child2[T.untyped]`
   T.reveal_type(y) # error: `Parent[T.untyped]`
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Taking a look at the new test in this PR, `Child1[String]` and `Child2[String]`
are bad types: they don't satisfy the bounds on the respective classes.

In our attempts to make the types collapse inside `glb`, we could sometimes
overstep and accidentally instantiate these types. The solution is to check
whether the bounds match before collapsing.

This came up as a problem when I attempted to implement #3527, but upon further
reflection I realized that the limitation holding that PR back was not my
approach to implementing generics + exhaustiveness, but rather `T.all` itself,
because the problem can be seen independently of any changes introduced in that
PR.

With this change I think I should be able to revive that PR.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.