### PR TITLE
wip: Revert "Change type caching to stop polluting modules (#4397)"

### DIFF
--- a/gems/sorbet-runtime/lib/types/types/simple.rb
+++ b/gems/sorbet-runtime/lib/types/types/simple.rb
@@ -57,10 +57,8 @@ module T::Types
 
     module Private
       module Pool
-        @cache = ObjectSpace::WeakMap.new
-
         def self.type_for_module(mod)
-          cached = @cache[mod]
+          cached = mod.instance_variable_get(:@__as_sorbet_type)
           return cached if cached
 
           type = if mod == ::Array
@@ -79,13 +77,7 @@ module T::Types
             Simple.new(mod)
           end
 
-          # Unfortunately, we still need to check if the module is frozen,
-          # since WeakMap adds a finalizer to the key that is added
-          # to the map, so that it can clear the map entry when the key is
-          # garbage collected.
-          # For a frozen object, though, adding a finalizer is not a valid
-          # operation, so this still raises if `mod` is frozen.
-          @cache[mod] = type unless mod.frozen?
+          mod.instance_variable_set(:@__as_sorbet_type, type) unless mod.frozen?
           type
         end
       end

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -95,14 +95,6 @@ module Opus::Types::Test
         assert_instance_of(T::Types::Simple, x)
       end
 
-      it 'does not add any instance variables to the module' do
-        m = Module.new
-        ivars = m.instance_variables
-
-        _ = T::Types::Simple::Private::Pool.type_for_module(m)
-        assert_equal(ivars, m.instance_variables)
-      end
-
       it "shows a detailed error for constant reloading problems" do
         klass = ReloadedClass
 


### PR DESCRIPTION
This reverts commit c53d6dd552fefe852e18fae8a69bb91c2f92587b.


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Speculatively testing whether this change caused a regression.

<https://stackoverflow.com/questions/72905858>

### Usage

```ruby
gem 'sorbet-runtime', git: 'https://github.com/sorbet/sorbet.git', glob: 'gems/sorbet-runtime/*.gemspec', ref: 'c2f0008e1ab90c5d1abb5fcf2efb223817688cbf'
# ... or, using branch name, which can be less reliable in the face of caching ...
gem 'sorbet-runtime', git: 'https://github.com/sorbet/sorbet.git', glob: 'gems/sorbet-runtime/*.gemspec', ref: 'jez-revert-weakmap'
```


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->