### PR TITLE
Follow symlinks if they point to directories

### DIFF
--- a/common/common.cc
+++ b/common/common.cc
@@ -275,6 +275,9 @@ void appendFilesInDir(string_view basePath, const string &path, const sorbet::Un
             }
             appendFilesInDir(basePath, fullPath, extensions, recursive, result, absoluteIgnorePatterns,
                              relativeIgnorePatterns);
+        } else if (recursive && entry->d_type == DT_LNK && sorbet::FileOps::dirExists(fullPath)) {
+            appendFilesInDir(basePath, fullPath, extensions, recursive, result, absoluteIgnorePatterns,
+                             relativeIgnorePatterns);
         } else {
             auto dotLocation = fullPath.rfind('.');
             if (dotLocation != string::npos) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
This change makes sorbet follow symlinks when loading ruby files from the `--dir` directive.

As of now, the following works:
`bundle exec srb tc --dir path_to_symlink`

The following _does not_ work:
`bundle exec srb tc --dir path_to_directory_containing_symlink`

Basically, specifying a symlink _directly_ work but any symlink _within_ that directory is ignored as it is a symlink and not a directory.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
For a bit of context:
Our organization uses sorbet in projects with symlinked gem dependencies (we use a monorepo).

Unfortunately, sorbet language server (--lsp) does not work wither either gems that include `rbi` folder or passing more than one `--dir` directive in the config file.

Normally this is solved witha tool like `tapioca` to essentially copy the distributed annotations to the project's `sorbet/rbi` folder. It does not, however, make sense with a symlinked gem as it's meant to be updated in various projects _without_ touching those projects.

One solution to this problem would be to symlink the `rbi` folder within `sorbet/rbi` folder, allowing sorbet to pick up the distributed annotations.

Note that this is a bandaid solution as realistically - it would make sense for sorbet LSP to suport multiple directories. Otherwise - users who follow Sorbet's recommendation on distributing annotations via `rbi` dir break compatibility for users who want to use the language server.

### Extra notes
- We do not check for cycles but I'm personally fine with it. If there's a symlink cycle - call it a user error.

- I haven't touched C++ in a very long time so suggestions in that regard are welcomed.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I can add tests when maintainers confirm that this approach is viable and does not require changes to the approach.
