### PR TITLE
Add RBI definition for `Fiber#raise`

### DIFF
--- a/rbi/core/fiber.rbi
+++ b/rbi/core/fiber.rbi
@@ -71,13 +71,42 @@
 # 1000000
 # FiberError: dead fiber called
 # ```
+#
+# ## Non-blocking Fibers
+#
+# The concept of *non-blocking fiber* was introduced in Ruby 3.0. A non-blocking
+# fiber, when reaching a operation that would normally block the fiber (like
+# `sleep`, or wait for another process or I/O) will yield control to other
+# fibers and allow the *scheduler* to handle blocking and waking up (resuming)
+# this fiber when it can proceed.
+#
+# For a [`Fiber`](https://docs.ruby-lang.org/en/2.7.0/Fiber.html) to behave as
+# non-blocking, it need to be created in
+# [`Fiber.new`](https://docs.ruby-lang.org/en/2.7.0/Fiber.html#method-c-new)
+# with `blocking: false` (which is the default), and
+# [`Fiber.scheduler`](https://docs.ruby-lang.org/en/2.7.0/Fiber.html#method-c-scheduler)
+# should be set with
+# [`Fiber.set_scheduler`](https://docs.ruby-lang.org/en/2.7.0/Fiber.html#method-c-set_scheduler).
+# If
+# [`Fiber.scheduler`](https://docs.ruby-lang.org/en/2.7.0/Fiber.html#method-c-scheduler)
+# is not set in the current thread, blocking and non-blocking fibers' behavior
+# is identical.
+#
+# Ruby doesn't provide a scheduler class: it is expected to be implemented by
+# the user and correspond to
+# [`Fiber::SchedulerInterface`](https://docs.ruby-lang.org/en/2.7.0/Fiber/SchedulerInterface.html).
+#
+# There is also
+# [`Fiber.schedule`](https://docs.ruby-lang.org/en/2.7.0/Fiber.html#method-c-schedule)
+# method, which is expected to immediately perform the given block in a
+# non-blocking manner. Its actual implementation is up to the scheduler.
 class Fiber < Object
   sig {returns(Fiber)}
   def current; end
 
   # Returns true if the fiber can still be resumed (or transferred to). After
-  # finishing execution of the fiber block this method will always return false.
-  # You need to `require 'fiber'` before using this method.
+  # finishing execution of the fiber block this method will always return
+  # `false`.
   sig {returns(T::Boolean)}
   def alive?; end
 
@@ -103,8 +132,6 @@ class Fiber < Object
   # [`Fiber.yield`](https://docs.ruby-lang.org/en/2.7.0/Fiber.html#method-c-yield)
   def resume(*_); end
 
-  # Returns fiber information string.
-  #
   # Also aliased as:
   # [`inspect`](https://docs.ruby-lang.org/en/2.7.0/Fiber.html#method-i-inspect)
   def to_s; end

--- a/rbi/core/fiber.rbi
+++ b/rbi/core/fiber.rbi
@@ -114,6 +114,21 @@ class Fiber < Object
   # [`to_s`](https://docs.ruby-lang.org/en/2.7.0/Fiber.html#method-i-to_s)
   def inspect; end
 
+  # Raises an exception in the fiber at the point at which the last
+  # `Fiber.yield` was called. If the fiber has not been started or has already
+  # run to completion, raises `FiberError`. If the fiber is yielding, it is
+  # resumed. If it is transferring, it is transferred into. But if it is
+  # resuming, raises `FiberError`.
+  #
+  # With no arguments, raises a `RuntimeError`. With a single `String` argument,
+  # raises a `RuntimeError` with the string as a message. Otherwise, the first
+  # parameter should be the name of an `Exception` class (or an object that
+  # returns an `Exception` object when sent an `exception` message). The
+  # optional second parameter sets the message associated with the exception,
+  # and the third parameter is an array of callback information. Exceptions are
+  # caught by the `rescue` clause of `begin...end` blocks.
+  def raise(message_or_exception, message = nil, callbacks = []); end
+
   # Resumes the fiber from the point at which the last
   # [`Fiber.yield`](https://docs.ruby-lang.org/en/2.7.0/Fiber.html#method-c-yield)
   # was called, or starts running it if it is the first call to


### PR DESCRIPTION
### Motivation

Add RBI for Ruby 2.7 method [`Fiver#raise`](https://ruby-doc.org/core-2.7.0/Fiber.html#method-i-raise).

I didn't add a signature since the method has multiple overloads that I wasn't sure how to represent.
I'm open to suggestions.

### Test plan

See included automated tests.
