### PR TITLE
Update RBI definition fore `Warning#warn`

### DIFF
--- a/rbi/core/warning.rbi
+++ b/rbi/core/warning.rbi
@@ -70,7 +70,11 @@ module Warning
   def self.[]=(category, setting); end
 
   # Writes warning message `msg` to $stderr. This method is called by Ruby for
-  # all emitted warnings.
-  sig {params(msg: Object).returns(NilClass)}
-  def warn(msg); end
+  # all emitted warnings. A `category` may be included with the warning.
+  #
+  # See the documentation of the
+  # [`Warning`](https://docs.ruby-lang.org/en/2.7.0/Warning.html) module for how
+  # to customize this.
+  sig {params(msg: Object, category: T.nilable(T.any(String, Symbol))).returns(NilClass)}
+  def warn(msg, category: nil); end
 end

--- a/rbi/core/warning.rbi
+++ b/rbi/core/warning.rbi
@@ -10,20 +10,40 @@
 # is called for all warnings issued by Ruby. By default, warnings are printed to
 # $stderr.
 #
-# By overriding
-# [`Warning.warn`](https://docs.ruby-lang.org/en/2.7.0/Warning.html#method-i-warn),
-# you can change how warnings are handled by Ruby, either filtering some
-# warnings, and/or outputting warnings somewhere other than $stderr. When
+# Changing the behavior of
 # [`Warning.warn`](https://docs.ruby-lang.org/en/2.7.0/Warning.html#method-i-warn)
-# is overridden, super can be called to get the default behavior of printing the
-# warning to $stderr.
+# is useful to customize how warnings are handled by Ruby, for instance by
+# filtering some warnings, and/or outputting warnings somewhere other than
+# $stderr.
+#
+# If you want to change the behavior of
+# [`Warning.warn`](https://docs.ruby-lang.org/en/2.7.0/Warning.html#method-i-warn)
+# you should use +Warning.extend(MyNewModuleWithWarnMethod)+ and you can use
+# `super` to get the default behavior of printing the warning to $stderr.
+#
+# Example:
+#
+# ```ruby
+# module MyWarningFilter
+#   def warn(message, category: nil, **kwargs)
+#     if /some warning I want to ignore/.match?(message)
+#       # ignore
+#     else
+#       super
+#     end
+#   end
+# end
+# Warning.extend MyWarningFilter
+# ```
+#
+# You should never redefine
+# [`Warning#warn`](https://docs.ruby-lang.org/en/2.7.0/Warning.html#method-i-warn)
+# (the instance method), as that will then no longer provide a way to use the
+# default behavior.
+#
+# The `warning` gem provides convenient ways to customize
+# [`Warning.warn`](https://docs.ruby-lang.org/en/2.7.0/Warning.html#method-i-warn).
 module Warning
-  # call-seq
-  #
-  # ```
-  # Warning[category]  -> true or false
-  # ```
-  #
   # Returns the flag to show the warning messages for `category`. Supported
   # categories are:
   #
@@ -43,12 +63,6 @@ module Warning
   sig {params(category: Symbol).returns(T::Boolean)}
   def self.[](category); end
 
-  # call-seq
-  #
-  # ```
-  # Warning[category] = flag -> flag
-  # ```
-  #
   # Sets the warning flags for `category`. See
   # [`Warning.[]`](https://docs.ruby-lang.org/en/2.7.0/Warning.html#method-c-5B-5D)
   # for the categories.


### PR DESCRIPTION
### Motivation

Mapping changes from Ruby 3.0:

1. Update documentation for `warning.rbi`
2. Update definition for [`Warning.warn`](https://ruby-doc.org/core-3.1.1/Warning.html#method-i-warn)

### Test plan

See included automated tests.
