### PR TITLE
Take the slow path for initialize, call, and new

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -2282,6 +2282,19 @@ uint32_t TypeParameter::hash(const GlobalState &gs) const {
 }
 
 uint32_t Method::methodShapeHash(const GlobalState &gs) const {
+    if (name == core::Names::initialize() || name == core::Names::call() || name == core::Names::new_()) {
+        // TODO(jez) This is a hack. LSP currently does a poor job of taking the fast path when
+        // there are thousands or tens of thousands of files to typecheck as a part of the fast path.
+        // The problem manifests as a fast path that is neither preemptible nor cancellable that
+        // runs on a single thread (not the typecheck worker pool) until everything has finished.
+        //
+        // This problem most frequently comes with these handful of methods, so to partially
+        // alleviate it before we build a longer-term solution, we're going to force any changes to
+        // these methods to take the slow path, even if it would have otherwise been possible to
+        // take the fast path.
+        return this->hash(gs);
+    }
+
     uint32_t result = _hash(name.shortName(gs));
     result = mix(result, this->flags.serialize());
     result = mix(result, this->owner.id());

--- a/test/testdata/lsp/fast_path/initialize.1.rbupdate
+++ b/test/testdata/lsp/fast_path/initialize.1.rbupdate
@@ -1,0 +1,28 @@
+# typed: true
+# no-stdlib: true
+# ^ this is a hack so that we can test whether this takes the fast/slow path
+#   without having to hard code the list of every payload file that mentions
+#   `initialize`
+# assert-fast-path: initialize.rb
+
+module Sorbet::Private::Static
+  def self.keep_for_ide(expr)
+  end
+end
+
+module T
+  def self.reveal_type(expr)
+  end
+end
+
+class A
+  def self.extend(*mod)
+  end
+
+  extend T::Sig
+  sig {params(x: String).void}
+  #    ^^^^^^ error: `params` does not exist
+  def initialize(x)
+    T.reveal_type(x) # error: `String`
+  end
+end

--- a/test/testdata/lsp/fast_path/initialize.1.rbupdate
+++ b/test/testdata/lsp/fast_path/initialize.1.rbupdate
@@ -10,19 +10,18 @@ module Sorbet::Private::Static
   end
 end
 
-module T
-  def self.reveal_type(expr)
-  end
-end
-
 class A
   def self.extend(*mod)
   end
+
+  sig {params(x: T.noreturn).void}
+  #    ^^^^^^ error: `params` does not exist
+  def takes_nothing(x); end
 
   extend T::Sig
   sig {params(x: String).void}
   #    ^^^^^^ error: `params` does not exist
   def initialize(x)
-    T.reveal_type(x) # error: `String`
+    takes_nothing(x) # error: but found `String`
   end
 end

--- a/test/testdata/lsp/fast_path/initialize.1.rbupdate
+++ b/test/testdata/lsp/fast_path/initialize.1.rbupdate
@@ -3,7 +3,7 @@
 # ^ this is a hack so that we can test whether this takes the fast/slow path
 #   without having to hard code the list of every payload file that mentions
 #   `initialize`
-# assert-fast-path: initialize.rb
+# assert-slow-path: true
 
 module Sorbet::Private::Static
   def self.keep_for_ide(expr)

--- a/test/testdata/lsp/fast_path/initialize.rb
+++ b/test/testdata/lsp/fast_path/initialize.rb
@@ -1,0 +1,27 @@
+# typed: true
+# no-stdlib: true
+# ^ this is a hack so that we can test whether this takes the fast/slow path
+#   without having to hard code the list of every payload file that mentions
+#   `initialize`
+
+module Sorbet::Private::Static
+  def self.keep_for_ide(expr)
+  end
+end
+
+module T
+  def self.reveal_type(expr)
+  end
+end
+
+class A
+  def self.extend(*mod)
+  end
+
+  extend T::Sig
+  sig {params(x: Integer).void}
+  #    ^^^^^^ error: `params` does not exist
+  def initialize(x)
+    T.reveal_type(x) # error: `Integer`
+  end
+end

--- a/test/testdata/lsp/fast_path/initialize.rb
+++ b/test/testdata/lsp/fast_path/initialize.rb
@@ -9,19 +9,18 @@ module Sorbet::Private::Static
   end
 end
 
-module T
-  def self.reveal_type(expr)
-  end
-end
-
 class A
   def self.extend(*mod)
   end
+
+  sig {params(x: T.noreturn).void}
+  #    ^^^^^^ error: `params` does not exist
+  def takes_nothing(x); end
 
   extend T::Sig
   sig {params(x: Integer).void}
   #    ^^^^^^ error: `params` does not exist
   def initialize(x)
-    T.reveal_type(x) # error: `Integer`
+    takes_nothing(x) # error: but found `Integer`
   end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is a hack. LSP currently does a poor job of taking the fast path when there
are thousands or tens of thousands of files to typecheck as a part of the fast
path. The problem manifests as a fast path that is neither preemptible nor
cancellable that runs on a single thread (not the typecheck worker pool) until
everything has finished.

This problem most frequently comes with these handful of methods, so to
partially alleviate it before we build a longer-term solution, we're going to
force any changes to these methods to take the slow path, even if it would have
otherwise been possible to take the fast path.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.