### PR TITLE
Implement dropSubtypesOf on sealed AppliedType

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1740,7 +1740,7 @@ TypePtr ClassOrModule::sealedSubclassesToUnion(const GlobalState &gs) const {
         auto classType = cast_type_nonnull<ClassType>(orType->right);
         auto subclass = classType.symbol.data(gs)->attachedClass(gs);
         ENFORCE(subclass.exists());
-        result = Types::any(gs, make_type<ClassType>(subclass), result);
+        result = Types::any(gs, subclass.data(gs)->externalType(), result);
         currentClasses = orType->left;
     }
 
@@ -1748,7 +1748,7 @@ TypePtr ClassOrModule::sealedSubclassesToUnion(const GlobalState &gs) const {
     auto lastClassType = cast_type_nonnull<ClassType>(currentClasses);
     auto subclass = lastClassType.symbol.data(gs)->attachedClass(gs);
     ENFORCE(subclass.exists());
-    result = Types::any(gs, make_type<ClassType>(subclass), result);
+    result = Types::any(gs, subclass.data(gs)->externalType(), result);
 
     return result;
 }

--- a/test/testdata/infer/sealed_applied_child_bounds.rb
+++ b/test/testdata/infer/sealed_applied_child_bounds.rb
@@ -1,0 +1,34 @@
+# typed: strict
+
+class Parent
+  extend T::Helpers
+  extend T::Generic
+  sealed!
+  abstract!
+  A = type_member
+end
+
+class Child1 < Parent
+  A = type_member {{lower: Integer}}
+end
+
+class Child2 < Parent
+  A = type_member {{upper: Integer}}
+end
+
+extend T::Sig
+
+sig {params(x: Parent[String]).void}
+def foo(x)
+  case x
+  when Child1
+    # TODO(jez)
+    # This is wrong: the revealed type should not be allowed to exists, because
+    # `String` is not a super type of `Integer`, which is a lower bound of `Child1::A`
+    T.reveal_type(x) # error: Revealed type: `Child1[String]`
+  when Child2
+    # TODO(jez) This is also wrong, for the same reason.
+    T.reveal_type(x) # error: Revealed type: `Child2[String]`
+  else T.absurd(x)
+  end
+end

--- a/test/testdata/infer/sealed_applied_child_bounds.rb
+++ b/test/testdata/infer/sealed_applied_child_bounds.rb
@@ -22,13 +22,9 @@ sig {params(x: Parent[String]).void}
 def foo(x)
   case x
   when Child1
-    # TODO(jez)
-    # This is wrong: the revealed type should not be allowed to exists, because
-    # `String` is not a super type of `Integer`, which is a lower bound of `Child1::A`
-    T.reveal_type(x) # error: Revealed type: `Child1[String]`
+    T.reveal_type(x) # error: Revealed type: `Child1[T.untyped]`
   when Child2
-    # TODO(jez) This is also wrong, for the same reason.
-    T.reveal_type(x) # error: Revealed type: `Child2[String]`
+    T.reveal_type(x) # error: Revealed type: `Child2[T.untyped]`
   else T.absurd(x)
   end
 end

--- a/test/testdata/infer/sealed_list_fixed_noreturn.rb
+++ b/test/testdata/infer/sealed_list_fixed_noreturn.rb
@@ -1,0 +1,50 @@
+# typed: strict
+module List
+  extend T::Sig
+  extend T::Helpers
+  extend T::Generic
+  Elem = type_member(:out)
+  sealed!
+  abstract!
+
+  class Cons < T::Struct
+    extend T::Sig
+    extend T::Generic
+    include List
+    Elem = type_member
+
+    prop :head, Elem
+    prop :tail, List[Elem]
+  end
+
+  class Nil < T::Struct
+    extend T::Sig
+    extend T::Generic
+    include List
+    Elem = type_member {{fixed: T.noreturn}}
+  end
+end
+
+extend T::Sig
+
+sig do
+  type_parameters(:U)
+    .params(xs: List[Integer])
+    .returns(List[String])
+end
+def list_integer_to_list_string(xs)
+  case xs
+  when List::Cons
+    List::Cons[String].new(head: xs.head.to_s, tail: list_integer_to_list_string(xs))
+  when List::Nil
+    T.reveal_type(xs) # error: Revealed type: `T.all(List[Integer], List::Nil)`
+
+    # Even though the T.all doesn't collapse above, it appears that type can
+    # still be used for any empty list?  Not sure if there's a bug in
+    # Types::glb, or in Types::isSubType, or if there's no bug.
+    _unused = T.let(xs, List[String])
+    xs
+  else
+    T.absurd(xs)
+  end
+end

--- a/test/testdata/infer/sealed_list_fixed_noreturn.rb
+++ b/test/testdata/infer/sealed_list_fixed_noreturn.rb
@@ -7,6 +7,9 @@ module List
   sealed!
   abstract!
 
+  sig {abstract.returns(Elem)}
+  def head; end
+
   class Cons < T::Struct
     extend T::Sig
     extend T::Generic
@@ -22,6 +25,9 @@ module List
     extend T::Generic
     include List
     Elem = type_member {{fixed: T.noreturn}}
+
+    sig {override.returns(Elem)}
+    def head; raise "head on empty list"; end
   end
 end
 
@@ -40,9 +46,11 @@ def list_integer_to_list_string(xs)
     T.reveal_type(xs) # error: Revealed type: `T.all(List[Integer], List::Nil)`
 
     # Even though the T.all doesn't collapse above, it appears that type can
-    # still be used for any empty list?  Not sure if there's a bug in
-    # Types::glb, or in Types::isSubType, or if there's no bug.
+    # still be used like an empty list.
     _unused = T.let(xs, List[String])
+    0.times do
+      puts(xs.head) # error: This code is unreachable
+    end
     xs
   else
     T.absurd(xs)

--- a/test/testdata/infer/sealed_list_module.rb
+++ b/test/testdata/infer/sealed_list_module.rb
@@ -82,11 +82,11 @@ def list_integer_to_list_string(xs)
   when List::Cons
     List::Cons[String].new(head: xs.head.to_s, tail: list_integer_to_list_string(xs))
   when List::Nil
-    # TODO(jez) This is another bad bounds bug
     T.reveal_type(xs) # error: Revealed type: `List::Nil[Integer]`
-    # The above error (result type) is because List::Cons does not fix the
-    # type_member to empty string, so each empty list can only be used at its
-    # own type, not at any other list's type.
+    # The above error (result type) is because List::Nil does not fix the
+    # type_member to T.noreturn, so each empty list can only be used at its
+    # own type, insead of being compatible with any list. This is mostly for
+    # test coverage; we also have tests that test the fixed noreturn case.
     _unused = T.let(xs, List[String]) # error: Argument does not have asserted type `List[String]`
     List::Nil[String].new
   else

--- a/test/testdata/infer/sealed_list_module.rb
+++ b/test/testdata/infer/sealed_list_module.rb
@@ -1,0 +1,161 @@
+# typed: strict
+require 'sorbet-runtime'
+module List
+  extend T::Sig
+  extend T::Helpers
+  extend T::Generic
+  include Enumerable
+  Elem = type_member(:out)
+  sealed!
+  abstract!
+
+  class Cons < T::Struct
+    extend T::Sig
+    extend T::Generic
+    include List
+    Elem = type_member
+
+    prop :head, Elem
+    prop :tail, List[Elem]
+
+    sig do
+      override
+        .params(blk: T.proc.params(arg0: Elem).returns(BasicObject))
+        .returns(T.untyped)
+    end
+    def each(&blk)
+      yield self.head
+      self.tail.each(&blk)
+    end
+  end
+
+  class Nil < T::Struct
+    extend T::Sig
+    extend T::Generic
+    include List
+    Elem = type_member
+    sig do
+      override
+        .params(blk: T.proc.params(arg0: Elem).returns(BasicObject))
+        .returns(T.untyped)
+    end
+    def each(&blk)
+      nil
+    end
+  end
+
+  sig {returns(Elem)}
+  def head!
+    case self
+    when List::Nil
+      raise ArgumentError.new("Can't get head of empty List")
+    when List::Cons
+      self.head
+    else
+      T.absurd(self)
+    end
+  end
+
+  sig {returns(List[Elem])}
+  def tail!
+    case self
+    when List::Nil
+      raise ArgumentError.new("Can't get tail of empty List")
+    # Intentionally omitted, to test exhaustiveness errors.
+    # when List::Cons
+    #   self.tail
+    else
+      T.absurd(self) # error: the type `List::Cons[List::Elem]` wasn't handled
+    end
+  end
+end
+
+extend T::Sig
+
+sig do
+  type_parameters(:U)
+    .params(xs: List[Integer])
+    .returns(List[String])
+end
+def list_integer_to_list_string(xs)
+  case xs
+  when List::Cons
+    List::Cons[String].new(head: xs.head.to_s, tail: list_integer_to_list_string(xs))
+  when List::Nil
+    # TODO(jez) This is another bad bounds bug
+    T.reveal_type(xs) # error: Revealed type: `List::Nil[Integer]`
+    # The above error (result type) is because List::Cons does not fix the
+    # type_member to empty string, so each empty list can only be used at its
+    # own type, not at any other list's type.
+    _unused = T.let(xs, List[String]) # error: Argument does not have asserted type `List[String]`
+    List::Nil[String].new
+  else
+    T.absurd(xs)
+  end
+end
+
+sig do
+  type_parameters(:U, :V)
+    .params(
+      xs: List[T.type_parameter(:U)],
+      f: T.proc.params(arg0: T.type_parameter(:U)).returns(T.type_parameter(:V))
+    )
+    .returns(List[T.type_parameter(:V)])
+end
+def list_map_pos(xs, f)
+  case xs
+  when List::Cons
+    head = f.call(xs.head)
+    tail = list_map_pos(xs.tail, f)
+    List::Cons[T.type_parameter(:V)].new(head: head, tail: tail)
+  when List::Nil
+    List::Nil[T.type_parameter(:V)].new
+  else
+    T.absurd(xs)
+  end
+end
+
+sig do
+  type_parameters(:U, :V)
+    .params(
+      xs: List[T.type_parameter(:U)],
+      blk: T.proc.params(arg0: T.type_parameter(:U)).returns(T.type_parameter(:V))
+    )
+    .returns(List[T.type_parameter(:V)])
+end
+def list_map_blk(xs, &blk)
+  case xs
+  when List::Cons
+    head = yield xs.head
+    # This error is a bug. Just capturing the existing behavior.
+    tail = list_map_blk(xs.tail, &blk) # error: Expected `T.proc.params(arg0: <top>).returns(<top>)`
+    List::Cons[T.type_parameter(:V)].new(head: head, tail: tail)
+  when List::Nil
+    List::Nil[T.type_parameter(:V)].new
+  else
+    T.absurd(xs)
+  end
+end
+
+xs = List::Cons[Integer].new(head: 2, tail: List::Cons[Integer].new(head: 1, tail: List::Nil[Integer].new))
+p xs
+# Enumerable#map actually creates an Array, because the Enumerable
+# interface doesn't include a way to create new instances.
+T.reveal_type(xs.map(&:to_s)) # error: Revealed type: `T::Array[String]`
+
+# This error is a bug. Just capturing the existing behavior.
+res1 = list_map_pos(xs, -> (x) {
+  # This error is a bug. Just capturing the existing behavior.
+  T.reveal_type(x) # error: Revealed type: `T.untyped`
+  x.even?
+})
+T.reveal_type(res1) # error: Revealed type: `List[T.untyped]`
+
+# This error is a bug. Just capturing the existing behavior.
+res2 = list_map_blk(xs) do |x|
+  # This error is a bug. Just capturing the existing behavior.
+  T.reveal_type(x) # error: Revealed type: `<top>`
+  # This error is a bug. Just capturing the existing behavior.
+  x.even? # error: Method `even?` does not exist on `<top>`
+end
+T.reveal_type(res2) # error: Revealed type: `List[T.untyped]`


### PR DESCRIPTION
Closes #2572
Closes #1714


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This implements exhaustiveness checking on sealed generic class
hierarchies, allowing for things like generic algebraic data types.

I started this work in #3527 but abandoned it because dmitry convinced me it was
wrong.

Instead, I think that it is fine, and that the bug dmitry pointed out was
actually just a bug in `T.all` itself, not this change. That should be fixed in
#6018, unblocking this change.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.