### PR TITLE
Add missing RBI definitions for `FrozenError`

### DIFF
--- a/rbi/core/errors.rbi
+++ b/rbi/core/errors.rbi
@@ -29,11 +29,10 @@
 class ArgumentError < StandardError
 end
 
-# The exception class which will be raised when pushing into a closed
-# [`Queue`](https://docs.ruby-lang.org/en/2.7.0/Queue.html). See
-# [`Queue#close`](https://docs.ruby-lang.org/en/2.7.0/Queue.html#method-i-close)
+# The exception class which will be raised when pushing into a closed Queue. See
+# [`Thread::Queue#close`](https://docs.ruby-lang.org/en/2.7.0/Thread/Queue.html#method-i-close)
 # and
-# [`SizedQueue#close`](https://docs.ruby-lang.org/en/2.7.0/SizedQueue.html#method-i-close).
+# [`Thread::SizedQueue#close`](https://docs.ruby-lang.org/en/2.7.0/Thread/SizedQueue.html#method-i-close).
 class ClosedQueueError < StopIteration
 end
 

--- a/rbi/core/errors.rbi
+++ b/rbi/core/errors.rbi
@@ -94,6 +94,12 @@ class FrozenError < RuntimeError
   # ```
   sig { params(msg: T.untyped, receiver: T.untyped).void }
   def initialize(msg = nil, receiver: nil); end
+
+  # Return the receiver associated with this
+  # [`FrozenError`](https://docs.ruby-lang.org/en/2.7.0/FrozenError.html)
+  # exception.
+  sig { returns(T.untyped) }
+  def receiver; end
 end
 
 # Raised when the given index is invalid.

--- a/rbi/core/errors.rbi
+++ b/rbi/core/errors.rbi
@@ -81,6 +81,19 @@ end
 # FrozenError: can't modify frozen Array
 # ```
 class FrozenError < RuntimeError
+  # Construct a new
+  # [`FrozenError`](https://docs.ruby-lang.org/en/2.7.0/FrozenError.html)
+  # exception. If given the *receiver* parameter may subsequently be examined
+  # using the
+  # [`FrozenError#receiver`](https://docs.ruby-lang.org/en/2.7.0/FrozenError.html#method-i-receiver)
+  # method.
+  #
+  # ```ruby
+  # a = [].freeze
+  # raise FrozenError.new("can't modify frozen array", receiver: a)
+  # ```
+  sig { params(msg: T.untyped, receiver: T.untyped).void }
+  def initialize(msg = nil, receiver: nil); end
 end
 
 # Raised when the given index is invalid.


### PR DESCRIPTION
### Motivation

Add new Ruby 2.7 methods for `FrozenError`:

1. Updated documentation in `errors.rbi`
2. Added RBI definition for [`FrozenError#initialize`](https://rubydoc.info/stdlib/core/FrozenError#initialize-instance_method)
3. Added RBI definition for [`FrozenError#receiver`](https://rubydoc.info/stdlib/core/FrozenError#receiver-instance_method)


### Test plan

See included automated tests.
